### PR TITLE
refactor: remove @ts-expect-error suppressions in test files 

### DIFF
--- a/src/platform/workflow/validation/schemas/workflowSchema.test.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.test.ts
@@ -141,13 +141,13 @@ describe('parseComfyWorkflow', () => {
     // Should automatically transform the legacy format object to array.
     workflow.nodes[0].pos = { '0': 3, '1': 4 }
     let validatedWorkflow = await validateComfyWorkflow(workflow)
-    // @ts-expect-error fixme ts strict error
-    expect(validatedWorkflow.nodes[0].pos).toEqual([3, 4])
+    expect(validatedWorkflow).not.toBeNull()
+    expect(validatedWorkflow!.nodes[0].pos).toEqual([3, 4])
 
     workflow.nodes[0].pos = { 0: 3, 1: 4 }
     validatedWorkflow = await validateComfyWorkflow(workflow)
-    // @ts-expect-error fixme ts strict error
-    expect(validatedWorkflow.nodes[0].pos).toEqual([3, 4])
+    expect(validatedWorkflow).not.toBeNull()
+    expect(validatedWorkflow!.nodes[0].pos).toEqual([3, 4])
 
     // Should accept the legacy bugged format object.
     // https://github.com/Comfy-Org/ComfyUI_frontend/issues/710
@@ -164,8 +164,8 @@ describe('parseComfyWorkflow', () => {
       '9': 0
     }
     validatedWorkflow = await validateComfyWorkflow(workflow)
-    // @ts-expect-error fixme ts strict error
-    expect(validatedWorkflow.nodes[0].pos).toEqual([600, 340])
+    expect(validatedWorkflow).not.toBeNull()
+    expect(validatedWorkflow!.nodes[0].pos).toEqual([600, 340])
   })
 
   it('workflow.nodes.widget_values', async () => {
@@ -183,8 +183,8 @@ describe('parseComfyWorkflow', () => {
     // dynamic widgets display.
     workflow.nodes[0].widgets_values = { foo: 'bar' }
     const validatedWorkflow = await validateComfyWorkflow(workflow)
-    // @ts-expect-error fixme ts strict error
-    expect(validatedWorkflow.nodes[0].widgets_values).toEqual({ foo: 'bar' })
+    expect(validatedWorkflow).not.toBeNull()
+    expect(validatedWorkflow!.nodes[0].widgets_values).toEqual({ foo: 'bar' })
   })
 
   it('workflow.links', async () => {

--- a/src/utils/nodeDefUtil.test.ts
+++ b/src/utils/nodeDefUtil.test.ts
@@ -18,14 +18,12 @@ describe('nodeDefUtil', () => {
         const spec1: IntInputSpec = ['INT', { min: 0, max: 10 }]
         const spec2: IntInputSpec = ['INT', { min: 5, max: 15 }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as IntInputSpec | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('INT')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].min).toBe(5)
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].max).toBe(10)
+        expect(result?.[1]?.min).toBe(5)
+        expect(result?.[1]?.max).toBe(10)
       })
 
       it('should return null for INT specs with non-overlapping ranges', () => {
@@ -41,64 +39,57 @@ describe('nodeDefUtil', () => {
         const spec1: FloatInputSpec = ['FLOAT', { min: 0.5, max: 10.5 }]
         const spec2: FloatInputSpec = ['FLOAT', { min: 5.5, max: 15.5 }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as FloatInputSpec | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('FLOAT')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].min).toBe(5.5)
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].max).toBe(10.5)
+        expect(result?.[1]?.min).toBe(5.5)
+        expect(result?.[1]?.max).toBe(10.5)
       })
 
       it('should handle specs with undefined min/max values', () => {
         const spec1: FloatInputSpec = ['FLOAT', { min: 0.5 }]
         const spec2: FloatInputSpec = ['FLOAT', { max: 15.5 }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as FloatInputSpec | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('FLOAT')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].min).toBe(0.5)
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].max).toBe(15.5)
+        expect(result?.[1]?.min).toBe(0.5)
+        expect(result?.[1]?.max).toBe(15.5)
       })
 
       it('should merge step values using least common multiple', () => {
         const spec1: IntInputSpec = ['INT', { min: 0, max: 10, step: 2 }]
         const spec2: IntInputSpec = ['INT', { min: 0, max: 10, step: 3 }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as IntInputSpec | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('INT')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].step).toBe(6) // LCM of 2 and 3 is 6
+        expect(result?.[1]?.step).toBe(6) // LCM of 2 and 3 is 6
       })
 
       it('should use default step of 1 when step is not specified', () => {
         const spec1: IntInputSpec = ['INT', { min: 0, max: 10 }]
         const spec2: IntInputSpec = ['INT', { min: 0, max: 10, step: 4 }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as IntInputSpec | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('INT')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].step).toBe(4) // LCM of 1 and 4 is 4
+        expect(result?.[1]?.step).toBe(4) // LCM of 1 and 4 is 4
       })
 
       it('should handle step values for FLOAT specs', () => {
         const spec1: FloatInputSpec = ['FLOAT', { min: 0, max: 10, step: 0.5 }]
         const spec2: FloatInputSpec = ['FLOAT', { min: 0, max: 10, step: 0.25 }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as FloatInputSpec | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('FLOAT')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].step).toBe(0.5)
+        expect(result?.[1]?.step).toBe(0.5)
       })
     })
 
@@ -108,12 +99,11 @@ describe('nodeDefUtil', () => {
         const spec1: ComboInputSpecV2 = ['COMBO', { options: ['A', 'B', 'C'] }]
         const spec2: ComboInputSpecV2 = ['COMBO', { options: ['B', 'C', 'D'] }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as ComboInputSpecV2 | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('COMBO')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].options).toEqual(['B', 'C'])
+        expect(result?.[1]?.options).toEqual(['B', 'C'])
       })
 
       it('should return null for COMBO specs with no overlapping options', () => {
@@ -143,30 +133,25 @@ describe('nodeDefUtil', () => {
           }
         ]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as ComboInputSpecV2 | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('COMBO')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].options).toEqual(['B', 'C'])
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].default).toBe('B')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].tooltip).toBe('Select an option')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].multiline).toBe(true)
+        expect(result?.[1]?.options).toEqual(['B', 'C'])
+        expect(result?.[1]?.default).toBe('B')
+        expect(result?.[1]?.tooltip).toBe('Select an option')
+        expect(result?.[1]?.multiline).toBe(true)
       })
 
       it('should handle v1 and v2 combo specs', () => {
         const spec1: ComboInputSpec = [['A', 'B', 'C', 'D'], {}]
         const spec2: ComboInputSpecV2 = ['COMBO', { options: ['C', 'D'] }]
 
-        const result = mergeInputSpec(spec1, spec2)
+        const result = mergeInputSpec(spec1, spec2) as ComboInputSpecV2 | null
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('COMBO')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].options).toEqual(['C', 'D'])
+        expect(result?.[1]?.options).toEqual(['C', 'D'])
       })
     })
 
@@ -206,12 +191,12 @@ describe('nodeDefUtil', () => {
 
         expect(result).not.toBeNull()
         expect(result?.[0]).toBe('STRING')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].default).toBe('value2')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].tooltip).toBe('Tooltip 2')
-        // @ts-expect-error fixme ts strict error
-        expect(result?.[1].step).toBe(1)
+        const options = result?.[1] as
+          | { default?: string; tooltip?: string; step?: number }
+          | undefined
+        expect(options?.default).toBe('value2')
+        expect(options?.tooltip).toBe('Tooltip 2')
+        expect(options?.step).toBe(1)
       })
 
       it('should return null if non-ignored properties differ', () => {


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                                                                                                        
Part of #11092 — Phase 3: remove @ts-expect-error suppressions from test files.
                                                                                                                                                                                                                                                                                                                          
  This phase targets 22 suppressions across two test files:                                                                                                                                                                                                                                                               
  - `src/utils/nodeDefUtil.test.ts` (18)                                                                                                                                                                                                                                                                                    
  - `src/platform/workflow/validation/schemas/workflowSchema.test.ts` (4)                                                                                                                                                                                                                                                   

## Changes                                                        
`nodeDefUtil.test.ts`: Each test already constrains the inputs to a known subtype (`IntInputSpec`, `FloatInputSpec`, `ComboInputSpecV2`), so casting result to the expected subtype at the declaration site is both correct and self-documenting. For the one test that uses the base `InputSpec` type, the options object is extracted with an inline structural cast.
                                                                                                                                                                                                                                                                                                                          
`workflowSchema.test.ts`: validateComfyWorkflow returns ComfyWorkflowJSON | null. The tests were accessing .nodes[0].pos without narrowing, causing "object is possibly null" errors. Fixed with explicit expect(validatedWorkflow).not.toBeNull() assertions before each property access, which also improves failure messages — previously a null result would throw a TypeError rather than a readable assertion failure.                                                                  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type-safety refactor with no runtime code changes; primary risk is minor test assertion behavior changes if a helper unexpectedly returns `null`.
> 
> **Overview**
> Removes `@ts-expect-error` suppressions from two test suites by making nullability and return-type expectations explicit.
> 
> `workflowSchema.test.ts` now asserts `validateComfyWorkflow` results are non-null before accessing `nodes[0]` fields, and `nodeDefUtil.test.ts` casts `mergeInputSpec` results to the expected spec subtype (or extracts typed options) so property assertions compile cleanly under stricter TS settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3829862bce11aab6891c6a851f51e58d28a4fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11337-refactor-remove-ts-expect-error-suppressions-in-test-files-3456d73d3650815aa2a2fca5a9332377) by [Unito](https://www.unito.io)
