### PR TITLE
[backport cloud/1.42] fix: gate cloud API calls behind Firebase authentication (#9909)

### DIFF
--- a/src/stores/bootstrapStore.test.ts
+++ b/src/stores/bootstrapStore.test.ts
@@ -1,7 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 
 import { useSettingStore } from '@/platform/settings/settingStore'
 
@@ -51,9 +51,11 @@ vi.mock('@/stores/userStore', () => ({
 }))
 
 const mockIsFirebaseInitialized = ref(false)
+const mockIsFirebaseAuthenticated = ref(false)
 vi.mock('@/stores/firebaseAuthStore', () => ({
   useFirebaseAuthStore: vi.fn(() => ({
-    isInitialized: mockIsFirebaseInitialized
+    isInitialized: mockIsFirebaseInitialized,
+    isAuthenticated: mockIsFirebaseAuthenticated
   }))
 }))
 
@@ -66,6 +68,7 @@ describe('bootstrapStore', () => {
   beforeEach(() => {
     mockIsSettingsReady.value = false
     mockIsFirebaseInitialized.value = false
+    mockIsFirebaseAuthenticated.value = false
     mockNeedsLogin.value = false
     mockDistributionTypes.isCloud = false
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -95,17 +98,23 @@ describe('bootstrapStore', () => {
       mockDistributionTypes.isCloud = true
     })
 
-    it('waits for Firebase auth before loading i18n and settings', async () => {
+    it('waits for Firebase auth before loading stores', async () => {
       const store = useBootstrapStore()
       const settingStore = useSettingStore()
       const bootstrapPromise = store.startStoreBootstrap()
 
-      // Bootstrap is blocked waiting for firebase
       expect(store.isI18nReady).toBe(false)
       expect(settingStore.isReady).toBe(false)
 
-      // Unblock by initializing firebase
+      // Firebase initialized but user not yet authenticated
       mockIsFirebaseInitialized.value = true
+      await nextTick()
+
+      expect(store.isI18nReady).toBe(false)
+      expect(settingStore.isReady).toBe(false)
+
+      // User authenticates (e.g. signs in on login page)
+      mockIsFirebaseAuthenticated.value = true
       await bootstrapPromise
 
       await vi.waitFor(() => {

--- a/src/stores/bootstrapStore.ts
+++ b/src/stores/bootstrapStore.ts
@@ -36,13 +36,16 @@ export const useBootstrapStore = defineStore('bootstrap', () => {
   }
 
   async function startStoreBootstrap() {
+    if (isCloud) {
+      const { isInitialized, isAuthenticated } = storeToRefs(
+        useFirebaseAuthStore()
+      )
+      await until(isInitialized).toBe(true)
+      await until(isAuthenticated).toBe(true)
+    }
+
     const userStore = useUserStore()
     await userStore.initialize()
-
-    if (isCloud) {
-      const { isInitialized } = storeToRefs(useFirebaseAuthStore())
-      await until(isInitialized).toBe(true)
-    }
 
     const { needsLogin } = storeToRefs(userStore)
     await until(needsLogin).toBe(false)


### PR DESCRIPTION
Backport of #9909 to cloud/1.42. Clean cherry-pick.