### PR TITLE
refactor: harden ChangeTracker lifecycle with self-defending API

### DIFF
--- a/browser_tests/tests/actionbar.spec.ts
+++ b/browser_tests/tests/actionbar.spec.ts
@@ -58,7 +58,7 @@ test.describe('Actionbar', { tag: '@ui' }, () => {
 
         ;(
           window.app!.extensionManager as WorkspaceStore
-        ).workflow.activeWorkflow?.changeTracker.checkState()
+        ).workflow.activeWorkflow?.changeTracker.captureCanvasState()
       }, value)
     }
 

--- a/browser_tests/tests/browserTabTitle.spec.ts
+++ b/browser_tests/tests/browserTabTitle.spec.ts
@@ -34,7 +34,7 @@ test.describe('Browser tab title', { tag: '@smoke' }, () => {
         window.app!.graph!.setDirtyCanvas(true, true)
         ;(
           window.app!.extensionManager as WorkspaceStore
-        ).workflow.activeWorkflow?.changeTracker?.checkState()
+        ).workflow.activeWorkflow?.changeTracker?.captureCanvasState()
       })
       await expect
         .poll(() => comfyPage.page.title())

--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -273,4 +273,42 @@ test.describe('Change Tracker', { tag: '@workflow' }, () => {
     await comfyPage.canvasOps.pan({ x: 10, y: 10 })
     await expect.poll(() => comfyPage.workflow.getUndoQueueSize()).toBe(0)
   })
+
+  test('Undo preserves viewport offset', async ({ comfyPage }) => {
+    // Pan to a distinct offset so we can detect drift
+    await comfyPage.canvasOps.pan({ x: 200, y: 150 })
+
+    const viewportBefore = await comfyPage.page.evaluate(() => {
+      const ds = window.app!.canvas.ds
+      return { scale: ds.scale, offset: [...ds.offset] }
+    })
+
+    // Make a graph change so we have something to undo
+    const node = (await comfyPage.nodeOps.getFirstNodeRef())!
+    await node.click('title')
+    await node.click('collapse')
+    await expect(node).toBeCollapsed()
+    await expect.poll(() => comfyPage.workflow.getUndoQueueSize()).toBe(1)
+
+    // Undo the collapse — viewport should be preserved
+    await comfyPage.keyboard.undo()
+    await expect(node).not.toBeCollapsed()
+
+    await expect
+      .poll(
+        () =>
+          comfyPage.page.evaluate(() => {
+            const ds = window.app!.canvas.ds
+            return { scale: ds.scale, offset: [...ds.offset] }
+          }),
+        { timeout: 2_000 }
+      )
+      .toEqual({
+        scale: expect.closeTo(viewportBefore.scale, 2),
+        offset: [
+          expect.closeTo(viewportBefore.offset[0], 0),
+          expect.closeTo(viewportBefore.offset[1], 0)
+        ]
+      })
+  })
 })

--- a/browser_tests/tests/changeTracker.spec.ts
+++ b/browser_tests/tests/changeTracker.spec.ts
@@ -71,7 +71,7 @@ async function waitForChangeTrackerSettled(
 ) {
   // Visible node flags can flip before undo finishes loadGraphData() and
   // updates the tracker. Poll the tracker's own settled state so we do not
-  // start the next transaction while checkState() is still gated.
+  // start the next transaction while captureCanvasState() is still gated.
   await expect
     .poll(() => getChangeTrackerDebugState(comfyPage))
     .toMatchObject({

--- a/browser_tests/tests/changeTrackerLoadGuard.spec.ts
+++ b/browser_tests/tests/changeTrackerLoadGuard.spec.ts
@@ -12,7 +12,7 @@ test.describe(
       await comfyPage.workflow.setupWorkflowsDirectory({})
     })
 
-    test('Prevents checkState from corrupting workflow state during tab switch', async ({
+    test('Prevents captureCanvasState from corrupting workflow state during tab switch', async ({
       comfyPage
     }) => {
       // Tab 0: default workflow (7 nodes)
@@ -21,9 +21,9 @@ test.describe(
       // Save tab 0 so it has a unique name for tab switching
       await comfyPage.menu.topbar.saveWorkflow('workflow-a')
 
-      // Register an extension that forces checkState during graph loading.
+      // Register an extension that forces captureCanvasState during graph loading.
       // This simulates the bug scenario where a user clicks during graph loading
-      // which triggers a checkState call on the wrong graph, corrupting the activeState.
+      // which triggers a captureCanvasState call on the wrong graph, corrupting the activeState.
       await comfyPage.page.evaluate(() => {
         window.app!.registerExtension({
           name: 'TestCheckStateDuringLoad',
@@ -35,7 +35,7 @@ test.describe(
             // ; (workflow.changeTracker.constructor as unknown as { isLoadingGraph: boolean }).isLoadingGraph = false
 
             // Simulate the user clicking during graph loading
-            workflow.changeTracker.checkState()
+            workflow.changeTracker.captureCanvasState()
           }
         })
       })

--- a/browser_tests/tests/workflowPersistence.spec.ts
+++ b/browser_tests/tests/workflowPersistence.spec.ts
@@ -121,9 +121,9 @@ test.describe('Workflow Persistence', () => {
     await comfyPage.page.evaluate(() => {
       const em = window.app!.extensionManager as unknown as Record<
         string,
-        { activeWorkflow?: { changeTracker?: { checkState(): void } } }
+        { activeWorkflow?: { changeTracker?: { captureCanvasState(): void } } }
       >
-      em.workflow?.activeWorkflow?.changeTracker?.checkState()
+      em.workflow?.activeWorkflow?.changeTracker?.captureCanvasState()
     })
 
     await expect.poll(() => getNodeOutputImageCount(comfyPage, nodeId)).toBe(1)
@@ -392,7 +392,7 @@ test.describe('Workflow Persistence', () => {
     test.info().annotations.push({
       type: 'regression',
       description:
-        'PR #10745 — saveWorkflow called checkState on inactive tab, serializing the active graph instead'
+        'PR #10745 — saveWorkflow called captureCanvasState on inactive tab, serializing the active graph instead'
     })
 
     await comfyPage.settings.setSetting(
@@ -424,13 +424,13 @@ test.describe('Workflow Persistence', () => {
       .toBe(nodeCountA + 1)
     const nodeCountB = await comfyPage.nodeOps.getNodeCount()
 
-    // Trigger checkState so isModified is set
+    // Trigger captureCanvasState so isModified is set
     await comfyPage.page.evaluate(() => {
       const em = window.app!.extensionManager as unknown as Record<
         string,
-        { activeWorkflow?: { changeTracker?: { checkState(): void } } }
+        { activeWorkflow?: { changeTracker?: { captureCanvasState(): void } } }
       >
-      em.workflow?.activeWorkflow?.changeTracker?.checkState()
+      em.workflow?.activeWorkflow?.changeTracker?.captureCanvasState()
     })
 
     // Switch to A via topbar tab (making B inactive)
@@ -469,7 +469,7 @@ test.describe('Workflow Persistence', () => {
     test.info().annotations.push({
       type: 'regression',
       description:
-        'PR #10745 — saveWorkflowAs called checkState on inactive temp tab, serializing the active graph'
+        'PR #10745 — saveWorkflowAs called captureCanvasState on inactive temp tab, serializing the active graph'
     })
 
     await comfyPage.settings.setSetting(
@@ -494,13 +494,13 @@ test.describe('Workflow Persistence', () => {
     })
     await comfyPage.nextFrame()
 
-    // Trigger checkState so isModified is set
+    // Trigger captureCanvasState so isModified is set
     await comfyPage.page.evaluate(() => {
       const em = window.app!.extensionManager as unknown as Record<
         string,
-        { activeWorkflow?: { changeTracker?: { checkState(): void } } }
+        { activeWorkflow?: { changeTracker?: { captureCanvasState(): void } } }
       >
-      em.workflow?.activeWorkflow?.changeTracker?.checkState()
+      em.workflow?.activeWorkflow?.changeTracker?.captureCanvasState()
     })
 
     await expect.poll(() => comfyPage.nodeOps.getNodeCount()).toBe(1)

--- a/docs/architecture/change-tracker.md
+++ b/docs/architecture/change-tracker.md
@@ -5,14 +5,18 @@ history by comparing serialized graph snapshots.
 
 ## How It Works
 
-`checkState()` is the core method. It:
+`captureCanvasState()` is the core method. It:
 
 1. Serializes the current graph via `app.rootGraph.serialize()`
 2. Deep-compares the result against the last known `activeState`
 3. If different, pushes `activeState` onto `undoQueue` and replaces it
 
 **It is not reactive.** Changes to the graph (widget values, node positions,
-links, etc.) are only captured when `checkState()` is explicitly triggered.
+links, etc.) are only captured when `captureCanvasState()` is explicitly triggered.
+
+**INVARIANT:** `captureCanvasState()` asserts that it is called on the active
+workflow's tracker. Calling it on an inactive tracker logs an error in DEV and
+returns early, preventing cross-workflow data corruption.
 
 ## Automatic Triggers
 
@@ -31,7 +35,7 @@ These are set up once in `ChangeTracker.init()`:
 | Graph cleared                       | `api` `graphCleared` event                         | Full graph clear                                    |
 | Transaction end                     | `litegraph:canvas` `after-change` event            | Batched operations via `beforeChange`/`afterChange` |
 
-## When You Must Call `checkState()` Manually
+## When You Must Call `captureCanvasState()` Manually
 
 The automatic triggers above are designed around LiteGraph's native DOM
 rendering. They **do not cover**:
@@ -50,17 +54,17 @@ rendering. They **do not cover**:
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 
 // After mutating the graph:
-useWorkflowStore().activeWorkflow?.changeTracker?.checkState()
+useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
 ```
 
 ### Existing Manual Call Sites
 
-These locations already call `checkState()` explicitly:
+These locations already call `captureCanvasState()` explicitly:
 
 - `WidgetSelectDropdown.vue` — After dropdown selection and file upload
 - `ColorPickerButton.vue` — After changing node colors
 - `NodeSearchBoxPopover.vue` — After adding a node from search
-- `useAppSetDefaultView.ts` — After setting default view
+- `builderViewOptions.ts` — After setting default view
 - `useSelectionOperations.ts` — After align, copy, paste, duplicate, group
 - `useSelectedNodeActions.ts` — After pin, bypass, collapse
 - `useGroupMenuOptions.ts` — After group operations
@@ -76,7 +80,7 @@ For operations that make multiple changes that should be a single undo entry:
 ```typescript
 changeTracker.beforeChange()
 // ... multiple graph mutations ...
-changeTracker.afterChange() // calls checkState() when nesting count hits 0
+changeTracker.afterChange() // calls captureCanvasState() when nesting count hits 0
 ```
 
 The `litegraph:canvas` custom event also supports this with `before-change` /
@@ -84,8 +88,10 @@ The `litegraph:canvas` custom event also supports this with `before-change` /
 
 ## Key Invariants
 
-- `checkState()` is a no-op during `loadGraphData` (guarded by
+- `captureCanvasState()` asserts it is called on the active workflow's tracker;
+  inactive trackers get an early return (and a DEV error log)
+- `captureCanvasState()` is a no-op during `loadGraphData` (guarded by
   `isLoadingGraph`) to prevent cross-workflow corruption
-- `checkState()` is a no-op when `changeCount > 0` (inside a transaction)
+- `captureCanvasState()` is a no-op when `changeCount > 0` (inside a transaction)
 - `undoQueue` is capped at 50 entries (`MAX_HISTORY`)
 - `graphEqual` ignores node order and `ds` (pan/zoom) when comparing

--- a/docs/architecture/change-tracker.md
+++ b/docs/architecture/change-tracker.md
@@ -73,7 +73,7 @@ These locations call `captureCanvasState()` directly:
 - `useCoreCommands.ts` — After metadata/subgraph commands
 
 `workflowService.ts` calls `captureCanvasState()` indirectly via
-`deactivate()` and `prepareForSave()` (see Lifecycle Methods above).
+`deactivate()` and `prepareForSave()` (see Lifecycle Methods below).
 
 ## Lifecycle Methods
 

--- a/docs/architecture/change-tracker.md
+++ b/docs/architecture/change-tracker.md
@@ -73,6 +73,17 @@ These locations already call `captureCanvasState()` explicitly:
 - `useCoreCommands.ts` — After metadata/subgraph commands
 - `workflowService.ts` — After workflow service operations
 
+## Lifecycle Methods
+
+| Method                 | Caller                          | Purpose                                                                                                                    |
+| ---------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `captureCanvasState()` | Event handlers, UI interactions | Snapshots canvas into activeState, pushes undo. Asserts active tracker.                                                    |
+| `deactivate()`         | `beforeLoadNewGraph` only       | `captureCanvasState()` + `store()`. Freezes everything for tab switch. Must be called while this workflow is still active. |
+| `prepareForSave()`     | Save paths only                 | Active: calls `captureCanvasState()`. Inactive: no-op (state was frozen by `deactivate()`).                                |
+| `store()`              | Internal to `deactivate()`      | Saves viewport scale/offset, node outputs, subgraph navigation.                                                            |
+| `restore()`            | `afterLoadNewGraph`             | Restores viewport, outputs, subgraph navigation.                                                                           |
+| `reset()`              | `afterLoadNewGraph`, save       | Resets initial state (marks workflow as "clean").                                                                          |
+
 ## Transaction Guards
 
 For operations that make multiple changes that should be a single undo entry:
@@ -92,6 +103,8 @@ The `litegraph:canvas` custom event also supports this with `before-change` /
   inactive trackers get an early return (and a DEV error log)
 - `captureCanvasState()` is a no-op during `loadGraphData` (guarded by
   `isLoadingGraph`) to prevent cross-workflow corruption
+- `captureCanvasState()` is a no-op during undo/redo (guarded by
+  `_restoringState`) to prevent undo history corruption
 - `captureCanvasState()` is a no-op when `changeCount > 0` (inside a transaction)
 - `undoQueue` is capped at 50 entries (`MAX_HISTORY`)
 - `graphEqual` ignores node order and `ds` (pan/zoom) when comparing

--- a/docs/architecture/change-tracker.md
+++ b/docs/architecture/change-tracker.md
@@ -15,7 +15,7 @@ history by comparing serialized graph snapshots.
 links, etc.) are only captured when `captureCanvasState()` is explicitly triggered.
 
 **INVARIANT:** `captureCanvasState()` asserts that it is called on the active
-workflow's tracker. Calling it on an inactive tracker logs an error in DEV and
+workflow's tracker. Calling it on an inactive tracker logs a warning and
 returns early, preventing cross-workflow data corruption.
 
 ## Automatic Triggers
@@ -71,20 +71,25 @@ These locations call `captureCanvasState()` directly:
 - `useSubgraphOperations.ts` — After subgraph enter/exit
 - `useCanvasRefresh.ts` — After canvas refresh
 - `useCoreCommands.ts` — After metadata/subgraph commands
+- `appModeStore.ts` — After app mode transitions
 
 `workflowService.ts` calls `captureCanvasState()` indirectly via
 `deactivate()` and `prepareForSave()` (see Lifecycle Methods below).
 
+> **Deprecated:** `checkState()` is an alias for `captureCanvasState()` kept
+> for extension compatibility. Extension authors should migrate to
+> `captureCanvasState()`. See the `@deprecated` JSDoc on the method.
+
 ## Lifecycle Methods
 
-| Method                 | Caller                          | Purpose                                                                                                                    |
-| ---------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `captureCanvasState()` | Event handlers, UI interactions | Snapshots canvas into activeState, pushes undo. Asserts active tracker.                                                    |
-| `deactivate()`         | `beforeLoadNewGraph` only       | `captureCanvasState()` + `store()`. Freezes everything for tab switch. Must be called while this workflow is still active. |
-| `prepareForSave()`     | Save paths only                 | Active: calls `captureCanvasState()`. Inactive: no-op (state was frozen by `deactivate()`).                                |
-| `store()`              | Internal to `deactivate()`      | Saves viewport scale/offset, node outputs, subgraph navigation.                                                            |
-| `restore()`            | `afterLoadNewGraph`             | Restores viewport, outputs, subgraph navigation.                                                                           |
-| `reset()`              | `afterLoadNewGraph`, save       | Resets initial state (marks workflow as "clean").                                                                          |
+| Method                 | Caller                          | Purpose                                                                                                                                          |
+| ---------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `captureCanvasState()` | Event handlers, UI interactions | Snapshots canvas into activeState, pushes undo. Asserts active tracker.                                                                          |
+| `deactivate()`         | `beforeLoadNewGraph` only       | `captureCanvasState()` (skipped during undo/redo) + `store()`. Freezes state for tab switch. Must be called while this workflow is still active. |
+| `prepareForSave()`     | Save paths only                 | Active: calls `captureCanvasState()`. Inactive: no-op (state was frozen by `deactivate()`).                                                      |
+| `store()`              | Internal to `deactivate()`      | Saves viewport scale/offset, node outputs, subgraph navigation.                                                                                  |
+| `restore()`            | `afterLoadNewGraph`             | Restores viewport, outputs, subgraph navigation.                                                                                                 |
+| `reset()`              | `afterLoadNewGraph`, save       | Resets initial state (marks workflow as "clean").                                                                                                |
 
 ## Transaction Guards
 
@@ -102,7 +107,7 @@ The `litegraph:canvas` custom event also supports this with `before-change` /
 ## Key Invariants
 
 - `captureCanvasState()` asserts it is called on the active workflow's tracker;
-  inactive trackers get an early return (and a DEV error log)
+  inactive trackers get an early return (and a warning log)
 - `captureCanvasState()` is a no-op during `loadGraphData` (guarded by
   `isLoadingGraph`) to prevent cross-workflow corruption
 - `captureCanvasState()` is a no-op during undo/redo (guarded by

--- a/docs/architecture/change-tracker.md
+++ b/docs/architecture/change-tracker.md
@@ -59,7 +59,7 @@ useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
 
 ### Existing Manual Call Sites
 
-These locations already call `captureCanvasState()` explicitly:
+These locations call `captureCanvasState()` directly:
 
 - `WidgetSelectDropdown.vue` — After dropdown selection and file upload
 - `ColorPickerButton.vue` — After changing node colors
@@ -71,7 +71,9 @@ These locations already call `captureCanvasState()` explicitly:
 - `useSubgraphOperations.ts` — After subgraph enter/exit
 - `useCanvasRefresh.ts` — After canvas refresh
 - `useCoreCommands.ts` — After metadata/subgraph commands
-- `workflowService.ts` — After workflow service operations
+
+`workflowService.ts` calls `captureCanvasState()` indirectly via
+`deactivate()` and `prepareForSave()` (see Lifecycle Methods above).
 
 ## Lifecycle Methods
 

--- a/src/components/builder/BuilderFooterToolbar.test.ts
+++ b/src/components/builder/BuilderFooterToolbar.test.ts
@@ -46,7 +46,7 @@ const mockActiveWorkflow = ref<{
   isTemporary: boolean
   initialMode?: string
   isModified?: boolean
-  changeTracker?: { checkState: () => void }
+  changeTracker?: { captureCanvasState: () => void }
 } | null>({
   isTemporary: true,
   initialMode: 'app'

--- a/src/components/builder/builderViewOptions.test.ts
+++ b/src/components/builder/builderViewOptions.test.ts
@@ -49,10 +49,10 @@ describe('setWorkflowDefaultView', () => {
     expect(app.rootGraph.extra.linearMode).toBe(false)
   })
 
-  it('calls changeTracker.checkState', () => {
+  it('calls changeTracker.captureCanvasState', () => {
     const workflow = createMockLoadedWorkflow()
     setWorkflowDefaultView(workflow, true)
-    expect(workflow.changeTracker.checkState).toHaveBeenCalledOnce()
+    expect(workflow.changeTracker.captureCanvasState).toHaveBeenCalledOnce()
   })
 
   it('tracks telemetry with correct default_view', () => {

--- a/src/components/builder/builderViewOptions.ts
+++ b/src/components/builder/builderViewOptions.ts
@@ -9,7 +9,7 @@ export function setWorkflowDefaultView(
   workflow.initialMode = openAsApp ? 'app' : 'graph'
   const extra = (app.rootGraph.extra ??= {})
   extra.linearMode = openAsApp
-  workflow.changeTracker?.checkState()
+  workflow.changeTracker?.captureCanvasState()
   useTelemetry()?.trackDefaultViewSet({
     default_view: openAsApp ? 'app' : 'graph'
   })

--- a/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.test.ts
@@ -31,7 +31,7 @@ function createMockWorkflow(
   const changeTracker = Object.assign(
     new ChangeTracker(workflow, structuredClone(defaultGraph)),
     {
-      checkState: vi.fn() as Mock
+      captureCanvasState: vi.fn() as Mock
     }
   )
 

--- a/src/components/graph/selectionToolbox/ColorPickerButton.vue
+++ b/src/components/graph/selectionToolbox/ColorPickerButton.vue
@@ -125,7 +125,7 @@ const applyColor = (colorOption: ColorOption | null) => {
   canvasStore.canvas?.setDirty(true, true)
   currentColorOption.value = canvasColorOption
   showColorPicker.value = false
-  workflowStore.activeWorkflow?.changeTracker.checkState()
+  workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
 }
 
 const currentColorOption = ref<CanvasColorOption | null>(null)

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -143,7 +143,7 @@ function addNode(nodeDef: ComfyNodeDefImpl, dragEvent?: MouseEvent) {
   disconnectOnReset = false
 
   // Notify changeTracker - new step should be added
-  useWorkflowStore().activeWorkflow?.changeTracker?.checkState()
+  useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
   window.requestAnimationFrame(closeDialog)
 }
 

--- a/src/composables/graph/useCanvasRefresh.ts
+++ b/src/composables/graph/useCanvasRefresh.ts
@@ -13,7 +13,7 @@ export function useCanvasRefresh() {
     canvasStore.canvas?.setDirty(true, true)
     canvasStore.canvas?.graph?.afterChange()
     canvasStore.canvas?.emitAfterChange()
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   return {

--- a/src/composables/graph/useGroupMenuOptions.ts
+++ b/src/composables/graph/useGroupMenuOptions.ts
@@ -36,7 +36,7 @@ export function useGroupMenuOptions() {
       groupContext.resizeTo(groupContext.children, padding)
       groupContext.graph?.change()
       canvasStore.canvas?.setDirty(true, true)
-      workflowStore.activeWorkflow?.changeTracker?.checkState()
+      workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
     }
   })
 
@@ -119,7 +119,7 @@ export function useGroupMenuOptions() {
         })
         canvasStore.canvas?.setDirty(true, true)
         groupContext.graph?.change()
-        workflowStore.activeWorkflow?.changeTracker?.checkState()
+        workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
         bump()
       }
     })

--- a/src/composables/graph/useSelectedNodeActions.ts
+++ b/src/composables/graph/useSelectedNodeActions.ts
@@ -23,7 +23,7 @@ export function useSelectedNodeActions() {
     })
 
     app.canvas.setDirty(true, true)
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const toggleNodeCollapse = () => {
@@ -33,7 +33,7 @@ export function useSelectedNodeActions() {
     })
 
     app.canvas.setDirty(true, true)
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const toggleNodePin = () => {
@@ -43,7 +43,7 @@ export function useSelectedNodeActions() {
     })
 
     app.canvas.setDirty(true, true)
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const toggleNodeBypass = () => {

--- a/src/composables/graph/useSelectionOperations.ts
+++ b/src/composables/graph/useSelectionOperations.ts
@@ -47,7 +47,7 @@ export function useSelectionOperations() {
     canvas.pasteFromClipboard({ connectInputs: false })
 
     // Trigger change tracking
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const duplicateSelection = () => {
@@ -73,7 +73,7 @@ export function useSelectionOperations() {
     canvas.pasteFromClipboard({ connectInputs: false })
 
     // Trigger change tracking
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const deleteSelection = () => {
@@ -92,7 +92,7 @@ export function useSelectionOperations() {
     canvas.setDirty(true, true)
 
     // Trigger change tracking
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const renameSelection = async () => {
@@ -122,7 +122,7 @@ export function useSelectionOperations() {
           const titledItem = item as { title: string }
           titledItem.title = newTitle
           app.canvas.setDirty(true, true)
-          workflowStore.activeWorkflow?.changeTracker?.checkState()
+          workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
         }
       }
       return
@@ -145,7 +145,7 @@ export function useSelectionOperations() {
           }
         })
         app.canvas.setDirty(true, true)
-        workflowStore.activeWorkflow?.changeTracker?.checkState()
+        workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
       }
       return
     }

--- a/src/composables/graph/useSubgraphOperations.ts
+++ b/src/composables/graph/useSubgraphOperations.ts
@@ -31,7 +31,7 @@ export function useSubgraphOperations() {
     canvas.select(node)
     canvasStore.updateSelectedItems()
     // Trigger change tracking
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const doUnpack = (
@@ -46,7 +46,7 @@ export function useSubgraphOperations() {
       nodeOutputStore.revokeSubgraphPreviews(subgraphNode)
       graph.unpackSubgraph(subgraphNode, { skipMissingNodes })
     }
-    workflowStore.activeWorkflow?.changeTracker?.checkState()
+    workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   const unpackSubgraph = () => {

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -94,7 +94,7 @@ vi.mock('@/stores/toastStore', () => ({
 }))
 
 const mockChangeTracker = vi.hoisted(() => ({
-  checkState: vi.fn()
+  captureCanvasState: vi.fn()
 }))
 const mockWorkflowStore = vi.hoisted(() => ({
   activeWorkflow: {
@@ -382,7 +382,7 @@ describe('useCoreCommands', () => {
 
         expect(mockDialogService.prompt).toHaveBeenCalled()
         expect(mockSubgraph.extra.BlueprintDescription).toBe('Test description')
-        expect(mockChangeTracker.checkState).toHaveBeenCalled()
+        expect(mockChangeTracker.captureCanvasState).toHaveBeenCalled()
       })
 
       it('should not set description when user cancels', async () => {
@@ -397,7 +397,7 @@ describe('useCoreCommands', () => {
         await setDescCommand.function()
 
         expect(mockSubgraph.extra.BlueprintDescription).toBeUndefined()
-        expect(mockChangeTracker.checkState).not.toHaveBeenCalled()
+        expect(mockChangeTracker.captureCanvasState).not.toHaveBeenCalled()
       })
     })
 
@@ -432,7 +432,7 @@ describe('useCoreCommands', () => {
           'alias2',
           'alias3'
         ])
-        expect(mockChangeTracker.checkState).toHaveBeenCalled()
+        expect(mockChangeTracker.captureCanvasState).toHaveBeenCalled()
       })
 
       it('should trim whitespace and filter empty strings', async () => {
@@ -478,7 +478,7 @@ describe('useCoreCommands', () => {
         await setAliasesCommand.function()
 
         expect(mockSubgraph.extra.BlueprintSearchAliases).toBeUndefined()
-        expect(mockChangeTracker.checkState).not.toHaveBeenCalled()
+        expect(mockChangeTracker.captureCanvasState).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -1164,7 +1164,7 @@ export function useCoreCommands(): ComfyCommand[] {
         if (description === null) return
 
         extra.BlueprintDescription = description.trim() || undefined
-        workflowStore.activeWorkflow?.changeTracker?.checkState()
+        workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
       }
     },
     {
@@ -1201,7 +1201,7 @@ export function useCoreCommands(): ComfyCommand[] {
         }
 
         extra.BlueprintSearchAliases = aliases.length > 0 ? aliases : undefined
-        workflowStore.activeWorkflow?.changeTracker?.checkState()
+        workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
       }
     },
     {

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -139,7 +139,8 @@ export const useWorkflowService = () => {
     }
 
     if (isSelfOverwrite) {
-      if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
+      if (workflowStore.isActive(workflow))
+        workflow.changeTracker?.captureCanvasState()
       await saveWorkflow(workflow)
     } else {
       let target: ComfyWorkflow
@@ -156,7 +157,8 @@ export const useWorkflowService = () => {
         app.rootGraph.extra.linearMode = isApp
         target.initialMode = isApp ? 'app' : 'graph'
       }
-      if (workflowStore.isActive(target)) target.changeTracker?.checkState()
+      if (workflowStore.isActive(target))
+        target.changeTracker?.captureCanvasState()
 
       await workflowStore.saveWorkflow(target)
     }
@@ -173,7 +175,8 @@ export const useWorkflowService = () => {
     if (workflow.isTemporary) {
       await saveWorkflowAs(workflow)
     } else {
-      if (workflowStore.isActive(workflow)) workflow.changeTracker?.checkState()
+      if (workflowStore.isActive(workflow))
+        workflow.changeTracker?.captureCanvasState()
 
       const isApp = workflow.initialMode === 'app'
       const expectedPath =

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -366,7 +366,7 @@ export const useWorkflowService = () => {
     const workflowStore = useWorkspaceStore().workflow
     const activeWorkflow = workflowStore.activeWorkflow
     if (activeWorkflow) {
-      activeWorkflow.changeTracker.deactivate()
+      activeWorkflow.changeTracker?.deactivate()
       if (settingStore.get('Comfy.Workflow.Persist') && activeWorkflow.path) {
         const activeState = activeWorkflow.activeState
         if (activeState) {

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -139,8 +139,7 @@ export const useWorkflowService = () => {
     }
 
     if (isSelfOverwrite) {
-      if (workflowStore.isActive(workflow))
-        workflow.changeTracker?.captureCanvasState()
+      workflow.changeTracker?.prepareForSave()
       await saveWorkflow(workflow)
     } else {
       let target: ComfyWorkflow
@@ -157,9 +156,7 @@ export const useWorkflowService = () => {
         app.rootGraph.extra.linearMode = isApp
         target.initialMode = isApp ? 'app' : 'graph'
       }
-      if (workflowStore.isActive(target))
-        target.changeTracker?.captureCanvasState()
-
+      target.changeTracker?.prepareForSave()
       await workflowStore.saveWorkflow(target)
     }
 
@@ -175,9 +172,7 @@ export const useWorkflowService = () => {
     if (workflow.isTemporary) {
       await saveWorkflowAs(workflow)
     } else {
-      if (workflowStore.isActive(workflow))
-        workflow.changeTracker?.captureCanvasState()
-
+      workflow.changeTracker?.prepareForSave()
       const isApp = workflow.initialMode === 'app'
       const expectedPath =
         workflow.directory +
@@ -371,7 +366,7 @@ export const useWorkflowService = () => {
     const workflowStore = useWorkspaceStore().workflow
     const activeWorkflow = workflowStore.activeWorkflow
     if (activeWorkflow) {
-      activeWorkflow.changeTracker.store()
+      activeWorkflow.changeTracker.deactivate()
       if (settingStore.get('Comfy.Workflow.Persist') && activeWorkflow.path) {
         const activeState = activeWorkflow.activeState
         if (activeState) {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -1,18 +1,21 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
+import { fromAny } from '@total-typescript/shoehorn'
+import { mount } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
-import { computed, nextTick, ref } from 'vue'
-import type { Ref } from 'vue'
+import { computed } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { FormDropdownItem } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import WidgetSelectDropdown from '@/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue'
+import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { createMockWidget } from './widgetTestUtils'
 
-const mockCheckState = vi.hoisted(() => vi.fn())
+const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
 const mockAssetsData = vi.hoisted(() => ({ items: [] as AssetItem[] }))
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
@@ -24,7 +27,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     useWorkflowStore: () => ({
       activeWorkflow: {
         changeTracker: {
-          checkState: mockCheckState
+          captureCanvasState: mockCaptureCanvasState
         }
       }
     })
@@ -52,7 +55,7 @@ vi.mock(
   })
 )
 
-const { mockMediaAssets } = vi.hoisted(() => {
+const { mockMediaAssets, mockResolveOutputAssetItems } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref } = require('vue')
   return {
@@ -65,7 +68,8 @@ const { mockMediaAssets } = vi.hoisted(() => {
       loadMore: vi.fn(),
       hasMore: ref(false),
       isLoadingMore: ref(false)
-    }
+    },
+    mockResolveOutputAssetItems: vi.fn()
   }
 })
 
@@ -74,59 +78,9 @@ vi.mock('@/platform/assets/composables/media/useMediaAssets', () => ({
 }))
 
 vi.mock('@/platform/assets/utils/outputAssetUtil', () => ({
-  resolveOutputAssetItems: vi.fn().mockResolvedValue([])
+  resolveOutputAssetItems: (...args: unknown[]) =>
+    mockResolveOutputAssetItems(...args)
 }))
-
-const mockUpdateSelectedItems = vi.hoisted(() => vi.fn())
-const mockHandleFilesUpdate = vi.hoisted(() => vi.fn())
-
-const { mockItemsRef, mockSelectedSetRef, mockFilterSelectedRef } = vi.hoisted(
-  () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { ref } = require('vue')
-    return {
-      mockItemsRef: ref([]) as Ref<FormDropdownItem[]>,
-      mockSelectedSetRef: ref(new Set()) as Ref<Set<string>>,
-      mockFilterSelectedRef: ref('all') as Ref<string>
-    }
-  }
-)
-
-vi.mock(
-  '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems',
-  () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { computed } = require('vue')
-    return {
-      useWidgetSelectItems: () => ({
-        dropdownItems: computed(() => mockItemsRef.value),
-        displayItems: computed(() => mockItemsRef.value),
-        filterSelected: mockFilterSelectedRef,
-        filterOptions: computed(() => [
-          { name: 'All', value: 'all' },
-          { name: 'Inputs', value: 'inputs' }
-        ]),
-        ownershipSelected: ref('all'),
-        showOwnershipFilter: computed(() => false),
-        ownershipOptions: computed(() => []),
-        baseModelSelected: ref(new Set<string>()),
-        showBaseModelFilter: computed(() => false),
-        baseModelOptions: computed(() => []),
-        selectedSet: computed(() => mockSelectedSetRef.value)
-      })
-    }
-  }
-)
-
-vi.mock(
-  '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions',
-  () => ({
-    useWidgetSelectActions: () => ({
-      updateSelectedItems: mockUpdateSelectedItems,
-      handleFilesUpdate: mockHandleFilesUpdate
-    })
-  })
-)
 
 const i18n = createI18n({
   legacy: false,
@@ -134,127 +88,722 @@ const i18n = createI18n({
   messages: { en: {} }
 })
 
-describe('WidgetSelectDropdown', () => {
-  beforeEach(() => {
-    mockMediaAssets.media.value = []
-    mockCheckState.mockClear()
-    mockAssetsData.items = []
-    mockItemsRef.value = []
-    mockSelectedSetRef.value = new Set()
-    mockFilterSelectedRef.value = 'all'
-    mockUpdateSelectedItems.mockClear()
-    mockHandleFilesUpdate.mockClear()
-  })
+interface WidgetSelectDropdownInstance extends ComponentPublicInstance {
+  inputItems: FormDropdownItem[]
+  outputItems: FormDropdownItem[]
+  dropdownItems: FormDropdownItem[]
+  filterSelected: string
+  updateSelectedItems: (selectedSet: Set<string>) => void
+}
 
-  function renderComponent(
+describe('WidgetSelectDropdown custom label mapping', () => {
+  const createSelectDropdownWidget = (
+    value: string = 'img_001.png',
+    options: {
+      values?: string[]
+      getOptionLabel?: (value?: string | null) => string
+    } = {},
+    spec?: ComboInputSpec
+  ) =>
+    createMockWidget<string | undefined>({
+      value,
+      name: 'test_image_select',
+      type: 'combo',
+      options: {
+        values: ['img_001.png', 'photo_abc.jpg', 'hash789.png'],
+        ...options
+      },
+      spec
+    })
+
+  const mountComponent = (
     widget: SimplifiedWidget<string | undefined>,
     modelValue: string | undefined,
-    extraProps: Record<string, unknown> = {}
-  ) {
-    return render(WidgetSelectDropdown, {
-      props: {
-        widget,
-        modelValue,
-        assetKind: 'image',
-        allowUpload: true,
-        uploadFolder: 'input',
-        ...extraProps
-      },
-      global: {
-        plugins: [PrimeVue, createTestingPinia(), i18n]
-      }
-    })
+    assetKind: 'image' | 'video' | 'audio' = 'image'
+  ): VueWrapper<WidgetSelectDropdownInstance> => {
+    return fromAny<VueWrapper<WidgetSelectDropdownInstance>, unknown>(
+      mount(WidgetSelectDropdown, {
+        props: {
+          widget,
+          modelValue,
+          assetKind,
+          allowUpload: true,
+          uploadFolder: 'input'
+        },
+        global: {
+          plugins: [PrimeVue, createTestingPinia(), i18n]
+        }
+      })
+    )
   }
 
-  it('renders the dropdown component', () => {
-    mockItemsRef.value = [
-      { id: 'input-0', name: 'img_001.png' },
-      { id: 'input-1', name: 'photo_abc.jpg' }
+  describe('when custom labels are not provided', () => {
+    it('uses values as labels when no mapping provided', () => {
+      const widget = createSelectDropdownWidget('img_001.png')
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const inputItems = wrapper.vm.inputItems
+      expect(inputItems).toHaveLength(3)
+      expect(inputItems[0].name).toBe('img_001.png')
+      expect(inputItems[0].label).toBe('img_001.png')
+      expect(inputItems[1].name).toBe('photo_abc.jpg')
+      expect(inputItems[1].label).toBe('photo_abc.jpg')
+      expect(inputItems[2].name).toBe('hash789.png')
+      expect(inputItems[2].label).toBe('hash789.png')
+    })
+  })
+
+  describe('when custom labels are provided via getOptionLabel', () => {
+    it('displays custom labels while preserving original values', () => {
+      const getOptionLabel = vi.fn((value?: string | null) => {
+        if (!value) return 'No file'
+        const mapping: Record<string, string> = {
+          'img_001.png': 'Vacation Photo',
+          'photo_abc.jpg': 'Family Portrait',
+          'hash789.png': 'Sunset Beach'
+        }
+        return mapping[value] || value
+      })
+
+      const widget = createSelectDropdownWidget('img_001.png', {
+        getOptionLabel
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const inputItems = wrapper.vm.inputItems
+      expect(inputItems).toHaveLength(3)
+      expect(inputItems[0].name).toBe('img_001.png')
+      expect(inputItems[0].label).toBe('Vacation Photo')
+      expect(inputItems[1].name).toBe('photo_abc.jpg')
+      expect(inputItems[1].label).toBe('Family Portrait')
+      expect(inputItems[2].name).toBe('hash789.png')
+      expect(inputItems[2].label).toBe('Sunset Beach')
+
+      expect(getOptionLabel).toHaveBeenCalledWith('img_001.png')
+      expect(getOptionLabel).toHaveBeenCalledWith('photo_abc.jpg')
+      expect(getOptionLabel).toHaveBeenCalledWith('hash789.png')
+    })
+
+    it('emits original values when items with custom labels are selected', async () => {
+      const getOptionLabel = vi.fn((value?: string | null) => {
+        if (!value) return 'No file'
+        return `Custom: ${value}`
+      })
+
+      const widget = createSelectDropdownWidget('img_001.png', {
+        getOptionLabel
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      // Simulate selecting an item
+      const selectedSet = new Set(['input-1']) // index 1 = photo_abc.jpg
+      wrapper.vm.updateSelectedItems(selectedSet)
+
+      // Should emit the original value, not the custom label
+      expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      expect(wrapper.emitted('update:modelValue')![0]).toEqual([
+        'photo_abc.jpg'
+      ])
+    })
+
+    it('falls back to original value when label mapping fails', () => {
+      const getOptionLabel = vi.fn((value?: string | null) => {
+        if (value === 'photo_abc.jpg') {
+          throw new Error('Mapping failed')
+        }
+        return `Labeled: ${value}`
+      })
+
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      const widget = createSelectDropdownWidget('img_001.png', {
+        getOptionLabel
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const inputItems = wrapper.vm.inputItems
+      expect(inputItems[0].name).toBe('img_001.png')
+      expect(inputItems[0].label).toBe('Labeled: img_001.png')
+      expect(inputItems[1].name).toBe('photo_abc.jpg')
+      expect(inputItems[1].label).toBe('photo_abc.jpg')
+      expect(inputItems[2].name).toBe('hash789.png')
+      expect(inputItems[2].label).toBe('Labeled: hash789.png')
+
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('falls back to original value when label mapping returns empty string', () => {
+      const getOptionLabel = vi.fn((value?: string | null) => {
+        if (value === 'photo_abc.jpg') {
+          return ''
+        }
+        return `Labeled: ${value}`
+      })
+
+      const widget = createSelectDropdownWidget('img_001.png', {
+        getOptionLabel
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const inputItems = wrapper.vm.inputItems
+      expect(inputItems[0].name).toBe('img_001.png')
+      expect(inputItems[0].label).toBe('Labeled: img_001.png')
+      expect(inputItems[1].name).toBe('photo_abc.jpg')
+      expect(inputItems[1].label).toBe('photo_abc.jpg')
+      expect(inputItems[2].name).toBe('hash789.png')
+      expect(inputItems[2].label).toBe('Labeled: hash789.png')
+    })
+
+    it('falls back to original value when label mapping returns undefined', () => {
+      const getOptionLabel = vi.fn((value?: string | null) => {
+        if (value === 'hash789.png') {
+          return fromAny<string, unknown>(undefined)
+        }
+        return `Labeled: ${value}`
+      })
+
+      const widget = createSelectDropdownWidget('img_001.png', {
+        getOptionLabel
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const inputItems = wrapper.vm.inputItems
+      expect(inputItems[0].name).toBe('img_001.png')
+      expect(inputItems[0].label).toBe('Labeled: img_001.png')
+      expect(inputItems[1].name).toBe('photo_abc.jpg')
+      expect(inputItems[1].label).toBe('Labeled: photo_abc.jpg')
+      expect(inputItems[2].name).toBe('hash789.png')
+      expect(inputItems[2].label).toBe('hash789.png')
+    })
+  })
+
+  describe('output items with custom label mapping', () => {
+    it('applies custom label mapping to output items from queue history', () => {
+      const getOptionLabel = vi.fn((value?: string | null) => {
+        if (!value) return 'No file'
+        return `Output: ${value}`
+      })
+
+      const widget = createSelectDropdownWidget('img_001.png', {
+        getOptionLabel
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const outputItems = wrapper.vm.outputItems
+      expect(outputItems).toBeDefined()
+      expect(Array.isArray(outputItems)).toBe(true)
+    })
+  })
+
+  describe('missing value handling for template-loaded nodes', () => {
+    it('creates a fallback item in "all" filter when modelValue is not in available items', () => {
+      const widget = createSelectDropdownWidget('template_image.png', {
+        values: ['img_001.png', 'photo_abc.jpg']
+      })
+      const wrapper = mountComponent(widget, 'template_image.png')
+
+      const inputItems = wrapper.vm.inputItems
+      expect(inputItems).toHaveLength(2)
+      expect(
+        inputItems.some((item) => item.name === 'template_image.png')
+      ).toBe(false)
+
+      // The missing value should be accessible via dropdownItems when filter is 'all' (default)
+      const dropdownItems = wrapper.vm.dropdownItems
+      expect(
+        dropdownItems.some((item) => item.name === 'template_image.png')
+      ).toBe(true)
+      expect(dropdownItems[0].name).toBe('template_image.png')
+      expect(dropdownItems[0].id).toBe('missing-template_image.png')
+    })
+
+    it('does not include fallback item when filter is "inputs"', async () => {
+      const widget = createSelectDropdownWidget('template_image.png', {
+        values: ['img_001.png', 'photo_abc.jpg']
+      })
+      const wrapper = mountComponent(widget, 'template_image.png')
+
+      wrapper.vm.filterSelected = 'inputs'
+      await wrapper.vm.$nextTick()
+
+      const dropdownItems = wrapper.vm.dropdownItems
+      expect(dropdownItems).toHaveLength(2)
+      expect(
+        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
+      ).toBe(true)
+    })
+
+    it('does not include fallback item when filter is "outputs"', async () => {
+      const widget = createSelectDropdownWidget('template_image.png', {
+        values: ['img_001.png', 'photo_abc.jpg']
+      })
+      const wrapper = mountComponent(widget, 'template_image.png')
+
+      wrapper.vm.filterSelected = 'outputs'
+      await wrapper.vm.$nextTick()
+
+      const dropdownItems = wrapper.vm.dropdownItems
+      expect(dropdownItems).toHaveLength(wrapper.vm.outputItems.length)
+      expect(
+        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
+      ).toBe(true)
+    })
+
+    it('does not create a fallback item when modelValue exists in available items', () => {
+      const widget = createSelectDropdownWidget('img_001.png', {
+        values: ['img_001.png', 'photo_abc.jpg']
+      })
+      const wrapper = mountComponent(widget, 'img_001.png')
+
+      const dropdownItems = wrapper.vm.dropdownItems
+      expect(dropdownItems).toHaveLength(2)
+      expect(
+        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
+      ).toBe(true)
+    })
+
+    it('does not create a fallback item when modelValue is undefined', () => {
+      const widget = createSelectDropdownWidget(
+        fromAny<string, unknown>(undefined),
+        {
+          values: ['img_001.png', 'photo_abc.jpg']
+        }
+      )
+      const wrapper = mountComponent(widget, undefined)
+
+      const dropdownItems = wrapper.vm.dropdownItems
+      expect(dropdownItems).toHaveLength(2)
+      expect(
+        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
+      ).toBe(true)
+    })
+  })
+})
+
+describe('WidgetSelectDropdown cloud asset mode (COM-14333)', () => {
+  interface CloudModeInstance extends ComponentPublicInstance {
+    dropdownItems: FormDropdownItem[]
+    displayItems: FormDropdownItem[]
+    selectedSet: Set<string>
+  }
+
+  const createTestAsset = (
+    id: string,
+    name: string,
+    preview_url: string
+  ): AssetItem => ({
+    id,
+    name,
+    preview_url,
+    tags: []
+  })
+
+  const createCloudModeWidget = (
+    value: string = 'model.safetensors'
+  ): SimplifiedWidget<string | undefined> => ({
+    name: 'test_model_select',
+    type: 'combo',
+    value,
+    options: {
+      values: [],
+      nodeType: 'CheckpointLoaderSimple'
+    }
+  })
+
+  const mountCloudComponent = (
+    widget: SimplifiedWidget<string | undefined>,
+    modelValue: string | undefined
+  ): VueWrapper<CloudModeInstance> => {
+    return fromAny<VueWrapper<CloudModeInstance>, unknown>(
+      mount(WidgetSelectDropdown, {
+        props: {
+          widget,
+          modelValue,
+          assetKind: 'model',
+          isAssetMode: true,
+          nodeType: 'CheckpointLoaderSimple'
+        },
+        global: {
+          plugins: [PrimeVue, createTestingPinia(), i18n]
+        }
+      })
+    )
+  }
+
+  beforeEach(() => {
+    mockAssetsData.items = []
+  })
+
+  it('does not include missing items in cloud asset mode dropdown', () => {
+    mockAssetsData.items = [
+      createTestAsset(
+        'asset-1',
+        'existing_model.safetensors',
+        'https://example.com/preview.jpg'
+      )
     ]
-    mockSelectedSetRef.value = new Set(['input-0'])
+
+    const widget = createCloudModeWidget('missing_model.safetensors')
+    const wrapper = mountCloudComponent(widget, 'missing_model.safetensors')
+
+    const dropdownItems = wrapper.vm.dropdownItems
+    expect(dropdownItems).toHaveLength(1)
+    expect(dropdownItems[0].name).toBe('existing_model.safetensors')
+    expect(
+      dropdownItems.some((item) => item.name === 'missing_model.safetensors')
+    ).toBe(false)
+  })
+
+  it('shows only available cloud assets in dropdown', () => {
+    mockAssetsData.items = [
+      createTestAsset(
+        'asset-1',
+        'model_a.safetensors',
+        'https://example.com/a.jpg'
+      ),
+      createTestAsset(
+        'asset-2',
+        'model_b.safetensors',
+        'https://example.com/b.jpg'
+      )
+    ]
+
+    const widget = createCloudModeWidget('model_a.safetensors')
+    const wrapper = mountCloudComponent(widget, 'model_a.safetensors')
+
+    const dropdownItems = wrapper.vm.dropdownItems
+    expect(dropdownItems).toHaveLength(2)
+    expect(dropdownItems.map((item) => item.name)).toEqual([
+      'model_a.safetensors',
+      'model_b.safetensors'
+    ])
+  })
+
+  it('returns empty dropdown when no cloud assets available', () => {
+    mockAssetsData.items = []
+
+    const widget = createCloudModeWidget('missing_model.safetensors')
+    const wrapper = mountCloudComponent(widget, 'missing_model.safetensors')
+
+    const dropdownItems = wrapper.vm.dropdownItems
+    expect(dropdownItems).toHaveLength(0)
+  })
+
+  it('includes missing cloud asset in displayItems for input field visibility', () => {
+    mockAssetsData.items = [
+      createTestAsset(
+        'asset-1',
+        'existing_model.safetensors',
+        'https://example.com/preview.jpg'
+      )
+    ]
+
+    const widget = createCloudModeWidget('missing_model.safetensors')
+    const wrapper = mountCloudComponent(widget, 'missing_model.safetensors')
+
+    const displayItems = wrapper.vm.displayItems
+    expect(displayItems).toHaveLength(2)
+    expect(displayItems[0].name).toBe('missing_model.safetensors')
+    expect(displayItems[0].id).toBe('missing-missing_model.safetensors')
+    expect(displayItems[1].name).toBe('existing_model.safetensors')
+
+    const selectedSet = wrapper.vm.selectedSet
+    expect(selectedSet.has('missing-missing_model.safetensors')).toBe(true)
+  })
+})
+
+describe('WidgetSelectDropdown multi-output jobs', () => {
+  interface MultiOutputInstance extends ComponentPublicInstance {
+    outputItems: FormDropdownItem[]
+  }
+
+  function makeMultiOutputAsset(
+    jobId: string,
+    name: string,
+    nodeId: string,
+    outputCount: number
+  ) {
+    return {
+      id: jobId,
+      name,
+      preview_url: `/api/view?filename=${name}&type=output`,
+      tags: ['output'],
+      user_metadata: {
+        jobId,
+        nodeId,
+        subfolder: '',
+        outputCount,
+        allOutputs: [
+          {
+            filename: name,
+            subfolder: '',
+            type: 'output',
+            nodeId,
+            mediaType: 'images'
+          }
+        ]
+      }
+    }
+  }
+
+  function mountMultiOutput(
+    widget: SimplifiedWidget<string | undefined>,
+    modelValue: string | undefined
+  ): VueWrapper<MultiOutputInstance> {
+    return fromAny<VueWrapper<MultiOutputInstance>, unknown>(
+      mount(WidgetSelectDropdown, {
+        props: { widget, modelValue, assetKind: 'image' as const },
+        global: { plugins: [PrimeVue, createTestingPinia(), i18n] }
+      })
+    )
+  }
+
+  const defaultWidget = () =>
+    createMockWidget<string | undefined>({
+      value: 'output_001.png',
+      name: 'test_image',
+      type: 'combo',
+      options: { values: [] }
+    })
+
+  beforeEach(() => {
+    mockMediaAssets.media.value = []
+    mockResolveOutputAssetItems.mockReset()
+  })
+
+  it('shows all outputs after resolving multi-output jobs', async () => {
+    mockMediaAssets.media.value = [
+      makeMultiOutputAsset('job-1', 'preview.png', '5', 3)
+    ]
+
+    mockResolveOutputAssetItems.mockResolvedValue([
+      {
+        id: 'job-1-5-output_001.png',
+        name: 'output_001.png',
+        preview_url: '/api/view?filename=output_001.png&type=output',
+        tags: ['output']
+      },
+      {
+        id: 'job-1-5-output_002.png',
+        name: 'output_002.png',
+        preview_url: '/api/view?filename=output_002.png&type=output',
+        tags: ['output']
+      },
+      {
+        id: 'job-1-5-output_003.png',
+        name: 'output_003.png',
+        preview_url: '/api/view?filename=output_003.png&type=output',
+        tags: ['output']
+      }
+    ])
+
+    const wrapper = mountMultiOutput(defaultWidget(), 'output_001.png')
+
+    await vi.waitFor(() => {
+      expect(wrapper.vm.outputItems).toHaveLength(3)
+    })
+
+    expect(wrapper.vm.outputItems.map((i) => i.name)).toEqual([
+      'output_001.png [output]',
+      'output_002.png [output]',
+      'output_003.png [output]'
+    ])
+  })
+
+  it('shows preview output when job has only one output', () => {
+    mockMediaAssets.media.value = [
+      makeMultiOutputAsset('job-2', 'single.png', '3', 1)
+    ]
+
+    const widget = createMockWidget<string | undefined>({
+      value: 'single.png',
+      name: 'test_image',
+      type: 'combo',
+      options: { values: [] }
+    })
+    const wrapper = mountMultiOutput(widget, 'single.png')
+
+    expect(wrapper.vm.outputItems).toHaveLength(1)
+    expect(wrapper.vm.outputItems[0].name).toBe('single.png [output]')
+    expect(mockResolveOutputAssetItems).not.toHaveBeenCalled()
+  })
+
+  it('resolves two multi-output jobs independently', async () => {
+    mockMediaAssets.media.value = [
+      makeMultiOutputAsset('job-A', 'previewA.png', '1', 2),
+      makeMultiOutputAsset('job-B', 'previewB.png', '2', 2)
+    ]
+
+    mockResolveOutputAssetItems.mockImplementation(async (meta) => {
+      if (meta.jobId === 'job-A') {
+        return [
+          { id: 'A-1', name: 'a1.png', preview_url: '', tags: ['output'] },
+          { id: 'A-2', name: 'a2.png', preview_url: '', tags: ['output'] }
+        ]
+      }
+      return [
+        { id: 'B-1', name: 'b1.png', preview_url: '', tags: ['output'] },
+        { id: 'B-2', name: 'b2.png', preview_url: '', tags: ['output'] }
+      ]
+    })
+
+    const wrapper = mountMultiOutput(defaultWidget(), undefined)
+
+    await vi.waitFor(() => {
+      expect(wrapper.vm.outputItems).toHaveLength(4)
+    })
+
+    const names = wrapper.vm.outputItems.map((i) => i.name)
+    expect(names).toContain('a1.png [output]')
+    expect(names).toContain('a2.png [output]')
+    expect(names).toContain('b1.png [output]')
+    expect(names).toContain('b2.png [output]')
+  })
+
+  it('resolves outputs when allOutputs already contains all items', async () => {
+    mockMediaAssets.media.value = [
+      {
+        id: 'job-complete',
+        name: 'preview.png',
+        preview_url: '/api/view?filename=preview.png&type=output',
+        tags: ['output'],
+        user_metadata: {
+          jobId: 'job-complete',
+          nodeId: '1',
+          subfolder: '',
+          outputCount: 2,
+          allOutputs: [
+            {
+              filename: 'out1.png',
+              subfolder: '',
+              type: 'output',
+              nodeId: '1',
+              mediaType: 'images'
+            },
+            {
+              filename: 'out2.png',
+              subfolder: '',
+              type: 'output',
+              nodeId: '1',
+              mediaType: 'images'
+            }
+          ]
+        }
+      }
+    ]
+
+    mockResolveOutputAssetItems.mockResolvedValue([
+      { id: 'c-1', name: 'out1.png', preview_url: '', tags: ['output'] },
+      { id: 'c-2', name: 'out2.png', preview_url: '', tags: ['output'] }
+    ])
+
+    const wrapper = mountMultiOutput(defaultWidget(), undefined)
+
+    await vi.waitFor(() => {
+      expect(wrapper.vm.outputItems).toHaveLength(2)
+    })
+
+    expect(mockResolveOutputAssetItems).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: 'job-complete' }),
+      expect.any(Object)
+    )
+    const names = wrapper.vm.outputItems.map((i) => i.name)
+    expect(names).toEqual(['out1.png [output]', 'out2.png [output]'])
+  })
+
+  it('falls back to preview when resolver rejects', async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {})
+
+    mockMediaAssets.media.value = [
+      makeMultiOutputAsset('job-fail', 'preview.png', '1', 3)
+    ]
+    mockResolveOutputAssetItems.mockRejectedValue(new Error('network error'))
+
+    const wrapper = mountMultiOutput(defaultWidget(), undefined)
+
+    await vi.waitFor(() => {
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to resolve multi-output job',
+        'job-fail',
+        expect.any(Error)
+      )
+    })
+
+    expect(wrapper.vm.outputItems).toHaveLength(1)
+    expect(wrapper.vm.outputItems[0].name).toBe('preview.png [output]')
+    consoleWarnSpy.mockRestore()
+  })
+})
+
+describe('WidgetSelectDropdown undo tracking', () => {
+  interface UndoTrackingInstance extends ComponentPublicInstance {
+    updateSelectedItems: (selectedSet: Set<string>) => void
+    handleFilesUpdate: (files: File[]) => Promise<void>
+  }
+
+  const mountForUndo = (
+    widget: SimplifiedWidget<string | undefined>,
+    modelValue: string | undefined
+  ): VueWrapper<UndoTrackingInstance> => {
+    return fromAny<VueWrapper<UndoTrackingInstance>, unknown>(
+      mount(WidgetSelectDropdown, {
+        props: {
+          widget,
+          modelValue,
+          assetKind: 'image',
+          allowUpload: true,
+          uploadFolder: 'input'
+        },
+        global: {
+          plugins: [PrimeVue, createTestingPinia(), i18n]
+        }
+      })
+    )
+  }
+
+  beforeEach(() => {
+    mockCaptureCanvasState.mockClear()
+  })
+
+  it('calls captureCanvasState after dropdown selection changes modelValue', () => {
     const widget = createMockWidget<string | undefined>({
       value: 'img_001.png',
       name: 'test_image',
       type: 'combo',
-      options: {
-        values: ['img_001.png', 'photo_abc.jpg']
-      }
+      options: { values: ['img_001.png', 'photo_abc.jpg'] }
     })
-    renderComponent(widget, 'img_001.png')
-    expect(screen.getByText('img_001.png')).toBeDefined()
+    const wrapper = mountForUndo(widget, 'img_001.png')
+
+    wrapper.vm.updateSelectedItems(new Set(['input-1']))
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['photo_abc.jpg'])
+    expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
   })
 
-  it('renders in cloud asset mode', () => {
-    mockAssetsData.items = [
-      {
-        id: 'asset-1',
-        name: 'model_a.safetensors',
-        preview_url: 'https://example.com/a.jpg',
-        tags: []
-      }
-    ]
-    mockItemsRef.value = [{ id: 'asset-1', name: 'model_a.safetensors' }]
-    mockSelectedSetRef.value = new Set(['asset-1'])
+  it('calls captureCanvasState after file upload completes', async () => {
+    const { api } = await import('@/scripts/api')
+    vi.mocked(api.fetchApi).mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ name: 'uploaded.png', subfolder: '' })
+    } as Response)
+
     const widget = createMockWidget<string | undefined>({
-      value: 'model_a.safetensors',
-      name: 'test_model',
+      value: 'img_001.png',
+      name: 'test_image',
       type: 'combo',
-      options: {
-        values: [],
-        nodeType: 'CheckpointLoaderSimple'
-      }
+      options: { values: ['img_001.png'] }
     })
-    renderComponent(widget, 'model_a.safetensors', {
-      assetKind: 'model',
-      isAssetMode: true,
-      nodeType: 'CheckpointLoaderSimple'
-    })
-    expect(screen.getByText('model_a.safetensors')).toBeDefined()
-  })
+    const wrapper = mountForUndo(widget, 'img_001.png')
 
-  describe('composable wiring', () => {
-    const items: FormDropdownItem[] = [
-      { id: 'input-0', name: 'cat.png', label: 'cat.png' },
-      { id: 'input-1', name: 'dog.png', label: 'dog.png' }
-    ]
+    const file = new File(['test'], 'uploaded.png', { type: 'image/png' })
+    await wrapper.vm.handleFilesUpdate([file])
 
-    function renderDefault() {
-      mockItemsRef.value = items
-      const widget = createMockWidget<string | undefined>({
-        value: 'cat.png',
-        name: 'test_image',
-        type: 'combo',
-        options: { values: ['cat.png', 'dog.png'] }
-      })
-      return renderComponent(widget, 'cat.png')
-    }
-
-    it('displays the item whose id is in selectedSet', async () => {
-      mockSelectedSetRef.value = new Set(['input-1'])
-      renderDefault()
-
-      expect(screen.getByText('dog.png')).toBeDefined()
-      expect(screen.queryByText('cat.png')).toBeNull()
-    })
-
-    it('shows placeholder when selectedSet is empty', () => {
-      mockSelectedSetRef.value = new Set()
-      renderDefault()
-
-      expect(screen.queryByText('cat.png')).toBeNull()
-      expect(screen.queryByText('dog.png')).toBeNull()
-    })
-
-    it('updates displayed selection when selectedSet changes', async () => {
-      mockSelectedSetRef.value = new Set(['input-0'])
-      renderDefault()
-      expect(screen.getByText('cat.png')).toBeDefined()
-
-      mockSelectedSetRef.value = new Set(['input-1'])
-      await nextTick()
-
-      expect(screen.getByText('dog.png')).toBeDefined()
-      expect(screen.queryByText('cat.png')).toBeNull()
-    })
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['uploaded.png'])
+    expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -1,21 +1,18 @@
 import { createTestingPinia } from '@pinia/testing'
-import { fromAny } from '@total-typescript/shoehorn'
-import { mount } from '@vue/test-utils'
-import type { VueWrapper } from '@vue/test-utils'
+import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { computed } from 'vue'
-import type { ComponentPublicInstance } from 'vue'
+import { computed, nextTick, ref } from 'vue'
+import type { Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { FormDropdownItem } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import WidgetSelectDropdown from '@/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue'
-import type { ComboInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import { createMockWidget } from './widgetTestUtils'
 
-const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
+const mockCheckState = vi.hoisted(() => vi.fn())
 const mockAssetsData = vi.hoisted(() => ({ items: [] as AssetItem[] }))
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
@@ -27,7 +24,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     useWorkflowStore: () => ({
       activeWorkflow: {
         changeTracker: {
-          captureCanvasState: mockCaptureCanvasState
+          checkState: mockCheckState
         }
       }
     })
@@ -55,7 +52,7 @@ vi.mock(
   })
 )
 
-const { mockMediaAssets, mockResolveOutputAssetItems } = vi.hoisted(() => {
+const { mockMediaAssets } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref } = require('vue')
   return {
@@ -68,8 +65,7 @@ const { mockMediaAssets, mockResolveOutputAssetItems } = vi.hoisted(() => {
       loadMore: vi.fn(),
       hasMore: ref(false),
       isLoadingMore: ref(false)
-    },
-    mockResolveOutputAssetItems: vi.fn()
+    }
   }
 })
 
@@ -78,9 +74,59 @@ vi.mock('@/platform/assets/composables/media/useMediaAssets', () => ({
 }))
 
 vi.mock('@/platform/assets/utils/outputAssetUtil', () => ({
-  resolveOutputAssetItems: (...args: unknown[]) =>
-    mockResolveOutputAssetItems(...args)
+  resolveOutputAssetItems: vi.fn().mockResolvedValue([])
 }))
+
+const mockUpdateSelectedItems = vi.hoisted(() => vi.fn())
+const mockHandleFilesUpdate = vi.hoisted(() => vi.fn())
+
+const { mockItemsRef, mockSelectedSetRef, mockFilterSelectedRef } = vi.hoisted(
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ref } = require('vue')
+    return {
+      mockItemsRef: ref([]) as Ref<FormDropdownItem[]>,
+      mockSelectedSetRef: ref(new Set()) as Ref<Set<string>>,
+      mockFilterSelectedRef: ref('all') as Ref<string>
+    }
+  }
+)
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems',
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { computed } = require('vue')
+    return {
+      useWidgetSelectItems: () => ({
+        dropdownItems: computed(() => mockItemsRef.value),
+        displayItems: computed(() => mockItemsRef.value),
+        filterSelected: mockFilterSelectedRef,
+        filterOptions: computed(() => [
+          { name: 'All', value: 'all' },
+          { name: 'Inputs', value: 'inputs' }
+        ]),
+        ownershipSelected: ref('all'),
+        showOwnershipFilter: computed(() => false),
+        ownershipOptions: computed(() => []),
+        baseModelSelected: ref(new Set<string>()),
+        showBaseModelFilter: computed(() => false),
+        baseModelOptions: computed(() => []),
+        selectedSet: computed(() => mockSelectedSetRef.value)
+      })
+    }
+  }
+)
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions',
+  () => ({
+    useWidgetSelectActions: () => ({
+      updateSelectedItems: mockUpdateSelectedItems,
+      handleFilesUpdate: mockHandleFilesUpdate
+    })
+  })
+)
 
 const i18n = createI18n({
   legacy: false,
@@ -88,722 +134,127 @@ const i18n = createI18n({
   messages: { en: {} }
 })
 
-interface WidgetSelectDropdownInstance extends ComponentPublicInstance {
-  inputItems: FormDropdownItem[]
-  outputItems: FormDropdownItem[]
-  dropdownItems: FormDropdownItem[]
-  filterSelected: string
-  updateSelectedItems: (selectedSet: Set<string>) => void
-}
-
-describe('WidgetSelectDropdown custom label mapping', () => {
-  const createSelectDropdownWidget = (
-    value: string = 'img_001.png',
-    options: {
-      values?: string[]
-      getOptionLabel?: (value?: string | null) => string
-    } = {},
-    spec?: ComboInputSpec
-  ) =>
-    createMockWidget<string | undefined>({
-      value,
-      name: 'test_image_select',
-      type: 'combo',
-      options: {
-        values: ['img_001.png', 'photo_abc.jpg', 'hash789.png'],
-        ...options
-      },
-      spec
-    })
-
-  const mountComponent = (
-    widget: SimplifiedWidget<string | undefined>,
-    modelValue: string | undefined,
-    assetKind: 'image' | 'video' | 'audio' = 'image'
-  ): VueWrapper<WidgetSelectDropdownInstance> => {
-    return fromAny<VueWrapper<WidgetSelectDropdownInstance>, unknown>(
-      mount(WidgetSelectDropdown, {
-        props: {
-          widget,
-          modelValue,
-          assetKind,
-          allowUpload: true,
-          uploadFolder: 'input'
-        },
-        global: {
-          plugins: [PrimeVue, createTestingPinia(), i18n]
-        }
-      })
-    )
-  }
-
-  describe('when custom labels are not provided', () => {
-    it('uses values as labels when no mapping provided', () => {
-      const widget = createSelectDropdownWidget('img_001.png')
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const inputItems = wrapper.vm.inputItems
-      expect(inputItems).toHaveLength(3)
-      expect(inputItems[0].name).toBe('img_001.png')
-      expect(inputItems[0].label).toBe('img_001.png')
-      expect(inputItems[1].name).toBe('photo_abc.jpg')
-      expect(inputItems[1].label).toBe('photo_abc.jpg')
-      expect(inputItems[2].name).toBe('hash789.png')
-      expect(inputItems[2].label).toBe('hash789.png')
-    })
-  })
-
-  describe('when custom labels are provided via getOptionLabel', () => {
-    it('displays custom labels while preserving original values', () => {
-      const getOptionLabel = vi.fn((value?: string | null) => {
-        if (!value) return 'No file'
-        const mapping: Record<string, string> = {
-          'img_001.png': 'Vacation Photo',
-          'photo_abc.jpg': 'Family Portrait',
-          'hash789.png': 'Sunset Beach'
-        }
-        return mapping[value] || value
-      })
-
-      const widget = createSelectDropdownWidget('img_001.png', {
-        getOptionLabel
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const inputItems = wrapper.vm.inputItems
-      expect(inputItems).toHaveLength(3)
-      expect(inputItems[0].name).toBe('img_001.png')
-      expect(inputItems[0].label).toBe('Vacation Photo')
-      expect(inputItems[1].name).toBe('photo_abc.jpg')
-      expect(inputItems[1].label).toBe('Family Portrait')
-      expect(inputItems[2].name).toBe('hash789.png')
-      expect(inputItems[2].label).toBe('Sunset Beach')
-
-      expect(getOptionLabel).toHaveBeenCalledWith('img_001.png')
-      expect(getOptionLabel).toHaveBeenCalledWith('photo_abc.jpg')
-      expect(getOptionLabel).toHaveBeenCalledWith('hash789.png')
-    })
-
-    it('emits original values when items with custom labels are selected', async () => {
-      const getOptionLabel = vi.fn((value?: string | null) => {
-        if (!value) return 'No file'
-        return `Custom: ${value}`
-      })
-
-      const widget = createSelectDropdownWidget('img_001.png', {
-        getOptionLabel
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      // Simulate selecting an item
-      const selectedSet = new Set(['input-1']) // index 1 = photo_abc.jpg
-      wrapper.vm.updateSelectedItems(selectedSet)
-
-      // Should emit the original value, not the custom label
-      expect(wrapper.emitted('update:modelValue')).toBeDefined()
-      expect(wrapper.emitted('update:modelValue')![0]).toEqual([
-        'photo_abc.jpg'
-      ])
-    })
-
-    it('falls back to original value when label mapping fails', () => {
-      const getOptionLabel = vi.fn((value?: string | null) => {
-        if (value === 'photo_abc.jpg') {
-          throw new Error('Mapping failed')
-        }
-        return `Labeled: ${value}`
-      })
-
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
-      const widget = createSelectDropdownWidget('img_001.png', {
-        getOptionLabel
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const inputItems = wrapper.vm.inputItems
-      expect(inputItems[0].name).toBe('img_001.png')
-      expect(inputItems[0].label).toBe('Labeled: img_001.png')
-      expect(inputItems[1].name).toBe('photo_abc.jpg')
-      expect(inputItems[1].label).toBe('photo_abc.jpg')
-      expect(inputItems[2].name).toBe('hash789.png')
-      expect(inputItems[2].label).toBe('Labeled: hash789.png')
-
-      expect(consoleErrorSpy).toHaveBeenCalled()
-      consoleErrorSpy.mockRestore()
-    })
-
-    it('falls back to original value when label mapping returns empty string', () => {
-      const getOptionLabel = vi.fn((value?: string | null) => {
-        if (value === 'photo_abc.jpg') {
-          return ''
-        }
-        return `Labeled: ${value}`
-      })
-
-      const widget = createSelectDropdownWidget('img_001.png', {
-        getOptionLabel
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const inputItems = wrapper.vm.inputItems
-      expect(inputItems[0].name).toBe('img_001.png')
-      expect(inputItems[0].label).toBe('Labeled: img_001.png')
-      expect(inputItems[1].name).toBe('photo_abc.jpg')
-      expect(inputItems[1].label).toBe('photo_abc.jpg')
-      expect(inputItems[2].name).toBe('hash789.png')
-      expect(inputItems[2].label).toBe('Labeled: hash789.png')
-    })
-
-    it('falls back to original value when label mapping returns undefined', () => {
-      const getOptionLabel = vi.fn((value?: string | null) => {
-        if (value === 'hash789.png') {
-          return fromAny<string, unknown>(undefined)
-        }
-        return `Labeled: ${value}`
-      })
-
-      const widget = createSelectDropdownWidget('img_001.png', {
-        getOptionLabel
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const inputItems = wrapper.vm.inputItems
-      expect(inputItems[0].name).toBe('img_001.png')
-      expect(inputItems[0].label).toBe('Labeled: img_001.png')
-      expect(inputItems[1].name).toBe('photo_abc.jpg')
-      expect(inputItems[1].label).toBe('Labeled: photo_abc.jpg')
-      expect(inputItems[2].name).toBe('hash789.png')
-      expect(inputItems[2].label).toBe('hash789.png')
-    })
-  })
-
-  describe('output items with custom label mapping', () => {
-    it('applies custom label mapping to output items from queue history', () => {
-      const getOptionLabel = vi.fn((value?: string | null) => {
-        if (!value) return 'No file'
-        return `Output: ${value}`
-      })
-
-      const widget = createSelectDropdownWidget('img_001.png', {
-        getOptionLabel
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const outputItems = wrapper.vm.outputItems
-      expect(outputItems).toBeDefined()
-      expect(Array.isArray(outputItems)).toBe(true)
-    })
-  })
-
-  describe('missing value handling for template-loaded nodes', () => {
-    it('creates a fallback item in "all" filter when modelValue is not in available items', () => {
-      const widget = createSelectDropdownWidget('template_image.png', {
-        values: ['img_001.png', 'photo_abc.jpg']
-      })
-      const wrapper = mountComponent(widget, 'template_image.png')
-
-      const inputItems = wrapper.vm.inputItems
-      expect(inputItems).toHaveLength(2)
-      expect(
-        inputItems.some((item) => item.name === 'template_image.png')
-      ).toBe(false)
-
-      // The missing value should be accessible via dropdownItems when filter is 'all' (default)
-      const dropdownItems = wrapper.vm.dropdownItems
-      expect(
-        dropdownItems.some((item) => item.name === 'template_image.png')
-      ).toBe(true)
-      expect(dropdownItems[0].name).toBe('template_image.png')
-      expect(dropdownItems[0].id).toBe('missing-template_image.png')
-    })
-
-    it('does not include fallback item when filter is "inputs"', async () => {
-      const widget = createSelectDropdownWidget('template_image.png', {
-        values: ['img_001.png', 'photo_abc.jpg']
-      })
-      const wrapper = mountComponent(widget, 'template_image.png')
-
-      wrapper.vm.filterSelected = 'inputs'
-      await wrapper.vm.$nextTick()
-
-      const dropdownItems = wrapper.vm.dropdownItems
-      expect(dropdownItems).toHaveLength(2)
-      expect(
-        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
-      ).toBe(true)
-    })
-
-    it('does not include fallback item when filter is "outputs"', async () => {
-      const widget = createSelectDropdownWidget('template_image.png', {
-        values: ['img_001.png', 'photo_abc.jpg']
-      })
-      const wrapper = mountComponent(widget, 'template_image.png')
-
-      wrapper.vm.filterSelected = 'outputs'
-      await wrapper.vm.$nextTick()
-
-      const dropdownItems = wrapper.vm.dropdownItems
-      expect(dropdownItems).toHaveLength(wrapper.vm.outputItems.length)
-      expect(
-        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
-      ).toBe(true)
-    })
-
-    it('does not create a fallback item when modelValue exists in available items', () => {
-      const widget = createSelectDropdownWidget('img_001.png', {
-        values: ['img_001.png', 'photo_abc.jpg']
-      })
-      const wrapper = mountComponent(widget, 'img_001.png')
-
-      const dropdownItems = wrapper.vm.dropdownItems
-      expect(dropdownItems).toHaveLength(2)
-      expect(
-        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
-      ).toBe(true)
-    })
-
-    it('does not create a fallback item when modelValue is undefined', () => {
-      const widget = createSelectDropdownWidget(
-        fromAny<string, unknown>(undefined),
-        {
-          values: ['img_001.png', 'photo_abc.jpg']
-        }
-      )
-      const wrapper = mountComponent(widget, undefined)
-
-      const dropdownItems = wrapper.vm.dropdownItems
-      expect(dropdownItems).toHaveLength(2)
-      expect(
-        dropdownItems.every((item) => !String(item.id).startsWith('missing-'))
-      ).toBe(true)
-    })
-  })
-})
-
-describe('WidgetSelectDropdown cloud asset mode (COM-14333)', () => {
-  interface CloudModeInstance extends ComponentPublicInstance {
-    dropdownItems: FormDropdownItem[]
-    displayItems: FormDropdownItem[]
-    selectedSet: Set<string>
-  }
-
-  const createTestAsset = (
-    id: string,
-    name: string,
-    preview_url: string
-  ): AssetItem => ({
-    id,
-    name,
-    preview_url,
-    tags: []
-  })
-
-  const createCloudModeWidget = (
-    value: string = 'model.safetensors'
-  ): SimplifiedWidget<string | undefined> => ({
-    name: 'test_model_select',
-    type: 'combo',
-    value,
-    options: {
-      values: [],
-      nodeType: 'CheckpointLoaderSimple'
-    }
-  })
-
-  const mountCloudComponent = (
-    widget: SimplifiedWidget<string | undefined>,
-    modelValue: string | undefined
-  ): VueWrapper<CloudModeInstance> => {
-    return fromAny<VueWrapper<CloudModeInstance>, unknown>(
-      mount(WidgetSelectDropdown, {
-        props: {
-          widget,
-          modelValue,
-          assetKind: 'model',
-          isAssetMode: true,
-          nodeType: 'CheckpointLoaderSimple'
-        },
-        global: {
-          plugins: [PrimeVue, createTestingPinia(), i18n]
-        }
-      })
-    )
-  }
-
-  beforeEach(() => {
-    mockAssetsData.items = []
-  })
-
-  it('does not include missing items in cloud asset mode dropdown', () => {
-    mockAssetsData.items = [
-      createTestAsset(
-        'asset-1',
-        'existing_model.safetensors',
-        'https://example.com/preview.jpg'
-      )
-    ]
-
-    const widget = createCloudModeWidget('missing_model.safetensors')
-    const wrapper = mountCloudComponent(widget, 'missing_model.safetensors')
-
-    const dropdownItems = wrapper.vm.dropdownItems
-    expect(dropdownItems).toHaveLength(1)
-    expect(dropdownItems[0].name).toBe('existing_model.safetensors')
-    expect(
-      dropdownItems.some((item) => item.name === 'missing_model.safetensors')
-    ).toBe(false)
-  })
-
-  it('shows only available cloud assets in dropdown', () => {
-    mockAssetsData.items = [
-      createTestAsset(
-        'asset-1',
-        'model_a.safetensors',
-        'https://example.com/a.jpg'
-      ),
-      createTestAsset(
-        'asset-2',
-        'model_b.safetensors',
-        'https://example.com/b.jpg'
-      )
-    ]
-
-    const widget = createCloudModeWidget('model_a.safetensors')
-    const wrapper = mountCloudComponent(widget, 'model_a.safetensors')
-
-    const dropdownItems = wrapper.vm.dropdownItems
-    expect(dropdownItems).toHaveLength(2)
-    expect(dropdownItems.map((item) => item.name)).toEqual([
-      'model_a.safetensors',
-      'model_b.safetensors'
-    ])
-  })
-
-  it('returns empty dropdown when no cloud assets available', () => {
-    mockAssetsData.items = []
-
-    const widget = createCloudModeWidget('missing_model.safetensors')
-    const wrapper = mountCloudComponent(widget, 'missing_model.safetensors')
-
-    const dropdownItems = wrapper.vm.dropdownItems
-    expect(dropdownItems).toHaveLength(0)
-  })
-
-  it('includes missing cloud asset in displayItems for input field visibility', () => {
-    mockAssetsData.items = [
-      createTestAsset(
-        'asset-1',
-        'existing_model.safetensors',
-        'https://example.com/preview.jpg'
-      )
-    ]
-
-    const widget = createCloudModeWidget('missing_model.safetensors')
-    const wrapper = mountCloudComponent(widget, 'missing_model.safetensors')
-
-    const displayItems = wrapper.vm.displayItems
-    expect(displayItems).toHaveLength(2)
-    expect(displayItems[0].name).toBe('missing_model.safetensors')
-    expect(displayItems[0].id).toBe('missing-missing_model.safetensors')
-    expect(displayItems[1].name).toBe('existing_model.safetensors')
-
-    const selectedSet = wrapper.vm.selectedSet
-    expect(selectedSet.has('missing-missing_model.safetensors')).toBe(true)
-  })
-})
-
-describe('WidgetSelectDropdown multi-output jobs', () => {
-  interface MultiOutputInstance extends ComponentPublicInstance {
-    outputItems: FormDropdownItem[]
-  }
-
-  function makeMultiOutputAsset(
-    jobId: string,
-    name: string,
-    nodeId: string,
-    outputCount: number
-  ) {
-    return {
-      id: jobId,
-      name,
-      preview_url: `/api/view?filename=${name}&type=output`,
-      tags: ['output'],
-      user_metadata: {
-        jobId,
-        nodeId,
-        subfolder: '',
-        outputCount,
-        allOutputs: [
-          {
-            filename: name,
-            subfolder: '',
-            type: 'output',
-            nodeId,
-            mediaType: 'images'
-          }
-        ]
-      }
-    }
-  }
-
-  function mountMultiOutput(
-    widget: SimplifiedWidget<string | undefined>,
-    modelValue: string | undefined
-  ): VueWrapper<MultiOutputInstance> {
-    return fromAny<VueWrapper<MultiOutputInstance>, unknown>(
-      mount(WidgetSelectDropdown, {
-        props: { widget, modelValue, assetKind: 'image' as const },
-        global: { plugins: [PrimeVue, createTestingPinia(), i18n] }
-      })
-    )
-  }
-
-  const defaultWidget = () =>
-    createMockWidget<string | undefined>({
-      value: 'output_001.png',
-      name: 'test_image',
-      type: 'combo',
-      options: { values: [] }
-    })
-
+describe('WidgetSelectDropdown', () => {
   beforeEach(() => {
     mockMediaAssets.media.value = []
-    mockResolveOutputAssetItems.mockReset()
+    mockCheckState.mockClear()
+    mockAssetsData.items = []
+    mockItemsRef.value = []
+    mockSelectedSetRef.value = new Set()
+    mockFilterSelectedRef.value = 'all'
+    mockUpdateSelectedItems.mockClear()
+    mockHandleFilesUpdate.mockClear()
   })
 
-  it('shows all outputs after resolving multi-output jobs', async () => {
-    mockMediaAssets.media.value = [
-      makeMultiOutputAsset('job-1', 'preview.png', '5', 3)
-    ]
-
-    mockResolveOutputAssetItems.mockResolvedValue([
-      {
-        id: 'job-1-5-output_001.png',
-        name: 'output_001.png',
-        preview_url: '/api/view?filename=output_001.png&type=output',
-        tags: ['output']
-      },
-      {
-        id: 'job-1-5-output_002.png',
-        name: 'output_002.png',
-        preview_url: '/api/view?filename=output_002.png&type=output',
-        tags: ['output']
-      },
-      {
-        id: 'job-1-5-output_003.png',
-        name: 'output_003.png',
-        preview_url: '/api/view?filename=output_003.png&type=output',
-        tags: ['output']
-      }
-    ])
-
-    const wrapper = mountMultiOutput(defaultWidget(), 'output_001.png')
-
-    await vi.waitFor(() => {
-      expect(wrapper.vm.outputItems).toHaveLength(3)
-    })
-
-    expect(wrapper.vm.outputItems.map((i) => i.name)).toEqual([
-      'output_001.png [output]',
-      'output_002.png [output]',
-      'output_003.png [output]'
-    ])
-  })
-
-  it('shows preview output when job has only one output', () => {
-    mockMediaAssets.media.value = [
-      makeMultiOutputAsset('job-2', 'single.png', '3', 1)
-    ]
-
-    const widget = createMockWidget<string | undefined>({
-      value: 'single.png',
-      name: 'test_image',
-      type: 'combo',
-      options: { values: [] }
-    })
-    const wrapper = mountMultiOutput(widget, 'single.png')
-
-    expect(wrapper.vm.outputItems).toHaveLength(1)
-    expect(wrapper.vm.outputItems[0].name).toBe('single.png [output]')
-    expect(mockResolveOutputAssetItems).not.toHaveBeenCalled()
-  })
-
-  it('resolves two multi-output jobs independently', async () => {
-    mockMediaAssets.media.value = [
-      makeMultiOutputAsset('job-A', 'previewA.png', '1', 2),
-      makeMultiOutputAsset('job-B', 'previewB.png', '2', 2)
-    ]
-
-    mockResolveOutputAssetItems.mockImplementation(async (meta) => {
-      if (meta.jobId === 'job-A') {
-        return [
-          { id: 'A-1', name: 'a1.png', preview_url: '', tags: ['output'] },
-          { id: 'A-2', name: 'a2.png', preview_url: '', tags: ['output'] }
-        ]
-      }
-      return [
-        { id: 'B-1', name: 'b1.png', preview_url: '', tags: ['output'] },
-        { id: 'B-2', name: 'b2.png', preview_url: '', tags: ['output'] }
-      ]
-    })
-
-    const wrapper = mountMultiOutput(defaultWidget(), undefined)
-
-    await vi.waitFor(() => {
-      expect(wrapper.vm.outputItems).toHaveLength(4)
-    })
-
-    const names = wrapper.vm.outputItems.map((i) => i.name)
-    expect(names).toContain('a1.png [output]')
-    expect(names).toContain('a2.png [output]')
-    expect(names).toContain('b1.png [output]')
-    expect(names).toContain('b2.png [output]')
-  })
-
-  it('resolves outputs when allOutputs already contains all items', async () => {
-    mockMediaAssets.media.value = [
-      {
-        id: 'job-complete',
-        name: 'preview.png',
-        preview_url: '/api/view?filename=preview.png&type=output',
-        tags: ['output'],
-        user_metadata: {
-          jobId: 'job-complete',
-          nodeId: '1',
-          subfolder: '',
-          outputCount: 2,
-          allOutputs: [
-            {
-              filename: 'out1.png',
-              subfolder: '',
-              type: 'output',
-              nodeId: '1',
-              mediaType: 'images'
-            },
-            {
-              filename: 'out2.png',
-              subfolder: '',
-              type: 'output',
-              nodeId: '1',
-              mediaType: 'images'
-            }
-          ]
-        }
-      }
-    ]
-
-    mockResolveOutputAssetItems.mockResolvedValue([
-      { id: 'c-1', name: 'out1.png', preview_url: '', tags: ['output'] },
-      { id: 'c-2', name: 'out2.png', preview_url: '', tags: ['output'] }
-    ])
-
-    const wrapper = mountMultiOutput(defaultWidget(), undefined)
-
-    await vi.waitFor(() => {
-      expect(wrapper.vm.outputItems).toHaveLength(2)
-    })
-
-    expect(mockResolveOutputAssetItems).toHaveBeenCalledWith(
-      expect.objectContaining({ jobId: 'job-complete' }),
-      expect.any(Object)
-    )
-    const names = wrapper.vm.outputItems.map((i) => i.name)
-    expect(names).toEqual(['out1.png [output]', 'out2.png [output]'])
-  })
-
-  it('falls back to preview when resolver rejects', async () => {
-    const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {})
-
-    mockMediaAssets.media.value = [
-      makeMultiOutputAsset('job-fail', 'preview.png', '1', 3)
-    ]
-    mockResolveOutputAssetItems.mockRejectedValue(new Error('network error'))
-
-    const wrapper = mountMultiOutput(defaultWidget(), undefined)
-
-    await vi.waitFor(() => {
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Failed to resolve multi-output job',
-        'job-fail',
-        expect.any(Error)
-      )
-    })
-
-    expect(wrapper.vm.outputItems).toHaveLength(1)
-    expect(wrapper.vm.outputItems[0].name).toBe('preview.png [output]')
-    consoleWarnSpy.mockRestore()
-  })
-})
-
-describe('WidgetSelectDropdown undo tracking', () => {
-  interface UndoTrackingInstance extends ComponentPublicInstance {
-    updateSelectedItems: (selectedSet: Set<string>) => void
-    handleFilesUpdate: (files: File[]) => Promise<void>
-  }
-
-  const mountForUndo = (
+  function renderComponent(
     widget: SimplifiedWidget<string | undefined>,
-    modelValue: string | undefined
-  ): VueWrapper<UndoTrackingInstance> => {
-    return fromAny<VueWrapper<UndoTrackingInstance>, unknown>(
-      mount(WidgetSelectDropdown, {
-        props: {
-          widget,
-          modelValue,
-          assetKind: 'image',
-          allowUpload: true,
-          uploadFolder: 'input'
-        },
-        global: {
-          plugins: [PrimeVue, createTestingPinia(), i18n]
-        }
-      })
-    )
+    modelValue: string | undefined,
+    extraProps: Record<string, unknown> = {}
+  ) {
+    return render(WidgetSelectDropdown, {
+      props: {
+        widget,
+        modelValue,
+        assetKind: 'image',
+        allowUpload: true,
+        uploadFolder: 'input',
+        ...extraProps
+      },
+      global: {
+        plugins: [PrimeVue, createTestingPinia(), i18n]
+      }
+    })
   }
 
-  beforeEach(() => {
-    mockCaptureCanvasState.mockClear()
-  })
-
-  it('calls captureCanvasState after dropdown selection changes modelValue', () => {
+  it('renders the dropdown component', () => {
+    mockItemsRef.value = [
+      { id: 'input-0', name: 'img_001.png' },
+      { id: 'input-1', name: 'photo_abc.jpg' }
+    ]
+    mockSelectedSetRef.value = new Set(['input-0'])
     const widget = createMockWidget<string | undefined>({
       value: 'img_001.png',
       name: 'test_image',
       type: 'combo',
-      options: { values: ['img_001.png', 'photo_abc.jpg'] }
+      options: {
+        values: ['img_001.png', 'photo_abc.jpg']
+      }
     })
-    const wrapper = mountForUndo(widget, 'img_001.png')
-
-    wrapper.vm.updateSelectedItems(new Set(['input-1']))
-
-    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['photo_abc.jpg'])
-    expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
+    renderComponent(widget, 'img_001.png')
+    expect(screen.getByText('img_001.png')).toBeDefined()
   })
 
-  it('calls captureCanvasState after file upload completes', async () => {
-    const { api } = await import('@/scripts/api')
-    vi.mocked(api.fetchApi).mockResolvedValue({
-      status: 200,
-      json: () => Promise.resolve({ name: 'uploaded.png', subfolder: '' })
-    } as Response)
-
+  it('renders in cloud asset mode', () => {
+    mockAssetsData.items = [
+      {
+        id: 'asset-1',
+        name: 'model_a.safetensors',
+        preview_url: 'https://example.com/a.jpg',
+        tags: []
+      }
+    ]
+    mockItemsRef.value = [{ id: 'asset-1', name: 'model_a.safetensors' }]
+    mockSelectedSetRef.value = new Set(['asset-1'])
     const widget = createMockWidget<string | undefined>({
-      value: 'img_001.png',
-      name: 'test_image',
+      value: 'model_a.safetensors',
+      name: 'test_model',
       type: 'combo',
-      options: { values: ['img_001.png'] }
+      options: {
+        values: [],
+        nodeType: 'CheckpointLoaderSimple'
+      }
     })
-    const wrapper = mountForUndo(widget, 'img_001.png')
+    renderComponent(widget, 'model_a.safetensors', {
+      assetKind: 'model',
+      isAssetMode: true,
+      nodeType: 'CheckpointLoaderSimple'
+    })
+    expect(screen.getByText('model_a.safetensors')).toBeDefined()
+  })
 
-    const file = new File(['test'], 'uploaded.png', { type: 'image/png' })
-    await wrapper.vm.handleFilesUpdate([file])
+  describe('composable wiring', () => {
+    const items: FormDropdownItem[] = [
+      { id: 'input-0', name: 'cat.png', label: 'cat.png' },
+      { id: 'input-1', name: 'dog.png', label: 'dog.png' }
+    ]
 
-    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['uploaded.png'])
-    expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
+    function renderDefault() {
+      mockItemsRef.value = items
+      const widget = createMockWidget<string | undefined>({
+        value: 'cat.png',
+        name: 'test_image',
+        type: 'combo',
+        options: { values: ['cat.png', 'dog.png'] }
+      })
+      return renderComponent(widget, 'cat.png')
+    }
+
+    it('displays the item whose id is in selectedSet', async () => {
+      mockSelectedSetRef.value = new Set(['input-1'])
+      renderDefault()
+
+      expect(screen.getByText('dog.png')).toBeDefined()
+      expect(screen.queryByText('cat.png')).toBeNull()
+    })
+
+    it('shows placeholder when selectedSet is empty', () => {
+      mockSelectedSetRef.value = new Set()
+      renderDefault()
+
+      expect(screen.queryByText('cat.png')).toBeNull()
+      expect(screen.queryByText('dog.png')).toBeNull()
+    })
+
+    it('updates displayed selection when selectedSet changes', async () => {
+      mockSelectedSetRef.value = new Set(['input-0'])
+      renderDefault()
+      expect(screen.getByText('cat.png')).toBeDefined()
+
+      mockSelectedSetRef.value = new Set(['input-1'])
+      await nextTick()
+
+      expect(screen.getByText('dog.png')).toBeDefined()
+      expect(screen.queryByText('cat.png')).toBeNull()
+    })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -1,45 +1,20 @@
 <script setup lang="ts">
-import { capitalize } from 'es-toolkit'
-import { computed, provide, ref, shallowRef, toRef, watch } from 'vue'
+import { computed, provide, ref, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useTransformCompatOverlayProps } from '@/composables/useTransformCompatOverlayProps'
-import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
 import { SUPPORTED_EXTENSIONS_ACCEPT } from '@/extensions/core/load3d/constants'
-import { useAssetFilterOptions } from '@/platform/assets/composables/useAssetFilterOptions'
 import { useMediaAssets } from '@/platform/assets/composables/media/useMediaAssets'
-import {
-  filterItemByBaseModels,
-  filterItemByOwnership
-} from '@/platform/assets/utils/assetFilterUtils'
-import {
-  getAssetBaseModels,
-  getAssetDisplayName,
-  getAssetFilename
-} from '@/platform/assets/utils/assetMetadataUtils'
-import { useToastStore } from '@/platform/updates/common/toastStore'
-import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import FormDropdown from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue'
-import type {
-  FilterOption,
-  OwnershipOption
-} from '@/platform/assets/types/filterTypes'
 import { AssetKindKey } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
-import type {
-  FormDropdownItem,
-  LayoutMode
-} from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
+import type { LayoutMode } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import WidgetLayoutField from '@/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue'
 import { useAssetWidgetData } from '@/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData'
-import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
-import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
+import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions'
+import { useWidgetSelectItems } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems'
 import type { ResultItemType } from '@/schemas/apiSchema'
-import { api } from '@/scripts/api'
-import { useAssetsStore } from '@/stores/assetsStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import type { AssetKind } from '@/types/widgetTypes'
-import { getMediaTypeFromFilename } from '@/utils/formatUtil'
 import {
   PANEL_EXCLUDED_PROPS,
   filterWidgetProps
@@ -71,7 +46,6 @@ const modelValue = defineModel<string | undefined>({
 })
 
 const { t } = useI18n()
-const toastStore = useToastStore()
 
 const outputMediaAssets = useMediaAssets('output')
 
@@ -92,261 +66,34 @@ const getAssetData = () => {
 }
 const assetData = getAssetData()
 
-const filterSelected = ref('all')
-const filterOptions = computed<FilterOption[]>(() => {
-  if (props.isAssetMode) {
-    const categoryName = assetData?.category.value ?? 'All'
-    return [{ name: capitalize(categoryName), value: 'all' }]
-  }
-  return [
-    { name: 'All', value: 'all' },
-    { name: 'Inputs', value: 'inputs' },
-    { name: 'Outputs', value: 'outputs' }
-  ]
+const {
+  dropdownItems,
+  displayItems,
+  filterSelected,
+  filterOptions,
+  ownershipSelected,
+  showOwnershipFilter,
+  ownershipOptions,
+  baseModelSelected,
+  showBaseModelFilter,
+  baseModelOptions,
+  selectedSet
+} = useWidgetSelectItems({
+  values: () => props.widget.options?.values as unknown[] | undefined,
+  getOptionLabel: () => props.widget.options?.getOptionLabel,
+  modelValue,
+  assetKind: () => props.assetKind,
+  outputMediaAssets,
+  assetData,
+  isAssetMode: () => props.isAssetMode
 })
 
-const ownershipSelected = ref<OwnershipOption>('all')
-const showOwnershipFilter = computed(() => props.isAssetMode)
-
-const { ownershipOptions, availableBaseModels } = useAssetFilterOptions(
-  () => assetData?.assets.value ?? []
-)
-
-const baseModelSelected = ref<Set<string>>(new Set())
-const showBaseModelFilter = computed(() => props.isAssetMode)
-const baseModelOptions = computed<FilterOption[]>(() => {
-  if (!props.isAssetMode || !assetData) return []
-  return availableBaseModels.value
-})
-
-const selectedSet = ref<Set<string>>(new Set())
-
-/**
- * Transforms a value using getOptionLabel if available.
- * Falls back to the original value if getOptionLabel is not provided,
- * returns undefined/null, or throws an error.
- */
-function getDisplayLabel(value: string): string {
-  const getOptionLabel = props.widget.options?.getOptionLabel
-  if (!getOptionLabel) return value
-
-  try {
-    return getOptionLabel(value) || value
-  } catch (e) {
-    console.error('Failed to map value:', e)
-    return value
-  }
-}
-
-const inputItems = computed<FormDropdownItem[]>(() => {
-  const values = props.widget.options?.values || []
-
-  if (!Array.isArray(values)) {
-    return []
-  }
-
-  return values.map((value, index) => ({
-    id: `input-${index}`,
-    preview_url: getMediaUrl(String(value), 'input'),
-    name: String(value),
-    label: getDisplayLabel(String(value))
-  }))
-})
-function assetKindToMediaType(kind: AssetKind): string {
-  return kind === 'mesh' ? '3D' : kind
-}
-
-/**
- * Per-job cache of resolved outputs for multi-output jobs.
- * Keyed by jobId, populated lazily via resolveOutputAssetItems which
- * fetches full outputs through getJobDetail (itself LRU-cached).
- */
-const resolvedByJobId = shallowRef(new Map<string, AssetItem[]>())
-const pendingJobIds = new Set<string>()
-
-watch(
-  () => outputMediaAssets.media.value,
-  (assets, _, onCleanup) => {
-    let cancelled = false
-    onCleanup(() => {
-      cancelled = true
-    })
-    pendingJobIds.clear()
-
-    for (const asset of assets) {
-      const meta = getOutputAssetMetadata(asset.user_metadata)
-      if (!meta) continue
-
-      const outputCount = meta.outputCount ?? meta.allOutputs?.length ?? 0
-      if (
-        outputCount <= 1 ||
-        resolvedByJobId.value.has(meta.jobId) ||
-        pendingJobIds.has(meta.jobId)
-      )
-        continue
-
-      pendingJobIds.add(meta.jobId)
-      void resolveOutputAssetItems(meta, { createdAt: asset.created_at })
-        .then((resolved) => {
-          if (cancelled || !resolved.length) return
-          const next = new Map(resolvedByJobId.value)
-          next.set(meta.jobId, resolved)
-          resolvedByJobId.value = next
-        })
-        .catch((error) => {
-          console.warn('Failed to resolve multi-output job', meta.jobId, error)
-        })
-        .finally(() => {
-          pendingJobIds.delete(meta.jobId)
-        })
-    }
-  },
-  { immediate: true }
-)
-
-const outputItems = computed<FormDropdownItem[]>(() => {
-  if (!['image', 'video', 'audio', 'mesh'].includes(props.assetKind ?? ''))
-    return []
-
-  const targetMediaType = assetKindToMediaType(props.assetKind!)
-  const seen = new Set<string>()
-  const items: FormDropdownItem[] = []
-
-  const assets = outputMediaAssets.media.value.flatMap((asset) => {
-    const meta = getOutputAssetMetadata(asset.user_metadata)
-    const resolved = meta ? resolvedByJobId.value.get(meta.jobId) : undefined
-    return resolved ?? [asset]
-  })
-
-  for (const asset of assets) {
-    if (getMediaTypeFromFilename(asset.name) !== targetMediaType) continue
-    if (seen.has(asset.id)) continue
-    seen.add(asset.id)
-    const annotatedPath = `${asset.name} [output]`
-    items.push({
-      id: `output-${annotatedPath}`,
-      preview_url: asset.preview_url || getMediaUrl(asset.name, 'output'),
-      name: annotatedPath,
-      label: getDisplayLabel(annotatedPath)
-    })
-  }
-
-  return items
-})
-
-/**
- * Creates a fallback item for the current modelValue when it doesn't exist
- * in the available items list. This handles cases like template-loaded nodes
- * where the saved value may not exist in the current server environment.
- * Works for both local mode (inputItems/outputItems) and cloud mode (assetData).
- */
-const missingValueItem = computed<FormDropdownItem | undefined>(() => {
-  const currentValue = modelValue.value
-  if (!currentValue) return undefined
-
-  // Check in cloud mode assets
-  if (props.isAssetMode && assetData) {
-    const existsInAssets = assetData.assets.value.some(
-      (asset) => getAssetFilename(asset) === currentValue
-    )
-    if (existsInAssets) return undefined
-
-    return {
-      id: `missing-${currentValue}`,
-      preview_url: '',
-      name: currentValue,
-      label: getDisplayLabel(currentValue)
-    }
-  }
-
-  // Check in local mode inputs/outputs
-  const existsInInputs = inputItems.value.some(
-    (item) => item.name === currentValue
-  )
-  const existsInOutputs = outputItems.value.some(
-    (item) => item.name === currentValue
-  )
-
-  if (existsInInputs || existsInOutputs) return undefined
-
-  const isOutput = currentValue.endsWith(' [output]')
-  const strippedValue = isOutput
-    ? currentValue.replace(' [output]', '')
-    : currentValue
-
-  return {
-    id: `missing-${currentValue}`,
-    preview_url: getMediaUrl(strippedValue, isOutput ? 'output' : 'input'),
-    name: currentValue,
-    label: getDisplayLabel(currentValue)
-  }
-})
-
-/**
- * Transforms AssetItem[] to FormDropdownItem[] for cloud mode.
- * Uses getAssetFilename for display name, asset.name for label.
- */
-const assetItems = computed<FormDropdownItem[]>(() => {
-  if (!props.isAssetMode || !assetData) return []
-  return assetData.assets.value.map((asset) => ({
-    id: asset.id,
-    name: getAssetFilename(asset),
-    label: getAssetDisplayName(asset),
-    preview_url: asset.preview_url,
-    is_immutable: asset.is_immutable,
-    base_models: getAssetBaseModels(asset)
-  }))
-})
-
-const ownershipFilteredAssetItems = computed<FormDropdownItem[]>(() =>
-  filterItemByOwnership(assetItems.value, ownershipSelected.value)
-)
-
-const baseModelFilteredAssetItems = computed<FormDropdownItem[]>(() =>
-  filterItemByBaseModels(
-    ownershipFilteredAssetItems.value,
-    baseModelSelected.value
-  )
-)
-
-const allItems = computed<FormDropdownItem[]>(() => {
-  if (props.isAssetMode && assetData) {
-    // Cloud assets not in user's library shouldn't appear as search results (COM-14333).
-    // Unlike local mode, cloud users can't access files they don't own.
-    return baseModelFilteredAssetItems.value
-  }
-  return [
-    ...(missingValueItem.value ? [missingValueItem.value] : []),
-    ...inputItems.value,
-    ...outputItems.value
-  ]
-})
-
-const dropdownItems = computed<FormDropdownItem[]>(() => {
-  if (props.isAssetMode) {
-    return allItems.value
-  }
-
-  switch (filterSelected.value) {
-    case 'inputs':
-      return inputItems.value
-    case 'outputs':
-      return outputItems.value
-    case 'all':
-    default:
-      return allItems.value
-  }
-})
-
-/**
- * Items used for display in the input field. In cloud mode, includes
- * missing items so users can see their selected value even if not in library.
- */
-const displayItems = computed<FormDropdownItem[]>(() => {
-  if (props.isAssetMode && assetData && missingValueItem.value) {
-    return [missingValueItem.value, ...baseModelFilteredAssetItems.value]
-  }
-  return dropdownItems.value
+const { updateSelectedItems, handleFilesUpdate } = useWidgetSelectActions({
+  modelValue,
+  dropdownItems,
+  widget: () => props.widget,
+  uploadFolder: () => props.uploadFolder,
+  uploadSubfolder: () => props.uploadSubfolder
 })
 
 const mediaPlaceholder = computed(() => {
@@ -392,140 +139,11 @@ const acceptTypes = computed(() => {
     case 'mesh':
       return SUPPORTED_EXTENSIONS_ACCEPT
     default:
-      return undefined // model or unknown
+      return undefined
   }
 })
 
 const layoutMode = ref<LayoutMode>(props.defaultLayoutMode ?? 'grid')
-
-watch(
-  [modelValue, displayItems],
-  ([currentValue]) => {
-    if (currentValue === undefined) {
-      selectedSet.value.clear()
-      return
-    }
-
-    const item = displayItems.value.find((item) => item.name === currentValue)
-    if (!item) {
-      selectedSet.value.clear()
-      return
-    }
-    selectedSet.value.clear()
-    selectedSet.value.add(item.id)
-  },
-  { immediate: true }
-)
-
-function updateSelectedItems(selectedItems: Set<string>) {
-  let id: string | undefined = undefined
-  if (selectedItems.size > 0) {
-    id = selectedItems.values().next().value!
-  }
-  if (id == null) {
-    modelValue.value = undefined
-    return
-  }
-  const name = dropdownItems.value.find((item) => item.id === id)?.name
-  if (!name) {
-    modelValue.value = undefined
-    return
-  }
-  modelValue.value = name
-  useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
-}
-
-const uploadFile = async (
-  file: File,
-  isPasted: boolean = false,
-  formFields: Partial<{ type: ResultItemType }> = {}
-) => {
-  const body = new FormData()
-  body.append('image', file)
-  if (isPasted) body.append('subfolder', 'pasted')
-  else if (props.uploadSubfolder)
-    body.append('subfolder', props.uploadSubfolder)
-  if (formFields.type) body.append('type', formFields.type)
-
-  const resp = await api.fetchApi('/upload/image', {
-    method: 'POST',
-    body
-  })
-
-  if (resp.status !== 200) {
-    toastStore.addAlert(resp.status + ' - ' + resp.statusText)
-    return null
-  }
-
-  const data = await resp.json()
-
-  // Update AssetsStore when uploading to input folder
-  if (formFields.type === 'input' || (!formFields.type && !isPasted)) {
-    const assetsStore = useAssetsStore()
-    await assetsStore.updateInputs()
-  }
-
-  return data.subfolder ? `${data.subfolder}/${data.name}` : data.name
-}
-
-const uploadFiles = async (files: File[]): Promise<string[]> => {
-  const folder = props.uploadFolder ?? 'input'
-  const uploadPromises = files.map((file) =>
-    uploadFile(file, false, { type: folder })
-  )
-  const results = await Promise.all(uploadPromises)
-  return results.filter((path): path is string => path !== null)
-}
-
-async function handleFilesUpdate(files: File[]) {
-  if (!files || files.length === 0) return
-
-  try {
-    // 1. Upload files to server
-    const uploadedPaths = await uploadFiles(files)
-
-    if (uploadedPaths.length === 0) {
-      toastStore.addAlert('File upload failed')
-      return
-    }
-
-    // 2. Update widget options to include new files
-    // This simulates what addToComboValues does but for SimplifiedWidget
-    const values = props.widget.options?.values
-    if (Array.isArray(values)) {
-      uploadedPaths.forEach((path) => {
-        if (!values.includes(path)) {
-          values.push(path)
-        }
-      })
-    }
-
-    // 3. Update widget value to the first uploaded file
-    modelValue.value = uploadedPaths[0]
-
-    // 4. Trigger callback to notify underlying LiteGraph widget
-    if (props.widget.callback) {
-      props.widget.callback(uploadedPaths[0])
-    }
-
-    // 5. Snapshot undo state so the image change gets its own undo entry
-    useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
-  } catch (error) {
-    console.error('Upload error:', error)
-    toastStore.addAlert(`Upload failed: ${error}`)
-  }
-}
-
-function getMediaUrl(
-  filename: string,
-  type: 'input' | 'output' = 'input'
-): string {
-  if (!['image', 'video', 'audio', 'mesh'].includes(props.assetKind ?? ''))
-    return ''
-  const params = new URLSearchParams({ filename, type })
-  appendCloudResParam(params, filename)
-  return `/api/view?${params}`
-}
 
 function handleIsOpenUpdate(isOpen: boolean) {
   if (isOpen && !outputMediaAssets.loading.value) {
@@ -537,11 +155,11 @@ function handleIsOpenUpdate(isOpen: boolean) {
 <template>
   <WidgetLayoutField :widget>
     <FormDropdown
-      v-model:selected="selectedSet"
       v-model:filter-selected="filterSelected"
       v-model:layout-mode="layoutMode"
       v-model:ownership-selected="ownershipSelected"
       v-model:base-model-selected="baseModelSelected"
+      :selected="selectedSet"
       :items="dropdownItems"
       :display-items="displayItems"
       :placeholder="mediaPlaceholder"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -1,20 +1,45 @@
 <script setup lang="ts">
-import { computed, provide, ref, toRef } from 'vue'
+import { capitalize } from 'es-toolkit'
+import { computed, provide, ref, shallowRef, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useTransformCompatOverlayProps } from '@/composables/useTransformCompatOverlayProps'
+import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
 import { SUPPORTED_EXTENSIONS_ACCEPT } from '@/extensions/core/load3d/constants'
+import { useAssetFilterOptions } from '@/platform/assets/composables/useAssetFilterOptions'
 import { useMediaAssets } from '@/platform/assets/composables/media/useMediaAssets'
+import {
+  filterItemByBaseModels,
+  filterItemByOwnership
+} from '@/platform/assets/utils/assetFilterUtils'
+import {
+  getAssetBaseModels,
+  getAssetDisplayName,
+  getAssetFilename
+} from '@/platform/assets/utils/assetMetadataUtils'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import FormDropdown from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue'
+import type {
+  FilterOption,
+  OwnershipOption
+} from '@/platform/assets/types/filterTypes'
 import { AssetKindKey } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
-import type { LayoutMode } from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
+import type {
+  FormDropdownItem,
+  LayoutMode
+} from '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/types'
 import WidgetLayoutField from '@/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue'
 import { useAssetWidgetData } from '@/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData'
-import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions'
-import { useWidgetSelectItems } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems'
+import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import type { ResultItemType } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import { useAssetsStore } from '@/stores/assetsStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 import type { AssetKind } from '@/types/widgetTypes'
+import { getMediaTypeFromFilename } from '@/utils/formatUtil'
 import {
   PANEL_EXCLUDED_PROPS,
   filterWidgetProps
@@ -46,6 +71,7 @@ const modelValue = defineModel<string | undefined>({
 })
 
 const { t } = useI18n()
+const toastStore = useToastStore()
 
 const outputMediaAssets = useMediaAssets('output')
 
@@ -66,34 +92,261 @@ const getAssetData = () => {
 }
 const assetData = getAssetData()
 
-const {
-  dropdownItems,
-  displayItems,
-  filterSelected,
-  filterOptions,
-  ownershipSelected,
-  showOwnershipFilter,
-  ownershipOptions,
-  baseModelSelected,
-  showBaseModelFilter,
-  baseModelOptions,
-  selectedSet
-} = useWidgetSelectItems({
-  values: () => props.widget.options?.values as unknown[] | undefined,
-  getOptionLabel: () => props.widget.options?.getOptionLabel,
-  modelValue,
-  assetKind: () => props.assetKind,
-  outputMediaAssets,
-  assetData,
-  isAssetMode: () => props.isAssetMode
+const filterSelected = ref('all')
+const filterOptions = computed<FilterOption[]>(() => {
+  if (props.isAssetMode) {
+    const categoryName = assetData?.category.value ?? 'All'
+    return [{ name: capitalize(categoryName), value: 'all' }]
+  }
+  return [
+    { name: 'All', value: 'all' },
+    { name: 'Inputs', value: 'inputs' },
+    { name: 'Outputs', value: 'outputs' }
+  ]
 })
 
-const { updateSelectedItems, handleFilesUpdate } = useWidgetSelectActions({
-  modelValue,
-  dropdownItems,
-  widget: () => props.widget,
-  uploadFolder: () => props.uploadFolder,
-  uploadSubfolder: () => props.uploadSubfolder
+const ownershipSelected = ref<OwnershipOption>('all')
+const showOwnershipFilter = computed(() => props.isAssetMode)
+
+const { ownershipOptions, availableBaseModels } = useAssetFilterOptions(
+  () => assetData?.assets.value ?? []
+)
+
+const baseModelSelected = ref<Set<string>>(new Set())
+const showBaseModelFilter = computed(() => props.isAssetMode)
+const baseModelOptions = computed<FilterOption[]>(() => {
+  if (!props.isAssetMode || !assetData) return []
+  return availableBaseModels.value
+})
+
+const selectedSet = ref<Set<string>>(new Set())
+
+/**
+ * Transforms a value using getOptionLabel if available.
+ * Falls back to the original value if getOptionLabel is not provided,
+ * returns undefined/null, or throws an error.
+ */
+function getDisplayLabel(value: string): string {
+  const getOptionLabel = props.widget.options?.getOptionLabel
+  if (!getOptionLabel) return value
+
+  try {
+    return getOptionLabel(value) || value
+  } catch (e) {
+    console.error('Failed to map value:', e)
+    return value
+  }
+}
+
+const inputItems = computed<FormDropdownItem[]>(() => {
+  const values = props.widget.options?.values || []
+
+  if (!Array.isArray(values)) {
+    return []
+  }
+
+  return values.map((value, index) => ({
+    id: `input-${index}`,
+    preview_url: getMediaUrl(String(value), 'input'),
+    name: String(value),
+    label: getDisplayLabel(String(value))
+  }))
+})
+function assetKindToMediaType(kind: AssetKind): string {
+  return kind === 'mesh' ? '3D' : kind
+}
+
+/**
+ * Per-job cache of resolved outputs for multi-output jobs.
+ * Keyed by jobId, populated lazily via resolveOutputAssetItems which
+ * fetches full outputs through getJobDetail (itself LRU-cached).
+ */
+const resolvedByJobId = shallowRef(new Map<string, AssetItem[]>())
+const pendingJobIds = new Set<string>()
+
+watch(
+  () => outputMediaAssets.media.value,
+  (assets, _, onCleanup) => {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    pendingJobIds.clear()
+
+    for (const asset of assets) {
+      const meta = getOutputAssetMetadata(asset.user_metadata)
+      if (!meta) continue
+
+      const outputCount = meta.outputCount ?? meta.allOutputs?.length ?? 0
+      if (
+        outputCount <= 1 ||
+        resolvedByJobId.value.has(meta.jobId) ||
+        pendingJobIds.has(meta.jobId)
+      )
+        continue
+
+      pendingJobIds.add(meta.jobId)
+      void resolveOutputAssetItems(meta, { createdAt: asset.created_at })
+        .then((resolved) => {
+          if (cancelled || !resolved.length) return
+          const next = new Map(resolvedByJobId.value)
+          next.set(meta.jobId, resolved)
+          resolvedByJobId.value = next
+        })
+        .catch((error) => {
+          console.warn('Failed to resolve multi-output job', meta.jobId, error)
+        })
+        .finally(() => {
+          pendingJobIds.delete(meta.jobId)
+        })
+    }
+  },
+  { immediate: true }
+)
+
+const outputItems = computed<FormDropdownItem[]>(() => {
+  if (!['image', 'video', 'audio', 'mesh'].includes(props.assetKind ?? ''))
+    return []
+
+  const targetMediaType = assetKindToMediaType(props.assetKind!)
+  const seen = new Set<string>()
+  const items: FormDropdownItem[] = []
+
+  const assets = outputMediaAssets.media.value.flatMap((asset) => {
+    const meta = getOutputAssetMetadata(asset.user_metadata)
+    const resolved = meta ? resolvedByJobId.value.get(meta.jobId) : undefined
+    return resolved ?? [asset]
+  })
+
+  for (const asset of assets) {
+    if (getMediaTypeFromFilename(asset.name) !== targetMediaType) continue
+    if (seen.has(asset.id)) continue
+    seen.add(asset.id)
+    const annotatedPath = `${asset.name} [output]`
+    items.push({
+      id: `output-${annotatedPath}`,
+      preview_url: asset.preview_url || getMediaUrl(asset.name, 'output'),
+      name: annotatedPath,
+      label: getDisplayLabel(annotatedPath)
+    })
+  }
+
+  return items
+})
+
+/**
+ * Creates a fallback item for the current modelValue when it doesn't exist
+ * in the available items list. This handles cases like template-loaded nodes
+ * where the saved value may not exist in the current server environment.
+ * Works for both local mode (inputItems/outputItems) and cloud mode (assetData).
+ */
+const missingValueItem = computed<FormDropdownItem | undefined>(() => {
+  const currentValue = modelValue.value
+  if (!currentValue) return undefined
+
+  // Check in cloud mode assets
+  if (props.isAssetMode && assetData) {
+    const existsInAssets = assetData.assets.value.some(
+      (asset) => getAssetFilename(asset) === currentValue
+    )
+    if (existsInAssets) return undefined
+
+    return {
+      id: `missing-${currentValue}`,
+      preview_url: '',
+      name: currentValue,
+      label: getDisplayLabel(currentValue)
+    }
+  }
+
+  // Check in local mode inputs/outputs
+  const existsInInputs = inputItems.value.some(
+    (item) => item.name === currentValue
+  )
+  const existsInOutputs = outputItems.value.some(
+    (item) => item.name === currentValue
+  )
+
+  if (existsInInputs || existsInOutputs) return undefined
+
+  const isOutput = currentValue.endsWith(' [output]')
+  const strippedValue = isOutput
+    ? currentValue.replace(' [output]', '')
+    : currentValue
+
+  return {
+    id: `missing-${currentValue}`,
+    preview_url: getMediaUrl(strippedValue, isOutput ? 'output' : 'input'),
+    name: currentValue,
+    label: getDisplayLabel(currentValue)
+  }
+})
+
+/**
+ * Transforms AssetItem[] to FormDropdownItem[] for cloud mode.
+ * Uses getAssetFilename for display name, asset.name for label.
+ */
+const assetItems = computed<FormDropdownItem[]>(() => {
+  if (!props.isAssetMode || !assetData) return []
+  return assetData.assets.value.map((asset) => ({
+    id: asset.id,
+    name: getAssetFilename(asset),
+    label: getAssetDisplayName(asset),
+    preview_url: asset.preview_url,
+    is_immutable: asset.is_immutable,
+    base_models: getAssetBaseModels(asset)
+  }))
+})
+
+const ownershipFilteredAssetItems = computed<FormDropdownItem[]>(() =>
+  filterItemByOwnership(assetItems.value, ownershipSelected.value)
+)
+
+const baseModelFilteredAssetItems = computed<FormDropdownItem[]>(() =>
+  filterItemByBaseModels(
+    ownershipFilteredAssetItems.value,
+    baseModelSelected.value
+  )
+)
+
+const allItems = computed<FormDropdownItem[]>(() => {
+  if (props.isAssetMode && assetData) {
+    // Cloud assets not in user's library shouldn't appear as search results (COM-14333).
+    // Unlike local mode, cloud users can't access files they don't own.
+    return baseModelFilteredAssetItems.value
+  }
+  return [
+    ...(missingValueItem.value ? [missingValueItem.value] : []),
+    ...inputItems.value,
+    ...outputItems.value
+  ]
+})
+
+const dropdownItems = computed<FormDropdownItem[]>(() => {
+  if (props.isAssetMode) {
+    return allItems.value
+  }
+
+  switch (filterSelected.value) {
+    case 'inputs':
+      return inputItems.value
+    case 'outputs':
+      return outputItems.value
+    case 'all':
+    default:
+      return allItems.value
+  }
+})
+
+/**
+ * Items used for display in the input field. In cloud mode, includes
+ * missing items so users can see their selected value even if not in library.
+ */
+const displayItems = computed<FormDropdownItem[]>(() => {
+  if (props.isAssetMode && assetData && missingValueItem.value) {
+    return [missingValueItem.value, ...baseModelFilteredAssetItems.value]
+  }
+  return dropdownItems.value
 })
 
 const mediaPlaceholder = computed(() => {
@@ -139,11 +392,140 @@ const acceptTypes = computed(() => {
     case 'mesh':
       return SUPPORTED_EXTENSIONS_ACCEPT
     default:
-      return undefined
+      return undefined // model or unknown
   }
 })
 
 const layoutMode = ref<LayoutMode>(props.defaultLayoutMode ?? 'grid')
+
+watch(
+  [modelValue, displayItems],
+  ([currentValue]) => {
+    if (currentValue === undefined) {
+      selectedSet.value.clear()
+      return
+    }
+
+    const item = displayItems.value.find((item) => item.name === currentValue)
+    if (!item) {
+      selectedSet.value.clear()
+      return
+    }
+    selectedSet.value.clear()
+    selectedSet.value.add(item.id)
+  },
+  { immediate: true }
+)
+
+function updateSelectedItems(selectedItems: Set<string>) {
+  let id: string | undefined = undefined
+  if (selectedItems.size > 0) {
+    id = selectedItems.values().next().value!
+  }
+  if (id == null) {
+    modelValue.value = undefined
+    return
+  }
+  const name = dropdownItems.value.find((item) => item.id === id)?.name
+  if (!name) {
+    modelValue.value = undefined
+    return
+  }
+  modelValue.value = name
+  useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
+}
+
+const uploadFile = async (
+  file: File,
+  isPasted: boolean = false,
+  formFields: Partial<{ type: ResultItemType }> = {}
+) => {
+  const body = new FormData()
+  body.append('image', file)
+  if (isPasted) body.append('subfolder', 'pasted')
+  else if (props.uploadSubfolder)
+    body.append('subfolder', props.uploadSubfolder)
+  if (formFields.type) body.append('type', formFields.type)
+
+  const resp = await api.fetchApi('/upload/image', {
+    method: 'POST',
+    body
+  })
+
+  if (resp.status !== 200) {
+    toastStore.addAlert(resp.status + ' - ' + resp.statusText)
+    return null
+  }
+
+  const data = await resp.json()
+
+  // Update AssetsStore when uploading to input folder
+  if (formFields.type === 'input' || (!formFields.type && !isPasted)) {
+    const assetsStore = useAssetsStore()
+    await assetsStore.updateInputs()
+  }
+
+  return data.subfolder ? `${data.subfolder}/${data.name}` : data.name
+}
+
+const uploadFiles = async (files: File[]): Promise<string[]> => {
+  const folder = props.uploadFolder ?? 'input'
+  const uploadPromises = files.map((file) =>
+    uploadFile(file, false, { type: folder })
+  )
+  const results = await Promise.all(uploadPromises)
+  return results.filter((path): path is string => path !== null)
+}
+
+async function handleFilesUpdate(files: File[]) {
+  if (!files || files.length === 0) return
+
+  try {
+    // 1. Upload files to server
+    const uploadedPaths = await uploadFiles(files)
+
+    if (uploadedPaths.length === 0) {
+      toastStore.addAlert('File upload failed')
+      return
+    }
+
+    // 2. Update widget options to include new files
+    // This simulates what addToComboValues does but for SimplifiedWidget
+    const values = props.widget.options?.values
+    if (Array.isArray(values)) {
+      uploadedPaths.forEach((path) => {
+        if (!values.includes(path)) {
+          values.push(path)
+        }
+      })
+    }
+
+    // 3. Update widget value to the first uploaded file
+    modelValue.value = uploadedPaths[0]
+
+    // 4. Trigger callback to notify underlying LiteGraph widget
+    if (props.widget.callback) {
+      props.widget.callback(uploadedPaths[0])
+    }
+
+    // 5. Snapshot undo state so the image change gets its own undo entry
+    useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
+  } catch (error) {
+    console.error('Upload error:', error)
+    toastStore.addAlert(`Upload failed: ${error}`)
+  }
+}
+
+function getMediaUrl(
+  filename: string,
+  type: 'input' | 'output' = 'input'
+): string {
+  if (!['image', 'video', 'audio', 'mesh'].includes(props.assetKind ?? ''))
+    return ''
+  const params = new URLSearchParams({ filename, type })
+  appendCloudResParam(params, filename)
+  return `/api/view?${params}`
+}
 
 function handleIsOpenUpdate(isOpen: boolean) {
   if (isOpen && !outputMediaAssets.loading.value) {
@@ -155,11 +537,11 @@ function handleIsOpenUpdate(isOpen: boolean) {
 <template>
   <WidgetLayoutField :widget>
     <FormDropdown
+      v-model:selected="selectedSet"
       v-model:filter-selected="filterSelected"
       v-model:layout-mode="layoutMode"
       v-model:ownership-selected="ownershipSelected"
       v-model:base-model-selected="baseModelSelected"
-      :selected="selectedSet"
       :items="dropdownItems"
       :display-items="displayItems"
       :placeholder="mediaPlaceholder"

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -20,7 +20,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     useWorkflowStore: () => ({
       activeWorkflow: {
         changeTracker: {
-          checkState: mockCheckState
+          captureCanvasState: mockCheckState
         }
       }
     })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.test.ts
@@ -9,7 +9,7 @@ import { useWidgetSelectActions } from '@/renderer/extensions/vueNodes/widgets/c
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
-const mockCheckState = vi.hoisted(() => vi.fn())
+const mockCaptureCanvasState = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   const actual = await vi.importActual(
@@ -20,7 +20,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     useWorkflowStore: () => ({
       activeWorkflow: {
         changeTracker: {
-          captureCanvasState: mockCheckState
+          captureCanvasState: mockCaptureCanvasState
         }
       }
     })
@@ -48,7 +48,7 @@ function createItems(...names: string[]): FormDropdownItem[] {
 describe('useWidgetSelectActions', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    mockCheckState.mockClear()
+    mockCaptureCanvasState.mockClear()
   })
 
   describe('updateSelectedItems', () => {
@@ -71,7 +71,7 @@ describe('useWidgetSelectActions', () => {
       updateSelectedItems(new Set(['input-1']))
 
       expect(modelValue.value).toBe('photo_abc.jpg')
-      expect(mockCheckState).toHaveBeenCalledOnce()
+      expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
     })
 
     it('clears modelValue when empty set', () => {
@@ -93,7 +93,7 @@ describe('useWidgetSelectActions', () => {
       updateSelectedItems(new Set())
 
       expect(modelValue.value).toBeUndefined()
-      expect(mockCheckState).toHaveBeenCalledOnce()
+      expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
     })
   })
 
@@ -130,7 +130,7 @@ describe('useWidgetSelectActions', () => {
       await handleFilesUpdate([file])
 
       expect(modelValue.value).toBe('uploaded.png')
-      expect(mockCheckState).toHaveBeenCalledOnce()
+      expect(mockCaptureCanvasState).toHaveBeenCalledOnce()
     })
 
     it('adds uploaded path to widget values array', async () => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectActions.ts
@@ -23,8 +23,8 @@ export function useWidgetSelectActions(options: UseWidgetSelectActionsOptions) {
   const toastStore = useToastStore()
   const { wrapWithErrorHandlingAsync } = useErrorHandling()
 
-  function checkWorkflowState() {
-    useWorkflowStore().activeWorkflow?.changeTracker?.checkState()
+  function captureWorkflowState() {
+    useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState()
   }
 
   function updateSelectedItems(selectedItems: Set<string>) {
@@ -36,7 +36,7 @@ export function useWidgetSelectActions(options: UseWidgetSelectActionsOptions) {
         : dropdownItems.value.find((item) => item.id === id)?.name
 
     modelValue.value = name
-    checkWorkflowState()
+    captureWorkflowState()
   }
 
   async function uploadFile(
@@ -109,7 +109,7 @@ export function useWidgetSelectActions(options: UseWidgetSelectActionsOptions) {
         widget.callback(uploadedPaths[0])
       }
 
-      checkWorkflowState()
+      captureWorkflowState()
     }
   )
 

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -244,14 +244,14 @@ describe('ChangeTracker', () => {
       expect(mockSubgraphNavigationStore.exportState).toHaveBeenCalled()
     })
 
-    it('is a no-op during undo/redo to avoid overwriting viewport', () => {
+    it('skips captureCanvasState but still calls store during undo/redo', () => {
       const tracker = createTracker(createState(1))
       tracker._restoringState = true
 
       tracker.deactivate()
 
       expect(app.rootGraph.serialize).not.toHaveBeenCalled()
-      expect(mockNodeOutputStore.snapshotOutputs).not.toHaveBeenCalled()
+      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
     })
 
     it('is a full no-op when called on inactive tracker', () => {

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -223,14 +223,14 @@ describe('ChangeTracker', () => {
       expect(mockSubgraphNavigationStore.exportState).toHaveBeenCalled()
     })
 
-    it('still stores viewport when captureCanvasState is no-op (inactive)', () => {
+    it('is a full no-op when called on inactive tracker', () => {
       const tracker = createTracker()
       mockWorkflowStore.activeWorkflow = { changeTracker: {} }
 
       tracker.deactivate()
 
       expect(app.rootGraph.serialize).not.toHaveBeenCalled()
-      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
+      expect(mockNodeOutputStore.snapshotOutputs).not.toHaveBeenCalled()
     })
   })
 

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -60,6 +60,7 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
 }))
 
 import { app } from '@/scripts/app'
+import { api } from '@/scripts/api'
 import { ChangeTracker } from '@/scripts/changeTracker'
 
 let nodeIdCounter = 0
@@ -161,7 +162,7 @@ describe('ChangeTracker', () => {
     })
 
     describe('state capture', () => {
-      it('pushes to undoQueue and updates activeState when state differs', () => {
+      it('pushes to undoQueue, updates activeState, and calls updateModified', () => {
         const initial = createState(1)
         const tracker = createTracker(initial)
         const changed = createState(2)
@@ -172,6 +173,10 @@ describe('ChangeTracker', () => {
         expect(tracker.undoQueue).toHaveLength(1)
         expect(tracker.undoQueue[0]).toEqual(initial)
         expect(tracker.activeState).toEqual(changed)
+        expect(api.dispatchCustomEvent).toHaveBeenCalledWith(
+          'graphChanged',
+          changed
+        )
       })
 
       it('does not push when state is identical', () => {
@@ -192,6 +197,23 @@ describe('ChangeTracker', () => {
         tracker.captureCanvasState()
 
         expect(tracker.redoQueue).toHaveLength(0)
+      })
+
+      it('produces a single undo entry for a beforeChange/afterChange transaction', () => {
+        const tracker = createTracker(createState(1))
+        const intermediate = createState(2)
+        const final = createState(3)
+
+        tracker.beforeChange()
+        mockCanvasState(intermediate)
+        tracker.captureCanvasState()
+        expect(tracker.undoQueue).toHaveLength(0)
+
+        mockCanvasState(final)
+        tracker.afterChange()
+
+        expect(tracker.undoQueue).toHaveLength(1)
+        expect(tracker.activeState).toEqual(final)
       })
 
       it('caps undoQueue at MAX_HISTORY', () => {
@@ -220,6 +242,16 @@ describe('ChangeTracker', () => {
       expect(tracker.activeState).toEqual(changed)
       expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
       expect(mockSubgraphNavigationStore.exportState).toHaveBeenCalled()
+    })
+
+    it('is a no-op during undo/redo to avoid overwriting viewport', () => {
+      const tracker = createTracker(createState(1))
+      tracker._restoringState = true
+
+      tracker.deactivate()
+
+      expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      expect(mockNodeOutputStore.snapshotOutputs).not.toHaveBeenCalled()
     })
 
     it('is a full no-op when called on inactive tracker', () => {

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+
+const mockNodeOutputStore = vi.hoisted(() => ({
+  snapshotOutputs: vi.fn(() => ({})),
+  restoreOutputs: vi.fn()
+}))
+
+const mockSubgraphNavigationStore = vi.hoisted(() => ({
+  exportState: vi.fn(() => []),
+  restoreState: vi.fn()
+}))
+
+const mockWorkflowStore = vi.hoisted(() => ({
+  activeWorkflow: null as { changeTracker: unknown } | null,
+  getWorkflowByPath: vi.fn()
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    graph: {},
+    rootGraph: {
+      serialize: vi.fn(() => ({
+        nodes: [],
+        links: [],
+        groups: [],
+        extra: {},
+        config: {},
+        version: 0.4,
+        last_node_id: 0,
+        last_link_id: 0
+      }))
+    },
+    canvas: {
+      ds: { scale: 1, offset: [0, 0] }
+    }
+  }
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    dispatchCustomEvent: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: vi.fn(() => mockNodeOutputStore)
+}))
+
+vi.mock('@/stores/subgraphNavigationStore', () => ({
+  useSubgraphNavigationStore: vi.fn(() => mockSubgraphNavigationStore)
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  ComfyWorkflow: class {},
+  useWorkflowStore: vi.fn(() => mockWorkflowStore)
+}))
+
+import { app } from '@/scripts/app'
+import { ChangeTracker } from '@/scripts/changeTracker'
+
+let nodeIdCounter = 0
+
+function createState(nodeCount = 0): ComfyWorkflowJSON {
+  const nodes = Array.from({ length: nodeCount }, () => ({
+    id: ++nodeIdCounter,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [100, 50],
+    flags: {},
+    order: 0,
+    inputs: [],
+    outputs: [],
+    properties: {}
+  }))
+  return {
+    nodes,
+    links: [],
+    groups: [],
+    extra: {},
+    config: {},
+    version: 0.4,
+    last_node_id: nodeIdCounter,
+    last_link_id: 0
+  } as unknown as ComfyWorkflowJSON
+}
+
+function createTracker(initialState?: ComfyWorkflowJSON): ChangeTracker {
+  const state = initialState ?? createState()
+  const workflow = { path: '/test/workflow.json' } as never
+  const tracker = new ChangeTracker(workflow, state)
+  mockWorkflowStore.activeWorkflow = { changeTracker: tracker }
+  return tracker
+}
+
+function mockCanvasState(state: ComfyWorkflowJSON) {
+  vi.mocked(app.rootGraph.serialize).mockReturnValue(state as never)
+}
+
+describe('ChangeTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    nodeIdCounter = 0
+    ChangeTracker.isLoadingGraph = false
+    mockWorkflowStore.activeWorkflow = null
+    mockWorkflowStore.getWorkflowByPath.mockReturnValue(null)
+  })
+
+  describe('captureCanvasState', () => {
+    describe('guards', () => {
+      it('is a no-op when app.graph is falsy', () => {
+        const tracker = createTracker()
+        const original = tracker.activeState
+
+        const savedGraph = app.graph
+        ;(app as { graph: unknown }).graph = null
+        tracker.captureCanvasState()
+        ;(app as { graph: unknown }).graph = savedGraph
+
+        expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+        expect(tracker.activeState).toBe(original)
+      })
+
+      it('is a no-op when changeCount > 0', () => {
+        const tracker = createTracker()
+        tracker.beforeChange()
+
+        tracker.captureCanvasState()
+
+        expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      })
+
+      it('is a no-op when isLoadingGraph is true', () => {
+        const tracker = createTracker()
+        ChangeTracker.isLoadingGraph = true
+
+        tracker.captureCanvasState()
+
+        expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      })
+
+      it('is a no-op when _restoringState is true', () => {
+        const tracker = createTracker()
+        tracker._restoringState = true
+
+        tracker.captureCanvasState()
+
+        expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      })
+
+      it('is a no-op and logs error when called on inactive tracker', () => {
+        const tracker = createTracker()
+        mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+
+        tracker.captureCanvasState()
+
+        expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('state capture', () => {
+      it('pushes to undoQueue and updates activeState when state differs', () => {
+        const initial = createState(1)
+        const tracker = createTracker(initial)
+        const changed = createState(2)
+        mockCanvasState(changed)
+
+        tracker.captureCanvasState()
+
+        expect(tracker.undoQueue).toHaveLength(1)
+        expect(tracker.undoQueue[0]).toEqual(initial)
+        expect(tracker.activeState).toEqual(changed)
+      })
+
+      it('does not push when state is identical', () => {
+        const state = createState()
+        const tracker = createTracker(state)
+        mockCanvasState(state)
+
+        tracker.captureCanvasState()
+
+        expect(tracker.undoQueue).toHaveLength(0)
+      })
+
+      it('clears redoQueue on new change', () => {
+        const tracker = createTracker(createState(1))
+        tracker.redoQueue.push(createState(3))
+        mockCanvasState(createState(2))
+
+        tracker.captureCanvasState()
+
+        expect(tracker.redoQueue).toHaveLength(0)
+      })
+
+      it('caps undoQueue at MAX_HISTORY', () => {
+        const tracker = createTracker(createState(1))
+        for (let i = 0; i < ChangeTracker.MAX_HISTORY; i++) {
+          tracker.undoQueue.push(createState(1))
+        }
+        expect(tracker.undoQueue).toHaveLength(ChangeTracker.MAX_HISTORY)
+
+        mockCanvasState(createState(2))
+        tracker.captureCanvasState()
+
+        expect(tracker.undoQueue).toHaveLength(ChangeTracker.MAX_HISTORY)
+      })
+    })
+  })
+
+  describe('deactivate', () => {
+    it('captures canvas state then stores viewport/outputs', () => {
+      const tracker = createTracker(createState(1))
+      const changed = createState(2)
+      mockCanvasState(changed)
+
+      tracker.deactivate()
+
+      expect(tracker.activeState).toEqual(changed)
+      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
+      expect(mockSubgraphNavigationStore.exportState).toHaveBeenCalled()
+    })
+
+    it('still stores viewport when captureCanvasState is no-op (inactive)', () => {
+      const tracker = createTracker()
+      mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+
+      tracker.deactivate()
+
+      expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      expect(mockNodeOutputStore.snapshotOutputs).toHaveBeenCalled()
+    })
+  })
+
+  describe('prepareForSave', () => {
+    it('captures canvas state when tracker is active', () => {
+      const tracker = createTracker(createState(1))
+      const changed = createState(2)
+      mockCanvasState(changed)
+
+      tracker.prepareForSave()
+
+      expect(tracker.activeState).toEqual(changed)
+    })
+
+    it('is a no-op when tracker is inactive', () => {
+      const tracker = createTracker()
+      const original = tracker.activeState
+      mockWorkflowStore.activeWorkflow = { changeTracker: {} }
+
+      tracker.prepareForSave()
+
+      expect(app.rootGraph.serialize).not.toHaveBeenCalled()
+      expect(tracker.activeState).toBe(original)
+    })
+  })
+
+  describe('checkState (deprecated)', () => {
+    it('delegates to captureCanvasState', () => {
+      const tracker = createTracker(createState(1))
+      const changed = createState(2)
+      mockCanvasState(changed)
+
+      tracker.checkState()
+
+      expect(tracker.activeState).toEqual(changed)
+    })
+  })
+})

--- a/src/scripts/changeTracker.test.ts
+++ b/src/scripts/changeTracker.test.ts
@@ -115,10 +115,9 @@ describe('ChangeTracker', () => {
         const tracker = createTracker()
         const original = tracker.activeState
 
-        const savedGraph = app.graph
-        ;(app as { graph: unknown }).graph = null
+        const spy = vi.spyOn(app, 'graph', 'get').mockReturnValue(null as never)
         tracker.captureCanvasState()
-        ;(app as { graph: unknown }).graph = savedGraph
+        spy.mockRestore()
 
         expect(app.rootGraph.serialize).not.toHaveBeenCalled()
         expect(tracker.activeState).toBe(original)

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -91,6 +91,26 @@ export class ChangeTracker {
     this.subgraphState = { navigation }
   }
 
+  /**
+   * Freeze this tracker's state before the workflow goes inactive.
+   * Captures the final canvas state + viewport/outputs.
+   * Called exactly once when switching away from this workflow.
+   */
+  deactivate() {
+    this.captureCanvasState()
+    this.store()
+  }
+
+  /**
+   * Ensure activeState is up-to-date for persistence.
+   * Active workflow: flushes canvas → activeState.
+   * Inactive workflow: no-op (activeState was frozen by deactivate()).
+   */
+  prepareForSave() {
+    const isActive = useWorkflowStore().activeWorkflow?.changeTracker === this
+    if (isActive) this.captureCanvasState()
+  }
+
   restore() {
     if (this.ds) {
       app.canvas.ds.scale = this.ds.scale

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -4,10 +4,8 @@ import log from 'loglevel'
 
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import {
-  ComfyWorkflow,
-  useWorkflowStore
-} from '@/platform/workflow/management/stores/workflowStore'
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { ExecutedWsMessage } from '@/schemas/apiSchema'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -97,28 +95,25 @@ export class ChangeTracker {
 
   /**
    * Freeze this tracker's state before the workflow goes inactive.
-   * Captures the final canvas state + viewport/outputs.
-   * Called exactly once when switching away from this workflow.
+   * Always calls store() to preserve viewport/outputs. Calls
+   * captureCanvasState() only when not in undo/redo (to avoid
+   * corrupting undo history with intermediate graph state).
    *
    * PRECONDITION: must be called while this workflow is still the active one
    * (before the activeWorkflow pointer is moved). If called after the pointer
    * has already moved, this is a no-op to avoid freezing wrong viewport data.
-   * Also skipped during undo/redo to avoid overwriting viewport with
-   * intermediate canvas state.
    *
    * @internal Not part of the public extension API.
    */
   deactivate() {
-    if (!isActiveTracker(this) || this._restoringState) {
-      if (import.meta.env.DEV && !this._restoringState) {
-        logger.error(
-          'deactivate() called on inactive tracker for:',
-          this.workflow.path
-        )
-      }
+    if (!isActiveTracker(this)) {
+      logger.warn(
+        'deactivate() called on inactive tracker for:',
+        this.workflow.path
+      )
       return
     }
-    this.captureCanvasState()
+    if (!this._restoringState) this.captureCanvasState()
     this.store()
   }
 
@@ -195,12 +190,10 @@ export class ChangeTracker {
       return
 
     if (!isActiveTracker(this)) {
-      if (import.meta.env.DEV) {
-        logger.error(
-          'captureCanvasState called on inactive tracker for:',
-          this.workflow.path
-        )
-      }
+      logger.warn(
+        'captureCanvasState called on inactive tracker for:',
+        this.workflow.path
+      )
       return
     }
 

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -95,6 +95,10 @@ export class ChangeTracker {
    * Freeze this tracker's state before the workflow goes inactive.
    * Captures the final canvas state + viewport/outputs.
    * Called exactly once when switching away from this workflow.
+   *
+   * PRECONDITION: must be called while this workflow is still the active one
+   * (before the activeWorkflow pointer is moved). captureCanvasState() will
+   * no-op if called after the pointer has already moved.
    */
   deactivate() {
     this.captureCanvasState()
@@ -164,7 +168,13 @@ export class ChangeTracker {
    * Calling this on an inactive tracker would capture the wrong graph.
    */
   captureCanvasState() {
-    if (!app.graph || this.changeCount || ChangeTracker.isLoadingGraph) return
+    if (
+      !app.graph ||
+      this.changeCount ||
+      this._restoringState ||
+      ChangeTracker.isLoadingGraph
+    )
+      return
 
     const activeTracker = useWorkflowStore().activeWorkflow?.changeTracker
     if (activeTracker !== this) {
@@ -193,6 +203,16 @@ export class ChangeTracker {
       this.redoQueue.length = 0
       this.updateModified()
     }
+  }
+
+  /** @deprecated Use {@link captureCanvasState} instead. */
+  checkState() {
+    if (import.meta.env.DEV) {
+      logger.warn(
+        'checkState() is deprecated — use captureCanvasState() instead.'
+      )
+    }
+    this.captureCanvasState()
   }
 
   async updateState(source: ComfyWorkflowJSON[], target: ComfyWorkflowJSON[]) {

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -97,10 +97,20 @@ export class ChangeTracker {
    * Called exactly once when switching away from this workflow.
    *
    * PRECONDITION: must be called while this workflow is still the active one
-   * (before the activeWorkflow pointer is moved). captureCanvasState() will
-   * no-op if called after the pointer has already moved.
+   * (before the activeWorkflow pointer is moved). If called after the pointer
+   * has already moved, this is a no-op to avoid freezing wrong viewport data.
    */
   deactivate() {
+    const isActive = useWorkflowStore().activeWorkflow?.changeTracker === this
+    if (!isActive) {
+      if (import.meta.env.DEV) {
+        logger.error(
+          'deactivate() called on inactive tracker for:',
+          this.workflow.path
+        )
+      }
+      return
+    }
     this.captureCanvasState()
     this.store()
   }

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -26,6 +26,10 @@ const logger = log.getLogger('ChangeTracker')
 // Change to debug for more verbose logging
 logger.setLevel('info')
 
+function isActiveTracker(tracker: ChangeTracker): boolean {
+  return useWorkflowStore().activeWorkflow?.changeTracker === tracker
+}
+
 export class ChangeTracker {
   static MAX_HISTORY = 50
   /**
@@ -99,11 +103,14 @@ export class ChangeTracker {
    * PRECONDITION: must be called while this workflow is still the active one
    * (before the activeWorkflow pointer is moved). If called after the pointer
    * has already moved, this is a no-op to avoid freezing wrong viewport data.
+   * Also skipped during undo/redo to avoid overwriting viewport with
+   * intermediate canvas state.
+   *
+   * @internal Not part of the public extension API.
    */
   deactivate() {
-    const isActive = useWorkflowStore().activeWorkflow?.changeTracker === this
-    if (!isActive) {
-      if (import.meta.env.DEV) {
+    if (!isActiveTracker(this) || this._restoringState) {
+      if (import.meta.env.DEV && !this._restoringState) {
         logger.error(
           'deactivate() called on inactive tracker for:',
           this.workflow.path
@@ -119,10 +126,11 @@ export class ChangeTracker {
    * Ensure activeState is up-to-date for persistence.
    * Active workflow: flushes canvas → activeState.
    * Inactive workflow: no-op (activeState was frozen by deactivate()).
+   *
+   * @internal Not part of the public extension API.
    */
   prepareForSave() {
-    const isActive = useWorkflowStore().activeWorkflow?.changeTracker === this
-    if (isActive) this.captureCanvasState()
+    if (isActiveTracker(this)) this.captureCanvasState()
   }
 
   restore() {
@@ -186,8 +194,7 @@ export class ChangeTracker {
     )
       return
 
-    const activeTracker = useWorkflowStore().activeWorkflow?.changeTracker
-    if (activeTracker !== this) {
+    if (!isActiveTracker(this)) {
       if (import.meta.env.DEV) {
         logger.error(
           'captureCanvasState called on inactive tracker for:',
@@ -217,13 +224,16 @@ export class ChangeTracker {
 
   /** @deprecated Use {@link captureCanvasState} instead. */
   checkState() {
-    if (import.meta.env.DEV) {
+    if (!ChangeTracker._checkStateWarned) {
+      ChangeTracker._checkStateWarned = true
       logger.warn(
         'checkState() is deprecated — use captureCanvasState() instead.'
       )
     }
     this.captureCanvasState()
   }
+
+  private static _checkStateWarned = false
 
   async updateState(source: ComfyWorkflowJSON[], target: ComfyWorkflowJSON[]) {
     const prevState = source.pop()

--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -29,11 +29,11 @@ logger.setLevel('info')
 export class ChangeTracker {
   static MAX_HISTORY = 50
   /**
-   * Guard flag to prevent checkState from running during loadGraphData.
+   * Guard flag to prevent captureCanvasState from running during loadGraphData.
    * Between rootGraph.configure() and afterLoadNewGraph(), the rootGraph
    * contains the NEW workflow's data while activeWorkflow still points to
-   * the OLD workflow. Any checkState call in that window would serialize
-   * the wrong graph into the old workflow's activeState, corrupting it.
+   * the OLD workflow. Any captureCanvasState call in that window would
+   * serialize the wrong graph into the old workflow's activeState, corrupting it.
    */
   static isLoadingGraph = false
   /**
@@ -138,8 +138,25 @@ export class ChangeTracker {
     }
   }
 
-  checkState() {
+  /**
+   * Snapshot the current canvas state into activeState and push undo.
+   * INVARIANT: only the active workflow's tracker may read from the canvas.
+   * Calling this on an inactive tracker would capture the wrong graph.
+   */
+  captureCanvasState() {
     if (!app.graph || this.changeCount || ChangeTracker.isLoadingGraph) return
+
+    const activeTracker = useWorkflowStore().activeWorkflow?.changeTracker
+    if (activeTracker !== this) {
+      if (import.meta.env.DEV) {
+        logger.error(
+          'captureCanvasState called on inactive tracker for:',
+          this.workflow.path
+        )
+      }
+      return
+    }
+
     const currentState = clone(app.rootGraph.serialize()) as ComfyWorkflowJSON
     if (!this.activeState) {
       this.activeState = currentState
@@ -217,14 +234,14 @@ export class ChangeTracker {
 
   afterChange() {
     if (!--this.changeCount) {
-      this.checkState()
+      this.captureCanvasState()
     }
   }
 
   static init() {
     const getCurrentChangeTracker = () =>
       useWorkflowStore().activeWorkflow?.changeTracker
-    const checkState = () => getCurrentChangeTracker()?.checkState()
+    const captureState = () => getCurrentChangeTracker()?.captureCanvasState()
 
     let keyIgnored = false
     window.addEventListener(
@@ -268,8 +285,8 @@ export class ChangeTracker {
 
           // If our active element is some type of input then handle changes after they're done
           if (ChangeTracker.bindInput(bindInputEl)) return
-          logger.debug('checkState on keydown')
-          changeTracker.checkState()
+          logger.debug('captureCanvasState on keydown')
+          changeTracker.captureCanvasState()
         })
       },
       true
@@ -278,34 +295,34 @@ export class ChangeTracker {
     window.addEventListener('keyup', () => {
       if (keyIgnored) {
         keyIgnored = false
-        logger.debug('checkState on keyup')
-        checkState()
+        logger.debug('captureCanvasState on keyup')
+        captureState()
       }
     })
 
     // Handle clicking DOM elements (e.g. widgets)
     window.addEventListener('mouseup', () => {
-      logger.debug('checkState on mouseup')
-      checkState()
+      logger.debug('captureCanvasState on mouseup')
+      captureState()
     })
 
     // Handle prompt queue event for dynamic widget changes
     api.addEventListener('promptQueued', () => {
-      logger.debug('checkState on promptQueued')
-      checkState()
+      logger.debug('captureCanvasState on promptQueued')
+      captureState()
     })
 
     api.addEventListener('graphCleared', () => {
-      logger.debug('checkState on graphCleared')
-      checkState()
+      logger.debug('captureCanvasState on graphCleared')
+      captureState()
     })
 
     // Handle litegraph clicks
     const processMouseUp = LGraphCanvas.prototype.processMouseUp
     LGraphCanvas.prototype.processMouseUp = function (e) {
       const v = processMouseUp.apply(this, [e])
-      logger.debug('checkState on processMouseUp')
-      checkState()
+      logger.debug('captureCanvasState on processMouseUp')
+      captureState()
       return v
     }
 
@@ -319,9 +336,9 @@ export class ChangeTracker {
     ) {
       const extendedCallback = (v: string) => {
         callback(v)
-        checkState()
+        captureState()
       }
-      logger.debug('checkState on prompt')
+      logger.debug('captureCanvasState on prompt')
       return prompt.apply(this, [title, value, extendedCallback, event])
     }
 
@@ -329,8 +346,8 @@ export class ChangeTracker {
     const close = LiteGraph.ContextMenu.prototype.close
     LiteGraph.ContextMenu.prototype.close = function (e: MouseEvent) {
       const v = close.apply(this, [e])
-      logger.debug('checkState on contextMenuClose')
-      checkState()
+      logger.debug('captureCanvasState on contextMenuClose')
+      captureState()
       return v
     }
 
@@ -382,7 +399,7 @@ export class ChangeTracker {
       const htmlElement = activeEl as HTMLElement
       if (`on${evt}` in htmlElement) {
         const listener = () => {
-          useWorkflowStore().activeWorkflow?.changeTracker?.checkState?.()
+          useWorkflowStore().activeWorkflow?.changeTracker?.captureCanvasState?.()
           htmlElement.removeEventListener(evt, listener)
         }
         htmlElement.addEventListener(evt, listener)

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -364,29 +364,29 @@ describe('appModeStore', () => {
       })
     })
 
-    it('calls checkState when input is selected', async () => {
+    it('calls captureCanvasState when input is selected', async () => {
       const workflow = createBuilderWorkflow()
       workflowStore.activeWorkflow = workflow
       await nextTick()
-      vi.mocked(workflow.changeTracker!.checkState).mockClear()
+      vi.mocked(workflow.changeTracker!.captureCanvasState).mockClear()
 
       store.selectedInputs.push([42, 'prompt'])
       await nextTick()
 
-      expect(workflow.changeTracker!.checkState).toHaveBeenCalled()
+      expect(workflow.changeTracker!.captureCanvasState).toHaveBeenCalled()
     })
 
-    it('calls checkState when input is deselected', async () => {
+    it('calls captureCanvasState when input is deselected', async () => {
       const workflow = createBuilderWorkflow()
       workflowStore.activeWorkflow = workflow
       store.selectedInputs.push([42, 'prompt'])
       await nextTick()
-      vi.mocked(workflow.changeTracker!.checkState).mockClear()
+      vi.mocked(workflow.changeTracker!.captureCanvasState).mockClear()
 
       store.selectedInputs.splice(0, 1)
       await nextTick()
 
-      expect(workflow.changeTracker!.checkState).toHaveBeenCalled()
+      expect(workflow.changeTracker!.captureCanvasState).toHaveBeenCalled()
     })
 
     it('reflects input changes in linearData', async () => {

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -93,7 +93,7 @@ export const useAppModeStore = defineStore('appMode', () => {
         inputs: [...data.inputs],
         outputs: [...data.outputs]
       }
-      workflowStore.activeWorkflow?.changeTracker?.checkState()
+      workflowStore.activeWorkflow?.changeTracker?.captureCanvasState()
     },
     { deep: true }
   )

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -257,6 +257,7 @@ export function createMockChangeTracker(
     redoQueue: [],
     changeCount: 0,
     captureCanvasState: vi.fn(),
+    checkState: vi.fn(),
     deactivate: vi.fn(),
     prepareForSave: vi.fn(),
     reset: vi.fn(),

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -257,6 +257,8 @@ export function createMockChangeTracker(
     redoQueue: [],
     changeCount: 0,
     captureCanvasState: vi.fn(),
+    deactivate: vi.fn(),
+    prepareForSave: vi.fn(),
     reset: vi.fn(),
     restore: vi.fn(),
     store: vi.fn(),

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -256,7 +256,7 @@ export function createMockChangeTracker(
     undoQueue: [],
     redoQueue: [],
     changeCount: 0,
-    checkState: vi.fn(),
+    captureCanvasState: vi.fn(),
     reset: vi.fn(),
     restore: vi.fn(),
     store: vi.fn(),


### PR DESCRIPTION
## Summary

Harden the `ChangeTracker` lifecycle to eliminate the class of bugs where an inactive workflow's tracker silently captures the wrong graph state. Renames `checkState()` to `captureCanvasState()` with a self-defending assertion, introduces `deactivate()` and `prepareForSave()` lifecycle methods, and closes a latent undo-history corruption bug discovered during code review.

## Background

ComfyUI supports multiple workflows open as tabs, but only one canvas (`app.rootGraph`) exists at a time. When the user switches tabs, the old workflow's graph is unloaded and the new one is loaded into this shared canvas.

The old `checkState()` method serialized `app.rootGraph` into `activeState` to track changes for undo/redo. It had no awareness of *which* workflow it belonged to -- if called on an inactive tab's tracker, it would capture the active tab's graph data and silently overwrite the inactive workflow's state. This caused permanent data loss (fixed in PR #10745 with caller-side `isActive` guards).

The caller-side guards were fragile: every new call site had to remember to add the guard, and forgetting would reintroduce the same silent data corruption. Additionally, `beforeLoadNewGraph` only called `store()` (viewport/outputs) without `checkState()`, meaning canvas state could be stale if a tab switch happened without a preceding mouseup event.

### Before (fragile)

```
saveWorkflow(workflow):
  if (isActive(workflow))              <-- caller must remember this guard
    workflow.changeTracker.checkState()      <-- name implies "read", actually writes
  ...

beforeLoadNewGraph():
  activeWorkflow.changeTracker.store()      <-- only saves viewport, NOT graph state
```

### After (self-defending)

```
saveWorkflow(workflow):
  workflow.changeTracker.prepareForSave()   <-- handles active/inactive internally
  ...

beforeLoadNewGraph():
  activeWorkflow.changeTracker.deactivate() <-- captures graph + viewport together
```

## Changes

- Rename `checkState` to `captureCanvasState` with active-tracker assertion
- Add `deactivate()` and `prepareForSave()` lifecycle methods
- Fix undo-history corruption: `captureCanvasState()` guarded by `_restoringState`
- Fix viewport regression during undo: `deactivate()` skips `captureCanvasState()` during undo/redo but always calls `store()` to preserve viewport (regression from PR #10247)
- Log inactive tracker warnings unconditionally at warn level (not DEV-only)
- Deprecated `checkState()` wrapper for extension compatibility
- Rename `checkState` to `captureCanvasState` in `useWidgetSelectActions` composable
- Add `appModeStore.ts` to manual call sites documentation
- Add `checkState()` deprecation note to architecture docs
- Add 16 unit tests covering all guard conditions, lifecycle methods, and undo behavior
- Add E2E test: "Undo preserves viewport offset"

## New ChangeTracker Public API

| Method | Caller | Purpose |
|--------|--------|---------|
| `captureCanvasState()` | Event handlers, UI interactions | Snapshots canvas into activeState, pushes undo. Asserts active tracker. |
| `deactivate()` | `beforeLoadNewGraph` only | `captureCanvasState()` (skipped during undo/redo) + `store()`. Freezes state for tab switch. |
| `prepareForSave()` | Save paths only | Active: `captureCanvasState()`. Inactive: no-op. |
| `checkState()` | **Deprecated** -- extensions only | Wrapper that delegates to `captureCanvasState()` with deprecation warning. |
| `store()` | Internal to `deactivate()` | Saves viewport, outputs, subgraph navigation. |
| `restore()` | `afterLoadNewGraph` | Restores viewport, outputs, subgraph navigation. |
| `reset()` | `afterLoadNewGraph`, save | Resets initial state (marks as "clean"). |

## Test plan

- [x] Unit tests: 16 tests covering all guard conditions, state capture, undo queue behavior
- [x] E2E test: "Undo preserves viewport offset" verifies no viewport drift on undo
- [x] E2E test: "Prevents captureCanvasState from corrupting workflow state during tab switch"
- [x] Existing E2E: "Closing an inactive tab with save preserves its own content"
- [ ] Manual: rapidly switch tabs during undo/redo, verify no viewport drift
- [ ] Manual: verify extensions calling `checkState()` see deprecation warning in console