### PR TITLE
[backport cloud/1.42] fix: use server response filename in WebcamCapture serialization (#10220)

### DIFF
--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -142,7 +142,10 @@ app.registerExtension({
         useToastStore().addAlert(err)
         throw new Error(err)
       }
-      return `webcam/${name} [temp]`
+      const data = await resp.json()
+      const serverName = data.name ?? name
+      const subfolder = data.subfolder ?? 'webcam'
+      return `${subfolder}/${serverName} [temp]`
     }
 
     // @ts-expect-error fixme ts strict error


### PR DESCRIPTION
Backport of #10220 to cloud/1.42. Clean cherry-pick.