### PR TITLE
fix: show file extensions in workflow sidebar

### DIFF
--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue
@@ -164,11 +164,7 @@ import {
 } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import type { TreeExplorerNode, TreeNode } from '@/types/treeExplorerTypes'
-import {
-  ensureWorkflowSuffix,
-  getFilenameDetails,
-  getWorkflowSuffix
-} from '@/utils/formatUtil'
+import { ensureWorkflowSuffix, getWorkflowSuffix } from '@/utils/formatUtil'
 import { buildTree, sortedTree } from '@/utils/treeUtil'
 
 const { title, filter, searchSubject, dataTestid, hideLeafIcon } = defineProps<{
@@ -328,7 +324,9 @@ const renderTreeNode = (
       }
     : { handleClick }
 
-  const label = node.leaf ? getFilenameDetails(node.label).filename : node.label
+  const label = node.leaf
+    ? (node.key.split('/').pop() ?? node.label)
+    : node.label
 
   return {
     key: node.key,

--- a/src/utils/treeUtil.test.ts
+++ b/src/utils/treeUtil.test.ts
@@ -65,6 +65,29 @@ describe('buildTree', () => {
   })
 })
 
+describe('buildTree workflow keys preserve file extensions', () => {
+  it('should set leaf label to full filename including extension', () => {
+    const workflows = [
+      { key: 'Workflow-A.json' },
+      { key: 'subfolder/Workflow-B.json' },
+      { key: 'my-app.app.json' }
+    ]
+
+    const tree = buildTree(workflows, (w) => w.key.split('/'))
+
+    const leafLabels = (node: TreeNode): string[] =>
+      node.leaf
+        ? [node.key.split('/').pop()!]
+        : (node.children ?? []).flatMap(leafLabels)
+
+    expect(leafLabels(tree)).toEqual([
+      'Workflow-A.json',
+      'Workflow-B.json',
+      'my-app.app.json'
+    ])
+  })
+})
+
 describe('sortedTree', () => {
   const createNode = (label: string, leaf = false): TreeNode => ({
     key: label,


### PR DESCRIPTION
## Summary
- Workflow sidebar now displays file extensions (.json, .app.json) instead of stripping them
- Uses `node.key` to derive leaf labels, bypassing PrimeVue Tree's label mutation
- Removes unused `getFilenameDetails` import

- Fixes #10409

## Test plan
- [x] Unit test added (`treeUtil.test.ts`) verifying key-based label extraction preserves extensions
- [ ] Visual verification: open Workflows sidebar → file names show `.json` suffix

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10833-fix-show-file-extensions-in-workflow-sidebar-3376d73d365081aaa063ee2ac94f66de) by [Unito](https://www.unito.io)
