### PR TITLE
fix: add packageManager field to unblock cloud asset predeploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@comfyorg/comfyui-frontend",
   "version": "1.42.6",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "description": "Official front-end implementation of ComfyUI",
   "homepage": "https://comfy.org",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
## Problem

`pnpm/action-setup@v5` requires the `packageManager` field in `package.json` to detect which pnpm version to install. This field was added to `main` after `cloud/1.42` was cut, so **every predeploy build for `cloud/1.42` has been failing**, which means testcloud has been stuck on `26b1ce2` despite 15 newer backport commits landing on the branch.

## Fix

Add `"packageManager": "pnpm@10.33.0"` to `package.json`, matching `main`.

## Impact

Once merged, the push to `cloud/1.42` will trigger `cloud-dispatch-build.yaml` → `frontend-asset-predeploy.yml`, which will:
1. Build the frontend assets
2. Upload to GCS (test + stg + prod buckets)
3. Auto-update the testcloud overlay to the branch tip

Then the staging deploy workflow will pick up the new SHA.