### PR TITLE
Handle Load3D "none" model selection in frontend

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -295,7 +295,7 @@ useExtensionService().registerExtension({
 
           const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
           if (modelWidget) {
-            modelWidget.value = ''
+            modelWidget.value = 'none'
           }
         })
 

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -9,7 +9,10 @@ import type {
   CameraState
 } from '@/extensions/core/load3d/interfaces'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
-import { SUPPORTED_EXTENSIONS_ACCEPT } from '@/extensions/core/load3d/constants'
+import {
+  LOAD3D_NONE_MODEL,
+  SUPPORTED_EXTENSIONS_ACCEPT
+} from '@/extensions/core/load3d/constants'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -290,13 +293,9 @@ useExtensionService().registerExtension({
         )
 
         node.addWidget('button', 'clear', 'clear', () => {
-          useLoad3d(node).waitForLoad3d((load3d) => {
-            load3d.clearModel()
-          })
-
           const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
           if (modelWidget) {
-            modelWidget.value = ''
+            modelWidget.value = LOAD3D_NONE_MODEL
           }
         })
 

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -594,3 +594,91 @@ describe('Load3DConfiguration.configure forwards persisted + settings to load3d'
     expect(load3d.setLightIntensity).toHaveBeenCalledWith(9)
   })
 })
+
+describe('Load3DConfiguration "none" model handling', () => {
+  let load3d: Load3d
+  let loadModelSpy: ReturnType<typeof vi.fn>
+  let clearModelSpy: ReturnType<typeof vi.fn>
+
+  function makeLoad3dMock(): Load3d {
+    loadModelSpy = vi.fn().mockResolvedValue(undefined)
+    clearModelSpy = vi.fn()
+    return {
+      loadModel: loadModelSpy,
+      clearModel: clearModelSpy,
+      setUpDirection: vi.fn(),
+      setMaterialMode: vi.fn(),
+      setTargetSize: vi.fn(),
+      setCameraState: vi.fn(),
+      toggleGrid: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setBackgroundImage: vi.fn().mockResolvedValue(undefined),
+      setBackgroundRenderMode: vi.fn(),
+      toggleCamera: vi.fn(),
+      setFOV: vi.fn(),
+      setLightIntensity: vi.fn(),
+      setHDRIIntensity: vi.fn(),
+      setHDRIAsBackground: vi.fn(),
+      setHDRIEnabled: vi.fn(),
+      emitModelReady: vi.fn()
+    } as unknown as Load3d
+  }
+
+  async function flush() {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+
+  beforeEach(() => {
+    load3d = makeLoad3dMock()
+    vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'model.glb'])
+    vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not load or clear a model when the initial widget value is "none"', async () => {
+    const config = new Load3DConfiguration(load3d)
+    config.configure({
+      modelWidget: { value: 'none' } as unknown as IBaseWidget,
+      loadFolder: 'input'
+    })
+    await flush()
+
+    expect(loadModelSpy).not.toHaveBeenCalled()
+    expect(clearModelSpy).not.toHaveBeenCalled()
+  })
+
+  it('clears the model (and skips loadModel) when the widget value changes to "none"', async () => {
+    const config = new Load3DConfiguration(load3d)
+    const widget = { value: 'model.glb' } as unknown as IBaseWidget
+    config.configure({ modelWidget: widget, loadFolder: 'input' })
+    await flush()
+
+    loadModelSpy.mockClear()
+    clearModelSpy.mockClear()
+
+    widget.value = 'none'
+    await flush()
+
+    expect(clearModelSpy).toHaveBeenCalledTimes(1)
+    expect(loadModelSpy).not.toHaveBeenCalled()
+  })
+
+  it('loads a model when the widget value transitions from "none" to a real path', async () => {
+    const config = new Load3DConfiguration(load3d)
+    const widget = { value: 'none' } as unknown as IBaseWidget
+    config.configure({ modelWidget: widget, loadFolder: 'input' })
+    await flush()
+
+    expect(loadModelSpy).not.toHaveBeenCalled()
+
+    widget.value = 'model.glb'
+    await flush()
+
+    expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
+      silentOnNotFound: false
+    })
+  })
+})

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -75,7 +75,7 @@ class Load3DConfiguration {
       loadFolder,
       cameraState
     )
-    if (modelWidget.value) {
+    if (modelWidget.value && modelWidget.value !== 'none') {
       onModelWidgetUpdate(modelWidget.value)
     }
 
@@ -226,7 +226,10 @@ class Load3DConfiguration {
   ) {
     let isFirstLoad = true
     return async (value: string | number | boolean | object) => {
-      if (!value) return
+      if (!value || value === 'none') {
+        this.load3d.clearModel()
+        return
+      }
 
       const filename = value as string
 

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -1,3 +1,4 @@
+import { LOAD3D_NONE_MODEL } from '@/extensions/core/load3d/constants'
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import type {
@@ -109,7 +110,7 @@ class Load3DConfiguration {
       cameraState,
       silentOnNotFound
     )
-    if (modelWidget.value) {
+    if (modelWidget.value && modelWidget.value !== LOAD3D_NONE_MODEL) {
       void onModelWidgetUpdate(modelWidget.value)
     }
 
@@ -280,7 +281,10 @@ class Load3DConfiguration {
   ) {
     let isFirstLoad = true
     return async (value: string | number | boolean | object) => {
-      if (!value) return
+      if (!value || value === LOAD3D_NONE_MODEL) {
+        this.load3d.clearModel()
+        return
+      }
 
       const { filename, folder } = parseAnnotatedFilename(
         value as string,

--- a/src/extensions/core/load3d/constants.ts
+++ b/src/extensions/core/load3d/constants.ts
@@ -22,3 +22,5 @@ export const SUPPORTED_HDRI_EXTENSIONS = new Set(['.hdr', '.exr'])
 export const SUPPORTED_HDRI_EXTENSIONS_ACCEPT = [
   ...SUPPORTED_HDRI_EXTENSIONS
 ].join(',')
+
+export const LOAD3D_NONE_MODEL = 'none'


### PR DESCRIPTION
## Summary
Load3D now supports panoramic images and HDRI loading, it can serve as a viewer for those without requiring a 3D model. Previously, the node required a model file to execute. Rather than making the input optional (which would break existing workflows that rely on it being required), a "none" option is added to the combo list, allowing users to run Load3D with no model loaded.

BE change is https://github.com/Comfy-Org/ComfyUI/pull/13379

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11178-Handle-Load3D-none-model-selection-in-frontend-3416d73d365081e589b3d89bc67f75e7) by [Unito](https://www.unito.io)
