### PR TITLE
[backport cloud/1.42] fix: search media assets by display_name in addition to name (#10254)

### DIFF
--- a/src/platform/assets/composables/useMediaAssetFiltering.ts
+++ b/src/platform/assets/composables/useMediaAssetFiltering.ts
@@ -37,7 +37,7 @@ export function useMediaAssetFiltering(assets: Ref<AssetItem[]>) {
   const mediaTypeFilters = ref<string[]>([])
 
   const fuseOptions = {
-    keys: ['name'],
+    keys: ['display_name', 'name'],
     threshold: 0.4,
     includeScore: true
   }


### PR DESCRIPTION
Backport of #10254 to cloud/1.42. Clean cherry-pick.