### PR TITLE
fix: detect storybook when run via pnpm exec

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -28,7 +28,9 @@ const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE === 'true'
 const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
-const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
+const IS_STORYBOOK =
+  process.env.npm_lifecycle_event === 'storybook' ||
+  process.argv.some((arg) => arg.includes('storybook'))
 
 // Open Graph / Twitter Meta Tags Constants
 const VITE_OG_URL = 'https://cloud.comfy.org'


### PR DESCRIPTION
## Summary

  Fix Storybook failing to start when run via `pnpm exec storybook dev`.

  ## Changes

  - **What**: Broaden `IS_STORYBOOK` detection in `vite.config.mts` to also check `process.argv` for storybook, not just
  `npm_lifecycle_event`. This prevents `vite-plugin-vue-devtools` (and its `vite-plugin-inspect` sub-plugin) from loading during Storybook
  builds, which crashes with `Error: Can not found environment context for client`.

  ## Review Focus

  Single line change. `npm_lifecycle_event` is only set when running via `pnpm storybook` script, not `pnpm exec storybook dev` or `nx
  storybook`. The argv check covers all invocation methods.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10812-fix-detect-storybook-when-run-via-pnpm-exec-3356d73d3650810797e4f19cd49d552f) by [Unito](https://www.unito.io)
