### PR TITLE
fix(ci): resolve pnpm version conflict in version bump workflow

### DIFF
--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -142,10 +142,22 @@ jobs:
           fi
           echo "✅ Branch '$BRANCH' exists"
 
+      - name: Ensure packageManager field exists
+        run: |
+          if ! grep -q '"packageManager"' package.json; then
+            # Old branches (e.g. core/1.42) predate the packageManager field.
+            # Inject it so pnpm/action-setup can resolve the version.
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+              pkg.packageManager = 'pnpm@10.33.0';
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "Injected packageManager into package.json for legacy branch"
+          fi
+
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Removes hardcoded `version: 10` from `pnpm/action-setup` and instead injects the `packageManager` field into `package.json` when absent (legacy `core/*` branches).

## Why

PR #10952 re-added `version: 10` to fix old branches lacking `packageManager`. But `main` now has **both** `version: 10` (workflow) and `packageManager: pnpm@10.33.0` (`package.json`), causing `pnpm/action-setup` to error with:

> Multiple versions of pnpm specified

Failed run: https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/24158869559

This fix handles both cases:
- **`main`**: has `packageManager` → action reads it directly, no conflict
- **`core/1.42` etc**: missing `packageManager` → step injects it before the action runs

E2E test not applicable — this is a CI workflow configuration change with no user-facing behavior.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10972-fix-ci-resolve-pnpm-version-conflict-in-version-bump-workflow-33c6d73d36508112802df75c0dd5ea50) by [Unito](https://www.unito.io)
