### PR TITLE
[backport cloud/1.42] fix: set topbar menus to non-modal so they dismiss on canvas interaction (#10310)

### DIFF
--- a/src/components/common/WorkflowActionsDropdown.vue
+++ b/src/components/common/WorkflowActionsDropdown.vue
@@ -80,7 +80,11 @@ const tooltipPt = {
 </script>
 
 <template>
-  <DropdownMenuRoot v-model:open="dropdownOpen" @update:open="handleOpen">
+  <DropdownMenuRoot
+    v-model:open="dropdownOpen"
+    :modal="false"
+    @update:open="handleOpen"
+  >
     <slot name="button" :has-unseen-items="hasUnseenItems">
       <div
         class="pointer-events-auto inline-flex items-center rounded-lg bg-secondary-background"

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <ContextMenuRoot>
+  <ContextMenuRoot :modal="false">
     <ContextMenuTrigger as-child>
       <div
         ref="workflowTabRef"


### PR DESCRIPTION
Backport of #10310 to cloud/1.42. Clean cherry-pick.