### PR TITLE
feat: polish settings dialog layout and keybinding display

### DIFF
--- a/src/components/common/FormItem.vue
+++ b/src/components/common/FormItem.vue
@@ -1,6 +1,6 @@
 <!-- A generalized form item for rendering in a form. -->
 <template>
-  <div class="flex flex-row items-center gap-2">
+  <div class="flex min-h-10 flex-row items-center gap-2">
     <div class="form-label flex grow items-center">
       <span
         :id="`${props.id}-label`"

--- a/src/components/dialog/content/setting/keybinding/KeyComboDisplay.vue
+++ b/src/components/dialog/content/setting/keybinding/KeyComboDisplay.vue
@@ -2,12 +2,12 @@
   <span>
     <template v-for="(sequence, index) in keySequences" :key="index">
       <Tag
-        class="bg-interface-menu-keybind-surface-default text-base-foreground"
+        class="min-w-6 justify-center bg-interface-menu-keybind-surface-default text-center font-normal text-base-foreground"
         :severity="isModified ? 'info' : 'secondary'"
       >
         {{ sequence }}
       </Tag>
-      <span v-if="index < keySequences.length - 1" class="px-2">+</span>
+      <span v-if="index < keySequences.length - 1" class="px-0.5" />
     </template>
   </span>
 </template>

--- a/src/platform/keybindings/keyCombo.ts
+++ b/src/platform/keybindings/keyCombo.ts
@@ -84,7 +84,7 @@ export class KeyComboImpl implements KeyCombo {
     if (this.shift) {
       sequences.push('Shift')
     }
-    sequences.push(this.key)
+    sequences.push(this.key.length === 1 ? this.key.toUpperCase() : this.key)
     return sequences
   }
 }

--- a/src/platform/settings/components/SettingDialog.vue
+++ b/src/platform/settings/components/SettingDialog.vue
@@ -57,26 +57,37 @@
     </template>
 
     <template #content>
-      <template v-if="activePanel">
-        <Suspense>
-          <component :is="activePanel.component" v-bind="activePanel.props" />
-          <template #fallback>
-            <div>
-              {{ $t('g.loadingPanel', { panel: activePanel.node.label }) }}
-            </div>
-          </template>
-        </Suspense>
-      </template>
-      <template v-else-if="inSearch">
-        <SettingsPanel :setting-groups="searchResults" />
-      </template>
-      <template v-else-if="activeSettingCategory">
-        <CurrentUserMessage v-if="activeSettingCategory.label === 'Comfy'" />
-        <ColorPaletteMessage
-          v-if="activeSettingCategory.label === 'Appearance'"
-        />
-        <SettingsPanel :setting-groups="sortedGroups(activeSettingCategory)" />
-      </template>
+      <div
+        :class="
+          cn(
+            'mx-auto w-full text-sm',
+            activeCategoryKey !== 'keybinding' && 'max-w-3xl'
+          )
+        "
+      >
+        <template v-if="activePanel">
+          <Suspense>
+            <component :is="activePanel.component" v-bind="activePanel.props" />
+            <template #fallback>
+              <div>
+                {{ $t('g.loadingPanel', { panel: activePanel.node.label }) }}
+              </div>
+            </template>
+          </Suspense>
+        </template>
+        <template v-else-if="inSearch">
+          <SettingsPanel :setting-groups="searchResults" />
+        </template>
+        <template v-else-if="activeSettingCategory">
+          <CurrentUserMessage v-if="activeSettingCategory.label === 'Comfy'" />
+          <ColorPaletteMessage
+            v-if="activeSettingCategory.label === 'Appearance'"
+          />
+          <SettingsPanel
+            :setting-groups="sortedGroups(activeSettingCategory)"
+          />
+        </template>
+      </div>
     </template>
   </BaseModalLayout>
 </template>
@@ -101,6 +112,7 @@ import type {
   SettingParams
 } from '@/platform/settings/types'
 import { OnCloseKey } from '@/types/widgetTypes'
+import { cn } from '@/utils/tailwindUtil'
 import { flattenTree } from '@/utils/treeUtil'
 
 const { onClose, defaultPanel, scrollToSettingId } = defineProps<{

--- a/src/platform/settings/components/SettingGroup.vue
+++ b/src/platform/settings/components/SettingGroup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="setting-group">
-    <Divider v-if="divider" />
-    <h3>
+    <div v-if="divider" class="my-8 border-t border-border-default" />
+    <h3 class="text-base">
       <span v-if="group.category" class="text-muted">
         {{
           $t(
@@ -19,7 +19,7 @@
       v-for="setting in group.settings.filter((s) => !s.deprecated)"
       :key="setting.id"
       :data-setting-id="setting.id"
-      class="setting-item mb-4"
+      class="setting-item mb-2"
     >
       <SettingItem :setting="setting" />
     </div>
@@ -27,8 +27,6 @@
 </template>
 
 <script setup lang="ts">
-import Divider from 'primevue/divider'
-
 import SettingItem from '@/platform/settings/components/SettingItem.vue'
 import type { SettingParams } from '@/platform/settings/types'
 import { normalizeI18nKey } from '@/utils/formatUtil'


### PR DESCRIPTION
For reference only. Here are the changes I was thinking about to increase readability for the Settings dialog. It reverts the settings dialog back to the full-width it was prior, but adds a max-width to the content for all tabs except the "Keybinding" tab.

- Add max-width (768px) to settings content (excluded for Keybinding tab)
- Reduce settings content font size from 16px to 14px for consistency with UI elsewhere
- Explicit text-base for section headers  ->  Needs clean up in formatting
- Increase spacing between setting sections with cleaner dividers for decluttering
- Consistent min-height for all form items (toggle, slider, dropdown)
- Capitalize single-letter keybinding badges
- Remove '+' separator between keybinding badges
- Unbold keybinding badges with fixed min-width

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11212-feat-polish-settings-dialog-layout-and-keybinding-display-3426d73d365081358021c0b8cd96458e) by [Unito](https://www.unito.io)
