### PR TITLE
fix cloud frontend runtime guard regressions

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -182,6 +182,20 @@ describe('Autogrow', () => {
     await nextTick()
     expect(node.inputs.length).toBe(5)
   })
+  test('Removing a connection ignores stale autogrow callbacks after group removal', async () => {
+    const graph = new LGraph()
+    const node = testNode()
+    graph.add(node)
+    addAutogrow(node, { min: 1, input: inputsSpec, prefix: 'test' })
+
+    connectInput(node, 0, graph)
+    expect(node.inputs.length).toBe(2)
+
+    node.disconnectInput(0)
+    delete node.comfyDynamic.autogrow['0']
+
+    await expect(nextTick()).resolves.toBeUndefined()
+  })
   test('Can deserialize a complex node', async () => {
     const graph = new LGraph()
     const node = testNode()

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -460,7 +460,10 @@ function autogrowInputDisconnected(index: number, node: AutogrowNode) {
   const input = node.inputs[index]
   if (!input) return
   const groupName = input.name.slice(0, input.name.lastIndexOf('.'))
-  const { min = 1, inputSpecs } = node.comfyDynamic.autogrow[groupName]
+  const autogrowGroup = node.comfyDynamic.autogrow[groupName]
+  if (!autogrowGroup) return
+
+  const { min = 1, inputSpecs } = autogrowGroup
   const ordinal = resolveAutogrowOrdinal(input.name, groupName, node)
   if (ordinal == undefined || ordinal + 1 < min) return
 

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -1,51 +1,16 @@
 import { shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
-import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LLink } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { LLink } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
+import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
+
 function applyToGraph(this: LGraphNode, extraLinks: LLink[] = []) {
-  if (!this.outputs[0].links?.length || !this.graph) return
-
-  const links = [
-    ...this.outputs[0].links.map((l) => this.graph!.links[l]),
-    ...extraLinks
-  ]
-  let v = this.widgets?.[0].value
-  // For each output link copy our value over the original widget value
-  for (const linkInfo of links) {
-    const node = this.graph?.getNodeById(linkInfo.target_id)
-    const input = node?.inputs[linkInfo.target_slot]
-    if (!input) {
-      console.warn('Unable to resolve node or input for link', linkInfo)
-      continue
-    }
-
-    const widgetName = input.widget?.name
-    if (!widgetName) {
-      console.warn('Invalid widget or widget name', input.widget)
-      continue
-    }
-
-    const widget = node.widgets?.find((w) => w.name === widgetName)
-    if (!widget) {
-      console.warn(`Unable to find widget "${widgetName}" on node [${node.id}]`)
-      continue
-    }
-
-    widget.value = v
-    widget.callback?.(
-      widget.value,
-      app.canvas,
-      node,
-      app.canvas.graph_mouse,
-      {} as CanvasPointerEvent
-    )
-  }
+  applyFirstWidgetValueToGraph(this, extraLinks)
 }
 
 function onCustomComboCreated(this: LGraphNode) {

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -26,6 +26,8 @@ import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { mergeInputSpec } from '@/utils/nodeDefUtil'
 import { applyTextReplacements } from '@/utils/searchAndReplace'
 
+import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
+
 const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: TWidgetValue[]
@@ -43,49 +45,15 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   override applyToGraph(extraLinks: LLink[] = []) {
-    if (!this.outputs[0].links?.length || !this.graph) return
+    const sourceWidget = this.widgets?.[0]
+    const graph = this.graph
+    if (!sourceWidget || !graph) return
 
-    const links = [
-      ...this.outputs[0].links.map((l) => this.graph!.links[l]),
-      ...extraLinks
-    ]
-    let v = this.widgets?.[0].value
+    let v = sourceWidget.value
     if (v && this.properties[replacePropertyName]) {
-      v = applyTextReplacements(this.graph, v as string)
+      v = applyTextReplacements(graph, v as string)
     }
-
-    // For each output link copy our value over the original widget value
-    for (const linkInfo of links) {
-      const node = this.graph?.getNodeById(linkInfo.target_id)
-      const input = node?.inputs[linkInfo.target_slot]
-      if (!input) {
-        console.warn('Unable to resolve node or input for link', linkInfo)
-        continue
-      }
-
-      const widgetName = input.widget?.name
-      if (!widgetName) {
-        console.warn('Invalid widget or widget name', input.widget)
-        continue
-      }
-
-      const widget = node.widgets?.find((w) => w.name === widgetName)
-      if (!widget) {
-        console.warn(
-          `Unable to find widget "${widgetName}" on node [${node.id}]`
-        )
-        continue
-      }
-
-      widget.value = v
-      widget.callback?.(
-        widget.value,
-        app.canvas,
-        node,
-        app.canvas.graph_mouse,
-        {} as CanvasPointerEvent
-      )
-    }
+    applyFirstWidgetValueToGraph(this, extraLinks, () => v)
   }
 
   override refreshComboInNode() {
@@ -98,7 +66,7 @@ export class PrimitiveNode extends LGraphNode {
       if (!widget.options.values.includes(widget.value as string)) {
         // @ts-expect-error fixme ts strict error
         widget.value = widget.options.values[0]
-        ;(widget.callback as Function)(widget.value)
+        widget.callback?.(widget.value)
       }
     }
   }
@@ -273,7 +241,7 @@ export class PrimitiveNode extends LGraphNode {
       )
       if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
 
-      let filter = this.widgets_values?.[2]
+      const filter = this.widgets_values?.[2]
       if (filter && this.widgets && this.widgets.length === 3) {
         this.widgets[2].value = filter
       }

--- a/src/extensions/core/widgetValuePropagation.test.ts
+++ b/src/extensions/core/widgetValuePropagation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  INodeInputSlot,
+  INodeOutputSlot,
+  LLink
+} from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: {
+      graph_mouse: {}
+    }
+  }
+}))
+
+import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
+
+type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
+
+function createWidget(
+  name: string,
+  value: unknown,
+  callback = vi.fn()
+): IBaseWidget {
+  return {
+    name,
+    value,
+    callback
+  } as unknown as IBaseWidget
+}
+
+function createTargetNode(
+  widget: IBaseWidget,
+  id = 7
+): Pick<LGraphNode, 'id' | 'inputs' | 'widgets'> {
+  return {
+    id,
+    inputs: [
+      {
+        widget: { name: widget.name }
+      } as unknown as INodeInputSlot
+    ],
+    widgets: [widget]
+  }
+}
+
+function createLink(targetId: LLink['target_id'], targetSlot = 0): LLink {
+  return {
+    target_id: targetId,
+    target_slot: targetSlot
+  } as LLink
+}
+
+function createSourceNode(options: {
+  link: LLink
+  targetNode: Pick<LGraphNode, 'id' | 'inputs' | 'widgets'>
+  widgets?: IBaseWidget[]
+}): SourceNode {
+  return {
+    graph: {
+      links: { 1: options.link },
+      getNodeById: vi.fn((id: LLink['target_id']) =>
+        id === options.targetNode.id ? options.targetNode : null
+      )
+    } as unknown as NonNullable<LGraphNode['graph']>,
+    outputs: [{ links: [1] } as INodeOutputSlot],
+    widgets: options.widgets ?? []
+  }
+}
+
+describe('applyFirstWidgetValueToGraph', () => {
+  it('returns early when the source widget is missing', () => {
+    const targetCallback = vi.fn()
+    const targetWidget = createWidget('value', 'unchanged', targetCallback)
+    const targetNode = createTargetNode(targetWidget)
+    const sourceNode = createSourceNode({
+      link: createLink(targetNode.id),
+      targetNode
+    })
+
+    expect(() => applyFirstWidgetValueToGraph(sourceNode)).not.toThrow()
+    expect(targetWidget.value).toBe('unchanged')
+    expect(targetCallback).not.toHaveBeenCalled()
+  })
+
+  it('propagates the first widget value to the linked widget', () => {
+    const targetCallback = vi.fn()
+    const targetWidget = createWidget('value', 'old', targetCallback)
+    const targetNode = createTargetNode(targetWidget)
+    const sourceNode = createSourceNode({
+      link: createLink(targetNode.id),
+      targetNode,
+      widgets: [createWidget('source', 'new value')]
+    })
+
+    applyFirstWidgetValueToGraph(sourceNode)
+
+    expect(targetWidget.value).toBe('new value')
+    expect(targetCallback).toHaveBeenCalledOnce()
+    expect(targetCallback).toHaveBeenCalledWith(
+      'new value',
+      expect.anything(),
+      targetNode,
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it('applies a transform before propagating the widget value', () => {
+    const targetWidget = createWidget('value', 'old')
+    const targetNode = createTargetNode(targetWidget)
+    const sourceNode = createSourceNode({
+      link: createLink(targetNode.id),
+      targetNode,
+      widgets: [createWidget('source', 'draft')]
+    })
+
+    applyFirstWidgetValueToGraph(sourceNode, [], (value) => `${value}-saved`)
+
+    expect(targetWidget.value).toBe('draft-saved')
+  })
+})

--- a/src/extensions/core/widgetValuePropagation.ts
+++ b/src/extensions/core/widgetValuePropagation.ts
@@ -1,0 +1,67 @@
+import type { LLink } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { app } from '@/scripts/app'
+
+type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
+
+export function applyFirstWidgetValueToGraph(
+  node: SourceNode,
+  extraLinks: LLink[] = [],
+  transformValue?: (value: TWidgetValue) => TWidgetValue
+) {
+  const output = node.outputs[0]
+  if (!output?.links?.length || !node.graph) return
+
+  const sourceWidget = node.widgets?.[0]
+  if (!sourceWidget) return
+
+  let value = sourceWidget.value
+  if (transformValue) {
+    value = transformValue(value)
+  }
+
+  const graphMouse = app.canvas?.graph_mouse ?? ({} as CanvasPointerEvent)
+
+  const links = [
+    ...output.links.map((linkId) => node.graph!.links[linkId]),
+    ...extraLinks
+  ]
+
+  for (const linkInfo of links) {
+    if (!linkInfo) continue
+
+    const targetNode = node.graph.getNodeById(linkInfo.target_id)
+    const input = targetNode?.inputs[linkInfo.target_slot]
+    if (!targetNode || !input) {
+      console.warn('Unable to resolve node or input for link', linkInfo)
+      continue
+    }
+
+    const widgetName = input.widget?.name
+    if (!widgetName) {
+      console.warn('Invalid widget or widget name', input.widget)
+      continue
+    }
+
+    const targetWidget = targetNode.widgets?.find(
+      (widget) => widget.name === widgetName
+    )
+    if (!targetWidget) {
+      console.warn(
+        `Unable to find widget "${widgetName}" on node [${targetNode.id}]`
+      )
+      continue
+    }
+
+    targetWidget.value = value
+    targetWidget.callback?.(
+      targetWidget.value,
+      app.canvas,
+      targetNode,
+      graphMouse,
+      {} as CanvasPointerEvent
+    )
+  }
+}

--- a/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
+++ b/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
@@ -11,6 +11,11 @@ function makeOutput(
 }
 
 describe(flattenNodeOutput, () => {
+  it('returns empty array for nullish node output', () => {
+    expect(flattenNodeOutput(['1', null])).toEqual([])
+    expect(flattenNodeOutput(['1', undefined])).toEqual([])
+  })
+
   it('returns empty array for output with no known media types', () => {
     const result = flattenNodeOutput(['1', makeOutput({ unknown: 'hello' })])
     expect(result).toEqual([])

--- a/src/renderer/extensions/linearMode/flattenNodeOutput.ts
+++ b/src/renderer/extensions/linearMode/flattenNodeOutput.ts
@@ -4,7 +4,7 @@ import type { ResultItemImpl } from '@/stores/queueStore'
 
 export function flattenNodeOutput([nodeId, nodeOutput]: [
   string | number,
-  NodeExecutionOutput
+  NodeExecutionOutput | null | undefined
 ]): ResultItemImpl[] {
   return parseNodeOutput(nodeId, nodeOutput)
 }

--- a/src/stores/resultItemParsing.test.ts
+++ b/src/stores/resultItemParsing.test.ts
@@ -11,6 +11,11 @@ function makeOutput(
 }
 
 describe(parseNodeOutput, () => {
+  it('returns empty array for nullish node output', () => {
+    expect(parseNodeOutput('1', null)).toEqual([])
+    expect(parseNodeOutput('1', undefined)).toEqual([])
+  })
+
   it('returns empty array for output with no known media types', () => {
     const result = parseNodeOutput('1', makeOutput({ text: 'hello' }))
     expect(result).toEqual([])
@@ -152,6 +157,22 @@ describe(parseNodeOutput, () => {
 })
 
 describe(parseTaskOutput, () => {
+  it('ignores nullish node outputs', () => {
+    const taskOutput: Record<string, NodeExecutionOutput | null | undefined> = {
+      '1': null,
+      '2': undefined,
+      '3': makeOutput({
+        images: [{ filename: 'a.png', subfolder: '', type: 'output' }]
+      })
+    }
+
+    const result = parseTaskOutput(taskOutput)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].nodeId).toBe('3')
+    expect(result[0].filename).toBe('a.png')
+  })
+
   it('flattens across multiple nodes', () => {
     const taskOutput: Record<string, NodeExecutionOutput> = {
       '1': makeOutput({

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -29,8 +29,10 @@ function isResultItem(item: unknown): item is ResultItem {
 
 export function parseNodeOutput(
   nodeId: string | number,
-  nodeOutput: NodeExecutionOutput
+  nodeOutput: NodeExecutionOutput | null | undefined
 ): ResultItemImpl[] {
+  if (!nodeOutput) return []
+
   return Object.entries(nodeOutput)
     .filter(([key, value]) => !METADATA_KEYS.has(key) && Array.isArray(value))
     .flatMap(([mediaType, items]) =>
@@ -41,7 +43,7 @@ export function parseNodeOutput(
 }
 
 export function parseTaskOutput(
-  taskOutput: Record<string, NodeExecutionOutput>
+  taskOutput: Record<string, NodeExecutionOutput | null | undefined>
 ): ResultItemImpl[] {
   return Object.entries(taskOutput).flatMap(([nodeId, nodeOutput]) =>
     parseNodeOutput(nodeId, nodeOutput)


### PR DESCRIPTION
## Summary
- harden cloud frontend runtime paths that were throwing on `cloud.comfy.org`
- guard widget value propagation when the source widget is missing
- treat nullish executed outputs as empty output during flatten/parsing
- ignore stale autogrow disconnect callbacks after an autogrow group is removed

## Root cause
This PR bundles three small runtime guard fixes from `cloud-frontend-staging` issues that reproduce on `https://cloud.comfy.org/`:

- `CLOUD-FRONTEND-STAGING-429`: widget propagation assumed `this.widgets[0]` always existed and crashed during group-node/widget lifecycle transitions
- `CLOUD-FRONTEND-STAGING-3QA` and sibling `3QB`: executed-event parsing assumed `detail.output` was always an object and crashed on nullish output payloads
- `CLOUD-FRONTEND-STAGING-42B`: `autogrowInputDisconnected()` could run from a stale `requestAnimationFrame()` callback after its autogrow group had already been removed

## User impact
- prevents unhandled frontend exceptions on `cloud.comfy.org`
- keeps node output rendering and linear-mode flattening resilient to sparse executed payloads
- avoids autogrow disconnect crashes during graph/widget churn

## Changes
- extracted shared widget propagation logic into `widgetValuePropagation.ts`
- added source-widget guards in custom widget / primitive widget propagation paths
- added null guards in result parsing and linear-mode output flattening
- added an autogrow-group existence guard in `dynamicWidgets.ts`
- added focused regression tests for all three bug shapes

## Red / Green Verification
### Red
I ran the new targeted regression suite in a temporary pre-fix worktree with the runtime guards reverted while keeping the new tests.

Failing tests in that state:
- `src/extensions/core/widgetValuePropagation.test.ts`
  - `returns early when the source widget is missing`
- `src/stores/resultItemParsing.test.ts`
  - `returns empty array for nullish node output`
  - `ignores nullish node outputs`
- `src/renderer/extensions/linearMode/flattenNodeOutput.test.ts`
  - `returns empty array for nullish node output`

Representative pre-fix errors:
- `TypeError: Cannot read properties of undefined (reading 'value')`
- `TypeError: Cannot convert undefined or null to object`

### Green
On the draft PR branch, the targeted regression suite passes:
- `pnpm exec vitest run src/core/graph/widgets/dynamicWidgets.test.ts src/stores/resultItemParsing.test.ts src/renderer/extensions/linearMode/flattenNodeOutput.test.ts src/extensions/core/widgetValuePropagation.test.ts src/extensions/core/customWidgets.test.ts`

Result:
- `5` test files passed
- `49` tests passed

## Validation
- `pnpm exec vitest run src/core/graph/widgets/dynamicWidgets.test.ts src/stores/resultItemParsing.test.ts src/renderer/extensions/linearMode/flattenNodeOutput.test.ts src/extensions/core/widgetValuePropagation.test.ts src/extensions/core/customWidgets.test.ts`
- `pnpm exec eslint --no-ignore src/core/graph/widgets/dynamicWidgets.ts src/core/graph/widgets/dynamicWidgets.test.ts src/stores/resultItemParsing.ts src/stores/resultItemParsing.test.ts src/renderer/extensions/linearMode/flattenNodeOutput.ts src/renderer/extensions/linearMode/flattenNodeOutput.test.ts src/extensions/core/customWidgets.ts src/extensions/core/widgetInputs.ts src/extensions/core/widgetValuePropagation.ts src/extensions/core/widgetValuePropagation.test.ts`
- `pnpm exec oxfmt --check src/core/graph/widgets/dynamicWidgets.ts src/core/graph/widgets/dynamicWidgets.test.ts src/stores/resultItemParsing.ts src/stores/resultItemParsing.test.ts src/renderer/extensions/linearMode/flattenNodeOutput.ts src/renderer/extensions/linearMode/flattenNodeOutput.test.ts src/extensions/core/customWidgets.ts src/extensions/core/widgetInputs.ts src/extensions/core/widgetValuePropagation.ts src/extensions/core/widgetValuePropagation.test.ts`

## Notes
- I explicitly skipped the `getCanvas: canvas is null` issue because it is already covered by open PRs `#11173` / `#11174`.
- `pnpm typecheck` was not included in validation because the temporary PR worktree used for publication hits local path-resolution issues through the shared dependency install, which is unrelated to the changes in this PR.
