### PR TITLE
fix: handle EPERM/EBUSY in global teardown restorePath

### DIFF
--- a/browser_tests/utils/backupUtils.ts
+++ b/browser_tests/utils/backupUtils.ts
@@ -54,6 +54,25 @@ export function backupPath(
   }
 }
 
+function removeWithRetry(targetPath: string, retries = 3, delayMs = 500) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      fs.removeSync(targetPath)
+      return
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException).code
+      if ((code === 'EPERM' || code === 'EBUSY') && attempt < retries) {
+        console.warn(
+          `Retry ${attempt}/${retries}: ${code} removing ${targetPath}`
+        )
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs)
+        continue
+      }
+      throw error
+    }
+  }
+}
+
 export function restorePath(pathParts: PathParts) {
   const originalPath = resolvePathIfExists(pathParts)
   if (!originalPath) return
@@ -62,8 +81,12 @@ export function restorePath(pathParts: PathParts) {
   if (!fs.pathExistsSync(backupPath)) return
 
   try {
-    fs.moveSync(backupPath, originalPath, { overwrite: true })
+    removeWithRetry(originalPath)
+    fs.moveSync(backupPath, originalPath)
   } catch (error) {
-    console.error(`Failed to restore ${originalPath} from ${backupPath}`, error)
+    console.warn(
+      `Could not fully restore ${originalPath} from ${backupPath}:`,
+      (error as NodeJS.ErrnoException).message
+    )
   }
 }


### PR DESCRIPTION
Fixes #11009

## Summary

On Windows, Chromium may still hold file handles on the user-data directory when global teardown runs `restorePath`. The `fs.moveSync(..., { overwrite: true })` call fails with EPERM because it can't remove the target while handles are held.

## Changes

- Split `restorePath` into explicit remove-then-move
- Added `removeWithRetry` that retries up to 3× on EPERM/EBUSY with 500ms delay between attempts
- Downgraded the catch from `console.error` (which looks like a test failure) to `console.warn` so teardown noise doesn't mask real failures

No E2E regression test added: this is a test-infrastructure fix for a Windows-specific race condition in teardown that cannot be reliably reproduced in CI.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11013-fix-handle-EPERM-EBUSY-in-global-teardown-restorePath-33e6d73d3650815ebe0cd42af23e6c0e) by [Unito](https://www.unito.io)
