### PR TITLE
fix(ci): restore pnpm version input for core/* branch compatibility

### DIFF
--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -144,6 +144,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Restores `version: 10` to the `pnpm/action-setup` step in `release-version-bump.yaml`.

## Why

PR #10687 removed the explicit `version: 10` input, relying on `packageManager` in `package.json` instead. However, this workflow checks out a **target branch** (e.g. `core/1.42`, `core/1.41`) that predates #10687 and lacks the `packageManager` field — causing the action to fail with:

> Error: No pnpm version is specified.

Failed run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/24110739586

Adding `version: 10` back is safe — the action only errors when `version` and `packageManager` **conflict**, and `pnpm@10.x` is compatible.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10952-fix-ci-restore-pnpm-version-input-for-core-branch-compatibility-33c6d73d3650819282bbf6c194d0d2f1) by [Unito](https://www.unito.io)
