### PR TITLE
feat: show success toast after ComfyHub publish

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3225,7 +3225,9 @@
     "createProfileToPublish": "Create a profile to publish to ComfyHub",
     "createProfileCta": "Create a profile",
     "publishFailedTitle": "Publish failed",
-    "publishFailedDescription": "Something went wrong while publishing your workflow. Please try again."
+    "publishFailedDescription": "Something went wrong while publishing your workflow. Please try again.",
+    "publishSuccessTitle": "Published successfully",
+    "publishSuccessDescription": "Your workflow is now live on ComfyHub."
   },
   "comfyHubProfile": {
     "checkingAccess": "Checking your publishing access...",

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.test.ts
@@ -11,8 +11,10 @@ vi.mock('vue-i18n', async (importOriginal) => {
   }
 })
 
+const mockToastAdd = vi.hoisted(() => vi.fn())
+
 vi.mock('primevue/usetoast', () => ({
-  useToast: () => ({ add: vi.fn() })
+  useToast: () => ({ add: mockToastAdd })
 }))
 
 import ComfyHubPublishDialog from '@/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue'
@@ -218,6 +220,9 @@ describe('ComfyHubPublishDialog', () => {
     await flushPromises()
 
     expect(mockSubmitToComfyHub).toHaveBeenCalledOnce()
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' })
+    )
     expect(onClose).toHaveBeenCalledOnce()
   })
 

--- a/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue
+++ b/src/platform/workflow/sharing/components/publish/ComfyHubPublishDialog.vue
@@ -213,6 +213,12 @@ async function handlePublish(): Promise<void> {
     if (path) {
       cachePublishPrefill(path, formData.value)
     }
+    toast.add({
+      severity: 'success',
+      summary: t('comfyHubPublish.publishSuccessTitle'),
+      detail: t('comfyHubPublish.publishSuccessDescription'),
+      life: 5000
+    })
     onClose()
   } catch (error) {
     console.error('Failed to publish workflow:', error)


### PR DESCRIPTION
## Summary

Adds a success toast in the ComfyHub publish flow so users get explicit confirmation that the workflow was published before the dialog closes.

## Changes

- **What**: `ComfyHubPublishDialog.handlePublish()` calls `toast.add({ severity: 'success', ... })` after `submitToComfyHub()` resolves and before `onClose()` runs. Adds two i18n keys (`publishSuccessTitle`, `publishSuccessDescription`) and an assertion in the existing success-path test.

## Review Focus

- This is the lightweight stop-gap discussed in [Slack thread](https://comfy-organization.slack.com/archives/C0AEPRS8N74/p1776370871654139?thread_ts=1776362591.237159&cid=C0AEPRS8N74) while the larger published-state design is still pending phase-2 work. Symmetric with the existing `publishFailedTitle/Description` error toast.
- `submitToComfyHub` is synchronous (asset uploads happen inside it), so a successful resolve means the workflow is live.
- `<Toast>` is mounted in `GlobalToast.vue`, so it persists after `onClose()` destroys the dialog.

## Screenshots (if applicable)
<img width="1135" height="634" alt="Screenshot 2026-04-17 at 8 11 34 AM" src="https://github.com/user-attachments/assets/a71400a7-2055-4c2a-a761-9298cfa24e9a" />

n/a — toast text only.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11316-feat-show-success-toast-after-ComfyHub-publish-3446d73d365081a7bbb3ca29ca3bb618) by [Unito](https://www.unito.io)
