### PR TITLE
feat: add Storybook stories for Dialogue component

### DIFF
--- a/src/components/common/Dialogue.stories.ts
+++ b/src/components/common/Dialogue.stories.ts
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import Button from '@/components/ui/button/Button.vue'
+
+import Dialogue from './Dialogue.vue'
+
+const meta = {
+  title: 'Components/Dialogue',
+  component: Dialogue,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  }
+} satisfies Meta<typeof Dialogue>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const WithTitle: Story = {
+  render: (args) => ({
+    components: { Dialogue, Button },
+    setup: () => ({ args }),
+    template: `
+      <Dialogue v-bind="args">
+        <template #button>
+          <Button>Open dialog</Button>
+        </template>
+        <template #default="{ close }">
+          <div class="flex flex-col gap-6 p-4">
+            <p class="text-sm text-muted-foreground">
+              A more descriptive lorem ipsum text...
+            </p>
+            <div class="flex items-center justify-end gap-4">
+              <Button variant="muted-textonly" size="sm" @click="close">
+                Cancel
+              </Button>
+              <Button variant="secondary" size="lg" @click="close">
+                Ok
+              </Button>
+            </div>
+          </div>
+        </template>
+      </Dialogue>
+    `
+  }),
+  args: {
+    title: 'Modal Title'
+  }
+}
+
+export const WithoutTitle: Story = {
+  render: () => ({
+    components: { Dialogue, Button },
+    template: `
+      <Dialogue>
+        <template #button>
+          <Button>Open dialog</Button>
+        </template>
+        <template #default="{ close }">
+          <div class="flex flex-col gap-4 p-4">
+            <p class="text-sm text-muted-foreground">
+              This dialog has no title header.
+            </p>
+            <div class="flex justify-end">
+              <Button variant="secondary" size="lg" @click="close">
+                Got it
+              </Button>
+            </div>
+          </div>
+        </template>
+      </Dialogue>
+    `
+  })
+}
+
+export const Confirmation: Story = {
+  render: () => ({
+    components: { Dialogue, Button },
+    template: `
+      <Dialogue title="Delete this item?">
+        <template #button>
+          <Button variant="destructive">Delete</Button>
+        </template>
+        <template #default="{ close }">
+          <div class="flex flex-col gap-6 p-4">
+            <p class="text-sm text-muted-foreground">
+              This action cannot be undone. The item will be permanently removed.
+            </p>
+            <div class="flex items-center justify-end gap-4">
+              <Button variant="muted-textonly" size="sm" @click="close">
+                Cancel
+              </Button>
+              <Button variant="destructive" size="lg" @click="close">
+                Delete
+              </Button>
+            </div>
+          </div>
+        </template>
+      </Dialogue>
+    `
+  })
+}
+
+export const WithLink: Story = {
+  render: () => ({
+    components: { Dialogue, Button },
+    template: `
+      <Dialogue title="Modal Title">
+        <template #button>
+          <Button>Open dialog</Button>
+        </template>
+        <template #default="{ close }">
+          <div class="flex flex-col gap-6 p-4">
+            <p class="text-sm text-muted-foreground">
+              A more descriptive lorem ipsum text...
+            </p>
+            <div class="flex items-center justify-between">
+              <button class="flex items-center gap-2 text-sm text-muted-foreground hover:text-base-foreground">
+                <i class="icon-[lucide--external-link] size-4" />
+                See what's new
+              </button>
+              <div class="flex items-center gap-4">
+                <Button variant="muted-textonly" size="sm" @click="close">
+                  Cancel
+                </Button>
+                <Button variant="secondary" size="lg" @click="close">
+                  Ok
+                </Button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </Dialogue>
+    `
+  })
+}


### PR DESCRIPTION
## Summary

  Add Storybook stories for the existing Dialogue (Reka UI Dialog) component.

  ## Changes

  - **What**: Four story variants — WithTitle, WithoutTitle, Confirmation, WithLink — demonstrating common dialog patterns

  ## Review Focus

  Stories only, no component changes. Uses existing Dialogue.vue and Button components.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10811-feat-add-Storybook-stories-for-Dialogue-component-3356d73d3650818d9ee4c270f24d9204) by [Unito](https://www.unito.io)
