### PR TITLE
feat: integrate Typeform survey into feedback button

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -159,7 +159,7 @@ import { useI18n } from 'vue-i18n'
 
 import PuzzleIcon from '@/components/icons/PuzzleIcon.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
-import { isCloud, isDesktop } from '@/platform/distribution/types'
+import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import type { ReleaseNote } from '@/platform/updates/common/releaseService'
@@ -299,9 +299,18 @@ const menuItems = computed<MenuItem[]>(() => {
       type: 'item',
       icon: 'icon-[lucide--clipboard-pen]',
       label: t('helpCenter.feedback'),
+      showExternalIcon: isCloud || isNightly,
       action: () => {
-        trackResourceClick('help_feedback', false)
-        void commandStore.execute('Comfy.ContactSupport')
+        trackResourceClick('help_feedback', isCloud || isNightly)
+        if (isCloud || isNightly) {
+          window.open(
+            'https://form.typeform.com/to/q7azbWPi',
+            '_blank',
+            'noopener,noreferrer'
+          )
+        } else {
+          void commandStore.execute('Comfy.ContactSupport')
+        }
         emit('close')
       }
     },

--- a/src/extensions/core/cloudFeedbackTopbarButton.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.ts
@@ -1,10 +1,9 @@
 import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { buildFeedbackUrl } from '@/platform/support/config'
 import { useExtensionService } from '@/services/extensionService'
 import type { ActionBarButton } from '@/types/comfy'
 
-const feedbackUrl = buildFeedbackUrl()
+const TYPEFORM_SURVEY_URL = 'https://form.typeform.com/to/q7azbWPi'
 
 const buttons: ActionBarButton[] = [
   {
@@ -12,7 +11,7 @@ const buttons: ActionBarButton[] = [
     label: t('actionbar.feedback'),
     tooltip: t('actionbar.feedbackTooltip'),
     onClick: () => {
-      window.open(feedbackUrl, '_blank', 'noopener,noreferrer')
+      window.open(TYPEFORM_SURVEY_URL, '_blank', 'noopener,noreferrer')
     }
   }
 ]


### PR DESCRIPTION
## Summary

Replace Zendesk feedback URLs with Typeform survey (`q7azbWPi`) in the action bar feedback button and Help Center menu for Cloud/Nightly distributions.

## Changes

- **What**: 
  - `cloudFeedbackTopbarButton.ts`: Replace `buildFeedbackUrl()` (Zendesk) with direct Typeform survey URL. Remove unused Zendesk import.
  - `HelpCenterMenuContent.vue`: Feedback menu item now opens Typeform URL for Cloud/Nightly builds; falls back to `Comfy.ContactSupport` (Zendesk) for other distributions. Added external link icon for Cloud/Nightly.
  - Help menu item and `Comfy.ContactSupport` command unchanged — support flows still route to Zendesk.

## Review Focus

- Gating logic: `isCloud || isNightly` correctly limits Typeform redirect to intended distributions
- Help item intentionally unchanged (support ≠ feedback)

Ticket: COM-17992

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10890-feat-integrate-Typeform-survey-into-feedback-button-33a6d73d36508185abbfe57e7a36b5f7) by [Unito](https://www.unito.io)
