### PR TITLE
fix: remove appendTo override from FormDropdown to restore correct positioning

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue
@@ -4,7 +4,6 @@ import Popover from 'primevue/popover'
 import { computed, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { useTransformCompatOverlayProps } from '@/composables/useTransformCompatOverlayProps'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import type {
@@ -51,7 +50,6 @@ interface Props {
 }
 
 const { t } = useI18n()
-const overlayProps = useTransformCompatOverlayProps()
 
 const {
   placeholder,
@@ -211,7 +209,6 @@ function handleSelection(item: FormDropdownItem, index: number) {
       ref="popoverRef"
       :dismissable="true"
       :close-on-escape="true"
-      :append-to="overlayProps.appendTo"
       unstyled
       :pt="{
         root: {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
@@ -4,7 +4,6 @@ import { ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import { useTransformCompatOverlayProps } from '@/composables/useTransformCompatOverlayProps'
 import type {
   FilterOption,
   OwnershipFilterOption,
@@ -16,7 +15,6 @@ import FormSearchInput from '../FormSearchInput.vue'
 import type { LayoutMode, SortOption } from './types'
 
 const { t } = useI18n()
-const overlayProps = useTransformCompatOverlayProps()
 
 defineProps<{
   sortOptions: SortOption[]
@@ -135,7 +133,7 @@ function toggleBaseModelSelection(item: FilterOption) {
       ref="sortPopoverRef"
       :dismissable="true"
       :close-on-escape="true"
-      :append-to="overlayProps.appendTo"
+
       unstyled
       :pt="{
         root: {
@@ -198,7 +196,7 @@ function toggleBaseModelSelection(item: FilterOption) {
       ref="ownershipPopoverRef"
       :dismissable="true"
       :close-on-escape="true"
-      :append-to="overlayProps.appendTo"
+
       unstyled
       :pt="{
         root: {
@@ -261,7 +259,7 @@ function toggleBaseModelSelection(item: FilterOption) {
       ref="baseModelPopoverRef"
       :dismissable="true"
       :close-on-escape="true"
-      :append-to="overlayProps.appendTo"
+
       unstyled
       :pt="{
         root: {

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.vue
@@ -133,7 +133,6 @@ function toggleBaseModelSelection(item: FilterOption) {
       ref="sortPopoverRef"
       :dismissable="true"
       :close-on-escape="true"
-
       unstyled
       :pt="{
         root: {
@@ -196,7 +195,6 @@ function toggleBaseModelSelection(item: FilterOption) {
       ref="ownershipPopoverRef"
       :dismissable="true"
       :close-on-escape="true"
-
       unstyled
       :pt="{
         root: {
@@ -259,7 +257,6 @@ function toggleBaseModelSelection(item: FilterOption) {
       ref="baseModelPopoverRef"
       :dismissable="true"
       :close-on-escape="true"
-
       unstyled
       :pt="{
         root: {


### PR DESCRIPTION
## Problem

PR #10338 added `useTransformCompatOverlayProps()` to FormDropdown and FormDropdownMenuActions, which sets `appendTo: 'self'` in graph mode. This breaks PrimeVue Popover positioning inside CSS-transformed containers — the dropdown appears at incorrect Y positions.

## Root Cause

PrimeVue Popover with `appendTo: 'self'` renders the overlay inside the component's DOM, inheriting parent CSS transforms. This causes the popover to miscalculate its position when the parent has `transform: scale()` or `translate()`.

## Fix

Remove the `appendTo` override from both FormDropdown and FormDropdownMenuActions. PrimeVue defaults to `appendTo: 'body'`, which teleports the popover to `<body>` — correctly positioning it outside any CSS transform context.

- **Graph mode**: restores pre-#10338 behavior (`appendTo: 'body'` default)
- **App mode**: unaffected — `'body'` is exactly what app mode needs (prevents sidebar overflow clipping)

## Testing

- Existing unit tests pass (5/5)
- Typecheck clean
- Lint clean
- **E2E test rationale**: No E2E test added — this is a pure removal of a prop override (reverting to PrimeVue defaults). The positioning bug requires CSS transforms at specific viewport scales which are impractical to assert reliably in Playwright. The existing `subgraph-dom-widget-clipping` perf test exercises dropdown rendering in transformed contexts and shows no regression.

Fixes #10499
Supersedes #11001 (temporary hotfix for backport)