### PR TITLE
fix: use getAssetFilename in ModelInfoPanel filename field

### DIFF
--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.test.ts
@@ -61,6 +61,15 @@ describe('ModelInfoPanel', () => {
       expect(wrapper.text()).toContain('my-model.safetensors')
     })
 
+    it('prefers user_metadata.filename over asset.name for filename field', () => {
+      const asset = createMockAsset({
+        name: 'registry-display-name',
+        user_metadata: { filename: 'checkpoints/real-file.safetensors' }
+      })
+      const wrapper = mountPanel(asset)
+      expect(wrapper.text()).toContain('checkpoints/real-file.safetensors')
+    })
+
     it('displays name from user_metadata when present', () => {
       const asset = createMockAsset({
         user_metadata: { name: 'My Custom Model' }

--- a/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
+++ b/src/platform/assets/components/modelInfo/ModelInfoPanel.vue
@@ -32,7 +32,9 @@
         </div>
       </ModelInfoField>
       <ModelInfoField :label="t('assetBrowser.modelInfo.fileName')">
-        <span class="break-all text-muted-foreground">{{ asset.name }}</span>
+        <span class="break-all text-muted-foreground">{{
+          getAssetFilename(asset)
+        }}</span>
       </ModelInfoField>
       <ModelInfoField
         v-if="sourceUrl"
@@ -232,6 +234,7 @@ import {
   getAssetBaseModels,
   getAssetDescription,
   getAssetDisplayName,
+  getAssetFilename,
   getAssetModelType,
   getAssetSourceUrl,
   getAssetTriggerPhrases,


### PR DESCRIPTION
# Summary

* Model Info sidebar panel displays `asset.name` (registry name) instead of the actual filename from `user_metadata.filename`
* Other UI components (asset cards, widgets, missing model scan) correctly use `getAssetFilename()` which prefers `user_metadata.filename` over `asset.name`
* One-line template fix: `{{ asset.name }}` → `{{ getAssetFilename(asset) }}`
* Fixes #10598 

# Bug

`ModelInfoPanel.vue:35` used raw `asset.name` for the "File Name" field. When `user_metadata.filename` differs from `asset.name` (e.g. registry name vs actual path like `checkpoints/v1-5-pruned.safetensors`), users see inconsistent filenames across the UI.

# AS-IS / TO-BE

<img width="800" height="600" alt="before-after-10598" src="https://github.com/user-attachments/assets/15beb6c8-4bad-4ed2-9c85-6f8c7c0b6d3e" />


| | File Name field shows |
| :--- | :--- |
| **AS-IS** (bug) | `sdxl-lightning-4step` — raw `asset.name` (registry display name) |
| **TO-BE** (fix) | `checkpoints/sdxl_lightning_4step.safetensors` — `getAssetFilename(asset)` (actual file path) |

# Red-Green Verification

| Commit | CI Status | Purpose |
| :--- | :--- | :--- |
| `test: add failing test for ModelInfoPanel showing wrong filename` | 🔴 Red | Proves the test catches the bug |
| `fix: use getAssetFilename in ModelInfoPanel filename field` | 🟢 Green | Proves the fix resolves the bug |

# Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [x] Unit test: `prefers user_metadata.filename over asset.name for filename field`
- [ ] Manual: open Asset Browser → click a model → verify File Name in Model Info panel matches the actual file path (requires `--enable-assets`)