### PR TITLE
[backport cloud/1.42] fix: track workspace subscription success on immediate subscribe

### DIFF
--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -81,6 +81,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useTelemetry } from '@/platform/telemetry'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
@@ -107,6 +108,7 @@ const { t } = useI18n()
 const toast = useToast()
 const { subscribe, previewSubscribe, plans, fetchStatus, fetchBalance } =
   useBillingContext()
+const telemetry = useTelemetry()
 
 const billingOperationStore = useBillingOperationStore()
 const isPolling = computed(() => billingOperationStore.hasPendingOperations)
@@ -206,6 +208,7 @@ async function handleAddCreditCard() {
     if (!response) return
 
     if (response.status === 'subscribed') {
+      telemetry?.trackMonthlySubscriptionSucceeded()
       toast.add({
         severity: 'success',
         summary: t('subscription.required.pollingSuccess'),
@@ -260,6 +263,7 @@ async function handleConfirmTransition() {
     if (!response) return
 
     if (response.status === 'subscribed') {
+      telemetry?.trackMonthlySubscriptionSucceeded()
       toast.add({
         severity: 'success',
         summary: t('subscription.required.pollingSuccess'),


### PR DESCRIPTION
## Summary

Backport `#11130` to `cloud/1.42` so immediate workspace subscribe success emits the same `subscription_success` telemetry event as the async billing-operation path.

## Changes

- **What**: Add `useTelemetry()` and emit `trackMonthlySubscriptionSucceeded()` in both synchronous `response.status === 'subscribed'` workspace subscription dialog paths on `cloud/1.42`.

## Review Focus

Verify this stays limited to the missing synchronous success telemetry and preserves the existing toast, billing refresh, dialog close, and async billing-operation behavior.

## Notes

- The automatic backport failed because cherry-picking merge commit `719ed16d3240ad098d1b4103f901119fa693ca3b` hit a trivial context conflict in `src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue` around the setup block where `const telemetry = useTelemetry()` is inserted. This manual backport applies the intended logic without pulling in unrelated `main`-only UI changes.

## Validation

- `pnpm lint`
- `pnpm typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11211-backport-cloud-1-42-fix-track-workspace-subscription-success-on-immediate-subscribe-3426d73d3650815296b4e1675bd54c20) by [Unito](https://www.unito.io)
