### PR TITLE
chore: add .editorconfig for cross-editor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Add `.editorconfig` for cross-editor formatting consistency, matching existing oxfmt settings.

## Changes

- **What**: New `.editorconfig` with 2-space indent, LF line endings, UTF-8, trailing whitespace trimming (except `.md`)

Fixes #11073

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11128-chore-add-editorconfig-for-cross-editor-consistency-33e6d73d365081faabf6fb996144940d) by [Unito](https://www.unito.io)
