### PR TITLE
test: add unit tests for numberUtil and dateTimeUtil

### DIFF
--- a/src/utils/dateTimeUtil.test.ts
+++ b/src/utils/dateTimeUtil.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  dateKey,
+  formatClockTime,
+  formatShortMonthDay,
+  isToday,
+  isYesterday
+} from './dateTimeUtil'
+
+describe('dateKey', () => {
+  it('returns YYYY-MM-DD for a given timestamp', () => {
+    // 2024-03-15 in UTC
+    const ts = new Date(2024, 2, 15, 10, 30).getTime()
+    expect(dateKey(ts)).toBe('2024-03-15')
+  })
+
+  it('zero-pads single-digit months and days', () => {
+    const ts = new Date(2024, 0, 5).getTime()
+    expect(dateKey(ts)).toBe('2024-01-05')
+  })
+})
+
+describe('isToday', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns true for a timestamp on the same day', () => {
+    const ts = new Date(2024, 5, 15, 8, 0, 0).getTime()
+    expect(isToday(ts)).toBe(true)
+  })
+
+  it('returns false for yesterday', () => {
+    const ts = new Date(2024, 5, 14, 23, 59, 59).getTime()
+    expect(isToday(ts)).toBe(false)
+  })
+
+  it('returns false for tomorrow', () => {
+    const ts = new Date(2024, 5, 16, 0, 0, 0).getTime()
+    expect(isToday(ts)).toBe(false)
+  })
+})
+
+describe('isYesterday', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 5, 15, 14, 0, 0))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns true for a timestamp yesterday', () => {
+    const ts = new Date(2024, 5, 14, 10, 0, 0).getTime()
+    expect(isYesterday(ts)).toBe(true)
+  })
+
+  it('returns false for today', () => {
+    const ts = new Date(2024, 5, 15, 10, 0, 0).getTime()
+    expect(isYesterday(ts)).toBe(false)
+  })
+
+  it('returns false for two days ago', () => {
+    const ts = new Date(2024, 5, 13, 10, 0, 0).getTime()
+    expect(isYesterday(ts)).toBe(false)
+  })
+})
+
+describe('formatShortMonthDay', () => {
+  it('formats a date as short month + day', () => {
+    const ts = new Date(2024, 0, 2, 12, 0, 0).getTime()
+    const result = formatShortMonthDay(ts, 'en-US')
+    expect(result).toBe('Jan 2')
+  })
+})
+
+describe('formatClockTime', () => {
+  it('formats time with hours, minutes, and seconds', () => {
+    const ts = new Date(2024, 5, 15, 14, 5, 6).getTime()
+    const result = formatClockTime(ts, 'en-GB')
+    // en-GB uses 24-hour format
+    expect(result).toBe('14:05:06')
+  })
+})

--- a/src/utils/numberUtil.test.ts
+++ b/src/utils/numberUtil.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampPercentInt, formatPercent0 } from './numberUtil'
+
+describe('clampPercentInt', () => {
+  it('clamps undefined to 0', () => {
+    expect(clampPercentInt()).toBe(0)
+    expect(clampPercentInt(undefined)).toBe(0)
+  })
+
+  it('rounds to nearest integer', () => {
+    expect(clampPercentInt(42.3)).toBe(42)
+    expect(clampPercentInt(42.7)).toBe(43)
+    expect(clampPercentInt(0.5)).toBe(1)
+  })
+
+  it('clamps below 0 to 0', () => {
+    expect(clampPercentInt(-10)).toBe(0)
+    expect(clampPercentInt(-0.1)).toBe(0)
+  })
+
+  it('clamps above 100 to 100', () => {
+    expect(clampPercentInt(150)).toBe(100)
+    expect(clampPercentInt(100.4)).toBe(100)
+  })
+
+  it('returns boundary values as-is', () => {
+    expect(clampPercentInt(0)).toBe(0)
+    expect(clampPercentInt(100)).toBe(100)
+  })
+})
+
+describe('formatPercent0', () => {
+  it('formats a percentage in en-US locale', () => {
+    expect(formatPercent0('en-US', 42)).toBe('42%')
+  })
+
+  it('formats 0%', () => {
+    expect(formatPercent0('en-US', 0)).toBe('0%')
+  })
+
+  it('formats 100%', () => {
+    expect(formatPercent0('en-US', 100)).toBe('100%')
+  })
+
+  it('rounds fractional values before formatting', () => {
+    expect(formatPercent0('en-US', 42.7)).toBe('43%')
+    expect(formatPercent0('en-US', 42.3)).toBe('42%')
+  })
+
+  it('clamps out-of-range values', () => {
+    expect(formatPercent0('en-US', 150)).toBe('100%')
+    expect(formatPercent0('en-US', -10)).toBe('0%')
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit tests for two untested utility modules to improve coverage:

- **`numberUtil.ts`** — `clampPercentInt`, `formatPercent0` (clamping, rounding, locale formatting)
- **`dateTimeUtil.ts`** — `dateKey`, `isToday`, `isYesterday`, `formatShortMonthDay`, `formatClockTime`

20 new tests total. This PR also serves as an E2E validation of the coverage Slack notification workflow (#10977) — merging should trigger a Slack notification showing the coverage improvement.

## Test Plan

- `pnpm test:unit -- src/utils/numberUtil.test.ts src/utils/dateTimeUtil.test.ts`
- All 20 tests pass locally

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11253-test-add-unit-tests-for-numberUtil-and-dateTimeUtil-3436d73d365081aab388fd1f1fcac7d7) by [Unito](https://www.unito.io)
