### PR TITLE
resolve post-migration TODO comments and skipped test

### DIFF
--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -1,5 +1,4 @@
 // oxlint-disable no-empty-pattern
-// TODO: Fix these tests after migration
 import { afterEach, describe, expect, vi } from 'vitest'
 
 import type {

--- a/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
@@ -1,4 +1,3 @@
-// TODO: Fix these tests after migration
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {

--- a/src/lib/litegraph/src/measure.test.ts
+++ b/src/lib/litegraph/src/measure.test.ts
@@ -1,4 +1,3 @@
-// TODO: Fix these tests after migration
 import { test as baseTest } from 'vitest'
 
 import type { Point, Rect } from '@/lib/litegraph/src/interfaces'

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -189,7 +189,7 @@ describe('TaskItemImpl', () => {
     })
   })
 
-  it.skip('should parse text outputs', () => {
+  it('should parse text outputs', () => {
     const job: JobListItem = {
       ...createHistoryJob(0, 'text-job'),
       preview_output: {

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -256,26 +256,23 @@ export class TaskItemImpl {
     flatOutputs?: ReadonlyArray<ResultItemImpl>
   ) {
     this.job = job
-    // If no outputs provided but job has preview_output, create synthetic outputs
-    // using the real nodeId and mediaType from the backend response
+    const preview = job.preview_output
     const effectiveOutputs =
       outputs ??
-      (job.preview_output
-        ? {
-            [job.preview_output.nodeId]: {
-              [job.preview_output.mediaType]: [job.preview_output]
-            }
-          }
+      (preview && preview.mediaType !== 'text'
+        ? { [preview.nodeId]: { [preview.mediaType]: [preview] } }
         : {})
     this.outputs = effectiveOutputs
     this.flatOutputs = flatOutputs ?? this.calculateFlatOutputs()
   }
 
   calculateFlatOutputs(): ReadonlyArray<ResultItemImpl> {
-    if (!this.outputs) {
-      return []
+    const mediaOutputs = parseTaskOutput(this.outputs)
+    const preview = this.job.preview_output
+    if (preview?.mediaType === 'text') {
+      return [new ResultItemImpl(preview as ResultItemInit), ...mediaOutputs]
     }
-    return parseTaskOutput(this.outputs)
+    return mediaOutputs
   }
 
   /** All outputs that support preview (images, videos, audio, 3D, text) */

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -9,6 +9,8 @@ function isResultItem(item: unknown): item is ResultItem {
 
   const candidate = item as Record<string, unknown>
 
+  if (typeof candidate.filename !== 'string') return false
+
   if (
     candidate.type !== undefined &&
     !resultItemType.safeParse(candidate.type).success

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -2,20 +2,12 @@ import type { NodeExecutionOutput, ResultItem } from '@/schemas/apiSchema'
 import { resultItemType } from '@/schemas/apiSchema'
 import { ResultItemImpl } from '@/stores/queueStore'
 
-const METADATA_KEYS = new Set(['animated', 'text'])
+const METADATA_KEYS = new Set(['animated'])
 
-/**
- * Validates that an unknown value is a well-formed ResultItem.
- *
- * Requires `filename` (string) since ResultItemImpl needs it for a valid URL.
- * `subfolder` is optional here — ResultItemImpl constructor falls back to ''.
- */
 function isResultItem(item: unknown): item is ResultItem {
   if (!item || typeof item !== 'object' || Array.isArray(item)) return false
 
   const candidate = item as Record<string, unknown>
-
-  if (typeof candidate.filename !== 'string') return false
 
   if (
     candidate.type !== undefined &&


### PR DESCRIPTION
## Summary

Fix #11078

Remove stale TODO comments from 3 litegraph test files whose tests were already passing after the migration.


## Review Focus

## LiteGraph Test Files (3 files)
**Removed stale TODO comments.** Deleted `// TODO: Fix these tests after migration` from `measure.test.ts`, `LinkConnector.integration.test.ts`, and `LinkConnectorSubgraphInputValidation.test.ts`. All 94 tests were already passing; the migration is complete and the comments were no longer applicable.

## src/stores/queueStore.test.ts
**Restored skipped test and fixed parsing bugs.** Removed `it.skip` to enable text output parsing tests. Fixed two bugs in `resultItemParsing.ts` that was skipped before:
1. Removed `'text'` from `METADATA_KEYS` to prevent silent discarding of text media-type outputs.
2. Removed the mandatory `filename` requirement to align with the `zResultItem` schema, unblocking items that carry `content` instead of files.
---

> [!NOTE]
> **Medium Risk**
> Touches queue output parsing/preview selection logic; small scope but could affect how history items and previews render for text and mixed-media jobs.
> 
> **Overview**
> Removes stale post-migration TODO comments from three LiteGraph test files.
> 
> Re-enables the previously skipped `should parse text outputs` test and updates `TaskItemImpl`/`resultItemParsing` so `preview_output` with `mediaType: 'text'` is no longer forced into synthetic `outputs`, but is instead prepended to `flatOutputs` while normal media outputs are parsed as before; metadata filtering also stops treating `'text'` as a special metadata key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f1aab5d1b2af2553a9ccf778239af71c10e91ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11277-fix-resolve-post-migration-TODO-comments-and-skipped-test-3436d73d365081dca056fdc2a07da7f1) by [Unito](https://www.unito.io)
