### PR TITLE
test: Improve speed of app mode input corruption test

### DIFF
--- a/browser_tests/assets/linear-basic-app-1.json
+++ b/browser_tests/assets/linear-basic-app-1.json
@@ -1,0 +1,154 @@
+{
+  "last_node_id": 9,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [413, 389],
+      "size": [425.27801513671875, 180.6060791015625],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [{ "name": "clip", "type": "CLIP", "link": 5 }],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [6],
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": ["text, watermark"]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [415, 186],
+      "size": [422.84503173828125, 164.31304931640625],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [{ "name": "clip", "type": "CLIP", "link": 3 }],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [4],
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [473, 609],
+      "size": [315, 106],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": [2], "slot_index": 0 }
+      ],
+      "properties": {},
+      "widgets_values": [512, 512, 1]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [863, 186],
+      "size": [315, 262],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        { "name": "model", "type": "MODEL", "link": 1 },
+        { "name": "positive", "type": "CONDITIONING", "link": 4 },
+        { "name": "negative", "type": "CONDITIONING", "link": 6 },
+        { "name": "latent_image", "type": "LATENT", "link": 2 }
+      ],
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": [7], "slot_index": 0 }
+      ],
+      "properties": {},
+      "widgets_values": [156680208700286, true, 20, 8, "euler", "normal", 1]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [1209, 188],
+      "size": [210, 46],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        { "name": "samples", "type": "LATENT", "link": 7 },
+        { "name": "vae", "type": "VAE", "link": 8 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [9], "slot_index": 0 }
+      ],
+      "properties": {}
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [1451, 189],
+      "size": [210, 26],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [{ "name": "images", "type": "IMAGE", "link": 9 }],
+      "properties": {}
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [26, 474],
+      "size": [315, 98],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "outputs": [
+        { "name": "MODEL", "type": "MODEL", "links": [1], "slot_index": 0 },
+        { "name": "CLIP", "type": "CLIP", "links": [3, 5], "slot_index": 1 },
+        { "name": "VAE", "type": "VAE", "links": [8], "slot_index": 2 }
+      ],
+      "properties": {},
+      "widgets_values": ["v1-5-pruned-emaonly-fp16.safetensors"]
+    }
+  ],
+  "links": [
+    [1, 4, 0, 3, 0, "MODEL"],
+    [2, 5, 0, 3, 3, "LATENT"],
+    [3, 4, 1, 6, 0, "CLIP"],
+    [4, 6, 0, 3, 1, "CONDITIONING"],
+    [5, 4, 1, 7, 0, "CLIP"],
+    [6, 7, 0, 3, 2, "CONDITIONING"],
+    [7, 3, 0, 8, 0, "LATENT"],
+    [8, 4, 2, 8, 1, "VAE"],
+    [9, 8, 0, 9, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    },
+    "linearData": {
+      "inputs": [
+        ["3", "seed"],
+        ["3", "steps"],
+        ["3", "cfg"]
+      ],
+      "outputs": ["9"]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/linear-basic-app-2.json
+++ b/browser_tests/assets/linear-basic-app-2.json
@@ -1,0 +1,153 @@
+{
+  "last_node_id": 9,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [413, 389],
+      "size": [425.27801513671875, 180.6060791015625],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [{ "name": "clip", "type": "CLIP", "link": 5 }],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [6],
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": ["text, watermark"]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [415, 186],
+      "size": [422.84503173828125, 164.31304931640625],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [{ "name": "clip", "type": "CLIP", "link": 3 }],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [4],
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [473, 609],
+      "size": [315, 106],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": [2], "slot_index": 0 }
+      ],
+      "properties": {},
+      "widgets_values": [512, 512, 1]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [863, 186],
+      "size": [315, 262],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        { "name": "model", "type": "MODEL", "link": 1 },
+        { "name": "positive", "type": "CONDITIONING", "link": 4 },
+        { "name": "negative", "type": "CONDITIONING", "link": 6 },
+        { "name": "latent_image", "type": "LATENT", "link": 2 }
+      ],
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": [7], "slot_index": 0 }
+      ],
+      "properties": {},
+      "widgets_values": [156680208700286, true, 20, 8, "euler", "normal", 1]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [1209, 188],
+      "size": [210, 46],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        { "name": "samples", "type": "LATENT", "link": 7 },
+        { "name": "vae", "type": "VAE", "link": 8 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [9], "slot_index": 0 }
+      ],
+      "properties": {}
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [1451, 189],
+      "size": [210, 26],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [{ "name": "images", "type": "IMAGE", "link": 9 }],
+      "properties": {}
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [26, 474],
+      "size": [315, 98],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "outputs": [
+        { "name": "MODEL", "type": "MODEL", "links": [1], "slot_index": 0 },
+        { "name": "CLIP", "type": "CLIP", "links": [3, 5], "slot_index": 1 },
+        { "name": "VAE", "type": "VAE", "links": [8], "slot_index": 2 }
+      ],
+      "properties": {},
+      "widgets_values": ["v1-5-pruned-emaonly-fp16.safetensors"]
+    }
+  ],
+  "links": [
+    [1, 4, 0, 3, 0, "MODEL"],
+    [2, 5, 0, 3, 3, "LATENT"],
+    [3, 4, 1, 6, 0, "CLIP"],
+    [4, 6, 0, 3, 1, "CONDITIONING"],
+    [5, 4, 1, 7, 0, "CLIP"],
+    [6, 7, 0, 3, 2, "CONDITIONING"],
+    [7, 3, 0, 8, 0, "LATENT"],
+    [8, 4, 2, 8, 1, "VAE"],
+    [9, 8, 0, 9, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "offset": [0, 0],
+      "scale": 1
+    },
+    "linearData": {
+      "inputs": [
+        ["3", "seed"],
+        ["3", "steps"]
+      ],
+      "outputs": ["9"]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/fixtures/helpers/WorkflowHelper.ts
+++ b/browser_tests/fixtures/helpers/WorkflowHelper.ts
@@ -175,6 +175,11 @@ export class WorkflowHelper {
     )
   }
 
+  async switchToTab(tabName: string): Promise<void> {
+    await this.comfyPage.menu.topbar.getWorkflowTab(tabName).click()
+    await this.waitForWorkflowIdle()
+  }
+
   async getExportedWorkflow(options: { api: true }): Promise<ComfyApiWorkflow>
   async getExportedWorkflow(options?: {
     api?: false

--- a/browser_tests/helpers/builderTestUtils.ts
+++ b/browser_tests/helpers/builderTestUtils.ts
@@ -122,21 +122,3 @@ export async function saveAndReopenInAppMode(
 
   await comfyPage.appMode.toggleAppMode()
 }
-
-/**
- * Enter builder, select the given widgets as inputs + SaveImage as output,
- * save as an app, and close the success dialog.
- *
- * Returns on the builder arrange/preview step.
- */
-export async function createAndSaveApp(
-  comfyPage: ComfyPage,
-  appName: string,
-  widgetNames: string[] = ['seed']
-): Promise<void> {
-  await setupBuilder(comfyPage, undefined, widgetNames)
-  await comfyPage.appMode.steps.goToPreview()
-  await builderSaveAs(comfyPage.appMode, appName)
-  await comfyPage.appMode.saveAs.closeButton.click()
-  await comfyPage.nextFrame()
-}

--- a/browser_tests/tests/builderReorder.spec.ts
+++ b/browser_tests/tests/builderReorder.spec.ts
@@ -2,11 +2,10 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import type { AppModeHelper } from '@e2e/fixtures/helpers/AppModeHelper'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   builderSaveAs,
-  createAndSaveApp,
   openWorkflowFromSidebar,
   setupBuilder
 } from '@e2e/helpers/builderTestUtils'
@@ -160,22 +159,20 @@ test.describe('Builder input reordering', { tag: '@ui' }, () => {
     comfyPage
   }) => {
     const { appMode } = comfyPage
-    const suffix = String(Date.now())
-    const app1Name = `app1-${suffix}`
-    const app2Name = `app2-${suffix}`
     const app2Widgets = ['seed', 'steps']
 
-    // Create and save app1 with [seed, steps, cfg]
-    await createAndSaveApp(comfyPage, app1Name, WIDGETS)
-    await appMode.footer.exitBuilder()
+    // Load app1 with [seed, steps, cfg]
+    await comfyPage.workflow.loadWorkflow('linear-basic-app-1')
+    // Load app2 with [seed, steps]
+    await comfyPage.workflow.loadWorkflow('linear-basic-app-2')
 
-    // Create app2 in a new tab so both apps are open simultaneously
-    await comfyPage.menu.topbar.triggerTopbarCommand(['New'])
-    await createAndSaveApp(comfyPage, app2Name, app2Widgets)
-    await appMode.footer.exitBuilder()
+    const switchToWorkflow = async (name: string) => {
+      await comfyPage.menu.topbar.getWorkflowTab(name).click()
+      await comfyPage.workflow.waitForWorkflowIdle()
+    }
 
     // Switch to app1 tab and enter builder
-    await comfyPage.menu.topbar.getWorkflowTab(app1Name).click()
+    await switchToWorkflow('linear-basic-app-1')
     await appMode.enterBuilder()
     await appMode.steps.goToInputs()
     await expect(appMode.select.inputItemTitles).toHaveText(WIDGETS)
@@ -187,7 +184,7 @@ test.describe('Builder input reordering', { tag: '@ui' }, () => {
 
     // Switch to app2 tab and enter builder
     await appMode.footer.exitBuilder()
-    await comfyPage.menu.topbar.getWorkflowTab(app2Name).click()
+    await switchToWorkflow('linear-basic-app-2')
     await appMode.enterBuilder()
     await appMode.steps.goToInputs()
 
@@ -196,10 +193,9 @@ test.describe('Builder input reordering', { tag: '@ui' }, () => {
 
     // Switch back to app1 and verify reorder persisted
     await appMode.footer.exitBuilder()
-    await comfyPage.menu.topbar.getWorkflowTab(app1Name).click()
+    await switchToWorkflow('linear-basic-app-1')
     await appMode.enterBuilder()
     await appMode.steps.goToInputs()
-
     await expect(appMode.select.inputItemTitles).toHaveText(app1Reordered)
   })
 })

--- a/browser_tests/tests/builderReorder.spec.ts
+++ b/browser_tests/tests/builderReorder.spec.ts
@@ -160,42 +160,37 @@ test.describe('Builder input reordering', { tag: '@ui' }, () => {
   }) => {
     const { appMode } = comfyPage
     const app2Widgets = ['seed', 'steps']
-
-    // Load app1 with [seed, steps, cfg]
-    await comfyPage.workflow.loadWorkflow('linear-basic-app-1')
-    // Load app2 with [seed, steps]
-    await comfyPage.workflow.loadWorkflow('linear-basic-app-2')
-
-    const switchToWorkflow = async (name: string) => {
-      await comfyPage.menu.topbar.getWorkflowTab(name).click()
-      await comfyPage.workflow.waitForWorkflowIdle()
-    }
-
-    // Switch to app1 tab and enter builder
-    await switchToWorkflow('linear-basic-app-1')
-    await appMode.enterBuilder()
-    await appMode.steps.goToInputs()
-    await expect(appMode.select.inputItemTitles).toHaveText(WIDGETS)
-
-    // Reorder app1 inputs: drag 'seed' from first to last
-    await appMode.select.dragInputItem(0, 2)
     const app1Reordered = ['steps', 'cfg', 'seed']
-    await expect(appMode.select.inputItemTitles).toHaveText(app1Reordered)
 
-    // Switch to app2 tab and enter builder
-    await appMode.footer.exitBuilder()
-    await switchToWorkflow('linear-basic-app-2')
-    await appMode.enterBuilder()
-    await appMode.steps.goToInputs()
+    await test.step('Load both apps', async () => {
+      await comfyPage.workflow.loadWorkflow('linear-basic-app-1')
+      await comfyPage.workflow.loadWorkflow('linear-basic-app-2')
+    })
 
-    // Verify app2 inputs are not corrupted — still [seed, steps]
-    await expect(appMode.select.inputItemTitles).toHaveText(app2Widgets)
+    await test.step('Reorder app1 inputs', async () => {
+      await comfyPage.workflow.switchToTab('linear-basic-app-1')
+      await appMode.enterBuilder()
+      await appMode.steps.goToInputs()
+      await expect(appMode.select.inputItemTitles).toHaveText(WIDGETS)
 
-    // Switch back to app1 and verify reorder persisted
-    await appMode.footer.exitBuilder()
-    await switchToWorkflow('linear-basic-app-1')
-    await appMode.enterBuilder()
-    await appMode.steps.goToInputs()
-    await expect(appMode.select.inputItemTitles).toHaveText(app1Reordered)
+      await appMode.select.dragInputItem(0, 2)
+      await expect(appMode.select.inputItemTitles).toHaveText(app1Reordered)
+    })
+
+    await test.step('Verify app2 inputs are not corrupted', async () => {
+      await appMode.footer.exitBuilder()
+      await comfyPage.workflow.switchToTab('linear-basic-app-2')
+      await appMode.enterBuilder()
+      await appMode.steps.goToInputs()
+      await expect(appMode.select.inputItemTitles).toHaveText(app2Widgets)
+    })
+
+    await test.step('Verify app1 reorder persisted', async () => {
+      await appMode.footer.exitBuilder()
+      await comfyPage.workflow.switchToTab('linear-basic-app-1')
+      await appMode.enterBuilder()
+      await appMode.steps.goToInputs()
+      await expect(appMode.select.inputItemTitles).toHaveText(app1Reordered)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Speeds up test that was timing out https://9b579efd.comfyui-playwright-chromium.pages.dev/#?testId=b97e313f05078cede9be-5e6b75a76880fb6a5d96

## Changes

- **What**:
- load prebuilt workflows to reduce test time (17s -> 11s)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11236-test-Improve-speed-of-app-mode-input-corruption-test-3426d73d3650815b9475ec96dfbd7ad5) by [Unito](https://www.unito.io)
