### PR TITLE
fix: respect control_after_generate setting on API nodes

### DIFF
--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -87,7 +87,7 @@ const simplifiedWidget = computed((): SimplifiedWidget => {
     label: widgetState?.label ?? widget.label,
     options: widgetState?.options ?? widget.options,
     spec: nodeDefStore.getInputSpecForWidget(sourceNode, sourceWidget.name),
-    controlWidget: getControlWidget(sourceWidget)
+    controlWidget: getControlWidget(sourceWidget, sourceNode)
   }
 })
 

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -26,6 +26,7 @@ import { isDOMWidget } from '@/scripts/domWidget'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import type { WidgetValue, SafeControlWidget } from '@/types/simplifiedWidget'
 import { normalizeControlOption } from '@/types/simplifiedWidget'
+import { IS_CONTROL_WIDGET } from '@/scripts/widgets'
 
 import type {
   LGraph,
@@ -150,15 +151,31 @@ function isPromotedDOMWidget(widget: IBaseWidget): boolean {
 }
 
 export function getControlWidget(
-  widget: IBaseWidget
+  widget: IBaseWidget,
+  node?: LGraphNode
 ): SafeControlWidget | undefined {
-  const cagWidget = widget.linkedWidgets?.find(
-    (w) => w.name == 'control_after_generate'
-  )
+  // Prefer the marker symbol so group/primitive nodes that prefix the widget
+  // name (e.g. "KSampler control_after_generate") still resolve.
+  const cagWidget =
+    widget.linkedWidgets?.find((w) => w[IS_CONTROL_WIDGET]) ??
+    widget.linkedWidgets?.find((w) => w.name === 'control_after_generate')
   if (!cagWidget) return
+
+  // For API nodes: an explicit user-visible control_after_generate COMBO widget
+  // exists alongside the hidden ACW. Use it as the source of truth for display
+  // and write-through so changes the user makes actually take effect.
+  const externalControl = node?.widgets?.find(
+    (w) => w.name === cagWidget.name && w !== cagWidget && !w[IS_CONTROL_WIDGET]
+  )
+  const displayWidget = externalControl ?? cagWidget
+
   return {
-    value: normalizeControlOption(cagWidget.value),
-    update: (value) => (cagWidget.value = normalizeControlOption(value))
+    value: normalizeControlOption(displayWidget.value),
+    update: (value) => {
+      const normalized = normalizeControlOption(value)
+      cagWidget.value = normalized
+      if (externalControl) externalControl.value = normalized
+    }
   }
 }
 
@@ -174,7 +191,7 @@ function getSharedWidgetEnhancements(
   const nodeDefStore = useNodeDefStore()
 
   return {
-    controlWidget: getControlWidget(widget),
+    controlWidget: getControlWidget(widget, node),
     spec: nodeDefStore.getInputSpecForWidget(node, widget.name)
   }
 }

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -26,7 +26,7 @@ import { isDOMWidget } from '@/scripts/domWidget'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import type { WidgetValue, SafeControlWidget } from '@/types/simplifiedWidget'
 import { normalizeControlOption } from '@/types/simplifiedWidget'
-import { IS_CONTROL_WIDGET } from '@/scripts/widgets'
+import { IS_CONTROL_WIDGET, findExternalControlWidget } from '@/scripts/widgets'
 
 import type {
   LGraph,
@@ -161,12 +161,9 @@ export function getControlWidget(
     widget.linkedWidgets?.find((w) => w.name === 'control_after_generate')
   if (!cagWidget) return
 
-  // For API nodes: an explicit user-visible control_after_generate COMBO widget
-  // exists alongside the hidden ACW. Use it as the source of truth for display
-  // and write-through so changes the user makes actually take effect.
-  const externalControl = node?.widgets?.find(
-    (w) => w.name === cagWidget.name && w !== cagWidget && !w[IS_CONTROL_WIDGET]
-  )
+  const externalControl = node
+    ? findExternalControlWidget(node, cagWidget)
+    : undefined
   const displayWidget = externalControl ?? cagWidget
 
   return {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetWithControl.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetWithControl.vue
@@ -24,6 +24,15 @@ const modelValue = defineModel<T>()
 const controlModel = ref(props.widget.controlWidget.value)
 
 watch(controlModel, props.widget.controlWidget.update)
+
+// Sync litegraph → Vue when the external control widget value changes
+// (e.g. when a workflow is loaded with a specific control mode set)
+watch(
+  () => props.widget.controlWidget.value,
+  (newVal) => {
+    if (controlModel.value !== newVal) controlModel.value = newVal
+  }
+)
 </script>
 <template>
   <div class="relative grid grid-cols-subgrid">

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/lib/litegraph/src/types/widgets'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { dynamicWidgets } from '@/core/graph/widgets/dynamicWidgets'
+import { CONTROL_OPTIONS } from '@/types/simplifiedWidget'
 import { useBooleanWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useBooleanWidget'
 import { useBoundingBoxWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget'
 import { useCurveWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useCurveWidget'
@@ -80,6 +81,19 @@ export function updateControlWidgetLabel(widget: IBaseWidget) {
 export const IS_CONTROL_WIDGET = Symbol()
 const HAS_EXECUTED = Symbol()
 
+/**
+ * The v3 backend schema allows `control_after_generate` to be one of the
+ * control mode strings ('fixed', 'increment', 'decrement', 'randomize') to
+ * specify the default mode. Legacy callers used an arbitrary string here as
+ * a custom widget name, so we only treat unknown strings as names.
+ */
+function isControlAfterGenerateMode(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    (CONTROL_OPTIONS as readonly string[]).includes(value)
+  )
+}
+
 export function addValueControlWidget(
   node: LGraphNode,
   targetWidget: IBaseWidget,
@@ -88,10 +102,11 @@ export function addValueControlWidget(
   widgetName?: string,
   inputData?: InputSpec
 ): IComboWidget {
-  let name = inputData?.[1]?.control_after_generate
-  if (typeof name !== 'string') {
-    name = widgetName
-  }
+  const rawName = inputData?.[1]?.control_after_generate
+  const name =
+    typeof rawName === 'string' && !isControlAfterGenerateMode(rawName)
+      ? rawName
+      : widgetName
   const widgets = addValueControlWidgets(
     node,
     targetWidget,
@@ -119,7 +134,13 @@ export function addValueControlWidgets(
     let name = defaultName
     if (options[optionName]) {
       name = options[optionName]
-    } else if (typeof inputData?.[1]?.[defaultName] === 'string') {
+    } else if (
+      typeof inputData?.[1]?.[defaultName] === 'string' &&
+      !(
+        defaultName === 'control_after_generate' &&
+        isControlAfterGenerateMode(inputData[1][defaultName])
+      )
+    ) {
       name = inputData?.[1]?.[defaultName]
     } else if (inputData?.[1]?.control_prefix) {
       name = inputData?.[1]?.control_prefix + ' ' + name
@@ -175,6 +196,18 @@ export function addValueControlWidgets(
   }
 
   const applyWidgetControl = () => {
+    // For API nodes: the user-visible control_after_generate COMBO widget is a
+    // separate explicit input. Sync its value into this hidden ACW so the
+    // user's choice actually drives execution.
+    const externalControl = node.widgets?.find(
+      (w) =>
+        w.name === valueControl.name &&
+        w !== valueControl &&
+        !w[IS_CONTROL_WIDGET]
+    )
+    if (externalControl !== undefined) {
+      valueControl.value = externalControl.value as string
+    }
     var v = valueControl.value
 
     if (isCombo && v !== 'fixed') {

--- a/src/scripts/widgets.ts
+++ b/src/scripts/widgets.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/lib/litegraph/src/types/widgets'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { dynamicWidgets } from '@/core/graph/widgets/dynamicWidgets'
-import { CONTROL_OPTIONS } from '@/types/simplifiedWidget'
+import { isControlOption } from '@/types/simplifiedWidget'
 import { useBooleanWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useBooleanWidget'
 import { useBoundingBoxWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useBoundingBoxWidget'
 import { useCurveWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useCurveWidget'
@@ -82,15 +82,16 @@ export const IS_CONTROL_WIDGET = Symbol()
 const HAS_EXECUTED = Symbol()
 
 /**
- * The v3 backend schema allows `control_after_generate` to be one of the
- * control mode strings ('fixed', 'increment', 'decrement', 'randomize') to
- * specify the default mode. Legacy callers used an arbitrary string here as
- * a custom widget name, so we only treat unknown strings as names.
+ * Finds a user-visible control_after_generate widget that is separate from
+ * the hidden ACW. API nodes define control_after_generate as an explicit
+ * COMBO input alongside seed, producing two widgets with the same name.
  */
-function isControlAfterGenerateMode(value: unknown): value is string {
-  return (
-    typeof value === 'string' &&
-    (CONTROL_OPTIONS as readonly string[]).includes(value)
+export function findExternalControlWidget(
+  node: LGraphNode,
+  cagWidget: IBaseWidget
+): IBaseWidget | undefined {
+  return node.widgets?.find(
+    (w) => w.name === cagWidget.name && w !== cagWidget && !w[IS_CONTROL_WIDGET]
   )
 }
 
@@ -104,7 +105,7 @@ export function addValueControlWidget(
 ): IComboWidget {
   const rawName = inputData?.[1]?.control_after_generate
   const name =
-    typeof rawName === 'string' && !isControlAfterGenerateMode(rawName)
+    typeof rawName === 'string' && !isControlOption(rawName)
       ? rawName
       : widgetName
   const widgets = addValueControlWidgets(
@@ -138,7 +139,7 @@ export function addValueControlWidgets(
       typeof inputData?.[1]?.[defaultName] === 'string' &&
       !(
         defaultName === 'control_after_generate' &&
-        isControlAfterGenerateMode(inputData[1][defaultName])
+        isControlOption(inputData[1][defaultName])
       )
     ) {
       name = inputData?.[1]?.[defaultName]
@@ -196,15 +197,7 @@ export function addValueControlWidgets(
   }
 
   const applyWidgetControl = () => {
-    // For API nodes: the user-visible control_after_generate COMBO widget is a
-    // separate explicit input. Sync its value into this hidden ACW so the
-    // user's choice actually drives execution.
-    const externalControl = node.widgets?.find(
-      (w) =>
-        w.name === valueControl.name &&
-        w !== valueControl &&
-        !w[IS_CONTROL_WIDGET]
-    )
+    const externalControl = findExternalControlWidget(node, valueControl)
     if (externalControl !== undefined) {
       valueControl.value = externalControl.value as string
     }

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -24,7 +24,7 @@ export const CONTROL_OPTIONS = [
 ] as const
 export type ControlOptions = (typeof CONTROL_OPTIONS)[number]
 
-function isControlOption(val: WidgetValue): val is ControlOptions {
+export function isControlOption(val: WidgetValue): val is ControlOptions {
   return CONTROL_OPTIONS.includes(val as ControlOptions)
 }
 


### PR DESCRIPTION
## Summary

API nodes define `control_after_generate` as an explicit COMBO input alongside `seed`, causing two separate widgets to exist. The user-visible dropdown was disconnected from the hidden widget that actually drives execution, so the seed always randomized on every run regardless of the selected mode (fixed/increment/decrement).

## Changes

- **What**: Connect the user-visible `control_after_generate` COMBO widget on API nodes to the hidden ACW that controls execution
  - `applyWidgetControl` syncs the visible widget's value into the hidden ACW before each run
  - `getControlWidget` accepts an optional `node` parameter to find and use the visible widget as the display/write-through source
  - `WidgetWithControl.vue` adds a reverse watch so loading a workflow correctly reflects the saved control mode
  - `WidgetItem.vue` passes `sourceNode` to `getControlWidget` so the parameters panel stays in sync

## Review Focus

The core fix is in `applyWidgetControl` (`src/scripts/widgets.ts`). For regular nodes this code path is a no-op (no external widget found). For API nodes it syncs the CCW value into the ACW just before the control logic runs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11364-fix-respect-control_after_generate-setting-on-API-nodes-3466d73d365081138a26f6cbf1952472) by [Unito](https://www.unito.io)
