### PR TITLE
test: address review comments on new browser tests

### DIFF
--- a/browser_tests/fixtures/helpers/AssetsHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetsHelper.ts
@@ -1,8 +1,12 @@
 import type { Page, Route } from '@playwright/test'
+import type { z } from 'zod'
 
-import type { JobsListResponse } from '@comfyorg/ingest-types'
+import type {
+  RawJobListItem,
+  zJobsListResponse
+} from '../../../src/platform/remote/comfyui/jobs/jobTypes'
 
-import type { RawJobListItem } from '../../../src/platform/remote/comfyui/jobs/jobTypes'
+type JobsListResponse = z.infer<typeof zJobsListResponse>
 
 const jobsListRoutePattern = /\/api\/jobs(?:\?.*)?$/
 const inputFilesRoutePattern = /\/internal\/files\/input(?:\?.*)?$/
@@ -145,7 +149,6 @@ export class AssetsHelper {
       const limit = parseLimit(url, total)
       const visibleJobs = filteredJobs.slice(offset, offset + limit)
 
-      // Response shape matches JobsListResponse from @comfyorg/ingest-types
       const response = {
         jobs: visibleJobs,
         pagination: {
@@ -154,10 +157,7 @@ export class AssetsHelper {
           total,
           has_more: offset + visibleJobs.length < total
         }
-      } satisfies {
-        jobs: unknown[]
-        pagination: JobsListResponse['pagination']
-      }
+      } satisfies JobsListResponse
 
       await route.fulfill({
         status: 200,

--- a/browser_tests/fixtures/helpers/AssetsHelper.ts
+++ b/browser_tests/fixtures/helpers/AssetsHelper.ts
@@ -1,12 +1,7 @@
 import type { Page, Route } from '@playwright/test'
-import type { z } from 'zod'
+import type { JobsListResponse } from '@comfyorg/ingest-types'
 
-import type {
-  RawJobListItem,
-  zJobsListResponse
-} from '../../../src/platform/remote/comfyui/jobs/jobTypes'
-
-type JobsListResponse = z.infer<typeof zJobsListResponse>
+import type { RawJobListItem } from '../../../src/platform/remote/comfyui/jobs/jobTypes'
 
 const jobsListRoutePattern = /\/api\/jobs(?:\?.*)?$/
 const inputFilesRoutePattern = /\/internal\/files\/input(?:\?.*)?$/
@@ -157,7 +152,10 @@ export class AssetsHelper {
           total,
           has_more: offset + visibleJobs.length < total
         }
-      } satisfies JobsListResponse
+      } satisfies {
+        jobs: unknown[]
+        pagination: JobsListResponse['pagination']
+      }
 
       await route.fulfill({
         status: 200,

--- a/browser_tests/tests/queue/queueOverlay.spec.ts
+++ b/browser_tests/tests/queue/queueOverlay.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
-import { createMockJob } from '../../fixtures/helpers/AssetsHelper'
-import { TestIds } from '../../fixtures/selectors'
-import type { RawJobListItem } from '../../../src/platform/remote/comfyui/jobs/jobTypes'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { createMockJob } from '@e2e/fixtures/helpers/AssetsHelper'
+import { TestIds } from '@e2e/fixtures/selectors'
+import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 
 const now = Date.now()
 
@@ -37,6 +37,7 @@ const MOCK_JOBS: RawJobListItem[] = [
 test.describe('Queue overlay', () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.assets.mockOutputHistory(MOCK_JOBS)
+    await comfyPage.settings.setSetting('Comfy.Queue.QPOV2', false)
     await comfyPage.setup()
   })
 
@@ -49,9 +50,7 @@ test.describe('Queue overlay', () => {
     await toggle.click()
 
     // Expanded overlay should show job items
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible({
-      timeout: 5000
-    })
+    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
   })
 
   test('Overlay shows filter tabs (All, Completed)', async ({ comfyPage }) => {
@@ -60,7 +59,7 @@ test.describe('Queue overlay', () => {
 
     await expect(
       comfyPage.page.getByRole('button', { name: 'All', exact: true })
-    ).toBeVisible({ timeout: 5000 })
+    ).toBeVisible()
     await expect(
       comfyPage.page.getByRole('button', { name: 'Completed', exact: true })
     ).toBeVisible()
@@ -72,9 +71,7 @@ test.describe('Queue overlay', () => {
     const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
     await toggle.click()
 
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible({
-      timeout: 5000
-    })
+    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
 
     await expect(
       comfyPage.page.getByRole('button', { name: 'Failed', exact: true })
@@ -85,9 +82,7 @@ test.describe('Queue overlay', () => {
     const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
     await toggle.click()
 
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible({
-      timeout: 5000
-    })
+    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
 
     await comfyPage.page
       .getByRole('button', { name: 'Completed', exact: true })
@@ -95,7 +90,7 @@ test.describe('Queue overlay', () => {
 
     await expect(
       comfyPage.page.locator('[data-job-id="job-completed-1"]')
-    ).toBeVisible({ timeout: 5000 })
+    ).toBeVisible()
     await expect(
       comfyPage.page.locator('[data-job-id="job-failed-1"]')
     ).not.toBeVisible()
@@ -105,14 +100,12 @@ test.describe('Queue overlay', () => {
     const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
     await toggle.click()
 
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible({
-      timeout: 5000
-    })
+    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
 
     await toggle.click()
 
     await expect(
       comfyPage.page.locator('[data-job-id]').first()
-    ).not.toBeVisible({ timeout: 5000 })
+    ).not.toBeVisible()
   })
 })

--- a/browser_tests/tests/sidebar/workflowSearch.spec.ts
+++ b/browser_tests/tests/sidebar/workflowSearch.spec.ts
@@ -1,12 +1,13 @@
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
-import { comfyPageFixture as test } from '../../fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
 
 /** Locate a workflow label in whatever panel is visible (browse or search). */
 function findWorkflow(page: Page, name: string) {
   return page
-    .getByTestId('workflows-sidebar')
+    .getByTestId(TestIds.sidebar.workflows)
     .locator('.node-label', { hasText: name })
 }
 
@@ -18,15 +19,6 @@ test.describe('Workflow sidebar - search', () => {
     })
   })
 
-  test('Search input is visible in workflows tab', async ({ comfyPage }) => {
-    const tab = comfyPage.menu.workflowsTab
-    await tab.open()
-
-    await expect(
-      comfyPage.page.getByPlaceholder('Search Workflow...')
-    ).toBeVisible()
-  })
-
   test('Search filters saved workflows by name', async ({ comfyPage }) => {
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
@@ -34,9 +26,7 @@ test.describe('Workflow sidebar - search', () => {
     const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
     await searchInput.fill('alpha')
 
-    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible({
-      timeout: 5000
-    })
+    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
     await expect(
       findWorkflow(comfyPage.page, 'beta-workflow')
     ).not.toBeVisible()
@@ -54,9 +44,7 @@ test.describe('Workflow sidebar - search', () => {
 
     await searchInput.fill('')
 
-    await expect(tab.getPersistedItem('alpha-workflow')).toBeVisible({
-      timeout: 5000
-    })
+    await expect(tab.getPersistedItem('alpha-workflow')).toBeVisible()
     await expect(tab.getPersistedItem('beta-workflow')).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary

Addresses the review comments on the new queue overlay and workflow search browser tests by tightening the queue overlay setup, removing redundant assertions, and aligning the jobs API mock with the frontend schema.

## Changes

- **What**: Switch the new browser test imports to `@e2e` aliases, pin `Comfy.Queue.QPOV2` to `false` in the queue overlay suite, remove redundant explicit 5s assertion overrides, fold the standalone workflow search visibility test into the behavioral coverage, and type the `/api/jobs` browser-test mock against the frontend jobs schema.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10852-test-address-review-comments-on-new-browser-tests-3386d73d365081c1aa1acdaa6ec2c4f5) by [Unito](https://www.unito.io)
