### PR TITLE
test: add regression test for getCanvasCenter null guard (#8399)

### DIFF
--- a/src/services/litegraphService.test.ts
+++ b/src/services/litegraphService.test.ts
@@ -1,0 +1,43 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: undefined },
+  ComfyApp: class {}
+}))
+
+import { app } from '@/scripts/app'
+import { useLitegraphService } from '@/services/litegraphService'
+
+describe('useLitegraphService().getCanvasCenter', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('returns origin when canvas is not yet initialised', () => {
+    Reflect.set(app, 'canvas', undefined)
+
+    const center = useLitegraphService().getCanvasCenter()
+
+    expect(center).toEqual([0, 0])
+  })
+
+  it('returns origin when canvas exists but ds.visible_area is missing', () => {
+    Reflect.set(app, 'canvas', { ds: {} })
+
+    const center = useLitegraphService().getCanvasCenter()
+
+    expect(center).toEqual([0, 0])
+  })
+
+  it('returns the visible-area centre once the canvas is ready', () => {
+    Reflect.set(app, 'canvas', {
+      ds: { visible_area: [10, 20, 200, 100] }
+    })
+
+    const center = useLitegraphService().getCanvasCenter()
+
+    expect(center).toEqual([110, 70])
+  })
+})


### PR DESCRIPTION
## Summary

Add a regression test for #8399 (null check in `getCanvasCenter` to prevent crash on asset insert). The fix in `src/services/litegraphService.ts` added optional chaining around `app.canvas?.ds?.visible_area` with a `[0, 0]` fallback so inserting an asset before the canvas finishes initializing no longer crashes. There was no existing unit test for `litegraphService`, so this regression could silently return.

## Changes

- **What**: New unit test file `src/services/litegraphService.test.ts` covering `useLitegraphService().getCanvasCenter`.
- Mocks `@/scripts/app` so `app.canvas` can be swapped per test via `Reflect.set`.
- Null-canvas case (regression for #8399): returns `[0, 0]` instead of throwing.
- Missing `ds.visible_area` case: also returns `[0, 0]`.
- Initialised case: returns the centre of the visible area.
- Verified RED→GREEN locally.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11271-test-add-regression-test-for-getCanvasCenter-null-guard-8399-3436d73d3650815c9925c8fdf9ec4bd3) by [Unito](https://www.unito.io)
