### PR TITLE
Show multitype slices of shared color

### DIFF
--- a/browser_tests/tests/vueNodes/slots.spec.ts
+++ b/browser_tests/tests/vueNodes/slots.spec.ts
@@ -1,0 +1,21 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+
+test('Can display a slot mismatched from widget type', async ({
+  comfyPage
+}) => {
+  await comfyPage.page.evaluate(() => {
+    const emptyLatent = window.app!.graph.getNodeById(5)!
+    emptyLatent.inputs[0].type = 'INT,FLOAT'
+  })
+  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
+  const width = comfyPage.vueNodes
+    .getNodeByTitle('Empty Latent')
+    .locator('.lg-node-widget')
+    .first()
+  await expect(width.locator('path[fill*="INT"]')).toBeVisible()
+  await expect(width.locator('path[fill*="FLOAT"]')).toBeVisible()
+})

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -45,6 +45,7 @@ export interface WidgetSlotMetadata {
   linked: boolean
   originNodeId?: string
   originOutputName?: string
+  type: string
 }
 
 /**
@@ -395,7 +396,8 @@ function buildSlotMetadata(
       index,
       linked: input.link != null,
       originNodeId,
-      originOutputName
+      originOutputName,
+      type: String(input.type)
     }
     if (input.name) metadata.set(input.name, slotInfo)
     if (input.widget?.name) metadata.set(input.widget.name, slotInfo)

--- a/src/constants/slotColors.ts
+++ b/src/constants/slotColors.ts
@@ -1,3 +1,5 @@
+export const MAX_MULTITYPE_SLICES = 3
+
 export function getSlotColor(type?: string | number | null): string {
   if (!type) return '#AAA'
   const typeStr = String(type).toUpperCase()

--- a/src/lib/litegraph/src/node/NodeSlot.ts
+++ b/src/lib/litegraph/src/node/NodeSlot.ts
@@ -1,3 +1,4 @@
+import { MAX_MULTITYPE_SLICES } from '@/constants/slotColors'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LabelPosition, SlotShape, SlotType } from '@/lib/litegraph/src/draw'
 import type {
@@ -172,15 +173,16 @@ export abstract class NodeSlot extends SlotBase implements INodeSlot {
           path.arc(pos[0], pos[1], highlight ? 2.5 : 1.5, 0, Math.PI * 2)
           ctx.clip(path, 'evenodd')
         }
+
         const radius = highlight ? 5 : 4
+        const colorMapper = this.isConnected
+          ? colorContext.getConnectedColor
+          : colorContext.getDisconnectedColor
         const types = `${this.type}`
           .split(',')
-          .map(
-            this.isConnected
-              ? (type) => colorContext.getConnectedColor(type)
-              : (type) => colorContext.getDisconnectedColor(type)
-          )
-          .slice(0, 3)
+          .map(colorMapper)
+          .slice(0, MAX_MULTITYPE_SLICES)
+
         if (types.length > 1) {
           doFill = false
           const arcLen = (Math.PI * 2) / types.length

--- a/src/lib/litegraph/src/node/NodeSlot.ts
+++ b/src/lib/litegraph/src/node/NodeSlot.ts
@@ -173,16 +173,14 @@ export abstract class NodeSlot extends SlotBase implements INodeSlot {
           ctx.clip(path, 'evenodd')
         }
         const radius = highlight ? 5 : 4
-        const typesSet = new Set(
-          `${this.type}`
-            .split(',')
-            .map(
-              this.isConnected
-                ? (type) => colorContext.getConnectedColor(type)
-                : (type) => colorContext.getDisconnectedColor(type)
-            )
-        )
-        const types = [...typesSet].slice(0, 3)
+        const types = `${this.type}`
+          .split(',')
+          .map(
+            this.isConnected
+              ? (type) => colorContext.getConnectedColor(type)
+              : (type) => colorContext.getDisconnectedColor(type)
+          )
+          .slice(0, 3)
         if (types.length > 1) {
           doFill = false
           const arcLen = (Math.PI * 2) / types.length

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -41,7 +41,7 @@
             v-if="widget.slotMetadata"
             :slot-data="{
               name: widget.name,
-              type: widget.type,
+              type: widget.slotMetadata.type,
               boundingRect: [0, 0, 0, 0]
             }"
             :node-id="nodeData?.id != null ? String(nodeData.id) : ''"

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -32,10 +32,7 @@ const types = computed(() => {
   //TODO Support connected/disconnected colors?
   if (!props.slotData) return [getSlotColor()]
   if (props.slotData.type === '*') return ['']
-  const typesSet = new Set(
-    `${props.slotData.type}`.split(',').map(getSlotColor)
-  )
-  return [...typesSet].slice(0, 3)
+  return `${props.slotData.type}`.split(',').map(getSlotColor).slice(0, 3)
 })
 
 defineExpose({

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
 
-import { getSlotColor } from '@/constants/slotColors'
+import { getSlotColor, MAX_MULTITYPE_SLICES } from '@/constants/slotColors'
 import type { INodeSlot } from '@/lib/litegraph/src/litegraph'
 import { RenderShape } from '@/lib/litegraph/src/types/globalEnums'
 import { cn } from '@/utils/tailwindUtil'
@@ -32,7 +32,10 @@ const types = computed(() => {
   //TODO Support connected/disconnected colors?
   if (!props.slotData) return [getSlotColor()]
   if (props.slotData.type === '*') return ['']
-  return `${props.slotData.type}`.split(',').map(getSlotColor).slice(0, 3)
+  return `${props.slotData.type}`
+    .split(',')
+    .map(getSlotColor)
+    .slice(0, MAX_MULTITYPE_SLICES)
 })
 
 defineExpose({


### PR DESCRIPTION
A tiny update requested by the backend team.

Previously, multitype slot indicators would have inputs that resolve to the same connection color display be combined into a single slice. For example, both `INT` and `FLOAT` have the same color, so an `INT,FLOAT` slot displays as a solid color instead of 2 semi-circles. This was a conscientious decision to improve readability on slots that allow many types, but meant that the more common cases (like `INT,FLOAT`) would have no indicator at all. Since priority is given to types based on order of listing, node authors can still control which types are elided on a slot accepting many types.

<img width="430" height="320" alt="image" src="https://github.com/user-attachments/assets/1fc7fb1c-a634-487c-bc03-711637aeef13" />

- I do not believe there are any core nodes affected by this change.
- The vue implementation of merging slot colors never functioned properly, but is still removed.
- Vue was bugged to incorrectly pass slot types for widgets. This is also fixed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11250-Show-multitype-slices-of-shared-color-3436d73d365081b6b484ea74423435a1) by [Unito](https://www.unito.io)
