### PR TITLE
Remove flex styling from svg

### DIFF
--- a/packages/design-system/src/icons/elevenlabs.svg
+++ b/packages/design-system/src/icons/elevenlabs.svg
@@ -1,1 +1,1 @@
-<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>ElevenLabs</title><path d="M5 0h5v24H5V0zM14 0h5v24h-5V0z"></path></svg>
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>ElevenLabs</title><path d="M5 0h5v24H5V0zM14 0h5v24h-5V0z"></path></svg>


### PR DESCRIPTION
This cleans up a minor warning message from the dev server.:
` WARN  Removing unexpected style on "svg": flex`

The icon is displayed in the header of some templates and is not visually impacted by the change.
<img width="268" height="365" alt="image" src="https://github.com/user-attachments/assets/a0c03e85-5275-4671-b903-8458d7ba3517" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10941-Remove-flex-styling-from-svg-33b6d73d36508113a7dce77c269fe4cb) by [Unito](https://www.unito.io)
