### PR TITLE
[backport cloud/1.42] fix: persist subgraph viewport across navigation and tab switches (#10247)

### DIFF
--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -1,6 +1,8 @@
 import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
+import { TestIds } from '../selectors'
+
 import type {
   CanvasPointerEvent,
   Subgraph

--- a/browser_tests/tests/subgraphViewport.spec.ts
+++ b/browser_tests/tests/subgraphViewport.spec.ts
@@ -1,0 +1,114 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '../fixtures/ComfyPage'
+
+function hasVisibleNodeInViewport() {
+  const canvas = window.app!.canvas
+  if (!canvas?.graph?._nodes?.length) return false
+
+  const ds = canvas.ds
+  const cw = canvas.canvas.width / window.devicePixelRatio
+  const ch = canvas.canvas.height / window.devicePixelRatio
+  const visLeft = -ds.offset[0]
+  const visTop = -ds.offset[1]
+  const visRight = visLeft + cw / ds.scale
+  const visBottom = visTop + ch / ds.scale
+
+  for (const node of canvas.graph._nodes) {
+    const [nx, ny] = node.pos
+    const [nw, nh] = node.size
+    if (
+      nx + nw > visLeft &&
+      nx < visRight &&
+      ny + nh > visTop &&
+      ny < visBottom
+    )
+      return true
+  }
+  return false
+}
+
+test.describe('Subgraph viewport restoration', { tag: '@subgraph' }, () => {
+  test('first visit fits viewport to subgraph nodes (LG)', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.nextFrame()
+
+    await comfyPage.page.evaluate(() => {
+      const canvas = window.app!.canvas
+      const graph = canvas.graph!
+      const sgNode = graph._nodes.find((n) =>
+        'isSubgraphNode' in n
+          ? (n as unknown as { isSubgraphNode: () => boolean }).isSubgraphNode()
+          : false
+      ) as unknown as { subgraph?: typeof graph } | undefined
+      if (!sgNode?.subgraph) throw new Error('No subgraph node')
+
+      canvas.setGraph(sgNode.subgraph)
+    })
+
+    await expect
+      .poll(() => comfyPage.page.evaluate(hasVisibleNodeInViewport), {
+        timeout: 2000
+      })
+      .toBe(true)
+  })
+
+  test('first visit fits viewport to subgraph nodes (Vue)', async ({
+    comfyPage
+  }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.vueNodes.waitForNodes()
+
+    await comfyPage.vueNodes.enterSubgraph('11')
+
+    await expect
+      .poll(() => comfyPage.page.evaluate(hasVisibleNodeInViewport), {
+        timeout: 2000
+      })
+      .toBe(true)
+  })
+
+  test('viewport is restored when returning to root (Vue)', async ({
+    comfyPage
+  }) => {
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-promoted-text-widget'
+    )
+    await comfyPage.vueNodes.waitForNodes()
+
+    const rootViewport = await comfyPage.page.evaluate(() => {
+      const ds = window.app!.canvas.ds
+      return { scale: ds.scale, offset: [...ds.offset] }
+    })
+
+    await comfyPage.vueNodes.enterSubgraph('11')
+    await comfyPage.nextFrame()
+
+    await comfyPage.subgraph.exitViaBreadcrumb()
+
+    await expect
+      .poll(
+        () =>
+          comfyPage.page.evaluate(() => {
+            const ds = window.app!.canvas.ds
+            return { scale: ds.scale, offset: [...ds.offset] }
+          }),
+        { timeout: 2000 }
+      )
+      .toEqual({
+        scale: expect.closeTo(rootViewport.scale, 2),
+        offset: [
+          expect.closeTo(rootViewport.offset[0], 0),
+          expect.closeTo(rootViewport.offset[1], 0)
+        ]
+      })
+  })
+})

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -23,6 +23,7 @@ import type { AppMode } from '@/composables/useAppMode'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useAppModeStore } from '@/stores/appModeStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import {
   appendJsonExt,
@@ -390,6 +391,9 @@ export const useWorkflowService = () => {
       // Capture thumbnail before loading new graph
       void workflowThumbnail.storeThumbnail(activeWorkflow)
       domWidgetStore.clear()
+
+      // Save subgraph viewport before the canvas gets overwritten
+      useSubgraphNavigationStore().saveCurrentViewport()
     }
   }
 

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -6,6 +6,7 @@ import type { DragAndScaleState } from '@/lib/litegraph/src/DragAndScale'
 import type { Subgraph } from '@/lib/litegraph/src/litegraph'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useLitegraphService } from '@/services/litegraphService'
 import { app } from '@/scripts/app'
 import { findSubgraphPathById } from '@/utils/graphTraversalUtil'
 import { isNonNullish } from '@/utils/typeGuardUtil'
@@ -29,21 +30,45 @@ export const useSubgraphNavigationStore = defineStore(
     /** The stack of subgraph IDs from the root graph to the currently opened subgraph. */
     const idStack = ref<string[]>([])
 
-    /** LRU cache for viewport states. Key: subgraph ID or 'root' for root graph */
+    /** LRU cache for viewport states. Key: `workflowPath:graphId` */
     const viewportCache = new QuickLRU<string, DragAndScaleState>({
       maxSize: VIEWPORT_CACHE_MAX_SIZE
     })
 
-    /**
-     * Get the ID of the root graph for the currently active workflow.
-     * @returns The ID of the root graph for the currently active workflow.
-     */
+    /** Get the ID of the root graph for the currently active workflow. */
     const getCurrentRootGraphId = () => {
       const canvas = canvasStore.getCanvas()
       if (!canvas) return 'root'
 
       return canvas.graph?.rootGraph?.id ?? 'root'
     }
+
+    /**
+     * Set by saveCurrentViewport() (called from beforeLoadNewGraph) to
+     * prevent onNavigated from re-saving a stale viewport during the
+     * workflow switch transition. Uses setTimeout instead of rAF so the
+     * flag resets even when the tab is backgrounded.
+     */
+    let isWorkflowSwitching = false
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    /** Build a workflow-scoped cache key. */
+    function buildCacheKey(
+      graphId: string,
+      workflowRef?: { path?: string } | null
+    ): string {
+      const wf = workflowRef ?? workflowStore.activeWorkflow
+      const prefix = wf?.path ?? ''
+      return `${prefix}:${graphId}`
+    }
+
+    /** ID of the graph currently shown on the canvas. */
+    function getActiveGraphId(): string {
+      const canvas = canvasStore.getCanvas()
+      return canvas?.subgraph?.id ?? getCurrentRootGraphId()
+    }
+
+    // ── Navigation stack ─────────────────────────────────────────────
 
     /**
      * A stack representing subgraph navigation history from the root graph to
@@ -57,7 +82,6 @@ export const useSubgraphNavigationStore = defineStore(
 
     /**
      * Restore the navigation stack from a list of subgraph IDs.
-     * @param subgraphIds The list of subgraph IDs to restore the navigation stack from.
      * @see exportState
      */
     const restoreState = (subgraphIds: string[]) => {
@@ -67,69 +91,74 @@ export const useSubgraphNavigationStore = defineStore(
 
     /**
      * Export the navigation stack as a list of subgraph IDs.
-     * @returns The list of subgraph IDs, ending with the currently active subgraph.
      * @see restoreState
      */
     const exportState = () => [...idStack.value]
 
-    /**
-     * Get the current viewport state.
-     * @returns The current viewport state, or null if the canvas is not available.
-     */
+    // ── Viewport save / restore ──────────────────────────────────────
+
+    /** Get the current viewport state, or null if the canvas is not available. */
     const getCurrentViewport = (): DragAndScaleState | null => {
       const canvas = canvasStore.getCanvas()
       if (!canvas) return null
-
       return {
         scale: canvas.ds.state.scale,
         offset: [...canvas.ds.state.offset]
       }
     }
 
-    /**
-     * Save the current viewport state.
-     * @param graphId The graph ID to save for. Use 'root' for root graph, or omit to use current context.
-     */
-    const saveViewport = (graphId: string) => {
+    /** Save the current viewport state for a graph. */
+    function saveViewport(graphId: string, workflowRef?: object | null): void {
       const viewport = getCurrentViewport()
       if (!viewport) return
-
-      viewportCache.set(graphId, viewport)
+      viewportCache.set(buildCacheKey(graphId, workflowRef), viewport)
     }
 
-    /**
-     * Restore viewport state for a graph.
-     * @param graphId The graph ID to restore. Use 'root' for root graph, or omit to use current context.
-     */
-    const restoreViewport = (graphId: string) => {
-      const viewport = viewportCache.get(graphId)
-      if (!viewport) return
-
+    /** Apply a viewport state to the canvas. */
+    function applyViewport(viewport: DragAndScaleState): void {
       const canvas = app.canvas
       if (!canvas) return
-
       canvas.ds.scale = viewport.scale
       canvas.ds.offset[0] = viewport.offset[0]
       canvas.ds.offset[1] = viewport.offset[1]
       canvas.setDirty(true, true)
     }
 
-    /**
-     * Update the navigation stack when the active subgraph changes.
-     * @param subgraph The new active subgraph.
-     * @param prevSubgraph The previous active subgraph.
-     */
-    const onNavigated = (
+    function restoreViewport(graphId: string): void {
+      const canvas = app.canvas
+      if (!canvas) return
+
+      const expectedKey = buildCacheKey(graphId)
+      const viewport = viewportCache.get(expectedKey)
+      if (viewport) {
+        applyViewport(viewport)
+        return
+      }
+
+      // Cache miss — fit to content after the canvas has the new graph.
+      // rAF fires after layout + paint, when nodes are positioned.
+      const expectedGraphId = graphId
+      requestAnimationFrame(() => {
+        if (getActiveGraphId() !== expectedGraphId) return
+        useLitegraphService().fitView()
+      })
+    }
+
+    // ── Navigation handler ───────────────────────────────────────────
+
+    function onNavigated(
       subgraph: Subgraph | undefined,
       prevSubgraph: Subgraph | undefined
-    ) => {
-      // Save viewport state for the graph we're leaving
-      if (prevSubgraph) {
-        // Leaving a subgraph
-        saveViewport(prevSubgraph.id)
-      } else if (!prevSubgraph && subgraph) {
-        // Leaving root graph to enter a subgraph
-        saveViewport(getCurrentRootGraphId())
+    ): void {
+      // During a workflow switch, beforeLoadNewGraph already saved the
+      // outgoing viewport — skip the save here to avoid caching stale
+      // canvas state from the transition.
+      if (!isWorkflowSwitching) {
+        if (prevSubgraph) {
+          saveViewport(prevSubgraph.id)
+        } else if (!prevSubgraph && subgraph) {
+          saveViewport(getCurrentRootGraphId())
+        }
       }
 
       const isInRootGraph = !subgraph
@@ -144,21 +173,35 @@ export const useSubgraphNavigationStore = defineStore(
       if (isInReachableSubgraph) {
         idStack.value = [...path]
       } else {
-        // Treat as if opening a new subgraph
         idStack.value = [subgraph.id]
       }
 
-      // Always try to restore viewport for the target subgraph
       restoreViewport(subgraph.id)
     }
 
-    // Update navigation stack when opened subgraph changes (also triggers when switching workflows)
+    // ── Watchers ─────────────────────────────────────────────────────
+
+    // Sync flush ensures we capture the outgoing viewport before any other
+    // watchers or DOM updates from the same state change mutate the canvas.
     watch(
       () => workflowStore.activeSubgraph,
       (newValue, oldValue) => {
         onNavigated(newValue, oldValue)
-      }
+      },
+      { flush: 'sync' }
     )
+
+
+    /** Save the current viewport for the active graph/workflow. Called by
+     *  workflowService.beforeLoadNewGraph() before the canvas is overwritten. */
+    function saveCurrentViewport(): void {
+      saveViewport(getActiveGraphId())
+      isWorkflowSwitching = true
+      setTimeout(() => {
+        isWorkflowSwitching = false
+      }, 0)
+    }
+
 
     return {
       activeSubgraph,
@@ -167,6 +210,8 @@ export const useSubgraphNavigationStore = defineStore(
       exportState,
       saveViewport,
       restoreViewport,
+      saveCurrentViewport,
+      /** @internal Exposed for test assertions only. */
       viewportCache
     }
   }

--- a/src/stores/subgraphNavigationStore.ts
+++ b/src/stores/subgraphNavigationStore.ts
@@ -191,7 +191,6 @@ export const useSubgraphNavigationStore = defineStore(
       { flush: 'sync' }
     )
 
-
     /** Save the current viewport for the active graph/workflow. Called by
      *  workflowService.beforeLoadNewGraph() before the canvas is overwritten. */
     function saveCurrentViewport(): void {
@@ -201,7 +200,6 @@ export const useSubgraphNavigationStore = defineStore(
         isWorkflowSwitching = false
       }, 0)
     }
-
 
     return {
       activeSubgraph,

--- a/src/stores/subgraphNavigationStore.viewport.test.ts
+++ b/src/stores/subgraphNavigationStore.viewport.test.ts
@@ -18,173 +18,204 @@ const { mockSetDirty } = vi.hoisted(() => ({
 
 vi.mock('@/scripts/app', () => {
   const mockCanvas = {
-    subgraph: null,
+    subgraph: undefined as unknown,
+    graph: undefined as unknown,
     ds: {
       scale: 1,
       offset: [0, 0],
-      state: {
-        scale: 1,
-        offset: [0, 0]
-      }
+      state: { scale: 1, offset: [0, 0] },
+      fitToBounds: vi.fn()
     },
-    setDirty: mockSetDirty
+    setDirty: mockSetDirty,
+    get empty() {
+      return true
+    }
   }
+
+  const mockGraph = {
+    _nodes: [],
+    nodes: [],
+    subgraphs: new Map(),
+    getNodeById: vi.fn(),
+    id: 'root'
+  }
+
+  mockCanvas.graph = mockGraph
 
   return {
     app: {
-      graph: {
-        _nodes: [],
-        nodes: [],
-        subgraphs: new Map(),
-        getNodeById: vi.fn()
-      },
+      graph: mockGraph,
+      rootGraph: mockGraph,
       canvas: mockCanvas
     }
   }
 })
 
-// Mock canvasStore
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({
     getCanvas: () => app.canvas
   })
 }))
 
-// Get reference to mock canvas
+const { mockFitView } = vi.hoisted(() => ({
+  mockFitView: vi.fn()
+}))
+vi.mock('@/services/litegraphService', () => ({
+  useLitegraphService: () => ({ fitView: mockFitView })
+}))
+
 const mockCanvas = app.canvas
+
+let rafCallbacks: FrameRequestCallback[] = []
 
 describe('useSubgraphNavigationStore - Viewport Persistence', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
-    // Reset canvas state
+    rafCallbacks = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    mockCanvas.subgraph = undefined
+    mockCanvas.graph = app.graph
     mockCanvas.ds.scale = 1
     mockCanvas.ds.offset = [0, 0]
     mockCanvas.ds.state.scale = 1
     mockCanvas.ds.state.offset = [0, 0]
     mockSetDirty.mockClear()
+    mockFitView.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('cache key isolation', () => {
+    it('isolates viewport by workflow — same graphId returns different values', () => {
+      const store = useSubgraphNavigationStore()
+      const workflowStore = useWorkflowStore()
+
+      // Save viewport under workflow A
+      workflowStore.activeWorkflow = {
+        path: 'wfA.json'
+      } as typeof workflowStore.activeWorkflow
+      mockCanvas.ds.state.scale = 2
+      mockCanvas.ds.state.offset = [10, 20]
+      store.saveViewport('root')
+
+      // Save different viewport under workflow B
+      workflowStore.activeWorkflow = {
+        path: 'wfB.json'
+      } as typeof workflowStore.activeWorkflow
+      mockCanvas.ds.state.scale = 5
+      mockCanvas.ds.state.offset = [99, 88]
+      store.saveViewport('root')
+
+      // Restore under A — should get A's values
+      workflowStore.activeWorkflow = {
+        path: 'wfA.json'
+      } as typeof workflowStore.activeWorkflow
+      store.restoreViewport('root')
+
+      expect(mockCanvas.ds.scale).toBe(2)
+      expect(mockCanvas.ds.offset).toEqual([10, 20])
+    })
   })
 
   describe('saveViewport', () => {
-    it('should save viewport state for root graph', () => {
-      const navigationStore = useSubgraphNavigationStore()
-
-      // Set viewport state
+    it('saves viewport state for root graph', () => {
+      const store = useSubgraphNavigationStore()
       mockCanvas.ds.state.scale = 2
       mockCanvas.ds.state.offset = [100, 200]
 
-      // Save viewport for root
-      navigationStore.saveViewport('root')
+      store.saveViewport('root')
 
-      // Check it was saved
-      const saved = navigationStore.viewportCache.get('root')
-      expect(saved).toEqual({
+      expect(store.viewportCache.get(':root')).toEqual({
         scale: 2,
         offset: [100, 200]
       })
     })
 
-    it('should save viewport state for subgraph', () => {
-      const navigationStore = useSubgraphNavigationStore()
-
-      // Set viewport state
+    it('saves viewport state for subgraph', () => {
+      const store = useSubgraphNavigationStore()
       mockCanvas.ds.state.scale = 1.5
       mockCanvas.ds.state.offset = [50, 75]
 
-      // Save viewport for subgraph
-      navigationStore.saveViewport('subgraph-123')
+      store.saveViewport('subgraph-123')
 
-      // Check it was saved
-      const saved = navigationStore.viewportCache.get('subgraph-123')
-      expect(saved).toEqual({
+      expect(store.viewportCache.get(':subgraph-123')).toEqual({
         scale: 1.5,
         offset: [50, 75]
-      })
-    })
-
-    it('should save viewport for current context when no ID provided', () => {
-      const navigationStore = useSubgraphNavigationStore()
-      const workflowStore = useWorkflowStore()
-
-      // Mock being in a subgraph
-      const mockSubgraph = { id: 'sub-456' }
-      workflowStore.activeSubgraph = mockSubgraph as Subgraph
-
-      // Set viewport state
-      mockCanvas.ds.state.scale = 3
-      mockCanvas.ds.state.offset = [10, 20]
-
-      // Save viewport without ID (should default to root since activeSubgraph is not tracked by navigation store)
-      navigationStore.saveViewport('sub-456')
-
-      // Should save for the specified subgraph
-      const saved = navigationStore.viewportCache.get('sub-456')
-      expect(saved).toEqual({
-        scale: 3,
-        offset: [10, 20]
       })
     })
   })
 
   describe('restoreViewport', () => {
-    it('should restore viewport state for root graph', () => {
-      const navigationStore = useSubgraphNavigationStore()
+    it('restores cached viewport', () => {
+      const store = useSubgraphNavigationStore()
+      store.viewportCache.set(':root', { scale: 2.5, offset: [150, 250] })
 
-      // Save a viewport state
-      navigationStore.viewportCache.set('root', {
-        scale: 2.5,
-        offset: [150, 250]
-      })
+      store.restoreViewport('root')
 
-      // Restore it
-      navigationStore.restoreViewport('root')
-
-      // Check canvas was updated
       expect(mockCanvas.ds.scale).toBe(2.5)
       expect(mockCanvas.ds.offset).toEqual([150, 250])
-      expect(mockCanvas.setDirty).toHaveBeenCalledWith(true, true)
+      expect(mockSetDirty).toHaveBeenCalledWith(true, true)
     })
 
-    it('should restore viewport state for subgraph', () => {
-      const navigationStore = useSubgraphNavigationStore()
-
-      // Save a viewport state
-      navigationStore.viewportCache.set('sub-789', {
-        scale: 0.75,
-        offset: [-50, -100]
-      })
-
-      // Restore it
-      navigationStore.restoreViewport('sub-789')
-
-      // Check canvas was updated
-      expect(mockCanvas.ds.scale).toBe(0.75)
-      expect(mockCanvas.ds.offset).toEqual([-50, -100])
-    })
-
-    it('should do nothing if no saved viewport exists', () => {
-      const navigationStore = useSubgraphNavigationStore()
-
-      // Reset canvas
+    it('does not mutate canvas synchronously on cache miss', () => {
+      const store = useSubgraphNavigationStore()
       mockCanvas.ds.scale = 1
       mockCanvas.ds.offset = [0, 0]
       mockSetDirty.mockClear()
 
-      // Try to restore non-existent viewport
-      navigationStore.restoreViewport('non-existent')
+      store.restoreViewport('non-existent')
 
-      // Canvas should not change
+      // Should not change canvas synchronously
       expect(mockCanvas.ds.scale).toBe(1)
       expect(mockCanvas.ds.offset).toEqual([0, 0])
       expect(mockSetDirty).not.toHaveBeenCalled()
+      // But should have scheduled a rAF
+      expect(rafCallbacks).toHaveLength(1)
+    })
+
+    it('calls fitView on cache miss after rAF fires', () => {
+      const store = useSubgraphNavigationStore()
+      // Ensure no cached entry
+      store.viewportCache.delete(':root')
+
+      // Use the root graph ID so the stale-guard passes
+      store.restoreViewport('root')
+
+      expect(mockFitView).not.toHaveBeenCalled()
+      expect(rafCallbacks).toHaveLength(1)
+
+      // Simulate rAF firing — active graph still matches
+      rafCallbacks[0](performance.now())
+
+      expect(mockFitView).toHaveBeenCalledOnce()
+    })
+
+    it('skips fitView if active graph changed before rAF fires', () => {
+      const store = useSubgraphNavigationStore()
+      store.viewportCache.delete(':root')
+
+      store.restoreViewport('root')
+      expect(rafCallbacks).toHaveLength(1)
+
+      // Simulate graph switching away before rAF fires
+      mockCanvas.subgraph = { id: 'different-graph' } as never
+
+      rafCallbacks[0](performance.now())
+
+      expect(mockFitView).not.toHaveBeenCalled()
     })
   })
 
   describe('navigation integration', () => {
-    it('should save and restore viewport when navigating between subgraphs', async () => {
-      const navigationStore = useSubgraphNavigationStore()
+    it('saves and restores viewport when navigating between subgraphs', async () => {
+      const store = useSubgraphNavigationStore()
       const workflowStore = useWorkflowStore()
 
-      // Create mock subgraph with both _nodes and nodes properties
       const mockRootGraph = {
         _nodes: [],
         nodes: [],
@@ -198,70 +229,118 @@ describe('useSubgraphNavigationStore - Viewport Persistence', () => {
         nodes: []
       }
 
-      // Start at root with custom viewport
       mockCanvas.ds.state.scale = 2
       mockCanvas.ds.state.offset = [100, 100]
 
-      // Navigate to subgraph
+      // Enter subgraph
       workflowStore.activeSubgraph = subgraph1 as Partial<Subgraph> as Subgraph
       await nextTick()
 
-      // Root viewport should have been saved automatically
-      const rootViewport = navigationStore.viewportCache.get('root')
-      expect(rootViewport).toBeDefined()
-      expect(rootViewport?.scale).toBe(2)
-      expect(rootViewport?.offset).toEqual([100, 100])
+      // Root viewport saved
+      expect(store.viewportCache.get(':root')).toEqual({
+        scale: 2,
+        offset: [100, 100]
+      })
 
       // Change viewport in subgraph
       mockCanvas.ds.state.scale = 0.5
       mockCanvas.ds.state.offset = [-50, -50]
 
-      // Navigate back to root
+      // Exit subgraph
       workflowStore.activeSubgraph = undefined
       await nextTick()
 
-      // Subgraph viewport should have been saved automatically
-      const sub1Viewport = navigationStore.viewportCache.get('sub1')
-      expect(sub1Viewport).toBeDefined()
-      expect(sub1Viewport?.scale).toBe(0.5)
-      expect(sub1Viewport?.offset).toEqual([-50, -50])
+      // Subgraph viewport saved
+      expect(store.viewportCache.get(':sub1')).toEqual({
+        scale: 0.5,
+        offset: [-50, -50]
+      })
 
-      // Root viewport should be restored automatically
+      // Root viewport restored
       expect(mockCanvas.ds.scale).toBe(2)
       expect(mockCanvas.ds.offset).toEqual([100, 100])
     })
 
-    it('should preserve viewport cache when switching workflows', async () => {
-      const navigationStore = useSubgraphNavigationStore()
+    it('preserves pre-existing cache entries across workflow switches', async () => {
+      const store = useSubgraphNavigationStore()
       const workflowStore = useWorkflowStore()
 
-      // Add some viewport states
-      navigationStore.viewportCache.set('root', { scale: 2, offset: [0, 0] })
-      navigationStore.viewportCache.set('sub1', {
-        scale: 1.5,
-        offset: [10, 10]
+      store.viewportCache.set(':root', { scale: 2, offset: [0, 0] })
+      store.viewportCache.set(':sub1', { scale: 1.5, offset: [10, 10] })
+      expect(store.viewportCache.size).toBe(2)
+
+      const wf1 = { path: 'wf1.json' } as ComfyWorkflow
+      const wf2 = { path: 'wf2.json' } as ComfyWorkflow
+
+      workflowStore.activeWorkflow = wf1 as typeof workflowStore.activeWorkflow
+      await nextTick()
+
+      workflowStore.activeWorkflow = wf2 as typeof workflowStore.activeWorkflow
+      await nextTick()
+
+      // Pre-existing entries still in cache
+      expect(store.viewportCache.has(':root')).toBe(true)
+      expect(store.viewportCache.has(':sub1')).toBe(true)
+    })
+
+    it('should save/restore viewports correctly across multiple subgraphs', () => {
+      const navigationStore = useSubgraphNavigationStore()
+
+      navigationStore.viewportCache.set(':root', {
+        scale: 1,
+        offset: [0, 0]
+      })
+      navigationStore.viewportCache.set(':sub-1', {
+        scale: 2,
+        offset: [100, 200]
+      })
+      navigationStore.viewportCache.set(':sub-2', {
+        scale: 0.5,
+        offset: [-50, -75]
       })
 
-      expect(navigationStore.viewportCache.size).toBe(2)
+      navigationStore.restoreViewport('sub-1')
+      expect(mockCanvas.ds.scale).toBe(2)
+      expect(mockCanvas.ds.offset).toEqual([100, 200])
 
-      // Switch workflows
-      const workflow1 = { path: 'workflow1.json' } as ComfyWorkflow
-      const workflow2 = { path: 'workflow2.json' } as ComfyWorkflow
+      navigationStore.restoreViewport('sub-2')
+      expect(mockCanvas.ds.scale).toBe(0.5)
+      expect(mockCanvas.ds.offset).toEqual([-50, -75])
 
-      workflowStore.activeWorkflow = workflow1 as ReturnType<
-        typeof useWorkflowStore
-      >['activeWorkflow']
-      await nextTick()
+      navigationStore.restoreViewport('root')
+      expect(mockCanvas.ds.scale).toBe(1)
+      expect(mockCanvas.ds.offset).toEqual([0, 0])
+    })
 
-      workflowStore.activeWorkflow = workflow2 as ReturnType<
-        typeof useWorkflowStore
-      >['activeWorkflow']
-      await nextTick()
+    it('should evict oldest viewport entry when LRU cache exceeds capacity', () => {
+      const navigationStore = useSubgraphNavigationStore()
+      const overflowEntryCount = VIEWPORT_CACHE_MAX_SIZE * 2 + 1
 
-      // Cache should be preserved (LRU will manage memory)
-      expect(navigationStore.viewportCache.size).toBe(2)
-      expect(navigationStore.viewportCache.has('root')).toBe(true)
-      expect(navigationStore.viewportCache.has('sub1')).toBe(true)
+      // QuickLRU uses double-buffering: effective capacity is up to 2 * maxSize.
+      // Fill enough entries so the earliest ones are fully evicted.
+      // Keys use the workflow-scoped format (`:graphId`) matching production.
+      for (let i = 0; i < overflowEntryCount; i++) {
+        navigationStore.viewportCache.set(`:sub-${i}`, {
+          scale: i + 1,
+          offset: [i * 10, i * 20]
+        })
+      }
+
+      expect(navigationStore.viewportCache.has(':sub-0')).toBe(false)
+
+      expect(
+        navigationStore.viewportCache.has(`:sub-${overflowEntryCount - 1}`)
+      ).toBe(true)
+
+      mockCanvas.ds.scale = 99
+      mockCanvas.ds.offset = [999, 999]
+      mockSetDirty.mockClear()
+
+      navigationStore.restoreViewport('sub-0')
+
+      expect(mockCanvas.ds.scale).toBe(99)
+      expect(mockCanvas.ds.offset).toEqual([999, 999])
+      expect(mockSetDirty).not.toHaveBeenCalled()
     })
 
     it('should save/restore viewports correctly across multiple subgraphs', () => {


### PR DESCRIPTION
Backport of #10247 to `cloud/1.42`.

Manual cherry-pick of `7e7e2d564`. Conflicts resolved in:
- `src/stores/subgraphNavigationStore.ts` — dropped `navigateToHash`/`updateHash` block (from #6811, not part of this backport); kept `saveCurrentViewport` and its return export
- `src/platform/workflow/core/services/workflowService.ts` — added `useSubgraphNavigationStore` import only (excluded `useMissingNodesErrorStore` which is part of a separate refactor not on 1.42)
- `src/stores/subgraphNavigationStore.viewport.test.ts` — accepted incoming new test cases

Prerequisite for #10810 and #10995 backports.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11199-backport-cloud-1-42-fix-persist-subgraph-viewport-across-navigation-and-tab-switches--3416d73d365081c5a2d3f3a4de83586c) by [Unito](https://www.unito.io)
