### PR TITLE
[backport cloud/1.42] fix: resolve node text bleed-through by isolating stacking contexts (#10022)

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -10,7 +10,7 @@
     :data-collapsed="isCollapsed || undefined"
     :class="
       cn(
-        'group/node lg-node absolute text-sm',
+        'group/node lg-node absolute isolate text-sm',
         'flex min-w-(--min-node-width) flex-col contain-layout contain-style',
         cursorClass,
         isSelected && 'outline-node-component-outline',


### PR DESCRIPTION
Backport of #10022 to cloud/1.42. Clean cherry-pick.