### PR TITLE
test: exclude legacy UI component library from e2e coverage

### DIFF
--- a/browser_tests/coverageConfig.ts
+++ b/browser_tests/coverageConfig.ts
@@ -1,0 +1,17 @@
+export const COVERAGE_OUTPUT_DIR = './coverage/playwright'
+
+/**
+ * Controls which source files are included in E2E coverage reports.
+ * Matched against the full file path of each covered source.
+ *
+ * - Patterns are evaluated in order; the first match wins.
+ * - `false` excludes; `true` includes.
+ * - The catch-all entry at the end includes everything not excluded above.
+ */
+export const coverageSourceFilter: Record<string, boolean> = {
+  '**/node_modules/**': false,
+  '**/browser_tests/**': false,
+  // Legacy DOM component library kept only for extension backwards-compat
+  '**/src/scripts/ui/**': false,
+  '**/*': true
+}

--- a/browser_tests/coverageConfig.ts
+++ b/browser_tests/coverageConfig.ts
@@ -8,7 +8,7 @@ export const COVERAGE_OUTPUT_DIR = './coverage/playwright'
  * - `false` excludes; `true` includes.
  * - The catch-all entry at the end includes everything not excluded above.
  */
-export const coverageSourceFilter: Record<string, boolean> = {
+export const coverageSourceFilter: Readonly<Record<string, boolean>> = {
   '**/node_modules/**': false,
   '**/browser_tests/**': false,
   // Legacy DOM component library kept only for extension backwards-compat

--- a/browser_tests/coverageConfig.ts
+++ b/browser_tests/coverageConfig.ts
@@ -12,6 +12,7 @@ export const coverageSourceFilter: Readonly<Record<string, boolean>> = {
   '**/node_modules/**': false,
   '**/browser_tests/**': false,
   // Legacy DOM component library kept only for extension backwards-compat
+  '**/src/scripts/ui.ts': false,
   '**/src/scripts/ui/**': false,
   '**/*': true
 }

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -3,6 +3,7 @@ import { test as base } from '@playwright/test'
 import { config as dotenvConfig } from 'dotenv'
 import MCR from 'monocart-coverage-reports'
 
+import { COVERAGE_OUTPUT_DIR } from '@e2e/coverageConfig'
 import { NodeBadgeMode } from '@/types/nodeSource'
 import { ComfyActionbar } from '@e2e/helpers/actionbar'
 import { ComfyTemplates } from '@e2e/helpers/templates'
@@ -438,7 +439,7 @@ export const comfyPageFixture = base.extend<{
     const coverage = await page.coverage.stopJSCoverage()
 
     const mcr = MCR({
-      outputDir: './coverage/playwright',
+      outputDir: COVERAGE_OUTPUT_DIR,
       reports: []
     })
     await mcr.add(coverage)

--- a/browser_tests/globalTeardown.ts
+++ b/browser_tests/globalTeardown.ts
@@ -1,6 +1,7 @@
 import { config as dotenvConfig } from 'dotenv'
 import MCR from 'monocart-coverage-reports'
 
+import { COVERAGE_OUTPUT_DIR, coverageSourceFilter } from '@e2e/coverageConfig'
 import { writePerfReport } from '@e2e/helpers/perfReporter'
 import { restorePath } from '@e2e/utils/backupUtils'
 
@@ -16,13 +17,9 @@ export default async function globalTeardown() {
 
   if (process.env.COLLECT_COVERAGE === 'true') {
     const mcr = MCR({
-      outputDir: './coverage/playwright',
+      outputDir: COVERAGE_OUTPUT_DIR,
       reports: [['lcovonly', { file: 'coverage.lcov' }], ['text-summary']],
-      sourceFilter: {
-        '**/node_modules/**': false,
-        '**/browser_tests/**': false,
-        '**/*': true
-      }
+      sourceFilter: coverageSourceFilter
     })
     await mcr.generate()
   }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

- Excludes `src/scripts/ui/**` (legacy DOM component library) from Playwright e2e coverage reports — this code is kept solely for extension backwards-compatibility and shouldn't count toward coverage metrics
- Extracts Monocart coverage config (`outputDir`, `sourceFilter`) into `browser_tests/coverageConfig.ts` so coverage exclusions are discoverable and centralized instead of buried in `globalTeardown.ts`

## Details

Monocart does support external config files (`mcr.config.ts` auto-discovery), but since MCR is instantiated in two places with different configs (per-worker collection in `ComfyPage.ts` vs final report in `globalTeardown.ts`), auto-discovery would affect both instances. A shared TypeScript constant is safer and more explicit.

## Changes
- **New**: `browser_tests/coverageConfig.ts` — shared `COVERAGE_OUTPUT_DIR` and `coverageSourceFilter`
- **Modified**: `browser_tests/globalTeardown.ts` — imports from shared config
- **Modified**: `browser_tests/fixtures/ComfyPage.ts` — imports `COVERAGE_OUTPUT_DIR`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11377-test-exclude-legacy-UI-component-library-from-e2e-coverage-3466d73d365081b78dc9e4e14d913295) by [Unito](https://www.unito.io)
