### PR TITLE
fix: read workspace ID from store instead of sessionStorage

### DIFF
--- a/src/platform/workflow/sharing/composables/useComfyHubProfileGate.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubProfileGate.test.ts
@@ -202,5 +202,22 @@ describe('useComfyHubProfileGate', () => {
       expect(requestCallOrder[0]).toBeLessThan(uploadCallOrder[0])
       expect(uploadCallOrder[0]).toBeLessThan(createCallOrder[0])
     })
+
+    it('creates profile without workspace_id when workspace is not available', async () => {
+      mockCurrentWorkspace.value = null
+
+      await gate.createProfile({
+        username: 'testuser',
+        name: 'Test User'
+      })
+
+      expect(mockCreateProfile).toHaveBeenCalledWith({
+        workspaceId: undefined,
+        username: 'testuser',
+        displayName: 'Test User',
+        description: undefined,
+        avatarToken: undefined
+      })
+    })
   })
 })

--- a/src/platform/workflow/sharing/composables/useComfyHubProfileGate.test.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubProfileGate.test.ts
@@ -10,6 +10,14 @@ const mockToastErrorHandler = vi.hoisted(() => vi.fn())
 const mockResolvedUserInfo = vi.hoisted(() => ({
   value: { id: 'user-a' }
 }))
+const mockCurrentWorkspace = vi.hoisted(() => ({
+  value: {
+    id: 'workspace-1',
+    type: 'team',
+    name: 'Test Workspace',
+    role: 'owner'
+  } as { id: string; type: string; name: string; role: string } | null
+}))
 
 vi.mock('@/platform/workflow/sharing/services/comfyHubService', () => ({
   useComfyHubService: () => ({
@@ -32,6 +40,14 @@ vi.mock('@/composables/useErrorHandling', () => ({
   })
 }))
 
+vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
+  useWorkspaceAuthStore: () => ({
+    get currentWorkspace() {
+      return mockCurrentWorkspace.value
+    }
+  })
+}))
+
 // Must import after vi.mock declarations
 const { useComfyHubProfileGate } = await import('./useComfyHubProfileGate')
 
@@ -41,25 +57,18 @@ const mockProfile: ComfyHubProfile = {
   description: 'A test profile'
 }
 
-function setCurrentWorkspace(workspaceId: string) {
-  sessionStorage.setItem(
-    'Comfy.Workspace.Current',
-    JSON.stringify({
-      id: workspaceId,
-      type: 'team',
-      name: 'Test Workspace',
-      role: 'owner'
-    })
-  )
-}
-
 describe('useComfyHubProfileGate', () => {
   let gate: ReturnType<typeof useComfyHubProfileGate>
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockResolvedUserInfo.value = { id: 'user-a' }
-    setCurrentWorkspace('workspace-1')
+    mockCurrentWorkspace.value = {
+      id: 'workspace-1',
+      type: 'team',
+      name: 'Test Workspace',
+      role: 'owner'
+    }
     mockGetMyProfile.mockResolvedValue(mockProfile)
     mockRequestAssetUploadUrl.mockResolvedValue({
       uploadUrl: 'https://upload.example.com/avatar.png',

--- a/src/platform/workflow/sharing/composables/useComfyHubProfileGate.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubProfileGate.ts
@@ -96,9 +96,6 @@ export function useComfyHubProfileGate() {
 
     const workspaceAuthStore = useWorkspaceAuthStore()
     const workspaceId = workspaceAuthStore.currentWorkspace?.id
-    if (!workspaceId) {
-      throw new Error('Unable to determine current workspace')
-    }
 
     let avatarToken: string | undefined
     if (data.profilePicture) {

--- a/src/platform/workflow/sharing/composables/useComfyHubProfileGate.ts
+++ b/src/platform/workflow/sharing/composables/useComfyHubProfileGate.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useComfyHubService } from '@/platform/workflow/sharing/services/comfyHubService'
-import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
+import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
 import type { ComfyHubProfile } from '@/schemas/apiSchema'
 
 // TODO: Migrate to a Pinia store for proper singleton state management
@@ -14,34 +14,6 @@ const isFetchingProfile = ref(false)
 const profile = ref<ComfyHubProfile | null>(null)
 const cachedUserId = ref<string | null>(null)
 let inflightFetch: Promise<ComfyHubProfile | null> | null = null
-
-function getCurrentWorkspaceId(): string {
-  const workspaceJson = sessionStorage.getItem(
-    WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE
-  )
-  if (!workspaceJson) {
-    throw new Error('Unable to determine current workspace')
-  }
-
-  let workspace: unknown
-  try {
-    workspace = JSON.parse(workspaceJson)
-  } catch {
-    throw new Error('Unable to determine current workspace')
-  }
-
-  if (
-    !workspace ||
-    typeof workspace !== 'object' ||
-    !('id' in workspace) ||
-    typeof workspace.id !== 'string' ||
-    workspace.id.length === 0
-  ) {
-    throw new Error('Unable to determine current workspace')
-  }
-
-  return workspace.id
-}
 
 export function useComfyHubProfileGate() {
   const { resolvedUserInfo } = useCurrentUser()
@@ -122,6 +94,12 @@ export function useComfyHubProfileGate() {
   }): Promise<ComfyHubProfile> {
     syncCachedProfileWithCurrentUser()
 
+    const workspaceAuthStore = useWorkspaceAuthStore()
+    const workspaceId = workspaceAuthStore.currentWorkspace?.id
+    if (!workspaceId) {
+      throw new Error('Unable to determine current workspace')
+    }
+
     let avatarToken: string | undefined
     if (data.profilePicture) {
       const contentType = data.profilePicture.type || 'application/octet-stream'
@@ -140,7 +118,7 @@ export function useComfyHubProfileGate() {
     }
 
     const createdProfile = await createComfyHubProfile({
-      workspaceId: getCurrentWorkspaceId(),
+      workspaceId,
       username: data.username,
       displayName: data.name,
       description: data.description,

--- a/src/platform/workflow/sharing/services/comfyHubService.ts
+++ b/src/platform/workflow/sharing/services/comfyHubService.ts
@@ -12,7 +12,7 @@ type HubThumbnailType = 'image' | 'video' | 'image_comparison'
 type ThumbnailTypeInput = HubThumbnailType | 'imageComparison'
 
 interface CreateProfileInput {
-  workspaceId: string
+  workspaceId?: string
   username: string
   displayName?: string
   description?: string


### PR DESCRIPTION
The problem is that createProfile internally calls getCurrentWorkspaceId() which reads from sessionStorage —
  and that sessionStorage entry is only written by switchWorkspace(), which is gated on teamWorkspacesEnabled.
  So the publish flow can be shown to users without team workspaces, but profile creation crashes because the
  workspace was never stored.


## Summary

- `createProfile` read workspace ID directly from `sessionStorage`, which is only populated when the `teamWorkspacesEnabled` feature flag is enabled via `switchWorkspace()`. For users without the flag, the key is never set, causing "Unable to determine current workspace" errors on profile creation.
- Replaced the raw `sessionStorage` read with `useWorkspaceAuthStore().currentWorkspace`, which is the canonical source of workspace state.

## Related

https://comfy-organization.slack.com/archives/C08HZ017M4Z/p1775616290764439?thread_ts=1775588488.612949&cid=C08HZ017M4Z

## test
### AS IS 
<img width="402" height="311" alt="Screenshot 2026-04-10 at 6 37 55 AM" src="https://github.com/user-attachments/assets/baf97040-a33a-4590-bed7-f8334a9ebfe0" />

### TO BE

## Test plan

- [x] Existing `useComfyHubProfileGate` tests updated and passing (8/8)
- [x] Typecheck passes
- [x] Lint passes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10998-fix-read-workspace-ID-from-store-instead-of-sessionStorage-33d6d73d365081ef9c12d99027bc8ca3) by [Unito](https://www.unito.io)
