### PR TITLE
Range editor

### DIFF
--- a/src/components/curve/CurveEditor.vue
+++ b/src/components/curve/CurveEditor.vue
@@ -89,7 +89,7 @@ import { cn } from '@/utils/tailwindUtil'
 
 import type { CurveInterpolation, CurvePoint } from './types'
 
-import { histogramToPath } from './curveUtils'
+import { histogramToPath } from '@/utils/histogramUtil'
 
 const {
   curveColor = 'white',

--- a/src/components/curve/curveUtils.test.ts
+++ b/src/components/curve/curveUtils.test.ts
@@ -5,8 +5,7 @@ import type { CurvePoint } from './types'
 import {
   createLinearInterpolator,
   createMonotoneInterpolator,
-  curvesToLUT,
-  histogramToPath
+  curvesToLUT
 } from './curveUtils'
 
 describe('createMonotoneInterpolator', () => {
@@ -162,39 +161,5 @@ describe('curvesToLUT', () => {
       expect(lut[i]).toBeGreaterThanOrEqual(0)
       expect(lut[i]).toBeLessThanOrEqual(255)
     }
-  })
-})
-
-describe('histogramToPath', () => {
-  it('returns empty string for empty histogram', () => {
-    expect(histogramToPath(new Uint32Array(0))).toBe('')
-  })
-
-  it('returns empty string when all bins are zero', () => {
-    expect(histogramToPath(new Uint32Array(256))).toBe('')
-  })
-
-  it('returns a closed SVG path for valid histogram', () => {
-    const histogram = new Uint32Array(256)
-    for (let i = 0; i < 256; i++) histogram[i] = i + 1
-    const path = histogramToPath(histogram)
-    expect(path).toMatch(/^M0,1/)
-    expect(path).toMatch(/L1,1 Z$/)
-  })
-
-  it('normalizes using 99.5th percentile to suppress outliers', () => {
-    const histogram = new Uint32Array(256)
-    for (let i = 0; i < 256; i++) histogram[i] = 100
-    histogram[255] = 100000
-    const path = histogramToPath(histogram)
-    // Most bins should map to y=0 (1 - 100/100 = 0) since
-    // the 99.5th percentile is 100, not the outlier 100000
-    const yValues = path
-      .split(/[ML]/)
-      .filter(Boolean)
-      .map((s) => parseFloat(s.split(',')[1]))
-      .filter((y) => !isNaN(y))
-    const nearZero = yValues.filter((y) => Math.abs(y) < 0.01)
-    expect(nearZero.length).toBeGreaterThan(200)
   })
 })

--- a/src/components/curve/curveUtils.ts
+++ b/src/components/curve/curveUtils.ts
@@ -149,34 +149,6 @@ export function createMonotoneInterpolator(
   }
 }
 
-/**
- * Convert a histogram (arbitrary number of bins) into an SVG path string.
- * Applies square-root scaling and normalizes using the 99.5th percentile
- * to avoid outlier spikes.
- */
-export function histogramToPath(histogram: Uint32Array): string {
-  const len = histogram.length
-  if (len === 0) return ''
-
-  const sqrtValues = new Float32Array(len)
-  for (let i = 0; i < len; i++) sqrtValues[i] = Math.sqrt(histogram[i])
-
-  const sorted = Array.from(sqrtValues).sort((a, b) => a - b)
-  const max = sorted[Math.floor((len - 1) * 0.995)]
-  if (max === 0) return ''
-
-  const invMax = 1 / max
-  const lastIdx = len - 1
-  const parts: string[] = ['M0,1']
-  for (let i = 0; i < len; i++) {
-    const x = lastIdx === 0 ? 0.5 : i / lastIdx
-    const y = 1 - Math.min(1, sqrtValues[i] * invMax)
-    parts.push(`L${x},${y}`)
-  }
-  parts.push('L1,1 Z')
-  return parts.join(' ')
-}
-
 export function curvesToLUT(
   points: CurvePoint[],
   interpolation: CurveInterpolation = 'monotone_cubic'

--- a/src/components/range/RangeEditor.test.ts
+++ b/src/components/range/RangeEditor.test.ts
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import RangeEditor from './RangeEditor.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+function mountEditor(props: InstanceType<typeof RangeEditor>['$props']) {
+  return mount(RangeEditor, {
+    props,
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('RangeEditor', () => {
+  it('renders with min and max handles', () => {
+    const wrapper = mountEditor({ modelValue: { min: 0.2, max: 0.8 } })
+
+    expect(wrapper.find('svg').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="handle-min"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="handle-max"]').exists()).toBe(true)
+  })
+
+  it('highlights selected range in plain mode', () => {
+    const wrapper = mountEditor({ modelValue: { min: 0.2, max: 0.8 } })
+
+    const highlight = wrapper.find('[data-testid="range-highlight"]')
+    expect(highlight.attributes('x')).toBe('0.2')
+    expect(
+      Number.parseFloat(highlight.attributes('width') ?? 'NaN')
+    ).toBeCloseTo(0.6, 6)
+  })
+
+  it('dims area outside the range in histogram mode', () => {
+    const histogram = new Uint32Array(256)
+    for (let i = 0; i < 256; i++)
+      histogram[i] = Math.floor(50 + 50 * Math.sin(i / 20))
+
+    const wrapper = mountEditor({
+      modelValue: { min: 0.2, max: 0.8 },
+      display: 'histogram',
+      histogram
+    })
+
+    const left = wrapper.find('[data-testid="range-dim-left"]')
+    const right = wrapper.find('[data-testid="range-dim-right"]')
+    expect(left.attributes('width')).toBe('0.2')
+    expect(right.attributes('x')).toBe('0.8')
+  })
+
+  it('hides midpoint handle by default', () => {
+    const wrapper = mountEditor({
+      modelValue: { min: 0, max: 1, midpoint: 0.5 }
+    })
+
+    expect(wrapper.find('[data-testid="handle-midpoint"]').exists()).toBe(false)
+  })
+
+  it('shows midpoint handle when showMidpoint is true', () => {
+    const wrapper = mountEditor({
+      modelValue: { min: 0, max: 1, midpoint: 0.5 },
+      showMidpoint: true
+    })
+
+    expect(wrapper.find('[data-testid="handle-midpoint"]').exists()).toBe(true)
+  })
+
+  it('renders gradient background when display is gradient', () => {
+    const wrapper = mountEditor({
+      modelValue: { min: 0, max: 1 },
+      display: 'gradient',
+      gradientStops: [
+        { offset: 0, color: [0, 0, 0] as const },
+        { offset: 1, color: [255, 255, 255] as const }
+      ]
+    })
+
+    expect(wrapper.find('[data-testid="gradient-bg"]').exists()).toBe(true)
+    expect(wrapper.find('linearGradient').exists()).toBe(true)
+  })
+
+  it('renders histogram path when display is histogram with data', () => {
+    const histogram = new Uint32Array(256)
+    for (let i = 0; i < 256; i++)
+      histogram[i] = Math.floor(50 + 50 * Math.sin(i / 20))
+
+    const wrapper = mountEditor({
+      modelValue: { min: 0, max: 1 },
+      display: 'histogram',
+      histogram
+    })
+
+    expect(wrapper.find('[data-testid="histogram-path"]').exists()).toBe(true)
+  })
+
+  it('renders inputs for min and max', () => {
+    const wrapper = mountEditor({ modelValue: { min: 0.2, max: 0.8 } })
+
+    const inputs = wrapper.findAll('input')
+    expect(inputs).toHaveLength(2)
+  })
+
+  it('renders midpoint input when showMidpoint is true', () => {
+    const wrapper = mountEditor({
+      modelValue: { min: 0, max: 1, midpoint: 0.5 },
+      showMidpoint: true
+    })
+
+    const inputs = wrapper.findAll('input')
+    expect(inputs).toHaveLength(3)
+  })
+
+  it('normalizes handle positions with custom value range', () => {
+    const wrapper = mountEditor({
+      modelValue: { min: 64, max: 192 },
+      valueMin: 0,
+      valueMax: 255
+    })
+
+    const minHandle = wrapper.find('[data-testid="handle-min"]')
+    const maxHandle = wrapper.find('[data-testid="handle-max"]')
+
+    expect(
+      Number.parseFloat((minHandle.element as HTMLElement).style.left)
+    ).toBeCloseTo(25, 0)
+    expect(
+      Number.parseFloat((maxHandle.element as HTMLElement).style.left)
+    ).toBeCloseTo(75, 0)
+  })
+})

--- a/src/components/range/RangeEditor.vue
+++ b/src/components/range/RangeEditor.vue
@@ -1,0 +1,290 @@
+<template>
+  <div>
+    <div
+      ref="trackRef"
+      class="relative select-none"
+      @pointerdown.stop="onTrackPointerDown"
+      @contextmenu.prevent.stop
+    >
+      <svg
+        viewBox="0 0 1 1"
+        preserveAspectRatio="none"
+        :class="
+          cn(
+            'block w-full rounded-sm bg-node-component-surface',
+            display === 'histogram' ? 'aspect-3/2' : 'h-8'
+          )
+        "
+      >
+        <defs v-if="display === 'gradient'">
+          <linearGradient :id="gradientId" x1="0" y1="0" x2="1" y2="0">
+            <stop
+              v-for="(stop, i) in computedStops"
+              :key="i"
+              :offset="stop.offset"
+              :stop-color="`rgb(${stop.color[0]},${stop.color[1]},${stop.color[2]})`"
+            />
+          </linearGradient>
+        </defs>
+
+        <rect
+          v-if="display === 'gradient'"
+          data-testid="gradient-bg"
+          x="0"
+          y="0"
+          width="1"
+          height="1"
+          :fill="`url(#${gradientId})`"
+        />
+
+        <path
+          v-if="display === 'histogram' && histogramPath"
+          data-testid="histogram-path"
+          :d="histogramPath"
+          fill="currentColor"
+          fill-opacity="0.3"
+        />
+
+        <rect
+          v-if="display === 'plain'"
+          data-testid="range-highlight"
+          :x="minNorm"
+          y="0"
+          :width="Math.max(0, maxNorm - minNorm)"
+          height="1"
+          fill="white"
+          fill-opacity="0.15"
+        />
+        <template v-if="display === 'histogram'">
+          <rect
+            v-if="minNorm > 0"
+            data-testid="range-dim-left"
+            x="0"
+            y="0"
+            :width="minNorm"
+            height="1"
+            fill="black"
+            fill-opacity="0.5"
+          />
+          <rect
+            v-if="maxNorm < 1"
+            data-testid="range-dim-right"
+            :x="maxNorm"
+            y="0"
+            :width="1 - maxNorm"
+            height="1"
+            fill="black"
+            fill-opacity="0.5"
+          />
+        </template>
+      </svg>
+
+      <template v-if="!disabled">
+        <div
+          data-testid="handle-min"
+          class="absolute -translate-x-1/2 cursor-grab"
+          :style="{ left: `${minNorm * 100}%`, bottom: '-10px' }"
+          @pointerdown.stop="startDrag('min', $event)"
+        >
+          <svg width="12" height="10" viewBox="0 0 12 10">
+            <polygon
+              points="6,0 0,10 12,10"
+              fill="#333"
+              stroke="#aaa"
+              stroke-width="0.5"
+            />
+          </svg>
+        </div>
+
+        <div
+          v-if="showMidpoint && modelValue.midpoint !== undefined"
+          data-testid="handle-midpoint"
+          class="absolute -translate-x-1/2 cursor-grab"
+          :style="{ left: `${midpointPercent}%`, bottom: '-10px' }"
+          @pointerdown.stop="startDrag('midpoint', $event)"
+        >
+          <svg width="12" height="10" viewBox="0 0 12 10">
+            <polygon
+              points="6,0 0,10 12,10"
+              fill="#888"
+              stroke="#ccc"
+              stroke-width="0.5"
+            />
+          </svg>
+        </div>
+
+        <div
+          data-testid="handle-max"
+          class="absolute -translate-x-1/2 cursor-grab"
+          :style="{ left: `${maxNorm * 100}%`, bottom: '-10px' }"
+          @pointerdown.stop="startDrag('max', $event)"
+        >
+          <svg width="12" height="10" viewBox="0 0 12 10">
+            <polygon
+              points="6,0 0,10 12,10"
+              fill="white"
+              stroke="#555"
+              stroke-width="0.5"
+            />
+          </svg>
+        </div>
+      </template>
+    </div>
+
+    <div
+      v-if="!disabled"
+      class="mt-3 flex items-center justify-between"
+      @pointerdown.stop
+    >
+      <ScrubableNumberInput
+        v-model="minValue"
+        :display-value="formatValue(minValue)"
+        :min="valueMin"
+        :max="valueMax"
+        :step="step"
+        hide-buttons
+        class="w-16"
+      />
+      <ScrubableNumberInput
+        v-if="showMidpoint && modelValue.midpoint !== undefined"
+        v-model="midpointValue"
+        :display-value="midpointValue.toFixed(2)"
+        :min="midpointScale === 'gamma' ? 0.01 : 0"
+        :max="midpointScale === 'gamma' ? 9.99 : 1"
+        :step="0.01"
+        hide-buttons
+        class="w-16"
+      />
+      <ScrubableNumberInput
+        v-model="maxValue"
+        :display-value="formatValue(maxValue)"
+        :min="valueMin"
+        :max="valueMax"
+        :step="step"
+        hide-buttons
+        class="w-16"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRef, useId, useTemplateRef } from 'vue'
+
+import ScrubableNumberInput from '@/components/common/ScrubableNumberInput.vue'
+import { cn } from '@/utils/tailwindUtil'
+import { histogramToPath } from '@/utils/histogramUtil'
+import { useRangeEditor } from '@/composables/useRangeEditor'
+import type { ColorStop } from '@/lib/litegraph/src/interfaces'
+import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
+
+import {
+  clamp,
+  gammaToPosition,
+  normalize,
+  positionToGamma
+} from './rangeUtils'
+
+const {
+  display = 'plain',
+  gradientStops,
+  showMidpoint = false,
+  midpointScale = 'linear',
+  histogram,
+  disabled = false,
+  valueMin = 0,
+  valueMax = 1
+} = defineProps<{
+  display?: 'plain' | 'gradient' | 'histogram'
+  gradientStops?: ColorStop[]
+  showMidpoint?: boolean
+  midpointScale?: 'linear' | 'gamma'
+  histogram?: Uint32Array | null
+  disabled?: boolean
+  valueMin?: number
+  valueMax?: number
+}>()
+
+const modelValue = defineModel<RangeValue>({ required: true })
+
+const trackRef = useTemplateRef<HTMLDivElement>('trackRef')
+const gradientId = useId()
+
+const { handleTrackPointerDown, startDrag } = useRangeEditor({
+  trackRef,
+  modelValue,
+  valueMin: toRef(() => valueMin),
+  valueMax: toRef(() => valueMax)
+})
+
+function onTrackPointerDown(e: PointerEvent) {
+  if (!disabled) handleTrackPointerDown(e)
+}
+
+const isIntegerRange = computed(() => valueMax - valueMin >= 2)
+const step = computed(() => (isIntegerRange.value ? 1 : 0.01))
+
+function formatValue(v: number): string {
+  return isIntegerRange.value ? Math.round(v).toString() : v.toFixed(2)
+}
+
+const minNorm = computed(() =>
+  normalize(modelValue.value.min, valueMin, valueMax)
+)
+const maxNorm = computed(() =>
+  normalize(modelValue.value.max, valueMin, valueMax)
+)
+
+const computedStops = computed(
+  () =>
+    gradientStops ?? [
+      { offset: 0, color: [0, 0, 0] as const },
+      { offset: 1, color: [255, 255, 255] as const }
+    ]
+)
+
+const midpointPercent = computed(() => {
+  const { min, max, midpoint } = modelValue.value
+  if (midpoint === undefined) return 0
+  const midAbs = min + midpoint * (max - min)
+  return normalize(midAbs, valueMin, valueMax) * 100
+})
+
+const minValue = computed({
+  get: () => modelValue.value.min,
+  set: (min) => {
+    modelValue.value = {
+      ...modelValue.value,
+      min: Math.min(clamp(min, valueMin, valueMax), modelValue.value.max)
+    }
+  }
+})
+
+const maxValue = computed({
+  get: () => modelValue.value.max,
+  set: (max) => {
+    modelValue.value = {
+      ...modelValue.value,
+      max: Math.max(clamp(max, valueMin, valueMax), modelValue.value.min)
+    }
+  }
+})
+
+const midpointValue = computed({
+  get: () => {
+    const pos = modelValue.value.midpoint ?? 0.5
+    return midpointScale === 'gamma' ? positionToGamma(pos) : pos
+  },
+  set: (val) => {
+    const position =
+      midpointScale === 'gamma'
+        ? clamp(gammaToPosition(val), 0, 1)
+        : clamp(val, 0, 1)
+    modelValue.value = { ...modelValue.value, midpoint: position }
+  }
+})
+
+const histogramPath = computed(() =>
+  histogram ? histogramToPath(histogram) : ''
+)
+</script>

--- a/src/components/range/RangeEditor.vue
+++ b/src/components/range/RangeEditor.vue
@@ -178,12 +178,11 @@ import { useRangeEditor } from '@/composables/useRangeEditor'
 import type { ColorStop } from '@/lib/litegraph/src/interfaces'
 import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
 
-import {
-  clamp,
-  gammaToPosition,
-  normalize,
-  positionToGamma
-} from './rangeUtils'
+import { normalize } from '@/utils/mathUtil'
+
+import { clamp } from 'es-toolkit'
+
+import { gammaToPosition, positionToGamma } from './rangeUtils'
 
 const {
   display = 'plain',
@@ -214,7 +213,8 @@ const { handleTrackPointerDown, startDrag } = useRangeEditor({
   trackRef,
   modelValue,
   valueMin: toRef(() => valueMin),
-  valueMax: toRef(() => valueMax)
+  valueMax: toRef(() => valueMax),
+  showMidpoint: toRef(() => showMidpoint)
 })
 
 function onTrackPointerDown(e: PointerEvent) {

--- a/src/components/range/WidgetRange.vue
+++ b/src/components/range/WidgetRange.vue
@@ -1,6 +1,6 @@
 <template>
   <RangeEditor
-    :model-value="effectiveValue.value"
+    :model-value="effectiveValue"
     :display="widget?.options?.display"
     :gradient-stops="widget?.options?.gradient_stops"
     :show-midpoint="widget?.options?.show_midpoint"
@@ -64,8 +64,8 @@ watch(upstreamValue, (upstream) => {
 
 const effectiveValue = computed(() =>
   isDisabled.value && upstreamValue.value
-    ? { value: upstreamValue.value }
-    : { value: modelValue.value }
+    ? upstreamValue.value
+    : modelValue.value
 )
 
 function onValueChange(value: RangeValue) {

--- a/src/components/range/WidgetRange.vue
+++ b/src/components/range/WidgetRange.vue
@@ -1,0 +1,74 @@
+<template>
+  <RangeEditor
+    :model-value="effectiveValue.value"
+    :display="widget?.options?.display"
+    :gradient-stops="widget?.options?.gradient_stops"
+    :show-midpoint="widget?.options?.show_midpoint"
+    :midpoint-scale="widget?.options?.midpoint_scale"
+    :histogram="histogram"
+    :disabled="isDisabled"
+    :value-min="widget?.options?.value_min"
+    :value-max="widget?.options?.value_max"
+    @update:model-value="onValueChange"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+
+import {
+  singleValueExtractor,
+  useUpstreamValue
+} from '@/composables/useUpstreamValue'
+import type {
+  IWidgetRangeOptions,
+  RangeValue
+} from '@/lib/litegraph/src/types/widgets'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import RangeEditor from './RangeEditor.vue'
+import { isRangeValue } from './rangeUtils'
+
+const { widget } = defineProps<{
+  widget: SimplifiedWidget<RangeValue, IWidgetRangeOptions>
+}>()
+
+const modelValue = defineModel<RangeValue>({
+  default: () => ({ min: 0, max: 1 })
+})
+
+const isDisabled = computed(() => !!widget.options?.disabled)
+
+const nodeOutputStore = useNodeOutputStore()
+const histogram = computed(() => {
+  const locatorId = widget.nodeLocatorId
+  if (!locatorId) return null
+  const output = nodeOutputStore.nodeOutputs[locatorId]
+  const key = `histogram_${widget.name}`
+  const data = (output as Record<string, unknown>)?.[key]
+  if (!Array.isArray(data) || data.length === 0) return null
+  return new Uint32Array(data)
+})
+
+const upstreamValue = useUpstreamValue(
+  () => widget.linkedUpstream,
+  singleValueExtractor(isRangeValue)
+)
+
+watch(upstreamValue, (upstream) => {
+  if (isDisabled.value && upstream) {
+    modelValue.value = upstream
+  }
+})
+
+const effectiveValue = computed(() =>
+  isDisabled.value && upstreamValue.value
+    ? { value: upstreamValue.value }
+    : { value: modelValue.value }
+)
+
+function onValueChange(value: RangeValue) {
+  modelValue.value = value
+}
+</script>

--- a/src/components/range/rangeUtils.test.ts
+++ b/src/components/range/rangeUtils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  constrainRange,
+  denormalize,
+  formatMidpointLabel,
+  gammaToPosition,
+  isRangeValue,
+  normalize,
+  positionToGamma
+} from './rangeUtils'
+
+describe('normalize', () => {
+  it('normalizes value to 0-1', () => {
+    expect(normalize(128, 0, 256)).toBe(0.5)
+    expect(normalize(0, 0, 255)).toBe(0)
+    expect(normalize(255, 0, 255)).toBe(1)
+  })
+
+  it('returns 0 when min equals max', () => {
+    expect(normalize(5, 5, 5)).toBe(0)
+  })
+})
+
+describe('denormalize', () => {
+  it('converts normalized value back to range', () => {
+    expect(denormalize(0.5, 0, 256)).toBe(128)
+    expect(denormalize(0, 0, 255)).toBe(0)
+    expect(denormalize(1, 0, 255)).toBe(255)
+  })
+
+  it('round-trips with normalize', () => {
+    expect(denormalize(normalize(100, 0, 255), 0, 255)).toBeCloseTo(100)
+  })
+})
+
+describe('positionToGamma', () => {
+  it('converts 0.5 to gamma 1.0', () => {
+    expect(positionToGamma(0.5)).toBeCloseTo(1.0)
+  })
+
+  it('converts 0.25 to gamma 2.0', () => {
+    expect(positionToGamma(0.25)).toBeCloseTo(2.0)
+  })
+})
+
+describe('gammaToPosition', () => {
+  it('converts gamma 1.0 to position 0.5', () => {
+    expect(gammaToPosition(1.0)).toBeCloseTo(0.5)
+  })
+
+  it('converts gamma 2.0 to position 0.25', () => {
+    expect(gammaToPosition(2.0)).toBeCloseTo(0.25)
+  })
+
+  it('round-trips with positionToGamma', () => {
+    for (const pos of [0.1, 0.3, 0.5, 0.7, 0.9]) {
+      expect(gammaToPosition(positionToGamma(pos))).toBeCloseTo(pos)
+    }
+  })
+})
+
+describe('formatMidpointLabel', () => {
+  it('formats linear scale as decimal', () => {
+    expect(formatMidpointLabel(0.5, 'linear')).toBe('0.50')
+  })
+
+  it('formats gamma scale as gamma value', () => {
+    expect(formatMidpointLabel(0.5, 'gamma')).toBe('1.00')
+  })
+})
+
+describe('constrainRange', () => {
+  it('passes through valid range unchanged', () => {
+    const result = constrainRange({ min: 0.2, max: 0.8 })
+    expect(result).toEqual({ min: 0.2, max: 0.8, midpoint: undefined })
+  })
+
+  it('clamps values to default [0, 1]', () => {
+    const result = constrainRange({ min: -0.5, max: 1.5 })
+    expect(result.min).toBe(0)
+    expect(result.max).toBe(1)
+  })
+
+  it('clamps values to custom range', () => {
+    const result = constrainRange({ min: -10, max: 300 }, 0, 255)
+    expect(result.min).toBe(0)
+    expect(result.max).toBe(255)
+  })
+
+  it('enforces min <= max', () => {
+    const result = constrainRange({ min: 0.8, max: 0.3 })
+    expect(result.min).toBe(0.8)
+    expect(result.max).toBe(0.8)
+  })
+
+  it('preserves midpoint when present', () => {
+    const result = constrainRange({ min: 0.2, max: 0.8, midpoint: 0.5 })
+    expect(result.midpoint).toBe(0.5)
+  })
+
+  it('clamps midpoint to [0, 1]', () => {
+    const result = constrainRange({ min: 0.2, max: 0.8, midpoint: 1.5 })
+    expect(result.midpoint).toBe(1)
+  })
+})
+
+describe('isRangeValue', () => {
+  it('returns true for valid range', () => {
+    expect(isRangeValue({ min: 0, max: 1 })).toBe(true)
+    expect(isRangeValue({ min: 0, max: 1, midpoint: 0.5 })).toBe(true)
+  })
+
+  it('returns false for non-objects', () => {
+    expect(isRangeValue(null)).toBe(false)
+    expect(isRangeValue(42)).toBe(false)
+    expect(isRangeValue('foo')).toBe(false)
+    expect(isRangeValue([0, 1])).toBe(false)
+  })
+
+  it('returns false for objects missing min or max', () => {
+    expect(isRangeValue({ min: 0 })).toBe(false)
+    expect(isRangeValue({ max: 1 })).toBe(false)
+    expect(isRangeValue({ min: 'a', max: 1 })).toBe(false)
+  })
+})

--- a/src/components/range/rangeUtils.test.ts
+++ b/src/components/range/rangeUtils.test.ts
@@ -1,38 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  constrainRange,
-  denormalize,
-  formatMidpointLabel,
-  gammaToPosition,
-  isRangeValue,
-  normalize,
-  positionToGamma
-} from './rangeUtils'
-
-describe('normalize', () => {
-  it('normalizes value to 0-1', () => {
-    expect(normalize(128, 0, 256)).toBe(0.5)
-    expect(normalize(0, 0, 255)).toBe(0)
-    expect(normalize(255, 0, 255)).toBe(1)
-  })
-
-  it('returns 0 when min equals max', () => {
-    expect(normalize(5, 5, 5)).toBe(0)
-  })
-})
-
-describe('denormalize', () => {
-  it('converts normalized value back to range', () => {
-    expect(denormalize(0.5, 0, 256)).toBe(128)
-    expect(denormalize(0, 0, 255)).toBe(0)
-    expect(denormalize(1, 0, 255)).toBe(255)
-  })
-
-  it('round-trips with normalize', () => {
-    expect(denormalize(normalize(100, 0, 255), 0, 255)).toBeCloseTo(100)
-  })
-})
+import { gammaToPosition, isRangeValue, positionToGamma } from './rangeUtils'
 
 describe('positionToGamma', () => {
   it('converts 0.5 to gamma 1.0', () => {
@@ -57,51 +25,6 @@ describe('gammaToPosition', () => {
     for (const pos of [0.1, 0.3, 0.5, 0.7, 0.9]) {
       expect(gammaToPosition(positionToGamma(pos))).toBeCloseTo(pos)
     }
-  })
-})
-
-describe('formatMidpointLabel', () => {
-  it('formats linear scale as decimal', () => {
-    expect(formatMidpointLabel(0.5, 'linear')).toBe('0.50')
-  })
-
-  it('formats gamma scale as gamma value', () => {
-    expect(formatMidpointLabel(0.5, 'gamma')).toBe('1.00')
-  })
-})
-
-describe('constrainRange', () => {
-  it('passes through valid range unchanged', () => {
-    const result = constrainRange({ min: 0.2, max: 0.8 })
-    expect(result).toEqual({ min: 0.2, max: 0.8, midpoint: undefined })
-  })
-
-  it('clamps values to default [0, 1]', () => {
-    const result = constrainRange({ min: -0.5, max: 1.5 })
-    expect(result.min).toBe(0)
-    expect(result.max).toBe(1)
-  })
-
-  it('clamps values to custom range', () => {
-    const result = constrainRange({ min: -10, max: 300 }, 0, 255)
-    expect(result.min).toBe(0)
-    expect(result.max).toBe(255)
-  })
-
-  it('enforces min <= max', () => {
-    const result = constrainRange({ min: 0.8, max: 0.3 })
-    expect(result.min).toBe(0.8)
-    expect(result.max).toBe(0.8)
-  })
-
-  it('preserves midpoint when present', () => {
-    const result = constrainRange({ min: 0.2, max: 0.8, midpoint: 0.5 })
-    expect(result.midpoint).toBe(0.5)
-  })
-
-  it('clamps midpoint to [0, 1]', () => {
-    const result = constrainRange({ min: 0.2, max: 0.8, midpoint: 1.5 })
-    expect(result.midpoint).toBe(1)
   })
 })
 

--- a/src/components/range/rangeUtils.ts
+++ b/src/components/range/rangeUtils.ts
@@ -1,0 +1,58 @@
+import { clamp } from 'es-toolkit'
+
+import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
+
+export { clamp }
+
+export function normalize(value: number, min: number, max: number): number {
+  return max === min ? 0 : (value - min) / (max - min)
+}
+
+export function denormalize(
+  normalized: number,
+  min: number,
+  max: number
+): number {
+  return min + normalized * (max - min)
+}
+
+export function positionToGamma(position: number): number {
+  const clamped = clamp(position, 0.001, 0.999)
+  return -Math.log2(clamped)
+}
+
+export function gammaToPosition(gamma: number): number {
+  return Math.pow(2, -gamma)
+}
+
+export function formatMidpointLabel(
+  position: number,
+  scale: 'linear' | 'gamma'
+): string {
+  if (scale === 'gamma') {
+    return positionToGamma(position).toFixed(2)
+  }
+  return position.toFixed(2)
+}
+
+export function constrainRange(
+  value: RangeValue,
+  valueMin: number = 0,
+  valueMax: number = 1
+): RangeValue {
+  const min = clamp(value.min, valueMin, valueMax)
+  const max = clamp(Math.max(min, value.max), valueMin, valueMax)
+  const midpoint =
+    value.midpoint !== undefined ? clamp(value.midpoint, 0, 1) : undefined
+  return { min, max, midpoint }
+}
+
+export function isRangeValue(value: unknown): value is RangeValue {
+  if (typeof value !== 'object' || value === null || Array.isArray(value))
+    return false
+  const v = value as Record<string, unknown>
+  const hasFiniteBounds = Number.isFinite(v.min) && Number.isFinite(v.max)
+  const hasValidMidpoint =
+    v.midpoint === undefined || Number.isFinite(v.midpoint)
+  return hasFiniteBounds && hasValidMidpoint
+}

--- a/src/components/range/rangeUtils.ts
+++ b/src/components/range/rangeUtils.ts
@@ -2,49 +2,14 @@ import { clamp } from 'es-toolkit'
 
 import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
 
-export { clamp }
-
-export function normalize(value: number, min: number, max: number): number {
-  return max === min ? 0 : (value - min) / (max - min)
-}
-
-export function denormalize(
-  normalized: number,
-  min: number,
-  max: number
-): number {
-  return min + normalized * (max - min)
-}
-
 export function positionToGamma(position: number): number {
+  // Avoid log2(0) = -Infinity and log2(1) = 0 (division by zero in gamma)
   const clamped = clamp(position, 0.001, 0.999)
   return -Math.log2(clamped)
 }
 
 export function gammaToPosition(gamma: number): number {
   return Math.pow(2, -gamma)
-}
-
-export function formatMidpointLabel(
-  position: number,
-  scale: 'linear' | 'gamma'
-): string {
-  if (scale === 'gamma') {
-    return positionToGamma(position).toFixed(2)
-  }
-  return position.toFixed(2)
-}
-
-export function constrainRange(
-  value: RangeValue,
-  valueMin: number = 0,
-  valueMax: number = 1
-): RangeValue {
-  const min = clamp(value.min, valueMin, valueMax)
-  const max = clamp(Math.max(min, value.max), valueMin, valueMax)
-  const midpoint =
-    value.midpoint !== undefined ? clamp(value.midpoint, 0, 1) : undefined
-  return { min, max, midpoint }
 }
 
 export function isRangeValue(value: unknown): value is RangeValue {

--- a/src/composables/useRangeEditor.ts
+++ b/src/composables/useRangeEditor.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 
 import { clamp } from 'es-toolkit'
 
-import { denormalize, normalize } from '@/components/range/rangeUtils'
+import { denormalize, normalize } from '@/utils/mathUtil'
 import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
 
 type HandleType = 'min' | 'max' | 'midpoint'
@@ -13,13 +13,15 @@ interface UseRangeEditorOptions {
   modelValue: Ref<RangeValue>
   valueMin: Ref<number>
   valueMax: Ref<number>
+  showMidpoint: Ref<boolean>
 }
 
 export function useRangeEditor({
   trackRef,
   modelValue,
   valueMin,
-  valueMax
+  valueMax,
+  showMidpoint
 }: UseRangeEditorOptions) {
   const activeHandle = ref<HandleType | null>(null)
   let cleanupDrag: (() => void) | null = null
@@ -28,10 +30,7 @@ export function useRangeEditor({
     const el = trackRef.value
     if (!el) return valueMin.value
     const rect = el.getBoundingClientRect()
-    const normalized = Math.max(
-      0,
-      Math.min(1, (e.clientX - rect.left) / rect.width)
-    )
+    const normalized = clamp((e.clientX - rect.left) / rect.width, 0, 1)
     return denormalize(normalized, valueMin.value, valueMax.value)
   }
 
@@ -41,7 +40,7 @@ export function useRangeEditor({
     const dMax = Math.abs(value - max)
     let best: HandleType = dMin <= dMax ? 'min' : 'max'
     const bestDist = Math.min(dMin, dMax)
-    if (midpoint !== undefined) {
+    if (midpoint !== undefined && showMidpoint.value) {
       const midAbs = min + midpoint * (max - min)
       if (Math.abs(value - midAbs) < bestDist) {
         best = 'midpoint'

--- a/src/composables/useRangeEditor.ts
+++ b/src/composables/useRangeEditor.ts
@@ -1,0 +1,115 @@
+import { onBeforeUnmount, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import { clamp } from 'es-toolkit'
+
+import { denormalize, normalize } from '@/components/range/rangeUtils'
+import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
+
+type HandleType = 'min' | 'max' | 'midpoint'
+
+interface UseRangeEditorOptions {
+  trackRef: Ref<HTMLElement | null>
+  modelValue: Ref<RangeValue>
+  valueMin: Ref<number>
+  valueMax: Ref<number>
+}
+
+export function useRangeEditor({
+  trackRef,
+  modelValue,
+  valueMin,
+  valueMax
+}: UseRangeEditorOptions) {
+  const activeHandle = ref<HandleType | null>(null)
+  let cleanupDrag: (() => void) | null = null
+
+  function pointerToValue(e: PointerEvent): number {
+    const el = trackRef.value
+    if (!el) return valueMin.value
+    const rect = el.getBoundingClientRect()
+    const normalized = Math.max(
+      0,
+      Math.min(1, (e.clientX - rect.left) / rect.width)
+    )
+    return denormalize(normalized, valueMin.value, valueMax.value)
+  }
+
+  function nearestHandle(value: number): HandleType {
+    const { min, max, midpoint } = modelValue.value
+    const dMin = Math.abs(value - min)
+    const dMax = Math.abs(value - max)
+    let best: HandleType = dMin <= dMax ? 'min' : 'max'
+    const bestDist = Math.min(dMin, dMax)
+    if (midpoint !== undefined) {
+      const midAbs = min + midpoint * (max - min)
+      if (Math.abs(value - midAbs) < bestDist) {
+        best = 'midpoint'
+      }
+    }
+    return best
+  }
+
+  function updateValue(handle: HandleType, value: number) {
+    const current = modelValue.value
+    const clamped = clamp(value, valueMin.value, valueMax.value)
+
+    if (handle === 'min') {
+      modelValue.value = { ...current, min: Math.min(clamped, current.max) }
+    } else if (handle === 'max') {
+      modelValue.value = { ...current, max: Math.max(clamped, current.min) }
+    } else {
+      const range = current.max - current.min
+      const midNorm =
+        range > 0 ? normalize(clamped, current.min, current.max) : 0
+      const midpoint = Math.max(0, Math.min(1, midNorm))
+      modelValue.value = { ...current, midpoint }
+    }
+  }
+
+  function handleTrackPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return
+    startDrag(nearestHandle(pointerToValue(e)), e)
+  }
+
+  function startDrag(handle: HandleType, e: PointerEvent) {
+    if (e.button !== 0) return
+    cleanupDrag?.()
+
+    activeHandle.value = handle
+    const el = trackRef.value
+    if (!el) return
+
+    el.setPointerCapture(e.pointerId)
+
+    const onMove = (ev: PointerEvent) => {
+      if (!activeHandle.value) return
+      updateValue(activeHandle.value, pointerToValue(ev))
+    }
+
+    const endDrag = () => {
+      if (!activeHandle.value) return
+      activeHandle.value = null
+      el.removeEventListener('pointermove', onMove)
+      el.removeEventListener('pointerup', endDrag)
+      el.removeEventListener('lostpointercapture', endDrag)
+      cleanupDrag = null
+    }
+
+    cleanupDrag = endDrag
+
+    el.addEventListener('pointermove', onMove)
+    el.addEventListener('pointerup', endDrag)
+    el.addEventListener('lostpointercapture', endDrag)
+  }
+
+  onBeforeUnmount(() => {
+    cleanupDrag?.()
+  })
+
+  return {
+    activeHandle,
+    handleTrackPointerDown,
+    startDrag
+  }
+}

--- a/src/composables/useRangeEditor.ts
+++ b/src/composables/useRangeEditor.ts
@@ -61,7 +61,7 @@ export function useRangeEditor({
       const range = current.max - current.min
       const midNorm =
         range > 0 ? normalize(clamped, current.min, current.max) : 0
-      const midpoint = Math.max(0, Math.min(1, midNorm))
+      const midpoint = clamp(midNorm, 0, 1)
       modelValue.value = { ...current, midpoint }
     }
   }
@@ -107,7 +107,6 @@ export function useRangeEditor({
   })
 
   return {
-    activeHandle,
     handleTrackPointerDown,
     startDrag
   }

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -355,7 +355,6 @@ export interface IWidgetRangeOptions extends IWidgetOptions {
   midpoint_scale?: 'linear' | 'gamma'
   value_min?: number
   value_max?: number
-  histogram?: Uint32Array | null
 }
 
 export interface IRangeWidget extends IBaseWidget<

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -139,6 +139,7 @@ export type IWidget =
   | IBoundingBoxWidget
   | ICurveWidget
   | IPainterWidget
+  | IRangeWidget
 
 export interface IBooleanWidget extends IBaseWidget<boolean, 'toggle'> {
   type: 'toggle'
@@ -339,6 +340,31 @@ export interface ICurveWidget extends IBaseWidget<CurveData, 'curve'> {
 export interface IPainterWidget extends IBaseWidget<string, 'painter'> {
   type: 'painter'
   value: string
+}
+
+export interface RangeValue {
+  min: number
+  max: number
+  midpoint?: number
+}
+
+export interface IWidgetRangeOptions extends IWidgetOptions {
+  display?: 'plain' | 'gradient' | 'histogram'
+  gradient_stops?: ColorStop[]
+  show_midpoint?: boolean
+  midpoint_scale?: 'linear' | 'gamma'
+  value_min?: number
+  value_max?: number
+  histogram?: Uint32Array | null
+}
+
+export interface IRangeWidget extends IBaseWidget<
+  RangeValue,
+  'range',
+  IWidgetRangeOptions
+> {
+  type: 'range'
+  value: RangeValue
 }
 
 /**

--- a/src/lib/litegraph/src/widgets/RangeWidget.ts
+++ b/src/lib/litegraph/src/widgets/RangeWidget.ts
@@ -1,0 +1,16 @@
+import type { IRangeWidget } from '../types/widgets'
+import { BaseWidget } from './BaseWidget'
+import type { DrawWidgetOptions, WidgetEventOptions } from './BaseWidget'
+
+export class RangeWidget
+  extends BaseWidget<IRangeWidget>
+  implements IRangeWidget
+{
+  override type = 'range' as const
+
+  drawWidget(ctx: CanvasRenderingContext2D, options: DrawWidgetOptions): void {
+    this.drawVueOnlyWarning(ctx, options, 'Range')
+  }
+
+  onClick(_options: WidgetEventOptions): void {}
+}

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -22,6 +22,7 @@ import { GalleriaWidget } from './GalleriaWidget'
 import { GradientSliderWidget } from './GradientSliderWidget'
 import { ImageCompareWidget } from './ImageCompareWidget'
 import { PainterWidget } from './PainterWidget'
+import { RangeWidget } from './RangeWidget'
 import { ImageCropWidget } from './ImageCropWidget'
 import { KnobWidget } from './KnobWidget'
 import { LegacyWidget } from './LegacyWidget'
@@ -60,6 +61,7 @@ export type WidgetTypeMap = {
   boundingbox: BoundingBoxWidget
   curve: CurveWidget
   painter: PainterWidget
+  range: RangeWidget
   [key: string]: BaseWidget
 }
 
@@ -140,6 +142,8 @@ export function toConcreteWidget<TWidget extends IWidget | IBaseWidget>(
       return toClass(CurveWidget, narrowedWidget, node)
     case 'painter':
       return toClass(PainterWidget, narrowedWidget, node)
+    case 'range':
+      return toClass(RangeWidget, narrowedWidget, node)
     default: {
       if (wrapLegacyWidgets) return toClass(LegacyWidget, widget, node)
     }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useRangeWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useRangeWidget.ts
@@ -1,0 +1,37 @@
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type {
+  IRangeWidget,
+  IWidgetRangeOptions
+} from '@/lib/litegraph/src/types/widgets'
+import type { RangeInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
+
+export const useRangeWidget = (): ComfyWidgetConstructorV2 => {
+  return (node: LGraphNode, inputSpec): IRangeWidget => {
+    const spec = inputSpec as RangeInputSpec
+    const defaultValue = spec.default ?? { min: 0.0, max: 1.0 }
+
+    const options: IWidgetRangeOptions = {
+      display: spec.display,
+      gradient_stops: spec.gradient_stops,
+      show_midpoint: spec.show_midpoint,
+      midpoint_scale: spec.midpoint_scale,
+      value_min: spec.value_min,
+      value_max: spec.value_max
+    }
+
+    const rawWidget = node.addWidget(
+      'range',
+      spec.name,
+      { ...defaultValue },
+      () => {},
+      options
+    )
+
+    if (rawWidget.type !== 'range') {
+      throw new Error(`Unexpected widget type: ${rawWidget.type}`)
+    }
+
+    return rawWidget as IRangeWidget
+  }
+}

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -63,6 +63,9 @@ const WidgetCurve = defineAsyncComponent(
 const WidgetPainter = defineAsyncComponent(
   () => import('@/components/painter/WidgetPainter.vue')
 )
+const WidgetRange = defineAsyncComponent(
+  () => import('@/components/range/WidgetRange.vue')
+)
 
 export const FOR_TESTING = {
   WidgetButton,
@@ -197,6 +200,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
       aliases: ['PAINTER'],
       essential: false
     }
+  ],
+  [
+    'range',
+    {
+      component: WidgetRange,
+      aliases: ['RANGE'],
+      essential: false
+    }
   ]
 ]
 
@@ -234,7 +245,8 @@ const EXPANDING_TYPES = [
   'load3D',
   'curve',
   'painter',
-  'imagecompare'
+  'imagecompare',
+  'range'
 ] as const
 
 export function shouldExpand(type: string): boolean {

--- a/src/schemas/nodeDef/nodeDefSchemaV2.ts
+++ b/src/schemas/nodeDef/nodeDefSchemaV2.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import {
   zBaseInputOptions,
   zBooleanInputOptions,
+  zColorStop,
   zComboInputOptions,
   zFloatInputOptions,
   zIntInputOptions,
@@ -140,6 +141,25 @@ const zCurveInputSpec = zBaseInputOptions.extend({
   default: zCurveData.optional()
 })
 
+const zRangeValue = z.object({
+  min: z.number(),
+  max: z.number(),
+  midpoint: z.number().optional()
+})
+
+const zRangeInputSpec = zBaseInputOptions.extend({
+  type: z.literal('RANGE'),
+  name: z.string(),
+  isOptional: z.boolean().optional(),
+  default: zRangeValue.optional(),
+  display: z.enum(['plain', 'gradient', 'histogram']).optional(),
+  gradient_stops: z.array(zColorStop).optional(),
+  show_midpoint: z.boolean().optional(),
+  midpoint_scale: z.enum(['linear', 'gamma']).optional(),
+  value_min: z.number().optional(),
+  value_max: z.number().optional()
+})
+
 const zCustomInputSpec = zBaseInputOptions.extend({
   type: z.string(),
   name: z.string(),
@@ -161,6 +181,7 @@ const zInputSpec = z.union([
   zGalleriaInputSpec,
   zTextareaInputSpec,
   zCurveInputSpec,
+  zRangeInputSpec,
   zCustomInputSpec
 ])
 
@@ -206,6 +227,7 @@ export type ChartInputSpec = z.infer<typeof zChartInputSpec>
 export type GalleriaInputSpec = z.infer<typeof zGalleriaInputSpec>
 export type TextareaInputSpec = z.infer<typeof zTextareaInputSpec>
 export type CurveInputSpec = z.infer<typeof zCurveInputSpec>
+export type RangeInputSpec = z.infer<typeof zRangeInputSpec>
 export type CustomInputSpec = z.infer<typeof zCustomInputSpec>
 
 export type InputSpec = z.infer<typeof zInputSpec>

--- a/src/schemas/nodeDefSchema.ts
+++ b/src/schemas/nodeDefSchema.ts
@@ -56,16 +56,14 @@ export const zIntInputOptions = zNumericInputOptions.extend({
     .optional()
 })
 
+export const zColorStop = z.object({
+  offset: z.number(),
+  color: z.tuple([z.number(), z.number(), z.number()])
+})
+
 export const zFloatInputOptions = zNumericInputOptions.extend({
   round: z.union([z.number(), z.literal(false)]).optional(),
-  gradient_stops: z
-    .array(
-      z.object({
-        offset: z.number(),
-        color: z.tuple([z.number(), z.number(), z.number()])
-      })
-    )
-    .optional()
+  gradient_stops: z.array(zColorStop).optional()
 })
 
 export const zBooleanInputOptions = zBaseInputOptions.extend({

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -20,6 +20,7 @@ import { useImageUploadWidget } from '@/renderer/extensions/vueNodes/widgets/com
 import { useIntWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useIntWidget'
 import { useMarkdownWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget'
 import { usePainterWidget } from '@/renderer/extensions/vueNodes/widgets/composables/usePainterWidget'
+import { useRangeWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useRangeWidget'
 import { useStringWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useStringWidget'
 import { useTextareaWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useTextareaWidget'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
@@ -310,6 +311,7 @@ export const ComfyWidgets = {
   PAINTER: transformWidgetConstructorV2ToV1(usePainterWidget()),
   TEXTAREA: transformWidgetConstructorV2ToV1(useTextareaWidget()),
   CURVE: transformWidgetConstructorV2ToV1(useCurveWidget()),
+  RANGE: transformWidgetConstructorV2ToV1(useRangeWidget()),
   ...dynamicWidgets
 } as const
 

--- a/src/utils/histogramUtil.test.ts
+++ b/src/utils/histogramUtil.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { histogramToPath } from './histogramUtil'
+
+describe('histogramToPath', () => {
+  it('returns empty string for empty histogram', () => {
+    expect(histogramToPath(new Uint32Array(0))).toBe('')
+  })
+
+  it('returns empty string when all bins are zero', () => {
+    expect(histogramToPath(new Uint32Array(256))).toBe('')
+  })
+
+  it('returns a closed SVG path for valid histogram', () => {
+    const histogram = new Uint32Array(256)
+    for (let i = 0; i < 256; i++) histogram[i] = i + 1
+    const path = histogramToPath(histogram)
+    expect(path).toMatch(/^M0,1/)
+    expect(path).toMatch(/L1,1 Z$/)
+  })
+
+  it('normalizes using 99.5th percentile to suppress outliers', () => {
+    const histogram = new Uint32Array(256)
+    for (let i = 0; i < 256; i++) histogram[i] = 100
+    histogram[255] = 100000
+    const path = histogramToPath(histogram)
+    const yValues = path
+      .split(/[ML]/)
+      .filter(Boolean)
+      .map((s) => parseFloat(s.split(',')[1]))
+      .filter((y) => !isNaN(y))
+    const nearZero = yValues.filter((y) => Math.abs(y) < 0.01)
+    expect(nearZero.length).toBeGreaterThan(200)
+  })
+})

--- a/src/utils/histogramUtil.ts
+++ b/src/utils/histogramUtil.ts
@@ -1,0 +1,27 @@
+/**
+ * Convert a histogram (arbitrary number of bins) into an SVG path string.
+ * Applies square-root scaling and normalizes using the 99.5th percentile
+ * to avoid outlier spikes.
+ */
+export function histogramToPath(histogram: Uint32Array): string {
+  const len = histogram.length
+  if (len === 0) return ''
+
+  const sqrtValues = new Float32Array(len)
+  for (let i = 0; i < len; i++) sqrtValues[i] = Math.sqrt(histogram[i])
+
+  const sorted = Array.from(sqrtValues).sort((a, b) => a - b)
+  const max = sorted[Math.floor((len - 1) * 0.995)]
+  if (max === 0) return ''
+
+  const invMax = 1 / max
+  const lastIdx = len - 1
+  const parts: string[] = ['M0,1']
+  for (let i = 0; i < len; i++) {
+    const x = lastIdx === 0 ? 0.5 : i / lastIdx
+    const y = 1 - Math.min(1, sqrtValues[i] * invMax)
+    parts.push(`L${x},${y}`)
+  }
+  parts.push('L1,1 Z')
+  return parts.join(' ')
+}

--- a/src/utils/mathUtil.test.ts
+++ b/src/utils/mathUtil.test.ts
@@ -1,9 +1,39 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
-import { computeUnionBounds, gcd, lcm } from '@/utils/mathUtil'
+import {
+  computeUnionBounds,
+  denormalize,
+  gcd,
+  lcm,
+  normalize
+} from '@/utils/mathUtil'
 
 describe('mathUtil', () => {
+  describe('normalize', () => {
+    it('normalizes value to 0-1', () => {
+      expect(normalize(128, 0, 256)).toBe(0.5)
+      expect(normalize(0, 0, 255)).toBe(0)
+      expect(normalize(255, 0, 255)).toBe(1)
+    })
+
+    it('returns 0 when min equals max', () => {
+      expect(normalize(5, 5, 5)).toBe(0)
+    })
+  })
+
+  describe('denormalize', () => {
+    it('converts normalized value back to range', () => {
+      expect(denormalize(0.5, 0, 256)).toBe(128)
+      expect(denormalize(0, 0, 255)).toBe(0)
+      expect(denormalize(1, 0, 255)).toBe(255)
+    })
+
+    it('round-trips with normalize', () => {
+      expect(denormalize(normalize(100, 0, 255), 0, 255)).toBeCloseTo(100)
+    })
+  })
+
   describe('gcd', () => {
     it('should compute greatest common divisor correctly', () => {
       expect(gcd(48, 18)).toBe(6)

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -1,4 +1,5 @@
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
+import type { Bounds } from '@/renderer/core/layout/types'
 
 /**
  * Linearly maps a value from [min, max] to [0, 1].
@@ -18,7 +19,6 @@ export function denormalize(
 ): number {
   return min + normalized * (max - min)
 }
-import type { Bounds } from '@/renderer/core/layout/types'
 
 /** Simple 2D point or size as [x, y] or [width, height] */
 type Vec2 = readonly [number, number]

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -1,4 +1,23 @@
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
+
+/**
+ * Linearly maps a value from [min, max] to [0, 1].
+ * Returns 0 when min equals max to avoid division by zero.
+ */
+export function normalize(value: number, min: number, max: number): number {
+  return max === min ? 0 : (value - min) / (max - min)
+}
+
+/**
+ * Linearly maps a normalized value from [0, 1] back to [min, max].
+ */
+export function denormalize(
+  normalized: number,
+  min: number,
+  max: number
+): number {
+  return min + normalized * (max - min)
+}
 import type { Bounds } from '@/renderer/core/layout/types'
 
 /** Simple 2D point or size as [x, y] or [width, height] */


### PR DESCRIPTION
BE change https://github.com/Comfy-Org/ComfyUI/pull/13322

## Summary
Add RANGE widget for image levels adjustment       
                                                                                                                                                                                                                                                                            - Add RangeEditor widget with three display modes: plain, gradient, and histogram                               
- Support optional midpoint (gamma) control for non-linear midtone adjustment                                   
- Integrate histogram display from upstream node outputs

## Screenshots (if applicable)
<img width="1450" height="715" alt="image" src="https://github.com/user-attachments/assets/864976af-9eb7-4dd0-9ce1-2f5d7f003117" />
<img width="1431" height="701" alt="image" src="https://github.com/user-attachments/assets/7ee2af65-f87a-407b-8bf2-6ec59a1dff59" />
<img width="705" height="822" alt="image" src="https://github.com/user-attachments/assets/7bcb8f17-795f-498a-9f8a-076ed6c05a98" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10936-Range-editor-33b6d73d365081089e8be040b40f6c8a) by [Unito](https://www.unito.io)
