### PR TITLE
fix(ci): resolve pnpm version in release workflow for frontend/ checkout path

### DIFF
--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          package_json_file: frontend/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/scripts/cicd/resolve-comfyui-release.ts
+++ b/scripts/cicd/resolve-comfyui-release.ts
@@ -140,7 +140,8 @@ function resolveRelease(
   // Determine target branch based on release type:
   //   'patch' → target current minor (hotfix for production version)
   //   'minor' → try next minor, fall back to current minor (bi-weekly cadence)
-  const releaseTypeInput = process.env.RELEASE_TYPE?.trim().toLowerCase() || 'minor'
+  const releaseTypeInput =
+    process.env.RELEASE_TYPE?.trim().toLowerCase() || 'minor'
   if (releaseTypeInput !== 'minor' && releaseTypeInput !== 'patch') {
     console.error(
       `Invalid RELEASE_TYPE: "${releaseTypeInput}". Expected "minor" or "patch"`


### PR DESCRIPTION
The release workflow checks out to `frontend/` subdirectory, but `pnpm/action-setup` looks for `package.json` at the repo root by default. This causes `No pnpm version is specified` failures.

Adds `package_json_file: frontend/package.json` so the action can read the `packageManager` field. Same pattern used in #10972 for the version-bump workflow.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11224-fix-ci-resolve-pnpm-version-in-release-workflow-for-frontend-checkout-path-3426d73d365081c28d16cb01bf8218ef) by [Unito](https://www.unito.io)
