### PR TITLE
fix: show asset display names in bulk delete confirmation

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -484,4 +484,56 @@ describe('useMediaAssetActions', () => {
       )
     })
   })
+
+  describe('deleteAssets - confirmation dialog item names', () => {
+    beforeEach(() => {
+      mockIsCloud.value = true
+      mockGetAssetType.mockReturnValue('output')
+      mockShowDialog.mockReset()
+    })
+
+    it('should show user_metadata display names instead of hash filenames', () => {
+      const actions = useMediaAssetActions()
+
+      const assets = [
+        createMockAsset({
+          id: 'asset-1',
+          name: 'c885097ab185ced82f017bcbc98948918499f7480315fd5b928b5bb8d4951efc.png',
+          user_metadata: { name: 'My Sunset Render' }
+        }),
+        createMockAsset({
+          id: 'asset-2',
+          name: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2.png',
+          display_name: 'Portrait Variation'
+        })
+      ]
+
+      void actions.deleteAssets(assets)
+
+      expect(mockShowDialog).toHaveBeenCalledTimes(1)
+      const dialogProps = mockShowDialog.mock.calls[0][0].props as {
+        itemList: string[]
+      }
+      expect(dialogProps.itemList).toEqual([
+        'My Sunset Render',
+        'Portrait Variation'
+      ])
+    })
+
+    it('should fall back to asset.name when no display name is available', () => {
+      const actions = useMediaAssetActions()
+
+      const asset = createMockAsset({
+        id: 'asset-3',
+        name: 'fallback-image.png'
+      })
+
+      void actions.deleteAssets(asset)
+
+      const dialogProps = mockShowDialog.mock.calls[0][0].props as {
+        itemList: string[]
+      }
+      expect(dialogProps.itemList).toEqual(['fallback-image.png'])
+    })
+  })
 })

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -595,7 +595,7 @@ export function useMediaAssetActions() {
                 count: assetArray.length
               }),
           type: 'delete',
-          itemList: assetArray.map((asset) => asset.name),
+          itemList: assetArray.map((asset) => getAssetDisplayName(asset)),
           onConfirm: async () => {
             // Show loading overlay for all assets being deleted
             assetArray.forEach((asset) =>


### PR DESCRIPTION
## Summary
Bulk-delete confirmation on Comfy Cloud listed raw SHA-256 filenames, making the modal impossible to use to verify what would be deleted.

## Changes
- **What**: `useMediaAssetActions.deleteAssets` now maps each asset through `getAssetDisplayName`, so the confirmation's `itemList` matches the user-assigned names shown in the left media panel (`MediaAssetCard`).
- **Tests**: Added two regression tests covering `user_metadata.name` / `display_name` resolution and the `asset.name` fallback.

## Review Focus
- Parity with `MediaAssetCard` display: we reuse the same `getAssetDisplayName` helper; extension stripping (via `getFilenameDetails`) is not applied in the modal since file extensions are useful context when confirming deletions.

Reported in Slack: https://comfy-organization.slack.com/archives/C0A4XMHANP3/p1776383570015289

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11321-fix-show-asset-display-names-in-bulk-delete-confirmation-3456d73d36508108a3d5f2290ca39e18) by [Unito](https://www.unito.io)
