### PR TITLE
fix: skip broken subgraph links in graphToPrompt instead of crashing

### DIFF
--- a/src/utils/executionUtil.test.ts
+++ b/src/utils/executionUtil.test.ts
@@ -1,0 +1,45 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+
+import { graphToPrompt } from './executionUtil'
+
+beforeEach(() => {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+})
+
+describe('graphToPrompt', () => {
+  it('skips inputs with broken links instead of crashing', async () => {
+    LiteGraph.registerNodeType(
+      'TestSampler',
+      class extends LGraphNode {
+        static override title = 'TestSampler'
+        constructor() {
+          super('TestSampler')
+          this.comfyClass = 'TestSampler'
+          this.addInput('model', 'MODEL')
+          this.addInput('seed', 'INT')
+          this.addOutput('output', 'LATENT')
+        }
+      }
+    )
+
+    const graph = new LGraph()
+    const node = LiteGraph.createNode('TestSampler')!
+    graph.add(node)
+
+    // Inject a broken link: input references a link ID that doesn't exist
+    node.inputs[0].link = 9999
+
+    // BUG: graphToPrompt throws InvalidLinkError instead of skipping
+    // the broken input. Workflows with stale link references should
+    // still be convertible to API format.
+    const result = await graphToPrompt(graph)
+    expect(result.output).toBeDefined()
+    expect(result.output[String(node.id)]).toBeDefined()
+    // Broken 'model' input should be skipped, not crash the conversion
+    expect(result.output[String(node.id)].inputs).not.toHaveProperty('model')
+  })
+})

--- a/src/utils/executionUtil.ts
+++ b/src/utils/executionUtil.ts
@@ -7,6 +7,7 @@ import {
   ExecutableNodeDTO,
   LGraphEventMode
 } from '@/lib/litegraph/src/litegraph'
+import { InvalidLinkError } from '@/lib/litegraph/src/infrastructure/InvalidLinkError'
 import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
@@ -117,7 +118,13 @@ export const graphToPrompt = async (
 
     // Store all node links
     for (const [i, input] of node.inputs.entries()) {
-      const resolvedInput = node.resolveInput(i)
+      let resolvedInput
+      try {
+        resolvedInput = node.resolveInput(i)
+      } catch (e) {
+        if (e instanceof InvalidLinkError) continue
+        throw e
+      }
       if (!resolvedInput) continue
 
       // Resolved to an actual widget value rather than a node connection


### PR DESCRIPTION
## Summary

- Workflows with stale link IDs in subgraph node data cause `graphToPrompt` to throw `InvalidLinkError`, preventing execution entirely
- Catch `InvalidLinkError` during input resolution and skip the broken input instead of aborting the entire API conversion
- Template workflows like `image_qwen_Image_2512` that have orphaned link references can now execute

- Fixes #10259

## Root Cause

`ExecutableNodeDTO.resolveInput()` throws `InvalidLinkError` when a node input references a link ID that doesn't exist in the graph's link table. `graphToPrompt()` calls `resolveInput()` in a loop (line 120) without catching this error, so a single broken link reference crashes the entire workflow-to-API conversion.

## Fix

Wrap `node.resolveInput(i)` in a try/catch that catches `InvalidLinkError` and `continue`s to the next input. Non-link errors are re-thrown.

## Red-Green Verification

| Commit | CI Status | Purpose |
|--------|-----------|---------|
| `test: add failing test for broken subgraph links crashing graphToPrompt` | :red_circle: Red | Proves the test catches the bug |
| `fix: skip broken subgraph links in graphToPrompt instead of crashing` | :green_circle: Green | Proves the fix resolves the bug |

## Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [x] Unit test: `skips inputs with broken links instead of crashing`
- [ ] Manual: open `image_qwen_Image_2512` template → execute → should not throw `InvalidLinkError`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10843-fix-skip-broken-subgraph-links-in-graphToPrompt-instead-of-crashing-3386d73d365081d38d36ee6416a1082f) by [Unito](https://www.unito.io)
