### PR TITLE
feat: Search - add ghost node following setting and increase opacity

### DIFF
--- a/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2Extended.spec.ts
@@ -369,5 +369,32 @@ test.describe('Node search box V2 extended', { tag: '@node' }, () => {
       await expect(searchBoxV2.nodeIdBadge.first()).toBeVisible()
       await expect(searchBoxV2.nodeIdBadge.first()).toContainText('VAEDecode')
     })
+
+    test('Follow-cursor disabled places node without ghost mode', async ({
+      comfyPage
+    }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.NodeSearchBoxImpl.FollowCursor',
+        false
+      )
+      const { searchBoxV2 } = comfyPage
+      const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+
+      await searchBoxV2.open()
+
+      await searchBoxV2.input.fill('KSampler')
+      await expect(searchBoxV2.results.first()).toBeVisible()
+
+      await searchBoxV2.results.first().click()
+      await expect(searchBoxV2.input).toBeHidden()
+
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+        .toBe(initialCount + 1)
+
+      await expect(
+        comfyPage.page.locator('[data-node-id][data-ghost]')
+      ).toHaveCount(0)
+    })
   })
 })

--- a/src/components/searchbox/NodeSearchBoxPopover.test.ts
+++ b/src/components/searchbox/NodeSearchBoxPopover.test.ts
@@ -1,59 +1,34 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, defineComponent, nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import { CORE_SETTINGS } from '@/platform/settings/constants/coreSettings'
+import type { Settings } from '@/schemas/apiSchema'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import type { FuseFilter, FuseFilterWithValue } from '@/utils/fuseUtil'
 
 import NodeSearchBoxPopover from './NodeSearchBoxPopover.vue'
 
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({
-    get: vi.fn()
-  })
+const coreSettingsById = Object.fromEntries(CORE_SETTINGS.map((s) => [s.id, s]))
+
+const { addNodeOnGraph } = vi.hoisted(() => ({
+  addNodeOnGraph: vi.fn()
 }))
 
 vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({
     getCanvasCenter: vi.fn(() => [0, 0]),
-    addNodeOnGraph: vi.fn()
-  })
-}))
-
-vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
-  useWorkflowStore: () => ({
-    activeWorkflow: null
-  })
-}))
-
-vi.mock('@/renderer/core/canvas/canvasStore', () => ({
-  useCanvasStore: () => ({
-    canvas: null,
-    getCanvas: vi.fn(() => ({
-      linkConnector: {
-        events: new EventTarget(),
-        renderLinks: []
-      }
-    }))
-  })
-}))
-
-vi.mock('@/stores/nodeDefStore', () => ({
-  useNodeDefStore: () => ({
-    nodeSearchService: {
-      nodeFilters: [],
-      inputTypeFilter: {},
-      outputTypeFilter: {}
-    }
+    addNodeOnGraph
   })
 }))
 
 type EmitAddFilter = (
   filter: FuseFilterWithValue<ComfyNodeDefImpl, string>
 ) => void
+type EmitAddNode = (nodeDef: ComfyNodeDefImpl, dragEvent?: MouseEvent) => void
 
 function createFilter(
   id: string,
@@ -72,26 +47,48 @@ describe('NodeSearchBoxPopover', () => {
     messages: { en: {} }
   })
 
-  function renderComponent() {
+  function renderComponent(settings: Partial<Settings> = {}) {
     let emitAddFilter: EmitAddFilter | null = null
+    let emitAddNodeV1: EmitAddNode | null = null
+    let emitAddNodeV2: EmitAddNode | null = null
 
     const NodeSearchBoxStub = defineComponent({
       name: 'NodeSearchBox',
       props: {
         filters: { type: Array, default: () => [] }
       },
-      emits: ['addFilter'],
+      emits: ['addFilter', 'addNode'],
       setup(props, { emit }) {
         emitAddFilter = (filter) => emit('addFilter', filter)
+        emitAddNodeV1 = (nodeDef, dragEvent) =>
+          emit('addNode', nodeDef, dragEvent)
         const filterCount = computed(() => props.filters.length)
         return { filterCount }
       },
       template: '<output aria-label="filter count">{{ filterCount }}</output>'
     })
 
+    const NodeSearchContentStub = defineComponent({
+      name: 'NodeSearchContent',
+      props: {
+        filters: { type: Array, default: () => [] }
+      },
+      emits: ['addFilter', 'removeFilter', 'addNode', 'hoverNode'],
+      setup(_, { emit }) {
+        emitAddNodeV2 = (nodeDef, dragEvent) =>
+          emit('addNode', nodeDef, dragEvent)
+        return {}
+      },
+      template: '<div data-testid="search-content-v2"></div>'
+    })
+
     const pinia = createTestingPinia({
       stubActions: false,
       initialState: {
+        setting: {
+          settingValues: settings,
+          settingsById: coreSettingsById
+        },
         searchBox: { visible: false }
       }
     })
@@ -101,6 +98,8 @@ describe('NodeSearchBoxPopover', () => {
         plugins: [i18n, PrimeVue, pinia],
         stubs: {
           NodeSearchBox: NodeSearchBoxStub,
+          NodeSearchContent: NodeSearchContentStub,
+          NodePreviewCard: true,
           Dialog: {
             template: '<div><slot name="container" /></div>',
             props: ['visible', 'modal', 'dismissableMask', 'pt']
@@ -109,14 +108,34 @@ describe('NodeSearchBoxPopover', () => {
       }
     })
 
-    if (!emitAddFilter) throw new Error('NodeSearchBox stub did not mount')
-
-    return { ...result, emitAddFilter: emitAddFilter as EmitAddFilter }
+    return {
+      ...result,
+      get emitAddFilter() {
+        if (!emitAddFilter) throw new Error('NodeSearchBox stub did not mount')
+        return emitAddFilter
+      },
+      get emitAddNodeV1() {
+        if (!emitAddNodeV1) throw new Error('NodeSearchBox stub did not mount')
+        return emitAddNodeV1
+      },
+      get emitAddNodeV2() {
+        if (!emitAddNodeV2)
+          throw new Error('NodeSearchContent stub did not mount')
+        return emitAddNodeV2
+      }
+    }
   }
+
+  beforeEach(() => {
+    addNodeOnGraph.mockReset()
+    addNodeOnGraph.mockReturnValue(null)
+  })
 
   describe('addFilter duplicate prevention', () => {
     it('should add a filter when no duplicates exist', async () => {
-      const { emitAddFilter } = renderComponent()
+      const { emitAddFilter } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'v1 (legacy)'
+      })
 
       emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
@@ -125,7 +144,9 @@ describe('NodeSearchBoxPopover', () => {
     })
 
     it('should not add a duplicate filter with same id and value', async () => {
-      const { emitAddFilter } = renderComponent()
+      const { emitAddFilter } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'v1 (legacy)'
+      })
 
       emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
@@ -136,7 +157,9 @@ describe('NodeSearchBoxPopover', () => {
     })
 
     it('should allow filters with same id but different values', async () => {
-      const { emitAddFilter } = renderComponent()
+      const { emitAddFilter } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'v1 (legacy)'
+      })
 
       emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
@@ -147,7 +170,9 @@ describe('NodeSearchBoxPopover', () => {
     })
 
     it('should allow filters with different ids but same value', async () => {
-      const { emitAddFilter } = renderComponent()
+      const { emitAddFilter } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'v1 (legacy)'
+      })
 
       emitAddFilter(createFilter('outputType', 'IMAGE'))
       await nextTick()
@@ -155,6 +180,100 @@ describe('NodeSearchBoxPopover', () => {
       await nextTick()
 
       expect(screen.getByLabelText('filter count')).toHaveTextContent('2')
+    })
+  })
+
+  describe('addNode ghost flag (FollowCursor setting)', () => {
+    const nodeDef = { name: 'KSampler' } as ComfyNodeDefImpl
+
+    it('should default ghost to true when v2 search is active and FollowCursor is unset', async () => {
+      const { emitAddNodeV2 } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'default'
+      })
+      emitAddNodeV2(nodeDef)
+      await nextTick()
+
+      expect(addNodeOnGraph).toHaveBeenCalledWith(
+        nodeDef,
+        expect.objectContaining({ pos: expect.any(Array) }),
+        expect.objectContaining({ ghost: true })
+      )
+    })
+
+    it('should pass ghost: true when v2 search is active and FollowCursor is enabled', async () => {
+      const { emitAddNodeV2 } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'default',
+        'Comfy.NodeSearchBoxImpl.FollowCursor': true
+      })
+      emitAddNodeV2(nodeDef)
+      await nextTick()
+
+      expect(addNodeOnGraph).toHaveBeenCalledWith(
+        nodeDef,
+        expect.objectContaining({ pos: expect.any(Array) }),
+        expect.objectContaining({ ghost: true })
+      )
+    })
+
+    it('should pass ghost: false when v2 search is active but FollowCursor is disabled', async () => {
+      const { emitAddNodeV2 } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'default',
+        'Comfy.NodeSearchBoxImpl.FollowCursor': false
+      })
+      emitAddNodeV2(nodeDef)
+      await nextTick()
+
+      expect(addNodeOnGraph).toHaveBeenCalledWith(
+        nodeDef,
+        expect.objectContaining({ pos: expect.any(Array) }),
+        expect.objectContaining({ ghost: false })
+      )
+    })
+
+    it('should pass ghost: false when v1 legacy search box is used', async () => {
+      const { emitAddNodeV1 } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'v1 (legacy)',
+        'Comfy.NodeSearchBoxImpl.FollowCursor': true
+      })
+      emitAddNodeV1(nodeDef)
+      await nextTick()
+
+      expect(addNodeOnGraph).toHaveBeenCalledWith(
+        nodeDef,
+        expect.objectContaining({ pos: expect.any(Array) }),
+        expect.objectContaining({ ghost: false })
+      )
+    })
+
+    it('should pass ghost: false when litegraph legacy search box is used', async () => {
+      const { emitAddNodeV1 } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'litegraph (legacy)',
+        'Comfy.NodeSearchBoxImpl.FollowCursor': true
+      })
+      emitAddNodeV1(nodeDef)
+      await nextTick()
+
+      expect(addNodeOnGraph).toHaveBeenCalledWith(
+        nodeDef,
+        expect.objectContaining({ pos: expect.any(Array) }),
+        expect.objectContaining({ ghost: false })
+      )
+    })
+
+    it('should forward the dragEvent through to addNodeOnGraph', async () => {
+      const dragEvent = new MouseEvent('mousedown')
+      const { emitAddNodeV2 } = renderComponent({
+        'Comfy.NodeSearchBoxImpl': 'default',
+        'Comfy.NodeSearchBoxImpl.FollowCursor': true
+      })
+      emitAddNodeV2(nodeDef, dragEvent)
+      await nextTick()
+
+      expect(addNodeOnGraph).toHaveBeenCalledWith(
+        nodeDef,
+        expect.objectContaining({ pos: expect.any(Array) }),
+        expect.objectContaining({ ghost: true, dragEvent })
+      )
     })
   })
 })

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -129,10 +129,11 @@ function closeDialog() {
 const canvasStore = useCanvasStore()
 
 function addNode(nodeDef: ComfyNodeDefImpl, dragEvent?: MouseEvent) {
+  const followCursor = settingStore.get('Comfy.NodeSearchBoxImpl.FollowCursor')
   const node = litegraphService.addNodeOnGraph(
     nodeDef,
     { pos: getNewNodeLocation() },
-    { ghost: useSearchBoxV2.value, dragEvent }
+    { ghost: useSearchBoxV2.value && followCursor, dragEvent }
   )
   if (!node) return
 

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -312,6 +312,10 @@
     "name": "Node preview",
     "tooltip": "Only applies to the default implementation"
   },
+  "Comfy_NodeSearchBoxImpl_FollowCursor": {
+    "name": "Added nodes follow the cursor",
+    "tooltip": "When enabled, nodes added from the search box follow the cursor until clicked to place. Only applies to the default implementation."
+  },
   "Comfy_NodeSearchBoxImpl_ShowCategory": {
     "name": "Show node category in search results",
     "tooltip": "Only applies to v1 (legacy)"

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -69,6 +69,16 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: true
   },
   {
+    id: 'Comfy.NodeSearchBoxImpl.FollowCursor',
+    category: ['Comfy', 'Node Search Box', 'FollowCursor'],
+    name: 'Added nodes follow the cursor',
+    tooltip:
+      'When enabled, nodes added from the search box follow the cursor until clicked to place. Only applies to the default implementation.',
+    type: 'boolean',
+    defaultValue: true,
+    versionAdded: '1.44.4'
+  },
+  {
     id: 'Comfy.NodeSearchBoxImpl.ShowCategory',
     category: ['Comfy', 'Node Search Box', 'ShowCategory'],
     name: 'Show node category in search results',

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -8,6 +8,7 @@
     tabindex="0"
     :data-node-id="nodeData.id"
     :data-collapsed="isCollapsed || undefined"
+    :data-ghost="nodeData.flags?.ghost || undefined"
     :class="
       cn(
         'group/node lg-node absolute isolate text-sm',
@@ -389,7 +390,7 @@ const muted = computed((): boolean => nodeData.mode === LGraphEventMode.NEVER)
 const nodeOpacity = computed(() => {
   const globalOpacity = settingStore.get('Comfy.Node.Opacity') ?? 1
 
-  if (nodeData.flags?.ghost) return globalOpacity * 0.3
+  if (nodeData.flags?.ghost) return globalOpacity * 0.6
 
   // For muted/bypassed nodes, apply the 0.5 multiplier on top of global opacity
   if (bypassed.value || muted.value) {

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -335,6 +335,7 @@ const zSettings = z.object({
   'Comfy.ModelLibrary.AutoLoadAll': z.boolean(),
   'Comfy.ModelLibrary.NameFormat': z.enum(['filename', 'title']),
   'Comfy.NodeSearchBoxImpl.NodePreview': z.boolean(),
+  'Comfy.NodeSearchBoxImpl.FollowCursor': z.boolean(),
   'Comfy.NodeSearchBoxImpl': z.enum([
     'default',
     'v1 (legacy)',


### PR DESCRIPTION
## Summary

Adds setting to disable the node auto-follow cursor behavior when adding nodes from the search, and increased the visibilty of Vue ghost nodes.

## Changes

- **What**: 
- add setting
- increase opacity
- add test

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

Before  
<img width="452" height="517" alt="image" src="https://github.com/user-attachments/assets/369c0d90-5352-482b-a1b3-36180bffb3ee" />

After  
<img width="440" height="536" alt="image" src="https://github.com/user-attachments/assets/2066fdd4-6eb4-4bfb-ac7c-559fc99de57d" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11365-feat-Search-add-ghost-node-following-setting-and-increase-opacity-3466d73d3650811b9c27ed4cc930816d) by [Unito](https://www.unito.io)
