### PR TITLE
fix: restore promoted widget visibility after graph→app→graph round-trip

### DIFF
--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -165,5 +165,39 @@ test.describe(
         })
       }
     )
+
+    test.describe('App Mode Round-Trip', { tag: ['@vue-nodes'] }, () => {
+      test.beforeEach(async ({ comfyPage }) => {
+        await comfyPage.appMode.enableLinearMode()
+        await comfyPage.appMode.suppressVueNodeSwitchPopup()
+      })
+
+      test('Promoted DOM widget stays visible after graph → app → graph round-trip', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-with-promoted-text-widget'
+        )
+
+        const promotedTextarea = comfyPage.vueNodes
+          .getNodeLocator('11')
+          .getByRole('textbox', { name: 'text' })
+        await expect(promotedTextarea).toBeVisible()
+
+        const graphContainer = comfyPage.page.locator('#graph-canvas-container')
+
+        // Enter app mode — the canvas is hidden via v-show so updateWidgets()
+        // never runs and widgetState.visible goes stale.
+        await comfyPage.appMode.toggleAppMode()
+        await expect(graphContainer).toBeHidden()
+
+        // Return to graph mode — the fix must restore visibility synchronously.
+        await comfyPage.appMode.toggleAppMode()
+        await expect(graphContainer).toBeVisible()
+
+        await expect(promotedTextarea).toBeVisible()
+        await expect(promotedTextarea).toHaveCount(1)
+      })
+    })
   }
 )

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -189,5 +189,39 @@ test.describe(
         comfyPage.page.getByTestId('custom-node-widget')
       ).toBeAttached()
     })
+
+    test.describe('App Mode Round-Trip', { tag: ['@vue-nodes'] }, () => {
+      test.beforeEach(async ({ comfyPage }) => {
+        await comfyPage.appMode.enableLinearMode()
+        await comfyPage.appMode.suppressVueNodeSwitchPopup()
+      })
+
+      test('Promoted DOM widget stays visible after graph → app → graph round-trip', async ({
+        comfyPage
+      }) => {
+        await comfyPage.workflow.loadWorkflow(
+          'subgraphs/subgraph-with-promoted-text-widget'
+        )
+
+        const promotedTextarea = comfyPage.vueNodes
+          .getNodeLocator('11')
+          .getByRole('textbox', { name: 'text' })
+        await expect(promotedTextarea).toBeVisible()
+
+        const graphContainer = comfyPage.page.locator('#graph-canvas-container')
+
+        // Enter app mode — the canvas is hidden via v-show so updateWidgets()
+        // never runs and widgetState.visible goes stale.
+        await comfyPage.appMode.toggleAppMode()
+        await expect(graphContainer).toBeHidden()
+
+        // Return to graph mode — the fix must restore visibility synchronously.
+        await comfyPage.appMode.toggleAppMode()
+        await expect(graphContainer).toBeVisible()
+
+        await expect(promotedTextarea).toBeVisible()
+        await expect(promotedTextarea).toHaveCount(1)
+      })
+    })
   }
 )

--- a/src/components/graph/DomWidgets.test.ts
+++ b/src/components/graph/DomWidgets.test.ts
@@ -3,11 +3,18 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import DomWidgets from '@/components/graph/DomWidgets.vue'
+import { useAppMode } from '@/composables/useAppMode'
 import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import {
+  ComfyWorkflow,
+  useWorkflowStore
+} from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
@@ -138,5 +145,57 @@ describe('DomWidgets positioning', () => {
     drawFrame(canvas)
 
     expect(widgetState.visible).toBe(false)
+  })
+})
+
+describe('DomWidgets app mode round-trip', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('restores widget visibility after graph → app → graph without a draw frame', async () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+    const { setMode } = useAppMode()
+
+    const workflowStore = useWorkflowStore()
+    const workflow = new ComfyWorkflow({
+      path: 'workflows/test.json',
+      modified: Date.now(),
+      size: 1
+    })
+    workflow.activeMode = 'graph'
+    workflowStore.activeWorkflow = workflow as unknown as LoadedComfyWorkflow
+
+    const graph = new LGraph()
+    const node = createNode(graph, 1, 'host', [100, 200])
+    const widget = createWidget('round-trip-widget', node, 14)
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    // Initial draw — widget is visible
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)!
+    expect(widgetState.visible).toBe(true)
+
+    // Enter app mode — canvas is hidden via v-show so updateWidgets() stops running
+    setMode('app')
+    await nextTick()
+
+    // Simulate the stale state that builds up while the canvas is hidden
+    widgetState.visible = false
+
+    // Return to graph mode — the fix calls updateWidgets() immediately via whenever()
+    setMode('graph')
+    await nextTick()
+
+    // Without the fix, visible stays false because no draw frame has run yet
+    expect(widgetState.visible).toBe(true)
   })
 })

--- a/src/components/graph/DomWidgets.test.ts
+++ b/src/components/graph/DomWidgets.test.ts
@@ -1,12 +1,20 @@
+import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
-import { watch } from 'vue'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, watch } from 'vue'
 
 import DomWidgets from '@/components/graph/DomWidgets.vue'
+import { useAppMode } from '@/composables/useAppMode'
 import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import {
+  ComfyWorkflow,
+  useWorkflowStore
+} from '@/platform/workflow/management/stores/workflowStore'
+import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
@@ -419,4 +427,56 @@ describe('DomWidgets deterministic update matrix', () => {
       expect(result.sizeChanges).toBe(0)
     }
   )
+})
+
+describe('DomWidgets app mode round-trip', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('restores widget visibility after graph → app → graph without a draw frame', async () => {
+    const canvasStore = useCanvasStore()
+    const domWidgetStore = useDomWidgetStore()
+    const { setMode } = useAppMode()
+
+    const workflowStore = useWorkflowStore()
+    const workflow = new ComfyWorkflow({
+      path: 'workflows/test.json',
+      modified: Date.now(),
+      size: 1
+    })
+    workflow.activeMode = 'graph'
+    workflowStore.activeWorkflow = workflow as unknown as LoadedComfyWorkflow
+
+    const graph = new LGraph()
+    const node = createNode(graph, 1, 'host', [100, 200])
+    const widget = createWidget('round-trip-widget', node, 14)
+    domWidgetStore.registerWidget(widget)
+
+    const canvas = createCanvas(graph)
+    canvasStore.canvas = canvas
+
+    render(DomWidgets, {
+      global: { stubs: { DomWidget: true } }
+    })
+
+    // Initial draw — widget is visible
+    drawFrame(canvas)
+    const widgetState = domWidgetStore.widgetStates.get(widget.id)!
+    expect(widgetState.visible).toBe(true)
+
+    // Enter app mode — canvas is hidden via v-show so updateWidgets() stops running
+    setMode('app')
+    await nextTick()
+
+    // Simulate the stale state that builds up while the canvas is hidden
+    widgetState.visible = false
+
+    // Return to graph mode — the fix calls updateWidgets() immediately via whenever()
+    setMode('graph')
+    await nextTick()
+
+    // Without the fix, visible stays false because no draw frame has run yet
+    expect(widgetState.visible).toBe(true)
+  })
 })

--- a/src/components/graph/DomWidgets.test.ts
+++ b/src/components/graph/DomWidgets.test.ts
@@ -1,8 +1,6 @@
-import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { render } from '@testing-library/vue'
-import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick, watch } from 'vue'
 
 import DomWidgets from '@/components/graph/DomWidgets.vue'
@@ -19,6 +17,8 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { BaseDOMWidget } from '@/scripts/domWidget'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { toNodeId } from '@/types/nodeId'
+import type { AppMode } from '@/utils/appMode'
+import { createMockChangeTracker } from '@/utils/__tests__/litegraphTestUtils'
 
 type TestWidget = BaseDOMWidget<object | string>
 
@@ -72,6 +72,19 @@ function createCanvas(graph: LGraph): LGraphCanvas {
     selected_nodes: {},
     selectedItems: new Set()
   })
+}
+
+function createLoadedWorkflow(activeMode: AppMode): LoadedComfyWorkflow {
+  const workflow = new ComfyWorkflow({
+    path: 'workflows/test.json',
+    modified: Date.now(),
+    size: 1
+  })
+  workflow.changeTracker = createMockChangeTracker()
+  workflow.content = '{}'
+  workflow.originalContent = '{}'
+  workflow.activeMode = activeMode
+  return workflow as LoadedComfyWorkflow
 }
 
 function drawFrame(canvas: LGraphCanvas) {
@@ -430,23 +443,13 @@ describe('DomWidgets deterministic update matrix', () => {
 })
 
 describe('DomWidgets app mode round-trip', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
   it('restores widget visibility after graph → app → graph without a draw frame', async () => {
     const canvasStore = useCanvasStore()
     const domWidgetStore = useDomWidgetStore()
     const { setMode } = useAppMode()
 
     const workflowStore = useWorkflowStore()
-    const workflow = new ComfyWorkflow({
-      path: 'workflows/test.json',
-      modified: Date.now(),
-      size: 1
-    })
-    workflow.activeMode = 'graph'
-    workflowStore.activeWorkflow = workflow as unknown as LoadedComfyWorkflow
+    workflowStore.activeWorkflow = createLoadedWorkflow('graph')
 
     const graph = new LGraph()
     const node = createNode(graph, 1, 'host', [100, 200])

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -75,4 +75,10 @@ whenever(
     )),
   { immediate: true }
 )
+
+// When returning from app mode, the canvas was hidden (v-show) so
+// updateWidgets() hasn't run — widgetState.visible is stale.
+// Run it immediately so widgets are correctly marked visible before
+// DomWidget tries to mount elements.
+whenever(() => !canvasStore.linearMode, updateWidgets)
 </script>

--- a/src/components/graph/DomWidgets.vue
+++ b/src/components/graph/DomWidgets.vue
@@ -131,4 +131,10 @@ whenever(
     )),
   { immediate: true }
 )
+
+// When returning from app mode, the canvas was hidden (v-show) so
+// updateWidgets() hasn't run — widgetState.visible is stale.
+// Run it immediately so widgets are correctly marked visible before
+// DomWidget tries to mount elements.
+whenever(() => !canvasStore.linearMode, updateWidgets)
 </script>


### PR DESCRIPTION
## Summary

Promoted DOM widgets on SubgraphNodes become invisible after switching from graph mode to app mode and back. The canvas is hidden via `v-show` during app mode, so `updateWidgets()` never runs and `widgetState.visible` stays stale (false).

## Root Cause

When the user switches to app mode, the canvas container is hidden with `v-show`, which means `onDrawForeground` (and thus `updateWidgets()`) never fires. When returning to graph mode, `widgetState.visible` remains `false` from the last stale state, causing promoted widgets to not render.

## Fix

A single-line `whenever(() => !canvasStore.linearMode, updateWidgets)` triggers `updateWidgets()` immediately when exiting app/linear mode, restoring correct visibility state before DomWidget mounts.

## Commit Structure (red/green)

**Commit 1 — tests only (red on main):**
- `src/components/graph/DomWidgets.test.ts`: Vitest unit test that fails without the fix — asserts `widgetState.visible` is restored to `true` immediately after returning from app mode, without requiring a canvas draw frame.
- `browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts`: Playwright e2e test that fails without the fix — asserts the promoted textarea in a subgraph node is visible after toggling through app mode via `Comfy.ToggleLinear`.

**Commit 2 — fix (green):**
- `src/components/graph/DomWidgets.vue`: The single-line fix.

## Changes

- **`src/components/graph/DomWidgets.vue`**: Add a `whenever` watcher that calls `updateWidgets()` when leaving linear/app mode.
- **`src/components/graph/DomWidgets.test.ts`**: Unit test proving the regression (fails on main without the fix).
- **`browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts`**: E2E test in the App Mode Round-Trip describe block (uses `comfyPage.appMode.toggleAppMode()` — the real UI path via `Comfy.ToggleLinear`).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-10999-fix-restore-promoted-widget-visibility-after-graph-app-graph-round-trip-33d6d73d365081f18895eced7287367b) by [Unito](https://www.unito.io)