### PR TITLE
fix: backport workspace subscription success telemetry to core 1.42

### DIFF
--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -81,6 +81,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useTelemetry } from '@/platform/telemetry'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
@@ -107,6 +108,7 @@ const { t } = useI18n()
 const toast = useToast()
 const { subscribe, previewSubscribe, plans, fetchStatus, fetchBalance } =
   useBillingContext()
+const telemetry = useTelemetry()
 
 const billingOperationStore = useBillingOperationStore()
 const isPolling = computed(() => billingOperationStore.hasPendingOperations)
@@ -206,6 +208,7 @@ async function handleAddCreditCard() {
     if (!response) return
 
     if (response.status === 'subscribed') {
+      telemetry?.trackMonthlySubscriptionSucceeded()
       toast.add({
         severity: 'success',
         summary: t('subscription.required.pollingSuccess'),
@@ -260,6 +263,7 @@ async function handleConfirmTransition() {
     if (!response) return
 
     if (response.status === 'subscribed') {
+      telemetry?.trackMonthlySubscriptionSucceeded()
       toast.add({
         severity: 'success',
         summary: t('subscription.required.pollingSuccess'),


### PR DESCRIPTION
## Summary

Backport the `#11130` telemetry fix to `core/1.42` so immediate workspace subscribe success emits `subscription_success` the same way the async billing-operation path already does.

## Changes

- **What**: Add `useTelemetry()` and emit `trackMonthlySubscriptionSucceeded()` in both synchronous `response.status === 'subscribed'` workspace subscription dialog paths on `core/1.42`.

## Review Focus

Verify this backport is limited to the missing synchronous success telemetry and does not change the existing toast, billing refresh, dialog close, or async billing-operation behavior.

## Validation

- `pnpm lint`
- `pnpm typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11202-fix-backport-workspace-subscription-success-telemetry-to-core-1-42-3416d73d36508122ba2dd54d39f726b0) by [Unito](https://www.unito.io)
