### PR TITLE
test: add E2E tests for queue button modes

### DIFF
--- a/browser_tests/tests/queueButtonModes.spec.ts
+++ b/browser_tests/tests/queueButtonModes.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+test.describe('Queue button modes', { tag: '@ui' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.setup()
+  })
+
+  test('Run button is visible in topbar', async ({ comfyPage }) => {
+    await expect(comfyPage.runButton).toBeVisible()
+  })
+
+  test('Queue mode trigger menu is visible', async ({ comfyPage }) => {
+    const trigger = comfyPage.page.getByTestId(
+      TestIds.topbar.queueModeMenuTrigger
+    )
+    await expect(trigger).toBeVisible()
+  })
+
+  test('Clicking queue mode trigger opens mode menu', async ({ comfyPage }) => {
+    const trigger = comfyPage.page.getByTestId(
+      TestIds.topbar.queueModeMenuTrigger
+    )
+    await trigger.click()
+
+    const menu = comfyPage.page.getByRole('menu')
+    await expect(menu).toBeVisible()
+  })
+
+  test('Queue mode menu shows available modes', async ({ comfyPage }) => {
+    const trigger = comfyPage.page.getByTestId(
+      TestIds.topbar.queueModeMenuTrigger
+    )
+    await trigger.click()
+
+    const menu = comfyPage.page.getByRole('menu')
+    await expect(menu).toBeVisible()
+
+    await expect(menu.getByRole('menuitemradio').first()).toBeVisible()
+  })
+
+  test('Queue mode menu closes after selecting a mode', async ({
+    comfyPage
+  }) => {
+    const trigger = comfyPage.page.getByTestId(
+      TestIds.topbar.queueModeMenuTrigger
+    )
+    await trigger.click()
+
+    const menu = comfyPage.page.getByRole('menu')
+    await expect(menu).toBeVisible()
+
+    const firstItem = menu.getByRole('menuitemradio').first()
+    await firstItem.click()
+
+    await expect(menu).toBeHidden()
+  })
+
+  test('Run button sends prompt when clicked', async ({ comfyPage }) => {
+    let promptQueued = false
+    await comfyPage.page.route('**/api/prompt', async (route) => {
+      promptQueued = true
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          prompt_id: 'test-id',
+          number: 1,
+          node_errors: {}
+        })
+      })
+    })
+
+    await comfyPage.runButton.click()
+
+    await expect.poll(() => promptQueued).toBe(true)
+  })
+})

--- a/browser_tests/tests/queueButtonModes.spec.ts
+++ b/browser_tests/tests/queueButtonModes.spec.ts
@@ -39,7 +39,7 @@ test.describe('Queue button modes', { tag: '@ui' }, () => {
     const menu = comfyPage.page.getByRole('menu')
     await expect(menu).toBeVisible()
 
-    await expect(menu.getByRole('menuitemradio').first()).toBeVisible()
+    await expect(menu.getByRole('menuitem').first()).toBeVisible()
   })
 
   test('Queue mode menu closes after selecting a mode', async ({
@@ -53,7 +53,7 @@ test.describe('Queue button modes', { tag: '@ui' }, () => {
     const menu = comfyPage.page.getByRole('menu')
     await expect(menu).toBeVisible()
 
-    const firstItem = menu.getByRole('menuitemradio').first()
+    const firstItem = menu.getByRole('menuitem').first()
     await firstItem.click()
 
     await expect(menu).toBeHidden()

--- a/browser_tests/tests/queueButtonModes.spec.ts
+++ b/browser_tests/tests/queueButtonModes.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from '@playwright/test'
 
+import type { PromptResponse } from '@/schemas/apiSchema'
+
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 
@@ -65,15 +67,16 @@ test.describe('Queue button modes', { tag: '@ui' }, () => {
 
   test('Run button sends prompt when clicked', async ({ comfyPage }) => {
     let promptQueued = false
+    const mockResponse: PromptResponse = {
+      prompt_id: 'test-id',
+      node_errors: {},
+      error: ''
+    }
     await comfyPage.page.route('**/api/prompt', async (route) => {
       promptQueued = true
       await route.fulfill({
         status: 200,
-        body: JSON.stringify({
-          prompt_id: 'test-id',
-          number: 1,
-          node_errors: {}
-        })
+        body: JSON.stringify(mockResponse)
       })
     })
 

--- a/browser_tests/tests/queueButtonModes.spec.ts
+++ b/browser_tests/tests/queueButtonModes.spec.ts
@@ -48,7 +48,7 @@ test.describe('Queue button modes', { tag: '@ui' }, () => {
     await expect(items.nth(2)).toHaveText('Run (Instant)')
   })
 
-  test('Queue mode menu closes after selecting a mode', async ({
+  test('Selecting a non-default mode updates the Run button label', async ({
     comfyPage
   }) => {
     const trigger = comfyPage.page.getByTestId(
@@ -59,10 +59,11 @@ test.describe('Queue button modes', { tag: '@ui' }, () => {
     const menu = comfyPage.page.getByRole('menu')
     await expect(menu).toBeVisible()
 
-    const firstItem = menu.getByRole('menuitem').first()
-    await firstItem.click()
+    // Select "Run (On Change)" — a non-default mode so we observe a real change
+    const onChangeItem = menu.getByRole('menuitem').nth(1)
+    await onChangeItem.click()
 
-    await expect(menu).toBeHidden()
+    await expect(comfyPage.runButton).toContainText('Run (On Change)')
   })
 
   test('Run button sends prompt when clicked', async ({ comfyPage }) => {

--- a/browser_tests/tests/queueButtonModes.spec.ts
+++ b/browser_tests/tests/queueButtonModes.spec.ts
@@ -39,7 +39,11 @@ test.describe('Queue button modes', { tag: '@ui' }, () => {
     const menu = comfyPage.page.getByRole('menu')
     await expect(menu).toBeVisible()
 
-    await expect(menu.getByRole('menuitem').first()).toBeVisible()
+    const items = menu.getByRole('menuitem')
+    await expect(items).toHaveCount(3)
+    await expect(items.nth(0)).toHaveText('Run')
+    await expect(items.nth(1)).toHaveText('Run (On Change)')
+    await expect(items.nth(2)).toHaveText('Run (Instant)')
   })
 
   test('Queue mode menu closes after selecting a mode', async ({

--- a/browser_tests/tests/queueButtonModes.spec.ts
+++ b/browser_tests/tests/queueButtonModes.spec.ts
@@ -6,11 +6,6 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 test.describe('Queue button modes', { tag: '@ui' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-    await comfyPage.setup()
-  })
-
   test('Run button is visible in topbar', async ({ comfyPage }) => {
     await expect(comfyPage.runButton).toBeVisible()
   })


### PR DESCRIPTION
## Changes

Add Playwright E2E tests for queue button modes in the topbar (6 tests):

- Run button visibility in topbar
- Queue mode trigger menu visibility
- Opening the mode menu via trigger click
- Verifying available modes are shown as menu item radios
- Menu closes after selecting a mode
- Run button sends prompt when clicked (via intercepted `/api/prompt` route)

## Test

```bash
pnpm test:browser:local -- browser_tests/tests/queueButtonModes.spec.ts
```

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11209-test-add-E2E-tests-for-queue-button-modes-3416d73d365081a5bf10f8b9c6bdc2a7) by [Unito](https://www.unito.io)
