### PR TITLE
test: add perf tests for workflow loading time

### DIFF
--- a/browser_tests/assets/profiling-workflow-media-heavy.json
+++ b/browser_tests/assets/profiling-workflow-media-heavy.json
@@ -1,0 +1,26661 @@
+{
+  "id": "d6228cf3-b94e-4d42-9369-fae1fe54cd5d",
+  "revision": 0,
+  "last_node_id": 2717,
+  "last_link_id": 1495,
+  "nodes": [
+    {
+      "id": 1357,
+      "type": "LoadImage",
+      "pos": [15276.31836562926, 6412.278869945942],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 1358,
+      "type": "LoadImage",
+      "pos": [15276.07910781676, 6807.604950268207],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 1359,
+      "type": "VHS_VideoCombine",
+      "pos": [27721.053473051135, 5796.232422192035],
+      "size": [580, 334],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 1360,
+      "type": "VHS_VideoCombine",
+      "pos": [28333.482672269885, 5999.648407299457],
+      "size": [580, 334],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 26,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 1362,
+      "type": "LoadVideo",
+      "pos": [14974.25392776305, 6323.458984692035],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 1363,
+      "type": "VHS_VideoCombine",
+      "pos": [27753.826910551135, 6460.255859692035],
+      "size": [580, 334],
+      "flags": {},
+      "order": 514,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1188
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 1364,
+      "type": "VHS_VideoCombine",
+      "pos": [28983.612066801135, 5740.376938183246],
+      "size": [580, 334],
+      "flags": {},
+      "order": 515,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1189
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "8a64f64a68b43f231063193799857eca229c7a2e48a16d2ed0a8b581fd8632f6.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00005.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 1365,
+      "type": "LoadImage",
+      "pos": [15601.524511869495, 6799.507873852192],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 1374,
+      "type": "LoadImage",
+      "pos": [15875.826269681995, 6425.427673656879],
+      "size": [282.78125, 340],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 1376,
+      "type": "LoadImage",
+      "pos": [14286.790052946155, 6434.648407299457],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 1377,
+      "type": "LoadImage",
+      "pos": [14286.541029508655, 6829.976013500629],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 1378,
+      "type": "LoadVideo",
+      "pos": [14599.987341459338, 6119.991195995746],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 1379,
+      "type": "LoadVideo",
+      "pos": [13984.724618490283, 6345.828064281879],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 1380,
+      "type": "LoadImage",
+      "pos": [14611.985403593128, 6821.876495678363],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 1381,
+      "type": "LoadImage",
+      "pos": [14609.479528959338, 6451.285675365863],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 1383,
+      "type": "LoadImage",
+      "pos": [14283.201185758655, 7525.392120678363],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1222]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 1384,
+      "type": "LoadImage",
+      "pos": [14282.95899062926, 7920.722320873676],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1223]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 1386,
+      "type": "LoadVideo",
+      "pos": [13981.135748918598, 7436.575744945942],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 1387,
+      "type": "LoadImage",
+      "pos": [14608.407217557971, 7912.623565990863],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 1388,
+      "type": "LoadImage",
+      "pos": [14605.900427396838, 7542.027862865863],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 1391,
+      "type": "LoadImage",
+      "pos": [15258.163153226917, 7526.258209545551],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 1392,
+      "type": "LoadImage",
+      "pos": [15257.917028959338, 7921.586578686176],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 1394,
+      "type": "LoadVideo",
+      "pos": [14956.091848905628, 7437.436951000629],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [1238]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 1395,
+      "type": "LoadImage",
+      "pos": [15583.36426406676, 7913.488434154926],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 1396,
+      "type": "LoadImage",
+      "pos": [15580.858465726917, 7542.897003490863],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 1398,
+      "type": "LoadImage",
+      "pos": [13410.30762344176, 7361.065948803363],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1219]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 1399,
+      "type": "LoadImage",
+      "pos": [13426.930662687366, 6249.394501049457],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1218]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 1400,
+      "type": "LoadImage",
+      "pos": [15938.672949369495, 6216.697815258442],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1220]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 1401,
+      "type": "LoadImage",
+      "pos": [15921.370092924182, 7347.410095531879],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1221]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 1428,
+      "type": "CheckpointLoaderSimple",
+      "pos": [17651.460882719104, 6949.584015209613],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 27,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1190, 1193]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 1429,
+      "type": "CheckpointLoaderSimple",
+      "pos": [17651.460882719104, 7169.585998852192],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 28,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1191, 1194]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 1430,
+      "type": "CheckpointLoaderSimple",
+      "pos": [17651.460882719104, 7389.584472973285],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 29,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1192, 1195]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 1431,
+      "type": "CheckpointLoaderSimple",
+      "pos": [17651.460882719104, 7609.584625561176],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 30,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1196]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 1432,
+      "type": "CLIPLoader",
+      "pos": [18081.460882719104, 6949.584015209613],
+      "size": [360, 140],
+      "flags": {},
+      "order": 31,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1197]
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 1433,
+      "type": "CLIPLoader",
+      "pos": [18081.460882719104, 7169.585998852192],
+      "size": [360, 140],
+      "flags": {},
+      "order": 32,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1198]
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 1434,
+      "type": "CLIPLoader",
+      "pos": [18081.460882719104, 7389.584472973285],
+      "size": [360, 140],
+      "flags": {},
+      "order": 33,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1199]
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 1435,
+      "type": "VAELoader",
+      "pos": [18511.460882719104, 6949.584015209613],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 34,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1200]
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 1436,
+      "type": "VAELoader",
+      "pos": [18511.460882719104, 7169.585998852192],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 35,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1201]
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 1437,
+      "type": "VAELoader",
+      "pos": [18511.460882719104, 7389.584472973285],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 36,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1202]
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 1438,
+      "type": "UNETLoader",
+      "pos": [18941.460882719104, 6949.584015209613],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 37,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 1439,
+      "type": "UNETLoader",
+      "pos": [18941.460882719104, 7169.585998852192],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 38,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 1440,
+      "type": "LoraLoaderModelOnly",
+      "pos": [18412.36542373473, 10518.934906322895],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 436,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1190
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 1441,
+      "type": "LoraLoaderModelOnly",
+      "pos": [18412.36542373473, 10688.930633861957],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 438,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1191
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 1442,
+      "type": "LoraLoaderModelOnly",
+      "pos": [18412.36542373473, 10858.934906322895],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 440,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1192
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 1443,
+      "type": "ImpactSwitch",
+      "pos": [21264.967047269885, 9272.250946361957],
+      "size": [280, 188],
+      "flags": {},
+      "order": 437,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1193
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1213]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 1",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [1, false]
+    },
+    {
+      "id": 1444,
+      "type": "ImpactSwitch",
+      "pos": [21784.959112699573, 9272.250946361957],
+      "size": [280, 188],
+      "flags": {},
+      "order": 439,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1194
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1214]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 2",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [2, false]
+    },
+    {
+      "id": 1445,
+      "type": "ImpactSwitch",
+      "pos": [22304.96094375426, 9272.250946361957],
+      "size": [280, 188],
+      "flags": {},
+      "order": 441,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1195
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1215]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 3",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [3, false]
+    },
+    {
+      "id": 1446,
+      "type": "ImpactSwitch",
+      "pos": [22824.97070937926, 9272.250946361957],
+      "size": [280, 188],
+      "flags": {},
+      "order": 442,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1196
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1216]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 4",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [1, false]
+    },
+    {
+      "id": 1447,
+      "type": "ImpactSwitch",
+      "pos": [23344.967047269885, 9272.250946361957],
+      "size": [280, 188],
+      "flags": {},
+      "order": 443,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1197
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1217]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 5",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [2, false]
+    },
+    {
+      "id": 1448,
+      "type": "ImpactSwitch",
+      "pos": [21264.967047269885, 9742.254913647113],
+      "size": [280, 188],
+      "flags": {},
+      "order": 444,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1198
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1203, 1208]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 6",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [1, false]
+    },
+    {
+      "id": 1449,
+      "type": "ImpactSwitch",
+      "pos": [21784.959112699573, 9742.254913647113],
+      "size": [280, 188],
+      "flags": {},
+      "order": 445,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1199
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1204, 1209]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 7",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [2, false]
+    },
+    {
+      "id": 1450,
+      "type": "ImpactSwitch",
+      "pos": [22304.96094375426, 9742.254913647113],
+      "size": [280, 188],
+      "flags": {},
+      "order": 446,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1200
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1205, 1210]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 8",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [3, false]
+    },
+    {
+      "id": 1451,
+      "type": "ImpactSwitch",
+      "pos": [22827.918097074573, 9728.622101147113],
+      "size": [280, 188],
+      "flags": {},
+      "order": 447,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1201
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1206, 1211]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 9",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [1, false]
+    },
+    {
+      "id": 1452,
+      "type": "ImpactSwitch",
+      "pos": [23304.675909574573, 9733.173797924457],
+      "size": [280, 188],
+      "flags": {},
+      "order": 448,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1202
+        }
+      ],
+      "outputs": [
+        {
+          "name": "selected_value",
+          "type": "*",
+          "links": [1207, 1212]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 10",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [2, false]
+    },
+    {
+      "id": 1453,
+      "type": "PreviewAny",
+      "pos": [18990.542913969104, 11960.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 521,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1203
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 1",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1454,
+      "type": "PreviewAny",
+      "pos": [19490.545050199573, 11960.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 523,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1204
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 2",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1455,
+      "type": "PreviewAny",
+      "pos": [19990.548712308948, 11960.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 525,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1205
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 3",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1456,
+      "type": "PreviewAny",
+      "pos": [20490.543219144885, 11960.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 527,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1206
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 4",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1457,
+      "type": "PreviewAny",
+      "pos": [20990.541388090198, 11960.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 529,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1207
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 5",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1458,
+      "type": "PreviewAny",
+      "pos": [18990.542913969104, 12200.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 522,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1208
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 6",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1459,
+      "type": "PreviewAny",
+      "pos": [19490.545050199573, 12200.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 524,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1209
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 7",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1460,
+      "type": "PreviewAny",
+      "pos": [19990.548712308948, 12200.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 526,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1210
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 8",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1461,
+      "type": "PreviewAny",
+      "pos": [20490.543219144885, 12200.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 528,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1211
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 9",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1462,
+      "type": "PreviewAny",
+      "pos": [20990.541388090198, 12200.067718822895],
+      "size": [240, 180],
+      "flags": {},
+      "order": 530,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1212
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 10",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1463,
+      "type": "PreviewAny",
+      "pos": [18990.542913969104, 12440.073211986957],
+      "size": [240, 180],
+      "flags": {},
+      "order": 516,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1213
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 11",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1464,
+      "type": "PreviewAny",
+      "pos": [19490.545050199573, 12440.073211986957],
+      "size": [240, 180],
+      "flags": {},
+      "order": 517,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1214
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 12",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1465,
+      "type": "PreviewAny",
+      "pos": [19990.548712308948, 12440.073211986957],
+      "size": [240, 180],
+      "flags": {},
+      "order": 518,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1215
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 13",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1466,
+      "type": "PreviewAny",
+      "pos": [20490.543219144885, 12440.073211986957],
+      "size": [240, 180],
+      "flags": {},
+      "order": 519,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1216
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 14",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1467,
+      "type": "PreviewAny",
+      "pos": [20990.541388090198, 12440.073211986957],
+      "size": [240, 180],
+      "flags": {},
+      "order": 520,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1217
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 15",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 1468,
+      "type": "9357f4a3-ff0c-448b-b2aa-7d30595f0eb0",
+      "pos": [24582.691656644885, 6921.576202709613],
+      "size": [400, 470],
+      "flags": {},
+      "order": 434,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1218
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1219
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1220
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1188]
+        }
+      ],
+      "title": "Subgraph Edit A",
+      "properties": {
+        "proxyWidgets": [
+          ["1101", "prompt"],
+          ["1106", "lora_name"],
+          ["1106", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 1469,
+      "type": "e842b445-b504-4302-abd8-a0b26e24f68e",
+      "pos": [25075.848394926135, 6917.403381664692],
+      "size": [400, 470],
+      "flags": {},
+      "order": 435,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1221
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1222
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1223
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1189]
+        }
+      ],
+      "title": "Subgraph Edit B",
+      "properties": {
+        "proxyWidgets": [
+          ["1117", "prompt"],
+          ["1122", "lora_name"],
+          ["1122", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 1470,
+      "type": "CLIPTextEncode",
+      "pos": [22471.508184965198, 7594.26571686977],
+      "size": [400, 200],
+      "flags": {},
+      "order": 39,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1471,
+      "type": "CLIPTextEncode",
+      "pos": [21058.17383437926, 5969.448746044574],
+      "size": [400, 200],
+      "flags": {},
+      "order": 40,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 1472,
+      "type": "CLIPTextEncode",
+      "pos": [21049.848028715198, 6261.112793285785],
+      "size": [260.40625, 407.109375],
+      "flags": {},
+      "order": 41,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1473,
+      "type": "CLIPTextEncode",
+      "pos": [21058.17383437926, 6561.112793285785],
+      "size": [400, 200],
+      "flags": {},
+      "order": 42,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 1474,
+      "type": "CLIPTextEncode",
+      "pos": [20991.472784574573, 6886.175354320942],
+      "size": [400, 200],
+      "flags": {},
+      "order": 43,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1475,
+      "type": "CLIPTextEncode",
+      "pos": [22492.322393949573, 7929.344147045551],
+      "size": [400, 200],
+      "flags": {},
+      "order": 44,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 1476,
+      "type": "CLIPTextEncode",
+      "pos": [23381.439825590198, 6753.607910473285],
+      "size": [341.8125, 653.40625],
+      "flags": {},
+      "order": 45,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1477,
+      "type": "CLIPTextEncode",
+      "pos": [22915.12695937926, 6822.763641674457],
+      "size": [435.71875, 630.359375],
+      "flags": {},
+      "order": 46,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1478,
+      "type": "CLIPTextEncode",
+      "pos": [22950.64453750426, 7812.674225170551],
+      "size": [400, 200],
+      "flags": {},
+      "order": 47,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1479,
+      "type": "CLIPTextEncode",
+      "pos": [22941.05469375426, 7591.585357983051],
+      "size": [400, 200],
+      "flags": {},
+      "order": 48,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 1480,
+      "type": "CLIPTextEncode",
+      "pos": [22983.982550199573, 8071.00888093227],
+      "size": [400, 200],
+      "flags": {},
+      "order": 49,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1481,
+      "type": "CLIPTextEncode",
+      "pos": [22966.041266019885, 8303.955963451801],
+      "size": [400, 200],
+      "flags": {},
+      "order": 50,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 1482,
+      "type": "CLIPTextEncode",
+      "pos": [23364.381109769885, 5959.973648388324],
+      "size": [354.546875, 726.03125],
+      "flags": {},
+      "order": 51,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1483,
+      "type": "CLIPTextEncode",
+      "pos": [23467.31445937926, 7871.008270580707],
+      "size": [400, 200],
+      "flags": {},
+      "order": 52,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1484,
+      "type": "CLIPTextEncode",
+      "pos": [22087.08008437926, 6818.009308178363],
+      "size": [366.640625, 378.671875],
+      "flags": {},
+      "order": 53,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1485,
+      "type": "CLIPTextEncode",
+      "pos": [23463.50586562926, 8126.757782299457],
+      "size": [400, 200],
+      "flags": {},
+      "order": 54,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1486,
+      "type": "CLIPTextEncode",
+      "pos": [22061.072393949573, 6231.048401195942],
+      "size": [385.15625, 472.625],
+      "flags": {},
+      "order": 55,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1487,
+      "type": "CLIPTextEncode",
+      "pos": [21516.505743558948, 6444.446838695942],
+      "size": [400, 200],
+      "flags": {},
+      "order": 56,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1488,
+      "type": "CLIPTextEncode",
+      "pos": [21524.832159574573, 6252.781189281879],
+      "size": [400, 200],
+      "flags": {},
+      "order": 57,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 1489,
+      "type": "CLIPTextEncode",
+      "pos": [21549.838263090198, 6702.780273754535],
+      "size": [400, 200],
+      "flags": {},
+      "order": 58,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1490,
+      "type": "CLIPTextEncode",
+      "pos": [21544.308477933948, 6969.443329174457],
+      "size": [400, 200],
+      "flags": {},
+      "order": 59,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 1491,
+      "type": "CLIPTextEncode",
+      "pos": [22538.267828519885, 5975.034149486957],
+      "size": [361.1875, 549.390625],
+      "flags": {},
+      "order": 60,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1492,
+      "type": "CLIPTextEncode",
+      "pos": [22512.115484769885, 6571.221130688129],
+      "size": [400, 200],
+      "flags": {},
+      "order": 61,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1493,
+      "type": "CLIPTextEncode",
+      "pos": [22955.642706449573, 5968.702591259418],
+      "size": [351.953125, 646.796875],
+      "flags": {},
+      "order": 62,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1494,
+      "type": "CLIPTextEncode",
+      "pos": [22062.507940824573, 5976.171387035785],
+      "size": [400, 200],
+      "flags": {},
+      "order": 63,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1495,
+      "type": "CLIPTextEncode",
+      "pos": [21072.465216215198, 7282.929199535785],
+      "size": [400, 200],
+      "flags": {},
+      "order": 64,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 1496,
+      "type": "CLIPTextEncode",
+      "pos": [21064.125372465198, 7574.59530671352],
+      "size": [400, 200],
+      "flags": {},
+      "order": 65,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1497,
+      "type": "CLIPTextEncode",
+      "pos": [21072.465216215198, 7874.594391186176],
+      "size": [400, 200],
+      "flags": {},
+      "order": 66,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 1498,
+      "type": "CLIPTextEncode",
+      "pos": [21055.797125394885, 8207.925690014301],
+      "size": [400, 200],
+      "flags": {},
+      "order": 67,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1499,
+      "type": "CLIPTextEncode",
+      "pos": [21530.795294340198, 7299.596222240863],
+      "size": [400, 200],
+      "flags": {},
+      "order": 68,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1500,
+      "type": "CLIPTextEncode",
+      "pos": [21530.795294340198, 7757.927215893207],
+      "size": [400, 200],
+      "flags": {},
+      "order": 69,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1501,
+      "type": "CLIPTextEncode",
+      "pos": [21539.13086562926, 7566.261871654926],
+      "size": [400, 200],
+      "flags": {},
+      "order": 70,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 1502,
+      "type": "CLIPTextEncode",
+      "pos": [21564.125372465198, 8016.259430248676],
+      "size": [400, 200],
+      "flags": {},
+      "order": 71,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1503,
+      "type": "CLIPTextEncode",
+      "pos": [21558.590094144885, 8282.926910717426],
+      "size": [400, 200],
+      "flags": {},
+      "order": 72,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 1504,
+      "type": "CLIPTextEncode",
+      "pos": [21989.127203519885, 7282.929199535785],
+      "size": [400, 200],
+      "flags": {},
+      "order": 73,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1505,
+      "type": "CLIPTextEncode",
+      "pos": [22059.871222074573, 7849.980133373676],
+      "size": [400, 200],
+      "flags": {},
+      "order": 74,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1506,
+      "type": "CLIPTextEncode",
+      "pos": [22016.915899808948, 7573.541534740863],
+      "size": [400, 200],
+      "flags": {},
+      "order": 75,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 1507,
+      "type": "CLIPTextEncode",
+      "pos": [22056.056524808948, 8105.73056061977],
+      "size": [400, 200],
+      "flags": {},
+      "order": 76,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 1508,
+      "type": "CLIPTextEncode",
+      "pos": [22479.90235000426, 7303.958557445942],
+      "size": [400, 200],
+      "flags": {},
+      "order": 77,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 1541,
+      "type": "CheckpointLoaderSimple",
+      "pos": [24283.97461562926, 9318.76766999477],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 78,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1224]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 1542,
+      "type": "CheckpointLoaderSimple",
+      "pos": [24283.97461562926, 9538.766754467426],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 79,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1225]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 1543,
+      "type": "CheckpointLoaderSimple",
+      "pos": [24288.748785551135, 9793.104523022113],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 80,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1226]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 1544,
+      "type": "CheckpointLoaderSimple",
+      "pos": [24288.748785551135, 10009.774444897113],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 81,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 1545,
+      "type": "CLIPLoader",
+      "pos": [21902.765509183948, 10723.66024811977],
+      "size": [360, 140],
+      "flags": {},
+      "order": 82,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 1546,
+      "type": "CLIPLoader",
+      "pos": [21902.765509183948, 10943.659027416645],
+      "size": [360, 140],
+      "flags": {},
+      "order": 83,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 1547,
+      "type": "CLIPLoader",
+      "pos": [21902.765509183948, 11163.658417065082],
+      "size": [360, 140],
+      "flags": {},
+      "order": 84,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 1548,
+      "type": "VAELoader",
+      "pos": [22332.76367812926, 10723.66024811977],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 85,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 1549,
+      "type": "VAELoader",
+      "pos": [22332.76367812926, 10943.659027416645],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 86,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 1550,
+      "type": "VAELoader",
+      "pos": [22332.76367812926, 11163.658417065082],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 87,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 1551,
+      "type": "UNETLoader",
+      "pos": [22762.76367812926, 10723.66024811977],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 88,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 1552,
+      "type": "UNETLoader",
+      "pos": [22762.76367812926, 10943.659027416645],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 89,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 1553,
+      "type": "LoraLoaderModelOnly",
+      "pos": [22762.76367812926, 11243.658417065082],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 449,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1224
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 1554,
+      "type": "LoraLoaderModelOnly",
+      "pos": [22762.76367812926, 11413.658417065082],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 450,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1225
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 1555,
+      "type": "LoraLoaderModelOnly",
+      "pos": [22762.76367812926, 11583.657196361957],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 451,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1226
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 1570,
+      "type": "UNETLoader",
+      "pos": [18412.35565810973, 11000.59384186977],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 90,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 3",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 1571,
+      "type": "UNETLoader",
+      "pos": [18412.35565810973, 11175.599945385395],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 91,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 4",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 1572,
+      "type": "CLIPLoader",
+      "pos": [17514.90448623473, 10586.168182690082],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 92,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader 4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 1573,
+      "type": "VAELoader",
+      "pos": [17944.908148344104, 10586.168182690082],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 93,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader 4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 1574,
+      "type": "UNETLoader",
+      "pos": [22762.76367812926, 11723.657196361957],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 94,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader B1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_t2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 1575,
+      "type": "CLIPLoader",
+      "pos": [21908.113409574573, 11407.153290111957],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 95,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader B4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 1576,
+      "type": "VAELoader",
+      "pos": [22332.76367812926, 10733.658417065082],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 96,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader B4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 1577,
+      "type": "9357f4a3-ff0c-448b-b2aa-7d30595f0eb0",
+      "pos": [25547.584234769885, 6917.781799633442],
+      "size": [400, 470],
+      "flags": {},
+      "order": 97,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit C",
+      "properties": {
+        "proxyWidgets": [
+          ["1101", "prompt"],
+          ["1106", "lora_name"],
+          ["1106", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 1578,
+      "type": "e842b445-b504-4302-abd8-a0b26e24f68e",
+      "pos": [26027.50000625426, 6924.614227611957],
+      "size": [400, 470],
+      "flags": {},
+      "order": 98,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit D",
+      "properties": {
+        "proxyWidgets": [
+          ["1117", "prompt"],
+          ["1122", "lora_name"],
+          ["1122", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 1579,
+      "type": "VHS_VideoCombine",
+      "pos": [29624.886480863635, 5740.078628857074],
+      "size": [580, 334],
+      "flags": {},
+      "order": 99,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 1582,
+      "type": "Reroute",
+      "pos": [19611.449591215198, 5666.858414013324],
+      "size": [75, 26],
+      "flags": {},
+      "order": 433,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 1238
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VIDEO",
+          "links": [1239]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 1583,
+      "type": "SaveVideo",
+      "pos": [28337.457281644885, 6747.744110424457],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 513,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1239
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 1584,
+      "type": "SaveVideo",
+      "pos": [28382.24854141051, 7361.813476879535],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 452,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1242
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 1586,
+      "type": "Reroute",
+      "pos": [17937.298895414417, 4651.219700176654],
+      "size": [75, 26],
+      "flags": {},
+      "order": 100,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 1587,
+      "type": "Reroute",
+      "pos": [21974.812628324573, 5445.501945812641],
+      "size": [75, 26],
+      "flags": {},
+      "order": 101,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "*",
+          "links": [1242]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 1588,
+      "type": "LoadVideo",
+      "pos": [13988.28613906676, 6747.875488598285],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 102,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 1589,
+      "type": "LoadVideo",
+      "pos": [14964.51271682555, 7887.428863842426],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 103,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 1590,
+      "type": "LoadVideo",
+      "pos": [13986.867195661609, 7863.95565827602],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 104,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 1591,
+      "type": "LoadVideo",
+      "pos": [14935.46387344176, 6793.989227611957],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 105,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 1592,
+      "type": "LoadVideo",
+      "pos": [14619.988333280628, 7199.988220531879],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 106,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 1593,
+      "type": "LoadVideo",
+      "pos": [15590.684668119495, 6109.031723339496],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 107,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 1594,
+      "type": "LoadVideo",
+      "pos": [15610.684668119495, 7189.029358227192],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 108,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2247,
+      "type": "LoadImage",
+      "pos": [33995.594762435954, 8906.594319274225],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 109,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2248,
+      "type": "LoadImage",
+      "pos": [33995.35662168345, 9301.920376987871],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 110,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2249,
+      "type": "VHS_VideoCombine",
+      "pos": [46440.27085753083, 8290.537911524301],
+      "size": [580, 334],
+      "flags": {},
+      "order": 111,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2250,
+      "type": "VHS_VideoCombine",
+      "pos": [47052.69950153473, 8493.951918218796],
+      "size": [580, 334],
+      "flags": {},
+      "order": 112,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 26,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2251,
+      "type": "LoadVideo",
+      "pos": [33693.53237268419, 8817.77406331374],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 113,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2252,
+      "type": "VHS_VideoCombine",
+      "pos": [46473.04420204827, 8954.559167148758],
+      "size": [580, 334],
+      "flags": {},
+      "order": 532,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1370
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2253,
+      "type": "VHS_VideoCombine",
+      "pos": [47702.82479126545, 8234.68141561502],
+      "size": [580, 334],
+      "flags": {},
+      "order": 533,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1371
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "8a64f64a68b43f231063193799857eca229c7a2e48a16d2ed0a8b581fd8632f6.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00005.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2254,
+      "type": "LoadImage",
+      "pos": [34320.80184484468, 9293.82272587758],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 114,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2255,
+      "type": "LoadImage",
+      "pos": [34595.102458675996, 8919.742762640099],
+      "size": [282.78125, 340],
+      "flags": {},
+      "order": 115,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2256,
+      "type": "LoadImage",
+      "pos": [33006.067648355405, 8928.963469037599],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 116,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2257,
+      "type": "LoadImage",
+      "pos": [33005.81760056528, 9324.290489344641],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 117,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2258,
+      "type": "LoadVideo",
+      "pos": [33319.266742167754, 8614.306313169529],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 118,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2259,
+      "type": "LoadVideo",
+      "pos": [32704.003705511772, 8840.143180721032],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 119,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2260,
+      "type": "LoadImage",
+      "pos": [33331.2628237265, 9316.191859462913],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 120,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2261,
+      "type": "LoadImage",
+      "pos": [33328.759239641484, 8945.601159768863],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 121,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2262,
+      "type": "LoadImage",
+      "pos": [33002.47793536005, 10019.706259382952],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 122,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1404]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2263,
+      "type": "LoadImage",
+      "pos": [33002.235653029245, 10415.035245321886],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 123,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1405]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2264,
+      "type": "LoadVideo",
+      "pos": [32700.419687186586, 9930.889918508208],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 124,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2265,
+      "type": "LoadImage",
+      "pos": [33327.685017768774, 10406.936647796238],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 125,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2266,
+      "type": "LoadImage",
+      "pos": [33325.17729210545, 10036.341038066972],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 126,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2267,
+      "type": "LoadImage",
+      "pos": [33977.442483576335, 10020.572496370187],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 127,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2268,
+      "type": "LoadImage",
+      "pos": [33977.19631851586, 10415.899540944289],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 128,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2269,
+      "type": "LoadVideo",
+      "pos": [33675.368445635584, 9931.75026668879],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 129,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [1409]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2270,
+      "type": "LoadImage",
+      "pos": [34302.64154167709, 10407.800878706481],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 130,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2271,
+      "type": "LoadImage",
+      "pos": [34300.13769874343, 10037.211157783866],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 131,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2272,
+      "type": "LoadImage",
+      "pos": [32129.58957336956, 9855.380177520838],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 132,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1401]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 2273,
+      "type": "LoadImage",
+      "pos": [32146.21076249977, 8743.709603730289],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 133,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1400]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 2274,
+      "type": "LoadImage",
+      "pos": [34657.95013289962, 8711.013331396605],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 134,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1402]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 2275,
+      "type": "LoadImage",
+      "pos": [34640.6492072302, 9841.72293478905],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 135,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1403]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 2276,
+      "type": "CheckpointLoaderSimple",
+      "pos": [36370.73465583463, 9443.898850147209],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 136,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1372, 1375]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 2277,
+      "type": "CheckpointLoaderSimple",
+      "pos": [36370.73465583463, 9663.899740437559],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 137,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1373, 1376]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 2278,
+      "type": "CheckpointLoaderSimple",
+      "pos": [36370.73465583463, 9883.897726769685],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 138,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1374, 1377]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 2279,
+      "type": "CheckpointLoaderSimple",
+      "pos": [36370.73465583463, 10103.898657505135],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 139,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1378]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 2280,
+      "type": "CLIPLoader",
+      "pos": [36800.734540988204, 9443.898850147209],
+      "size": [360, 140],
+      "flags": {},
+      "order": 140,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1379]
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2281,
+      "type": "CLIPLoader",
+      "pos": [36800.734540988204, 9663.899740437559],
+      "size": [360, 140],
+      "flags": {},
+      "order": 141,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1380]
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2282,
+      "type": "CLIPLoader",
+      "pos": [36800.734540988204, 9883.897726769685],
+      "size": [360, 140],
+      "flags": {},
+      "order": 142,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1381]
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2283,
+      "type": "VAELoader",
+      "pos": [37230.734426141775, 9443.898850147209],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 143,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1382]
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 2284,
+      "type": "VAELoader",
+      "pos": [37230.734426141775, 9663.899740437559],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 144,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1383]
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2285,
+      "type": "VAELoader",
+      "pos": [37230.734426141775, 9883.897726769685],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 145,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1384]
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 2286,
+      "type": "UNETLoader",
+      "pos": [37660.734278939264, 9443.898850147209],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 146,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2287,
+      "type": "UNETLoader",
+      "pos": [37660.734278939264, 9663.899740437559],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 147,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 2288,
+      "type": "LoraLoaderModelOnly",
+      "pos": [37131.63681126279, 13013.24235813707],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 456,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1372
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 2289,
+      "type": "LoraLoaderModelOnly",
+      "pos": [37131.63681126279, 13183.238357766175],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 458,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1373
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 2290,
+      "type": "LoraLoaderModelOnly",
+      "pos": [37131.63681126279, 13353.242381703247],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 460,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1374
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 2291,
+      "type": "ImpactSwitch",
+      "pos": [39984.23364136216, 11766.561282102786],
+      "size": [280, 212],
+      "flags": {},
+      "order": 457,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1375
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1395]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 1",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2292,
+      "type": "ImpactSwitch",
+      "pos": [40504.22173991414, 11766.561282102786],
+      "size": [280, 212],
+      "flags": {},
+      "order": 459,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1376
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1396]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 2",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2293,
+      "type": "ImpactSwitch",
+      "pos": [41024.22536938476, 11766.561282102786],
+      "size": [280, 212],
+      "flags": {},
+      "order": 461,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1377
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1397]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 3",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2294,
+      "type": "ImpactSwitch",
+      "pos": [41544.23314043369, 11766.561282102786],
+      "size": [280, 212],
+      "flags": {},
+      "order": 462,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1378
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1398]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 4",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2295,
+      "type": "ImpactSwitch",
+      "pos": [42064.22900444499, 11766.561282102786],
+      "size": [280, 212],
+      "flags": {},
+      "order": 463,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1379
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1399]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 5",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2296,
+      "type": "ImpactSwitch",
+      "pos": [39984.23364136216, 12236.563895552805],
+      "size": [280, 212],
+      "flags": {},
+      "order": 464,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1380
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1385, 1390]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 6",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2297,
+      "type": "ImpactSwitch",
+      "pos": [40504.22173991414, 12236.563895552805],
+      "size": [280, 212],
+      "flags": {},
+      "order": 465,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1381
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1386, 1391]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 7",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2298,
+      "type": "ImpactSwitch",
+      "pos": [41024.22536938476, 12236.563895552805],
+      "size": [280, 212],
+      "flags": {},
+      "order": 466,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1382
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1387, 1392]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 8",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2299,
+      "type": "ImpactSwitch",
+      "pos": [41547.182203035074, 12222.931114017876],
+      "size": [280, 212],
+      "flags": {},
+      "order": 467,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1383
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1388, 1393]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 9",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2300,
+      "type": "ImpactSwitch",
+      "pos": [42023.93998954825, 12227.482967423077],
+      "size": [280, 212],
+      "flags": {},
+      "order": 468,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "*",
+          "link": 1384
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "selected_value",
+          "type": "*",
+          "links": [1389, 1394]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 10",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2301,
+      "type": "PreviewAny",
+      "pos": [37709.812390342144, 14454.373900596187],
+      "size": [240, 180],
+      "flags": {},
+      "order": 539,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1385
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 1",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2302,
+      "type": "PreviewAny",
+      "pos": [38209.81224109203, 14454.373900596187],
+      "size": [240, 180],
+      "flags": {},
+      "order": 541,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1386
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 2",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2303,
+      "type": "PreviewAny",
+      "pos": [38709.81596243805, 14454.373900596187],
+      "size": [240, 180],
+      "flags": {},
+      "order": 543,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1387
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 3",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2304,
+      "type": "PreviewAny",
+      "pos": [39209.811950680836, 14454.373900596187],
+      "size": [240, 180],
+      "flags": {},
+      "order": 545,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1388
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 4",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2305,
+      "type": "PreviewAny",
+      "pos": [39709.80787421145, 14454.373900596187],
+      "size": [240, 180],
+      "flags": {},
+      "order": 547,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1389
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 5",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2306,
+      "type": "PreviewAny",
+      "pos": [37709.812390342144, 14694.372668667089],
+      "size": [240, 180],
+      "flags": {},
+      "order": 540,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1390
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 6",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2307,
+      "type": "PreviewAny",
+      "pos": [38209.81224109203, 14694.372668667089],
+      "size": [240, 180],
+      "flags": {},
+      "order": 542,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1391
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 7",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2308,
+      "type": "PreviewAny",
+      "pos": [38709.81596243805, 14694.372668667089],
+      "size": [240, 180],
+      "flags": {},
+      "order": 544,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1392
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 8",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2309,
+      "type": "PreviewAny",
+      "pos": [39209.811950680836, 14694.372668667089],
+      "size": [240, 180],
+      "flags": {},
+      "order": 546,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1393
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 9",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2310,
+      "type": "PreviewAny",
+      "pos": [39709.80787421145, 14694.372668667089],
+      "size": [240, 180],
+      "flags": {},
+      "order": 548,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1394
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 10",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2311,
+      "type": "PreviewAny",
+      "pos": [37709.812390342144, 14934.377649105445],
+      "size": [240, 180],
+      "flags": {},
+      "order": 534,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1395
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 11",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2312,
+      "type": "PreviewAny",
+      "pos": [38209.81224109203, 14934.377649105445],
+      "size": [240, 180],
+      "flags": {},
+      "order": 535,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1396
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 12",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2313,
+      "type": "PreviewAny",
+      "pos": [38709.81596243805, 14934.377649105445],
+      "size": [240, 180],
+      "flags": {},
+      "order": 536,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1397
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 13",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2314,
+      "type": "PreviewAny",
+      "pos": [39209.811950680836, 14934.377649105445],
+      "size": [240, 180],
+      "flags": {},
+      "order": 537,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1398
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 14",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2315,
+      "type": "PreviewAny",
+      "pos": [39709.80787421145, 14934.377649105445],
+      "size": [240, 180],
+      "flags": {},
+      "order": 538,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1399
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 15",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2316,
+      "type": "3f323234-d98d-4a21-9623-ff5f7e7db5ad",
+      "pos": [43301.95107006088, 9415.890067908196],
+      "size": [400, 470],
+      "flags": {},
+      "order": 454,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1400
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1401
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1402
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1370]
+        }
+      ],
+      "title": "Subgraph Edit A",
+      "properties": {
+        "proxyWidgets": [
+          ["1604", "prompt"],
+          ["1609", "lora_name"],
+          ["1609", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2317,
+      "type": "c73951c4-0095-48c1-8337-c4ff4001b55d",
+      "pos": [43795.1074358704, 9411.717217451971],
+      "size": [400, 470],
+      "flags": {},
+      "order": 455,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1403
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1404
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1405
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1371]
+        }
+      ],
+      "title": "Subgraph Edit B",
+      "properties": {
+        "proxyWidgets": [
+          ["1620", "prompt"],
+          ["1625", "lora_name"],
+          ["1625", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2318,
+      "type": "CLIPTextEncode",
+      "pos": [41190.77221083222, 10088.57831223548],
+      "size": [400, 200],
+      "flags": {},
+      "order": 148,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2319,
+      "type": "CLIPTextEncode",
+      "pos": [39777.440624468545, 8463.76537762543],
+      "size": [400, 200],
+      "flags": {},
+      "order": 149,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2320,
+      "type": "CLIPTextEncode",
+      "pos": [39769.11644034963, 8755.428393679125],
+      "size": [260.40625, 407.109375],
+      "flags": {},
+      "order": 150,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2321,
+      "type": "CLIPTextEncode",
+      "pos": [39777.440624468545, 9055.428277435292],
+      "size": [400, 200],
+      "flags": {},
+      "order": 151,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2322,
+      "type": "CLIPTextEncode",
+      "pos": [39710.74141184613, 9380.489688725082],
+      "size": [400, 200],
+      "flags": {},
+      "order": 152,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2323,
+      "type": "CLIPTextEncode",
+      "pos": [41211.5846772065, 10423.657299517914],
+      "size": [400, 200],
+      "flags": {},
+      "order": 153,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2324,
+      "type": "CLIPTextEncode",
+      "pos": [42100.701813782856, 9247.923328401972],
+      "size": [341.8125, 653.40625],
+      "flags": {},
+      "order": 154,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2325,
+      "type": "CLIPTextEncode",
+      "pos": [41634.389346602075, 9317.078577849104],
+      "size": [435.71875, 630.359375],
+      "flags": {},
+      "order": 155,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2326,
+      "type": "CLIPTextEncode",
+      "pos": [41669.90881638399, 10306.988391560826],
+      "size": [400, 200],
+      "flags": {},
+      "order": 156,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2327,
+      "type": "CLIPTextEncode",
+      "pos": [41660.31899182011, 10085.899617042774],
+      "size": [400, 200],
+      "flags": {},
+      "order": 157,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2328,
+      "type": "CLIPTextEncode",
+      "pos": [41703.2446390049, 10565.32134437594],
+      "size": [400, 200],
+      "flags": {},
+      "order": 158,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2329,
+      "type": "CLIPTextEncode",
+      "pos": [41685.303321790154, 10798.267522291704],
+      "size": [400, 200],
+      "flags": {},
+      "order": 159,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2330,
+      "type": "CLIPTextEncode",
+      "pos": [42083.643170444244, 8454.28879934331],
+      "size": [354.546875, 726.03125],
+      "flags": {},
+      "order": 160,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2331,
+      "type": "CLIPTextEncode",
+      "pos": [42186.5764045304, 10365.321421871828],
+      "size": [400, 200],
+      "flags": {},
+      "order": 161,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2332,
+      "type": "CLIPTextEncode",
+      "pos": [40806.342629459454, 9312.324672854693],
+      "size": [366.640625, 378.671875],
+      "flags": {},
+      "order": 162,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2333,
+      "type": "CLIPTextEncode",
+      "pos": [42182.76822327949, 10621.070353385789],
+      "size": [400, 200],
+      "flags": {},
+      "order": 163,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2334,
+      "type": "CLIPTextEncode",
+      "pos": [40780.334811950925, 8725.363900221417],
+      "size": [385.15625, 472.625],
+      "flags": {},
+      "order": 164,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2335,
+      "type": "CLIPTextEncode",
+      "pos": [40235.76851695137, 8938.76228152545],
+      "size": [400, 200],
+      "flags": {},
+      "order": 165,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2336,
+      "type": "CLIPTextEncode",
+      "pos": [40244.10059595393, 8747.097285358981],
+      "size": [400, 200],
+      "flags": {},
+      "order": 166,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2337,
+      "type": "CLIPTextEncode",
+      "pos": [40269.10071569127, 9197.094247480109],
+      "size": [400, 200],
+      "flags": {},
+      "order": 167,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2338,
+      "type": "CLIPTextEncode",
+      "pos": [40263.57714447639, 9463.75724086471],
+      "size": [400, 200],
+      "flags": {},
+      "order": 168,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2339,
+      "type": "CLIPTextEncode",
+      "pos": [41257.530052672504, 8469.3503606811],
+      "size": [361.1875, 549.390625],
+      "flags": {},
+      "order": 169,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2340,
+      "type": "CLIPTextEncode",
+      "pos": [41231.37753877196, 9065.535702218986],
+      "size": [400, 200],
+      "flags": {},
+      "order": 170,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2341,
+      "type": "CLIPTextEncode",
+      "pos": [41674.90485406233, 8463.019311121185],
+      "size": [351.953125, 646.796875],
+      "flags": {},
+      "order": 171,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2342,
+      "type": "CLIPTextEncode",
+      "pos": [40781.77245731985, 8470.488000471594],
+      "size": [400, 200],
+      "flags": {},
+      "order": 172,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2343,
+      "type": "CLIPTextEncode",
+      "pos": [39791.73359947006, 9777.24247567499],
+      "size": [400, 200],
+      "flags": {},
+      "order": 173,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2344,
+      "type": "CLIPTextEncode",
+      "pos": [39783.39375500818, 10068.908403775931],
+      "size": [400, 200],
+      "flags": {},
+      "order": 174,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2345,
+      "type": "CLIPTextEncode",
+      "pos": [39791.73359947006, 10368.907316849683],
+      "size": [400, 200],
+      "flags": {},
+      "order": 175,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2346,
+      "type": "CLIPTextEncode",
+      "pos": [39775.0656881596, 10702.238299239008],
+      "size": [400, 200],
+      "flags": {},
+      "order": 176,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2347,
+      "type": "CLIPTextEncode",
+      "pos": [40250.06162137721, 9793.909481015193],
+      "size": [400, 200],
+      "flags": {},
+      "order": 177,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2348,
+      "type": "CLIPTextEncode",
+      "pos": [40250.06162137721, 10252.240414969587],
+      "size": [400, 200],
+      "flags": {},
+      "order": 178,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2349,
+      "type": "CLIPTextEncode",
+      "pos": [40258.39758310943, 10060.575418803119],
+      "size": [400, 200],
+      "flags": {},
+      "order": 179,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2350,
+      "type": "CLIPTextEncode",
+      "pos": [40283.3896785388, 10510.572397102285],
+      "size": [400, 200],
+      "flags": {},
+      "order": 180,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2351,
+      "type": "CLIPTextEncode",
+      "pos": [40277.85445913494, 10777.239176148305],
+      "size": [400, 200],
+      "flags": {},
+      "order": 181,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2352,
+      "type": "CLIPTextEncode",
+      "pos": [40708.39352601402, 9777.24247567499],
+      "size": [400, 200],
+      "flags": {},
+      "order": 182,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2353,
+      "type": "CLIPTextEncode",
+      "pos": [40779.135566183155, 10344.29307572843],
+      "size": [400, 200],
+      "flags": {},
+      "order": 183,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2354,
+      "type": "CLIPTextEncode",
+      "pos": [40736.178598312435, 10067.855666340676],
+      "size": [400, 200],
+      "flags": {},
+      "order": 184,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2355,
+      "type": "CLIPTextEncode",
+      "pos": [40775.31910177563, 10600.043042636968],
+      "size": [400, 200],
+      "flags": {},
+      "order": 185,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2356,
+      "type": "CLIPTextEncode",
+      "pos": [41199.166672357984, 9798.272763183219],
+      "size": [400, 200],
+      "flags": {},
+      "order": 186,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2357,
+      "type": "CheckpointLoaderSimple",
+      "pos": [43003.232487092646, 11813.076901131577],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 187,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1406]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 2358,
+      "type": "CheckpointLoaderSimple",
+      "pos": [43003.232487092646, 12033.076764116371],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 188,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1407]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 2359,
+      "type": "CheckpointLoaderSimple",
+      "pos": [43008.006173785776, 12287.41367627717],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 189,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1408]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 2360,
+      "type": "CheckpointLoaderSimple",
+      "pos": [43008.006173785776, 12504.083451456567],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 190,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 2361,
+      "type": "CLIPLoader",
+      "pos": [40622.03022902655, 13217.9688568811],
+      "size": [360, 140],
+      "flags": {},
+      "order": 191,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2362,
+      "type": "CLIPLoader",
+      "pos": [40622.03022902655, 13437.966907925385],
+      "size": [360, 140],
+      "flags": {},
+      "order": 192,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2363,
+      "type": "CLIPLoader",
+      "pos": [40622.03022902655, 13657.965735515605],
+      "size": [360, 140],
+      "flags": {},
+      "order": 193,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2364,
+      "type": "VAELoader",
+      "pos": [41052.02623145046, 13217.9688568811],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 194,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 2365,
+      "type": "VAELoader",
+      "pos": [41052.02623145046, 13437.966907925385],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 195,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2366,
+      "type": "VAELoader",
+      "pos": [41052.02623145046, 13657.965735515605],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 196,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 2367,
+      "type": "UNETLoader",
+      "pos": [41482.02611660403, 13217.9688568811],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 197,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2368,
+      "type": "UNETLoader",
+      "pos": [41482.02611660403, 13437.966907925385],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 198,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 2369,
+      "type": "LoraLoaderModelOnly",
+      "pos": [41482.02611660403, 13737.964720892402],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 469,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1406
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 2370,
+      "type": "LoraLoaderModelOnly",
+      "pos": [41482.02611660403, 13907.965638645743],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 470,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1407
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 2371,
+      "type": "LoraLoaderModelOnly",
+      "pos": [41482.02611660403, 14077.963967912645],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 471,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1408
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 2372,
+      "type": "UNETLoader",
+      "pos": [37131.62898109131, 13494.90247911945],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 199,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 3",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2373,
+      "type": "UNETLoader",
+      "pos": [37131.62898109131, 13669.907200010464],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 200,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 4",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2374,
+      "type": "CLIPLoader",
+      "pos": [36234.176206343545, 13080.476740331003],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 201,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader 4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 2375,
+      "type": "VAELoader",
+      "pos": [36664.17990951461, 13080.476740331003],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 202,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader 4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2376,
+      "type": "UNETLoader",
+      "pos": [41482.02611660403, 14217.963810126066],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 203,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader B1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_t2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2377,
+      "type": "CLIPLoader",
+      "pos": [40627.37778316349, 13901.45973682679],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 204,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader B4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 2378,
+      "type": "VAELoader",
+      "pos": [41052.02623145046, 13227.96688575661],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 205,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader B4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2379,
+      "type": "3f323234-d98d-4a21-9623-ff5f7e7db5ad",
+      "pos": [44266.84148790031, 9412.096123332703],
+      "size": [400, 470],
+      "flags": {},
+      "order": 206,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit C",
+      "properties": {
+        "proxyWidgets": [
+          ["1604", "prompt"],
+          ["1609", "lora_name"],
+          ["1609", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2380,
+      "type": "c73951c4-0095-48c1-8337-c4ff4001b55d",
+      "pos": [44746.75929865975, 9418.92815422058],
+      "size": [400, 470],
+      "flags": {},
+      "order": 207,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit D",
+      "properties": {
+        "proxyWidgets": [
+          ["1620", "prompt"],
+          ["1625", "lora_name"],
+          ["1625", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2381,
+      "type": "VHS_VideoCombine",
+      "pos": [48344.09849276504, 8234.384645644644],
+      "size": [580, 334],
+      "flags": {},
+      "order": 208,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2382,
+      "type": "Reroute",
+      "pos": [38330.71846899575, 8161.175130776332],
+      "size": [75, 26],
+      "flags": {},
+      "order": 453,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 1409
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VIDEO",
+          "links": [1410]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 2383,
+      "type": "SaveVideo",
+      "pos": [47056.71165551713, 9242.058093155025],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 531,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1410
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 2384,
+      "type": "SaveVideo",
+      "pos": [47101.50075409027, 9856.127247063578],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 472,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1411
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 2385,
+      "type": "Reroute",
+      "pos": [40694.07712521022, 7939.818771472517],
+      "size": [75, 26],
+      "flags": {},
+      "order": 209,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "*",
+          "links": [1411]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 2386,
+      "type": "LoadVideo",
+      "pos": [32707.568051340015, 9242.19090677647],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 210,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2387,
+      "type": "LoadVideo",
+      "pos": [33683.79034511762, 10381.741291469145],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 211,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2388,
+      "type": "LoadVideo",
+      "pos": [32706.148007678887, 10358.26870229237],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 212,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2389,
+      "type": "LoadVideo",
+      "pos": [33654.743385679576, 9288.304169855182],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 213,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2390,
+      "type": "LoadVideo",
+      "pos": [33339.26694149708, 9694.302096087882],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 214,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2391,
+      "type": "LoadVideo",
+      "pos": [34309.9620401788, 8603.348344097647],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 215,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2392,
+      "type": "LoadVideo",
+      "pos": [34329.96198065948, 9683.343123977504],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 216,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2393,
+      "type": "LoadImage",
+      "pos": [18174.340610082665, 14177.586916114662],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 217,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2394,
+      "type": "LoadImage",
+      "pos": [18174.10246933016, 14572.912860582026],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 218,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2395,
+      "type": "VHS_VideoCombine",
+      "pos": [30619.019811361268, 13561.530120091773],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 219,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2396,
+      "type": "VHS_VideoCombine",
+      "pos": [31231.449361335417, 13764.94425621059],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 220,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 26,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2397,
+      "type": "LoadVideo",
+      "pos": [17872.278220330896, 14088.766627798095],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 221,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2398,
+      "type": "VHS_VideoCombine",
+      "pos": [30651.793285303032, 14225.551440428391],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 550,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1412
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2399,
+      "type": "VHS_VideoCombine",
+      "pos": [31881.574003944523, 13505.673688894653],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 551,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1413
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "8a64f64a68b43f231063193799857eca229c7a2e48a16d2ed0a8b581fd8632f6.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00005.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2400,
+      "type": "LoadImage",
+      "pos": [18499.5471747941, 14564.815298450956],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 222,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2401,
+      "type": "LoadImage",
+      "pos": [18773.848047474065, 14190.735262412292],
+      "size": [282.78125, 340],
+      "flags": {},
+      "order": 223,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2402,
+      "type": "LoadImage",
+      "pos": [17184.813496002116, 14199.955968809794],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 224,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2403,
+      "type": "LoadImage",
+      "pos": [17184.563448211986, 14595.283078096058],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 225,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2404,
+      "type": "LoadVideo",
+      "pos": [17498.012589814465, 13885.29981598022],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 226,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2405,
+      "type": "LoadVideo",
+      "pos": [16882.749035461195, 14111.135680493227],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 227,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2406,
+      "type": "LoadImage",
+      "pos": [17510.008671373216, 14587.184351146088],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 228,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2407,
+      "type": "LoadImage",
+      "pos": [17507.504569590907, 14216.594630223473],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 229,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2408,
+      "type": "LoadImage",
+      "pos": [17181.22378300676, 15290.69885622339],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 230,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1446]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2409,
+      "type": "LoadImage",
+      "pos": [17180.981500675953, 15686.027777450161],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 231,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1447]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2410,
+      "type": "LoadVideo",
+      "pos": [16879.16501713601, 15201.882450636484],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 232,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2411,
+      "type": "LoadImage",
+      "pos": [17506.430347718197, 15677.929179924515],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 233,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2412,
+      "type": "LoadImage",
+      "pos": [17503.922622054874, 15307.333505483088],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 234,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2413,
+      "type": "LoadImage",
+      "pos": [18156.188072374396, 15291.5649637863],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 235,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2414,
+      "type": "LoadImage",
+      "pos": [18155.94216616257, 15686.892073072564],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 236,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2415,
+      "type": "LoadVideo",
+      "pos": [17854.11429328229, 15202.742863529227],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 237,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [1451]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2416,
+      "type": "LoadImage",
+      "pos": [18481.3873893238, 15678.793475546918],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 238,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2417,
+      "type": "LoadImage",
+      "pos": [18478.883287541492, 15308.203754624303],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 239,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2418,
+      "type": "LoadImage",
+      "pos": [16308.33542101627, 15126.372677293033],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 240,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1443]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 2419,
+      "type": "LoadImage",
+      "pos": [16324.95609244919, 14014.702135858564],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 241,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1442]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 2420,
+      "type": "LoadImage",
+      "pos": [18836.69598054633, 13982.005928237042],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 242,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1444]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 2421,
+      "type": "LoadImage",
+      "pos": [18819.395054876906, 15112.715563985566],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 243,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1445]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 2422,
+      "type": "CheckpointLoaderSimple",
+      "pos": [20549.48037405702, 14714.891341830384],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 244,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1414, 1417]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 2423,
+      "type": "CheckpointLoaderSimple",
+      "pos": [20549.48037405702, 14934.892240209754],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 245,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1415, 1418]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 2424,
+      "type": "CheckpointLoaderSimple",
+      "pos": [20549.48037405702, 15154.89029125404],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 246,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1416, 1419]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 2425,
+      "type": "CheckpointLoaderSimple",
+      "pos": [20549.48037405702, 15374.89118963341],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 247,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1420]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 2426,
+      "type": "CLIPLoader",
+      "pos": [20979.48025921059, 14714.891341830384],
+      "size": [360, 140],
+      "flags": {},
+      "order": 248,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1421]
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2427,
+      "type": "CLIPLoader",
+      "pos": [20979.48025921059, 14934.892240209754],
+      "size": [360, 140],
+      "flags": {},
+      "order": 249,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1422]
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2428,
+      "type": "CLIPLoader",
+      "pos": [20979.48025921059, 15154.89029125404],
+      "size": [360, 140],
+      "flags": {},
+      "order": 250,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1423]
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2429,
+      "type": "VAELoader",
+      "pos": [21409.480144364163, 14714.891341830384],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 251,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1424]
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 2430,
+      "type": "VAELoader",
+      "pos": [21409.480144364163, 14934.892240209754],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 252,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1425]
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2431,
+      "type": "VAELoader",
+      "pos": [21409.480144364163, 15154.89029125404],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 253,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1426]
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 2432,
+      "type": "UNETLoader",
+      "pos": [21839.48002951773, 14714.891341830384],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 254,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2433,
+      "type": "UNETLoader",
+      "pos": [21839.48002951773, 14934.892240209754],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 255,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 2434,
+      "type": "LoraLoaderModelOnly",
+      "pos": [21310.38252948518, 18284.234760841024],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 476,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1414
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 2435,
+      "type": "LoraLoaderModelOnly",
+      "pos": [21310.38252948518, 18454.231019318773],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 478,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1415
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 2436,
+      "type": "LoraLoaderModelOnly",
+      "pos": [21310.38252948518, 18624.235043255845],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 480,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1416
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 2437,
+      "type": "ImpactSwitch",
+      "pos": [24162.979197804143, 17037.55368480674],
+      "size": [280, 212],
+      "flags": {},
+      "order": 477,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1417
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1437]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 1",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2438,
+      "type": "ImpactSwitch",
+      "pos": [24682.967328712202, 17037.55368480674],
+      "size": [280, 212],
+      "flags": {},
+      "order": 479,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1418
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1438]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 2",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2439,
+      "type": "ImpactSwitch",
+      "pos": [25202.971087607148, 17037.55368480674],
+      "size": [280, 212],
+      "flags": {},
+      "order": 481,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1419
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1439]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 3",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2440,
+      "type": "ImpactSwitch",
+      "pos": [25722.978729231752, 17037.55368480674],
+      "size": [280, 212],
+      "flags": {},
+      "order": 482,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1420
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1440]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 4",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2441,
+      "type": "ImpactSwitch",
+      "pos": [26242.974593243056, 17037.55368480674],
+      "size": [280, 212],
+      "flags": {},
+      "order": 483,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1421
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1441]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 5",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2442,
+      "type": "ImpactSwitch",
+      "pos": [24162.979197804143, 17507.55526286218],
+      "size": [280, 212],
+      "flags": {},
+      "order": 484,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1422
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1427, 1432]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 6",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2443,
+      "type": "ImpactSwitch",
+      "pos": [24682.967328712202, 17507.55526286218],
+      "size": [280, 212],
+      "flags": {},
+      "order": 485,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1423
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1428, 1433]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 7",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2444,
+      "type": "ImpactSwitch",
+      "pos": [25202.971087607148, 17507.55526286218],
+      "size": [280, 212],
+      "flags": {},
+      "order": 486,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1424
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1429, 1434]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 8",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2445,
+      "type": "ImpactSwitch",
+      "pos": [25725.927921257466, 17493.92481096505],
+      "size": [280, 212],
+      "flags": {},
+      "order": 487,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1425
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1430, 1435]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 9",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2446,
+      "type": "ImpactSwitch",
+      "pos": [26202.685578346314, 17498.47537012703],
+      "size": [280, 212],
+      "flags": {},
+      "order": 488,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1426
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1431, 1436]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 10",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2447,
+      "type": "PreviewAny",
+      "pos": [21888.557991273738, 19725.365267905567],
+      "size": [240, 180],
+      "flags": {},
+      "order": 557,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1427
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 1",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2448,
+      "type": "PreviewAny",
+      "pos": [22388.55792695834, 19725.365267905567],
+      "size": [240, 180],
+      "flags": {},
+      "order": 559,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1428
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 2",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2449,
+      "type": "PreviewAny",
+      "pos": [22888.56161594828, 19725.365267905567],
+      "size": [240, 180],
+      "flags": {},
+      "order": 561,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1429
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 3",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2450,
+      "type": "PreviewAny",
+      "pos": [23388.557539478898, 19725.365267905567],
+      "size": [240, 180],
+      "flags": {},
+      "order": 563,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1430
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 4",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2451,
+      "type": "PreviewAny",
+      "pos": [23888.5534953656, 19725.365267905567],
+      "size": [240, 180],
+      "flags": {},
+      "order": 565,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1431
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 5",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2452,
+      "type": "PreviewAny",
+      "pos": [21888.557991273738, 19965.36507137104],
+      "size": [240, 180],
+      "flags": {},
+      "order": 558,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1432
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 6",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2453,
+      "type": "PreviewAny",
+      "pos": [22388.55792695834, 19965.36507137104],
+      "size": [240, 180],
+      "flags": {},
+      "order": 560,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1433
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 7",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2454,
+      "type": "PreviewAny",
+      "pos": [22888.56161594828, 19965.36507137104],
+      "size": [240, 180],
+      "flags": {},
+      "order": 562,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1434
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 8",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2455,
+      "type": "PreviewAny",
+      "pos": [23388.557539478898, 19965.36507137104],
+      "size": [240, 180],
+      "flags": {},
+      "order": 564,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1435
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 9",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2456,
+      "type": "PreviewAny",
+      "pos": [23888.5534953656, 19965.36507137104],
+      "size": [240, 180],
+      "flags": {},
+      "order": 566,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1436
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 10",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2457,
+      "type": "PreviewAny",
+      "pos": [21888.557991273738, 20205.369016414825],
+      "size": [240, 180],
+      "flags": {},
+      "order": 552,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1437
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 11",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2458,
+      "type": "PreviewAny",
+      "pos": [22388.55792695834, 20205.369016414825],
+      "size": [240, 180],
+      "flags": {},
+      "order": 553,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1438
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 12",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2459,
+      "type": "PreviewAny",
+      "pos": [22888.56161594828, 20205.369016414825],
+      "size": [240, 180],
+      "flags": {},
+      "order": 554,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1439
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 13",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2460,
+      "type": "PreviewAny",
+      "pos": [23388.557539478898, 20205.369016414825],
+      "size": [240, 180],
+      "flags": {},
+      "order": 555,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1440
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 14",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2461,
+      "type": "PreviewAny",
+      "pos": [23888.5534953656, 20205.369016414825],
+      "size": [240, 180],
+      "flags": {},
+      "order": 556,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1441
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 15",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2462,
+      "type": "c1348745-88ee-4088-83f2-e6804e872a82",
+      "pos": [27480.696917707595, 14686.882624303531],
+      "size": [400, 470],
+      "flags": {},
+      "order": 474,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1442
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1443
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1444
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1412]
+        }
+      ],
+      "title": "Subgraph Edit A",
+      "properties": {
+        "proxyWidgets": [
+          ["2223", "prompt"],
+          ["2228", "lora_name"],
+          ["2228", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2463,
+      "type": "75d18ee0-62fa-4994-9e0d-e7786f283ed4",
+      "pos": [27973.853024668464, 14682.709725313185],
+      "size": [400, 470],
+      "flags": {},
+      "order": 475,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1445
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1446
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1447
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1413]
+        }
+      ],
+      "title": "Subgraph Edit B",
+      "properties": {
+        "proxyWidgets": [
+          ["2239", "prompt"],
+          ["2244", "lora_name"],
+          ["2244", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2464,
+      "type": "CLIPTextEncode",
+      "pos": [25369.517929054608, 15359.570973788077],
+      "size": [400, 200],
+      "flags": {},
+      "order": 256,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2465,
+      "type": "CLIPTextEncode",
+      "pos": [23956.18629415681, 13734.757909753705],
+      "size": [400, 200],
+      "flags": {},
+      "order": 257,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2466,
+      "type": "CLIPTextEncode",
+      "pos": [23947.862077681813, 14026.42086109524],
+      "size": [260.40625, 407.109375],
+      "flags": {},
+      "order": 258,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2467,
+      "type": "CLIPTextEncode",
+      "pos": [23956.18629415681, 14326.420744851408],
+      "size": [400, 200],
+      "flags": {},
+      "order": 259,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2468,
+      "type": "CLIPTextEncode",
+      "pos": [23889.48709771244, 14651.482224897867],
+      "size": [400, 200],
+      "flags": {},
+      "order": 260,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2469,
+      "type": "CLIPTextEncode",
+      "pos": [25390.330395428886, 15694.649766934028],
+      "size": [400, 200],
+      "flags": {},
+      "order": 261,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2470,
+      "type": "CLIPTextEncode",
+      "pos": [26279.447143732275, 14518.915868619268],
+      "size": [341.8125, 653.40625],
+      "flags": {},
+      "order": 262,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2471,
+      "type": "CLIPTextEncode",
+      "pos": [25813.13493540014, 14588.07116660052],
+      "size": [435.71875, 630.359375],
+      "flags": {},
+      "order": 263,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2472,
+      "type": "CLIPTextEncode",
+      "pos": [25848.654405182053, 15577.980988401263],
+      "size": [400, 200],
+      "flags": {},
+      "order": 264,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2473,
+      "type": "CLIPTextEncode",
+      "pos": [25839.06458061817, 15356.89214917105],
+      "size": [400, 200],
+      "flags": {},
+      "order": 265,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2474,
+      "type": "CLIPTextEncode",
+      "pos": [25881.990357227285, 15836.313747079894],
+      "size": [400, 200],
+      "flags": {},
+      "order": 266,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2475,
+      "type": "CLIPTextEncode",
+      "pos": [25864.048910588222, 16069.2601838443],
+      "size": [400, 200],
+      "flags": {},
+      "order": 267,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2476,
+      "type": "CLIPTextEncode",
+      "pos": [26262.388759242305, 13725.281331471586],
+      "size": [354.546875, 726.03125],
+      "flags": {},
+      "order": 268,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2477,
+      "type": "CLIPTextEncode",
+      "pos": [26365.32225217711, 15636.313824575782],
+      "size": [400, 200],
+      "flags": {},
+      "order": 269,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2478,
+      "type": "CLIPTextEncode",
+      "pos": [24985.088282969682, 14583.317152404337],
+      "size": [366.640625, 378.671875],
+      "flags": {},
+      "order": 270,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2479,
+      "type": "CLIPTextEncode",
+      "pos": [26361.51355322891, 15892.062756089743],
+      "size": [400, 200],
+      "flags": {},
+      "order": 271,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2480,
+      "type": "CLIPTextEncode",
+      "pos": [24959.080530173313, 13996.357403032107],
+      "size": [385.15625, 472.625],
+      "flags": {},
+      "order": 272,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2481,
+      "type": "CLIPTextEncode",
+      "pos": [24414.51426752984, 14209.754813653726],
+      "size": [400, 200],
+      "flags": {},
+      "order": 273,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2482,
+      "type": "CLIPTextEncode",
+      "pos": [24422.846314176317, 14018.089817487256],
+      "size": [400, 200],
+      "flags": {},
+      "order": 274,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2483,
+      "type": "CLIPTextEncode",
+      "pos": [24447.846304489332, 14468.086795786425],
+      "size": [400, 200],
+      "flags": {},
+      "order": 275,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2484,
+      "type": "CLIPTextEncode",
+      "pos": [24442.32286269878, 14734.749821527106],
+      "size": [400, 200],
+      "flags": {},
+      "order": 276,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2485,
+      "type": "CLIPTextEncode",
+      "pos": [25436.275641470565, 13740.342892809374],
+      "size": [361.1875, 549.390625],
+      "flags": {},
+      "order": 277,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2486,
+      "type": "CLIPTextEncode",
+      "pos": [25410.12338641867, 14336.529172673596],
+      "size": [400, 200],
+      "flags": {},
+      "order": 278,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2487,
+      "type": "CLIPTextEncode",
+      "pos": [25853.650572284725, 13734.0117785373],
+      "size": [351.953125, 646.796875],
+      "flags": {},
+      "order": 279,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2488,
+      "type": "CLIPTextEncode",
+      "pos": [24960.517981405752, 13741.480532599871],
+      "size": [400, 200],
+      "flags": {},
+      "order": 280,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2489,
+      "type": "CLIPTextEncode",
+      "pos": [23970.479257024796, 15048.235072515428],
+      "size": [400, 200],
+      "flags": {},
+      "order": 281,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2490,
+      "type": "CLIPTextEncode",
+      "pos": [23962.139416607428, 15339.90106532853],
+      "size": [400, 200],
+      "flags": {},
+      "order": 282,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2491,
+      "type": "CLIPTextEncode",
+      "pos": [23970.479257024796, 15639.89991369012],
+      "size": [400, 200],
+      "flags": {},
+      "order": 283,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2492,
+      "type": "CLIPTextEncode",
+      "pos": [23953.81129313571, 15973.230701942963],
+      "size": [400, 200],
+      "flags": {},
+      "order": 284,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2493,
+      "type": "CLIPTextEncode",
+      "pos": [24428.807242531355, 15064.90207785563],
+      "size": [400, 200],
+      "flags": {},
+      "order": 285,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2494,
+      "type": "CLIPTextEncode",
+      "pos": [24428.807242531355, 15523.232947097862],
+      "size": [400, 200],
+      "flags": {},
+      "order": 286,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2495,
+      "type": "CLIPTextEncode",
+      "pos": [24437.143171907494, 15331.567950931394],
+      "size": [400, 200],
+      "flags": {},
+      "order": 287,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2496,
+      "type": "CLIPTextEncode",
+      "pos": [24462.135364405105, 15781.56492923056],
+      "size": [400, 200],
+      "flags": {},
+      "order": 288,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2497,
+      "type": "CLIPTextEncode",
+      "pos": [24456.60020971341, 16048.231837700903],
+      "size": [400, 200],
+      "flags": {},
+      "order": 289,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2498,
+      "type": "CLIPTextEncode",
+      "pos": [24887.139114812086, 15048.235072515428],
+      "size": [400, 200],
+      "flags": {},
+      "order": 290,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2499,
+      "type": "CLIPTextEncode",
+      "pos": [24957.881284405543, 15615.285737281027],
+      "size": [400, 200],
+      "flags": {},
+      "order": 291,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2500,
+      "type": "CLIPTextEncode",
+      "pos": [24914.92425182266, 15338.848327893274],
+      "size": [400, 200],
+      "flags": {},
+      "order": 292,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2501,
+      "type": "CLIPTextEncode",
+      "pos": [24954.06488471018, 15871.03544534092],
+      "size": [400, 200],
+      "flags": {},
+      "order": 293,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2502,
+      "type": "CLIPTextEncode",
+      "pos": [25377.912390580375, 15069.265230599334],
+      "size": [400, 200],
+      "flags": {},
+      "order": 294,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2503,
+      "type": "CheckpointLoaderSimple",
+      "pos": [27181.978334739357, 17084.069562684173],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 295,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1448]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 2504,
+      "type": "CheckpointLoaderSimple",
+      "pos": [27181.978334739357, 17304.069166820325],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 296,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1449]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 2505,
+      "type": "CheckpointLoaderSimple",
+      "pos": [27186.75176258384, 17558.4071143757],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 297,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1450]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 2506,
+      "type": "CheckpointLoaderSimple",
+      "pos": [27186.75176258384, 17775.074818765945],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 298,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 2507,
+      "type": "CLIPLoader",
+      "pos": [24800.77588253678, 18488.961259585052],
+      "size": [360, 140],
+      "flags": {},
+      "order": 299,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2508,
+      "type": "CLIPLoader",
+      "pos": [24800.77588253678, 18708.95931062934],
+      "size": [360, 140],
+      "flags": {},
+      "order": 300,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2509,
+      "type": "CLIPLoader",
+      "pos": [24800.77588253678, 18928.959432462776],
+      "size": [360, 140],
+      "flags": {},
+      "order": 301,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2510,
+      "type": "VAELoader",
+      "pos": [25230.771820248527, 18488.961259585052],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 302,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 2511,
+      "type": "VAELoader",
+      "pos": [25230.771820248527, 18708.95931062934],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 303,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2512,
+      "type": "VAELoader",
+      "pos": [25230.771820248527, 18928.959432462776],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 304,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 2513,
+      "type": "UNETLoader",
+      "pos": [25660.771705402094, 18488.961259585052],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 305,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2514,
+      "type": "UNETLoader",
+      "pos": [25660.771705402094, 18708.95931062934],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 306,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 2515,
+      "type": "LoraLoaderModelOnly",
+      "pos": [25660.771705402094, 19008.957123596356],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 489,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1448
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 2516,
+      "type": "LoraLoaderModelOnly",
+      "pos": [25660.771705402094, 19178.95907674427],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 490,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1449
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 2517,
+      "type": "LoraLoaderModelOnly",
+      "pos": [25660.771705402094, 19348.957406011177],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 491,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1450
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 2518,
+      "type": "UNETLoader",
+      "pos": [21310.37476402586, 18765.895140672048],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 307,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 3",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2519,
+      "type": "UNETLoader",
+      "pos": [21310.37476402586, 18940.900638108993],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 308,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 4",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2520,
+      "type": "CLIPLoader",
+      "pos": [20412.92192456593, 18351.469143034956],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 309,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader 4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 2521,
+      "type": "VAELoader",
+      "pos": [20842.92569244916, 18351.469143034956],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 310,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader 4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2522,
+      "type": "UNETLoader",
+      "pos": [25660.771705402094, 19488.957248224597],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 311,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader B1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_t2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2523,
+      "type": "CLIPLoader",
+      "pos": [24806.123501385875, 19172.45317492532],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 312,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader B4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 2524,
+      "type": "VAELoader",
+      "pos": [25230.771820248527, 18498.95954730921],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 313,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader B4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2525,
+      "type": "c1348745-88ee-4088-83f2-e6804e872a82",
+      "pos": [28445.587335547018, 14683.08867972804],
+      "size": [400, 470],
+      "flags": {},
+      "order": 314,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit C",
+      "properties": {
+        "proxyWidgets": [
+          ["2223", "prompt"],
+          ["2228", "lora_name"],
+          ["2228", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2526,
+      "type": "75d18ee0-62fa-4994-9e0d-e7786f283ed4",
+      "pos": [28925.50514630646, 14689.920730838467],
+      "size": [400, 470],
+      "flags": {},
+      "order": 315,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit D",
+      "properties": {
+        "proxyWidgets": [
+          ["2239", "prompt"],
+          ["2244", "lora_name"],
+          ["2244", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2527,
+      "type": "VHS_VideoCombine",
+      "pos": [32522.84744659548, 13505.376789499955],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 316,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2528,
+      "type": "Reroute",
+      "pos": [22509.46405779381, 13432.16720991948],
+      "size": [75, 26],
+      "flags": {},
+      "order": 473,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 1451
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VIDEO",
+          "links": [1452]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 2529,
+      "type": "SaveVideo",
+      "pos": [31235.45750316384, 14513.05061719428],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 549,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1452
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 2530,
+      "type": "SaveVideo",
+      "pos": [31280.24660173698, 15127.119714479692],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 492,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1453
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 2531,
+      "type": "Reroute",
+      "pos": [24872.822714008285, 13210.810818259586],
+      "size": [75, 26],
+      "flags": {},
+      "order": 317,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "*",
+          "links": [1453]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 2532,
+      "type": "LoadVideo",
+      "pos": [16886.313381289438, 14513.183406548666],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 318,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2533,
+      "type": "LoadVideo",
+      "pos": [17862.53567506704, 15652.733888309582],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 319,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2534,
+      "type": "LoadVideo",
+      "pos": [16884.893855325594, 15629.261234420645],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 320,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2535,
+      "type": "LoadVideo",
+      "pos": [17833.489233326287, 14559.296645360319],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 321,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2536,
+      "type": "LoadVideo",
+      "pos": [17518.01278914379, 14965.294531147916],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 322,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2537,
+      "type": "LoadVideo",
+      "pos": [18488.70762897686, 13874.34081151376],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 323,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2538,
+      "type": "LoadVideo",
+      "pos": [18508.707828306186, 14954.336691500357],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 324,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2572,
+      "type": "LoadImage",
+      "pos": [29405.01035232733, 18740.814939635464],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 325,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2573,
+      "type": "LoadImage",
+      "pos": [29404.772211574826, 19136.140981171073],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 326,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2574,
+      "type": "VHS_VideoCombine",
+      "pos": [41849.68903590865, 18124.756089001465],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 327,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2575,
+      "type": "VHS_VideoCombine",
+      "pos": [42462.118715307115, 18328.17202088275],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 328,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 26,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "41aa7f4a9160f486d734d0e64b61d173ac66eca59ef468eb1550a4dc9e6846a5.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 25,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00006.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2576,
+      "type": "LoadVideo",
+      "pos": [29102.94796257556, 18651.9946513189],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 329,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2577,
+      "type": "VHS_VideoCombine",
+      "pos": [41882.462380426085, 18788.77930216879],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 568,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1454
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2578,
+      "type": "VHS_VideoCombine",
+      "pos": [43112.243487340544, 18068.900628486757],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 569,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1455
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 0,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "8a64f64a68b43f231063193799857eca229c7a2e48a16d2ed0a8b581fd8632f6.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00005.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2579,
+      "type": "LoadImage",
+      "pos": [29730.217434736052, 19128.043354327838],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 330,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2580,
+      "type": "LoadImage",
+      "pos": [30004.51804856737, 18753.963383001337],
+      "size": [282.78125, 340],
+      "flags": {},
+      "order": 331,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2581,
+      "type": "LoadImage",
+      "pos": [28415.48323824678, 18763.184089398837],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 332,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2582,
+      "type": "LoadImage",
+      "pos": [28415.23319045665, 19158.512039943194],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 333,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2583,
+      "type": "LoadVideo",
+      "pos": [28728.68233205913, 18448.527920391225],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 334,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2584,
+      "type": "LoadVideo",
+      "pos": [28113.418777705858, 18674.36376872619],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 335,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2585,
+      "type": "LoadImage",
+      "pos": [28740.67841361788, 19150.412471735133],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 336,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2586,
+      "type": "LoadImage",
+      "pos": [28738.174829532858, 18779.82275081252],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 337,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2587,
+      "type": "LoadImage",
+      "pos": [28411.893525251424, 19853.92788278269],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 338,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1488]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2588,
+      "type": "LoadImage",
+      "pos": [28411.651242920616, 20249.255898039206],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 339,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1489]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2589,
+      "type": "LoadVideo",
+      "pos": [28109.834759380672, 19765.109535830954],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 340,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2590,
+      "type": "LoadImage",
+      "pos": [28737.100607660148, 20241.15820648381],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 341,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2591,
+      "type": "LoadImage",
+      "pos": [28734.592364299537, 19870.56266146671],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 342,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2592,
+      "type": "LoadImage",
+      "pos": [29386.857814619063, 19854.793084375346],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 343,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_04.png", "image"]
+    },
+    {
+      "id": 2593,
+      "type": "LoadImage",
+      "pos": [29386.611908407234, 20250.121099631862],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 344,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_03.png", "image"]
+    },
+    {
+      "id": 2594,
+      "type": "LoadVideo",
+      "pos": [29084.784035526955, 19765.97085469395],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 345,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [1493]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_01.mp4", "image"]
+    },
+    {
+      "id": 2595,
+      "type": "LoadImage",
+      "pos": [29712.057131568465, 20242.021466711638],
+      "size": [282.75, 344],
+      "flags": {},
+      "order": 346,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_05.jpg", "image"]
+    },
+    {
+      "id": 2596,
+      "type": "LoadImage",
+      "pos": [29709.553029786155, 19871.431745789025],
+      "size": [282.78125, 344],
+      "flags": {},
+      "order": 347,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.11.0"
+      },
+      "widgets_values": ["profiling_test_img_02.png", "image"]
+    },
+    {
+      "id": 2597,
+      "type": "LoadImage",
+      "pos": [27539.005163260936, 19689.5997624875],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 348,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1485]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 2598,
+      "type": "LoadImage",
+      "pos": [27555.626352391144, 18577.930224091528],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 349,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1484]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_01.png", "image"]
+    },
+    {
+      "id": 2599,
+      "type": "LoadImage",
+      "pos": [30067.365722790993, 18545.23294871935],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 350,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1486]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 2600,
+      "type": "LoadImage",
+      "pos": [30050.064797121573, 19675.94355515029],
+      "size": [508.640625, 910],
+      "flags": {},
+      "order": 351,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1487]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["profiling_test_img_06.jpg", "image"]
+    },
+    {
+      "id": 2601,
+      "type": "CheckpointLoaderSimple",
+      "pos": [31780.150116301687, 19278.11946241943],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 352,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1456, 1459]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 2602,
+      "type": "CheckpointLoaderSimple",
+      "pos": [31780.150116301687, 19498.121266769052],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 353,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1457, 1460]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 2603,
+      "type": "CheckpointLoaderSimple",
+      "pos": [31780.150116301687, 19718.11931781334],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 354,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1458, 1461]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 2604,
+      "type": "CheckpointLoaderSimple",
+      "pos": [31780.150116301687, 19938.119180798134],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 355,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1462]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 2605,
+      "type": "CLIPLoader",
+      "pos": [32210.150130879578, 19278.11946241943],
+      "size": [360, 140],
+      "flags": {},
+      "order": 356,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1463]
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2606,
+      "type": "CLIPLoader",
+      "pos": [32210.150130879578, 19498.121266769052],
+      "size": [360, 140],
+      "flags": {},
+      "order": 357,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1464]
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2607,
+      "type": "CLIPLoader",
+      "pos": [32210.150130879578, 19718.11931781334],
+      "size": [360, 140],
+      "flags": {},
+      "order": 358,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [1465]
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2608,
+      "type": "VAELoader",
+      "pos": [32640.15001603315, 19278.11946241943],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 359,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1466]
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 2609,
+      "type": "VAELoader",
+      "pos": [32640.15001603315, 19498.121266769052],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 360,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1467]
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2610,
+      "type": "VAELoader",
+      "pos": [32640.15001603315, 19718.11931781334],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 361,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [1468]
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 2611,
+      "type": "UNETLoader",
+      "pos": [33070.14977176239, 19278.11946241943],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 362,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2612,
+      "type": "UNETLoader",
+      "pos": [33070.14977176239, 19498.121266769052],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 363,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 2613,
+      "type": "LoraLoaderModelOnly",
+      "pos": [32541.052271729845, 22847.464046248966],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 496,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1456
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 2614,
+      "type": "LoraLoaderModelOnly",
+      "pos": [32541.052271729845, 23017.459787029427],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 498,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1457
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 2615,
+      "type": "LoraLoaderModelOnly",
+      "pos": [32541.052271729845, 23187.461740177347],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 500,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1458
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 2616,
+      "type": "ImpactSwitch",
+      "pos": [35393.64903711705, 21600.78271136604],
+      "size": [280, 212],
+      "flags": {},
+      "order": 497,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1459
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1479]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 1",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2617,
+      "type": "ImpactSwitch",
+      "pos": [35913.63720038119, 21600.78271136604],
+      "size": [280, 212],
+      "flags": {},
+      "order": 499,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1460
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1480]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 2",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2618,
+      "type": "ImpactSwitch",
+      "pos": [36433.640959276134, 21600.78271136604],
+      "size": [280, 212],
+      "flags": {},
+      "order": 501,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1461
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1481]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 3",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2619,
+      "type": "ImpactSwitch",
+      "pos": [36953.648471476416, 21600.78271136604],
+      "size": [280, 212],
+      "flags": {},
+      "order": 502,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1462
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1482]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 4",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2620,
+      "type": "ImpactSwitch",
+      "pos": [37473.644594336365, 21600.78271136604],
+      "size": [280, 212],
+      "flags": {},
+      "order": 503,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1463
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1483]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 5",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2621,
+      "type": "ImpactSwitch",
+      "pos": [35393.64903711705, 22070.784548270123],
+      "size": [280, 212],
+      "flags": {},
+      "order": 504,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1464
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1469, 1474]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 6",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2622,
+      "type": "ImpactSwitch",
+      "pos": [35913.63720038119, 22070.784548270123],
+      "size": [280, 212],
+      "flags": {},
+      "order": 505,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1465
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1470, 1475]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 7",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2623,
+      "type": "ImpactSwitch",
+      "pos": [36433.640959276134, 22070.784548270123],
+      "size": [280, 212],
+      "flags": {},
+      "order": 506,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1466
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1471, 1476]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 8",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2624,
+      "type": "ImpactSwitch",
+      "pos": [36956.59779292645, 22057.151766735198],
+      "size": [280, 212],
+      "flags": {},
+      "order": 507,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1467
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1472, 1477]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 9",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2625,
+      "type": "ImpactSwitch",
+      "pos": [37433.35532059098, 22061.70439668633],
+      "size": [280, 212],
+      "flags": {},
+      "order": 508,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input1",
+          "shape": 7,
+          "type": "INT",
+          "link": 1468
+        },
+        {
+          "name": "input2",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input3",
+          "type": "INT",
+          "link": null
+        },
+        {
+          "name": "input4",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1473, 1478]
+        },
+        {
+          "name": "selected_label",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "selected_index",
+          "type": "INT",
+          "links": []
+        }
+      ],
+      "title": "Impact Switch 10",
+      "properties": {
+        "Node name for S&R": "ImpactSwitch"
+      },
+      "widgets_values": [0, false]
+    },
+    {
+      "id": 2626,
+      "type": "PreviewAny",
+      "pos": [33119.227862942724, 24288.59455331351],
+      "size": [240, 180],
+      "flags": {},
+      "order": 575,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1469
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 1",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2627,
+      "type": "PreviewAny",
+      "pos": [33619.22773391516, 24288.59455331351],
+      "size": [240, 180],
+      "flags": {},
+      "order": 577,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1470
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 2",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2628,
+      "type": "PreviewAny",
+      "pos": [34119.23150379531, 24288.59455331351],
+      "size": [240, 180],
+      "flags": {},
+      "order": 579,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1471
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 3",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2629,
+      "type": "PreviewAny",
+      "pos": [34619.227443503965, 24288.59455331351],
+      "size": [240, 180],
+      "flags": {},
+      "order": 581,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1472
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 4",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2630,
+      "type": "PreviewAny",
+      "pos": [35119.22339939066, 24288.59455331351],
+      "size": [240, 180],
+      "flags": {},
+      "order": 583,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1473
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 5",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2631,
+      "type": "PreviewAny",
+      "pos": [33119.227862942724, 24528.594356778987],
+      "size": [240, 180],
+      "flags": {},
+      "order": 576,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1474
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 6",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2632,
+      "type": "PreviewAny",
+      "pos": [33619.22773391516, 24528.594356778987],
+      "size": [240, 180],
+      "flags": {},
+      "order": 578,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1475
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 7",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2633,
+      "type": "PreviewAny",
+      "pos": [34119.23150379531, 24528.594356778987],
+      "size": [240, 180],
+      "flags": {},
+      "order": 580,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1476
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 8",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2634,
+      "type": "PreviewAny",
+      "pos": [34619.227443503965, 24528.594356778987],
+      "size": [240, 180],
+      "flags": {},
+      "order": 582,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1477
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 9",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2635,
+      "type": "PreviewAny",
+      "pos": [35119.22339939066, 24528.594356778987],
+      "size": [240, 180],
+      "flags": {},
+      "order": 584,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1478
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 10",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2636,
+      "type": "PreviewAny",
+      "pos": [33119.227862942724, 24768.598301822767],
+      "size": [240, 180],
+      "flags": {},
+      "order": 570,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1479
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 11",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2637,
+      "type": "PreviewAny",
+      "pos": [33619.22773391516, 24768.598301822767],
+      "size": [240, 180],
+      "flags": {},
+      "order": 571,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1480
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 12",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2638,
+      "type": "PreviewAny",
+      "pos": [34119.23150379531, 24768.598301822767],
+      "size": [240, 180],
+      "flags": {},
+      "order": 572,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1481
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 13",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2639,
+      "type": "PreviewAny",
+      "pos": [34619.227443503965, 24768.598301822767],
+      "size": [240, 180],
+      "flags": {},
+      "order": 573,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1482
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 14",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2640,
+      "type": "PreviewAny",
+      "pos": [35119.22339939066, 24768.598301822767],
+      "size": [240, 180],
+      "flags": {},
+      "order": 574,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source",
+          "type": "*",
+          "link": 1483
+        }
+      ],
+      "outputs": [],
+      "title": "Anchor 15",
+      "properties": {
+        "Node name for S&R": "PreviewAny"
+      },
+      "widgets_values": [null, null, null]
+    },
+    {
+      "id": 2641,
+      "type": "278e37b2-bbad-4c90-b99d-05fd3f58885e",
+      "pos": [38711.366659952255, 19250.11165086283],
+      "size": [400, 470],
+      "flags": {},
+      "order": 494,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1484
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1485
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1486
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1454]
+        }
+      ],
+      "title": "Subgraph Edit A",
+      "properties": {
+        "proxyWidgets": [
+          ["2548", "prompt"],
+          ["2553", "lora_name"],
+          ["2553", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2642,
+      "type": "f5e3d92c-c465-493e-897c-1df9320725a2",
+      "pos": [39204.52302576177, 19245.93784590223],
+      "size": [400, 470],
+      "flags": {},
+      "order": 495,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 1487
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": 1488
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1489
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [1455]
+        }
+      ],
+      "title": "Subgraph Edit B",
+      "properties": {
+        "proxyWidgets": [
+          ["2564", "prompt"],
+          ["2569", "lora_name"],
+          ["2569", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2643,
+      "type": "CLIPTextEncode",
+      "pos": [36600.187800723594, 19922.7989649528],
+      "size": [400, 200],
+      "flags": {},
+      "order": 364,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2644,
+      "type": "CLIPTextEncode",
+      "pos": [35186.856149647756, 18297.986952491043],
+      "size": [400, 200],
+      "flags": {},
+      "order": 365,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2645,
+      "type": "CLIPTextEncode",
+      "pos": [35178.53196552884, 18589.648981684284],
+      "size": [260.40625, 407.109375],
+      "flags": {},
+      "order": 366,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2646,
+      "type": "CLIPTextEncode",
+      "pos": [35186.856149647756, 18889.648865440453],
+      "size": [400, 200],
+      "flags": {},
+      "order": 367,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2647,
+      "type": "CLIPTextEncode",
+      "pos": [35120.15693702535, 19214.711251457167],
+      "size": [400, 200],
+      "flags": {},
+      "order": 368,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2648,
+      "type": "CLIPTextEncode",
+      "pos": [36621.00026709787, 20257.876981552818],
+      "size": [400, 200],
+      "flags": {},
+      "order": 369,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2649,
+      "type": "CLIPTextEncode",
+      "pos": [37510.117144825585, 19082.144895178568],
+      "size": [341.8125, 653.40625],
+      "flags": {},
+      "order": 370,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2650,
+      "type": "CLIPTextEncode",
+      "pos": [37043.8046776448, 19151.299157765243],
+      "size": [435.71875, 630.359375],
+      "flags": {},
+      "order": 371,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2651,
+      "type": "CLIPTextEncode",
+      "pos": [37079.324406275366, 20141.208979565985],
+      "size": [400, 200],
+      "flags": {},
+      "order": 372,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2652,
+      "type": "CLIPTextEncode",
+      "pos": [37069.734581711484, 19920.12117573035],
+      "size": [400, 200],
+      "flags": {},
+      "order": 373,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2653,
+      "type": "CLIPTextEncode",
+      "pos": [37112.660228896275, 20399.540961698684],
+      "size": [400, 200],
+      "flags": {},
+      "order": 374,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2654,
+      "type": "CLIPTextEncode",
+      "pos": [37094.71891168153, 20632.488175009024],
+      "size": [400, 200],
+      "flags": {},
+      "order": 375,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2655,
+      "type": "CLIPTextEncode",
+      "pos": [37493.05850148697, 18288.510390386964],
+      "size": [354.546875, 726.03125],
+      "flags": {},
+      "order": 376,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2656,
+      "type": "CLIPTextEncode",
+      "pos": [37595.991994421776, 20199.542980559403],
+      "size": [400, 200],
+      "flags": {},
+      "order": 377,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2657,
+      "type": "CLIPTextEncode",
+      "pos": [36215.75821935083, 19146.545272993382],
+      "size": [366.640625, 378.671875],
+      "flags": {},
+      "order": 378,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2658,
+      "type": "CLIPTextEncode",
+      "pos": [37592.18355432222, 20455.29100610311],
+      "size": [400, 200],
+      "flags": {},
+      "order": 379,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2659,
+      "type": "CLIPTextEncode",
+      "pos": [36189.7504018423, 18559.584520582655],
+      "size": [385.15625, 472.625],
+      "flags": {},
+      "order": 380,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2660,
+      "type": "CLIPTextEncode",
+      "pos": [35645.184106842746, 18772.98286953061],
+      "size": [400, 200],
+      "flags": {},
+      "order": 381,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2661,
+      "type": "CLIPTextEncode",
+      "pos": [35653.51618584531, 18581.316935037805],
+      "size": [400, 200],
+      "flags": {},
+      "order": 382,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2662,
+      "type": "CLIPTextEncode",
+      "pos": [35678.516176158315, 19031.31485166331],
+      "size": [400, 200],
+      "flags": {},
+      "order": 383,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2663,
+      "type": "CLIPTextEncode",
+      "pos": [35672.99273436776, 19297.976906721575],
+      "size": [400, 200],
+      "flags": {},
+      "order": 384,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2664,
+      "type": "CLIPTextEncode",
+      "pos": [36666.94564256387, 18303.570932508217],
+      "size": [361.1875, 549.390625],
+      "flags": {},
+      "order": 385,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2665,
+      "type": "CLIPTextEncode",
+      "pos": [36640.79312866333, 18899.756257868063],
+      "size": [400, 200],
+      "flags": {},
+      "order": 386,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2666,
+      "type": "CLIPTextEncode",
+      "pos": [37084.32044395371, 18297.24085363072],
+      "size": [351.953125, 646.796875],
+      "flags": {},
+      "order": 387,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2667,
+      "type": "CLIPTextEncode",
+      "pos": [36191.1879177869, 18304.70765015042],
+      "size": [400, 200],
+      "flags": {},
+      "order": 388,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2668,
+      "type": "CLIPTextEncode",
+      "pos": [35201.14912464927, 19611.46306368015],
+      "size": [400, 200],
+      "flags": {},
+      "order": 389,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2669,
+      "type": "CLIPTextEncode",
+      "pos": [35192.80928018739, 19903.12905649325],
+      "size": [400, 200],
+      "flags": {},
+      "order": 390,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2670,
+      "type": "CLIPTextEncode",
+      "pos": [35201.14912464927, 20203.12894024942],
+      "size": [400, 200],
+      "flags": {},
+      "order": 391,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2671,
+      "type": "CLIPTextEncode",
+      "pos": [35184.481148626655, 20536.45895195633],
+      "size": [400, 200],
+      "flags": {},
+      "order": 392,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2672,
+      "type": "CLIPTextEncode",
+      "pos": [35659.47708184426, 19628.131104414926],
+      "size": [400, 200],
+      "flags": {},
+      "order": 393,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2673,
+      "type": "CLIPTextEncode",
+      "pos": [35659.47708184426, 20086.460938262586],
+      "size": [400, 200],
+      "flags": {},
+      "order": 394,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2674,
+      "type": "CLIPTextEncode",
+      "pos": [35667.81304357648, 19894.796977490692],
+      "size": [400, 200],
+      "flags": {},
+      "order": 395,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2675,
+      "type": "CLIPTextEncode",
+      "pos": [35692.80526843017, 20344.792920395284],
+      "size": [400, 200],
+      "flags": {},
+      "order": 396,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2676,
+      "type": "CLIPTextEncode",
+      "pos": [35687.270049026316, 20611.460864260203],
+      "size": [400, 200],
+      "flags": {},
+      "order": 397,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Portrait of a woman, soft light, shallow depth of field, cinematic"
+      ]
+    },
+    {
+      "id": 2677,
+      "type": "CLIPTextEncode",
+      "pos": [36117.80898648107, 19611.46306368015],
+      "size": [400, 200],
+      "flags": {},
+      "order": 398,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2678,
+      "type": "CLIPTextEncode",
+      "pos": [36188.55115607453, 20178.51372844575],
+      "size": [400, 200],
+      "flags": {},
+      "order": 399,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2679,
+      "type": "CLIPTextEncode",
+      "pos": [36145.59418820381, 19902.076319057996],
+      "size": [400, 200],
+      "flags": {},
+      "order": 400,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly detailed cinematic scene set in a futuristic megacity at night, where towering skyscrapers covered in holographic advertisements stretch endlessly into the sky, glowing neon lights reflecting across layers of glass and metal surfaces, flying vehicles moving slowly between buildings, creating streaks of light in the air, while far below on the streets, small groups of people walk through narrow alleys illuminated by flickering signs, steam rising from vents, and rainwater pooling on the ground.\n\nIn the mid-ground, a lone character stands on a balcony, looking out across the city, wearing a long coat that moves slightly in the wind, subtle reflections of neon lights appearing on the fabric, their face partially obscured by shadow, suggesting a sense of mystery and introspection, while distant thunder can be imagined echoing through the dense urban environment.\n\nThe atmosphere is filled with volumetric fog, soft diffused lighting, and a layered sense of depth, with foreground elements slightly blurred and background structures fading into haze, emphasizing scale and distance, while maintaining sharp details on key focal points such as the character and nearby architectural features.\n\nThe color palette consists of deep blues, purples, and occasional warm orange highlights from interior lights, creating contrast and visual interest, with careful attention to lighting composition, reflections, and material realism, including wet surfaces, glass transparency, and metallic textures.\n\nStyle inspired by cinematic science fiction films, high-resolution concept art, ultra-realistic rendering, depth of field, global illumination, subtle film grain, and a slightly imperfect, lived-in aesthetic that avoids overly clean or sterile environments, instead emphasizing atmosphere, narrative, and mood.\n\nAdditional details include small environmental storytelling elements such as flickering screens, distant silhouettes moving behind windows, cables hanging between buildings, and subtle motion in background elements to give a sense of life and continuity within the scene."
+      ]
+    },
+    {
+      "id": 2680,
+      "type": "CLIPTextEncode",
+      "pos": [36184.73469166701, 20434.263695354286],
+      "size": [400, 200],
+      "flags": {},
+      "order": 401,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A surreal landscape where floating islands drift slowly in the sky, connected by thin glowing bridges, waterfalls cascading into clouds below, a lone traveler standing at the edge looking into the vast distance, soft pastel color palette, volumetric lighting, dreamlike atmosphere, highly detailed textures, concept art style"
+      ]
+    },
+    {
+      "id": 2681,
+      "type": "CLIPTextEncode",
+      "pos": [36608.58226224936, 19632.492315793803],
+      "size": [400, 200],
+      "flags": {},
+      "order": 402,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A cinematic scene of a quiet city at night, rain falling gently on the streets, neon lights reflecting on wet asphalt, people walking with umbrellas, soft fog in the distance, highly detailed, realistic lighting, 35mm film look"
+      ]
+    },
+    {
+      "id": 2682,
+      "type": "CheckpointLoaderSimple",
+      "pos": [38412.64807698402, 21647.29651845432],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 403,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1490]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 1",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["sd_xl_base_1.0.safetensors"]
+    },
+    {
+      "id": 2683,
+      "type": "CheckpointLoaderSimple",
+      "pos": [38412.64807698402, 21867.298193379625],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 404,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1491]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 2",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["v1-5-pruned-emaonly.safetensors"]
+    },
+    {
+      "id": 2684,
+      "type": "CheckpointLoaderSimple",
+      "pos": [38417.421504828504, 22121.634070145847],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 405,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [1492]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 3",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["dreamshaper_8.safetensors"]
+    },
+    {
+      "id": 2685,
+      "type": "CheckpointLoaderSimple",
+      "pos": [38417.421504828504, 22338.304104173887],
+      "size": [340, 130.65625],
+      "flags": {},
+      "order": 406,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "Checkpoint Loader 4",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": ["juggernautXL.safetensors"]
+    },
+    {
+      "id": 2686,
+      "type": "CLIPLoader",
+      "pos": [36031.4456894936, 23052.190544992995],
+      "size": [360, 140],
+      "flags": {},
+      "order": 407,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 1",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "t5xxl_fp16.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2687,
+      "type": "CLIPLoader",
+      "pos": [36031.4456894936, 23272.188596037282],
+      "size": [360, 140],
+      "flags": {},
+      "order": 408,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 2",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_l.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2688,
+      "type": "CLIPLoader",
+      "pos": [36031.4456894936, 23492.186647081566],
+      "size": [360, 140],
+      "flags": {},
+      "order": 409,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "CLIP Loader 3",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": ["clip_g.safetensors", "stable_diffusion", "default"]
+    },
+    {
+      "id": 2689,
+      "type": "VAELoader",
+      "pos": [36461.44169191751, 23052.190544992995],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 410,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 1",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["sdxl_vae.safetensors"]
+    },
+    {
+      "id": 2690,
+      "type": "VAELoader",
+      "pos": [36461.44169191751, 23272.188596037282],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 411,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 2",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2691,
+      "type": "VAELoader",
+      "pos": [36461.44169191751, 23492.186647081566],
+      "size": [360, 105.984375],
+      "flags": {},
+      "order": 412,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "VAE Loader 3",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 2692,
+      "type": "UNETLoader",
+      "pos": [36891.44144764676, 23052.190544992995],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 413,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_ti2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2693,
+      "type": "UNETLoader",
+      "pos": [36891.44144764676, 23272.188596037282],
+      "size": [390, 125.984375],
+      "flags": {},
+      "order": 414,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "UNET Loader 2",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["flux1-dev-fp8.safetensors", "default"]
+    },
+    {
+      "id": 2694,
+      "type": "LoraLoaderModelOnly",
+      "pos": [36891.44144764676, 23572.1864090043],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 509,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1490
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 1",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["detail_tweaker.safetensors", 0.8]
+    },
+    {
+      "id": 2695,
+      "type": "LoraLoaderModelOnly",
+      "pos": [36891.44144764676, 23742.186291363065],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 510,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1491
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 2",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["filmgrain_boost.safetensors", 1]
+    },
+    {
+      "id": 2696,
+      "type": "LoraLoaderModelOnly",
+      "pos": [36891.44144764676, 23912.184620629967],
+      "size": [360, 125.984375],
+      "flags": {},
+      "order": 511,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1492
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "LoRA Loader 3",
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": ["contrast_helper.safetensors", 0.6]
+    },
+    {
+      "id": 2697,
+      "type": "UNETLoader",
+      "pos": [32541.044506270522, 23329.123908382702],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 415,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 3",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2698,
+      "type": "UNETLoader",
+      "pos": [32541.044506270522, 23504.127852727783],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 416,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader 4",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2699,
+      "type": "CLIPLoader",
+      "pos": [31643.591666810593, 22914.698428442898],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 417,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader 4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 2700,
+      "type": "VAELoader",
+      "pos": [32073.595434693823, 22914.698428442898],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 418,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader 4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2701,
+      "type": "UNETLoader",
+      "pos": [36891.44144764676, 24052.184462843386],
+      "size": [350, 98.328125],
+      "flags": {},
+      "order": 419,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": []
+        }
+      ],
+      "title": "WAN UNET Loader B1",
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": ["wan2.2_t2v_14B_fp8_scaled.safetensors", "default"]
+    },
+    {
+      "id": 2702,
+      "type": "CLIPLoader",
+      "pos": [36036.79337305486, 23735.68038954411],
+      "size": [350, 146.65625],
+      "flags": {},
+      "order": 420,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "WAN CLIP Loader B4",
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 2703,
+      "type": "VAELoader",
+      "pos": [36461.44169191751, 23062.188315019863],
+      "size": [345, 89.15625],
+      "flags": {},
+      "order": 421,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": []
+        }
+      ],
+      "title": "WAN VAE Loader B4",
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": ["wan_2.1_vae.safetensors"]
+    },
+    {
+      "id": 2704,
+      "type": "278e37b2-bbad-4c90-b99d-05fd3f58885e",
+      "pos": [39676.257077791684, 19246.316735604923],
+      "size": [400, 470],
+      "flags": {},
+      "order": 422,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit C",
+      "properties": {
+        "proxyWidgets": [
+          ["2548", "prompt"],
+          ["2553", "lora_name"],
+          ["2553", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2705,
+      "type": "f5e3d92c-c465-493e-897c-1df9320725a2",
+      "pos": [40156.174888551126, 19253.14872200319],
+      "size": [400, 470],
+      "flags": {},
+      "order": 423,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "lora_strength",
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "title": "Subgraph Edit D",
+      "properties": {
+        "proxyWidgets": [
+          ["2564", "prompt"],
+          ["2569", "lora_name"],
+          ["2569", "strength_model"]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "enableTabs": false,
+        "hasSecondTab": false,
+        "secondTabOffset": 80,
+        "secondTabText": "Send Back",
+        "secondTabWidth": 65,
+        "tabWidth": 65,
+        "tabXOffset": 10
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 2706,
+      "type": "VHS_VideoCombine",
+      "pos": [43753.51304726184, 18068.60375335912],
+      "size": [580, 453.328125],
+      "flags": {},
+      "order": 424,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "1.7.9",
+        "ue_properties": {
+          "input_ue_unconnectable": {},
+          "version": "7.7",
+          "widget_ue_connectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 24,
+        "loop_count": 89,
+        "filename_prefix": "INFL8/GENS/VID",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 10,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "params": {
+            "filename": "bdb4d96d5fd8318b60364ba782856c6695dcd7d7de967c84c0f059aa40912e01.mp4",
+            "format": "video/h264-mp4",
+            "frame_rate": 24,
+            "fullpath": "",
+            "subfolder": "INFL8/GENS",
+            "type": "output",
+            "workflow": "VID_00004.png"
+          },
+          "paused": false
+        }
+      }
+    },
+    {
+      "id": 2707,
+      "type": "Reroute",
+      "pos": [33740.13399417496, 17995.395249618323],
+      "size": [225, 26],
+      "flags": {},
+      "order": 493,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 1493
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VIDEO",
+          "links": [1494]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 2708,
+      "type": "SaveVideo",
+      "pos": [42466.127245408505, 19076.27964375358],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 567,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1494
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 2709,
+      "type": "SaveVideo",
+      "pos": [42510.91634398165, 19690.347835068736],
+      "size": [575.75, 561.140625],
+      "flags": {},
+      "order": 512,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1495
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["video/ComfyUI", "auto", "auto"]
+    },
+    {
+      "id": 2710,
+      "type": "Reroute",
+      "pos": [36103.492585677275, 17774.039844818886],
+      "size": [225, 26],
+      "flags": {},
+      "order": 425,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "*",
+          "links": [1495]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 2711,
+      "type": "LoadVideo",
+      "pos": [28116.98364123139, 19076.412497820125],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 426,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2712,
+      "type": "LoadVideo",
+      "pos": [29093.20593500899, 20215.96291486888],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 427,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2713,
+      "type": "LoadVideo",
+      "pos": [28115.56359757026, 20192.488319615113],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 428,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2714,
+      "type": "LoadVideo",
+      "pos": [29064.15897557095, 19122.52379526695],
+      "size": [235.640625, 320],
+      "flags": {},
+      "order": 429,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_04.mp4", "image"]
+    },
+    {
+      "id": 2715,
+      "type": "LoadVideo",
+      "pos": [28748.682531388455, 19528.521745766706],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 430,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2716,
+      "type": "LoadVideo",
+      "pos": [29719.377371221526, 18437.568932102808],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 431,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    },
+    {
+      "id": 2717,
+      "type": "LoadVideo",
+      "pos": [29739.377570550852, 19517.564682665077],
+      "size": [288.890625, 272.375],
+      "flags": {},
+      "order": 432,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": ["profiling_test_video_05.mp4", "image"]
+    }
+  ],
+  "links": [
+    [1188, 1468, 0, 1363, 0, "IMAGE"],
+    [1189, 1469, 0, 1364, 0, "IMAGE"],
+    [1190, 1428, 0, 1440, 0, "MODEL"],
+    [1191, 1429, 0, 1441, 0, "MODEL"],
+    [1192, 1430, 0, 1442, 0, "MODEL"],
+    [1193, 1428, 0, 1443, 0, "MODEL"],
+    [1194, 1429, 0, 1444, 0, "MODEL"],
+    [1195, 1430, 0, 1445, 0, "MODEL"],
+    [1196, 1431, 0, 1446, 0, "MODEL"],
+    [1197, 1432, 0, 1447, 0, "CLIP"],
+    [1198, 1433, 0, 1448, 0, "CLIP"],
+    [1199, 1434, 0, 1449, 0, "CLIP"],
+    [1200, 1435, 0, 1450, 0, "VAE"],
+    [1201, 1436, 0, 1451, 0, "VAE"],
+    [1202, 1437, 0, 1452, 0, "VAE"],
+    [1203, 1448, 0, 1453, 0, "*"],
+    [1204, 1449, 0, 1454, 0, "*"],
+    [1205, 1450, 0, 1455, 0, "*"],
+    [1206, 1451, 0, 1456, 0, "*"],
+    [1207, 1452, 0, 1457, 0, "*"],
+    [1208, 1448, 0, 1458, 0, "*"],
+    [1209, 1449, 0, 1459, 0, "*"],
+    [1210, 1450, 0, 1460, 0, "*"],
+    [1211, 1451, 0, 1461, 0, "*"],
+    [1212, 1452, 0, 1462, 0, "*"],
+    [1213, 1443, 0, 1463, 0, "*"],
+    [1214, 1444, 0, 1464, 0, "*"],
+    [1215, 1445, 0, 1465, 0, "*"],
+    [1216, 1446, 0, 1466, 0, "*"],
+    [1217, 1447, 0, 1467, 0, "*"],
+    [1218, 1399, 0, 1468, 0, "IMAGE"],
+    [1219, 1398, 0, 1468, 1, "IMAGE"],
+    [1220, 1400, 0, 1468, 2, "IMAGE"],
+    [1221, 1401, 0, 1469, 0, "IMAGE"],
+    [1222, 1383, 0, 1469, 1, "IMAGE"],
+    [1223, 1384, 0, 1469, 2, "IMAGE"],
+    [1224, 1541, 0, 1553, 0, "MODEL"],
+    [1225, 1542, 0, 1554, 0, "MODEL"],
+    [1226, 1543, 0, 1555, 0, "MODEL"],
+    [1238, 1394, 0, 1582, 0, "VIDEO"],
+    [1239, 1582, 0, 1583, 0, "VIDEO"],
+    [1242, 1587, 0, 1584, 0, "VIDEO"],
+    [1370, 2316, 0, 2252, 0, "IMAGE"],
+    [1371, 2317, 0, 2253, 0, "IMAGE"],
+    [1372, 2276, 0, 2288, 0, "MODEL"],
+    [1373, 2277, 0, 2289, 0, "MODEL"],
+    [1374, 2278, 0, 2290, 0, "MODEL"],
+    [1375, 2276, 0, 2291, 0, "MODEL"],
+    [1376, 2277, 0, 2292, 0, "MODEL"],
+    [1377, 2278, 0, 2293, 0, "MODEL"],
+    [1378, 2279, 0, 2294, 0, "MODEL"],
+    [1379, 2280, 0, 2295, 0, "CLIP"],
+    [1380, 2281, 0, 2296, 0, "CLIP"],
+    [1381, 2282, 0, 2297, 0, "CLIP"],
+    [1382, 2283, 0, 2298, 0, "VAE"],
+    [1383, 2284, 0, 2299, 0, "VAE"],
+    [1384, 2285, 0, 2300, 0, "VAE"],
+    [1385, 2296, 0, 2301, 0, "INT"],
+    [1386, 2297, 0, 2302, 0, "INT"],
+    [1387, 2298, 0, 2303, 0, "INT"],
+    [1388, 2299, 0, 2304, 0, "INT"],
+    [1389, 2300, 0, 2305, 0, "INT"],
+    [1390, 2296, 0, 2306, 0, "INT"],
+    [1391, 2297, 0, 2307, 0, "INT"],
+    [1392, 2298, 0, 2308, 0, "INT"],
+    [1393, 2299, 0, 2309, 0, "INT"],
+    [1394, 2300, 0, 2310, 0, "INT"],
+    [1395, 2291, 0, 2311, 0, "INT"],
+    [1396, 2292, 0, 2312, 0, "INT"],
+    [1397, 2293, 0, 2313, 0, "INT"],
+    [1398, 2294, 0, 2314, 0, "INT"],
+    [1399, 2295, 0, 2315, 0, "INT"],
+    [1400, 2273, 0, 2316, 0, "IMAGE"],
+    [1401, 2272, 0, 2316, 1, "IMAGE"],
+    [1402, 2274, 0, 2316, 2, "IMAGE"],
+    [1403, 2275, 0, 2317, 0, "IMAGE"],
+    [1404, 2262, 0, 2317, 1, "IMAGE"],
+    [1405, 2263, 0, 2317, 2, "IMAGE"],
+    [1406, 2357, 0, 2369, 0, "MODEL"],
+    [1407, 2358, 0, 2370, 0, "MODEL"],
+    [1408, 2359, 0, 2371, 0, "MODEL"],
+    [1409, 2269, 0, 2382, 0, "VIDEO"],
+    [1410, 2382, 0, 2383, 0, "VIDEO"],
+    [1411, 2385, 0, 2384, 0, "VIDEO"],
+    [1412, 2462, 0, 2398, 0, "IMAGE"],
+    [1413, 2463, 0, 2399, 0, "IMAGE"],
+    [1414, 2422, 0, 2434, 0, "MODEL"],
+    [1415, 2423, 0, 2435, 0, "MODEL"],
+    [1416, 2424, 0, 2436, 0, "MODEL"],
+    [1417, 2422, 0, 2437, 0, "MODEL"],
+    [1418, 2423, 0, 2438, 0, "MODEL"],
+    [1419, 2424, 0, 2439, 0, "MODEL"],
+    [1420, 2425, 0, 2440, 0, "MODEL"],
+    [1421, 2426, 0, 2441, 0, "CLIP"],
+    [1422, 2427, 0, 2442, 0, "CLIP"],
+    [1423, 2428, 0, 2443, 0, "CLIP"],
+    [1424, 2429, 0, 2444, 0, "VAE"],
+    [1425, 2430, 0, 2445, 0, "VAE"],
+    [1426, 2431, 0, 2446, 0, "VAE"],
+    [1427, 2442, 0, 2447, 0, "INT"],
+    [1428, 2443, 0, 2448, 0, "INT"],
+    [1429, 2444, 0, 2449, 0, "INT"],
+    [1430, 2445, 0, 2450, 0, "INT"],
+    [1431, 2446, 0, 2451, 0, "INT"],
+    [1432, 2442, 0, 2452, 0, "INT"],
+    [1433, 2443, 0, 2453, 0, "INT"],
+    [1434, 2444, 0, 2454, 0, "INT"],
+    [1435, 2445, 0, 2455, 0, "INT"],
+    [1436, 2446, 0, 2456, 0, "INT"],
+    [1437, 2437, 0, 2457, 0, "INT"],
+    [1438, 2438, 0, 2458, 0, "INT"],
+    [1439, 2439, 0, 2459, 0, "INT"],
+    [1440, 2440, 0, 2460, 0, "INT"],
+    [1441, 2441, 0, 2461, 0, "INT"],
+    [1442, 2419, 0, 2462, 0, "IMAGE"],
+    [1443, 2418, 0, 2462, 1, "IMAGE"],
+    [1444, 2420, 0, 2462, 2, "IMAGE"],
+    [1445, 2421, 0, 2463, 0, "IMAGE"],
+    [1446, 2408, 0, 2463, 1, "IMAGE"],
+    [1447, 2409, 0, 2463, 2, "IMAGE"],
+    [1448, 2503, 0, 2515, 0, "MODEL"],
+    [1449, 2504, 0, 2516, 0, "MODEL"],
+    [1450, 2505, 0, 2517, 0, "MODEL"],
+    [1451, 2415, 0, 2528, 0, "VIDEO"],
+    [1452, 2528, 0, 2529, 0, "VIDEO"],
+    [1453, 2531, 0, 2530, 0, "VIDEO"],
+    [1454, 2641, 0, 2577, 0, "IMAGE"],
+    [1455, 2642, 0, 2578, 0, "IMAGE"],
+    [1456, 2601, 0, 2613, 0, "MODEL"],
+    [1457, 2602, 0, 2614, 0, "MODEL"],
+    [1458, 2603, 0, 2615, 0, "MODEL"],
+    [1459, 2601, 0, 2616, 0, "MODEL"],
+    [1460, 2602, 0, 2617, 0, "MODEL"],
+    [1461, 2603, 0, 2618, 0, "MODEL"],
+    [1462, 2604, 0, 2619, 0, "MODEL"],
+    [1463, 2605, 0, 2620, 0, "CLIP"],
+    [1464, 2606, 0, 2621, 0, "CLIP"],
+    [1465, 2607, 0, 2622, 0, "CLIP"],
+    [1466, 2608, 0, 2623, 0, "VAE"],
+    [1467, 2609, 0, 2624, 0, "VAE"],
+    [1468, 2610, 0, 2625, 0, "VAE"],
+    [1469, 2621, 0, 2626, 0, "INT"],
+    [1470, 2622, 0, 2627, 0, "INT"],
+    [1471, 2623, 0, 2628, 0, "INT"],
+    [1472, 2624, 0, 2629, 0, "INT"],
+    [1473, 2625, 0, 2630, 0, "INT"],
+    [1474, 2621, 0, 2631, 0, "INT"],
+    [1475, 2622, 0, 2632, 0, "INT"],
+    [1476, 2623, 0, 2633, 0, "INT"],
+    [1477, 2624, 0, 2634, 0, "INT"],
+    [1478, 2625, 0, 2635, 0, "INT"],
+    [1479, 2616, 0, 2636, 0, "INT"],
+    [1480, 2617, 0, 2637, 0, "INT"],
+    [1481, 2618, 0, 2638, 0, "INT"],
+    [1482, 2619, 0, 2639, 0, "INT"],
+    [1483, 2620, 0, 2640, 0, "INT"],
+    [1484, 2598, 0, 2641, 0, "IMAGE"],
+    [1485, 2597, 0, 2641, 1, "IMAGE"],
+    [1486, 2599, 0, 2641, 2, "IMAGE"],
+    [1487, 2600, 0, 2642, 0, "IMAGE"],
+    [1488, 2587, 0, 2642, 1, "IMAGE"],
+    [1489, 2588, 0, 2642, 2, "IMAGE"],
+    [1490, 2682, 0, 2694, 0, "MODEL"],
+    [1491, 2683, 0, 2695, 0, "MODEL"],
+    [1492, 2684, 0, 2696, 0, "MODEL"],
+    [1493, 2594, 0, 2707, 0, "VIDEO"],
+    [1494, 2707, 0, 2708, 0, "VIDEO"],
+    [1495, 2710, 0, 2709, 0, "VIDEO"]
+  ],
+  "groups": [
+    {
+      "id": 28,
+      "title": "Loader / Model Cluster",
+      "bounding": [17611.477708095426, 6909.59502616738, 1780, 1180],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 29,
+      "title": "Switch Cluster",
+      "bounding": [21214.986915290912, 9212.266532210777, 2660, 940],
+      "color": "#6a3f9e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 30,
+      "title": "Anchor / Reroute-like Cluster",
+      "bounding": [18940.565171221384, 11890.089241836757, 2680, 840],
+      "color": "#9e7a3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 31,
+      "title": "Media / Preview Cluster",
+      "bounding": [
+        13310.314693830547, 6014.438609589066, 3237.017008463542,
+        2356.638361612956
+      ],
+      "color": "#3f9e7a",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 34,
+      "title": "Video Output Cluster",
+      "bounding": [
+        27638.79773269744, 5677.011139133863, 3954.7136192831267,
+        2996.962961669819
+      ],
+      "color": "#9e5f3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 35,
+      "title": "Prompt / Widget Cluster B",
+      "bounding": [
+        20941.530599514408, 5869.454445853025, 3013.4007771809897,
+        2734.5138549804688
+      ],
+      "color": "#6a4c93",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 37,
+      "title": "Loader / Model Cluster B",
+      "bounding": [
+        24184.000001163313, 9218.780683057937, 651.6333110162676,
+        1080.5848915565382
+      ],
+      "color": "#8a6d3b",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 41,
+      "title": "Subgraph Edit Cluster",
+      "bounding": [
+        24492.57785541997, 6813.839992327126, 2085.8785619707214,
+        711.2052108480082
+      ],
+      "color": "#355c7d",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 42,
+      "title": "WAN Loader Extension",
+      "bounding": [17413.614015121646, 10473.386740360536, 1500, 875],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 43,
+      "title": "WAN Loader Extension B",
+      "bounding": [
+        21797.261590549693, 10610.416267362842, 1458.3333333333335,
+        1333.3333333333335
+      ],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 44,
+      "title": "Loader / Model Cluster",
+      "bounding": [36330.7686603717, 9403.922742346276, 1780, 1180],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 45,
+      "title": "Switch Cluster",
+      "bounding": [39934.27786756719, 11706.594248389674, 2660, 940],
+      "color": "#6a3f9e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 46,
+      "title": "Anchor / Reroute-like Cluster",
+      "bounding": [37659.85612349766, 14384.41695801565, 2680, 840],
+      "color": "#9e7a3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 47,
+      "title": "Media / Preview Cluster",
+      "bounding": [
+        32029.605646106822, 8508.766325767963, 3237.017008463542,
+        2356.638361612956
+      ],
+      "color": "#3f9e7a",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 48,
+      "title": "Video Output Cluster",
+      "bounding": [
+        46358.088684973714, 8171.33885531276, 3954.7136192831267,
+        2996.962961669819
+      ],
+      "color": "#9e5f3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 49,
+      "title": "Prompt / Widget Cluster B",
+      "bounding": [
+        39660.82155179069, 8363.782162031923, 3013.4007771809897,
+        2734.5138549804688
+      ],
+      "color": "#6a4c93",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 50,
+      "title": "Loader / Model Cluster B",
+      "bounding": [
+        42903.29095343959, 11713.108399236835, 651.6333110162676,
+        1080.5848915565382
+      ],
+      "color": "#8a6d3b",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 51,
+      "title": "Subgraph Edit Cluster",
+      "bounding": [
+        43211.86880769625, 9308.167708506022, 2085.8785619707214,
+        711.2052108480082
+      ],
+      "color": "#355c7d",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 52,
+      "title": "WAN Loader Extension",
+      "bounding": [36132.904967397924, 12967.714456539432, 1500, 875],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 53,
+      "title": "WAN Loader Extension B",
+      "bounding": [
+        40516.552542825964, 13104.743983541737, 1458.3333333333335,
+        1333.3333333333335
+      ],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 44,
+      "title": "Loader / Model Cluster",
+      "bounding": [20509.512470816477, 14674.915918715196, 1780, 1180],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 45,
+      "title": "Switch Cluster",
+      "bounding": [24113.021678011963, 16977.587424758596, 2660, 940],
+      "color": "#6a3f9e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 46,
+      "title": "Anchor / Reroute-like Cluster",
+      "bounding": [21838.599933942434, 19655.41013438457, 2680, 840],
+      "color": "#9e7a3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 47,
+      "title": "Media / Preview Cluster",
+      "bounding": [
+        16208.349456551598, 13779.759502136883, 3237.017008463542,
+        2356.638361612956
+      ],
+      "color": "#3f9e7a",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 48,
+      "title": "Video Output Cluster",
+      "bounding": [
+        30536.83249541849, 13442.332031681679, 3954.7136192831267,
+        2996.962961669819
+      ],
+      "color": "#9e5f3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 49,
+      "title": "Prompt / Widget Cluster B",
+      "bounding": [
+        23839.565362235462, 13634.775338400843, 3013.4007771809897,
+        2734.5138549804688
+      ],
+      "color": "#6a4c93",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 50,
+      "title": "Loader / Model Cluster B",
+      "bounding": [
+        27082.034763884363, 16984.101575605753, 651.6333110162676,
+        1080.5848915565382
+      ],
+      "color": "#8a6d3b",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 51,
+      "title": "Subgraph Edit Cluster",
+      "bounding": [
+        27390.612618141025, 14579.160884874942, 2085.8785619707214,
+        711.2052108480082
+      ],
+      "color": "#355c7d",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 52,
+      "title": "WAN Loader Extension",
+      "bounding": [20311.6487778427, 18238.70763290835, 1500, 875],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 53,
+      "title": "WAN Loader Extension B",
+      "bounding": [
+        24695.29635327074, 18375.737159910655, 1458.3333333333335,
+        1333.3333333333335
+      ],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 44,
+      "title": "Loader / Model Cluster",
+      "bounding": [31740.18221306114, 19238.14346103958, 1780, 1180],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 45,
+      "title": "Switch Cluster",
+      "bounding": [35343.691420256626, 21540.81496708298, 2660, 940],
+      "color": "#6a3f9e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 46,
+      "title": "Anchor / Reroute-like Cluster",
+      "bounding": [33069.2696761871, 24218.637676708957, 2680, 840],
+      "color": "#9e7a3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 47,
+      "title": "Media / Preview Cluster",
+      "bounding": [
+        27439.01919879626, 18342.987044461268, 3237.017008463542,
+        2356.638361612956
+      ],
+      "color": "#3f9e7a",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 48,
+      "title": "Video Output Cluster",
+      "bounding": [
+        41767.50223766315, 18005.559574006067, 3954.7136192831267,
+        2996.962961669819
+      ],
+      "color": "#9e5f3f",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 49,
+      "title": "Prompt / Widget Cluster B",
+      "bounding": [
+        35070.235104480125, 18198.002880725227, 3013.4007771809897,
+        2734.5138549804688
+      ],
+      "color": "#6a4c93",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 50,
+      "title": "Loader / Model Cluster B",
+      "bounding": [
+        38312.70450612903, 21547.32911793014, 651.6333110162676,
+        1080.5848915565382
+      ],
+      "color": "#8a6d3b",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 51,
+      "title": "Subgraph Edit Cluster",
+      "bounding": [
+        38621.28236038569, 19142.38842719933, 2085.8785619707214,
+        711.2052108480082
+      ],
+      "color": "#355c7d",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 52,
+      "title": "WAN Loader Extension",
+      "bounding": [31542.318520087363, 22801.93517523274, 1500, 875],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 53,
+      "title": "WAN Loader Extension B",
+      "bounding": [
+        35925.9660955154, 22938.964702235044, 1458.3333333333335,
+        1333.3333333333335
+      ],
+      "color": "#b56576",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "9357f4a3-ff0c-448b-b2aa-7d30595f0eb0",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1092,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0019172974644, -329.9993552257147],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 1093,
+            "type": "VAELoader",
+            "pos": [-645.9970517826987, 186.9859555531366],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 1094,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, 40.00063826408132],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1095,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, -89.9994138435568],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1096,
+            "type": "CFGNorm",
+            "pos": [320.0019172974644, -219.9994659511949],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 1097,
+            "type": "MarkdownNote",
+            "pos": [640.001302442939, 280.0005796462401],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1098,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, 30.000758109047638],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1099,
+            "type": "Note",
+            "pos": [330.00219997554814, 160.00081021668575],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 1100,
+            "type": "VAEDecode",
+            "pos": [960.0022976806213, -319.9994750706819],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1101,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, -289.9994320825308],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 1102,
+            "type": "KSampler",
+            "pos": [630.0026298570592, -329.9993552257147],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 1103,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978482311708, 380.0005887657262],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1104,
+            "type": "UNETLoader",
+            "pos": [-645.9970517826987, -299.01393580880995],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 1105,
+            "type": "CLIPLoader",
+            "pos": [-649.9981309092545, 0.0007151208965296973],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 1106,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9981309092545, -149.999499819859],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1107,
+            "type": "VAEEncode",
+            "pos": [60.002618128288304, 380.0005887657262],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 1098,
+            "origin_slot": 0,
+            "target_id": 1094,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 1101,
+            "origin_slot": 0,
+            "target_id": 1095,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 1092,
+            "origin_slot": 0,
+            "target_id": 1096,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 1105,
+            "origin_slot": 0,
+            "target_id": 1098,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 1093,
+            "origin_slot": 0,
+            "target_id": 1098,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 1103,
+            "origin_slot": 0,
+            "target_id": 1098,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 1103,
+            "origin_slot": 0,
+            "target_id": 1107,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 1093,
+            "origin_slot": 0,
+            "target_id": 1107,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 1105,
+            "origin_slot": 0,
+            "target_id": 1101,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 1093,
+            "origin_slot": 0,
+            "target_id": 1101,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 1096,
+            "origin_slot": 0,
+            "target_id": 1102,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 1095,
+            "origin_slot": 0,
+            "target_id": 1102,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 1094,
+            "origin_slot": 0,
+            "target_id": 1102,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 1107,
+            "origin_slot": 0,
+            "target_id": 1102,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 1102,
+            "origin_slot": 0,
+            "target_id": 1100,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 1093,
+            "origin_slot": 0,
+            "target_id": 1100,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 1100,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1101,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1103,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1101,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1098,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1101,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1098,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 1103,
+            "origin_slot": 0,
+            "target_id": 1101,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 1104,
+            "origin_slot": 0,
+            "target_id": 1106,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 1106,
+            "origin_slot": 0,
+            "target_id": 1092,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1106,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1106,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "e842b445-b504-4302-abd8-a0b26e24f68e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1108,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0009189841585, -330.00029127418566],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 1109,
+            "type": "VAELoader",
+            "pos": [-645.9976161720915, 186.98579271018934],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 1110,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, 40.000319077376844],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1111,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, -89.99968092262316],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1112,
+            "type": "CFGNorm",
+            "pos": [320.0009189841585, -219.9993757468419],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 1113,
+            "type": "MarkdownNote",
+            "pos": [640.0009189841585, 280.00031907737684],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1114,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, 30.000624253158094],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1115,
+            "type": "Note",
+            "pos": [330.0021396872835, 160.00031907737684],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 1116,
+            "type": "VAEDecode",
+            "pos": [960.0021396872835, -319.99968092262316],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1117,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, -289.99968092262316],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 1118,
+            "type": "KSampler",
+            "pos": [630.0021396872835, -330.00029127418566],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 1119,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978603127165, 380.00031907737684],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1120,
+            "type": "UNETLoader",
+            "pos": [-645.9976161720915, -299.01457350074816],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 1121,
+            "type": "CLIPLoader",
+            "pos": [-649.9990810158415, 0.0006242531580937793],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 1122,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9990810158415, -149.99968092262316],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1123,
+            "type": "VAEEncode",
+            "pos": [60.00213968728349, 380.00031907737684],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 1114,
+            "origin_slot": 0,
+            "target_id": 1110,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 1117,
+            "origin_slot": 0,
+            "target_id": 1111,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 1108,
+            "origin_slot": 0,
+            "target_id": 1112,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 1121,
+            "origin_slot": 0,
+            "target_id": 1114,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 1109,
+            "origin_slot": 0,
+            "target_id": 1114,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 1119,
+            "origin_slot": 0,
+            "target_id": 1114,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 1119,
+            "origin_slot": 0,
+            "target_id": 1123,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 1109,
+            "origin_slot": 0,
+            "target_id": 1123,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 1121,
+            "origin_slot": 0,
+            "target_id": 1117,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 1109,
+            "origin_slot": 0,
+            "target_id": 1117,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 1112,
+            "origin_slot": 0,
+            "target_id": 1118,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 1111,
+            "origin_slot": 0,
+            "target_id": 1118,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 1110,
+            "origin_slot": 0,
+            "target_id": 1118,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 1123,
+            "origin_slot": 0,
+            "target_id": 1118,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 1118,
+            "origin_slot": 0,
+            "target_id": 1116,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 1109,
+            "origin_slot": 0,
+            "target_id": 1116,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 1116,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1117,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1119,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1117,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1114,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1117,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1114,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 1119,
+            "origin_slot": 0,
+            "target_id": 1117,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 1120,
+            "origin_slot": 0,
+            "target_id": 1122,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 1122,
+            "origin_slot": 0,
+            "target_id": 1108,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1122,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1122,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "3f323234-d98d-4a21-9623-ff5f7e7db5ad",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1595,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0019172974644, -329.9993552257147],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 1596,
+            "type": "VAELoader",
+            "pos": [-645.9970517826987, 186.9859555531366],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 1597,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, 40.00063826408132],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1598,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, -89.9994138435568],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1599,
+            "type": "CFGNorm",
+            "pos": [320.0019172974644, -219.9994659511949],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 1600,
+            "type": "MarkdownNote",
+            "pos": [640.001302442939, 280.0005796462401],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1601,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, 30.000758109047638],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1602,
+            "type": "Note",
+            "pos": [330.00219997554814, 160.00081021668575],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 1603,
+            "type": "VAEDecode",
+            "pos": [960.0022976806213, -319.9994750706819],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1604,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, -289.9994320825308],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 1605,
+            "type": "KSampler",
+            "pos": [630.0026298570592, -329.9993552257147],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 1606,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978482311708, 380.0005887657262],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1607,
+            "type": "UNETLoader",
+            "pos": [-645.9970517826987, -299.01393580880995],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 1608,
+            "type": "CLIPLoader",
+            "pos": [-649.9981309092545, 0.0007151208965296973],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 1609,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9981309092545, -149.999499819859],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1610,
+            "type": "VAEEncode",
+            "pos": [60.002618128288304, 380.0005887657262],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 1601,
+            "origin_slot": 0,
+            "target_id": 1597,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 1604,
+            "origin_slot": 0,
+            "target_id": 1598,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 1595,
+            "origin_slot": 0,
+            "target_id": 1599,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 1608,
+            "origin_slot": 0,
+            "target_id": 1601,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 1596,
+            "origin_slot": 0,
+            "target_id": 1601,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 1606,
+            "origin_slot": 0,
+            "target_id": 1601,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 1606,
+            "origin_slot": 0,
+            "target_id": 1610,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 1596,
+            "origin_slot": 0,
+            "target_id": 1610,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 1608,
+            "origin_slot": 0,
+            "target_id": 1604,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 1596,
+            "origin_slot": 0,
+            "target_id": 1604,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 1599,
+            "origin_slot": 0,
+            "target_id": 1605,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 1598,
+            "origin_slot": 0,
+            "target_id": 1605,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 1597,
+            "origin_slot": 0,
+            "target_id": 1605,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 1610,
+            "origin_slot": 0,
+            "target_id": 1605,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 1605,
+            "origin_slot": 0,
+            "target_id": 1603,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 1596,
+            "origin_slot": 0,
+            "target_id": 1603,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 1603,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1604,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1606,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1604,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1601,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1604,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1601,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 1606,
+            "origin_slot": 0,
+            "target_id": 1604,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 1607,
+            "origin_slot": 0,
+            "target_id": 1609,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 1609,
+            "origin_slot": 0,
+            "target_id": 1595,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1609,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1609,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "c73951c4-0095-48c1-8337-c4ff4001b55d",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1611,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0009189841585, -330.00029127418566],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 1612,
+            "type": "VAELoader",
+            "pos": [-645.9976161720915, 186.98579271018934],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 1613,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, 40.000319077376844],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1614,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, -89.99968092262316],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1615,
+            "type": "CFGNorm",
+            "pos": [320.0009189841585, -219.9993757468419],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 1616,
+            "type": "MarkdownNote",
+            "pos": [640.0009189841585, 280.00031907737684],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 1617,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, 30.000624253158094],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1618,
+            "type": "Note",
+            "pos": [330.0021396872835, 160.00031907737684],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 1619,
+            "type": "VAEDecode",
+            "pos": [960.0021396872835, -319.99968092262316],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1620,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, -289.99968092262316],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 1621,
+            "type": "KSampler",
+            "pos": [630.0021396872835, -330.00029127418566],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 1622,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978603127165, 380.00031907737684],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1623,
+            "type": "UNETLoader",
+            "pos": [-645.9976161720915, -299.01457350074816],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 1624,
+            "type": "CLIPLoader",
+            "pos": [-649.9990810158415, 0.0006242531580937793],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 1625,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9990810158415, -149.99968092262316],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 1626,
+            "type": "VAEEncode",
+            "pos": [60.00213968728349, 380.00031907737684],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 1617,
+            "origin_slot": 0,
+            "target_id": 1613,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 1620,
+            "origin_slot": 0,
+            "target_id": 1614,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 1611,
+            "origin_slot": 0,
+            "target_id": 1615,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 1624,
+            "origin_slot": 0,
+            "target_id": 1617,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 1612,
+            "origin_slot": 0,
+            "target_id": 1617,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 1622,
+            "origin_slot": 0,
+            "target_id": 1617,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 1622,
+            "origin_slot": 0,
+            "target_id": 1626,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 1612,
+            "origin_slot": 0,
+            "target_id": 1626,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 1624,
+            "origin_slot": 0,
+            "target_id": 1620,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 1612,
+            "origin_slot": 0,
+            "target_id": 1620,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 1615,
+            "origin_slot": 0,
+            "target_id": 1621,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 1614,
+            "origin_slot": 0,
+            "target_id": 1621,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 1613,
+            "origin_slot": 0,
+            "target_id": 1621,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 1626,
+            "origin_slot": 0,
+            "target_id": 1621,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 1621,
+            "origin_slot": 0,
+            "target_id": 1619,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 1612,
+            "origin_slot": 0,
+            "target_id": 1619,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 1619,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1620,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1622,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1620,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1617,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1620,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1617,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 1622,
+            "origin_slot": 0,
+            "target_id": 1620,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 1623,
+            "origin_slot": 0,
+            "target_id": 1625,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 1625,
+            "origin_slot": 0,
+            "target_id": 1611,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1625,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1625,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "c1348745-88ee-4088-83f2-e6804e872a82",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 2214,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0019172974644, -329.9993552257147],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 2215,
+            "type": "VAELoader",
+            "pos": [-645.9970517826987, 186.9859555531366],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 2216,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, 40.00063826408132],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2217,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, -89.9994138435568],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2218,
+            "type": "CFGNorm",
+            "pos": [320.0019172974644, -219.9994659511949],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 2219,
+            "type": "MarkdownNote",
+            "pos": [640.001302442939, 280.0005796462401],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2220,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, 30.000758109047638],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2221,
+            "type": "Note",
+            "pos": [330.00219997554814, 160.00081021668575],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 2222,
+            "type": "VAEDecode",
+            "pos": [960.0022976806213, -319.9994750706819],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2223,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, -289.9994320825308],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 2224,
+            "type": "KSampler",
+            "pos": [630.0026298570592, -329.9993552257147],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 2225,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978482311708, 380.0005887657262],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2226,
+            "type": "UNETLoader",
+            "pos": [-645.9970517826987, -299.01393580880995],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 2227,
+            "type": "CLIPLoader",
+            "pos": [-649.9981309092545, 0.0007151208965296973],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 2228,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9981309092545, -149.999499819859],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2229,
+            "type": "VAEEncode",
+            "pos": [60.002618128288304, 380.0005887657262],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 2220,
+            "origin_slot": 0,
+            "target_id": 2216,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 2223,
+            "origin_slot": 0,
+            "target_id": 2217,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 2214,
+            "origin_slot": 0,
+            "target_id": 2218,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 2227,
+            "origin_slot": 0,
+            "target_id": 2220,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 2215,
+            "origin_slot": 0,
+            "target_id": 2220,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 2225,
+            "origin_slot": 0,
+            "target_id": 2220,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 2225,
+            "origin_slot": 0,
+            "target_id": 2229,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 2215,
+            "origin_slot": 0,
+            "target_id": 2229,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 2227,
+            "origin_slot": 0,
+            "target_id": 2223,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 2215,
+            "origin_slot": 0,
+            "target_id": 2223,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 2218,
+            "origin_slot": 0,
+            "target_id": 2224,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 2217,
+            "origin_slot": 0,
+            "target_id": 2224,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 2216,
+            "origin_slot": 0,
+            "target_id": 2224,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 2229,
+            "origin_slot": 0,
+            "target_id": 2224,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 2224,
+            "origin_slot": 0,
+            "target_id": 2222,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 2215,
+            "origin_slot": 0,
+            "target_id": 2222,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 2222,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 2223,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 2225,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2223,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2220,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2223,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2220,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 2225,
+            "origin_slot": 0,
+            "target_id": 2223,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 2226,
+            "origin_slot": 0,
+            "target_id": 2228,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 2228,
+            "origin_slot": 0,
+            "target_id": 2214,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 2228,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 2228,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "75d18ee0-62fa-4994-9e0d-e7786f283ed4",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 2230,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0009189841585, -330.00029127418566],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 2231,
+            "type": "VAELoader",
+            "pos": [-645.9976161720915, 186.98579271018934],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 2232,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, 40.000319077376844],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2233,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, -89.99968092262316],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2234,
+            "type": "CFGNorm",
+            "pos": [320.0009189841585, -219.9993757468419],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 2235,
+            "type": "MarkdownNote",
+            "pos": [640.0009189841585, 280.00031907737684],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2236,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, 30.000624253158094],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2237,
+            "type": "Note",
+            "pos": [330.0021396872835, 160.00031907737684],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 2238,
+            "type": "VAEDecode",
+            "pos": [960.0021396872835, -319.99968092262316],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2239,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, -289.99968092262316],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 2240,
+            "type": "KSampler",
+            "pos": [630.0021396872835, -330.00029127418566],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 2241,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978603127165, 380.00031907737684],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2242,
+            "type": "UNETLoader",
+            "pos": [-645.9976161720915, -299.01457350074816],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 2243,
+            "type": "CLIPLoader",
+            "pos": [-649.9990810158415, 0.0006242531580937793],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 2244,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9990810158415, -149.99968092262316],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2245,
+            "type": "VAEEncode",
+            "pos": [60.00213968728349, 380.00031907737684],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 2236,
+            "origin_slot": 0,
+            "target_id": 2232,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 2239,
+            "origin_slot": 0,
+            "target_id": 2233,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 2230,
+            "origin_slot": 0,
+            "target_id": 2234,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 2243,
+            "origin_slot": 0,
+            "target_id": 2236,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 2231,
+            "origin_slot": 0,
+            "target_id": 2236,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 2241,
+            "origin_slot": 0,
+            "target_id": 2236,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 2241,
+            "origin_slot": 0,
+            "target_id": 2245,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 2231,
+            "origin_slot": 0,
+            "target_id": 2245,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 2243,
+            "origin_slot": 0,
+            "target_id": 2239,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 2231,
+            "origin_slot": 0,
+            "target_id": 2239,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 2234,
+            "origin_slot": 0,
+            "target_id": 2240,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 2233,
+            "origin_slot": 0,
+            "target_id": 2240,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 2232,
+            "origin_slot": 0,
+            "target_id": 2240,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 2245,
+            "origin_slot": 0,
+            "target_id": 2240,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 2240,
+            "origin_slot": 0,
+            "target_id": 2238,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 2231,
+            "origin_slot": 0,
+            "target_id": 2238,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 2238,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 2239,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 2241,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2239,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2236,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2239,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2236,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 2241,
+            "origin_slot": 0,
+            "target_id": 2239,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 2242,
+            "origin_slot": 0,
+            "target_id": 2244,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 2244,
+            "origin_slot": 0,
+            "target_id": 2230,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 2244,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 2244,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "278e37b2-bbad-4c90-b99d-05fd3f58885e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 2539,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0019172974644, -329.9993552257147],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 2540,
+            "type": "VAELoader",
+            "pos": [-645.9970517826987, 186.9859555531366],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 2541,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, 40.00063826408132],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2542,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.00163461938064, -89.9994138435568],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2543,
+            "type": "CFGNorm",
+            "pos": [320.0019172974644, -219.9994659511949],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 2544,
+            "type": "MarkdownNote",
+            "pos": [640.001302442939, 280.0005796462401],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2545,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, 30.000758109047638],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2546,
+            "type": "Note",
+            "pos": [330.00219997554814, 160.00081021668575],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 2547,
+            "type": "VAEDecode",
+            "pos": [960.0022976806213, -319.9994750706819],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2548,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.99744309883317, -289.9994320825308],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 2549,
+            "type": "KSampler",
+            "pos": [630.0026298570592, -329.9993552257147],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 2550,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978482311708, 380.0005887657262],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2551,
+            "type": "UNETLoader",
+            "pos": [-645.9970517826987, -299.01393580880995],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 2552,
+            "type": "CLIPLoader",
+            "pos": [-649.9981309092545, 0.0007151208965296973],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 2553,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9981309092545, -149.999499819859],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2554,
+            "type": "VAEEncode",
+            "pos": [60.002618128288304, 380.0005887657262],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 2545,
+            "origin_slot": 0,
+            "target_id": 2541,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 2548,
+            "origin_slot": 0,
+            "target_id": 2542,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 2539,
+            "origin_slot": 0,
+            "target_id": 2543,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 2552,
+            "origin_slot": 0,
+            "target_id": 2545,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 2540,
+            "origin_slot": 0,
+            "target_id": 2545,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 2550,
+            "origin_slot": 0,
+            "target_id": 2545,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 2550,
+            "origin_slot": 0,
+            "target_id": 2554,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 2540,
+            "origin_slot": 0,
+            "target_id": 2554,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 2552,
+            "origin_slot": 0,
+            "target_id": 2548,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 2540,
+            "origin_slot": 0,
+            "target_id": 2548,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 2543,
+            "origin_slot": 0,
+            "target_id": 2549,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 2542,
+            "origin_slot": 0,
+            "target_id": 2549,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 2541,
+            "origin_slot": 0,
+            "target_id": 2549,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 2554,
+            "origin_slot": 0,
+            "target_id": 2549,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 2549,
+            "origin_slot": 0,
+            "target_id": 2547,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 2540,
+            "origin_slot": 0,
+            "target_id": 2547,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 2547,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 2548,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 2550,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2548,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2545,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2548,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2545,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 2550,
+            "origin_slot": 0,
+            "target_id": 2548,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 2551,
+            "origin_slot": 0,
+            "target_id": 2553,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 2553,
+            "origin_slot": 0,
+            "target_id": 2539,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 2553,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 2553,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      },
+      {
+        "id": "f5e3d92c-c465-493e-897c-1df9320725a2",
+        "version": 1,
+        "state": {
+          "lastGroupId": 53,
+          "lastNodeId": 2717,
+          "lastLinkId": 1495,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen 2511)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-840, 175, 141.2265625, 160]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1160, 195, 120, 60]
+        },
+        "inputs": [
+          {
+            "id": "dd7b081e-ea65-43c8-bd68-0f82506c4246",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [219],
+            "localized_name": "image2",
+            "label": "image_1",
+            "shape": 7,
+            "pos": [-718.7734375, 195]
+          },
+          {
+            "id": "70e82187-e90b-49d7-88cd-fce5c0522cc4",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [222, 223],
+            "localized_name": "image3",
+            "label": "image_2(optional)",
+            "shape": 7,
+            "pos": [-718.7734375, 215]
+          },
+          {
+            "id": "342882bc-746e-471e-afc5-cac803d00044",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [220, 221],
+            "localized_name": "image",
+            "label": "image_3(optional)",
+            "pos": [-718.7734375, 235]
+          },
+          {
+            "id": "37ec7435-5be8-4f68-a490-136ebe1a15f2",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [217],
+            "pos": [-718.7734375, 255]
+          },
+          {
+            "id": "7aa394b9-32c5-4604-9cb1-d15947e2a6f0",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [229],
+            "pos": [-718.7734375, 275]
+          },
+          {
+            "id": "12234894-db00-418c-a024-3e2a8e79c41e",
+            "name": "strength_model",
+            "type": "FLOAT",
+            "linkIds": [230],
+            "label": "lora_strength",
+            "pos": [-718.7734375, 295]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "213ca908-7f8f-492b-9998-d4b74688db71",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [9],
+            "localized_name": "IMAGE",
+            "pos": [1180, 215]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 2555,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [320.0009189841585, -330.00029127418566],
+            "size": [270, 80],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [177]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [3.1]
+          },
+          {
+            "id": 2556,
+            "type": "VAELoader",
+            "pos": [-645.9976161720915, 186.98579271018934],
+            "size": [396.125, 82.65625],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [12, 184, 185, 193]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["qwen_image_vae.safetensors"]
+          },
+          {
+            "id": 2557,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, 40.000319077376844],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 188
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [189]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2558,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [310.0009189841585, -89.99968092262316],
+            "size": [309.671875, 76],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 186
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [187]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["index_timestep_zero"],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2559,
+            "type": "CFGNorm",
+            "pos": [320.0009189841585, -219.9993757468419],
+            "size": [270, 104],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 177
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [171]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [1]
+          },
+          {
+            "id": 2560,
+            "type": "MarkdownNote",
+            "pos": [640.0009189841585, 280.00031907737684],
+            "size": [270, 331.375],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "KSampler settings",
+            "properties": {},
+            "widgets_values": [
+              "You can test and find the best setting by yourself. The following table is for reference.\n|   | Qwen | Comfy | lightning LoRA |\n|--------|---------|------------|---------------------------|\n| Steps  | 40      | 20         | 4                         |\n| CFG    | 4.0     | 4.0       | 1.0                       |\n\nBy default, we use 20 steps as we just don't want it to take too long. Try 40 if you want a better result, but it will take longer."
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 2561,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, 30.000624253158094],
+            "size": [420, 220],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 181
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 185
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 214
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 223
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 221
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [188]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [""],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2562,
+            "type": "Note",
+            "pos": [330.0021396872835, 160.00031907737684],
+            "size": [280, 92],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {},
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 2563,
+            "type": "VAEDecode",
+            "pos": [960.0021396872835, -319.99968092262316],
+            "size": [225, 72],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 175
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 12
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [9]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2564,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [-169.9978603127165, -289.99968092262316],
+            "size": [426.625, 265.546875],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 178
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 184
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 225
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 222
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 220
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [186]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": ["inflate the woman"],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 2565,
+            "type": "KSampler",
+            "pos": [630.0021396872835, -330.00029127418566],
+            "size": [280, 536],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 171
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 187
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 189
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 195
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [175]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              544553820212047,
+              "randomize",
+              40,
+              4,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 2566,
+            "type": "FluxKontextImageScale",
+            "pos": [-639.9978603127165, 380.00031907737684],
+            "size": [225, 48],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 219
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [213, 214, 215, 225]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 2567,
+            "type": "UNETLoader",
+            "pos": [-645.9976161720915, -299.01457350074816],
+            "size": [396.125, 96.65625],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [227]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 2568,
+            "type": "CLIPLoader",
+            "pos": [-649.9990810158415, 0.0006242531580937793],
+            "size": [396.125, 125],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [178, 181]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 2569,
+            "type": "LoraLoaderModelOnly",
+            "pos": [-649.9990810158415, -149.99968092262316],
+            "size": [390, 114.65625],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 227
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "strength_model",
+                "name": "strength_model",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "strength_model"
+                },
+                "link": 230
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [228]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.11.0",
+              "models": [
+                {
+                  "name": "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+                  "url": "https://huggingface.co/systms/SYSTMS-INFL8-LoRA-Qwen-Image-Edit-2511/resolve/main/SYSTMS_INFL8_LoRA_Qwen_Image_Edit_2511.safetensors",
+                  "directory": "loras"
+                }
+              ]
+            },
+            "widgets_values": [
+              "Qwen_Image_Edit_2511-SYSTMS_INFL8.safetensors",
+              1
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 2570,
+            "type": "VAEEncode",
+            "pos": [60.00213968728349, 380.00031907737684],
+            "size": [225, 72],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 215
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 193
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [195]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [-660, -370, 416.1419982910156, 630.0299011230469],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [-220, -370, 510, 630],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 188,
+            "origin_id": 2561,
+            "origin_slot": 0,
+            "target_id": 2557,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 186,
+            "origin_id": 2564,
+            "origin_slot": 0,
+            "target_id": 2558,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 177,
+            "origin_id": 2555,
+            "origin_slot": 0,
+            "target_id": 2559,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 181,
+            "origin_id": 2568,
+            "origin_slot": 0,
+            "target_id": 2561,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 185,
+            "origin_id": 2556,
+            "origin_slot": 0,
+            "target_id": 2561,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 214,
+            "origin_id": 2566,
+            "origin_slot": 0,
+            "target_id": 2561,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 215,
+            "origin_id": 2566,
+            "origin_slot": 0,
+            "target_id": 2570,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 193,
+            "origin_id": 2556,
+            "origin_slot": 0,
+            "target_id": 2570,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 178,
+            "origin_id": 2568,
+            "origin_slot": 0,
+            "target_id": 2564,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 184,
+            "origin_id": 2556,
+            "origin_slot": 0,
+            "target_id": 2564,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 171,
+            "origin_id": 2559,
+            "origin_slot": 0,
+            "target_id": 2565,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 187,
+            "origin_id": 2558,
+            "origin_slot": 0,
+            "target_id": 2565,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 189,
+            "origin_id": 2557,
+            "origin_slot": 0,
+            "target_id": 2565,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 195,
+            "origin_id": 2570,
+            "origin_slot": 0,
+            "target_id": 2565,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 175,
+            "origin_id": 2565,
+            "origin_slot": 0,
+            "target_id": 2563,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 2556,
+            "origin_slot": 0,
+            "target_id": 2563,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 9,
+            "origin_id": 2563,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 2564,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 2566,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 220,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2564,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 221,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 2561,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2564,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 223,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2561,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 225,
+            "origin_id": 2566,
+            "origin_slot": 0,
+            "target_id": 2564,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 227,
+            "origin_id": 2567,
+            "origin_slot": 0,
+            "target_id": 2569,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 228,
+            "origin_id": 2569,
+            "origin_slot": 0,
+            "target_id": 2555,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 2569,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 2569,
+            "target_slot": 2,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.23579476910000013,
+      "offset": [-34261.05491852785, -17903.8655194438]
+    },
+    "frontendVersion": "1.42.8",
+    "workflowRendererVersion": "Vue-corrected",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/performance.spec.ts
+++ b/browser_tests/tests/performance.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import { assetPath } from '../fixtures/utils/paths'
 import { logMeasurement, recordMeasurement } from '../helpers/perfReporter'
 
 test.describe('Performance', { tag: ['@perf'] }, () => {
@@ -345,6 +346,63 @@ test.describe('Performance', { tag: ['@perf'] }, () => {
       console.log(
         `Vue zoom culling: ${m.styleRecalcs} style recalcs, ${m.layouts} layouts, ${m.frameDurationMs.toFixed(1)}ms/frame`
       )
+    })
+  })
+
+  test.describe('workflow loading', () => {
+    test('large workflow load and settle', async ({ comfyPage }) => {
+      await comfyPage.perf.startMeasuring()
+
+      await comfyPage.workflow.loadWorkflow('large-graph-workflow')
+
+      // Settling period: 120 frames (~2s) for DOM creation + layout stabilization
+      for (let i = 0; i < 120; i++) {
+        await comfyPage.nextFrame()
+      }
+
+      const m = await comfyPage.perf.stopMeasuring('large-workflow-load')
+      recordMeasurement(m)
+      logMeasurement('Large workflow load', m, [
+        'durationMs',
+        'styleRecalcs',
+        'layouts',
+        'taskDurationMs',
+        'totalBlockingTimeMs',
+        'domNodes',
+        'heapDeltaBytes'
+      ])
+    })
+
+    test('media-heavy workflow load and settle', async ({ comfyPage }) => {
+      // Intercept all media preview requests with a small test image
+      await comfyPage.page.route(/\/api\/view\?/, (route) =>
+        route.fulfill({
+          path: assetPath('image64x64.webp'),
+          contentType: 'image/webp'
+        })
+      )
+
+      await comfyPage.perf.startMeasuring()
+
+      await comfyPage.workflow.loadWorkflow('profiling-workflow-media-heavy')
+
+      // Longer settling: 240 frames (~4s) for 585 nodes + 128 media previews
+      for (let i = 0; i < 240; i++) {
+        await comfyPage.nextFrame()
+      }
+
+      const m = await comfyPage.perf.stopMeasuring('media-heavy-workflow-load')
+      recordMeasurement(m)
+      logMeasurement('Media-heavy workflow load', m, [
+        'durationMs',
+        'styleRecalcs',
+        'layouts',
+        'taskDurationMs',
+        'totalBlockingTimeMs',
+        'frameDurationMs',
+        'domNodes',
+        'heapDeltaBytes'
+      ])
     })
   })
 


### PR DESCRIPTION
Adds two `@perf` tests measuring workflow load + settling time to establish baselines for upcoming optimization work.

## What
- **large workflow load and settle**: 245-node workflow, measures DOM creation + layout stabilization cost
- **media-heavy workflow load and settle**: 585-node workflow with 128 media references, measures combined node creation + media preview loading pressure (media requests intercepted with a small test image for determinism)

## Why
PR 1 of 2. Establishes CI baselines so the follow-up optimization PR can show proven improvement via `ci-perf-report`.

## Test plan
- [x] Both tests pass locally with `pnpm exec playwright test --project=performance --grep "workflow load"`
- [x] Lint, typecheck pass

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10823-test-add-perf-tests-for-workflow-loading-time-3366d73d36508120b672deade09540a4) by [Unito](https://www.unito.io)
