### PR TITLE
fix: prevent re-opening same workflow from silently discarding unsaved edits

### DIFF
--- a/browser_tests/tests/workflowReopenOverwrite.spec.ts
+++ b/browser_tests/tests/workflowReopenOverwrite.spec.ts
@@ -32,46 +32,50 @@ test.describe('Workflow reopen overwrites unsaved changes', () => {
     }, modifiedSeed)
     await comfyPage.nextFrame()
 
+    // Capture workflow count before reload for relative comparison
+    const countBeforeReload = await comfyPage.workflow.getOpenWorkflowCount()
+
     // Step 4: Re-load the SAME workflow via loadGraphData with the same
     // filename. This mirrors what handleFile() does when the user drags
     // the same file onto the canvas a second time.
-    const seedAfterReload = await comfyPage.page.evaluate(async () => {
+    const seedAfterReload = await comfyPage.page.evaluate(async (seed) => {
       const app = window.app!
       const workflow = JSON.parse(JSON.stringify(app.graph.serialize()))
 
-      // Reset the seed back to its original serialized value to simulate
-      // re-reading the unmodified file from disk.
+      // Find seed widget index by name rather than hardcoding position
+      const liveNode = app.graph.nodes.find((n) => n.type === 'KSampler')
+      const seedIndex =
+        liveNode?.widgets?.findIndex((w) => w.name === 'seed') ?? 0
       const ksNode = workflow.nodes.find(
         (n: { type: string }) => n.type === 'KSampler'
       )
       if (ksNode?.widgets_values) {
-        ksNode.widgets_values[0] = 0
+        ksNode.widgets_values[seedIndex] = seed
       }
 
       // This is the exact call handleFile makes — same filename triggers
       // isSameActiveWorkflowLoad in afterLoadNewGraph.
       await app.loadGraphData(workflow, true, true, 'single_ksampler', {})
 
-      // Return the seed value after reload
       const reloadedNode = app.graph.nodes.find((n) => n.type === 'KSampler')
       return reloadedNode?.widgets?.find((w) => w.name === 'seed')
         ?.value as number
-    })
+    }, originalSeed)
 
-    const workflowCount = await comfyPage.workflow.getOpenWorkflowCount()
+    const countAfterReload = await comfyPage.workflow.getOpenWorkflowCount()
 
     // The unsaved edits must not be silently discarded.
     // Acceptable outcomes:
     //   a) The modified seed value is preserved (user stays on modified tab)
     //   b) A new tab was opened for the re-loaded file
     const changesPreserved = seedAfterReload === modifiedSeed
-    const newTabOpened = workflowCount > 2
+    const newTabOpened = countAfterReload === countBeforeReload + 1
 
     expect(
       changesPreserved || newTabOpened,
       `Unsaved changes were silently discarded. ` +
         `Seed was ${modifiedSeed} before reload, became ${seedAfterReload} after. ` +
-        `Workflow count: ${workflowCount} (expected > 2 if new tab opened).`
+        `Tabs before: ${countBeforeReload}, after: ${countAfterReload}.`
     ).toBe(true)
   })
 })

--- a/browser_tests/tests/workflowReopenOverwrite.spec.ts
+++ b/browser_tests/tests/workflowReopenOverwrite.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+test.describe('Workflow reopen overwrites unsaved changes', () => {
+  test('Re-loading same workflow file should not silently discard unsaved edits', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'Issue #10766 — dragging the same workflow file again overwrites unsaved changes without warning'
+    })
+
+    // Step 1: Load a workflow from file (establishes a "source" filename)
+    await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')
+    await comfyPage.nextFrame()
+
+    // Step 2: Read the original KSampler seed value
+    const originalSeed = await comfyPage.page.evaluate(() => {
+      const node = window.app!.graph.nodes.find((n) => n.type === 'KSampler')
+      return node?.widgets?.find((w) => w.name === 'seed')?.value as number
+    })
+
+    // Step 3: Modify the seed to a distinct value
+    const modifiedSeed = originalSeed === 99999 ? 88888 : 99999
+    await comfyPage.page.evaluate((newSeed) => {
+      const node = window.app!.graph.nodes.find((n) => n.type === 'KSampler')
+      const widget = node?.widgets?.find((w) => w.name === 'seed')
+      if (widget) widget.value = newSeed
+      window.app!.graph.setDirtyCanvas(true, true)
+    }, modifiedSeed)
+    await comfyPage.nextFrame()
+
+    // Step 4: Re-load the SAME workflow via loadGraphData with the same
+    // filename. This mirrors what handleFile() does when the user drags
+    // the same file onto the canvas a second time.
+    const seedAfterReload = await comfyPage.page.evaluate(async () => {
+      const app = window.app!
+      const workflow = JSON.parse(JSON.stringify(app.graph.serialize()))
+
+      // Reset the seed back to its original serialized value to simulate
+      // re-reading the unmodified file from disk.
+      const ksNode = workflow.nodes.find(
+        (n: { type: string }) => n.type === 'KSampler'
+      )
+      if (ksNode?.widgets_values) {
+        ksNode.widgets_values[0] = 0
+      }
+
+      // This is the exact call handleFile makes — same filename triggers
+      // isSameActiveWorkflowLoad in afterLoadNewGraph.
+      await app.loadGraphData(workflow, true, true, 'single_ksampler', {})
+
+      // Return the seed value after reload
+      const reloadedNode = app.graph.nodes.find((n) => n.type === 'KSampler')
+      return reloadedNode?.widgets?.find((w) => w.name === 'seed')
+        ?.value as number
+    })
+
+    const workflowCount = await comfyPage.workflow.getOpenWorkflowCount()
+
+    // The unsaved edits must not be silently discarded.
+    // Acceptable outcomes:
+    //   a) The modified seed value is preserved (user stays on modified tab)
+    //   b) A new tab was opened for the re-loaded file
+    const changesPreserved = seedAfterReload === modifiedSeed
+    const newTabOpened = workflowCount > 2
+
+    expect(
+      changesPreserved || newTabOpened,
+      `Unsaved changes were silently discarded. ` +
+        `Seed was ${modifiedSeed} before reload, became ${seedAfterReload} after. ` +
+        `Workflow count: ${workflowCount} (expected > 2 if new tab opened).`
+    ).toBe(true)
+  })
+})

--- a/browser_tests/tests/workflowReopenOverwrite.spec.ts
+++ b/browser_tests/tests/workflowReopenOverwrite.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+import type { WorkspaceStore } from '../types/globals'
 
 test.describe('Workflow reopen overwrites unsaved changes', () => {
   test('Re-loading same workflow file should not silently discard unsaved edits', async ({
@@ -22,13 +23,19 @@ test.describe('Workflow reopen overwrites unsaved changes', () => {
       return node?.widgets?.find((w) => w.name === 'seed')?.value as number
     })
 
-    // Step 3: Modify the seed to a distinct value
+    // Step 3: Modify the seed to a distinct value and trigger change tracking
     const modifiedSeed = originalSeed === 99999 ? 88888 : 99999
     await comfyPage.page.evaluate((newSeed) => {
-      const node = window.app!.graph.nodes.find((n) => n.type === 'KSampler')
+      const app = window.app!
+      const node = app.graph.nodes.find((n) => n.type === 'KSampler')
       const widget = node?.widgets?.find((w) => w.name === 'seed')
       if (widget) widget.value = newSeed
-      window.app!.graph.setDirtyCanvas(true, true)
+      app.graph.setDirtyCanvas(true, true)
+
+      // Trigger change tracking so isModified reflects the edit — this is
+      // what happens on mouseup / keyup during normal user interaction.
+      const store = (app.extensionManager as WorkspaceStore).workflow
+      store.activeWorkflow?.changeTracker?.checkState?.()
     }, modifiedSeed)
     await comfyPage.nextFrame()
 

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -442,9 +442,13 @@ export const useWorkflowService = () => {
         //
         // This prevents accidental duplicate tabs when startup/load flows
         // invoke loadGraphData more than once for the same workflow name.
+        //
+        // However, if the active workflow has unsaved modifications, open a
+        // new tab instead of silently overwriting (fixes #10766).
         const isSameActiveWorkflowLoad =
           !!existingWorkflow &&
           workflowStore.isActive(existingWorkflow) &&
+          !existingWorkflow.isModified &&
           (existingWorkflow.activeState?.id === undefined ||
             workflowData.id === undefined ||
             existingWorkflow.activeState.id === workflowData.id)


### PR DESCRIPTION
## Summary

When a user loads a workflow file that is already open in a tab and has unsaved modifications, the second load silently overwrites all changes via `changeTracker.reset()` without any save/discard prompt or new tab creation.

**Root cause**: `isSameActiveWorkflowLoad` in `workflowService.ts` matched the active workflow by path/id but did not check `isModified`, so modified workflows were treated identically to unmodified ones.

**Fix**: Add `!existingWorkflow.isModified` guard to `isSameActiveWorkflowLoad`. When the active workflow has unsaved edits, the condition falls through to `createNewTemporary()`, opening a new tab instead of overwriting.

- Fixes #10766

## Reproduction Steps

1. Load a workflow from a file (drag-and-drop or file input) — e.g. `test_workflow.json`
2. Modify widget values (e.g. change KSampler seed from `0` to `99999`)
3. Load the same file again (drag the same file onto the canvas)
4. **AS IS**: Changes are silently discarded — seed reverts to `0`, no save prompt shown
5. **TO BE**: A new tab opens with the file's original content; the modified tab is preserved

## AS IS (Before Fix)

Re-loading `test_workflow.json` after editing seed to `99999`:
- Same tab is reused, `changeTracker.reset()` overwrites seed back to `0`
- No save/discard dialog appears
- User's unsaved work is permanently lost

## TO BE (After Fix)

Re-loading `test_workflow.json` after editing seed to `99999`:
- A new tab opens with the file's original content (seed = `0`)
- The existing modified tab is preserved with seed = `99999`
- User can compare both versions or continue editing

## Red-Green Verification

| Commit | CI Status | Purpose |
|--------|-----------|---------|
| `test: add failing test for workflow reopen overwriting unsaved changes` | :red_circle: Red | Proves the test catches the bug |
| `fix: prevent re-opening same workflow from silently discarding unsaved edits` | :green_circle: Green | Proves the fix resolves the bug |

## Test Plan

- [ ] CI red on test-only commit
- [ ] CI green on fix commit
- [ ] E2E regression test added under `browser_tests/tests/workflowReopenOverwrite.spec.ts`
- [ ] Manual verification: load file → edit → re-load same file → edits preserved in original tab

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10834-fix-prevent-re-opening-same-workflow-from-silently-discarding-unsaved-edits-3376d73d3650815b90c4c4aa61734ca1) by [Unito](https://www.unito.io)
