### PR TITLE
[backport cloud/1.42] fix: make gradient_stops enumerable so it survives object spread (#10406)

### DIFF
--- a/src/extensions/core/customWidgets.test.ts
+++ b/src/extensions/core/customWidgets.test.ts
@@ -30,6 +30,7 @@ describe('PrimitiveFloat widget type bridging', () => {
     })
 
     Object.defineProperty(widget.options, 'gradient_stops', {
+      enumerable: true,
       get: () => properties.gradient_stops,
       set: (v) => {
         properties.gradient_stops = v

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -169,6 +169,7 @@ function onCustomFloatCreated(this: LGraphNode) {
   })
 
   Object.defineProperty(valueWidget.options, 'gradient_stops', {
+    enumerable: true,
     get: () => this.properties.gradient_stops,
     set: (v) => {
       this.properties.gradient_stops = v


### PR DESCRIPTION
Backport of #10406 to cloud/1.42. Clean cherry-pick.