### PR TITLE
refactor(mask editor): make 'clear mask' much easier

### DIFF
--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -94,6 +94,8 @@ export class AppModeHelper {
 
   /** Enter builder mode via the "Workflow actions" dropdown. */
   async enterBuilder() {
+    await this.page.keyboard.press('Escape')
+    await this.comfyPage.nextFrame()
     await this.page
       .getByRole('button', { name: 'Workflow actions' })
       .first()

--- a/browser_tests/fixtures/helpers/CanvasHelper.ts
+++ b/browser_tests/fixtures/helpers/CanvasHelper.ts
@@ -65,7 +65,10 @@ export class CanvasHelper {
   }
 
   async doubleClick(): Promise<void> {
-    await this.page.mouse.dblclick(10, 10, { delay: 5 })
+    await this.canvas.dblclick({
+      position: DefaultGraphPositions.emptySpaceClick,
+      delay: 5
+    })
     await this.nextFrame()
   }
 

--- a/src/components/maskeditor/dialog/TopBarHeader.vue
+++ b/src/components/maskeditor/dialog/TopBarHeader.vue
@@ -106,7 +106,6 @@
         <button :class="textButtonClass" @click="onInvert">
           {{ t('maskEditor.invert') }}
         </button>
-
         <button :class="textButtonClass" @click="onClear">
           {{ t('maskEditor.clear') }}
         </button>

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -15,8 +15,14 @@ vi.mock('vue-i18n', async (importOriginal) => {
   }
 })
 
-vi.mock('@/stores/commandStore', () => ({
-  useCommandStore: () => ({ execute: vi.fn() })
+const mockOpenMaskEditor = vi.fn()
+
+vi.mock('@/composables/maskeditor/useMaskEditor', () => ({
+  useMaskEditor: () => ({
+    openMaskEditor: mockOpenMaskEditor,
+    clearMask: vi.fn(),
+    isClearingMask: { value: false }
+  })
 }))
 
 function mockClipboard(clipboard: Partial<Clipboard> | undefined) {
@@ -100,6 +106,17 @@ describe('useImageMenuOptions', () => {
 
       expect(copyIdx).toBeLessThan(pasteIdx)
       expect(pasteIdx).toBeLessThan(saveIdx)
+    })
+
+    it('calls openMaskEditor with the node when Open in Mask Editor is chosen', () => {
+      const node = createImageNode()
+      const { getImageMenuOptions } = useImageMenuOptions()
+      const options = getImageMenuOptions(node)
+      const maskOption = options.find((o) => o.label === 'Open in Mask Editor')
+
+      maskOption!.action!()
+
+      expect(mockOpenMaskEditor).toHaveBeenCalledWith(node)
     })
   })
 

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -1,8 +1,8 @@
 import { useI18n } from 'vue-i18n'
 
 import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
+import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { useCommandStore } from '@/stores/commandStore'
 
 import type { MenuOption } from './useMoreOptionsMenu'
 
@@ -41,10 +41,10 @@ async function pasteClipboardImageToNode(node: LGraphNode): Promise<void> {
  */
 export function useImageMenuOptions() {
   const { t } = useI18n()
+  const maskEditor = useMaskEditor()
 
-  const openMaskEditor = () => {
-    const commandStore = useCommandStore()
-    void commandStore.execute('Comfy.MaskEditor.OpenMaskEditor')
+  const openMaskEditorForNode = (node: LGraphNode) => {
+    maskEditor.openMaskEditor(node)
   }
 
   const openImage = (node: LGraphNode) => {
@@ -118,7 +118,7 @@ export function useImageMenuOptions() {
       options.push(
         {
           label: t('contextMenu.Open in Mask Editor'),
-          action: () => openMaskEditor()
+          action: () => openMaskEditorForNode(node)
         },
         {
           label: t('contextMenu.Open Image'),

--- a/src/composables/maskeditor/useMaskEditor.ts
+++ b/src/composables/maskeditor/useMaskEditor.ts
@@ -1,3 +1,5 @@
+import { createSharedComposable } from '@vueuse/core'
+
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useDialogStore } from '@/stores/dialogStore'
 import TopBarHeader from '@/components/maskeditor/dialog/TopBarHeader.vue'
@@ -11,10 +13,19 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useI18n } from 'vue-i18n'
 import { ref } from 'vue'
 
+const useSharedCanvasTools = createSharedComposable(useCanvasTools)
+
+const sharedIsClearingMask = ref(false)
+
 export function useMaskEditor() {
-  const isClearingMask = ref(false)
+  const isClearingMask = sharedIsClearingMask
   const toastStore = useToastStore()
   const { t } = useI18n()
+  const dataStore = useMaskEditorDataStore()
+  const editorStore = useMaskEditorStore()
+  const loader = useMaskEditorLoader()
+  const saver = useMaskEditorSaver()
+  const canvasTools = useSharedCanvasTools()
   const openMaskEditor = (node: LGraphNode) => {
     if (!node) {
       console.error('[MaskEditor] No node provided')
@@ -78,12 +89,6 @@ export function useMaskEditor() {
 
     isClearingMask.value = true
 
-    const dataStore = useMaskEditorDataStore()
-    const editorStore = useMaskEditorStore()
-    const loader = useMaskEditorLoader()
-    const saver = useMaskEditorSaver()
-    const canvasTools = useCanvasTools()
-
     try {
       await loader.loadFromNode(node)
 
@@ -114,18 +119,31 @@ export function useMaskEditor() {
         editorStore.imgCanvas = imgCanvas
         editorStore.maskCanvas = maskCanvas
         editorStore.rgbCanvas = rgbCanvas
+        const maskCtx = maskCanvas.getContext('2d', {
+          willReadFrequently: true
+        })
+        const rgbCtx = rgbCanvas.getContext('2d', {
+          willReadFrequently: true
+        })
+        if (!maskCtx || !rgbCtx) {
+          throw new Error('Failed to get mask or RGB canvas context')
+        }
+        editorStore.maskCtx = maskCtx
+        editorStore.rgbCtx = rgbCtx
+        editorStore.imgCtx = imgCtx
       }
 
       canvasTools.clearMask()
       await saver.save()
     } finally {
-      if (!dialogStore.isDialogOpen('global-mask-editor')) {
+      const dialogOpen = dialogStore.isDialogOpen('global-mask-editor')
+      if (!dialogOpen) {
         editorStore.imgCanvas = null
         editorStore.maskCanvas = null
         editorStore.rgbCanvas = null
+        dataStore.reset()
+        editorStore.resetState()
       }
-      dataStore.reset()
-      editorStore.resetState()
       isClearingMask.value = false
     }
   }

--- a/src/composables/maskeditor/useMaskEditor.ts
+++ b/src/composables/maskeditor/useMaskEditor.ts
@@ -2,8 +2,19 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useDialogStore } from '@/stores/dialogStore'
 import TopBarHeader from '@/components/maskeditor/dialog/TopBarHeader.vue'
 import MaskEditorContent from '@/components/maskeditor/MaskEditorContent.vue'
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { useMaskEditorLoader } from '@/composables/maskeditor/useMaskEditorLoader'
+import { useMaskEditorSaver } from '@/composables/maskeditor/useMaskEditorSaver'
+import { useCanvasTools } from '@/composables/maskeditor/useCanvasTools'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useI18n } from 'vue-i18n'
+import { ref } from 'vue'
 
 export function useMaskEditor() {
+  const isClearingMask = ref(false)
+  const toastStore = useToastStore()
+  const { t } = useI18n()
   const openMaskEditor = (node: LGraphNode) => {
     if (!node) {
       console.error('[MaskEditor] No node provided')
@@ -42,7 +53,86 @@ export function useMaskEditor() {
     })
   }
 
+  const clearMask = async (node: LGraphNode) => {
+    if (!node) {
+      return
+    }
+
+    if (isClearingMask.value) {
+      return
+    }
+
+    const dialogStore = useDialogStore()
+    if (dialogStore.isDialogOpen('global-mask-editor')) {
+      console.warn(
+        '[MaskEditor] Cannot clear mask while the mask editor is open'
+      )
+      toastStore.add({
+        severity: 'warn',
+        summary: t('maskEditor.cannotClearWhenOpenSummary'),
+        detail: t('maskEditor.cannotClearWhenOpenDetail'),
+        life: 3000
+      })
+      return
+    }
+
+    isClearingMask.value = true
+
+    const dataStore = useMaskEditorDataStore()
+    const editorStore = useMaskEditorStore()
+    const loader = useMaskEditorLoader()
+    const saver = useMaskEditorSaver()
+    const canvasTools = useCanvasTools()
+
+    try {
+      await loader.loadFromNode(node)
+
+      if (!dataStore.inputData) throw new Error('Failed to load image data')
+
+      if (!editorStore.maskCanvas) {
+        const { image } = dataStore.inputData.baseLayer
+        const width = image.naturalWidth || image.width || 1
+        const height = image.naturalHeight || image.height || 1
+
+        const imgCanvas = document.createElement('canvas')
+        imgCanvas.width = width
+        imgCanvas.height = height
+        const imgCtx = imgCanvas.getContext('2d')
+        if (!imgCtx) {
+          throw new Error('Failed to get image canvas context')
+        }
+        imgCtx.drawImage(image, 0, 0)
+
+        const maskCanvas = document.createElement('canvas')
+        maskCanvas.width = width
+        maskCanvas.height = height
+
+        const rgbCanvas = document.createElement('canvas')
+        rgbCanvas.width = width
+        rgbCanvas.height = height
+
+        editorStore.imgCanvas = imgCanvas
+        editorStore.maskCanvas = maskCanvas
+        editorStore.rgbCanvas = rgbCanvas
+      }
+
+      canvasTools.clearMask()
+      await saver.save()
+    } finally {
+      if (!dialogStore.isDialogOpen('global-mask-editor')) {
+        editorStore.imgCanvas = null
+        editorStore.maskCanvas = null
+        editorStore.rgbCanvas = null
+      }
+      dataStore.reset()
+      editorStore.resetState()
+      isClearingMask.value = false
+    }
+  }
+
   return {
-    openMaskEditor
+    isClearingMask,
+    openMaskEditor,
+    clearMask
   }
 }

--- a/src/composables/maskeditor/useMaskEditor.ts
+++ b/src/composables/maskeditor/useMaskEditor.ts
@@ -92,7 +92,10 @@ export function useMaskEditor() {
     try {
       await loader.loadFromNode(node)
 
-      if (!dataStore.inputData) throw new Error('Failed to load image data')
+      if (!dataStore.inputData) {
+        console.error('[MaskEditor] Failed to load image data')
+        return
+      }
 
       if (!editorStore.maskCanvas) {
         const { image } = dataStore.inputData.baseLayer
@@ -104,7 +107,8 @@ export function useMaskEditor() {
         imgCanvas.height = height
         const imgCtx = imgCanvas.getContext('2d')
         if (!imgCtx) {
-          throw new Error('Failed to get image canvas context')
+          console.error('[MaskEditor] Failed to get image canvas context')
+          return
         }
         imgCtx.drawImage(image, 0, 0)
 
@@ -126,7 +130,8 @@ export function useMaskEditor() {
           willReadFrequently: true
         })
         if (!maskCtx || !rgbCtx) {
-          throw new Error('Failed to get mask or RGB canvas context')
+          console.error('[MaskEditor] Failed to get mask or RGB canvas context')
+          return
         }
         editorStore.maskCtx = maskCtx
         editorStore.rgbCtx = rgbCtx

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -12,6 +12,7 @@
     "downloadVideo": "Download video",
     "downloadAudio": "Download audio",
     "editOrMaskImage": "Edit or mask image",
+    "clearMask": "Clear mask",
     "editImage": "Edit image",
     "decrement": "Decrement",
     "deleteImage": "Delete image",
@@ -1194,6 +1195,8 @@
   "maskEditor": {
     "title": "Mask Editor",
     "openMaskEditor": "Open in Mask Editor",
+    "cannotClearWhenOpenSummary": "Warning",
+    "cannotClearWhenOpenDetail": "Please close the mask editor before clearing masks.",
     "invert": "Invert",
     "clear": "Clear",
     "undo": "Undo",
@@ -1233,7 +1236,9 @@
     "baseLayerPreview": "Base layer preview",
     "black": "Black",
     "white": "White",
-    "negative": "Negative"
+    "negative": "Negative",
+    "clearMaskError": "Clear Mask Error",
+    "clearMaskFailed": "Failed to clear mask. Please try again."
   },
   "commands": {
     "runWorkflow": "Run workflow",

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -1,14 +1,32 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access */
-/* eslint-disable testing-library/prefer-user-event */
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen, fireEvent } from '@testing-library/vue'
-import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VueWrapper } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+const mockClearMask = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('@/composables/maskeditor/useMaskEditor', async () => {
+  const { ref } = await import('vue')
+  return {
+    useMaskEditor: () => ({
+      openMaskEditor: vi.fn(),
+      clearMask: mockClearMask,
+      isClearingMask: ref(false)
+    })
+  }
+})
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  resolveNode: vi.fn(() => undefined)
+}))
+
 import { downloadFile } from '@/base/common/downloadUtil'
 import ImagePreview from '@/renderer/extensions/vueNodes/components/ImagePreview.vue'
+import { resolveNode } from '@/utils/litegraphUtil'
 
 // Mock downloadFile to avoid DOM errors
 vi.mock('@/base/common/downloadUtil', () => ({
@@ -35,7 +53,12 @@ const i18n = createI18n({
         unknownFile: 'Unknown file',
         loading: 'Loading',
         viewGrid: 'Grid view',
-        galleryThumbnail: 'Gallery thumbnail'
+        galleryThumbnail: 'Gallery thumbnail',
+        clearMask: 'Clear mask'
+      },
+      maskEditor: {
+        clearMaskError: 'Clear Mask Error',
+        clearMaskFailed: 'Failed to clear mask. Please try again.'
       }
     }
   }
@@ -48,9 +71,10 @@ describe('ImagePreview', () => {
       '/api/view?filename=test2.png&type=output'
     ]
   }
+  const wrapperRegistry = new Set<VueWrapper>()
 
-  function renderImagePreview(props = {}) {
-    return render(ImagePreview, {
+  const mountImagePreview = (props = {}) => {
+    const wrapper = mount(ImagePreview, {
       props: { ...defaultProps, ...props },
       global: {
         plugins: [
@@ -68,354 +92,351 @@ describe('ImagePreview', () => {
         }
       }
     })
+    wrapperRegistry.add(wrapper)
+    return wrapper
   }
 
-  async function switchToGallery(user: ReturnType<typeof userEvent.setup>) {
-    const thumbnails = screen.getAllByRole('button', { name: /^View image/ })
-    await user.click(thumbnails[0])
+  async function switchToGallery(wrapper: VueWrapper) {
+    const thumbnails = wrapper.findAll('button[aria-label^="View image"]')
+    await thumbnails[0].trigger('click')
     await nextTick()
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(resolveNode).mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    wrapperRegistry.forEach((wrapper) => {
+      wrapper.unmount()
+    })
+    wrapperRegistry.clear()
   })
 
   it('does not render when no imageUrls provided', () => {
-    const { container } = renderImagePreview({ imageUrls: [] })
+    const wrapper = mountImagePreview({ imageUrls: [] })
 
-    expect(container.querySelector('.image-preview')).not.toBeInTheDocument()
+    expect(wrapper.find('.image-preview').exists()).toBe(false)
   })
 
   it('displays calculating dimensions text in gallery mode', async () => {
-    renderImagePreview({
+    const wrapper = mountImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    screen.getByText('Calculating dimensions')
+    expect(wrapper.text()).toContain('Calculating dimensions')
   })
 
   it('shows navigation dots for multiple images in gallery mode', async () => {
-    renderImagePreview()
-    const user = userEvent.setup()
-    await switchToGallery(user)
+    const wrapper = mountImagePreview()
+    await switchToGallery(wrapper)
 
-    const navigationDots = screen.getAllByRole('button', {
-      name: /View image/
-    })
+    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
     expect(navigationDots).toHaveLength(2)
   })
 
   it('does not show navigation dots for single image', () => {
-    renderImagePreview({
+    const wrapper = mountImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    const navigationDots = screen.queryAllByRole('button', {
-      name: /View image/
-    })
+    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
     expect(navigationDots).toHaveLength(0)
   })
 
-  it('does not show mask/edit button for multiple images in gallery mode', async () => {
-    renderImagePreview()
-    const user = userEvent.setup()
-    await switchToGallery(user)
+  it('shows mask/edit button only for single images', async () => {
+    // Multiple images in gallery mode - should not show mask button
+    const multipleImagesWrapper = mountImagePreview()
+    await switchToGallery(multipleImagesWrapper)
 
     expect(
-      screen.queryByRole('button', { name: 'Edit or mask image' })
-    ).not.toBeInTheDocument()
-  })
+      multipleImagesWrapper.find('[aria-label="Edit or mask image"]').exists()
+    ).toBe(false)
 
-  it('shows mask/edit button for single images', () => {
-    renderImagePreview({
+    // Single image - should show mask button
+    const singleImageWrapper = mountImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    screen.getByRole('button', { name: 'Edit or mask image' })
+    expect(
+      singleImageWrapper.find('[aria-label="Edit or mask image"]').exists()
+    ).toBe(true)
   })
 
   it('handles download button click', async () => {
-    renderImagePreview({
+    const wrapper = mountImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
-    const user = userEvent.setup()
 
-    const downloadButton = screen.getByRole('button', {
-      name: 'Download image'
-    })
-    await user.click(downloadButton)
+    const downloadButton = wrapper.find('[aria-label="Download image"]')
+    expect(downloadButton.exists()).toBe(true)
+    await downloadButton.trigger('click')
 
     expect(downloadFile).toHaveBeenCalledWith(defaultProps.imageUrls[0])
   })
 
+  it('calls clearMask with resolved node when clear mask is clicked', async () => {
+    const stubNode = { id: 99, imgs: [] } as unknown as LGraphNode
+    vi.mocked(resolveNode).mockReturnValue(stubNode)
+
+    const wrapper = mountImagePreview({
+      imageUrls: [defaultProps.imageUrls[0]],
+      nodeId: '99'
+    })
+
+    const clearButton = wrapper.find('[aria-label="Clear mask"]')
+    expect(clearButton.exists()).toBe(true)
+    await clearButton.trigger('click')
+    await flushPromises()
+
+    expect(mockClearMask).toHaveBeenCalledTimes(1)
+    expect(mockClearMask).toHaveBeenCalledWith(stubNode)
+  })
+
   it('switches images when navigation dots are clicked', async () => {
-    renderImagePreview()
-    const user = userEvent.setup()
-    await switchToGallery(user)
+    const wrapper = mountImagePreview()
+    await switchToGallery(wrapper)
 
     // Initially shows first image
-    expect(screen.getByRole('img')).toHaveAttribute(
-      'src',
+    expect(wrapper.find('img').attributes('src')).toBe(
       defaultProps.imageUrls[0]
     )
 
     // Click second navigation dot
-    const navigationDots = screen.getAllByRole('button', {
-      name: /View image/
-    })
-    await user.click(navigationDots[1])
+    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
+    await navigationDots[1].trigger('click')
     await nextTick()
 
-    expect(screen.getByRole('img')).toHaveAttribute(
-      'src',
+    expect(wrapper.find('img').attributes('src')).toBe(
       defaultProps.imageUrls[1]
     )
   })
 
   it('marks active navigation dot with aria-current', async () => {
-    renderImagePreview()
-    const user = userEvent.setup()
-    await switchToGallery(user)
+    const wrapper = mountImagePreview()
+    await switchToGallery(wrapper)
 
-    const navigationDots = screen.getAllByRole('button', {
-      name: /View image/
-    })
+    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
 
     // First dot should be active
-    expect(navigationDots[0]).toHaveAttribute('aria-current', 'true')
-    expect(navigationDots[1]).not.toHaveAttribute('aria-current')
+    expect(navigationDots[0].attributes('aria-current')).toBe('true')
+    expect(navigationDots[1].attributes('aria-current')).toBeUndefined()
 
-    await user.click(navigationDots[1])
+    await navigationDots[1].trigger('click')
     await nextTick()
 
     // Second dot should now be active
-    expect(navigationDots[0]).not.toHaveAttribute('aria-current')
-    expect(navigationDots[1]).toHaveAttribute('aria-current', 'true')
+    expect(navigationDots[0].attributes('aria-current')).toBeUndefined()
+    expect(navigationDots[1].attributes('aria-current')).toBe('true')
   })
 
   it('has proper accessibility attributes', () => {
-    renderImagePreview({
+    const wrapper = mountImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    expect(screen.getByRole('img')).toHaveAttribute('alt', 'View image 1 of 1')
+    const img = wrapper.find('img')
+    expect(img.attributes('alt')).toBe('View image 1 of 1')
   })
 
   it('updates alt text when switching images', async () => {
-    renderImagePreview()
-    const user = userEvent.setup()
-    await switchToGallery(user)
+    const wrapper = mountImagePreview()
+    await switchToGallery(wrapper)
 
-    expect(screen.getByRole('img')).toHaveAttribute('alt', 'View image 1 of 2')
+    expect(wrapper.find('img').attributes('alt')).toBe('View image 1 of 2')
 
     // Switch to second image
-    const navigationDots = screen.getAllByRole('button', {
-      name: /View image/
-    })
-    await user.click(navigationDots[1])
+    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
+    await navigationDots[1].trigger('click')
     await nextTick()
 
-    expect(screen.getByRole('img')).toHaveAttribute('alt', 'View image 2 of 2')
+    expect(wrapper.find('img').attributes('alt')).toBe('View image 2 of 2')
   })
 
   describe('keyboard navigation', () => {
     it('navigates to next image with ArrowRight', async () => {
-      const { container } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
 
-      expect(screen.getByTestId('main-image')).toHaveAttribute(
-        'src',
+      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
         defaultProps.imageUrls[1]
       )
     })
 
     it('navigates to previous image with ArrowLeft', async () => {
-      const { container } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
 
-      await fireEvent.keyDown(preview, { key: 'ArrowLeft' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowLeft' })
       await nextTick()
 
-      expect(screen.getByTestId('main-image')).toHaveAttribute(
-        'src',
+      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
         defaultProps.imageUrls[0]
       )
     })
 
     it('wraps around from last to first with ArrowRight', async () => {
-      const { container } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
 
-      expect(screen.getByTestId('main-image')).toHaveAttribute(
-        'src',
+      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
         defaultProps.imageUrls[0]
       )
     })
 
     it('wraps around from first to last with ArrowLeft', async () => {
-      const { container } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowLeft' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowLeft' })
       await nextTick()
 
-      expect(screen.getByTestId('main-image')).toHaveAttribute(
-        'src',
+      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
         defaultProps.imageUrls[1]
       )
     })
 
     it('navigates to first image with Home', async () => {
-      const { container } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
 
-      await fireEvent.keyDown(preview, { key: 'Home' })
+      await wrapper.find('.image-preview').trigger('keydown', { key: 'Home' })
       await nextTick()
 
-      expect(screen.getByTestId('main-image')).toHaveAttribute(
-        'src',
+      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
         defaultProps.imageUrls[0]
       )
     })
 
     it('navigates to last image with End', async () => {
-      const { container } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'End' })
+      await wrapper.find('.image-preview').trigger('keydown', { key: 'End' })
       await nextTick()
 
-      expect(screen.getByTestId('main-image')).toHaveAttribute(
-        'src',
+      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
         defaultProps.imageUrls[1]
       )
     })
 
     it('ignores arrow keys in grid mode', async () => {
-      const { container } = renderImagePreview()
+      const wrapper = mountImagePreview()
 
-      const gridThumbnails = screen.getAllByRole('button', {
-        name: /^View image/
-      })
+      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
       expect(gridThumbnails).toHaveLength(2)
 
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
 
-      expect(screen.queryByRole('region')).not.toBeInTheDocument()
+      expect(wrapper.find('[role="region"]').exists()).toBe(false)
     })
 
     it('ignores arrow keys for single image', async () => {
-      const { container } = renderImagePreview({
+      const wrapper = mountImagePreview({
         imageUrls: [defaultProps.imageUrls[0]]
       })
 
-      const initialSrc = screen.getByRole('img').getAttribute('src')
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      const initialSrc = wrapper.find('img').attributes('src')
+      await wrapper
+        .find('.image-preview')
+        .trigger('keydown', { key: 'ArrowRight' })
       await nextTick()
 
-      expect(screen.getByRole('img')).toHaveAttribute('src', initialSrc!)
+      expect(wrapper.find('img').attributes('src')).toBe(initialSrc)
     })
   })
 
   describe('grid view', () => {
     it('defaults to grid mode for multiple images', () => {
-      renderImagePreview()
+      const wrapper = mountImagePreview()
 
-      const gridThumbnails = screen.getAllByRole('button', {
-        name: /^View image/
-      })
+      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
       expect(gridThumbnails).toHaveLength(2)
     })
 
     it('defaults to gallery mode for single image', () => {
-      renderImagePreview({
+      const wrapper = mountImagePreview({
         imageUrls: [defaultProps.imageUrls[0]]
       })
 
-      screen.getByRole('region')
-      const gridThumbnails = screen.queryAllByRole('button', {
-        name: /^View image/
-      })
+      expect(wrapper.find('[role="region"]').exists()).toBe(true)
+      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
       expect(gridThumbnails).toHaveLength(0)
     })
 
     it('switches to gallery mode when grid thumbnail is clicked', async () => {
-      renderImagePreview()
-      const user = userEvent.setup()
+      const wrapper = mountImagePreview()
 
-      const thumbnails = screen.getAllByRole('button', {
-        name: /^View image/
-      })
-      await user.click(thumbnails[1])
+      const thumbnails = wrapper.findAll('button[aria-label^="View image"]')
+      await thumbnails[1].trigger('click')
       await nextTick()
 
-      const mainImg = screen.getByTestId('main-image')
-      expect(mainImg).toHaveAttribute('src', defaultProps.imageUrls[1])
+      const mainImg = wrapper.find('[data-testid="main-image"]')
+      expect(mainImg.exists()).toBe(true)
+      expect(mainImg.attributes('src')).toBe(defaultProps.imageUrls[1])
     })
 
     it('shows back-to-grid button next to navigation dots', async () => {
-      renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const gridButtons = screen.getAllByRole('button', { name: 'Grid view' })
-      expect(gridButtons.length).toBeGreaterThanOrEqual(1)
+      const gridButton = wrapper.find('[aria-label="Grid view"]')
+      expect(gridButton.exists()).toBe(true)
     })
 
     it('switches back to grid mode via back-to-grid button', async () => {
-      renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
-      const gridButtons = screen.getAllByRole('button', { name: 'Grid view' })
-      await user.click(gridButtons[0])
+      const gridButton = wrapper.find('[aria-label="Grid view"]')
+      await gridButton.trigger('click')
       await nextTick()
 
-      const gridThumbnails = screen.getAllByRole('button', {
-        name: /^View image/
-      })
+      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
       expect(gridThumbnails).toHaveLength(2)
     })
 
     it('resets to grid mode when URLs change to multiple images', async () => {
-      const { rerender } = renderImagePreview()
-      const user = userEvent.setup()
-      await switchToGallery(user)
+      const wrapper = mountImagePreview()
+      await switchToGallery(wrapper)
 
       // Verify we're in gallery mode
-      screen.getByRole('region')
+      expect(wrapper.find('[role="region"]').exists()).toBe(true)
 
       // Change URLs
-      await rerender({
+      await wrapper.setProps({
         imageUrls: [
           '/api/view?filename=new1.png&type=output',
           '/api/view?filename=new2.png&type=output',
@@ -425,9 +446,7 @@ describe('ImagePreview', () => {
       await nextTick()
 
       // Should be back in grid mode
-      const gridThumbnails = screen.getAllByRole('button', {
-        name: /^View image/
-      })
+      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
       expect(gridThumbnails).toHaveLength(3)
     })
   })
@@ -435,26 +454,21 @@ describe('ImagePreview', () => {
   describe('batch cycling with identical URLs', () => {
     it('should not enter persistent loading state when cycling through identical images', async () => {
       vi.useFakeTimers()
-      const user = userEvent.setup({
-        advanceTimers: vi.advanceTimersByTime
-      })
       try {
         const sameUrl = '/api/view?filename=test.png&type=output'
-        const { container } = renderImagePreview({
+        const wrapper = mountImagePreview({
           imageUrls: [sameUrl, sameUrl, sameUrl]
         })
-        await switchToGallery(user)
+        await switchToGallery(wrapper)
 
         // Simulate initial image load
-        await fireEvent.load(screen.getByRole('img'))
+        await wrapper.find('img').trigger('load')
         await nextTick()
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
 
         // Click second navigation dot to cycle
-        const dots = screen.getAllByRole('button', { name: /View image/ })
-        await user.click(dots[1])
+        const dots = wrapper.findAll('[aria-label*="View image"]')
+        await dots[1].trigger('click')
         await nextTick()
 
         // Advance past the delayed loader timeout
@@ -462,9 +476,7 @@ describe('ImagePreview', () => {
         await nextTick()
 
         // Should NOT be in loading state since URL didn't change
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
       } finally {
         vi.useRealTimers()
       }
@@ -474,27 +486,20 @@ describe('ImagePreview', () => {
   describe('URL change detection', () => {
     it('should NOT reset loading state when imageUrls prop is reassigned with identical URLs', async () => {
       vi.useFakeTimers()
-      const user = userEvent.setup({
-        advanceTimers: vi.advanceTimersByTime
-      })
       try {
         const urls = ['/api/view?filename=test.png&type=output']
-        const { container, rerender } = renderImagePreview({
-          imageUrls: urls
-        })
-        void user
+        const wrapper = mountImagePreview({ imageUrls: urls })
 
         // Simulate image load completing
-        await fireEvent.load(screen.getByRole('img'))
+        const img = wrapper.find('img')
+        await img.trigger('load')
         await nextTick()
 
         // Verify loader is hidden after load
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
 
         // Reassign with new array reference but same content
-        await rerender({ imageUrls: [...urls] })
+        await wrapper.setProps({ imageUrls: [...urls] })
         await nextTick()
 
         // Advance past the 250ms delayed loader timeout
@@ -502,9 +507,7 @@ describe('ImagePreview', () => {
         await nextTick()
 
         // Loading state should NOT have been reset
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
       } finally {
         vi.useRealTimers()
       }
@@ -512,27 +515,20 @@ describe('ImagePreview', () => {
 
     it('should reset loading state when imageUrls prop changes to different URLs', async () => {
       vi.useFakeTimers()
-      const user = userEvent.setup({
-        advanceTimers: vi.advanceTimersByTime
-      })
       try {
         const urls = ['/api/view?filename=test.png&type=output']
-        const { container, rerender } = renderImagePreview({
-          imageUrls: urls
-        })
+        const wrapper = mountImagePreview({ imageUrls: urls })
 
         // Simulate image load completing
-        await fireEvent.load(screen.getByRole('img'))
+        const img = wrapper.find('img')
+        await img.trigger('load')
         await nextTick()
 
         // Verify loader is hidden
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).not.toBeInTheDocument()
+        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
 
-        void user
         // Change to different URL
-        await rerender({
+        await wrapper.setProps({
           imageUrls: ['/api/view?filename=different.png&type=output']
         })
         await nextTick()
@@ -541,26 +537,24 @@ describe('ImagePreview', () => {
         await vi.advanceTimersByTimeAsync(300)
         await nextTick()
 
-        expect(
-          container.querySelector('[aria-busy="true"]')
-        ).toBeInTheDocument()
+        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(true)
       } finally {
         vi.useRealTimers()
       }
     })
 
     it('should handle empty to non-empty URL transitions correctly', async () => {
-      const { container, rerender } = renderImagePreview({ imageUrls: [] })
+      const wrapper = mountImagePreview({ imageUrls: [] })
 
-      expect(container.querySelector('.image-preview')).not.toBeInTheDocument()
+      expect(wrapper.find('.image-preview').exists()).toBe(false)
 
-      await rerender({
+      await wrapper.setProps({
         imageUrls: ['/api/view?filename=test.png&type=output']
       })
       await nextTick()
 
-      expect(container.querySelector('.image-preview')).toBeInTheDocument()
-      screen.getByRole('img')
+      expect(wrapper.find('.image-preview').exists()).toBe(true)
+      expect(wrapper.find('img').exists()).toBe(true)
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -1,6 +1,12 @@
 import { createTestingPinia } from '@pinia/testing'
-import type { VueWrapper } from '@vue/test-utils'
-import { flushPromises, mount } from '@vue/test-utils'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -28,7 +34,6 @@ import { downloadFile } from '@/base/common/downloadUtil'
 import ImagePreview from '@/renderer/extensions/vueNodes/components/ImagePreview.vue'
 import { resolveNode } from '@/utils/litegraphUtil'
 
-// Mock downloadFile to avoid DOM errors
 vi.mock('@/base/common/downloadUtil', () => ({
   downloadFile: vi.fn()
 }))
@@ -54,7 +59,8 @@ const i18n = createI18n({
         loading: 'Loading',
         viewGrid: 'Grid view',
         galleryThumbnail: 'Gallery thumbnail',
-        clearMask: 'Clear mask'
+        clearMask: 'Clear mask',
+        imageGallery: 'image gallery'
       },
       maskEditor: {
         clearMaskError: 'Clear Mask Error',
@@ -64,114 +70,109 @@ const i18n = createI18n({
   }
 })
 
-describe('ImagePreview', () => {
-  const defaultProps = {
-    imageUrls: [
-      '/api/view?filename=test1.png&type=output',
-      '/api/view?filename=test2.png&type=output'
-    ]
-  }
-  const wrapperRegistry = new Set<VueWrapper>()
+const defaultProps = {
+  imageUrls: [
+    '/api/view?filename=test1.png&type=output',
+    '/api/view?filename=test2.png&type=output'
+  ]
+}
 
-  const mountImagePreview = (props = {}) => {
-    const wrapper = mount(ImagePreview, {
-      props: { ...defaultProps, ...props },
-      global: {
-        plugins: [
-          createTestingPinia({
-            createSpy: vi.fn
-          }),
-          i18n
-        ],
-        stubs: {
-          'i-lucide:venetian-mask': true,
-          'i-lucide:download': true,
-          'i-lucide:x': true,
-          'i-lucide:image-off': true,
-          Skeleton: true
-        }
+function renderImagePreview(props: Record<string, unknown> = {}) {
+  return render(ImagePreview, {
+    props: { ...defaultProps, ...props },
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+      stubs: {
+        'i-comfy:mask': true,
+        'i-lucide:venetian-mask': true,
+        'i-lucide:download': true,
+        'i-lucide:x': true,
+        'i-lucide:image-off': true,
+        Skeleton: true
       }
-    })
-    wrapperRegistry.add(wrapper)
-    return wrapper
-  }
+    }
+  })
+}
 
-  async function switchToGallery(wrapper: VueWrapper) {
-    const thumbnails = wrapper.findAll('button[aria-label^="View image"]')
-    await thumbnails[0].trigger('click')
-    await nextTick()
-  }
+async function switchToGallery(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'View image 1 of 2' }))
+  await nextTick()
+}
+
+function viewImageNavButtons() {
+  return screen.getAllByRole('button', {
+    name: /View image \d+ of \d+/
+  })
+}
+
+describe('ImagePreview', () => {
+  afterEach(() => {
+    cleanup()
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(resolveNode).mockReturnValue(undefined)
   })
 
-  afterEach(() => {
-    wrapperRegistry.forEach((wrapper) => {
-      wrapper.unmount()
-    })
-    wrapperRegistry.clear()
-  })
-
   it('does not render when no imageUrls provided', () => {
-    const wrapper = mountImagePreview({ imageUrls: [] })
+    renderImagePreview({ imageUrls: [] })
 
-    expect(wrapper.find('.image-preview').exists()).toBe(false)
+    expect(screen.queryByTestId('image-preview-root')).not.toBeInTheDocument()
   })
 
   it('displays calculating dimensions text in gallery mode', async () => {
-    const wrapper = mountImagePreview({
+    renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    expect(wrapper.text()).toContain('Calculating dimensions')
+    expect(screen.getByText('Calculating dimensions')).toBeInTheDocument()
   })
 
   it('shows navigation dots for multiple images in gallery mode', async () => {
-    const wrapper = mountImagePreview()
-    await switchToGallery(wrapper)
+    const user = userEvent.setup()
+    renderImagePreview()
+    await switchToGallery(user)
 
-    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
-    expect(navigationDots).toHaveLength(2)
+    expect(viewImageNavButtons()).toHaveLength(2)
   })
 
   it('does not show navigation dots for single image', () => {
-    const wrapper = mountImagePreview({
+    renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
-    expect(navigationDots).toHaveLength(0)
+    expect(
+      screen.queryByRole('button', { name: /View image \d+ of \d+/ })
+    ).not.toBeInTheDocument()
   })
 
   it('shows mask/edit button only for single images', async () => {
-    // Multiple images in gallery mode - should not show mask button
-    const multipleImagesWrapper = mountImagePreview()
-    await switchToGallery(multipleImagesWrapper)
+    const user = userEvent.setup()
+    renderImagePreview()
+    await switchToGallery(user)
 
     expect(
-      multipleImagesWrapper.find('[aria-label="Edit or mask image"]').exists()
-    ).toBe(false)
+      screen.queryByRole('button', { name: 'Edit or mask image' })
+    ).not.toBeInTheDocument()
 
-    // Single image - should show mask button
-    const singleImageWrapper = mountImagePreview({
+    cleanup()
+    renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
     expect(
-      singleImageWrapper.find('[aria-label="Edit or mask image"]').exists()
-    ).toBe(true)
+      screen.getByRole('button', { name: 'Edit or mask image' })
+    ).toBeInTheDocument()
   })
 
   it('handles download button click', async () => {
-    const wrapper = mountImagePreview({
+    const user = userEvent.setup()
+    renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    const downloadButton = wrapper.find('[aria-label="Download image"]')
-    expect(downloadButton.exists()).toBe(true)
-    await downloadButton.trigger('click')
+    await user.click(screen.getByRole('button', { name: 'Download image' }))
 
     expect(downloadFile).toHaveBeenCalledWith(defaultProps.imageUrls[0])
   })
@@ -180,263 +181,286 @@ describe('ImagePreview', () => {
     const stubNode = { id: 99, imgs: [] } as unknown as LGraphNode
     vi.mocked(resolveNode).mockReturnValue(stubNode)
 
-    const wrapper = mountImagePreview({
+    const user = userEvent.setup()
+    renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]],
       nodeId: '99'
     })
 
-    const clearButton = wrapper.find('[aria-label="Clear mask"]')
-    expect(clearButton.exists()).toBe(true)
-    await clearButton.trigger('click')
-    await flushPromises()
+    await user.click(screen.getByRole('button', { name: 'Clear mask' }))
 
-    expect(mockClearMask).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(mockClearMask).toHaveBeenCalledTimes(1)
+    })
     expect(mockClearMask).toHaveBeenCalledWith(stubNode)
   })
 
   it('switches images when navigation dots are clicked', async () => {
-    const wrapper = mountImagePreview()
-    await switchToGallery(wrapper)
+    const user = userEvent.setup()
+    renderImagePreview()
+    await switchToGallery(user)
 
-    // Initially shows first image
-    expect(wrapper.find('img').attributes('src')).toBe(
+    expect(screen.getByTestId('main-image')).toHaveAttribute(
+      'src',
       defaultProps.imageUrls[0]
     )
 
-    // Click second navigation dot
-    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
-    await navigationDots[1].trigger('click')
+    const navigationDots = viewImageNavButtons()
+    await user.click(navigationDots[1])
     await nextTick()
 
-    expect(wrapper.find('img').attributes('src')).toBe(
+    expect(screen.getByTestId('main-image')).toHaveAttribute(
+      'src',
       defaultProps.imageUrls[1]
     )
   })
 
   it('marks active navigation dot with aria-current', async () => {
-    const wrapper = mountImagePreview()
-    await switchToGallery(wrapper)
+    const user = userEvent.setup()
+    renderImagePreview()
+    await switchToGallery(user)
 
-    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
+    const navigationDots = viewImageNavButtons()
 
-    // First dot should be active
-    expect(navigationDots[0].attributes('aria-current')).toBe('true')
-    expect(navigationDots[1].attributes('aria-current')).toBeUndefined()
+    expect(navigationDots[0]).toHaveAttribute('aria-current', 'true')
+    expect(navigationDots[1]).not.toHaveAttribute('aria-current')
 
-    await navigationDots[1].trigger('click')
+    await user.click(navigationDots[1])
     await nextTick()
 
-    // Second dot should now be active
-    expect(navigationDots[0].attributes('aria-current')).toBeUndefined()
-    expect(navigationDots[1].attributes('aria-current')).toBe('true')
+    expect(navigationDots[0]).not.toHaveAttribute('aria-current')
+    expect(navigationDots[1]).toHaveAttribute('aria-current', 'true')
   })
 
   it('has proper accessibility attributes', () => {
-    const wrapper = mountImagePreview({
+    renderImagePreview({
       imageUrls: [defaultProps.imageUrls[0]]
     })
 
-    const img = wrapper.find('img')
-    expect(img.attributes('alt')).toBe('View image 1 of 1')
+    expect(screen.getByRole('img', { name: 'View image 1 of 1' })).toBeTruthy()
   })
 
   it('updates alt text when switching images', async () => {
-    const wrapper = mountImagePreview()
-    await switchToGallery(wrapper)
+    const user = userEvent.setup()
+    renderImagePreview()
+    await switchToGallery(user)
 
-    expect(wrapper.find('img').attributes('alt')).toBe('View image 1 of 2')
+    expect(screen.getByTestId('main-image')).toHaveAttribute(
+      'alt',
+      'View image 1 of 2'
+    )
 
-    // Switch to second image
-    const navigationDots = wrapper.findAll('[aria-label*="View image"]')
-    await navigationDots[1].trigger('click')
+    const navigationDots = viewImageNavButtons()
+    await user.click(navigationDots[1])
     await nextTick()
 
-    expect(wrapper.find('img').attributes('alt')).toBe('View image 2 of 2')
+    expect(screen.getByTestId('main-image')).toHaveAttribute(
+      'alt',
+      'View image 2 of 2'
+    )
   })
 
   describe('keyboard navigation', () => {
     it('navigates to next image with ArrowRight', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      await user.keyboard('{ArrowRight}')
       await nextTick()
 
-      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
+      expect(screen.getByTestId('main-image')).toHaveAttribute(
+        'src',
         defaultProps.imageUrls[1]
       )
     })
 
     it('navigates to previous image with ArrowLeft', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      await user.keyboard('{ArrowRight}')
+      await nextTick()
+      await user.keyboard('{ArrowLeft}')
       await nextTick()
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowLeft' })
-      await nextTick()
-
-      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
+      expect(screen.getByTestId('main-image')).toHaveAttribute(
+        'src',
         defaultProps.imageUrls[0]
       )
     })
 
     it('wraps around from last to first with ArrowRight', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      await user.keyboard('{ArrowRight}')
       await nextTick()
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      await user.keyboard('{ArrowRight}')
       await nextTick()
 
-      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
+      expect(screen.getByTestId('main-image')).toHaveAttribute(
+        'src',
         defaultProps.imageUrls[0]
       )
     })
 
     it('wraps around from first to last with ArrowLeft', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowLeft' })
+      await user.keyboard('{ArrowLeft}')
       await nextTick()
 
-      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
+      expect(screen.getByTestId('main-image')).toHaveAttribute(
+        'src',
         defaultProps.imageUrls[1]
       )
     })
 
     it('navigates to first image with Home', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      await user.keyboard('{ArrowRight}')
+      await nextTick()
+      await user.keyboard('{Home}')
       await nextTick()
 
-      await wrapper.find('.image-preview').trigger('keydown', { key: 'Home' })
-      await nextTick()
-
-      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
+      expect(screen.getByTestId('main-image')).toHaveAttribute(
+        'src',
         defaultProps.imageUrls[0]
       )
     })
 
     it('navigates to last image with End', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      await wrapper.find('.image-preview').trigger('keydown', { key: 'End' })
+      await user.keyboard('{End}')
       await nextTick()
 
-      expect(wrapper.find('[data-testid="main-image"]').attributes('src')).toBe(
+      expect(screen.getByTestId('main-image')).toHaveAttribute(
+        'src',
         defaultProps.imageUrls[1]
       )
     })
 
     it('ignores arrow keys in grid mode', async () => {
-      const wrapper = mountImagePreview()
+      renderImagePreview()
 
-      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
-      expect(gridThumbnails).toHaveLength(2)
+      expect(
+        screen.getAllByRole('button', { name: /View image \d+ of 2/ })
+      ).toHaveLength(2)
 
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      const root = screen.getByTestId('image-preview-root')
+      // Thumbnail click opens gallery; grid-mode arrows are a no-op on the shell without moving focus into it.
+      // eslint-disable-next-line testing-library/prefer-user-event -- need keydown on root while view stays grid
+      void fireEvent.keyDown(root, { key: 'ArrowRight' })
       await nextTick()
 
-      expect(wrapper.find('[role="region"]').exists()).toBe(false)
+      expect(screen.queryByRole('region')).not.toBeInTheDocument()
     })
 
     it('ignores arrow keys for single image', async () => {
-      const wrapper = mountImagePreview({
+      const user = userEvent.setup()
+      renderImagePreview({
         imageUrls: [defaultProps.imageUrls[0]]
       })
 
-      const initialSrc = wrapper.find('img').attributes('src')
-      await wrapper
-        .find('.image-preview')
-        .trigger('keydown', { key: 'ArrowRight' })
+      const img = screen.getByRole('img')
+      const initialSrc = img.getAttribute('src')
+      await user.click(
+        screen.getByRole('region', {
+          name: 'Image preview - Use arrow keys to navigate between images'
+        })
+      )
+      await user.keyboard('{ArrowRight}')
       await nextTick()
 
-      expect(wrapper.find('img').attributes('src')).toBe(initialSrc)
+      expect(screen.getByRole('img').getAttribute('src')).toBe(initialSrc)
     })
   })
 
   describe('grid view', () => {
     it('defaults to grid mode for multiple images', () => {
-      const wrapper = mountImagePreview()
+      renderImagePreview()
 
-      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
-      expect(gridThumbnails).toHaveLength(2)
+      expect(
+        screen.getAllByRole('button', { name: /View image \d+ of 2/ })
+      ).toHaveLength(2)
     })
 
     it('defaults to gallery mode for single image', () => {
-      const wrapper = mountImagePreview({
+      renderImagePreview({
         imageUrls: [defaultProps.imageUrls[0]]
       })
 
-      expect(wrapper.find('[role="region"]').exists()).toBe(true)
-      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
-      expect(gridThumbnails).toHaveLength(0)
+      expect(
+        screen.getByRole('region', {
+          name: 'Image preview - Use arrow keys to navigate between images'
+        })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /View image \d+ of 1/ })
+      ).not.toBeInTheDocument()
     })
 
     it('switches to gallery mode when grid thumbnail is clicked', async () => {
-      const wrapper = mountImagePreview()
+      const user = userEvent.setup()
+      renderImagePreview()
 
-      const thumbnails = wrapper.findAll('button[aria-label^="View image"]')
-      await thumbnails[1].trigger('click')
+      const thumbnails = screen.getAllByRole('button', {
+        name: /View image \d+ of 2/
+      })
+      await user.click(thumbnails[1])
       await nextTick()
 
-      const mainImg = wrapper.find('[data-testid="main-image"]')
-      expect(mainImg.exists()).toBe(true)
-      expect(mainImg.attributes('src')).toBe(defaultProps.imageUrls[1])
+      const mainImg = screen.getByTestId('main-image')
+      expect(mainImg).toBeInTheDocument()
+      expect(mainImg).toHaveAttribute('src', defaultProps.imageUrls[1])
     })
 
     it('shows back-to-grid button next to navigation dots', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      const gridButton = wrapper.find('[aria-label="Grid view"]')
-      expect(gridButton.exists()).toBe(true)
+      expect(
+        screen.getAllByRole('button', { name: 'Grid view' })[0]
+      ).toBeInTheDocument()
     })
 
     it('switches back to grid mode via back-to-grid button', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      renderImagePreview()
+      await switchToGallery(user)
 
-      const gridButton = wrapper.find('[aria-label="Grid view"]')
-      await gridButton.trigger('click')
+      await user.click(screen.getAllByRole('button', { name: 'Grid view' })[0])
       await nextTick()
 
-      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
-      expect(gridThumbnails).toHaveLength(2)
+      expect(
+        screen.getAllByRole('button', { name: /View image \d+ of 2/ })
+      ).toHaveLength(2)
     })
 
     it('resets to grid mode when URLs change to multiple images', async () => {
-      const wrapper = mountImagePreview()
-      await switchToGallery(wrapper)
+      const user = userEvent.setup()
+      const { rerender } = renderImagePreview()
+      await switchToGallery(user)
 
-      // Verify we're in gallery mode
-      expect(wrapper.find('[role="region"]').exists()).toBe(true)
+      expect(
+        screen.getByRole('region', {
+          name: 'Image preview - Use arrow keys to navigate between images'
+        })
+      ).toBeInTheDocument()
 
-      // Change URLs
-      await wrapper.setProps({
+      await rerender({
         imageUrls: [
           '/api/view?filename=new1.png&type=output',
           '/api/view?filename=new2.png&type=output',
@@ -445,9 +469,9 @@ describe('ImagePreview', () => {
       })
       await nextTick()
 
-      // Should be back in grid mode
-      const gridThumbnails = wrapper.findAll('button[aria-label^="View image"]')
-      expect(gridThumbnails).toHaveLength(3)
+      expect(
+        screen.getAllByRole('button', { name: /View image \d+ of 3/ })
+      ).toHaveLength(3)
     })
   })
 
@@ -455,28 +479,40 @@ describe('ImagePreview', () => {
     it('should not enter persistent loading state when cycling through identical images', async () => {
       vi.useFakeTimers()
       try {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
         const sameUrl = '/api/view?filename=test.png&type=output'
-        const wrapper = mountImagePreview({
+        renderImagePreview({
           imageUrls: [sameUrl, sameUrl, sameUrl]
         })
-        await switchToGallery(wrapper)
-
-        // Simulate initial image load
-        await wrapper.find('img').trigger('load')
-        await nextTick()
-        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
-
-        // Click second navigation dot to cycle
-        const dots = wrapper.findAll('[aria-label*="View image"]')
-        await dots[1].trigger('click')
+        await user.click(
+          screen.getByRole('button', { name: 'View image 1 of 3' })
+        )
         await nextTick()
 
-        // Advance past the delayed loader timeout
+        void fireEvent.load(screen.getByTestId('main-image'))
+        await nextTick()
+        expect(
+          screen
+            .getByRole('region', {
+              name: 'Image preview - Use arrow keys to navigate between images'
+            })
+            .getAttribute('aria-busy')
+        ).not.toBe('true')
+
+        const dots = viewImageNavButtons()
+        await user.click(dots[1])
+        await nextTick()
+
         await vi.advanceTimersByTimeAsync(300)
         await nextTick()
 
-        // Should NOT be in loading state since URL didn't change
-        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
+        expect(
+          screen
+            .getByRole('region', {
+              name: 'Image preview - Use arrow keys to navigate between images'
+            })
+            .getAttribute('aria-busy')
+        ).not.toBe('true')
       } finally {
         vi.useRealTimers()
       }
@@ -488,26 +524,29 @@ describe('ImagePreview', () => {
       vi.useFakeTimers()
       try {
         const urls = ['/api/view?filename=test.png&type=output']
-        const wrapper = mountImagePreview({ imageUrls: urls })
+        const { rerender } = renderImagePreview({ imageUrls: urls })
 
-        // Simulate image load completing
-        const img = wrapper.find('img')
-        await img.trigger('load')
+        void fireEvent.load(screen.getByTestId('main-image'))
         await nextTick()
 
-        // Verify loader is hidden after load
-        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
+        const region = screen.getByRole('region', {
+          name: 'Image preview - Use arrow keys to navigate between images'
+        })
+        expect(region.getAttribute('aria-busy')).not.toBe('true')
 
-        // Reassign with new array reference but same content
-        await wrapper.setProps({ imageUrls: [...urls] })
+        await rerender({ imageUrls: [...urls] })
         await nextTick()
 
-        // Advance past the 250ms delayed loader timeout
         await vi.advanceTimersByTimeAsync(300)
         await nextTick()
 
-        // Loading state should NOT have been reset
-        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
+        expect(
+          screen
+            .getByRole('region', {
+              name: 'Image preview - Use arrow keys to navigate between images'
+            })
+            .getAttribute('aria-busy')
+        ).not.toBe('true')
       } finally {
         vi.useRealTimers()
       }
@@ -517,44 +556,46 @@ describe('ImagePreview', () => {
       vi.useFakeTimers()
       try {
         const urls = ['/api/view?filename=test.png&type=output']
-        const wrapper = mountImagePreview({ imageUrls: urls })
+        const { rerender } = renderImagePreview({ imageUrls: urls })
 
-        // Simulate image load completing
-        const img = wrapper.find('img')
-        await img.trigger('load')
+        void fireEvent.load(screen.getByTestId('main-image'))
         await nextTick()
 
-        // Verify loader is hidden
-        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(false)
+        const region = screen.getByRole('region', {
+          name: 'Image preview - Use arrow keys to navigate between images'
+        })
+        expect(region.getAttribute('aria-busy')).not.toBe('true')
 
-        // Change to different URL
-        await wrapper.setProps({
+        await rerender({
           imageUrls: ['/api/view?filename=different.png&type=output']
         })
         await nextTick()
 
-        // Advance past the 250ms delayed loader timeout
         await vi.advanceTimersByTimeAsync(300)
         await nextTick()
 
-        expect(wrapper.find('[aria-busy="true"]').exists()).toBe(true)
+        expect(
+          screen.getByRole('region', {
+            name: 'Image preview - Use arrow keys to navigate between images'
+          })
+        ).toHaveAttribute('aria-busy', 'true')
       } finally {
         vi.useRealTimers()
       }
     })
 
     it('should handle empty to non-empty URL transitions correctly', async () => {
-      const wrapper = mountImagePreview({ imageUrls: [] })
+      const { rerender } = renderImagePreview({ imageUrls: [] })
 
-      expect(wrapper.find('.image-preview').exists()).toBe(false)
+      expect(screen.queryByTestId('image-preview-root')).not.toBeInTheDocument()
 
-      await wrapper.setProps({
+      await rerender({
         imageUrls: ['/api/view?filename=test.png&type=output']
       })
       await nextTick()
 
-      expect(wrapper.find('.image-preview').exists()).toBe(true)
-      expect(wrapper.find('img').exists()).toBe(true)
+      expect(screen.getByTestId('image-preview-root')).toBeInTheDocument()
+      expect(screen.getByRole('img')).toBeInTheDocument()
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="imageUrls.length > 0"
+    data-testid="image-preview-root"
     class="image-preview group relative flex size-full min-h-55 min-w-16 flex-col justify-center px-2"
     @keydown="handleKeyDown"
   >

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -90,7 +90,7 @@
         </button>
 
         <button
-          v-if="!hasMultipleImages"
+          v-if="!hasMultipleImages && nodeId"
           :class="actionButtonClass"
           :title="$t('g.clearMask')"
           :aria-label="$t('g.clearMask')"

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -89,6 +89,22 @@
           <i-comfy:mask class="size-4" />
         </button>
 
+        <button
+          v-if="!hasMultipleImages"
+          :class="actionButtonClass"
+          :title="$t('g.clearMask')"
+          :aria-label="$t('g.clearMask')"
+          :disabled="isClearingMask"
+          @click.stop="handleClearMask"
+        >
+          <i
+            v-if="isClearingMask"
+            class="icon-[lucide--loader-circle] size-4 animate-spin"
+            aria-hidden="true"
+          />
+          <i v-else class="icon-[lucide--eraser] size-4" aria-hidden="true" />
+        </button>
+
         <!-- Download Button -->
         <button
           :class="actionButtonClass"
@@ -188,7 +204,7 @@ interface ImagePreviewProps {
 const { imageUrls, nodeId } = defineProps<ImagePreviewProps>()
 
 const { t } = useI18n()
-const maskEditor = useMaskEditor()
+const { openMaskEditor, clearMask, isClearingMask } = useMaskEditor()
 const nodeOutputStore = useNodeOutputStore()
 const toastStore = useToastStore()
 
@@ -284,7 +300,22 @@ function handleEditMask() {
   if (!nodeId) return
   const node = resolveNode(Number(nodeId))
   if (!node) return
-  maskEditor.openMaskEditor(node)
+  openMaskEditor(node)
+}
+
+async function handleClearMask() {
+  if (!nodeId) return
+  const node = resolveNode(Number(nodeId))
+  if (!node) return
+  try {
+    await clearMask(node)
+  } catch {
+    toastStore.add({
+      severity: 'error',
+      summary: t('maskEditor.clearMaskError'),
+      detail: t('maskEditor.clearMaskFailed')
+    })
+  }
 }
 
 function handleDownload() {

--- a/src/types/vue-component.d.ts
+++ b/src/types/vue-component.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+
+  const component: DefineComponent<object, object, unknown>
+  export default component
+}


### PR DESCRIPTION
## Summary

Follow-up to #9183.

This PR replaces #9183, which was closed due to being significantly behind the main branch and having too many conflicts. This is a clean implementation based on the current upstream.

Added a "Clear mask" button directly to the `Image Preview` component, allowing users to clear masks with a single click without needing to open the full Mask Editor dialog.

## Changes
Added a new eraser icon button that clears the image mask in the background using the existing MaskEditor

## Screenshots 

https://github.com/user-attachments/assets/ac9f0aae-f959-4131-a977-544a85b38666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background mask-clearing flow that loads/saves mask editor state without opening the dialog, which could impact mask data integrity and editor store lifecycle if state cleanup or concurrency handling is wrong.
> 
> **Overview**
> Users can now clear an image mask directly from `ImagePreview` via a new *Clear mask* button (with busy/disabled state and toast on failure) without opening the full Mask Editor dialog.
> 
> `useMaskEditor` is extended with a shared `isClearingMask` flag and a new `clearMask(node)` implementation that loads mask data from the node, clears the canvas, saves, and performs store cleanup; the image context menu is also refactored to call `openMaskEditor(node)` directly instead of executing a command.
> 
> Updates include new i18n strings, a new `*.vue` TypeScript module declaration, and test/e2e stability tweaks (new unit tests for mask/menu behavior and minor Playwright helper adjustments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3787e1fae922d13c6c3d4490a4e86f096ef48cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11012-refactor-mask-editor-make-clear-mask-much-easier-33e6d73d3650815fabaaebf7d0aab1e0) by [Unito](https://www.unito.io)
