### PR TITLE
test: add queue notification banners lifecycle browser tests

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -211,7 +211,8 @@ export const TestIds = {
   queue: {
     overlayToggle: 'queue-overlay-toggle',
     clearHistoryAction: 'clear-history-action',
-    jobAssetsList: 'job-assets-list'
+    jobAssetsList: 'job-assets-list',
+    notificationBanner: 'queue-notification-banner'
   },
   errors: {
     imageLoadError: 'error-loading-image',

--- a/browser_tests/tests/queueNotificationBanners.spec.ts
+++ b/browser_tests/tests/queueNotificationBanners.spec.ts
@@ -1,0 +1,170 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+const BANNER_DISMISS_TIMEOUT = 6_000
+
+function bannerLocator(page: Page) {
+  return page.getByTestId(TestIds.queue.notificationBanner)
+}
+
+function dispatchPromptQueueing(
+  page: Page,
+  opts: { batchCount?: number; requestId?: number } = {}
+) {
+  return page.evaluate(
+    ([batchCount, requestId]) => {
+      window.app!.api.dispatchCustomEvent('promptQueueing', {
+        batchCount,
+        requestId
+      })
+    },
+    [opts.batchCount ?? 1, opts.requestId ?? Date.now()] as const
+  )
+}
+
+function dispatchPromptQueued(
+  page: Page,
+  opts: { batchCount?: number; requestId?: number } = {}
+) {
+  return page.evaluate(
+    ([batchCount, requestId]) => {
+      window.app!.api.dispatchCustomEvent('promptQueued', {
+        number: 0,
+        batchCount,
+        requestId
+      })
+    },
+    [opts.batchCount ?? 1, opts.requestId ?? Date.now()] as const
+  )
+}
+
+test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+  })
+
+  test.describe('Queuing lifecycle', () => {
+    test('promptQueueing event shows a queueing banner', async ({
+      comfyPage
+    }) => {
+      await dispatchPromptQueueing(comfyPage.page)
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toBeVisible()
+      await expect(banner).toContainText('queuing')
+    })
+
+    test('promptQueued upgrades a pending banner to queued', async ({
+      comfyPage
+    }) => {
+      const requestId = Date.now()
+
+      await dispatchPromptQueueing(comfyPage.page, {
+        batchCount: 1,
+        requestId
+      })
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toContainText('queuing')
+
+      await dispatchPromptQueued(comfyPage.page, {
+        batchCount: 1,
+        requestId
+      })
+      await comfyPage.nextFrame()
+
+      await expect(banner).toContainText('queued')
+    })
+
+    test('promptQueued with batch count > 1 shows plural text', async ({
+      comfyPage
+    }) => {
+      await dispatchPromptQueued(comfyPage.page, { batchCount: 3 })
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toBeVisible()
+      await expect(banner).toContainText('3')
+      await expect(banner).toContainText('jobs added to queue')
+    })
+
+    test('promptQueued with mismatched requestId does not upgrade pending banner', async ({
+      comfyPage
+    }) => {
+      await dispatchPromptQueueing(comfyPage.page, {
+        batchCount: 1,
+        requestId: 100
+      })
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toContainText('queuing')
+
+      await dispatchPromptQueued(comfyPage.page, {
+        batchCount: 1,
+        requestId: 999
+      })
+      await comfyPage.nextFrame()
+
+      await expect(banner).toContainText('queuing')
+    })
+  })
+
+  test.describe('Auto-dismiss', () => {
+    test('Banner auto-dismisses after timeout', async ({ comfyPage }) => {
+      await dispatchPromptQueued(comfyPage.page)
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toBeVisible()
+
+      await expect(banner).toBeHidden({ timeout: BANNER_DISMISS_TIMEOUT })
+    })
+  })
+
+  test.describe('Notification queue (FIFO)', () => {
+    test('Second notification shows after first auto-dismisses', async ({
+      comfyPage
+    }) => {
+      await dispatchPromptQueued(comfyPage.page, {
+        batchCount: 1,
+        requestId: 1
+      })
+      await comfyPage.nextFrame()
+
+      await dispatchPromptQueued(comfyPage.page, {
+        batchCount: 2,
+        requestId: 2
+      })
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toContainText('Job queued')
+
+      await expect(banner).toContainText('2 jobs added to queue', {
+        timeout: BANNER_DISMISS_TIMEOUT
+      })
+    })
+  })
+
+  test.describe('Direct queued event (no pending predecessor)', () => {
+    test('promptQueued without prior queueing shows queued banner directly', async ({
+      comfyPage
+    }) => {
+      await dispatchPromptQueued(comfyPage.page, {
+        batchCount: 1,
+        requestId: 999
+      })
+      await comfyPage.nextFrame()
+
+      const banner = bannerLocator(comfyPage.page)
+      await expect(banner).toBeVisible()
+      await expect(banner).toContainText('queued')
+    })
+  })
+})

--- a/browser_tests/tests/queueNotificationBanners.spec.ts
+++ b/browser_tests/tests/queueNotificationBanners.spec.ts
@@ -3,8 +3,11 @@ import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
-import { BANNER_DISMISS_DELAY_MS } from '@/composables/queue/useQueueNotificationBanners'
 
+// Mirrors BANNER_DISMISS_DELAY_MS in src/composables/queue/useQueueNotificationBanners.ts.
+// Duplicated here to avoid pulling production source (and its litegraph
+// transitive deps) into the Playwright TS loader.
+const BANNER_DISMISS_DELAY_MS = 4000
 const BANNER_ASSERT_TIMEOUT_MS = BANNER_DISMISS_DELAY_MS + 2000
 
 const REQUEST_ID_PRIMARY = 1

--- a/browser_tests/tests/queueNotificationBanners.spec.ts
+++ b/browser_tests/tests/queueNotificationBanners.spec.ts
@@ -3,17 +3,24 @@ import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { BANNER_DISMISS_DELAY_MS } from '@/composables/queue/useQueueNotificationBanners'
 
-const BANNER_DISMISS_TIMEOUT = 6_000
+const BANNER_ASSERT_TIMEOUT_MS = BANNER_DISMISS_DELAY_MS + 2000
+
+const REQUEST_ID_PRIMARY = 1
+const REQUEST_ID_SECONDARY = 2
+const REQUEST_ID_MISMATCH = 999
+
+let nextRequestId = 1000
+const newRequestId = () => nextRequestId++
 
 function bannerLocator(page: Page) {
   return page.getByTestId(TestIds.queue.notificationBanner)
 }
 
-function dispatchPromptQueueing(
-  page: Page,
-  opts: { batchCount?: number; requestId?: number } = {}
-) {
+type DispatchOpts = { batchCount?: number; requestId?: number }
+
+function dispatchPromptQueueing(page: Page, opts: DispatchOpts = {}) {
   return page.evaluate(
     ([batchCount, requestId]) => {
       window.app!.api.dispatchCustomEvent('promptQueueing', {
@@ -21,14 +28,11 @@ function dispatchPromptQueueing(
         requestId
       })
     },
-    [opts.batchCount ?? 1, opts.requestId ?? Date.now()] as const
+    [opts.batchCount ?? 1, opts.requestId ?? newRequestId()]
   )
 }
 
-function dispatchPromptQueued(
-  page: Page,
-  opts: { batchCount?: number; requestId?: number } = {}
-) {
+function dispatchPromptQueued(page: Page, opts: DispatchOpts = {}) {
   return page.evaluate(
     ([batchCount, requestId]) => {
       window.app!.api.dispatchCustomEvent('promptQueued', {
@@ -37,21 +41,16 @@ function dispatchPromptQueued(
         requestId
       })
     },
-    [opts.batchCount ?? 1, opts.requestId ?? Date.now()] as const
+    [opts.batchCount ?? 1, opts.requestId ?? newRequestId()]
   )
 }
 
-test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-  })
-
+test.describe('Queue notification banners', { tag: ['@ui'] }, () => {
   test.describe('Queuing lifecycle', () => {
     test('promptQueueing event shows a queueing banner', async ({
       comfyPage
     }) => {
       await dispatchPromptQueueing(comfyPage.page)
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toBeVisible()
@@ -61,22 +60,18 @@ test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
     test('promptQueued upgrades a pending banner to queued', async ({
       comfyPage
     }) => {
-      const requestId = Date.now()
-
       await dispatchPromptQueueing(comfyPage.page, {
         batchCount: 1,
-        requestId
+        requestId: REQUEST_ID_PRIMARY
       })
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toContainText('queuing')
 
       await dispatchPromptQueued(comfyPage.page, {
         batchCount: 1,
-        requestId
+        requestId: REQUEST_ID_PRIMARY
       })
-      await comfyPage.nextFrame()
 
       await expect(banner).toContainText('queued')
     })
@@ -85,7 +80,6 @@ test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
       comfyPage
     }) => {
       await dispatchPromptQueued(comfyPage.page, { batchCount: 3 })
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toBeVisible()
@@ -93,37 +87,39 @@ test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
       await expect(banner).toContainText('jobs added to queue')
     })
 
-    test('promptQueued with mismatched requestId does not upgrade pending banner', async ({
+    test('promptQueued with mismatched requestId enqueues a separate queued banner', async ({
       comfyPage
     }) => {
       await dispatchPromptQueueing(comfyPage.page, {
         batchCount: 1,
-        requestId: 100
+        requestId: REQUEST_ID_PRIMARY
       })
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toContainText('queuing')
 
       await dispatchPromptQueued(comfyPage.page, {
         batchCount: 1,
-        requestId: 999
+        requestId: REQUEST_ID_MISMATCH
       })
-      await comfyPage.nextFrame()
 
+      // Pending banner is not upgraded — still shows "queuing".
       await expect(banner).toContainText('queuing')
+
+      // After the pending banner auto-dismisses, the queued banner appears.
+      await expect(banner).toContainText('queued', {
+        timeout: BANNER_ASSERT_TIMEOUT_MS
+      })
     })
   })
 
   test.describe('Auto-dismiss', () => {
     test('Banner auto-dismisses after timeout', async ({ comfyPage }) => {
       await dispatchPromptQueued(comfyPage.page)
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toBeVisible()
-
-      await expect(banner).toBeHidden({ timeout: BANNER_DISMISS_TIMEOUT })
+      await expect(banner).toBeHidden({ timeout: BANNER_ASSERT_TIMEOUT_MS })
     })
   })
 
@@ -133,21 +129,17 @@ test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
     }) => {
       await dispatchPromptQueued(comfyPage.page, {
         batchCount: 1,
-        requestId: 1
+        requestId: REQUEST_ID_PRIMARY
       })
-      await comfyPage.nextFrame()
-
       await dispatchPromptQueued(comfyPage.page, {
         batchCount: 2,
-        requestId: 2
+        requestId: REQUEST_ID_SECONDARY
       })
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toContainText('Job queued')
-
       await expect(banner).toContainText('2 jobs added to queue', {
-        timeout: BANNER_DISMISS_TIMEOUT
+        timeout: BANNER_ASSERT_TIMEOUT_MS
       })
     })
   })
@@ -158,9 +150,8 @@ test.describe('Queue notification banners', { tag: ['@ui', '@queue'] }, () => {
     }) => {
       await dispatchPromptQueued(comfyPage.page, {
         batchCount: 1,
-        requestId: 999
+        requestId: REQUEST_ID_PRIMARY
       })
-      await comfyPage.nextFrame()
 
       const banner = bannerLocator(comfyPage.page)
       await expect(banner).toBeVisible()

--- a/src/components/queue/QueueNotificationBannerHost.vue
+++ b/src/components/queue/QueueNotificationBannerHost.vue
@@ -5,6 +5,7 @@
     role="status"
     aria-live="polite"
     aria-atomic="true"
+    data-testid="queue-notification-banner"
   >
     <QueueNotificationBanner :notification="currentNotification" />
   </div>

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -9,7 +9,7 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { useQueueStore } from '@/stores/queueStore'
 import { jobStateFromTask } from '@/utils/queueUtil'
 
-const BANNER_DISMISS_DELAY_MS = 4000
+export const BANNER_DISMISS_DELAY_MS = 4000
 const MAX_COMPLETION_THUMBNAILS = 2
 
 type QueueQueuedNotificationType = 'queuedPending' | 'queued'

--- a/src/composables/queue/useQueueNotificationBanners.ts
+++ b/src/composables/queue/useQueueNotificationBanners.ts
@@ -9,7 +9,7 @@ import { useExecutionStore } from '@/stores/executionStore'
 import { useQueueStore } from '@/stores/queueStore'
 import { jobStateFromTask } from '@/utils/queueUtil'
 
-export const BANNER_DISMISS_DELAY_MS = 4000
+const BANNER_DISMISS_DELAY_MS = 4000
 const MAX_COMPLETION_THUMBNAILS = 2
 
 type QueueQueuedNotificationType = 'queuedPending' | 'queued'


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

- Adds `browser_tests/tests/queueNotificationBanners.spec.ts` covering `useQueueNotificationBanners` composable E2E behavior
- Adds `data-testid="queue-notification-banner"` to `QueueNotificationBannerHost.vue` for stable test targeting
- Registers the new test ID in `TestIds.queue.notificationBanner`

### Test coverage added (7 tests)

| Group | Tests | Behavior |
|---|---|---|
| Queuing lifecycle | 4 | `promptQueueing` → banner appears, `promptQueued` upgrades to queued, batch plural text, requestId mismatch doesn't upgrade |
| Auto-dismiss | 1 | Banner disappears after 4s timeout |
| FIFO queue | 1 | Second notification shows after first auto-dismisses |
| Direct queued | 1 | `promptQueued` without prior `promptQueueing` shows banner directly |

### Approach
Tests dispatch `promptQueueing`/`promptQueued` custom events directly via `window.app.api.dispatchCustomEvent()` inside `page.evaluate()`, matching how `app.ts` triggers these events during real queue operations. This avoids needing a running execution pipeline while exercising the full composable → component → DOM rendering chain.

### Verification
- TypeScript: zero errors
- ESLint: clean
- oxlint: clean
- oxfmt: formatted
- Playwright execution requires running ComfyUI backend (not available in sandbox)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11366-test-add-queue-notification-banners-lifecycle-browser-tests-3466d73d36508172a7ffd3fe3b4fd925) by [Unito](https://www.unito.io)
