### PR TITLE
fix: right-click Paste Image missing on cloud LoadImage

### DIFF
--- a/src/extensions/core/uploadImage.test.ts
+++ b/src/extensions/core/uploadImage.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { ComfyExtension } from '@/types/comfy'
+
+interface CapturedExtension {
+  name: string
+  beforeRegisterNodeDef?: ComfyExtension['beforeRegisterNodeDef']
+}
+
+const registerExtension = vi.fn<(ext: CapturedExtension) => void>()
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    registerExtension: (ext: CapturedExtension) => registerExtension(ext)
+  }
+}))
+
+let uploadImageExtension: CapturedExtension | undefined
+
+beforeAll(async () => {
+  await import('./uploadImage')
+  uploadImageExtension = registerExtension.mock.calls
+    .map(([ext]) => ext)
+    .find((ext) => ext.name === 'Comfy.UploadImage')
+})
+
+describe('Comfy.UploadImage extension', () => {
+  it('attaches an IMAGEUPLOAD widget when the image input declares image_upload', () => {
+    const nodeData = {
+      name: 'LoadImage',
+      input: {
+        required: {
+          image: ['COMBO', { image_upload: true }]
+        }
+      }
+    }
+
+    uploadImageExtension!.beforeRegisterNodeDef!(
+      undefined as unknown as typeof LGraphNode,
+      nodeData as never,
+      undefined as never
+    )
+
+    const upload = (nodeData.input.required as Record<string, unknown>).upload
+    expect(upload).toBeDefined()
+    expect((upload as [string, { imageInputName: string }])[0]).toBe(
+      'IMAGEUPLOAD'
+    )
+    expect(
+      (upload as [string, { imageInputName: string }])[1].imageInputName
+    ).toBe('image')
+  })
+
+  it('attaches an IMAGEUPLOAD widget for LoadImage even when the backend omits image_upload', () => {
+    // Reproduces the cloud bug: the cloud backend serves LoadImage without
+    // image_upload: true on the image input, so Comfy.UploadImage skips
+    // attaching the IMAGEUPLOAD widget. That cascade leaves node.pasteFiles
+    // unset, which hides the right-click "Paste Image" menu item on cloud.
+    const nodeData = {
+      name: 'LoadImage',
+      input: {
+        required: {
+          image: ['COMBO', {}]
+        }
+      }
+    }
+
+    uploadImageExtension!.beforeRegisterNodeDef!(
+      undefined as unknown as typeof LGraphNode,
+      nodeData as never,
+      undefined as never
+    )
+
+    const upload = (nodeData.input.required as Record<string, unknown>).upload
+    expect(upload).toBeDefined()
+    expect((upload as [string, { imageInputName: string }])[0]).toBe(
+      'IMAGEUPLOAD'
+    )
+    expect(
+      (upload as [string, { imageInputName: string }])[1].imageInputName
+    ).toBe('image')
+  })
+})

--- a/src/extensions/core/uploadImage.test.ts
+++ b/src/extensions/core/uploadImage.test.ts
@@ -74,11 +74,92 @@ describe('Comfy.UploadImage extension', () => {
 
     const upload = (nodeData.input.required as Record<string, unknown>).upload
     expect(upload).toBeDefined()
-    expect((upload as [string, { imageInputName: string }])[0]).toBe(
-      'IMAGEUPLOAD'
-    )
     expect(
-      (upload as [string, { imageInputName: string }])[1].imageInputName
-    ).toBe('image')
+      (upload as [string, { imageInputName: string; image_upload: boolean }])[0]
+    ).toBe('IMAGEUPLOAD')
+    const opts = (
+      upload as [string, { imageInputName: string; image_upload: boolean }]
+    )[1]
+    expect(opts.imageInputName).toBe('image')
+    expect(opts.image_upload).toBe(true)
+  })
+
+  it('attaches an IMAGEUPLOAD widget for LoadVideo with video_upload synthesized', () => {
+    // Without injecting video_upload, useImageUploadWidget would default to
+    // image-only filters and reject pasted/dropped video files on cloud.
+    const nodeData = {
+      name: 'LoadVideo',
+      input: {
+        required: {
+          file: ['COMBO', {}]
+        }
+      }
+    }
+
+    uploadImageExtension!.beforeRegisterNodeDef!(
+      undefined as unknown as typeof LGraphNode,
+      nodeData as never,
+      undefined as never
+    )
+
+    const upload = (nodeData.input.required as Record<string, unknown>).upload
+    expect(upload).toBeDefined()
+    expect(
+      (upload as [string, { imageInputName: string; video_upload: boolean }])[0]
+    ).toBe('IMAGEUPLOAD')
+    const opts = (
+      upload as [string, { imageInputName: string; video_upload: boolean }]
+    )[1]
+    expect(opts.imageInputName).toBe('file')
+    expect(opts.video_upload).toBe(true)
+  })
+
+  it('does not touch LoadAudio — audio is handled by Comfy.UploadAudio', () => {
+    // Routing audio through the IMAGEUPLOAD widget would reject every pasted
+    // or dropped audio file. Comfy.UploadImage must stay out of LoadAudio.
+    const nodeData = {
+      name: 'LoadAudio',
+      input: {
+        required: {
+          audio: ['COMBO', {}]
+        }
+      }
+    }
+
+    uploadImageExtension!.beforeRegisterNodeDef!(
+      undefined as unknown as typeof LGraphNode,
+      nodeData as never,
+      undefined as never
+    )
+
+    expect(
+      (nodeData.input.required as Record<string, unknown>).upload
+    ).toBeUndefined()
+  })
+
+  it('never overwrites an upload widget another extension already attached', () => {
+    // Comfy.UploadAudio is imported before Comfy.UploadImage and may have
+    // already set required.upload = ['AUDIOUPLOAD', {}]. The fallback must
+    // not clobber it on LoadAudio (or any future sibling uploader).
+    const existingUpload = ['AUDIOUPLOAD', {}]
+    const nodeData = {
+      name: 'LoadAudio',
+      input: {
+        required: {
+          audio: ['COMBO', {}],
+          upload: existingUpload
+        }
+      }
+    }
+
+    uploadImageExtension!.beforeRegisterNodeDef!(
+      undefined as unknown as typeof LGraphNode,
+      nodeData as never,
+      undefined as never
+    )
+
+    expect((nodeData.input.required as Record<string, unknown>).upload).toBe(
+      existingUpload
+    )
   })
 })

--- a/src/extensions/core/uploadImage.test.ts
+++ b/src/extensions/core/uploadImage.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import type { ComfyExtension } from '@/types/comfy'
 
 interface CapturedExtension {
@@ -8,7 +9,9 @@ interface CapturedExtension {
   beforeRegisterNodeDef?: ComfyExtension['beforeRegisterNodeDef']
 }
 
-const registerExtension = vi.fn<(ext: CapturedExtension) => void>()
+const registerExtension = vi.hoisted(() =>
+  vi.fn<(ext: CapturedExtension) => void>()
+)
 
 vi.mock('@/scripts/app', () => ({
   app: {
@@ -16,14 +19,34 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
-let uploadImageExtension: CapturedExtension | undefined
+// Static import — vi.mock hoisting ensures the mock is ready before the
+// module's top-level app.registerExtension() call executes.
+import './uploadImage'
 
-beforeAll(async () => {
-  await import('./uploadImage')
-  uploadImageExtension = registerExtension.mock.calls
-    .map(([ext]) => ext)
-    .find((ext) => ext.name === 'Comfy.UploadImage')
-})
+function getExtension(): CapturedExtension {
+  const ext = registerExtension.mock.calls
+    .map(([e]) => e)
+    .find((e) => e.name === 'Comfy.UploadImage')
+  if (!ext) throw new Error('Comfy.UploadImage not registered')
+  return ext
+}
+
+function callBeforeRegister(nodeData: {
+  name: string
+  input: { required: Record<string, unknown> }
+}) {
+  getExtension().beforeRegisterNodeDef!(
+    undefined as unknown as typeof LGraphNode,
+    nodeData as ComfyNodeDef,
+    undefined as never
+  )
+}
+
+function getUpload(
+  required: Record<string, unknown>
+): [string, Record<string, unknown>] | undefined {
+  return required.upload as [string, Record<string, unknown>] | undefined
+}
 
 describe('Comfy.UploadImage extension', () => {
   it('attaches an IMAGEUPLOAD widget when the image input declares image_upload', () => {
@@ -36,27 +59,15 @@ describe('Comfy.UploadImage extension', () => {
       }
     }
 
-    uploadImageExtension!.beforeRegisterNodeDef!(
-      undefined as unknown as typeof LGraphNode,
-      nodeData as never,
-      undefined as never
-    )
+    callBeforeRegister(nodeData)
 
-    const upload = (nodeData.input.required as Record<string, unknown>).upload
+    const upload = getUpload(nodeData.input.required as Record<string, unknown>)
     expect(upload).toBeDefined()
-    expect((upload as [string, { imageInputName: string }])[0]).toBe(
-      'IMAGEUPLOAD'
-    )
-    expect(
-      (upload as [string, { imageInputName: string }])[1].imageInputName
-    ).toBe('image')
+    expect(upload![0]).toBe('IMAGEUPLOAD')
+    expect(upload![1].imageInputName).toBe('image')
   })
 
   it('attaches an IMAGEUPLOAD widget for LoadImage even when the backend omits image_upload', () => {
-    // Reproduces the cloud bug: the cloud backend serves LoadImage without
-    // image_upload: true on the image input, so Comfy.UploadImage skips
-    // attaching the IMAGEUPLOAD widget. That cascade leaves node.pasteFiles
-    // unset, which hides the right-click "Paste Image" menu item on cloud.
     const nodeData = {
       name: 'LoadImage',
       input: {
@@ -66,27 +77,16 @@ describe('Comfy.UploadImage extension', () => {
       }
     }
 
-    uploadImageExtension!.beforeRegisterNodeDef!(
-      undefined as unknown as typeof LGraphNode,
-      nodeData as never,
-      undefined as never
-    )
+    callBeforeRegister(nodeData)
 
-    const upload = (nodeData.input.required as Record<string, unknown>).upload
+    const upload = getUpload(nodeData.input.required as Record<string, unknown>)
     expect(upload).toBeDefined()
-    expect(
-      (upload as [string, { imageInputName: string; image_upload: boolean }])[0]
-    ).toBe('IMAGEUPLOAD')
-    const opts = (
-      upload as [string, { imageInputName: string; image_upload: boolean }]
-    )[1]
-    expect(opts.imageInputName).toBe('image')
-    expect(opts.image_upload).toBe(true)
+    expect(upload![0]).toBe('IMAGEUPLOAD')
+    expect(upload![1].imageInputName).toBe('image')
+    expect(upload![1].image_upload).toBe(true)
   })
 
   it('attaches an IMAGEUPLOAD widget for LoadVideo with video_upload synthesized', () => {
-    // Without injecting video_upload, useImageUploadWidget would default to
-    // image-only filters and reject pasted/dropped video files on cloud.
     const nodeData = {
       name: 'LoadVideo',
       input: {
@@ -96,27 +96,33 @@ describe('Comfy.UploadImage extension', () => {
       }
     }
 
-    uploadImageExtension!.beforeRegisterNodeDef!(
-      undefined as unknown as typeof LGraphNode,
-      nodeData as never,
-      undefined as never
-    )
+    callBeforeRegister(nodeData)
 
-    const upload = (nodeData.input.required as Record<string, unknown>).upload
+    const upload = getUpload(nodeData.input.required as Record<string, unknown>)
     expect(upload).toBeDefined()
+    expect(upload![0]).toBe('IMAGEUPLOAD')
+    expect(upload![1].imageInputName).toBe('file')
+    expect(upload![1].video_upload).toBe(true)
+  })
+
+  it('does not attach an upload widget for unknown node types', () => {
+    const nodeData = {
+      name: 'UnknownNode',
+      input: {
+        required: {
+          image: ['COMBO', {}]
+        }
+      }
+    }
+
+    callBeforeRegister(nodeData)
+
     expect(
-      (upload as [string, { imageInputName: string; video_upload: boolean }])[0]
-    ).toBe('IMAGEUPLOAD')
-    const opts = (
-      upload as [string, { imageInputName: string; video_upload: boolean }]
-    )[1]
-    expect(opts.imageInputName).toBe('file')
-    expect(opts.video_upload).toBe(true)
+      getUpload(nodeData.input.required as Record<string, unknown>)
+    ).toBeUndefined()
   })
 
   it('does not touch LoadAudio — audio is handled by Comfy.UploadAudio', () => {
-    // Routing audio through the IMAGEUPLOAD widget would reject every pasted
-    // or dropped audio file. Comfy.UploadImage must stay out of LoadAudio.
     const nodeData = {
       name: 'LoadAudio',
       input: {
@@ -126,21 +132,14 @@ describe('Comfy.UploadImage extension', () => {
       }
     }
 
-    uploadImageExtension!.beforeRegisterNodeDef!(
-      undefined as unknown as typeof LGraphNode,
-      nodeData as never,
-      undefined as never
-    )
+    callBeforeRegister(nodeData)
 
     expect(
-      (nodeData.input.required as Record<string, unknown>).upload
+      getUpload(nodeData.input.required as Record<string, unknown>)
     ).toBeUndefined()
   })
 
   it('never overwrites an upload widget another extension already attached', () => {
-    // Comfy.UploadAudio is imported before Comfy.UploadImage and may have
-    // already set required.upload = ['AUDIOUPLOAD', {}]. The fallback must
-    // not clobber it on LoadAudio (or any future sibling uploader).
     const existingUpload = ['AUDIOUPLOAD', {}]
     const nodeData = {
       name: 'LoadAudio',
@@ -152,11 +151,7 @@ describe('Comfy.UploadImage extension', () => {
       }
     }
 
-    uploadImageExtension!.beforeRegisterNodeDef!(
-      undefined as unknown as typeof LGraphNode,
-      nodeData as never,
-      undefined as never
-    )
+    callBeforeRegister(nodeData)
 
     expect((nodeData.input.required as Record<string, unknown>).upload).toBe(
       existingUpload

--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -11,23 +11,30 @@ import { app } from '../../scripts/app'
 // Adds an upload button to the nodes
 
 // Cloud's backend may serve these loader nodes without the image_upload /
-// video_upload / animated_image_upload flag. Without a fallback the IMAGEUPLOAD
+// video_upload flag on their media input. Without a fallback the IMAGEUPLOAD
 // widget is never attached, so node.pasteFiles stays unset and the right-click
 // "Paste Image" menu item never appears on cloud LoadImage nodes.
-const KNOWN_MEDIA_LOADER_INPUTS: Record<string, string> = {
-  LoadImage: 'image',
-  LoadImageMask: 'image',
-  LoadVideo: 'file',
-  LoadAudio: 'audio'
+//
+// LoadAudio is intentionally excluded — audio uses a separate AUDIOUPLOAD
+// widget owned by Comfy.UploadAudio. Routing audio through IMAGEUPLOAD would
+// reject every audio file the user pasted or dropped.
+const FALLBACK_MEDIA_LOADER_INPUTS: Record<
+  string,
+  { inputName: string; flag: 'image_upload' | 'video_upload' }
+> = {
+  LoadImage: { inputName: 'image', flag: 'image_upload' },
+  LoadVideo: { inputName: 'file', flag: 'video_upload' }
 }
 
 const createUploadInput = (
   imageInputName: string,
-  imageInputOptions: InputSpec
+  imageInputOptions: InputSpec,
+  extraOptions: Record<string, unknown> = {}
 ): InputSpec => [
   'IMAGEUPLOAD',
   {
     ...imageInputOptions[1],
+    ...extraOptions,
     imageInputName
   }
 ]
@@ -38,6 +45,8 @@ app.registerExtension({
     const { input } = nodeData ?? {}
     const { required } = input ?? {}
     if (!required) return
+    // Don't clobber a sibling uploader (e.g. Comfy.UploadAudio's AUDIOUPLOAD).
+    if (required.upload) return
 
     const found = Object.entries(required).find(([_, input]) =>
       isMediaUploadComboInput(input)
@@ -50,10 +59,14 @@ app.registerExtension({
       return
     }
 
-    const fallbackInputName = KNOWN_MEDIA_LOADER_INPUTS[nodeData?.name ?? '']
-    if (!fallbackInputName) return
-    const fallbackSpec = required[fallbackInputName] as InputSpec | undefined
+    const fallback = FALLBACK_MEDIA_LOADER_INPUTS[nodeData?.name ?? '']
+    if (!fallback) return
+    const fallbackSpec = required[fallback.inputName] as InputSpec | undefined
     if (!fallbackSpec || !isComboInputSpec(fallbackSpec)) return
-    required.upload = createUploadInput(fallbackInputName, fallbackSpec)
+    // Synthesize the missing media-type flag so useImageUploadWidget picks the
+    // right accept filter (image/* vs video/*) for the loader's media kind.
+    required.upload = createUploadInput(fallback.inputName, fallbackSpec, {
+      [fallback.flag]: true
+    })
   }
 })

--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -59,9 +59,9 @@ app.registerExtension({
       return
     }
 
-    const fallback = FALLBACK_MEDIA_LOADER_INPUTS[nodeData?.name ?? '']
+    const fallback = FALLBACK_MEDIA_LOADER_INPUTS[nodeData.name]
     if (!fallback) return
-    const fallbackSpec = required[fallback.inputName] as InputSpec | undefined
+    const fallbackSpec = required[fallback.inputName]
     if (!fallbackSpec || !isComboInputSpec(fallbackSpec)) return
     // Synthesize the missing media-type flag so useImageUploadWidget picks the
     // right accept filter (image/* vs video/*) for the loader's media kind.

--- a/src/extensions/core/uploadImage.ts
+++ b/src/extensions/core/uploadImage.ts
@@ -2,12 +2,24 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import {
   type ComfyNodeDef,
   type InputSpec,
+  isComboInputSpec,
   isMediaUploadComboInput
 } from '@/schemas/nodeDefSchema'
 
 import { app } from '../../scripts/app'
 
 // Adds an upload button to the nodes
+
+// Cloud's backend may serve these loader nodes without the image_upload /
+// video_upload / animated_image_upload flag. Without a fallback the IMAGEUPLOAD
+// widget is never attached, so node.pasteFiles stays unset and the right-click
+// "Paste Image" menu item never appears on cloud LoadImage nodes.
+const KNOWN_MEDIA_LOADER_INPUTS: Record<string, string> = {
+  LoadImage: 'image',
+  LoadImageMask: 'image',
+  LoadVideo: 'file',
+  LoadAudio: 'audio'
+}
 
 const createUploadInput = (
   imageInputName: string,
@@ -35,6 +47,13 @@ app.registerExtension({
     if (found) {
       const [inputName, inputSpec] = found
       required.upload = createUploadInput(inputName, inputSpec)
+      return
     }
+
+    const fallbackInputName = KNOWN_MEDIA_LOADER_INPUTS[nodeData?.name ?? '']
+    if (!fallbackInputName) return
+    const fallbackSpec = required[fallbackInputName] as InputSpec | undefined
+    if (!fallbackSpec || !isComboInputSpec(fallbackSpec)) return
+    required.upload = createUploadInput(fallbackInputName, fallbackSpec)
   }
 })


### PR DESCRIPTION
## Summary

In Comfy Cloud, right-clicking a LoadImage node does not show the "Paste Image" menu item even when the user has an image in their clipboard. It works locally.

**Root cause:** `Comfy.UploadImage` adds the `IMAGEUPLOAD` widget only when an input declares `image_upload: true`. The cloud backend serves LoadImage's `image` input without that flag, so the upload widget is never attached → `useNodeImageUpload` → `useNodePaste` never run → `node.pasteFiles` stays unset → `useImageMenuOptions.canPasteImage` returns false → menu item hidden.

- Fixes the bug reported in [Slack thread](https://comfy-organization.slack.com/archives/C0A7ADM4797/p1776367302536219?thread_ts=1776231163.862009)

## Red-Green Verification

| Commit | CI Status | Purpose |
|--------|-----------|---------|
| `test: ...` | :red_circle: Red | Proves the test catches the bug |
| `fix: ...` | :green_circle: Green | (added next) — proves the fix resolves the bug |

## Test Plan

- [ ] CI red on test-only commit
- [ ] CI green on fix commit
- [ ] Manual: right-click a LoadImage on cloud.comfy.org → "Paste Image" appears with image in clipboard

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11356-fix-right-click-Paste-Image-missing-on-cloud-LoadImage-3466d73d3650817588a8ead621e8c546) by [Unito](https://www.unito.io)
