### PR TITLE
ops: add patch release support to ComfyUI release workflow

### DIFF
--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -1,14 +1,23 @@
-# Automated bi-weekly workflow to bump ComfyUI frontend RC releases
-name: 'Release: Bi-weekly ComfyUI'
+# Release workflow for ComfyUI frontend: version bump → PyPI publish → ComfyUI PR.
+# Runs on a bi-weekly schedule for minor releases, or manually for patch/hotfix releases.
+name: 'Release: ComfyUI'
 
 on:
-  # Schedule for Monday at 12:00 PM PST (20:00 UTC)
+  # Bi-weekly schedule: Monday at 12:00 PM PST (20:00 UTC)
   schedule:
     - cron: '0 20 * * 1'
 
-  # Allow manual triggering (bypasses bi-weekly check)
+  # Manual trigger for both on-demand minor and patch/hotfix releases
   workflow_dispatch:
     inputs:
+      release_type:
+        description: 'minor = next minor version (bi-weekly cadence), patch = hotfix for current production version'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - minor
+          - patch
       comfyui_fork:
         description: 'ComfyUI fork to use for PR (e.g., Comfy-Org/ComfyUI)'
         required: false
@@ -41,10 +50,11 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Bi-weekly Check" >> $GITHUB_STEP_SUMMARY
+          echo "## Release Check" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- Is release week: ${{ steps.check.outputs.is_release_week }}" >> $GITHUB_STEP_SUMMARY
           echo "- Manual trigger: ${{ github.event_name == 'workflow_dispatch' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Release type: ${{ inputs.release_type || 'minor (scheduled)' }}" >> $GITHUB_STEP_SUMMARY
 
   resolve-version:
     needs: check-release-week
@@ -89,6 +99,8 @@ jobs:
       - name: Resolve release information
         id: resolve
         working-directory: frontend
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type || 'minor' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -3,7 +3,7 @@
 name: 'Release: ComfyUI'
 
 on:
-  # Bi-weekly schedule: Monday at 12:00 PM PST (20:00 UTC)
+  # Bi-weekly schedule: Monday at 20:00 UTC
   schedule:
     - cron: '0 20 * * 1'
 

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -140,7 +140,14 @@ function resolveRelease(
   // Determine target branch based on release type:
   //   'patch' → target current minor (hotfix for production version)
   //   'minor' → try next minor, fall back to current minor (bi-weekly cadence)
-  const releaseType = process.env.RELEASE_TYPE?.trim() || 'minor'
+  const releaseTypeInput = process.env.RELEASE_TYPE?.trim().toLowerCase() || 'minor'
+  if (releaseTypeInput !== 'minor' && releaseTypeInput !== 'patch') {
+    console.error(
+      `Invalid RELEASE_TYPE: "${releaseTypeInput}". Expected "minor" or "patch"`
+    )
+    return null
+  }
+  const releaseType: 'minor' | 'patch' = releaseTypeInput
   let targetMinor: number
   let targetBranch: string
 
@@ -174,7 +181,7 @@ function resolveRelease(
     )
 
     if (!nextMinorExists) {
-      // Fall back to current minor for patch releases
+      // Fall back to current minor for minor release
       targetMinor = currentMinor
       targetBranch = `core/1.${targetMinor}`
 
@@ -191,7 +198,7 @@ function resolveRelease(
       }
 
       console.error(
-        `Next minor branch core/1.${currentMinor + 1} not found, falling back to core/1.${currentMinor} for patch release`
+        `Next minor branch core/1.${currentMinor + 1} not found, falling back to core/1.${currentMinor} for minor release`
       )
     }
   }

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -137,35 +137,63 @@ function resolveRelease(
   // Fetch all branches
   exec('git fetch origin', frontendRepoPath)
 
-  // Try next minor first, fall back to current minor if not available
-  let targetMinor = currentMinor + 1
-  let targetBranch = `core/1.${targetMinor}`
+  // Determine target branch based on release type:
+  //   'patch' → target current minor (hotfix for production version)
+  //   'minor' → try next minor, fall back to current minor (bi-weekly cadence)
+  const releaseType = process.env.RELEASE_TYPE?.trim() || 'minor'
+  let targetMinor: number
+  let targetBranch: string
 
-  const nextMinorExists = exec(
-    `git rev-parse --verify origin/${targetBranch}`,
-    frontendRepoPath
-  )
-
-  if (!nextMinorExists) {
-    // Fall back to current minor for patch releases
+  if (releaseType === 'patch') {
     targetMinor = currentMinor
     targetBranch = `core/1.${targetMinor}`
 
-    const currentMinorExists = exec(
+    const branchExists = exec(
       `git rev-parse --verify origin/${targetBranch}`,
       frontendRepoPath
     )
 
-    if (!currentMinorExists) {
+    if (!branchExists) {
       console.error(
-        `Neither core/1.${currentMinor + 1} nor core/1.${currentMinor} branches exist in frontend repo`
+        `Patch release requested but branch ${targetBranch} does not exist`
       )
       return null
     }
 
     console.error(
-      `Next minor branch core/1.${currentMinor + 1} not found, falling back to core/1.${currentMinor} for patch release`
+      `Patch release: targeting current production branch ${targetBranch}`
     )
+  } else {
+    // Try next minor first, fall back to current minor if not available
+    targetMinor = currentMinor + 1
+    targetBranch = `core/1.${targetMinor}`
+
+    const nextMinorExists = exec(
+      `git rev-parse --verify origin/${targetBranch}`,
+      frontendRepoPath
+    )
+
+    if (!nextMinorExists) {
+      // Fall back to current minor for patch releases
+      targetMinor = currentMinor
+      targetBranch = `core/1.${targetMinor}`
+
+      const currentMinorExists = exec(
+        `git rev-parse --verify origin/${targetBranch}`,
+        frontendRepoPath
+      )
+
+      if (!currentMinorExists) {
+        console.error(
+          `Neither core/1.${currentMinor + 1} nor core/1.${currentMinor} branches exist in frontend repo`
+        )
+        return null
+      }
+
+      console.error(
+        `Next minor branch core/1.${currentMinor + 1} not found, falling back to core/1.${currentMinor} for patch release`
+      )
+    }
   }
 
   // Get latest patch tag for target minor

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -299,7 +299,7 @@ if (!releaseInfo) {
 }
 
 // Output as JSON for GitHub Actions
-
+// oxlint-disable-next-line no-console -- stdout is captured by the workflow
 console.log(JSON.stringify(releaseInfo, null, 2))
 
 export { resolveRelease }


### PR DESCRIPTION
## Summary

Add `release_type` input (`minor`/`patch`) to the release workflow so patch releases can target the current production branch instead of always preferring the next minor.

## Problem

When a patch release is needed for `core/1.42` but `core/1.43` already exists, the resolver always prefers `1.43`. There was no way to do a patch release with PyPI publish + ComfyUI PR for the current production version.

## Changes

- Rename workflow from "Release: Bi-weekly ComfyUI" → "Release: ComfyUI" (serves both cadences)
- Add `release_type` choice input: `minor` (default, bi-weekly) vs `patch` (hotfix for current production version)
- Update `resolve-comfyui-release.ts` to read `RELEASE_TYPE` env var for branch targeting
- Scheduled runs continue to work as before (default to `minor`)

## Usage

```bash
# Bi-weekly minor release (or just let the schedule run)
gh workflow run release-biweekly-comfyui.yaml --ref main

# Patch release for current production version
gh workflow run release-biweekly-comfyui.yaml --ref main --field release_type=patch
```

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11223-ops-add-patch-release-support-to-ComfyUI-release-workflow-3426d73d365081498c15ff978a7f1116) by [Unito](https://www.unito.io)
