### PR TITLE
fix: auto fit-to-view on first subgraph entry

### DIFF
--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -9,10 +9,9 @@ import type { Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { useLitegraphService } from '@/services/litegraphService'
 import { app } from '@/scripts/app'
+import { useLitegraphService } from '@/services/litegraphService'
 import { findSubgraphPathById } from '@/utils/graphTraversalUtil'
-import { anyItemOverlapsRect } from '@/utils/mathUtil'
 import { isNonNullish, isSubgraph } from '@/utils/typeGuardUtil'
 
 export const VIEWPORT_CACHE_MAX_SIZE = 32
@@ -139,19 +138,10 @@ export const useSubgraphNavigationStore = defineStore(
         return
       }
 
-      // Cache miss — fit to content only if no nodes are currently visible.
-      // loadGraphData may have already restored extra.ds or called fitView
-      // for templates, so only intervene when the viewport is truly empty.
+      // First visit — fit to content so subgraph nodes are visible
       requestAnimationFrame(() => {
         if (getActiveGraphId() !== graphId) return
-        if (!canvas.graph) return
-
-        const nodes = canvas.graph.nodes
-        if (!nodes?.length) return
-
-        canvas.ds.computeVisibleArea(canvas.viewport)
-        if (anyItemOverlapsRect(nodes, canvas.ds.visible_area)) return
-
+        if (!canvas.graph?.nodes?.length) return
         useLitegraphService().fitView()
       })
     }

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import type { LGraph, Subgraph } from '@/lib/litegraph/src/litegraph'
@@ -12,8 +12,9 @@ import {
   VIEWPORT_CACHE_MAX_SIZE
 } from '@/stores/subgraphNavigationStore'
 
-const { mockSetDirty } = vi.hoisted(() => ({
-  mockSetDirty: vi.fn()
+const { mockSetDirty, mockFitView } = vi.hoisted(() => ({
+  mockSetDirty: vi.fn(),
+  mockFitView: vi.fn()
 }))
 
 vi.mock('@/scripts/app', () => {
@@ -61,9 +62,6 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 }))
 vi.mock('@vueuse/router', () => ({ useRouteHash: vi.fn() }))
 
-const { mockFitView } = vi.hoisted(() => ({
-  mockFitView: vi.fn()
-}))
 vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({ fitView: mockFitView })
 }))
@@ -182,30 +180,41 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
       expect(rafCallbacks).toHaveLength(1)
     })
 
-    it('calls fitView on cache miss after rAF fires', () => {
+    it('calls fitView on cache miss when graph has nodes', () => {
       const store = useSubgraphNavigationStore()
-      // Ensure no cached entry
       store.viewportCache.delete(':root')
 
-      // Add a node outside the visible area so anyItemOverlapsRect returns false
       const mockGraph = app.graph as { nodes: unknown[]; _nodes: unknown[] }
-      mockGraph.nodes = [{ pos: [9999, 9999], size: [100, 100] }]
+      mockGraph.nodes = [{ pos: [0, 0], size: [100, 100] }]
       mockGraph._nodes = mockGraph.nodes
 
-      // Use the root graph ID so the stale-guard passes
       store.restoreViewport('root')
 
       expect(mockFitView).not.toHaveBeenCalled()
       expect(rafCallbacks).toHaveLength(1)
 
-      // Simulate rAF firing — active graph still matches
       rafCallbacks[0](performance.now())
 
       expect(mockFitView).toHaveBeenCalledOnce()
 
-      // Cleanup
       mockGraph.nodes = []
       mockGraph._nodes = []
+    })
+
+    it('does not call fitView on cache miss when graph has no nodes', () => {
+      const store = useSubgraphNavigationStore()
+      store.viewportCache.delete(':root')
+
+      const mockGraph = app.graph as { nodes: unknown[]; _nodes: unknown[] }
+      mockGraph.nodes = []
+      mockGraph._nodes = []
+
+      store.restoreViewport('root')
+
+      expect(rafCallbacks).toHaveLength(1)
+      rafCallbacks[0](performance.now())
+
+      expect(mockFitView).not.toHaveBeenCalled()
     })
 
     it('skips fitView if active graph changed before rAF fires', () => {


### PR DESCRIPTION
## Summary

Auto-fit viewport to subgraph content on first entry so interior nodes are immediately visible.

## Changes

- **What**: On cache miss in `restoreViewport()`, call `fitView()` via `requestAnimationFrame` instead of silently returning. Existing cache-hit path (revisiting a subgraph) is unchanged.

## Review Focus

The `anyItemOverlapsRect` guard in `app.ts` (workflow load path) is intentionally **not** touched — it serves a different purpose (respecting `extra.ds` on workflow load). This fix only affects subgraph navigation transitions where there is no saved viewport to respect.

Fixes #8173

## Screenshots (if applicable)

N/A — viewport positioning fix; before: empty canvas on subgraph entry, after: nodes visible.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10995-fix-auto-fit-to-view-on-first-subgraph-entry-33d6d73d365081f3a9b3cc2124979624) by [Unito](https://www.unito.io)
