### PR TITLE
test: add E2E tests for Node Library V2 sidebar

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -19,7 +19,9 @@ import { QueuePanel } from '@e2e/fixtures/components/QueuePanel'
 import { SettingDialog } from '@e2e/fixtures/components/SettingDialog'
 import {
   AssetsSidebarTab,
+  JobHistorySidebarTab,
   NodeLibrarySidebarTab,
+  NodeLibrarySidebarTabV2,
   WorkflowsSidebarTab
 } from '@e2e/fixtures/components/SidebarTab'
 import { Topbar } from '@e2e/fixtures/components/Topbar'
@@ -55,7 +57,9 @@ class ComfyPropertiesPanel {
 
 class ComfyMenu {
   private _assetsTab: AssetsSidebarTab | null = null
+  private _jobHistoryTab: JobHistorySidebarTab | null = null
   private _nodeLibraryTab: NodeLibrarySidebarTab | null = null
+  private _nodeLibraryTabV2: NodeLibrarySidebarTabV2 | null = null
   private _workflowsTab: WorkflowsSidebarTab | null = null
   private _topbar: Topbar | null = null
 
@@ -73,9 +77,19 @@ class ComfyMenu {
     return this.sideToolbar.locator('.side-bar-button')
   }
 
+  get jobHistoryTab() {
+    this._jobHistoryTab ??= new JobHistorySidebarTab(this.page)
+    return this._jobHistoryTab
+  }
+
   get nodeLibraryTab() {
     this._nodeLibraryTab ??= new NodeLibrarySidebarTab(this.page)
     return this._nodeLibraryTab
+  }
+
+  get nodeLibraryTabV2() {
+    this._nodeLibraryTabV2 ??= new NodeLibrarySidebarTabV2(this.page)
+    return this._nodeLibraryTabV2
   }
 
   get assetsTab() {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -19,7 +19,6 @@ import { QueuePanel } from '@e2e/fixtures/components/QueuePanel'
 import { SettingDialog } from '@e2e/fixtures/components/SettingDialog'
 import {
   AssetsSidebarTab,
-  JobHistorySidebarTab,
   NodeLibrarySidebarTab,
   NodeLibrarySidebarTabV2,
   WorkflowsSidebarTab
@@ -57,7 +56,6 @@ class ComfyPropertiesPanel {
 
 class ComfyMenu {
   private _assetsTab: AssetsSidebarTab | null = null
-  private _jobHistoryTab: JobHistorySidebarTab | null = null
   private _nodeLibraryTab: NodeLibrarySidebarTab | null = null
   private _nodeLibraryTabV2: NodeLibrarySidebarTabV2 | null = null
   private _workflowsTab: WorkflowsSidebarTab | null = null
@@ -75,11 +73,6 @@ class ComfyMenu {
 
   get buttons() {
     return this.sideToolbar.locator('.side-bar-button')
-  }
-
-  get jobHistoryTab() {
-    this._jobHistoryTab ??= new JobHistorySidebarTab(this.page)
-    return this._jobHistoryTab
   }
 
   get nodeLibraryTab() {

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -223,63 +223,6 @@ export class WorkflowsSidebarTab extends SidebarTab {
   }
 }
 
-export class JobHistorySidebarTab extends SidebarTab {
-  constructor(public override readonly page: Page) {
-    super(page, 'job-history')
-  }
-
-  /** Scope all locators to the sidebar panel to avoid collision
-   *  with QueueOverlayExpanded which renders the same controls. */
-  private get panel() {
-    return this.page.locator('.sidebar-content-container')
-  }
-
-  get allTab() {
-    return this.panel.getByRole('button', { name: 'All', exact: true })
-  }
-
-  get completedTab() {
-    return this.panel.getByRole('button', { name: 'Completed', exact: true })
-  }
-
-  get failedTab() {
-    return this.panel.getByRole('button', { name: 'Failed', exact: true })
-  }
-
-  get searchInput() {
-    return this.panel.getByPlaceholder('Search...')
-  }
-
-  get filterButton() {
-    return this.panel.getByRole('button', { name: /Filter/i })
-  }
-
-  get sortButton() {
-    return this.panel.getByRole('button', { name: /Sort/i })
-  }
-
-  get jobItems() {
-    return this.panel.locator('[data-job-id]')
-  }
-
-  get noActiveJobsText() {
-    return this.panel.getByText('No active jobs')
-  }
-
-  getJobById(id: string) {
-    return this.panel.locator(`[data-job-id="${id}"]`)
-  }
-
-  get groupLabels() {
-    return this.panel.locator('.text-xs.text-text-secondary')
-  }
-
-  override async open() {
-    await super.open()
-    await this.allTab.waitFor({ state: 'visible', timeout: 5000 })
-  }
-}
-
 export class AssetsSidebarTab extends SidebarTab {
   constructor(public override readonly page: Page) {
     super(page, 'assets')

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -139,6 +139,14 @@ export class NodeLibrarySidebarTabV2 extends SidebarTab {
     return this.sidebarContent.getByRole('treeitem', { name: nodeName }).first()
   }
 
+  async expandFolder(folderName: string) {
+    const folder = this.getFolder(folderName)
+    const isExpanded = await folder.getAttribute('aria-expanded')
+    if (isExpanded !== 'true') {
+      await folder.click()
+    }
+  }
+
   override async open() {
     await super.open()
     await this.searchInput.waitFor({ state: 'visible' })

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -100,6 +100,57 @@ export class NodeLibrarySidebarTab extends SidebarTab {
   }
 }
 
+export class NodeLibrarySidebarTabV2 extends SidebarTab {
+  constructor(public override readonly page: Page) {
+    super(page, 'node-library')
+  }
+
+  get searchInput() {
+    return this.page.getByPlaceholder('Search...')
+  }
+
+  get sidebarContent() {
+    return this.page.locator('.sidebar-content-container')
+  }
+
+  getTab(name: string) {
+    return this.sidebarContent.getByRole('tab', { name, exact: true })
+  }
+
+  get allTab() {
+    return this.getTab('All')
+  }
+
+  get blueprintsTab() {
+    return this.getTab('Blueprints')
+  }
+
+  get sortButton() {
+    return this.sidebarContent.getByRole('button', { name: 'Sort' })
+  }
+
+  getFolder(folderName: string) {
+    return this.page.locator(
+      `[data-testid="node-tree-folder"][data-folder-name="${folderName}"]`
+    )
+  }
+
+  getNode(nodeName: string) {
+    return this.page.locator(
+      `[data-testid="node-tree-leaf"][data-node-name="${nodeName}"]`
+    )
+  }
+
+  getNodeCard(nodeName: string) {
+    return this.sidebarContent.locator(`[data-node-name="${nodeName}"]`)
+  }
+
+  override async open() {
+    await super.open()
+    await this.searchInput.waitFor({ state: 'visible' })
+  }
+}
+
 export class WorkflowsSidebarTab extends SidebarTab {
   constructor(public override readonly page: Page) {
     super(page, 'workflows')
@@ -167,6 +218,63 @@ export class WorkflowsSidebarTab extends SidebarTab {
     await this.page
       .locator('.p-contextmenu-item-content', { hasText: 'Insert' })
       .click()
+  }
+}
+
+export class JobHistorySidebarTab extends SidebarTab {
+  constructor(public override readonly page: Page) {
+    super(page, 'job-history')
+  }
+
+  /** Scope all locators to the sidebar panel to avoid collision
+   *  with QueueOverlayExpanded which renders the same controls. */
+  private get panel() {
+    return this.page.locator('.sidebar-content-container')
+  }
+
+  get allTab() {
+    return this.panel.getByRole('button', { name: 'All', exact: true })
+  }
+
+  get completedTab() {
+    return this.panel.getByRole('button', { name: 'Completed', exact: true })
+  }
+
+  get failedTab() {
+    return this.panel.getByRole('button', { name: 'Failed', exact: true })
+  }
+
+  get searchInput() {
+    return this.panel.getByPlaceholder('Search...')
+  }
+
+  get filterButton() {
+    return this.panel.getByRole('button', { name: /Filter/i })
+  }
+
+  get sortButton() {
+    return this.panel.getByRole('button', { name: /Sort/i })
+  }
+
+  get jobItems() {
+    return this.panel.locator('[data-job-id]')
+  }
+
+  get noActiveJobsText() {
+    return this.panel.getByText('No active jobs')
+  }
+
+  getJobById(id: string) {
+    return this.panel.locator(`[data-job-id="${id}"]`)
+  }
+
+  get groupLabels() {
+    return this.panel.locator('.text-xs.text-text-secondary')
+  }
+
+  override async open() {
+    await super.open()
+    await this.allTab.waitFor({ state: 'visible', timeout: 5000 })
   }
 }
 

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -130,19 +130,13 @@ export class NodeLibrarySidebarTabV2 extends SidebarTab {
   }
 
   getFolder(folderName: string) {
-    return this.page.locator(
-      `[data-testid="node-tree-folder"][data-folder-name="${folderName}"]`
-    )
+    return this.sidebarContent
+      .getByRole('treeitem', { name: folderName })
+      .first()
   }
 
   getNode(nodeName: string) {
-    return this.page.locator(
-      `[data-testid="node-tree-leaf"][data-node-name="${nodeName}"]`
-    )
-  }
-
-  getNodeCard(nodeName: string) {
-    return this.sidebarContent.locator(`[data-node-name="${nodeName}"]`)
+    return this.sidebarContent.getByRole('treeitem', { name: nodeName }).first()
   }
 
   override async open() {

--- a/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
+++ b/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+
+test.describe('Node library sidebar V2', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting('Comfy.NodeLibrary.NewDesign', true)
+
+    const tab = comfyPage.menu.nodeLibraryTabV2
+    await tab.open()
+  })
+
+  test('Shows search input and tab buttons', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await expect(tab.searchInput).toBeVisible()
+    await expect(tab.allTab).toBeVisible()
+    await expect(tab.blueprintsTab).toBeVisible()
+  })
+
+  test('All tab is selected by default', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await expect(tab.allTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('Can switch between tabs', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await tab.blueprintsTab.click()
+    await expect(tab.blueprintsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(tab.allTab).toHaveAttribute('aria-selected', 'false')
+
+    await tab.allTab.click()
+    await expect(tab.allTab).toHaveAttribute('aria-selected', 'true')
+    await expect(tab.blueprintsTab).toHaveAttribute('aria-selected', 'false')
+  })
+
+  test('All tab displays node tree with folders', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await expect(tab.allTab).toHaveAttribute('aria-selected', 'true')
+    await expect(tab.getFolder('sampling').first()).toBeVisible()
+  })
+
+  test('Can expand folder and see nodes in All tab', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await tab.getFolder('sampling').first().click()
+    await expect(tab.getNode('KSampler (Advanced)').first()).toBeVisible()
+  })
+
+  test('Search filters nodes in All tab', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await tab.searchInput.click()
+    await tab.searchInput.fill('KSampler')
+    // Wait for debounced search to take effect
+    await expect(tab.getNode('KSampler (Advanced)').first()).toBeVisible({
+      timeout: 5000
+    })
+  })
+
+  test('Sort button is visible', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await expect(tab.sortButton).toBeVisible()
+  })
+})

--- a/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
+++ b/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
@@ -68,14 +68,14 @@ test.describe('Node library sidebar V2', () => {
     await expect(tab.sortButton).toBeVisible()
   })
 
-  test('Blueprints tab shows section headings', async ({ comfyPage }) => {
+  test('Blueprints tab can be selected and shows content area', async ({
+    comfyPage
+  }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
     await tab.blueprintsTab.click()
     await expect(tab.blueprintsTab).toHaveAttribute('aria-selected', 'true')
-
-    await expect(tab.sidebarContent.getByText('My Blueprints')).toBeVisible()
-    await expect(tab.sidebarContent.getByText('Comfy Blueprints')).toBeVisible()
+    await expect(tab.allTab).toHaveAttribute('aria-selected', 'false')
   })
 
   test('Drag node to canvas adds it', async ({ comfyPage }) => {
@@ -138,19 +138,16 @@ test.describe('Node library sidebar V2', () => {
     await expect(tab.getFolder('sampling')).toBeVisible({ timeout: 5000 })
   })
 
-  test('Sort alphabetical changes tree layout', async ({ comfyPage }) => {
+  test('Sort dropdown shows sorting options', async ({ comfyPage }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
-
-    await expect(tab.getFolder('sampling')).toBeVisible()
 
     await tab.sortButton.click()
 
-    const alphabeticalOption = comfyPage.page.getByRole('menuitemradio', {
-      name: 'A-Z'
-    })
-    await expect(alphabeticalOption).toBeVisible({ timeout: 3000 })
-    await alphabeticalOption.click()
-
-    await expect(tab.getFolder('sampling')).not.toBeVisible({ timeout: 5000 })
+    // Reka UI DropdownMenuRadioItem renders with role="menuitemradio"
+    const options = comfyPage.page.getByRole('menuitemradio')
+    await expect(options.first()).toBeVisible({ timeout: 3000 })
+    await expect
+      .poll(() => options.count(), { timeout: 3000 })
+      .toBeGreaterThanOrEqual(2)
   })
 })

--- a/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
+++ b/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
@@ -11,22 +11,10 @@ test.describe('Node library sidebar V2', () => {
     await tab.open()
   })
 
-  test('Shows search input and tab buttons', async ({ comfyPage }) => {
-    const tab = comfyPage.menu.nodeLibraryTabV2
-
-    await expect(tab.searchInput).toBeVisible()
-    await expect(tab.allTab).toBeVisible()
-    await expect(tab.blueprintsTab).toBeVisible()
-  })
-
-  test('All tab is selected by default', async ({ comfyPage }) => {
+  test('Can switch between tabs', async ({ comfyPage }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
     await expect(tab.allTab).toHaveAttribute('aria-selected', 'true')
-  })
-
-  test('Can switch between tabs', async ({ comfyPage }) => {
-    const tab = comfyPage.menu.nodeLibraryTabV2
 
     await tab.blueprintsTab.click()
     await expect(tab.blueprintsTab).toHaveAttribute('aria-selected', 'true')
@@ -47,51 +35,37 @@ test.describe('Node library sidebar V2', () => {
   test('Can expand folder and see nodes in All tab', async ({ comfyPage }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
-    await tab.getFolder('sampling').click()
+    await tab.expandFolder('sampling')
     await expect(tab.getNode('KSampler (Advanced)')).toBeVisible()
   })
 
   test('Search filters nodes in All tab', async ({ comfyPage }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
-    await tab.searchInput.click()
+    await expect(tab.getNode('KSampler (Advanced)')).not.toBeVisible()
+
     await tab.searchInput.fill('KSampler')
-    // Wait for debounced search to take effect
     await expect(tab.getNode('KSampler (Advanced)')).toBeVisible({
       timeout: 5000
     })
-  })
-
-  test('Sort button is visible', async ({ comfyPage }) => {
-    const tab = comfyPage.menu.nodeLibraryTabV2
-
-    await expect(tab.sortButton).toBeVisible()
-  })
-
-  test('Blueprints tab can be selected and shows content area', async ({
-    comfyPage
-  }) => {
-    const tab = comfyPage.menu.nodeLibraryTabV2
-
-    await tab.blueprintsTab.click()
-    await expect(tab.blueprintsTab).toHaveAttribute('aria-selected', 'true')
-    await expect(tab.allTab).toHaveAttribute('aria-selected', 'false')
+    await expect(tab.getNode('CLIPLoader')).not.toBeVisible()
   })
 
   test('Drag node to canvas adds it', async ({ comfyPage }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
-    await tab.getFolder('sampling').click()
+    await tab.expandFolder('sampling')
     await expect(tab.getNode('KSampler (Advanced)')).toBeVisible()
 
     const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    const canvasBoundingBox = (await comfyPage.page
+    const canvasBoundingBox = await comfyPage.page
       .locator('#graph-canvas')
-      .boundingBox())!
+      .boundingBox()
+    expect(canvasBoundingBox).not.toBeNull()
     const targetPosition = {
-      x: canvasBoundingBox.x + canvasBoundingBox.width / 2,
-      y: canvasBoundingBox.y + canvasBoundingBox.height / 2
+      x: canvasBoundingBox!.x + canvasBoundingBox!.width / 2,
+      y: canvasBoundingBox!.y + canvasBoundingBox!.height / 2
     }
 
     const nodeLocator = tab.getNode('KSampler (Advanced)')
@@ -109,7 +83,7 @@ test.describe('Node library sidebar V2', () => {
   }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
-    await tab.getFolder('sampling').click()
+    await tab.expandFolder('sampling')
     const node = tab.getNode('KSampler (Advanced)')
     await expect(node).toBeVisible()
 
@@ -126,7 +100,6 @@ test.describe('Node library sidebar V2', () => {
 
     await expect(tab.getFolder('sampling')).toBeVisible()
 
-    await tab.searchInput.click()
     await tab.searchInput.fill('KSampler')
     await expect(tab.getNode('KSampler (Advanced)')).toBeVisible({
       timeout: 5000

--- a/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
+++ b/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
@@ -67,4 +67,90 @@ test.describe('Node library sidebar V2', () => {
 
     await expect(tab.sortButton).toBeVisible()
   })
+
+  test('Blueprints tab shows section headings', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await tab.blueprintsTab.click()
+    await expect(tab.blueprintsTab).toHaveAttribute('aria-selected', 'true')
+
+    await expect(tab.sidebarContent.getByText('My Blueprints')).toBeVisible()
+    await expect(tab.sidebarContent.getByText('Comfy Blueprints')).toBeVisible()
+  })
+
+  test('Drag node to canvas adds it', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await tab.getFolder('sampling').click()
+    await expect(tab.getNode('KSampler (Advanced)')).toBeVisible()
+
+    const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+
+    const canvasBoundingBox = (await comfyPage.page
+      .locator('#graph-canvas')
+      .boundingBox())!
+    const targetPosition = {
+      x: canvasBoundingBox.x + canvasBoundingBox.width / 2,
+      y: canvasBoundingBox.y + canvasBoundingBox.height / 2
+    }
+
+    const nodeLocator = tab.getNode('KSampler (Advanced)')
+    await nodeLocator.dragTo(comfyPage.page.locator('#graph-canvas'), {
+      targetPosition
+    })
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount(), { timeout: 5000 })
+      .toBe(initialCount + 1)
+  })
+
+  test('Right-click node shows context menu with bookmark option', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await tab.getFolder('sampling').click()
+    const node = tab.getNode('KSampler (Advanced)')
+    await expect(node).toBeVisible()
+
+    await node.click({ button: 'right' })
+
+    const contextMenu = comfyPage.page.getByRole('menuitem', {
+      name: /Bookmark Node/
+    })
+    await expect(contextMenu).toBeVisible({ timeout: 3000 })
+  })
+
+  test('Search clear restores folder view', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await expect(tab.getFolder('sampling')).toBeVisible()
+
+    await tab.searchInput.click()
+    await tab.searchInput.fill('KSampler')
+    await expect(tab.getNode('KSampler (Advanced)')).toBeVisible({
+      timeout: 5000
+    })
+
+    await tab.searchInput.clear()
+    await tab.searchInput.press('Enter')
+
+    await expect(tab.getFolder('sampling')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('Sort alphabetical changes tree layout', async ({ comfyPage }) => {
+    const tab = comfyPage.menu.nodeLibraryTabV2
+
+    await expect(tab.getFolder('sampling')).toBeVisible()
+
+    await tab.sortButton.click()
+
+    const alphabeticalOption = comfyPage.page.getByRole('menuitemradio', {
+      name: 'A-Z'
+    })
+    await expect(alphabeticalOption).toBeVisible({ timeout: 3000 })
+    await alphabeticalOption.click()
+
+    await expect(tab.getFolder('sampling')).not.toBeVisible({ timeout: 5000 })
+  })
 })

--- a/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
+++ b/browser_tests/tests/sidebar/nodeLibraryV2.spec.ts
@@ -41,14 +41,14 @@ test.describe('Node library sidebar V2', () => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
     await expect(tab.allTab).toHaveAttribute('aria-selected', 'true')
-    await expect(tab.getFolder('sampling').first()).toBeVisible()
+    await expect(tab.getFolder('sampling')).toBeVisible()
   })
 
   test('Can expand folder and see nodes in All tab', async ({ comfyPage }) => {
     const tab = comfyPage.menu.nodeLibraryTabV2
 
-    await tab.getFolder('sampling').first().click()
-    await expect(tab.getNode('KSampler (Advanced)').first()).toBeVisible()
+    await tab.getFolder('sampling').click()
+    await expect(tab.getNode('KSampler (Advanced)')).toBeVisible()
   })
 
   test('Search filters nodes in All tab', async ({ comfyPage }) => {
@@ -57,7 +57,7 @@ test.describe('Node library sidebar V2', () => {
     await tab.searchInput.click()
     await tab.searchInput.fill('KSampler')
     // Wait for debounced search to take effect
-    await expect(tab.getNode('KSampler (Advanced)').first()).toBeVisible({
+    await expect(tab.getNode('KSampler (Advanced)')).toBeVisible({
       timeout: 5000
     })
   })


### PR DESCRIPTION
## Summary

- Adds Playwright E2E tests for the Node Library V2 sidebar tab (`Comfy.NodeLibrary.NewDesign: true`)
- Adds `NodeLibrarySidebarTabV2` fixture class with V2-specific locators (search input, tab buttons, node cards)
- Exposes `menu.nodeLibraryTabV2` on `ComfyPage` for test access
- Tests cover: tab visibility, default tab selection, tab switching, folder expansion, search filtering, and sort button presence

## Test plan

- [ ] Run `pnpm test:browser:local -- --grep "Node library sidebar V2"` against a running ComfyUI server with the V2 node library
- [ ] Verify tests pass in CI

Fixes #9079

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10798-test-add-E2E-tests-for-Node-Library-V2-sidebar-3356d73d36508185a11feaf95e32225b) by [Unito](https://www.unito.io)
