### PR TITLE
[backport core/1.42] Support svg outputs in assets panel

### DIFF
--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -62,7 +62,8 @@ describe('formatUtil', () => {
         { filename: 'animation.gif', expected: 'image' },
         { filename: 'web.webp', expected: 'image' },
         { filename: 'bitmap.bmp', expected: 'image' },
-        { filename: 'modern.avif', expected: 'image' }
+        { filename: 'modern.avif', expected: 'image' },
+        { filename: 'logo.svg', expected: 'image' }
       ]
 
       it.for(imageTestCases)(

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -542,7 +542,8 @@ const IMAGE_EXTENSIONS = [
   'bmp',
   'avif',
   'tif',
-  'tiff'
+  'tiff',
+  'svg'
 ] as const
 const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'avi'] as const
 const AUDIO_EXTENSIONS = ['mp3', 'wav', 'ogg', 'flac'] as const

--- a/src/platform/distribution/cloudPreviewUtil.ts
+++ b/src/platform/distribution/cloudPreviewUtil.ts
@@ -14,6 +14,11 @@ export function appendCloudResParam(
   filename?: string
 ): void {
   if (!isCloud) return
-  if (filename && getMediaTypeFromFilename(filename) !== 'image') return
+  if (
+    filename &&
+    (getMediaTypeFromFilename(filename) !== 'image' ||
+      filename.toLowerCase().endsWith('.svg'))
+  )
+    return
   params.set('res', '512')
 }


### PR DESCRIPTION
Manual backport of #10470 to `core/1.42`

PR added a test to a file which did not exist. That test has been removed from this backport PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11152-backport-core-1-42-Support-svg-outputs-in-assets-panel-33f6d73d365081c5aba9c63ff0950be8) by [Unito](https://www.unito.io)
