### PR TITLE
test: add unit tests for slotCalculations

### DIFF
--- a/src/renderer/core/canvas/litegraph/slotCalculations.test.ts
+++ b/src/renderer/core/canvas/litegraph/slotCalculations.test.ts
@@ -1,0 +1,193 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockLiteGraph = vi.hoisted(() => ({
+  NODE_TITLE_HEIGHT: 30,
+  NODE_SLOT_HEIGHT: 20,
+  NODE_COLLAPSED_WIDTH: 80,
+  vueNodesMode: false
+}))
+
+vi.mock('@/lib/litegraph/src/litegraph', () => ({
+  LiteGraph: mockLiteGraph
+}))
+
+vi.mock('@/renderer/core/layout/slots/slotIdentifier', () => ({
+  getSlotKey: vi.fn()
+}))
+
+vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
+  layoutStore: {
+    getSlotLayout: vi.fn().mockReturnValue(null),
+    getNodeLayoutRef: vi.fn().mockReturnValue({ value: null })
+  }
+}))
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type {
+  INodeInputSlot,
+  INodeOutputSlot
+} from '@/lib/litegraph/src/interfaces'
+
+import { calculateInputSlotPosFromSlot, getSlotPosition } from './slotCalculations';
+import type { SlotPositionContext } from './slotCalculations';
+
+const SLOT_HEIGHT = mockLiteGraph.NODE_SLOT_HEIGHT
+const TITLE_HEIGHT = mockLiteGraph.NODE_TITLE_HEIGHT
+
+function makeContext(
+  overrides: Partial<SlotPositionContext> = {}
+): SlotPositionContext {
+  return {
+    nodeX: 100,
+    nodeY: 200,
+    nodeWidth: 180,
+    nodeHeight: 120,
+    collapsed: false,
+    inputs: [],
+    outputs: [],
+    ...overrides
+  }
+}
+
+function makeInput(overrides: Partial<INodeInputSlot> = {}): INodeInputSlot {
+  return { name: 'input', type: 'INT', ...overrides } as INodeInputSlot
+}
+
+function makeOutput(overrides: Partial<INodeOutputSlot> = {}): INodeOutputSlot {
+  return { name: 'output', type: 'INT', ...overrides } as INodeOutputSlot
+}
+
+function makeNode(
+  overrides: Partial<{
+    inputs: INodeInputSlot[]
+    outputs: INodeOutputSlot[]
+    collapsed: boolean
+  }> = {}
+): LGraphNode {
+  return fromPartial<LGraphNode>({
+    id: 1,
+    pos: [100, 200],
+    size: [180, 120],
+    flags: { collapsed: overrides.collapsed ?? false },
+    _collapsed_width: mockLiteGraph.NODE_COLLAPSED_WIDTH,
+    constructor: { slot_start_y: undefined },
+    inputs: overrides.inputs ?? [],
+    outputs: overrides.outputs ?? [],
+    widgets: []
+  })
+}
+
+describe('calculateInputSlotPosFromSlot', () => {
+  describe('collapsed node', () => {
+    it('returns node origin offset upward by half title height', () => {
+      const input = makeInput()
+      const ctx = makeContext({ collapsed: true })
+      const [x, y] = calculateInputSlotPosFromSlot(ctx, input)
+      expect(x).toBe(100)
+      expect(y).toBe(200 - TITLE_HEIGHT * 0.5)
+    })
+  })
+
+  describe('hard-coded slot position', () => {
+    it('returns node origin plus the hard-coded offset', () => {
+      const input = makeInput({ pos: [10, 25] })
+      const ctx = makeContext()
+      const [x, y] = calculateInputSlotPosFromSlot(ctx, input)
+      expect(x).toBe(110)
+      expect(y).toBe(225)
+    })
+  })
+
+  describe('default vertical layout', () => {
+    it('places the first input slot at the correct x and y', () => {
+      const input = makeInput()
+      const ctx = makeContext({ inputs: [input] })
+      const [x, y] = calculateInputSlotPosFromSlot(ctx, input)
+      expect(x).toBe(100 + SLOT_HEIGHT * 0.5)
+      expect(y).toBeCloseTo(200 + 0.7 * SLOT_HEIGHT)
+    })
+
+    it('places subsequent slots below the first', () => {
+      const first = makeInput({ name: 'a' })
+      const second = makeInput({ name: 'b' })
+      const ctx = makeContext({ inputs: [first, second] })
+      const [, y1] = calculateInputSlotPosFromSlot(ctx, first)
+      const [, y2] = calculateInputSlotPosFromSlot(ctx, second)
+      expect(y2).toBeCloseTo(y1 + SLOT_HEIGHT)
+    })
+
+    it('respects slotStartY offset', () => {
+      const input = makeInput()
+      const base = makeContext({ inputs: [input] })
+      const withOffset = makeContext({ inputs: [input], slotStartY: 40 })
+      const [, yBase] = calculateInputSlotPosFromSlot(base, input)
+      const [, yOffset] = calculateInputSlotPosFromSlot(withOffset, input)
+      expect(yOffset).toBeCloseTo(yBase + 40)
+    })
+
+    it('excludes widget input slots from vertical ordering', () => {
+      const widget = makeInput({ name: 'widget', widget: { name: 'widget' } })
+      const regular = makeInput({ name: 'regular' })
+      const ctx = makeContext({
+        inputs: [widget, regular],
+        widgets: [{ name: 'widget' }]
+      })
+      const [, yRegular] = calculateInputSlotPosFromSlot(ctx, regular)
+      expect(yRegular).toBeCloseTo(200 + 0.7 * SLOT_HEIGHT)
+    })
+
+    it('excludes slots with hard-coded positions from vertical ordering', () => {
+      const fixed = makeInput({ name: 'fixed', pos: [0, 50] })
+      const regular = makeInput({ name: 'regular' })
+      const ctx = makeContext({ inputs: [fixed, regular] })
+      const [, y] = calculateInputSlotPosFromSlot(ctx, regular)
+      expect(y).toBeCloseTo(200 + 0.7 * SLOT_HEIGHT)
+    })
+  })
+})
+
+describe('getSlotPosition — legacy fallback (vueNodesMode disabled)', () => {
+  beforeEach(() => {
+    mockLiteGraph.vueNodesMode = false
+  })
+
+  it('calculates input slot position from node.pos', () => {
+    const input = makeInput()
+    const node = makeNode({ inputs: [input] })
+    const [x, y] = getSlotPosition(node, 0, true)
+    expect(x).toBe(100 + SLOT_HEIGHT * 0.5)
+    expect(y).toBeCloseTo(200 + 0.7 * SLOT_HEIGHT)
+  })
+
+  it('calculates output slot position from node.pos', () => {
+    const output = makeOutput()
+    const node = makeNode({ outputs: [output] })
+    const [x, y] = getSlotPosition(node, 0, false)
+    expect(x).toBeCloseTo(100 + 180 + 1 - SLOT_HEIGHT * 0.5)
+    expect(y).toBeCloseTo(200 + 0.7 * SLOT_HEIGHT)
+  })
+
+  it('returns node origin offset upward when node is collapsed and requesting input', () => {
+    const input = makeInput()
+    const node = makeNode({ inputs: [input], collapsed: true })
+    const [x, y] = getSlotPosition(node, 0, true)
+    expect(x).toBe(100)
+    expect(y).toBe(200 - TITLE_HEIGHT * 0.5)
+  })
+
+  it('returns node origin offset right when node is collapsed and requesting output', () => {
+    const output = makeOutput()
+    const node = makeNode({ outputs: [output], collapsed: true })
+    const [x, y] = getSlotPosition(node, 0, false)
+    expect(x).toBe(100 + mockLiteGraph.NODE_COLLAPSED_WIDTH)
+    expect(y).toBe(200 - TITLE_HEIGHT * 0.5)
+  })
+
+  it('returns node origin for out-of-range input slot index', () => {
+    const node = makeNode()
+    const [x, y] = getSlotPosition(node, 5, true)
+    expect(x).toBe(100)
+    expect(y).toBe(200)
+  })
+})

--- a/src/renderer/core/canvas/litegraph/slotCalculations.test.ts
+++ b/src/renderer/core/canvas/litegraph/slotCalculations.test.ts
@@ -29,8 +29,11 @@ import type {
   INodeOutputSlot
 } from '@/lib/litegraph/src/interfaces'
 
-import { calculateInputSlotPosFromSlot, getSlotPosition } from './slotCalculations';
-import type { SlotPositionContext } from './slotCalculations';
+import {
+  calculateInputSlotPosFromSlot,
+  getSlotPosition
+} from './slotCalculations'
+import type { SlotPositionContext } from './slotCalculations'
 
 const SLOT_HEIGHT = mockLiteGraph.NODE_SLOT_HEIGHT
 const TITLE_HEIGHT = mockLiteGraph.NODE_TITLE_HEIGHT


### PR DESCRIPTION
# PR Description

#11106 
**This PR only focus on `slotCalculations.ts`.**

Add unit tests for `slotCalculations.ts` — the centralized utility that calculates input/output slot positions in graph coordinates. This file had zero test coverage despite containing non-trivial branching logic used by both the litegraph adapter and the Vue renderer layout system.

## What's covered

### `calculateInputSlotPosFromSlot`
- [x] **Collapsed nodes**: Returns the node origin shifted up by half the title height.
- [x] **Hard-coded offsets**: Slots with specific `pos` offsets return `nodeOrigin + pos` directly.
- [x] **Default vertical layout**: Covers first slot x/y, multi-slot vertical ordering, `slotStartY` offset, exclusion of widget input slots, and exclusion of fixed-position slots from index ordering.

### `getSlotPosition` (Legacy fallback path, `vueNodesMode` disabled)
- [x] **Coordinate derivation**: Input and output slot positions derived correctly from `node.pos`.
- [x] **Collapsed state**: Collapsed input and output nodes use `title-height` and `NODE_COLLAPSED_WIDTH` offsets.
- [x] **Boundary handling**: Out-of-range slot index falls back to node origin.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that don’t affect runtime behavior; risk is limited to potential brittleness if slot layout constants or expectations change.
> 
> **Overview**
> Adds a new `slotCalculations.test.ts` suite covering `calculateInputSlotPosFromSlot` and the legacy (`LiteGraph.vueNodesMode` disabled) path of `getSlotPosition`.
> 
> Tests exercise key branches for collapsed nodes, hard-coded slot `pos` overrides, default vertical slot ordering (including `slotStartY`), and filtering of widget/fixed-position inputs, plus boundary behavior for out-of-range slot indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c5318695c084d794a13dabf9607b9bc76931fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11302-test-add-unit-tests-for-slotCalculations-3446d73d36508181a0ade81be05bd25f) by [Unito](https://www.unito.io)
