### PR TITLE
ci: Update actions for queue merge validation

### DIFF
--- a/.github/actions/lint-format-verify/action.yml
+++ b/.github/actions/lint-format-verify/action.yml
@@ -1,0 +1,31 @@
+name: 'Lint and format verify'
+description: >
+  Runs the lint/format/knip verification suite plus a conditional
+  browser-tests typecheck. Shared by ci-lint-format.yaml (PR) and
+  ci-lint-format-queue.yaml (merge queue) so both paths run the exact
+  same checks. The caller is responsible for checkout and frontend setup
+  before invoking this action.
+
+runs:
+  using: composite
+  steps:
+    - name: Detect browser_tests changes
+      id: changed-paths
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      with:
+        filters: |
+          browser_tests:
+            - 'browser_tests/**'
+
+    - name: Verify lint and format
+      shell: bash
+      run: |
+        pnpm lint
+        pnpm stylelint
+        pnpm format:check
+        pnpm knip
+
+    - name: Typecheck browser tests
+      if: steps.changed-paths.outputs.browser_tests == 'true'
+      shell: bash
+      run: pnpm typecheck:browser

--- a/.github/workflows/ci-lint-format-queue.yaml
+++ b/.github/workflows/ci-lint-format-queue.yaml
@@ -1,0 +1,29 @@
+# Description: Lint and format verification for GitHub merge queue runs.
+# Paired with ci-lint-format.yaml — workflow name and job name must match
+# so branch protection resolves a single required check in both the
+# pull_request and merge_group contexts. This file runs verify-only steps
+# with a read-only token; auto-fix and PR comments live in the PR workflow.
+name: 'CI: Lint Format'
+
+on:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merge group ref
+        uses: actions/checkout@v6
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Verify lint and format
+        uses: ./.github/actions/lint-format-verify

--- a/.github/workflows/ci-lint-format.yaml
+++ b/.github/workflows/ci-lint-format.yaml
@@ -4,6 +4,7 @@ name: 'CI: Lint Format'
 on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,16 +36,20 @@ jobs:
               - 'browser_tests/**'
 
       - name: Run ESLint with auto-fix
+        if: github.event_name == 'pull_request'
         run: pnpm lint:fix
 
       - name: Run Stylelint with auto-fix
+        if: github.event_name == 'pull_request'
         run: pnpm stylelint:fix
 
       - name: Run oxfmt with auto-format
+        if: github.event_name == 'pull_request'
         run: pnpm format
 
       - name: Check for changes
         id: verify-changed-files
+        if: github.event_name == 'pull_request'
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -53,7 +58,7 @@ jobs:
           fi
 
       - name: Commit changes
-        if: steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request' && steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -62,7 +67,7 @@ jobs:
           git push
 
       - name: Fail for fork PRs with unfixed lint/format issues
-        if: steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event_name == 'pull_request' && steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           echo "::error::Linting/formatting issues found. Since this PR is from a fork, auto-fix cannot be applied automatically."
           echo ""
@@ -89,7 +94,7 @@ jobs:
         run: pnpm typecheck:browser
 
       - name: Comment on PR about auto-fix
-        if: steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request' && steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/ci-lint-format.yaml
+++ b/.github/workflows/ci-lint-format.yaml
@@ -1,10 +1,12 @@
-# Description: Linting and code formatting validation for pull requests
+# Description: Linting and code formatting validation for pull requests.
+# Paired with ci-lint-format-queue.yaml - workflow name and job name must
+# match so branch protection resolves a single required check in both the
+# pull_request and merge_group contexts.
 name: 'CI: Lint Format'
 
 on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,29 +29,17 @@ jobs:
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
 
-      - name: Detect browser_tests changes
-        id: changed-paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            browser_tests:
-              - 'browser_tests/**'
-
       - name: Run ESLint with auto-fix
-        if: github.event_name == 'pull_request'
         run: pnpm lint:fix
 
       - name: Run Stylelint with auto-fix
-        if: github.event_name == 'pull_request'
         run: pnpm stylelint:fix
 
       - name: Run oxfmt with auto-format
-        if: github.event_name == 'pull_request'
         run: pnpm format
 
       - name: Check for changes
         id: verify-changed-files
-        if: github.event_name == 'pull_request'
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -58,7 +48,7 @@ jobs:
           fi
 
       - name: Commit changes
-        if: github.event_name == 'pull_request' && steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -67,7 +57,7 @@ jobs:
           git push
 
       - name: Fail for fork PRs with unfixed lint/format issues
-        if: github.event_name == 'pull_request' && steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        if: steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           echo "::error::Linting/formatting issues found. Since this PR is from a fork, auto-fix cannot be applied automatically."
           echo ""
@@ -82,19 +72,11 @@ jobs:
           echo "See CONTRIBUTING.md for more details."
           exit 1
 
-      - name: Final validation
-        run: |
-          pnpm lint
-          pnpm stylelint
-          pnpm format:check
-          pnpm knip
-
-      - name: Typecheck browser tests
-        if: steps.changed-paths.outputs.browser_tests == 'true'
-        run: pnpm typecheck:browser
+      - name: Verify lint and format
+        uses: ./.github/actions/lint-format-verify
 
       - name: Comment on PR about auto-fix
-        if: github.event_name == 'pull_request' && steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.verify-changed-files.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
     paths-ignore: ['**/*.md']
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
     paths-ignore: ['**/*.md']
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

PR merge queue was enabled but actions were not updated to trigger on `merge_group`:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## Changes

- **What**: 
- `.github/actions/lint-format-verify/action.yml` extrated shared Verify lint and format steps
- `.github/workflows/ci-lint-format.yaml` updated to use shared composite action
- `.github/workflows/ci-lint-format-queue.yaml` new action that triggers on merge_group to validate format
- `.github/workflows/ci-tests-e2e.yaml` triggers on merge_group
- `.github/workflows/ci-tests-unit.yaml` triggers on merge_group

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11114-ci-Update-actions-for-queue-merge-validation-33e6d73d3650815f8c88f40736b513ec) by [Unito](https://www.unito.io)
