### PR TITLE
feat(load3d): add optional HDRI environment lighting to 3D preview nodes

### DIFF
--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -25,8 +25,10 @@
         :is-splat-model="isSplatModel"
         :is-ply-model="isPlyModel"
         :has-skeleton="hasSkeleton"
+        :hdri-supported="hdriSupported"
         @update-background-image="handleBackgroundImageUpdate"
         @export-model="handleExportModel"
+        @update-hdri-file="handleHDRIFileUpdate"
       />
       <AnimationControls
         v-if="animations && animations.length > 0"
@@ -113,6 +115,7 @@ const {
   lightConfig,
 
   // other state
+  hdriSupported,
   isRecording,
   isPreview,
   isSplatModel,
@@ -139,6 +142,7 @@ const {
   handleClearRecording,
   handleSeek,
   handleBackgroundImageUpdate,
+  handleHDRIFileUpdate,
   handleExportModel,
   handleModelDrop,
   cleanup

--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -25,7 +25,6 @@
         :is-splat-model="isSplatModel"
         :is-ply-model="isPlyModel"
         :has-skeleton="hasSkeleton"
-        :hdri-supported="hdriSupported"
         @update-background-image="handleBackgroundImageUpdate"
         @export-model="handleExportModel"
         @update-hdri-file="handleHDRIFileUpdate"
@@ -115,7 +114,6 @@ const {
   lightConfig,
 
   // other state
-  hdriSupported,
   isRecording,
   isPreview,
   isSplatModel,

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -6,8 +6,9 @@
     @pointerup.stop
     @wheel.stop
   >
-    <div class="show-menu relative">
+    <div class="relative">
       <Button
+        ref="menuTriggerRef"
         variant="textonly"
         size="icon"
         :aria-label="$t('menu.showMenu')"
@@ -19,6 +20,7 @@
 
       <div
         v-show="isMenuOpen"
+        ref="menuPanelRef"
         class="absolute top-0 left-12 rounded-lg bg-interface-menu-surface shadow-lg"
       >
         <div class="flex flex-col">
@@ -70,10 +72,18 @@
         v-model:fov="cameraConfig!.fov"
       />
 
+      <HDRIControls
+        v-if="showLightControls"
+        v-model:hdri-config="lightConfig!.hdri"
+        :hdri-supported="hdriSupported"
+        @update-hdri-file="handleHDRIFileUpdate"
+      />
+
       <LightControls
         v-if="showLightControls"
         v-model:light-intensity="lightConfig!.intensity"
         v-model:material-mode="modelConfig!.materialMode"
+        :hdri-enabled="lightConfig?.hdri?.enabled ?? false"
       />
 
       <ExportControls
@@ -85,10 +95,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import CameraControls from '@/components/load3d/controls/CameraControls.vue'
+import { useDismissableOverlay } from '@/composables/useDismissableOverlay'
 import ExportControls from '@/components/load3d/controls/ExportControls.vue'
+import HDRIControls from '@/components/load3d/controls/HDRIControls.vue'
 import LightControls from '@/components/load3d/controls/LightControls.vue'
 import ModelControls from '@/components/load3d/controls/ModelControls.vue'
 import SceneControls from '@/components/load3d/controls/SceneControls.vue'
@@ -104,11 +116,13 @@ import { cn } from '@/utils/tailwindUtil'
 const {
   isSplatModel = false,
   isPlyModel = false,
-  hasSkeleton = false
+  hasSkeleton = false,
+  hdriSupported = false
 } = defineProps<{
   isSplatModel?: boolean
   isPlyModel?: boolean
   hasSkeleton?: boolean
+  hdriSupported?: boolean
 }>()
 
 const sceneConfig = defineModel<SceneConfig>('sceneConfig')
@@ -117,6 +131,17 @@ const cameraConfig = defineModel<CameraConfig>('cameraConfig')
 const lightConfig = defineModel<LightConfig>('lightConfig')
 
 const isMenuOpen = ref(false)
+const menuPanelRef = ref<HTMLElement | null>(null)
+const menuTriggerRef = ref<InstanceType<typeof Button> | null>(null)
+
+useDismissableOverlay({
+  isOpen: isMenuOpen,
+  getOverlayEl: () => menuPanelRef.value,
+  getTriggerEl: () => menuTriggerRef.value?.$el ?? null,
+  onDismiss: () => {
+    isMenuOpen.value = false
+  }
+})
 const activeCategory = ref<string>('scene')
 const categoryLabels: Record<string, string> = {
   scene: 'load3d.scene',
@@ -175,6 +200,7 @@ const getCategoryIcon = (category: string) => {
 const emit = defineEmits<{
   (e: 'updateBackgroundImage', file: File | null): void
   (e: 'exportModel', format: string): void
+  (e: 'updateHdriFile', file: File | null): void
 }>()
 
 const handleBackgroundImageUpdate = (file: File | null) => {
@@ -185,19 +211,7 @@ const handleExportModel = (format: string) => {
   emit('exportModel', format)
 }
 
-const closeSlider = (e: MouseEvent) => {
-  const target = e.target as HTMLElement
-
-  if (!target.closest('.show-menu')) {
-    isMenuOpen.value = false
-  }
+const handleHDRIFileUpdate = (file: File | null) => {
+  emit('updateHdriFile', file)
 }
-
-onMounted(() => {
-  document.addEventListener('click', closeSlider)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', closeSlider)
-})
 </script>

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -15,7 +15,7 @@
         class="rounded-full"
         @click="toggleMenu"
       >
-        <i class="pi pi-bars text-lg text-base-foreground" />
+        <i class="icon-[lucide--menu] text-lg text-base-foreground" />
       </Button>
 
       <div
@@ -43,6 +43,21 @@
           </Button>
         </div>
       </div>
+    </div>
+    <div v-if="activeCategory === 'light'" class="mt-2 flex flex-col">
+      <Button
+        variant="textonly"
+        size="icon"
+        :class="
+          cn(
+            'flex items-center justify-center rounded-full',
+            'bg-button-active-surface'
+          )
+        "
+        @click="selectCategory('light')"
+      >
+        <i :class="getCategoryIcon('light')" />
+      </Button>
     </div>
 
     <div v-show="activeCategory" class="rounded-lg bg-smoke-700/30">
@@ -72,19 +87,24 @@
         v-model:fov="cameraConfig!.fov"
       />
 
-      <HDRIControls
+      <div
         v-if="showLightControls"
-        v-model:hdri-config="lightConfig!.hdri"
-        :hdri-supported="hdriSupported"
-        @update-hdri-file="handleHDRIFileUpdate"
-      />
+        class="flex max-h-[min(70vh,520px)] w-[216px] flex-col gap-3 overflow-y-auto p-2"
+      >
+        <LightControls
+          v-model:light-intensity="lightConfig!.intensity"
+          v-model:material-mode="modelConfig!.materialMode"
+          v-model:hdri-config="lightConfig!.hdri"
+          embedded
+        />
 
-      <LightControls
-        v-if="showLightControls"
-        v-model:light-intensity="lightConfig!.intensity"
-        v-model:material-mode="modelConfig!.materialMode"
-        :hdri-enabled="lightConfig?.hdri?.enabled ?? false"
-      />
+        <HDRIControls
+          v-model:hdri-config="lightConfig!.hdri"
+          embedded
+          :hdri-supported="hdriSupported"
+          @update-hdri-file="handleHDRIFileUpdate"
+        />
+      </div>
 
       <ExportControls
         v-if="showExportControls"
@@ -181,20 +201,28 @@ const toggleMenu = () => {
 }
 
 const selectCategory = (category: string) => {
-  activeCategory.value = category
+  if (category === 'light') {
+    activeCategory.value = activeCategory.value === 'light' ? '' : 'light'
+  } else {
+    activeCategory.value = category
+  }
   isMenuOpen.value = false
 }
 
+const categoryIcons = {
+  scene: 'icon-[lucide--image]',
+  model: 'icon-[lucide--box]',
+  camera: 'icon-[lucide--camera]',
+  light: 'icon-[lucide--sun]',
+  export: 'icon-[lucide--download]'
+} as const
+
 const getCategoryIcon = (category: string) => {
-  const icons = {
-    scene: 'pi pi-image',
-    model: 'pi pi-box',
-    camera: 'pi pi-camera',
-    light: 'pi pi-sun',
-    export: 'pi pi-download'
-  }
-  // @ts-expect-error fixme ts strict error
-  return `${icons[category]} text-base-foreground text-lg`
+  const icon =
+    category in categoryIcons
+      ? categoryIcons[category as keyof typeof categoryIcons]
+      : 'icon-[lucide--circle]'
+  return cn(icon, 'text-lg text-base-foreground')
 }
 
 const emit = defineEmits<{

--- a/src/components/load3d/Load3DControls.vue
+++ b/src/components/load3d/Load3DControls.vue
@@ -44,22 +44,6 @@
         </div>
       </div>
     </div>
-    <div v-if="activeCategory === 'light'" class="mt-2 flex flex-col">
-      <Button
-        variant="textonly"
-        size="icon"
-        :class="
-          cn(
-            'flex items-center justify-center rounded-full',
-            'bg-button-active-surface'
-          )
-        "
-        @click="selectCategory('light')"
-      >
-        <i :class="getCategoryIcon('light')" />
-      </Button>
-    </div>
-
     <div v-show="activeCategory" class="rounded-lg bg-smoke-700/30">
       <SceneControls
         v-if="showSceneControls"
@@ -68,6 +52,9 @@
         v-model:background-image="sceneConfig!.backgroundImage"
         v-model:background-render-mode="sceneConfig!.backgroundRenderMode"
         v-model:fov="cameraConfig!.fov"
+        :hdri-active="
+          !!lightConfig?.hdri?.hdriPath && !!lightConfig?.hdri?.enabled
+        "
         @update-background-image="handleBackgroundImageUpdate"
       />
 
@@ -87,21 +74,16 @@
         v-model:fov="cameraConfig!.fov"
       />
 
-      <div
-        v-if="showLightControls"
-        class="flex max-h-[min(70vh,520px)] w-[216px] flex-col gap-3 overflow-y-auto p-2"
-      >
+      <div v-if="showLightControls" class="flex flex-col">
         <LightControls
           v-model:light-intensity="lightConfig!.intensity"
           v-model:material-mode="modelConfig!.materialMode"
           v-model:hdri-config="lightConfig!.hdri"
-          embedded
         />
 
         <HDRIControls
           v-model:hdri-config="lightConfig!.hdri"
-          embedded
-          :hdri-supported="hdriSupported"
+          :has-background-image="!!sceneConfig?.backgroundImage"
           @update-hdri-file="handleHDRIFileUpdate"
         />
       </div>
@@ -136,13 +118,11 @@ import { cn } from '@/utils/tailwindUtil'
 const {
   isSplatModel = false,
   isPlyModel = false,
-  hasSkeleton = false,
-  hdriSupported = false
+  hasSkeleton = false
 } = defineProps<{
   isSplatModel?: boolean
   isPlyModel?: boolean
   hasSkeleton?: boolean
-  hdriSupported?: boolean
 }>()
 
 const sceneConfig = defineModel<SceneConfig>('sceneConfig')
@@ -201,11 +181,7 @@ const toggleMenu = () => {
 }
 
 const selectCategory = (category: string) => {
-  if (category === 'light') {
-    activeCategory.value = activeCategory.value === 'light' ? '' : 'light'
-  } else {
-    activeCategory.value = category
-  }
+  activeCategory.value = category
   isMenuOpen.value = false
 }
 

--- a/src/components/load3d/controls/HDRIControls.vue
+++ b/src/components/load3d/controls/HDRIControls.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="flex flex-col">
+    <div class="relative">
+      <Button
+        ref="triggerRef"
+        v-tooltip.right="{
+          value: $t('load3d.hdri.label'),
+          showDelay: 300
+        }"
+        size="icon"
+        variant="textonly"
+        :class="
+          cn(
+            'rounded-full',
+            hdriConfig?.enabled && 'bg-button-active-surface text-highlight'
+          )
+        "
+        :aria-label="$t('load3d.hdri.label')"
+        :disabled="!hdriSupported"
+        @click="toggleHDRIPanel"
+      >
+        <i class="pi pi-globe text-lg text-base-foreground" />
+      </Button>
+
+      <div
+        v-show="showPanel"
+        ref="panelRef"
+        class="absolute top-0 left-12 z-30 w-[200px] rounded-lg bg-black/50 p-3 shadow-lg"
+      >
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              class="w-full truncate text-xs"
+              @click="triggerFileInput"
+            >
+              {{
+                hdriConfig?.hdriPath
+                  ? $t('load3d.hdri.changeFile')
+                  : $t('load3d.hdri.uploadFile')
+              }}
+            </Button>
+            <Button
+              v-if="hdriConfig?.hdriPath"
+              size="icon"
+              variant="textonly"
+              :aria-label="$t('load3d.hdri.removeFile')"
+              @click="onRemoveHDRI"
+            >
+              <i class="pi pi-times text-sm text-base-foreground" />
+            </Button>
+          </div>
+
+          <template v-if="hdriConfig?.hdriPath">
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-sm text-base-foreground">{{
+                $t('load3d.hdri.label')
+              }}</span>
+              <SwitchRoot
+                :model-value="hdriConfig?.enabled ?? false"
+                class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
+                @update:model-value="onEnabledChange"
+              >
+                <SwitchThumb
+                  class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+                />
+              </SwitchRoot>
+            </div>
+
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-sm text-base-foreground">{{
+                $t('load3d.hdri.showAsBackground')
+              }}</span>
+              <SwitchRoot
+                :model-value="hdriConfig?.showAsBackground ?? false"
+                class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
+                @update:model-value="onShowAsBackgroundChange"
+              >
+                <SwitchThumb
+                  class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+                />
+              </SwitchRoot>
+            </div>
+
+            <div v-if="hdriConfig?.enabled" class="flex flex-col gap-1">
+              <span class="text-sm text-base-foreground">{{
+                $t('load3d.hdri.intensity')
+              }}</span>
+              <Slider
+                :model-value="[hdriConfig?.intensity ?? 1]"
+                class="w-full"
+                :min="0"
+                :max="5"
+                :step="0.1"
+                @update:model-value="onIntensityChange"
+              />
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <input
+      ref="fileInputRef"
+      type="file"
+      class="hidden"
+      :accept="SUPPORTED_HDRI_EXTENSIONS_ACCEPT"
+      @change="onFileChange"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SwitchRoot, SwitchThumb } from 'reka-ui'
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import Slider from '@/components/ui/slider/Slider.vue'
+import { useDismissableOverlay } from '@/composables/useDismissableOverlay'
+import {
+  SUPPORTED_HDRI_EXTENSIONS,
+  SUPPORTED_HDRI_EXTENSIONS_ACCEPT
+} from '@/extensions/core/load3d/constants'
+import type { HDRIConfig } from '@/extensions/core/load3d/interfaces'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { cn } from '@/utils/tailwindUtil'
+
+const { t } = useI18n()
+
+const { hdriSupported = false } = defineProps<{
+  hdriSupported?: boolean
+}>()
+
+const hdriConfig = defineModel<HDRIConfig>('hdriConfig')
+
+const emit = defineEmits<{
+  (e: 'updateHdriFile', file: File | null): void
+}>()
+
+const showPanel = ref(false)
+const panelRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<InstanceType<typeof Button> | null>(null)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+
+useDismissableOverlay({
+  isOpen: showPanel,
+  getOverlayEl: () => panelRef.value,
+  getTriggerEl: () => triggerRef.value?.$el ?? null,
+  onDismiss: () => {
+    showPanel.value = false
+  }
+})
+
+function toggleHDRIPanel() {
+  if (!hdriSupported) return
+  showPanel.value = !showPanel.value
+}
+
+function triggerFileInput() {
+  fileInputRef.value?.click()
+}
+
+function onFileChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0] ?? null
+  input.value = ''
+  if (file) {
+    const ext = `.${file.name.split('.').pop()?.toLowerCase() ?? ''}`
+    if (!SUPPORTED_HDRI_EXTENSIONS.has(ext)) {
+      useToastStore().addAlert(t('toastMessages.unsupportedHDRIFormat'))
+      return
+    }
+  }
+  emit('updateHdriFile', file)
+}
+
+function onEnabledChange(value: boolean) {
+  if (!hdriConfig.value) return
+  hdriConfig.value = { ...hdriConfig.value, enabled: value }
+}
+
+function onShowAsBackgroundChange(value: boolean) {
+  if (!hdriConfig.value) return
+  hdriConfig.value = { ...hdriConfig.value, showAsBackground: value }
+}
+
+function onIntensityChange(value: number[] | undefined) {
+  if (!hdriConfig.value || !value?.length) return
+  hdriConfig.value = { ...hdriConfig.value, intensity: value[0] }
+}
+
+function onRemoveHDRI() {
+  emit('updateHdriFile', null)
+  showPanel.value = false
+}
+</script>

--- a/src/components/load3d/controls/HDRIControls.vue
+++ b/src/components/load3d/controls/HDRIControls.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="flex flex-col">
-    <div class="relative">
+    <div :class="embedded ? undefined : 'relative'">
       <Button
+        v-if="!embedded"
         ref="triggerRef"
         v-tooltip.right="{
           value: $t('load3d.hdri.label'),
@@ -19,85 +20,75 @@
         :disabled="!hdriSupported"
         @click="toggleHDRIPanel"
       >
-        <i class="pi pi-globe text-lg text-base-foreground" />
+        <i class="icon-[lucide--globe] text-lg text-base-foreground" />
       </Button>
 
       <div
-        v-show="showPanel"
+        v-show="embedded || showPanel"
         ref="panelRef"
-        class="absolute top-0 left-12 z-30 w-[200px] rounded-lg bg-black/50 p-3 shadow-lg"
+        :class="
+          cn(
+            'flex w-[200px] flex-col gap-3 rounded-lg bg-black/50 p-3 shadow-lg',
+            !embedded && 'absolute top-0 left-12 z-30'
+          )
+        "
       >
-        <div class="flex flex-col gap-3">
-          <div class="flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="secondary"
-              class="w-full truncate text-xs"
-              @click="triggerFileInput"
+        <div class="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            class="w-full truncate text-xs"
+            :disabled="!hdriSupported"
+            @click="triggerFileInput"
+          >
+            {{
+              hdriConfig?.hdriPath
+                ? $t('load3d.hdri.changeFile')
+                : $t('load3d.hdri.uploadFile')
+            }}
+          </Button>
+          <Button
+            v-if="hdriConfig?.hdriPath"
+            size="icon"
+            variant="textonly"
+            :aria-label="$t('load3d.hdri.removeFile')"
+            @click="onRemoveHDRI"
+          >
+            <i class="icon-[lucide--x] text-sm text-base-foreground" />
+          </Button>
+        </div>
+
+        <template v-if="hdriConfig?.hdriPath">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm text-base-foreground">{{
+              $t('load3d.hdri.label')
+            }}</span>
+            <SwitchRoot
+              :model-value="hdriConfig?.enabled ?? false"
+              class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
+              @update:model-value="onEnabledChange"
             >
-              {{
-                hdriConfig?.hdriPath
-                  ? $t('load3d.hdri.changeFile')
-                  : $t('load3d.hdri.uploadFile')
-              }}
-            </Button>
-            <Button
-              v-if="hdriConfig?.hdriPath"
-              size="icon"
-              variant="textonly"
-              :aria-label="$t('load3d.hdri.removeFile')"
-              @click="onRemoveHDRI"
-            >
-              <i class="pi pi-times text-sm text-base-foreground" />
-            </Button>
+              <SwitchThumb
+                class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+              />
+            </SwitchRoot>
           </div>
 
-          <template v-if="hdriConfig?.hdriPath">
-            <div class="flex items-center justify-between gap-2">
-              <span class="text-sm text-base-foreground">{{
-                $t('load3d.hdri.label')
-              }}</span>
-              <SwitchRoot
-                :model-value="hdriConfig?.enabled ?? false"
-                class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
-                @update:model-value="onEnabledChange"
-              >
-                <SwitchThumb
-                  class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-                />
-              </SwitchRoot>
-            </div>
-
-            <div class="flex items-center justify-between gap-2">
-              <span class="text-sm text-base-foreground">{{
-                $t('load3d.hdri.showAsBackground')
-              }}</span>
-              <SwitchRoot
-                :model-value="hdriConfig?.showAsBackground ?? false"
-                class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
-                @update:model-value="onShowAsBackgroundChange"
-              >
-                <SwitchThumb
-                  class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-                />
-              </SwitchRoot>
-            </div>
-
-            <div v-if="hdriConfig?.enabled" class="flex flex-col gap-1">
-              <span class="text-sm text-base-foreground">{{
-                $t('load3d.hdri.intensity')
-              }}</span>
-              <Slider
-                :model-value="[hdriConfig?.intensity ?? 1]"
-                class="w-full"
-                :min="0"
-                :max="5"
-                :step="0.1"
-                @update:model-value="onIntensityChange"
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm text-base-foreground">{{
+              $t('load3d.hdri.showAsBackground')
+            }}</span>
+            <SwitchRoot
+              :model-value="hdriConfig?.showAsBackground ?? false"
+              class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
+              @update:model-value="onShowAsBackgroundChange"
+            >
+              <SwitchThumb
+                class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
               />
-            </div>
-          </template>
-        </div>
+            </SwitchRoot>
+          </div>
+        </template>
       </div>
     </div>
 
@@ -117,7 +108,6 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import Slider from '@/components/ui/slider/Slider.vue'
 import { useDismissableOverlay } from '@/composables/useDismissableOverlay'
 import {
   SUPPORTED_HDRI_EXTENSIONS,
@@ -129,8 +119,9 @@ import { cn } from '@/utils/tailwindUtil'
 
 const { t } = useI18n()
 
-const { hdriSupported = false } = defineProps<{
+const { hdriSupported = false, embedded = false } = defineProps<{
   hdriSupported?: boolean
+  embedded?: boolean
 }>()
 
 const hdriConfig = defineModel<HDRIConfig>('hdriConfig')
@@ -154,7 +145,7 @@ useDismissableOverlay({
 })
 
 function toggleHDRIPanel() {
-  if (!hdriSupported) return
+  if (embedded || !hdriSupported) return
   showPanel.value = !showPanel.value
 }
 
@@ -184,11 +175,6 @@ function onEnabledChange(value: boolean) {
 function onShowAsBackgroundChange(value: boolean) {
   if (!hdriConfig.value) return
   hdriConfig.value = { ...hdriConfig.value, showAsBackground: value }
-}
-
-function onIntensityChange(value: number[] | undefined) {
-  if (!hdriConfig.value || !value?.length) return
-  hdriConfig.value = { ...hdriConfig.value, intensity: value[0] }
 }
 
 function onRemoveHDRI() {

--- a/src/components/load3d/controls/HDRIControls.vue
+++ b/src/components/load3d/controls/HDRIControls.vue
@@ -1,9 +1,27 @@
 <template>
-  <div class="flex flex-col">
-    <div :class="embedded ? undefined : 'relative'">
+  <div v-if="!hasBackgroundImage || hdriConfig?.hdriPath" class="flex flex-col">
+    <Button
+      v-tooltip.right="{
+        value: hdriConfig?.hdriPath
+          ? $t('load3d.hdri.changeFile')
+          : $t('load3d.hdri.uploadFile'),
+        showDelay: 300
+      }"
+      size="icon"
+      variant="textonly"
+      class="rounded-full"
+      :aria-label="
+        hdriConfig?.hdriPath
+          ? $t('load3d.hdri.changeFile')
+          : $t('load3d.hdri.uploadFile')
+      "
+      @click="triggerFileInput"
+    >
+      <i class="icon-[lucide--upload] text-lg text-base-foreground" />
+    </Button>
+
+    <template v-if="hdriConfig?.hdriPath">
       <Button
-        v-if="!embedded"
-        ref="triggerRef"
         v-tooltip.right="{
           value: $t('load3d.hdri.label'),
           showDelay: 300
@@ -11,86 +29,47 @@
         size="icon"
         variant="textonly"
         :class="
-          cn(
-            'rounded-full',
-            hdriConfig?.enabled && 'bg-button-active-surface text-highlight'
-          )
+          cn('rounded-full', hdriConfig?.enabled && 'ring-2 ring-white/50')
         "
         :aria-label="$t('load3d.hdri.label')"
-        :disabled="!hdriSupported"
-        @click="toggleHDRIPanel"
+        @click="toggleEnabled"
       >
         <i class="icon-[lucide--globe] text-lg text-base-foreground" />
       </Button>
 
-      <div
-        v-show="embedded || showPanel"
-        ref="panelRef"
+      <Button
+        v-tooltip.right="{
+          value: $t('load3d.hdri.showAsBackground'),
+          showDelay: 300
+        }"
+        size="icon"
+        variant="textonly"
         :class="
           cn(
-            'flex w-[200px] flex-col gap-3 rounded-lg bg-black/50 p-3 shadow-lg',
-            !embedded && 'absolute top-0 left-12 z-30'
+            'rounded-full',
+            hdriConfig?.showAsBackground && 'ring-2 ring-white/50'
           )
         "
+        :aria-label="$t('load3d.hdri.showAsBackground')"
+        @click="toggleShowAsBackground"
       >
-        <div class="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="secondary"
-            class="w-full truncate text-xs"
-            :disabled="!hdriSupported"
-            @click="triggerFileInput"
-          >
-            {{
-              hdriConfig?.hdriPath
-                ? $t('load3d.hdri.changeFile')
-                : $t('load3d.hdri.uploadFile')
-            }}
-          </Button>
-          <Button
-            v-if="hdriConfig?.hdriPath"
-            size="icon"
-            variant="textonly"
-            :aria-label="$t('load3d.hdri.removeFile')"
-            @click="onRemoveHDRI"
-          >
-            <i class="icon-[lucide--x] text-sm text-base-foreground" />
-          </Button>
-        </div>
+        <i class="icon-[lucide--image] text-lg text-base-foreground" />
+      </Button>
 
-        <template v-if="hdriConfig?.hdriPath">
-          <div class="flex items-center justify-between gap-2">
-            <span class="text-sm text-base-foreground">{{
-              $t('load3d.hdri.label')
-            }}</span>
-            <SwitchRoot
-              :model-value="hdriConfig?.enabled ?? false"
-              class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
-              @update:model-value="onEnabledChange"
-            >
-              <SwitchThumb
-                class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-              />
-            </SwitchRoot>
-          </div>
-
-          <div class="flex items-center justify-between gap-2">
-            <span class="text-sm text-base-foreground">{{
-              $t('load3d.hdri.showAsBackground')
-            }}</span>
-            <SwitchRoot
-              :model-value="hdriConfig?.showAsBackground ?? false"
-              class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-colors data-[state=checked]:bg-primary-background data-[state=unchecked]:bg-node-stroke"
-              @update:model-value="onShowAsBackgroundChange"
-            >
-              <SwitchThumb
-                class="pointer-events-none block size-4 rounded-full bg-white shadow-sm transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-              />
-            </SwitchRoot>
-          </div>
-        </template>
-      </div>
-    </div>
+      <Button
+        v-tooltip.right="{
+          value: $t('load3d.hdri.removeFile'),
+          showDelay: 300
+        }"
+        size="icon"
+        variant="textonly"
+        class="rounded-full"
+        :aria-label="$t('load3d.hdri.removeFile')"
+        @click="onRemoveHDRI"
+      >
+        <i class="icon-[lucide--x] text-lg text-base-foreground" />
+      </Button>
+    </template>
 
     <input
       ref="fileInputRef"
@@ -103,12 +82,10 @@
 </template>
 
 <script setup lang="ts">
-import { SwitchRoot, SwitchThumb } from 'reka-ui'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import { useDismissableOverlay } from '@/composables/useDismissableOverlay'
 import {
   SUPPORTED_HDRI_EXTENSIONS,
   SUPPORTED_HDRI_EXTENSIONS_ACCEPT
@@ -119,9 +96,8 @@ import { cn } from '@/utils/tailwindUtil'
 
 const { t } = useI18n()
 
-const { hdriSupported = false, embedded = false } = defineProps<{
-  hdriSupported?: boolean
-  embedded?: boolean
+const { hasBackgroundImage = false } = defineProps<{
+  hasBackgroundImage?: boolean
 }>()
 
 const hdriConfig = defineModel<HDRIConfig>('hdriConfig')
@@ -130,24 +106,7 @@ const emit = defineEmits<{
   (e: 'updateHdriFile', file: File | null): void
 }>()
 
-const showPanel = ref(false)
-const panelRef = ref<HTMLElement | null>(null)
-const triggerRef = ref<InstanceType<typeof Button> | null>(null)
 const fileInputRef = ref<HTMLInputElement | null>(null)
-
-useDismissableOverlay({
-  isOpen: showPanel,
-  getOverlayEl: () => panelRef.value,
-  getTriggerEl: () => triggerRef.value?.$el ?? null,
-  onDismiss: () => {
-    showPanel.value = false
-  }
-})
-
-function toggleHDRIPanel() {
-  if (embedded || !hdriSupported) return
-  showPanel.value = !showPanel.value
-}
 
 function triggerFileInput() {
   fileInputRef.value?.click()
@@ -167,18 +126,23 @@ function onFileChange(event: Event) {
   emit('updateHdriFile', file)
 }
 
-function onEnabledChange(value: boolean) {
+function toggleEnabled() {
   if (!hdriConfig.value) return
-  hdriConfig.value = { ...hdriConfig.value, enabled: value }
+  hdriConfig.value = {
+    ...hdriConfig.value,
+    enabled: !hdriConfig.value.enabled
+  }
 }
 
-function onShowAsBackgroundChange(value: boolean) {
+function toggleShowAsBackground() {
   if (!hdriConfig.value) return
-  hdriConfig.value = { ...hdriConfig.value, showAsBackground: value }
+  hdriConfig.value = {
+    ...hdriConfig.value,
+    showAsBackground: !hdriConfig.value.showAsBackground
+  }
 }
 
 function onRemoveHDRI() {
   emit('updateHdriFile', null)
-  showPanel.value = false
 }
 </script>

--- a/src/components/load3d/controls/LightControls.vue
+++ b/src/components/load3d/controls/LightControls.vue
@@ -1,6 +1,22 @@
 <template>
   <div class="flex flex-col">
-    <div v-if="showLightIntensityButton" class="relative">
+    <div
+      v-if="embedded && showIntensityControl"
+      class="flex w-[200px] flex-col gap-2 rounded-lg bg-black/50 p-3 shadow-lg"
+    >
+      <span class="text-sm font-medium text-base-foreground">{{
+        $t('load3d.lightIntensity')
+      }}</span>
+      <Slider
+        :model-value="sliderValue"
+        class="w-full"
+        :min="sliderMin"
+        :max="sliderMax"
+        :step="sliderStep"
+        @update:model-value="onSliderUpdate"
+      />
+    </div>
+    <div v-else-if="showIntensityControl" class="relative">
       <Button
         ref="triggerRef"
         v-tooltip.right="{
@@ -13,19 +29,20 @@
         :aria-label="$t('load3d.lightIntensity')"
         @click="toggleLightIntensity"
       >
-        <i class="pi pi-sun text-lg text-base-foreground" />
+        <i class="icon-[lucide--sun] text-lg text-base-foreground" />
       </Button>
       <div
         v-show="showLightIntensity"
         ref="panelRef"
-        class="absolute top-0 left-12 w-[150px] rounded-lg bg-black/50 p-4 shadow-lg"
+        class="absolute top-0 left-12 w-[200px] rounded-lg bg-black/50 p-3 shadow-lg"
       >
         <Slider
-          v-model="lightIntensity"
+          :model-value="sliderValue"
           class="w-full"
-          :min="lightIntensityMinimum"
-          :max="lightIntensityMaximum"
-          :step="lightAdjustmentIncrement"
+          :min="sliderMin"
+          :max="sliderMax"
+          :step="sliderStep"
+          @update:model-value="onSliderUpdate"
         />
       </div>
     </div>
@@ -33,27 +50,30 @@
 </template>
 
 <script setup lang="ts">
-import Slider from 'primevue/slider'
 import { computed, ref } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
+import Slider from '@/components/ui/slider/Slider.vue'
 import { useDismissableOverlay } from '@/composables/useDismissableOverlay'
-import type { MaterialMode } from '@/extensions/core/load3d/interfaces'
+import type {
+  HDRIConfig,
+  MaterialMode
+} from '@/extensions/core/load3d/interfaces'
 import { useSettingStore } from '@/platform/settings/settingStore'
 
 const lightIntensity = defineModel<number>('lightIntensity')
 const materialMode = defineModel<MaterialMode>('materialMode')
+const hdriConfig = defineModel<HDRIConfig | undefined>('hdriConfig')
 
-const { hdriEnabled = false } = defineProps<{
-  hdriEnabled?: boolean
+const { embedded = false } = defineProps<{
+  embedded?: boolean
 }>()
 
-const showLightIntensityButton = computed(
-  () => materialMode.value === 'original' && !hdriEnabled
+const usesHdriIntensity = computed(
+  () => !!hdriConfig.value?.hdriPath?.length && !!hdriConfig.value?.enabled
 )
-const showLightIntensity = ref(false)
-const panelRef = ref<HTMLElement | null>(null)
-const triggerRef = ref<InstanceType<typeof Button> | null>(null)
+
+const showIntensityControl = computed(() => materialMode.value === 'original')
 
 const lightIntensityMaximum = useSettingStore().get(
   'Comfy.Load3D.LightIntensityMaximum'
@@ -64,6 +84,27 @@ const lightIntensityMinimum = useSettingStore().get(
 const lightAdjustmentIncrement = useSettingStore().get(
   'Comfy.Load3D.LightAdjustmentIncrement'
 )
+
+const sliderMin = computed(() =>
+  usesHdriIntensity.value ? 0 : lightIntensityMinimum
+)
+const sliderMax = computed(() =>
+  usesHdriIntensity.value ? 5 : lightIntensityMaximum
+)
+const sliderStep = computed(() =>
+  usesHdriIntensity.value ? 0.1 : lightAdjustmentIncrement
+)
+
+const sliderValue = computed(() => {
+  if (usesHdriIntensity.value) {
+    return [hdriConfig.value?.intensity ?? 1]
+  }
+  return [lightIntensity.value ?? lightIntensityMinimum]
+})
+
+const showLightIntensity = ref(false)
+const panelRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<InstanceType<typeof Button> | null>(null)
 
 useDismissableOverlay({
   isOpen: showLightIntensity,
@@ -76,5 +117,17 @@ useDismissableOverlay({
 
 function toggleLightIntensity() {
   showLightIntensity.value = !showLightIntensity.value
+}
+
+function onSliderUpdate(value: number[] | undefined) {
+  if (!value?.length) return
+  const next = value[0]
+  if (usesHdriIntensity.value) {
+    const h = hdriConfig.value
+    if (!h) return
+    hdriConfig.value = { ...h, intensity: next }
+  } else {
+    lightIntensity.value = next
+  }
 }
 </script>

--- a/src/components/load3d/controls/LightControls.vue
+++ b/src/components/load3d/controls/LightControls.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="flex flex-col">
-    <div v-if="showLightIntensityButton" class="show-light-intensity relative">
+    <div v-if="showLightIntensityButton" class="relative">
       <Button
+        ref="triggerRef"
         v-tooltip.right="{
           value: $t('load3d.lightIntensity'),
           showDelay: 300
@@ -16,8 +17,8 @@
       </Button>
       <div
         v-show="showLightIntensity"
-        class="absolute top-0 left-12 rounded-lg bg-black/50 p-4 shadow-lg"
-        style="width: 150px"
+        ref="panelRef"
+        class="absolute top-0 left-12 w-[150px] rounded-lg bg-black/50 p-4 shadow-lg"
       >
         <Slider
           v-model="lightIntensity"
@@ -33,19 +34,26 @@
 
 <script setup lang="ts">
 import Slider from 'primevue/slider'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
+import { useDismissableOverlay } from '@/composables/useDismissableOverlay'
 import type { MaterialMode } from '@/extensions/core/load3d/interfaces'
 import { useSettingStore } from '@/platform/settings/settingStore'
 
 const lightIntensity = defineModel<number>('lightIntensity')
 const materialMode = defineModel<MaterialMode>('materialMode')
 
+const { hdriEnabled = false } = defineProps<{
+  hdriEnabled?: boolean
+}>()
+
 const showLightIntensityButton = computed(
-  () => materialMode.value === 'original'
+  () => materialMode.value === 'original' && !hdriEnabled
 )
 const showLightIntensity = ref(false)
+const panelRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<InstanceType<typeof Button> | null>(null)
 
 const lightIntensityMaximum = useSettingStore().get(
   'Comfy.Load3D.LightIntensityMaximum'
@@ -57,23 +65,16 @@ const lightAdjustmentIncrement = useSettingStore().get(
   'Comfy.Load3D.LightAdjustmentIncrement'
 )
 
+useDismissableOverlay({
+  isOpen: showLightIntensity,
+  getOverlayEl: () => panelRef.value,
+  getTriggerEl: () => triggerRef.value?.$el ?? null,
+  onDismiss: () => {
+    showLightIntensity.value = false
+  }
+})
+
 function toggleLightIntensity() {
   showLightIntensity.value = !showLightIntensity.value
 }
-
-function closeLightSlider(e: MouseEvent) {
-  const target = e.target as HTMLElement
-
-  if (!target.closest('.show-light-intensity')) {
-    showLightIntensity.value = false
-  }
-}
-
-onMounted(() => {
-  document.addEventListener('click', closeLightSlider)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', closeLightSlider)
-})
 </script>

--- a/src/components/load3d/controls/SceneControls.vue
+++ b/src/components/load3d/controls/SceneControls.vue
@@ -11,53 +11,55 @@
       <i class="pi pi-table text-lg text-base-foreground" />
     </Button>
 
-    <div v-if="!hasBackgroundImage">
-      <Button
-        v-tooltip.right="{
-          value: $t('load3d.backgroundColor'),
-          showDelay: 300
-        }"
-        variant="textonly"
-        size="icon"
-        class="rounded-full"
-        :aria-label="$t('load3d.backgroundColor')"
-        @click="openColorPicker"
-      >
-        <i class="pi pi-palette text-lg text-base-foreground" />
-        <input
-          ref="colorPickerRef"
-          type="color"
-          :value="backgroundColor"
-          class="pointer-events-none absolute m-0 size-0 p-0 opacity-0"
-          @input="
-            updateBackgroundColor(($event.target as HTMLInputElement).value)
-          "
-        />
-      </Button>
-    </div>
+    <template v-if="!hdriActive">
+      <div v-if="!hasBackgroundImage">
+        <Button
+          v-tooltip.right="{
+            value: $t('load3d.backgroundColor'),
+            showDelay: 300
+          }"
+          variant="textonly"
+          size="icon"
+          class="rounded-full"
+          :aria-label="$t('load3d.backgroundColor')"
+          @click="openColorPicker"
+        >
+          <i class="pi pi-palette text-lg text-base-foreground" />
+          <input
+            ref="colorPickerRef"
+            type="color"
+            :value="backgroundColor"
+            class="pointer-events-none absolute m-0 size-0 p-0 opacity-0"
+            @input="
+              updateBackgroundColor(($event.target as HTMLInputElement).value)
+            "
+          />
+        </Button>
+      </div>
 
-    <div v-if="!hasBackgroundImage">
-      <Button
-        v-tooltip.right="{
-          value: $t('load3d.uploadBackgroundImage'),
-          showDelay: 300
-        }"
-        variant="textonly"
-        size="icon"
-        class="rounded-full"
-        :aria-label="$t('load3d.uploadBackgroundImage')"
-        @click="openImagePicker"
-      >
-        <i class="pi pi-image text-lg text-base-foreground" />
-        <input
-          ref="imagePickerRef"
-          type="file"
-          accept="image/*"
-          class="pointer-events-none absolute m-0 size-0 p-0 opacity-0"
-          @change="uploadBackgroundImage"
-        />
-      </Button>
-    </div>
+      <div v-if="!hasBackgroundImage">
+        <Button
+          v-tooltip.right="{
+            value: $t('load3d.uploadBackgroundImage'),
+            showDelay: 300
+          }"
+          variant="textonly"
+          size="icon"
+          class="rounded-full"
+          :aria-label="$t('load3d.uploadBackgroundImage')"
+          @click="openImagePicker"
+        >
+          <i class="pi pi-image text-lg text-base-foreground" />
+          <input
+            ref="imagePickerRef"
+            type="file"
+            accept="image/*"
+            class="pointer-events-none absolute m-0 size-0 p-0 opacity-0"
+            @change="uploadBackgroundImage"
+          />
+        </Button>
+      </div>
+    </template>
 
     <div v-if="hasBackgroundImage">
       <Button
@@ -111,6 +113,10 @@ import PopupSlider from '@/components/load3d/controls/PopupSlider.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { BackgroundRenderModeType } from '@/extensions/core/load3d/interfaces'
 import { cn } from '@/utils/tailwindUtil'
+
+const { hdriActive = false } = defineProps<{
+  hdriActive?: boolean
+}>()
 
 const emit = defineEmits<{
   (e: 'updateBackgroundImage', file: File | null): void

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -138,7 +138,6 @@ describe('useLoad3d', () => {
       isPlyModel: vi.fn().mockReturnValue(false),
       hasSkeleton: vi.fn().mockReturnValue(false),
       setShowSkeleton: vi.fn(),
-      supportsHDRI: vi.fn().mockReturnValue(false),
       loadHDRI: vi.fn().mockResolvedValue(undefined),
       setHDRIEnabled: vi.fn(),
       setHDRIAsBackground: vi.fn(),
@@ -941,53 +940,6 @@ describe('useLoad3d', () => {
   })
 
   describe('hdri controls', () => {
-    it('should update hdriSupported on modelLoadingEnd', async () => {
-      let modelLoadingEndHandler: (() => void) | undefined
-
-      vi.mocked(mockLoad3d.addEventListener!).mockImplementation(
-        (event: string, handler: unknown) => {
-          if (event === 'modelLoadingEnd') {
-            modelLoadingEndHandler = handler as () => void
-          }
-        }
-      )
-      vi.mocked(mockLoad3d.supportsHDRI!).mockReturnValue(true)
-
-      const composable = useLoad3d(mockNode)
-      const containerRef = document.createElement('div')
-      await composable.initializeLoad3d(containerRef)
-
-      modelLoadingEndHandler?.()
-
-      expect(composable.hdriSupported.value).toBe(true)
-    })
-
-    it('should disable hdri when model does not support it', async () => {
-      let modelLoadingEndHandler: (() => void) | undefined
-
-      vi.mocked(mockLoad3d.addEventListener!).mockImplementation(
-        (event: string, handler: unknown) => {
-          if (event === 'modelLoadingEnd') {
-            modelLoadingEndHandler = handler as () => void
-          }
-        }
-      )
-      vi.mocked(mockLoad3d.supportsHDRI!).mockReturnValue(false)
-
-      const composable = useLoad3d(mockNode)
-      const containerRef = document.createElement('div')
-      await composable.initializeLoad3d(containerRef)
-
-      composable.lightConfig.value = {
-        ...composable.lightConfig.value,
-        hdri: { ...composable.lightConfig.value.hdri!, enabled: true }
-      }
-      modelLoadingEndHandler?.()
-
-      expect(composable.hdriSupported.value).toBe(false)
-      expect(composable.lightConfig.value.hdri!.enabled).toBe(false)
-    })
-
     it('should call setHDRIEnabled when hdriConfig.enabled changes', async () => {
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')
@@ -1043,8 +995,6 @@ describe('useLoad3d', () => {
       const composable = useLoad3d(mockNode)
       const containerRef = document.createElement('div')
       await composable.initializeLoad3d(containerRef)
-
-      composable.hdriSupported.value = true
 
       const file = new File([''], 'env.hdr', { type: 'image/x-hdr' })
       await composable.handleHDRIFileUpdate(file)

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -23,7 +23,17 @@ vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
   default: {
     splitFilePath: vi.fn(),
     getResourceURL: vi.fn(),
-    uploadFile: vi.fn()
+    uploadFile: vi.fn(),
+    mapSceneLightIntensityToHdri: vi.fn(
+      (scene: number, min: number, max: number) => {
+        const span = max - min
+        const t = span > 0 ? (scene - min) / span : 0
+        const clampedT = Math.min(1, Math.max(0, t))
+        const mapped = clampedT * 5
+        const minHdri = 0.25
+        return Math.min(5, Math.max(minHdri, mapped))
+      }
+    )
   }
 }))
 

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -72,7 +72,13 @@ describe('useLoad3d', () => {
           state: null
         },
         'Light Config': {
-          intensity: 5
+          intensity: 5,
+          hdri: {
+            enabled: false,
+            hdriPath: '',
+            showAsBackground: false,
+            intensity: 1
+          }
         },
         'Resource Folder': ''
       },
@@ -122,6 +128,12 @@ describe('useLoad3d', () => {
       isPlyModel: vi.fn().mockReturnValue(false),
       hasSkeleton: vi.fn().mockReturnValue(false),
       setShowSkeleton: vi.fn(),
+      supportsHDRI: vi.fn().mockReturnValue(false),
+      loadHDRI: vi.fn().mockResolvedValue(undefined),
+      setHDRIEnabled: vi.fn(),
+      setHDRIAsBackground: vi.fn(),
+      setHDRIIntensity: vi.fn(),
+      clearHDRI: vi.fn(),
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       remove: vi.fn(),
@@ -167,7 +179,13 @@ describe('useLoad3d', () => {
         fov: 75
       })
       expect(composable.lightConfig.value).toEqual({
-        intensity: 5
+        intensity: 5,
+        hdri: {
+          enabled: false,
+          hdriPath: '',
+          showAsBackground: false,
+          intensity: 1
+        }
       })
       expect(composable.isRecording.value).toBe(false)
       expect(composable.hasRecording.value).toBe(false)
@@ -476,7 +494,7 @@ describe('useLoad3d', () => {
       await nextTick()
 
       expect(mockLoad3d.setLightIntensity).toHaveBeenCalledWith(10)
-      expect(mockNode.properties['Light Config']).toEqual({
+      expect(mockNode.properties['Light Config']).toMatchObject({
         intensity: 10
       })
     })
@@ -909,6 +927,146 @@ describe('useLoad3d', () => {
         'test.glb',
         'output'
       )
+    })
+  })
+
+  describe('hdri controls', () => {
+    it('should update hdriSupported on modelLoadingEnd', async () => {
+      let modelLoadingEndHandler: (() => void) | undefined
+
+      vi.mocked(mockLoad3d.addEventListener!).mockImplementation(
+        (event: string, handler: unknown) => {
+          if (event === 'modelLoadingEnd') {
+            modelLoadingEndHandler = handler as () => void
+          }
+        }
+      )
+      vi.mocked(mockLoad3d.supportsHDRI!).mockReturnValue(true)
+
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      modelLoadingEndHandler?.()
+
+      expect(composable.hdriSupported.value).toBe(true)
+    })
+
+    it('should disable hdri when model does not support it', async () => {
+      let modelLoadingEndHandler: (() => void) | undefined
+
+      vi.mocked(mockLoad3d.addEventListener!).mockImplementation(
+        (event: string, handler: unknown) => {
+          if (event === 'modelLoadingEnd') {
+            modelLoadingEndHandler = handler as () => void
+          }
+        }
+      )
+      vi.mocked(mockLoad3d.supportsHDRI!).mockReturnValue(false)
+
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      composable.lightConfig.value = {
+        ...composable.lightConfig.value,
+        hdri: { ...composable.lightConfig.value.hdri!, enabled: true }
+      }
+      modelLoadingEndHandler?.()
+
+      expect(composable.hdriSupported.value).toBe(false)
+      expect(composable.lightConfig.value.hdri!.enabled).toBe(false)
+    })
+
+    it('should call setHDRIEnabled when hdriConfig.enabled changes', async () => {
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      composable.lightConfig.value = {
+        ...composable.lightConfig.value,
+        hdri: { ...composable.lightConfig.value.hdri!, enabled: true }
+      }
+      await nextTick()
+
+      expect(mockLoad3d.setHDRIEnabled).toHaveBeenCalledWith(true)
+    })
+
+    it('should call setHDRIAsBackground when hdriConfig.showAsBackground changes', async () => {
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      composable.lightConfig.value = {
+        ...composable.lightConfig.value,
+        hdri: { ...composable.lightConfig.value.hdri!, showAsBackground: true }
+      }
+      await nextTick()
+
+      expect(mockLoad3d.setHDRIAsBackground).toHaveBeenCalledWith(true)
+    })
+
+    it('should call setHDRIIntensity when hdriConfig.intensity changes', async () => {
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      composable.lightConfig.value = {
+        ...composable.lightConfig.value,
+        hdri: { ...composable.lightConfig.value.hdri!, intensity: 2.5 }
+      }
+      await nextTick()
+
+      expect(mockLoad3d.setHDRIIntensity).toHaveBeenCalledWith(2.5)
+    })
+
+    it('should upload file, load HDRI and update hdriConfig', async () => {
+      vi.mocked(Load3dUtils.uploadFile).mockResolvedValue('3d/env.hdr')
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['3d', 'env.hdr'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue(
+        '/view?filename=env.hdr'
+      )
+      vi.mocked(api.apiURL).mockReturnValue(
+        'http://localhost/view?filename=env.hdr'
+      )
+
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      composable.hdriSupported.value = true
+
+      const file = new File([''], 'env.hdr', { type: 'image/x-hdr' })
+      await composable.handleHDRIFileUpdate(file)
+
+      expect(Load3dUtils.uploadFile).toHaveBeenCalledWith(file, '3d')
+      expect(mockLoad3d.loadHDRI).toHaveBeenCalledWith(
+        'http://localhost/view?filename=env.hdr'
+      )
+      expect(composable.lightConfig.value.hdri!.hdriPath).toBe('3d/env.hdr')
+      expect(composable.lightConfig.value.hdri!.enabled).toBe(true)
+    })
+
+    it('should clear HDRI when file is null', async () => {
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      composable.lightConfig.value = {
+        ...composable.lightConfig.value,
+        hdri: {
+          enabled: true,
+          hdriPath: '3d/env.hdr',
+          showAsBackground: true,
+          intensity: 1
+        }
+      }
+
+      await composable.handleHDRIFileUpdate(null)
+
+      expect(mockLoad3d.clearHDRI).toHaveBeenCalled()
+      expect(composable.lightConfig.value.hdri!.hdriPath).toBe('')
+      expect(composable.lightConfig.value.hdri!.enabled).toBe(false)
     })
   })
 

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -58,8 +58,16 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   })
 
   const lightConfig = ref<LightConfig>({
-    intensity: 5
+    intensity: 5,
+    hdri: {
+      enabled: false,
+      hdriPath: '',
+      showAsBackground: false,
+      intensity: 1
+    }
   })
+
+  const hdriSupported = ref(false)
 
   const isRecording = ref(false)
   const hasRecording = ref(false)
@@ -186,7 +194,25 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
 
     const savedLightConfig = node.properties['Light Config'] as LightConfig
     if (savedLightConfig) {
-      lightConfig.value = savedLightConfig
+      lightConfig.value = {
+        intensity: savedLightConfig.intensity ?? lightConfig.value.intensity,
+        hdri: { ...lightConfig.value.hdri!, ...savedLightConfig.hdri }
+      }
+    }
+
+    const hdri = lightConfig.value.hdri
+    if (hdri?.hdriPath) {
+      const hdriUrl = api.apiURL(
+        Load3dUtils.getResourceURL(
+          ...Load3dUtils.splitFilePath(hdri.hdriPath),
+          'input'
+        )
+      )
+      try {
+        await load3d.loadHDRI(hdriUrl)
+      } catch (error) {
+        console.warn('Failed to restore HDRI:', error)
+      }
     }
 
     const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
@@ -303,10 +329,21 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
 
   watch(
     lightConfig,
-    (newValue) => {
-      if (load3d && nodeRef.value) {
-        nodeRef.value.properties['Light Config'] = newValue
-        load3d.setLightIntensity(newValue.intensity)
+    (newValue, oldValue) => {
+      if (!load3d || !nodeRef.value) return
+      nodeRef.value.properties['Light Config'] = newValue
+      load3d.setLightIntensity(newValue.intensity)
+      const hdri = newValue.hdri
+      if (!hdri) return
+      const prevHdri = oldValue?.hdri
+      if (hdri.intensity !== prevHdri?.intensity) {
+        load3d.setHDRIIntensity(hdri.intensity)
+      }
+      if (hdri.showAsBackground !== prevHdri?.showAsBackground) {
+        load3d.setHDRIAsBackground(hdri.showAsBackground)
+      }
+      if (hdri.enabled !== prevHdri?.enabled) {
+        load3d.setHDRIEnabled(hdri.enabled)
       }
     },
     { deep: true }
@@ -374,6 +411,76 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     if (load3d && animationDuration.value > 0) {
       const time = (progress / 100) * animationDuration.value
       load3d.setAnimationTime(time)
+    }
+  }
+
+  const handleHDRIFileUpdate = async (file: File | null) => {
+    const capturedLoad3d = load3d
+    if (!capturedLoad3d) return
+
+    if (!file) {
+      lightConfig.value = {
+        ...lightConfig.value,
+        hdri: {
+          ...lightConfig.value.hdri!,
+          hdriPath: '',
+          enabled: false,
+          showAsBackground: false
+        }
+      }
+      capturedLoad3d.clearHDRI()
+      return
+    }
+
+    const resourceFolder =
+      (nodeRef.value?.properties['Resource Folder'] as string) || ''
+
+    const subfolder = resourceFolder.trim()
+      ? `3d/${resourceFolder.trim()}`
+      : '3d'
+
+    const uploadedPath = await Load3dUtils.uploadFile(file, subfolder)
+    if (!uploadedPath) {
+      return
+    }
+
+    // Re-validate: node may have been removed or model swapped during upload
+    if (load3d !== capturedLoad3d || !hdriSupported.value) return
+
+    const hdriUrl = api.apiURL(
+      Load3dUtils.getResourceURL(
+        ...Load3dUtils.splitFilePath(uploadedPath),
+        'input'
+      )
+    )
+
+    try {
+      loading.value = true
+      loadingMessage.value = t('load3d.loadingHDRI')
+      await capturedLoad3d.loadHDRI(hdriUrl)
+
+      // Re-validate after load: model may have changed during the async load
+      if (load3d !== capturedLoad3d || !hdriSupported.value) return
+
+      lightConfig.value = {
+        ...lightConfig.value,
+        hdri: {
+          ...lightConfig.value.hdri!,
+          hdriPath: uploadedPath,
+          enabled: true,
+          showAsBackground: true
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load HDRI:', error)
+      lightConfig.value = {
+        ...lightConfig.value,
+        hdri: { ...lightConfig.value.hdri!, showAsBackground: false }
+      }
+      useToastStore().addAlert(t('toastMessages.failedToLoadHDRI'))
+    } finally {
+      loading.value = false
+      loadingMessage.value = ''
     }
   }
 
@@ -518,6 +625,15 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       // Reset skeleton visibility when loading new model
       modelConfig.value.showSkeleton = false
 
+      const supported = load3d?.supportsHDRI() ?? false
+      hdriSupported.value = supported
+      if (!supported && lightConfig.value.hdri?.enabled) {
+        lightConfig.value = {
+          ...lightConfig.value,
+          hdri: { ...lightConfig.value.hdri!, enabled: false }
+        }
+      }
+
       if (load3d && isAssetPreviewSupported()) {
         const node = nodeRef.value
 
@@ -615,6 +731,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     modelConfig,
     cameraConfig,
     lightConfig,
+    hdriSupported,
     isRecording,
     isPreview,
     isSplatModel,
@@ -642,6 +759,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     handleClearRecording,
     handleSeek,
     handleBackgroundImageUpdate,
+    handleHDRIFileUpdate,
     handleExportModel,
     handleModelDrop,
     cleanup

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -70,8 +70,6 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   })
   const lastNonHdriLightIntensity = ref(lightConfig.value.intensity)
 
-  const hdriSupported = ref(false)
-
   const isRecording = ref(false)
   const hasRecording = ref(false)
   const recordingDuration = ref(0)
@@ -196,15 +194,21 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     }
 
     const savedLightConfig = node.properties['Light Config'] as LightConfig
+    const savedHdriEnabled = savedLightConfig?.hdri?.enabled ?? false
     if (savedLightConfig) {
       lightConfig.value = {
         intensity: savedLightConfig.intensity ?? lightConfig.value.intensity,
-        hdri: { ...lightConfig.value.hdri!, ...savedLightConfig.hdri }
+        hdri: {
+          ...lightConfig.value.hdri!,
+          ...savedLightConfig.hdri,
+          enabled: false
+        }
       }
       lastNonHdriLightIntensity.value = lightConfig.value.intensity
     }
 
     const hdri = lightConfig.value.hdri
+    let hdriLoaded = false
     if (hdri?.hdriPath) {
       const hdriUrl = api.apiURL(
         Load3dUtils.getResourceURL(
@@ -214,8 +218,20 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       )
       try {
         await load3d.loadHDRI(hdriUrl)
+        hdriLoaded = true
       } catch (error) {
         console.warn('Failed to restore HDRI:', error)
+        lightConfig.value = {
+          ...lightConfig.value,
+          hdri: { ...lightConfig.value.hdri!, hdriPath: '', enabled: false }
+        }
+      }
+    }
+
+    if (hdriLoaded && savedHdriEnabled) {
+      lightConfig.value = {
+        ...lightConfig.value,
+        hdri: { ...lightConfig.value.hdri!, enabled: true }
       }
     }
 
@@ -244,7 +260,20 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       load3d.setCameraState(cameraStateToRestore)
     }
 
+    applySceneConfigToLoad3d()
     applyLightConfigToLoad3d()
+  }
+
+  const applySceneConfigToLoad3d = () => {
+    if (!load3d) return
+    const cfg = sceneConfig.value
+    load3d.toggleGrid(cfg.showGrid)
+    if (!lightConfig.value.hdri?.enabled) {
+      load3d.setBackgroundColor(cfg.backgroundColor)
+    }
+    if (cfg.backgroundRenderMode) {
+      load3d.setBackgroundRenderMode(cfg.backgroundRenderMode)
+    }
   }
 
   const applyLightConfigToLoad3d = () => {
@@ -310,20 +339,42 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
 
   watch(
     sceneConfig,
-    async (newValue) => {
-      if (load3d && nodeRef.value) {
+    (newValue) => {
+      if (nodeRef.value) {
         nodeRef.value.properties['Scene Config'] = newValue
-        load3d.toggleGrid(newValue.showGrid)
-        load3d.setBackgroundColor(newValue.backgroundColor)
-
-        await load3d.setBackgroundImage(newValue.backgroundImage || '')
-
-        if (newValue.backgroundRenderMode) {
-          load3d.setBackgroundRenderMode(newValue.backgroundRenderMode)
-        }
       }
     },
     { deep: true }
+  )
+
+  watch(
+    () => sceneConfig.value.showGrid,
+    (showGrid) => {
+      load3d?.toggleGrid(showGrid)
+    }
+  )
+
+  watch(
+    () => sceneConfig.value.backgroundColor,
+    (color) => {
+      if (!load3d || lightConfig.value.hdri?.enabled) return
+      load3d.setBackgroundColor(color)
+    }
+  )
+
+  watch(
+    () => sceneConfig.value.backgroundImage,
+    async (image) => {
+      if (!load3d) return
+      await load3d.setBackgroundImage(image || '')
+    }
+  )
+
+  watch(
+    () => sceneConfig.value.backgroundRenderMode,
+    (mode) => {
+      if (mode) load3d?.setBackgroundRenderMode(mode)
+    }
   )
 
   watch(
@@ -497,8 +548,8 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       return
     }
 
-    // Re-validate: node may have been removed or model swapped during upload
-    if (load3d !== capturedLoad3d || !hdriSupported.value) return
+    // Re-validate: node may have been removed during upload
+    if (load3d !== capturedLoad3d) return
 
     const hdriUrl = api.apiURL(
       Load3dUtils.getResourceURL(
@@ -512,8 +563,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       loadingMessage.value = t('load3d.loadingHDRI')
       await capturedLoad3d.loadHDRI(hdriUrl)
 
-      // Re-validate after load: model may have changed during the async load
-      if (load3d !== capturedLoad3d || !hdriSupported.value) return
+      if (load3d !== capturedLoad3d) return
 
       let sceneMin = 1
       let sceneMax = 10
@@ -543,9 +593,15 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       }
     } catch (error) {
       console.error('Failed to load HDRI:', error)
+      capturedLoad3d.clearHDRI()
       lightConfig.value = {
         ...lightConfig.value,
-        hdri: { ...lightConfig.value.hdri!, showAsBackground: false }
+        hdri: {
+          ...lightConfig.value.hdri!,
+          hdriPath: '',
+          enabled: false,
+          showAsBackground: false
+        }
       }
       useToastStore().addAlert(t('toastMessages.failedToLoadHDRI'))
     } finally {
@@ -695,15 +751,6 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       // Reset skeleton visibility when loading new model
       modelConfig.value.showSkeleton = false
 
-      const supported = load3d?.supportsHDRI() ?? false
-      hdriSupported.value = supported
-      if (!supported && lightConfig.value.hdri?.enabled) {
-        lightConfig.value = {
-          ...lightConfig.value,
-          hdri: { ...lightConfig.value.hdri!, enabled: false }
-        }
-      }
-
       if (load3d && isAssetPreviewSupported()) {
         const node = nodeRef.value
 
@@ -801,7 +848,6 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     modelConfig,
     cameraConfig,
     lightConfig,
-    hdriSupported,
     isRecording,
     isPreview,
     isSplatModel,

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from 'vue'
 
 import { toRef } from '@vueuse/core'
+import { getActivePinia } from 'pinia'
 import { nextTick, ref, toRaw, watch } from 'vue'
 
 import Load3d from '@/extensions/core/load3d/Load3d'
@@ -24,6 +25,7 @@ import type {
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -66,6 +68,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       intensity: 1
     }
   })
+  const lastNonHdriLightIntensity = ref(lightConfig.value.intensity)
 
   const hdriSupported = ref(false)
 
@@ -198,6 +201,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         intensity: savedLightConfig.intensity ?? lightConfig.value.intensity,
         hdri: { ...lightConfig.value.hdri!, ...savedLightConfig.hdri }
       }
+      lastNonHdriLightIntensity.value = lightConfig.value.intensity
     }
 
     const hdri = lightConfig.value.hdri
@@ -238,6 +242,26 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       }
     } else if (cameraStateToRestore) {
       load3d.setCameraState(cameraStateToRestore)
+    }
+
+    applyLightConfigToLoad3d()
+  }
+
+  const applyLightConfigToLoad3d = () => {
+    if (!load3d) return
+    const cfg = lightConfig.value
+    load3d.setLightIntensity(cfg.intensity)
+    const hdri = cfg.hdri
+    if (!hdri) return
+    load3d.setHDRIIntensity(hdri.intensity)
+    load3d.setHDRIAsBackground(hdri.showAsBackground)
+    load3d.setHDRIEnabled(hdri.enabled)
+  }
+
+  const persistLightConfigToNode = () => {
+    const n = nodeRef.value
+    if (n) {
+      n.properties['Light Config'] = lightConfig.value
     }
   }
 
@@ -328,25 +352,54 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   )
 
   watch(
-    lightConfig,
-    (newValue, oldValue) => {
+    () => lightConfig.value.intensity,
+    (intensity) => {
       if (!load3d || !nodeRef.value) return
-      nodeRef.value.properties['Light Config'] = newValue
-      load3d.setLightIntensity(newValue.intensity)
-      const hdri = newValue.hdri
-      if (!hdri) return
-      const prevHdri = oldValue?.hdri
-      if (hdri.intensity !== prevHdri?.intensity) {
-        load3d.setHDRIIntensity(hdri.intensity)
+      if (!lightConfig.value.hdri?.enabled) {
+        lastNonHdriLightIntensity.value = intensity
       }
-      if (hdri.showAsBackground !== prevHdri?.showAsBackground) {
-        load3d.setHDRIAsBackground(hdri.showAsBackground)
+      persistLightConfigToNode()
+      load3d.setLightIntensity(intensity)
+    }
+  )
+
+  watch(
+    () => lightConfig.value.hdri?.intensity,
+    (intensity) => {
+      if (!load3d || !nodeRef.value) return
+      if (intensity === undefined) return
+      persistLightConfigToNode()
+      load3d.setHDRIIntensity(intensity)
+    }
+  )
+
+  watch(
+    () => lightConfig.value.hdri?.showAsBackground,
+    (show) => {
+      if (!load3d || !nodeRef.value) return
+      if (show === undefined) return
+      persistLightConfigToNode()
+      load3d.setHDRIAsBackground(show)
+    }
+  )
+
+  watch(
+    () => lightConfig.value.hdri?.enabled,
+    (enabled, prevEnabled) => {
+      if (!load3d || !nodeRef.value) return
+      if (enabled === undefined) return
+      if (enabled && prevEnabled === false) {
+        lastNonHdriLightIntensity.value = lightConfig.value.intensity
       }
-      if (hdri.enabled !== prevHdri?.enabled) {
-        load3d.setHDRIEnabled(hdri.enabled)
+      if (!enabled && prevEnabled === true) {
+        lightConfig.value = {
+          ...lightConfig.value,
+          intensity: lastNonHdriLightIntensity.value
+        }
       }
-    },
-    { deep: true }
+      persistLightConfigToNode()
+      load3d.setHDRIEnabled(enabled)
+    }
   )
 
   watch(playing, (newValue) => {
@@ -462,13 +515,30 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       // Re-validate after load: model may have changed during the async load
       if (load3d !== capturedLoad3d || !hdriSupported.value) return
 
+      let sceneMin = 1
+      let sceneMax = 10
+      if (getActivePinia() != null) {
+        const settingStore = useSettingStore()
+        sceneMin = settingStore.get(
+          'Comfy.Load3D.LightIntensityMinimum'
+        ) as number
+        sceneMax = settingStore.get(
+          'Comfy.Load3D.LightIntensityMaximum'
+        ) as number
+      }
+      const mappedHdriIntensity = Load3dUtils.mapSceneLightIntensityToHdri(
+        lightConfig.value.intensity,
+        sceneMin,
+        sceneMax
+      )
       lightConfig.value = {
         ...lightConfig.value,
         hdri: {
           ...lightConfig.value.hdri!,
           hdriPath: uploadedPath,
           enabled: true,
-          showAsBackground: true
+          showAsBackground: true,
+          intensity: mappedHdriIntensity
         }
       }
     } catch (error) {

--- a/src/extensions/core/load3d/HDRIManager.test.ts
+++ b/src/extensions/core/load3d/HDRIManager.test.ts
@@ -1,0 +1,220 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HDRIManager } from './HDRIManager'
+import Load3dUtils from './Load3dUtils'
+
+const { mockFromEquirectangular, mockDisposePMREM } = vi.hoisted(() => ({
+  mockFromEquirectangular: vi.fn(),
+  mockDisposePMREM: vi.fn()
+}))
+
+vi.mock('./Load3dUtils', () => ({
+  default: {
+    getFilenameExtension: vi.fn()
+  }
+}))
+
+vi.mock('three', async (importOriginal) => {
+  const actual = await importOriginal<typeof THREE>()
+  class MockPMREMGenerator {
+    compileEquirectangularShader = vi.fn()
+    fromEquirectangular = mockFromEquirectangular
+    dispose = mockDisposePMREM
+  }
+  return { ...actual, PMREMGenerator: MockPMREMGenerator }
+})
+
+vi.mock('three/examples/jsm/loaders/EXRLoader', () => {
+  class EXRLoader {
+    load(
+      _url: string,
+      resolve: (t: THREE.Texture) => void,
+      _onProgress: undefined,
+      _reject: (e: unknown) => void
+    ) {
+      resolve(new THREE.DataTexture(new Uint8Array(4), 1, 1))
+    }
+  }
+  return { EXRLoader }
+})
+
+vi.mock('three/examples/jsm/loaders/RGBELoader', () => {
+  class RGBELoader {
+    load(
+      _url: string,
+      resolve: (t: THREE.Texture) => void,
+      _onProgress: undefined,
+      _reject: (e: unknown) => void
+    ) {
+      resolve(new THREE.DataTexture(new Uint8Array(4), 1, 1))
+    }
+  }
+  return { RGBELoader }
+})
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  }
+}
+
+describe('HDRIManager', () => {
+  let scene: THREE.Scene
+  let eventManager: ReturnType<typeof makeMockEventManager>
+  let manager: HDRIManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    scene = new THREE.Scene()
+    eventManager = makeMockEventManager()
+
+    mockFromEquirectangular.mockReturnValue({ texture: new THREE.Texture() })
+
+    manager = new HDRIManager(scene, {} as THREE.WebGLRenderer, eventManager)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('initial state', () => {
+    it('starts disabled with default intensity', () => {
+      expect(manager.isEnabled).toBe(false)
+      expect(manager.showAsBackground).toBe(false)
+      expect(manager.intensity).toBe(1)
+    })
+  })
+
+  describe('loadHDRI', () => {
+    it('loads .exr files without error', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('exr')
+
+      await expect(
+        manager.loadHDRI('http://example.com/env.exr')
+      ).resolves.toBeUndefined()
+    })
+
+    it('loads .hdr files without error', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+
+      await expect(
+        manager.loadHDRI('http://example.com/env.hdr')
+      ).resolves.toBeUndefined()
+    })
+
+    it('applies to scene immediately when already enabled', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      manager.setEnabled(true)
+      // No texture loaded yet so scene.environment stays null
+      expect(scene.environment).toBeNull()
+
+      await manager.loadHDRI('http://example.com/env.hdr')
+
+      expect(scene.environment).not.toBeNull()
+    })
+
+    it('does not apply to scene when disabled', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+
+      await manager.loadHDRI('http://example.com/env.hdr')
+
+      expect(scene.environment).toBeNull()
+    })
+  })
+
+  describe('setEnabled', () => {
+    it('applies environment map to scene when enabled after loading', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      await manager.loadHDRI('http://example.com/env.hdr')
+
+      manager.setEnabled(true)
+
+      expect(scene.environment).not.toBeNull()
+      expect(eventManager.emitEvent).toHaveBeenCalledWith('hdriChange', {
+        enabled: true,
+        showAsBackground: false
+      })
+    })
+
+    it('removes environment map from scene when disabled', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      await manager.loadHDRI('http://example.com/env.hdr')
+      manager.setEnabled(true)
+
+      manager.setEnabled(false)
+
+      expect(scene.environment).toBeNull()
+      expect(eventManager.emitEvent).toHaveBeenLastCalledWith('hdriChange', {
+        enabled: false,
+        showAsBackground: false
+      })
+    })
+  })
+
+  describe('setIntensity', () => {
+    it('updates scene intensity when enabled', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      await manager.loadHDRI('http://example.com/env.hdr')
+      manager.setEnabled(true)
+
+      manager.setIntensity(2.5)
+
+      expect(scene.environmentIntensity).toBe(2.5)
+      expect(manager.intensity).toBe(2.5)
+    })
+
+    it('stores intensity without applying when disabled', () => {
+      manager.setIntensity(3)
+
+      expect(manager.intensity).toBe(3)
+      expect(scene.environmentIntensity).not.toBe(3)
+    })
+  })
+
+  describe('setShowAsBackground', () => {
+    it('sets scene background texture when enabled and showing as background', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      await manager.loadHDRI('http://example.com/env.hdr')
+      manager.setEnabled(true)
+
+      manager.setShowAsBackground(true)
+
+      expect(scene.background).not.toBeNull()
+    })
+
+    it('clears scene background when showAsBackground is false', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      await manager.loadHDRI('http://example.com/env.hdr')
+      manager.setEnabled(true)
+      manager.setShowAsBackground(true)
+
+      manager.setShowAsBackground(false)
+
+      expect(scene.background).toBeNull()
+    })
+  })
+
+  describe('clear', () => {
+    it('removes HDRI from scene and resets state', async () => {
+      vi.mocked(Load3dUtils.getFilenameExtension).mockReturnValue('hdr')
+      await manager.loadHDRI('http://example.com/env.hdr')
+      manager.setEnabled(true)
+
+      manager.clear()
+
+      expect(manager.isEnabled).toBe(false)
+      expect(scene.environment).toBeNull()
+    })
+  })
+
+  describe('dispose', () => {
+    it('disposes PMREMGenerator', () => {
+      manager.dispose()
+
+      expect(mockDisposePMREM).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/extensions/core/load3d/HDRIManager.test.ts
+++ b/src/extensions/core/load3d/HDRIManager.test.ts
@@ -71,7 +71,10 @@ describe('HDRIManager', () => {
     scene = new THREE.Scene()
     eventManager = makeMockEventManager()
 
-    mockFromEquirectangular.mockReturnValue({ texture: new THREE.Texture() })
+    mockFromEquirectangular.mockReturnValue({
+      texture: new THREE.Texture(),
+      dispose: vi.fn()
+    })
 
     manager = new HDRIManager(scene, {} as THREE.WebGLRenderer, eventManager)
   })

--- a/src/extensions/core/load3d/HDRIManager.ts
+++ b/src/extensions/core/load3d/HDRIManager.ts
@@ -7,11 +7,12 @@ import type { EventManagerInterface } from './interfaces'
 
 export class HDRIManager {
   private scene: THREE.Scene
+  private renderer: THREE.WebGLRenderer
   private pmremGenerator: THREE.PMREMGenerator
   private eventManager: EventManagerInterface
 
   private hdriTexture: THREE.Texture | null = null
-  private envMap: THREE.Texture | null = null
+  private envMapTarget: THREE.WebGLRenderTarget | null = null
 
   private _isEnabled: boolean = false
   private _showAsBackground: boolean = false
@@ -35,6 +36,7 @@ export class HDRIManager {
     eventManager: EventManagerInterface
   ) {
     this.scene = scene
+    this.renderer = renderer
     this.pmremGenerator = new THREE.PMREMGenerator(renderer)
     this.pmremGenerator.compileEquirectangularShader()
     this.eventManager = eventManager
@@ -55,14 +57,13 @@ export class HDRIManager {
     }
 
     newTexture.mapping = THREE.EquirectangularReflectionMapping
-    const newEnvMap =
-      this.pmremGenerator.fromEquirectangular(newTexture).texture
+    const newEnvMapTarget = this.pmremGenerator.fromEquirectangular(newTexture)
 
-    // Dispose old textures only after the new one is ready
+    // Dispose old resources only after the new one is ready
     this.hdriTexture?.dispose()
-    this.envMap?.dispose()
+    this.envMapTarget?.dispose()
     this.hdriTexture = newTexture
-    this.envMap = newEnvMap
+    this.envMapTarget = newEnvMapTarget
 
     if (this._isEnabled) {
       this.applyToScene()
@@ -72,7 +73,7 @@ export class HDRIManager {
   setEnabled(enabled: boolean): void {
     this._isEnabled = enabled
     if (enabled) {
-      if (this.envMap) {
+      if (this.envMapTarget) {
         this.applyToScene()
       }
     } else {
@@ -82,7 +83,7 @@ export class HDRIManager {
 
   setShowAsBackground(show: boolean): void {
     this._showAsBackground = show
-    if (this._isEnabled && this.envMap) {
+    if (this._isEnabled && this.envMapTarget) {
       this.applyToScene()
     }
   }
@@ -95,10 +96,13 @@ export class HDRIManager {
   }
 
   private applyToScene(): void {
-    if (!this.envMap) return
-    this.scene.environment = this.envMap
+    const envMap = this.envMapTarget?.texture
+    if (!envMap) return
+    this.scene.environment = envMap
     this.scene.environmentIntensity = this._intensity
     this.scene.background = this._showAsBackground ? this.hdriTexture : null
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping
+    this.renderer.toneMappingExposure = 1.0
     this.eventManager.emitEvent('hdriChange', {
       enabled: this._isEnabled,
       showAsBackground: this._showAsBackground
@@ -110,27 +114,29 @@ export class HDRIManager {
     if (this.scene.background === this.hdriTexture) {
       this.scene.background = null
     }
+    this.renderer.toneMapping = THREE.NoToneMapping
+    this.renderer.toneMappingExposure = 1.0
     this.eventManager.emitEvent('hdriChange', {
       enabled: false,
       showAsBackground: this._showAsBackground
     })
   }
 
-  private clearTextures(): void {
+  private clearResources(): void {
     this.removeFromScene()
     this.hdriTexture?.dispose()
-    this.envMap?.dispose()
+    this.envMapTarget?.dispose()
     this.hdriTexture = null
-    this.envMap = null
+    this.envMapTarget = null
   }
 
   clear(): void {
-    this.clearTextures()
+    this.clearResources()
     this._isEnabled = false
   }
 
   dispose(): void {
-    this.clearTextures()
+    this.clearResources()
     this.pmremGenerator.dispose()
   }
 }

--- a/src/extensions/core/load3d/HDRIManager.ts
+++ b/src/extensions/core/load3d/HDRIManager.ts
@@ -1,0 +1,136 @@
+import * as THREE from 'three'
+import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader'
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+
+import Load3dUtils from './Load3dUtils'
+import type { EventManagerInterface } from './interfaces'
+
+export class HDRIManager {
+  private scene: THREE.Scene
+  private pmremGenerator: THREE.PMREMGenerator
+  private eventManager: EventManagerInterface
+
+  private hdriTexture: THREE.Texture | null = null
+  private envMap: THREE.Texture | null = null
+
+  private _isEnabled: boolean = false
+  private _showAsBackground: boolean = false
+  private _intensity: number = 1
+
+  get isEnabled() {
+    return this._isEnabled
+  }
+
+  get showAsBackground() {
+    return this._showAsBackground
+  }
+
+  get intensity() {
+    return this._intensity
+  }
+
+  constructor(
+    scene: THREE.Scene,
+    renderer: THREE.WebGLRenderer,
+    eventManager: EventManagerInterface
+  ) {
+    this.scene = scene
+    this.pmremGenerator = new THREE.PMREMGenerator(renderer)
+    this.pmremGenerator.compileEquirectangularShader()
+    this.eventManager = eventManager
+  }
+
+  async loadHDRI(url: string): Promise<void> {
+    const ext = Load3dUtils.getFilenameExtension(url)
+
+    let newTexture: THREE.Texture
+    if (ext === 'exr') {
+      newTexture = await new Promise<THREE.Texture>((resolve, reject) => {
+        new EXRLoader().load(url, resolve, undefined, reject)
+      })
+    } else {
+      newTexture = await new Promise<THREE.Texture>((resolve, reject) => {
+        new RGBELoader().load(url, resolve, undefined, reject)
+      })
+    }
+
+    newTexture.mapping = THREE.EquirectangularReflectionMapping
+    const newEnvMap =
+      this.pmremGenerator.fromEquirectangular(newTexture).texture
+
+    // Dispose old textures only after the new one is ready
+    this.hdriTexture?.dispose()
+    this.envMap?.dispose()
+    this.hdriTexture = newTexture
+    this.envMap = newEnvMap
+
+    if (this._isEnabled) {
+      this.applyToScene()
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    this._isEnabled = enabled
+    if (enabled) {
+      if (this.envMap) {
+        this.applyToScene()
+      }
+    } else {
+      this.removeFromScene()
+    }
+  }
+
+  setShowAsBackground(show: boolean): void {
+    this._showAsBackground = show
+    if (this._isEnabled && this.envMap) {
+      this.applyToScene()
+    }
+  }
+
+  setIntensity(intensity: number): void {
+    this._intensity = intensity
+    if (this._isEnabled) {
+      this.scene.environmentIntensity = intensity
+    }
+  }
+
+  private applyToScene(): void {
+    if (!this.envMap) return
+    this.scene.environment = this.envMap
+    this.scene.environmentIntensity = this._intensity
+    this.scene.background = this._showAsBackground ? this.hdriTexture : null
+    this.eventManager.emitEvent('hdriChange', {
+      enabled: this._isEnabled,
+      showAsBackground: this._showAsBackground
+    })
+  }
+
+  private removeFromScene(): void {
+    this.scene.environment = null
+    if (this.scene.background === this.hdriTexture) {
+      this.scene.background = null
+    }
+    this.eventManager.emitEvent('hdriChange', {
+      enabled: false,
+      showAsBackground: this._showAsBackground
+    })
+  }
+
+  private clearTextures(): void {
+    this.removeFromScene()
+    this.hdriTexture?.dispose()
+    this.envMap?.dispose()
+    this.hdriTexture = null
+    this.envMap = null
+  }
+
+  clear(): void {
+    this.clearTextures()
+    this._isEnabled = false
+  }
+
+  dispose(): void {
+    this.clearTextures()
+    this.pmremGenerator.dispose()
+  }
+}

--- a/src/extensions/core/load3d/LightingManager.ts
+++ b/src/extensions/core/load3d/LightingManager.ts
@@ -10,6 +10,7 @@ export class LightingManager implements LightingManagerInterface {
   currentIntensity: number = 3
   private scene: THREE.Scene
   private eventManager: EventManagerInterface
+  private lightMultipliers = new Map<THREE.Light, number>()
 
   constructor(scene: THREE.Scene, eventManager: EventManagerInterface) {
     this.scene = scene
@@ -25,58 +26,52 @@ export class LightingManager implements LightingManagerInterface {
       this.scene.remove(light)
     })
     this.lights = []
+    this.lightMultipliers.clear()
   }
 
   setupLights(): void {
-    const ambientLight = new THREE.AmbientLight(0xffffff, 0.5)
-    this.scene.add(ambientLight)
-    this.lights.push(ambientLight)
+    const addLight = (light: THREE.Light, multiplier: number) => {
+      this.scene.add(light)
+      this.lights.push(light)
+      this.lightMultipliers.set(light, multiplier)
+    }
+
+    addLight(new THREE.AmbientLight(0xffffff, 0.5), 0.5)
 
     const mainLight = new THREE.DirectionalLight(0xffffff, 0.8)
     mainLight.position.set(0, 10, 10)
-    this.scene.add(mainLight)
-    this.lights.push(mainLight)
+    addLight(mainLight, 0.8)
 
     const backLight = new THREE.DirectionalLight(0xffffff, 0.5)
     backLight.position.set(0, 10, -10)
-    this.scene.add(backLight)
-    this.lights.push(backLight)
+    addLight(backLight, 0.5)
 
     const leftFillLight = new THREE.DirectionalLight(0xffffff, 0.3)
     leftFillLight.position.set(-10, 0, 0)
-    this.scene.add(leftFillLight)
-    this.lights.push(leftFillLight)
+    addLight(leftFillLight, 0.3)
 
     const rightFillLight = new THREE.DirectionalLight(0xffffff, 0.3)
     rightFillLight.position.set(10, 0, 0)
-    this.scene.add(rightFillLight)
-    this.lights.push(rightFillLight)
+    addLight(rightFillLight, 0.3)
 
     const bottomLight = new THREE.DirectionalLight(0xffffff, 0.2)
     bottomLight.position.set(0, -10, 0)
-    this.scene.add(bottomLight)
-    this.lights.push(bottomLight)
+    addLight(bottomLight, 0.2)
   }
 
   setLightIntensity(intensity: number): void {
     this.currentIntensity = intensity
     this.lights.forEach((light) => {
-      if (light instanceof THREE.DirectionalLight) {
-        if (light === this.lights[1]) {
-          light.intensity = intensity * 0.8
-        } else if (light === this.lights[2]) {
-          light.intensity = intensity * 0.5
-        } else if (light === this.lights[5]) {
-          light.intensity = intensity * 0.2
-        } else {
-          light.intensity = intensity * 0.3
-        }
-      } else if (light instanceof THREE.AmbientLight) {
-        light.intensity = intensity * 0.5
-      }
+      light.intensity = intensity * (this.lightMultipliers.get(light) ?? 1)
     })
 
     this.eventManager.emitEvent('lightIntensityChange', intensity)
+  }
+
+  setHDRIMode(hdriActive: boolean): void {
+    this.lights.forEach((light) => {
+      light.visible = !hdriActive
+    })
   }
 
   reset(): void {}

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -114,7 +114,7 @@ class Load3DConfiguration {
 
     const lightConfig = this.loadLightConfig()
     this.applyLightConfig(lightConfig)
-    if (lightConfig.hdri) void this.applyHDRI(lightConfig.hdri)
+    if (lightConfig.hdri) this.applyHDRISettings(lightConfig.hdri)
   }
 
   private loadSceneConfig(): SceneConfig {
@@ -206,23 +206,12 @@ class Load3DConfiguration {
     this.load3d.setLightIntensity(config.intensity)
   }
 
-  private async applyHDRI(config: HDRIConfig): Promise<void> {
+  private applyHDRISettings(config: HDRIConfig) {
     if (!config.hdriPath) return
-    try {
-      const hdriUrl = api.apiURL(
-        Load3dUtils.getResourceURL(
-          ...Load3dUtils.splitFilePath(config.hdriPath),
-          'input'
-        )
-      )
-      await this.load3d.loadHDRI(hdriUrl)
-      this.load3d.setHDRIIntensity(config.intensity)
-      this.load3d.setHDRIAsBackground(config.showAsBackground)
-      if (config.enabled) {
-        this.load3d.setHDRIEnabled(true)
-      }
-    } catch (error) {
-      console.warn('Failed to restore HDRI:', error)
+    this.load3d.setHDRIIntensity(config.intensity)
+    this.load3d.setHDRIAsBackground(config.showAsBackground)
+    if (config.enabled) {
+      this.load3d.setHDRIEnabled(true)
     }
   }
 

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -3,6 +3,7 @@ import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import type {
   CameraConfig,
   CameraState,
+  HDRIConfig,
   LightConfig,
   ModelConfig,
   SceneConfig
@@ -113,6 +114,7 @@ class Load3DConfiguration {
 
     const lightConfig = this.loadLightConfig()
     this.applyLightConfig(lightConfig)
+    if (lightConfig.hdri) void this.applyHDRI(lightConfig.hdri)
   }
 
   private loadSceneConfig(): SceneConfig {
@@ -140,13 +142,27 @@ class Load3DConfiguration {
   }
 
   private loadLightConfig(): LightConfig {
+    const hdriDefaults: HDRIConfig = {
+      enabled: false,
+      hdriPath: '',
+      showAsBackground: false,
+      intensity: 1
+    }
+
     if (this.properties && 'Light Config' in this.properties) {
-      return this.properties['Light Config'] as LightConfig
+      const saved = this.properties['Light Config'] as Partial<LightConfig>
+      return {
+        intensity:
+          saved.intensity ??
+          (useSettingStore().get('Comfy.Load3D.LightIntensity') as number),
+        hdri: { ...hdriDefaults, ...(saved.hdri ?? {}) }
+      }
     }
 
     return {
-      intensity: useSettingStore().get('Comfy.Load3D.LightIntensity')
-    } as LightConfig
+      intensity: useSettingStore().get('Comfy.Load3D.LightIntensity') as number,
+      hdri: hdriDefaults
+    }
   }
 
   private loadModelConfig(): ModelConfig {
@@ -188,6 +204,26 @@ class Load3DConfiguration {
 
   private applyLightConfig(config: LightConfig) {
     this.load3d.setLightIntensity(config.intensity)
+  }
+
+  private async applyHDRI(config: HDRIConfig): Promise<void> {
+    if (!config.hdriPath) return
+    try {
+      const hdriUrl = api.apiURL(
+        Load3dUtils.getResourceURL(
+          ...Load3dUtils.splitFilePath(config.hdriPath),
+          'input'
+        )
+      )
+      await this.load3d.loadHDRI(hdriUrl)
+      this.load3d.setHDRIIntensity(config.intensity)
+      this.load3d.setHDRIAsBackground(config.showAsBackground)
+      if (config.enabled) {
+        this.load3d.setHDRIEnabled(true)
+      }
+    } catch (error) {
+      console.warn('Failed to restore HDRI:', error)
+    }
   }
 
   private applyModelConfig(config: ModelConfig) {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -14,8 +14,6 @@ import { RecordingManager } from './RecordingManager'
 import { SceneManager } from './SceneManager'
 import { SceneModelManager } from './SceneModelManager'
 import { ViewHelperManager } from './ViewHelperManager'
-import { HDRI_COMPATIBLE_MODEL_EXTENSIONS } from './constants'
-import Load3dUtils from './Load3dUtils'
 import {
   type CameraState,
   type CaptureResult,
@@ -97,8 +95,6 @@ class Load3d {
     this.renderer.setClearColor(0x282828)
     this.renderer.autoClear = false
     this.renderer.outputColorSpace = THREE.SRGBColorSpace
-    this.renderer.toneMapping = THREE.ACESFilmicToneMapping
-    this.renderer.toneMappingExposure = 1.0
     this.renderer.domElement.classList.add(
       'absolute',
       'inset-0',
@@ -645,13 +641,6 @@ class Load3d {
   setLightIntensity(intensity: number): void {
     this.lightingManager.setLightIntensity(intensity)
     this.forceRender()
-  }
-
-  supportsHDRI(): boolean {
-    const url = this.modelManager.originalURL
-    if (!url) return false
-    const ext = Load3dUtils.getFilenameExtension(url)
-    return ext ? HDRI_COMPATIBLE_MODEL_EXTENSIONS.has(`.${ext}`) : false
   }
 
   async loadHDRI(url: string): Promise<void> {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -6,6 +6,7 @@ import { AnimationManager } from './AnimationManager'
 import { CameraManager } from './CameraManager'
 import { ControlsManager } from './ControlsManager'
 import { EventManager } from './EventManager'
+import { HDRIManager } from './HDRIManager'
 import { LightingManager } from './LightingManager'
 import { LoaderManager } from './LoaderManager'
 import { ModelExporter } from './ModelExporter'
@@ -13,6 +14,8 @@ import { RecordingManager } from './RecordingManager'
 import { SceneManager } from './SceneManager'
 import { SceneModelManager } from './SceneModelManager'
 import { ViewHelperManager } from './ViewHelperManager'
+import { HDRI_COMPATIBLE_MODEL_EXTENSIONS } from './constants'
+import Load3dUtils from './Load3dUtils'
 import {
   type CameraState,
   type CaptureResult,
@@ -54,6 +57,7 @@ class Load3d {
   cameraManager: CameraManager
   controlsManager: ControlsManager
   lightingManager: LightingManager
+  hdriManager: HDRIManager
   viewHelperManager: ViewHelperManager
   loaderManager: LoaderManager
   modelManager: SceneModelManager
@@ -93,6 +97,8 @@ class Load3d {
     this.renderer.setClearColor(0x282828)
     this.renderer.autoClear = false
     this.renderer.outputColorSpace = THREE.SRGBColorSpace
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping
+    this.renderer.toneMappingExposure = 1.0
     this.renderer.domElement.classList.add(
       'absolute',
       'inset-0',
@@ -123,6 +129,12 @@ class Load3d {
 
     this.lightingManager = new LightingManager(
       this.sceneManager.scene,
+      this.eventManager
+    )
+
+    this.hdriManager = new HDRIManager(
+      this.sceneManager.scene,
+      this.renderer,
       this.eventManager
     )
 
@@ -635,6 +647,40 @@ class Load3d {
     this.forceRender()
   }
 
+  supportsHDRI(): boolean {
+    const url = this.modelManager.originalURL
+    if (!url) return false
+    const ext = Load3dUtils.getFilenameExtension(url)
+    return ext ? HDRI_COMPATIBLE_MODEL_EXTENSIONS.has(`.${ext}`) : false
+  }
+
+  async loadHDRI(url: string): Promise<void> {
+    await this.hdriManager.loadHDRI(url)
+    this.forceRender()
+  }
+
+  setHDRIEnabled(enabled: boolean): void {
+    this.hdriManager.setEnabled(enabled)
+    this.lightingManager.setHDRIMode(enabled)
+    this.forceRender()
+  }
+
+  setHDRIAsBackground(show: boolean): void {
+    this.hdriManager.setShowAsBackground(show)
+    this.forceRender()
+  }
+
+  setHDRIIntensity(intensity: number): void {
+    this.hdriManager.setIntensity(intensity)
+    this.forceRender()
+  }
+
+  clearHDRI(): void {
+    this.hdriManager.clear()
+    this.lightingManager.setHDRIMode(false)
+    this.forceRender()
+  }
+
   setTargetSize(width: number, height: number): void {
     this.targetWidth = width
     this.targetHeight = height
@@ -858,6 +904,7 @@ class Load3d {
     this.cameraManager.dispose()
     this.controlsManager.dispose()
     this.lightingManager.dispose()
+    this.hdriManager.dispose()
     this.viewHelperManager.dispose()
     this.loaderManager.dispose()
     this.modelManager.dispose()

--- a/src/extensions/core/load3d/Load3dUtils.test.ts
+++ b/src/extensions/core/load3d/Load3dUtils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+
+describe('Load3dUtils.mapSceneLightIntensityToHdri', () => {
+  it('maps scene slider low end to a small positive HDRI intensity', () => {
+    expect(Load3dUtils.mapSceneLightIntensityToHdri(1, 1, 10)).toBe(0.25)
+    expect(Load3dUtils.mapSceneLightIntensityToHdri(10, 1, 10)).toBe(5)
+  })
+
+  it('maps midpoint proportionally', () => {
+    expect(Load3dUtils.mapSceneLightIntensityToHdri(5.5, 1, 10)).toBeCloseTo(
+      2.5
+    )
+  })
+
+  it('clamps scene ratio and HDRI ceiling', () => {
+    expect(Load3dUtils.mapSceneLightIntensityToHdri(-10, 1, 10)).toBe(0.25)
+    expect(Load3dUtils.mapSceneLightIntensityToHdri(100, 1, 10)).toBe(5)
+  })
+
+  it('uses minimum HDRI when span is zero', () => {
+    expect(Load3dUtils.mapSceneLightIntensityToHdri(3, 5, 5)).toBe(0.25)
+  })
+})

--- a/src/extensions/core/load3d/Load3dUtils.ts
+++ b/src/extensions/core/load3d/Load3dUtils.ts
@@ -131,6 +131,19 @@ class Load3dUtils {
 
     await Promise.all(uploadPromises)
   }
+
+  static mapSceneLightIntensityToHdri(
+    sceneIntensity: number,
+    sceneMin: number,
+    sceneMax: number
+  ): number {
+    const span = sceneMax - sceneMin
+    const t = span > 0 ? (sceneIntensity - sceneMin) / span : 0
+    const clampedT = Math.min(1, Math.max(0, t))
+    const mapped = clampedT * 5
+    const minHdri = 0.25
+    return Math.min(5, Math.max(minHdri, mapped))
+  }
 }
 
 export default Load3dUtils

--- a/src/extensions/core/load3d/Load3dUtils.ts
+++ b/src/extensions/core/load3d/Load3dUtils.ts
@@ -89,6 +89,15 @@ class Load3dUtils {
     return uploadPath
   }
 
+  static getFilenameExtension(url: string): string | undefined {
+    const queryString = url.split('?')[1]
+    if (queryString) {
+      const filename = new URLSearchParams(queryString).get('filename')
+      if (filename) return filename.split('.').pop()?.toLowerCase()
+    }
+    return url.split('?')[0].split('.').pop()?.toLowerCase()
+  }
+
   static splitFilePath(path: string): [string, string] {
     const folder_separator = path.lastIndexOf('/')
     if (folder_separator === -1) {

--- a/src/extensions/core/load3d/constants.ts
+++ b/src/extensions/core/load3d/constants.ts
@@ -17,13 +17,6 @@ export const SUPPORTED_EXTENSIONS = new Set([
 
 export const SUPPORTED_EXTENSIONS_ACCEPT = [...SUPPORTED_EXTENSIONS].join(',')
 
-export const HDRI_COMPATIBLE_MODEL_EXTENSIONS = new Set([
-  '.gltf',
-  '.glb',
-  '.fbx',
-  '.obj'
-])
-
 export const SUPPORTED_HDRI_EXTENSIONS = new Set(['.hdr', '.exr'])
 
 export const SUPPORTED_HDRI_EXTENSIONS_ACCEPT = [

--- a/src/extensions/core/load3d/constants.ts
+++ b/src/extensions/core/load3d/constants.ts
@@ -16,3 +16,16 @@ export const SUPPORTED_EXTENSIONS = new Set([
 ])
 
 export const SUPPORTED_EXTENSIONS_ACCEPT = [...SUPPORTED_EXTENSIONS].join(',')
+
+export const HDRI_COMPATIBLE_MODEL_EXTENSIONS = new Set([
+  '.gltf',
+  '.glb',
+  '.fbx',
+  '.obj'
+])
+
+export const SUPPORTED_HDRI_EXTENSIONS = new Set(['.hdr', '.exr'])
+
+export const SUPPORTED_HDRI_EXTENSIONS_ACCEPT = [
+  ...SUPPORTED_HDRI_EXTENSIONS
+].join(',')

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -47,6 +47,14 @@ export interface CameraConfig {
 
 export interface LightConfig {
   intensity: number
+  hdri?: HDRIConfig
+}
+
+export interface HDRIConfig {
+  enabled: boolean
+  hdriPath: string
+  showAsBackground: boolean
+  intensity: number
 }
 
 export interface EventCallback<T = unknown> {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1988,7 +1988,16 @@
     "openIn3DViewer": "Open in 3D Viewer",
     "dropToLoad": "Drop 3D model to load",
     "unsupportedFileType": "Unsupported file type (supports .gltf, .glb, .obj, .fbx, .stl, .ply, .spz, .splat, .ksplat)",
-    "uploadingModel": "Uploading 3D model..."
+    "uploadingModel": "Uploading 3D model...",
+    "loadingHDRI": "Loading HDRI...",
+    "hdri": {
+      "label": "HDRI Environment",
+      "uploadFile": "Upload HDRI (.hdr, .exr)",
+      "changeFile": "Change HDRI",
+      "removeFile": "Remove HDRI",
+      "showAsBackground": "Show as Background",
+      "intensity": "Intensity"
+    }
   },
   "imageCrop": {
     "loading": "Loading...",
@@ -2083,7 +2092,9 @@
     "failedToUpdateMaterialMode": "Failed to update material mode",
     "failedToUpdateEdgeThreshold": "Failed to update edge threshold",
     "failedToUploadBackgroundImage": "Failed to upload background image",
-    "failedToUpdateBackgroundRenderMode": "Failed to update background render mode to {mode}"
+    "failedToUpdateBackgroundRenderMode": "Failed to update background render mode to {mode}",
+    "failedToLoadHDRI": "Failed to load HDRI file",
+    "unsupportedHDRIFormat": "Unsupported file format. Please upload a .hdr or .exr file."
   },
   "nodeErrors": {
     "render": "Node Render Error",


### PR DESCRIPTION
## Summary

Adds `HDRIManager` to load `.hdr/.exr` files as equirectangular environment maps via **three.js** `RGBELoader/EXRLoader`
  - Uploads HDRI files to the server via `/upload/image` API so they persist across page reloads
  - Restores HDRI state (enabled, **intensity**, **background**) from node properties on reload
  - Auto-enables "**Show as Background**" on successful upload for immediate visual feedback
  - Hides standard directional lights when HDRI is active; restores them when disabled
  - Hides the Light Intensity control while HDRI is active (lights have no effect when HDRI overrides scene lighting)
  - Limits HDRI availability to PBR-capable formats (.gltf, .glb, .fbx, .obj); automatically disables when switching to an incompatible model
  - Adds intensity slider and "**Show as Background**" toggle to the HDRI panel

## How to Use HDRI Environment Lighting
                                                                                                                                  
  1. Load a 3D model using a Load3D or Load3DViewer node (supported formats: .gltf, .glb, .fbx, .obj)                                                                                                                                          
  2. Open the control panel → go to the Light tab                                                                                                                                                                                              
  3. Click the globe icon to open the **HDRI panel**                                                                                                                                                                                               
  4. Click Upload HDRI and select a` .hdr` or `.exr` file                                                                                                                                                                                          
  5. The environment lighting applies automatically — the scene background also updates to preview the panorama                                                                                                                                
  6. Use the intensity slider to adjust the strength of the environment lighting                                                                                                                                                               
  7. Toggle Show as Background to show or hide the HDRI panorama behind the model                                                                                                                                                              

## Screenshots


https://github.com/user-attachments/assets/1ec56ef0-853e-452f-ae2b-2474c9d0d781



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10818-feat-load3d-add-optional-HDRI-environment-lighting-to-3D-preview-nodes-3366d73d365081ea8c7ad9226b8b1e2f) by [Unito](https://www.unito.io)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new HDRI loading/rendering path and persists new `LightConfig.hdri` state, touching Three.js rendering, file uploads, and node property restoration. Risk is moderate due to new async flows and potential compatibility/performance issues with model switching and renderer settings.
> 
> **Overview**
> Adds optional **HDRI environment lighting** to Load3D previews, including a new `HDRIManager` that loads `.hdr`/`.exr` files into Three.js environment/background and exposes controls for enable/disable, background display, and intensity.
> 
> Extends `LightConfig` with an `hdri` block that is persisted on nodes and restored on reload; `useLoad3d` now uploads HDRI files, loads them into `Load3d`, maps scene light intensity to HDRI intensity, and auto-disables HDRI when the current model format doesn’t support it.
> 
> Updates the UI to include embedded HDRI controls under the Light panel (with dismissable overlays and icon updates), adjusts light intensity behavior when HDRI is active, and adds tests/strings/utilities (`getFilenameExtension`, `mapSceneLightIntensityToHdri`, new constants) to support the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12c9722dc54a227004bdc383e3bf583504ebdce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->