### PR TITLE
chore: disable vitest/require-mock-type-parameters oxlint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -84,6 +84,7 @@
     "typescript/no-unsafe-declaration-merging": "off",
     "typescript/no-unused-vars": "off",
     "unicorn/no-empty-file": "off",
+    "vitest/require-mock-type-parameters": "off",
     "unicorn/no-new-array": "off",
     "unicorn/no-single-promise-in-promise-methods": "off",
     "unicorn/no-useless-fallback-in-spread": "off",


### PR DESCRIPTION
## Summary

Disables the `vitest/require-mock-type-parameters` oxlint rule, eliminating all 2,813 lint warnings in the codebase.

## Details

Every warning came from this single rule requiring explicit type parameters on `vi.fn()` calls. Investigation showed:

- **85% are bare `vi.fn()`** — no type info available without manual cross-referencing
- The rule's auto-fixer is **declared but not implemented** — `lint:fix` doesn't help
- No existing codemods exist for this
- A full manual sweep would take 3–5 days across ~210 test files

## Test Plan

- `pnpm lint` passes with 0 warnings, 0 errors

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11146-fix-disable-vitest-require-mock-type-parameters-oxlint-rule-33e6d73d36508186bf1cdc2ce6d2ba57) by [Unito](https://www.unito.io)
