### PR TITLE
refactor: consolidate inline role badges into StatusBadge

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
@@ -27,18 +27,16 @@
         </span>
       </div>
     </div>
-    <span
+    <StatusBadge
       v-if="showRoleColumn && !isSingleSeatPlan"
-      :class="
-        cn('text-sm text-muted-foreground', !showCreditsColumn && 'text-right')
-      "
-    >
-      {{
+      :label="
         member.role === 'owner'
           ? $t('workspaceSwitcher.roleOwner')
           : $t('workspaceSwitcher.roleMember')
-      }}
-    </span>
+      "
+      severity="contrast"
+      :class="cn('py-0.5 text-2xs font-bold', !showCreditsColumn && 'text-right')"
+    />
     <div v-if="showCreditsColumn" class="text-sm tabular-nums">
       <div v-if="hasCreditLimit" class="flex flex-col gap-1">
         <span class="text-base-foreground">{{ creditsLabel }}</span>
@@ -86,6 +84,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import DropdownMenu from '@/components/common/DropdownMenu.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'

--- a/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
@@ -35,7 +35,9 @@
           : $t('workspaceSwitcher.roleMember')
       "
       severity="contrast"
-      :class="cn('py-0.5 text-2xs font-bold', !showCreditsColumn && 'text-right')"
+      :class="
+        cn('py-0.5 text-2xs font-bold', !showCreditsColumn && 'text-right')
+      "
     />
     <div v-if="showCreditsColumn" class="text-sm tabular-nums">
       <div v-if="hasCreditLimit" class="flex flex-col gap-1">

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -151,12 +151,12 @@
                           ({{ $t('g.you') }})
                         </span>
                       </span>
-                      <span
+                      <StatusBadge
                         v-if="uiConfig.showRoleBadge"
-                        class="rounded-full bg-base-foreground px-1 py-0.5 text-2xs font-bold text-base-background uppercase"
-                      >
-                        {{ $t('workspaceSwitcher.roleOwner') }}
-                      </span>
+                        :label="$t('workspaceSwitcher.roleOwner')"
+                        severity="contrast"
+                        class="py-0.5 text-2xs font-bold"
+                      />
                     </div>
                     <span class="text-sm text-muted-foreground">
                       {{ userEmail }}
@@ -200,12 +200,12 @@
                           ({{ $t('g.you') }})
                         </span>
                       </span>
-                      <span
+                      <StatusBadge
                         v-if="uiConfig.showRoleBadge"
-                        class="rounded-full bg-base-foreground px-1 py-0.5 text-2xs font-bold text-base-background uppercase"
-                      >
-                        {{ getRoleBadgeLabel(member.role) }}
-                      </span>
+                        :label="getRoleBadgeLabel(member.role)"
+                        severity="contrast"
+                        class="py-0.5 text-2xs font-bold"
+                      />
                     </div>
                     <span class="text-sm text-muted-foreground">
                       {{ member.email }}
@@ -367,6 +367,7 @@ import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import Button from '@/components/ui/button/Button.vue'


### PR DESCRIPTION
## Summary

Replace inline `<span>` role badges in `MembersPanelContent.vue` with the shared `StatusBadge` component (`severity="contrast"`), preserving original sizing via class overrides.

## Changes

- **What**: Replaced 2 inline role badge spans with `<StatusBadge>` in `MembersPanelContent.vue`. Added `class="py-0.5 text-2xs font-bold"` to match the original sizing tokens exactly (avoiding visual regression vs the default `StatusBadge` label variant).

## Review Focus

The `StatusBadge` label variant uses `text-3xs h-3.5 font-semibold`, while the original inline badges used `text-2xs py-0.5 font-bold`. The `class` prop override on `StatusBadge` preserves the original appearance. Verify this is acceptable vs standardizing on the default `StatusBadge` sizing.

Fixes #10979

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11141-refactor-consolidate-inline-role-badges-into-StatusBadge-33e6d73d365081e0b4a0c2aa0c663f10) by [Unito](https://www.unito.io)
