### PR TITLE
Test/edit attention unit tests

### DIFF
--- a/src/extensions/core/editAttention.test.ts
+++ b/src/extensions/core/editAttention.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    registerExtension: vi.fn(),
+    ui: { settings: { addSetting: vi.fn() } }
+  }
+}))
+
+import {
+  addWeightToParentheses,
+  findNearestEnclosure,
+  incrementWeight
+} from './editAttention'
+
+describe('incrementWeight', () => {
+  it('increments a weight by the given delta', () => {
+    expect(incrementWeight('1.0', 0.05)).toBe('1.05')
+  })
+
+  it('decrements a weight by the given delta', () => {
+    expect(incrementWeight('1.05', -0.05)).toBe('1')
+  })
+
+  it('returns the original string when weight is not a number', () => {
+    expect(incrementWeight('abc', 0.05)).toBe('abc')
+  })
+
+  it('rounds correctly and avoids floating point accumulation', () => {
+    expect(incrementWeight('1.1', 0.1)).toBe('1.2')
+  })
+
+  it('can produce a weight of zero', () => {
+    expect(incrementWeight('0.05', -0.05)).toBe('0')
+  })
+
+  it('produces negative weights', () => {
+    expect(incrementWeight('0.0', -0.05)).toBe('-0.05')
+  })
+})
+
+describe('findNearestEnclosure', () => {
+  it('returns start and end of a simple parenthesized expression', () => {
+    expect(findNearestEnclosure('(cat)', 2)).toEqual({ start: 1, end: 4 })
+  })
+
+  it('returns null when there are no parentheses', () => {
+    expect(findNearestEnclosure('cat dog', 3)).toBeNull()
+  })
+
+  it('returns null when cursor is outside any enclosure', () => {
+    expect(findNearestEnclosure('(cat) dog', 7)).toBeNull()
+  })
+
+  it('finds the inner enclosure when cursor is on nested content', () => {
+    expect(findNearestEnclosure('(outer (inner) end)', 9)).toEqual({
+      start: 8,
+      end: 13
+    })
+  })
+
+  it('finds the outer enclosure when cursor is on outer content', () => {
+    expect(findNearestEnclosure('(outer (inner) end)', 2)).toEqual({
+      start: 1,
+      end: 18
+    })
+  })
+
+  it('returns null for empty string', () => {
+    expect(findNearestEnclosure('', 0)).toBeNull()
+  })
+
+  it('returns null when opening paren has no matching closing paren', () => {
+    expect(findNearestEnclosure('(cat', 2)).toBeNull()
+  })
+})
+
+describe('addWeightToParentheses', () => {
+  it('adds weight 1.0 to a bare parenthesized token', () => {
+    expect(addWeightToParentheses('(cat)')).toBe('(cat:1.0)')
+  })
+
+  it('leaves a token that already has a weight unchanged', () => {
+    expect(addWeightToParentheses('(cat:1.5)')).toBe('(cat:1.5)')
+  })
+
+  it('leaves a token without parentheses unchanged', () => {
+    expect(addWeightToParentheses('cat')).toBe('cat')
+  })
+
+  it('leaves a token with scientific notation weight unchanged', () => {
+    expect(addWeightToParentheses('(cat:1e-3)')).toBe('(cat:1e-3)')
+  })
+
+  it('leaves a token with a negative weight unchanged', () => {
+    expect(addWeightToParentheses('(cat:-0.5)')).toBe('(cat:-0.5)')
+  })
+
+  it('adds weight to a multi-word parenthesized token', () => {
+    expect(addWeightToParentheses('(cat dog)')).toBe('(cat dog:1.0)')
+  })
+})

--- a/src/extensions/core/editAttention.test.ts
+++ b/src/extensions/core/editAttention.test.ts
@@ -40,63 +40,75 @@ describe('incrementWeight', () => {
 })
 
 describe('findNearestEnclosure', () => {
-  it('returns start and end of a simple parenthesized expression', () => {
-    expect(findNearestEnclosure('(cat)', 2)).toEqual({ start: 1, end: 4 })
-  })
-
-  it('returns null when there are no parentheses', () => {
-    expect(findNearestEnclosure('cat dog', 3)).toBeNull()
-  })
-
-  it('returns null when cursor is outside any enclosure', () => {
-    expect(findNearestEnclosure('(cat) dog', 7)).toBeNull()
-  })
-
-  it('finds the inner enclosure when cursor is on nested content', () => {
-    expect(findNearestEnclosure('(outer (inner) end)', 9)).toEqual({
-      start: 8,
-      end: 13
-    })
-  })
-
-  it('finds the outer enclosure when cursor is on outer content', () => {
-    expect(findNearestEnclosure('(outer (inner) end)', 2)).toEqual({
-      start: 1,
-      end: 18
-    })
-  })
-
-  it('returns null for empty string', () => {
-    expect(findNearestEnclosure('', 0)).toBeNull()
-  })
-
-  it('returns null when opening paren has no matching closing paren', () => {
-    expect(findNearestEnclosure('(cat', 2)).toBeNull()
+  it.each([
+    [
+      'returns start and end of a simple parenthesized expression',
+      '(cat)',
+      2,
+      { start: 1, end: 4 }
+    ],
+    [
+      'finds enclosure when cursor is on opening paren',
+      '(cat)',
+      0,
+      { start: 1, end: 4 }
+    ],
+    ['returns null when there are no parentheses', 'cat dog', 3, null],
+    ['returns null when cursor is outside any enclosure', '(cat) dog', 7, null],
+    [
+      'finds the inner enclosure when cursor is on nested content',
+      '(outer (inner) end)',
+      9,
+      { start: 8, end: 13 }
+    ],
+    [
+      'finds the outer enclosure when cursor is on outer content',
+      '(outer (inner) end)',
+      2,
+      { start: 1, end: 18 }
+    ],
+    ['returns null for empty string', '', 0, null],
+    [
+      'returns null when opening paren has no matching closing paren',
+      '(cat',
+      2,
+      null
+    ]
+  ])('%s', (_, text, cursor, expected) => {
+    expect(findNearestEnclosure(text, cursor)).toEqual(expected)
   })
 })
 
 describe('addWeightToParentheses', () => {
-  it('adds weight 1.0 to a bare parenthesized token', () => {
-    expect(addWeightToParentheses('(cat)')).toBe('(cat:1.0)')
-  })
-
-  it('leaves a token that already has a weight unchanged', () => {
-    expect(addWeightToParentheses('(cat:1.5)')).toBe('(cat:1.5)')
-  })
-
-  it('leaves a token without parentheses unchanged', () => {
-    expect(addWeightToParentheses('cat')).toBe('cat')
-  })
-
-  it('leaves a token with scientific notation weight unchanged', () => {
-    expect(addWeightToParentheses('(cat:1e-3)')).toBe('(cat:1e-3)')
-  })
-
-  it('leaves a token with a negative weight unchanged', () => {
-    expect(addWeightToParentheses('(cat:-0.5)')).toBe('(cat:-0.5)')
-  })
-
-  it('adds weight to a multi-word parenthesized token', () => {
-    expect(addWeightToParentheses('(cat dog)')).toBe('(cat dog:1.0)')
+  it.each([
+    ['adds weight 1.0 to a bare parenthesized token', '(cat)', '(cat:1.0)'],
+    [
+      'leaves a token that already has a weight unchanged',
+      '(cat:1.5)',
+      '(cat:1.5)'
+    ],
+    ['leaves a token without parentheses unchanged', 'cat', 'cat'],
+    [
+      'leaves a token with scientific notation weight unchanged',
+      '(cat:1e-3)',
+      '(cat:1e-3)'
+    ],
+    [
+      'leaves a token with a negative weight unchanged',
+      '(cat:-0.5)',
+      '(cat:-0.5)'
+    ],
+    [
+      'adds weight to a multi-word parenthesized token',
+      '(cat dog)',
+      '(cat dog:1.0)'
+    ],
+    [
+      'adds weight when colon-number appears in content but no trailing weight exists',
+      '(time 12:30)',
+      '(time 12:30:1.0)'
+    ]
+  ])('%s', (_, input, expected) => {
+    expect(addWeightToParentheses(input)).toBe(expected)
   })
 })

--- a/src/extensions/core/editAttention.test.ts
+++ b/src/extensions/core/editAttention.test.ts
@@ -107,6 +107,16 @@ describe('addWeightToParentheses', () => {
       'adds weight when colon-number appears in content but no trailing weight exists',
       '(time 12:30)',
       '(time 12:30:1.0)'
+    ],
+    [
+      'preserves existing weight on a digit-ending token name',
+      '(v2:1.5)',
+      '(v2:1.5)'
+    ],
+    [
+      'preserves existing weight on a LoRA name ending in a digit',
+      '(sdxl1:0.8)',
+      '(sdxl1:0.8)'
     ]
   ])('%s', (_, input, expected) => {
     expect(addWeightToParentheses(input)).toBe(expected)

--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -1,6 +1,6 @@
 import { app } from '../../scripts/app'
 
-export type Enclosure = {
+type Enclosure = {
   start: number
   end: number
 }

--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -1,6 +1,61 @@
 import { app } from '../../scripts/app'
 
-// Allows you to edit the attention weight by holding ctrl (or cmd) and using the up/down arrow keys
+export type Enclosure = {
+  start: number
+  end: number
+}
+
+export function incrementWeight(weight: string, delta: number): string {
+  const floatWeight = parseFloat(weight)
+  if (isNaN(floatWeight)) return weight
+  const newWeight = floatWeight + delta
+  return String(Number(newWeight.toFixed(10)))
+}
+
+export function findNearestEnclosure(
+  text: string,
+  cursorPos: number
+): Enclosure | null {
+  let start = cursorPos,
+    end = cursorPos
+  let openCount = 0,
+    closeCount = 0
+
+  while (start >= 0) {
+    start--
+    if (text[start] === '(' && openCount === closeCount) break
+    if (text[start] === '(') openCount++
+    if (text[start] === ')') closeCount++
+  }
+  if (start < 0) return null
+
+  openCount = 0
+  closeCount = 0
+
+  while (end < text.length) {
+    if (text[end] === ')' && openCount === closeCount) break
+    if (text[end] === '(') openCount++
+    if (text[end] === ')') closeCount++
+    end++
+  }
+  if (end === text.length) return null
+
+  return { start: start + 1, end: end }
+}
+
+export function addWeightToParentheses(text: string): string {
+  const parenRegex = /^\((.*)\)$/
+  const parenMatch = text.match(parenRegex)
+
+  const floatRegex = /:([+-]?(\d*\.)?\d+([eE][+-]?\d+)?)/
+  const floatMatch = text.match(floatRegex)
+
+  if (parenMatch && !floatMatch) {
+    return `(${parenMatch[1]}:1.0)`
+  } else {
+    return text
+  }
+}
 
 app.registerExtension({
   name: 'Comfy.EditAttention',
@@ -18,65 +73,6 @@ app.registerExtension({
       defaultValue: 0.05
     })
 
-    function incrementWeight(weight: string, delta: number): string {
-      const floatWeight = parseFloat(weight)
-      if (isNaN(floatWeight)) return weight
-      const newWeight = floatWeight + delta
-      return String(Number(newWeight.toFixed(10)))
-    }
-
-    type Enclosure = {
-      start: number
-      end: number
-    }
-
-    function findNearestEnclosure(
-      text: string,
-      cursorPos: number
-    ): Enclosure | null {
-      let start = cursorPos,
-        end = cursorPos
-      let openCount = 0,
-        closeCount = 0
-
-      // Find opening parenthesis before cursor
-      while (start >= 0) {
-        start--
-        if (text[start] === '(' && openCount === closeCount) break
-        if (text[start] === '(') openCount++
-        if (text[start] === ')') closeCount++
-      }
-      if (start < 0) return null
-
-      openCount = 0
-      closeCount = 0
-
-      // Find closing parenthesis after cursor
-      while (end < text.length) {
-        if (text[end] === ')' && openCount === closeCount) break
-        if (text[end] === '(') openCount++
-        if (text[end] === ')') closeCount++
-        end++
-      }
-      if (end === text.length) return null
-
-      return { start: start + 1, end: end }
-    }
-
-    function addWeightToParentheses(text: string): string {
-      const parenRegex = /^\((.*)\)$/
-      const parenMatch = text.match(parenRegex)
-
-      const floatRegex = /:([+-]?(\d*\.)?\d+([eE][+-]?\d+)?)/
-      const floatMatch = text.match(floatRegex)
-
-      if (parenMatch && !floatMatch) {
-        return `(${parenMatch[1]}:1.0)`
-      } else {
-        return text
-      }
-    }
-
     function editAttention(event: KeyboardEvent) {
       // @ts-expect-error Runtime narrowing not impl.
       const inputField: HTMLTextAreaElement = event.composedPath()[0]
@@ -92,7 +88,6 @@ app.registerExtension({
       let end = inputField.selectionEnd
       let selectedText = inputField.value.substring(start, end)
 
-      // If there is no selection, attempt to find the nearest enclosure, or select the current word
       if (!selectedText) {
         const nearestEnclosure = findNearestEnclosure(inputField.value, start)
         if (nearestEnclosure) {
@@ -100,7 +95,6 @@ app.registerExtension({
           end = nearestEnclosure.end
           selectedText = inputField.value.substring(start, end)
         } else {
-          // Select the current word, find the start and end of the word
           const delimiters = ' .,\\/!?%^*;:{}=-_`~()\r\n\t'
 
           while (
@@ -122,13 +116,11 @@ app.registerExtension({
         }
       }
 
-      // If the selection ends with a space, remove it
       if (selectedText[selectedText.length - 1] === ' ') {
         selectedText = selectedText.substring(0, selectedText.length - 1)
         end -= 1
       }
 
-      // If there are parentheses left and right of the selection, select them
       if (
         inputField.value[start - 1] === '(' &&
         inputField.value[end] === ')'
@@ -138,7 +130,6 @@ app.registerExtension({
         selectedText = inputField.value.substring(start, end)
       }
 
-      // If the selection is not enclosed in parentheses, add them
       if (
         selectedText[0] !== '(' ||
         selectedText[selectedText.length - 1] !== ')'
@@ -146,10 +137,8 @@ app.registerExtension({
         selectedText = `(${selectedText})`
       }
 
-      // If the selection does not have a weight, add a weight of 1.0
       selectedText = addWeightToParentheses(selectedText)
 
-      // Increment the weight
       const weightDelta = event.key === 'ArrowUp' ? delta : -delta
       const updatedText = selectedText.replace(
         /\((.*):([+-]?\d+(?:\.\d+)?)\)/,

--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -50,9 +50,11 @@ export function addWeightToParentheses(text: string): string {
   const parenMatch = text.match(/^\((.*)\)$/)
   if (!parenMatch) return text
   const innerText = parenMatch[1]
-  const hasTrailingWeight = /(?<!\d):[+-]?(?:\d*\.)?\d+(?:[eE][+-]?\d+)?$/.test(
-    innerText
-  )
+  // A time-like pattern (e.g. "12:30") is preceded by whitespace or string-start;
+  // everything else ending in ":number" is a weight, including digit-ending names like "v2:1.5".
+  const looksLikeTime = /(?:^|\s)\d{1,2}:\d{2}$/.test(innerText)
+  const hasTrailingWeight =
+    !looksLikeTime && /:[+-]?(?:\d*\.)?\d+(?:[eE][+-]?\d+)?$/.test(innerText)
   return hasTrailingWeight ? text : `(${innerText}:1.0)`
 }
 

--- a/src/extensions/core/editAttention.ts
+++ b/src/extensions/core/editAttention.ts
@@ -16,21 +16,24 @@ export function findNearestEnclosure(
   text: string,
   cursorPos: number
 ): Enclosure | null {
-  let start = cursorPos,
-    end = cursorPos
-  let openCount = 0,
+  let start = cursorPos
+  let end = cursorPos
+  let openCount = 0
+  let closeCount = 0
+
+  if (text[cursorPos] === '(') {
+    end = cursorPos + 1
+  } else {
+    while (start >= 0) {
+      start--
+      if (text[start] === '(' && openCount === closeCount) break
+      if (text[start] === '(') openCount++
+      if (text[start] === ')') closeCount++
+    }
+    if (start < 0) return null
+    openCount = 0
     closeCount = 0
-
-  while (start >= 0) {
-    start--
-    if (text[start] === '(' && openCount === closeCount) break
-    if (text[start] === '(') openCount++
-    if (text[start] === ')') closeCount++
   }
-  if (start < 0) return null
-
-  openCount = 0
-  closeCount = 0
 
   while (end < text.length) {
     if (text[end] === ')' && openCount === closeCount) break
@@ -44,17 +47,13 @@ export function findNearestEnclosure(
 }
 
 export function addWeightToParentheses(text: string): string {
-  const parenRegex = /^\((.*)\)$/
-  const parenMatch = text.match(parenRegex)
-
-  const floatRegex = /:([+-]?(\d*\.)?\d+([eE][+-]?\d+)?)/
-  const floatMatch = text.match(floatRegex)
-
-  if (parenMatch && !floatMatch) {
-    return `(${parenMatch[1]}:1.0)`
-  } else {
-    return text
-  }
+  const parenMatch = text.match(/^\((.*)\)$/)
+  if (!parenMatch) return text
+  const innerText = parenMatch[1]
+  const hasTrailingWeight = /(?<!\d):[+-]?(?:\d*\.)?\d+(?:[eE][+-]?\d+)?$/.test(
+    innerText
+  )
+  return hasTrailingWeight ? text : `(${innerText}:1.0)`
 }
 
 app.registerExtension({
@@ -116,32 +115,30 @@ app.registerExtension({
         }
       }
 
-      if (selectedText[selectedText.length - 1] === ' ') {
+      const selectionEndsWithSpace =
+        selectedText[selectedText.length - 1] === ' '
+      if (selectionEndsWithSpace) {
         selectedText = selectedText.substring(0, selectedText.length - 1)
         end -= 1
       }
 
-      if (
-        inputField.value[start - 1] === '(' &&
-        inputField.value[end] === ')'
-      ) {
+      const selectionIsSurroundedByParens =
+        inputField.value[start - 1] === '(' && inputField.value[end] === ')'
+      if (selectionIsSurroundedByParens) {
         start -= 1
         end += 1
         selectedText = inputField.value.substring(start, end)
       }
 
-      if (
-        selectedText[0] !== '(' ||
-        selectedText[selectedText.length - 1] !== ')'
-      ) {
-        selectedText = `(${selectedText})`
-      }
+      const selectionIsNotEnclosedInParens =
+        selectedText[0] !== '(' || selectedText[selectedText.length - 1] !== ')'
+      if (selectionIsNotEnclosedInParens) selectedText = `(${selectedText})`
 
       selectedText = addWeightToParentheses(selectedText)
 
       const weightDelta = event.key === 'ArrowUp' ? delta : -delta
       const updatedText = selectedText.replace(
-        /\((.*):([+-]?\d+(?:\.\d+)?)\)/,
+        /\((.*):([+-]?(?:\d*\.)?\d+(?:[eE][+-]?\d+)?)\)/,
         (_, text, weight) => {
           weight = incrementWeight(weight, weightDelta)
           if (weight == 1) {


### PR DESCRIPTION
## Summary

A follow-up PR of https://github.com/Comfy-Org/ComfyUI_frontend/issues/11107.


## Changes

Add unit test to `editAttention.ts` 
- [x] `Extract pure functions to module level`: **Moved** `incrementWeight`, `findNearestEnclosure`, and `addWeightToParentheses` out of the `init()` closure and **promoted** them to module-level functions with `export` to allow for independent testing.
- [x] `Add unit tests for incrementWeight`: **Added** 6 tests covering edge cases such as normal increment/decrement, NaN input, negative weights, and floating-point precision.
- [x] `Add unit tests for findNearestEnclosure`: **Added** 7 tests covering edge cases including simple brackets, no brackets, cursor outside, nested brackets (inner/outer), empty strings, and missing closing brackets.
- [x] `Add unit tests for addWeightToParentheses`: **Added** 6 tests covering scenarios like adding a default 1.0 weight, retaining existing weights, no changes when brackets are absent, scientific notation weights, negative weights, and multi-word tokens.
- [x] `Mock app module`: **Used** `vi.mock('@/scripts/app')` to intercept side effects from `app.registerExtension`, **preventing** the triggering of ComfyUI extension registration logic during module import.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts token selection/weight-detection logic used during Ctrl/Cmd+Arrow editing, which could subtly change how prompts are rewritten in edge cases (nested parens, scientific notation, time-like text). Adds tests that should reduce regression risk but behavior changes still warrant verification in the UI.
> 
> **Overview**
> Adds a new `vitest` unit test suite for `editAttention` by mocking `app.registerExtension` side effects and validating `incrementWeight`, `findNearestEnclosure`, and `addWeightToParentheses` across common and edge cases.
> 
> Refactors those helpers to exported module-level functions and tightens parsing/selection behavior: `findNearestEnclosure` now handles the cursor being on an opening `(`, `addWeightToParentheses` improves trailing weight detection (supports scientific notation/negatives and avoids misclassifying time-like `12:30`), and the weight-rewrite regex now matches exponent forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df20340b492be3a2d85b8359d2eef64aa0239e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11301-Test-edit-attention-unit-tests-3446d73d365081f29e8dfceefc06f5d3) by [Unito](https://www.unito.io)
