### PR TITLE
test: add E2E tests for keyboard shortcut actions

### DIFF
--- a/browser_tests/tests/keyboardShortcutActions.spec.ts
+++ b/browser_tests/tests/keyboardShortcutActions.spec.ts
@@ -1,0 +1,113 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe('Keyboard shortcut actions', { tag: '@keyboard' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Topbar'
+    )
+    await comfyPage.setup()
+  })
+
+  test('Ctrl+Z undoes the last graph change', async ({ comfyPage }) => {
+    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
+
+    await comfyPage.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode('Note')
+      window.app!.graph!.add(node)
+    })
+    await comfyPage.nextFrame()
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount + 1)
+
+    await comfyPage.canvas.click()
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount)
+  })
+
+  test('Ctrl+Shift+Z redoes after undo', async ({ comfyPage }) => {
+    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
+
+    await comfyPage.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode('Note')
+      window.app!.graph!.add(node)
+    })
+    await comfyPage.nextFrame()
+
+    await comfyPage.canvas.click()
+    await comfyPage.page.keyboard.press('ControlOrMeta+z')
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount)
+
+    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount + 1)
+  })
+
+  test('Ctrl+S opens save dialog', async ({ comfyPage }) => {
+    await comfyPage.canvas.click()
+    await comfyPage.page.keyboard.press('ControlOrMeta+s')
+
+    const saveDialog = comfyPage.menu.topbar.getSaveDialog()
+    await expect(saveDialog).toBeVisible()
+  })
+
+  test('Ctrl+, opens settings dialog', async ({ comfyPage }) => {
+    await comfyPage.page.keyboard.down('ControlOrMeta')
+    await comfyPage.page.keyboard.press(',')
+    await comfyPage.page.keyboard.up('ControlOrMeta')
+
+    const settingsDialog = comfyPage.page.getByTestId('settings-dialog')
+    await expect(settingsDialog).toBeVisible()
+  })
+
+  test('Escape closes settings dialog', async ({ comfyPage }) => {
+    await comfyPage.page.keyboard.down('ControlOrMeta')
+    await comfyPage.page.keyboard.press(',')
+    await comfyPage.page.keyboard.up('ControlOrMeta')
+
+    const settingsDialog = comfyPage.page.getByTestId('settings-dialog')
+    await expect(settingsDialog).toBeVisible()
+
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(settingsDialog).toBeHidden()
+  })
+
+  test('Delete key removes selected nodes', async ({ comfyPage }) => {
+    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
+    expect(initialNodeCount, 'Default graph should have nodes').toBeGreaterThan(
+      0
+    )
+
+    await comfyPage.nodeOps.selectNodes(['KSampler'])
+    await comfyPage.page.keyboard.press('Delete')
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBeLessThan(initialNodeCount)
+  })
+
+  test('Ctrl+A selects all nodes', async ({ comfyPage }) => {
+    await comfyPage.canvas.click()
+    await comfyPage.page.keyboard.press('ControlOrMeta+a')
+
+    const totalNodes = await comfyPage.nodeOps.getNodeCount()
+    const selectedNodes = await comfyPage.page.evaluate(() =>
+      window.app!.canvas?.selected_nodes
+        ? Object.keys(window.app!.canvas.selected_nodes).length
+        : 0
+    )
+
+    expect(selectedNodes).toBe(totalNodes)
+  })
+})

--- a/browser_tests/tests/topbarMenuCommands.spec.ts
+++ b/browser_tests/tests/topbarMenuCommands.spec.ts
@@ -1,0 +1,81 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe('Topbar menu commands', { tag: '@ui' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+    await comfyPage.settings.setSetting(
+      'Comfy.Workflow.WorkflowTabsPosition',
+      'Topbar'
+    )
+    await comfyPage.setup()
+  })
+
+  test('New command creates a new workflow tab', async ({ comfyPage }) => {
+    const topbar = comfyPage.menu.topbar
+    await expect.poll(() => topbar.getTabNames()).toHaveLength(1)
+
+    await topbar.triggerTopbarCommand(['New'])
+
+    await expect.poll(() => topbar.getTabNames()).toHaveLength(2)
+  })
+
+  test('Edit > Undo undoes the last action', async ({ comfyPage }) => {
+    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
+
+    await comfyPage.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode('Note')
+      window.app!.graph!.add(node)
+    })
+    await comfyPage.nextFrame()
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount + 1)
+
+    await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Undo'])
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount)
+  })
+
+  test('Edit > Redo restores an undone action', async ({ comfyPage }) => {
+    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
+
+    await comfyPage.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode('Note')
+      window.app!.graph!.add(node)
+    })
+    await comfyPage.nextFrame()
+
+    await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Undo'])
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount)
+
+    await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Redo'])
+    await expect
+      .poll(() => comfyPage.nodeOps.getNodeCount())
+      .toBe(initialNodeCount + 1)
+  })
+
+  test('File > Save opens save dialog', async ({ comfyPage }) => {
+    await comfyPage.menu.topbar.triggerTopbarCommand(['File', 'Save'])
+
+    const saveDialog = comfyPage.menu.topbar.getSaveDialog()
+    await expect(saveDialog).toBeVisible()
+  })
+
+  test('View > Bottom Panel toggles bottom panel', async ({ comfyPage }) => {
+    await expect(comfyPage.bottomPanel.root).toBeHidden()
+
+    await comfyPage.menu.topbar.triggerTopbarCommand(['View', 'Bottom Panel'])
+    await expect(comfyPage.bottomPanel.root).toBeVisible()
+
+    await comfyPage.menu.topbar.triggerTopbarCommand(['View', 'Bottom Panel'])
+    await expect(comfyPage.bottomPanel.root).toBeHidden()
+  })
+})


### PR DESCRIPTION
## Summary

Add Playwright E2E tests covering core keyboard shortcut actions.

## Changes

- **What**: 7 new E2E tests in `browser_tests/tests/keyboardShortcutActions.spec.ts` covering:
  - Ctrl+Z undoes the last graph change
  - Ctrl+Shift+Z redoes after undo
  - Ctrl+S opens save dialog
  - Ctrl+, opens settings dialog
  - Escape closes settings dialog
  - Delete key removes selected nodes
  - Ctrl+A selects all nodes

## Review Focus

- Tests use `expect.poll()` for async graph state assertions
- `@keyboard` tag for selective test runs
- Uses `comfyPage.nodeOps` and `comfyPage.menu.topbar` helpers

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11210-test-add-E2E-tests-for-keyboard-shortcut-actions-3416d73d3650812eafd5e789cf8463a6) by [Unito](https://www.unito.io)
