### PR TITLE
feat: enable node replacement by default

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1238,8 +1238,8 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'When enabled, missing nodes with known replacements will be shown as replaceable in the missing nodes dialog, allowing you to review and apply replacements.',
     type: 'boolean',
-    defaultValue: false,
-    experimental: true,
+    defaultValue: true,
+    experimental: false,
     versionAdded: '1.40.0'
   },
   {


### PR DESCRIPTION
## Summary

Enable node replacement suggestions by default so users see Quick Fix options for deprecated/renamed nodes without toggling an experimental setting.

## Changes

- **What**: Change `Comfy.NodeReplacement.Enabled` default from `false` to `true` and remove `experimental` flag
- **Breaking**: None -- users who previously disabled this setting keep their preference

## Review Focus

This is gated by two additional checks:
1. Server must provide `node_replacements` feature flag as true (PostHog controlled)
2. `GET /api/node_replacements` must return data (cloud PR #2686)

Without both, changing this default alone has no effect. The three gates ensure safe rollout.

## Companion PRs

- Comfy-Org/cloud#2686 -- backend `GET /api/node_replacements` endpoint + server-side validation bypass

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11246-feat-enable-node-replacement-by-default-3436d73d3650818e8c33cf24638d8412) by [Unito](https://www.unito.io)
