### PR TITLE
fix(vite): hide git rev-parse window on Windows

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -63,7 +63,10 @@ const IS_NIGHTLY = process.env.IS_NIGHTLY === 'true'
 let GIT_COMMIT = process.env.FRONTEND_COMMIT_HASH || ''
 if (!GIT_COMMIT) {
   try {
-    GIT_COMMIT = execSync('git rev-parse HEAD', { timeout: 5000 })
+    GIT_COMMIT = execSync('git rev-parse HEAD', {
+      timeout: 5000,
+      windowsHide: true
+    })
       .toString()
       .trim()
   } catch {


### PR DESCRIPTION
## Summary

Add `windowsHide: true` to the `execSync('git rev-parse HEAD')` call in `vite.config.mts` to prevent a console window from flashing on Windows during builds.

## Changes

- **What**: Pass `windowsHide: true` option to `execSync` when fetching the git commit hash at build time. This suppresses the transient cmd.exe popup that appears on Windows.

## Review Focus

Minimal, single-option change. `windowsHide` is a Node.js built-in option for `child_process` methods — no-op on non-Windows platforms.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11144-fix-vite-hide-git-rev-parse-window-on-Windows-33e6d73d365081ed9a14da5f47ccac4d) by [Unito](https://www.unito.io)
