### PR TITLE
test: Auto wait for nodes after loadWorkflow in vue-node tests

### DIFF
--- a/browser_tests/fixtures/helpers/WorkflowHelper.ts
+++ b/browser_tests/fixtures/helpers/WorkflowHelper.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'fs'
 
+import { test } from '@playwright/test'
+
 import type { AppMode } from '@/composables/useAppMode'
 import type {
   ComfyApiWorkflow,
@@ -73,6 +75,9 @@ export class WorkflowHelper {
       assetPath(`${workflowName}.json`)
     )
     await this.comfyPage.nextFrame()
+    if (test.info().tags.includes('@vue-nodes')) {
+      await this.comfyPage.vueNodes.waitForNodes()
+    }
   }
 
   async deleteWorkflow(

--- a/browser_tests/tests/collapsedNodeLinks.spec.ts
+++ b/browser_tests/tests/collapsedNodeLinks.spec.ts
@@ -12,7 +12,6 @@ test.describe(
   () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.workflow.loadWorkflow('default')
-      await comfyPage.vueNodes.waitForNodes()
     })
 
     test.afterEach(async ({ comfyPage }) => {

--- a/browser_tests/tests/imageCompare.spec.ts
+++ b/browser_tests/tests/imageCompare.spec.ts
@@ -7,7 +7,6 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 test.describe('Image Compare', { tag: ['@widget', '@vue-nodes'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.workflow.loadWorkflow('widgets/image_compare_widget')
-    await comfyPage.vueNodes.waitForNodes()
   })
 
   function createTestImageDataUrl(label: string, color: string): string {

--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -6,7 +6,6 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
   async function loadImageOnNode(comfyPage: ComfyPage) {
     await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
-    await comfyPage.vueNodes.waitForNodes()
 
     const loadImageNode = (
       await comfyPage.nodeOps.getNodeRefsByType('LoadImage')

--- a/browser_tests/tests/painter.spec.ts
+++ b/browser_tests/tests/painter.spec.ts
@@ -13,7 +13,6 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.page.evaluate(() => window.app?.graph?.clear())
     await comfyPage.workflow.loadWorkflow('widgets/painter_widget')
-    await comfyPage.vueNodes.waitForNodes()
   })
 
   test(

--- a/browser_tests/tests/resultGallery.spec.ts
+++ b/browser_tests/tests/resultGallery.spec.ts
@@ -12,7 +12,6 @@ test.describe('MediaLightbox', { tag: ['@slow', '@vue-nodes'] }, () => {
     await comfyPage.workflow.loadWorkflow(
       'widgets/save_image_and_animated_webp'
     )
-    await comfyPage.vueNodes.waitForNodes()
     await comfyPage.runButton.click()
 
     // Wait for SaveImage node to produce output

--- a/browser_tests/tests/saveImageAndWebp.spec.ts
+++ b/browser_tests/tests/saveImageAndWebp.spec.ts
@@ -12,7 +12,6 @@ test.describe(
       await comfyPage.workflow.loadWorkflow(
         'widgets/save_image_and_animated_webp'
       )
-      await comfyPage.vueNodes.waitForNodes()
 
       await comfyPage.runButton.click()
 

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -106,7 +106,6 @@ test.describe(
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'default')
       await comfyPage.workflow.loadWorkflow('vueNodes/simple-triple')
-      await comfyPage.vueNodes.waitForNodes()
       await fitToViewInstant(comfyPage)
     })
 

--- a/browser_tests/tests/vueNodes/interactions/node/bringToFront.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/bringToFront.spec.ts
@@ -12,7 +12,6 @@ test.describe(
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
       await comfyPage.workflow.loadWorkflow('vueNodes/simple-triple')
-      await comfyPage.vueNodes.waitForNodes()
       await fitToViewInstant(comfyPage)
     })
 

--- a/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
@@ -10,7 +10,6 @@ import {
 test.describe('Vue Nodes Image Preview', { tag: '@vue-nodes' }, () => {
   async function loadImageOnNode(comfyPage: ComfyPage) {
     await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
-    await comfyPage.vueNodes.waitForNodes()
 
     const loadImageNode = (
       await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
@@ -69,7 +68,6 @@ test.describe('Vue Nodes Image Preview', { tag: '@vue-nodes' }, () => {
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-with-multiple-promoted-previews'
       )
-      await comfyPage.vueNodes.waitForNodes()
 
       const firstSubgraphNode = comfyPage.vueNodes.getNodeLocator('7')
       const secondSubgraphNode = comfyPage.vueNodes.getNodeLocator('8')

--- a/browser_tests/tests/vueNodes/nodeStates/colors.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/colors.spec.ts
@@ -41,7 +41,6 @@ test.describe(
 
     test('should load node colors from workflow', async ({ comfyPage }) => {
       await comfyPage.workflow.loadWorkflow('nodes/every_node_color')
-      await comfyPage.vueNodes.waitForNodes()
       await expect(comfyPage.canvas).toHaveScreenshot(
         'vue-node-custom-colors-dark-all-colors.png'
       )
@@ -52,7 +51,6 @@ test.describe(
     }) => {
       await comfyPage.settings.setSetting('Comfy.ColorPalette', 'light')
       await comfyPage.workflow.loadWorkflow('nodes/every_node_color')
-      await comfyPage.vueNodes.waitForNodes()
       await expect(comfyPage.canvas).toHaveScreenshot(
         'vue-node-custom-colors-light-all-colors.png'
       )

--- a/browser_tests/tests/vueNodes/rerouteNodeSize.spec.ts
+++ b/browser_tests/tests/vueNodes/rerouteNodeSize.spec.ts
@@ -7,7 +7,6 @@ test.describe('Vue Reroute Node Size', { tag: '@vue-nodes' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.settings.setSetting('Comfy.Minimap.Visible', false)
     await comfyPage.workflow.loadWorkflow('links/single_connected_reroute_node')
-    await comfyPage.vueNodes.waitForNodes()
   })
 
   test(

--- a/browser_tests/tests/vueNodes/widgets/imageCrop.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/imageCrop.spec.ts
@@ -10,7 +10,6 @@ test.describe('Image Crop', { tag: ['@widget', '@vue-nodes'] }, () => {
   test.describe('without source image', () => {
     test.beforeEach(async ({ comfyPage }) => {
       await comfyPage.workflow.loadWorkflow('widgets/image_crop_widget')
-      await comfyPage.vueNodes.waitForNodes()
     })
 
     test(
@@ -72,7 +71,6 @@ test.describe('Image Crop', { tag: ['@widget', '@vue-nodes'] }, () => {
 
       test.beforeEach(async ({ comfyPage }) => {
         await comfyPage.workflow.loadWorkflow('widgets/image_crop_with_source')
-        await comfyPage.vueNodes.waitForNodes()
         await comfyPage.runButton.click()
         await expect(
           comfyPage.vueNodes.getNodeLocator('2').locator('img')

--- a/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/int/integerWidget.spec.ts
@@ -8,7 +8,6 @@ test.describe('Vue Integer Widget', { tag: '@vue-nodes' }, () => {
     comfyPage
   }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
-    await comfyPage.vueNodes.waitForNodes()
 
     const seedWidget = comfyPage.vueNodes
       .getWidgetByName('KSampler', 'seed')

--- a/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/load/uploadWidgets.spec.ts
@@ -8,7 +8,6 @@ test.describe('Vue Upload Widgets', { tag: '@vue-nodes' }, () => {
   test('should hide canvas-only upload buttons', async ({ comfyPage }) => {
     await comfyPage.setup()
     await comfyPage.workflow.loadWorkflow('widgets/all_load_widgets')
-    await comfyPage.vueNodes.waitForNodes()
 
     await expect(
       comfyPage.page.getByText('choose file to upload', { exact: true })


### PR DESCRIPTION
## Summary

Updates tests to auto wait for vue-nodes when loading a workflow in a test with the vue-nodes tag

## Changes

- **What**: 
- If tag includes vue-nodes, wait 
- Remove all load->wait calls

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11238-test-Auto-wait-for-nodes-after-loadWorkflow-in-vue-node-tests-3426d73d3650810e8760c5601186fde8) by [Unito](https://www.unito.io)
