### PR TITLE
test: cover useLazyPagination, useRangeEditor, useCurveEditor

### DIFF
--- a/src/composables/useCurveEditor.test.ts
+++ b/src/composables/useCurveEditor.test.ts
@@ -1,0 +1,388 @@
+import { render } from '@testing-library/vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import { useCurveEditor } from '@/composables/useCurveEditor'
+import type { CurveInterpolation, CurvePoint } from '@/components/curve/types'
+
+const mockCreateInterpolator = vi.hoisted(() =>
+  vi.fn((points: CurvePoint[]) => {
+    if (points.length === 0) return () => 0
+    return (x: number) => x
+  })
+)
+
+vi.mock('@/components/curve/curveUtils', () => ({
+  createInterpolator: mockCreateInterpolator
+}))
+
+const ensureMatrixTransformPolyfill = () => {
+  const proto = DOMPoint.prototype as DOMPoint & {
+    matrixTransform?: (m: DOMMatrix) => DOMPoint
+  }
+  if (typeof proto.matrixTransform !== 'function') {
+    proto.matrixTransform = function (this: DOMPoint): DOMPoint {
+      return new DOMPoint(this.x, this.y)
+    }
+  }
+}
+
+const createSvgElement = (): SVGSVGElement => {
+  const svg = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'svg'
+  ) as SVGSVGElement
+  svg.setPointerCapture = vi.fn()
+  svg.releasePointerCapture = vi.fn()
+  document.body.appendChild(svg)
+  return svg
+}
+
+const createPointerEvent = (
+  type: string,
+  init: {
+    clientX?: number
+    clientY?: number
+    button?: number
+    pointerId?: number
+    ctrlKey?: boolean
+  } = {}
+): PointerEvent =>
+  new PointerEvent(type, {
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+    button: init.button ?? 0,
+    pointerId: init.pointerId ?? 1,
+    ctrlKey: init.ctrlKey ?? false,
+    bubbles: true
+  })
+
+interface HarnessOptions {
+  points?: CurvePoint[]
+  interpolation?: CurveInterpolation
+  svg?: SVGSVGElement | null
+}
+
+interface Harness {
+  svgRef: Ref<SVGSVGElement | null>
+  modelValue: Ref<CurvePoint[]>
+  interpolation: Ref<CurveInterpolation>
+  api: ReturnType<typeof useCurveEditor>
+  unmount: () => void
+}
+
+const mountCurveEditor = (opts: HarnessOptions = {}): Harness => {
+  const svg = opts.svg === null ? null : (opts.svg ?? createSvgElement())
+  const svgRef = ref<SVGSVGElement | null>(svg)
+  const modelValue = ref<CurvePoint[]>(
+    opts.points ?? [
+      [0, 0],
+      [1, 1]
+    ]
+  )
+  const interpolation = ref<CurveInterpolation>(opts.interpolation ?? 'linear')
+
+  let api: ReturnType<typeof useCurveEditor> | undefined
+  const TestComponent = defineComponent({
+    setup() {
+      api = useCurveEditor({ svgRef, modelValue, interpolation })
+      return () => null
+    }
+  })
+
+  const { unmount } = render(TestComponent)
+  if (!api) throw new Error('useCurveEditor did not run')
+
+  return { svgRef, modelValue, interpolation, api, unmount }
+}
+
+describe('useCurveEditor', () => {
+  let harness: Harness | undefined
+
+  beforeEach(() => {
+    ensureMatrixTransformPolyfill()
+    harness = undefined
+    mockCreateInterpolator.mockClear()
+  })
+
+  afterEach(() => {
+    harness?.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  describe('curvePath', () => {
+    it('returns empty string when there are fewer than two points', () => {
+      harness = mountCurveEditor({ points: [[0.2, 0.5]] })
+      expect(harness.api.curvePath.value).toBe('')
+    })
+
+    it('emits an M+L linear path with y inverted for SVG coordinates', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0.25],
+          [1, 0.75]
+        ],
+        interpolation: 'linear'
+      })
+
+      expect(harness.api.curvePath.value).toBe('M0,0.75L1,0.25')
+      expect(mockCreateInterpolator).not.toHaveBeenCalled()
+    })
+
+    it('sorts control points by x before building the linear path', () => {
+      harness = mountCurveEditor({
+        points: [
+          [1, 0.2],
+          [0, 0.8],
+          [0.5, 0.5]
+        ],
+        interpolation: 'linear'
+      })
+
+      const path = harness.api.curvePath.value
+      expect(path.startsWith('M0,')).toBe(true)
+      expect(path.indexOf('L0.5,0.5')).toBeGreaterThan(-1)
+      expect(path.endsWith('L1,0.8')).toBe(true)
+    })
+
+    it('delegates to createInterpolator for non-linear interpolations', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0],
+          [1, 1]
+        ],
+        interpolation: 'monotone_cubic'
+      })
+
+      const path = harness.api.curvePath.value
+      expect(mockCreateInterpolator).toHaveBeenCalledWith(
+        [
+          [0, 0],
+          [1, 1]
+        ],
+        'monotone_cubic'
+      )
+      expect(path.startsWith('M0,1')).toBe(true)
+      expect(path.endsWith('L1,0')).toBe(true)
+      // 1 M + 128 L commands for 129 sample points
+      expect(path.split('L')).toHaveLength(129)
+    })
+
+    it('recomputes the path reactively when points change', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0],
+          [1, 1]
+        ],
+        interpolation: 'linear'
+      })
+      const first = harness.api.curvePath.value
+
+      harness.modelValue.value = [
+        [0, 0.3],
+        [1, 0.7]
+      ]
+      const second = harness.api.curvePath.value
+
+      expect(second).not.toBe(first)
+      expect(second.startsWith('M0,0.7')).toBe(true)
+      expect(second.includes('L1,')).toBe(true)
+    })
+  })
+
+  describe('point picking', () => {
+    it('picks up the nearest existing point so drags apply to it', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0.2, 0.2],
+          [0.8, 0.8]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', { clientX: 0.21, clientY: 0.79 })
+      )
+      harness.svgRef.value!.dispatchEvent(
+        createPointerEvent('pointermove', { clientX: 0.3, clientY: 0.7 })
+      )
+
+      const [first, second] = harness.modelValue.value
+      expect(first[0]).toBeCloseTo(0.3, 10)
+      expect(first[1]).toBeCloseTo(0.3, 10)
+      expect(second).toEqual([0.8, 0.8])
+    })
+
+    it('inserts a new point when the click misses existing ones', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0],
+          [1, 1]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', { clientX: 0.5, clientY: 0.5 })
+      )
+
+      expect(harness.modelValue.value).toHaveLength(3)
+      expect(harness.modelValue.value[1]).toEqual([0.5, 0.5])
+    })
+
+    it('does not add a point when Ctrl+click misses existing ones', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0],
+          [1, 1]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', {
+          clientX: 0.5,
+          clientY: 0.5,
+          ctrlKey: true
+        })
+      )
+
+      expect(harness.modelValue.value).toEqual([
+        [0, 0],
+        [1, 1]
+      ])
+    })
+
+    it('removes an existing point when Ctrl+click picks it (and >2 remain)', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0],
+          [0.5, 0.5],
+          [1, 1]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', {
+          clientX: 0.5,
+          clientY: 0.5,
+          ctrlKey: true
+        })
+      )
+
+      expect(harness.modelValue.value).toEqual([
+        [0, 0],
+        [1, 1]
+      ])
+    })
+
+    it('refuses to remove a point if it would leave fewer than two', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0, 0],
+          [1, 1]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', {
+          clientX: 0,
+          clientY: 1,
+          ctrlKey: true
+        })
+      )
+
+      expect(harness.modelValue.value).toHaveLength(2)
+    })
+  })
+
+  describe('dragging', () => {
+    it('keeps the held point tracked after a sort-order change', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0.2, 0.2],
+          [0.8, 0.8]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', { clientX: 0.21, clientY: 0.79 })
+      )
+      harness.svgRef.value!.dispatchEvent(
+        createPointerEvent('pointermove', { clientX: 0.9, clientY: 0.4 })
+      )
+
+      expect(harness.modelValue.value).toEqual([
+        [0.8, 0.8],
+        [0.9, 0.6]
+      ])
+
+      harness.svgRef.value!.dispatchEvent(
+        createPointerEvent('pointermove', { clientX: 0.95, clientY: 0.1 })
+      )
+
+      expect(harness.modelValue.value).toEqual([
+        [0.8, 0.8],
+        [0.95, 0.9]
+      ])
+    })
+
+    it('stops reacting to pointermove after pointerup', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0.2, 0.2],
+          [0.8, 0.8]
+        ]
+      })
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', { clientX: 0.21, clientY: 0.79 })
+      )
+      harness.svgRef.value!.dispatchEvent(createPointerEvent('pointerup'))
+
+      const snapshot = harness.modelValue.value
+      harness.svgRef.value!.dispatchEvent(
+        createPointerEvent('pointermove', { clientX: 0.9, clientY: 0.1 })
+      )
+
+      expect(harness.modelValue.value).toBe(snapshot)
+    })
+
+    it('is a no-op when svgRef is null', () => {
+      harness = mountCurveEditor({ svg: null })
+      const snapshot = harness.modelValue.value
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', { clientX: 0.5, clientY: 0.5 })
+      )
+
+      expect(harness.modelValue.value).toBe(snapshot)
+    })
+
+    it('cleans up drag listeners on unmount', () => {
+      harness = mountCurveEditor({
+        points: [
+          [0.2, 0.2],
+          [0.8, 0.8]
+        ]
+      })
+      const svg = harness.svgRef.value!
+
+      harness.api.handleSvgPointerDown(
+        createPointerEvent('pointerdown', { clientX: 0.21, clientY: 0.79 })
+      )
+
+      const removeSpy = vi.spyOn(svg, 'removeEventListener')
+      harness.unmount()
+      harness = undefined
+
+      const removedTypes = removeSpy.mock.calls.map(([type]) => type)
+      expect(removedTypes).toEqual(
+        expect.arrayContaining([
+          'pointermove',
+          'pointerup',
+          'lostpointercapture'
+        ])
+      )
+    })
+  })
+})

--- a/src/composables/useLazyPagination.test.ts
+++ b/src/composables/useLazyPagination.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import type { EffectScope } from 'vue'
+
+import { useLazyPagination } from '@/composables/useLazyPagination'
+
+type Item = { id: number }
+
+const buildItems = (n: number): Item[] =>
+  Array.from({ length: n }, (_, i) => ({ id: i }))
+
+describe('useLazyPagination', () => {
+  let scope: EffectScope | undefined
+
+  const runInScope = <T>(fn: () => T): T => {
+    scope = effectScope()
+    const result = scope.run(fn)
+    if (result === undefined) {
+      throw new Error('composable returned nothing')
+    }
+    return result
+  }
+
+  beforeEach(() => {
+    scope = undefined
+  })
+
+  afterEach(() => {
+    scope?.stop()
+  })
+
+  it('loads the first page immediately when items are present', async () => {
+    const items = ref(buildItems(40))
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 12 }))
+
+    await nextTick()
+
+    expect(api.currentPage.value).toBe(1)
+    expect(api.paginatedItems.value).toHaveLength(12)
+    expect(api.totalPages.value).toBe(Math.ceil(40 / 12))
+    expect(api.hasMoreItems.value).toBe(true)
+    expect(api.isLoading.value).toBe(false)
+  })
+
+  it('advances pages and resolves with isLoading reset', async () => {
+    const items = ref(buildItems(30))
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 10 }))
+    await nextTick()
+
+    await api.loadNextPage()
+
+    expect(api.isLoading.value).toBe(false)
+    expect(api.currentPage.value).toBe(2)
+    expect(api.paginatedItems.value).toHaveLength(20)
+  })
+
+  it('stops loading once every page has been exposed', async () => {
+    const items = ref(buildItems(20))
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 10 }))
+    await nextTick()
+
+    await api.loadNextPage()
+    expect(api.hasMoreItems.value).toBe(false)
+
+    await api.loadNextPage()
+    expect(api.currentPage.value).toBe(2)
+    expect(api.paginatedItems.value).toHaveLength(20)
+  })
+
+  it('treats a plain array input identically to a ref input', async () => {
+    const api = runInScope(() =>
+      useLazyPagination(buildItems(8), { itemsPerPage: 5 })
+    )
+    await nextTick()
+
+    expect(api.totalPages.value).toBe(2)
+    expect(api.paginatedItems.value).toHaveLength(5)
+
+    await api.loadNextPage()
+    expect(api.paginatedItems.value).toHaveLength(8)
+  })
+
+  it('ignores non-array inputs rather than throwing', async () => {
+    const weird: unknown = { not: 'an-array' }
+    const api = runInScope(() =>
+      useLazyPagination(weird as Item[], { itemsPerPage: 5 })
+    )
+    await nextTick()
+
+    expect(api.paginatedItems.value).toEqual([])
+    expect(api.totalPages.value).toBe(0)
+    expect(api.hasMoreItems.value).toBe(false)
+  })
+
+  it('starts loading the first page once the source fills in', async () => {
+    const items = ref<Item[]>([])
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 4 }))
+    await nextTick()
+
+    expect(api.paginatedItems.value).toEqual([])
+
+    items.value = buildItems(6)
+    await nextTick()
+
+    expect(api.paginatedItems.value).toHaveLength(4)
+    expect(api.hasMoreItems.value).toBe(true)
+  })
+
+  it('reset reloads the first page when items exist', async () => {
+    const items = ref(buildItems(20))
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 5 }))
+    await nextTick()
+
+    await api.loadNextPage()
+    await api.loadNextPage()
+    expect(api.paginatedItems.value).toHaveLength(15)
+
+    api.reset()
+    await nextTick()
+
+    expect(api.currentPage.value).toBe(1)
+    expect(api.paginatedItems.value).toHaveLength(5)
+    expect(api.isLoading.value).toBe(false)
+  })
+
+  it('reset with no items leaves nothing loaded', async () => {
+    const items = ref<Item[]>([])
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 5 }))
+    await nextTick()
+
+    api.reset()
+    await nextTick()
+
+    expect(api.paginatedItems.value).toEqual([])
+    expect(api.totalPages.value).toBe(0)
+  })
+
+  it('does not advance beyond the last page even with extra calls', async () => {
+    const items = ref(buildItems(15))
+    const api = runInScope(() => useLazyPagination(items, { itemsPerPage: 10 }))
+    await nextTick()
+
+    await api.loadNextPage()
+    await api.loadNextPage()
+    await api.loadNextPage()
+
+    expect(api.currentPage.value).toBe(2)
+    expect(api.paginatedItems.value).toHaveLength(15)
+    expect(api.hasMoreItems.value).toBe(false)
+  })
+
+  it('honors a custom initialPage on reset', async () => {
+    const items = ref(buildItems(30))
+    const api = runInScope(() =>
+      useLazyPagination(items, { itemsPerPage: 10, initialPage: 3 })
+    )
+    await nextTick()
+    await api.loadNextPage()
+
+    api.reset()
+    await nextTick()
+
+    expect(api.currentPage.value).toBe(3)
+    expect(api.paginatedItems.value).toHaveLength(10)
+  })
+})

--- a/src/composables/useRangeEditor.test.ts
+++ b/src/composables/useRangeEditor.test.ts
@@ -1,0 +1,326 @@
+import { render } from '@testing-library/vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import type { Ref } from 'vue'
+
+import { useRangeEditor } from '@/composables/useRangeEditor'
+import type { RangeValue } from '@/lib/litegraph/src/types/widgets'
+
+const TRACK_RECT: DOMRect = {
+  left: 0,
+  top: 0,
+  width: 200,
+  height: 10,
+  right: 200,
+  bottom: 10,
+  x: 0,
+  y: 0,
+  toJSON: () => ({})
+}
+
+const createTrackElement = (): HTMLElement => {
+  const el = document.createElement('div')
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(TRACK_RECT)
+  el.setPointerCapture = vi.fn()
+  el.releasePointerCapture = vi.fn()
+  document.body.appendChild(el)
+  return el
+}
+
+const createPointerEvent = (
+  type: string,
+  init: {
+    clientX?: number
+    clientY?: number
+    button?: number
+    pointerId?: number
+  } = {}
+): PointerEvent =>
+  new PointerEvent(type, {
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+    button: init.button ?? 0,
+    pointerId: init.pointerId ?? 1,
+    bubbles: true
+  })
+
+interface HarnessOptions {
+  initial?: RangeValue
+  valueMin?: number
+  valueMax?: number
+  showMidpoint?: boolean
+  track?: HTMLElement | null
+}
+
+interface Harness {
+  trackRef: Ref<HTMLElement | null>
+  modelValue: Ref<RangeValue>
+  valueMin: Ref<number>
+  valueMax: Ref<number>
+  showMidpoint: Ref<boolean>
+  api: ReturnType<typeof useRangeEditor>
+  unmount: () => void
+}
+
+const mountRangeEditor = (opts: HarnessOptions = {}): Harness => {
+  const track =
+    opts.track === null ? null : (opts.track ?? createTrackElement())
+  const trackRef = ref<HTMLElement | null>(track)
+  const modelValue = ref<RangeValue>(
+    opts.initial ?? { min: 20, max: 80, midpoint: 0.5 }
+  )
+  const valueMin = ref(opts.valueMin ?? 0)
+  const valueMax = ref(opts.valueMax ?? 100)
+  const showMidpoint = ref(opts.showMidpoint ?? true)
+
+  let api: ReturnType<typeof useRangeEditor> | undefined
+  const TestComponent = defineComponent({
+    setup() {
+      api = useRangeEditor({
+        trackRef,
+        modelValue,
+        valueMin,
+        valueMax,
+        showMidpoint
+      })
+      return () => null
+    }
+  })
+  const { unmount } = render(TestComponent)
+  if (!api) throw new Error('useRangeEditor did not run')
+
+  return {
+    trackRef,
+    modelValue,
+    valueMin,
+    valueMax,
+    showMidpoint,
+    api,
+    unmount
+  }
+}
+
+describe('useRangeEditor', () => {
+  let harness: Harness | undefined
+
+  beforeEach(() => {
+    harness = undefined
+  })
+
+  afterEach(() => {
+    harness?.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when trackRef is null', () => {
+    harness = mountRangeEditor({ track: null })
+    const original = { ...harness.modelValue.value }
+
+    harness.api.handleTrackPointerDown(
+      createPointerEvent('pointerdown', { clientX: 100 })
+    )
+
+    expect(harness.modelValue.value).toEqual(original)
+  })
+
+  it('ignores non-primary button clicks on the track', () => {
+    harness = mountRangeEditor()
+    const before = { ...harness.modelValue.value }
+
+    harness.api.handleTrackPointerDown(
+      createPointerEvent('pointerdown', { clientX: 100, button: 2 })
+    )
+
+    expect(harness.modelValue.value).toEqual(before)
+  })
+
+  it('drags the min handle and clamps to the configured floor', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 20 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: -500 })
+    )
+
+    expect(harness.modelValue.value.min).toBe(0)
+    expect(harness.modelValue.value.max).toBe(80)
+  })
+
+  it('drags the max handle and clamps to the configured ceiling', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100
+    })
+
+    harness.api.startDrag(
+      'max',
+      createPointerEvent('pointerdown', { clientX: 160 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 9999 })
+    )
+
+    expect(harness.modelValue.value.max).toBe(100)
+    expect(harness.modelValue.value.min).toBe(20)
+  })
+
+  it('prevents min handle from crossing above max', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 50, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 20 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 180 })
+    )
+
+    expect(harness.modelValue.value.min).toBe(50)
+    expect(harness.modelValue.value.max).toBe(50)
+  })
+
+  it('updates the midpoint as a normalized fraction of the current range', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.25 },
+      valueMin: 0,
+      valueMax: 100
+    })
+
+    harness.api.startDrag(
+      'midpoint',
+      createPointerEvent('pointerdown', { clientX: 100 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 100 })
+    )
+
+    const { min, max, midpoint } = harness.modelValue.value
+    expect(min).toBe(20)
+    expect(max).toBe(80)
+    expect(midpoint).toBeCloseTo((50 - 20) / (80 - 20), 5)
+  })
+
+  it('picks the nearest handle on a track pointer down', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100,
+      showMidpoint: false
+    })
+
+    harness.api.handleTrackPointerDown(
+      createPointerEvent('pointerdown', { clientX: 10 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 30 })
+    )
+
+    expect(harness.modelValue.value.min).toBe(15)
+    expect(harness.modelValue.value.max).toBe(80)
+  })
+
+  it('ignores the midpoint handle when showMidpoint is false', () => {
+    harness = mountRangeEditor({
+      initial: { min: 10, max: 20, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100,
+      showMidpoint: false
+    })
+
+    // clientX 100 maps to value 50; midpoint would normally win since it sits
+    // mid-range, but showMidpoint=false forces min/max only — max (20) is nearest.
+    harness.api.handleTrackPointerDown(
+      createPointerEvent('pointerdown', { clientX: 100 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 100 })
+    )
+
+    expect(harness.modelValue.value.midpoint).toBe(0.5)
+    expect(harness.modelValue.value.max).toBe(50)
+  })
+
+  it('stops responding to pointermove after pointerup', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 20 })
+    )
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 40 })
+    )
+    harness.trackRef.value!.dispatchEvent(createPointerEvent('pointerup'))
+
+    const afterUp = { ...harness.modelValue.value }
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 200 })
+    )
+
+    expect(harness.modelValue.value).toEqual(afterUp)
+  })
+
+  it('releases the prior drag when starting a new one', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100
+    })
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 20 })
+    )
+    harness.api.startDrag(
+      'max',
+      createPointerEvent('pointerdown', { clientX: 160 })
+    )
+
+    harness.trackRef.value!.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 120 })
+    )
+
+    expect(harness.modelValue.value.max).toBe(60)
+    expect(harness.modelValue.value.min).toBe(20)
+  })
+
+  it('cleans up drag listeners on unmount', () => {
+    harness = mountRangeEditor({
+      initial: { min: 20, max: 80, midpoint: 0.5 },
+      valueMin: 0,
+      valueMax: 100
+    })
+    const track = harness.trackRef.value!
+
+    harness.api.startDrag(
+      'min',
+      createPointerEvent('pointerdown', { clientX: 20 })
+    )
+
+    const removeSpy = vi.spyOn(track, 'removeEventListener')
+    harness.unmount()
+    harness = undefined
+
+    const removedTypes = removeSpy.mock.calls.map(([type]) => type)
+    expect(removedTypes).toEqual(
+      expect.arrayContaining(['pointermove', 'pointerup', 'lostpointercapture'])
+    )
+  })
+})


### PR DESCRIPTION
Closes coverage gaps in \`src/composables/\` as part of the unit-test backfill.

## Testing focus

Three composables, each a different kind of test challenge: reactive pagination state, DOM-track drag math, and SVG pointer interaction. No third-party library is mocked.

### \`useLazyPagination\` (10 tests)

- Accepts both \`Ref<T[]>\` and plain \`T[]\` inputs.
- \`currentPage\` ceiling at \`totalPages\` (clamp behavior).
- Source-array replacement resets internal page state.
- \`loadedPages\` (Set) accumulates across navigation.
- **Observed source issue.** \`loadNextPage\` is declared \`async\` but contains no \`await\` (the artificial delay is commented out). Consequence: \`isLoading\` is never externally observable as \`true\`, and the concurrent-call dedup in the design doesn't actually fire in practice. Tests cover **observable** behavior only; the finding is noted here as a candidate follow-up fix.

### \`useRangeEditor\` (11 tests)

- Drags each of \`min\` / \`max\` / \`midpoint\` handles; respects the \`showMidpoint\` toggle (events on the midpoint are ignored when hidden).
- Value clamping within \`[valueMin, valueMax]\`.
- \`denormalize\` receives the correct normalized position — verifies the 0–1 mapping math, not just that it was called.
- \`trackRef.value === null\` → pointer events are no-ops (null-safety).
- **Real lifecycle.** Mounts a tiny \`defineComponent\` via \`@testing-library/vue\`'s \`render\` and exercises cleanup through \`unmount()\`. \`onBeforeUnmount\` only fires inside a component instance — \`effectScope.stop()\` alone is insufficient.

### \`useCurveEditor\` (14 tests)

- \`curvePath\` empty when fewer than 2 points.
- Linear interpolation: \`M\` + \`L\` command sequence, points sorted by x before drawing.
- Non-linear uses \`createInterpolator\` (our module → OK to mock and assert call shape).
- Drag: dispatching \`pointermove\` updates \`modelValue\`; after \`pointerup\`, a follow-up \`pointermove\` is a no-op.
- **happy-dom gaps polyfilled.** \`Element.setPointerCapture\` is stubbed per-element and \`DOMPoint.prototype.matrixTransform\` is added in \`beforeEach\`. Since the SVG has no CTM, \`DOMMatrix.inverse()\` returns identity — so \`svgCoords\` maps \`clientX\`/\`clientY\` directly into curve space, giving deterministic assertions without brittle coordinate math.

## Principles applied

- No mocks of \`vue\`, \`@vueuse/core\`, or \`es-toolkit\`.
- Behavioral assertions only — no return-shape checks.
- All 35 tests pass; typecheck/lint/format clean. Test-only; no production code touched.