### PR TITLE
refactor: remove @ts-expect-error suppressions in sidebar components

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
@@ -1,0 +1,191 @@
+import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
+import type { ComfyModelDef } from '@/stores/modelStore'
+
+import ModelLibrarySidebarTab from './ModelLibrarySidebarTab.vue'
+
+const {
+  captureRoot,
+  getRoot,
+  resetRoot,
+  mockAddNodeOnGraph,
+  mockGetNodeProvider,
+  mockToggleNodeOnEvent
+} = vi.hoisted(() => {
+  let capturedRoot: TreeExplorerNode<unknown> | null = null
+  return {
+    captureRoot: (root: TreeExplorerNode<unknown>) => {
+      capturedRoot = root
+    },
+    getRoot: () => capturedRoot as TreeExplorerNode<ComfyModelDef>,
+    resetRoot: () => {
+      capturedRoot = null
+    },
+    mockAddNodeOnGraph: vi.fn(),
+    mockGetNodeProvider: vi.fn(),
+    mockToggleNodeOnEvent: vi.fn()
+  }
+})
+
+vi.mock('@/services/litegraphService', () => ({
+  useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/stores/modelToNodeStore', () => ({
+  useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
+}))
+
+const mockModel = fromPartial<ComfyModelDef>({
+  key: 'checkpoints/model.safetensors',
+  file_name: 'model.safetensors',
+  simplified_file_name: 'model',
+  title: 'Model',
+  directory: 'checkpoints',
+  searchable: 'checkpoints/model.safetensors'
+})
+
+vi.mock('@/stores/modelStore', () => ({
+  ResourceState: {
+    Loading: 'loading',
+    Loaded: 'loaded'
+  },
+  useModelStore: () => ({
+    modelFolders: [],
+    models: [mockModel],
+    loadModels: vi.fn().mockResolvedValue([]),
+    loadModelFolders: vi.fn().mockResolvedValue([])
+  })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: vi.fn((key: string) => {
+      if (key === 'Comfy.ModelLibrary.NameFormat') return 'filename'
+      return false
+    })
+  })
+}))
+
+vi.mock('@/composables/useTreeExpansion', () => ({
+  useTreeExpansion: () => ({
+    expandNode: vi.fn(),
+    toggleNodeOnEvent: mockToggleNodeOnEvent
+  })
+}))
+
+vi.mock('@/components/common/TreeExplorer.vue', () => ({
+  default: {
+    name: 'TreeExplorer',
+    template: '<div data-testid="tree-explorer" />',
+    props: ['root', 'expandedKeys'],
+    setup(props: { root: TreeExplorerNode<unknown> }) {
+      captureRoot(props.root)
+    }
+  }
+}))
+
+vi.mock('@/components/ui/search-input/SearchInput.vue', () => ({
+  default: {
+    name: 'SearchInput',
+    template: '<input data-testid="search-input" />',
+    props: ['modelValue', 'placeholder'],
+    setup() {
+      return { focus: vi.fn() }
+    },
+    expose: ['focus']
+  }
+}))
+
+vi.mock('./SidebarTopArea.vue', () => ({
+  default: { name: 'SidebarTopArea', template: '<div><slot /></div>' }
+}))
+
+vi.mock('./SidebarTabTemplate.vue', () => ({
+  default: {
+    name: 'SidebarTabTemplate',
+    template: '<div><slot name="header" /><slot name="body" /></div>'
+  }
+}))
+
+vi.mock('./modelLibrary/ElectronDownloadItems.vue', () => ({
+  default: { name: 'ElectronDownloadItems', template: '<div />' }
+}))
+
+vi.mock('./modelLibrary/ModelTreeLeaf.vue', () => ({
+  default: { name: 'ModelTreeLeaf', template: '<div />', props: ['node'] }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
+describe('ModelLibrarySidebarTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRoot()
+  })
+
+  function renderComponent() {
+    return render(ModelLibrarySidebarTab, {
+      global: {
+        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        stubs: { teleport: true }
+      }
+    })
+  }
+
+  it('renders search input', () => {
+    renderComponent()
+    expect(screen.getByTestId('search-input')).toBeInTheDocument()
+  })
+
+  it('handles model click and adds node to graph', async () => {
+    const mockNodeDef = { name: 'CheckpointLoaderSimple' }
+    const mockWidget = { name: 'ckpt_name', value: '' }
+    const mockGraphNode = { widgets: [mockWidget] }
+
+    mockGetNodeProvider.mockReturnValue({
+      nodeDef: mockNodeDef,
+      key: 'ckpt_name'
+    })
+    mockAddNodeOnGraph.mockReturnValue(mockGraphNode)
+
+    renderComponent()
+    await nextTick()
+
+    const root = getRoot()
+    const checkpointsFolder = root.children?.[0]
+    const modelLeaf = checkpointsFolder?.children?.[0]
+
+    expect(modelLeaf?.label).toBe('model')
+    expect(modelLeaf?.leaf).toBe(true)
+
+    const mockEvent = new MouseEvent('click')
+    await modelLeaf?.handleClick?.(mockEvent)
+
+    expect(mockGetNodeProvider).toHaveBeenCalledWith('checkpoints')
+    expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockNodeDef)
+    expect(mockWidget.value).toBe('model.safetensors')
+  })
+
+  it('toggles folder expansion on click', async () => {
+    renderComponent()
+    await nextTick()
+
+    const root = getRoot()
+    const checkpointsFolder = root.children?.[0]
+    const mockEvent = new MouseEvent('click')
+
+    await checkpointsFolder?.handleClick?.(mockEvent)
+
+    expect(mockToggleNodeOnEvent).toHaveBeenCalled()
+  })
+})

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -150,17 +150,16 @@ const renderedRoot = computed<TreeExplorerNode<ModelOrFolder>>(() => {
       children,
       draggable: node.leaf,
       handleClick(e: MouseEvent) {
-        if (this.leaf) {
-          // @ts-expect-error fixme ts strict error
+        if (this.leaf && model) {
           const provider = modelToNodeStore.getNodeProvider(model.directory)
           if (provider) {
-            const node = useLitegraphService().addNodeOnGraph(provider.nodeDef)
-            // @ts-expect-error fixme ts strict error
-            const widget = node.widgets.find(
+            const graphNode = useLitegraphService().addNodeOnGraph(
+              provider.nodeDef
+            )
+            const widget = graphNode?.widgets?.find(
               (widget) => widget.name === provider.key
             )
             if (widget) {
-              // @ts-expect-error fixme ts strict error
               widget.value = model.file_name
             }
           }

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.test.ts
@@ -1,0 +1,227 @@
+import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { TreeExplorerNode, TreeNode } from '@/types/treeExplorerTypes'
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+
+import NodeLibrarySidebarTab from './NodeLibrarySidebarTab.vue'
+
+const {
+  captureRoot,
+  getRoot,
+  resetRoot,
+  mockAddNodeOnGraph,
+  mockSearchNode,
+  mockOrganizeNodes,
+  mockToggleNodeOnEvent
+} = vi.hoisted(() => {
+  let capturedRoot: TreeExplorerNode<unknown> | null = null
+  return {
+    captureRoot: (root: TreeExplorerNode<unknown>) => {
+      capturedRoot = root
+    },
+    getRoot: () => capturedRoot as TreeExplorerNode<ComfyNodeDefImpl>,
+    resetRoot: () => {
+      capturedRoot = null
+    },
+    mockAddNodeOnGraph: vi.fn(),
+    mockSearchNode: vi.fn(() => []),
+    mockOrganizeNodes: vi.fn(
+      (): TreeNode => ({
+        key: 'root',
+        label: 'Root',
+        children: []
+      })
+    ),
+    mockToggleNodeOnEvent: vi.fn()
+  }
+})
+
+vi.mock('@/services/litegraphService', () => ({
+  useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/services/nodeOrganizationService', () => ({
+  DEFAULT_GROUPING_ID: 'group',
+  DEFAULT_SORTING_ID: 'sort',
+  nodeOrganizationService: {
+    getGroupingStrategies: vi.fn(() => []),
+    getSortingStrategies: vi.fn(() => []),
+    getGroupingIcon: vi.fn(() => 'pi pi-folder'),
+    getSortingIcon: vi.fn(() => 'pi pi-sort'),
+    organizeNodes: mockOrganizeNodes
+  }
+}))
+
+vi.mock('@/stores/nodeDefStore', () => ({
+  useNodeDefStore: () => ({
+    visibleNodeDefs: [],
+    nodeSearchService: { searchNode: mockSearchNode }
+  })
+}))
+
+vi.mock('@/stores/nodeBookmarkStore', () => ({
+  useNodeBookmarkStore: () => ({
+    bookmarks: []
+  })
+}))
+
+vi.mock('@/stores/workspace/nodeHelpStore', () => ({
+  useNodeHelpStore: () => ({
+    currentHelpNode: ref(null),
+    isHelpOpen: ref(false),
+    openHelp: vi.fn(),
+    closeHelp: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({
+    execute: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useTreeExpansion', () => ({
+  useTreeExpansion: () => ({
+    expandNode: vi.fn(),
+    toggleNodeOnEvent: mockToggleNodeOnEvent
+  })
+}))
+
+vi.mock('@/components/common/TreeExplorer.vue', () => ({
+  default: {
+    name: 'TreeExplorer',
+    template: '<div data-testid="tree-explorer" />',
+    props: ['root', 'expandedKeys'],
+    setup(props: { root: TreeExplorerNode<unknown> }) {
+      captureRoot(props.root)
+    }
+  }
+}))
+
+vi.mock('@/components/ui/search-input/SearchInput.vue', () => ({
+  default: {
+    name: 'SearchInput',
+    template: '<input data-testid="search-input" />',
+    props: ['modelValue', 'placeholder'],
+    setup() {
+      return { focus: vi.fn() }
+    },
+    expose: ['focus']
+  }
+}))
+
+vi.mock('./nodeLibrary/NodeBookmarkTreeExplorer.vue', () => ({
+  default: {
+    name: 'NodeBookmarkTreeExplorer',
+    template: '<div />',
+    props: ['filteredNodeDefs', 'openNodeHelp']
+  }
+}))
+
+vi.mock('./SidebarTabTemplate.vue', () => ({
+  default: {
+    name: 'SidebarTabTemplate',
+    template: '<div><slot name="header" /><slot name="body" /></div>'
+  }
+}))
+
+vi.mock('@/components/common/SearchFilterChip.vue', () => ({
+  default: {
+    name: 'SearchFilterChip',
+    template:
+      '<div data-testid="filter-chip"><button data-testid="remove-filter" @click="$emit(\'remove\')">X</button></div>',
+    props: ['text', 'badge', 'badgeClass']
+  }
+}))
+
+vi.mock('@/components/searchbox/NodeSearchFilter.vue', () => ({
+  default: {
+    name: 'NodeSearchFilter',
+    template:
+      "<div data-testid=\"node-search-filter\" @click=\"$emit('add-filter', { filterDef: { invokeSequence: 'test' }, value: 'test-val' })\" />"
+  }
+}))
+
+vi.mock('primevue/divider', () => ({
+  default: { name: 'Divider', template: '<div />' }
+}))
+vi.mock('primevue/popover', () => ({
+  default: {
+    name: 'Popover',
+    template: '<div><slot /></div>',
+    methods: { toggle: vi.fn(), hide: vi.fn() }
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
+const mockNode = fromPartial<ComfyNodeDefImpl>({
+  name: 'CLIPTextEncode',
+  display_name: 'CLIP Text Encode'
+})
+
+describe('NodeLibrarySidebarTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRoot()
+  })
+
+  function renderComponent() {
+    return render(NodeLibrarySidebarTab, {
+      global: {
+        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        stubs: { teleport: true }
+      }
+    })
+  }
+
+  it('handles node click and adds node to graph', async () => {
+    mockOrganizeNodes.mockReturnValue({
+      key: 'root',
+      label: 'Root',
+      children: [{ key: 'leaf', label: 'Leaf', leaf: true, data: mockNode }]
+    })
+
+    renderComponent()
+    await nextTick()
+
+    const root = getRoot()
+    const leaf = root.children?.[0]
+    expect(leaf?.leaf).toBe(true)
+
+    await leaf?.handleClick?.(new MouseEvent('click'))
+    expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockNode)
+  })
+
+  it('adds and removes filters', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    await nextTick()
+
+    // Add filter by clicking the mocked search filter
+    const searchFilter = screen.getByTestId('node-search-filter')
+    await user.click(searchFilter)
+    await nextTick()
+
+    expect(screen.getByTestId('filter-chip')).toBeInTheDocument()
+    expect(mockSearchNode).toHaveBeenCalled()
+
+    // Remove filter
+    const removeButton = screen.getByTestId('remove-filter')
+    await user.click(removeButton)
+    await nextTick()
+
+    expect(screen.queryByTestId('filter-chip')).not.toBeInTheDocument()
+    expect(mockSearchNode).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -321,8 +321,7 @@ const renderedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(() => {
         }
       },
       handleClick(e: MouseEvent) {
-        if (this.leaf) {
-          // @ts-expect-error fixme ts strict error
+        if (this.leaf && this.data) {
           useLitegraphService().addNodeOnGraph(this.data)
         } else {
           toggleNodeOnEvent(e, this)
@@ -379,8 +378,11 @@ const onAddFilter = async (
   await handleSearch(searchQuery.value)
 }
 
-// @ts-expect-error fixme ts strict error
-const onRemoveFilter = async (filterAndValue) => {
+const onRemoveFilter = async (
+  filterAndValue: SearchFilter & {
+    filter: FuseFilterWithValue<ComfyNodeDefImpl, string>
+  }
+) => {
   const index = filters.value.findIndex((f) => f === filterAndValue)
   if (index !== -1) {
     filters.value.splice(index, 1)

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
@@ -1,0 +1,261 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
+import type {
+  TreeExplorerDragAndDropData,
+  TreeExplorerNode,
+  TreeNode
+} from '@/types/treeExplorerTypes'
+
+import NodeBookmarkTreeExplorer from './NodeBookmarkTreeExplorer.vue'
+
+const {
+  mockAddBookmark,
+  mockDeleteBookmarkFolder,
+  mockIsBookmarked,
+  mockToggleBookmark,
+  mockAddNodeOnGraph,
+  mockToggleNodeOnEvent,
+  captureRoot,
+  getRoot,
+  resetRoot
+} = vi.hoisted(() => {
+  let capturedRoot: TreeExplorerNode<unknown> | null = null
+  return {
+    mockAddBookmark: vi.fn(),
+    mockDeleteBookmarkFolder: vi.fn(),
+    mockIsBookmarked: vi.fn().mockReturnValue(false),
+    mockToggleBookmark: vi.fn(),
+    mockAddNodeOnGraph: vi.fn(),
+    mockToggleNodeOnEvent: vi.fn(),
+    captureRoot: (root: TreeExplorerNode<unknown>) => {
+      capturedRoot = root
+    },
+    getRoot: () => capturedRoot as TreeExplorerNode<ComfyNodeDefImpl>,
+    resetRoot: () => {
+      capturedRoot = null
+    }
+  }
+})
+
+const mockFolderNodeDef = fromPartial<ComfyNodeDefImpl>({
+  name: 'MyFolder',
+  category: '',
+  nodePath: 'MyFolder/',
+  isDummyFolder: true,
+  display_name: 'MyFolder'
+})
+
+const mockLeafNodeDef = fromPartial<ComfyNodeDefImpl>({
+  name: 'CLIPTextEncode',
+  category: 'MyFolder',
+  nodePath: 'MyFolder/CLIPTextEncode',
+  isDummyFolder: false,
+  display_name: 'CLIP Text Encode'
+})
+
+const mockBookmarkedRoot: TreeNode = {
+  key: 'root',
+  label: 'Root',
+  leaf: false,
+  children: [
+    {
+      key: 'MyFolder/',
+      label: 'MyFolder',
+      leaf: false,
+      data: mockFolderNodeDef,
+      children: [
+        {
+          key: 'CLIPTextEncode',
+          label: 'CLIP Text Encode',
+          leaf: true,
+          data: mockLeafNodeDef
+        }
+      ]
+    }
+  ]
+}
+
+vi.mock('@/stores/nodeBookmarkStore', () => ({
+  useNodeBookmarkStore: () => ({
+    bookmarks: [],
+    bookmarkedRoot: mockBookmarkedRoot,
+    isBookmarked: mockIsBookmarked,
+    toggleBookmark: mockToggleBookmark,
+    addBookmark: mockAddBookmark,
+    deleteBookmarkFolder: mockDeleteBookmarkFolder,
+    addNewBookmarkFolder: vi.fn(),
+    renameBookmarkFolder: vi.fn(),
+    bookmarksCustomization: {},
+    defaultBookmarkIcon: 'pi-bookmark-fill',
+    defaultBookmarkColor: '#a1a1aa',
+    updateCustomization: vi.fn()
+  })
+}))
+
+vi.mock('@/services/litegraphService', () => ({
+  useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/composables/useTreeExpansion', () => ({
+  useTreeExpansion: () => ({
+    expandNode: vi.fn(),
+    toggleNodeOnEvent: mockToggleNodeOnEvent
+  })
+}))
+
+vi.mock('@/components/common/TreeExplorer.vue', () => ({
+  default: {
+    name: 'TreeExplorer',
+    template: '<div />',
+    props: ['root', 'expandedKeys'],
+    setup(props: { root: TreeExplorerNode<unknown> }) {
+      captureRoot(props.root)
+    }
+  }
+}))
+
+vi.mock('@/components/common/CustomizationDialog.vue', () => ({
+  default: {
+    name: 'FolderCustomizationDialog',
+    template: '<div />',
+    props: ['modelValue', 'initialIcon', 'initialColor']
+  }
+}))
+
+vi.mock('@/components/node/NodePreview.vue', () => ({
+  default: { name: 'NodePreview', template: '<div />' }
+}))
+
+vi.mock('@/components/sidebar/tabs/nodeLibrary/NodeTreeFolder.vue', () => ({
+  default: { name: 'NodeTreeFolder', template: '<div />', props: ['node'] }
+}))
+
+vi.mock('@/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue', () => ({
+  default: {
+    name: 'NodeTreeLeaf',
+    template: '<div />',
+    props: ['node', 'openNodeHelp']
+  }
+}))
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+describe('NodeBookmarkTreeExplorer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsBookmarked.mockReturnValue(false)
+    resetRoot()
+  })
+
+  async function renderAndGetRoot(): Promise<
+    TreeExplorerNode<ComfyNodeDefImpl>
+  > {
+    render(NodeBookmarkTreeExplorer, {
+      global: { plugins: [i18n], stubs: { teleport: true } },
+      props: { filteredNodeDefs: [], openNodeHelp: vi.fn() }
+    })
+    await nextTick()
+    const root = getRoot()
+    expect(root).not.toBeNull()
+    return root!
+  }
+
+  describe('handleDrop', () => {
+    it('adds bookmark when a node is dragged onto a folder', async () => {
+      const root = await renderAndGetRoot()
+      const folderNode = root.children?.[0]
+
+      await folderNode?.handleDrop?.call(
+        folderNode,
+        fromPartial<TreeExplorerDragAndDropData<ComfyNodeDefImpl>>({
+          data: { data: mockLeafNodeDef }
+        })
+      )
+
+      expect(mockAddBookmark).toHaveBeenCalled()
+    })
+
+    it('moves bookmark when a node is dragged onto a folder and is bookmarked', async () => {
+      mockIsBookmarked.mockReturnValue(true)
+      const root = await renderAndGetRoot()
+      const folderNode = root.children?.[0]
+
+      await folderNode?.handleDrop?.call(
+        folderNode,
+        fromPartial<TreeExplorerDragAndDropData<ComfyNodeDefImpl>>({
+          data: { data: mockLeafNodeDef }
+        })
+      )
+
+      expect(mockToggleBookmark).toHaveBeenCalledWith(mockLeafNodeDef)
+      expect(mockAddBookmark).toHaveBeenCalled()
+    })
+
+    it('is a no-op when the dragged node carries no data', async () => {
+      const root = await renderAndGetRoot()
+      const folderNode = root.children?.[0]
+
+      await folderNode?.handleDrop?.call(
+        folderNode,
+        fromPartial<TreeExplorerDragAndDropData<ComfyNodeDefImpl>>({
+          data: { data: undefined }
+        })
+      )
+
+      expect(mockAddBookmark).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleClick', () => {
+    it('adds node on graph when a leaf node is clicked', async () => {
+      const root = await renderAndGetRoot()
+      const leafNode = root.children?.[0].children?.[0]
+      const mockEvent = new MouseEvent('click')
+
+      await leafNode?.handleClick?.call(leafNode, mockEvent)
+
+      expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockLeafNodeDef)
+    })
+
+    it('toggles node expansion when a folder node is clicked', async () => {
+      const root = await renderAndGetRoot()
+      const folderNode = root.children?.[0]
+      const mockEvent = new MouseEvent('click')
+
+      await folderNode?.handleClick?.call(folderNode, mockEvent)
+
+      expect(mockToggleNodeOnEvent).toHaveBeenCalledWith(
+        mockEvent,
+        expect.objectContaining({ key: folderNode?.key })
+      )
+    })
+  })
+
+  describe('handleDelete', () => {
+    it('deletes the bookmark folder when node data is present', async () => {
+      const root = await renderAndGetRoot()
+      const folderNode = root.children?.[0]
+
+      await folderNode?.handleDelete?.call({
+        ...folderNode,
+        data: mockFolderNodeDef
+      })
+
+      expect(mockDeleteBookmarkFolder).toHaveBeenCalledWith(mockFolderNodeDef)
+    })
+
+    it('is a no-op when node data is missing', async () => {
+      const root = await renderAndGetRoot()
+      const folderNode = root.children?.[0]
+
+      await folderNode?.handleDelete?.call({ ...folderNode, data: undefined })
+
+      expect(mockDeleteBookmarkFolder).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
@@ -173,20 +173,17 @@ const renderedBookmarkedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(
         droppable: !node.leaf,
         async handleDrop(data: TreeExplorerDragAndDropData<ComfyNodeDefImpl>) {
           const nodeDefToAdd = data.data.data
+          if (!nodeDefToAdd) return
           // Remove bookmark if the source is the top level bookmarked node.
-          // @ts-expect-error fixme ts strict error
           if (nodeBookmarkStore.isBookmarked(nodeDefToAdd)) {
-            // @ts-expect-error fixme ts strict error
             await nodeBookmarkStore.toggleBookmark(nodeDefToAdd)
           }
           const folderNodeDef = node.data as ComfyNodeDefImpl
-          // @ts-expect-error fixme ts strict error
           const nodePath = folderNodeDef.category + '/' + nodeDefToAdd.name
           await nodeBookmarkStore.addBookmark(nodePath)
         },
         handleClick(e: MouseEvent) {
-          if (this.leaf) {
-            // @ts-expect-error fixme ts strict error
+          if (this.leaf && this.data) {
             useLitegraphService().addNodeOnGraph(this.data)
           } else {
             toggleNodeOnEvent(e, node)
@@ -205,7 +202,7 @@ const renderedBookmarkedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(
                 }
               },
               async handleDelete() {
-                // @ts-expect-error fixme ts strict error
+                if (!this.data) return
                 await nodeBookmarkStore.deleteBookmarkFolder(this.data)
               }
             })


### PR DESCRIPTION
…(issue #11092 phase 4a)

## Summary
Part of #11092 — Phase 4a: remove 10 @ts-expect-error suppressions from three sidebar component files.                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                          
## Changes
                                                                                                                                                                                                                                                                                                                          
3 files in the sidebar had `@ts-expect-error` suppressions that all traced back to the same root cause: **optional properties on generic interfaces that TypeScript cannot narrow through indirect conditions.**

`TreeExplorerNode<T>` declares `data?: T` — optional by design, since folder nodes may carry no payload. Every `handleClick`, `handleDrop`, and `handleDelete` method that accessed `this.data` was relying on the runtime invariant that leaf nodes always have data, but TypeScript has no way to derive `data !== undefined` from `this.leaf === true`. The fix was to make the invariant explicit in the condition (`if (this.leaf && this.data)`) or add an early-return guard (`if (!nodeDefToAdd) return`).

The same pattern appeared in a closure in `ModelLibrarySidebarTab.vue`: `model` was `ComfyModelDef | null` from an outer const, and `if (this.leaf)` inside a method cannot narrow a captured variable. Widening the condition to `if (this.leaf && model)` resolved it. Two additional suppressions in that file covered `addNodeOnGraph`'s nullable return and its optional `widgets` property, both fixed with optional chaining.

The remaining suppression was an unannotated function parameter inferred as `any`; adding the explicit type from the `filters` ref removed it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are TypeScript-safety refactors (extra null/undefined guards) plus new unit tests; runtime behavior should only differ in edge cases where `data`/`model`/`widgets` are unexpectedly missing.
> 
> **Overview**
> Removes several `@ts-expect-error` suppressions in sidebar library tabs by making leaf-node invariants explicit (`if (this.leaf && this.data/model)`), adding early returns for missing drag-drop payloads, and using optional chaining for nullable `addNodeOnGraph`/`widgets` access.
> 
> Adds new Vitest coverage for `ModelLibrarySidebarTab`, `NodeLibrarySidebarTab`, and `NodeBookmarkTreeExplorer` to validate click-to-add-node behavior, folder expansion toggling, filter add/remove flow, bookmark drag/drop, and safe no-op paths when required data is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd285515164cea6fb03d0693adbb3465f6fa40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11338-refactor-remove-ts-expect-error-suppressions-in-sidebar-components-3456d73d365081e2858af020b88d7f05) by [Unito](https://www.unito.io)
