### PR TITLE
feat: add automated QA pipeline with E2E test-driven bug reproduction

### DIFF
--- a/.claude/skills/comfy-qa/REPRODUCE.md
+++ b/.claude/skills/comfy-qa/REPRODUCE.md
@@ -1,0 +1,278 @@
+---
+name: reproduce-issue
+description: 'Reproduce a GitHub issue by researching prerequisites, setting up the environment (custom nodes, workflows, settings), and interactively exploring ComfyUI via playwright-cli until the bug is confirmed. Then records a clean demo video.'
+---
+
+# Issue Reproduction Skill
+
+Reproduce a reported GitHub issue against a running ComfyUI instance. This skill uses an interactive, agent-driven approach — not a static script. You will research, explore, retry, and adapt until the bug is reproduced, then record a clean demo.
+
+## Architecture
+
+Two videos are produced:
+
+1. **Research video** — the full exploration session: installing deps, trying things, failing, retrying, figuring out the bug. Valuable for debugging context.
+2. **Reproduce video** — a clean, minimal recording of just the reproduction steps. This is the demo you'd attach to the issue.
+
+```
+Phase 1: Research       → Read issue, understand prerequisites
+Phase 2: Environment    → Install custom nodes, load workflows, configure settings
+Phase 3: Explore        → [VIDEO 1: research] Interactively try to reproduce (retries OK)
+Phase 4: Record         → [VIDEO 2: reproduce] Clean recording of just the minimal repro steps
+Phase 5: Report         → Generate a structured reproduction report
+```
+
+## Prerequisites
+
+- ComfyUI server running (ask user for URL, default: `http://127.0.0.1:8188`)
+- `playwright-cli` installed: `npm install -g @playwright/cli@latest`
+- `gh` CLI (authenticated, for reading issues)
+- ComfyUI backend with Python environment (for installing custom nodes)
+
+## Phase 1: Research the Issue
+
+1. Fetch the issue details:
+
+   ```bash
+   gh issue view <number> --repo Comfy-Org/ComfyUI_frontend --json title,body,comments
+   ```
+
+2. Extract from the issue body:
+   - **Reproduction steps** (the exact sequence)
+   - **Prerequisites**: specific workflows, custom nodes, settings, models
+   - **Environment**: OS, browser, ComfyUI version
+   - **Media**: screenshots or videos showing the bug
+
+3. Search the codebase for related code:
+   - Find the feature/component mentioned in the issue
+   - Understand how it works currently
+   - Identify what state the UI needs to be in
+
+## Phase 2: Environment Setup
+
+Set up everything the issue requires BEFORE attempting reproduction.
+
+### Custom Nodes
+
+If the issue mentions custom nodes:
+
+```bash
+# Find the custom node repo
+# Clone into ComfyUI's custom_nodes directory
+cd <comfyui_path>/custom_nodes
+git clone <custom_node_repo_url>
+
+# Install dependencies if needed
+cd <custom_node_name>
+pip install -r requirements.txt 2>/dev/null || true
+
+# Restart ComfyUI server to load the new nodes
+```
+
+### Workflows
+
+If the issue references a specific workflow:
+
+```bash
+# Download workflow JSON if a URL is provided
+curl -L "<workflow_url>" -o /tmp/test-workflow.json
+
+# Load it via the API
+curl -X POST http://127.0.0.1:8188/api/workflow \
+  -H "Content-Type: application/json" \
+  -d @/tmp/test-workflow.json
+```
+
+Or load via playwright-cli:
+
+```bash
+playwright-cli goto "http://127.0.0.1:8188"
+# Drag-and-drop or use File > Open to load the workflow
+```
+
+### Settings
+
+If the issue requires specific settings:
+
+```bash
+# Use playwright-cli to open settings and change them
+playwright-cli press "Control+,"
+playwright-cli snapshot
+# Find and modify the relevant setting
+```
+
+## Phase 3: Interactive Exploration — Research Video
+
+Start recording the **research video** (Video 1). This captures the full exploration — mistakes, retries, dead ends — all valuable context.
+
+```bash
+# Open browser and start video recording
+playwright-cli open "http://127.0.0.1:8188"
+playwright-cli video-start
+
+# Take a snapshot to see current state
+playwright-cli snapshot
+
+# Interact based on what you see
+playwright-cli click <ref>
+playwright-cli fill <ref> "text"
+playwright-cli press "Control+s"
+
+# Check results
+playwright-cli snapshot
+playwright-cli screenshot --filename=/tmp/qa/research-step-1.png
+```
+
+### Key Principles
+
+- **Observe before acting**: Always `snapshot` before interacting
+- **Retry and adapt**: If a step fails, try a different approach
+- **Document what works**: Keep notes on which steps trigger the bug
+- **Don't give up**: Try multiple approaches if the first doesn't work
+- **Establish prerequisites**: Many bugs require specific UI state:
+  - Save a workflow first (File > Save)
+  - Make changes to dirty the workflow
+  - Open multiple tabs
+  - Add specific node types
+  - Change settings
+  - Resize the window
+
+### Common ComfyUI Interactions via playwright-cli
+
+| Action              | Command                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| Open hamburger menu | `playwright-cli click` on the C logo button                    |
+| Navigate menu       | `playwright-cli hover <ref>` then `playwright-cli click <ref>` |
+| Add node            | Double-click canvas → type node name → select from results     |
+| Connect nodes       | Drag from output slot to input slot                            |
+| Save workflow       | `playwright-cli press "Control+s"`                             |
+| Save As             | Menu > File > Save As                                          |
+| Select node         | Click on the node                                              |
+| Delete node         | Select → `playwright-cli press "Delete"`                       |
+| Right-click menu    | `playwright-cli click <ref> --button right`                    |
+| Keyboard shortcut   | `playwright-cli press "Control+z"`                             |
+
+## Phase 4: Record Clean Demo — Reproduce Video (max 5 minutes)
+
+Once the bug is confirmed, **stop the research video** and **close the research browser**:
+
+```bash
+playwright-cli video-stop
+playwright-cli close
+```
+
+Now start a **fresh browser session** for the clean reproduce video (Video 2).
+
+**IMPORTANT constraints:**
+
+- **Max 5 minutes** — the reproduce video must be short and focused
+- **No environment setup** — server, user, custom nodes are already set up from Phase 3. Just log in and go.
+- **No exploration** — you already know the exact steps. Execute them quickly and precisely.
+- **Start video recording immediately**, execute steps, stop. Don't leave the recording running while thinking.
+
+1. **Open browser and start recording**:
+
+   ```bash
+   playwright-cli open "http://127.0.0.1:8188"
+   playwright-cli video-start
+   ```
+
+2. **Execute only the minimal reproduction steps** — no exploration, no mistakes. Just the clean sequence that demonstrates the bug. You already know exactly what works from Phase 3.
+
+3. **Take key screenshots** at critical moments:
+
+   ```bash
+   playwright-cli screenshot --filename=/tmp/qa/before-bug.png
+   # ... trigger the bug ...
+   playwright-cli screenshot --filename=/tmp/qa/bug-visible.png
+   ```
+
+4. **Stop recording and close** immediately after the bug is demonstrated:
+   ```bash
+   playwright-cli video-stop
+   playwright-cli close
+   ```
+
+## Phase 5: Generate Report
+
+Create a reproduction report at `tmp/qa/reproduce-report.md`:
+
+```markdown
+# Issue Reproduction Report
+
+- **Issue**: <issue_url>
+- **Title**: <issue_title>
+- **Date**: <today>
+- **Status**: Reproduced / Not Reproduced / Partially Reproduced
+
+## Environment
+
+- ComfyUI Server: <url>
+- OS: <os>
+- Custom Nodes Installed: <list or "none">
+- Settings Changed: <list or "none">
+
+## Prerequisites
+
+List everything that had to be set up before the bug could be triggered:
+
+1. ...
+2. ...
+
+## Reproduction Steps
+
+Minimal steps to reproduce (the clean sequence):
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+<from the issue>
+
+## Actual Behavior
+
+<what actually happened>
+
+## Evidence
+
+- Research video: `research-video/video.webm` (full exploration session)
+- Reproduce video: `reproduce-video/video.webm` (clean minimal repro)
+- Screenshots: `before-bug.png`, `bug-visible.png`
+
+## Root Cause Analysis (if identified)
+
+<code pointers, hypothesis about what's going wrong>
+
+## Notes
+
+<any additional observations, workarounds discovered, related issues>
+```
+
+## Handling Failures
+
+If the bug **cannot be reproduced**:
+
+1. Document what you tried and why it didn't work
+2. Check if the issue was already fixed (search git log for related commits)
+3. Check if it's environment-specific (OS, browser, specific version)
+4. Set report status to "Not Reproduced" with detailed notes
+5. The report is still valuable — it saves others from repeating the same investigation
+
+## CI Integration
+
+In CI, this skill runs as a Claude Code agent with:
+
+- `ANTHROPIC_API_KEY` for Claude
+- `GEMINI_API_KEY` for initial issue analysis (optional)
+- ComfyUI server pre-started in the container
+- `playwright-cli` pre-installed
+
+The CI workflow:
+
+1. Gemini generates a reproduce guide (markdown) from the issue
+2. Claude agent receives the guide and runs this skill
+3. Claude explores interactively, installs dependencies, retries
+4. Claude records a clean demo once reproduced
+5. Video and report are uploaded as artifacts

--- a/.claude/skills/comfy-qa/SKILL.md
+++ b/.claude/skills/comfy-qa/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: comfy-qa
+description: 'Comprehensive QA of ComfyUI frontend. Navigates all routes, tests all interactive features using playwright-cli, generates a report, and submits a draft PR. Works in CI and local environments, cross-platform.'
+---
+
+# ComfyUI Frontend QA Skill
+
+Automated quality assurance for the ComfyUI frontend. The pipeline reproduces reported bugs using Playwright E2E tests, records video evidence, and deploys reports to Cloudflare Pages.
+
+## Architecture Overview
+
+The QA pipeline uses a **three-phase approach**:
+
+1. **RESEARCH** — Claude writes Playwright E2E tests to reproduce bugs (assertion-backed, no hallucination)
+2. **REPRODUCE** — Deterministic replay of the research test with video recording
+3. **REPORT** — Deploy results to Cloudflare Pages with badge, video, and verdict
+
+### Key Design Decision
+
+Earlier iterations used AI vision (Gemini) to drive a browser and judge results from video. This was abandoned after discovering **AI reviewers hallucinate** — Gemini reported "REPRODUCED" when videos showed idle screens. The current approach uses **Playwright assertions** as the source of truth: if the test passes, the bug is proven.
+
+## Prerequisites
+
+- Node.js 22+
+- `pnpm` package manager
+- `gh` CLI (authenticated)
+- Playwright browsers: `npx playwright install chromium`
+- Environment variables:
+  - `GEMINI_API_KEY` — for PR analysis and video review
+  - `ANTHROPIC_API_KEY` — for Claude Agent SDK (research phase)
+  - `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` — for report deployment
+
+## Pipeline Scripts
+
+| Script                            | Role                                                    | Model                         |
+| --------------------------------- | ------------------------------------------------------- | ----------------------------- |
+| `scripts/qa-analyze-pr.ts`        | Deep PR/issue analysis → QA guide                       | gemini-3.1-pro-preview        |
+| `scripts/qa-agent.ts`             | Research phase: Claude writes E2E tests                 | claude-sonnet-4-6 (Agent SDK) |
+| `scripts/qa-record.ts`            | Before/after video recording with Gemini-driven actions | gemini-3.1-pro-preview        |
+| `scripts/qa-reproduce.ts`         | Deterministic replay with narration                     | gemini-3-flash-preview        |
+| `scripts/qa-video-review.ts`      | Video comparison review                                 | gemini-3-flash-preview        |
+| `scripts/qa-generate-test.ts`     | Regression test generation from QA report               | gemini-3-flash-preview        |
+| `scripts/qa-deploy-pages.sh`      | Deploy to Cloudflare Pages + badge                      | —                             |
+| `scripts/qa-batch.sh`             | Batch-trigger QA for multiple issues                    | —                             |
+| `scripts/qa-report-template.html` | Report site (light/dark, seekbar, copy badge)           | —                             |
+
+## Triggering QA
+
+### Via GitHub Labels
+
+- **`qa-changes`** — Focused QA on a PR (Linux-only, before/after comparison)
+- **`qa-full`** — Full QA (3-OS matrix, after-only)
+- **`qa-issue`** — Reproduce a bug from an issue
+
+### Via Batch Script
+
+```bash
+# Trigger QA for specific issue numbers
+./scripts/qa-batch.sh 10394 10238 9996
+
+# From a triage file (top 5 Tier 1 issues)
+./scripts/qa-batch.sh --from tmp/issues.md --top 5
+
+# Preview without pushing
+./scripts/qa-batch.sh --dry-run 10394
+
+# Clean up old trigger branches
+./scripts/qa-batch.sh --cleanup
+```
+
+### Via Workflow Dispatch
+
+Go to Actions → "PR: QA" → Run workflow → choose mode (focused/full).
+
+## CI Workflow (`.github/workflows/pr-qa.yaml`)
+
+```
+resolve-matrix → analyze-pr ──┐
+                               ├→ qa-before (main branch, worktree build)
+                               ├→ qa-after  (PR branch)
+                               └→ report (video review, deploy, comment)
+```
+
+Before/after jobs run **in parallel** on separate runners for clean isolation.
+
+### Issue Reproduce Mode
+
+For issues (not PRs), the pipeline:
+
+1. Fetches the issue body and comments
+2. Runs `qa-analyze-pr.ts --type issue` to generate a QA guide
+3. Runs the research phase (Claude writes E2E test to reproduce)
+4. Records video of the test execution
+5. Posts results as a comment on the issue
+
+## Running Locally
+
+### Step 1: Environment Setup
+
+```bash
+# Ensure ComfyUI server is running
+# Default: http://127.0.0.1:8188
+
+# Install Playwright browsers
+npx playwright install chromium
+```
+
+### Step 2: Analyze the Issue/PR
+
+```bash
+# For a PR
+pnpm exec tsx scripts/qa-analyze-pr.ts \
+  --pr-number 10394 \
+  --repo Comfy-Org/ComfyUI_frontend \
+  --output-dir qa-guides
+
+# For an issue
+pnpm exec tsx scripts/qa-analyze-pr.ts \
+  --pr-number 10394 \
+  --repo Comfy-Org/ComfyUI_frontend \
+  --output-dir qa-guides \
+  --type issue
+```
+
+### Step 3: Record Before/After
+
+```bash
+# Before (main branch)
+pnpm exec tsx scripts/qa-record.ts \
+  --mode before \
+  --diff /tmp/pr-diff.txt \
+  --output-dir /tmp/qa-before \
+  --qa-guide qa-guides/qa-guide-1.json
+
+# After (PR branch)
+pnpm exec tsx scripts/qa-record.ts \
+  --mode after \
+  --diff /tmp/pr-diff.txt \
+  --output-dir /tmp/qa-after \
+  --qa-guide qa-guides/qa-guide-1.json
+```
+
+### Step 4: Review Videos
+
+```bash
+pnpm exec tsx scripts/qa-video-review.ts \
+  --artifacts-dir /tmp/qa-artifacts \
+  --video-file qa-session.mp4 \
+  --before-video qa-before-session.mp4 \
+  --output-dir /tmp/video-reviews \
+  --pr-context /tmp/pr-context.txt
+```
+
+## Research Phase Details (`qa-agent.ts`)
+
+Claude receives:
+
+- The issue description and comments
+- A QA guide from `qa-analyze-pr.ts`
+- An accessibility tree snapshot of the current UI
+
+Claude's tools:
+
+- **`inspect(selector?)`** — Read a11y tree to discover element selectors
+- **`writeTest(code)`** — Write a Playwright `.spec.ts` file
+- **`runTest()`** — Execute the test and get pass/fail + errors
+- **`done(verdict, summary, evidence, testCode)`** — Finish with verdict
+
+The test uses the project's Playwright fixtures (`comfyPageFixture`), giving access to `comfyPage.page`, `comfyPage.menu`, `comfyPage.settings`, etc.
+
+### Verdict Logic
+
+- **REPRODUCED** — Test passes (asserting the bug exists) → bug is proven
+- **NOT_REPRODUCIBLE** — Claude exhausted attempts, test cannot pass
+- **INCONCLUSIVE** — Agent timed out or encountered infrastructure issues
+
+Auto-completion: if a test passed but `done()` was never called, the pipeline auto-completes with REPRODUCED.
+
+## Manual QA (Fallback)
+
+When the automated pipeline isn't suitable (e.g., visual-only bugs, complex multi-step interactions), use **playwright-cli** for manual browser interaction:
+
+```bash
+# Install
+npm install -g @playwright/cli@latest
+
+# Open browser and navigate
+playwright-cli open http://127.0.0.1:8188
+
+# Get element references
+playwright-cli snapshot
+
+# Interact
+playwright-cli click e1
+playwright-cli fill e2 "test text"
+playwright-cli press Escape
+playwright-cli screenshot --filename=f.png
+```
+
+Snapshots return element references (`e1`, `e2`, …). Always run `snapshot` after navigation to refresh refs.
+
+## Manual QA Test Plan
+
+When performing manual QA (either via playwright-cli or the automated pipeline), systematically test each area below.
+
+### Application Load & Routes
+
+| Test              | Steps                                                        |
+| ----------------- | ------------------------------------------------------------ |
+| Root route loads  | Navigate to `/` — GraphView should render with canvas        |
+| User select route | Navigate to `/user-select` — user selection UI should appear |
+| 404 handling      | Navigate to `/nonexistent` — should handle gracefully        |
+
+### Canvas & Graph View
+
+| Test                      | Steps                                                          |
+| ------------------------- | -------------------------------------------------------------- |
+| Canvas renders            | The LiteGraph canvas is visible and interactive                |
+| Pan canvas                | Click and drag on empty canvas area                            |
+| Zoom in/out               | Use scroll wheel or Alt+=/Alt+-                                |
+| Add node via double-click | Double-click canvas to open search, type "KSampler", select it |
+| Delete node               | Select a node, press Delete key                                |
+| Connect nodes             | Drag from output slot to input slot                            |
+| Copy/Paste                | Select nodes, Ctrl+C then Ctrl+V                               |
+| Undo/Redo                 | Make changes, Ctrl+Z to undo, Ctrl+Y to redo                   |
+| Context menus             | Right-click node vs empty canvas — different menus             |
+
+### Sidebar Tabs
+
+| Test              | Steps                                 |
+| ----------------- | ------------------------------------- |
+| Workflows tab     | Press W — workflows sidebar opens     |
+| Node Library tab  | Press N — node library opens          |
+| Model Library tab | Press M — model library opens         |
+| Tab toggle        | Press same key again — sidebar closes |
+| Search in sidebar | Type in search box — results filter   |
+
+### Settings Dialog
+
+| Test             | Steps                                                |
+| ---------------- | ---------------------------------------------------- |
+| Open settings    | Press Ctrl+, or click settings button                |
+| Change a setting | Toggle a boolean setting — it persists after closing |
+| Search settings  | Type in settings search box — results filter         |
+| Close settings   | Press Escape or click close button                   |
+
+### Execution & Queue
+
+| Test           | Steps                                                 |
+| -------------- | ----------------------------------------------------- |
+| Queue prompt   | Load default workflow, click Queue — execution starts |
+| Queue progress | Progress indicator shows during execution             |
+| Interrupt      | Press Ctrl+Alt+Enter during execution — interrupts    |
+
+## Report Site
+
+Deployed to Cloudflare Pages at `https://comfy-qa.pages.dev/<branch>/`.
+
+Features:
+
+- Light/dark theme
+- Seekable video player with preload
+- Copy badge button (markdown)
+- Date-stamped badges (e.g., `QA0327`)
+- Vertical box badge for issues and PRs
+
+## Known Issues & Troubleshooting
+
+See `docs/qa/TROUBLESHOOTING.md` for common failures:
+
+- `set -euo pipefail` + grep with no match → append `|| true`
+- `__name is not defined` in `page.evaluate` → use `addScriptTag`
+- Cursor not visible in videos → monkey-patch `page.mouse` methods
+- Agent not calling `done()` → auto-complete from passing test
+
+## Backlog
+
+See `docs/qa/backlog.md` for planned improvements:
+
+- **Type B comparison**: Different commits for regression detection
+- **Type C comparison**: Cross-browser testing
+- **Pre-seed assets**: Upload test images before recording
+- **Lazy a11y tree**: Reduce token usage with `inspect(selector)` vs full dump

--- a/.github/workflows/pr-qa.yaml
+++ b/.github/workflows/pr-qa.yaml
@@ -1,0 +1,1066 @@
+# Automated QA of ComfyUI frontend using Playwright video recordings + Gemini review.
+# Architecture:
+#   resolve-matrix → qa-before (main) ─┐
+#                  → qa-after  (PR)   ─┴→ report
+#
+# Before/after run in PARALLEL on separate runners for clean isolation.
+# Two modes:
+#   Focused (qa-changes label): Linux-only, before/after comparison
+#   Full (qa-full label): 3-OS matrix, after-only
+name: 'PR: QA'
+
+on:
+  pull_request:
+    types: [labeled]
+    branches: [main]
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'QA mode'
+        type: choice
+        options: [focused, full]
+        default: focused
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set.outputs.os }}
+      mode: ${{ steps.set.outputs.mode }}
+      skip: ${{ steps.set.outputs.skip }}
+      number: ${{ steps.resolve-number.outputs.number }}
+      target_type: ${{ steps.resolve-number.outputs.target_type }}
+      before_sha: ${{ steps.resolve-refs.outputs.before_sha }}
+      after_sha: ${{ steps.resolve-refs.outputs.after_sha }}
+    steps:
+      - name: Determine QA mode
+        id: set
+        env:
+          LABEL: ${{ github.event.label.name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODE: ${{ inputs.mode }}
+        run: |
+          FULL=false
+
+          # Only run on label events if it's one of our labels
+          if [ "$EVENT_ACTION" = "labeled" ] && \
+             [ "$LABEL" != "qa-changes" ] && [ "$LABEL" != "qa-full" ] && [ "$LABEL" != "qa-issue" ]; then
+             echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Full QA triggers
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && \
+             [ "$INPUT_MODE" = "full" ]; then
+            FULL=true
+          fi
+          if [ "$LABEL" = "qa-full" ]; then
+            FULL=true
+          fi
+
+          if [ "$FULL" = "true" ]; then
+            echo 'os=["ubuntu-latest","macos-latest","windows-latest"]' >> "$GITHUB_OUTPUT"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo "mode=focused" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Mode: $([ "$FULL" = "true" ] && echo full || echo focused)"
+
+      - name: Resolve target number and type
+        id: resolve-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          BRANCH: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -n "$ISSUE_NUM" ]; then
+            NUM="$ISSUE_NUM"
+          elif [ -n "$PR_NUM" ]; then
+            NUM="$PR_NUM"
+          else
+            NUM=$(gh pr list --repo "$REPO" \
+              --head "$BRANCH" --state open \
+              --json number --jq '.[0].number // empty')
+          fi
+          echo "number=${NUM}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$NUM" ]; then
+            if gh api "repos/${REPO}/pulls/${NUM}" --jq '.number' >/dev/null 2>&1; then
+              echo "target_type=pr" >> "$GITHUB_OUTPUT"
+              echo "Target: PR #$NUM"
+            else
+              echo "target_type=issue" >> "$GITHUB_OUTPUT"
+              echo "Target: Issue #$NUM"
+            fi
+          fi
+
+      - name: Resolve commit SHAs for immutable references
+        id: resolve-refs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUM: ${{ steps.resolve-number.outputs.number }}
+          TARGET_TYPE: ${{ steps.resolve-number.outputs.target_type }}
+          REPO: ${{ github.repository }}
+        run: |
+          MAIN_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
+          echo "before_sha=${MAIN_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Main: ${MAIN_SHA:0:7}"
+
+          if [ "$TARGET_TYPE" = "pr" ] && [ -n "$NUM" ]; then
+            PR_SHA=$(gh pr view "$NUM" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+            echo "after_sha=${PR_SHA}" >> "$GITHUB_OUTPUT"
+            echo "PR #${NUM}: ${PR_SHA:0:7}"
+          fi
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # Analyze PR — deep analysis via Gemini Pro to generate QA guides
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  analyze-pr:
+    needs: [resolve-matrix]
+    if: needs.resolve-matrix.outputs.skip != 'true' && needs.resolve-matrix.outputs.mode == 'focused'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+
+      - name: Setup frontend (scripts only)
+        uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: false
+
+      - name: Install QA dependencies
+        run: pnpm add -D @google/generative-ai@^0.24.1
+
+      - name: Run analysis
+        if: needs.resolve-matrix.outputs.number
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p qa-guides
+          pnpm exec tsx scripts/qa-analyze-pr.ts \
+            --pr-number "${{ needs.resolve-matrix.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --output-dir qa-guides \
+            --type "${{ needs.resolve-matrix.outputs.target_type }}"
+
+      - name: Upload QA guides
+        if: always() && needs.resolve-matrix.outputs.number
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v6.2.0
+        with:
+          name: qa-guides-${{ github.run_id }}
+          path: qa-guides/qa-guide-*.json
+          retention-days: 14
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # BEFORE recording — main branch frontend on its own runner
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  qa-before:
+    needs: [resolve-matrix, analyze-pr]
+    if: >-
+      always() &&
+      needs.resolve-matrix.outputs.skip != 'true' &&
+      needs.resolve-matrix.outputs.mode == 'focused' &&
+      needs.resolve-matrix.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.resolve-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: Set QA artifacts path
+        shell: bash
+        run: echo "QA_ARTIFACTS=$RUNNER_TEMP/qa-artifacts" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup frontend (scripts only)
+        uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: false
+
+      - name: Install QA dependencies
+        run: pnpm add -D @google/generative-ai@^0.24.1 @anthropic-ai/claude-agent-sdk@^0.2.85
+
+      - name: Cache main branch dist
+        id: cache-main-dist
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: dist
+          key: qa-main-dist-${{ needs.resolve-matrix.outputs.before_sha }}
+
+      - name: Build main branch frontend via worktree
+        if: steps.cache-main-dist.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git worktree add ../main-build origin/main
+          cd ../main-build
+          pnpm install --frozen-lockfile || pnpm install
+          pnpm exec vite build
+          cd "$GITHUB_WORKSPACE"
+          mv ../main-build/dist dist
+          git worktree remove ../main-build --force
+          echo "Built main branch frontend"
+          ls -la dist/index.html
+
+      - name: Setup ComfyUI server (no launch)
+        uses: ./.github/actions/setup-comfyui-server
+        with:
+          launch_server: 'false'
+
+      - name: Install Playwright browser
+        shell: bash
+        run: |
+          npx playwright install chromium
+          mkdir -p "$QA_ARTIFACTS"
+
+      - name: Get PR diff
+        if: needs.resolve-matrix.outputs.target_type == 'pr'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number || '' }} \
+            --repo ${{ github.repository }} > "${{ runner.temp }}/pr-diff.txt" 2>/dev/null || \
+          git diff origin/main...HEAD > "${{ runner.temp }}/pr-diff.txt"
+
+          echo "Changed files:"
+          grep '^diff --git' "${{ runner.temp }}/pr-diff.txt" | \
+            sed 's|diff --git a/||;s| b/.*||' | sort -u
+
+      - name: Get issue body (for reproduce mode)
+        if: needs.resolve-matrix.outputs.target_type == 'issue' && needs.resolve-matrix.outputs.number
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue view ${{ needs.resolve-matrix.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --json title,body,labels --jq '"Labels: \([.labels[].name] | join(", "))\nTitle: \(.title)\n\n\(.body)"' \
+            > "${{ runner.temp }}/issue-body.txt"
+          echo "Issue body saved ($(wc -c < "${{ runner.temp }}/issue-body.txt") bytes)"
+
+      - name: Download QA guide
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: qa-guides-${{ github.run_id }}
+          path: qa-guides
+
+      - name: Start server with main branch frontend
+        shell: bash
+        working-directory: ComfyUI
+        run: |
+          python main.py --cpu --multi-user --front-end-root ../dist &
+          echo $! > /tmp/comfyui-server.pid
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:8188/api/system_stats >/dev/null 2>&1 && echo "Server ready (main)" && exit 0
+            sleep 2
+          done
+          echo "::error::Server timeout (main)"; exit 1
+
+      - name: Pre-seed settings
+        shell: bash
+        run: |
+          curl -sf -X POST http://127.0.0.1:8188/api/users \
+            -H 'Content-Type: application/json' \
+            -d '{"username":"qa-ci"}' || echo "User creation failed (may already exist)"
+          curl -sf -X POST http://127.0.0.1:8188/api/devtools/set_settings \
+            -H 'Content-Type: application/json' \
+            -d '{"Comfy.TutorialCompleted":true}' || \
+          curl -sf -X POST http://127.0.0.1:8188/api/settings \
+            -H 'Content-Type: application/json' \
+            -d '{"Comfy.TutorialCompleted":true}' || echo "Settings pre-seed skipped"
+
+      - name: Run QA recording
+        shell: bash
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_QA }}
+          TARGET_TYPE: ${{ needs.resolve-matrix.outputs.target_type }}
+        run: |
+          MODE="before"
+          if [ "$TARGET_TYPE" = "issue" ]; then
+            MODE="reproduce"
+          fi
+
+          QA_GUIDE_FLAG=""
+          if [ -f qa-guides/qa-guide-before.json ]; then
+            echo "Using QA guide for $MODE recording"
+            QA_GUIDE_FLAG="--qa-guide qa-guides/qa-guide-before.json"
+          fi
+
+          DIFF_FLAG=""
+          if [ -f "${{ runner.temp }}/pr-diff.txt" ]; then
+            DIFF_FLAG="--diff ${{ runner.temp }}/pr-diff.txt"
+          elif [ -f "${{ runner.temp }}/issue-body.txt" ]; then
+            DIFF_FLAG="--diff ${{ runner.temp }}/issue-body.txt"
+          fi
+
+          pnpm exec tsx scripts/qa-record.ts \
+            --mode "$MODE" \
+            $DIFF_FLAG \
+            --output-dir "$QA_ARTIFACTS" \
+            --url http://127.0.0.1:8188 \
+            --test-plan .claude/skills/comfy-qa/SKILL.md \
+            $QA_GUIDE_FLAG
+
+      - name: Collect artifacts
+        if: always()
+        shell: bash
+        run: |
+          kill "$(cat /tmp/comfyui-server.pid)" 2>/dev/null || true
+          echo "=== QA BEFORE artifacts ==="
+          ls -la "$QA_ARTIFACTS/" 2>/dev/null | head -30
+
+      - name: Upload QA artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v6.2.0
+        with:
+          name: qa-before-${{ runner.os }}-${{ github.run_id }}
+          path: ${{ env.QA_ARTIFACTS }}/
+          retention-days: 14
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # AFTER recording — PR branch frontend on its own runner
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  qa-after:
+    needs: [resolve-matrix, analyze-pr]
+    if: >-
+      always() &&
+      needs.resolve-matrix.outputs.skip != 'true' &&
+      needs.resolve-matrix.result == 'success' &&
+      needs.resolve-matrix.outputs.target_type == 'pr'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(needs.resolve-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: Set QA artifacts path
+        shell: bash
+        run: echo "QA_ARTIFACTS=$RUNNER_TEMP/qa-artifacts" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: true
+
+      - name: Install QA dependencies
+        run: pnpm add -D @google/generative-ai@^0.24.1
+
+      - name: Setup ComfyUI server (no launch)
+        uses: ./.github/actions/setup-comfyui-server
+        with:
+          launch_server: 'false'
+
+      - name: Install Playwright browser
+        shell: bash
+        run: |
+          npx playwright install chromium
+          mkdir -p "$QA_ARTIFACTS"
+
+      - name: Get PR diff
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number || '' }} \
+            --repo ${{ github.repository }} > "${{ runner.temp }}/pr-diff.txt" 2>/dev/null || \
+          git diff origin/main...HEAD > "${{ runner.temp }}/pr-diff.txt"
+
+          echo "Changed files:"
+          grep '^diff --git' "${{ runner.temp }}/pr-diff.txt" | \
+            sed 's|diff --git a/||;s| b/.*||' | sort -u
+
+      - name: Download QA guide
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: qa-guides-${{ github.run_id }}
+          path: qa-guides
+
+      - name: Start server with PR branch frontend
+        shell: bash
+        working-directory: ComfyUI
+        run: |
+          python main.py --cpu --multi-user --front-end-root ../dist &
+          echo $! > /tmp/comfyui-server.pid
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:8188/api/system_stats >/dev/null 2>&1 && echo "Server ready (PR)" && exit 0
+            sleep 2
+          done
+          echo "::error::Server timeout (PR)"; exit 1
+
+      - name: Pre-seed settings
+        shell: bash
+        run: |
+          curl -sf -X POST http://127.0.0.1:8188/api/users \
+            -H 'Content-Type: application/json' \
+            -d '{"username":"qa-ci"}' || echo "User creation failed (may already exist)"
+          curl -sf -X POST http://127.0.0.1:8188/api/devtools/set_settings \
+            -H 'Content-Type: application/json' \
+            -d '{"Comfy.TutorialCompleted":true}' || \
+          curl -sf -X POST http://127.0.0.1:8188/api/settings \
+            -H 'Content-Type: application/json' \
+            -d '{"Comfy.TutorialCompleted":true}' || echo "Settings pre-seed skipped"
+
+      - name: Run AFTER QA recording
+        shell: bash
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          QA_GUIDE_FLAG=""
+          if [ -f qa-guides/qa-guide-after.json ]; then
+            echo "Using QA guide for after recording"
+            QA_GUIDE_FLAG="--qa-guide qa-guides/qa-guide-after.json"
+          fi
+          pnpm exec tsx scripts/qa-record.ts \
+            --mode after \
+            --diff "${{ runner.temp }}/pr-diff.txt" \
+            --output-dir "$QA_ARTIFACTS" \
+            --url http://127.0.0.1:8188 \
+            --test-plan .claude/skills/comfy-qa/SKILL.md \
+            $QA_GUIDE_FLAG
+
+      - name: Collect artifacts
+        if: always()
+        shell: bash
+        run: |
+          kill "$(cat /tmp/comfyui-server.pid)" 2>/dev/null || true
+          echo "=== QA AFTER artifacts ==="
+          ls -la "$QA_ARTIFACTS/" 2>/dev/null | head -30
+
+      - name: Upload QA artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v6.2.0
+        with:
+          name: qa-after-${{ runner.os }}-${{ github.run_id }}
+          path: ${{ env.QA_ARTIFACTS }}/
+          retention-days: 14
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # Report — merges artifacts, runs Gemini video review, deploys
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  report:
+    needs: [resolve-matrix, analyze-pr, qa-before, qa-after]
+    if: >-
+      always() &&
+      (needs.qa-after.result == 'success' || needs.qa-before.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup badge deploy function
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RAW_BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          npm install -g wrangler@4.74.0 >/dev/null 2>&1
+          BRANCH=$(echo "$RAW_BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-28)
+          echo "QA_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+          # Create badge generator script
+          cat > /tmp/gen-badge.sh <<'BADGESCRIPT'
+          #!/bin/bash
+          # Usage: gen-badge.sh <status> <color> <output-path> [label]
+          STATUS="$1" COLOR="$2" OUT="$3"
+          LABEL="${4:-QA Bot}"
+          LABEL_W=$(( ${#LABEL} * 7 + 12 ))
+          STATUS_W=$(( ${#STATUS} * 7 + 12 ))
+          TOTAL_W=$(( LABEL_W + STATUS_W ))
+          cat > "$OUT" <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="${TOTAL_W}" height="20" role="img" aria-label="${LABEL}: ${STATUS}">
+            <title>${LABEL}: ${STATUS}</title>
+            <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+            <clipPath id="r"><rect width="${TOTAL_W}" height="20" rx="3" fill="#fff"/></clipPath>
+            <g clip-path="url(#r)">
+              <rect width="${LABEL_W}" height="20" fill="#555"/>
+              <rect x="${LABEL_W}" width="${STATUS_W}" height="20" fill="${COLOR}"/>
+              <rect width="${TOTAL_W}" height="20" fill="url(#s)"/>
+            </g>
+            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+              <text aria-hidden="true" x="$(( LABEL_W / 2 ))" y="15" fill="#010101" fill-opacity=".3">${LABEL}</text>
+              <text x="$(( LABEL_W / 2 ))" y="14">${LABEL}</text>
+              <text aria-hidden="true" x="$(( LABEL_W + STATUS_W / 2 ))" y="15" fill="#010101" fill-opacity=".3">${STATUS}</text>
+              <text x="$(( LABEL_W + STATUS_W / 2 ))" y="14">${STATUS}</text>
+            </g>
+          </svg>
+          SVGEOF
+          BADGESCRIPT
+          chmod +x /tmp/gen-badge.sh
+
+          # Create badge deploy script — deploys badge + placeholder status page
+          cat > /tmp/deploy-badge.sh <<'DEPLOYBADGE'
+          #!/bin/bash
+          # Usage: deploy-badge.sh <status> <color> [label] [run_url]
+          STATUS="$1" COLOR="${2:-#555}" LABEL="${3:-QA}" RUN_URL="$4"
+          DIR=$(mktemp -d)
+          /tmp/gen-badge.sh "$STATUS" "$COLOR" "$DIR/badge.svg" "$LABEL"
+          RUN_LINK=""
+          [ -n "$RUN_URL" ] && RUN_LINK="<a href=\"${RUN_URL}\" style=\"color:#7c8aff;text-decoration:none;font-size:.8rem\">View CI run &rarr;</a>"
+          cat > "$DIR/index.html" <<PAGEEOF
+          <!DOCTYPE html><html lang=en><head><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1">
+          <title>${LABEL} — ${STATUS}</title>
+          <meta http-equiv="refresh" content="30">
+          <style>:root{--bg:#0d0f14;--fg:#e8e8ec;--muted:#8b8fa3;--primary:#7c8aff}*{margin:0;padding:0;box-sizing:border-box}body{background:var(--bg);color:var(--fg);font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;text-align:center}
+          .wrap{max-width:420px;padding:2rem}.badge{margin:1.5rem 0}.status{font-size:1.5rem;font-weight:700;letter-spacing:-.02em;margin:.5rem 0}
+          .hint{color:var(--muted);font-size:.85rem;line-height:1.6;margin-top:1rem}
+          @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}.dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--primary);animation:pulse 1.5s ease-in-out infinite;margin-right:.5rem;vertical-align:middle}
+          </style></head><body><div class=wrap>
+          <div class=badge><img src=badge.svg alt="${LABEL}: ${STATUS}"></div>
+          <p class=status><span class=dot></span>${STATUS}</p>
+          <p class=hint>QA pipeline is running. This page auto-refreshes every 30 seconds.<br>Results will appear here when analysis is complete.</p>
+          <p style="margin-top:1rem">${RUN_LINK}</p>
+          </div></body></html>
+          PAGEEOF
+          DEPLOYBADGE
+          # Append the wrangler deploy (uses outer BRANCH variable)
+          cat >> /tmp/deploy-badge.sh <<DEPLOYWRANGLER
+          wrangler pages deploy "\$DIR" \
+            --project-name="comfy-qa" \
+            --branch="${BRANCH}" 2>&1 | tail -3
+          rm -rf "\$DIR"
+          echo "Deployed: \${STATUS}"
+          DEPLOYWRANGLER
+          chmod +x /tmp/deploy-badge.sh
+
+      - name: Setup dual badge generator
+        run: |
+          cat > /tmp/gen-badge-dual.sh <<'DUALBADGE'
+          #!/bin/bash
+          # Usage: gen-badge-dual.sh <repro> <repro_color> <fix> <fix_color> <output-path> [label]
+          BUG="$1" BUG_C="$2" FIX="Fix: $3" FIX_C="$4" OUT="$5"
+          LABEL="${6:-QA Bot}"
+          LW=$(( ${#LABEL} * 7 + 12 ))
+          BW=$(( ${#BUG} * 7 + 12 ))
+          FW=$(( ${#FIX} * 7 + 12 ))
+          TW=$(( LW + BW + FW ))
+          cat > "$OUT" <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="${TW}" height="20" role="img" aria-label="${LABEL}: ${BUG} | ${FIX}">
+            <title>${LABEL}: ${BUG} | ${FIX}</title>
+            <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+            <clipPath id="r"><rect width="${TW}" height="20" rx="3" fill="#fff"/></clipPath>
+            <g clip-path="url(#r)">
+              <rect width="${LW}" height="20" fill="#555"/>
+              <rect x="${LW}" width="${BW}" height="20" fill="${BUG_C}"/>
+              <rect x="$(( LW + BW ))" width="${FW}" height="20" fill="${FIX_C}"/>
+              <rect width="${TW}" height="20" fill="url(#s)"/>
+            </g>
+            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+              <text aria-hidden="true" x="$(( LW / 2 ))" y="15" fill="#010101" fill-opacity=".3">${LABEL}</text>
+              <text x="$(( LW / 2 ))" y="14">${LABEL}</text>
+              <text aria-hidden="true" x="$(( LW + BW / 2 ))" y="15" fill="#010101" fill-opacity=".3">${BUG}</text>
+              <text x="$(( LW + BW / 2 ))" y="14">${BUG}</text>
+              <text aria-hidden="true" x="$(( LW + BW + FW / 2 ))" y="15" fill="#010101" fill-opacity=".3">${FIX}</text>
+              <text x="$(( LW + BW + FW / 2 ))" y="14">${FIX}</text>
+            </g>
+          </svg>
+          SVGEOF
+          DUALBADGE
+          chmod +x /tmp/gen-badge-dual.sh
+
+          # Universal vertical box badge — used for all badges (issues + PRs)
+          cat > /tmp/gen-badge-box.sh <<'BOXBADGE'
+          #!/bin/bash
+          # Usage: gen-badge-box.sh <output-path> <label> <repro> <not_repro> <fail> <total> [fix_result] [fix_color] [repro_method]
+          OUT="$1" LABEL="$2" REPRO="$3" NOREPRO="$4" FAIL="$5" TOTAL="$6"
+          FIX_RESULT="${7:-}" FIX_COLOR="${8:-#4c1}" REPRO_METHOD="${9:-}"
+          W=160
+          ROW=18
+          HEADER=22
+          ROWS=0
+          [ "$REPRO" -gt 0 ] 2>/dev/null && ROWS=$((ROWS+1))
+          [ "$NOREPRO" -gt 0 ] 2>/dev/null && ROWS=$((ROWS+1))
+          [ "$FAIL" -gt 0 ] 2>/dev/null && ROWS=$((ROWS+1))
+          [ "$ROWS" -eq 0 ] && ROWS=1
+          # Add fix quality row for PRs
+          [ -n "$FIX_RESULT" ] && ROWS=$((ROWS+1))
+          H=$((HEADER + ROWS * ROW + 4))
+          Y=$((HEADER + 2))
+          cat > "$OUT" <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" role="img" aria-label="${LABEL}">
+            <title>${LABEL}: ${REPRO} reproduced, ${NOREPRO} not-repro, ${FAIL} inconclusive / ${TOTAL}${FIX_RESULT:+ | Fix: ${FIX_RESULT}}</title>
+            <rect width="${W}" height="${H}" rx="4" fill="#2a2d35"/>
+            <rect width="${W}" height="${HEADER}" rx="4" fill="#555"/>
+            <rect y="$((HEADER-4))" width="${W}" height="4" fill="#555"/>
+            <text x="$((W/2))" y="15" fill="#fff" text-anchor="middle" font-family="Verdana,sans-serif" font-size="11" font-weight="bold">${LABEL}</text>
+          SVGEOF
+          add_row() {
+            local icon="$1" text="$2" color="$3"
+            echo "  <rect x='4' y='${Y}' width='$((W-8))' height='$((ROW-2))' rx='3' fill='${color}' opacity='.15'/>" >> "$OUT"
+            echo "  <text x='10' y='$((Y+13))' fill='${color}' font-family='Verdana,sans-serif' font-size='11'>${icon} ${text}</text>" >> "$OUT"
+            Y=$((Y+ROW))
+          }
+          REPRO_LABEL="${REPRO} reproduced"
+          case "$REPRO_METHOD" in
+            e2e_test) REPRO_LABEL="${REPRO} via E2E test" ;;
+            video)    REPRO_LABEL="${REPRO} via video" ;;
+            both)     REPRO_LABEL="${REPRO} via E2E+video" ;;
+          esac
+          [ "$REPRO" -gt 0 ] 2>/dev/null && add_row "✓" "$REPRO_LABEL" "#58a6ff"
+          [ "$NOREPRO" -gt 0 ] 2>/dev/null && add_row "✗" "${NOREPRO} not reproducible" "#8b949e"
+          [ "$FAIL" -gt 0 ] 2>/dev/null && add_row "⚠" "${FAIL} inconclusive" "#d29922"
+          [ -n "$FIX_RESULT" ] && add_row "⚙" "Fix: ${FIX_RESULT}" "$FIX_COLOR"
+          echo "</svg>" >> "$OUT"
+          BOXBADGE
+          chmod +x /tmp/gen-badge-box.sh
+
+      - name: Resolve target number and type
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          NUM="${PR_NUM:-$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')}"
+          echo "number=${NUM}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$NUM" ]; then
+            if gh api "repos/${REPO}/pulls/${NUM}" --jq '.number' >/dev/null 2>&1; then
+              echo "target_type=pr" >> "$GITHUB_OUTPUT"
+            else
+              echo "target_type=issue" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+          LABEL="QA"
+          [ -n "$NUM" ] && LABEL="#${NUM} QA"
+          echo "badge_label=${LABEL}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Install QA dependencies
+        run: pnpm add -D @google/generative-ai@^0.24.1
+
+      - name: Download QA guides
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: qa-guides-${{ github.run_id }}
+          path: qa-guides
+
+      - name: Download BEFORE artifacts
+        if: needs.qa-before.result == 'success'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: qa-artifacts/before
+          pattern: qa-before-*
+
+      - name: Download AFTER artifacts
+        if: needs.qa-after.result == 'success'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: qa-artifacts/after
+          pattern: qa-after-*
+
+      - name: Merge artifacts into per-OS report directories
+        run: |
+          echo "=== Downloaded BEFORE artifacts ==="
+          find qa-artifacts/before -type f 2>/dev/null | head -20
+          echo "=== Downloaded AFTER artifacts ==="
+          find qa-artifacts/after -type f 2>/dev/null | head -20
+
+          for os in Linux macOS Windows; do
+            REPORT_DIR="qa-artifacts/qa-report-${os}-${{ github.run_id }}"
+            HAS_FILES=false
+
+            # Check for before files (flat or in subdirectory)
+            if [ -d "qa-artifacts/before" ] && find qa-artifacts/before -name '*.webm' -o -name '*.png' 2>/dev/null | grep -q .; then
+              HAS_FILES=true
+            fi
+            # Check for after files
+            if [ -d "qa-artifacts/after" ] && find qa-artifacts/after -name '*.webm' -o -name '*.png' 2>/dev/null | grep -q .; then
+              HAS_FILES=true
+            fi
+
+            if [ "$HAS_FILES" = true ]; then
+              mkdir -p "$REPORT_DIR"
+              # Copy all before files (handles both flat and nested layouts)
+              find qa-artifacts/before -type f 2>/dev/null | while read f; do
+                cp "$f" "$REPORT_DIR/" 2>/dev/null || true
+              done
+              # Copy all after files (overwrites duplicates with after versions)
+              find qa-artifacts/after -type f 2>/dev/null | while read f; do
+                cp "$f" "$REPORT_DIR/" 2>/dev/null || true
+              done
+              echo "Merged $os artifacts into $REPORT_DIR"
+              ls -la "$REPORT_DIR/" | head -20
+              break  # Only create one report dir (multi-OS not yet supported in parallel mode)
+            fi
+          done
+
+      - name: Install ffmpeg
+        run: |
+          if command -v ffmpeg &>/dev/null; then
+            echo "ffmpeg already installed"
+          else
+            echo "Downloading static ffmpeg..."
+            TMP=$(mktemp -d)
+            curl -sL "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz" | tar xJ -C "$TMP"
+            sudo cp "$TMP"/ffmpeg-*/ffmpeg "$TMP"/ffmpeg-*/ffprobe /usr/local/bin/
+            rm -rf "$TMP"
+          fi
+          ffmpeg -version | head -1
+          ffprobe -version | head -1
+
+      - name: Convert videos to mp4
+        run: |
+          convert_video() {
+            local WEBM="$1" MP4="$2"
+            echo "Converting $WEBM ($(du -h "$WEBM" | cut -f1)) to $MP4"
+            ffmpeg -y -i "$WEBM" \
+              -c:v libx264 -preset ultrafast -crf 23 -pix_fmt yuv420p \
+              -movflags +faststart -g 60 \
+              "$MP4" 2>&1 | tail -5 \
+            || echo "ffmpeg conversion failed for $WEBM (non-fatal)"
+            [ -f "$MP4" ] && echo "Created: $MP4 ($(du -h "$MP4" | cut -f1))"
+          }
+
+          for dir in qa-artifacts/qa-report-*; do
+            [ -d "$dir" ] || continue
+            # Convert known video names (single + multi-pass + before)
+            for name in qa-session qa-session-1 qa-session-2 qa-session-3 qa-before-session; do
+              if [ -f "$dir/${name}.webm" ] && [ -s "$dir/${name}.webm" ]; then
+                convert_video "$dir/${name}.webm" "$dir/${name}.mp4"
+              fi
+            done
+            # Fallback: find any non-empty webm not yet converted
+            if [ ! -f "$dir/qa-session.mp4" ] && [ ! -f "$dir/qa-session-1.mp4" ]; then
+              WEBM=$(find "$dir" -name '*.webm' -type f -size +0c | head -1)
+              [ -n "$WEBM" ] && convert_video "$WEBM" "$dir/qa-session.mp4"
+            fi
+          done
+
+      - name: Build context for video review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_NUM: ${{ steps.pr.outputs.number }}
+          TARGET_TYPE: ${{ steps.pr.outputs.target_type }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TARGET_NUM" ]; then
+            echo "No target number available, skipping context"
+            exit 0
+          fi
+
+          if [ "$TARGET_TYPE" = "issue" ]; then
+            {
+              echo "### Issue #${TARGET_NUM}"
+              gh issue view "$TARGET_NUM" --repo "$REPO" \
+                --json title,body,labels --jq '"Labels: \([.labels[].name] | join(", "))\nTitle: \(.title)\n\nDescription:\n\(.body)"' 2>/dev/null || true
+              echo ""
+              echo "### Comments"
+              # Filter out QA bot comments to prevent INCONCLUSIVE feedback loop
+              gh api "repos/${REPO}/issues/${TARGET_NUM}/comments" \
+                --jq '.[] | select(.user.login != "github-actions[bot]") | .body' 2>/dev/null | head -200 || true
+              echo ""
+              echo "This video attempts to reproduce a reported bug on the main branch."
+            } > pr-context.txt
+            echo "Issue context saved ($(wc -l < pr-context.txt) lines)"
+          else
+            {
+              echo "### PR #${TARGET_NUM}"
+              gh pr view "$TARGET_NUM" --repo "$REPO" \
+                --json title,body --jq '"Title: \(.title)\n\nDescription:\n\(.body)"' 2>/dev/null || true
+              echo ""
+              echo "### Changed files"
+              gh pr diff "$TARGET_NUM" --repo "$REPO" 2>/dev/null \
+                | grep '^diff --git' | sed 's|diff --git a/||;s| b/.*||' | sort -u || true
+              echo ""
+              echo "### Diff (truncated to 300 lines)"
+              gh pr diff "$TARGET_NUM" --repo "$REPO" 2>/dev/null \
+                | head -300 || true
+            } > pr-context.txt
+            echo "PR context saved ($(wc -l < pr-context.txt) lines)"
+          fi
+
+      - name: Run video review
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          TARGET_NUM: ${{ steps.pr.outputs.number }}
+          TARGET_TYPE: ${{ steps.pr.outputs.target_type }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p video-reviews
+          PR_CTX_FLAG=""
+          if [ -f pr-context.txt ]; then
+            PR_CTX_FLAG="--pr-context pr-context.txt"
+          fi
+          TARGET_URL_FLAG=""
+          if [ -n "$TARGET_NUM" ]; then
+            if [ "$TARGET_TYPE" = "issue" ]; then
+              TARGET_URL_FLAG="--target-url https://github.com/${REPO}/issues/${TARGET_NUM}"
+            else
+              TARGET_URL_FLAG="--target-url https://github.com/${REPO}/pull/${TARGET_NUM}"
+            fi
+          fi
+          for vid in qa-artifacts/qa-report-*/qa-session*.mp4; do
+            [ -f "$vid" ] || continue
+            DIR=$(dirname "$vid")
+            BEFORE_FLAG=""
+            if [ -f "$DIR/qa-before-session.mp4" ]; then
+              BEFORE_FLAG="--before-video $DIR/qa-before-session.mp4"
+            fi
+            # Extract pass label from multi-pass filenames (qa-session-1.mp4 → pass1)
+            PASS_LABEL_FLAG=""
+            case "$(basename "$vid")" in
+              qa-session-[0-9].mp4)
+                PASS_NUM=$(basename "$vid" | sed 's/qa-session-\([0-9]\).mp4/\1/')
+                PASS_LABEL_FLAG="--pass-label pass${PASS_NUM}"
+                ;;
+            esac
+            echo "::group::Reviewing $vid"
+            pnpm exec tsx scripts/qa-video-review.ts \
+              --artifacts-dir qa-artifacts \
+              --output-dir video-reviews \
+              --video-file "$vid" \
+              --model gemini-3-flash-preview $PR_CTX_FLAG $BEFORE_FLAG $TARGET_URL_FLAG $PASS_LABEL_FLAG || true
+            echo "::endgroup::"
+          done
+
+      - name: Generate regression test from QA report
+        if: needs.resolve-matrix.outputs.mode == 'focused' && steps.pr.outputs.target_type == 'pr'
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.number }}"
+          PR_BRANCH="${{ github.head_ref || github.ref_name }}"
+          if [ -z "$PR_NUM" ]; then
+            echo "No PR number, skipping test generation"
+            exit 0
+          fi
+
+          # Find the first QA report
+          REPORT=$(find video-reviews -name '*-qa-video-report.md' -type f | head -1)
+          if [ ! -f "$REPORT" ]; then
+            echo "No QA report found, skipping test generation"
+            exit 0
+          fi
+
+          # Ensure we have the PR diff
+          DIFF_FILE="${{ runner.temp }}/pr-diff.txt"
+          if [ ! -f "$DIFF_FILE" ]; then
+            gh pr diff "$PR_NUM" --repo "${{ github.repository }}" > "$DIFF_FILE" 2>/dev/null || true
+          fi
+
+          # Generate the test
+          TEST_NAME="qa-pr${PR_NUM}"
+          TEST_PATH="browser_tests/tests/${TEST_NAME}.spec.ts"
+          echo "::group::Generating regression test from QA report"
+          pnpm exec tsx scripts/qa-generate-test.ts \
+            --qa-report "$REPORT" \
+            --pr-diff "$DIFF_FILE" \
+            --output "$TEST_PATH" || {
+            echo "Test generation failed (non-fatal)"
+            exit 0
+          }
+          echo "::endgroup::"
+
+          # Push to {branch}-add-qa-test
+          TEST_BRANCH="${PR_BRANCH}-add-qa-test"
+          git checkout -b "$TEST_BRANCH" HEAD 2>/dev/null || git checkout "$TEST_BRANCH" 2>/dev/null || true
+          git add "$TEST_PATH"
+          git commit -m "test: add QA regression test for PR #${PR_NUM}" || {
+            echo "Nothing to commit"
+            exit 0
+          }
+          git push origin "$TEST_BRANCH" --force-with-lease || echo "Push failed (non-fatal)"
+          echo "Pushed regression test to branch: $TEST_BRANCH"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy-videos
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RAW_BRANCH: ${{ github.head_ref || github.ref_name }}
+          BEFORE_SHA: ${{ needs.resolve-matrix.outputs.before_sha }}
+          AFTER_SHA: ${{ needs.resolve-matrix.outputs.after_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_NUM: ${{ steps.pr.outputs.number }}
+          TARGET_TYPE: ${{ steps.pr.outputs.target_type }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          PIPELINE_SHA: ${{ github.sha }}
+          RUN_START_TIME: ${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at || '' }}
+        run: bash scripts/qa-deploy-pages.sh
+
+      - name: Post unified QA comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VIDEO_BASE: ${{ steps.deploy-videos.outputs.url }}
+          QA_MODE: ${{ needs.resolve-matrix.outputs.mode }}
+          TARGET_TYPE: ${{ steps.pr.outputs.target_type }}
+          BEFORE_SHA: ${{ needs.resolve-matrix.outputs.before_sha }}
+          AFTER_SHA: ${{ needs.resolve-matrix.outputs.after_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          RUN="https://github.com/${REPO}/actions/runs/${{ github.run_id }}"
+          COMMENT_MARKER="<!-- QA_REPORT_COMMENT -->"
+
+          MODE_BADGE="🔍 Focused"
+          if [ "$QA_MODE" = "full" ]; then MODE_BADGE="🔬 Full (3-OS)"; fi
+          if [ "$TARGET_TYPE" = "issue" ]; then MODE_BADGE="🐛 Issue Reproduce"; fi
+
+          # Build commit links
+          COMMIT_LINE=""
+          REPO_URL="https://github.com/${REPO}"
+          if [ -n "$BEFORE_SHA" ] || [ -n "$AFTER_SHA" ]; then
+            PARTS=""
+            [ -n "$BEFORE_SHA" ] && PARTS="main [\`${BEFORE_SHA:0:7}\`](${REPO_URL}/commit/${BEFORE_SHA})"
+            [ -n "$AFTER_SHA" ] && PARTS="${PARTS:+${PARTS} · }PR [\`${AFTER_SHA:0:7}\`](${REPO_URL}/commit/${AFTER_SHA})"
+            COMMIT_LINE="**Commits**: ${PARTS}"
+          fi
+
+          # Build video section with GIF thumbnails linking to full videos
+          VIDEO_SECTION=""
+          for os in Linux macOS Windows; do
+            GIF_URL="${VIDEO_BASE}/qa-${os}-thumb.gif"
+            VID_URL="${VIDEO_BASE}/qa-${os}.mp4"
+            # Fallback to pass1 for multi-pass recordings
+            curl -sf --head "$VID_URL" >/dev/null 2>&1 || VID_URL="${VIDEO_BASE}/qa-${os}-pass1.mp4"
+            if curl -sf --head "$VID_URL" >/dev/null 2>&1; then
+              if curl -sf --head "$GIF_URL" >/dev/null 2>&1; then
+                VIDEO_SECTION="${VIDEO_SECTION}[![${os} QA](${GIF_URL})](${VID_URL})"$'\n'
+              else
+                VIDEO_SECTION="${VIDEO_SECTION}[${os} video](${VID_URL})"$'\n'
+              fi
+            fi
+          done
+
+          # Build video review section from per-platform reports
+          VIDEO_REVIEW=""
+          for f in video-reviews/*-qa-video-report.md; do
+            [ -f "$f" ] || continue
+            [ -n "$VIDEO_REVIEW" ] && VIDEO_REVIEW="${VIDEO_REVIEW}
+          ---
+          "
+            VIDEO_REVIEW="${VIDEO_REVIEW}$(cat "$f")"
+          done
+
+          VIDEO_REVIEW_SECTION=""
+          if [ -n "$VIDEO_REVIEW" ]; then
+            VIDEO_REVIEW_SECTION=$(cat <<REVIEWEOF
+
+          <details>
+          <summary>Video Review</summary>
+
+          ${VIDEO_REVIEW}
+
+          </details>
+          REVIEWEOF
+          )
+          fi
+
+          BODY=$(cat <<EOF
+          ${COMMENT_MARKER}
+          ## QA ${MODE_BADGE}
+
+          [![QA Badge](${VIDEO_BASE}/badge.svg)](${VIDEO_BASE}/)
+
+          ${VIDEO_SECTION}
+          **Run**: [${RUN}](${RUN}) · [Download artifacts](${RUN}#artifacts) · [All videos](${VIDEO_BASE})
+          ${COMMIT_LINE:+${COMMIT_LINE}
+          }${VIDEO_REVIEW_SECTION}
+          EOF
+          )
+
+          PR_NUM="${{ steps.pr.outputs.number }}"
+          if [ -z "$PR_NUM" ]; then
+            echo "No PR found, skipping comment"
+            exit 0
+          fi
+
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUM}/comments" \
+            --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              --field body="$BODY"
+          elif [ "$TARGET_TYPE" = "issue" ]; then
+            gh issue comment "$PR_NUM" \
+              --repo ${{ github.repository }} --body "$BODY"
+          else
+            gh pr comment "$PR_NUM" \
+              --repo ${{ github.repository }} --body "$BODY"
+          fi
+
+      - name: Cleanup old video review comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.number }}"
+          if [ -z "$PR_NUM" ]; then exit 0; fi
+          OLD_MARKER="<!-- QA_VIDEO_REVIEW_COMMENT -->"
+          gh api "repos/${{ github.repository }}/issues/${PR_NUM}/comments" \
+            --jq ".[] | select(.body | contains(\"${OLD_MARKER}\")) | .id" | \
+          while read -r comment_id; do
+            echo "Deleting old video review comment: $comment_id"
+            gh api --method DELETE "repos/${{ github.repository }}/issues/comments/${comment_id}" || true
+          done
+
+      - name: Remove QA label
+        if: >-
+          github.event.label.name == 'qa-changes' ||
+          github.event.label.name == 'qa-full' ||
+          github.event.label.name == 'qa-issue'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          TARGET_NUM: ${{ steps.pr.outputs.number }}
+          TARGET_TYPE: ${{ steps.pr.outputs.target_type }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$TARGET_TYPE" = "issue" ]; then
+            [ -n "$TARGET_NUM" ] && gh issue edit "$TARGET_NUM" --repo "$REPO" --remove-label "$LABEL_NAME" || true
+          else
+            [ -n "$TARGET_NUM" ] && gh pr edit "$TARGET_NUM" --repo "$REPO" --remove-label "$LABEL_NAME" || true
+          fi
+
+      - name: Deploy FAILED badge on error
+        if: failure()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: /tmp/deploy-badge.sh "FAILED" "#e05d44" "${{ steps.pr.outputs.badge_label || 'QA' }}" "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/docs/qa/TROUBLESHOOTING.md
+++ b/docs/qa/TROUBLESHOOTING.md
@@ -1,0 +1,93 @@
+# QA Pipeline Troubleshooting
+
+## Common Failures
+
+### `set -euo pipefail` + grep with no match
+
+**Symptom**: Deploy script crashes silently, badge shows FAILED.
+**Cause**: `grep -oP` returns exit code 1 when no match. Under `pipefail`, this kills the entire script.
+**Fix**: Always append `|| true` to grep pipelines in bash scripts.
+
+### `__name is not defined` in page.evaluate
+
+**Symptom**: Recording crashes with `ReferenceError: __name is not defined`.
+**Cause**: tsx compiles arrow functions inside `page.evaluate()` with `__name` helpers. The browser context doesn't have these.
+**Fix**: Use `page.addScriptTag({ content: '...' })` with plain JS strings instead of `page.evaluate(() => { ... })` with arrow functions.
+
+### `Set<string>()` in page.evaluate
+
+**Symptom**: Same `__name` error.
+**Cause**: TypeScript generics like `new Set<string>()` get compiled incorrectly for browser context.
+**Fix**: Use `new Set()` without type parameter.
+
+### `zod/v4` import error
+
+**Symptom**: `ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './v4' is not defined`.
+**Cause**: claude-agent-sdk depends on `zod/v4` internally, but the project's zod doesn't export it.
+**Fix**: Import from `zod` (not `zod/v4`) in project code.
+
+### `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`
+
+**Symptom**: pnpm install fails with frozen lockfile mismatch.
+**Cause**: Adding a new dependency changes the workspace catalog but lockfile wasn't regenerated.
+**Fix**: Run `pnpm install` to regenerate lockfile, commit `pnpm-workspace.yaml` + `pnpm-lock.yaml`.
+
+### `loadDefaultWorkflow` — "Load Default" not found
+
+**Symptom**: Menu item "Load Default" not found, canvas stays empty.
+**Cause**: The menu item name varies by version/locale. Menu navigation is fragile.
+**Fix**: Use `app.resetToDefaultWorkflow()` JS API via `page.evaluate` instead of menu navigation.
+
+### Model ID not found (Claude Agent SDK)
+
+**Symptom**: `There's an issue with the selected model (claude-sonnet-4-6-20250514)`.
+**Cause**: Dated model IDs like `claude-sonnet-4-6-20250514` don't exist.
+**Fix**: Use `claude-sonnet-4-6` (no date suffix).
+
+### Model not found (Gemini)
+
+**Symptom**: 404 from Gemini API.
+**Cause**: Preview model names like `gemini-2.5-flash-preview-05-20` expire.
+**Fix**: Use `gemini-3-flash-preview` (latest stable).
+
+## Badge Mismatches
+
+### False REPRODUCED
+
+**Symptom**: Badge says REPRODUCED but AI review says "could not reproduce".
+**Root cause**: Grep pattern `reproduc|confirm` matches neutral words like "reproduction steps" or "could not be confirmed".
+**Fix**: Use structured JSON verdict from AI (`## Verdict` section with `{"verdict": "..."}`) instead of regex matching the prose.
+
+### INCONCLUSIVE feedback loop
+
+**Symptom**: Once an issue gets INCONCLUSIVE, all future runs stay INCONCLUSIVE.
+**Cause**: QA bot's own previous comments contain "INCONCLUSIVE", which gets fed back into pr-context.txt.
+**Fix**: Filter out `github-actions[bot]` comments when building pr-context.
+
+### pressKey with hold prevents event propagation
+
+**Symptom**: BEFORE video doesn't show the bug (e.g., Escape doesn't close dialog).
+**Cause**: `keyboard.down()` + 400ms sleep + `keyboard.up()` changes event timing. Some UI frameworks handle held keys differently than instant presses.
+**Fix**: Use instant `keyboard.press()` for testing. Show key name via subtitle overlay instead.
+
+## Cursor Not Visible
+
+**Symptom**: No mouse cursor in recorded videos.
+**Cause**: Headless Chrome doesn't render system cursor. The CSS cursor overlay relies on DOM `mousemove` events which Playwright CDP doesn't reliably trigger.
+**Fix**: Monkey-patch `page.mouse.move/click/dblclick/down/up` to call `__moveCursor(x,y)` on the injected cursor div. This makes ALL mouse operations update the overlay.
+
+## Credit Balance Too Low
+
+**Symptom**: Research phase produces INCONCLUSIVE with 0 tool calls. Log shows "Credit balance is too low".
+**Cause**: The `ANTHROPIC_API_KEY` secret in the repo has exhausted its credits.
+**Fix**: Top up the Anthropic API account linked to the key, or rotate to a new key in repo Settings → Secrets.
+
+## Agent Doesn't Perform Steps
+
+**Symptom**: Agent opens menus and settings but never interacts with the canvas.
+**Causes**:
+
+1. `loadDefaultWorkflow` failed (no nodes on canvas)
+2. Agent ran out of turn budget (30 turns / 120s)
+3. Gemini Flash (old agent) ignores prompt hints
+   **Fix**: Use hybrid agent (Claude Sonnet 4.6 + Gemini vision). Claude's superior reasoning follows instructions precisely.

--- a/docs/qa/backlog.md
+++ b/docs/qa/backlog.md
@@ -1,0 +1,72 @@
+# QA Pipeline Backlog
+
+## Comparison Modes
+
+### Type A: Same code, different settings (IMPLEMENTED)
+
+Agent demonstrates both working (control) and broken (test) states in one session by toggling settings. E.g., Nodes 2.0 OFF → drag works, Nodes 2.0 ON → drag broken.
+
+### Type B: Different commits
+
+For regressions reported as "worked in vX.Y, broken in vX.Z":
+
+- `qa-analyze-pr.ts` detects regression markers ("since v1.38", "after PR #1234")
+- Pipeline checks out the old commit, records control video
+- Records test video on current main
+- Side-by-side comparison on report page (reuses PR before/after infra)
+
+### Type C: Different browsers
+
+For browser-specific bugs ("works on Chrome, broken on Firefox"):
+
+- Run recording with different Playwright browser contexts
+- Compare behavior across browsers in one report
+
+## Agent Improvements
+
+### TTS Narration
+
+- OpenAI TTS (`tts-1`, nova voice) generates audio from agent reasoning
+- Merged into video via ffmpeg at correct timestamps
+- Currently in qa-record.ts but needs wiring into hybrid agent path
+
+### Image/Screenshot Reading
+
+- `qa-analyze-pr.ts` already downloads and sends images from issue bodies to Gemini
+- Could also send them to the Claude agent as context ("the reporter showed this screenshot")
+
+### Placeholder Page
+
+- Deploy a status page immediately when CI starts
+- Auto-refreshes every 30s until final report replaces it
+- Shows spinner, CI link, badge
+
+### Pre-seed Assets
+
+- Upload test images via ComfyUI API before recording
+- Enables reproduction of bugs requiring assets (#10424 zoom button)
+
+### Environment-Dependent Issues
+
+- #7942: needs custom TestNode — could install a test custom node pack in CI
+- #9101: needs completed generation — could run with a tiny model checkpoint
+
+## Cost Optimization
+
+### Lazy A11y Tree
+
+- `inspect(selector)` searches tree for specific element (~20 tokens)
+- `getUIChanges()` diffs against previous snapshot (~100 tokens)
+- vs dumping full tree every turn (~2000 tokens)
+
+### Gemini Video vs Images
+
+- 30s video clip: ~7,700 tokens (258 tok/s)
+- 15 screenshots: ~19,500 tokens (1,300 tok/frame)
+- Video is 2.5x cheaper and shows temporal changes
+
+### Model Selection
+
+- Claude Sonnet 4.6: $3/$15 per 1M in/out — best reasoning
+- Gemini 2.5 Flash: $0.10/$0.40 per 1M — best vision-per-dollar
+- Hybrid uses each where it's strongest

--- a/docs/qa/models.md
+++ b/docs/qa/models.md
@@ -1,0 +1,60 @@
+# QA Pipeline Model Selection
+
+## Current Configuration
+
+| Script                | Role                                   | Model                    | Why                                                                                                 |
+| --------------------- | -------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `qa-analyze-pr.ts`    | PR/issue analysis, QA guide generation | `gemini-3.1-pro-preview` | Needs deep reasoning over PR diffs, screenshots, and issue threads                                  |
+| `qa-record.ts`        | Playwright step generation             | `gemini-3.1-pro-preview` | Step quality is critical — must understand ComfyUI's canvas UI and produce precise action sequences |
+| `qa-video-review.ts`  | Video comparison review                | `gemini-3-flash-preview` | Video analysis with structured output; flash is sufficient and faster                               |
+| `qa-generate-test.ts` | Regression test generation             | `gemini-3-flash-preview` | Code generation from QA reports; flash handles this well                                            |
+
+## Model Comparison
+
+### Gemini 3.1 Pro vs GPT-5.4
+
+|                   | Gemini 3.1 Pro Preview | GPT-5.4           |
+| ----------------- | ---------------------- | ----------------- |
+| Context window    | 1M tokens              | 1M tokens         |
+| Max output        | 65K tokens             | 128K tokens       |
+| Video input       | Yes                    | No                |
+| Image input       | Yes                    | Yes               |
+| Audio input       | Yes                    | No                |
+| Pricing (input)   | $2/1M tokens           | $2.50/1M tokens   |
+| Pricing (output)  | $12/1M tokens          | $15/1M tokens     |
+| Function calling  | Yes                    | Yes               |
+| Code execution    | Yes                    | Yes (interpreter) |
+| Structured output | Yes                    | Yes               |
+
+**Why Gemini over GPT for QA:**
+
+- Native video understanding (can review recordings directly)
+- Lower cost at comparable quality
+- Native multimodal input (screenshots, videos, audio from issue threads)
+- Better price/performance for high-volume CI usage
+
+### Gemini 3 Flash vs GPT-5.4 Mini
+
+|                  | Gemini 3 Flash Preview | GPT-5.4 Mini    |
+| ---------------- | ---------------------- | --------------- |
+| Context window   | 1M tokens              | 1M tokens       |
+| Pricing (input)  | $0.50/1M tokens        | $0.40/1M tokens |
+| Pricing (output) | $3/1M tokens           | $1.60/1M tokens |
+| Video input      | Yes                    | No              |
+
+**Why Gemini Flash for video review:**
+
+- Video input support is required — GPT models cannot process video files
+- Good enough quality for structured comparison reports
+
+## Upgrade History
+
+| Date       | Change                                                           | Reason                                                                     |
+| ---------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 2026-03-24 | `gemini-2.5-flash` → `gemini-3.1-pro-preview` (record)           | Shallow step generation; pro model needed for complex ComfyUI interactions |
+| 2026-03-24 | `gemini-2.5-pro` → `gemini-3.1-pro-preview` (analyze)            | Keep analysis on latest pro                                                |
+| 2026-03-24 | `gemini-2.5-flash` → `gemini-3-flash-preview` (review, test-gen) | Latest flash for cost-efficient tasks                                      |
+
+## Override
+
+All scripts accept `--model <name>` to override the default. Pass any Gemini model ID.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -48,7 +48,10 @@ const config: KnipConfig = {
     '@primeuix/forms',
     '@primeuix/styled',
     '@primeuix/utils',
-    '@primevue/icons'
+    '@primevue/icons',
+    // QA pipeline deps — installed inline in CI workflow
+    '@anthropic-ai/claude-agent-sdk',
+    '@google/generative-ai'
   ],
   ignore: [
     // Auto generated API types

--- a/scripts/qa-agent.ts
+++ b/scripts/qa-agent.ts
@@ -1,0 +1,573 @@
+#!/usr/bin/env tsx
+/**
+ * QA Research Phase — Claude writes & debugs E2E tests to reproduce bugs
+ *
+ * Instead of driving a browser interactively, Claude:
+ * 1. Reads the issue + a11y snapshot of the UI
+ * 2. Writes a Playwright E2E test (.spec.ts) that reproduces the bug
+ * 3. Runs the test → reads errors → rewrites → repeats until it works
+ * 4. Outputs the passing test + verdict
+ *
+ * Tools:
+ *   - inspect(selector) — read a11y tree to understand UI state
+ *   - writeTest(code) — write a Playwright test file
+ *   - runTest() — execute the test and get results
+ *   - done(verdict, summary, testCode) — finish with the working test
+ */
+
+import type { Page } from '@playwright/test'
+import { query, tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk'
+import { z } from 'zod'
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { execSync } from 'child_process'
+
+// ── Types ──
+
+interface ResearchOptions {
+  page: Page
+  issueContext: string
+  qaGuide: string
+  outputDir: string
+  serverUrl: string
+  anthropicApiKey?: string
+  maxTurns?: number
+  timeBudgetMs?: number
+}
+
+export type ReproMethod = 'e2e_test' | 'video' | 'both' | 'none'
+
+export interface ResearchResult {
+  verdict: 'REPRODUCED' | 'NOT_REPRODUCIBLE' | 'INCONCLUSIVE'
+  reproducedBy: ReproMethod
+  summary: string
+  evidence: string
+  testCode: string
+  log: Array<{
+    turn: number
+    timestampMs: number
+    toolName: string
+    toolInput: unknown
+    toolResult: string
+  }>
+}
+
+// ── Main research function ──
+
+export async function runResearchPhase(
+  opts: ResearchOptions
+): Promise<ResearchResult> {
+  const { page, issueContext, qaGuide, outputDir, serverUrl, anthropicApiKey } =
+    opts
+  const maxTurns = opts.maxTurns ?? 50
+
+  let agentDone = false
+  let finalVerdict: ResearchResult['verdict'] = 'INCONCLUSIVE'
+  let finalReproducedBy: ReproMethod = 'none'
+  let finalSummary = 'Agent did not complete'
+  let finalEvidence = ''
+  let finalTestCode = ''
+  let turnCount = 0
+  let lastPassedTurn = -1
+  const startTime = Date.now()
+  const researchLog: ResearchResult['log'] = []
+
+  const testDir = `${outputDir}/research`
+  mkdirSync(testDir, { recursive: true })
+  const testPath = `${testDir}/reproduce.spec.ts`
+
+  // Get initial a11y snapshot for context
+  let initialA11y = ''
+  try {
+    initialA11y = await page.locator('body').ariaSnapshot({ timeout: 5000 })
+    initialA11y = initialA11y.slice(0, 3000)
+  } catch {
+    initialA11y = '(could not capture initial a11y snapshot)'
+  }
+
+  // ── Tool: inspect ──
+  const inspectTool = tool(
+    'inspect',
+    'Read the current accessibility tree to understand UI state. Use this to discover element names, roles, and selectors for your test.',
+    {
+      selector: z
+        .string()
+        .optional()
+        .describe(
+          'Optional filter — only show elements matching this name/role. Omit for full tree.'
+        )
+    },
+    async (args) => {
+      let resultText: string
+      try {
+        const ariaText = await page
+          .locator('body')
+          .ariaSnapshot({ timeout: 5000 })
+        if (args.selector) {
+          const lines = ariaText.split('\n')
+          const matches = lines.filter((l: string) =>
+            l.toLowerCase().includes(args.selector!.toLowerCase())
+          )
+          resultText =
+            matches.length > 0
+              ? `Found "${args.selector}":\n${matches.slice(0, 15).join('\n')}`
+              : `"${args.selector}" not found. Full tree:\n${ariaText.slice(0, 2000)}`
+        } else {
+          resultText = ariaText.slice(0, 3000)
+        }
+      } catch (e) {
+        resultText = `inspect failed: ${e instanceof Error ? e.message : e}`
+      }
+
+      researchLog.push({
+        turn: turnCount,
+        timestampMs: Date.now() - startTime,
+        toolName: 'inspect',
+        toolInput: args,
+        toolResult: resultText.slice(0, 500)
+      })
+
+      return { content: [{ type: 'text' as const, text: resultText }] }
+    }
+  )
+
+  // ── Tool: readFixture ──
+  const readFixtureTool = tool(
+    'readFixture',
+    'Read a fixture or helper file from browser_tests/fixtures/ to understand the API. Use this to discover available methods on comfyPage helpers before writing your test.',
+    {
+      path: z
+        .string()
+        .describe(
+          'Relative path within browser_tests/fixtures/, e.g. "helpers/CanvasHelper.ts" or "components/Topbar.ts" or "ComfyPage.ts"'
+        )
+    },
+    async (args) => {
+      let resultText: string
+      try {
+        const fullPath = `${projectRoot}/browser_tests/fixtures/${args.path}`
+        const content = readFileSync(fullPath, 'utf-8')
+        resultText = content.slice(0, 4000)
+        if (content.length > 4000) {
+          resultText += `\n\n... (truncated, ${content.length} total chars)`
+        }
+      } catch (e) {
+        resultText = `Could not read fixture: ${e instanceof Error ? e.message : e}`
+      }
+
+      researchLog.push({
+        turn: turnCount,
+        timestampMs: Date.now() - startTime,
+        toolName: 'readFixture',
+        toolInput: args,
+        toolResult: resultText.slice(0, 500)
+      })
+
+      return { content: [{ type: 'text' as const, text: resultText }] }
+    }
+  )
+
+  // ── Tool: readTest ──
+  const readTestTool = tool(
+    'readTest',
+    'Read an existing E2E test file from browser_tests/tests/ to learn patterns and conventions used in this project.',
+    {
+      path: z
+        .string()
+        .describe(
+          'Relative path within browser_tests/tests/, e.g. "workflow.spec.ts" or "subgraph.spec.ts"'
+        )
+    },
+    async (args) => {
+      let resultText: string
+      try {
+        const fullPath = `${projectRoot}/browser_tests/tests/${args.path}`
+        const content = readFileSync(fullPath, 'utf-8')
+        resultText = content.slice(0, 4000)
+        if (content.length > 4000) {
+          resultText += `\n\n... (truncated, ${content.length} total chars)`
+        }
+      } catch (e) {
+        // List available test files if the path doesn't exist
+        try {
+          const { readdirSync } = await import('fs')
+          const files = readdirSync(`${projectRoot}/browser_tests/tests/`)
+            .filter((f: string) => f.endsWith('.spec.ts'))
+            .slice(0, 30)
+          resultText = `File not found: ${args.path}\n\nAvailable test files:\n${files.join('\n')}`
+        } catch {
+          resultText = `Could not read test: ${e instanceof Error ? e.message : e}`
+        }
+      }
+
+      researchLog.push({
+        turn: turnCount,
+        timestampMs: Date.now() - startTime,
+        toolName: 'readTest',
+        toolInput: args,
+        toolResult: resultText.slice(0, 500)
+      })
+
+      return { content: [{ type: 'text' as const, text: resultText }] }
+    }
+  )
+
+  // ── Tool: writeTest ──
+  const writeTestTool = tool(
+    'writeTest',
+    'Write a Playwright E2E test file that reproduces the bug. The test should assert the broken behavior exists.',
+    {
+      code: z
+        .string()
+        .describe('Complete Playwright test file content (.spec.ts)')
+    },
+    async (args) => {
+      writeFileSync(testPath, args.code)
+
+      researchLog.push({
+        turn: turnCount,
+        timestampMs: Date.now() - startTime,
+        toolName: 'writeTest',
+        toolInput: { path: testPath, codeLength: args.code.length },
+        toolResult: `Test written to ${testPath} (${args.code.length} chars)`
+      })
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Test written to ${testPath}. Use runTest() to execute it.`
+          }
+        ]
+      }
+    }
+  )
+
+  // ── Tool: runTest ──
+  // Place test in browser_tests/ so Playwright config finds fixtures
+  const projectRoot = process.cwd()
+  const browserTestPath = `${projectRoot}/browser_tests/tests/qa-reproduce.spec.ts`
+
+  const runTestTool = tool(
+    'runTest',
+    'Run the Playwright test and get results. Returns stdout/stderr including assertion errors.',
+    {},
+    async () => {
+      turnCount++
+      // Copy the test to browser_tests/tests/ where Playwright expects it
+      const { copyFileSync } = await import('fs')
+      try {
+        copyFileSync(testPath, browserTestPath)
+      } catch {
+        // directory may not exist
+        mkdirSync(`${projectRoot}/browser_tests/tests`, { recursive: true })
+        copyFileSync(testPath, browserTestPath)
+      }
+
+      let resultText: string
+      try {
+        const output = execSync(
+          `cd "${projectRoot}" && npx playwright test browser_tests/tests/qa-reproduce.spec.ts --reporter=list --timeout=30000 --retries=0 --workers=1 2>&1`,
+          {
+            timeout: 90000,
+            encoding: 'utf-8',
+            env: {
+              ...process.env,
+              COMFYUI_BASE_URL: serverUrl
+            }
+          }
+        )
+        resultText = `TEST PASSED:\n${output.slice(-1500)}`
+      } catch (e) {
+        const err = e as { stdout?: string; stderr?: string; message?: string }
+        const output = (err.stdout || '') + '\n' + (err.stderr || '')
+        resultText = `TEST FAILED:\n${output.slice(-2000)}`
+      }
+
+      researchLog.push({
+        turn: turnCount,
+        timestampMs: Date.now() - startTime,
+        toolName: 'runTest',
+        toolInput: { testPath },
+        toolResult: resultText.slice(0, 1000)
+      })
+
+      // Auto-save passing test code for fallback completion
+      if (resultText.startsWith('TEST PASSED')) {
+        try {
+          finalTestCode = readFileSync(browserTestPath, 'utf-8')
+          lastPassedTurn = turnCount
+        } catch {
+          // ignore
+        }
+        resultText +=
+          '\n\n⚠️ Test PASSED — call done() now with verdict REPRODUCED and the test code. Do NOT write more tests.'
+      }
+
+      return { content: [{ type: 'text' as const, text: resultText }] }
+    }
+  )
+
+  // ── Tool: done ──
+  const doneTool = tool(
+    'done',
+    'Finish research with verdict and the final test code.',
+    {
+      verdict: z.enum(['REPRODUCED', 'NOT_REPRODUCIBLE', 'INCONCLUSIVE']),
+      reproducedBy: z
+        .enum(['e2e_test', 'video', 'both', 'none'])
+        .describe(
+          'How the bug was proven: e2e_test = Playwright assertion passed, video = visual evidence only, both = both methods, none = not reproduced'
+        ),
+      summary: z.string().describe('What you found and why'),
+      evidence: z.string().describe('Test output that proves the verdict'),
+      testCode: z
+        .string()
+        .describe(
+          'Final Playwright test code. If REPRODUCED, this test asserts the bug exists and passes.'
+        )
+    },
+    async (args) => {
+      agentDone = true
+      finalVerdict = args.verdict
+      finalReproducedBy = args.reproducedBy
+      finalSummary = args.summary
+      finalEvidence = args.evidence
+      finalTestCode = args.testCode
+      writeFileSync(testPath, args.testCode)
+      return {
+        content: [
+          { type: 'text' as const, text: `Research complete: ${args.verdict}` }
+        ]
+      }
+    }
+  )
+
+  // ── MCP Server ──
+  const server = createSdkMcpServer({
+    name: 'qa-research',
+    version: '1.0.0',
+    tools: [
+      inspectTool,
+      readFixtureTool,
+      readTestTool,
+      writeTestTool,
+      runTestTool,
+      doneTool
+    ]
+  })
+
+  // ── System prompt ──
+  const systemPrompt = `You are a senior QA engineer who writes Playwright E2E tests to reproduce reported bugs.
+
+## Your tools
+- inspect(selector?) — Read the accessibility tree to understand the current UI. Use to discover selectors, element names, and UI state.
+- readFixture(path) — Read fixture source code from browser_tests/fixtures/. Use to discover available methods. E.g. "helpers/CanvasHelper.ts", "components/Topbar.ts", "ComfyPage.ts"
+- readTest(path) — Read an existing test from browser_tests/tests/ to learn patterns. E.g. "workflow.spec.ts". Pass any name to list available files.
+- writeTest(code) — Write a Playwright test file (.spec.ts)
+- runTest() — Execute the test and get results (pass/fail + errors)
+- done(verdict, summary, evidence, testCode) — Finish with the final test
+
+## Workflow
+1. Read the issue description carefully
+2. Use inspect() to understand the current UI state and discover element selectors
+3. If unsure about the fixture API, use readFixture() to read the relevant helper source code
+4. If unsure about test patterns, use readTest() to read an existing test for reference
+5. Write a Playwright test that:
+   - Performs the exact reproduction steps from the issue
+   - Asserts the BROKEN behavior (the bug) — so the test PASSES when the bug exists
+6. Run the test with runTest()
+7. If it fails: read the error, fix the test, run again (max 5 attempts)
+8. Call done() with the final verdict and test code
+
+## Test writing guidelines
+- Import the project fixture: \`import { comfyPageFixture as test } from '../fixtures/ComfyPage'\`
+- Import expect: \`import { expect } from '@playwright/test'\`
+- The fixture provides \`comfyPage\` which has all the helpers listed below
+- If the bug IS present, the test should PASS. If the bug is fixed, the test would FAIL.
+- Keep tests focused and minimal — test ONLY the reported bug
+- Write ONE test, not multiple. Focus on the single clearest reproduction.
+- The test file will be placed in browser_tests/tests/qa-reproduce.spec.ts
+- Use \`comfyPage.nextFrame()\` after interactions that trigger UI updates
+- NEVER use \`page.waitForTimeout()\` — use Locator actions and retrying assertions instead
+- ALWAYS call done() when finished, even if the test passed — do not keep iterating after a passing test
+- Use \`expect.poll()\` for async assertions: \`await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(8)\`
+- CRITICAL: Your assertions must be SPECIFIC TO THE BUG. A test that asserts \`expect(count).toBeGreaterThan(0)\` proves nothing — it would pass even without the bug. Instead assert the exact broken state, e.g. \`expect(clonedWidgets).toHaveLength(0)\` (missing widgets) or \`expect(zIndex).toBeLessThan(parentZIndex)\` (wrong z-order). If a test passes trivially, it's a false positive.
+- If you cannot write a bug-specific assertion, call done() with verdict NOT_REPRODUCIBLE and explain why.
+
+## ComfyPage Fixture API Reference
+
+### Core properties
+- \`comfyPage.page\` — raw Playwright Page
+- \`comfyPage.canvas\` — Locator for #graph-canvas
+- \`comfyPage.queueButton\` — "Queue Prompt" button
+- \`comfyPage.runButton\` — "Run" button (new UI)
+- \`comfyPage.confirmDialog\` — ConfirmDialog (has .confirm, .delete, .overwrite, .reject locators + .click(name) method)
+- \`comfyPage.nextFrame()\` — wait for next requestAnimationFrame
+- \`comfyPage.setup()\` — navigate + wait for app ready (called automatically by fixture)
+
+### Menu (comfyPage.menu)
+- \`comfyPage.menu.topbar\` — Topbar helper:
+  - \`.triggerTopbarCommand(['File', 'Save As'])\` — navigate menu hierarchy
+  - \`.openTopbarMenu()\` / \`.closeTopbarMenu()\` — open/close hamburger
+  - \`.openSubmenu('File')\` — hover to open submenu, returns submenu Locator
+  - \`.getTabNames()\` — get all open workflow tab names
+  - \`.getActiveTabName()\` — get active tab name
+  - \`.getWorkflowTab(name)\` — get tab Locator
+  - \`.closeWorkflowTab(name)\` — close a tab
+  - \`.saveWorkflow(name)\` / \`.saveWorkflowAs(name)\` / \`.exportWorkflow(name)\`
+  - \`.switchTheme('dark' | 'light')\`
+- \`comfyPage.menu.workflowsTab\` — WorkflowsSidebarTab:
+  - \`.open()\` / \`.close()\` — toggle workflows sidebar
+  - \`.getTopLevelSavedWorkflowNames()\` — list saved workflow names
+- \`comfyPage.menu.nodeLibraryTab\` — NodeLibrarySidebarTab
+- \`comfyPage.menu.assetsTab\` — AssetsSidebarTab
+
+### Canvas (comfyPage.canvasOps)
+- \`.click({x, y})\` — click at position on canvas
+- \`.rightClick(x, y)\` — right-click (opens context menu)
+- \`.doubleClick()\` — double-click canvas (opens node search)
+- \`.clickEmptySpace()\` — click known empty area
+- \`.dragAndDrop(source, target)\` — drag from source to target position
+- \`.pan(offset, safeSpot?)\` — pan canvas by offset
+- \`.zoom(deltaY, steps?)\` — zoom via scroll wheel
+- \`.resetView()\` — reset zoom/pan to default
+- \`.getScale()\` / \`.setScale(n)\` — get/set canvas zoom
+- \`.getNodeCenterByTitle(title)\` — get screen coords of node center
+- \`.disconnectEdge()\` / \`.connectEdge()\` — default graph edge operations
+
+### Node Operations (comfyPage.nodeOps)
+- \`.getGraphNodesCount()\` — count all nodes
+- \`.getSelectedGraphNodesCount()\` — count selected nodes
+- \`.getNodes()\` — get all nodes
+- \`.getFirstNodeRef()\` — get NodeReference for first node
+- \`.getNodeRefById(id)\` — get NodeReference by ID
+- \`.getNodeRefsByType(type)\` — get all nodes of a type
+- \`.waitForGraphNodes(count)\` — wait until node count matches
+
+### Settings (comfyPage.settings)
+- \`.setSetting(id, value)\` — change a ComfyUI setting
+- \`.getSetting(id)\` — read current setting value
+
+### Keyboard (comfyPage.keyboard)
+- \`.undo()\` / \`.redo()\` — Ctrl+Z / Ctrl+Y
+- \`.bypass()\` — Ctrl+B
+- \`.selectAll()\` — Ctrl+A
+- \`.ctrlSend(key)\` — send Ctrl+key
+
+### Workflow (comfyPage.workflow)
+- \`.loadWorkflow(name)\` — load from browser_tests/assets/{name}.json
+- \`.setupWorkflowsDirectory(structure)\` — setup test directory
+- \`.deleteWorkflow(name)\`
+- \`.isCurrentWorkflowModified()\` — check dirty state
+
+### Context Menu (comfyPage.contextMenu)
+- \`.openFor(locator)\` — right-click locator and wait for menu
+- \`.clickMenuItem(name)\` — click a menu item by name
+- \`.isVisible()\` — check if context menu is showing
+- \`.assertHasItems(items)\` — assert menu contains items
+
+### Other helpers
+- \`comfyPage.settingDialog\` — SettingDialog component
+- \`comfyPage.searchBox\` / \`comfyPage.searchBoxV2\` — node search
+- \`comfyPage.toast\` — ToastHelper (\`.visibleToasts\`)
+- \`comfyPage.subgraph\` — SubgraphHelper
+- \`comfyPage.vueNodes\` — VueNodeHelpers
+- \`comfyPage.bottomPanel\` — BottomPanel
+- \`comfyPage.clipboard\` — ClipboardHelper
+- \`comfyPage.dragDrop\` — DragDropHelper
+
+### Available fixture files (use readFixture to explore)
+- ComfyPage.ts — main fixture with all helpers
+- helpers/CanvasHelper.ts, NodeOperationsHelper.ts, WorkflowHelper.ts
+- helpers/KeyboardHelper.ts, SettingsHelper.ts, SubgraphHelper.ts
+- components/Topbar.ts, ContextMenu.ts, SettingDialog.ts, SidebarTab.ts
+
+## Current UI state (accessibility tree)
+${initialA11y}
+
+${qaGuide ? `## QA Analysis Guide\n${qaGuide}\n` : ''}
+## Issue to Reproduce
+${issueContext}`
+
+  // ── Run the agent ──
+  console.warn('Starting research phase (Claude writes E2E tests)...')
+
+  try {
+    for await (const message of query({
+      prompt:
+        'Write a Playwright E2E test that reproduces the reported bug. Use inspect() to discover selectors, readFixture() or readTest() if you need to understand the fixture API or see existing test patterns, writeTest() to write the test, runTest() to execute it. Iterate until it works or you determine the bug cannot be reproduced.',
+      options: {
+        model: 'claude-sonnet-4-6',
+        systemPrompt,
+        ...(anthropicApiKey ? { apiKey: anthropicApiKey } : {}),
+        maxTurns,
+        mcpServers: { 'qa-research': server },
+        allowedTools: [
+          'mcp__qa-research__inspect',
+          'mcp__qa-research__readFixture',
+          'mcp__qa-research__readTest',
+          'mcp__qa-research__writeTest',
+          'mcp__qa-research__runTest',
+          'mcp__qa-research__done'
+        ]
+      }
+    })) {
+      if (message.type === 'assistant' && message.message?.content) {
+        for (const block of message.message.content) {
+          if ('text' in block && block.text) {
+            console.warn(`  Claude: ${block.text.slice(0, 200)}`)
+          }
+          if ('name' in block) {
+            console.warn(
+              `  Tool: ${block.name}(${JSON.stringify(block.input).slice(0, 100)})`
+            )
+          }
+        }
+      }
+      if (agentDone) break
+    }
+  } catch (e) {
+    const errMsg = e instanceof Error ? e.message : String(e)
+    console.warn(`Research error: ${errMsg}`)
+
+    // Detect billing/auth errors and surface them clearly
+    if (
+      errMsg.includes('Credit balance is too low') ||
+      errMsg.includes('insufficient_quota') ||
+      errMsg.includes('rate_limit')
+    ) {
+      finalSummary = `API error: ${errMsg.slice(0, 200)}`
+      finalEvidence = 'Agent could not start due to API billing/auth issue'
+      console.warn(
+        '::error::Anthropic API credits exhausted — cannot run research phase'
+      )
+    }
+  }
+
+  // Auto-complete: if a test passed but done() was never called, use the passing test
+  if (!agentDone && lastPassedTurn >= 0 && finalTestCode) {
+    console.warn(
+      `Auto-completing: test passed at turn ${lastPassedTurn} but done() was not called`
+    )
+    finalVerdict = 'REPRODUCED'
+    finalReproducedBy = 'e2e_test'
+    finalSummary = `Test passed at turn ${lastPassedTurn} (auto-completed — agent did not call done())`
+    finalEvidence = `Test passed with exit code 0`
+  }
+
+  const result: ResearchResult = {
+    verdict: finalVerdict,
+    reproducedBy: finalReproducedBy,
+    summary: finalSummary,
+    evidence: finalEvidence,
+    testCode: finalTestCode,
+    log: researchLog
+  }
+
+  writeFileSync(`${testDir}/research-log.json`, JSON.stringify(result, null, 2))
+  console.warn(
+    `Research complete: ${finalVerdict} (${researchLog.length} tool calls)`
+  )
+
+  return result
+}

--- a/scripts/qa-analyze-pr.test.ts
+++ b/scripts/qa-analyze-pr.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractMediaUrls } from './qa-analyze-pr'
+
+describe('extractMediaUrls', () => {
+  it('extracts markdown image URLs', () => {
+    const text = '![screenshot](https://example.com/image.png)'
+    expect(extractMediaUrls(text)).toEqual(['https://example.com/image.png'])
+  })
+
+  it('extracts multiple markdown images', () => {
+    const text = [
+      '![before](https://example.com/before.png)',
+      'Some text',
+      '![after](https://example.com/after.jpg)'
+    ].join('\n')
+    expect(extractMediaUrls(text)).toEqual([
+      'https://example.com/before.png',
+      'https://example.com/after.jpg'
+    ])
+  })
+
+  it('extracts raw URLs with media extensions', () => {
+    const text = 'Check this: https://cdn.example.com/demo.mp4 for details'
+    expect(extractMediaUrls(text)).toEqual(['https://cdn.example.com/demo.mp4'])
+  })
+
+  it('extracts GitHub user-attachments URLs', () => {
+    const text =
+      'https://github.com/user-attachments/assets/abc12345-6789-0def-1234-567890abcdef'
+    expect(extractMediaUrls(text)).toEqual([
+      'https://github.com/user-attachments/assets/abc12345-6789-0def-1234-567890abcdef'
+    ])
+  })
+
+  it('extracts private-user-images URLs', () => {
+    const text =
+      'https://private-user-images.githubusercontent.com/12345/abcdef-1234?jwt=token123'
+    expect(extractMediaUrls(text)).toEqual([
+      'https://private-user-images.githubusercontent.com/12345/abcdef-1234?jwt=token123'
+    ])
+  })
+
+  it('extracts URLs with query parameters', () => {
+    const text = 'https://example.com/image.png?w=800&h=600'
+    expect(extractMediaUrls(text)).toEqual([
+      'https://example.com/image.png?w=800&h=600'
+    ])
+  })
+
+  it('deduplicates URLs', () => {
+    const text = [
+      '![img](https://example.com/same.png)',
+      '![img2](https://example.com/same.png)',
+      'Also https://example.com/same.png'
+    ].join('\n')
+    expect(extractMediaUrls(text)).toEqual(['https://example.com/same.png'])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(extractMediaUrls('')).toEqual([])
+  })
+
+  it('returns empty array for text with no media URLs', () => {
+    expect(extractMediaUrls('Just some text without any URLs')).toEqual([])
+  })
+
+  it('handles mixed media types', () => {
+    const text = [
+      '![screen](https://example.com/screenshot.png)',
+      'Video: https://example.com/demo.webm',
+      '![gif](https://example.com/animation.gif)'
+    ].join('\n')
+    const urls = extractMediaUrls(text)
+    expect(urls).toContain('https://example.com/screenshot.png')
+    expect(urls).toContain('https://example.com/demo.webm')
+    expect(urls).toContain('https://example.com/animation.gif')
+  })
+
+  it('ignores non-http URLs in markdown', () => {
+    const text = '![local](./local-image.png)'
+    expect(extractMediaUrls(text)).toEqual([])
+  })
+})

--- a/scripts/qa-analyze-pr.ts
+++ b/scripts/qa-analyze-pr.ts
@@ -1,0 +1,799 @@
+#!/usr/bin/env tsx
+/**
+ * QA PR Analysis Script
+ *
+ * Deeply analyzes a PR using Gemini Pro to generate targeted QA guides
+ * for before/after recording sessions. Fetches PR thread, extracts media,
+ * and produces structured test plans.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/qa-analyze-pr.ts \
+ *     --pr-number 10270 \
+ *     --repo owner/repo \
+ *     --output-dir qa-guides/ \
+ *     [--model gemini-3.1-pro-preview]
+ *
+ * Env: GEMINI_API_KEY (required)
+ */
+
+import { execSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+// ── Types ──
+
+interface QaGuideStep {
+  action: string
+  description: string
+  expected_before?: string
+  expected_after?: string
+}
+
+interface QaGuide {
+  summary: string
+  test_focus: string
+  prerequisites: string[]
+  steps: QaGuideStep[]
+  visual_checks: string[]
+}
+
+interface PrThread {
+  title: string
+  body: string
+  labels: string[]
+  issueComments: string[]
+  reviewComments: string[]
+  reviews: string[]
+  diff: string
+}
+
+type TargetType = 'pr' | 'issue'
+
+interface Options {
+  prNumber: string
+  repo: string
+  outputDir: string
+  model: string
+  apiKey: string
+  mediaBudgetBytes: number
+  maxVideoBytes: number
+  type: TargetType
+}
+
+// ── CLI parsing ──
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2)
+  const opts: Partial<Options> = {
+    model: 'gemini-3.1-pro-preview',
+    apiKey: process.env.GEMINI_API_KEY || '',
+    mediaBudgetBytes: 20 * 1024 * 1024,
+    maxVideoBytes: 10 * 1024 * 1024,
+    type: 'pr'
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--pr-number':
+        opts.prNumber = args[++i]
+        break
+      case '--repo':
+        opts.repo = args[++i]
+        break
+      case '--output-dir':
+        opts.outputDir = args[++i]
+        break
+      case '--model':
+        opts.model = args[++i]
+        break
+      case '--type':
+        opts.type = args[++i] as TargetType
+        break
+      case '--help':
+        console.warn(
+          'Usage: qa-analyze-pr.ts --pr-number <num> --repo <owner/repo> --output-dir <path> [--model <model>] [--type pr|issue]'
+        )
+        process.exit(0)
+    }
+  }
+
+  if (!opts.prNumber || !opts.repo || !opts.outputDir) {
+    console.error(
+      'Required: --pr-number <num> --repo <owner/repo> --output-dir <path>'
+    )
+    process.exit(1)
+  }
+
+  if (!opts.apiKey) {
+    console.error('GEMINI_API_KEY environment variable is required')
+    process.exit(1)
+  }
+
+  return opts as Options
+}
+
+// ── PR thread fetching ──
+
+function ghExec(cmd: string): string {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim()
+  } catch (err) {
+    console.warn(`gh command failed: ${cmd}`)
+    console.warn((err as Error).message)
+    return ''
+  }
+}
+
+function fetchPrThread(prNumber: string, repo: string): PrThread {
+  console.warn('Fetching PR thread...')
+
+  const prView = ghExec(
+    `gh pr view ${prNumber} --repo ${repo} --json title,body,labels`
+  )
+  const prData = prView
+    ? JSON.parse(prView)
+    : { title: '', body: '', labels: [] }
+
+  const issueCommentsRaw = ghExec(
+    `gh api repos/${repo}/issues/${prNumber}/comments --paginate`
+  )
+  const issueComments: string[] = issueCommentsRaw
+    ? JSON.parse(issueCommentsRaw).map((c: { body: string }) => c.body)
+    : []
+
+  const reviewCommentsRaw = ghExec(
+    `gh api repos/${repo}/pulls/${prNumber}/comments --paginate`
+  )
+  const reviewComments: string[] = reviewCommentsRaw
+    ? JSON.parse(reviewCommentsRaw).map((c: { body: string }) => c.body)
+    : []
+
+  const reviewsRaw = ghExec(
+    `gh api repos/${repo}/pulls/${prNumber}/reviews --paginate`
+  )
+  const reviews: string[] = reviewsRaw
+    ? JSON.parse(reviewsRaw)
+        .filter((r: { body: string }) => r.body)
+        .map((r: { body: string }) => r.body)
+    : []
+
+  const diff = ghExec(`gh pr diff ${prNumber} --repo ${repo}`)
+
+  console.warn(
+    `PR #${prNumber}: "${prData.title}" | ` +
+      `${issueComments.length} issue comments, ` +
+      `${reviewComments.length} review comments, ` +
+      `${reviews.length} reviews, ` +
+      `diff: ${diff.length} chars`
+  )
+
+  return {
+    title: prData.title || '',
+    body: prData.body || '',
+    labels: (prData.labels || []).map((l: { name: string }) => l.name),
+    issueComments,
+    reviewComments,
+    reviews,
+    diff
+  }
+}
+
+interface IssueThread {
+  title: string
+  body: string
+  labels: string[]
+  comments: string[]
+}
+
+function fetchIssueThread(issueNumber: string, repo: string): IssueThread {
+  console.warn('Fetching issue thread...')
+
+  const issueView = ghExec(
+    `gh issue view ${issueNumber} --repo ${repo} --json title,body,labels`
+  )
+  const issueData = issueView
+    ? JSON.parse(issueView)
+    : { title: '', body: '', labels: [] }
+
+  const commentsRaw = ghExec(
+    `gh api repos/${repo}/issues/${issueNumber}/comments --paginate`
+  )
+  const comments: string[] = commentsRaw
+    ? JSON.parse(commentsRaw).map((c: { body: string }) => c.body)
+    : []
+
+  console.warn(
+    `Issue #${issueNumber}: "${issueData.title}" | ` +
+      `${comments.length} comments`
+  )
+
+  return {
+    title: issueData.title || '',
+    body: issueData.body || '',
+    labels: (issueData.labels || []).map((l: { name: string }) => l.name),
+    comments
+  }
+}
+
+// ── Media extraction ──
+
+const MEDIA_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|mp4|webm|mov)$/i
+
+const MEDIA_URL_PATTERNS = [
+  // Markdown images: ![alt](url)
+  /!\[[^\]]*\]\(([^)]+)\)/g,
+  // GitHub user-attachments
+  /https:\/\/github\.com\/user-attachments\/assets\/[a-f0-9-]+/g,
+  // Private user images
+  /https:\/\/private-user-images\.githubusercontent\.com\/[^\s)"]+/g,
+  // Raw URLs with media extensions (standalone or in text)
+  /(?<!="|=')https?:\/\/[^\s)<>"]+\.(?:png|jpg|jpeg|gif|webp|mp4|webm|mov)(?:\?[^\s)<>"]*)?/gi
+]
+
+export function extractMediaUrls(text: string): string[] {
+  if (!text) return []
+
+  const urls = new Set<string>()
+
+  for (const pattern of MEDIA_URL_PATTERNS) {
+    // Reset lastIndex for global patterns
+    pattern.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(text)) !== null) {
+      // For markdown images, the URL is in capture group 1
+      const url = match[1] || match[0]
+      // Clean trailing markdown/html artifacts
+      const cleaned = url.replace(/[)>"'\s]+$/, '')
+      if (cleaned.startsWith('http')) {
+        urls.add(cleaned)
+      }
+    }
+  }
+
+  return [...urls]
+}
+
+// ── Media downloading ──
+
+const ALLOWED_MEDIA_DOMAINS = [
+  'github.com',
+  'raw.githubusercontent.com',
+  'user-images.githubusercontent.com',
+  'private-user-images.githubusercontent.com',
+  'objects.githubusercontent.com',
+  'github.githubassets.com'
+]
+
+function isAllowedMediaDomain(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname
+    return ALLOWED_MEDIA_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+    )
+  } catch {
+    return false
+  }
+}
+
+async function downloadMedia(
+  urls: string[],
+  outputDir: string,
+  budgetBytes: number,
+  maxVideoBytes: number
+): Promise<Array<{ path: string; mimeType: string }>> {
+  const downloaded: Array<{ path: string; mimeType: string }> = []
+  let totalBytes = 0
+
+  const mediaDir = resolve(outputDir, 'media')
+  mkdirSync(mediaDir, { recursive: true })
+
+  for (const url of urls) {
+    if (totalBytes >= budgetBytes) {
+      console.warn(
+        `Media budget exhausted (${totalBytes} bytes), skipping rest`
+      )
+      break
+    }
+
+    if (!isAllowedMediaDomain(url)) {
+      console.warn(`Skipping non-GitHub URL: ${url.slice(0, 80)}`)
+      continue
+    }
+
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(15_000),
+        headers: { Accept: 'image/*,video/*' },
+        redirect: 'follow'
+      })
+
+      if (!response.ok) {
+        console.warn(`Failed to download ${url}: ${response.status}`)
+        continue
+      }
+
+      const contentLength = response.headers.get('content-length')
+      if (contentLength) {
+        const declaredSize = Number.parseInt(contentLength, 10)
+        if (declaredSize > budgetBytes - totalBytes) {
+          console.warn(
+            `Content-Length ${declaredSize} would exceed budget, skipping ${url}`
+          )
+          continue
+        }
+      }
+
+      const contentType = response.headers.get('content-type') || ''
+      const buffer = Buffer.from(await response.arrayBuffer())
+
+      // Skip oversized videos
+      const isVideo =
+        contentType.startsWith('video/') || /\.(mp4|webm|mov)$/i.test(url)
+      if (isVideo && buffer.length > maxVideoBytes) {
+        console.warn(
+          `Skipping large video ${url} (${(buffer.length / 1024 / 1024).toFixed(1)}MB > ${(maxVideoBytes / 1024 / 1024).toFixed(0)}MB cap)`
+        )
+        continue
+      }
+
+      if (totalBytes + buffer.length > budgetBytes) {
+        console.warn(`Would exceed budget, skipping ${url}`)
+        continue
+      }
+
+      const ext = guessExtension(url, contentType)
+      const filename = `media-${downloaded.length}${ext}`
+      const filepath = resolve(mediaDir, filename)
+      writeFileSync(filepath, buffer)
+      totalBytes += buffer.length
+
+      const mimeType = contentType.split(';')[0].trim() || guessMimeType(ext)
+
+      downloaded.push({ path: filepath, mimeType })
+      console.warn(
+        `Downloaded: ${url.slice(0, 80)}... (${(buffer.length / 1024).toFixed(0)}KB)`
+      )
+    } catch (err) {
+      console.warn(`Failed to download ${url}: ${(err as Error).message}`)
+    }
+  }
+
+  console.warn(
+    `Downloaded ${downloaded.length}/${urls.length} media files ` +
+      `(${(totalBytes / 1024 / 1024).toFixed(1)}MB)`
+  )
+  return downloaded
+}
+
+function guessExtension(url: string, contentType: string): string {
+  const urlMatch = url.match(MEDIA_EXTENSIONS)
+  if (urlMatch) return urlMatch[0].toLowerCase()
+
+  const typeMap: Record<string, string> = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+    'video/mp4': '.mp4',
+    'video/webm': '.webm'
+  }
+  return typeMap[contentType.split(';')[0]] || '.bin'
+}
+
+function guessMimeType(ext: string): string {
+  const map: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.mp4': 'video/mp4',
+    '.webm': 'video/webm',
+    '.mov': 'video/quicktime'
+  }
+  return map[ext] || 'application/octet-stream'
+}
+
+// ── Gemini analysis ──
+
+function buildIssueAnalysisPrompt(issue: IssueThread): string {
+  const allText = [
+    `# Issue: ${issue.title}`,
+    '',
+    '## Description',
+    issue.body,
+    '',
+    issue.comments.length > 0
+      ? `## Comments\n${issue.comments.join('\n\n---\n\n')}`
+      : ''
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return `You are a senior QA engineer analyzing a bug report for ComfyUI frontend — a node-based visual workflow editor for AI image generation (Vue 3 + TypeScript).
+
+The UI has:
+- A large canvas (1280x720 viewport) showing a node graph centered at ~(640, 400)
+- Nodes are boxes with input/output slots connected by wires
+- A hamburger menu (top-left C logo) with File, Edit, Help submenus
+- Sidebars (Workflows, Node Library, Models)
+- A topbar with workflow tabs and Queue button
+- The default workflow loads with these nodes (approximate center coordinates):
+  - Load Checkpoint (~150, 300), CLIP Text Encode x2 (~450, 250 and ~450, 450)
+  - Empty Latent Image (~450, 600), KSampler (~750, 350), VAE Decode (~1000, 350), Save Image (~1200, 350)
+- Right-clicking ON a node shows node actions (Clone, Bypass, Convert, etc.)
+- Right-clicking on EMPTY canvas shows Add Node menu — different from node context menu
+
+Your task: Generate a DETAILED reproduction guide (8-15 steps) to trigger this bug on main.
+
+${allText}
+
+## Available test actions
+Each step must use one of these actions:
+
+### Menu actions
+- "openMenu" — clicks the Comfy hamburger menu (top-left C logo)
+- "hoverMenuItem" — hovers a top-level menu item to open submenu (label required)
+- "clickMenuItem" — clicks an item in the visible submenu (label required)
+
+### Element actions (by visible text)
+- "click" — clicks an element by visible text (text required)
+- "rightClick" — right-clicks an element to open context menu (text required)
+- "doubleClick" — double-clicks an element or coordinates (text or x,y)
+- "fillDialog" — fills dialog input and presses Enter (text required)
+- "pressKey" — presses a keyboard key (key required: Escape, Tab, Delete, Enter, etc.)
+
+### Canvas actions (by coordinates — viewport is 1280x720)
+- "clickCanvas" — click at coordinates (x, y required)
+- "rightClickCanvas" — right-click at coordinates (x, y required)
+- "doubleClick" — double-click at coordinates to open node search (x, y)
+- "dragCanvas" — drag from one point to another (fromX, fromY, toX, toY)
+- "scrollCanvas" — scroll wheel for zoom (x, y, deltaY: negative=zoom in, positive=zoom out)
+
+### Utility
+- "wait" — waits briefly (ms required, max 3000)
+- "screenshot" — takes a screenshot (name required)
+
+## Common ComfyUI interactions
+- Right-click a node → context menu with Clone, Bypass, Remove, Colors, etc.
+- Double-click empty canvas → opens node search dialog
+- Ctrl+C / Ctrl+V → copy/paste selected nodes
+- Delete key → remove selected node
+- Ctrl+G → group selected nodes
+- Drag from output slot to input slot → create connection
+- Click a node to select it, Shift+click for multi-select
+
+## Output format
+Return a JSON object with exactly one key: "reproduce", containing:
+{
+  "summary": "One sentence: what bug this issue reports",
+  "test_focus": "Specific behavior to reproduce",
+  "prerequisites": ["e.g. Load default workflow"],
+  "steps": [
+    {
+      "action": "clickCanvas",
+      "description": "Click on first node to select it",
+      "expected_before": "What should happen if the bug is present"
+    }
+  ],
+  "visual_checks": ["Specific visual evidence of the bug to look for"]
+}
+
+## Rules
+- Generate 8-15 DETAILED steps that actually trigger the reported bug.
+- Follow the issue's reproduction steps PRECISELY — translate them into available actions.
+- Use canvas coordinates for node interactions (nodes are typically in the center area 300-900 x 200-500).
+- Take screenshots BEFORE and AFTER critical actions to capture the bug state.
+- Do NOT just open a menu and screenshot — actually perform the full reproduction sequence.
+- Do NOT include login steps.
+- Output ONLY valid JSON, no markdown fences or explanation.`
+}
+
+function buildAnalysisPrompt(thread: PrThread): string {
+  const allText = [
+    `# PR: ${thread.title}`,
+    '',
+    '## Description',
+    thread.body,
+    '',
+    thread.issueComments.length > 0
+      ? `## Issue Comments\n${thread.issueComments.join('\n\n---\n\n')}`
+      : '',
+    thread.reviewComments.length > 0
+      ? `## Review Comments\n${thread.reviewComments.join('\n\n---\n\n')}`
+      : '',
+    thread.reviews.length > 0
+      ? `## Reviews\n${thread.reviews.join('\n\n---\n\n')}`
+      : '',
+    '',
+    '## Diff (truncated)',
+    '```',
+    thread.diff.slice(0, 8000),
+    '```'
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return `You are a senior QA engineer analyzing a pull request for ComfyUI frontend (a Vue 3 + TypeScript web application for AI image generation workflows).
+
+Your task: Generate TWO targeted QA test guides — one for BEFORE the PR (main branch) and one for AFTER (PR branch).
+
+${allText}
+
+## Available test actions
+Each step must use one of these actions:
+- "openMenu" — clicks the Comfy hamburger menu (top-left C logo)
+- "hoverMenuItem" — hovers a top-level menu item to open submenu (label required)
+- "clickMenuItem" — clicks an item in the visible submenu (label required)
+- "fillDialog" — fills dialog input and presses Enter (text required)
+- "pressKey" — presses a keyboard key (key required)
+- "click" — clicks an element by visible text (text required)
+- "wait" — waits briefly (ms required, max 3000)
+- "screenshot" — takes a screenshot (name required)
+
+## Output format
+Return a JSON object with exactly two keys: "before" and "after", each containing:
+{
+  "summary": "One sentence: what this PR changes",
+  "test_focus": "Specific behaviors to verify in this recording",
+  "prerequisites": ["e.g. Load default workflow"],
+  "steps": [
+    {
+      "action": "openMenu",
+      "description": "Open the main menu to check file options",
+      "expected_before": "Old behavior description (before key only)",
+      "expected_after": "New behavior description (after key only)"
+    }
+  ],
+  "visual_checks": ["Specific visual elements to look for"]
+}
+
+## Rules
+- BEFORE guide: 2-4 steps, under 15 seconds. Show OLD/missing behavior.
+- AFTER guide: 3-6 steps, under 30 seconds. Prove the fix/feature works.
+- Focus on the SPECIFIC behavior changed by this PR, not generic testing.
+- Use information from PR description, screenshots, and comments to understand intended behavior.
+- Include at least one screenshot step in each guide.
+- Do NOT include login steps.
+- Menu pattern: openMenu -> hoverMenuItem -> clickMenuItem or screenshot.
+- Output ONLY valid JSON, no markdown fences or explanation.`
+}
+
+async function analyzeWithGemini(
+  thread: PrThread,
+  media: Array<{ path: string; mimeType: string }>,
+  model: string,
+  apiKey: string
+): Promise<{ before: QaGuide; after: QaGuide }> {
+  const genAI = new GoogleGenerativeAI(apiKey)
+  const geminiModel = genAI.getGenerativeModel({ model })
+
+  const prompt = buildAnalysisPrompt(thread)
+
+  const parts: Array<
+    { text: string } | { inlineData: { mimeType: string; data: string } }
+  > = [{ text: prompt }]
+
+  // Add media as inline data
+  for (const item of media) {
+    try {
+      const buffer = readFileSync(item.path)
+      parts.push({
+        inlineData: {
+          mimeType: item.mimeType,
+          data: buffer.toString('base64')
+        }
+      })
+    } catch (err) {
+      console.warn(
+        `Failed to read media ${item.path}: ${(err as Error).message}`
+      )
+    }
+  }
+
+  console.warn(
+    `Sending to ${model}: ${prompt.length} chars text, ${media.length} media files`
+  )
+
+  const result = await geminiModel.generateContent({
+    contents: [{ role: 'user', parts }],
+    generationConfig: {
+      temperature: 0.2,
+      maxOutputTokens: 8192,
+      responseMimeType: 'application/json'
+    }
+  })
+
+  let text = result.response.text()
+  // Strip markdown fences if present
+  text = text
+    .replace(/^```(?:json)?\n?/gm, '')
+    .replace(/```$/gm, '')
+    .trim()
+
+  console.warn('Gemini response received')
+  console.warn('Raw response (first 500 chars):', text.slice(0, 500))
+  const parsed = JSON.parse(text)
+
+  // Handle different response shapes from Gemini
+  let before: QaGuide
+  let after: QaGuide
+
+  if (Array.isArray(parsed) && parsed.length >= 2) {
+    // Array format: [before, after]
+    before = parsed[0]
+    after = parsed[1]
+  } else if (parsed.before && parsed.after) {
+    // Object format: { before, after }
+    before = parsed.before
+    after = parsed.after
+  } else {
+    // Try nested wrapper keys
+    const inner = parsed.qa_guide ?? parsed.guides ?? parsed
+    if (inner.before && inner.after) {
+      before = inner.before
+      after = inner.after
+    } else {
+      console.warn(
+        'Full response:',
+        JSON.stringify(parsed, null, 2).slice(0, 2000)
+      )
+      throw new Error(
+        `Unexpected response shape. Got keys: ${Object.keys(parsed).join(', ')}`
+      )
+    }
+  }
+
+  return { before, after }
+}
+
+async function analyzeIssueWithGemini(
+  issue: IssueThread,
+  media: Array<{ path: string; mimeType: string }>,
+  model: string,
+  apiKey: string
+): Promise<QaGuide> {
+  const genAI = new GoogleGenerativeAI(apiKey)
+  const geminiModel = genAI.getGenerativeModel({ model })
+
+  const prompt = buildIssueAnalysisPrompt(issue)
+
+  const parts: Array<
+    { text: string } | { inlineData: { mimeType: string; data: string } }
+  > = [{ text: prompt }]
+
+  for (const item of media) {
+    try {
+      const buffer = readFileSync(item.path)
+      parts.push({
+        inlineData: {
+          mimeType: item.mimeType,
+          data: buffer.toString('base64')
+        }
+      })
+    } catch (err) {
+      console.warn(
+        `Failed to read media ${item.path}: ${(err as Error).message}`
+      )
+    }
+  }
+
+  console.warn(
+    `Sending to ${model}: ${prompt.length} chars text, ${media.length} media files`
+  )
+
+  const result = await geminiModel.generateContent({
+    contents: [{ role: 'user', parts }],
+    generationConfig: {
+      temperature: 0.2,
+      maxOutputTokens: 8192,
+      responseMimeType: 'application/json'
+    }
+  })
+
+  let text = result.response.text()
+  text = text
+    .replace(/^```(?:json)?\n?/gm, '')
+    .replace(/```$/gm, '')
+    .trim()
+
+  console.warn('Gemini response received')
+  console.warn('Raw response (first 500 chars):', text.slice(0, 500))
+  const parsed = JSON.parse(text)
+
+  const guide: QaGuide =
+    parsed.reproduce ?? parsed.qa_guide?.reproduce ?? parsed
+  return guide
+}
+
+// ── Main ──
+
+async function main() {
+  const opts = parseArgs()
+  mkdirSync(opts.outputDir, { recursive: true })
+
+  if (opts.type === 'issue') {
+    await analyzeIssue(opts)
+  } else {
+    await analyzePr(opts)
+  }
+}
+
+async function analyzeIssue(opts: Options) {
+  const issue = fetchIssueThread(opts.prNumber, opts.repo)
+
+  const allText = [issue.body, ...issue.comments].join('\n')
+  const mediaUrls = extractMediaUrls(allText)
+  console.warn(`Found ${mediaUrls.length} media URLs`)
+
+  const media = await downloadMedia(
+    mediaUrls,
+    opts.outputDir,
+    opts.mediaBudgetBytes,
+    opts.maxVideoBytes
+  )
+
+  const guide = await analyzeIssueWithGemini(
+    issue,
+    media,
+    opts.model,
+    opts.apiKey
+  )
+
+  const beforePath = resolve(opts.outputDir, 'qa-guide-before.json')
+  writeFileSync(beforePath, JSON.stringify(guide, null, 2))
+
+  console.warn(`Wrote QA guide:`)
+  console.warn(`  Reproduce: ${beforePath}`)
+}
+
+async function analyzePr(opts: Options) {
+  const thread = fetchPrThread(opts.prNumber, opts.repo)
+
+  const allText = [
+    thread.body,
+    ...thread.issueComments,
+    ...thread.reviewComments,
+    ...thread.reviews
+  ].join('\n')
+  const mediaUrls = extractMediaUrls(allText)
+  console.warn(`Found ${mediaUrls.length} media URLs`)
+
+  const media = await downloadMedia(
+    mediaUrls,
+    opts.outputDir,
+    opts.mediaBudgetBytes,
+    opts.maxVideoBytes
+  )
+
+  const guides = await analyzeWithGemini(thread, media, opts.model, opts.apiKey)
+
+  const beforePath = resolve(opts.outputDir, 'qa-guide-before.json')
+  const afterPath = resolve(opts.outputDir, 'qa-guide-after.json')
+  writeFileSync(beforePath, JSON.stringify(guides.before, null, 2))
+  writeFileSync(afterPath, JSON.stringify(guides.after, null, 2))
+
+  console.warn(`Wrote QA guides:`)
+  console.warn(`  Before: ${beforePath}`)
+  console.warn(`  After:  ${afterPath}`)
+}
+
+function isExecutedAsScript(metaUrl: string): boolean {
+  const modulePath = fileURLToPath(metaUrl)
+  const scriptPath = process.argv[1] ? resolve(process.argv[1]) : ''
+  return modulePath === scriptPath
+}
+
+if (isExecutedAsScript(import.meta.url)) {
+  main().catch((err) => {
+    console.error('PR analysis failed:', err)
+    process.exit(1)
+  })
+}

--- a/scripts/qa-batch.sh
+++ b/scripts/qa-batch.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Batch-trigger QA runs by creating and pushing sno-qa-* branches.
+#
+# Usage:
+#   ./scripts/qa-batch.sh 10394 10238 9996          # Trigger specific numbers
+#   ./scripts/qa-batch.sh --from tmp/issues.md --top 5  # From triage file
+#   ./scripts/qa-batch.sh --dry-run 10394 10238     # Preview only
+#   ./scripts/qa-batch.sh --cleanup                 # Delete old sno-qa-* branches
+
+set -euo pipefail
+
+DELAY=5
+DRY_RUN=false
+CLEANUP=false
+FROM_FILE=""
+TOP_N=0
+NUMBERS=()
+
+die() { echo "error: $*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: qa-batch.sh [options] [numbers...]
+
+Options:
+  --from <file>   Extract numbers from a triage markdown file
+  --top <N>       Take first N entries from Tier 1 (requires --from)
+  --dry-run       Print what would happen without pushing
+  --cleanup       Delete all sno-qa-* remote branches
+  --delay <secs>  Seconds between pushes (default: 5)
+  -h, --help      Show this help
+EOF
+  exit 0
+}
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)     FROM_FILE="$2"; shift 2 ;;
+    --top)      TOP_N="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    --cleanup)  CLEANUP=true; shift ;;
+    --delay)    DELAY="$2"; shift 2 ;;
+    -h|--help)  usage ;;
+    -*)         die "unknown option: $1" ;;
+    *)          NUMBERS+=("$1"); shift ;;
+  esac
+done
+
+# --- Cleanup mode ---
+if $CLEANUP; then
+  echo "Fetching remote sno-qa-* branches..."
+  branches=$(git ls-remote --heads origin 'refs/heads/sno-qa-*' | awk '{print $2}' | sed 's|refs/heads/||')
+
+  if [[ -z "$branches" ]]; then
+    echo "No sno-qa-* branches found on remote."
+    exit 0
+  fi
+
+  echo "Found branches:"
+  while IFS= read -r b; do echo "  $b"; done <<< "$branches"
+  echo
+
+  if $DRY_RUN; then
+    echo "[dry-run] Would delete the above branches."
+    exit 0
+  fi
+
+  read -rp "Delete all of the above? [y/N] " confirm
+  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  for branch in $branches; do
+    echo "Deleting origin/$branch..."
+    git push origin --delete "$branch"
+  done
+  echo "Done. Cleaned up $(echo "$branches" | wc -l | tr -d ' ') branches."
+  exit 0
+fi
+
+# --- Extract numbers from markdown ---
+if [[ -n "$FROM_FILE" ]]; then
+  [[ -f "$FROM_FILE" ]] || die "file not found: $FROM_FILE"
+  [[ "$TOP_N" -gt 0 ]] || die "--top N required with --from"
+
+  # Extract Tier 1 table rows: | N | [#NNNNN](...) | ...
+  # Stop at the next ## heading after Tier 1
+  extracted=$(awk '/^## Tier 1/,/^## Tier [^1]/' "$FROM_FILE" \
+    | grep -oP '\[#\K\d+' \
+    | head -n "$TOP_N")
+
+  if [[ -z "$extracted" ]]; then
+    die "no numbers found in $FROM_FILE"
+  fi
+
+  while IFS= read -r num; do
+    NUMBERS+=("$num")
+  done <<< "$extracted"
+fi
+
+[[ ${#NUMBERS[@]} -gt 0 ]] || die "no numbers specified. Use positional args or --from/--top."
+
+# --- Validate ---
+for num in "${NUMBERS[@]}"; do
+  [[ "$num" =~ ^[0-9]+$ ]] || die "invalid number: $num"
+done
+
+# Deduplicate
+# shellcheck disable=SC2207 # mapfile not available on macOS default bash
+NUMBERS=($(printf '%s\n' "${NUMBERS[@]}" | sort -un))
+
+# --- Push branches ---
+echo "Triggering QA for: ${NUMBERS[*]}"
+if $DRY_RUN; then
+  echo "[dry-run]"
+fi
+echo
+
+pushed=()
+skipped=()
+
+# Fetch remote refs once
+remote_refs=$(git ls-remote --heads origin 'refs/heads/sno-qa-*' 2>/dev/null | awk '{print $2}' | sed 's|refs/heads/||')
+
+for num in "${NUMBERS[@]}"; do
+  branch="sno-qa-$num"
+
+  # Check if already exists on remote
+  if echo "$remote_refs" | grep -qx "$branch"; then
+    echo "  skip: $branch (already exists on remote)"
+    skipped+=("$num")
+    continue
+  fi
+
+  if $DRY_RUN; then
+    echo "  would push: $branch"
+    pushed+=("$num")
+    continue
+  fi
+
+  # Create branch at current HEAD and push
+  git branch -f "$branch" HEAD
+  git push origin "$branch"
+  pushed+=("$num")
+  echo "  pushed: $branch"
+
+  # Clean up local branch
+  git branch -D "$branch" 2>/dev/null || true
+
+  # Delay between pushes to avoid CI concurrency storm
+  if [[ "$num" != "${NUMBERS[-1]}" ]]; then
+    echo "  waiting ${DELAY}s..."
+    sleep "$DELAY"
+  fi
+done
+
+# --- Summary ---
+echo
+echo "=== Summary ==="
+echo "Triggered: ${#pushed[@]}"
+echo "Skipped:   ${#skipped[@]}"
+
+if [[ ${#pushed[@]} -gt 0 ]]; then
+  echo
+  echo "Triggered numbers: ${pushed[*]}"
+  repo_url=$(git remote get-url origin | sed 's/\.git$//' | sed 's|git@github.com:|https://github.com/|')
+  echo "Actions: ${repo_url}/actions"
+fi
+
+if [[ ${#skipped[@]} -gt 0 ]]; then
+  echo
+  echo "Skipped (already exist): ${skipped[*]}"
+  echo "Use --cleanup first to remove old branches."
+fi

--- a/scripts/qa-deploy-pages.sh
+++ b/scripts/qa-deploy-pages.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# Deploy QA report to Cloudflare Pages.
+# Expected env vars: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, RAW_BRANCH,
+#   BEFORE_SHA, AFTER_SHA, TARGET_NUM, TARGET_TYPE, REPO, RUN_ID
+# Writes outputs to GITHUB_OUTPUT: badge_status, url
+set -euo pipefail
+
+npm install -g wrangler@4.74.0 >/dev/null 2>&1
+
+DEPLOY_DIR=$(mktemp -d)
+mkdir -p "$DEPLOY_DIR"
+
+for os in Linux macOS Windows; do
+  DIR="qa-artifacts/qa-report-${os}-${RUN_ID}"
+  for prefix in qa qa-before; do
+    VID="${DIR}/${prefix}-session.mp4"
+    if [ -f "$VID" ]; then
+      DEST="$DEPLOY_DIR/${prefix}-${os}.mp4"
+      cp "$VID" "$DEST"
+      echo "Found ${prefix} ${os} video ($(du -h "$VID" | cut -f1))"
+    fi
+  done
+  # Copy multi-pass session videos (qa-session-1, qa-session-2, etc.)
+  for numbered in "$DIR"/qa-session-[0-9].mp4; do
+    [ -f "$numbered" ] || continue
+    NUM=$(basename "$numbered" | sed 's/qa-session-\([0-9]\).mp4/\1/')
+    DEST="$DEPLOY_DIR/qa-${os}-pass${NUM}.mp4"
+    cp "$numbered" "$DEST"
+    echo "Found pass ${NUM} ${os} video ($(du -h "$numbered" | cut -f1))"
+  done
+  # Generate GIF thumbnail from after video (or first pass)
+  THUMB_SRC="$DEPLOY_DIR/qa-${os}.mp4"
+  [ ! -f "$THUMB_SRC" ] && THUMB_SRC="$DEPLOY_DIR/qa-${os}-pass1.mp4"
+  if [ -f "$THUMB_SRC" ]; then
+    ffmpeg -y -ss 10 -i "$THUMB_SRC" -t 8 \
+      -vf "fps=8,scale=480:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=64[p];[s1][p]paletteuse=dither=bayer" \
+      -loop 0 "$DEPLOY_DIR/qa-${os}-thumb.gif" 2>/dev/null \
+    || echo "GIF generation failed for ${os} (non-fatal)"
+  fi
+done
+
+# Build video cards and report sections
+CARDS=""
+# shellcheck disable=SC2034 # accessed via eval
+ICONS_Linux="&#x1F427;" ICONS_macOS="&#x1F34E;" ICONS_Windows="&#x1FA9F;"
+CARD_COUNT=0
+DL_ICON="<svg width=14 height=14 viewBox='0 0 24 24' fill=none stroke=currentColor stroke-width=2><path d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4'/><polyline points='7 10 12 15 17 10'/><line x1=12 y1=15 x2=12 y2=3'/></svg>"
+
+for os in Linux macOS Windows; do
+  eval "ICON=\$ICONS_${os}"
+  OS_LOWER=$(echo "$os" | tr '[:upper:]' '[:lower:]')
+  HAS_BEFORE=$([ -f "$DEPLOY_DIR/qa-before-${os}.mp4" ] && echo 1 || echo 0)
+  HAS_AFTER=$( { [ -f "$DEPLOY_DIR/qa-${os}.mp4" ] || [ -f "$DEPLOY_DIR/qa-${os}-pass1.mp4" ]; } && echo 1 || echo 0)
+  [ "$HAS_AFTER" = "0" ] && continue
+
+  # Collect all reports for this platform (single + multi-pass)
+  REPORT_FILES=""
+  REPORT_LINK=""
+  REPORT_HTML=""
+  for rpt in "video-reviews/${OS_LOWER}-qa-video-report.md" "video-reviews/${OS_LOWER}-pass"*-qa-video-report.md; do
+    [ -f "$rpt" ] && REPORT_FILES="${REPORT_FILES} ${rpt}"
+  done
+
+  if [ -n "$REPORT_FILES" ]; then
+    # Concatenate all reports into one combined report file
+    COMBINED_MD=""
+    for rpt in $REPORT_FILES; do
+      cp "$rpt" "$DEPLOY_DIR/$(basename "$rpt")"
+      RPT_MD=$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' "$rpt")
+      [ -n "$COMBINED_MD" ] && COMBINED_MD="${COMBINED_MD}&#10;&#10;---&#10;&#10;"
+      COMBINED_MD="${COMBINED_MD}${RPT_MD}"
+    done
+    FIRST_REPORT=$(echo "$REPORT_FILES" | awk '{print $1}')
+    FIRST_BASENAME=$(basename "$FIRST_REPORT")
+    REPORT_LINK="<a class=dl href=${FIRST_BASENAME}><svg width=14 height=14 viewBox='0 0 24 24' fill=none stroke=currentColor stroke-width=2><path d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/><polyline points='14 2 14 8 20 8'/><line x1=16 y1=13 x2=8 y2=13/><line x1=16 y1=17 x2=8 y2=17'/></svg>Report</a>"
+    REPORT_HTML="<details class=report open><summary><svg width=14 height=14 viewBox='0 0 24 24' fill=none stroke=currentColor stroke-width=2><circle cx=12 cy=12 r=10/><line x1=12 y1=16 x2=12 y2=12/><line x1=12 y1=8 x2=12.01 y2=8'/></svg> AI Comparative Review</summary><div class=report-body data-md>${COMBINED_MD}</div></details>"
+  fi
+
+  if [ "$HAS_BEFORE" = "1" ]; then
+    CARDS="${CARDS}<div class='card reveal' style='--i:${CARD_COUNT}'><div class=card-header><span class=platform><span class=icon>${ICON}</span>${os}</span><span class=links>${REPORT_LINK}</span></div><div class=comparison><div class=comp-panel><div class=comp-label>Before <span class=comp-tag>main</span></div><div class=video-wrap><video controls muted preload=auto><source src=qa-before-${os}.mp4 type=video/mp4></video></div><div class=comp-dl><a class=dl href=qa-before-${os}.mp4 download>${DL_ICON}Before</a></div></div><div class=comp-panel><div class=comp-label>After <span class=comp-tag>PR</span></div><div class=video-wrap><video controls muted preload=auto><source src=qa-${os}.mp4 type=video/mp4></video></div><div class=comp-dl><a class=dl href=qa-${os}.mp4 download>${DL_ICON}After</a></div></div></div>${REPORT_HTML}</div>"
+  elif [ -f "$DEPLOY_DIR/qa-${os}.mp4" ]; then
+    CARDS="${CARDS}<div class='card reveal' style='--i:${CARD_COUNT}'><div class=video-wrap><video controls muted preload=auto><source src=qa-${os}.mp4 type=video/mp4></video></div><div class=card-body><span class=platform><span class=icon>${ICON}</span>${os}</span><span class=links><a class=dl href=qa-${os}.mp4 download>${DL_ICON}Download</a>${REPORT_LINK}</span></div>${REPORT_HTML}</div>"
+  else
+    PASS_VIDEOS=""
+    for pass_vid in "$DEPLOY_DIR/qa-${os}-pass"[0-9].mp4; do
+      [ -f "$pass_vid" ] || continue
+      PASS_NUM=$(basename "$pass_vid" | sed "s/qa-${os}-pass\([0-9]\).mp4/\1/")
+      PASS_VIDEOS="${PASS_VIDEOS}<div class=comp-panel><div class=comp-label>Pass ${PASS_NUM}</div><div class=video-wrap><video controls muted preload=auto><source src=qa-${os}-pass${PASS_NUM}.mp4 type=video/mp4></video></div><div class=comp-dl><a class=dl href=qa-${os}-pass${PASS_NUM}.mp4 download>${DL_ICON}Pass ${PASS_NUM}</a></div></div>"
+    done
+    CARDS="${CARDS}<div class='card reveal' style='--i:${CARD_COUNT}'><div class=card-header><span class=platform><span class=icon>${ICON}</span>${os}</span><span class=links>${REPORT_LINK}</span></div><div class=comparison>${PASS_VIDEOS}</div>${REPORT_HTML}</div>"
+  fi
+  CARD_COUNT=$((CARD_COUNT + 1))
+done
+
+# Build commit info and target link for the report header
+COMMIT_HTML=""
+REPO_URL="https://github.com/${REPO}"
+if [ -n "${TARGET_NUM:-}" ]; then
+  if [ "$TARGET_TYPE" = "issue" ]; then
+    COMMIT_HTML="<a href=${REPO_URL}/issues/${TARGET_NUM} class=sha title='Issue'>Issue #${TARGET_NUM}</a>"
+  else
+    COMMIT_HTML="<a href=${REPO_URL}/pull/${TARGET_NUM} class=sha title='Pull Request'>PR #${TARGET_NUM}</a>"
+  fi
+fi
+if [ -n "${BEFORE_SHA:-}" ]; then
+  SHORT_BEFORE="${BEFORE_SHA:0:7}"
+  COMMIT_HTML="${COMMIT_HTML:+${COMMIT_HTML} &middot; }<a href=${REPO_URL}/commit/${BEFORE_SHA} class=sha title='main branch'>main @ ${SHORT_BEFORE}</a>"
+fi
+if [ -n "${AFTER_SHA:-}" ]; then
+  SHORT_AFTER="${AFTER_SHA:0:7}"
+  AFTER_LABEL="PR"
+  [ -n "${TARGET_NUM:-}" ] && AFTER_LABEL="#${TARGET_NUM}"
+  COMMIT_HTML="${COMMIT_HTML:+${COMMIT_HTML} &middot; }<a href=${REPO_URL}/commit/${AFTER_SHA} class=sha title='PR head commit'>${AFTER_LABEL} @ ${SHORT_AFTER}</a>"
+fi
+if [ -n "${PIPELINE_SHA:-}" ]; then
+  SHORT_PIPE="${PIPELINE_SHA:0:7}"
+  COMMIT_HTML="${COMMIT_HTML:+${COMMIT_HTML} &middot; }<a href=${REPO_URL}/commit/${PIPELINE_SHA} class=sha title='QA pipeline version'>QA @ ${SHORT_PIPE}</a>"
+fi
+[ -n "$COMMIT_HTML" ] && COMMIT_HTML=" &middot; ${COMMIT_HTML}"
+
+RUN_LINK=""
+if [ -n "${RUN_URL:-}" ]; then
+  RUN_LINK=" &middot; <a href=\"${RUN_URL}\" class=sha title=\"GitHub Actions run\">CI Job</a>"
+fi
+
+# Timing info
+DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M UTC')
+TIMING_HTML=""
+if [ -n "${RUN_START_TIME:-}" ]; then
+  TIMING_HTML=" &middot; <span class=sha title='Pipeline timing'>${RUN_START_TIME} &rarr; ${DEPLOY_TIME}</span>"
+fi
+
+# Generate index.html from template
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/qa-report-template.html"
+
+# Write dynamic content to temp files for safe substitution
+# Cloudflare Pages _headers file — enable range requests for video seeking
+cat > "$DEPLOY_DIR/_headers" <<'HEADERSEOF'
+/*.mp4
+  Accept-Ranges: bytes
+  Cache-Control: public, max-age=86400
+HEADERSEOF
+
+# Build purpose description from pr-context.txt
+PURPOSE_HTML=""
+if [ -f pr-context.txt ]; then
+  # Extract title line and first paragraph of description
+  PR_TITLE=$(grep -m1 '^Title:' pr-context.txt 2>/dev/null | sed 's/^Title: //' || true)
+  if [ "$TARGET_TYPE" = "issue" ]; then
+    PURPOSE_LABEL="Issue #${TARGET_NUM}"
+    PURPOSE_VERB="reports"
+  else
+    PURPOSE_LABEL="PR #${TARGET_NUM}"
+    PURPOSE_VERB="aims to"
+  fi
+  # Get first ~300 chars of description body (after "Description:" line)
+  PR_DESC=$(sed -n '/^Description:/,/^###/p' pr-context.txt 2>/dev/null | grep -v '^Description:\|^###' | head -5 | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' | tr '\n' ' ' | head -c 400 || true)
+  [ -z "$PR_DESC" ] && PR_DESC=$(sed -n '3,8p' pr-context.txt 2>/dev/null | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' | tr '\n' ' ' | head -c 400 || true)
+  # Build requirements from QA guide JSON
+  REQS_HTML=""
+  QA_GUIDE=$(ls qa-guides/qa-guide-*.json 2>/dev/null | head -1 || true)
+  if [ -f "$QA_GUIDE" ]; then
+    PREREQS=$(python3 -c "
+import json, sys, html
+try:
+  g = json.load(open(sys.argv[1]))
+  prereqs = g.get('prerequisites', [])
+  steps = g.get('steps', [])
+  focus = g.get('test_focus', '')
+  parts = []
+  if focus:
+    parts.append('<strong>Test focus:</strong> ' + html.escape(focus))
+  if prereqs:
+    parts.append('<strong>Prerequisites:</strong> ' + ', '.join(html.escape(p) for p in prereqs))
+  if steps:
+    parts.append('<strong>Steps:</strong> ' + ' → '.join(html.escape(s.get('description', str(s))) for s in steps[:6]))
+    if len(steps) > 6:
+      parts[-1] += ' → ...'
+  print('<br>'.join(parts))
+except: pass
+" "$QA_GUIDE" 2>/dev/null)
+    [ -n "$PREREQS" ] && REQS_HTML="<div class=purpose-reqs>${PREREQS}</div>"
+  fi
+
+  PURPOSE_HTML="<div class=purpose><div class=purpose-label>${PURPOSE_LABEL} ${PURPOSE_VERB}</div><strong>${PR_TITLE}</strong><br>${PR_DESC}${REQS_HTML}</div>"
+fi
+
+echo -n "$COMMIT_HTML" > "$DEPLOY_DIR/.commit_html"
+echo -n "$CARDS" > "$DEPLOY_DIR/.cards_html"
+echo -n "$RUN_LINK" > "$DEPLOY_DIR/.run_link"
+# Badge HTML with copy button (placeholder URL filled after deploy)
+echo -n '<div class="badge-bar"><img src="badge.svg" alt="QA Badge" class="badge-img"/><button class="copy-badge" title="Copy badge markdown" onclick="copyBadge()"><svg width=14 height=14 viewBox="0 0 24 24" fill=none stroke=currentColor stroke-width=2><rect x=9 y=9 width=13 height=13 rx=2/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></div>' > "$DEPLOY_DIR/.badge_html"
+echo -n "${TIMING_HTML:-}" > "$DEPLOY_DIR/.timing_html"
+echo -n "$PURPOSE_HTML" > "$DEPLOY_DIR/.purpose_html"
+python3 -c "
+import sys, pathlib
+d = pathlib.Path(sys.argv[1])
+t = pathlib.Path(sys.argv[2]).read_text()
+t = t.replace('{{COMMIT_HTML}}', (d / '.commit_html').read_text())
+t = t.replace('{{CARDS}}', (d / '.cards_html').read_text())
+t = t.replace('{{RUN_LINK}}', (d / '.run_link').read_text())
+t = t.replace('{{BADGE_HTML}}', (d / '.badge_html').read_text())
+t = t.replace('{{TIMING_HTML}}', (d / '.timing_html').read_text())
+t = t.replace('{{PURPOSE_HTML}}', (d / '.purpose_html').read_text())
+sys.stdout.write(t)
+" "$DEPLOY_DIR" "$TEMPLATE" > "$DEPLOY_DIR/index.html"
+rm -f "$DEPLOY_DIR/.commit_html" "$DEPLOY_DIR/.cards_html" "$DEPLOY_DIR/.run_link" "$DEPLOY_DIR/.badge_html" "$DEPLOY_DIR/.timing_html" "$DEPLOY_DIR/.purpose_html"
+
+cat > "$DEPLOY_DIR/404.html" <<'ERROREOF'
+<!DOCTYPE html><html lang=en><head><meta charset=utf-8><title>404</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel=stylesheet>
+<style>:root{--bg:oklch(8% 0.02 265);--fg:oklch(45% 0.01 265);--err:oklch(62% 0.22 25)}*{margin:0;padding:0;box-sizing:border-box}body{background:var(--bg);color:var(--fg);font-family:'Inter',system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh}div{text-align:center}h1{color:var(--err);font-size:clamp(3rem,8vw,5rem);font-weight:700;letter-spacing:-.04em;margin-bottom:.5rem}p{font-size:1rem;max-width:32ch;line-height:1.5}</style>
+</head><body><div><h1>404</h1><p>File not found. The QA recording may have failed or been cancelled.</p></div></body></html>
+ERROREOF
+
+# Copy research log to deploy dir if it exists
+for rlog in qa-artifacts/*/research/research-log.json qa-artifacts/*/*/research/research-log.json qa-artifacts/before/*/research/research-log.json; do
+  if [ -f "$rlog" ]; then
+    cp "$rlog" "$DEPLOY_DIR/research-log.json"
+    echo "Found research log: $rlog"
+    break
+  fi
+done
+
+# Copy generated test code to deploy dir
+for tfile in qa-artifacts/*/research/reproduce.spec.ts qa-artifacts/*/*/research/reproduce.spec.ts qa-artifacts/before/*/research/reproduce.spec.ts; do
+  if [ -f "$tfile" ]; then
+    cp "$tfile" "$DEPLOY_DIR/reproduce.spec.ts"
+    echo "Found test code: $tfile"
+    break
+  fi
+done
+
+# Generate badge SVGs into deploy dir
+# Priority: research-log.json verdict (a11y-verified) > video review verdict (AI interpretation)
+REPRO_COUNT=0 INCONC_COUNT=0 NOT_REPRO_COUNT=0 TOTAL_REPORTS=0
+
+# Try research log first (ground truth from a11y assertions)
+RESEARCH_VERDICT=""
+REPRO_METHOD=""
+if [ -f "$DEPLOY_DIR/research-log.json" ]; then
+  RESEARCH_VERDICT=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('verdict',''))" "$DEPLOY_DIR/research-log.json" 2>/dev/null || true)
+  REPRO_METHOD=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('reproducedBy','none'))" "$DEPLOY_DIR/research-log.json" 2>/dev/null || true)
+  echo "Research verdict (a11y-verified): ${RESEARCH_VERDICT:-none} (by: ${REPRO_METHOD:-none})"
+  if [ -n "$RESEARCH_VERDICT" ]; then
+    TOTAL_REPORTS=1
+    case "$RESEARCH_VERDICT" in
+      REPRODUCED) REPRO_COUNT=1 ;;
+      NOT_REPRODUCIBLE) NOT_REPRO_COUNT=1 ;;
+      INCONCLUSIVE) INCONC_COUNT=1 ;;
+    esac
+  fi
+fi
+
+# Fall back to video review verdicts if no research log
+if [ -z "$RESEARCH_VERDICT" ] && [ -d video-reviews ]; then
+  for rpt in video-reviews/*-qa-video-report.md; do
+    [ -f "$rpt" ] || continue
+    TOTAL_REPORTS=$((TOTAL_REPORTS + 1))
+    # Try structured JSON verdict first (from ## Verdict section)
+    VERDICT_JSON=$(grep -oP '"verdict":\s*"[A-Z_]+' "$rpt" 2>/dev/null | tail -1 | grep -oP '[A-Z_]+$' || true)
+    RISK_JSON=$(grep -oP '"risk":\s*"[a-z]+' "$rpt" 2>/dev/null | tail -1 | grep -oP '[a-z]+$' || true)
+
+    if [ -n "$VERDICT_JSON" ]; then
+      case "$VERDICT_JSON" in
+        REPRODUCED) REPRO_COUNT=$((REPRO_COUNT + 1)) ;;
+        NOT_REPRODUCIBLE) NOT_REPRO_COUNT=$((NOT_REPRO_COUNT + 1)) ;;
+        INCONCLUSIVE) INCONC_COUNT=$((INCONC_COUNT + 1)) ;;
+      esac
+    else
+      # Fallback: grep Summary section (for older reports without ## Verdict)
+      SUMM=$(sed -n '/^## Summary/,/^## /p' "$rpt" 2>/dev/null | head -15)
+      if echo "$SUMM" | grep -iq 'INCONCLUSIVE'; then
+        INCONC_COUNT=$((INCONC_COUNT + 1))
+      elif echo "$SUMM" | grep -iq 'not reproduced\|could not reproduce\|could not be confirmed\|unable to reproduce\|fails\? to reproduce\|fails\? to perform\|was NOT\|NOT visible\|not observed\|fail.* to demonstrate\|does not demonstrate\|steps were not performed\|never.*tested\|never.*accessed\|not.* confirmed'; then
+        NOT_REPRO_COUNT=$((NOT_REPRO_COUNT + 1))
+      elif echo "$SUMM" | grep -iq 'reproduc\|confirm'; then
+        REPRO_COUNT=$((REPRO_COUNT + 1))
+      fi
+    fi
+  done
+fi
+FAIL_COUNT=$((TOTAL_REPORTS - REPRO_COUNT - NOT_REPRO_COUNT))
+[ "$FAIL_COUNT" -lt 0 ] && FAIL_COUNT=0
+echo "DEBUG verdict: repro=${REPRO_COUNT} not_repro=${NOT_REPRO_COUNT} inconc=${INCONC_COUNT} fail=${FAIL_COUNT} total=${TOTAL_REPORTS}"
+echo "Verdict: ${REPRO_COUNT}✓ ${NOT_REPRO_COUNT}✗ ${FAIL_COUNT}⚠ / ${TOTAL_REPORTS}"
+
+# Badge text:
+#   Single pass: "REPRODUCED" / "NOT REPRODUCIBLE" / "INCONCLUSIVE"
+#   Multi pass:  "2✓ 0✗ 1⚠ / 3" with color based on dominant result
+REPRO_RESULT="" REPRO_COLOR="#9f9f9f"
+if [ "$TOTAL_REPORTS" -le 1 ]; then
+  # Single report — simple label
+  if [ "$REPRO_COUNT" -gt 0 ]; then
+    REPRO_RESULT="REPRODUCED" REPRO_COLOR="#2196f3"
+  elif [ "$NOT_REPRO_COUNT" -gt 0 ]; then
+    REPRO_RESULT="NOT REPRODUCIBLE" REPRO_COLOR="#9f9f9f"
+  elif [ "$FAIL_COUNT" -gt 0 ]; then
+    REPRO_RESULT="INCONCLUSIVE" REPRO_COLOR="#9f9f9f"
+  fi
+else
+  # Multi pass — show breakdown: X✓ Y✗ Z⚠ / N
+  PARTS=""
+  [ "$REPRO_COUNT" -gt 0 ] && PARTS="${REPRO_COUNT}✓"
+  [ "$NOT_REPRO_COUNT" -gt 0 ] && PARTS="${PARTS:+${PARTS} }${NOT_REPRO_COUNT}✗"
+  [ "$FAIL_COUNT" -gt 0 ] && PARTS="${PARTS:+${PARTS} }${FAIL_COUNT}⚠"
+  REPRO_RESULT="${PARTS} / ${TOTAL_REPORTS}"
+  # Color based on best outcome
+  if [ "$REPRO_COUNT" -gt 0 ]; then
+    REPRO_COLOR="#2196f3"
+  elif [ "$NOT_REPRO_COUNT" -gt 0 ]; then
+    REPRO_COLOR="#9f9f9f"
+  fi
+fi
+
+# Badge label: #NUM QA0327 (with today's date)
+QA_DATE=$(date -u '+%m%d')
+BADGE_LABEL="QA${QA_DATE}"
+[ -n "${TARGET_NUM:-}" ] && BADGE_LABEL="#${TARGET_NUM} QA${QA_DATE}"
+
+# For PRs, also extract fix quality from Overall Risk section
+FIX_RESULT="" FIX_COLOR="#4c1"
+if [ "$TARGET_TYPE" != "issue" ]; then
+  # Try structured JSON risk first
+  ALL_RISKS=$(grep -ohP '"risk":\s*"[a-z]+' video-reviews/*.md 2>/dev/null | grep -oP '[a-z]+$' || true)
+  if [ -n "$ALL_RISKS" ]; then
+    # Use worst risk across all reports
+    if echo "$ALL_RISKS" | grep -q 'high'; then
+      FIX_RESULT="MAJOR ISSUES" FIX_COLOR="#e05d44"
+    elif echo "$ALL_RISKS" | grep -q 'medium'; then
+      FIX_RESULT="MINOR ISSUES" FIX_COLOR="#dfb317"
+    elif echo "$ALL_RISKS" | grep -q 'low'; then
+      FIX_RESULT="APPROVED" FIX_COLOR="#4c1"
+    fi
+  else
+    # Fallback: grep Overall Risk section
+    RISK_TEXT=""
+    if [ -d video-reviews ]; then
+      RISK_TEXT=$(sed -n '/^## Overall Risk/,/^## /p' video-reviews/*.md 2>/dev/null | sed 's/\*//g' | head -20 || true)
+    fi
+    RISK_FIRST=$(echo "$RISK_TEXT" | grep -oiP '^\s*(high|medium|moderate|low|minimal|critical)' | head -1 | tr '[:upper:]' '[:lower:]' || true)
+    if [ -n "$RISK_FIRST" ]; then
+      case "$RISK_FIRST" in
+        *low*|*minimal*) FIX_RESULT="APPROVED" FIX_COLOR="#4c1" ;;
+        *medium*|*moderate*) FIX_RESULT="MINOR ISSUES" FIX_COLOR="#dfb317" ;;
+        *high*|*critical*) FIX_RESULT="MAJOR ISSUES" FIX_COLOR="#e05d44" ;;
+      esac
+    elif echo "$RISK_TEXT" | grep -iq 'no.*risk\|approved\|looks good'; then
+      FIX_RESULT="APPROVED" FIX_COLOR="#4c1"
+    fi
+  fi
+fi
+
+# Always use vertical box badge
+/tmp/gen-badge-box.sh "$DEPLOY_DIR/badge.svg" "$BADGE_LABEL" \
+  "$REPRO_COUNT" "$NOT_REPRO_COUNT" "$FAIL_COUNT" "$TOTAL_REPORTS" \
+  "$FIX_RESULT" "$FIX_COLOR" "$REPRO_METHOD"
+BADGE_STATUS="${REPRO_RESULT:-UNKNOWN}${FIX_RESULT:+ | Fix: ${FIX_RESULT}}"
+echo "badge_status=${BADGE_STATUS:-FINISHED}" >> "$GITHUB_OUTPUT"
+
+# Remove files exceeding Cloudflare Pages 25MB limit to prevent silent deploy failures
+MAX_SIZE=$((25 * 1024 * 1024))
+find "$DEPLOY_DIR" -type f -size +${MAX_SIZE}c | while read -r big_file; do
+  SIZE_MB=$(( $(stat -c%s "$big_file") / 1024 / 1024 ))
+  echo "Removing oversized file: $(basename "$big_file") (${SIZE_MB}MB > 25MB limit)"
+  rm "$big_file"
+done
+
+BRANCH=$(echo "$RAW_BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-28)
+
+DEPLOY_OUTPUT=$(wrangler pages deploy "$DEPLOY_DIR" \
+  --project-name="comfy-qa" \
+  --branch="$BRANCH" 2>&1) || true
+echo "$DEPLOY_OUTPUT" | tail -5
+
+URL=$(echo "$DEPLOY_OUTPUT" | grep -oE 'https://[a-zA-Z0-9.-]+\.pages\.dev\S*' | head -1 || true)
+FALLBACK_URL="https://${BRANCH}.comfy-qa.pages.dev"
+
+echo "url=${URL:-$FALLBACK_URL}" >> "$GITHUB_OUTPUT"
+echo "Deployed to: ${URL:-$FALLBACK_URL}"

--- a/scripts/qa-generate-test.ts
+++ b/scripts/qa-generate-test.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env tsx
+/**
+ * Generates a Playwright regression test (.spec.ts) from a QA report + PR diff.
+ * Uses Gemini to produce a test that asserts UIUX behavior verified during QA.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/qa-generate-test.ts \
+ *     --qa-report <path>       QA video review report (markdown)
+ *     --pr-diff <path>         PR diff file
+ *     --output <path>          Output .spec.ts file path
+ *     --model <name>           Gemini model (default: gemini-3-flash-preview)
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { basename, resolve } from 'node:path'
+
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+interface CliOptions {
+  qaReport: string
+  prDiff: string
+  output: string
+  model: string
+}
+
+const DEFAULTS: CliOptions = {
+  qaReport: '',
+  prDiff: '',
+  output: '',
+  model: 'gemini-3-flash-preview'
+}
+
+// ── Fixture API reference for the prompt ────────────────────────────
+const FIXTURE_API = `
+## ComfyUI Playwright Test Fixture API
+
+Import pattern:
+\`\`\`typescript
+import { expect } from '@playwright/test'
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+\`\`\`
+
+### Available helpers on \`comfyPage\`:
+- \`comfyPage.page\` — raw Playwright Page
+- \`comfyPage.menu.topbar\` — Topbar helper:
+  - \`.getTabNames(): Promise<string[]>\` — get all open tab names
+  - \`.getActiveTabName(): Promise<string>\` — get active tab name
+  - \`.saveWorkflow(name)\` — Save via File > Save dialog
+  - \`.saveWorkflowAs(name)\` — Save via File > Save As dialog
+  - \`.exportWorkflow(name)\` — Export via File > Export dialog
+  - \`.triggerTopbarCommand(path: string[])\` — e.g. ['File', 'Save As']
+  - \`.getWorkflowTab(name)\` — get a tab locator by name
+  - \`.closeWorkflowTab(name)\` — close a tab
+  - \`.openTopbarMenu()\` — open the hamburger menu
+  - \`.openSubmenu(label)\` — hover to open a submenu
+- \`comfyPage.menu.workflowsTab\` — Workflows sidebar:
+  - \`.open()\` / \`.close()\` — toggle sidebar
+  - \`.getTopLevelSavedWorkflowNames()\` — list saved workflows
+  - \`.getPersistedItem(name)\` — get a workflow item locator
+- \`comfyPage.workflow\` — WorkflowHelper:
+  - \`.loadWorkflow(name)\` — load from browser_tests/assets/{name}.json
+  - \`.setupWorkflowsDirectory(structure)\` — setup test directory
+  - \`.deleteWorkflow(name)\` — delete a workflow
+  - \`.isCurrentWorkflowModified(): Promise<boolean>\` — check dirty state
+  - \`.getUndoQueueSize()\` / \`.getRedoQueueSize()\`
+- \`comfyPage.settings.setSetting(key, value)\` — change settings
+- \`comfyPage.keyboard\` — KeyboardHelper:
+  - \`.undo()\` / \`.redo()\` / \`.bypass()\`
+- \`comfyPage.nodeOps\` — NodeOperationsHelper
+- \`comfyPage.canvas\` — CanvasHelper
+- \`comfyPage.contextMenu\` — ContextMenu
+- \`comfyPage.toast\` — ToastHelper
+- \`comfyPage.confirmDialog\` — confirmation dialog
+- \`comfyPage.nextFrame()\` — wait for Vue re-render
+
+### Test patterns:
+- Use \`test.describe('Name', { tag: '@ui' }, () => { ... })\` for UI tests
+- Use \`test.beforeEach\` to set up common state (settings, workflow dir)
+- Use \`expect(locator).toHaveScreenshot('name.png')\` for visual assertions
+- Use \`expect(locator).toBeVisible()\` / \`.toHaveText()\` for behavioral assertions
+- Use \`comfyPage.workflow.setupWorkflowsDirectory({})\` to ensure clean state
+`
+
+// ── Prompt builder ──────────────────────────────────────────────────
+function buildPrompt(qaReport: string, prDiff: string): string {
+  return `You are a Playwright test generator for the ComfyUI frontend.
+
+Your task: Generate a single .spec.ts regression test file that asserts the UIUX behavior
+described in the QA report below. The test must:
+
+1. Use the ComfyUI Playwright fixture API (documented below)
+2. Test UIUX behavior ONLY — element visibility, tab names, dialog states, workflow states
+3. NOT test code implementation details
+4. Be concise — only test the behavior that the PR changed
+5. Follow existing test conventions (see API reference)
+
+${FIXTURE_API}
+
+## QA Video Review Report
+${qaReport}
+
+## PR Diff (for context on what changed)
+${prDiff.slice(0, 8000)}
+
+## Output Requirements
+- Output ONLY the .spec.ts file content — no markdown fences, no explanations
+- Start with imports, end with closing brace
+- Use descriptive test names that explain the expected behavior
+- Add screenshot assertions where visual verification matters
+- Keep it focused: 2-5 test cases covering the core behavioral change
+- Use \`test.beforeEach\` for common setup (settings, workflow directory)
+- Tag the describe block with \`{ tag: '@ui' }\` or \`{ tag: '@workflow' }\` as appropriate
+`
+}
+
+// ── Gemini call ─────────────────────────────────────────────────────
+async function generateTest(
+  qaReport: string,
+  prDiff: string,
+  model: string
+): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) throw new Error('GEMINI_API_KEY env var required')
+
+  const genAI = new GoogleGenerativeAI(apiKey)
+  const genModel = genAI.getGenerativeModel({ model })
+
+  const prompt = buildPrompt(qaReport, prDiff)
+  console.warn(`Sending prompt to ${model} (${prompt.length} chars)...`)
+
+  const result = await genModel.generateContent({
+    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    generationConfig: {
+      temperature: 0.2,
+      maxOutputTokens: 8192
+    }
+  })
+
+  const text = result.response.text()
+
+  // Strip markdown fences if model wraps output
+  return text
+    .replace(/^```(?:typescript|ts)?\n?/, '')
+    .replace(/\n?```$/, '')
+    .trim()
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2)
+  const opts = { ...DEFAULTS }
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--qa-report':
+        opts.qaReport = args[++i]
+        break
+      case '--pr-diff':
+        opts.prDiff = args[++i]
+        break
+      case '--output':
+        opts.output = args[++i]
+        break
+      case '--model':
+        opts.model = args[++i]
+        break
+      case '--help':
+        console.warn(`Usage:
+  pnpm exec tsx scripts/qa-generate-test.ts [options]
+
+Options:
+  --qa-report <path>   QA video review report (markdown) [required]
+  --pr-diff <path>     PR diff file [required]
+  --output <path>      Output .spec.ts path [required]
+  --model <name>       Gemini model (default: gemini-3-flash-preview)`)
+        process.exit(0)
+    }
+  }
+
+  if (!opts.qaReport || !opts.prDiff || !opts.output) {
+    console.error('Missing required args. Run with --help for usage.')
+    process.exit(1)
+  }
+
+  return opts
+}
+
+async function main() {
+  const opts = parseArgs()
+
+  const qaReport = await readFile(resolve(opts.qaReport), 'utf-8')
+  const prDiff = await readFile(resolve(opts.prDiff), 'utf-8')
+
+  console.warn(
+    `QA report: ${basename(opts.qaReport)} (${qaReport.length} chars)`
+  )
+  console.warn(`PR diff: ${basename(opts.prDiff)} (${prDiff.length} chars)`)
+
+  const testCode = await generateTest(qaReport, prDiff, opts.model)
+
+  const outputPath = resolve(opts.output)
+  await writeFile(outputPath, testCode + '\n')
+  console.warn(`Generated test: ${outputPath} (${testCode.length} chars)`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/qa-record.ts
+++ b/scripts/qa-record.ts
@@ -1,0 +1,2129 @@
+#!/usr/bin/env tsx
+/**
+ * QA Recording Script
+ *
+ * Records a ComfyUI frontend QA session using Playwright with video capture.
+ * Uses Gemini to generate targeted test steps based on the PR diff.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/qa-record.ts \
+ *     --mode before|after \
+ *     --diff <path-to-diff> \
+ *     --output-dir <path> \
+ *     [--url <server-url>] \
+ *     [--model <gemini-model>]
+ *
+ * Env: GEMINI_API_KEY (required)
+ */
+
+import { chromium } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  statSync
+} from 'fs'
+import { execSync } from 'child_process'
+
+// ── Types ──
+
+type TestAction =
+  | { action: 'openMenu' }
+  | { action: 'hoverMenuItem'; label: string }
+  | { action: 'clickMenuItem'; label: string }
+  | { action: 'fillDialog'; text: string }
+  | { action: 'pressKey'; key: string }
+  | { action: 'click'; text: string }
+  | { action: 'rightClick'; text: string }
+  | { action: 'doubleClick'; text?: string; x?: number; y?: number }
+  | { action: 'clickCanvas'; x: number; y: number }
+  | { action: 'rightClickCanvas'; x: number; y: number }
+  | {
+      action: 'dragCanvas'
+      fromX: number
+      fromY: number
+      toX: number
+      toY: number
+    }
+  | { action: 'scrollCanvas'; x: number; y: number; deltaY: number }
+  | { action: 'wait'; ms: number }
+  | { action: 'screenshot'; name: string }
+  | { action: 'loadWorkflow'; url: string }
+  | { action: 'setSetting'; id: string; value: string | number | boolean }
+  | { action: 'loadDefaultWorkflow' }
+  | { action: 'openSettings' }
+  | { action: 'reload' }
+  | { action: 'done'; reason: string }
+  | {
+      action: 'annotate'
+      text: string
+      x: number
+      y: number
+      durationMs?: number
+    }
+  | { action: 'addNode'; nodeName: string; x?: number; y?: number }
+  | { action: 'cloneNode'; x: number; y: number }
+  | { action: 'copyPaste'; x?: number; y?: number }
+  | {
+      action: 'holdKeyAndDrag'
+      key: string
+      fromX: number
+      fromY: number
+      toX: number
+      toY: number
+    }
+  | { action: 'resizeNode'; x: number; y: number; dx: number; dy: number }
+  | { action: 'middleClick'; x: number; y: number }
+
+export interface ActionResult {
+  action: TestAction
+  success: boolean
+  error?: string
+}
+
+interface SubIssue {
+  title: string
+  focus: string
+}
+
+type RecordMode = 'before' | 'after' | 'reproduce'
+
+interface Options {
+  mode: RecordMode
+  diffFile?: string
+  outputDir: string
+  serverUrl: string
+  model: string
+  apiKey: string
+  testPlanFile?: string
+  qaGuideFile?: string
+}
+
+// ── CLI parsing ──
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2)
+  const opts: Partial<Options> = {
+    model: 'gemini-3.1-pro-preview',
+    serverUrl: 'http://127.0.0.1:8188',
+    apiKey: process.env.GEMINI_API_KEY || ''
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--mode':
+        opts.mode = args[++i] as RecordMode
+        break
+      case '--diff':
+        opts.diffFile = args[++i]
+        break
+      case '--output-dir':
+        opts.outputDir = args[++i]
+        break
+      case '--url':
+        opts.serverUrl = args[++i]
+        break
+      case '--model':
+        opts.model = args[++i]
+        break
+      case '--test-plan':
+        opts.testPlanFile = args[++i]
+        break
+      case '--qa-guide':
+        opts.qaGuideFile = args[++i]
+        break
+      case '--help':
+        console.warn(
+          'Usage: qa-record.ts --mode before|after|reproduce --output-dir <path> [--diff <path>] [--url <url>] [--model <model>] [--test-plan <path>] [--qa-guide <path>]'
+        )
+        process.exit(0)
+    }
+  }
+
+  if (!opts.mode || !opts.outputDir) {
+    console.error('Required: --mode before|after|reproduce --output-dir <path>')
+    process.exit(1)
+  }
+
+  const validModes: RecordMode[] = ['before', 'after', 'reproduce']
+  if (!validModes.includes(opts.mode)) {
+    console.error(
+      `Invalid --mode "${opts.mode}". Must be one of: ${validModes.join(', ')}`
+    )
+    process.exit(1)
+  }
+
+  if (!opts.diffFile && opts.mode !== 'reproduce') {
+    console.error('--diff is required for before/after modes')
+    process.exit(1)
+  }
+
+  if (!opts.apiKey) {
+    console.error('GEMINI_API_KEY environment variable is required')
+    process.exit(1)
+  }
+
+  return opts as Options
+}
+
+// ── Gemini test step generation ──
+
+function buildPrompt(
+  mode: string,
+  diff: string,
+  testPlan?: string,
+  qaGuide?: string
+): string {
+  const modeDescriptions: Record<string, string> = {
+    before:
+      'BEFORE (main branch). Show the OLD state briefly — under 15 seconds. One quick demonstration of missing feature / old behavior.',
+    after:
+      'AFTER (PR branch). Prove the changes work — 3-6 targeted steps, under 30 seconds.',
+    reproduce:
+      'REPRODUCE a reported issue on main branch. Follow the reproduction steps PRECISELY to trigger and demonstrate the reported bug. Use 8-15 detailed steps, up to 60 seconds. You must actually perform the actions that trigger the bug — not just open a menu and take a screenshot.'
+  }
+  const modeDesc = modeDescriptions[mode] ?? modeDescriptions.before
+
+  const qaGuideSection = qaGuide
+    ? `
+## QA Analysis Guide (follow closely)
+A deep analysis of this PR has produced the following targeted test guide.
+Follow these steps closely — they were generated from the full PR thread,
+screenshots, and reviewer comments.
+
+${qaGuide.slice(0, 6000)}
+`
+    : ''
+
+  const testPlanSection = testPlan
+    ? `
+## QA Test Plan Reference
+Use this test plan to identify which test categories are relevant to the PR diff.
+Pick test steps from the most relevant categories.
+
+${testPlan.slice(0, 4000)}
+`
+    : ''
+
+  return `You are generating test steps for a ComfyUI frontend QA recording.
+
+ComfyUI is a node-based visual workflow editor for AI image generation. The UI has:
+- A large **canvas** (1280x720 viewport) showing a node graph, centered roughly at (640, 400)
+- Nodes are boxes with input/output slots that can be connected with wires
+- A **hamburger menu** (top-left C logo) with File, Edit, Help submenus
+- A **sidebar** on the left (Workflows, Node Library, Models)
+- A **topbar** with workflow tabs and Queue button
+- The **default workflow** loads with these nodes on canvas (approximate center coordinates):
+  - Load Checkpoint (~150, 300)
+  - CLIP Text Encode (positive prompt) (~450, 250)
+  - CLIP Text Encode (negative prompt) (~450, 450)
+  - Empty Latent Image (~450, 600)
+  - KSampler (~750, 350)
+  - VAE Decode (~1000, 350)
+  - Save Image (~1200, 350)
+- To interact with a specific node, use its coordinates (e.g., rightClickCanvas on KSampler at ~750, 350)
+- Right-clicking ON a node shows node actions (Clone, Bypass, Convert, etc.)
+- Right-clicking on EMPTY canvas shows Add Node menu — NOT the same as node context menu
+
+MODE: ${modeDesc}
+
+## Available actions (JSON array)
+Each step is an object with an "action" field:
+
+### Menu actions
+- { "action": "openMenu" } — clicks the Comfy hamburger menu (top-left C logo)
+- { "action": "hoverMenuItem", "label": "File" } — hovers a top-level menu item to open submenu
+- { "action": "clickMenuItem", "label": "Save As" } — clicks an item in the visible submenu
+
+### Element actions (by visible text)
+- { "action": "click", "text": "Button Text" } — clicks an element by visible text
+- { "action": "rightClick", "text": "NodeTitle" } — right-clicks an element (opens context menu)
+- { "action": "doubleClick", "text": "NodeTitle" } — double-clicks an element
+- { "action": "fillDialog", "text": "test-name" } — fills dialog input and presses Enter
+- { "action": "pressKey", "key": "Escape" } — presses a keyboard key (Escape, Tab, Delete, Enter, etc.)
+
+### Canvas actions (by coordinates — viewport is 1280x720)
+- { "action": "clickCanvas", "x": 640, "y": 400 } — click at coordinates on canvas
+- { "action": "rightClickCanvas", "x": 500, "y": 350 } — right-click on canvas (node/canvas context menu)
+- { "action": "doubleClick", "x": 640, "y": 400 } — double-click on canvas (opens node search)
+- { "action": "dragCanvas", "fromX": 400, "fromY": 300, "toX": 600, "toY": 300 } — drag (move nodes, pan canvas)
+- { "action": "scrollCanvas", "x": 640, "y": 400, "deltaY": -300 } — scroll wheel (zoom in: negative, zoom out: positive)
+
+### Setup actions (use to establish prerequisites)
+- { "action": "loadWorkflow", "url": "https://..." } — loads a workflow JSON from a URL
+- { "action": "setSetting", "id": "Comfy.Setting.Id", "value": true } — changes a ComfyUI setting
+
+### Compound actions (save multiple turns)
+- { "action": "addNode", "nodeName": "KSampler", "x": 640, "y": 400 } — double-clicks canvas, types name, presses Enter
+- { "action": "cloneNode", "x": 750, "y": 350 } — right-clicks node, clicks Clone
+- { "action": "copyPaste", "x": 640, "y": 400 } — clicks node at coords, Ctrl+C then Ctrl+V
+- { "action": "holdKeyAndDrag", "key": " ", "fromX": 640, "fromY": 400, "toX": 400, "toY": 300 } — hold key + drag (Space=pan)
+- { "action": "resizeNode", "x": 200, "y": 380, "dx": 100, "dy": 50 } — drag node edge to resize
+- { "action": "middleClick", "x": 640, "y": 400 } — middle mouse button
+
+### Utility actions
+- { "action": "wait", "ms": 1000 } — waits (use sparingly, max 3000ms)
+- { "action": "screenshot", "name": "step-name" } — takes a screenshot
+- { "action": "annotate", "text": "Look here!", "x": 640, "y": 400 } — shows a floating label at coordinates for 2s (use to draw viewer attention to important UI state)
+- { "action": "annotate", "text": "Bug: tab still dirty", "x": 100, "y": 20, "durationMs": 3000 } — annotation with custom duration
+- { "action": "reload" } — reloads the page (use for testing state persistence across page loads)
+${qaGuideSection}${testPlanSection}
+${diff ? `## PR Diff\n\`\`\`\n${diff.slice(0, 3000)}\n\`\`\`` : ''}
+
+## Rules
+- Output ONLY a valid JSON array of actions, no markdown fences or explanation
+- ${mode === 'reproduce' ? 'You MUST follow the reproduction steps from the issue closely. Generate 8-15 steps that actually trigger the bug. Do NOT just open a menu and take a screenshot — perform the FULL reproduction sequence including node interactions, context menus, keyboard shortcuts, and canvas operations' : mode === 'before' ? 'Keep it minimal — just show the old/missing behavior' : 'CRITICAL: Test the EXACT behavior changed by the PR. Read the diff carefully to understand what UI feature was modified. Do NOT just open menus and take screenshots — you must TRIGGER the specific scenario the PR fixes. For example: if the PR fixes "tabs lost on restart", actually create tabs AND reload the page. If the PR fixes "widget disappears on collapse", create a subgraph with widgets AND collapse it. Generic UI walkthrough is USELESS — demonstrate the actual fix working.'}
+- Always include at least one screenshot
+- Do NOT include login steps (handled automatically)
+- The default workflow is already loaded when your steps start
+- CRITICAL menu navigation: You MUST use ALL THREE steps in order: openMenu → hoverMenuItem("File") → clickMenuItem("Save As"). NEVER use clickMenuItem without openMenu and hoverMenuItem first — the menu items are NOT visible until you open the menu and hover the correct submenu. The top-level menu items are: "File", "Edit", "View", "Theme", "Help". Example: [{"action":"openMenu"},{"action":"hoverMenuItem","label":"File"},{"action":"clickMenuItem","label":"Save As"}]
+- For node interactions: right-click a node to get its context menu, double-click canvas to add nodes
+- Take screenshots BEFORE and AFTER critical actions to capture the bug state
+${qaGuide ? '- Follow the QA Analysis Guide steps closely — they are well-researched and specific' : diff ? '- Pick test steps from the QA test plan categories that are most relevant to the diff' : '- Pick test steps from the QA test plan categories most likely to reveal bugs'}
+${
+  mode === 'reproduce'
+    ? `- Common ComfyUI actions: right-click node for context menu (Clone, Bypass, etc.), Ctrl+C/Ctrl+V to copy/paste, Delete key to remove, double-click canvas to add node via search, drag from output to input to connect
+- CRITICAL: Establish all prerequisites BEFORE testing the bug. If the bug requires a saved workflow, SAVE it first. If it requires a dirty workflow, MODIFY it first. If it requires specific nodes, ADD them. If it requires a specific setting, use setSetting. Think step by step about what state the UI must be in to trigger the bug.
+- Use loadWorkflow if the issue references a specific workflow JSON URL
+- Use setSetting to configure any non-default settings needed to reproduce`
+    : ''
+}
+
+## Example output
+[
+  {"action":"clickCanvas","x":450,"y":350},
+  {"action":"screenshot","name":"node-selected"},
+  {"action":"rightClickCanvas","x":450,"y":350},
+  {"action":"wait","ms":500},
+  {"action":"screenshot","name":"context-menu"},
+  {"action":"clickMenuItem","label":"Clone"},
+  {"action":"wait","ms":500},
+  {"action":"screenshot","name":"after-clone"},
+  {"action":"pressKey","key":"Delete"},
+  {"action":"screenshot","name":"after-delete"}
+]`
+}
+
+async function generateTestSteps(opts: Options): Promise<TestAction[]> {
+  const diff = opts.diffFile ? readFileSync(opts.diffFile, 'utf-8') : ''
+  const testPlan = opts.testPlanFile
+    ? readFileSync(opts.testPlanFile, 'utf-8')
+    : undefined
+  let qaGuide: string | undefined
+  if (opts.qaGuideFile) {
+    try {
+      qaGuide = readFileSync(opts.qaGuideFile, 'utf-8')
+      console.warn(`Using QA guide: ${opts.qaGuideFile}`)
+    } catch {
+      console.warn(
+        `QA guide not found: ${opts.qaGuideFile}, continuing without`
+      )
+    }
+  }
+  const prompt = buildPrompt(opts.mode, diff, testPlan, qaGuide)
+
+  const genAI = new GoogleGenerativeAI(opts.apiKey)
+  const model = genAI.getGenerativeModel({ model: opts.model })
+
+  console.warn(`Generating ${opts.mode} test steps with ${opts.model}...`)
+
+  const result = await model.generateContent({
+    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    generationConfig: { temperature: 0.2, maxOutputTokens: 4096 }
+  })
+
+  let text = result.response.text()
+  // Strip markdown fences if present
+  text = text
+    .replace(/^```(?:json)?\n?/gm, '')
+    .replace(/```$/gm, '')
+    .trim()
+
+  console.warn('Generated steps:', text)
+
+  const steps: TestAction[] = JSON.parse(text)
+  if (!Array.isArray(steps)) throw new Error('Expected JSON array')
+  return steps
+}
+
+// ── Fallback steps ──
+
+const FALLBACK_BEFORE: TestAction[] = [
+  { action: 'openMenu' },
+  { action: 'wait', ms: 300 },
+  { action: 'hoverMenuItem', label: 'File' },
+  { action: 'wait', ms: 500 },
+  { action: 'screenshot', name: 'file-menu-before' },
+  { action: 'pressKey', key: 'Escape' },
+  { action: 'wait', ms: 500 },
+  { action: 'screenshot', name: 'editor-before' }
+]
+
+const FALLBACK_AFTER: TestAction[] = [
+  { action: 'openMenu' },
+  { action: 'wait', ms: 300 },
+  { action: 'hoverMenuItem', label: 'File' },
+  { action: 'wait', ms: 500 },
+  { action: 'screenshot', name: 'file-menu-after' },
+  { action: 'pressKey', key: 'Escape' },
+  { action: 'wait', ms: 500 },
+  { action: 'screenshot', name: 'editor-after' }
+]
+
+const FALLBACK_REPRODUCE: TestAction[] = [
+  { action: 'screenshot', name: 'initial-state' },
+  { action: 'clickCanvas', x: 450, y: 350 },
+  { action: 'wait', ms: 300 },
+  { action: 'screenshot', name: 'node-selected' },
+  { action: 'rightClickCanvas', x: 450, y: 350 },
+  { action: 'wait', ms: 500 },
+  { action: 'screenshot', name: 'context-menu' },
+  { action: 'pressKey', key: 'Escape' },
+  { action: 'openMenu' },
+  { action: 'hoverMenuItem', label: 'File' },
+  { action: 'screenshot', name: 'file-menu' },
+  { action: 'pressKey', key: 'Escape' },
+  { action: 'screenshot', name: 'final-state' }
+]
+
+const FALLBACK_STEPS: Record<RecordMode, TestAction[]> = {
+  before: FALLBACK_BEFORE,
+  after: FALLBACK_AFTER,
+  reproduce: FALLBACK_REPRODUCE
+}
+
+// ── Playwright helpers ──
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function moveCursorOverlay(page: Page, x: number, y: number) {
+  await page.evaluate(
+    ([cx, cy]) => {
+      const fn = (window as unknown as Record<string, unknown>).__moveCursor as
+        | ((x: number, y: number) => void)
+        | undefined
+      if (fn) fn(cx, cy)
+    },
+    [x, y]
+  )
+}
+
+async function clickCursorOverlay(page: Page, down: boolean) {
+  await page.evaluate((d) => {
+    const fn = (window as unknown as Record<string, unknown>).__clickCursor as
+      | ((down: boolean) => void)
+      | undefined
+    if (fn) fn(d)
+  }, down)
+}
+
+interface NarrationSegment {
+  turn: number
+  timestampMs: number
+  text: string
+}
+
+// Collected during recording, used for TTS post-processing
+const narrationSegments: NarrationSegment[] = []
+const recordingStartMs = 0
+
+async function showSubtitle(page: Page, text: string, turn: number) {
+  const safeText = text.slice(0, 120).replace(/'/g, "\\'").replace(/\n/g, ' ')
+  const encoded = encodeURIComponent(safeText)
+
+  // Track for TTS post-processing
+  narrationSegments.push({
+    turn,
+    timestampMs: Date.now() - recordingStartMs,
+    text: safeText
+  })
+
+  await page.addScriptTag({
+    content: `(function(){
+      var id='qa-subtitle';
+      var el=document.getElementById(id);
+      if(!el){
+        el=document.createElement('div');
+        el.id=id;
+        Object.assign(el.style,{position:'fixed',bottom:'32px',left:'50%',transform:'translateX(-50%)',zIndex:'2147483646',maxWidth:'90%',padding:'6px 14px',borderRadius:'6px',background:'rgba(0,0,0,0.8)',color:'rgba(255,255,255,0.95)',fontSize:'12px',fontFamily:'system-ui,sans-serif',fontWeight:'400',lineHeight:'1.4',pointerEvents:'none',textAlign:'center',transition:'opacity 0.3s',whiteSpace:'normal'});
+        document.body.appendChild(el);
+      }
+      var msg=decodeURIComponent('${encoded}');
+      el.textContent='['+${turn}+'] '+msg;
+      el.style.opacity='1';
+    })()`
+  })
+}
+
+async function generateNarrationAudio(
+  segments: NarrationSegment[],
+  outputDir: string,
+  _apiKey: string
+): Promise<string | null> {
+  if (segments.length === 0) return null
+
+  const narrationDir = `${outputDir}/narration`
+  mkdirSync(narrationDir, { recursive: true })
+
+  // Save narration metadata
+  writeFileSync(
+    `${narrationDir}/segments.json`,
+    JSON.stringify(segments, null, 2)
+  )
+
+  // Generate TTS using OpenAI API (high quality, fast)
+  const ttsKey = process.env.OPENAI_API_KEY
+  if (!ttsKey) {
+    console.warn('  OPENAI_API_KEY not set, skipping TTS narration')
+    return null
+  }
+
+  const audioFiles: Array<{ path: string; offsetMs: number }> = []
+
+  for (const seg of segments) {
+    const audioPath = `${narrationDir}/turn-${seg.turn}.mp3`
+    try {
+      const resp = await fetch('https://api.openai.com/v1/audio/speech', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${ttsKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'tts-1',
+          voice: 'nova',
+          input: seg.text,
+          speed: 1.15
+        })
+      })
+      if (!resp.ok)
+        throw new Error(`TTS API ${resp.status}: ${await resp.text()}`)
+      const audioBuffer = Buffer.from(await resp.arrayBuffer())
+      writeFileSync(audioPath, audioBuffer)
+      audioFiles.push({ path: audioPath, offsetMs: seg.timestampMs })
+      console.warn(
+        `  TTS [${seg.turn}]: ${audioPath} (${audioBuffer.length} bytes)`
+      )
+    } catch (e) {
+      console.warn(
+        `  TTS [${seg.turn}] failed: ${e instanceof Error ? e.message.slice(0, 80) : e}`
+      )
+    }
+  }
+
+  if (audioFiles.length === 0) return null
+
+  // Build ffmpeg filter to mix all audio clips at correct timestamps
+  const inputArgs: string[] = []
+  const filterParts: string[] = []
+
+  for (let i = 0; i < audioFiles.length; i++) {
+    inputArgs.push('-i', audioFiles[i].path)
+    filterParts.push(
+      `[${i}]adelay=${audioFiles[i].offsetMs}|${audioFiles[i].offsetMs}[a${i}]`
+    )
+  }
+
+  const mixInputs = audioFiles.map((_, i) => `[a${i}]`).join('')
+  const filter = `${filterParts.join(';')};${mixInputs}amix=inputs=${audioFiles.length}:normalize=0[aout]`
+
+  const mixedAudio = `${narrationDir}/mixed.mp3`
+  try {
+    execSync(
+      `ffmpeg -y ${inputArgs.join(' ')} -filter_complex "${filter}" -map "[aout]" "${mixedAudio}" 2>/dev/null`,
+      { timeout: 30000 }
+    )
+    console.warn(`  TTS mixed: ${mixedAudio}`)
+    return mixedAudio
+  } catch (e) {
+    console.warn(
+      `  TTS mix failed: ${e instanceof Error ? e.message.slice(0, 80) : e}`
+    )
+    return null
+  }
+}
+
+function mergeAudioIntoVideo(
+  videoPath: string,
+  audioPath: string,
+  outputPath: string
+): boolean {
+  try {
+    execSync(
+      `ffmpeg -y -i "${videoPath}" -i "${audioPath}" -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 -shortest "${outputPath}" 2>/dev/null`,
+      { timeout: 60000 }
+    )
+    // Replace original with narrated version
+    renameSync(outputPath, videoPath)
+    console.warn(`  Narrated video: ${videoPath}`)
+    return true
+  } catch (e) {
+    console.warn(
+      `  Audio merge failed: ${e instanceof Error ? e.message.slice(0, 80) : e}`
+    )
+    return false
+  }
+}
+
+async function openComfyMenu(page: Page) {
+  const menuTrigger = page.locator('.comfy-menu-button-wrapper')
+  const menuPopup = page.locator('.comfy-command-menu')
+
+  // Close if already open
+  if (await menuPopup.isVisible().catch(() => false)) {
+    await page.locator('body').click({ position: { x: 500, y: 300 } })
+    await sleep(500)
+  }
+
+  if (await menuTrigger.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await menuTrigger.click()
+  } else {
+    // Fallback: click where the C logo menu button typically is
+    console.warn('Menu button not found by selector, using coordinate click')
+    await page.mouse.click(46, 36)
+    await sleep(300)
+  }
+
+  try {
+    await menuPopup.waitFor({ state: 'visible', timeout: 3000 })
+  } catch {
+    console.warn('Menu popup did not appear')
+  }
+  await sleep(300)
+}
+
+async function hoverMenuItem(page: Page, label: string) {
+  // Top-level items use .p-menubar-item-label in the comfy-command-menu
+  const menuLabel = page.locator(`.p-menubar-item-label:text-is("${label}")`)
+  if (await menuLabel.isVisible().catch(() => false)) {
+    // Hover the parent .p-tieredmenu-item to trigger submenu
+    const menuItem = page
+      .locator('.comfy-command-menu .p-tieredmenu-item')
+      .filter({ has: menuLabel })
+    const box = await menuItem.boundingBox().catch(() => null)
+    if (box)
+      await moveCursorOverlay(
+        page,
+        box.x + box.width / 2,
+        box.y + box.height / 2
+      )
+    await menuItem.hover()
+    // Wait for submenu to appear
+    try {
+      await page
+        .locator('.p-tieredmenu-submenu:visible')
+        .last()
+        .waitFor({ state: 'visible', timeout: 2000 })
+    } catch {
+      console.warn(`Submenu for "${label}" did not appear`)
+    }
+    await sleep(300)
+  } else {
+    console.warn(`Menu item "${label}" not visible`)
+  }
+}
+
+async function clickSubmenuItem(page: Page, label: string) {
+  // Try PrimeVue tiered menu first (hamburger menu submenus)
+  const submenu = page.locator('.p-tieredmenu-submenu:visible').last()
+  const primeItem = submenu
+    .locator('.p-tieredmenu-item')
+    .filter({ hasText: label })
+    .first()
+  if (await primeItem.isVisible().catch(() => false)) {
+    const box = await primeItem.boundingBox().catch(() => null)
+    if (box)
+      await moveCursorOverlay(
+        page,
+        box.x + box.width / 2,
+        box.y + box.height / 2
+      )
+    if (box) await clickCursorOverlay(page, true)
+    await primeItem.click({ timeout: 5000 }).catch(() => {
+      console.warn(`Click on PrimeVue menu item "${label}" failed`)
+    })
+    if (box) await clickCursorOverlay(page, false)
+    await sleep(800)
+    return
+  }
+
+  // Try litegraph context menu (right-click on nodes/canvas)
+  const liteItem = page
+    .locator('.litemenu-entry')
+    .filter({ hasText: label })
+    .first()
+  if (await liteItem.isVisible().catch(() => false)) {
+    const box = await liteItem.boundingBox().catch(() => null)
+    if (box)
+      await moveCursorOverlay(
+        page,
+        box.x + box.width / 2,
+        box.y + box.height / 2
+      )
+    if (box) await clickCursorOverlay(page, true)
+    await liteItem.click({ timeout: 5000 }).catch(() => {
+      console.warn(`Click on litegraph menu item "${label}" failed`)
+    })
+    if (box) await clickCursorOverlay(page, false)
+    await sleep(800)
+    return
+  }
+
+  // Try any visible menu/context menu item
+  const anyItem = page.locator(`[role="menuitem"]:has-text("${label}")`).first()
+  if (await anyItem.isVisible().catch(() => false)) {
+    await anyItem.click({ timeout: 5000 }).catch(() => {
+      console.warn(`Click on menu role item "${label}" failed`)
+    })
+    await sleep(800)
+    return
+  }
+
+  console.warn(`Submenu item "${label}" not found in any menu type`)
+}
+
+async function fillDialogAndConfirm(page: Page, text: string) {
+  // Try PrimeVue dialog input first
+  const dialogInput = page.locator('.p-dialog-content input')
+  if (await dialogInput.isVisible().catch(() => false)) {
+    await dialogInput.fill(text)
+    await sleep(300)
+    await page.keyboard.press('Enter')
+    await sleep(2000)
+    return
+  }
+
+  // Try node search box input (opened by double-clicking canvas)
+  const searchInput = page.locator(
+    '[id^="comfy-vue-node-search-box-input"], [role="search"] input, .comfy-vue-node-search-container input, .p-autocomplete-input'
+  )
+  if (
+    await searchInput
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await searchInput.first().fill(text)
+    await sleep(500)
+    // Select first result from dropdown
+    const firstOption = page
+      .locator('.p-autocomplete-item, .p-autocomplete-option, [role="option"]')
+      .first()
+    if (await firstOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await firstOption.click({ timeout: 3000 }).catch(() => {
+        console.warn('Could not click autocomplete option, pressing Enter')
+      })
+    } else {
+      await page.keyboard.press('Enter')
+    }
+    await sleep(1000)
+    return
+  }
+
+  // Fallback: type into whatever is focused
+  const activeInput = page.locator('input:focus, textarea:focus')
+  if (await activeInput.isVisible().catch(() => false)) {
+    await activeInput.fill(text)
+    await sleep(300)
+    await page.keyboard.press('Enter')
+    await sleep(1000)
+    return
+  }
+
+  // Last resort: keyboard type
+  console.warn('No input found, typing via keyboard')
+  await page.keyboard.type(text, { delay: 50 })
+  await sleep(300)
+  await page.keyboard.press('Enter')
+  await sleep(1000)
+}
+
+async function clickByText(page: Page, text: string) {
+  const el = page.locator(`text=${text}`).first()
+  if (await el.isVisible().catch(() => false)) {
+    // Get element position for cursor overlay
+    const box = await el.boundingBox().catch(() => null)
+    if (box) {
+      await moveCursorOverlay(
+        page,
+        box.x + box.width / 2,
+        box.y + box.height / 2
+      )
+    }
+    await el.hover({ timeout: 3000 }).catch(() => {})
+    await sleep(400)
+    if (box) await clickCursorOverlay(page, true)
+    await el.click({ timeout: 5000 }).catch((e) => {
+      console.warn(
+        `Click on "${text}" failed: ${e instanceof Error ? e.message.split('\n')[0] : e}`
+      )
+    })
+    if (box) await clickCursorOverlay(page, false)
+    await sleep(500)
+  } else {
+    console.warn(`Element with text "${text}" not found`)
+  }
+}
+
+// ── Action executor ──
+
+async function waitForEditorReady(page: Page) {
+  try {
+    await page
+      .locator('.comfy-menu-button-wrapper')
+      .waitFor({ state: 'visible', timeout: 15000 })
+  } catch {
+    console.warn('Editor not ready after reload (menu button not visible)')
+  }
+  await sleep(1000)
+}
+
+export async function executeAction(
+  page: Page,
+  step: TestAction,
+  outputDir: string
+): Promise<ActionResult> {
+  console.warn(
+    `  → ${step.action}${('label' in step && `: ${step.label}`) || ('nodeName' in step && `: ${step.nodeName}`) || ('text' in step && `: ${step.text}`) || ('name' in step && `: ${step.name}`) || ('x' in step && `: (${step.x},${step.y})`) || ''}`
+  )
+  // Reject invalid click targets
+  const INVALID_TARGETS = ['undefined', 'null', '[object Object]', '']
+  if (
+    'text' in step &&
+    typeof step.text === 'string' &&
+    INVALID_TARGETS.includes(step.text.trim())
+  ) {
+    const error = `Invalid click target: "${step.text}". Use a real UI label or coordinates instead.`
+    console.warn(`  ${error}`)
+    return { action: step, success: false, error }
+  }
+
+  try {
+    switch (step.action) {
+      case 'openMenu':
+        await openComfyMenu(page)
+        break
+      case 'hoverMenuItem':
+        await hoverMenuItem(page, step.label)
+        break
+      case 'clickMenuItem':
+        await clickSubmenuItem(page, step.label)
+        break
+      case 'fillDialog':
+        await fillDialogAndConfirm(page, step.text)
+        break
+      case 'pressKey':
+        try {
+          // Show key in subtitle (persists 2s) then instant press
+          const keyLabel =
+            step.key === ' '
+              ? 'Space'
+              : step.key.length === 1
+                ? step.key.toUpperCase()
+                : step.key
+          await showSubtitle(page, `⌨ ${keyLabel}`, 0)
+          await sleep(200) // Let subtitle render before pressing
+          await page.keyboard.press(step.key)
+          await sleep(500)
+        } catch (e) {
+          console.warn(
+            `Skipping invalid key "${step.key}": ${e instanceof Error ? e.message : e}`
+          )
+        }
+        break
+      case 'click':
+        await clickByText(page, step.text)
+        break
+      case 'rightClick': {
+        const rcEl = page.locator(`text=${step.text}`).first()
+        if (await rcEl.isVisible().catch(() => false)) {
+          await rcEl.click({ button: 'right' })
+          await sleep(500)
+        } else {
+          console.warn(
+            `Element with text "${step.text}" not found for rightClick`
+          )
+        }
+        break
+      }
+      case 'doubleClick': {
+        if (step.x !== undefined && step.y !== undefined) {
+          await page.mouse.dblclick(step.x, step.y)
+        } else if (step.text) {
+          const dcEl = page.locator(`text=${step.text}`).first()
+          if (await dcEl.isVisible().catch(() => false)) {
+            await dcEl.dblclick()
+          } else {
+            console.warn(
+              `Element with text "${step.text}" not found for doubleClick`
+            )
+          }
+        } else {
+          await page.mouse.dblclick(640, 400)
+        }
+        await sleep(500)
+        break
+      }
+      case 'clickCanvas':
+        await page.mouse.move(step.x, step.y)
+        await sleep(300)
+        await page.mouse.click(step.x, step.y)
+        await sleep(300)
+        break
+      case 'rightClickCanvas':
+        await page.mouse.move(step.x, step.y)
+        await sleep(300)
+        await page.mouse.click(step.x, step.y, { button: 'right' })
+        await sleep(500)
+        break
+      case 'dragCanvas': {
+        await page.mouse.move(step.fromX, step.fromY)
+        await page.mouse.down()
+        await sleep(100)
+        const dragSteps = 5
+        for (let i = 1; i <= dragSteps; i++) {
+          const x = step.fromX + ((step.toX - step.fromX) * i) / dragSteps
+          const y = step.fromY + ((step.toY - step.fromY) * i) / dragSteps
+          await page.mouse.move(x, y)
+          await sleep(50)
+        }
+        await page.mouse.up()
+        await sleep(300)
+        break
+      }
+      case 'scrollCanvas':
+        await page.mouse.move(step.x, step.y)
+        await page.mouse.wheel(0, step.deltaY)
+        await sleep(500)
+        break
+      case 'wait':
+        await sleep(Math.min(step.ms, 5000))
+        break
+      case 'screenshot': {
+        const safeName = step.name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 100)
+        await page.screenshot({
+          path: `${outputDir}/${safeName}.png`
+        })
+        break
+      }
+      case 'loadWorkflow': {
+        console.warn(`  Loading workflow from: ${step.url}`)
+        await page.evaluate(async (workflowUrl) => {
+          const resp = await fetch(workflowUrl)
+          const workflow = await resp.json()
+          const app = (window as unknown as Record<string, unknown>).app as {
+            loadGraphData: (data: unknown) => Promise<void>
+          }
+          if (app?.loadGraphData) {
+            await app.loadGraphData(workflow)
+          }
+        }, step.url)
+        await sleep(2000)
+        break
+      }
+      case 'setSetting': {
+        console.warn(`  Setting ${step.id} = ${step.value}`)
+        await page.evaluate(
+          ({ id, value }) => {
+            const app = (window as unknown as Record<string, unknown>).app as {
+              ui: {
+                settings: {
+                  setSettingValue: (id: string, value: unknown) => void
+                }
+              }
+            }
+            app?.ui?.settings?.setSettingValue(id, value)
+          },
+          { id: step.id, value: step.value }
+        )
+        await sleep(500)
+        break
+      }
+      case 'loadDefaultWorkflow':
+        // Load default workflow via app API (most reliable, no menu navigation)
+        try {
+          await page.evaluate(() => {
+            const app = (window as unknown as Record<string, unknown>).app as {
+              loadGraphData?: (d: unknown) => Promise<void>
+              resetToDefaultWorkflow?: () => Promise<void>
+            }
+            if (app?.resetToDefaultWorkflow) return app.resetToDefaultWorkflow()
+            return Promise.resolve()
+          })
+          await sleep(1000)
+        } catch {
+          // Fallback: try menu navigation with multiple possible item names
+          await openComfyMenu(page)
+          await hoverMenuItem(page, 'File')
+          const loaded = await clickSubmenuItem(page, 'Load Default')
+            .then(() => true)
+            .catch(() => false)
+          if (!loaded) {
+            await clickSubmenuItem(page, 'Default Workflow').catch(() => {})
+          }
+          await sleep(1000)
+        }
+        break
+      case 'openSettings':
+        // Convenience: open Settings dialog in one action
+        await openComfyMenu(page)
+        await clickSubmenuItem(page, 'Settings')
+        await sleep(1000)
+        break
+      case 'reload':
+        await page.reload({ waitUntil: 'domcontentloaded' })
+        await waitForEditorReady(page)
+        break
+      case 'done':
+        console.warn(`  Agent done: ${step.reason}`)
+        break
+      case 'annotate': {
+        const duration = Math.min(step.durationMs ?? 2000, 5000)
+        await page.evaluate(
+          ({ text, x, y, ms }) => {
+            const el = document.createElement('div')
+            el.textContent = 'QA: ' + text
+            Object.assign(el.style, {
+              position: 'fixed',
+              left: x + 'px',
+              top: y + 'px',
+              zIndex: '2147483646',
+              padding: '3px 8px',
+              borderRadius: '3px',
+              background: 'rgba(0, 0, 0, 0.6)',
+              border: '1.5px dashed rgba(120, 200, 255, 0.8)',
+              color: 'rgba(120, 200, 255, 0.9)',
+              fontSize: '11px',
+              fontWeight: '500',
+              fontFamily: 'monospace',
+              pointerEvents: 'none',
+              whiteSpace: 'nowrap',
+              transform: 'translateY(-100%) translateX(-50%)',
+              animation: 'qa-ann-in 200ms ease-out'
+            })
+            const style = document.createElement('style')
+            style.textContent =
+              '@keyframes qa-ann-in{from{opacity:0;transform:translateY(-80%) translateX(-50%)}to{opacity:1;transform:translateY(-100%) translateX(-50%)}}'
+            document.head.appendChild(style)
+            document.body.appendChild(el)
+            setTimeout(() => {
+              el.remove()
+              style.remove()
+            }, ms)
+          },
+          { text: step.text, x: step.x, y: step.y, ms: duration }
+        )
+        await sleep(duration + 200)
+        break
+      }
+      case 'addNode': {
+        const nx = step.x ?? 640
+        const ny = step.y ?? 400
+        await page.mouse.dblclick(nx, ny)
+        await sleep(500)
+        await page.keyboard.type(step.nodeName, { delay: 30 })
+        await sleep(300)
+        await page.keyboard.press('Enter')
+        await sleep(500)
+        console.warn(`  Added node "${step.nodeName}" at (${nx}, ${ny})`)
+        break
+      }
+      case 'cloneNode': {
+        // Select node then Ctrl+C/Ctrl+V — works in both legacy and Nodes 2.0
+        await page.mouse.click(step.x, step.y)
+        await sleep(300)
+        await page.keyboard.press('Control+c')
+        await sleep(200)
+        await page.keyboard.press('Control+v')
+        await sleep(500)
+        console.warn(`  Cloned node at (${step.x}, ${step.y}) via Ctrl+C/V`)
+        break
+      }
+      case 'copyPaste': {
+        const cx = step.x ?? 640
+        const cy = step.y ?? 400
+        await page.mouse.click(cx, cy)
+        await sleep(200)
+        await page.keyboard.press('Control+c')
+        await sleep(300)
+        await page.keyboard.press('Control+v')
+        await sleep(500)
+        console.warn(`  Copy-pasted at (${cx}, ${cy})`)
+        break
+      }
+      case 'holdKeyAndDrag': {
+        await page.keyboard.down(step.key)
+        await sleep(100)
+        await page.mouse.move(step.fromX, step.fromY)
+        await page.mouse.down()
+        await sleep(100)
+        const hkSteps = 5
+        for (let i = 1; i <= hkSteps; i++) {
+          const hx = step.fromX + ((step.toX - step.fromX) * i) / hkSteps
+          const hy = step.fromY + ((step.toY - step.fromY) * i) / hkSteps
+          await page.mouse.move(hx, hy)
+          await sleep(50)
+        }
+        await page.mouse.up()
+        await page.keyboard.up(step.key)
+        await sleep(300)
+        console.warn(
+          `  Hold ${step.key} + drag (${step.fromX},${step.fromY})→(${step.toX},${step.toY})`
+        )
+        break
+      }
+      case 'resizeNode': {
+        // Click bottom-right corner of node, then drag
+        await page.mouse.move(step.x, step.y)
+        await page.mouse.down()
+        await sleep(100)
+        await page.mouse.move(step.x + step.dx, step.y + step.dy)
+        await sleep(100)
+        await page.mouse.up()
+        await sleep(300)
+        console.warn(
+          `  Resized node at (${step.x},${step.y}) by (${step.dx},${step.dy})`
+        )
+        break
+      }
+      case 'middleClick': {
+        await page.mouse.click(step.x, step.y, { button: 'middle' })
+        await sleep(300)
+        console.warn(`  Middle-clicked at (${step.x}, ${step.y})`)
+        break
+      }
+      default:
+        console.warn(`Unknown action: ${JSON.stringify(step)}`)
+    }
+    return { action: step, success: true }
+  } catch (e) {
+    const error = e instanceof Error ? e.message.split('\n')[0] : String(e)
+    console.warn(`Step ${step.action} failed: ${error}`)
+    return { action: step, success: false, error }
+  }
+}
+
+// ── Step executor (batch mode for before/after) ──
+
+async function executeSteps(
+  page: Page,
+  steps: TestAction[],
+  outputDir: string
+) {
+  for (const step of steps) {
+    await executeAction(page, step, outputDir)
+  }
+}
+
+// ── Login flow ──
+
+async function loginAsQaCi(page: Page, _serverUrl: string) {
+  console.warn('Logging in as qa-ci...')
+
+  // Detect login page by looking for the "New user" input
+  const newUserInput = page.locator('input[placeholder*="username"]').first()
+  const isLoginPage = await newUserInput
+    .isVisible({ timeout: 5000 })
+    .catch(() => false)
+
+  if (isLoginPage) {
+    console.warn('Login page detected, selecting existing user...')
+
+    // Try selecting existing user from dropdown (created by Pre-seed step)
+    const dropdown = page
+      .locator('.p-select, .p-dropdown, [role="combobox"]')
+      .first()
+    let loginDone = false
+
+    if (await dropdown.isVisible().catch(() => false)) {
+      await dropdown.click()
+      await sleep(500)
+
+      // Look for qa-ci in the dropdown options
+      const option = page.locator('text=qa-ci').first()
+      if (await option.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await option.click()
+        await sleep(300)
+        console.warn('Selected qa-ci from dropdown')
+
+        const nextBtn = page.getByRole('button', { name: 'Next' })
+        if (await nextBtn.isVisible().catch(() => false)) {
+          await nextBtn.click({ timeout: 5000 })
+          console.warn('Clicked Next with existing user')
+          loginDone = true
+          await sleep(5000)
+        }
+      } else {
+        // Close dropdown
+        await page.keyboard.press('Escape')
+        await sleep(300)
+        console.warn('qa-ci not found in dropdown')
+      }
+    }
+
+    // Fallback: create new user with unique name
+    if (!loginDone) {
+      const uniqueName = `qa-${Date.now()}`
+      console.warn(`Creating new user: ${uniqueName}`)
+      await newUserInput.fill(uniqueName)
+      await sleep(500)
+      const nextBtn = page.getByRole('button', { name: 'Next' })
+      await nextBtn.click({ timeout: 5000 })
+      console.warn('Clicked Next with new user')
+      await sleep(5000)
+    }
+  } else {
+    console.warn('No login page detected, continuing...')
+  }
+
+  // Skip tutorial/template gallery
+  await page.evaluate(() => {
+    localStorage.setItem('Comfy.TutorialCompleted', 'true')
+  })
+
+  // Close template gallery if it appeared
+  await page.keyboard.press('Escape')
+  await sleep(1000)
+
+  // Dismiss error popup if present
+  const dismissBtn = page.locator('text=Dismiss').first()
+  if (await dismissBtn.isVisible().catch(() => false)) {
+    await dismissBtn.click()
+    await sleep(500)
+  }
+
+  // Wait for the editor UI to be fully loaded (menu button visible)
+  try {
+    await page
+      .locator('.comfy-menu-button-wrapper')
+      .waitFor({ state: 'visible', timeout: 15000 })
+    console.warn('Editor UI loaded (menu button visible)')
+  } catch {
+    console.warn('Menu button not visible after 15s')
+    console.warn(`Current URL: ${page.url()}`)
+  }
+  await sleep(1000)
+}
+
+// ── Agentic loop (reproduce mode) ──
+
+async function captureScreenshotForGemini(page: Page): Promise<string> {
+  const buffer = await page.screenshot({ type: 'jpeg', quality: 50 })
+  return buffer.toString('base64')
+}
+
+function buildIssueSpecificHints(context: string): string {
+  const ctx = context.toLowerCase()
+  const hints: string[] = []
+
+  if (/clone|z.?index|overlap|above.*origin|layering/.test(ctx))
+    hints.push(
+      'Preflight already cloned a node. NOW: take a screenshot to see the cloned node, then dragCanvas from (~800,350) to (~750,350) to overlap the clone on the original. Take screenshot to capture z-index. The clone should be ABOVE the original.'
+    )
+  if (/copy.*paste|paste.*offset|ctrl\+c|ctrl\+v|clipboard/.test(ctx))
+    hints.push(
+      'MUST: loadDefaultWorkflow, then clickCanvas on a node (~450,250), then use copyPaste to copy+paste it. Check if pasted nodes are offset or misaligned.'
+    )
+  if (/group.*paste|paste.*group/.test(ctx))
+    hints.push(
+      'MUST: Select multiple nodes by drag-selecting, then copyPaste. Check if the group frame and nodes align after paste.'
+    )
+  if (/numeric.*drag|drag.*numeric|drag.*value|widget.*drag|slider/.test(ctx))
+    hints.push(
+      'Preflight already enabled Nodes 2.0 and loaded the workflow. NOW: take a screenshot, find a numeric widget (e.g. KSampler seed/cfg around ~750,300), then use dragCanvas from that widget value to the right (fromX:750,fromY:300,toX:850,toY:300) to attempt changing the value by dragging. Take screenshot after to compare.'
+    )
+  if (
+    /sidebar.*file|file.*extension|workflow.*sidebar|workflow.*tree/.test(ctx)
+  )
+    hints.push(
+      'MUST: Click the "Workflows" button in the left sidebar to open the file tree. Take a screenshot of the file list to check for missing extensions.'
+    )
+  if (/spacebar|space.*pan|pan.*space|space.*drag/.test(ctx))
+    hints.push(
+      'Preflight already loaded the workflow. NOW: first take a screenshot, then use holdKeyAndDrag with key=" " (Space) fromX:640 fromY:400 toX:400 toY:300 to test spacebar panning. Take screenshot after. Then try: clickCanvas on an output slot (~200,320), then holdKeyAndDrag with key=" " to test panning while connecting.'
+    )
+  if (/resize.*node|node.*resize|gap.*widget|widget.*gap/.test(ctx))
+    hints.push(
+      'MUST: loadDefaultWorkflow, then use resizeNode on the bottom-right corner of a node (e.g. KSampler at ~830,430 with dx=100,dy=50) to resize it. Screenshot before and after.'
+    )
+  if (/new.*tab|open.*tab|tab.*open/.test(ctx))
+    hints.push(
+      'MUST: Right-click on a workflow tab in the topbar, then look for "Open in new tab" option in the context menu.'
+    )
+  if (/hover.*image|zoom.*button|asset.*column|thumbnail/.test(ctx))
+    hints.push(
+      'MUST: Open the sidebar, navigate to assets/models, hover over image thumbnails to trigger the zoom button overlay. Screenshot the hover state.'
+    )
+  if (/scroll.*leak|scroll.*text|text.*widget.*scroll|scroll.*canvas/.test(ctx))
+    hints.push(
+      'MUST: loadDefaultWorkflow, click on a text widget (e.g. CLIP Text Encode prompt at ~450,250), type some text, then use scrollCanvas inside the widget area to test if scroll leaks to canvas zoom.'
+    )
+  if (/middle.*click|mmb|reroute/.test(ctx))
+    hints.push(
+      'MUST: loadDefaultWorkflow, then use middleClick on a link/wire between two nodes to test reroute creation.'
+    )
+  if (/node.*shape|change.*shape/.test(ctx))
+    hints.push(
+      'MUST: loadDefaultWorkflow, then rightClickCanvas on a node (~750,350), look for "Shape" or "Properties" in context menu to change node shape.'
+    )
+  if (/nodes.*2\.0|vue.*node|new.*node/.test(ctx))
+    hints.push(
+      'MUST: Enable Nodes 2.0 via setSetting("Comfy.UseNewMenu","Top") and setSetting("Comfy.NodeBeta.Enabled",true) FIRST before testing.'
+    )
+
+  if (hints.length === 0) return ''
+  return `\n## Issue-Specific Action Plan\nBased on keyword analysis of this issue, you MUST follow these steps:\n${hints.map((h, i) => `${i + 1}. ${h}`).join('\n')}\nDo NOT skip these steps. They are the minimum required to attempt reproduction.\n`
+}
+
+function buildPreflightActions(context: string): TestAction[] {
+  const ctx = context.toLowerCase()
+  const actions: TestAction[] = []
+
+  // Enable Nodes 2.0 if issue mentions it — requires reload to take effect
+  if (/nodes.*2\.0|vue.*node|new.*node|node.*beta/.test(ctx)) {
+    actions.push({
+      action: 'setSetting',
+      id: 'Comfy.NodeBeta.Enabled',
+      value: true
+    })
+    actions.push({ action: 'reload' })
+  }
+
+  // Load default workflow for most reproduction scenarios
+  if (
+    /clone|z.?index|overlap|copy.*paste|paste|resize|drag|scroll.*leak|scroll.*text|spacebar|space.*pan|node.*shape|numeric/.test(
+      ctx
+    )
+  ) {
+    actions.push({ action: 'loadDefaultWorkflow' })
+    actions.push({ action: 'screenshot', name: 'preflight-default-workflow' })
+  }
+
+  // Issue-specific preflight: perform the actual reproduction steps
+  // mechanically so the agent starts with the right state
+  if (/clone|z.?index|above.*origin/.test(ctx)) {
+    // #10307: clone a node and check z-index
+    actions.push({ action: 'cloneNode', x: 750, y: 350 })
+    actions.push({ action: 'screenshot', name: 'preflight-after-clone' })
+  }
+
+  if (/numeric.*drag|drag.*numeric|drag.*value|widget.*drag/.test(ctx)) {
+    // #7414: click on a numeric widget value to prepare for drag test
+    actions.push({ action: 'clickCanvas', x: 750, y: 300 })
+    actions.push({ action: 'screenshot', name: 'preflight-numeric-widget' })
+  }
+
+  if (/spacebar.*pan|space.*pan|pan.*space/.test(ctx)) {
+    // #7806: start a connection drag then try spacebar pan
+    // First click an output slot to start dragging a wire
+    actions.push({ action: 'screenshot', name: 'preflight-before-connection' })
+  }
+
+  return actions
+}
+
+function buildAgenticSystemPrompt(
+  issueContext: string,
+  subIssueFocus?: string,
+  qaGuide?: string,
+  preflightNote?: string
+): string {
+  const focusSection = subIssueFocus
+    ? `\n## Current Focus\nYou are reproducing this specific sub-issue: ${subIssueFocus}\nStay focused on this particular bug. When you have demonstrated it, return done.\n`
+    : ''
+
+  const qaSection = qaGuide
+    ? `\n## QA Analysis\nA deep analysis of this issue produced the following guide. Follow it closely:\n${qaGuide}\n`
+    : ''
+
+  const issueHints = buildIssueSpecificHints(issueContext)
+
+  return `You are an AI QA agent controlling a ComfyUI browser session to reproduce reported bugs.
+You see the ACTUAL screen after each action and decide what to do next.
+
+## ComfyUI Layout (viewport 1280x720)
+- A large canvas showing a node graph, centered roughly at (640, 400)
+- Nodes are boxes with input/output slots connected by wires
+- Hamburger menu (top-left C logo) with File, Edit, Help submenus
+- Sidebar on the left (Workflows, Node Library, Models)
+- Topbar with workflow tabs and Queue button
+- Default workflow nodes (approximate center coordinates):
+  - Load Checkpoint (~150, 300)
+  - CLIP Text Encode (positive) (~450, 250)
+  - CLIP Text Encode (negative) (~450, 450)
+  - Empty Latent Image (~450, 600)
+  - KSampler (~750, 350)
+  - VAE Decode (~1000, 350)
+  - Save Image (~1200, 350)
+
+## Available Actions
+Each action is a JSON object with an "action" field:
+- { "action": "openMenu" } — clicks the hamburger menu
+- { "action": "hoverMenuItem", "label": "File" } — hovers a top-level menu item
+- { "action": "clickMenuItem", "label": "Save As" } — clicks submenu item
+- { "action": "click", "text": "Button Text" } — clicks element by text
+- { "action": "rightClick", "text": "NodeTitle" } — right-clicks element
+- { "action": "doubleClick", "text": "NodeTitle" } — double-clicks element
+- { "action": "doubleClick", "x": 640, "y": 400 } — double-click at coords (opens node search)
+- { "action": "fillDialog", "text": "search-text" } — fills input and presses Enter
+- { "action": "pressKey", "key": "Escape" } — presses a key
+- { "action": "clickCanvas", "x": 640, "y": 400 } — click at coordinates
+- { "action": "rightClickCanvas", "x": 500, "y": 350 } — right-click on canvas
+- { "action": "dragCanvas", "fromX": 400, "fromY": 300, "toX": 600, "toY": 300 }
+- { "action": "scrollCanvas", "x": 640, "y": 400, "deltaY": -300 } — scroll (negative=zoom in)
+- { "action": "loadWorkflow", "url": "https://..." } — loads workflow JSON from URL
+- { "action": "setSetting", "id": "Comfy.Setting.Id", "value": true } — changes a setting
+- { "action": "loadDefaultWorkflow" } — loads the default workflow (File → Load Default)
+- { "action": "openSettings" } — opens the Settings dialog
+- { "action": "reload" } — reloads the page (for bugs that manifest on load)
+- { "action": "wait", "ms": 1000 } — waits (max 3000ms)
+- { "action": "screenshot", "name": "step-name" } — takes a named screenshot
+- { "action": "addNode", "nodeName": "KSampler", "x": 640, "y": 400 } — double-clicks canvas to open search, types node name, presses Enter
+- { "action": "cloneNode", "x": 750, "y": 350 } — right-clicks node at coords and clicks Clone
+- { "action": "copyPaste", "x": 640, "y": 400 } — clicks at coords then Ctrl+C, Ctrl+V
+- { "action": "holdKeyAndDrag", "key": " ", "fromX": 640, "fromY": 400, "toX": 400, "toY": 300 } — holds key (e.g. Space for pan) while dragging
+- { "action": "resizeNode", "x": 200, "y": 380, "dx": 100, "dy": 50 } — drags from node edge to resize
+- { "action": "middleClick", "x": 640, "y": 400 } — middle mouse button click
+- { "action": "done", "reason": "..." } — signals you are finished
+
+## Response Format
+Return JSON: { "reasoning": "brief explanation of what you see and plan to do", "action": { "action": "...", ...params } }
+Return { "reasoning": "...", "action": { "action": "done", "reason": "..." } } when finished.
+
+## Rules
+- You see the ACTUAL screen state via the screenshot. Use it to decide your next action.
+- If an action failed, try an alternative approach (different coordinates, different selector).
+- Take screenshots before and after critical state changes to capture the bug.
+- Never repeat the same failing action more than twice. Adapt your approach.
+- Establish prerequisites first: if the bug requires a specific setting, use setSetting. If it needs a workflow, use loadWorkflow.
+- Use reload for bugs that manifest on page load/startup.
+- Common interactions: right-click node for context menu, Ctrl+C/V to copy/paste, Delete to remove, double-click canvas to add node via search.
+
+## Strategy Hints
+- For accessibility/UI bugs: use openSettings, setSetting to change themes or display options.
+- For workflow bugs: use loadDefaultWorkflow first to ensure a clean starting state.
+- Prefer convenience actions (loadDefaultWorkflow, openSettings, addNode, cloneNode) over manual menu navigation — they save turns and are more reliable.
+- To add nodes to the canvas: use addNode (double-clicks canvas → types name → Enter), or loadDefaultWorkflow (loads 7 default nodes).
+- For visual/rendering bugs (z-index, overlap, z-fighting): ALWAYS start with loadDefaultWorkflow to get nodes on canvas. You cannot reproduce visual bugs on an empty canvas.
+- To clone a node: use cloneNode at the node's coordinates (right-clicks → Clone).
+- To overlap nodes for z-index testing: use dragCanvas to move one node on top of another.
+- For copy-paste bugs: use copyPaste to select+copy+paste a node or group.
+- For panning bugs: use holdKeyAndDrag with key=" " (Space) to test spacebar panning.
+- For node resize bugs: use resizeNode on the bottom-right corner of a node.
+- For reroute/middle-click bugs: use middleClick on a link or slot.
+- Do NOT waste turns on generic exploration. Focus on reproducing the specific bug.
+${preflightNote || ''}${issueHints}${focusSection}${qaSection}
+## Issue to Reproduce
+${issueContext}`
+}
+
+interface AgenticTurnContent {
+  role: 'user' | 'model'
+  parts: Array<
+    { text: string } | { inlineData: { mimeType: string; data: string } }
+  >
+}
+
+// @ts-expect-error TS6133 — legacy function kept for fallback
+async function _runAgenticLoop(
+  page: Page,
+  opts: Options,
+  outputDir: string,
+  subIssue?: SubIssue
+): Promise<void> {
+  const MAX_TURNS = 30
+  const TIME_BUDGET_MS = 120_000
+  const SCREENSHOT_HISTORY_WINDOW = 3
+
+  const issueContext = opts.diffFile
+    ? readFileSync(opts.diffFile, 'utf-8').slice(0, 6000)
+    : 'No issue context provided'
+
+  // Read QA guide if available — contains structured analysis from analyze-pr
+  let qaGuideSummary = ''
+  if (opts.qaGuideFile) {
+    try {
+      const raw = readFileSync(opts.qaGuideFile, 'utf-8')
+      const guide = JSON.parse(raw)
+      const parts: string[] = []
+      if (guide.summary) parts.push(`Summary: ${guide.summary}`)
+      if (guide.test_focus) parts.push(`Test focus: ${guide.test_focus}`)
+      if (guide.steps?.length) {
+        parts.push(
+          'Steps:\n' +
+            guide.steps
+              .map(
+                (s: { description?: string }, i: number) =>
+                  `${i + 1}. ${s.description || JSON.stringify(s)}`
+              )
+              .join('\n')
+        )
+      }
+      if (guide.expected_result)
+        parts.push(`Expected: ${guide.expected_result}`)
+      qaGuideSummary = parts.join('\n')
+      console.warn(`Loaded QA guide: ${qaGuideSummary.slice(0, 200)}...`)
+    } catch {
+      console.warn(`Could not load QA guide from ${opts.qaGuideFile}`)
+    }
+  }
+
+  // Auto-execute prerequisite actions based on issue keywords BEFORE the
+  // agentic loop starts. This guarantees nodes are on canvas, settings are
+  // correct, etc. — the agent model often ignores prompt-only hints.
+  const preflight = buildPreflightActions(issueContext)
+  if (preflight.length > 0) {
+    console.warn(`Running ${preflight.length} preflight actions...`)
+    for (const action of preflight) {
+      await executeAction(page, action, outputDir)
+    }
+    await sleep(500)
+  }
+
+  // Tell the agent what preflight already did so it doesn't repeat
+  const preflightNote =
+    preflight.length > 0
+      ? `\n## Already Done (by preflight)\nThe following actions were ALREADY executed before you started. Do NOT repeat them:\n${preflight.map((a) => `- ${a.action}${('id' in a && `: ${a.id}=${a.value}`) || ''}`).join('\n')}\nThe default workflow is loaded and settings are configured. Start with the REPRODUCTION steps immediately.\n`
+      : ''
+
+  const systemInstruction = buildAgenticSystemPrompt(
+    issueContext,
+    subIssue?.focus,
+    qaGuideSummary,
+    preflightNote
+  )
+
+  const anthropicKey =
+    process.env.ANTHROPIC_API_KEY_QA || process.env.ANTHROPIC_API_KEY
+  const useHybrid = Boolean(anthropicKey)
+
+  const genAI = new GoogleGenerativeAI(opts.apiKey)
+  // @ts-expect-error TS6133 — kept for hybrid mode fallback
+  const _geminiVisionModel = genAI.getGenerativeModel({
+    model: 'gemini-3-flash-preview'
+  })
+
+  // Gemini-only fallback model (used when no ANTHROPIC_API_KEY_QA)
+  const agenticModel = opts.model.includes('flash')
+    ? opts.model
+    : 'gemini-3-flash-preview'
+  const _geminiOnlyModel = genAI.getGenerativeModel({
+    model: agenticModel,
+    systemInstruction
+  })
+
+  console.warn(
+    `Starting ${useHybrid ? 'hybrid (Claude planner + Gemini vision)' : 'Gemini-only'} agentic loop` +
+      (subIssue ? ` — focus: ${subIssue.title}` : '')
+  )
+
+  const history: AgenticTurnContent[] = []
+  let lastResult: ActionResult | undefined
+  let consecutiveFailures = 0
+  let lastActionKey = ''
+  let repeatCount = 0
+  const actionTypeCounts: Record<string, number> = {}
+  const startTime = Date.now()
+
+  for (let turn = 0; turn < MAX_TURNS; turn++) {
+    const elapsed = Date.now() - startTime
+    if (elapsed > TIME_BUDGET_MS) {
+      console.warn(`Time budget exhausted (${elapsed}ms), stopping loop`)
+      break
+    }
+
+    // 1. Capture screenshot
+    const screenshotB64 = await captureScreenshotForGemini(page)
+
+    // 2. Build user message for this turn
+    const userParts: AgenticTurnContent['parts'] = []
+
+    // Build focus reminder from QA guide or sub-issue
+    const focusGoal = subIssue?.focus || qaGuideSummary.split('\n')[0] || ''
+
+    if (turn === 0) {
+      userParts.push({
+        text: 'Here is the current screen state. What action should I take first to reproduce the reported issue?'
+      })
+    } else if (lastResult) {
+      const statusText = lastResult.success
+        ? `Action "${lastResult.action.action}" succeeded.`
+        : `Action "${lastResult.action.action}" FAILED: ${lastResult.error}`
+      const reminder =
+        turn >= 3 && focusGoal ? `\nRemember your goal: ${focusGoal}` : ''
+      userParts.push({
+        text: `${statusText}\nHere is the screen after that action. What should I do next? (Turn ${turn + 1}/${MAX_TURNS}, ${Math.round((TIME_BUDGET_MS - elapsed) / 1000)}s remaining)${reminder}`
+      })
+    }
+
+    userParts.push({
+      inlineData: { mimeType: 'image/jpeg', data: screenshotB64 }
+    })
+
+    // Add to history, trimming old screenshots
+    history.push({ role: 'user', parts: userParts })
+
+    // Build contents with sliding window for screenshots
+    const contents: AgenticTurnContent[] = history.map((entry, idx) => {
+      // Keep screenshots only in last SCREENSHOT_HISTORY_WINDOW user turns
+      const userTurnIndices = history
+        .map((e, i) => (e.role === 'user' ? i : -1))
+        .filter((i) => i >= 0)
+      const recentUserTurns = userTurnIndices.slice(-SCREENSHOT_HISTORY_WINDOW)
+
+      if (entry.role === 'user' && !recentUserTurns.includes(idx)) {
+        // Replace screenshot with placeholder text
+        return {
+          role: entry.role,
+          parts: entry.parts.map((p) =>
+            'inlineData' in p ? { text: '[screenshot omitted]' } : p
+          )
+        }
+      }
+      return entry
+    })
+
+    // 3. Call Gemini
+    let actionObj: TestAction
+    try {
+      const result = await _geminiOnlyModel.generateContent({
+        contents,
+        generationConfig: {
+          temperature: 0.2,
+          maxOutputTokens: 1024,
+          responseMimeType: 'application/json'
+        }
+      })
+
+      const responseText = result.response.text().trim()
+      console.warn(`  Gemini [${turn}]: ${responseText.slice(0, 200)}`)
+
+      const parsed = JSON.parse(responseText)
+      if (parsed.reasoning) {
+        console.warn(`  Reasoning: ${parsed.reasoning.slice(0, 150)}`)
+        // Show reasoning as subtitle overlay in the video
+        await showSubtitle(page, parsed.reasoning, turn)
+      }
+      actionObj = parsed.action || parsed.actions?.[0] || parsed
+      if (!actionObj?.action) {
+        throw new Error('No action field in response')
+      }
+
+      consecutiveFailures = 0
+    } catch (e) {
+      consecutiveFailures++
+      const errMsg = e instanceof Error ? e.message.split('\n')[0] : String(e)
+      console.warn(`  Gemini call failed (${consecutiveFailures}/3): ${errMsg}`)
+
+      // Add a placeholder model response to keep history balanced
+      history.push({
+        role: 'model',
+        parts: [
+          {
+            text: `{"reasoning": "API error", "action": {"action": "wait", "ms": 500}}`
+          }
+        ]
+      })
+
+      if (consecutiveFailures >= 3) {
+        console.warn('3 consecutive API failures, falling back to static steps')
+        await executeSteps(page, FALLBACK_REPRODUCE, outputDir)
+        return
+      }
+      continue
+    }
+
+    // Add model response to history
+    history.push({
+      role: 'model',
+      parts: [{ text: JSON.stringify({ action: actionObj }) }]
+    })
+
+    // 4. Check for done
+    if (actionObj.action === 'done') {
+      console.warn(
+        `Agent signaled done: ${'reason' in actionObj ? actionObj.reason : 'no reason'}`
+      )
+      // Take a final screenshot
+      await page.screenshot({
+        path: `${outputDir}/agentic-final.png`
+      })
+      break
+    }
+
+    // 5. Stuck detection — normalize coords to 50px grid for fuzzy matching
+    const normalizedAction = { ...actionObj } as Record<string, unknown>
+    for (const key of ['x', 'y', 'fromX', 'fromY', 'toX', 'toY']) {
+      if (typeof normalizedAction[key] === 'number') {
+        normalizedAction[key] =
+          Math.round((normalizedAction[key] as number) / 50) * 50
+      }
+    }
+    const actionKey = JSON.stringify(normalizedAction)
+    if (actionKey === lastActionKey) {
+      repeatCount++
+      if (repeatCount >= 3) {
+        console.warn('Stuck: same action repeated 3x, breaking loop')
+        break
+      }
+    } else {
+      repeatCount = 0
+      lastActionKey = actionKey
+    }
+
+    // Track action-type frequency — inject nudge if stuck in a pattern
+    actionTypeCounts[actionObj.action] =
+      (actionTypeCounts[actionObj.action] || 0) + 1
+    let stuckNudge = ''
+    if (actionTypeCounts[actionObj.action] >= 5) {
+      stuckNudge = ` You have used "${actionObj.action}" ${actionTypeCounts[actionObj.action]} times. Try a different approach or action type.`
+    }
+    if (stuckNudge && lastResult) {
+      // Append nudge to the last user message
+      const lastUserEntry = history[history.length - 2] // -2 because model response was just pushed
+      if (lastUserEntry?.role === 'user') {
+        const textPart = lastUserEntry.parts.find(
+          (p): p is { text: string } => 'text' in p
+        )
+        if (textPart) textPart.text += stuckNudge
+      }
+    }
+
+    // 6. Execute the action
+    lastResult = await executeAction(page, actionObj, outputDir)
+  }
+
+  console.warn('Agentic loop complete')
+}
+
+// ── Multi-pass issue decomposition ──
+
+async function decomposeIssue(opts: Options): Promise<SubIssue[]> {
+  const issueContext = opts.diffFile
+    ? readFileSync(opts.diffFile, 'utf-8').slice(0, 8000)
+    : ''
+
+  if (!issueContext) {
+    return [{ title: 'General reproduction', focus: 'Reproduce the issue' }]
+  }
+
+  const genAI = new GoogleGenerativeAI(opts.apiKey)
+  const model = genAI.getGenerativeModel({ model: opts.model })
+
+  console.warn('Decomposing issue into sub-issues...')
+
+  try {
+    const result = await model.generateContent({
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text: `Analyze this GitHub issue and decompose it into 1-3 independent, testable sub-issues that can each be reproduced in a separate browser session. Each sub-issue should focus on ONE specific bug or visual problem.
+
+If the issue describes only one bug, return just one sub-issue.
+
+Return JSON array: [{ "title": "short title", "focus": "specific instruction for what to test and how to trigger it" }]
+
+Issue context:
+${issueContext}`
+            }
+          ]
+        }
+      ],
+      generationConfig: {
+        temperature: 0.1,
+        maxOutputTokens: 1024,
+        responseMimeType: 'application/json'
+      }
+    })
+
+    let text = result.response.text().trim()
+    text = text
+      .replace(/^```(?:json)?\n?/gm, '')
+      .replace(/```$/gm, '')
+      .trim()
+
+    const subIssues: SubIssue[] = JSON.parse(text)
+    if (!Array.isArray(subIssues) || subIssues.length === 0) {
+      throw new Error('Expected non-empty array')
+    }
+
+    // Cap at 3 sub-issues
+    const capped = subIssues.slice(0, 3)
+    console.warn(
+      `Decomposed into ${capped.length} sub-issue(s):`,
+      capped.map((s) => s.title)
+    )
+    return capped
+  } catch (e) {
+    console.warn(
+      'Issue decomposition failed, using single pass:',
+      e instanceof Error ? e.message : e
+    )
+    return [
+      { title: 'Issue reproduction', focus: 'Reproduce the reported issue' }
+    ]
+  }
+}
+
+// ── Video file management ──
+
+function renameLatestWebm(
+  outputDir: string,
+  targetName: string,
+  knownNames: Set<string>
+) {
+  const files = readdirSync(outputDir)
+    .filter((f) => f.endsWith('.webm') && !knownNames.has(f))
+    .sort((a, b) => {
+      const mtimeA = statSync(`${outputDir}/${a}`).mtimeMs
+      const mtimeB = statSync(`${outputDir}/${b}`).mtimeMs
+      return mtimeB - mtimeA
+    })
+  if (files.length > 0) {
+    renameSync(`${outputDir}/${files[0]}`, `${outputDir}/${targetName}`)
+    console.warn(`Video saved: ${outputDir}/${targetName}`)
+  } else {
+    console.warn(`WARNING: No .webm video found for ${targetName}`)
+  }
+}
+
+// ── Browser session helpers ──
+
+async function launchSessionAndLogin(
+  opts: Options,
+  videoDir: string
+): Promise<{
+  browser: Awaited<ReturnType<typeof chromium.launch>>
+  context: Awaited<
+    ReturnType<Awaited<ReturnType<typeof chromium.launch>>['newContext']>
+  >
+  page: Page
+}> {
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage'
+    ]
+  })
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    recordVideo: { dir: videoDir, size: { width: 1280, height: 720 } }
+  })
+  const page = await context.newPage()
+
+  // Cursor overlay placeholder — injected after login when DOM is stable
+
+  // Monkey-patch page.mouse to auto-update cursor overlay on ALL mouse ops
+  const origMove = page.mouse.move.bind(page.mouse)
+  const origClick = page.mouse.click.bind(page.mouse)
+  const origDown = page.mouse.down.bind(page.mouse)
+  const origUp = page.mouse.up.bind(page.mouse)
+  const origDblclick = page.mouse.dblclick.bind(page.mouse)
+
+  page.mouse.move = async (
+    x: number,
+    y: number,
+    options?: Parameters<typeof origMove>[2]
+  ) => {
+    await origMove(x, y, options)
+    await moveCursorOverlay(page, x, y)
+  }
+  page.mouse.click = async (
+    x: number,
+    y: number,
+    options?: Parameters<typeof origClick>[2]
+  ) => {
+    await moveCursorOverlay(page, x, y)
+    await clickCursorOverlay(page, true)
+    await origClick(x, y, options)
+    await clickCursorOverlay(page, false)
+  }
+  page.mouse.dblclick = async (
+    x: number,
+    y: number,
+    options?: Parameters<typeof origDblclick>[2]
+  ) => {
+    await moveCursorOverlay(page, x, y)
+    await clickCursorOverlay(page, true)
+    await origDblclick(x, y, options)
+    await clickCursorOverlay(page, false)
+  }
+  page.mouse.down = async (options?: Parameters<typeof origDown>[0]) => {
+    await clickCursorOverlay(page, true)
+    await origDown(options)
+  }
+  page.mouse.up = async (options?: Parameters<typeof origUp>[0]) => {
+    await origUp(options)
+    await clickCursorOverlay(page, false)
+  }
+
+  console.warn(`Opening ComfyUI at ${opts.serverUrl}`)
+  await page.goto(opts.serverUrl, {
+    waitUntil: 'domcontentloaded',
+    timeout: 30000
+  })
+  await sleep(2000)
+  await loginAsQaCi(page, opts.serverUrl)
+  await sleep(1000)
+
+  // Inject cursor overlay AFTER login (addInitScript gets destroyed by Vue mount)
+  await page.addScriptTag({
+    content: `(function(){
+      var s=document.createElement('style');
+      s.textContent='#qa-cursor{position:fixed;z-index:2147483647;pointer-events:none;width:20px;height:20px;margin:-2px 0 0 -2px;opacity:0.95;transition:transform 80ms ease-out;transform:scale(1)}#qa-cursor.clicking{transform:scale(1.4)}';
+      document.head.appendChild(s);
+      var c=document.createElement('div');c.id='qa-cursor';
+      c.innerHTML='<svg width="20" height="20" viewBox="0 0 24 24" fill="white" stroke="black" stroke-width="1.5"><path d="M4 2l14 10-6.5 1.5L15 21l-3.5-1.5L8 21l-1.5-7.5L2 16z"/></svg>';
+      document.body.appendChild(c);
+      window.__moveCursor=function(x,y){c.style.left=x+'px';c.style.top=y+'px'};
+      window.__clickCursor=function(d){if(d)c.classList.add('clicking');else c.classList.remove('clicking')};
+    })()`
+  })
+
+  // Inject keyboard HUD — shows pressed keys in bottom-right corner of video
+  // Uses addScriptTag to avoid tsx __name compilation artifacts in page.evaluate
+  await page.addScriptTag({
+    content: `(function(){
+      var hud=document.createElement('div');
+      Object.assign(hud.style,{position:'fixed',bottom:'8px',right:'8px',zIndex:'2147483647',padding:'3px 8px',borderRadius:'4px',background:'rgba(0,0,0,0.7)',border:'1px solid rgba(120,200,255,0.4)',color:'rgba(120,200,255,0.9)',fontSize:'11px',fontFamily:'monospace',fontWeight:'500',pointerEvents:'none',display:'none',whiteSpace:'nowrap'});
+      document.body.appendChild(hud);
+      var held=new Set();
+      function update(){if(held.size===0){hud.style.display='none'}else{hud.style.display='block';hud.textContent=String.fromCharCode(9000)+' '+Array.from(held).map(function(k){return k===' '?'Space':k.length===1?k.toUpperCase():k}).join('+')}}
+      document.addEventListener('keydown',function(e){held.add(e.key);update()},true);
+      document.addEventListener('keyup',function(e){held.delete(e.key);update()},true);
+      window.addEventListener('blur',function(){held.clear();update()});
+    })()`
+  })
+
+  return { browser, context, page }
+}
+
+// ── Main ──
+
+async function main() {
+  const opts = parseArgs()
+  mkdirSync(opts.outputDir, { recursive: true })
+
+  if (opts.mode === 'reproduce') {
+    // Agentic multi-pass mode
+    const subIssues = await decomposeIssue(opts)
+    const knownNames = new Set<string>()
+
+    for (let i = 0; i < subIssues.length; i++) {
+      const subIssue = subIssues[i]
+      const sessionLabel = subIssues.length === 1 ? '' : `-${i + 1}`
+      const videoName = `qa-session${sessionLabel}.webm`
+
+      console.warn(
+        `\n=== Pass ${i + 1}/${subIssues.length}: ${subIssue.title} ===`
+      )
+
+      const { browser, context, page } = await launchSessionAndLogin(
+        opts,
+        opts.outputDir
+      )
+
+      try {
+        await page.screenshot({
+          path: `${opts.outputDir}/debug-after-login-reproduce${sessionLabel}.png`
+        })
+        // ═══ Phase 1: RESEARCH — Claude writes E2E test to reproduce ═══
+        console.warn('Phase 1: Research — Claude writes E2E test')
+        const anthropicKey =
+          process.env.ANTHROPIC_API_KEY_QA || process.env.ANTHROPIC_API_KEY
+        const { runResearchPhase } = await import('./qa-agent.js')
+        const issueCtx = opts.diffFile
+          ? readFileSync(opts.diffFile, 'utf-8').slice(0, 6000)
+          : 'No issue context provided'
+        let qaGuideText = ''
+        if (opts.qaGuideFile) {
+          try {
+            qaGuideText = readFileSync(opts.qaGuideFile, 'utf-8')
+          } catch {
+            // QA guide not available
+          }
+        }
+        const research = await runResearchPhase({
+          page,
+          issueContext: issueCtx,
+          qaGuide: qaGuideText,
+          outputDir: opts.outputDir,
+          serverUrl: opts.serverUrl,
+          anthropicApiKey: anthropicKey
+        })
+        console.warn(
+          `Research complete: ${research.verdict} — ${research.summary.slice(0, 100)}`
+        )
+        console.warn(`Evidence: ${research.evidence.slice(0, 200)}`)
+
+        // ═══ Phase 2: Run passing test with video recording ═══
+        if (research.verdict === 'REPRODUCED' && research.testCode) {
+          console.warn('Phase 2: Recording test execution with video')
+          const projectRoot = process.cwd()
+          const browserTestFile = `${projectRoot}/browser_tests/tests/qa-reproduce.spec.ts`
+          const testResultsDir = `${opts.outputDir}/test-results`
+          // Inject cursor overlay into the test — add page.addInitScript in beforeEach
+          const cursorScript = `await comfyPage.page.addInitScript(() => {
+  var c=document.createElement('div');c.id='qa-cursor';
+  c.innerHTML='<svg width="20" height="20" viewBox="0 0 24 24" fill="white" stroke="black" stroke-width="1.5"><path d="M4 2l14 10-6.5 1.5L15 21l-3.5-1.5L8 21l-1.5-7.5L2 16z"/></svg>';
+  Object.assign(c.style,{position:'fixed',zIndex:'2147483647',pointerEvents:'none',width:'20px',height:'20px',margin:'-2px 0 0 -2px',opacity:'0.95'});
+  if(document.body)document.body.appendChild(c);
+  else document.addEventListener('DOMContentLoaded',function(){document.body.appendChild(c)});
+  document.addEventListener('mousemove',function(e){c.style.left=e.clientX+'px';c.style.top=e.clientY+'px'});
+});`
+          // Insert cursor injection after the first line of the test body (after async ({ comfyPage }) => {)
+          let testCode = research.testCode
+          const testBodyMatch = testCode.match(
+            /async\s*\(\{\s*comfyPage\s*\}\)\s*=>\s*\{/
+          )
+          if (testBodyMatch && testBodyMatch.index !== undefined) {
+            const insertPos = testBodyMatch.index + testBodyMatch[0].length
+            testCode =
+              testCode.slice(0, insertPos) +
+              '\n    ' +
+              cursorScript +
+              '\n' +
+              testCode.slice(insertPos)
+          }
+          // Inject 800ms pauses between actions for human-readable video
+          // Uses comfyPage.page since test code uses comfyPageFixture
+          testCode = testCode.replace(
+            /(\n\s*)(await\s+(?:comfyPage|topbar|firstNode|page|canvas|expect))/g,
+            '$1await comfyPage.page.waitForTimeout(800);\n$1$2'
+          )
+          writeFileSync(browserTestFile, testCode)
+          try {
+            const output = execSync(
+              `cd "${projectRoot}" && npx playwright test browser_tests/tests/qa-reproduce.spec.ts --reporter=list --timeout=30000 --retries=0 --workers=1 --output="${testResultsDir}" 2>&1`,
+              {
+                timeout: 90000,
+                encoding: 'utf-8',
+                env: {
+                  ...process.env,
+                  COMFYUI_BASE_URL: opts.serverUrl,
+                  PLAYWRIGHT_LOCAL: '1' // Enables video=on + trace=on in playwright.config.ts
+                }
+              }
+            )
+            console.warn(`Phase 2: Test passed\n${output.slice(-300)}`)
+          } catch (e) {
+            const err = e as { stdout?: string }
+            console.warn(
+              `Phase 2: Test failed\n${(err.stdout || '').slice(-300)}`
+            )
+          }
+          // Copy recorded video to outputDir so deploy script finds it
+          try {
+            const videos = execSync(
+              `find "${testResultsDir}" -name '*.webm' -type f 2>/dev/null`,
+              { encoding: 'utf-8' }
+            )
+              .trim()
+              .split('\n')
+              .filter(Boolean)
+            if (videos.length > 0) {
+              execSync(`cp "${videos[0]}" "${opts.outputDir}/qa-session.webm"`)
+              console.warn(`Phase 2: Video → ${opts.outputDir}/qa-session.webm`)
+            }
+          } catch {
+            console.warn('Phase 2: No test video found')
+          }
+          // Cleanup
+          try {
+            execSync(`rm -f "${browserTestFile}"`)
+          } catch {
+            /* ignore */
+          }
+        } else {
+          console.warn(`Skipping Phase 2: verdict=${research.verdict}`)
+        }
+        await sleep(2000)
+      } finally {
+        await context.close()
+        await browser.close()
+      }
+
+      knownNames.add(videoName)
+      // If Phase 2 already copied a test video as qa-session.webm, don't overwrite it
+      // with the idle research browser video
+      const videoPath = `${opts.outputDir}/${videoName}`
+      if (statSync(videoPath, { throwIfNoEntry: false })) {
+        console.warn(
+          'Phase 2 test video exists — skipping research video rename'
+        )
+      } else {
+        renameLatestWebm(opts.outputDir, videoName, knownNames)
+      }
+
+      // Post-process: add TTS narration audio to the video
+      if (narrationSegments.length > 0) {
+        const videoPath = `${opts.outputDir}/${videoName}`
+        if (statSync(videoPath, { throwIfNoEntry: false })) {
+          console.warn(
+            `Generating TTS narration for ${narrationSegments.length} segments...`
+          )
+          const audioPath = await generateNarrationAudio(
+            narrationSegments,
+            opts.outputDir,
+            opts.apiKey
+          )
+          if (audioPath) {
+            mergeAudioIntoVideo(
+              videoPath,
+              audioPath,
+              `${opts.outputDir}/${videoName.replace('.webm', '-narrated.webm')}`
+            )
+          }
+        }
+      }
+    }
+  } else {
+    // Before/after batch mode (unchanged)
+    let steps: TestAction[]
+    try {
+      steps = await generateTestSteps(opts)
+    } catch (err) {
+      console.warn('Gemini generation failed, using fallback steps:', err)
+      steps = FALLBACK_STEPS[opts.mode]
+    }
+
+    const { browser, context, page } = await launchSessionAndLogin(
+      opts,
+      opts.outputDir
+    )
+
+    try {
+      await page.screenshot({
+        path: `${opts.outputDir}/debug-after-login-${opts.mode}.png`
+      })
+      console.warn(`Debug screenshot saved: debug-after-login-${opts.mode}.png`)
+      console.warn('Editor ready — executing test steps')
+      await executeSteps(page, steps, opts.outputDir)
+      await sleep(2000)
+    } finally {
+      await context.close()
+      await browser.close()
+    }
+
+    const videoName =
+      opts.mode === 'before' ? 'qa-before-session.webm' : 'qa-session.webm'
+    const knownNames = new Set(['qa-before-session.webm', 'qa-session.webm'])
+    renameLatestWebm(opts.outputDir, videoName, knownNames)
+  }
+
+  console.warn('Recording complete!')
+}
+
+main().catch((err) => {
+  console.error('Recording failed:', err)
+  process.exit(1)
+})

--- a/scripts/qa-report-template.html
+++ b/scripts/qa-report-template.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html><html lang=en><head><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1"><title>QA Session Recordings</title>
+<link rel=preconnect href=https://fonts.googleapis.com><link rel=preconnect href=https://fonts.gstatic.com crossorigin><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel=stylesheet>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<style>
+:root{--bg:oklch(97% 0.01 265);--surface:oklch(100% 0 0);--surface-up:oklch(94% 0.01 265);--fg:oklch(15% 0.02 265);--fg-muted:oklch(40% 0.01 265);--fg-dim:oklch(55% 0.01 265);--primary:oklch(50% 0.21 265);--primary-up:oklch(45% 0.21 265);--primary-glow:oklch(55% 0.15 265);--ok:oklch(45% 0.18 155);--err:oklch(50% 0.22 25);--border:oklch(85% 0.01 265);--border-faint:oklch(90% 0.01 265);--r:0.75rem;--r-lg:1rem;--ease-out:cubic-bezier(0.22,1,0.36,1);--dur-base:250ms;--dur-slow:500ms;--font:'Inter',system-ui,sans-serif;--font-mono:'JetBrains Mono',monospace}
+@media(prefers-color-scheme:dark){:root{--bg:oklch(8% 0.02 265);--surface:oklch(12% 0.02 265);--surface-up:oklch(16% 0.02 265);--fg:oklch(96% 0.01 95);--fg-muted:oklch(65% 0.01 265);--fg-dim:oklch(45% 0.01 265);--primary:oklch(62% 0.21 265);--primary-up:oklch(68% 0.21 265);--primary-glow:oklch(62% 0.15 265);--ok:oklch(62% 0.18 155);--err:oklch(62% 0.22 25);--border:oklch(22% 0.02 265);--border-faint:oklch(15% 0.01 265)}}
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:var(--bg);color:var(--fg);font-family:var(--font);min-height:100vh;padding:clamp(1.5rem,4vw,3rem) clamp(1rem,3vw,2rem);position:relative}
+@media(prefers-color-scheme:dark){body::after{content:'';position:fixed;inset:0;pointer-events:none;opacity:.03;background:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}}
+.container{max-width:1200px;margin:0 auto}
+header{display:flex;align-items:center;gap:1rem;margin-bottom:clamp(1.5rem,4vw,3rem);padding-bottom:1.25rem;border-bottom:1px solid var(--border)}
+.header-icon{width:36px;height:36px;display:grid;place-items:center;background:linear-gradient(135deg,oklch(100% 0 0/.06),oklch(100% 0 0/.02));backdrop-filter:blur(12px);border:1px solid oklch(100% 0 0/.1);border-radius:var(--r);flex-shrink:0}
+.header-icon svg{color:var(--primary)}
+h1{font-size:clamp(1.25rem,2.5vw,1.625rem);font-weight:700;letter-spacing:-.03em;background:linear-gradient(135deg,var(--fg),var(--fg-muted));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.meta{color:var(--fg-dim);font-size:.8125rem;margin-top:.15rem;letter-spacing:.01em}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(min(480px,100%),1fr));gap:1.5rem}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;transition:border-color var(--dur-base) var(--ease-out),box-shadow var(--dur-base) var(--ease-out),transform var(--dur-base) var(--ease-out)}
+.card:hover{border-color:var(--primary);box-shadow:0 4px 16px oklch(0% 0 0/.1);transform:translateY(-2px)}
+.video-wrap{position:relative;background:var(--surface);border-bottom:1px solid var(--border-faint)}
+.video-wrap video{width:100%;display:block;aspect-ratio:16/9;object-fit:contain}
+.card-body{padding:.75rem 1rem;display:flex;align-items:center;justify-content:space-between}
+.platform{display:flex;align-items:center;gap:.5rem;font-weight:600;font-size:.9375rem;letter-spacing:-.01em}
+.icon{font-size:1.125rem}
+.links{display:flex;gap:.5rem}
+.dl{color:var(--fg-muted);text-decoration:none;font-size:.75rem;font-weight:500;display:inline-flex;align-items:center;gap:.3rem;padding:.25rem .6rem;border-radius:9999px;border:1px solid var(--border);background:oklch(100% 0 0/.03);transition:all var(--dur-base) var(--ease-out)}
+.dl:hover{color:var(--primary-up);border-color:var(--primary);background:oklch(62% 0.21 265/.08)}
+.badge{font-size:.6875rem;font-weight:600;padding:.2rem .625rem;border-radius:9999px;text-transform:uppercase;letter-spacing:.05em}
+.card-header{padding:.75rem 1rem;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--border-faint)}
+.comparison{display:grid;grid-template-columns:1fr 1fr;gap:0}
+.comp-panel{border-right:1px solid var(--border-faint)}
+.comp-panel:last-child{border-right:none}
+.comp-label{padding:.4rem .75rem;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--fg-muted);background:var(--surface);display:flex;align-items:center;gap:.4rem}
+.comp-tag{font-size:.6rem;padding:.1rem .4rem;border-radius:9999px;font-weight:600}
+.comp-panel:first-child .comp-tag{background:oklch(65% 0.01 265/.15);color:var(--fg-muted);border:1px solid var(--border)}
+.comp-panel:last-child .comp-tag{background:oklch(62% 0.18 155/.15);color:var(--ok);border:1px solid oklch(62% 0.18 155/.25)}
+.comp-dl{padding:.4rem .75rem;display:flex;justify-content:center}
+.report{border-top:1px solid var(--border-faint);padding:.75rem 1rem;font-size:.8125rem}
+.report summary{cursor:pointer;color:var(--fg-muted);font-weight:500;display:flex;align-items:center;gap:.4rem;user-select:none;transition:color var(--dur-base) var(--ease-out)}
+.report summary:hover{color:var(--fg)}
+.report summary svg{flex-shrink:0;opacity:.5}
+.report[open] summary{margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--border-faint)}
+.report-body{line-height:1.7;color:oklch(80% 0.01 265);overflow-x:auto}
+.report-body h1,.report-body h2{margin:1.25rem 0 .5rem;color:var(--fg);font-size:1rem;font-weight:600;letter-spacing:-.02em;border-bottom:1px solid var(--border-faint);padding-bottom:.4rem}
+.report-body h3{margin:.75rem 0 .4rem;color:var(--fg);font-size:.875rem;font-weight:600}
+.report-body p{margin:.4rem 0}
+.report-body ul,.report-body ol{margin:.4rem 0 .4rem 1.5rem}
+.report-body li{margin:.25rem 0}
+.report-body code{background:var(--surface-up);padding:.125rem .375rem;border-radius:.25rem;font-size:.7rem;font-family:var(--font-mono);border:1px solid var(--border-faint)}
+.report-body h3+p>code:first-child{background:oklch(62% 0.22 25/.15);color:var(--err);border-color:oklch(62% 0.22 25/.25)}
+.report-body h3+p>code:nth-child(2){background:oklch(62% 0.21 265/.15);color:var(--primary-up);border-color:oklch(62% 0.21 265/.25)}
+.report-body h3+p>code:nth-child(3){background:oklch(65% 0.01 265/.15);color:var(--fg-muted);border-color:var(--border)}
+.report-body table{width:100%;border-collapse:collapse;margin:.75rem 0;font-size:.75rem;border:1px solid var(--border);border-radius:var(--r);overflow:hidden}
+.report-body th,.report-body td{border:1px solid var(--border-faint);padding:.5rem .75rem;text-align:left;vertical-align:top;word-wrap:break-word}
+.report-body th{background:var(--surface-up);color:var(--fg);font-weight:600;font-size:.6875rem;text-transform:uppercase;letter-spacing:.05em;position:sticky;top:0;white-space:nowrap}
+.report-body tr:nth-child(even){background:color-mix(in oklch,var(--surface) 50%,transparent)}
+.report-body tr:hover{background:color-mix(in oklch,var(--surface-up) 50%,transparent)}
+.report-body strong{color:var(--fg)}
+.report-body hr{border:none;border-top:1px solid var(--border-faint);margin:1rem 0}
+@keyframes fade-up{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:translateY(0)}}
+.reveal{animation:fade-up var(--dur-slow) var(--ease-out) both;animation-delay:calc(var(--i,0) * 120ms)}
+@media(prefers-reduced-motion:reduce){.reveal{animation:none}}
+@media(max-width:480px){.grid{grid-template-columns:1fr}.card-body{flex-wrap:wrap;gap:.5rem}}
+.sha{color:var(--primary);text-decoration:none;font-family:var(--font-mono);font-size:.75rem;font-weight:500;padding:.1rem .4rem;border-radius:.25rem;background:oklch(62% 0.21 265/.08);border:1px solid oklch(62% 0.21 265/.15);transition:all var(--dur-base) var(--ease-out)}
+.sha:hover{background:oklch(62% 0.21 265/.15);border-color:var(--primary)}
+.badge-bar{display:flex;align-items:center;gap:.5rem;margin-bottom:1rem}
+.badge-img{height:20px;display:block}
+.copy-badge{background:oklch(100% 0 0/.06);border:1px solid var(--border);color:var(--fg-muted);padding:.3rem .4rem;border-radius:var(--r);cursor:pointer;display:inline-flex;align-items:center;transition:all var(--dur-base) var(--ease-out)}
+.copy-badge:hover{color:var(--primary-up);border-color:var(--primary);background:oklch(62% 0.21 265/.1)}
+.copy-badge.copied{color:var(--ok);border-color:var(--ok)}
+.vseek{width:100%;padding:0 .75rem;background:var(--surface);border-top:1px solid var(--border-faint);position:relative;height:24px;display:flex;align-items:center}
+.vseek input[type=range]{-webkit-appearance:none;appearance:none;width:100%;height:4px;background:var(--border);border-radius:2px;outline:none;cursor:pointer;position:relative;z-index:2}
+.vseek input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:var(--primary);cursor:pointer;border:2px solid var(--bg);box-shadow:0 0 4px oklch(0% 0 0/.3)}
+.vseek input[type=range]::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:var(--primary);cursor:pointer;border:2px solid var(--bg)}
+.vseek .vbuf{position:absolute;left:.75rem;right:.75rem;height:4px;border-radius:2px;pointer-events:none;top:50%;transform:translateY(-50%)}
+.vseek .vbuf-bar{height:100%;background:oklch(62% 0.21 265/.25);border-radius:2px;transition:width 200ms linear}
+.vctrl{display:flex;align-items:center;gap:.375rem;padding:.5rem .75rem;background:var(--surface);border-top:1px solid var(--border-faint);flex-wrap:wrap}
+.vctrl button{background:oklch(100% 0 0/.06);border:1px solid var(--border);color:var(--fg-muted);font-size:.6875rem;font-weight:600;font-family:var(--font-mono);padding:.25rem .5rem;border-radius:.25rem;cursor:pointer;transition:all var(--dur-base) var(--ease-out);white-space:nowrap}
+.vctrl button:hover{color:var(--primary-up);border-color:var(--primary);background:oklch(62% 0.21 265/.1)}
+.vctrl button.active{color:var(--primary);border-color:var(--primary);background:oklch(62% 0.21 265/.15)}
+.vctrl .vtime{font-family:var(--font-mono);font-size:.6875rem;color:var(--fg-dim);min-width:10ch;text-align:center}
+.vctrl .vsep{width:1px;height:1rem;background:var(--border);flex-shrink:0}
+.vctrl .vhint{font-size:.6rem;color:var(--fg-dim);margin-left:auto}
+.purpose{background:linear-gradient(135deg,oklch(100% 0 0/.04),oklch(100% 0 0/.02));border:1px solid oklch(100% 0 0/.08);border-radius:var(--r-lg);padding:1rem 1.25rem;margin-bottom:1.5rem;font-size:.85rem;line-height:1.7;color:oklch(80% 0.01 265)}
+.purpose strong{color:var(--fg);font-weight:600}
+.purpose .purpose-label{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--fg-muted);margin-bottom:.4rem}
+.purpose .purpose-reqs{margin-top:.75rem;padding-top:.75rem;border-top:1px solid oklch(100% 0 0/.06);font-size:.8rem;color:oklch(70% 0.01 265);line-height:1.8}
+</style></head><body><div class=container>
+<header><div class=header-icon><svg width=20 height=20 viewBox="0 0 24 24" fill=none stroke=currentColor stroke-width=2 stroke-linecap=round stroke-linejoin=round><polygon points="23 7 16 12 23 17 23 7"/><rect x=1 y=5 width=15 height=14 rx=2 ry=2/></svg></div><div><h1>QA Session Recordings</h1><div class=meta>ComfyUI Frontend &middot; Automated QA{{COMMIT_HTML}}{{RUN_LINK}}{{TIMING_HTML}}</div>{{BADGE_HTML}}</div></header>
+{{PURPOSE_HTML}}<div class=grid>{{CARDS}}</div>
+</div><script>
+function copyBadge(){const u=location.href.replace(/\/[^/]*$/,'/');const b=u+'badge.svg';const md='[![QA Badge]('+b+')]('+u+')';navigator.clipboard.writeText(md).then(()=>{const btn=document.querySelector('.copy-badge');btn.classList.add('copied');btn.innerHTML='<svg width=14 height=14 viewBox="0 0 24 24" fill=none stroke=currentColor stroke-width=2><polyline points="20 6 9 17 4 12"/></svg>';setTimeout(()=>{btn.classList.remove('copied');btn.innerHTML='<svg width=14 height=14 viewBox="0 0 24 24" fill=none stroke=currentColor stroke-width=2><rect x=9 y=9 width=13 height=13 rx=2/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>'},2000)})}
+document.querySelectorAll('[data-md]').forEach(el=>{const t=el.textContent;el.removeAttribute('data-md');el.innerHTML=marked.parse(t)});
+const FPS=30,FT=1/FPS,SPEEDS=[0.1,0.25,0.5,1,1.5,2];
+document.querySelectorAll('.video-wrap video').forEach(v=>{
+  v.playbackRate=0.5;v.removeAttribute('autoplay');v.pause();
+  const c=document.createElement('div');c.className='vctrl';
+  const btn=(label,fn)=>{const b=document.createElement('button');b.textContent=label;b.onclick=fn;c.appendChild(b);return b};
+  const sep=()=>{const s=document.createElement('div');s.className='vsep';c.appendChild(s)};
+  const time=document.createElement('span');time.className='vtime';time.textContent='0:00.000';
+  btn('\u23EE',()=>{v.currentTime=0});
+  btn('\u25C0\u25C0',()=>{v.currentTime=Math.max(0,v.currentTime-FT*10)});
+  btn('\u25C0',()=>{v.pause();v.currentTime=Math.max(0,v.currentTime-FT)});
+  const playBtn=btn('\u25B6',()=>{v.paused?v.play():v.pause()});
+  btn('\u25B6\u25B6',()=>{v.pause();v.currentTime+=FT});
+  btn('\u25B6\u25B6\u25B6',()=>{v.currentTime+=FT*10});
+  sep();
+  const spdBtns=SPEEDS.map(s=>{const b=btn(s+'x',()=>{v.playbackRate=s;spdBtns.forEach(x=>x.classList.remove('active'));b.classList.add('active')});if(s===0.5)b.classList.add('active');return b});
+  sep();c.appendChild(time);
+  const hint=document.createElement('span');hint.className='vhint';hint.textContent='\u2190\u2192 frame \u2022 space play';c.appendChild(hint);
+  // Custom seekbar — works even without server range request support
+  const seekWrap=document.createElement('div');seekWrap.className='vseek';
+  const seekBar=document.createElement('input');seekBar.type='range';seekBar.min=0;seekBar.max=1000;seekBar.value=0;seekBar.step=1;
+  const bufWrap=document.createElement('div');bufWrap.className='vbuf';
+  const bufBar=document.createElement('div');bufBar.className='vbuf-bar';bufBar.style.width='0%';
+  bufWrap.appendChild(bufBar);seekWrap.appendChild(bufWrap);seekWrap.appendChild(seekBar);
+  let seeking=false;
+  seekBar.oninput=()=>{seeking=true;if(v.duration){v.currentTime=v.duration*(seekBar.value/1000)}};
+  seekBar.onchange=()=>{seeking=false};
+  v.closest('.video-wrap').after(seekWrap);
+  seekWrap.after(c);
+  v.ontimeupdate=()=>{
+    const m=Math.floor(v.currentTime/60),s=Math.floor(v.currentTime%60),ms=Math.floor((v.currentTime%1)*1000);
+    time.textContent=m+':'+(s<10?'0':'')+s+'.'+String(ms).padStart(3,'0');
+    if(!seeking&&v.duration){seekBar.value=Math.round((v.currentTime/v.duration)*1000)}
+  };
+  v.onprogress=v.onloadeddata=()=>{if(v.buffered.length&&v.duration){bufBar.style.width=(v.buffered.end(v.buffered.length-1)/v.duration*100)+'%'}};
+  v.onplay=()=>{playBtn.textContent='\u23F8'};v.onpause=()=>{playBtn.textContent='\u25B6'};
+  v.parentElement.addEventListener('keydown',e=>{
+    if(e.key==='ArrowLeft'){e.preventDefault();v.pause();v.currentTime=Math.max(0,v.currentTime-FT)}
+    if(e.key==='ArrowRight'){e.preventDefault();v.pause();v.currentTime+=FT}
+    if(e.key===' '){e.preventDefault();v.paused?v.play():v.pause()}
+  });
+  v.parentElement.setAttribute('tabindex','0');
+});
+</script></body></html>

--- a/scripts/qa-reproduce.ts
+++ b/scripts/qa-reproduce.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env tsx
+/**
+ * QA Reproduce Phase — Deterministic replay of research plan with narration
+ *
+ * Takes a reproduction plan from the research phase and replays it:
+ * 1. Execute each action deterministically (no AI decisions)
+ * 2. Capture a11y snapshot before/after each action
+ * 3. Gemini describes what visually changed (narration for humans)
+ * 4. Output: narration-log.json with full evidence chain
+ */
+
+import type { Page } from '@playwright/test'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { mkdirSync, writeFileSync } from 'fs'
+
+import type { ActionResult } from './qa-record.js'
+
+// ── Types ──
+
+interface ReproductionStep {
+  action: Record<string, unknown> & { action: string }
+  expectedAssertion: string
+}
+
+interface NarrationEntry {
+  step: number
+  action: string
+  params: Record<string, unknown>
+  result: ActionResult
+  a11yBefore: unknown
+  a11yAfter: unknown
+  assertionExpected: string
+  assertionPassed: boolean
+  assertionActual: string
+  geminiNarration: string
+  timestampMs: number
+}
+
+export interface NarrationLog {
+  entries: NarrationEntry[]
+  allAssertionsPassed: boolean
+}
+
+interface ReproduceOptions {
+  page: Page
+  plan: ReproductionStep[]
+  geminiApiKey: string
+  outputDir: string
+}
+
+// ── A11y helpers ──
+
+interface A11yNode {
+  role: string
+  name: string
+  value?: string
+  checked?: boolean
+  disabled?: boolean
+  expanded?: boolean
+  children?: A11yNode[]
+}
+
+function searchA11y(node: A11yNode | null, selector: string): A11yNode | null {
+  if (!node) return null
+  const sel = selector.toLowerCase()
+  if (
+    node.name?.toLowerCase().includes(sel) ||
+    node.role?.toLowerCase().includes(sel)
+  ) {
+    return node
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      const found = searchA11y(child, selector)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+function summarizeA11y(node: A11yNode | null): string {
+  if (!node) return 'null'
+  const parts = [`role=${node.role}`, `name="${node.name}"`]
+  if (node.value !== undefined) parts.push(`value="${node.value}"`)
+  if (node.checked !== undefined) parts.push(`checked=${node.checked}`)
+  if (node.disabled) parts.push('disabled')
+  if (node.expanded !== undefined) parts.push(`expanded=${node.expanded}`)
+  return `{${parts.join(', ')}}`
+}
+
+// ── Subtitle overlay ──
+
+async function showSubtitle(page: Page, text: string, step: number) {
+  const encoded = encodeURIComponent(
+    text.slice(0, 120).replace(/'/g, "\\'").replace(/\n/g, ' ')
+  )
+  await page.addScriptTag({
+    content: `(function(){
+      var id='qa-subtitle';
+      var el=document.getElementById(id);
+      if(!el){
+        el=document.createElement('div');
+        el.id=id;
+        Object.assign(el.style,{position:'fixed',bottom:'32px',left:'50%',transform:'translateX(-50%)',zIndex:'2147483646',maxWidth:'90%',padding:'6px 14px',borderRadius:'6px',background:'rgba(0,0,0,0.8)',color:'rgba(255,255,255,0.95)',fontSize:'12px',fontFamily:'system-ui,sans-serif',fontWeight:'400',lineHeight:'1.4',pointerEvents:'none',textAlign:'center',whiteSpace:'normal'});
+        document.body.appendChild(el);
+      }
+      el.textContent='['+${step}+'] '+decodeURIComponent('${encoded}');
+    })()`
+  })
+}
+
+// ── Gemini visual narration ──
+
+async function geminiDescribe(
+  page: Page,
+  geminiApiKey: string,
+  focus: string
+): Promise<string> {
+  try {
+    const screenshot = await page.screenshot({ type: 'jpeg', quality: 70 })
+    const genAI = new GoogleGenerativeAI(geminiApiKey)
+    const model = genAI.getGenerativeModel({ model: 'gemini-3-flash-preview' })
+
+    const result = await model.generateContent([
+      {
+        text: `Describe in 1-2 sentences what you see on this ComfyUI screen. Focus on: ${focus}. Be factual — only describe what is visible.`
+      },
+      {
+        inlineData: {
+          mimeType: 'image/jpeg',
+          data: screenshot.toString('base64')
+        }
+      }
+    ])
+    return result.response.text().trim()
+  } catch (e) {
+    return `(Gemini narration failed: ${e instanceof Error ? e.message.slice(0, 50) : e})`
+  }
+}
+
+// ── Main reproduce function ──
+
+export async function runReproducePhase(
+  opts: ReproduceOptions
+): Promise<NarrationLog> {
+  const { page, plan, geminiApiKey, outputDir } = opts
+  const { executeAction } = await import('./qa-record.js')
+
+  const narrationDir = `${outputDir}/narration`
+  mkdirSync(narrationDir, { recursive: true })
+
+  const entries: NarrationEntry[] = []
+  const startMs = Date.now()
+
+  console.warn(`Reproduce phase: replaying ${plan.length} steps...`)
+
+  for (let i = 0; i < plan.length; i++) {
+    const step = plan[i]
+    const actionObj = step.action
+    const elapsed = Date.now() - startMs
+
+    // Show subtitle
+    await showSubtitle(page, `Step ${i + 1}: ${actionObj.action}`, i + 1)
+    console.warn(`  [${i + 1}/${plan.length}] ${actionObj.action}`)
+
+    // Capture a11y BEFORE
+    const a11yBefore = await page
+      .locator('body')
+      .ariaSnapshot({ timeout: 3000 })
+      .catch(() => null)
+
+    // Execute action
+    const result = await executeAction(
+      page,
+      actionObj as Parameters<typeof executeAction>[1],
+      outputDir
+    )
+    await new Promise((r) => setTimeout(r, 500))
+
+    // Capture a11y AFTER
+    const a11yAfter = await page
+      .locator('body')
+      .ariaSnapshot({ timeout: 3000 })
+      .catch(() => null)
+
+    // Check assertion
+    let assertionPassed = false
+    let assertionActual = ''
+    if (step.expectedAssertion) {
+      // Parse the expected assertion — e.g. "Settings dialog: visible" or "tab count: 2"
+      const parts = step.expectedAssertion.split(':').map((s) => s.trim())
+      const selectorName = parts[0]
+      const expectedState = parts.slice(1).join(':').trim()
+
+      const found = searchA11y(a11yAfter as A11yNode | null, selectorName)
+      assertionActual = found ? summarizeA11y(found) : 'NOT FOUND'
+
+      if (expectedState === 'visible' || expectedState === 'exists') {
+        assertionPassed = found !== null
+      } else if (expectedState === 'hidden' || expectedState === 'gone') {
+        assertionPassed = found === null
+      } else {
+        // Generic: check if the actual state contains the expected text
+        assertionPassed = assertionActual
+          .toLowerCase()
+          .includes(expectedState.toLowerCase())
+      }
+
+      console.warn(
+        `    Assertion: "${step.expectedAssertion}" → ${assertionPassed ? '✓ PASS' : '✗ FAIL'} (actual: ${assertionActual})`
+      )
+    }
+
+    // Gemini narration (visual description for humans)
+    const geminiNarration = await geminiDescribe(
+      page,
+      geminiApiKey,
+      `What changed after ${actionObj.action}?`
+    )
+
+    entries.push({
+      step: i + 1,
+      action: actionObj.action,
+      params: actionObj,
+      result,
+      a11yBefore,
+      a11yAfter,
+      assertionExpected: step.expectedAssertion,
+      assertionPassed,
+      assertionActual,
+      geminiNarration,
+      timestampMs: elapsed
+    })
+  }
+
+  // Final screenshot
+  await page.screenshot({ path: `${outputDir}/reproduce-final.png` })
+
+  const log: NarrationLog = {
+    entries,
+    allAssertionsPassed: entries.every((e) => e.assertionPassed)
+  }
+
+  writeFileSync(
+    `${narrationDir}/narration-log.json`,
+    JSON.stringify(log, null, 2)
+  )
+  console.warn(
+    `Reproduce phase complete: ${entries.filter((e) => e.assertionPassed).length}/${entries.length} assertions passed`
+  )
+
+  return log
+}

--- a/scripts/qa-video-review.test.ts
+++ b/scripts/qa-video-review.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractPlatformFromArtifactDirName,
+  pickLatestVideosByPlatform,
+  selectVideoCandidateByFile
+} from './qa-video-review'
+
+describe('extractPlatformFromArtifactDirName', () => {
+  it('extracts and normalizes known qa artifact directory names', () => {
+    expect(
+      extractPlatformFromArtifactDirName('qa-report-Windows-22818315023')
+    ).toBe('windows')
+    expect(
+      extractPlatformFromArtifactDirName('qa-report-macOS-22818315023')
+    ).toBe('macos')
+    expect(
+      extractPlatformFromArtifactDirName('qa-report-Linux-22818315023')
+    ).toBe('linux')
+  })
+
+  it('falls back to slugifying unknown directory names', () => {
+    expect(extractPlatformFromArtifactDirName('custom platform run')).toBe(
+      'custom-platform-run'
+    )
+  })
+})
+
+describe('pickLatestVideosByPlatform', () => {
+  it('keeps only the latest candidate per platform', () => {
+    const selected = pickLatestVideosByPlatform([
+      {
+        platformName: 'windows',
+        videoPath: '/tmp/windows-old.mp4',
+        mtimeMs: 100
+      },
+      {
+        platformName: 'windows',
+        videoPath: '/tmp/windows-new.mp4',
+        mtimeMs: 200
+      },
+      {
+        platformName: 'linux',
+        videoPath: '/tmp/linux.mp4',
+        mtimeMs: 150
+      }
+    ])
+
+    expect(selected).toEqual([
+      {
+        platformName: 'linux',
+        videoPath: '/tmp/linux.mp4',
+        mtimeMs: 150
+      },
+      {
+        platformName: 'windows',
+        videoPath: '/tmp/windows-new.mp4',
+        mtimeMs: 200
+      }
+    ])
+  })
+})
+
+describe('selectVideoCandidateByFile', () => {
+  it('selects a single candidate by artifacts-relative path', () => {
+    const selected = selectVideoCandidateByFile(
+      [
+        {
+          platformName: 'windows',
+          videoPath: '/tmp/qa-artifacts/qa-report-Windows-1/qa-session.mp4',
+          mtimeMs: 100
+        },
+        {
+          platformName: 'linux',
+          videoPath: '/tmp/qa-artifacts/qa-report-Linux-1/qa-session.mp4',
+          mtimeMs: 200
+        }
+      ],
+      {
+        artifactsDir: '/tmp/qa-artifacts',
+        videoFile: 'qa-report-Linux-1/qa-session.mp4'
+      }
+    )
+
+    expect(selected).toEqual({
+      platformName: 'linux',
+      videoPath: '/tmp/qa-artifacts/qa-report-Linux-1/qa-session.mp4',
+      mtimeMs: 200
+    })
+  })
+
+  it('throws when basename matches multiple videos', () => {
+    expect(() =>
+      selectVideoCandidateByFile(
+        [
+          {
+            platformName: 'windows',
+            videoPath: '/tmp/qa-artifacts/qa-report-Windows-1/qa-session.mp4',
+            mtimeMs: 100
+          },
+          {
+            platformName: 'linux',
+            videoPath: '/tmp/qa-artifacts/qa-report-Linux-1/qa-session.mp4',
+            mtimeMs: 200
+          }
+        ],
+        {
+          artifactsDir: '/tmp/qa-artifacts',
+          videoFile: 'qa-session.mp4'
+        }
+      )
+    ).toThrow('matched 2 videos')
+  })
+
+  it('throws when there is no matching video', () => {
+    expect(() =>
+      selectVideoCandidateByFile(
+        [
+          {
+            platformName: 'windows',
+            videoPath: '/tmp/qa-artifacts/qa-report-Windows-1/qa-session.mp4',
+            mtimeMs: 100
+          }
+        ],
+        {
+          artifactsDir: '/tmp/qa-artifacts',
+          videoFile: 'qa-report-macOS-1/qa-session.mp4'
+        }
+      )
+    ).toThrow('No video matched')
+  })
+
+  it('throws when video file is missing', () => {
+    expect(() =>
+      selectVideoCandidateByFile(
+        [
+          {
+            platformName: 'windows',
+            videoPath: '/tmp/qa-artifacts/qa-report-Windows-1/qa-session.mp4',
+            mtimeMs: 100
+          }
+        ],
+        {
+          artifactsDir: '/tmp/qa-artifacts',
+          videoFile: '   '
+        }
+      )
+    ).toThrow('--video-file is required')
+  })
+})

--- a/scripts/qa-video-review.ts
+++ b/scripts/qa-video-review.ts
@@ -1,0 +1,765 @@
+#!/usr/bin/env tsx
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, extname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { globSync } from 'glob'
+
+interface CliOptions {
+  artifactsDir: string
+  videoFile: string
+  beforeVideo: string
+  outputDir: string
+  model: string
+  requestTimeoutMs: number
+  dryRun: boolean
+  prContext: string
+  targetUrl: string
+  passLabel: string
+}
+
+interface VideoCandidate {
+  platformName: string
+  videoPath: string
+  mtimeMs: number
+}
+
+const DEFAULT_OPTIONS: CliOptions = {
+  artifactsDir: './tmp/qa-artifacts',
+  videoFile: '',
+  beforeVideo: '',
+  outputDir: './tmp',
+  model: 'gemini-3-flash-preview',
+  requestTimeoutMs: 300_000,
+  dryRun: false,
+  prContext: '',
+  targetUrl: '',
+  passLabel: ''
+}
+
+const USAGE = `Usage:
+  pnpm exec tsx scripts/qa-video-review.ts [options]
+
+Options:
+  --artifacts-dir <path>        Artifacts root directory
+                                 (default: ./tmp/qa-artifacts)
+  --video-file <name-or-path>   Video file to analyze (required)
+                                 (supports basename or relative/absolute path)
+  --before-video <path>         Before video (main branch) for comparison
+                                 When provided, sends both videos to Gemini
+                                 for comparative before/after analysis
+  --output-dir <path>           Output directory for markdown reports
+                                 (default: ./tmp)
+  --model <name>                Gemini model
+                                 (default: gemini-3-flash-preview)
+  --request-timeout-ms <n>      Request timeout in milliseconds
+                                 (default: 300000)
+  --pr-context <file>           File with PR context (title, body, diff)
+                                 for PR-aware review
+  --target-url <url>            Issue or PR URL to include in the report
+  --pass-label <label>          Label for multi-pass reports (e.g. pass1)
+                                 Output becomes {platform}-{label}-qa-video-report.md
+  --dry-run                     Discover videos and output targets only
+  --help                        Show this help text
+
+Environment:
+  GEMINI_API_KEY                Required unless --dry-run
+`
+
+function parsePositiveInteger(rawValue: string, flagName: string): number {
+  const parsedValue = Number.parseInt(rawValue, 10)
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(`Invalid value for ${flagName}: "${rawValue}"`)
+  }
+  return parsedValue
+}
+
+function parseCliOptions(args: string[]): CliOptions {
+  const options: CliOptions = { ...DEFAULT_OPTIONS }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    const nextValue = args[index + 1]
+    const requireValue = (flagName: string): string => {
+      if (!nextValue || nextValue.startsWith('--')) {
+        throw new Error(`Missing value for ${flagName}`)
+      }
+      index += 1
+      return nextValue
+    }
+
+    if (argument === '--help') {
+      process.stdout.write(USAGE)
+      process.exit(0)
+    }
+
+    if (argument === '--artifacts-dir') {
+      options.artifactsDir = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--video-file') {
+      options.videoFile = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--output-dir') {
+      options.outputDir = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--model') {
+      options.model = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--request-timeout-ms') {
+      options.requestTimeoutMs = parsePositiveInteger(
+        requireValue(argument),
+        argument
+      )
+      continue
+    }
+
+    if (argument === '--before-video') {
+      options.beforeVideo = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--pr-context') {
+      options.prContext = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--target-url') {
+      options.targetUrl = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--pass-label') {
+      options.passLabel = requireValue(argument)
+      continue
+    }
+
+    if (argument === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${argument}`)
+  }
+
+  return options
+}
+
+function normalizePlatformName(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return slug.length > 0 ? slug : 'unknown-platform'
+}
+
+export function extractPlatformFromArtifactDirName(dirName: string): string {
+  const matchedValue = dirName.match(/^qa-report-(.+?)(?:-\d+)?$/i)?.[1]
+  return normalizePlatformName(matchedValue ?? dirName)
+}
+
+function extractPlatformFromVideoPath(videoPath: string): string {
+  const artifactDirName = basename(dirname(videoPath))
+  return extractPlatformFromArtifactDirName(artifactDirName)
+}
+
+export function pickLatestVideosByPlatform(
+  candidates: VideoCandidate[]
+): VideoCandidate[] {
+  const latestByPlatform = new Map<string, VideoCandidate>()
+
+  for (const candidate of candidates) {
+    const current = latestByPlatform.get(candidate.platformName)
+    if (!current || candidate.mtimeMs > current.mtimeMs) {
+      latestByPlatform.set(candidate.platformName, candidate)
+    }
+  }
+
+  return [...latestByPlatform.values()].sort((a, b) =>
+    a.platformName.localeCompare(b.platformName)
+  )
+}
+
+function toProjectRelativePath(targetPath: string): string {
+  const relativePath = relative(process.cwd(), targetPath)
+  if (relativePath.startsWith('.')) {
+    return relativePath
+  }
+  return `./${relativePath}`
+}
+
+function errorToString(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function normalizePathForMatch(value: string): string {
+  return value.replaceAll('\\', '/').replace(/^\.\/+/, '')
+}
+
+export function selectVideoCandidateByFile(
+  candidates: VideoCandidate[],
+  options: { artifactsDir: string; videoFile: string }
+): VideoCandidate {
+  const requestedValue = options.videoFile.trim()
+  if (requestedValue.length === 0) {
+    throw new Error('--video-file is required')
+  }
+
+  const artifactsRoot = resolve(options.artifactsDir)
+  const requestedAbsolutePath = resolve(requestedValue)
+  const requestedPathKey = normalizePathForMatch(requestedValue)
+
+  const matches = candidates.filter((candidate) => {
+    const candidateAbsolutePath = resolve(candidate.videoPath)
+    if (candidateAbsolutePath === requestedAbsolutePath) {
+      return true
+    }
+
+    const candidateBaseName = basename(candidate.videoPath)
+    if (candidateBaseName === requestedValue) {
+      return true
+    }
+
+    const relativeToCwd = normalizePathForMatch(
+      relative(process.cwd(), candidateAbsolutePath)
+    )
+    if (relativeToCwd === requestedPathKey) {
+      return true
+    }
+
+    const relativeToArtifacts = normalizePathForMatch(
+      relative(artifactsRoot, candidateAbsolutePath)
+    )
+    return relativeToArtifacts === requestedPathKey
+  })
+
+  if (matches.length === 1) {
+    return matches[0]
+  }
+
+  if (matches.length === 0) {
+    const availableVideos = candidates.map((candidate) =>
+      toProjectRelativePath(candidate.videoPath)
+    )
+    throw new Error(
+      [
+        `No video matched --video-file "${options.videoFile}".`,
+        'Available videos:',
+        ...availableVideos.map((videoPath) => `- ${videoPath}`)
+      ].join('\n')
+    )
+  }
+
+  throw new Error(
+    [
+      `--video-file "${options.videoFile}" matched ${matches.length} videos.`,
+      'Please pass a more specific path.',
+      ...matches.map((match) => `- ${toProjectRelativePath(match.videoPath)}`)
+    ].join('\n')
+  )
+}
+
+async function collectVideoCandidates(
+  artifactsDir: string
+): Promise<VideoCandidate[]> {
+  const absoluteArtifactsDir = resolve(artifactsDir)
+  const videoPaths = globSync('**/qa-session{,-[0-9]}.mp4', {
+    cwd: absoluteArtifactsDir,
+    absolute: true,
+    nodir: true
+  }).sort()
+
+  const candidates = await Promise.all(
+    videoPaths.map(async (videoPath) => {
+      const videoStat = await stat(videoPath)
+      return {
+        platformName: extractPlatformFromVideoPath(videoPath),
+        videoPath,
+        mtimeMs: videoStat.mtimeMs
+      }
+    })
+  )
+
+  return candidates
+}
+
+function getMimeType(filePath: string): string {
+  const ext = extname(filePath).toLowerCase()
+  const mimeMap: Record<string, string> = {
+    '.mp4': 'video/mp4',
+    '.webm': 'video/webm',
+    '.mov': 'video/quicktime',
+    '.avi': 'video/x-msvideo',
+    '.mkv': 'video/x-matroska',
+    '.m4v': 'video/mp4'
+  }
+  return mimeMap[ext] || 'video/mp4'
+}
+
+function buildReviewPrompt(options: {
+  platformName: string
+  videoPath: string
+  prContext: string
+  isComparative: boolean
+}): string {
+  const { platformName, videoPath, prContext, isComparative } = options
+
+  if (isComparative) {
+    return buildComparativePrompt(platformName, videoPath, prContext)
+  }
+
+  return buildSingleVideoPrompt(platformName, videoPath, prContext)
+}
+
+function buildComparativePrompt(
+  platformName: string,
+  videoPath: string,
+  prContext: string
+): string {
+  const lines = [
+    'You are a senior QA engineer performing a BEFORE/AFTER comparison review.',
+    '',
+    'You are given TWO videos:',
+    '- **Video 1 (BEFORE)**: The main branch BEFORE the PR. This shows the OLD behavior.',
+    '- **Video 2 (AFTER)**: The PR branch AFTER the changes. This shows the NEW behavior.',
+    '',
+    'Both videos show the same test steps executed on different code versions.',
+    ''
+  ]
+
+  if (prContext) {
+    lines.push('## PR Context', prContext, '')
+  }
+
+  lines.push(
+    '## Your Task',
+    `Platform: "${platformName}". After video: ${toProjectRelativePath(videoPath)}.`,
+    '',
+    '1. **BEFORE video**: Does it demonstrate the old behavior or bug that the PR aims to fix?',
+    '   Describe what you observe — this establishes the baseline.',
+    '2. **AFTER video**: Does it prove the PR fix works? Is the intended new behavior visible?',
+    '3. **Comparison**: What specifically changed between before and after?',
+    '4. **Regressions**: Did the PR introduce any new problems visible in the AFTER video',
+    '   that were NOT present in the BEFORE video?',
+    '',
+    'Note: Brief black frames during page transitions are NORMAL.',
+    'Note: Small cyan/purple dashed labels prefixed with "QA:" are annotations placed by the automated test script — they are NOT part of the application UI. Do not treat them as bugs or evidence.',
+    'Report only concrete, visible differences. Avoid speculation.',
+    '',
+    'Return markdown with these sections exactly:',
+    '## Summary',
+    '(What the PR changes, whether BEFORE confirms the old behavior, whether AFTER proves the fix)',
+    '',
+    '## Behavior Changes',
+    'Summarize ALL behavioral differences as a markdown TABLE:',
+    '| Behavior | Before (main) | After (PR) | Verdict |',
+    '',
+    '- **Behavior**: short name for the behavior (e.g. "Save shortcut label", "Menu hover style")',
+    '- **Before (main)**: how it works/looks in the BEFORE video',
+    '- **After (PR)**: how it works/looks in the AFTER video',
+    '- **Verdict**: `Fixed`, `Improved`, `Changed`, `Regression`, or `No Change`',
+    '',
+    'One row per distinct behavior. Include both changed AND unchanged key behaviors',
+    'that were tested, so reviewers can confirm nothing was missed.',
+    '',
+    '## Timeline Comparison',
+    'Present a chronological frame-by-frame comparison as a markdown TABLE:',
+    '| Time | Type | Severity | Before (main) | After (PR) |',
+    '',
+    '- **Time**: timestamp or range from the videos (e.g. `0:05-0:08`)',
+    '- **Type**: category such as `Visual`, `Behavior`, `Layout`, `Text`, `Animation`, `Menu`, `State`',
+    '- **Severity**: `None` (neutral change), `Fixed` (bug resolved), `Regression`, `Minor`, `Major`',
+    '- **Before (main)**: what is observed in the BEFORE video at that time',
+    '- **After (PR)**: what is observed in the AFTER video at that time',
+    '',
+    'Include one row per distinct observable difference. If behavior is identical at a timestamp,',
+    'omit that row. Focus on meaningful differences, not narrating every frame.',
+    '',
+    '## Confirmed Issues',
+    'For each issue, use this exact format:',
+    '',
+    '### [Short issue title]',
+    '`SEVERITY` `TIMESTAMP` `Confidence: LEVEL`',
+    '',
+    '[Description — specify whether it appears in BEFORE, AFTER, or both]',
+    '',
+    '**Evidence:** [What you observed at the given timestamp in which video]',
+    '',
+    '**Suggested Fix:** [Actionable recommendation]',
+    '',
+    '---',
+    '',
+    '## Possible Issues (Needs Human Verification)',
+    '## Overall Risk',
+    '(Assess whether the PR achieves its goal based on the before/after comparison)',
+    '',
+    '## Verdict',
+    'End your report with this EXACT JSON block (no markdown fence):',
+    '{"verdict": "REPRODUCED" | "NOT_REPRODUCIBLE" | "INCONCLUSIVE", "risk": "low" | "medium" | "high", "confidence": "high" | "medium" | "low"}',
+    '- REPRODUCED: the before video confirms the old behavior and the after video shows the fix working',
+    '- NOT_REPRODUCIBLE: the before video does not show the reported bug',
+    '- INCONCLUSIVE: the videos do not adequately demonstrate the behavior change'
+  )
+
+  return lines.filter(Boolean).join('\n')
+}
+
+function buildSingleVideoPrompt(
+  platformName: string,
+  videoPath: string,
+  prContext: string
+): string {
+  const lines = [
+    'You are a senior QA engineer reviewing a UI test session recording.',
+    '',
+    '## ANTI-HALLUCINATION RULES (READ FIRST)',
+    '- Describe ONLY what you can directly observe in the video frames',
+    '- NEVER infer or assume what "must have happened" between frames',
+    '- If a step is not visible in the video, say "NOT SHOWN" — do not guess',
+    '- Your job is to be a CAMERA — report facts, not interpretations',
+    ''
+  ]
+
+  const isIssueContext =
+    prContext &&
+    /^### Issue #|^Title:.*\bbug\b|^This video attempts to reproduce/im.test(
+      prContext
+    )
+
+  if (prContext) {
+    lines.push(
+      '## Phase 1: Blind Observation (describe what you SEE)',
+      'First, describe every UI interaction chronologically WITHOUT knowing the expected outcome:',
+      '- What elements does the user click/hover/type?',
+      '- What dialogs/menus open and close?',
+      '- What keyboard indicators appear? (look for subtitle overlays)',
+      '- What is the BEFORE state and AFTER state of each action?',
+      '',
+      '## Phase 2: Compare against expected behavior',
+      'Now compare your observations against the context below.',
+      'Only claim a match if your Phase 1 observations EXPLICITLY support it.',
+      ''
+    )
+
+    if (isIssueContext) {
+      lines.push(
+        '## Issue Context',
+        prContext,
+        '',
+        '## Comparison Questions',
+        '1. Did the video perform the reproduction steps described in the issue?',
+        '2. Did your Phase 1 observations show the reported bug behavior?',
+        '3. If the steps were not performed or the bug was not visible, say INCONCLUSIVE.',
+        ''
+      )
+    } else {
+      lines.push(
+        '## PR Context',
+        prContext,
+        '',
+        '## Comparison Questions',
+        '1. Did the video test the specific behavior the PR changes?',
+        '2. Did your Phase 1 observations show the expected before/after difference?',
+        '3. If the test was incomplete or inconclusive, say so honestly.',
+        ''
+      )
+    }
+  }
+
+  lines.push(
+    `Review this QA session video for platform "${platformName}".`,
+    `Source video: ${toProjectRelativePath(videoPath)}.`,
+    'The video shows the full test session — analyze it chronologically.',
+    'Focus on UI regressions, broken states, visual glitches, unreadable text, missing labels/i18n, and clear workflow failures.',
+    'Note: Brief black frames during page transitions are NORMAL and should NOT be reported as issues.',
+    'Note: Small cyan/purple dashed labels prefixed with "QA:" are annotations placed by the automated test script — they are NOT part of the application UI. Do not treat them as bugs or evidence.',
+    'Report only concrete, visible problems and avoid speculation.',
+    'If confidence is low, mark it explicitly.',
+    '',
+    'Return markdown with these sections exactly:',
+    '## Summary',
+    isIssueContext
+      ? '(Explain what bug was reported and whether the video confirms it is reproducible)'
+      : prContext
+        ? '(Explain what the PR intended and whether the video confirms it works)'
+        : '',
+    '## Confirmed Issues',
+    'For each confirmed issue, use this exact format (one block per issue):',
+    '',
+    '### [Short issue title]',
+    '`HIGH` `01:03` `Confidence: High`',
+    '',
+    '[Description of the issue — what went wrong and what was expected]',
+    '',
+    '**Evidence:** [What you observed in the video at the given timestamp]',
+    '',
+    '**Suggested Fix:** [Actionable recommendation]',
+    '',
+    '---',
+    '',
+    'The first line after the heading MUST be exactly three backtick-wrapped labels:',
+    '`SEVERITY` `TIMESTAMP` `Confidence: LEVEL`',
+    'Do NOT use a table for issues — use the block format above.',
+    '## Possible Issues (Needs Human Verification)',
+    '## Overall Risk',
+    '',
+    '## Verdict',
+    'End your report with this EXACT JSON block (no markdown fence):',
+    '{"verdict": "REPRODUCED" | "NOT_REPRODUCIBLE" | "INCONCLUSIVE", "risk": "low" | "medium" | "high" | null, "confidence": "high" | "medium" | "low"}',
+    '- REPRODUCED: the bug/behavior is clearly visible in the video',
+    '- NOT_REPRODUCIBLE: the steps were performed correctly but the bug was not observed',
+    '- INCONCLUSIVE: the reproduction steps were not performed or the video is insufficient'
+  )
+
+  return lines.filter(Boolean).join('\n')
+}
+
+const MAX_VIDEO_BYTES = 100 * 1024 * 1024
+
+async function readVideoFile(videoPath: string): Promise<Buffer> {
+  const fileStat = await stat(videoPath)
+  if (fileStat.size > MAX_VIDEO_BYTES) {
+    throw new Error(
+      `Video ${basename(videoPath)} is ${formatBytes(fileStat.size)}, exceeds ${formatBytes(MAX_VIDEO_BYTES)} limit`
+    )
+  }
+  return readFile(videoPath)
+}
+
+async function requestGeminiReview(options: {
+  apiKey: string
+  model: string
+  platformName: string
+  videoPath: string
+  beforeVideoPath: string
+  timeoutMs: number
+  prContext: string
+}): Promise<string> {
+  const genAI = new GoogleGenerativeAI(options.apiKey)
+  const model = genAI.getGenerativeModel({ model: options.model })
+
+  const isComparative = options.beforeVideoPath.length > 0
+  const prompt = buildReviewPrompt({
+    platformName: options.platformName,
+    videoPath: options.videoPath,
+    prContext: options.prContext,
+    isComparative
+  })
+
+  const parts: Array<
+    { text: string } | { inlineData: { mimeType: string; data: string } }
+  > = [{ text: prompt }]
+
+  if (isComparative) {
+    const beforeBuffer = await readVideoFile(options.beforeVideoPath)
+    parts.push(
+      { text: 'Video 1 — BEFORE (main branch):' },
+      {
+        inlineData: {
+          mimeType: getMimeType(options.beforeVideoPath),
+          data: beforeBuffer.toString('base64')
+        }
+      }
+    )
+  }
+
+  const afterBuffer = await readVideoFile(options.videoPath)
+  if (isComparative) {
+    parts.push({ text: 'Video 2 — AFTER (PR branch):' })
+  }
+  parts.push({
+    inlineData: {
+      mimeType: getMimeType(options.videoPath),
+      data: afterBuffer.toString('base64')
+    }
+  })
+
+  const result = await model.generateContent(parts, {
+    timeout: options.timeoutMs
+  })
+  const response = result.response
+  const text = response.text()
+
+  if (!text || text.trim().length === 0) {
+    throw new Error('Gemini API returned no output text')
+  }
+
+  return text.trim()
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function buildReportMarkdown(input: {
+  platformName: string
+  model: string
+  videoPath: string
+  videoSizeBytes: number
+  beforeVideoPath?: string
+  beforeVideoSizeBytes?: number
+  reviewText: string
+  targetUrl?: string
+}): string {
+  const headerLines = [
+    `# ${input.platformName} QA Video Report`,
+    '',
+    `- Generated at: ${new Date().toISOString()}`,
+    `- Model: \`${input.model}\``
+  ]
+
+  if (input.targetUrl) {
+    headerLines.push(`- Target: ${input.targetUrl}`)
+  }
+
+  if (input.beforeVideoPath) {
+    headerLines.push(
+      `- Before video: \`${toProjectRelativePath(input.beforeVideoPath)}\` (${formatBytes(input.beforeVideoSizeBytes ?? 0)})`,
+      `- After video: \`${toProjectRelativePath(input.videoPath)}\` (${formatBytes(input.videoSizeBytes)})`,
+      '- Mode: **Comparative (before/after)**'
+    )
+  } else {
+    headerLines.push(
+      `- Source video: \`${toProjectRelativePath(input.videoPath)}\``,
+      `- Video size: ${formatBytes(input.videoSizeBytes)}`
+    )
+  }
+
+  headerLines.push('', '## AI Review', '')
+  return `${headerLines.join('\n')}${input.reviewText.trim()}\n`
+}
+
+async function reviewVideo(
+  video: VideoCandidate,
+  options: CliOptions,
+  apiKey: string
+): Promise<void> {
+  let prContext = ''
+  if (options.prContext) {
+    try {
+      prContext = await readFile(options.prContext, 'utf-8')
+      process.stdout.write(
+        `[${video.platformName}] Loaded PR context from ${options.prContext}\n`
+      )
+    } catch {
+      process.stdout.write(
+        `[${video.platformName}] Warning: Could not read PR context file ${options.prContext}\n`
+      )
+    }
+  }
+
+  const beforeVideoPath = options.beforeVideo
+    ? resolve(options.beforeVideo)
+    : ''
+
+  if (beforeVideoPath) {
+    const beforeStat = await stat(beforeVideoPath)
+    process.stdout.write(
+      `[${video.platformName}] Before video: ${toProjectRelativePath(beforeVideoPath)} (${formatBytes(beforeStat.size)})\n`
+    )
+  }
+
+  process.stdout.write(
+    `[${video.platformName}] Sending ${beforeVideoPath ? '2 videos (comparative)' : 'video'} to ${options.model}\n`
+  )
+
+  const reviewText = await requestGeminiReview({
+    apiKey,
+    model: options.model,
+    platformName: video.platformName,
+    videoPath: video.videoPath,
+    beforeVideoPath,
+    timeoutMs: options.requestTimeoutMs,
+    prContext
+  })
+
+  const videoStat = await stat(video.videoPath)
+  const passSegment = options.passLabel ? `-${options.passLabel}` : ''
+  const outputPath = resolve(
+    options.outputDir,
+    `${video.platformName}${passSegment}-qa-video-report.md`
+  )
+
+  const reportInput: Parameters<typeof buildReportMarkdown>[0] = {
+    platformName: video.platformName,
+    model: options.model,
+    videoPath: video.videoPath,
+    videoSizeBytes: videoStat.size,
+    reviewText,
+    targetUrl: options.targetUrl || undefined
+  }
+
+  if (beforeVideoPath) {
+    const beforeStat = await stat(beforeVideoPath)
+    reportInput.beforeVideoPath = beforeVideoPath
+    reportInput.beforeVideoSizeBytes = beforeStat.size
+  }
+
+  const reportMarkdown = buildReportMarkdown(reportInput)
+
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, reportMarkdown, 'utf-8')
+
+  process.stdout.write(
+    `[${video.platformName}] Wrote ${toProjectRelativePath(outputPath)}\n`
+  )
+}
+
+function isExecutedAsScript(metaUrl: string): boolean {
+  const modulePath = fileURLToPath(metaUrl)
+  const scriptPath = process.argv[1] ? resolve(process.argv[1]) : ''
+  return modulePath === scriptPath
+}
+
+async function main(): Promise<void> {
+  const options = parseCliOptions(process.argv.slice(2))
+  const candidates = await collectVideoCandidates(options.artifactsDir)
+
+  if (candidates.length === 0) {
+    process.stdout.write(
+      `No qa-session.mp4 files found under ${toProjectRelativePath(resolve(options.artifactsDir))}\n`
+    )
+    return
+  }
+
+  const selectedVideo = selectVideoCandidateByFile(candidates, {
+    artifactsDir: options.artifactsDir,
+    videoFile: options.videoFile
+  })
+
+  process.stdout.write(
+    `Selected ${selectedVideo.platformName}: ${toProjectRelativePath(selectedVideo.videoPath)}\n`
+  )
+
+  if (options.dryRun) {
+    process.stdout.write('\nDry run mode enabled, no API calls were made.\n')
+    return
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY is required unless --dry-run is set')
+  }
+
+  await reviewVideo(selectedVideo, options, apiKey)
+}
+
+if (isExecutedAsScript(import.meta.url)) {
+  void main().catch((error: unknown) => {
+    const message = errorToString(error)
+    process.stderr.write(`qa-video-review failed: ${message}\n`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

Automated QA pipeline that uses Claude to write Playwright E2E tests reproducing reported bugs, records video evidence, and deploys results to Cloudflare Pages.

## Changes

- **What**: Three-phase QA pipeline triggered by GitHub labels (`qa-changes`, `qa-full`, `qa-issue`):
  1. **Research**: Claude writes Playwright tests to reproduce bugs using project fixtures
  2. **Reproduce**: Deterministic replay with Playwright video recording
  3. **Report**: Deploy badge + videos + AI review to Cloudflare Pages, post PR/issue comment
- **Dependencies**: `@google/generative-ai` and `@anthropic-ai/claude-agent-sdk` (installed inline in CI, not added to package.json)

### Files added (17 files, ~7.5k lines)

| File | Purpose |
|------|---------|
| `.github/workflows/pr-qa.yaml` | CI workflow (resolve-matrix → analyze → before/after → report) |
| `scripts/qa-agent.ts` | Research phase: Claude writes E2E tests via MCP tools |
| `scripts/qa-record.ts` | Video recording with Gemini-generated test steps |
| `scripts/qa-reproduce.ts` | Deterministic replay with a11y assertion checking |
| `scripts/qa-analyze-pr.ts` | PR/issue analysis to generate targeted QA guides |
| `scripts/qa-video-review.ts` | Gemini video review for human-readable reports |
| `scripts/qa-deploy-pages.sh` | Cloudflare Pages deployment with badge generation |
| `scripts/qa-generate-test.ts` | Generate regression tests from QA reports |
| `scripts/qa-report-template.html` | Report page template |
| `scripts/qa-batch.sh` | Batch runner for testing multiple issues |
| `.claude/skills/comfy-qa/SKILL.md` | Agent skill for running QA |
| `docs/qa/TROUBLESHOOTING.md` | Known failure modes and fixes |
| `docs/qa/backlog.md`, `models.md` | Planning docs |
| `knip.config.ts` | Ignore CI-only deps |

## Review Focus

- The pipeline uses label-triggered activation (`qa-changes`, `qa-full`, `qa-issue`) — no automatic runs
- QA deps are installed inline in CI steps (not in package.json) to avoid lockfile changes
- Playwright assertions are the source of truth for verdicts, not AI vision
- Trivial assertions (e.g., `count > 0`) are banned — tests must assert bug-specific behavior
- Main branch `dist/` is cached by SHA to speed up before/after comparisons
- Pre-existing knip failures (UniformSource, config hints) are unrelated to this PR

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10835-feat-add-automated-QA-pipeline-with-E2E-test-driven-bug-reproduction-3376d73d36508115b2f1d399bbe9a808) by [Unito](https://www.unito.io)
