### PR TITLE
fix(#10988): register replacement node widgets in WidgetValueStore and update link types

### DIFF
--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -713,7 +713,9 @@ describe('useNodeReplacement', () => {
 
       // Each widget's setNodeId should be called with the node ID
       for (const widget of newNode.widgets!) {
-        const bindable = widget as unknown as { setNodeId: ReturnType<typeof vi.fn> }
+        const bindable = widget as unknown as {
+          setNodeId: ReturnType<typeof vi.fn>
+        }
         expect(bindable.setNodeId).toHaveBeenCalledWith(1)
       }
     })

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -45,6 +45,14 @@ vi.mock('@/i18n', () => ({
     params ? `${key}:${JSON.stringify(params)}` : key
 }))
 
+vi.mock('@/lib/litegraph/src/utils/type', () => ({
+  isNodeBindable: (widget: unknown): boolean =>
+    typeof widget === 'object' &&
+    widget !== null &&
+    'setNodeId' in widget &&
+    typeof (widget as Record<string, unknown>).setNodeId === 'function'
+}))
+
 const { mockRemoveMissingNodesByType } = vi.hoisted(() => ({
   mockRemoveMissingNodesByType: vi.fn()
 }))
@@ -137,7 +145,7 @@ function createPlaceholderNode(
 
 function createNewNode(
   inputs: { name: string; link: number | null }[] = [],
-  outputs: { name: string; links: number[] | null }[] = [],
+  outputs: { name: string; links: number[] | null; type?: string }[] = [],
   widgets: { name: string; value: unknown }[] = []
 ): LGraphNode {
   return fromAny<LGraphNode, unknown>({
@@ -150,8 +158,16 @@ function createNewNode(
     flags: {},
     has_errors: false,
     inputs: inputs.map((i) => ({ ...i, type: 'IMAGE' })),
-    outputs: outputs.map((o) => ({ ...o, type: 'IMAGE' })),
-    widgets: widgets.map((w) => ({ ...w, type: 'combo', options: {} })),
+    outputs: outputs.map((o) => ({
+      ...o,
+      type: o.type ?? 'IMAGE'
+    })),
+    widgets: widgets.map((w) => ({
+      ...w,
+      type: 'combo',
+      options: {},
+      setNodeId: vi.fn()
+    })),
     configure: vi.fn(),
     serialize: vi.fn()
   })
@@ -659,6 +675,81 @@ describe('useNodeReplacement', () => {
 
       // Should still succeed (dot-notation skipped gracefully)
       expect(result).toEqual(['ImageBatch'])
+    })
+
+    it('should register new node widgets with WidgetValueStore via setNodeId', () => {
+      const placeholder = createPlaceholderNode(1, 'OldNode')
+      placeholder.last_serialization!.widgets_values = [42, 'hello']
+
+      const graph = createMockGraph([placeholder])
+      placeholder.graph = graph
+      Object.assign(app, { rootGraph: graph })
+
+      vi.mocked(collectAllNodes).mockReturnValue([placeholder])
+
+      const newNode = createNewNode(
+        [],
+        [],
+        [
+          { name: 'exposure', value: 0 },
+          { name: 'annotation', value: '' }
+        ]
+      )
+      vi.mocked(LiteGraph.createNode).mockReturnValue(newNode)
+
+      const { replaceNodesInPlace } = useNodeReplacement()
+      replaceNodesInPlace([
+        makeMissingNodeType('OldNode', {
+          new_node_id: 'NewNode',
+          old_node_id: 'OldNode',
+          old_widget_ids: ['gain', 'label'],
+          input_mapping: [
+            { new_id: 'exposure', old_id: 'gain' },
+            { new_id: 'annotation', old_id: 'label' }
+          ],
+          output_mapping: null
+        })
+      ])
+
+      // Each widget's setNodeId should be called with the node ID
+      for (const widget of newNode.widgets!) {
+        const bindable = widget as unknown as { setNodeId: ReturnType<typeof vi.fn> }
+        expect(bindable.setNodeId).toHaveBeenCalledWith(1)
+      }
+    })
+
+    it('should update link type to match new output slot type', () => {
+      const link = createMockLink(20, 1, 0, 5, 0)
+      const placeholder = createPlaceholderNode(
+        1,
+        'OldNode',
+        [],
+        [{ name: 'output_image', links: [20] }]
+      )
+      const graph = createMockGraph([placeholder], [link])
+      placeholder.graph = graph
+      Object.assign(app, { rootGraph: graph })
+
+      vi.mocked(collectAllNodes).mockReturnValue([placeholder])
+
+      const newNode = createNewNode(
+        [],
+        [{ name: 'image_mean', links: null, type: 'FLOAT' }]
+      )
+      vi.mocked(LiteGraph.createNode).mockReturnValue(newNode)
+
+      const { replaceNodesInPlace } = useNodeReplacement()
+      replaceNodesInPlace([
+        makeMissingNodeType('OldNode', {
+          new_node_id: 'NewNode',
+          old_node_id: 'OldNode',
+          old_widget_ids: null,
+          input_mapping: null,
+          output_mapping: [{ new_idx: 0, old_idx: 0 }]
+        })
+      ])
+
+      expect(link.type).toBe('FLOAT')
     })
   })
 

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -1166,7 +1166,9 @@ describe('useNodeReplacement', () => {
 
       // Each widget's setNodeId should be called with the node ID
       for (const widget of newNode.widgets!) {
-        const bindable = widget as unknown as { setNodeId: ReturnType<typeof vi.fn> }
+        const bindable = widget as unknown as {
+          setNodeId: ReturnType<typeof vi.fn>
+        }
         expect(bindable.setNodeId).toHaveBeenCalledWith(1)
       }
     })

--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -228,7 +228,7 @@ function createPlaceholderNode(
 
 function createNewNode(
   inputs: { name: string; link: number | null }[] = [],
-  outputs: { name: string; links: number[] | null }[] = [],
+  outputs: { name: string; links: number[] | null; type?: string }[] = [],
   widgets: { name: string; value: unknown }[] = []
 ): LGraphNode {
   return fromAny<LGraphNode, unknown>({
@@ -241,8 +241,16 @@ function createNewNode(
     flags: {},
     has_errors: false,
     inputs: inputs.map((i) => ({ ...i, type: 'IMAGE' })),
-    outputs: outputs.map((o) => ({ ...o, type: 'IMAGE' })),
-    widgets: widgets.map((w) => ({ ...w, type: 'combo', options: {} })),
+    outputs: outputs.map((o) => ({
+      ...o,
+      type: o.type ?? 'IMAGE'
+    })),
+    widgets: widgets.map((w) => ({
+      ...w,
+      type: 'combo',
+      options: {},
+      setNodeId: vi.fn()
+    })),
     configure: vi.fn(),
     serialize: vi.fn()
   })
@@ -1120,6 +1128,81 @@ describe('useNodeReplacement', () => {
 
       // Should still succeed (dot-notation skipped gracefully)
       expect(result).toEqual(['ImageBatch'])
+    })
+
+    it('should register new node widgets with WidgetValueStore via setNodeId', () => {
+      const placeholder = createPlaceholderNode(1, 'OldNode')
+      placeholder.last_serialization!.widgets_values = [42, 'hello']
+
+      const graph = createMockGraph([placeholder])
+      placeholder.graph = graph
+      Object.assign(app, { rootGraph: graph })
+
+      vi.mocked(collectAllNodes).mockReturnValue([placeholder])
+
+      const newNode = createNewNode(
+        [],
+        [],
+        [
+          { name: 'exposure', value: 0 },
+          { name: 'annotation', value: '' }
+        ]
+      )
+      vi.mocked(LiteGraph.createNode).mockReturnValue(newNode)
+
+      const { replaceNodesInPlace } = useNodeReplacement()
+      replaceNodesInPlace([
+        makeMissingNodeType('OldNode', {
+          new_node_id: 'NewNode',
+          old_node_id: 'OldNode',
+          old_widget_ids: ['gain', 'label'],
+          input_mapping: [
+            { new_id: 'exposure', old_id: 'gain' },
+            { new_id: 'annotation', old_id: 'label' }
+          ],
+          output_mapping: null
+        })
+      ])
+
+      // Each widget's setNodeId should be called with the node ID
+      for (const widget of newNode.widgets!) {
+        const bindable = widget as unknown as { setNodeId: ReturnType<typeof vi.fn> }
+        expect(bindable.setNodeId).toHaveBeenCalledWith(1)
+      }
+    })
+
+    it('should update link type to match new output slot type', () => {
+      const link = createMockLink(20, 1, 0, 5, 0)
+      const placeholder = createPlaceholderNode(
+        1,
+        'OldNode',
+        [],
+        [{ name: 'output_image', links: [20] }]
+      )
+      const graph = createMockGraph([placeholder], [link])
+      placeholder.graph = graph
+      Object.assign(app, { rootGraph: graph })
+
+      vi.mocked(collectAllNodes).mockReturnValue([placeholder])
+
+      const newNode = createNewNode(
+        [],
+        [{ name: 'image_mean', links: null, type: 'FLOAT' }]
+      )
+      vi.mocked(LiteGraph.createNode).mockReturnValue(newNode)
+
+      const { replaceNodesInPlace } = useNodeReplacement()
+      replaceNodesInPlace([
+        makeMissingNodeType('OldNode', {
+          new_node_id: 'NewNode',
+          old_node_id: 'OldNode',
+          old_widget_ids: null,
+          input_mapping: null,
+          output_mapping: [{ new_idx: 0, old_idx: 0 }]
+        })
+      ])
+
+      expect(link.type).toBe('FLOAT')
     })
   })
 

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -2,6 +2,7 @@ import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { isNodeBindable } from '@/lib/litegraph/src/utils/type'
 import { t } from '@/i18n'
 import type { NodeReplacement } from '@/platform/nodeReplacement/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -62,15 +63,18 @@ function transferOutputConnections(
 ): void {
   const oldLinks = oldNode.outputs?.[oldOutputIdx]?.links
   if (!oldLinks?.length) return
-  if (!newNode.outputs?.[newOutputIdx]) return
+
+  const newOutput = newNode.outputs?.[newOutputIdx]
+  if (!newOutput) return
 
   for (const linkId of oldLinks) {
     const link = graph.links.get(linkId)
     if (!link) continue
     link.origin_id = newNode.id
     link.origin_slot = newOutputIdx
+    link.type = newOutput.type ?? link.type
   }
-  newNode.outputs[newOutputIdx].links = [...oldLinks]
+  newOutput.links = [...oldLinks]
   oldNode.outputs[oldOutputIdx].links = []
 }
 
@@ -216,6 +220,14 @@ function replaceWithMapping(
         nodeGraph
       )
     }
+  }
+
+  // Register the new node's widgets with the WidgetValueStore.
+  // replaceWithMapping bypasses graph.add(), which normally handles this
+  // registration. Without it, Nodes 2.0 (Vue) reads default/missing values
+  // from the store instead of the transferred widget values.
+  for (const widget of newNode.widgets ?? []) {
+    if (isNodeBindable(widget)) widget.setNodeId(newNode.id)
   }
 
   newNode.has_errors = false

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -96,9 +96,15 @@ function planReplacementTopology(
   }
 
   for (const outputMap of replacement.output_mapping ?? []) {
-    if (!newNode.outputs?.[outputMap.new_idx]) continue
+    const newOutput = newNode.outputs?.[outputMap.new_idx]
+    if (!newOutput) continue
     for (const link of outputLinks(graph, oldNode.id, outputMap.old_idx)) {
       addUpdate(link, { originSlot: outputMap.new_idx })
+      // link.type is not part of EndpointPatch/topology identity, so it is
+      // safe to update directly here rather than deferring it into the
+      // batched endpoint update below. Keeps port colors correct after the
+      // link is retargeted to the replacement node's output slot.
+      link.type = newOutput.type ?? link.type
     }
   }
 


### PR DESCRIPTION
## Summary

Register replacement node widgets in the WidgetValueStore and update link types during node replacement, fixing Nodes 2.0 displaying default widget values and wrong port colors after custom node replacement.

## Changes

- **What**: `replaceWithMapping` bypasses `graph.add()`, which normally registers widgets in the `WidgetValueStore`. Added the missing `setNodeId` call after widget values are transferred, so Nodes 2.0 (Vue) reads the correct values from the store. Also updated `transferOutputConnections` to sync `link.type` with the new output slot type, fixing port color mismatches.

## Review Focus

- The widget registration must happen **after** `transferWidgetValue`/`applySetValue` so the correct values are captured in the store.
- `link.type` update uses `newOutput.type ?? link.type` to preserve the existing type if the new output has no explicit type.
- The placeholder node's old widgets (if any existed) are not explicitly unregistered from the store — they get overwritten by the new registration since the node ID is reused.

Fixes #10988

## E2E Verification Steps

1. Load a workflow containing a missing node that has a registered replacement with renamed widgets (e.g., `gain` → `exposure`)
2. Enable Nodes 2.0
3. Use the replacement UI to replace the missing node
4. Verify widget values are correctly transferred (not showing defaults)
5. Verify output port colors match the new node's output types
6. Verify output connections are attached to the correct ports
7. Disable Nodes 2.0 and verify the same workflow still looks correct in LiteGraph mode

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11132-fix-10988-register-replacement-node-widgets-in-WidgetValueStore-and-update-link-types-33e6d73d36508151ac8bdf548e1c0ed9) by [Unito](https://www.unito.io)
