### PR TITLE
perf: add preload and  content-visibility attribute to media preview for improved performance

### DIFF
--- a/src/renderer/extensions/vueNodes/VideoPreview.vue
+++ b/src/renderer/extensions/vueNodes/VideoPreview.vue
@@ -46,6 +46,7 @@
         v-if="!videoError"
         :src="currentVideoUrl"
         :class="cn('block size-full object-contain', showLoader && 'invisible')"
+        preload="metadata"
         controls
         loop
         playsinline

--- a/src/renderer/extensions/vueNodes/components/AudioPreview.vue
+++ b/src/renderer/extensions/vueNodes/components/AudioPreview.vue
@@ -5,6 +5,7 @@
       :key="index"
       :src="url"
       controls
+      preload="metadata"
       class="w-full"
     />
   </div>

--- a/src/renderer/extensions/vueNodes/components/NodeContent.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeContent.vue
@@ -2,7 +2,10 @@
   <div v-if="renderError" class="node-error p-2 text-sm text-red-500">
     {{ st('nodeErrors.content', 'Node Content Error') }}
   </div>
-  <div v-else class="lg-node-content flex flex-auto grow flex-col">
+  <div
+    v-else
+    class="lg-node-content flex flex-auto grow flex-col [content-visibility:auto]"
+  >
     <!-- Default slot for custom content -->
     <slot>
       <VideoPreview


### PR DESCRIPTION
## Summary

this pull request is to improve the performance of large workflows containing numerous Media Previews.

Added content-visibility: auto, which enables the browser to lazily render Media Previews outside the viewport.

Added preload="metadata", which makes <video> and <audio> elements only preload metadata instead of the full content.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10806-perf-add-preload-and-content-visibility-attribute-to-media-preview-for-improved-perfor-3356d73d365081238ce8f1a82f8694ec) by [Unito](https://www.unito.io)
