### PR TITLE
fix: count files (not jobs) in export ZIP toast

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -19,19 +19,25 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
+const mockToastAdd = vi.hoisted(() => vi.fn())
 vi.mock('primevue/usetoast', () => ({
   useToast: () => ({
-    add: vi.fn()
+    add: mockToastAdd
   })
 }))
 
+const mockI18nT = vi.hoisted(() =>
+  vi.fn((key: string, count?: number) =>
+    typeof count === 'number' ? `${key}:${count}` : key
+  )
+)
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
-    t: (key: string) => key
+    t: mockI18nT
   }),
   createI18n: () => ({
     global: {
-      t: (key: string) => key
+      t: mockI18nT
     }
   })
 }))
@@ -372,6 +378,115 @@ describe('useMediaAssetActions', () => {
       expect(payload.job_asset_name_filters).toEqual({
         job2: ['img2.png']
       })
+    })
+  })
+
+  describe('downloadMultipleAssets - export toast file count', () => {
+    beforeEach(() => {
+      mockIsCloud.value = true
+      mockCreateAssetExport.mockClear()
+      mockTrackExport.mockClear()
+      mockToastAdd.mockClear()
+      mockGetAssetType.mockReturnValue('output')
+      mockGetOutputAssetMetadata.mockImplementation(
+        (meta: Record<string, unknown> | undefined) =>
+          meta && 'jobId' in meta ? meta : null
+      )
+    })
+
+    function createOutputAsset(
+      id: string,
+      name: string,
+      jobId: string,
+      outputCount?: number
+    ): AssetItem {
+      return createMockAsset({
+        id,
+        name,
+        tags: ['output'],
+        user_metadata: { jobId, nodeId: '1', subfolder: '', outputCount }
+      })
+    }
+
+    type ToastArg = { severity?: string; detail?: unknown }
+
+    async function getExportToastDetail(): Promise<unknown> {
+      await vi.waitFor(() => {
+        const hasInfoToast = mockToastAdd.mock.calls.some(
+          ([arg]) => (arg as ToastArg).severity === 'info'
+        )
+        expect(hasInfoToast).toBe(true)
+      })
+      const exportToastCall = mockToastAdd.mock.calls.find(
+        ([arg]) => (arg as ToastArg).severity === 'info'
+      )
+      if (!exportToastCall) throw new Error('export info toast not found')
+      return (exportToastCall[0] as ToastArg).detail
+    }
+
+    it('sums outputCount across job-level selections', async () => {
+      // 3 jobs each with 2 outputs => 6 files total
+      const j1 = createOutputAsset('a1', 'img1.png', 'job1', 2)
+      const j2 = createOutputAsset('a2', 'img2.png', 'job2', 2)
+      const j3 = createOutputAsset('a3', 'img3.png', 'job3', 2)
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([j1, j2, j3])
+
+      const detail = await getExportToastDetail()
+      expect(detail).toBe('mediaAsset.selection.exportStarted:6')
+    })
+
+    it('counts assets without outputCount as a single file each', async () => {
+      const a1 = createOutputAsset('a1', 'img1.png', 'job1')
+      const a2 = createOutputAsset('a2', 'img2.png', 'job2')
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([a1, a2])
+
+      const detail = await getExportToastDetail()
+      expect(detail).toBe('mediaAsset.selection.exportStarted:2')
+    })
+
+    it('counts outputCount once per job when multiple job-level assets share a jobId', async () => {
+      // User selects 2 cards from the same job-level stack (outputCount=3
+      // on each). The export is still one job-wide export of 3 files.
+      const j1a = createOutputAsset('a1', 'img1.png', 'job1', 3)
+      const j1b = createOutputAsset('a2', 'img2.png', 'job1', 3)
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([j1a, j1b])
+
+      const detail = await getExportToastDetail()
+      expect(detail).toBe('mediaAsset.selection.exportStarted:3')
+    })
+
+    it('mixes job-level and asset-level selections correctly', async () => {
+      // job1 = job-level selection with 3 outputs
+      // job2 = 2 individually selected outputs (no outputCount)
+      const j1 = createOutputAsset('a1', 'img1.png', 'job1', 3)
+      const j2a = createOutputAsset('a2', 'out2a.png', 'job2')
+      const j2b = createOutputAsset('a3', 'out2b.png', 'job2')
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([j1, j2a, j2b])
+
+      const detail = await getExportToastDetail()
+      expect(detail).toBe('mediaAsset.selection.exportStarted:5')
+    })
+
+    it('does not double-count when a job-level and asset-level selection share a jobId', async () => {
+      // job1 is selected at the job level (outputCount=3) and the user also
+      // selects one individual output from the same job. The export is still
+      // one job-wide export of 3 files, not 4.
+      const j1Job = createOutputAsset('a1', 'img1.png', 'job1', 3)
+      const j1Asset = createOutputAsset('a2', 'img2.png', 'job1')
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([j1Job, j1Asset])
+
+      const detail = await getExportToastDetail()
+      expect(detail).toBe('mediaAsset.selection.exportStarted:3')
     })
   })
 

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -379,6 +379,22 @@ describe('useMediaAssetActions', () => {
         job2: ['img2.png']
       })
     })
+
+    it('should omit name filters when job-level and asset-level selections share a jobId', async () => {
+      const jobLevelAsset = createOutputAsset('a1', 'img1.png', 'job1', 3)
+      const assetLevelSelection = createOutputAsset('a2', 'img2.png', 'job1')
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([jobLevelAsset, assetLevelSelection])
+
+      await vi.waitFor(() => {
+        expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
+      })
+
+      const payload = mockCreateAssetExport.mock.calls[0][0]
+      expect(payload.job_ids).toEqual(['job1'])
+      expect(payload.job_asset_name_filters).toBeUndefined()
+    })
   })
 
   describe('downloadMultipleAssets - export toast file count', () => {

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -504,6 +504,17 @@ describe('useMediaAssetActions', () => {
       const detail = await getExportToastDetail()
       expect(detail).toBe('mediaAsset.selection.exportStarted:3')
     })
+
+    it('does not overcount when an asset-level selection comes before a job-level selection for the same jobId', async () => {
+      const j1Asset = createOutputAsset('a1', 'img1.png', 'job1')
+      const j1Job = createOutputAsset('a2', 'img2.png', 'job1', 3)
+
+      const actions = useMediaAssetActions()
+      actions.downloadMultipleAssets([j1Asset, j1Job])
+
+      const detail = await getExportToastDetail()
+      expect(detail).toBe('mediaAsset.selection.exportStarted:3')
+    })
   })
 
   describe('deleteAssets - model cache invalidation', () => {

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -131,6 +131,15 @@ export function useMediaAssetActions() {
     }
   }
 
+  /**
+   * Build and dispatch a ZIP export for the given assets.
+   *
+   * Assets split into job-level selections (gallery cards representing a whole
+   * job, identified by `outputCount` being set in metadata) and individual
+   * asset selections. Job-level selections count as `outputCount` files in the
+   * resulting toast and are deduplicated by `jobId` so that mixed selections
+   * (the same job selected both as a whole and per-asset) don't double-count.
+   */
   async function downloadMultipleAssetsAsZip(assets: AssetItem[]) {
     const assetExportStore = useAssetExportStore()
 
@@ -138,6 +147,8 @@ export function useMediaAssetActions() {
       const jobIds: string[] = []
       const assetIds: string[] = []
       const jobAssetNameFilters: Record<string, string[]> = {}
+      const countedJobLevelIds = new Set<string>()
+      let fileCount = 0
 
       for (const asset of assets) {
         if (getAssetType(asset) === 'output') {
@@ -157,8 +168,23 @@ export function useMediaAssetActions() {
               jobAssetNameFilters[metadata.jobId].push(asset.name)
             }
           }
+          // Count outputCount once per job: selecting multiple assets from the
+          // same job-level entry (same jobId with outputCount set) still
+          // represents a single job-wide export of outputCount files. Once a
+          // job has been counted at the job level, skip any further assets
+          // from the same jobId so mixed selections don't double-count.
+          const outputCount = metadata?.outputCount
+          if (countedJobLevelIds.has(jobId)) {
+            // already counted at the job level, ignore this asset
+          } else if (typeof outputCount === 'number') {
+            fileCount += outputCount
+            countedJobLevelIds.add(jobId)
+          } else {
+            fileCount += 1
+          }
         } else {
           assetIds.push(asset.id)
+          fileCount += 1
         }
       }
 
@@ -176,7 +202,7 @@ export function useMediaAssetActions() {
       toast.add({
         severity: 'info',
         summary: t('exportToast.exportStarted'),
-        detail: t('mediaAsset.selection.exportStarted', assets.length),
+        detail: t('mediaAsset.selection.exportStarted', fileCount),
         life: 3000
       })
     } catch (error) {

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -147,8 +147,7 @@ export function useMediaAssetActions() {
       const jobIds: string[] = []
       const assetIds: string[] = []
       const jobAssetNameFilters: Record<string, string[]> = {}
-      const countedJobLevelIds = new Set<string>()
-      let fileCount = 0
+      const jobLevelCounts = new Map<string, number>()
 
       for (const asset of assets) {
         if (getAssetType(asset) === 'output') {
@@ -165,10 +164,11 @@ export function useMediaAssetActions() {
           // from the gallery and the user wants all outputs for that job.
           if (typeof outputCount === 'number') {
             delete jobAssetNameFilters[jobId]
+            jobLevelCounts.set(jobId, outputCount)
           } else if (
             metadata?.jobId &&
             asset.name &&
-            !countedJobLevelIds.has(jobId)
+            !jobLevelCounts.has(jobId)
           ) {
             if (!jobAssetNameFilters[metadata.jobId]) {
               jobAssetNameFilters[metadata.jobId] = []
@@ -177,26 +177,21 @@ export function useMediaAssetActions() {
               jobAssetNameFilters[metadata.jobId].push(asset.name)
             }
           }
-          // Count outputCount once per job: selecting multiple assets from the
-          // same job-level entry (same jobId with outputCount set) still
-          // represents a single job-wide export of outputCount files. Once a
-          // job has been counted at the job level, skip any further assets
-          // from the same jobId so mixed selections don't double-count.
-          if (typeof outputCount === 'number') {
-            if (!countedJobLevelIds.has(jobId)) {
-              countedJobLevelIds.add(jobId)
-              fileCount += outputCount
-            }
-          } else if (countedJobLevelIds.has(jobId)) {
-            // already counted at the job level, ignore this asset
-          } else {
-            fileCount += 1
-          }
         } else {
           assetIds.push(asset.id)
-          fileCount += 1
         }
       }
+
+      const fileCount =
+        assetIds.length +
+        jobIds.reduce((total, jobId) => {
+          const jobLevelCount = jobLevelCounts.get(jobId)
+          if (typeof jobLevelCount === 'number') {
+            return total + jobLevelCount
+          }
+
+          return total + (jobAssetNameFilters[jobId]?.length ?? 1)
+        }, 0)
 
       const result = await assetService.createAssetExport({
         ...(jobIds.length > 0 ? { job_ids: jobIds } : {}),

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -154,13 +154,22 @@ export function useMediaAssetActions() {
         if (getAssetType(asset) === 'output') {
           const metadata = getOutputAssetMetadata(asset.user_metadata)
           const jobId = metadata?.jobId || asset.id
+          const outputCount = metadata?.outputCount
+
           if (!jobIds.includes(jobId)) {
             jobIds.push(jobId)
           }
+
           // Only add name filters when outputCount is unknown.
           // When outputCount is set, the asset is a job-level selection
           // from the gallery and the user wants all outputs for that job.
-          if (metadata?.jobId && asset.name && metadata.outputCount == null) {
+          if (typeof outputCount === 'number') {
+            delete jobAssetNameFilters[jobId]
+          } else if (
+            metadata?.jobId &&
+            asset.name &&
+            !countedJobLevelIds.has(jobId)
+          ) {
             if (!jobAssetNameFilters[metadata.jobId]) {
               jobAssetNameFilters[metadata.jobId] = []
             }
@@ -173,12 +182,13 @@ export function useMediaAssetActions() {
           // represents a single job-wide export of outputCount files. Once a
           // job has been counted at the job level, skip any further assets
           // from the same jobId so mixed selections don't double-count.
-          const outputCount = metadata?.outputCount
-          if (countedJobLevelIds.has(jobId)) {
+          if (typeof outputCount === 'number') {
+            if (!countedJobLevelIds.has(jobId)) {
+              countedJobLevelIds.add(jobId)
+              fileCount += outputCount
+            }
+          } else if (countedJobLevelIds.has(jobId)) {
             // already counted at the job level, ignore this asset
-          } else if (typeof outputCount === 'number') {
-            fileCount += outputCount
-            countedJobLevelIds.add(jobId)
           } else {
             fileCount += 1
           }


### PR DESCRIPTION
## Summary

The export started toast showed the number of selected jobs instead of the number of files being exported, e.g. selecting 3 jobs each with 2 outputs incorrectly said \"Preparing ZIP export for 3 files\" instead of 6.

## Changes

- **What**: In \`downloadMultipleAssetsAsZip\`, sum \`outputCount\` per asset (defaulting to 1 when unknown) and use that as the toast count instead of \`assets.length\`.

## Review Focus

The fallback when \`outputCount\` is missing: assets without metadata or input assets count as 1 file each, which matches the export behavior (one entry per asset).

Reported in [Slack thread](https://comfy-organization.slack.com/archives/C075ANWQ8KS/p1774577719111479).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10947-fix-count-files-not-jobs-in-export-ZIP-toast-33b6d73d365081d09c34fce18a019d96) by [Unito](https://www.unito.io)
