### PR TITLE
test: Remove unnecessary setup, UseNewMenu and waitForNodes calls

### DIFF
--- a/browser_tests/tests/browserTabTitle.spec.ts
+++ b/browser_tests/tests/browserTabTitle.spec.ts
@@ -5,10 +5,6 @@ import type { WorkspaceStore } from '@e2e/types/globals'
 
 test.describe('Browser tab title', { tag: '@smoke' }, () => {
   test.describe('Beta Menu', () => {
-    test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-    })
-
     test('Can display workflow name', async ({ comfyPage }) => {
       const workflowName = await comfyPage.page.evaluate(async () => {
         return (window.app!.extensionManager as WorkspaceStore).workflow

--- a/browser_tests/tests/dialogs/queueClearHistory.spec.ts
+++ b/browser_tests/tests/dialogs/queueClearHistory.spec.ts
@@ -5,7 +5,6 @@ import {
 
 test.describe('Queue Clear History Dialog', { tag: '@ui' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
     await comfyPage.queuePanel.overlayToggle.click()
   })
 

--- a/browser_tests/tests/focusMode.spec.ts
+++ b/browser_tests/tests/focusMode.spec.ts
@@ -4,10 +4,6 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Focus Mode', { tag: '@ui' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-  })
-
   test('Focus mode hides UI chrome', async ({ comfyPage }) => {
     await expect(comfyPage.menu.sideToolbar).toBeVisible()
 

--- a/browser_tests/tests/jobHistoryActions.spec.ts
+++ b/browser_tests/tests/jobHistoryActions.spec.ts
@@ -7,8 +7,6 @@ import {
 
 test.describe('Job History Actions', { tag: '@ui' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-
     // Expand the queue overlay so the JobHistoryActionsMenu is visible
     await comfyPage.page.getByTestId('queue-overlay-toggle').click()
   })

--- a/browser_tests/tests/linearMode.spec.ts
+++ b/browser_tests/tests/linearMode.spec.ts
@@ -4,10 +4,6 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Linear Mode', { tag: '@ui' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-  })
-
   test('Displays linear controls when app mode active', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/nodeHelp.spec.ts
+++ b/browser_tests/tests/nodeHelp.spec.ts
@@ -87,7 +87,6 @@ async function setLocaleAndWaitForWorkflowReload(
 
 test.describe('Node Help', { tag: ['@slow', '@ui'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
     await comfyPage.settings.setSetting('Comfy.NodeLibrary.NewDesign', false)
   })
 

--- a/browser_tests/tests/rerouteNode.spec.ts
+++ b/browser_tests/tests/rerouteNode.spec.ts
@@ -4,10 +4,6 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { getMiddlePoint } from '@e2e/fixtures/utils/litegraphUtils'
 
 test.describe('Reroute Node', { tag: ['@screenshot', '@node'] }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-  })
-
   test.afterEach(async ({ comfyPage }) => {
     await comfyPage.workflow.setupWorkflowsDirectory({})
   })

--- a/browser_tests/tests/resultGallery.spec.ts
+++ b/browser_tests/tests/resultGallery.spec.ts
@@ -4,10 +4,6 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 test.describe('MediaLightbox', { tag: ['@slow', '@vue-nodes'] }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-  })
-
   async function runAndOpenGallery(comfyPage: ComfyPage) {
     await comfyPage.workflow.loadWorkflow(
       'widgets/save_image_and_animated_webp'

--- a/browser_tests/tests/toastNotifications.spec.ts
+++ b/browser_tests/tests/toastNotifications.spec.ts
@@ -4,10 +4,6 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Toast Notifications', { tag: '@ui' }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-  })
-
   async function triggerErrorToast(comfyPage: {
     page: { evaluate: (fn: () => void) => Promise<void> }
     nextFrame: () => Promise<void>

--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -128,7 +128,6 @@ test.describe('Vue Node Groups', { tag: ['@screenshot', '@vue-nodes'] }, () => {
   })
 
   test('should allow fitting group to contents', async ({ comfyPage }) => {
-    await comfyPage.setup()
     await comfyPage.workflow.loadWorkflow('groups/oversized_group')
     await comfyPage.keyboard.selectAll()
     await comfyPage.command.executeCommand('Comfy.Graph.FitGroupToContents')

--- a/browser_tests/tests/vueNodes/interactions/node/remove.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/remove.spec.ts
@@ -2,24 +2,13 @@ import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
-test.beforeEach(async ({ comfyPage }) => {
-  await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
-})
-
 test.describe(
   'Vue Nodes - Delete Key Interaction',
   { tag: '@vue-nodes' },
   () => {
-    test.beforeEach(async ({ comfyPage }) => {
-      await comfyPage.settings.setSetting('Comfy.Graph.CanvasMenu', false)
-      await comfyPage.setup()
-    })
-
     test('Can select all and delete Vue nodes with Delete key', async ({
       comfyPage
     }) => {
-      await comfyPage.vueNodes.waitForNodes()
-
       // Get initial Vue node count
       await expect
         .poll(() => comfyPage.vueNodes.getNodeCount())
@@ -44,8 +33,6 @@ test.describe(
     test('Can select specific Vue node and delete it', async ({
       comfyPage
     }) => {
-      await comfyPage.vueNodes.waitForNodes()
-
       // Get initial Vue node count
       await expect
         .poll(() => comfyPage.vueNodes.getNodeCount())
@@ -71,8 +58,6 @@ test.describe(
     test('Can select and delete Vue node with Backspace key', async ({
       comfyPage
     }) => {
-      await comfyPage.vueNodes.waitForNodes()
-
       const initialNodeCount = await comfyPage.vueNodes.getNodeCount()
 
       // Select first Vue node
@@ -114,8 +99,6 @@ test.describe(
     test('Delete key does not delete node when nothing is selected', async ({
       comfyPage
     }) => {
-      await comfyPage.vueNodes.waitForNodes()
-
       // Ensure no Vue nodes are selected
       await comfyPage.vueNodes.clearSelection()
       await expect(comfyPage.vueNodes.selectedNodes).toHaveCount(0)
@@ -132,7 +115,6 @@ test.describe(
     test('Can multi-select with Ctrl+click and delete multiple Vue nodes', async ({
       comfyPage
     }) => {
-      await comfyPage.vueNodes.waitForNodes()
       const initialNodeCount = await comfyPage.vueNodes.getNodeCount()
 
       // Multi-select first two Vue nodes using Ctrl+click

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -9,7 +9,6 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
   test('should display error state when node is missing (node from workflow is not installed)', async ({
     comfyPage
   }) => {
-    await comfyPage.setup()
     await comfyPage.workflow.loadWorkflow('missing/missing_nodes')
 
     // Expect error state on missing unknown node
@@ -23,7 +22,6 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
   test('should display error state when node causes execution error', async ({
     comfyPage
   }) => {
-    await comfyPage.setup()
     await comfyPage.workflow.loadWorkflow('nodes/execution_error')
     await comfyPage.runButton.click()
 

--- a/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
@@ -6,7 +6,6 @@ import { TestIds } from '@e2e/fixtures/selectors'
 
 test.describe('Vue Upload Widgets', { tag: '@vue-nodes' }, () => {
   test('should hide canvas-only upload buttons', async ({ comfyPage }) => {
-    await comfyPage.setup()
     await comfyPage.workflow.loadWorkflow('widgets/all_load_widgets')
     await comfyPage.vueNodes.waitForNodes()
 


### PR DESCRIPTION
## Summary

More simplification

## Changes

- **What**: 
- Remove more UseNewMenu settings calls
- Remove `await comfyPage.setup()`
- Remove `waitForNodes` in vue node tagged tests

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11237-test-Remove-unnecessary-setup-UseNewMenu-and-waitForNodes-calls-3426d73d36508198a100c218420d479c) by [Unito](https://www.unito.io)
