### PR TITLE
fix: update upload dialog status when async download completes

### DIFF
--- a/src/platform/assets/composables/useUploadModelWizard.test.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.test.ts
@@ -1,0 +1,134 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import type { AsyncUploadResponse } from '@/platform/assets/schemas/assetSchema'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
+
+import { useUploadModelWizard } from './useUploadModelWizard'
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    uploadAssetAsync: vi.fn(),
+    uploadAssetPreviewImage: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/assets/importSources/civitaiImportSource', () => ({
+  civitaiImportSource: {
+    name: 'Civitai',
+    hostnames: ['civitai.com'],
+    fetchMetadata: vi.fn()
+  }
+}))
+
+vi.mock('@/platform/assets/importSources/huggingfaceImportSource', () => ({
+  huggingfaceImportSource: {
+    name: 'HuggingFace',
+    hostnames: ['huggingface.co'],
+    fetchMetadata: vi.fn()
+  }
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn(),
+    addEventListener: vi.fn(),
+    apiURL: vi.fn((path: string) => path)
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  st: (_key: string, fallback: string) => fallback,
+  t: (key: string) => key,
+  te: () => false,
+  d: (date: Date) => date.toISOString()
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+describe('useUploadModelWizard', () => {
+  const modelTypes = ref([{ name: 'Checkpoint', value: 'checkpoints' }])
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('updates uploadStatus to success when async download completes', async () => {
+    const { assetService } =
+      await import('@/platform/assets/services/assetService')
+
+    const asyncResponse: AsyncUploadResponse = {
+      type: 'async',
+      task: {
+        task_id: 'task-123',
+        status: 'created',
+        message: 'Download queued'
+      }
+    }
+    vi.mocked(assetService.uploadAssetAsync).mockResolvedValue(asyncResponse)
+
+    const wizard = useUploadModelWizard(modelTypes)
+    wizard.wizardData.value.url = 'https://civitai.com/models/12345'
+    wizard.selectedModelType.value = 'checkpoints'
+
+    await wizard.uploadModel()
+
+    expect(wizard.uploadStatus.value).toBe('processing')
+
+    // Simulate WebSocket: download completes
+    const downloadStore = useAssetDownloadStore()
+    downloadStore.$patch({})
+    const detail = {
+      task_id: 'task-123',
+      asset_id: 'asset-456',
+      asset_name: 'model.safetensors',
+      bytes_total: 1000,
+      bytes_downloaded: 1000,
+      progress: 100,
+      status: 'completed' as const
+    }
+    // Directly call the store's internal handler via the event system
+    const event = new CustomEvent('asset_download', { detail })
+    const { api } = await import('@/scripts/api')
+    const handler = vi
+      .mocked(api.addEventListener)
+      .mock.calls.find((c) => c[0] === 'asset_download')?.[1] as
+      | ((e: CustomEvent) => void)
+      | undefined
+
+    // If handler was registered, call it; otherwise set store state directly
+    if (handler) {
+      handler(event)
+    } else {
+      // Manually update store state as WS handler would
+      downloadStore.downloadList.push?.({
+        taskId: 'task-123',
+        assetId: 'asset-456',
+        assetName: 'model.safetensors',
+        bytesTotal: 1000,
+        bytesDownloaded: 1000,
+        progress: 100,
+        status: 'completed',
+        lastUpdate: Date.now(),
+        modelType: 'checkpoints'
+      })
+      downloadStore.$patch({
+        lastCompletedDownload: {
+          taskId: 'task-123',
+          modelType: 'checkpoints',
+          timestamp: Date.now()
+        }
+      })
+    }
+
+    await nextTick()
+
+    // BUG: uploadStatus should be 'success' but remains 'processing'
+    expect(wizard.uploadStatus.value).toBe('success')
+  })
+})

--- a/src/platform/assets/composables/useUploadModelWizard.test.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 
 import type { AsyncUploadResponse } from '@/platform/assets/schemas/assetSchema'
-import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 
 import { useUploadModelWizard } from './useUploadModelWizard'
 
@@ -81,8 +80,6 @@ describe('useUploadModelWizard', () => {
     expect(wizard.uploadStatus.value).toBe('processing')
 
     // Simulate WebSocket: download completes
-    const downloadStore = useAssetDownloadStore()
-    downloadStore.$patch({})
     const detail = {
       task_id: 'task-123',
       asset_id: 'asset-456',
@@ -92,7 +89,6 @@ describe('useUploadModelWizard', () => {
       progress: 100,
       status: 'completed' as const
     }
-    // Directly call the store's internal handler via the event system
     const event = new CustomEvent('asset_download', { detail })
     const { api } = await import('@/scripts/api')
     const handler = vi
@@ -100,35 +96,11 @@ describe('useUploadModelWizard', () => {
       .mock.calls.find((c) => c[0] === 'asset_download')?.[1] as
       | ((e: CustomEvent) => void)
       | undefined
-
-    // If handler was registered, call it; otherwise set store state directly
-    if (handler) {
-      handler(event)
-    } else {
-      // Manually update store state as WS handler would
-      downloadStore.downloadList.push?.({
-        taskId: 'task-123',
-        assetId: 'asset-456',
-        assetName: 'model.safetensors',
-        bytesTotal: 1000,
-        bytesDownloaded: 1000,
-        progress: 100,
-        status: 'completed',
-        lastUpdate: Date.now(),
-        modelType: 'checkpoints'
-      })
-      downloadStore.$patch({
-        lastCompletedDownload: {
-          taskId: 'task-123',
-          modelType: 'checkpoints',
-          timestamp: Date.now()
-        }
-      })
-    }
+    expect(handler).toBeDefined()
+    handler!(event)
 
     await nextTick()
 
-    // BUG: uploadStatus should be 'success' but remains 'processing'
     expect(wizard.uploadStatus.value).toBe('success')
   })
 
@@ -174,9 +146,8 @@ describe('useUploadModelWizard', () => {
       }
     })
 
-    if (handler) {
-      handler(failEvent)
-    }
+    expect(handler).toBeDefined()
+    handler!(failEvent)
 
     await nextTick()
 

--- a/src/platform/assets/composables/useUploadModelWizard.test.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.test.ts
@@ -131,4 +131,56 @@ describe('useUploadModelWizard', () => {
     // BUG: uploadStatus should be 'success' but remains 'processing'
     expect(wizard.uploadStatus.value).toBe('success')
   })
+
+  it('updates uploadStatus to error when async download fails', async () => {
+    const { assetService } =
+      await import('@/platform/assets/services/assetService')
+
+    const asyncResponse: AsyncUploadResponse = {
+      type: 'async',
+      task: {
+        task_id: 'task-fail',
+        status: 'created',
+        message: 'Download queued'
+      }
+    }
+    vi.mocked(assetService.uploadAssetAsync).mockResolvedValue(asyncResponse)
+
+    const wizard = useUploadModelWizard(modelTypes)
+    wizard.wizardData.value.url = 'https://civitai.com/models/99999'
+    wizard.selectedModelType.value = 'checkpoints'
+
+    await wizard.uploadModel()
+    expect(wizard.uploadStatus.value).toBe('processing')
+
+    // Simulate WebSocket: download fails
+    const { api } = await import('@/scripts/api')
+    const handler = vi
+      .mocked(api.addEventListener)
+      .mock.calls.find((c) => c[0] === 'asset_download')?.[1] as
+      | ((e: CustomEvent) => void)
+      | undefined
+
+    const failEvent = new CustomEvent('asset_download', {
+      detail: {
+        task_id: 'task-fail',
+        asset_id: '',
+        asset_name: 'model.safetensors',
+        bytes_total: 1000,
+        bytes_downloaded: 500,
+        progress: 50,
+        status: 'failed' as const,
+        error: 'Network error'
+      }
+    })
+
+    if (handler) {
+      handler(failEvent)
+    }
+
+    await nextTick()
+
+    expect(wizard.uploadStatus.value).toBe('error')
+    expect(wizard.uploadError.value).toBe('Network error')
+  })
 })

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -36,6 +36,7 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
   const isUploading = ref(false)
   const uploadStatus = ref<'processing' | 'success' | 'error'>()
   const uploadError = ref('')
+  let stopAsyncWatch: (() => void) | undefined
 
   const wizardData = ref<WizardData>({
     url: '',
@@ -203,6 +204,7 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
   }
 
   async function uploadModel(): Promise<boolean> {
+    if (isUploading.value) return false
     if (!canUploadModel.value) {
       return false
     }
@@ -248,7 +250,8 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
         }
         uploadStatus.value = 'processing'
 
-        const stopWatch = watch(
+        stopAsyncWatch?.()
+        stopAsyncWatch = watch(
           () =>
             assetDownloadStore.downloadList.find(
               (d) => d.taskId === result.task.task_id
@@ -257,7 +260,8 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
             if (status === 'completed') {
               uploadStatus.value = 'success'
               await refreshModelCaches()
-              stopWatch()
+              stopAsyncWatch?.()
+              stopAsyncWatch = undefined
             } else if (status === 'failed') {
               const download = assetDownloadStore.downloadList.find(
                 (d) => d.taskId === result.task.task_id
@@ -268,7 +272,8 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
                 t('assetBrowser.downloadFailed', {
                   name: download?.assetName || ''
                 })
-              stopWatch()
+              stopAsyncWatch?.()
+              stopAsyncWatch = undefined
             }
           }
         )
@@ -296,6 +301,8 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
   }
 
   function resetWizard() {
+    stopAsyncWatch?.()
+    stopAsyncWatch = undefined
     currentStep.value = 1
     isFetchingMetadata.value = false
     isUploading.value = false

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -263,7 +263,11 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
                 (d) => d.taskId === result.task.task_id
               )
               uploadStatus.value = 'error'
-              uploadError.value = download?.error || 'Download failed'
+              uploadError.value =
+                download?.error ||
+                t('assetBrowser.downloadFailed', {
+                  name: download?.assetName || ''
+                })
               stopWatch()
             }
           }

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -247,6 +247,17 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
           )
         }
         uploadStatus.value = 'processing'
+
+        const stopWatch = watch(
+          () => assetDownloadStore.lastCompletedDownload,
+          async (completed) => {
+            if (completed?.taskId === result.task.task_id) {
+              uploadStatus.value = 'success'
+              await refreshModelCaches()
+              stopWatch()
+            }
+          }
+        )
       } else {
         uploadStatus.value = 'success'
         await refreshModelCaches()

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -249,11 +249,21 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
         uploadStatus.value = 'processing'
 
         const stopWatch = watch(
-          () => assetDownloadStore.lastCompletedDownload,
-          async (completed) => {
-            if (completed?.taskId === result.task.task_id) {
+          () =>
+            assetDownloadStore.downloadList.find(
+              (d) => d.taskId === result.task.task_id
+            )?.status,
+          async (status) => {
+            if (status === 'completed') {
               uploadStatus.value = 'success'
               await refreshModelCaches()
+              stopWatch()
+            } else if (status === 'failed') {
+              const download = assetDownloadStore.downloadList.find(
+                (d) => d.taskId === result.task.task_id
+              )
+              uploadStatus.value = 'error'
+              uploadError.value = download?.error || 'Download failed'
               stopWatch()
             }
           }

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -275,7 +275,8 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
               stopAsyncWatch?.()
               stopAsyncWatch = undefined
             }
-          }
+          },
+          { immediate: true }
         )
       } else {
         uploadStatus.value = 'success'

--- a/src/platform/assets/composables/useUploadModelWizard.ts
+++ b/src/platform/assets/composables/useUploadModelWizard.ts
@@ -251,18 +251,21 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
         uploadStatus.value = 'processing'
 
         stopAsyncWatch?.()
-        stopAsyncWatch = watch(
+        let resolved = false
+        const stop = watch(
           () =>
             assetDownloadStore.downloadList.find(
               (d) => d.taskId === result.task.task_id
             )?.status,
           async (status) => {
             if (status === 'completed') {
+              resolved = true
               uploadStatus.value = 'success'
               await refreshModelCaches()
               stopAsyncWatch?.()
               stopAsyncWatch = undefined
             } else if (status === 'failed') {
+              resolved = true
               const download = assetDownloadStore.downloadList.find(
                 (d) => d.taskId === result.task.task_id
               )
@@ -278,6 +281,12 @@ export function useUploadModelWizard(modelTypes: Ref<ModelTypeOption[]>) {
           },
           { immediate: true }
         )
+        if (resolved) {
+          stop()
+          stopAsyncWatch = undefined
+        } else {
+          stopAsyncWatch = stop
+        }
       } else {
         uploadStatus.value = 'success'
         await refreshModelCaches()


### PR DESCRIPTION
## Summary

- Upload Model dialog stays stuck in "Processing" after async download completes because the wizard never watches for task completion
- `useUploadModelWizard.ts` sets `uploadStatus = 'processing'` but has no watcher linking it to `assetDownloadStore.lastCompletedDownload`
- Added a `watch` on `lastCompletedDownload` that transitions `uploadStatus` to `'success'` when the tracked task finishes

- Fixes #10609

## Root Cause

`uploadModel()` (line 249) sets `uploadStatus = 'processing'` when the async task starts, but control flow ends there. The `assetDownloadStore` receives WebSocket completion events and updates `lastCompletedDownload`, but the wizard never watches this reactive state.

## Fix

Added a `watch` inside the async branch that monitors `assetDownloadStore.lastCompletedDownload`. When the completed task ID matches the upload's task ID, it transitions `uploadStatus` from `'processing'` to `'success'` and refreshes model caches. The watcher auto-disposes after firing.

## Red-Green Verification

| Commit | CI Status | Purpose |
|--------|-----------|---------|
| `test: add failing test for upload dialog stuck in processing state` | :red_circle: Red | Proves the test catches the bug |
| `fix: update upload dialog status when async download completes` | :green_circle: Green | Proves the fix resolves the bug |

## Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [x] Unit test: `updates uploadStatus to success when async download completes`
- [ ] Manual: Import model via URL → verify dialog transitions from Processing to Success (requires `--enable-assets`)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10838-fix-update-upload-dialog-status-when-async-download-completes-3376d73d365081b6a5b1d2be3804ce4b) by [Unito](https://www.unito.io)
