### PR TITLE
fix: use || instead of ?? and server type in WebcamCapture upload path

### DIFF
--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -143,9 +143,10 @@ app.registerExtension({
         throw new Error(err)
       }
       const data = await resp.json()
-      const serverName = data.name ?? name
-      const subfolder = data.subfolder ?? 'webcam'
-      return `${subfolder}/${serverName} [temp]`
+      const serverName = data.name || name
+      const subfolder = data.subfolder || 'webcam'
+      const type = data.type || 'temp'
+      return `${subfolder}/${serverName} [${type}]`
     }
 
     // @ts-expect-error fixme ts strict error


### PR DESCRIPTION
## Description

Fixes the WebcamCapture image upload path construction that was still broken on cloud environments after #10220.

### Root cause

The cloud `/upload/image` endpoint returns:
```json
{ "name": "hash.png", "subfolder": "", "type": "input" }
```

The previous fix used `??` (nullish coalescing), which doesn't catch empty strings:
- `subfolder: ""` → `"" ?? "webcam"` = `""` → path becomes `/hash.png` (wrong)
- `type` was hardcoded as `[temp]` but cloud stores as `input` → file not found

### Fix

- `??` → `||` so empty strings fall back to defaults
- Use `data.type` from server response instead of hardcoding `[temp]`

### QA evidence

Prod (cloud/1.42): `ImageDownloadError: the input file 'webcam/1775685296883.png [temp]' doesn't exist`
Staging (cloud/1.42): `ImageDownloadError: Failed to validate images`

### Related

- Fixes the remaining issue from #10220

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11000-fix-use-instead-of-and-server-type-in-WebcamCapture-upload-path-33d6d73d36508156b93cfce0aae8e017) by [Unito](https://www.unito.io)
