### PR TITLE
fix: add packageManager field to unblock asset predeploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@comfyorg/comfyui-frontend",
   "version": "1.42.10",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "description": "Official front-end implementation of ComfyUI",
   "homepage": "https://comfy.org",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
Same fix as #11225 but for `core/1.42`.

`pnpm/action-setup@v5` requires `packageManager` in `package.json`. This field exists on `main` but was never backported to the 1.42 release branches, causing predeploy builds to fail.