### PR TITLE
[backport cloud/1.42] fix: don't override loadGraphData viewport on cache miss

### DIFF
--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -8,6 +8,8 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { findSubgraphPathById } from '@/utils/graphTraversalUtil'
+import { useLitegraphService } from '@/services/litegraphService'
+import { anyItemOverlapsRect } from '@/utils/mathUtil'
 import { isNonNullish } from '@/utils/typeGuardUtil'
 
 export const VIEWPORT_CACHE_MAX_SIZE = 32
@@ -102,23 +104,34 @@ export const useSubgraphNavigationStore = defineStore(
      * @param graphId The graph ID to restore. Use 'root' for root graph, or omit to use current context.
      */
     const restoreViewport = (graphId: string) => {
-      const viewport = viewportCache.get(graphId)
-      if (!viewport) return
-
       const canvas = app.canvas
       if (!canvas) return
 
-      canvas.ds.scale = viewport.scale
-      canvas.ds.offset[0] = viewport.offset[0]
-      canvas.ds.offset[1] = viewport.offset[1]
-      canvas.setDirty(true, true)
+      const viewport = viewportCache.get(graphId)
+      if (viewport) {
+        canvas.ds.scale = viewport.scale
+        canvas.ds.offset[0] = viewport.offset[0]
+        canvas.ds.offset[1] = viewport.offset[1]
+        canvas.setDirty(true, true)
+        return
+      }
+
+      // Cache miss — fit to content only if no nodes are currently visible.
+      // loadGraphData may have already restored extra.ds or called fitView
+      // for templates, so only intervene when the viewport is truly empty.
+      requestAnimationFrame(() => {
+        if (!canvas.graph) return
+
+        const nodes = canvas.graph.nodes
+        if (!nodes?.length) return
+
+        canvas.ds.computeVisibleArea(canvas.viewport)
+        if (anyItemOverlapsRect(nodes, canvas.ds.visible_area)) return
+
+        useLitegraphService().fitView()
+      })
     }
 
-    /**
-     * Update the navigation stack when the active subgraph changes.
-     * @param subgraph The new active subgraph.
-     * @param prevSubgraph The previous active subgraph.
-     */
     const onNavigated = (
       subgraph: Subgraph | undefined,
       prevSubgraph: Subgraph | undefined

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -22,11 +22,12 @@ vi.mock('@/scripts/app', () => {
     ds: {
       scale: 1,
       offset: [0, 0],
-      state: {
-        scale: 1,
-        offset: [0, 0]
-      }
+      state: { scale: 1, offset: [0, 0] },
+      fitToBounds: vi.fn(),
+      visible_area: [0, 0, 1000, 1000],
+      computeVisibleArea: vi.fn()
     },
+    viewport: [0, 0, 1000, 1000],
     setDirty: mockSetDirty
   }
 


### PR DESCRIPTION
Backport of #10810 to cloud/1.42.

Cherry-pick of merge commit 6cd3b59d5 with conflict resolution:
- Added `anyItemOverlapsRect` import and `useLitegraphService` import
- Adapted `restoreViewport` to add visibility check on cache miss (fits to content only if no nodes visible)
- Added mock canvas fields (`visible_area`, `computeVisibleArea`, `viewport`) to test

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10940-backport-cloud-1-42-fix-don-t-override-loadGraphData-viewport-on-cache-miss-33b6d73d3650811595e9c356f2be96da) by [Unito](https://www.unito.io)
