### PR TITLE
chore: remove unused gcd() export from mathUtil.ts

### DIFF
--- a/src/utils/mathUtil.test.ts
+++ b/src/utils/mathUtil.test.ts
@@ -4,7 +4,6 @@ import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
 import {
   computeUnionBounds,
   denormalize,
-  gcd,
   lcm,
   normalize
 } from '@/utils/mathUtil'
@@ -31,29 +30,6 @@ describe('mathUtil', () => {
 
     it('round-trips with normalize', () => {
       expect(denormalize(normalize(100, 0, 255), 0, 255)).toBeCloseTo(100)
-    })
-  })
-
-  describe('gcd', () => {
-    it('should compute greatest common divisor correctly', () => {
-      expect(gcd(48, 18)).toBe(6)
-      expect(gcd(100, 25)).toBe(25)
-      expect(gcd(17, 13)).toBe(1)
-      expect(gcd(0, 5)).toBe(5)
-      expect(gcd(5, 0)).toBe(5)
-    })
-
-    it('should handle negative numbers', () => {
-      expect(gcd(-48, 18)).toBe(6)
-      expect(gcd(48, -18)).toBe(6)
-      expect(gcd(-48, -18)).toBe(6)
-    })
-
-    it('should not cause stack overflow with small floating-point step values', () => {
-      // This would cause Maximum call stack size exceeded with recursive impl
-      // when used in lcm calculations with small step values
-      expect(() => gcd(0.0001, 0.0003)).not.toThrow()
-      expect(() => gcd(1e-10, 1e-9)).not.toThrow()
     })
   })
 

--- a/src/utils/mathUtil.ts
+++ b/src/utils/mathUtil.ts
@@ -35,7 +35,7 @@ type Vec2 = readonly [number, number]
  * @param b - The second number.
  * @returns The GCD of the two numbers.
  */
-export const gcd = (a: number, b: number): number => {
+const gcd = (a: number, b: number): number => {
   // Use absolute values to handle negative numbers
   let x = Math.abs(a)
   let y = Math.abs(b)


### PR DESCRIPTION
## Summary

Remove the unused public `gcd()` export from `mathUtil.ts`, keeping it as a private helper for the `lcm()` function which is used by `nodeDefUtil.ts`.

## Changes

- **What**: Un-exported `gcd()` (no production consumer), removed its dedicated tests

## Review Focus

`lcm()` still works correctly since `gcd` remains as a module-private function. The `lcm` tests continue to pass and indirectly validate `gcd` behavior.

Fixes #11082

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11111-chore-remove-unused-gcd-export-from-mathUtil-ts-33e6d73d3650814e8f2adf806990c3aa) by [Unito](https://www.unito.io)
