### PR TITLE
test: remove redundant setup/settings now handled by @vue-nodes fixture

### DIFF
--- a/browser_tests/tests/selectionRectangle.spec.ts
+++ b/browser_tests/tests/selectionRectangle.spec.ts
@@ -4,11 +4,6 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 
 test.describe('@canvas Selection Rectangle', { tag: '@vue-nodes' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-    await comfyPage.vueNodes.waitForNodes()
-  })
-
   test('Ctrl+A selects all nodes', async ({ comfyPage }) => {
     await expect
       .poll(() => comfyPage.vueNodes.getNodeCount())

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -182,10 +182,6 @@ test.describe(
     })
 
     test.describe('Manual Promote/Demote via Context Menu', () => {
-      test.beforeEach(async ({ comfyPage }) => {
-        await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-      })
-
       test('Can promote and un-promote a widget from inside a subgraph', async ({
         comfyPage
       }) => {
@@ -477,7 +473,6 @@ test.describe(
       test('Nested promoted widget entries reflect interior changes after slot removal', async ({
         comfyPage
       }) => {
-        await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
         await comfyPage.workflow.loadWorkflow(
           'subgraphs/subgraph-nested-promotion'
         )
@@ -521,7 +516,6 @@ test.describe(
       test('Removing I/O slot removes associated promoted widget', async ({
         comfyPage
       }) => {
-        await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
         await comfyPage.workflow.loadWorkflow(
           'subgraphs/subgraph-with-promoted-text-widget'
         )

--- a/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotionDom.spec.ts
@@ -115,7 +115,6 @@ test.describe('Subgraph Promotion DOM', { tag: ['@subgraph'] }, () => {
     test('DOM elements are cleaned up when widget is disconnected from I/O', async ({
       comfyPage
     }) => {
-      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-with-promoted-text-widget'
       )

--- a/browser_tests/tests/subgraph/subgraphZeroUuid.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphZeroUuid.spec.ts
@@ -6,12 +6,6 @@ test.describe(
   'Zero UUID workflow: subgraph undo rendering',
   { tag: ['@workflow', '@subgraph', '@vue-nodes'] },
   () => {
-    test.beforeEach(async ({ comfyPage }) => {
-      test.setTimeout(30000) // Extend timeout as we need to reload the page an additional time
-      await comfyPage.page.reload() // Reload page to ensure Vue mode is active
-      await comfyPage.page.waitForFunction(() => !!window.app?.graph)
-    })
-
     test('Undo after subgraph enter/exit renders all nodes when workflow starts with zero UUID', async ({
       comfyPage
     }) => {

--- a/browser_tests/tests/vueNodes/interactions/canvas/zoom.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/zoom.spec.ts
@@ -6,7 +6,6 @@ import {
 test.describe('Vue Nodes Zoom', { tag: '@vue-nodes' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.settings.setSetting('LiteGraph.Canvas.MinFontSizeForLOD', 8)
-    await comfyPage.vueNodes.waitForNodes()
   })
 
   test(

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -5,12 +5,6 @@ import {
 import { TestIds } from '@e2e/fixtures/selectors'
 
 test.describe('Vue Nodes Renaming', { tag: '@vue-nodes' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Graph.CanvasMenu', false)
-    await comfyPage.setup()
-    await comfyPage.vueNodes.waitForNodes()
-  })
-
   test('should display node title', async ({ comfyPage }) => {
     const vueNode = await comfyPage.vueNodes.getFixtureByTitle('KSampler')
     await expect(vueNode.header).toContainText('KSampler')

--- a/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/collapse.spec.ts
@@ -5,10 +5,7 @@ import {
 
 test.describe('Vue Node Collapse', { tag: '@vue-nodes' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Graph.CanvasMenu', false)
     await comfyPage.settings.setSetting('Comfy.EnableTooltips', true)
-    await comfyPage.setup()
-    await comfyPage.vueNodes.waitForNodes()
   })
 
   test('should allow collapsing node with collapse icon', async ({

--- a/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
@@ -4,10 +4,6 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Vue Integer Widget', { tag: '@vue-nodes' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-  })
-
   test('should be disabled and not allow changing value when link connected to slot', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/widgetCopyButton.spec.ts
+++ b/browser_tests/tests/widgetCopyButton.spec.ts
@@ -5,8 +5,6 @@ import {
 
 test.describe('Widget copy button', { tag: ['@ui', '@vue-nodes'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-
     // Add a PreviewAny node which has a read-only textarea with a copy button
     await comfyPage.page.evaluate(() => {
       const node = window.LiteGraph!.createNode('PreviewAny')


### PR DESCRIPTION
## Summary

Follow-up cleanup for #11184 — removes redundant test setup calls that the `@vue-nodes` fixture now handles.

## Changes

- **What**: Remove 40 lines of redundant `setSetting`, `setup()`, and `waitForNodes()` calls across 11 test files
  - `UseNewMenu: 'Top'` calls (already fixture default)
  - `setup()` + `waitForNodes()` on default workflow (fixture already does this for `@vue-nodes`)
  - Page reload in `subgraphZeroUuid` (fixture applies VueNodes.Enabled server-side before navigation)

## Review Focus

Each removal was verified against the fixture's `setupSettings()` defaults (ComfyPage.ts:420-442) and the `@vue-nodes` auto-setup (lines 454-456). Tests that call `setup()`/`waitForNodes()` after `loadWorkflow()` or `page.evaluate()` were intentionally kept.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11195-test-remove-redundant-setup-settings-now-handled-by-vue-nodes-fixture-3416d73d36508154827df116a97e9130) by [Unito](https://www.unito.io)
