### PR TITLE
fix: resolve incorrect GLSL live preview for non-primitive widget types

### DIFF
--- a/src/renderer/glsl/useGLSLPreview.test.ts
+++ b/src/renderer/glsl/useGLSLPreview.test.ts
@@ -323,6 +323,38 @@ describe('useGLSLPreview', () => {
       expect(mockRendererFactory.compileFragment).not.toHaveBeenCalled()
     })
 
+    it('uses custom resolution when size_mode is custom', async () => {
+      const store = fromAny<WidgetValueStoreStub, unknown>(
+        useWidgetValueStore()
+      )
+      store._widgetMap.set('size_mode', { value: 'custom' })
+      store._widgetMap.set('size_mode.width', { value: 800 })
+      store._widgetMap.set('size_mode.height', { value: 600 })
+
+      const node = createMockNode()
+      await setupAndRender(node)
+
+      expect(mockRendererFactory.setResolution).toHaveBeenCalledWith(800, 600)
+
+      store._widgetMap.delete('size_mode')
+      store._widgetMap.delete('size_mode.width')
+      store._widgetMap.delete('size_mode.height')
+    })
+
+    it('uses default resolution when size_mode is not custom', async () => {
+      const store = fromAny<WidgetValueStoreStub, unknown>(
+        useWidgetValueStore()
+      )
+      store._widgetMap.set('size_mode', { value: 'from_input' })
+
+      const node = createMockNode()
+      await setupAndRender(node)
+
+      expect(mockRendererFactory.setResolution).toHaveBeenCalledWith(512, 512)
+
+      store._widgetMap.delete('size_mode')
+    })
+
     it('disposes renderer and cancels debounce on cleanup', async () => {
       const node = createMockNode()
       const { dispose } = await setupAndRender(node)

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -282,7 +282,44 @@ function createInnerPreview(
     }
   }
 
+  function getCustomResolution(): [number, number] | null {
+    const gId = graphId.value
+    if (!gId) return null
+
+    const sizeModeNodeId = innerGLSLNode
+      ? (innerGLSLNode.id as NodeId)
+      : nodeId.value
+    if (sizeModeNodeId == null) return null
+
+    const sizeMode = widgetValueStore.getWidget(
+      gId,
+      sizeModeNodeId,
+      'size_mode'
+    )
+    if (sizeMode?.value !== 'custom') return null
+
+    const widthWidget = widgetValueStore.getWidget(
+      gId,
+      sizeModeNodeId,
+      'size_mode.width'
+    )
+    const heightWidget = widgetValueStore.getWidget(
+      gId,
+      sizeModeNodeId,
+      'size_mode.height'
+    )
+    if (!widthWidget || !heightWidget) return null
+
+    return clampResolution(
+      normalizeDimension(widthWidget.value),
+      normalizeDimension(heightWidget.value)
+    )
+  }
+
   function getResolution(): [number, number] {
+    const custom = getCustomResolution()
+    if (custom) return custom
+
     const node = nodeRef.value
     if (!node?.inputs) return [DEFAULT_SIZE, DEFAULT_SIZE]
 
@@ -322,27 +359,6 @@ function createInnerPreview(
             img.naturalHeight || DEFAULT_SIZE
           )
         }
-      }
-    }
-
-    const gId = graphId.value
-    const nId = nodeId.value
-    if (gId && nId != null) {
-      const widthWidget = widgetValueStore.getWidget(
-        gId,
-        nId,
-        'size_mode.width'
-      )
-      const heightWidget = widgetValueStore.getWidget(
-        gId,
-        nId,
-        'size_mode.height'
-      )
-      if (widthWidget && heightWidget) {
-        return clampResolution(
-          normalizeDimension(widthWidget.value),
-          normalizeDimension(heightWidget.value)
-        )
       }
     }
 

--- a/src/renderer/glsl/useGLSLUniforms.test.ts
+++ b/src/renderer/glsl/useGLSLUniforms.test.ts
@@ -57,6 +57,21 @@ describe('extractUniformSources', () => {
     expect(result.ints[1].widgetName).toBe('value')
   })
 
+  it('skips source when origin_slot exceeds widget count', () => {
+    const glslNode = fromAny<LGraphNode, unknown>({
+      inputs: [{ name: 'floats.u_float0', link: 1 }]
+    })
+
+    const subgraph = createMockSubgraph(
+      { 1: { origin_id: 10, origin_slot: 5 } },
+      { 10: { id: 10, widgets: [{ name: 'value', value: 3.14 }] } }
+    )
+
+    const result = extractUniformSources(glslNode, subgraph)
+
+    expect(result.floats).toHaveLength(0)
+  })
+
   it('provides directValue getter that reads from the widget', () => {
     const indexWidget = {
       name: 'index',

--- a/src/renderer/glsl/useGLSLUniforms.test.ts
+++ b/src/renderer/glsl/useGLSLUniforms.test.ts
@@ -1,0 +1,100 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { describe, expect, it } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
+
+import {
+  extractUniformSources,
+  toNumber
+} from '@/renderer/glsl/useGLSLUniforms'
+
+function createMockSubgraph(
+  links: Record<number, { origin_id: number; origin_slot: number }>,
+  nodes: Record<
+    number,
+    { id: number; widgets: Array<{ name: string; value: unknown }> }
+  >
+) {
+  return fromAny<Subgraph, unknown>({
+    getLink: (id: number) => links[id] ?? null,
+    getNodeById: (id: number) => nodes[id] ?? null
+  })
+}
+
+describe('extractUniformSources', () => {
+  it('uses origin_slot to select the correct widget from source node', () => {
+    const glslNode = fromAny<LGraphNode, unknown>({
+      inputs: [
+        { name: 'ints.u_int0', link: 1 },
+        { name: 'ints.u_int1', link: 2 }
+      ]
+    })
+
+    const subgraph = createMockSubgraph(
+      {
+        1: { origin_id: 10, origin_slot: 1 },
+        2: { origin_id: 20, origin_slot: 0 }
+      },
+      {
+        10: {
+          id: 10,
+          widgets: [
+            { name: 'choice', value: 'Master' },
+            { name: 'index', value: 0 }
+          ]
+        },
+        20: {
+          id: 20,
+          widgets: [{ name: 'value', value: 42 }]
+        }
+      }
+    )
+
+    const result = extractUniformSources(glslNode, subgraph)
+
+    expect(result.ints[0].widgetName).toBe('index')
+    expect(result.ints[1].widgetName).toBe('value')
+  })
+
+  it('provides directValue getter that reads from the widget', () => {
+    const indexWidget = {
+      name: 'index',
+      get value() {
+        return choiceWidget.value === 'Reds' ? 1 : 0
+      }
+    }
+    const choiceWidget = { name: 'choice', value: 'Master' }
+
+    const glslNode = fromAny<LGraphNode, unknown>({
+      inputs: [{ name: 'ints.u_int0', link: 1 }]
+    })
+
+    const subgraph = createMockSubgraph(
+      { 1: { origin_id: 10, origin_slot: 1 } },
+      { 10: { id: 10, widgets: [choiceWidget, indexWidget] } }
+    )
+
+    const result = extractUniformSources(glslNode, subgraph)
+
+    expect(result.ints[0].directValue()).toBe(0)
+
+    choiceWidget.value = 'Reds'
+    expect(result.ints[0].directValue()).toBe(1)
+  })
+})
+
+describe('toNumber', () => {
+  it('coerces hex color strings via hexToInt', () => {
+    expect(toNumber('#45edf5')).toBe(0x45edf5)
+  })
+
+  it('coerces plain numeric values', () => {
+    expect(toNumber(42)).toBe(42)
+    expect(toNumber('10')).toBe(10)
+  })
+
+  it('returns 0 for non-numeric strings', () => {
+    expect(toNumber('Master')).toBe(0)
+  })
+})

--- a/src/renderer/glsl/useGLSLUniforms.ts
+++ b/src/renderer/glsl/useGLSLUniforms.ts
@@ -10,6 +10,7 @@ import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { isCurveData } from '@/components/curve/curveUtils'
 import type { CurveData } from '@/components/curve/types'
 import type { GLSLRendererConfig } from '@/renderer/glsl/useGLSLRenderer'
+import { hexToInt } from '@/utils/colorUtil'
 
 interface AutogrowGroup {
   max: number
@@ -20,6 +21,8 @@ interface AutogrowGroup {
 interface UniformSource {
   nodeId: NodeId
   widgetName: string
+  /** Fallback getter for widgets not registered in widgetValueStore (e.g. hidden computed widgets). */
+  directValue: () => unknown
 }
 
 interface UniformSources {
@@ -78,16 +81,20 @@ export function extractUniformSources(
     if (!link || link.origin_id === SUBGRAPH_INPUT_ID) continue
 
     const sourceNode = subgraph.getNodeById(link.origin_id)
-    if (!sourceNode?.widgets?.[0]) continue
+    if (!sourceNode?.widgets?.length) continue
 
     const inputName = input.name ?? ''
     const dotIndex = inputName.indexOf('.')
     if (dotIndex === -1) continue
 
     const prefix = inputName.slice(0, dotIndex)
+    const widgetIndex =
+      link.origin_slot < sourceNode.widgets.length ? link.origin_slot : 0
+    const widget = sourceNode.widgets[widgetIndex]
     const source: UniformSource = {
       nodeId: sourceNode.id as NodeId,
-      widgetName: sourceNode.widgets[0].name
+      widgetName: widget.name,
+      directValue: () => widget.value
     }
 
     if (prefix === 'floats') floats.push(source)
@@ -97,6 +104,11 @@ export function extractUniformSources(
   }
 
   return { floats, ints, bools, curves }
+}
+
+export function toNumber(v: unknown): number {
+  if (typeof v === 'string' && v.startsWith('#')) return hexToInt(v)
+  return Number(v) || 0
 }
 
 export function useGLSLUniforms(
@@ -120,9 +132,9 @@ export function useGLSLUniforms(
     if (!gId) return []
 
     if (subgraphSources) {
-      return subgraphSources.map(({ nodeId: nId, widgetName }) => {
+      return subgraphSources.map(({ nodeId: nId, widgetName, directValue }) => {
         const widget = widgetValueStore.getWidget(gId, nId, widgetName)
-        return coerce(widget?.value ?? defaultValue)
+        return coerce(widget?.value ?? directValue() ?? defaultValue)
       })
     }
 
@@ -142,6 +154,8 @@ export function useGLSLUniforms(
       const slot = node.inputs?.findIndex((inp) => inp.name === inputName)
       if (slot == null || slot < 0) break
 
+      const link = node.getInputLink(slot)
+      if (!link) break
       const upstreamNode = node.getInputNode(slot)
       if (!upstreamNode) break
       const upstreamWidgets = widgetValueStore.getNodeWidgets(
@@ -149,12 +163,13 @@ export function useGLSLUniforms(
         upstreamNode.id as NodeId
       )
       if (upstreamWidgets.length === 0) break
-      values.push(coerce(upstreamWidgets[0].value))
+      const wIdx =
+        link.origin_slot < upstreamWidgets.length ? link.origin_slot : 0
+      values.push(coerce(upstreamWidgets[wIdx].value))
     }
     return values
   }
 
-  const toNumber = (v: unknown): number => Number(v) || 0
   const toBool = (v: unknown): boolean => Boolean(v)
 
   const floatValues = computed(() =>
@@ -197,11 +212,10 @@ export function useGLSLUniforms(
     const sources = uniformSources.value?.curves
     if (sources && sources.length > 0) {
       return sources
-        .map(({ nodeId: nId, widgetName }) => {
+        .map(({ nodeId: nId, widgetName, directValue }) => {
           const widget = widgetValueStore.getWidget(gId, nId, widgetName)
-          return widget && isCurveData(widget.value)
-            ? (widget.value as CurveData)
-            : null
+          const value = widget?.value ?? directValue()
+          return isCurveData(value) ? (value as CurveData) : null
         })
         .filter((v): v is CurveData => v !== null)
     }

--- a/src/renderer/glsl/useGLSLUniforms.ts
+++ b/src/renderer/glsl/useGLSLUniforms.ts
@@ -88,9 +88,8 @@ export function extractUniformSources(
     if (dotIndex === -1) continue
 
     const prefix = inputName.slice(0, dotIndex)
-    const widgetIndex =
-      link.origin_slot < sourceNode.widgets.length ? link.origin_slot : 0
-    const widget = sourceNode.widgets[widgetIndex]
+    if (link.origin_slot >= sourceNode.widgets.length) continue
+    const widget = sourceNode.widgets[link.origin_slot]
     const source: UniformSource = {
       nodeId: sourceNode.id as NodeId,
       widgetName: widget.name,
@@ -162,10 +161,12 @@ export function useGLSLUniforms(
         gId,
         upstreamNode.id as NodeId
       )
-      if (upstreamWidgets.length === 0) break
-      const wIdx =
-        link.origin_slot < upstreamWidgets.length ? link.origin_slot : 0
-      values.push(coerce(upstreamWidgets[wIdx].value))
+      if (
+        upstreamWidgets.length === 0 ||
+        link.origin_slot >= upstreamWidgets.length
+      )
+        break
+      values.push(coerce(upstreamWidgets[link.origin_slot].value))
     }
     return values
   }

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -4,6 +4,7 @@ import type { ColorAdjustOptions } from '@/utils/colorUtil'
 import {
   adjustColor,
   hexToHsva,
+  hexToInt,
   hexToRgb,
   hsbToRgb,
   hsvaToHex,
@@ -92,6 +93,20 @@ describe('colorUtil conversions', () => {
     it('round-trips #hex -> rgb -> #hex', () => {
       const hex = '#123abc'
       expect(rgbToHex(hexToRgb(hex))).toBe('#123abc')
+    })
+  })
+
+  describe('hexToInt', () => {
+    it('converts 6-digit hex to packed integer', () => {
+      expect(hexToInt('#ff0000')).toBe(0xff0000)
+      expect(hexToInt('#00ff00')).toBe(0x00ff00)
+      expect(hexToInt('#45edf5')).toBe(0x45edf5)
+      expect(hexToInt('#000000')).toBe(0)
+    })
+
+    it('converts 3-digit hex to packed integer', () => {
+      expect(hexToInt('#fff')).toBe(0xffffff)
+      expect(hexToInt('#f00')).toBe(0xff0000)
     })
   })
 

--- a/src/utils/colorUtil.ts
+++ b/src/utils/colorUtil.ts
@@ -82,6 +82,11 @@ export function hexToRgb(hex: string): RGB {
   return { r, g, b }
 }
 
+export function hexToInt(hex: string): number {
+  const { r, g, b } = hexToRgb(hex)
+  return (r << 16) | (g << 8) | b
+}
+
 export function rgbToHex({ r, g, b }: RGB): string {
   const toHex = (n: number) =>
     Math.max(0, Math.min(255, Math.round(n)))


### PR DESCRIPTION
## Summary

Three issues caused GLSL preview to diverge from backend results:

1. Uniform source resolution always read widgets[0] instead of using link.origin_slot to select the correct widget. Added directValue fallback for widgets not registered in widgetValueStore.

2. Hex color strings (e.g. "#45edf5") were coerced to 0 by Number(). Added hexToInt to colorUtil and used it in toNumber coercion.

3. Custom size_mode was ignored — preview always used upstream image dimensions. Now checks size_mode widget first and respects "custom".

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11010-fix-resolve-incorrect-GLSL-live-preview-for-non-primitive-widget-types-33e6d73d36508101a76bfe8383c0c6ab) by [Unito](https://www.unito.io)
