### PR TITLE
fix: properties panel drag reorder visual flicker

### DIFF
--- a/src/components/common/DraggableList.vue
+++ b/src/components/common/DraggableList.vue
@@ -3,6 +3,10 @@ import { onBeforeUnmount, ref, useTemplateRef, watchPostEffect } from 'vue'
 
 import { DraggableList } from '@/scripts/ui/draggableList'
 
+const { dragAxis } = defineProps<{
+  dragAxis?: 'x' | 'y' | 'both'
+}>()
+
 const modelValue = defineModel<T[]>({ required: true })
 const draggableList = ref<DraggableList>()
 const draggableItems = useTemplateRef('draggableItems')
@@ -13,7 +17,8 @@ watchPostEffect(() => {
   if (!draggableItems.value?.children?.length) return
   draggableList.value = new DraggableList(
     draggableItems.value,
-    '.draggable-item'
+    '.draggable-item',
+    { dragAxis }
   )
   draggableList.value.applyNewItemsOrder = function () {
     const reorderedItems = []

--- a/src/components/common/DraggableList.vue
+++ b/src/components/common/DraggableList.vue
@@ -4,7 +4,7 @@ import { onBeforeUnmount, ref, useTemplateRef, watchPostEffect } from 'vue'
 import { DraggableList } from '@/scripts/ui/draggableList'
 
 const { dragAxis } = defineProps<{
-  dragAxis?: 'x' | 'y' | 'both'
+  dragAxis?: 'y' | 'both'
 }>()
 
 const modelValue = defineModel<T[]>({ required: true })

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -31,6 +31,7 @@ const {
   widgets: widgetsProp,
   showLocateButton = false,
   isDraggable = false,
+  isDragging = false,
   hiddenFavoriteIndicator = false,
   showNodeName = false,
   parents = [],
@@ -43,6 +44,7 @@ const {
   widgets: { widget: IBaseWidget; node: LGraphNode }[]
   showLocateButton?: boolean
   isDraggable?: boolean
+  isDragging?: boolean
   hiddenFavoriteIndicator?: boolean
   showNodeName?: boolean
   /**
@@ -272,7 +274,7 @@ defineExpose({
         ref="widgetsContainer"
         class="relative space-y-2 rounded-lg px-4 pt-1"
       >
-        <TransitionGroup name="list-scale">
+        <TransitionGroup :name="isDragging ? undefined : 'list-scale'">
           <WidgetItem
             v-for="{ widget, node } in widgets"
             :key="getStableWidgetRenderKey(widget)"

--- a/src/components/rightSidePanel/parameters/TabGlobalParameters.vue
+++ b/src/components/rightSidePanel/parameters/TabGlobalParameters.vue
@@ -65,6 +65,14 @@ function setDraggableState() {
     isDragging.value = true
   })
 
+  const baseDragEnd = draggableList.value.dragEnd
+  draggableList.value.dragEnd = function () {
+    baseDragEnd.call(this)
+    nextTick(() => {
+      isDragging.value = false
+    })
+  }
+
   /**
    * Override to skip the base class's DOM `appendChild` reorder, which breaks
    * Vue's vdom tracking inside <TransitionGroup> fragments. Instead, only
@@ -106,9 +114,6 @@ function setDraggableState() {
       searchedFavoritedWidgets.value = widgets
       favoritedWidgetsStore.reorderFavorites(widgets)
     }
-    nextTick(() => {
-      isDragging.value = false
-    })
   }
 }
 

--- a/src/components/rightSidePanel/parameters/TabGlobalParameters.vue
+++ b/src/components/rightSidePanel/parameters/TabGlobalParameters.vue
@@ -97,6 +97,8 @@ function setDraggableState() {
       reorderedItems[newIndex] = item
     })
 
+    if (oldPosition === -1) return
+
     for (let index = 0; index < this.getAllItems().length; index++) {
       const item = reorderedItems[index]
       if (typeof item === 'undefined') {

--- a/src/components/rightSidePanel/parameters/TabGlobalParameters.vue
+++ b/src/components/rightSidePanel/parameters/TabGlobalParameters.vue
@@ -28,6 +28,7 @@ const { t } = useI18n()
 const draggableList = ref<DraggableList | undefined>(undefined)
 const sectionWidgetsRef = ref<{ widgetsContainer: HTMLElement }>()
 const isSearching = ref(false)
+const isDragging = ref(false)
 
 const favoritedWidgets = computed(
   () => favoritedWidgetsStore.validFavoritedWidgets
@@ -56,8 +57,21 @@ function setDraggableState() {
   const container = sectionWidgetsRef.value?.widgetsContainer
   if (isSearching.value || !container?.children?.length) return
 
-  draggableList.value = new DraggableList(container, '.draggable-item')
+  draggableList.value = new DraggableList(container, '.draggable-item', {
+    dragAxis: 'y'
+  })
 
+  draggableList.value.addEventListener('dragstart', () => {
+    isDragging.value = true
+  })
+
+  /**
+   * Override to skip the base class's DOM `appendChild` reorder, which breaks
+   * Vue's vdom tracking inside <TransitionGroup> fragments. Instead, only
+   * update reactive state and let Vue handle the DOM reconciliation.
+   * TransitionGroup's move animation is suppressed via the `isDragging` prop
+   * on SectionWidgets to prevent the FLIP "snap-back" effect.
+   */
   draggableList.value.applyNewItemsOrder = function () {
     const reorderedItems: HTMLElement[] = []
 
@@ -85,11 +99,16 @@ function setDraggableState() {
     const newPosition = reorderedItems.indexOf(
       this.draggableItem as HTMLElement
     )
-    const widgets = [...searchedFavoritedWidgets.value]
-    const [widget] = widgets.splice(oldPosition, 1)
-    widgets.splice(newPosition, 0, widget)
-    searchedFavoritedWidgets.value = widgets
-    favoritedWidgetsStore.reorderFavorites(widgets)
+    if (oldPosition !== newPosition) {
+      const widgets = [...searchedFavoritedWidgets.value]
+      const [widget] = widgets.splice(oldPosition, 1)
+      widgets.splice(newPosition, 0, widget)
+      searchedFavoritedWidgets.value = widgets
+      favoritedWidgetsStore.reorderFavorites(widgets)
+    }
+    nextTick(() => {
+      isDragging.value = false
+    })
   }
 }
 
@@ -131,6 +150,7 @@ function onCollapseUpdate() {
     :label
     :widgets="searchedFavoritedWidgets"
     :is-draggable="!isSearching"
+    :is-dragging="isDragging"
     hidden-favorite-indicator
     show-node-name
     enable-empty-state

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -164,6 +164,14 @@ function setDraggableState() {
     isDragging.value = true
   })
 
+  const baseDragEnd = draggableList.value.dragEnd
+  draggableList.value.dragEnd = function () {
+    baseDragEnd.call(this)
+    nextTick(() => {
+      isDragging.value = false
+    })
+  }
+
   /**
    * Override to skip the base class's DOM `appendChild` reorder, which breaks
    * Vue's vdom tracking inside <TransitionGroup> fragments. Instead, only
@@ -212,9 +220,6 @@ function setDraggableState() {
       )
       canvasStore.canvas?.setDirty(true, true)
     }
-    nextTick(() => {
-      isDragging.value = false
-    })
   }
 }
 

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -52,6 +52,7 @@ const isAllCollapsed = computed({
   }
 })
 const draggableList = ref<DraggableList | undefined>(undefined)
+const isDragging = ref(false)
 const sectionWidgetsRef = useTemplateRef('sectionWidgetsRef')
 const advancedInputsSectionRef = useTemplateRef('advancedInputsSectionRef')
 
@@ -155,8 +156,21 @@ function setDraggableState() {
   const container = sectionWidgetsRef.value?.widgetsContainer
   if (isSearching.value || !container?.children?.length) return
 
-  draggableList.value = new DraggableList(container, '.draggable-item')
+  draggableList.value = new DraggableList(container, '.draggable-item', {
+    dragAxis: 'y'
+  })
 
+  draggableList.value.addEventListener('dragstart', () => {
+    isDragging.value = true
+  })
+
+  /**
+   * Override to skip the base class's DOM `appendChild` reorder, which breaks
+   * Vue's vdom tracking inside <TransitionGroup> fragments. Instead, only
+   * update reactive state and let Vue handle the DOM reconciliation.
+   * TransitionGroup's move animation is suppressed via the `isDragging` prop
+   * on SectionWidgets to prevent the FLIP "snap-back" effect.
+   */
   draggableList.value.applyNewItemsOrder = function () {
     const reorderedItems: HTMLElement[] = []
 
@@ -189,14 +203,18 @@ function setDraggableState() {
     const newPosition = reorderedItems.indexOf(
       this.draggableItem as HTMLElement
     )
-
-    promotionStore.movePromotion(
-      node.rootGraph.id,
-      node.id,
-      oldPosition,
-      newPosition
-    )
-    canvasStore.canvas?.setDirty(true, true)
+    if (oldPosition !== newPosition) {
+      promotionStore.movePromotion(
+        node.rootGraph.id,
+        node.id,
+        oldPosition,
+        newPosition
+      )
+      canvasStore.canvas?.setDirty(true, true)
+    }
+    nextTick(() => {
+      isDragging.value = false
+    })
   }
 }
 
@@ -236,6 +254,7 @@ const label = computed(() => {
     :parents
     :widgets="searchedWidgetsList"
     :is-draggable="!isSearching"
+    :is-dragging="isDragging"
     :enable-empty-state="isSearching"
     :tooltip="
       isSearching || searchedWidgetsList.length

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -259,7 +259,11 @@ onMounted(() => {
             {{ $t('subgraphStore.hideAll') }}</a
           >
         </div>
-        <DraggableList v-slot="{ dragClass }" v-model="activeWidgets">
+        <DraggableList
+          v-slot="{ dragClass }"
+          v-model="activeWidgets"
+          drag-axis="y"
+        >
           <SubgraphNodeWidget
             v-for="[node, widget] in filteredActive"
             :key="toKey([node, widget])"

--- a/src/scripts/ui/draggableList.ts
+++ b/src/scripts/ui/draggableList.ts
@@ -53,14 +53,19 @@ export class DraggableList extends EventTarget {
   items = []
   itemSelector
   handleClass = 'drag-handle'
+  dragAxis: 'x' | 'y' | 'both' = 'both'
   off = []
   offDrag = []
 
-  // @ts-expect-error fixme ts strict error
-  constructor(element, itemSelector) {
+  constructor(
+    element: HTMLElement,
+    itemSelector: string,
+    options?: { dragAxis?: 'x' | 'y' | 'both' }
+  ) {
     super()
     this.listContainer = element
     this.itemSelector = itemSelector
+    if (options?.dragAxis) this.dragAxis = options.dragAxis
 
     if (!this.listContainer) return
 
@@ -203,8 +208,10 @@ export class DraggableList extends EventTarget {
       this.listContainer.scrollBy(0, -10)
     }
 
-    const pointerOffsetX = clientX - this.pointerStartX
-    const pointerOffsetY = clientY - this.pointerStartY
+    const pointerOffsetX =
+      this.dragAxis === 'y' ? 0 : clientX - this.pointerStartX
+    const pointerOffsetY =
+      this.dragAxis === 'x' ? 0 : clientY - this.pointerStartY
 
     this.updateIdleItemsStateAndPosition()
     this.draggableItem.style.transform = `translate(${pointerOffsetX}px, ${pointerOffsetY}px)`

--- a/src/scripts/ui/draggableList.ts
+++ b/src/scripts/ui/draggableList.ts
@@ -53,14 +53,14 @@ export class DraggableList extends EventTarget {
   items = []
   itemSelector
   handleClass = 'drag-handle'
-  dragAxis: 'x' | 'y' | 'both' = 'both'
+  dragAxis: 'y' | 'both' = 'both'
   off = []
   offDrag = []
 
   constructor(
     element: HTMLElement,
     itemSelector: string,
-    options?: { dragAxis?: 'x' | 'y' | 'both' }
+    options?: { dragAxis?: 'y' | 'both' }
   ) {
     super()
     this.listContainer = element
@@ -210,8 +210,7 @@ export class DraggableList extends EventTarget {
 
     const pointerOffsetX =
       this.dragAxis === 'y' ? 0 : clientX - this.pointerStartX
-    const pointerOffsetY =
-      this.dragAxis === 'x' ? 0 : clientY - this.pointerStartY
+    const pointerOffsetY = clientY - this.pointerStartY
 
     this.updateIdleItemsStateAndPosition()
     this.draggableItem.style.transform = `translate(${pointerOffsetX}px, ${pointerOffsetY}px)`


### PR DESCRIPTION
## Summary
- Fix visual flicker when reordering items in the properties panel via drag-and-drop. Items no longer snap back to their original position before animating to the new one.
- Root cause: the base `DraggableList.applyNewItemsOrder` uses `appendChild` to reorder DOM, which conflicts with Vue's vdom tracking inside `<TransitionGroup>` fragments. The override skips DOM reorder and lets Vue reconcile; `TransitionGroup`'s move animation is suppressed during drag via a dynamic `name` prop.
- Add configurable `dragAxis` option (`'x' | 'y' | 'both'`) to `DraggableList` class and Vue component, locking drag movement to a single axis. Applied `dragAxis: 'y'` to all vertical list usages.

## Test plan
- [x] Drag reorder items in **Favorites** tab (properties panel) — no flicker on drop
- [x] Drag reorder items in **Subgraph Inputs** tab — no flicker on drop
- [x] Drag reorder in **Subgraph Editor** widget list — no flicker, Y-axis only
- [x] Verify items only move along Y axis during drag (no horizontal drift)
- [x] Verify add/remove animations (e.g. un-favoriting a widget) still work normally

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10987-fix-properties-panel-drag-reorder-visual-flicker-33d6d73d3650819b8c08fe985917d156) by [Unito](https://www.unito.io)
