### PR TITLE
Change footer logo to fixed animation

### DIFF
--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -21,9 +21,8 @@ useFrameScrub(canvasRef, {
   scrollTrigger: (canvas) => ({
     trigger: canvas,
     start: 'top bottom',
-    endTrigger: footerRef.value,
-    end: 'bottom bottom',
-    scrub: true
+    end: 'top bottom',
+    scrub: 1
   })
 })
 


### PR DESCRIPTION
The animation for the footer logo was a little rough. To smooth things over, it's now a fixed 1 second animation across all frames that is triggered by the logo coming into view.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11314-Change-footer-logo-to-fixed-animation-3446d73d365081d3abd9c00459008590) by [Unito](https://www.unito.io)
