### PR TITLE
test: remove --listen 0.0.0.0 from E2E test mock argv

### DIFF
--- a/browser_tests/fixtures/data/systemStats.ts
+++ b/browser_tests/fixtures/data/systemStats.ts
@@ -7,7 +7,7 @@ export const mockSystemStats: SystemStatsResponse = {
     embedded_python: false,
     comfyui_version: '0.3.10',
     pytorch_version: '2.4.0+cu124',
-    argv: ['main.py', '--listen', '0.0.0.0'],
+    argv: ['main.py'],
     ram_total: 67108864000,
     ram_free: 52428800000
   },

--- a/browser_tests/tests/dialogs/managerDialog.spec.ts
+++ b/browser_tests/tests/dialogs/managerDialog.spec.ts
@@ -167,7 +167,7 @@ test.describe('ManagerDialog', { tag: '@ui' }, () => {
       ...mockSystemStats,
       system: {
         ...mockSystemStats.system,
-        argv: ['main.py', '--listen', '0.0.0.0', '--enable-manager']
+        argv: ['main.py', '--enable-manager']
       }
     }
     await comfyPage.page.route('**/system_stats**', async (route) => {


### PR DESCRIPTION
## Summary

Remove `--listen 0.0.0.0` from mock `argv` in E2E test fixtures to avoid normalizing a flag that exposes the server to all network interfaces.

## Changes

- **What**: Removed `--listen` and `0.0.0.0` from `mockSystemStats.system.argv` in `browser_tests/fixtures/data/systemStats.ts` (shared fixture) and the ManagerDialog-specific override in `browser_tests/tests/dialogs/managerDialog.spec.ts`. Neither value is required for any test assertion.

Fixes #11008

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11021-test-remove-listen-0-0-0-0-from-E2E-test-mock-argv-33e6d73d365081c59d3fe9610afbeb6f) by [Unito](https://www.unito.io)
