### PR TITLE
test: add unit test suite for apps/desktop-ui

### DIFF
--- a/apps/desktop-ui/package.json
+++ b/apps/desktop-ui/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "nx run @comfyorg/desktop-ui:lint",
     "typecheck": "nx run @comfyorg/desktop-ui:typecheck",
+    "test:unit": "vitest run --config vitest.config.mts",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build -o dist/storybook"
   },

--- a/apps/desktop-ui/src/components/common/StartupDisplay.test.ts
+++ b/apps/desktop-ui/src/components/common/StartupDisplay.test.ts
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import StartupDisplay from '@/components/common/StartupDisplay.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: { g: { logoAlt: 'ComfyUI' } } }
+})
+
+const ProgressBarStub = {
+  props: ['mode', 'value', 'showValue'],
+  template:
+    '<div data-testid="progress-bar" :data-mode="mode" :data-value="value" />'
+}
+
+function renderDisplay(
+  props: {
+    progressPercentage?: number
+    title?: string
+    statusText?: string
+    hideProgress?: boolean
+    fullScreen?: boolean
+  } = {}
+) {
+  return render(StartupDisplay, {
+    props,
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }], i18n],
+      stubs: { ProgressBar: ProgressBarStub }
+    }
+  })
+}
+
+describe('StartupDisplay', () => {
+  describe('progressMode', () => {
+    it('renders indeterminate mode when progressPercentage is undefined', () => {
+      renderDisplay()
+      expect(screen.getByTestId('progress-bar').dataset.mode).toBe(
+        'indeterminate'
+      )
+    })
+
+    it('renders determinate mode when progressPercentage is provided', () => {
+      renderDisplay({ progressPercentage: 50 })
+      expect(screen.getByTestId('progress-bar').dataset.mode).toBe(
+        'determinate'
+      )
+    })
+
+    it('passes progressPercentage as value to the progress bar', () => {
+      renderDisplay({ progressPercentage: 75 })
+      expect(screen.getByTestId('progress-bar').dataset.value).toBe('75')
+    })
+  })
+
+  describe('hideProgress', () => {
+    it('hides the progress bar when hideProgress is true', () => {
+      renderDisplay({ hideProgress: true })
+      expect(screen.queryByTestId('progress-bar')).toBeNull()
+    })
+
+    it('shows the progress bar by default', () => {
+      renderDisplay()
+      expect(screen.getByTestId('progress-bar')).toBeDefined()
+    })
+  })
+
+  describe('title', () => {
+    it('renders the title text when provided', () => {
+      renderDisplay({ title: 'Loading...' })
+      expect(screen.getByText('Loading...')).toBeDefined()
+    })
+
+    it('does not render h1 when title is not provided', () => {
+      renderDisplay()
+      expect(screen.queryByRole('heading', { level: 1 })).toBeNull()
+    })
+  })
+
+  describe('statusText', () => {
+    it('renders statusText with data-testid attribute', () => {
+      renderDisplay({ statusText: 'Starting server' })
+      expect(screen.getByTestId('startup-status-text').textContent).toContain(
+        'Starting server'
+      )
+    })
+
+    it('does not render statusText element when not provided', () => {
+      renderDisplay()
+      expect(screen.queryByTestId('startup-status-text')).toBeNull()
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/common/UrlInput.test.ts
+++ b/apps/desktop-ui/src/components/common/UrlInput.test.ts
@@ -163,7 +163,7 @@ describe('UrlInput', () => {
       await user.tab()
 
       const emittedUrl = onUpdate.mock.calls[0]?.[0]
-      expect(typeof emittedUrl).toBe('string')
+      expect(emittedUrl).toBe('https://example.com/')
     })
   })
 

--- a/apps/desktop-ui/src/components/common/UrlInput.test.ts
+++ b/apps/desktop-ui/src/components/common/UrlInput.test.ts
@@ -1,0 +1,208 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@comfyorg/shared-frontend-utils/networkUtil', () => ({
+  checkUrlReachable: vi.fn()
+}))
+
+import { checkUrlReachable } from '@comfyorg/shared-frontend-utils/networkUtil'
+import UrlInput from '@/components/common/UrlInput.vue'
+import { ValidationState } from '@/utils/validationUtil'
+
+const InputTextStub = {
+  props: ['modelValue', 'invalid'],
+  emits: ['update:modelValue', 'blur'],
+  template: `<input
+    data-testid="url-input"
+    :value="modelValue"
+    :data-invalid="invalid"
+    @input="$emit('update:modelValue', $event.target.value)"
+    @blur="$emit('blur')"
+  />`
+}
+
+const InputIconStub = {
+  template: '<span data-testid="input-icon" />'
+}
+
+const IconFieldStub = {
+  template: '<div><slot /></div>'
+}
+
+function renderUrlInput(
+  modelValue = '',
+  validateUrlFn?: (url: string) => Promise<boolean>
+) {
+  return render(UrlInput, {
+    props: { modelValue, ...(validateUrlFn ? { validateUrlFn } : {}) },
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }]],
+      stubs: {
+        InputText: InputTextStub,
+        InputIcon: InputIconStub,
+        IconField: IconFieldStub
+      }
+    }
+  })
+}
+
+describe('UrlInput', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('initial validation on mount', () => {
+    it('stays IDLE when modelValue is empty on mount', async () => {
+      renderUrlInput('')
+      await waitFor(() => {
+        expect(screen.getByTestId('url-input').dataset.invalid).toBe('false')
+      })
+    })
+
+    it('sets VALID state when modelValue is a reachable URL on mount', async () => {
+      vi.mocked(checkUrlReachable).mockResolvedValue(true)
+      renderUrlInput('https://example.com')
+      await waitFor(() => {
+        expect(screen.getByTestId('url-input').dataset.invalid).toBe('false')
+      })
+    })
+
+    it('sets INVALID state when URL is not reachable on mount', async () => {
+      vi.mocked(checkUrlReachable).mockResolvedValue(false)
+      renderUrlInput('https://unreachable.example')
+      await waitFor(() => {
+        expect(screen.getByTestId('url-input').dataset.invalid).toBe('true')
+      })
+    })
+  })
+
+  describe('input handling', () => {
+    it('resets validation state to IDLE on user input', async () => {
+      vi.mocked(checkUrlReachable).mockResolvedValue(false)
+      renderUrlInput('https://bad.example')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('url-input').dataset.invalid).toBe('true')
+      })
+
+      const user = userEvent.setup()
+      await user.type(screen.getByTestId('url-input'), 'x')
+      expect(screen.getByTestId('url-input').dataset.invalid).toBe('false')
+    })
+
+    it('strips whitespace from typed input', async () => {
+      const onUpdate = vi.fn()
+      render(UrlInput, {
+        props: {
+          modelValue: '',
+          'onUpdate:modelValue': onUpdate
+        },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }]],
+          stubs: {
+            InputText: InputTextStub,
+            InputIcon: InputIconStub,
+            IconField: IconFieldStub
+          }
+        }
+      })
+
+      const user = userEvent.setup()
+      const input = screen.getByTestId('url-input')
+      await user.type(input, 'htt ps')
+      expect((input as HTMLInputElement).value).not.toContain(' ')
+    })
+  })
+
+  describe('blur handling', () => {
+    it('emits update:modelValue on blur', async () => {
+      const onUpdate = vi.fn()
+      render(UrlInput, {
+        props: {
+          modelValue: 'https://example.com',
+          'onUpdate:modelValue': onUpdate
+        },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }]],
+          stubs: {
+            InputText: InputTextStub,
+            InputIcon: InputIconStub,
+            IconField: IconFieldStub
+          }
+        }
+      })
+
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('url-input'))
+      await user.tab()
+
+      expect(onUpdate).toHaveBeenCalled()
+    })
+
+    it('normalizes URL on blur', async () => {
+      const onUpdate = vi.fn()
+      render(UrlInput, {
+        props: {
+          modelValue: 'https://example.com',
+          'onUpdate:modelValue': onUpdate
+        },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }]],
+          stubs: {
+            InputText: InputTextStub,
+            InputIcon: InputIconStub,
+            IconField: IconFieldStub
+          }
+        }
+      })
+
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('url-input'))
+      await user.tab()
+
+      const emittedUrl = onUpdate.mock.calls[0]?.[0]
+      expect(typeof emittedUrl).toBe('string')
+    })
+  })
+
+  describe('custom validateUrlFn', () => {
+    it('uses custom validateUrlFn when provided', async () => {
+      const customValidator = vi.fn().mockResolvedValue(true)
+      renderUrlInput('https://custom.example', customValidator)
+
+      await waitFor(() => {
+        expect(customValidator).toHaveBeenCalledWith('https://custom.example')
+      })
+
+      expect(checkUrlReachable).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('state-change emission', () => {
+    it('emits state-change when validation state changes', async () => {
+      const onStateChange = vi.fn()
+      vi.mocked(checkUrlReachable).mockResolvedValue(true)
+
+      render(UrlInput, {
+        props: {
+          modelValue: 'https://example.com',
+          'onState-change': onStateChange
+        },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }]],
+          stubs: {
+            InputText: InputTextStub,
+            InputIcon: InputIconStub,
+            IconField: IconFieldStub
+          }
+        }
+      })
+
+      await waitFor(() => {
+        expect(onStateChange).toHaveBeenCalledWith(ValidationState.VALID)
+      })
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/install/GpuPicker.test.ts
+++ b/apps/desktop-ui/src/components/install/GpuPicker.test.ts
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => ({
+    getPlatform: vi.fn().mockReturnValue('win32')
+  }))
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key,
+  te: () => false,
+  st: (_key: string, fallback: string) => fallback
+}))
+
+import type { TorchDeviceType } from '@comfyorg/comfyui-electron-types'
+import GpuPicker from '@/components/install/GpuPicker.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: {} }
+})
+
+const HardwareOptionStub = {
+  props: ['imagePath', 'placeholderText', 'subtitle', 'selected'],
+  emits: ['click'],
+  template:
+    '<button :data-testid="placeholderText" :data-selected="selected" @click="$emit(\'click\')" >{{ placeholderText }}</button>'
+}
+
+function renderPicker(device: TorchDeviceType | null = null) {
+  return render(GpuPicker, {
+    props: { device },
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }], i18n],
+      stubs: {
+        HardwareOption: HardwareOptionStub,
+        Tag: {
+          props: ['value'],
+          template: '<span data-testid="recommended-tag">{{ value }}</span>'
+        }
+      }
+    }
+  })
+}
+
+describe('GpuPicker', () => {
+  describe('recommended badge', () => {
+    it('shows recommended badge for nvidia', () => {
+      renderPicker('nvidia')
+      expect(screen.getByTestId('recommended-tag')).toBeVisible()
+    })
+
+    it('shows recommended badge for amd', () => {
+      renderPicker('amd')
+      expect(screen.getByTestId('recommended-tag')).toBeVisible()
+    })
+
+    it('does not show recommended badge for cpu', () => {
+      renderPicker('cpu')
+      expect(screen.getByTestId('recommended-tag')).not.toBeVisible()
+    })
+
+    it('does not show recommended badge for unsupported', () => {
+      renderPicker('unsupported')
+      expect(screen.getByTestId('recommended-tag')).not.toBeVisible()
+    })
+
+    it('does not show recommended badge when no device is selected', () => {
+      renderPicker(null)
+      expect(screen.getByTestId('recommended-tag')).not.toBeVisible()
+    })
+  })
+
+  describe('selection state', () => {
+    it('marks nvidia as selected when device is nvidia', () => {
+      renderPicker('nvidia')
+      expect(screen.getByTestId('NVIDIA').dataset.selected).toBe('true')
+    })
+
+    it('marks cpu as selected when device is cpu', () => {
+      renderPicker('cpu')
+      expect(screen.getByTestId('CPU').dataset.selected).toBe('true')
+    })
+
+    it('marks unsupported as selected when device is unsupported', () => {
+      renderPicker('unsupported')
+      expect(screen.getByTestId('Manual Install').dataset.selected).toBe('true')
+    })
+
+    it('no option is selected when device is null', () => {
+      renderPicker(null)
+      expect(screen.getByTestId('CPU').dataset.selected).toBe('false')
+      expect(screen.getByTestId('NVIDIA').dataset.selected).toBe('false')
+    })
+  })
+
+  describe('gpu options on non-darwin platform', () => {
+    it('shows NVIDIA, AMD, CPU, and Manual Install options', () => {
+      renderPicker(null)
+      expect(screen.getByTestId('NVIDIA')).toBeDefined()
+      expect(screen.getByTestId('AMD')).toBeDefined()
+      expect(screen.getByTestId('CPU')).toBeDefined()
+      expect(screen.getByTestId('Manual Install')).toBeDefined()
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/install/MigrationPicker.test.ts
+++ b/apps/desktop-ui/src/components/install/MigrationPicker.test.ts
@@ -1,0 +1,223 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+const mockValidateComfyUISource = vi.fn()
+const mockShowDirectoryPicker = vi.fn()
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => ({
+    validateComfyUISource: mockValidateComfyUISource,
+    showDirectoryPicker: mockShowDirectoryPicker
+  }))
+}))
+
+import MigrationPicker from '@/components/install/MigrationPicker.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      install: {
+        migrationSourcePathDescription: 'Source path description',
+        migrationOptional: 'Migration is optional',
+        selectItemsToMigrate: 'Select items to migrate',
+        pathValidationFailed: 'Validation failed',
+        failedToSelectDirectory: 'Failed to select directory',
+        locationPicker: {
+          migrationPathPlaceholder: 'Enter path'
+        }
+      }
+    }
+  }
+})
+
+const InputTextStub = {
+  props: ['modelValue', 'invalid'],
+  emits: ['update:modelValue'],
+  template: `<input
+    data-testid="source-input"
+    :value="modelValue"
+    @input="$emit('update:modelValue', $event.target.value)"
+  />`
+}
+
+const CheckboxStub = {
+  props: ['modelValue', 'inputId', 'binary'],
+  emits: ['update:modelValue', 'click'],
+  template: `<input
+    type="checkbox"
+    :data-testid="'checkbox-' + inputId"
+    :checked="modelValue"
+    @change="$emit('update:modelValue', $event.target.checked)"
+    @click.stop="$emit('click')"
+  />`
+}
+
+function renderPicker(sourcePath = '', migrationItemIds: string[] = []) {
+  return render(MigrationPicker, {
+    props: { sourcePath, migrationItemIds },
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }], i18n],
+      stubs: {
+        InputText: InputTextStub,
+        Checkbox: CheckboxStub,
+        Button: { template: '<button data-testid="browse-btn" />' },
+        Message: {
+          props: ['severity'],
+          template: '<div data-testid="error-msg"><slot /></div>'
+        }
+      }
+    }
+  })
+}
+
+describe('MigrationPicker', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('isValidSource', () => {
+    it('hides migration options when source path is empty', () => {
+      renderPicker('')
+      expect(screen.queryByText('Select items to migrate')).toBeNull()
+    })
+
+    it('shows migration options when source path is valid', async () => {
+      mockValidateComfyUISource.mockResolvedValue({ isValid: true })
+      const { rerender } = renderPicker('')
+
+      await rerender({ sourcePath: '/valid/path' })
+      await waitFor(() => {
+        expect(screen.getByText('Select items to migrate')).toBeDefined()
+      })
+    })
+
+    it('shows optional message when no valid source', () => {
+      renderPicker('')
+      expect(screen.getByText('Migration is optional')).toBeDefined()
+    })
+  })
+
+  describe('validateSource', () => {
+    it('clears error when source path becomes empty', async () => {
+      mockValidateComfyUISource.mockResolvedValue({
+        isValid: false,
+        error: 'Not found'
+      })
+
+      const user = userEvent.setup()
+      renderPicker()
+
+      await user.type(screen.getByTestId('source-input'), '/bad/path')
+      await waitFor(() => {
+        expect(screen.getByTestId('error-msg')).toBeDefined()
+      })
+
+      await user.clear(screen.getByTestId('source-input'))
+      await waitFor(() => {
+        expect(screen.queryByTestId('error-msg')).toBeNull()
+      })
+    })
+
+    it('shows error message when validation fails', async () => {
+      mockValidateComfyUISource.mockResolvedValue({
+        isValid: false,
+        error: 'Path not found'
+      })
+
+      const user = userEvent.setup()
+      renderPicker()
+
+      await user.type(screen.getByTestId('source-input'), '/bad/path')
+      await waitFor(() => {
+        expect(screen.getByTestId('error-msg')).toBeDefined()
+      })
+    })
+
+    it('shows no error when validation passes', async () => {
+      mockValidateComfyUISource.mockResolvedValue({ isValid: true })
+
+      const user = userEvent.setup()
+      renderPicker()
+
+      await user.type(screen.getByTestId('source-input'), '/valid/path')
+      await waitFor(() => {
+        expect(screen.queryByTestId('error-msg')).toBeNull()
+      })
+    })
+  })
+
+  describe('migrationItemIds watchEffect', () => {
+    it('emits all item IDs by default (all items start selected)', async () => {
+      const onUpdate = vi.fn()
+      render(MigrationPicker, {
+        props: {
+          sourcePath: '',
+          migrationItemIds: [],
+          'onUpdate:migrationItemIds': onUpdate
+        },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }], i18n],
+          stubs: {
+            InputText: InputTextStub,
+            Checkbox: CheckboxStub,
+            Button: { template: '<button />' },
+            Message: { template: '<div />' }
+          }
+        }
+      })
+
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalled()
+        const emittedIds = onUpdate.mock.calls[0][0]
+        expect(Array.isArray(emittedIds)).toBe(true)
+        expect(emittedIds.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('browse path', () => {
+    it('opens directory picker on browse click', async () => {
+      mockShowDirectoryPicker.mockResolvedValue(null)
+      renderPicker()
+
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('browse-btn'))
+
+      expect(mockShowDirectoryPicker).toHaveBeenCalledOnce()
+    })
+
+    it('updates source path when directory is selected', async () => {
+      mockShowDirectoryPicker.mockResolvedValue('/selected/path')
+      mockValidateComfyUISource.mockResolvedValue({ isValid: true })
+
+      const onUpdate = vi.fn()
+      render(MigrationPicker, {
+        props: {
+          sourcePath: '',
+          'onUpdate:sourcePath': onUpdate
+        },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }], i18n],
+          stubs: {
+            InputText: InputTextStub,
+            Checkbox: CheckboxStub,
+            Button: { template: '<button data-testid="browse-btn" />' },
+            Message: { template: '<div />' }
+          }
+        }
+      })
+
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('browse-btn'))
+
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalledWith('/selected/path')
+      })
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/maintenance/StatusTag.test.ts
+++ b/apps/desktop-ui/src/components/maintenance/StatusTag.test.ts
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+import StatusTag from '@/components/maintenance/StatusTag.vue'
+
+const TagStub = defineComponent({
+  name: 'Tag',
+  props: {
+    icon: String,
+    severity: String,
+    value: String
+  },
+  template: `<span data-testid="tag" :data-icon="icon" :data-severity="severity" :data-value="value">{{ value }}</span>`
+})
+
+function renderStatusTag(props: { error: boolean; refreshing?: boolean }) {
+  return render(StatusTag, {
+    props,
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }]],
+      stubs: { Tag: TagStub }
+    }
+  })
+}
+
+describe('StatusTag', () => {
+  describe('refreshing state', () => {
+    it('shows info severity when refreshing', () => {
+      renderStatusTag({ error: false, refreshing: true })
+      expect(screen.getByTestId('tag').dataset.severity).toBe('info')
+    })
+
+    it('shows refreshing translation key when refreshing', () => {
+      renderStatusTag({ error: false, refreshing: true })
+      expect(screen.getByTestId('tag').dataset.value).toBe(
+        'maintenance.refreshing'
+      )
+    })
+
+    it('shows question icon when refreshing', () => {
+      renderStatusTag({ error: false, refreshing: true })
+      expect(screen.getByTestId('tag').dataset.icon).toBeDefined()
+    })
+  })
+
+  describe('error state', () => {
+    it('shows danger severity when error is true', () => {
+      renderStatusTag({ error: true })
+      expect(screen.getByTestId('tag').dataset.severity).toBe('danger')
+    })
+
+    it('shows error translation key when error is true', () => {
+      renderStatusTag({ error: true })
+      expect(screen.getByTestId('tag').dataset.value).toBe('g.error')
+    })
+  })
+
+  describe('OK state', () => {
+    it('shows success severity when not refreshing and not error', () => {
+      renderStatusTag({ error: false })
+      expect(screen.getByTestId('tag').dataset.severity).toBe('success')
+    })
+
+    it('shows OK translation key when not refreshing and not error', () => {
+      renderStatusTag({ error: false })
+      expect(screen.getByTestId('tag').dataset.value).toBe('maintenance.OK')
+    })
+  })
+
+  describe('precedence', () => {
+    it('shows refreshing state when both refreshing and error are true', () => {
+      renderStatusTag({ error: true, refreshing: true })
+      expect(screen.getByTestId('tag').dataset.severity).toBe('info')
+      expect(screen.getByTestId('tag').dataset.value).toBe(
+        'maintenance.refreshing'
+      )
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/maintenance/TaskCard.test.ts
+++ b/apps/desktop-ui/src/components/maintenance/TaskCard.test.ts
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => ({
+    Validation: { validateInstallation: vi.fn() }
+  }))
+}))
+
+vi.mock('@/constants/desktopMaintenanceTasks', () => ({
+  DESKTOP_MAINTENANCE_TASKS: []
+}))
+
+vi.mock('@/utils/refUtil', () => ({
+  useMinLoadingDurationRef: (source: { value: boolean }) => source
+}))
+
+const mockGetRunner = vi.fn()
+vi.mock('@/stores/maintenanceTaskStore', () => ({
+  useMaintenanceTaskStore: vi.fn(() => ({
+    getRunner: mockGetRunner
+  }))
+}))
+
+import type { MaintenanceTask } from '@/types/desktop/maintenanceTypes'
+import TaskCard from '@/components/maintenance/TaskCard.vue'
+
+const baseTask: MaintenanceTask = {
+  id: 'testTask',
+  name: 'Test Task',
+  shortDescription: 'Short description',
+  errorDescription: 'Error occurred',
+  execute: vi.fn().mockResolvedValue(true)
+}
+
+function renderCard(state: 'OK' | 'error' | 'warning' | 'skipped') {
+  mockGetRunner.mockReturnValue({
+    state,
+    executing: false,
+    refreshing: false,
+    resolved: false
+  })
+
+  return render(TaskCard, {
+    props: { task: baseTask },
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }]],
+      stubs: {
+        Card: {
+          template:
+            '<div data-testid="card"><slot name="content" /></slot></div>'
+        },
+        Button: {
+          template: '<button />'
+        }
+      }
+    }
+  })
+}
+
+describe('TaskCard', () => {
+  describe('description computed', () => {
+    it('shows errorDescription when task state is error', () => {
+      renderCard('error')
+      expect(screen.getByText('Error occurred')).toBeDefined()
+    })
+
+    it('shows shortDescription when task state is OK', () => {
+      renderCard('OK')
+      expect(screen.getByText('Short description')).toBeDefined()
+    })
+
+    it('shows shortDescription when task state is warning', () => {
+      renderCard('warning')
+      expect(screen.getByText('Short description')).toBeDefined()
+    })
+
+    it('falls back to shortDescription when errorDescription is absent and state is error', () => {
+      const taskWithoutErrorDesc: MaintenanceTask = {
+        ...baseTask,
+        errorDescription: undefined
+      }
+      mockGetRunner.mockReturnValue({
+        state: 'error',
+        executing: false,
+        refreshing: false
+      })
+
+      render(TaskCard, {
+        props: { task: taskWithoutErrorDesc },
+        global: {
+          plugins: [[PrimeVue, { unstyled: true }]],
+          stubs: {
+            Card: {
+              template:
+                '<div data-testid="card"><slot name="content" /></slot></div>'
+            },
+            Button: { template: '<button />' }
+          }
+        }
+      })
+
+      expect(screen.getByText('Short description')).toBeDefined()
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/maintenance/TaskCard.test.ts
+++ b/apps/desktop-ui/src/components/maintenance/TaskCard.test.ts
@@ -33,7 +33,17 @@ const baseTask: MaintenanceTask = {
   execute: vi.fn().mockResolvedValue(true)
 }
 
-function renderCard(state: 'OK' | 'error' | 'warning' | 'skipped') {
+const cardStubs = {
+  Card: {
+    template: '<div data-testid="card"><slot name="content"></slot></div>'
+  },
+  Button: { template: '<button />' }
+}
+
+function renderCard(
+  state: 'OK' | 'error' | 'warning' | 'skipped',
+  task: MaintenanceTask = baseTask
+) {
   mockGetRunner.mockReturnValue({
     state,
     executing: false,
@@ -42,18 +52,10 @@ function renderCard(state: 'OK' | 'error' | 'warning' | 'skipped') {
   })
 
   return render(TaskCard, {
-    props: { task: baseTask },
+    props: { task },
     global: {
       plugins: [[PrimeVue, { unstyled: true }]],
-      stubs: {
-        Card: {
-          template:
-            '<div data-testid="card"><slot name="content" /></slot></div>'
-        },
-        Button: {
-          template: '<button />'
-        }
-      }
+      stubs: cardStubs
     }
   })
 }
@@ -80,26 +82,7 @@ describe('TaskCard', () => {
         ...baseTask,
         errorDescription: undefined
       }
-      mockGetRunner.mockReturnValue({
-        state: 'error',
-        executing: false,
-        refreshing: false
-      })
-
-      render(TaskCard, {
-        props: { task: taskWithoutErrorDesc },
-        global: {
-          plugins: [[PrimeVue, { unstyled: true }]],
-          stubs: {
-            Card: {
-              template:
-                '<div data-testid="card"><slot name="content" /></slot></div>'
-            },
-            Button: { template: '<button />' }
-          }
-        }
-      })
-
+      renderCard('error', taskWithoutErrorDesc)
       expect(screen.getByText('Short description')).toBeDefined()
     })
   })

--- a/apps/desktop-ui/src/components/maintenance/TaskListItem.test.ts
+++ b/apps/desktop-ui/src/components/maintenance/TaskListItem.test.ts
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => ({
+    Validation: { validateInstallation: vi.fn() }
+  }))
+}))
+
+vi.mock('@/constants/desktopMaintenanceTasks', () => ({
+  DESKTOP_MAINTENANCE_TASKS: []
+}))
+
+vi.mock('@/utils/refUtil', () => ({
+  useMinLoadingDurationRef: (source: { value: boolean }) => source
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+const mockGetRunner = vi.fn()
+vi.mock('@/stores/maintenanceTaskStore', () => ({
+  useMaintenanceTaskStore: vi.fn(() => ({
+    getRunner: mockGetRunner
+  }))
+}))
+
+import type { MaintenanceTask } from '@/types/desktop/maintenanceTypes'
+import TaskListItem from '@/components/maintenance/TaskListItem.vue'
+
+const baseTask: MaintenanceTask = {
+  id: 'testTask',
+  name: 'Test Task',
+  button: { text: 'Fix', icon: 'pi pi-check' },
+  execute: vi.fn().mockResolvedValue(true)
+}
+
+const ButtonStub = {
+  props: ['severity', 'label', 'icon', 'loading'],
+  template:
+    '<button :data-severity="severity" :data-label="label" :data-testid="label ? \'action-button\' : \'icon-button\'" />'
+}
+
+function renderItem(state: 'OK' | 'error' | 'warning' | 'skipped') {
+  mockGetRunner.mockReturnValue({
+    state,
+    executing: false,
+    refreshing: false,
+    resolved: false
+  })
+
+  return render(TaskListItem, {
+    props: { task: baseTask },
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }]],
+      stubs: {
+        Button: ButtonStub,
+        Popover: { template: '<div />' },
+        TaskListStatusIcon: { template: '<span />' }
+      }
+    }
+  })
+}
+
+describe('TaskListItem', () => {
+  describe('severity computed', () => {
+    it('uses primary severity for error state', () => {
+      renderItem('error')
+      expect(screen.getByTestId('action-button').dataset.severity).toBe(
+        'primary'
+      )
+    })
+
+    it('uses primary severity for warning state', () => {
+      renderItem('warning')
+      expect(screen.getByTestId('action-button').dataset.severity).toBe(
+        'primary'
+      )
+    })
+
+    it('uses secondary severity for OK state', () => {
+      renderItem('OK')
+      expect(screen.getByTestId('action-button').dataset.severity).toBe(
+        'secondary'
+      )
+    })
+
+    it('uses secondary severity for skipped state', () => {
+      renderItem('skipped')
+      expect(screen.getByTestId('action-button').dataset.severity).toBe(
+        'secondary'
+      )
+    })
+  })
+})

--- a/apps/desktop-ui/src/components/maintenance/TaskListStatusIcon.test.ts
+++ b/apps/desktop-ui/src/components/maintenance/TaskListStatusIcon.test.ts
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+import TaskListStatusIcon from '@/components/maintenance/TaskListStatusIcon.vue'
+
+type TaskState = 'warning' | 'error' | 'resolved' | 'OK' | 'skipped' | undefined
+
+function renderIcon(state: TaskState, loading?: boolean) {
+  return render(TaskListStatusIcon, {
+    props: { state, loading },
+    global: {
+      plugins: [[PrimeVue, { unstyled: true }]],
+      stubs: {
+        ProgressSpinner: {
+          template: '<div data-testid="spinner" />'
+        }
+      }
+    }
+  })
+}
+
+describe('TaskListStatusIcon', () => {
+  describe('loading / no state', () => {
+    it('renders spinner when state is undefined', () => {
+      renderIcon(undefined)
+      expect(screen.getByTestId('spinner')).toBeDefined()
+    })
+
+    it('renders spinner when loading is true', () => {
+      renderIcon('OK', true)
+      expect(screen.getByTestId('spinner')).toBeDefined()
+    })
+
+    it('hides spinner when state is defined and not loading', () => {
+      renderIcon('OK', false)
+      expect(screen.queryByTestId('spinner')).toBeNull()
+    })
+  })
+})

--- a/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminal.test.ts
+++ b/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminal.test.ts
@@ -1,0 +1,138 @@
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+const { mockTerminal, MockTerminal, mockFitAddon, MockFitAddon } = vi.hoisted(
+  () => {
+    const mockTerminal = {
+      loadAddon: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
+      open: vi.fn(),
+      dispose: vi.fn(),
+      hasSelection: vi.fn<[], boolean>(),
+      resize: vi.fn(),
+      cols: 80,
+      rows: 24
+    }
+    const MockTerminal = vi.fn(function () {
+      return mockTerminal
+    })
+
+    const mockFitAddon = {
+      proposeDimensions: vi.fn().mockReturnValue({ cols: 80, rows: 24 })
+    }
+    const MockFitAddon = vi.fn(function () {
+      return mockFitAddon
+    })
+
+    return { mockTerminal, MockTerminal, mockFitAddon, MockFitAddon }
+  }
+)
+
+vi.mock('@xterm/xterm', () => ({ Terminal: MockTerminal }))
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: MockFitAddon }))
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+import { useTerminal } from '@/composables/bottomPanelTabs/useTerminal'
+
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  render(
+    defineComponent({
+      setup() {
+        result = composable()
+        return {}
+      },
+      template: '<div />'
+    })
+  )
+  return result
+}
+
+function getKeyHandler(): (event: KeyboardEvent) => boolean {
+  return mockTerminal.attachCustomKeyEventHandler.mock.calls[0][0]
+}
+
+describe('useTerminal key event handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTerminal.hasSelection.mockReturnValue(false)
+
+    const element = ref<HTMLElement | undefined>(undefined)
+    withSetup(() => useTerminal(element))
+  })
+
+  it('allows browser to handle copy when text is selected (Ctrl+C)', () => {
+    mockTerminal.hasSelection.mockReturnValue(true)
+    const event = {
+      type: 'keydown',
+      ctrlKey: true,
+      metaKey: false,
+      key: 'c'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(false)
+  })
+
+  it('allows browser to handle copy when text is selected (Meta+C)', () => {
+    mockTerminal.hasSelection.mockReturnValue(true)
+    const event = {
+      type: 'keydown',
+      ctrlKey: false,
+      metaKey: true,
+      key: 'c'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(false)
+  })
+
+  it('does not pass copy to browser when no text is selected', () => {
+    mockTerminal.hasSelection.mockReturnValue(false)
+    const event = {
+      type: 'keydown',
+      ctrlKey: true,
+      metaKey: false,
+      key: 'c'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(true)
+  })
+
+  it('allows browser to handle paste (Ctrl+V)', () => {
+    const event = {
+      type: 'keydown',
+      ctrlKey: true,
+      metaKey: false,
+      key: 'v'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(false)
+  })
+
+  it('allows browser to handle paste (Meta+V)', () => {
+    const event = {
+      type: 'keydown',
+      ctrlKey: false,
+      metaKey: true,
+      key: 'v'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(false)
+  })
+
+  it('does not intercept non-keydown events', () => {
+    mockTerminal.hasSelection.mockReturnValue(true)
+    const event = {
+      type: 'keyup',
+      ctrlKey: true,
+      metaKey: false,
+      key: 'c'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(true)
+  })
+
+  it('passes through unrelated key combinations', () => {
+    const event = {
+      type: 'keydown',
+      ctrlKey: false,
+      metaKey: false,
+      key: 'Enter'
+    } as KeyboardEvent
+    expect(getKeyHandler()(event)).toBe(true)
+  })
+})

--- a/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminal.test.ts
+++ b/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminal.test.ts
@@ -1,6 +1,5 @@
-import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, ref } from 'vue'
+import { ref } from 'vue'
 
 const { mockTerminal, MockTerminal, mockFitAddon, MockFitAddon } = vi.hoisted(
   () => {
@@ -33,21 +32,8 @@ vi.mock('@xterm/xterm', () => ({ Terminal: MockTerminal }))
 vi.mock('@xterm/addon-fit', () => ({ FitAddon: MockFitAddon }))
 vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
 
+import { withSetup } from '@/test/withSetup'
 import { useTerminal } from '@/composables/bottomPanelTabs/useTerminal'
-
-function withSetup<T>(composable: () => T): T {
-  let result!: T
-  render(
-    defineComponent({
-      setup() {
-        result = composable()
-        return {}
-      },
-      template: '<div />'
-    })
-  )
-  return result
-}
 
 function getKeyHandler(): (event: KeyboardEvent) => boolean {
   return mockTerminal.attachCustomKeyEventHandler.mock.calls[0][0]

--- a/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminalBuffer.test.ts
+++ b/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminalBuffer.test.ts
@@ -1,6 +1,4 @@
-import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent } from 'vue'
 
 const { mockSerialize, MockSerializeAddon } = vi.hoisted(() => {
   const mockSerialize = vi.fn<[], string>()
@@ -21,21 +19,8 @@ vi.mock('@xterm/addon-serialize', () => ({
 }))
 
 import type { Terminal } from '@xterm/xterm'
+import { withSetup } from '@/test/withSetup'
 import { useTerminalBuffer } from '@/composables/bottomPanelTabs/useTerminalBuffer'
-
-function withSetup<T>(composable: () => T): T {
-  let result!: T
-  render(
-    defineComponent({
-      setup() {
-        result = composable()
-        return {}
-      },
-      template: '<div />'
-    })
-  )
-  return result
-}
 
 describe('useTerminalBuffer', () => {
   beforeEach(() => {
@@ -48,7 +33,7 @@ describe('useTerminalBuffer', () => {
       mockSerialize.mockReturnValue('hello world')
       const { copyTo } = withSetup(() => useTerminalBuffer())
       const mockWrite = vi.fn()
-      copyTo({ write: mockWrite } as unknown as Terminal)
+      copyTo({ write: mockWrite } as Pick<Terminal, 'write'>)
       expect(mockWrite).toHaveBeenCalledWith('hello world')
     })
 
@@ -56,7 +41,7 @@ describe('useTerminalBuffer', () => {
       mockSerialize.mockReturnValue('')
       const { copyTo } = withSetup(() => useTerminalBuffer())
       const mockWrite = vi.fn()
-      copyTo({ write: mockWrite } as unknown as Terminal)
+      copyTo({ write: mockWrite } as Pick<Terminal, 'write'>)
       expect(mockWrite).toHaveBeenCalledWith('')
     })
   })

--- a/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminalBuffer.test.ts
+++ b/apps/desktop-ui/src/composables/bottomPanelTabs/useTerminalBuffer.test.ts
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+const { mockSerialize, MockSerializeAddon } = vi.hoisted(() => {
+  const mockSerialize = vi.fn<[], string>()
+  const MockSerializeAddon = vi.fn(function () {
+    return { serialize: mockSerialize }
+  })
+  return { mockSerialize, MockSerializeAddon }
+})
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function () {
+    return { loadAddon: vi.fn(), dispose: vi.fn(), write: vi.fn() }
+  })
+}))
+
+vi.mock('@xterm/addon-serialize', () => ({
+  SerializeAddon: MockSerializeAddon
+}))
+
+import type { Terminal } from '@xterm/xterm'
+import { useTerminalBuffer } from '@/composables/bottomPanelTabs/useTerminalBuffer'
+
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  render(
+    defineComponent({
+      setup() {
+        result = composable()
+        return {}
+      },
+      template: '<div />'
+    })
+  )
+  return result
+}
+
+describe('useTerminalBuffer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSerialize.mockReturnValue('')
+  })
+
+  describe('copyTo', () => {
+    it('writes serialized buffer content to the destination terminal', () => {
+      mockSerialize.mockReturnValue('hello world')
+      const { copyTo } = withSetup(() => useTerminalBuffer())
+      const mockWrite = vi.fn()
+      copyTo({ write: mockWrite } as unknown as Terminal)
+      expect(mockWrite).toHaveBeenCalledWith('hello world')
+    })
+
+    it('writes empty string when buffer is empty', () => {
+      mockSerialize.mockReturnValue('')
+      const { copyTo } = withSetup(() => useTerminalBuffer())
+      const mockWrite = vi.fn()
+      copyTo({ write: mockWrite } as unknown as Terminal)
+      expect(mockWrite).toHaveBeenCalledWith('')
+    })
+  })
+})

--- a/apps/desktop-ui/src/constants/desktopDialogs.test.ts
+++ b/apps/desktop-ui/src/constants/desktopDialogs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { DESKTOP_DIALOGS, getDialog } from '@/constants/desktopDialogs'
+
+describe('getDialog', () => {
+  it('returns the matching dialog for a valid ID', () => {
+    const result = getDialog('reinstallVenv')
+    expect(result.id).toBe('reinstallVenv')
+    expect(result.title).toBe(DESKTOP_DIALOGS.reinstallVenv.title)
+    expect(result.message).toBe(DESKTOP_DIALOGS.reinstallVenv.message)
+  })
+
+  it('returns invalidDialog for an unknown string ID', () => {
+    const result = getDialog('unknownDialog')
+    expect(result.id).toBe('invalidDialog')
+  })
+
+  it('returns invalidDialog when given an array of strings', () => {
+    const result = getDialog(['reinstallVenv', 'other'])
+    expect(result.id).toBe('invalidDialog')
+  })
+
+  it('returns invalidDialog for empty string', () => {
+    const result = getDialog('')
+    expect(result.id).toBe('invalidDialog')
+  })
+
+  it('includes id, title, message, and buttons in the result', () => {
+    const result = getDialog('reinstallVenv')
+    expect(result).toHaveProperty('id')
+    expect(result).toHaveProperty('title')
+    expect(result).toHaveProperty('message')
+    expect(result).toHaveProperty('buttons')
+    expect(Array.isArray(result.buttons)).toBe(true)
+  })
+
+  it('returns a deep clone — mutations do not affect the original', () => {
+    const result = getDialog('reinstallVenv')
+    const originalFirstLabel = DESKTOP_DIALOGS.reinstallVenv.buttons[0].label
+    result.buttons[0].label = 'Mutated'
+    expect(DESKTOP_DIALOGS.reinstallVenv.buttons[0].label).toBe(
+      originalFirstLabel
+    )
+  })
+
+  it('every button has a returnValue', () => {
+    for (const id of Object.keys(DESKTOP_DIALOGS)) {
+      const result = getDialog(id)
+      for (const button of result.buttons) {
+        expect(button.returnValue).toBeDefined()
+      }
+    }
+  })
+
+  it('invalidDialog has a close/cancel button', () => {
+    const result = getDialog('invalidDialog')
+    expect(result.buttons.some((b) => b.action === 'cancel')).toBe(true)
+  })
+})

--- a/apps/desktop-ui/src/constants/desktopDialogs.test.ts
+++ b/apps/desktop-ui/src/constants/desktopDialogs.test.ts
@@ -25,15 +25,6 @@ describe('getDialog', () => {
     expect(result.id).toBe('invalidDialog')
   })
 
-  it('includes id, title, message, and buttons in the result', () => {
-    const result = getDialog('reinstallVenv')
-    expect(result).toHaveProperty('id')
-    expect(result).toHaveProperty('title')
-    expect(result).toHaveProperty('message')
-    expect(result).toHaveProperty('buttons')
-    expect(Array.isArray(result.buttons)).toBe(true)
-  })
-
   it('returns a deep clone — mutations do not affect the original', () => {
     const result = getDialog('reinstallVenv')
     const originalFirstLabel = DESKTOP_DIALOGS.reinstallVenv.buttons[0].label

--- a/apps/desktop-ui/src/constants/desktopMaintenanceTasks.test.ts
+++ b/apps/desktop-ui/src/constants/desktopMaintenanceTasks.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockElectron } = vi.hoisted(() => ({
+  mockElectron: {
+    setBasePath: vi.fn(),
+    reinstall: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+    uv: {
+      installRequirements: vi.fn<[], Promise<void>>(),
+      clearCache: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+      resetVenv: vi.fn<[], Promise<void>>().mockResolvedValue(undefined)
+    }
+  }
+}))
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => mockElectron)
+}))
+
+import { DESKTOP_MAINTENANCE_TASKS } from '@/constants/desktopMaintenanceTasks'
+
+function findTask(id: string) {
+  const task = DESKTOP_MAINTENANCE_TASKS.find((t) => t.id === id)
+  if (!task) throw new Error(`Task not found: ${id}`)
+  return task
+}
+
+describe('desktopMaintenanceTasks', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(window, 'open').mockReturnValue(null)
+    mockElectron.reinstall.mockResolvedValue(undefined)
+    mockElectron.uv.clearCache.mockResolvedValue(undefined)
+    mockElectron.uv.resetVenv.mockResolvedValue(undefined)
+  })
+
+  describe('pythonPackages', () => {
+    it('returns true when installation succeeds', async () => {
+      mockElectron.uv.installRequirements.mockResolvedValue(undefined)
+      expect(await findTask('pythonPackages').execute()).toBe(true)
+    })
+
+    it('returns false when installation throws', async () => {
+      mockElectron.uv.installRequirements.mockRejectedValue(
+        new Error('install failed')
+      )
+      expect(await findTask('pythonPackages').execute()).toBe(false)
+    })
+  })
+
+  describe('URL-opening tasks', () => {
+    it('git execute opens a browser tab', () => {
+      findTask('git').execute()
+      expect(window.open).toHaveBeenCalledOnce()
+    })
+
+    it('uv execute opens a browser tab', () => {
+      findTask('uv').execute()
+      expect(window.open).toHaveBeenCalledOnce()
+    })
+
+    it('vcRedist execute opens a browser tab', () => {
+      findTask('vcRedist').execute()
+      expect(window.open).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/apps/desktop-ui/src/constants/desktopMaintenanceTasks.test.ts
+++ b/apps/desktop-ui/src/constants/desktopMaintenanceTasks.test.ts
@@ -48,19 +48,28 @@ describe('desktopMaintenanceTasks', () => {
   })
 
   describe('URL-opening tasks', () => {
-    it('git execute opens a browser tab', () => {
+    it('git execute opens the git download page', () => {
       findTask('git').execute()
-      expect(window.open).toHaveBeenCalledOnce()
+      expect(window.open).toHaveBeenCalledWith(
+        'https://git-scm.com/downloads/',
+        '_blank'
+      )
     })
 
-    it('uv execute opens a browser tab', () => {
+    it('uv execute opens the uv installation page', () => {
       findTask('uv').execute()
-      expect(window.open).toHaveBeenCalledOnce()
+      expect(window.open).toHaveBeenCalledWith(
+        'https://docs.astral.sh/uv/getting-started/installation/',
+        '_blank'
+      )
     })
 
-    it('vcRedist execute opens a browser tab', () => {
+    it('vcRedist execute opens the VC++ redistributable download', () => {
       findTask('vcRedist').execute()
-      expect(window.open).toHaveBeenCalledOnce()
+      expect(window.open).toHaveBeenCalledWith(
+        'https://aka.ms/vs/17/release/vc_redist.x64.exe',
+        '_blank'
+      )
     })
   })
 })

--- a/apps/desktop-ui/src/stores/maintenanceTaskStore.test.ts
+++ b/apps/desktop-ui/src/stores/maintenanceTaskStore.test.ts
@@ -1,0 +1,313 @@
+import { createTestingPinia } from '@pinia/testing'
+import type { InstallValidation } from '@comfyorg/comfyui-electron-types'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockElectron, testTasks } = vi.hoisted(() => {
+  const terminalTaskExecute = vi.fn().mockResolvedValue(true)
+  const basicTaskExecute = vi.fn().mockResolvedValue(true)
+
+  return {
+    mockElectron: {
+      Validation: {
+        validateInstallation: vi.fn()
+      }
+    },
+    testTasks: [
+      {
+        id: 'basicTask',
+        name: 'Basic Task',
+        execute: basicTaskExecute
+      },
+      {
+        id: 'terminalTask',
+        name: 'Terminal Task',
+        execute: terminalTaskExecute,
+        usesTerminal: true,
+        isInstallationFix: true
+      }
+    ]
+  }
+})
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => mockElectron)
+}))
+
+vi.mock('@/constants/desktopMaintenanceTasks', () => ({
+  DESKTOP_MAINTENANCE_TASKS: testTasks
+}))
+
+import { useMaintenanceTaskStore } from '@/stores/maintenanceTaskStore'
+import type { MaintenanceTask } from '@/types/desktop/maintenanceTypes'
+
+type PartialInstallValidation = Partial<InstallValidation> &
+  Record<string, unknown>
+
+function makeUpdate(
+  overrides: PartialInstallValidation = {}
+): InstallValidation {
+  return {
+    inProgress: false,
+    installState: 'installed',
+    ...overrides
+  } as InstallValidation
+}
+
+function createStore() {
+  setActivePinia(createTestingPinia({ stubActions: false }))
+  return useMaintenanceTaskStore()
+}
+
+describe('useMaintenanceTaskStore', () => {
+  let store: ReturnType<typeof useMaintenanceTaskStore>
+  const [basicTask, terminalTask] = testTasks as MaintenanceTask[]
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    store = createStore()
+  })
+
+  describe('initial state', () => {
+    it('creates runners for all tasks', () => {
+      expect(store.tasks.length).toBe(testTasks.length)
+    })
+
+    it('starts with isRefreshing false', () => {
+      expect(store.isRefreshing).toBe(false)
+    })
+
+    it('starts with no errors', () => {
+      expect(store.anyErrors).toBe(false)
+    })
+
+    it('starts with unsafeBasePath false', () => {
+      expect(store.unsafeBasePath).toBe(false)
+    })
+
+    it('starts with no running terminal commands', () => {
+      expect(store.isRunningTerminalCommand).toBe(false)
+    })
+
+    it('starts with no running installation fixes', () => {
+      expect(store.isRunningInstallationFix).toBe(false)
+    })
+  })
+
+  describe('processUpdate', () => {
+    it('sets isRefreshing to true during in-progress update', () => {
+      store.processUpdate(makeUpdate({ inProgress: true }))
+      expect(store.isRefreshing).toBe(true)
+    })
+
+    it('sets isRefreshing to false when update is complete', () => {
+      store.processUpdate(makeUpdate({ inProgress: false, basicTask: 'OK' }))
+      expect(store.isRefreshing).toBe(false)
+    })
+
+    it('updates runner state for tasks present in the final update', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'error' }))
+      expect(store.getRunner(basicTask).state).toBe('error')
+    })
+
+    it('sets task state to warning from update', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'warning' }))
+      expect(store.getRunner(basicTask).state).toBe('warning')
+    })
+
+    it('marks runners as refreshing when task id is absent from in-progress update', () => {
+      store.processUpdate(makeUpdate({ inProgress: true }))
+      expect(store.getRunner(basicTask).refreshing).toBe(true)
+    })
+
+    it('marks task as skipped when absent from final update', () => {
+      store.processUpdate(makeUpdate({ inProgress: false }))
+      expect(store.getRunner(basicTask).state).toBe('skipped')
+    })
+
+    it('clears refreshing flag after final update', () => {
+      store.processUpdate(makeUpdate({ inProgress: true }))
+      store.processUpdate(makeUpdate({ inProgress: false }))
+      expect(store.getRunner(basicTask).refreshing).toBe(false)
+    })
+
+    it('stores lastUpdate and exposes unsafeBasePath', () => {
+      store.processUpdate(makeUpdate({ unsafeBasePath: true }))
+      expect(store.unsafeBasePath).toBe(true)
+    })
+
+    it('exposes unsafeBasePathReason from the update', () => {
+      store.processUpdate(
+        makeUpdate({ unsafeBasePath: true, unsafeBasePathReason: 'oneDrive' })
+      )
+      expect(store.unsafeBasePathReason).toBe('oneDrive')
+    })
+  })
+
+  describe('anyErrors', () => {
+    it('returns true when any task has error state', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'error' }))
+      expect(store.anyErrors).toBe(true)
+    })
+
+    it('returns false when all tasks are OK', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'OK', terminalTask: 'OK' }))
+      expect(store.anyErrors).toBe(false)
+    })
+
+    it('returns false when all tasks are warning', () => {
+      store.processUpdate(
+        makeUpdate({ basicTask: 'warning', terminalTask: 'warning' })
+      )
+      expect(store.anyErrors).toBe(false)
+    })
+  })
+
+  describe('runner state transitions', () => {
+    it('marks runner as resolved when transitioning from error to OK', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'error' }))
+      store.processUpdate(makeUpdate({ basicTask: 'OK' }))
+      expect(store.getRunner(basicTask).resolved).toBe(true)
+    })
+
+    it('does not mark resolved for warning to OK transition', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'warning' }))
+      store.processUpdate(makeUpdate({ basicTask: 'OK' }))
+      expect(store.getRunner(basicTask).resolved).toBeFalsy()
+    })
+
+    it('clears resolved flag when task returns to error', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'error' }))
+      store.processUpdate(makeUpdate({ basicTask: 'OK' }))
+      store.processUpdate(makeUpdate({ basicTask: 'error' }))
+      expect(store.getRunner(basicTask).resolved).toBeFalsy()
+    })
+  })
+
+  describe('clearResolved', () => {
+    it('clears resolved flags on all runners', () => {
+      store.processUpdate(makeUpdate({ basicTask: 'error' }))
+      store.processUpdate(makeUpdate({ basicTask: 'OK' }))
+      expect(store.getRunner(basicTask).resolved).toBe(true)
+
+      store.clearResolved()
+      expect(store.getRunner(basicTask).resolved).toBeFalsy()
+    })
+  })
+
+  describe('execute', () => {
+    it('returns true when task execution succeeds', async () => {
+      vi.mocked(basicTask.execute).mockResolvedValue(true)
+      const result = await store.execute(basicTask)
+      expect(result).toBe(true)
+    })
+
+    it('returns false when task execution fails', async () => {
+      vi.mocked(basicTask.execute).mockResolvedValue(false)
+      const result = await store.execute(basicTask)
+      expect(result).toBe(false)
+    })
+
+    it('calls refreshDesktopTasks after successful installation-fix task', async () => {
+      vi.mocked(terminalTask.execute).mockResolvedValue(true)
+      await store.execute(terminalTask)
+      expect(
+        mockElectron.Validation.validateInstallation
+      ).toHaveBeenCalledOnce()
+    })
+
+    it('does not call refreshDesktopTasks when task is not an installation fix', async () => {
+      vi.mocked(basicTask.execute).mockResolvedValue(true)
+      await store.execute(basicTask)
+      expect(
+        mockElectron.Validation.validateInstallation
+      ).not.toHaveBeenCalled()
+    })
+
+    it('does not call refreshDesktopTasks when installation-fix task fails', async () => {
+      vi.mocked(terminalTask.execute).mockResolvedValue(false)
+      await store.execute(terminalTask)
+      expect(
+        mockElectron.Validation.validateInstallation
+      ).not.toHaveBeenCalled()
+    })
+
+    it('sets runner executing to true during task execution', async () => {
+      let resolveTask!: (value: boolean) => void
+      vi.mocked(basicTask.execute).mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveTask = resolve
+        })
+      )
+
+      const executePromise = store.execute(basicTask)
+      expect(store.getRunner(basicTask).executing).toBe(true)
+
+      resolveTask(true)
+      await executePromise
+      expect(store.getRunner(basicTask).executing).toBe(false)
+    })
+
+    it('clears executing flag when task throws', async () => {
+      vi.mocked(basicTask.execute).mockRejectedValue(new Error('fail'))
+      await expect(store.execute(basicTask)).rejects.toThrow('fail')
+      expect(store.getRunner(basicTask).executing).toBe(false)
+    })
+
+    it('sets runner error message when task throws', async () => {
+      vi.mocked(basicTask.execute).mockRejectedValue(
+        new Error('something broke')
+      )
+      await expect(store.execute(basicTask)).rejects.toThrow()
+      expect(store.getRunner(basicTask).error).toBe('something broke')
+    })
+
+    it('clears runner error on successful execution', async () => {
+      vi.mocked(basicTask.execute).mockRejectedValue(new Error('fail'))
+      await expect(store.execute(basicTask)).rejects.toThrow()
+
+      vi.mocked(basicTask.execute).mockResolvedValue(true)
+      await store.execute(basicTask)
+      expect(store.getRunner(basicTask).error).toBeUndefined()
+    })
+  })
+
+  describe('isRunningTerminalCommand', () => {
+    it('returns true while a terminal task is executing', async () => {
+      let resolveTask!: (value: boolean) => void
+      vi.mocked(terminalTask.execute).mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveTask = resolve
+        })
+      )
+
+      const executePromise = store.execute(terminalTask)
+      expect(store.isRunningTerminalCommand).toBe(true)
+
+      resolveTask(true)
+      await executePromise
+      expect(store.isRunningTerminalCommand).toBe(false)
+    })
+
+    it('returns false when no terminal tasks are executing', () => {
+      expect(store.isRunningTerminalCommand).toBe(false)
+    })
+  })
+
+  describe('isRunningInstallationFix', () => {
+    it('returns true while an installation-fix task is executing', async () => {
+      let resolveTask!: (value: boolean) => void
+      vi.mocked(terminalTask.execute).mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveTask = resolve
+        })
+      )
+
+      const executePromise = store.execute(terminalTask)
+      expect(store.isRunningInstallationFix).toBe(true)
+
+      resolveTask(true)
+      await executePromise
+    })
+  })
+})

--- a/apps/desktop-ui/src/stores/maintenanceTaskStore.test.ts
+++ b/apps/desktop-ui/src/stores/maintenanceTaskStore.test.ts
@@ -68,32 +68,6 @@ describe('useMaintenanceTaskStore', () => {
     store = createStore()
   })
 
-  describe('initial state', () => {
-    it('creates runners for all tasks', () => {
-      expect(store.tasks.length).toBe(testTasks.length)
-    })
-
-    it('starts with isRefreshing false', () => {
-      expect(store.isRefreshing).toBe(false)
-    })
-
-    it('starts with no errors', () => {
-      expect(store.anyErrors).toBe(false)
-    })
-
-    it('starts with unsafeBasePath false', () => {
-      expect(store.unsafeBasePath).toBe(false)
-    })
-
-    it('starts with no running terminal commands', () => {
-      expect(store.isRunningTerminalCommand).toBe(false)
-    })
-
-    it('starts with no running installation fixes', () => {
-      expect(store.isRunningInstallationFix).toBe(false)
-    })
-  })
-
   describe('processUpdate', () => {
     it('sets isRefreshing to true during in-progress update', () => {
       store.processUpdate(makeUpdate({ inProgress: true }))
@@ -308,6 +282,7 @@ describe('useMaintenanceTaskStore', () => {
 
       resolveTask(true)
       await executePromise
+      expect(store.isRunningInstallationFix).toBe(false)
     })
   })
 })

--- a/apps/desktop-ui/src/test/setup.ts
+++ b/apps/desktop-ui/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/apps/desktop-ui/src/test/withSetup.ts
+++ b/apps/desktop-ui/src/test/withSetup.ts
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/vue'
+import { defineComponent } from 'vue'
+
+export function withSetup<T>(composable: () => T): T {
+  let result!: T
+  render(
+    defineComponent({
+      setup() {
+        result = composable()
+        return {}
+      },
+      template: '<div />'
+    })
+  )
+  return result
+}

--- a/apps/desktop-ui/src/utils/electronMirrorCheck.test.ts
+++ b/apps/desktop-ui/src/utils/electronMirrorCheck.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockElectron } = vi.hoisted(() => ({
+  mockElectron: {
+    NetWork: {
+      canAccessUrl: vi.fn<[url: string], Promise<boolean>>()
+    }
+  }
+}))
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: vi.fn(() => mockElectron)
+}))
+
+import { checkMirrorReachable } from '@/utils/electronMirrorCheck'
+
+describe('checkMirrorReachable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns false for an invalid URL without calling canAccessUrl', async () => {
+    const result = await checkMirrorReachable('not-a-url')
+    expect(result).toBe(false)
+    expect(mockElectron.NetWork.canAccessUrl).not.toHaveBeenCalled()
+  })
+
+  it('returns false when canAccessUrl returns false', async () => {
+    mockElectron.NetWork.canAccessUrl.mockResolvedValue(false)
+    const result = await checkMirrorReachable('https://example.com')
+    expect(result).toBe(false)
+  })
+
+  it('returns true when URL is valid and canAccessUrl returns true', async () => {
+    mockElectron.NetWork.canAccessUrl.mockResolvedValue(true)
+    const result = await checkMirrorReachable('https://example.com')
+    expect(result).toBe(true)
+  })
+
+  it('passes the mirror URL to canAccessUrl', async () => {
+    const url = 'https://pypi.org/simple/'
+    mockElectron.NetWork.canAccessUrl.mockResolvedValue(true)
+    await checkMirrorReachable(url)
+    expect(mockElectron.NetWork.canAccessUrl).toHaveBeenCalledWith(url)
+  })
+
+  it('returns false for empty string', async () => {
+    const result = await checkMirrorReachable('')
+    expect(result).toBe(false)
+    expect(mockElectron.NetWork.canAccessUrl).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop-ui/src/utils/envUtil.test.ts
+++ b/apps/desktop-ui/src/utils/envUtil.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isElectron, isNativeWindow } from '@/utils/envUtil'
+
+describe('isElectron', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns true when window.electronAPI is an object', () => {
+    vi.stubGlobal('window', { ...window, electronAPI: {} })
+    expect(isElectron()).toBe(true)
+  })
+
+  it('returns false when window.electronAPI is undefined', () => {
+    vi.stubGlobal('window', { ...window, electronAPI: undefined })
+    expect(isElectron()).toBe(false)
+  })
+
+  it('returns false when window.electronAPI is absent', () => {
+    const copy = { ...window } as Record<string, unknown>
+    delete copy['electronAPI']
+    vi.stubGlobal('window', copy)
+    expect(isElectron()).toBe(false)
+  })
+})
+
+describe('isNativeWindow', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns true when Electron and windowControlsOverlay.visible is true', () => {
+    vi.stubGlobal('window', {
+      ...window,
+      electronAPI: {},
+      navigator: {
+        ...window.navigator,
+        windowControlsOverlay: { visible: true }
+      }
+    })
+    expect(isNativeWindow()).toBe(true)
+  })
+
+  it('returns false when not in Electron', () => {
+    const copy = { ...window } as Record<string, unknown>
+    delete copy['electronAPI']
+    vi.stubGlobal('window', copy)
+    expect(isNativeWindow()).toBe(false)
+  })
+
+  it('returns false when windowControlsOverlay.visible is false', () => {
+    vi.stubGlobal('window', {
+      ...window,
+      electronAPI: {},
+      navigator: {
+        ...window.navigator,
+        windowControlsOverlay: { visible: false }
+      }
+    })
+    expect(isNativeWindow()).toBe(false)
+  })
+
+  it('returns false when windowControlsOverlay is absent', () => {
+    vi.stubGlobal('window', {
+      ...window,
+      electronAPI: {},
+      navigator: { ...window.navigator, windowControlsOverlay: undefined }
+    })
+    expect(isNativeWindow()).toBe(false)
+  })
+})

--- a/apps/desktop-ui/src/utils/refUtil.test.ts
+++ b/apps/desktop-ui/src/utils/refUtil.test.ts
@@ -1,0 +1,116 @@
+import { render } from '@testing-library/vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, defineComponent, nextTick, ref } from 'vue'
+
+import { useMinLoadingDurationRef } from '@/utils/refUtil'
+
+function withSetup<T>(composable: () => T): T {
+  let result!: T
+  render(
+    defineComponent({
+      setup() {
+        result = composable()
+        return {}
+      },
+      template: '<div />'
+    })
+  )
+  return result
+}
+
+describe('useMinLoadingDurationRef', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reflects false when source is initially false', () => {
+    const source = ref(false)
+    const result = withSetup(() => useMinLoadingDurationRef(source))
+    expect(result.value).toBe(false)
+  })
+
+  it('reflects true when source is initially true', () => {
+    const source = ref(true)
+    const result = withSetup(() => useMinLoadingDurationRef(source))
+    expect(result.value).toBe(true)
+  })
+
+  it('becomes true immediately when source transitions to true', async () => {
+    const source = ref(false)
+    const result = withSetup(() => useMinLoadingDurationRef(source))
+    source.value = true
+    await nextTick()
+    expect(result.value).toBe(true)
+  })
+
+  it('stays true within minDuration after source returns to false', async () => {
+    const source = ref(false)
+    const result = withSetup(() => useMinLoadingDurationRef(source, 250))
+
+    source.value = true
+    await nextTick()
+    source.value = false
+    await nextTick()
+
+    vi.advanceTimersByTime(100)
+    await nextTick()
+    expect(result.value).toBe(true)
+  })
+
+  it('becomes false after minDuration has elapsed', async () => {
+    const source = ref(false)
+    const result = withSetup(() => useMinLoadingDurationRef(source, 250))
+
+    source.value = true
+    await nextTick()
+    source.value = false
+    await nextTick()
+
+    vi.advanceTimersByTime(250)
+    await nextTick()
+    expect(result.value).toBe(false)
+  })
+
+  it('remains true while source is true even after minDuration elapses', async () => {
+    const source = ref(false)
+    const result = withSetup(() => useMinLoadingDurationRef(source, 250))
+
+    source.value = true
+    await nextTick()
+    vi.advanceTimersByTime(500)
+    await nextTick()
+    expect(result.value).toBe(true)
+  })
+
+  it('works with a computed ref as input', async () => {
+    const raw = ref(false)
+    const source = computed(() => raw.value)
+    const result = withSetup(() => useMinLoadingDurationRef(source))
+
+    raw.value = true
+    await nextTick()
+    expect(result.value).toBe(true)
+  })
+
+  it('uses 250ms as default minDuration', async () => {
+    const source = ref(false)
+    const result = withSetup(() => useMinLoadingDurationRef(source))
+
+    source.value = true
+    await nextTick()
+    source.value = false
+    await nextTick()
+
+    vi.advanceTimersByTime(249)
+    await nextTick()
+    expect(result.value).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    await nextTick()
+    expect(result.value).toBe(false)
+  })
+})

--- a/apps/desktop-ui/src/utils/refUtil.test.ts
+++ b/apps/desktop-ui/src/utils/refUtil.test.ts
@@ -1,22 +1,8 @@
-import { render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, defineComponent, nextTick, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 
+import { withSetup } from '@/test/withSetup'
 import { useMinLoadingDurationRef } from '@/utils/refUtil'
-
-function withSetup<T>(composable: () => T): T {
-  let result!: T
-  render(
-    defineComponent({
-      setup() {
-        result = composable()
-        return {}
-      },
-      template: '<div />'
-    })
-  )
-  return result
-}
 
 describe('useMinLoadingDurationRef', () => {
   beforeEach(() => {

--- a/apps/desktop-ui/tsconfig.json
+++ b/apps/desktop-ui/tsconfig.json
@@ -13,7 +13,8 @@
     "src/**/*.ts",
     "src/**/*.vue",
     "src/**/*.d.ts",
-    "vite.config.mts"
+    "vite.config.mts",
+    "vitest.config.mts"
   ],
   "references": []
 }

--- a/apps/desktop-ui/vitest.config.mts
+++ b/apps/desktop-ui/vitest.config.mts
@@ -1,0 +1,22 @@
+import vue from '@vitejs/plugin-vue'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(projectRoot, 'src'),
+      '@frontend-locales': path.resolve(projectRoot, '../../src/locales')
+    }
+  },
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    setupFiles: ['./src/test/setup.ts']
+  }
+})


### PR DESCRIPTION
## Summary

Resolves #11102

| Requirement | Status | Implementation |
| :--- | :--- | :--- |
| Add vitest configuration for desktop-ui workspace | ✅ Done | Added `apps/desktop-ui/vitest.config.mts` with `happy-dom` environment, `@` alias, and `setupFiles` pointing to `src/test/setup.ts` (registers `@testing-library/jest-dom` matchers) |
| Add test:unit script to package.json | ✅ Done | Added `"test:unit": "vitest run --config vitest.config.mts"` to `apps/desktop-ui/package.json` |
| stores/maintenanceTaskStore.ts | ✅ Done | 34 tests covering task state machine, IPC integration, executeTask flow, and error handling via `@pinia/testing` |
| utils/electronMirrorCheck.ts | ✅ Done | 5 tests covering URL validation, canAccessUrl delegation, and true/false return logic |
| utils/refUtil.ts (useMinLoadingDurationRef) | ✅ Done | 7 tests covering initial state, timing behavior using `vi.useFakeTimers`, and computed ref input |
| utils/envUtil.ts | ✅ Done | 7 tests covering electronAPI detection and fallback behavior |
| constants/desktopDialogs.ts | ✅ Done | 8 tests covering dialog structure and field contracts |
| constants/desktopMaintenanceTasks.ts | ✅ Done | 5 tests covering `pythonPackages.execute` success/failure return values, and URL-opening tasks calling `window.open` |
| composables/bottomPanelTabs/useTerminal.ts | ✅ Done | 7 tests covering key event handler: Ctrl/Meta+C with/without selection, Ctrl/Meta+V, non-keydown events, and unrelated keys — mocked xterm with Vitest v4-compatible function constructors |
| composables/bottomPanelTabs/useTerminalBuffer.ts | ✅ Done | 2 tests for `copyTo`: verifies serialized buffer content is written to destination terminal |
| utils/validationUtil.ts | ⛔ Skipped | The current file contains only a `ValidationState` enum with no logic. There is no behavior to test without writing a change-detector test (asserting enum values), which violates project testing guidelines |

**Additional config changes (not in issue but required to make tests work):**

| Change | Reason |
| :--- | :--- |
| Added `"vitest.config.mts"` to `apps/desktop-ui/tsconfig.json` include | Required for ESLint's TypeScript parser to process the config file without a parsing error |
| Removed 6 redundant test devDependencies from `apps/desktop-ui/package.json` | `vitest`, `@testing-library/*`, `@pinia/testing`, `happy-dom` are already declared at the root and hoisted by pnpm — re-declaring them in the sub-package is unnecessary |

## Changes
- Add vitest.config.mts with happy-dom environment and path aliases
- Add src/test/setup.ts to register @testing-library/jest-dom matchers
- Add test:unit script to package.json
- Add vitest.config.mts to tsconfig.json include for ESLint compatibility
- Remove redundant test devDependencies already declared at root
- Add 132 tests across 16 files covering stores, composables, utils, and constants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test- and config-only changes; main risk is CI/build instability from new Vitest configuration or brittle mocks, with no runtime behavior changes shipped to users.
> 
> **Overview**
> Adds a dedicated Vitest setup for `apps/desktop-ui` (new `vitest.config.mts` using `happy-dom`, aliases, and a `jest-dom` setup file) and wires it into the workspace via a new `test:unit` script plus `tsconfig.json` inclusion.
> 
> Introduces a broad set of new unit tests for desktop UI components, composables, constants, utilities, and the `maintenanceTaskStore` (mocking Electron/PrimeVue/Xterm as needed) to validate state transitions, validation flows, and key UI behaviors without changing production logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a96ffb37c49900d157498c96178207363b5ac86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11275-test-add-unit-test-suite-for-apps-desktop-ui-3436d73d36508145ae1fe99ec7a3a4fa) by [Unito](https://www.unito.io)
