### PR TITLE
fix: include focusMode in splitter refresh key to prevent panel resize

### DIFF
--- a/src/components/LiteGraphCanvasSplitterOverlay.vue
+++ b/src/components/LiteGraphCanvasSplitterOverlay.vue
@@ -264,7 +264,7 @@ function normalizeSavedSizes() {
  * to recalculate the width and panel order
  */
 const splitterRefreshKey = computed(() => {
-  return `main-splitter${rightSidePanelVisible.value ? '-with-right-panel' : ''}${isSelectMode.value ? '-builder' : ''}-${sidebarLocation.value}`
+  return `main-splitter${rightSidePanelVisible.value ? '-with-right-panel' : ''}${isSelectMode.value ? '-builder' : ''}-${sidebarLocation.value}${focusMode.value ? '-focus' : ''}`
 })
 
 const firstPanelStyle = computed(() => {


### PR DESCRIPTION
## Summary

Include `focusMode` in the splitter refresh key so toggling focus mode forces the Splitter component to remount instead of reusing stale localStorage sizes.

## Changes

- **What**: Added `focusMode` to `splitterRefreshKey` computed in `LiteGraphCanvasSplitterOverlay.vue`. When focus mode toggles, side panels are hidden/shown via `v-if`, but the Splitter instance was reused because its `:key` didn't change, causing PrimeVue Splitter to restore stale panel sizes from localStorage.

## Review Focus

Single-line change. Verify that toggling focus mode on/off no longer causes the properties panel to resize unexpectedly.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11292-fix-include-focusMode-in-splitter-refresh-key-to-prevent-panel-resize-3446d73d3650816f95dad37c5ab65e0c) by [Unito](https://www.unito.io)
