### PR TITLE
test: add E2E Playwright tests for SubscribeButton and SubscribeToRun

### DIFF
--- a/browser_tests/fixtures/data/subscriptionFixtures.ts
+++ b/browser_tests/fixtures/data/subscriptionFixtures.ts
@@ -1,0 +1,90 @@
+import type { operations } from '@comfyorg/registry-types'
+
+export type SubscriptionStatusResponse =
+  operations['GetCloudSubscriptionStatus']['responses']['200']['content']['application/json']
+
+export type BalanceResponse =
+  operations['GetCustomerBalance']['responses']['200']['content']['application/json']
+
+export function createSubscriptionStatus(
+  overrides: Partial<SubscriptionStatusResponse> = {}
+): SubscriptionStatusResponse {
+  return {
+    is_active: false,
+    subscription_id: null,
+    subscription_tier: 'FREE',
+    subscription_duration: null,
+    has_fund: false,
+    renewal_date: null,
+    end_date: null,
+    ...overrides
+  }
+}
+
+export function createBalance(
+  overrides: Partial<BalanceResponse> = {}
+): BalanceResponse {
+  return {
+    amount_micros: 0,
+    prepaid_balance_micros: 0,
+    cloud_credit_balance_micros: 0,
+    pending_charges_micros: 0,
+    effective_balance_micros: 0,
+    currency: 'USD',
+    ...overrides
+  }
+}
+
+export const UNSUBSCRIBED: SubscriptionStatusResponse =
+  createSubscriptionStatus({
+    is_active: false,
+    subscription_id: null,
+    subscription_tier: 'FREE',
+    end_date: null
+  })
+
+export const FREE_TIER_ACTIVE: SubscriptionStatusResponse =
+  createSubscriptionStatus({
+    is_active: true,
+    subscription_id: 'sub_free_001',
+    subscription_tier: 'FREE',
+    renewal_date: '2099-12-31T00:00:00.000Z'
+  })
+
+export const CREATOR_ACTIVE: SubscriptionStatusResponse =
+  createSubscriptionStatus({
+    is_active: true,
+    subscription_id: 'sub_creator_001',
+    subscription_tier: 'CREATOR',
+    subscription_duration: 'MONTHLY',
+    renewal_date: '2099-12-31T00:00:00.000Z'
+  })
+
+export const PRO_ACTIVE: SubscriptionStatusResponse = createSubscriptionStatus({
+  is_active: true,
+  subscription_id: 'sub_pro_001',
+  subscription_tier: 'PRO',
+  subscription_duration: 'MONTHLY',
+  renewal_date: '2099-12-31T00:00:00.000Z'
+})
+
+export const CANCELLED_SUBSCRIPTION: SubscriptionStatusResponse =
+  createSubscriptionStatus({
+    is_active: true,
+    subscription_id: 'sub_cancelled_001',
+    subscription_tier: 'CREATOR',
+    subscription_duration: 'MONTHLY',
+    end_date: '2099-12-31T00:00:00.000Z'
+  })
+
+export const ZERO_BALANCE: BalanceResponse = createBalance({
+  amount_micros: 0,
+  effective_balance_micros: 0
+})
+
+export const FUNDED_BALANCE: BalanceResponse = createBalance({
+  amount_micros: 2_500_000,
+  prepaid_balance_micros: 1_000_000,
+  cloud_credit_balance_micros: 1_500_000,
+  effective_balance_micros: 2_500_000
+})

--- a/browser_tests/fixtures/data/subscriptionFixtures.ts
+++ b/browser_tests/fixtures/data/subscriptionFixtures.ts
@@ -43,48 +43,7 @@ export const UNSUBSCRIBED: SubscriptionStatusResponse =
     end_date: null
   })
 
-export const FREE_TIER_ACTIVE: SubscriptionStatusResponse =
-  createSubscriptionStatus({
-    is_active: true,
-    subscription_id: 'sub_free_001',
-    subscription_tier: 'FREE',
-    renewal_date: '2099-12-31T00:00:00.000Z'
-  })
-
-export const CREATOR_ACTIVE: SubscriptionStatusResponse =
-  createSubscriptionStatus({
-    is_active: true,
-    subscription_id: 'sub_creator_001',
-    subscription_tier: 'CREATOR',
-    subscription_duration: 'MONTHLY',
-    renewal_date: '2099-12-31T00:00:00.000Z'
-  })
-
-export const PRO_ACTIVE: SubscriptionStatusResponse = createSubscriptionStatus({
-  is_active: true,
-  subscription_id: 'sub_pro_001',
-  subscription_tier: 'PRO',
-  subscription_duration: 'MONTHLY',
-  renewal_date: '2099-12-31T00:00:00.000Z'
-})
-
-export const CANCELLED_SUBSCRIPTION: SubscriptionStatusResponse =
-  createSubscriptionStatus({
-    is_active: true,
-    subscription_id: 'sub_cancelled_001',
-    subscription_tier: 'CREATOR',
-    subscription_duration: 'MONTHLY',
-    end_date: '2099-12-31T00:00:00.000Z'
-  })
-
 export const ZERO_BALANCE: BalanceResponse = createBalance({
   amount_micros: 0,
   effective_balance_micros: 0
-})
-
-export const FUNDED_BALANCE: BalanceResponse = createBalance({
-  amount_micros: 2_500_000,
-  prepaid_balance_micros: 1_000_000,
-  cloud_credit_balance_micros: 1_500_000,
-  effective_balance_micros: 2_500_000
 })

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -1,0 +1,191 @@
+import type { Page, Route } from '@playwright/test'
+
+import {
+  createBalance,
+  createSubscriptionStatus,
+  UNSUBSCRIBED,
+  ZERO_BALANCE
+} from '@e2e/fixtures/data/subscriptionFixtures'
+import type {
+  BalanceResponse,
+  SubscriptionStatusResponse
+} from '@e2e/fixtures/data/subscriptionFixtures'
+
+export interface SubscriptionConfig {
+  status: SubscriptionStatusResponse
+  balance: BalanceResponse
+}
+
+function emptyConfig(): SubscriptionConfig {
+  return {
+    status: createSubscriptionStatus(UNSUBSCRIBED),
+    balance: createBalance(ZERO_BALANCE)
+  }
+}
+
+export type SubscriptionOperator = (
+  config: SubscriptionConfig
+) => SubscriptionConfig
+
+export function withSubscriptionStatus(
+  overrides: Partial<SubscriptionStatusResponse>
+): SubscriptionOperator {
+  return (config) => ({
+    ...config,
+    status: { ...config.status, ...overrides }
+  })
+}
+
+export function withBalance(
+  overrides: Partial<BalanceResponse>
+): SubscriptionOperator {
+  return (config) => ({
+    ...config,
+    balance: { ...config.balance, ...overrides }
+  })
+}
+
+export function withActiveSubscription(
+  tier: NonNullable<SubscriptionStatusResponse['subscription_tier']> = 'CREATOR'
+): SubscriptionOperator {
+  return withSubscriptionStatus({
+    is_active: true,
+    subscription_tier: tier,
+    renewal_date: '2099-12-31T00:00:00.000Z',
+    end_date: null
+  })
+}
+
+export function withFreeTier(): SubscriptionOperator {
+  return withSubscriptionStatus({
+    is_active: true,
+    subscription_tier: 'FREE',
+    end_date: null
+  })
+}
+
+export function withCancelledSubscription(): SubscriptionOperator {
+  return withSubscriptionStatus({
+    is_active: true,
+    subscription_tier: 'CREATOR',
+    end_date: '2099-12-31T00:00:00.000Z'
+  })
+}
+
+export function withUnsubscribed(): SubscriptionOperator {
+  return withSubscriptionStatus({
+    is_active: false,
+    subscription_tier: 'FREE',
+    end_date: null,
+    renewal_date: null
+  })
+}
+
+export function withCredits(amountMicros: number): SubscriptionOperator {
+  return withBalance({
+    amount_micros: amountMicros,
+    effective_balance_micros: amountMicros
+  })
+}
+
+export class SubscriptionHelper {
+  private statusResponse: SubscriptionStatusResponse
+  private balanceResponse: BalanceResponse
+  private routeHandlers: Array<{
+    pattern: string
+    handler: (route: Route) => Promise<void>
+  }> = []
+
+  constructor(
+    private readonly page: Page,
+    config: SubscriptionConfig = emptyConfig()
+  ) {
+    this.statusResponse = createSubscriptionStatus(config.status)
+    this.balanceResponse = createBalance(config.balance)
+  }
+
+  async mock(): Promise<void> {
+    await this.page.addInitScript(() => {
+      window.__CONFIG__ = {
+        ...window.__CONFIG__,
+        subscription_required: true
+      }
+    })
+
+    const statusPattern = '**/customers/cloud-subscription-status'
+    const statusHandler = async (route: Route) => {
+      await route.fulfill({ json: this.statusResponse })
+    }
+    this.routeHandlers.push({ pattern: statusPattern, handler: statusHandler })
+    await this.page.route(statusPattern, statusHandler)
+
+    const balancePattern = '**/customers/balance'
+    const balanceHandler = async (route: Route) => {
+      await route.fulfill({ json: this.balanceResponse })
+    }
+    this.routeHandlers.push({
+      pattern: balancePattern,
+      handler: balanceHandler
+    })
+    await this.page.route(balancePattern, balanceHandler)
+
+    const checkoutPattern = '**/customers/cloud-subscription-checkout'
+    const checkoutHandler = async (route: Route) => {
+      await route.fulfill({
+        json: { checkout_url: 'https://checkout.stripe.com/mock' }
+      })
+    }
+    this.routeHandlers.push({
+      pattern: checkoutPattern,
+      handler: checkoutHandler
+    })
+    await this.page.route(checkoutPattern, checkoutHandler)
+  }
+
+  configure(...operators: SubscriptionOperator[]): void {
+    const base: SubscriptionConfig = {
+      status: createSubscriptionStatus(this.statusResponse),
+      balance: createBalance(this.balanceResponse)
+    }
+    const config = operators.reduce<SubscriptionConfig>(
+      (cfg, op) => op(cfg),
+      base
+    )
+    this.statusResponse = createSubscriptionStatus(config.status)
+    this.balanceResponse = createBalance(config.balance)
+  }
+
+  setStatus(overrides: Partial<SubscriptionStatusResponse>): void {
+    this.statusResponse = {
+      ...this.statusResponse,
+      ...overrides
+    }
+  }
+
+  setBalance(overrides: Partial<BalanceResponse>): void {
+    this.balanceResponse = {
+      ...this.balanceResponse,
+      ...overrides
+    }
+  }
+
+  async clearMocks(): Promise<void> {
+    for (const { pattern, handler } of this.routeHandlers) {
+      await this.page.unroute(pattern, handler)
+    }
+    this.routeHandlers = []
+    this.statusResponse = createSubscriptionStatus(UNSUBSCRIBED)
+    this.balanceResponse = createBalance(ZERO_BALANCE)
+  }
+}
+
+export function createSubscriptionHelper(
+  page: Page,
+  ...operators: SubscriptionOperator[]
+): SubscriptionHelper {
+  const config = operators.reduce<SubscriptionConfig>(
+    (cfg, op) => op(cfg),
+    emptyConfig()
+  )
+  return new SubscriptionHelper(page, config)
+}

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -1,5 +1,6 @@
 import type { Page, Route } from '@playwright/test'
 
+import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import {
   createBalance,
   createSubscriptionStatus,
@@ -181,10 +182,11 @@ export class SubscriptionHelper {
     tier: string = 'standard',
     cycle: string = 'monthly'
   ): Promise<void> {
+    const storageKey = PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY
     await this.page.evaluate(
-      ([t, c]) => {
+      ([key, t, c]) => {
         localStorage.setItem(
-          'comfy.subscription.pending_checkout_attempt',
+          key,
           JSON.stringify({
             attempt_id: `test-${Date.now()}`,
             started_at_ms: Date.now(),
@@ -194,7 +196,7 @@ export class SubscriptionHelper {
           })
         )
       },
-      [tier, cycle] as const
+      [storageKey, tier, cycle] as const
     )
   }
 

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -129,7 +129,7 @@ export class SubscriptionHelper {
     })
     await this.page.route(balancePattern, balanceHandler)
 
-    const checkoutPattern = '**/customers/cloud-subscription-checkout'
+    const checkoutPattern = '**/customers/cloud-subscription-checkout**'
     const checkoutHandler = async (route: Route) => {
       await route.fulfill({
         json: { checkout_url: 'https://checkout.stripe.com/mock' }

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -169,6 +169,46 @@ export class SubscriptionHelper {
     }
   }
 
+  /**
+   * Seed localStorage with a pending checkout attempt.
+   * Required for `visibilitychange` to trigger a subscription re-fetch,
+   * because `recoverPendingSubscriptionCheckout` checks
+   * `hasPendingSubscriptionCheckoutAttempt()` before fetching.
+   *
+   * Call AFTER page navigation (localStorage needs a page context).
+   */
+  async seedPendingCheckout(
+    tier: string = 'standard',
+    cycle: string = 'monthly'
+  ): Promise<void> {
+    await this.page.evaluate(
+      ([t, c]) => {
+        localStorage.setItem(
+          'comfy.subscription.pending_checkout_attempt',
+          JSON.stringify({
+            attempt_id: `test-${Date.now()}`,
+            started_at_ms: Date.now(),
+            tier: t,
+            cycle: c,
+            checkout_type: 'new'
+          })
+        )
+      },
+      [tier, cycle] as const
+    )
+  }
+
+  /**
+   * Dispatch `visibilitychange` to trigger pending-checkout recovery.
+   * The app listens for this event and re-fetches subscription status
+   * when a pending checkout attempt exists in localStorage.
+   */
+  async triggerSubscriptionRefetch(): Promise<void> {
+    await this.page.evaluate(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+  }
+
   async clearMocks(): Promise<void> {
     for (const { pattern, handler } of this.routeHandlers) {
       await this.page.unroute(pattern, handler)

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -113,6 +113,19 @@ export class SubscriptionHelper {
       }
     })
 
+    // The cloud build calls `/api/features` at boot via `refreshRemoteConfig`,
+    // which overwrites `window.__CONFIG__` wholesale. Mock it to preserve
+    // `subscription_required: true` after that fetch resolves.
+    const featuresPattern = '**/api/features'
+    const featuresHandler = async (route: Route) => {
+      await route.fulfill({ json: { subscription_required: true } })
+    }
+    this.routeHandlers.push({
+      pattern: featuresPattern,
+      handler: featuresHandler
+    })
+    await this.page.route(featuresPattern, featuresHandler)
+
     const statusPattern = '**/customers/cloud-subscription-status'
     const statusHandler = async (route: Route) => {
       await route.fulfill({ json: this.statusResponse })

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -1,3 +1,4 @@
+import { expect, errors } from '@playwright/test'
 import type { Page, Route } from '@playwright/test'
 
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
@@ -11,6 +12,7 @@ import type {
   BalanceResponse,
   SubscriptionStatusResponse
 } from '@e2e/fixtures/data/subscriptionFixtures'
+import { TestIds } from '@e2e/fixtures/selectors'
 
 export interface SubscriptionConfig {
   status: SubscriptionStatusResponse
@@ -77,8 +79,8 @@ export class SubscriptionHelper {
     private readonly page: Page,
     config: SubscriptionConfig = emptyConfig()
   ) {
-    this.statusResponse = createSubscriptionStatus(config.status)
-    this.balanceResponse = createBalance(config.balance)
+    this.statusResponse = { ...config.status }
+    this.balanceResponse = { ...config.balance }
   }
 
   async mock(): Promise<void> {
@@ -96,10 +98,7 @@ export class SubscriptionHelper {
     const featuresHandler = async (route: Route) => {
       await route.fulfill({ json: { subscription_required: true } })
     }
-    this.routeHandlers.push({
-      pattern: featuresPattern,
-      handler: featuresHandler
-    })
+    this.routeHandlers.push({ pattern: featuresPattern, handler: featuresHandler })
     await this.page.route(featuresPattern, featuresHandler)
 
     const statusPattern = '**/customers/cloud-subscription-status'
@@ -113,10 +112,7 @@ export class SubscriptionHelper {
     const balanceHandler = async (route: Route) => {
       await route.fulfill({ json: this.balanceResponse })
     }
-    this.routeHandlers.push({
-      pattern: balancePattern,
-      handler: balanceHandler
-    })
+    this.routeHandlers.push({ pattern: balancePattern, handler: balanceHandler })
     await this.page.route(balancePattern, balanceHandler)
 
     const checkoutPattern = '**/customers/cloud-subscription-checkout**'
@@ -125,47 +121,34 @@ export class SubscriptionHelper {
         json: { checkout_url: 'https://checkout.stripe.com/mock' }
       })
     }
-    this.routeHandlers.push({
-      pattern: checkoutPattern,
-      handler: checkoutHandler
-    })
+    this.routeHandlers.push({ pattern: checkoutPattern, handler: checkoutHandler })
     await this.page.route(checkoutPattern, checkoutHandler)
   }
 
   configure(...operators: SubscriptionOperator[]): void {
-    const base: SubscriptionConfig = {
-      status: createSubscriptionStatus(this.statusResponse),
-      balance: createBalance(this.balanceResponse)
-    }
     const config = operators.reduce<SubscriptionConfig>(
       (cfg, op) => op(cfg),
-      base
+      {
+        status: { ...this.statusResponse },
+        balance: { ...this.balanceResponse }
+      }
     )
-    this.statusResponse = createSubscriptionStatus(config.status)
-    this.balanceResponse = createBalance(config.balance)
+    this.statusResponse = { ...config.status }
+    this.balanceResponse = { ...config.balance }
   }
 
   setStatus(overrides: Partial<SubscriptionStatusResponse>): void {
-    this.statusResponse = {
-      ...this.statusResponse,
-      ...overrides
-    }
+    this.statusResponse = { ...this.statusResponse, ...overrides }
   }
 
   setBalance(overrides: Partial<BalanceResponse>): void {
-    this.balanceResponse = {
-      ...this.balanceResponse,
-      ...overrides
-    }
+    this.balanceResponse = { ...this.balanceResponse, ...overrides }
   }
 
   /**
-   * Seed localStorage with a pending checkout attempt.
-   * Required for `visibilitychange` to trigger a subscription re-fetch,
-   * because `recoverPendingSubscriptionCheckout` checks
-   * `hasPendingSubscriptionCheckoutAttempt()` before fetching.
-   *
-   * Call AFTER page navigation (localStorage needs a page context).
+   * Seed localStorage with a pending checkout attempt so that
+   * `recoverPendingSubscriptionCheckout` triggers a status re-fetch on
+   * the next `visibilitychange` event. Must be called after navigation.
    */
   async seedPendingCheckout(
     tier: string = 'standard',
@@ -190,9 +173,9 @@ export class SubscriptionHelper {
   }
 
   /**
-   * Dispatch `visibilitychange` to trigger pending-checkout recovery.
-   * The app listens for this event and re-fetches subscription status
-   * when a pending checkout attempt exists in localStorage.
+   * Dispatch `visibilitychange` to simulate returning from Stripe checkout.
+   * The app re-fetches subscription status when a pending checkout attempt
+   * exists in localStorage (seeded via `seedPendingCheckout`).
    */
   async triggerSubscriptionRefetch(): Promise<void> {
     await this.page.evaluate(() => {
@@ -200,13 +183,64 @@ export class SubscriptionHelper {
     })
   }
 
+  /**
+   * Open the user popover and return its locator after verifying visibility.
+   * Uses `dispatchEvent` to bypass Playwright's actionability check — a
+   * subscription dialog backdrop can intercept a normal `.click()` during
+   * initial page load.
+   */
+  async openUserPopover() {
+    await this.page.getByTestId(TestIds.user.currentUserButton).dispatchEvent('click')
+    const popover = this.page.getByTestId(TestIds.user.currentUserPopover)
+    await expect(popover).toBeVisible()
+    return popover
+  }
+
+  /**
+   * Open the user popover and click the subscribe button.
+   * Uses `dispatchEvent` on the button too — the subscription dialog's
+   * backdrop appears mid-action, which would cause Playwright's actionability
+   * re-check to block a standard `.click()`.
+   */
+  async clickPopoverSubscribe(): Promise<void> {
+    const popover = await this.openUserPopover()
+    await popover
+      .getByRole('button', { name: /subscribe/i })
+      .first()
+      .dispatchEvent('click')
+  }
+
+  /**
+   * Dismiss the subscription-required dialog if it appears after boot.
+   * The dialog opens asynchronously after the `isLoggedIn` watcher fires,
+   * so we poll briefly; absence is not a failure.
+   */
+  async dismissSubscriptionDialogIfOpen(): Promise<void> {
+    const dialog = this.page.locator('[aria-labelledby="subscription-required"]')
+    const appeared = await expect(dialog)
+      .toBeVisible({ timeout: 2000 })
+      .then(() => true)
+      .catch((e: unknown) => {
+        if (e instanceof errors.TimeoutError) return false
+        throw e
+      })
+    if (!appeared) return
+    const closeButton = dialog.getByRole('button', { name: /close/i }).first()
+    if (await closeButton.isVisible()) {
+      await closeButton.click()
+    } else {
+      await this.page.keyboard.press('Escape')
+    }
+    await expect(dialog).toBeHidden()
+  }
+
   async clearMocks(): Promise<void> {
     for (const { pattern, handler } of this.routeHandlers) {
       await this.page.unroute(pattern, handler)
     }
     this.routeHandlers = []
-    this.statusResponse = createSubscriptionStatus(UNSUBSCRIBED)
-    this.balanceResponse = createBalance(ZERO_BALANCE)
+    this.statusResponse = { ...UNSUBSCRIBED }
+    this.balanceResponse = { ...ZERO_BALANCE }
   }
 }
 

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -98,7 +98,10 @@ export class SubscriptionHelper {
     const featuresHandler = async (route: Route) => {
       await route.fulfill({ json: { subscription_required: true } })
     }
-    this.routeHandlers.push({ pattern: featuresPattern, handler: featuresHandler })
+    this.routeHandlers.push({
+      pattern: featuresPattern,
+      handler: featuresHandler
+    })
     await this.page.route(featuresPattern, featuresHandler)
 
     const statusPattern = '**/customers/cloud-subscription-status'
@@ -112,7 +115,10 @@ export class SubscriptionHelper {
     const balanceHandler = async (route: Route) => {
       await route.fulfill({ json: this.balanceResponse })
     }
-    this.routeHandlers.push({ pattern: balancePattern, handler: balanceHandler })
+    this.routeHandlers.push({
+      pattern: balancePattern,
+      handler: balanceHandler
+    })
     await this.page.route(balancePattern, balanceHandler)
 
     const checkoutPattern = '**/customers/cloud-subscription-checkout**'
@@ -121,18 +127,18 @@ export class SubscriptionHelper {
         json: { checkout_url: 'https://checkout.stripe.com/mock' }
       })
     }
-    this.routeHandlers.push({ pattern: checkoutPattern, handler: checkoutHandler })
+    this.routeHandlers.push({
+      pattern: checkoutPattern,
+      handler: checkoutHandler
+    })
     await this.page.route(checkoutPattern, checkoutHandler)
   }
 
   configure(...operators: SubscriptionOperator[]): void {
-    const config = operators.reduce<SubscriptionConfig>(
-      (cfg, op) => op(cfg),
-      {
-        status: { ...this.statusResponse },
-        balance: { ...this.balanceResponse }
-      }
-    )
+    const config = operators.reduce<SubscriptionConfig>((cfg, op) => op(cfg), {
+      status: { ...this.statusResponse },
+      balance: { ...this.balanceResponse }
+    })
     this.statusResponse = { ...config.status }
     this.balanceResponse = { ...config.balance }
   }
@@ -190,7 +196,9 @@ export class SubscriptionHelper {
    * initial page load.
    */
   async openUserPopover() {
-    await this.page.getByTestId(TestIds.user.currentUserButton).dispatchEvent('click')
+    await this.page
+      .getByTestId(TestIds.user.currentUserButton)
+      .dispatchEvent('click')
     const popover = this.page.getByTestId(TestIds.user.currentUserPopover)
     await expect(popover).toBeVisible()
     return popover
@@ -216,7 +224,9 @@ export class SubscriptionHelper {
    * so we poll briefly; absence is not a failure.
    */
   async dismissSubscriptionDialogIfOpen(): Promise<void> {
-    const dialog = this.page.locator('[aria-labelledby="subscription-required"]')
+    const dialog = this.page.locator(
+      '[aria-labelledby="subscription-required"]'
+    )
     // `expect().toBeVisible()` throws a Playwright AssertionError (not
     // errors.TimeoutError) when the element is absent — both cases mean
     // "dialog not present", which is the expected happy path here.

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -1,4 +1,4 @@
-import { expect, errors } from '@playwright/test'
+import { expect } from '@playwright/test'
 import type { Page, Route } from '@playwright/test'
 
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
@@ -217,13 +217,13 @@ export class SubscriptionHelper {
    */
   async dismissSubscriptionDialogIfOpen(): Promise<void> {
     const dialog = this.page.locator('[aria-labelledby="subscription-required"]')
+    // `expect().toBeVisible()` throws a Playwright AssertionError (not
+    // errors.TimeoutError) when the element is absent — both cases mean
+    // "dialog not present", which is the expected happy path here.
     const appeared = await expect(dialog)
       .toBeVisible({ timeout: 2000 })
       .then(() => true)
-      .catch((e: unknown) => {
-        if (e instanceof errors.TimeoutError) return false
-        throw e
-      })
+      .catch(() => false)
     if (!appeared) return
     const closeButton = dialog.getByRole('button', { name: /close/i }).first()
     if (await closeButton.isVisible()) {

--- a/browser_tests/fixtures/helpers/SubscriptionHelper.ts
+++ b/browser_tests/fixtures/helpers/SubscriptionHelper.ts
@@ -28,21 +28,12 @@ export type SubscriptionOperator = (
   config: SubscriptionConfig
 ) => SubscriptionConfig
 
-export function withSubscriptionStatus(
+function withSubscriptionStatus(
   overrides: Partial<SubscriptionStatusResponse>
 ): SubscriptionOperator {
   return (config) => ({
     ...config,
     status: { ...config.status, ...overrides }
-  })
-}
-
-export function withBalance(
-  overrides: Partial<BalanceResponse>
-): SubscriptionOperator {
-  return (config) => ({
-    ...config,
-    balance: { ...config.balance, ...overrides }
   })
 }
 
@@ -65,27 +56,12 @@ export function withFreeTier(): SubscriptionOperator {
   })
 }
 
-export function withCancelledSubscription(): SubscriptionOperator {
-  return withSubscriptionStatus({
-    is_active: true,
-    subscription_tier: 'CREATOR',
-    end_date: '2099-12-31T00:00:00.000Z'
-  })
-}
-
 export function withUnsubscribed(): SubscriptionOperator {
   return withSubscriptionStatus({
     is_active: false,
     subscription_tier: 'FREE',
     end_date: null,
     renewal_date: null
-  })
-}
-
-export function withCredits(amountMicros: number): SubscriptionOperator {
-  return withBalance({
-    amount_micros: amountMicros,
-    effective_balance_micros: amountMicros
   })
 }
 

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -248,7 +248,8 @@ export const TestIds = {
     workflowCard: (id: string) => `template-workflow-${id}`
   },
   user: {
-    currentUserIndicator: 'current-user-indicator'
+    currentUserIndicator: 'current-user-indicator',
+    currentUserPopover: 'current-user-popover'
   },
   queue: {
     jobHistorySidebar: 'job-history-sidebar',

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -248,6 +248,7 @@ export const TestIds = {
     workflowCard: (id: string) => `template-workflow-${id}`
   },
   user: {
+    currentUserButton: 'current-user-button',
     currentUserIndicator: 'current-user-indicator',
     currentUserPopover: 'current-user-popover'
   },

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -98,6 +98,7 @@ export const TestIds = {
     queueModeMenuTrigger: 'queue-mode-menu-trigger',
     saveButton: 'save-workflow-button',
     subscribeButton: 'topbar-subscribe-button',
+    subscribeToRunButton: 'subscribe-to-run-button',
     loginButton: 'login-button',
     loginButtonPopover: 'login-button-popover',
     loginButtonPopoverLearnMore: 'login-button-popover-learn-more',

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -45,7 +45,7 @@ unsubscribedTest.describe(
       'SubscribeToRun visible when unsubscribed',
       async ({ comfyPage }) => {
         await expect(
-          comfyPage.page.getByTestId('subscribe-to-run-button')
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).toBeVisible({ timeout: 10_000 })
       }
     )
@@ -53,7 +53,9 @@ unsubscribedTest.describe(
     unsubscribedTest(
       'SubscribeToRun click opens subscription dialog',
       async ({ comfyPage }) => {
-        await comfyPage.page.getByTestId('subscribe-to-run-button').click()
+        await comfyPage.page
+          .getByTestId(TestIds.topbar.subscribeToRunButton)
+          .click()
         await expect(comfyPage.page.getByRole('dialog')).toBeVisible({
           timeout: 10_000
         })
@@ -64,7 +66,9 @@ unsubscribedTest.describe(
       'SubscribeToRun shows short label on mobile',
       { tag: '@mobile' },
       async ({ comfyPage }) => {
-        const btn = comfyPage.page.getByTestId('subscribe-to-run-button')
+        const btn = comfyPage.page.getByTestId(
+          TestIds.topbar.subscribeToRunButton
+        )
         await expect(btn).toBeVisible({ timeout: 10_000 })
         await expect(btn).not.toContainText(/to run/i)
       }
@@ -104,7 +108,7 @@ unsubscribedTest.describe(
       'Subscription state transition updates UI after re-fetch',
       async ({ comfyPage, subscriptionHelper }) => {
         await expect(
-          comfyPage.page.getByTestId('subscribe-to-run-button')
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).toBeVisible({ timeout: 10_000 })
 
         // Simulate returning from Stripe checkout: seed pending checkout,
@@ -118,7 +122,7 @@ unsubscribedTest.describe(
         await subscriptionHelper.triggerSubscriptionRefetch()
 
         await expect(
-          comfyPage.page.getByTestId('subscribe-to-run-button')
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).not.toBeVisible({ timeout: 10_000 })
       }
     )
@@ -170,7 +174,7 @@ subscribedTest.describe(
           comfyPage.page.getByTestId(TestIds.topbar.queueButton)
         ).toBeVisible({ timeout: 10_000 })
         await expect(
-          comfyPage.page.getByTestId('subscribe-to-run-button')
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).toBeHidden()
       }
     )

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -63,9 +63,9 @@ unsubscribedTest.describe(
     )
 
     unsubscribedTest(
-      'SubscribeToRun shows short label on mobile',
-      { tag: '@mobile' },
+      'SubscribeToRun shows short label at narrow viewport',
       async ({ comfyPage }) => {
+        await comfyPage.page.setViewportSize({ width: 393, height: 851 })
         const btn = comfyPage.page.getByTestId(
           TestIds.topbar.subscribeToRunButton
         )

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -46,7 +46,7 @@ unsubscribedTest.describe(
       async ({ comfyPage }) => {
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
-        ).toBeVisible({ timeout: 10_000 })
+        ).toBeVisible()
       }
     )
 
@@ -56,9 +56,7 @@ unsubscribedTest.describe(
         await comfyPage.page
           .getByTestId(TestIds.topbar.subscribeToRunButton)
           .click()
-        await expect(comfyPage.page.getByRole('dialog')).toBeVisible({
-          timeout: 10_000
-        })
+        await expect(comfyPage.page.getByRole('dialog')).toBeVisible()
       }
     )
 
@@ -69,7 +67,7 @@ unsubscribedTest.describe(
         const btn = comfyPage.page.getByTestId(
           TestIds.topbar.subscribeToRunButton
         )
-        await expect(btn).toBeVisible({ timeout: 10_000 })
+        await expect(btn).toBeVisible()
         await expect(btn).not.toContainText(/to run/i)
       }
     )
@@ -83,7 +81,7 @@ unsubscribedTest.describe(
         const popover = comfyPage.page.locator('.current-user-popover')
         await expect(
           popover.getByRole('button', { name: /subscribe/i })
-        ).toBeVisible({ timeout: 10_000 })
+        ).toBeVisible()
       }
     )
 
@@ -98,9 +96,7 @@ unsubscribedTest.describe(
           .getByRole('button', { name: /subscribe/i })
           .first()
           .click()
-        await expect(comfyPage.page.getByRole('dialog')).toBeVisible({
-          timeout: 10_000
-        })
+        await expect(comfyPage.page.getByRole('dialog')).toBeVisible()
       }
     )
 
@@ -109,7 +105,7 @@ unsubscribedTest.describe(
       async ({ comfyPage, subscriptionHelper }) => {
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
-        ).toBeVisible({ timeout: 10_000 })
+        ).toBeVisible()
 
         // Simulate returning from Stripe checkout: seed pending checkout,
         // mutate mock to return active subscription, trigger re-fetch.
@@ -123,7 +119,7 @@ unsubscribedTest.describe(
 
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
-        ).not.toBeVisible({ timeout: 10_000 })
+        ).toBeHidden()
       }
     )
 
@@ -140,11 +136,11 @@ unsubscribedTest.describe(
           .first()
           .click()
         const dialog = comfyPage.page.getByRole('dialog')
-        await expect(dialog).toBeVisible({ timeout: 10_000 })
+        await expect(dialog).toBeVisible()
 
         // Close dialog → SubscribeButton unmounts → onBeforeUnmount resets ref
         await dialog.getByRole('button', { name: /close/i }).first().click()
-        await expect(dialog).not.toBeVisible({ timeout: 10_000 })
+        await expect(dialog).toBeHidden()
 
         // Now change subscription state — the unmounted SubscribeButton's watcher
         // should not fire because isAwaitingStripeSubscription was reset.
@@ -157,7 +153,7 @@ unsubscribedTest.describe(
         await subscriptionHelper.triggerSubscriptionRefetch()
 
         // No dialog should reappear from the stale SubscribeButton state
-        await expect(dialog).not.toBeVisible({ timeout: 2_000 })
+        await expect(dialog).toBeHidden()
       }
     )
   }
@@ -172,7 +168,7 @@ subscribedTest.describe(
       async ({ comfyPage }) => {
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.queueButton)
-        ).toBeVisible({ timeout: 10_000 })
+        ).toBeVisible()
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).toBeHidden()
@@ -184,7 +180,7 @@ subscribedTest.describe(
       async ({ comfyPage }) => {
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.queueButton)
-        ).toBeVisible({ timeout: 10_000 })
+        ).toBeVisible()
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeButton)
         ).toBeHidden()
@@ -202,7 +198,7 @@ freeTierTest.describe(
       async ({ comfyPage }) => {
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeButton)
-        ).toBeVisible({ timeout: 10_000 })
+        ).toBeVisible()
       }
     )
   }

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -11,6 +11,9 @@ import {
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import type { SubscriptionOperator } from '@e2e/fixtures/helpers/SubscriptionHelper'
 
+const SUBSCRIPTION_DIALOG_SELECTOR =
+  '[aria-labelledby="subscription-required"], [aria-labelledby="free-tier-info"]'
+
 async function setupSubscriptionMocks(
   comfyPage: ComfyPage,
   ...operators: SubscriptionOperator[]
@@ -24,10 +27,7 @@ async function setupSubscriptionMocks(
 async function openUserPopover(
   page: Parameters<typeof createSubscriptionHelper>[0]
 ) {
-  const currentUserIndicator = page
-    .getByTestId(TestIds.user.currentUserIndicator)
-    .or(page.getByRole('button', { name: /current user/i }))
-  await currentUserIndicator.click()
+  await page.getByRole('button', { name: /current user/i }).click()
 }
 
 test.describe('Subscription buttons', { tag: '@cloud' }, () => {
@@ -68,10 +68,11 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
     await comfyPage.page.getByTestId('subscribe-to-run-button').click()
 
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
-      .toBe(1)
+      .poll(
+        () => comfyPage.page.locator(SUBSCRIPTION_DIALOG_SELECTOR).count(),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0)
 
     await helper.clearMocks()
   })
@@ -99,12 +100,11 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
 
     await openUserPopover(comfyPage.page)
 
+    const popover = comfyPage.page.locator('.current-user-popover')
     await expect
-      .poll(
-        () =>
-          comfyPage.page.getByRole('button', { name: /subscribe/i }).count(),
-        { timeout: 10_000 }
-      )
+      .poll(() => popover.getByRole('button', { name: /subscribe/i }).count(), {
+        timeout: 10_000
+      })
       .toBeGreaterThan(0)
 
     await helper.clearMocks()
@@ -114,16 +114,18 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
     const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
 
     await openUserPopover(comfyPage.page)
-    await comfyPage.page
+    const popover = comfyPage.page.locator('.current-user-popover')
+    await popover
       .getByRole('button', { name: /subscribe/i })
       .first()
       .click()
 
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
-      .toBe(1)
+      .poll(
+        () => comfyPage.page.locator(SUBSCRIPTION_DIALOG_SELECTOR).count(),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0)
 
     await helper.clearMocks()
   })
@@ -176,16 +178,18 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
     )
 
     await openUserPopover(comfyPage.page)
-    await comfyPage.page
+    const popover = comfyPage.page.locator('.current-user-popover')
+    await popover
       .getByRole('button', { name: /subscribe/i })
       .first()
       .click()
 
+    const subscriptionDialog = comfyPage.page.locator(
+      SUBSCRIPTION_DIALOG_SELECTOR
+    )
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
-      .toBe(1)
+      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
+      .toBeGreaterThan(0)
 
     helper.setStatus({ is_active: true })
     await comfyPage.page.evaluate(() => {
@@ -193,9 +197,7 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
     })
 
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
+      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
       .toBe(0)
 
     await helper.clearMocks()
@@ -214,22 +216,26 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
     )
 
     await openUserPopover(comfyPage.page)
-    await comfyPage.page
+    const popover = comfyPage.page.locator('.current-user-popover')
+    await popover
       .getByRole('button', { name: /subscribe/i })
       .first()
       .click()
 
+    const subscriptionDialog = comfyPage.page.locator(
+      SUBSCRIPTION_DIALOG_SELECTOR
+    )
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
-      .toBe(1)
+      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
+      .toBeGreaterThan(0)
 
-    await comfyPage.page.getByRole('button', { name: /close/i }).first().click()
+    await comfyPage.page
+      .locator('.global-dialog')
+      .getByRole('button', { name: /close/i })
+      .first()
+      .click()
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
+      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
       .toBe(0)
 
     helper.setStatus({ is_active: true })
@@ -238,9 +244,7 @@ test.describe('Subscription buttons', { tag: '@cloud' }, () => {
     })
 
     await expect
-      .poll(() => comfyPage.page.getByRole('dialog').count(), {
-        timeout: 10_000
-      })
+      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
       .toBe(0)
 
     await helper.clearMocks()

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -1,0 +1,248 @@
+import { expect } from '@playwright/test'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import {
+  createSubscriptionHelper,
+  withActiveSubscription,
+  withFreeTier,
+  withSubscriptionStatus,
+  withUnsubscribed
+} from '@e2e/fixtures/helpers/SubscriptionHelper'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import type { SubscriptionOperator } from '@e2e/fixtures/helpers/SubscriptionHelper'
+
+async function setupSubscriptionMocks(
+  comfyPage: ComfyPage,
+  ...operators: SubscriptionOperator[]
+) {
+  const helper = createSubscriptionHelper(comfyPage.page, ...operators)
+  await helper.mock()
+  await comfyPage.setup({ clearStorage: false })
+  return helper
+}
+
+async function openUserPopover(
+  page: Parameters<typeof createSubscriptionHelper>[0]
+) {
+  const currentUserIndicator = page
+    .getByTestId(TestIds.user.currentUserIndicator)
+    .or(page.getByRole('button', { name: /current user/i }))
+  await currentUserIndicator.click()
+}
+
+test.describe('Subscription buttons', { tag: '@cloud' }, () => {
+  test('SubscribeToRun visible when unsubscribed', async ({ comfyPage }) => {
+    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
+
+    await expect
+      .poll(
+        () => comfyPage.page.getByTestId('subscribe-to-run-button').isVisible(),
+        { timeout: 10_000 }
+      )
+      .toBe(true)
+
+    await helper.clearMocks()
+  })
+
+  test('SubscribeToRun hidden when subscribed', async ({ comfyPage }) => {
+    const helper = await setupSubscriptionMocks(
+      comfyPage,
+      withActiveSubscription('CREATOR')
+    )
+
+    await expect
+      .poll(
+        () => comfyPage.page.getByTestId('subscribe-to-run-button').count(),
+        { timeout: 10_000 }
+      )
+      .toBe(0)
+
+    await helper.clearMocks()
+  })
+
+  test('SubscribeToRun click opens subscription dialog', async ({
+    comfyPage
+  }) => {
+    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
+
+    await comfyPage.page.getByTestId('subscribe-to-run-button').click()
+
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(1)
+
+    await helper.clearMocks()
+  })
+
+  test(
+    'SubscribeToRun shows short label on mobile',
+    { tag: '@mobile' },
+    async ({ comfyPage }) => {
+      const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
+      const subscribeToRunButton = comfyPage.page.getByTestId(
+        'subscribe-to-run-button'
+      )
+
+      await expect(subscribeToRunButton).toBeVisible()
+      await expect(subscribeToRunButton).not.toContainText(/to run/i)
+
+      await helper.clearMocks()
+    }
+  )
+
+  test('User popover shows subscribe when unsubscribed', async ({
+    comfyPage
+  }) => {
+    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
+
+    await openUserPopover(comfyPage.page)
+
+    await expect
+      .poll(
+        () =>
+          comfyPage.page.getByRole('button', { name: /subscribe/i }).count(),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0)
+
+    await helper.clearMocks()
+  })
+
+  test('User popover subscribe click opens dialog', async ({ comfyPage }) => {
+    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
+
+    await openUserPopover(comfyPage.page)
+    await comfyPage.page
+      .getByRole('button', { name: /subscribe/i })
+      .first()
+      .click()
+
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(1)
+
+    await helper.clearMocks()
+  })
+
+  test('Topbar subscribe button visible for free tier', async ({
+    comfyPage
+  }) => {
+    const helper = await setupSubscriptionMocks(comfyPage, withFreeTier())
+
+    await expect
+      .poll(
+        () =>
+          comfyPage.page
+            .getByTestId(TestIds.topbar.subscribeButton)
+            .isVisible(),
+        { timeout: 10_000 }
+      )
+      .toBe(true)
+
+    await helper.clearMocks()
+  })
+
+  test('Topbar subscribe button hidden for paid tier', async ({
+    comfyPage
+  }) => {
+    const helper = await setupSubscriptionMocks(
+      comfyPage,
+      withActiveSubscription('PRO')
+    )
+
+    await expect
+      .poll(
+        () =>
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeButton).count(),
+        { timeout: 10_000 }
+      )
+      .toBe(0)
+
+    await helper.clearMocks()
+  })
+
+  test('Subscription state transition closes dialog', async ({ comfyPage }) => {
+    const helper = await setupSubscriptionMocks(
+      comfyPage,
+      withSubscriptionStatus({
+        is_active: false,
+        subscription_tier: 'CREATOR',
+        end_date: null
+      })
+    )
+
+    await openUserPopover(comfyPage.page)
+    await comfyPage.page
+      .getByRole('button', { name: /subscribe/i })
+      .first()
+      .click()
+
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(1)
+
+    helper.setStatus({ is_active: true })
+    await comfyPage.page.evaluate(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(0)
+
+    await helper.clearMocks()
+  })
+
+  test('Cleanup prevents false subscribed after unmount', async ({
+    comfyPage
+  }) => {
+    const helper = await setupSubscriptionMocks(
+      comfyPage,
+      withSubscriptionStatus({
+        is_active: false,
+        subscription_tier: 'CREATOR',
+        end_date: null
+      })
+    )
+
+    await openUserPopover(comfyPage.page)
+    await comfyPage.page
+      .getByRole('button', { name: /subscribe/i })
+      .first()
+      .click()
+
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(1)
+
+    await comfyPage.page.getByRole('button', { name: /close/i }).first().click()
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(0)
+
+    helper.setStatus({ is_active: true })
+    await comfyPage.page.evaluate(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await expect
+      .poll(() => comfyPage.page.getByRole('dialog').count(), {
+        timeout: 10_000
+      })
+      .toBe(0)
+
+    await helper.clearMocks()
+  })
+})

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -1,252 +1,205 @@
 import { expect } from '@playwright/test'
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 import {
   createSubscriptionHelper,
   withActiveSubscription,
   withFreeTier,
-  withSubscriptionStatus,
   withUnsubscribed
 } from '@e2e/fixtures/helpers/SubscriptionHelper'
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
-import type { SubscriptionOperator } from '@e2e/fixtures/helpers/SubscriptionHelper'
+import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelper'
 
-const SUBSCRIPTION_DIALOG_SELECTOR =
-  '[aria-labelledby="subscription-required"], [aria-labelledby="free-tier-info"]'
-
-async function setupSubscriptionMocks(
-  comfyPage: ComfyPage,
-  ...operators: SubscriptionOperator[]
+// Installs subscription mocks BEFORE comfyPage's first navigation via an
+// auto-fixture that depends on `page` (resolved before `comfyPage`).
+function createSubscriptionTest(
+  ...defaultOps: Parameters<typeof createSubscriptionHelper>[1][]
 ) {
-  const helper = createSubscriptionHelper(comfyPage.page, ...operators)
-  await helper.mock()
-  await comfyPage.setup({ clearStorage: false })
-  return helper
-}
-
-async function openUserPopover(
-  page: Parameters<typeof createSubscriptionHelper>[0]
-) {
-  await page.getByRole('button', { name: /current user/i }).click()
-}
-
-test.describe('Subscription buttons', { tag: '@cloud' }, () => {
-  test('SubscribeToRun visible when unsubscribed', async ({ comfyPage }) => {
-    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
-
-    await expect
-      .poll(
-        () => comfyPage.page.getByTestId('subscribe-to-run-button').isVisible(),
-        { timeout: 10_000 }
-      )
-      .toBe(true)
-
-    await helper.clearMocks()
-  })
-
-  test('SubscribeToRun hidden when subscribed', async ({ comfyPage }) => {
-    const helper = await setupSubscriptionMocks(
-      comfyPage,
-      withActiveSubscription('CREATOR')
-    )
-
-    await expect
-      .poll(
-        () => comfyPage.page.getByTestId('subscribe-to-run-button').count(),
-        { timeout: 10_000 }
-      )
-      .toBe(0)
-
-    await helper.clearMocks()
-  })
-
-  test('SubscribeToRun click opens subscription dialog', async ({
-    comfyPage
-  }) => {
-    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
-
-    await comfyPage.page.getByTestId('subscribe-to-run-button').click()
-
-    await expect
-      .poll(
-        () => comfyPage.page.locator(SUBSCRIPTION_DIALOG_SELECTOR).count(),
-        { timeout: 10_000 }
-      )
-      .toBeGreaterThan(0)
-
-    await helper.clearMocks()
-  })
-
-  test(
-    'SubscribeToRun shows short label on mobile',
-    { tag: '@mobile' },
-    async ({ comfyPage }) => {
-      const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
-      const subscribeToRunButton = comfyPage.page.getByTestId(
-        'subscribe-to-run-button'
-      )
-
-      await expect(subscribeToRunButton).toBeVisible()
-      await expect(subscribeToRunButton).not.toContainText(/to run/i)
-
+  return comfyPageFixture.extend<{
+    subscriptionHelper: SubscriptionHelper
+    _subscriptionMocks: void
+  }>({
+    subscriptionHelper: async ({ page }, use) => {
+      const helper = createSubscriptionHelper(page, ...defaultOps)
+      await use(helper)
       await helper.clearMocks()
-    }
-  )
-
-  test('User popover shows subscribe when unsubscribed', async ({
-    comfyPage
-  }) => {
-    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
-
-    await openUserPopover(comfyPage.page)
-
-    const popover = comfyPage.page.locator('.current-user-popover')
-    await expect
-      .poll(() => popover.getByRole('button', { name: /subscribe/i }).count(), {
-        timeout: 10_000
-      })
-      .toBeGreaterThan(0)
-
-    await helper.clearMocks()
+    },
+    _subscriptionMocks: [
+      async ({ subscriptionHelper }, use) => {
+        await subscriptionHelper.mock()
+        await use()
+      },
+      { auto: true }
+    ]
   })
+}
 
-  test('User popover subscribe click opens dialog', async ({ comfyPage }) => {
-    const helper = await setupSubscriptionMocks(comfyPage, withUnsubscribed())
+const unsubscribedTest = createSubscriptionTest(withUnsubscribed())
+const subscribedTest = createSubscriptionTest(withActiveSubscription('CREATOR'))
+const freeTierTest = createSubscriptionTest(withFreeTier())
 
-    await openUserPopover(comfyPage.page)
-    const popover = comfyPage.page.locator('.current-user-popover')
-    await popover
-      .getByRole('button', { name: /subscribe/i })
-      .first()
-      .click()
-
-    await expect
-      .poll(
-        () => comfyPage.page.locator(SUBSCRIPTION_DIALOG_SELECTOR).count(),
-        { timeout: 10_000 }
-      )
-      .toBeGreaterThan(0)
-
-    await helper.clearMocks()
-  })
-
-  test('Topbar subscribe button visible for free tier', async ({
-    comfyPage
-  }) => {
-    const helper = await setupSubscriptionMocks(comfyPage, withFreeTier())
-
-    await expect
-      .poll(
-        () =>
-          comfyPage.page
-            .getByTestId(TestIds.topbar.subscribeButton)
-            .isVisible(),
-        { timeout: 10_000 }
-      )
-      .toBe(true)
-
-    await helper.clearMocks()
-  })
-
-  test('Topbar subscribe button hidden for paid tier', async ({
-    comfyPage
-  }) => {
-    const helper = await setupSubscriptionMocks(
-      comfyPage,
-      withActiveSubscription('PRO')
+unsubscribedTest.describe(
+  'Subscription buttons — unsubscribed',
+  { tag: '@cloud' },
+  () => {
+    unsubscribedTest(
+      'SubscribeToRun visible when unsubscribed',
+      async ({ comfyPage }) => {
+        await expect(
+          comfyPage.page.getByTestId('subscribe-to-run-button')
+        ).toBeVisible({ timeout: 10_000 })
+      }
     )
 
-    await expect
-      .poll(
-        () =>
-          comfyPage.page.getByTestId(TestIds.topbar.subscribeButton).count(),
-        { timeout: 10_000 }
-      )
-      .toBe(0)
-
-    await helper.clearMocks()
-  })
-
-  test('Subscription state transition closes dialog', async ({ comfyPage }) => {
-    const helper = await setupSubscriptionMocks(
-      comfyPage,
-      withSubscriptionStatus({
-        is_active: false,
-        subscription_tier: 'CREATOR',
-        end_date: null
-      })
+    unsubscribedTest(
+      'SubscribeToRun click opens subscription dialog',
+      async ({ comfyPage }) => {
+        await comfyPage.page.getByTestId('subscribe-to-run-button').click()
+        await expect(comfyPage.page.getByRole('dialog')).toBeVisible({
+          timeout: 10_000
+        })
+      }
     )
 
-    await openUserPopover(comfyPage.page)
-    const popover = comfyPage.page.locator('.current-user-popover')
-    await popover
-      .getByRole('button', { name: /subscribe/i })
-      .first()
-      .click()
-
-    const subscriptionDialog = comfyPage.page.locator(
-      SUBSCRIPTION_DIALOG_SELECTOR
-    )
-    await expect
-      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
-      .toBeGreaterThan(0)
-
-    helper.setStatus({ is_active: true })
-    await comfyPage.page.evaluate(() => {
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
-
-    await expect
-      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
-      .toBe(0)
-
-    await helper.clearMocks()
-  })
-
-  test('Cleanup prevents false subscribed after unmount', async ({
-    comfyPage
-  }) => {
-    const helper = await setupSubscriptionMocks(
-      comfyPage,
-      withSubscriptionStatus({
-        is_active: false,
-        subscription_tier: 'CREATOR',
-        end_date: null
-      })
+    unsubscribedTest(
+      'SubscribeToRun shows short label on mobile',
+      { tag: '@mobile' },
+      async ({ comfyPage }) => {
+        const btn = comfyPage.page.getByTestId('subscribe-to-run-button')
+        await expect(btn).toBeVisible({ timeout: 10_000 })
+        await expect(btn).not.toContainText(/to run/i)
+      }
     )
 
-    await openUserPopover(comfyPage.page)
-    const popover = comfyPage.page.locator('.current-user-popover')
-    await popover
-      .getByRole('button', { name: /subscribe/i })
-      .first()
-      .click()
-
-    const subscriptionDialog = comfyPage.page.locator(
-      SUBSCRIPTION_DIALOG_SELECTOR
+    unsubscribedTest(
+      'User popover shows subscribe when unsubscribed',
+      async ({ comfyPage }) => {
+        await comfyPage.page
+          .getByTestId(TestIds.user.currentUserIndicator)
+          .click()
+        const popover = comfyPage.page.locator('.current-user-popover')
+        await expect(
+          popover.getByRole('button', { name: /subscribe/i })
+        ).toBeVisible({ timeout: 10_000 })
+      }
     )
-    await expect
-      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
-      .toBeGreaterThan(0)
 
-    await comfyPage.page
-      .locator('.global-dialog')
-      .getByRole('button', { name: /close/i })
-      .first()
-      .click()
-    await expect
-      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
-      .toBe(0)
+    unsubscribedTest(
+      'User popover subscribe click opens dialog',
+      async ({ comfyPage }) => {
+        await comfyPage.page
+          .getByTestId(TestIds.user.currentUserIndicator)
+          .click()
+        const popover = comfyPage.page.locator('.current-user-popover')
+        await popover
+          .getByRole('button', { name: /subscribe/i })
+          .first()
+          .click()
+        await expect(comfyPage.page.getByRole('dialog')).toBeVisible({
+          timeout: 10_000
+        })
+      }
+    )
 
-    helper.setStatus({ is_active: true })
-    await comfyPage.page.evaluate(() => {
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
+    unsubscribedTest(
+      'Subscription state transition updates UI after re-fetch',
+      async ({ comfyPage, subscriptionHelper }) => {
+        await expect(
+          comfyPage.page.getByTestId('subscribe-to-run-button')
+        ).toBeVisible({ timeout: 10_000 })
 
-    await expect
-      .poll(() => subscriptionDialog.count(), { timeout: 10_000 })
-      .toBe(0)
+        // Simulate returning from Stripe checkout: seed pending checkout,
+        // mutate mock to return active subscription, trigger re-fetch.
+        await subscriptionHelper.seedPendingCheckout('standard', 'monthly')
+        subscriptionHelper.setStatus({
+          is_active: true,
+          subscription_tier: 'STANDARD',
+          subscription_duration: 'MONTHLY'
+        })
+        await subscriptionHelper.triggerSubscriptionRefetch()
 
-    await helper.clearMocks()
-  })
-})
+        await expect(
+          comfyPage.page.getByTestId('subscribe-to-run-button')
+        ).not.toBeVisible({ timeout: 10_000 })
+      }
+    )
+
+    unsubscribedTest(
+      'Cleanup prevents stale subscription state after dialog close',
+      async ({ comfyPage, subscriptionHelper }) => {
+        // Open popover → click subscribe → dialog opens, isAwaitingStripeSubscription = true
+        await comfyPage.page
+          .getByTestId(TestIds.user.currentUserIndicator)
+          .click()
+        const popover = comfyPage.page.locator('.current-user-popover')
+        await popover
+          .getByRole('button', { name: /subscribe/i })
+          .first()
+          .click()
+        const dialog = comfyPage.page.getByRole('dialog')
+        await expect(dialog).toBeVisible({ timeout: 10_000 })
+
+        // Close dialog → SubscribeButton unmounts → onBeforeUnmount resets ref
+        await dialog.getByRole('button', { name: /close/i }).first().click()
+        await expect(dialog).not.toBeVisible({ timeout: 10_000 })
+
+        // Now change subscription state — the unmounted SubscribeButton's watcher
+        // should not fire because isAwaitingStripeSubscription was reset.
+        await subscriptionHelper.seedPendingCheckout('standard', 'monthly')
+        subscriptionHelper.setStatus({
+          is_active: true,
+          subscription_tier: 'STANDARD',
+          subscription_duration: 'MONTHLY'
+        })
+        await subscriptionHelper.triggerSubscriptionRefetch()
+
+        // No dialog should reappear from the stale SubscribeButton state
+        await expect(dialog).not.toBeVisible({ timeout: 2_000 })
+      }
+    )
+  }
+)
+
+subscribedTest.describe(
+  'Subscription buttons — subscribed',
+  { tag: '@cloud' },
+  () => {
+    subscribedTest(
+      'SubscribeToRun hidden when subscribed',
+      async ({ comfyPage }) => {
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.queueButton)
+        ).toBeVisible({ timeout: 10_000 })
+        await expect(
+          comfyPage.page.getByTestId('subscribe-to-run-button')
+        ).toBeHidden()
+      }
+    )
+
+    subscribedTest(
+      'Topbar subscribe button hidden for paid tier',
+      async ({ comfyPage }) => {
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.queueButton)
+        ).toBeVisible({ timeout: 10_000 })
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeButton)
+        ).toBeHidden()
+      }
+    )
+  }
+)
+
+freeTierTest.describe(
+  'Subscription buttons — free tier',
+  { tag: '@cloud' },
+  () => {
+    freeTierTest(
+      'Topbar subscribe button visible for free tier',
+      async ({ comfyPage }) => {
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeButton)
+        ).toBeVisible({ timeout: 10_000 })
+      }
+    )
+  }
+)

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -134,12 +134,9 @@ unsubscribedTest.describe(
         const dialog = comfyPage.page.getByRole('dialog')
         await expect(dialog).toBeVisible()
 
-        // Close dialog → SubscribeButton unmounts → onBeforeUnmount resets ref
         await dialog.getByRole('button', { name: /close/i }).first().click()
         await expect(dialog).toBeHidden()
 
-        // Now change subscription state — the unmounted SubscribeButton's watcher
-        // should not fire because isAwaitingStripeSubscription was reset.
         await subscriptionHelper.seedPendingCheckout('standard', 'monthly')
         subscriptionHelper.setStatus({
           is_active: true,
@@ -148,7 +145,6 @@ unsubscribedTest.describe(
         })
         await subscriptionHelper.triggerSubscriptionRefetch()
 
-        // No dialog should reappear from the stale SubscribeButton state
         await expect(dialog).toBeHidden()
       }
     )

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -38,18 +38,24 @@ async function dismissSubscriptionDialogIfOpen(page: Page): Promise<void> {
   // key — avoids strict-mode violations when multiple GlobalDialog items are
   // on the stack simultaneously.
   const dialog = page.locator('[aria-labelledby="subscription-required"]')
-  try {
-    await dialog.waitFor({ state: 'visible', timeout: 2000 })
-  } catch {
-    return
-  }
+  // Use expect with a short timeout: this is intentionally a "dismiss if open"
+  // helper, so absence of the dialog (TimeoutError) is not a failure — we
+  // discard only the timeout error, not any other unexpected exception.
+  const appeared = await expect(dialog)
+    .toBeVisible({ timeout: 2000 })
+    .then(() => true)
+    .catch((e: Error) => {
+      if (e.message.includes('Timeout')) return false
+      throw e
+    })
+  if (!appeared) return
   const closeButton = dialog.getByRole('button', { name: /close/i }).first()
-  if (await closeButton.isVisible().catch(() => false)) {
+  if (await closeButton.isVisible()) {
     await closeButton.click()
   } else {
     await page.keyboard.press('Escape')
   }
-  await dialog.waitFor({ state: 'hidden' }).catch(() => {})
+  await expect(dialog).toBeHidden()
 }
 
 // Installs subscription mocks AFTER comfyPage.setup() and reloads the page

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -7,7 +7,21 @@ import {
   withFreeTier,
   withUnsubscribed
 } from '@e2e/fixtures/helpers/SubscriptionHelper'
+import type { Locator, Page } from '@playwright/test'
 import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelper'
+
+async function openUserPopover(page: Page): Promise<Locator> {
+  await page.getByTestId(TestIds.user.currentUserIndicator).click()
+  return page.getByTestId(TestIds.user.currentUserPopover)
+}
+
+async function clickPopoverSubscribe(page: Page): Promise<void> {
+  const popover = await openUserPopover(page)
+  await popover
+    .getByRole('button', { name: /subscribe/i })
+    .first()
+    .click()
+}
 
 // Installs subscription mocks BEFORE comfyPage's first navigation via an
 // auto-fixture that depends on `page` (resolved before `comfyPage`).
@@ -75,12 +89,7 @@ unsubscribedTest.describe(
     unsubscribedTest(
       'User popover shows subscribe when unsubscribed',
       async ({ comfyPage }) => {
-        await comfyPage.page
-          .getByTestId(TestIds.user.currentUserIndicator)
-          .click()
-        const popover = comfyPage.page.getByTestId(
-          TestIds.user.currentUserPopover
-        )
+        const popover = await openUserPopover(comfyPage.page)
         await expect(
           popover.getByRole('button', { name: /subscribe/i })
         ).toBeVisible()
@@ -90,16 +99,7 @@ unsubscribedTest.describe(
     unsubscribedTest(
       'User popover subscribe click opens dialog',
       async ({ comfyPage }) => {
-        await comfyPage.page
-          .getByTestId(TestIds.user.currentUserIndicator)
-          .click()
-        const popover = comfyPage.page.getByTestId(
-          TestIds.user.currentUserPopover
-        )
-        await popover
-          .getByRole('button', { name: /subscribe/i })
-          .first()
-          .click()
+        await clickPopoverSubscribe(comfyPage.page)
         await expect(comfyPage.page.getByRole('dialog')).toBeVisible()
       }
     )
@@ -130,17 +130,7 @@ unsubscribedTest.describe(
     unsubscribedTest(
       'Cleanup prevents stale subscription state after dialog close',
       async ({ comfyPage, subscriptionHelper }) => {
-        // Open popover → click subscribe → dialog opens, isAwaitingStripeSubscription = true
-        await comfyPage.page
-          .getByTestId(TestIds.user.currentUserIndicator)
-          .click()
-        const popover = comfyPage.page.getByTestId(
-          TestIds.user.currentUserPopover
-        )
-        await popover
-          .getByRole('button', { name: /subscribe/i })
-          .first()
-          .click()
+        await clickPopoverSubscribe(comfyPage.page)
         const dialog = comfyPage.page.getByRole('dialog')
         await expect(dialog).toBeVisible()
 

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -11,7 +11,7 @@ import type { Locator, Page } from '@playwright/test'
 import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelper'
 
 async function openUserPopover(page: Page): Promise<Locator> {
-  await page.getByTestId(TestIds.user.currentUserIndicator).click()
+  await page.getByTestId(TestIds.user.currentUserButton).click()
   const popover = page.getByTestId(TestIds.user.currentUserPopover)
   await expect(popover).toBeVisible()
   return popover
@@ -25,24 +25,31 @@ async function clickPopoverSubscribe(page: Page): Promise<void> {
     .click()
 }
 
-// Installs subscription mocks BEFORE comfyPage's first navigation via an
-// auto-fixture that depends on `page` (resolved before `comfyPage`).
+// Installs subscription mocks AFTER comfyPage.setup() and reloads the page
+// so `addInitScript` (which sets `window.__CONFIG__.subscription_required`)
+// applies before module-level reads in `ComfyRunButton/index.ts` evaluate.
+// Depending on `comfyPage` here forces ordering: comfyPage's auth + setup
+// runs first, then mocks are installed, then the page reloads with the
+// mocked config + intercepted endpoints in place.
 function createSubscriptionTest(
   ...defaultOps: Parameters<typeof createSubscriptionHelper>[1][]
 ) {
   return comfyPageFixture.extend<{
     subscriptionHelper: SubscriptionHelper
-    _subscriptionMocks: void
   }>({
-    subscriptionHelper: async ({ page }, use) => {
-      const helper = createSubscriptionHelper(page, ...defaultOps)
-      await use(helper)
-      await helper.clearMocks()
-    },
-    _subscriptionMocks: [
-      async ({ subscriptionHelper }, use) => {
-        await subscriptionHelper.mock()
-        await use()
+    subscriptionHelper: [
+      async ({ comfyPage }, use) => {
+        const helper = createSubscriptionHelper(comfyPage.page, ...defaultOps)
+        await helper.mock()
+        // Disable the cloud-subscription extension so it doesn't auto-open
+        // the subscription-required modal on app load (which would block
+        // clicks on the topbar buttons we're testing).
+        await comfyPage.setupSettings({
+          'Comfy.Extension.Disabled': ['Comfy.Cloud.Subscription']
+        })
+        await comfyPage.page.reload()
+        await use(helper)
+        await helper.clearMocks()
       },
       { auto: true }
     ]

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -82,6 +82,14 @@ function createSubscriptionTest(
           'Comfy.Extension.Disabled': ['Comfy.Cloud.Subscription']
         })
         await comfyPage.page.reload()
+        // Wait for Firebase auth to resolve: the user button is v-if="isLoggedIn"
+        // and only renders after onAuthStateChanged fires with the mock user from
+        // IndexedDB. waitForAppReady() does not wait for this — Firebase resolves
+        // asynchronously after app boot. Waiting here ensures the button is
+        // present before any test body tries to click it.
+        await expect(
+          comfyPage.page.getByTestId(TestIds.user.currentUserButton)
+        ).toBeVisible()
         // Defense-in-depth: if the dialog still surfaces (e.g. via a
         // different code path), dismiss it before the test runs.
         await dismissSubscriptionDialogIfOpen(comfyPage.page)

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -12,7 +12,9 @@ import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelpe
 
 async function openUserPopover(page: Page): Promise<Locator> {
   await page.getByTestId(TestIds.user.currentUserIndicator).click()
-  return page.getByTestId(TestIds.user.currentUserPopover)
+  const popover = page.getByTestId(TestIds.user.currentUserPopover)
+  await expect(popover).toBeVisible()
+  return popover
 }
 
 async function clickPopoverSubscribe(page: Page): Promise<void> {

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -25,6 +25,25 @@ async function clickPopoverSubscribe(page: Page): Promise<void> {
     .click()
 }
 
+// Closes the auto-opened subscription-required dialog if present.
+// Polls briefly because the dialog opens asynchronously after the
+// `isLoggedIn` watcher fires on app boot.
+async function dismissSubscriptionDialogIfOpen(page: Page): Promise<void> {
+  const dialog = page.getByRole('dialog')
+  try {
+    await dialog.waitFor({ state: 'visible', timeout: 2000 })
+  } catch {
+    return
+  }
+  const closeButton = dialog.getByRole('button', { name: /close/i }).first()
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click()
+  } else {
+    await page.keyboard.press('Escape')
+  }
+  await dialog.waitFor({ state: 'hidden' }).catch(() => {})
+}
+
 // Installs subscription mocks AFTER comfyPage.setup() and reloads the page
 // so `addInitScript` (which sets `window.__CONFIG__.subscription_required`)
 // applies before module-level reads in `ComfyRunButton/index.ts` evaluate.
@@ -41,13 +60,12 @@ function createSubscriptionTest(
       async ({ comfyPage }, use) => {
         const helper = createSubscriptionHelper(comfyPage.page, ...defaultOps)
         await helper.mock()
-        // Disable the cloud-subscription extension so it doesn't auto-open
-        // the subscription-required modal on app load (which would block
-        // clicks on the topbar buttons we're testing).
-        await comfyPage.setupSettings({
-          'Comfy.Extension.Disabled': ['Comfy.Cloud.Subscription']
-        })
         await comfyPage.page.reload()
+        // For unsubscribed status, the cloud build auto-opens the
+        // subscription-required modal whose backdrop intercepts pointer
+        // events on the topbar. Dismiss it so tests can interact with
+        // the buttons under test.
+        await dismissSubscriptionDialogIfOpen(comfyPage.page)
         await use(helper)
         await helper.clearMocks()
       },

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -19,10 +19,15 @@ async function openUserPopover(page: Page): Promise<Locator> {
 
 async function clickPopoverSubscribe(page: Page): Promise<void> {
   const popover = await openUserPopover(page)
+  // Use dispatchEvent instead of click() because the click opens the
+  // subscription dialog whose backdrop appears mid-action; Playwright's
+  // actionability re-check would otherwise see the mask intercepting and
+  // retry until timeout. The button is already known-visible from
+  // openUserPopover, so dispatching a synthetic click is safe here.
   await popover
     .getByRole('button', { name: /subscribe/i })
     .first()
-    .click()
+    .dispatchEvent('click')
 }
 
 // Closes the auto-opened subscription-required dialog if present.
@@ -60,11 +65,16 @@ function createSubscriptionTest(
       async ({ comfyPage }, use) => {
         const helper = createSubscriptionHelper(comfyPage.page, ...defaultOps)
         await helper.mock()
+        // Disable the cloud-subscription extension so its `requireActive
+        // Subscription` watcher doesn't auto-open the subscription dialog
+        // on app boot. The PrimeVue Dialog mask would otherwise intercept
+        // pointer events on every topbar button these tests interact with.
+        await comfyPage.setupSettings({
+          'Comfy.Extension.Disabled': ['Comfy.Cloud.Subscription']
+        })
         await comfyPage.page.reload()
-        // For unsubscribed status, the cloud build auto-opens the
-        // subscription-required modal whose backdrop intercepts pointer
-        // events on the topbar. Dismiss it so tests can interact with
-        // the buttons under test.
+        // Defense-in-depth: if the dialog still surfaces (e.g. via a
+        // different code path), dismiss it before the test runs.
         await dismissSubscriptionDialogIfOpen(comfyPage.page)
         await use(helper)
         await helper.clearMocks()

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -78,7 +78,9 @@ unsubscribedTest.describe(
         await comfyPage.page
           .getByTestId(TestIds.user.currentUserIndicator)
           .click()
-        const popover = comfyPage.page.locator('.current-user-popover')
+        const popover = comfyPage.page.getByTestId(
+          TestIds.user.currentUserPopover
+        )
         await expect(
           popover.getByRole('button', { name: /subscribe/i })
         ).toBeVisible()
@@ -91,7 +93,9 @@ unsubscribedTest.describe(
         await comfyPage.page
           .getByTestId(TestIds.user.currentUserIndicator)
           .click()
-        const popover = comfyPage.page.locator('.current-user-popover')
+        const popover = comfyPage.page.getByTestId(
+          TestIds.user.currentUserPopover
+        )
         await popover
           .getByRole('button', { name: /subscribe/i })
           .first()
@@ -130,7 +134,9 @@ unsubscribedTest.describe(
         await comfyPage.page
           .getByTestId(TestIds.user.currentUserIndicator)
           .click()
-        const popover = comfyPage.page.locator('.current-user-popover')
+        const popover = comfyPage.page.getByTestId(
+          TestIds.user.currentUserPopover
+        )
         await popover
           .getByRole('button', { name: /subscribe/i })
           .first()

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -34,7 +34,10 @@ async function clickPopoverSubscribe(page: Page): Promise<void> {
 // Polls briefly because the dialog opens asynchronously after the
 // `isLoggedIn` watcher fires on app boot.
 async function dismissSubscriptionDialogIfOpen(page: Page): Promise<void> {
-  const dialog = page.getByRole('dialog')
+  // Target only the subscription-required dialog by its known aria-labelledby
+  // key — avoids strict-mode violations when multiple GlobalDialog items are
+  // on the stack simultaneously.
+  const dialog = page.locator('[aria-labelledby="subscription-required"]')
   try {
     await dialog.waitFor({ state: 'visible', timeout: 2000 })
   } catch {
@@ -107,7 +110,9 @@ unsubscribedTest.describe(
         await comfyPage.page
           .getByTestId(TestIds.topbar.subscribeToRunButton)
           .click()
-        await expect(comfyPage.page.getByRole('dialog')).toBeVisible()
+        await expect(
+          comfyPage.page.locator('[aria-labelledby="subscription-required"]')
+        ).toBeVisible()
       }
     )
 
@@ -137,7 +142,9 @@ unsubscribedTest.describe(
       'User popover subscribe click opens dialog',
       async ({ comfyPage }) => {
         await clickPopoverSubscribe(comfyPage.page)
-        await expect(comfyPage.page.getByRole('dialog')).toBeVisible()
+        await expect(
+          comfyPage.page.locator('[aria-labelledby="subscription-required"]')
+        ).toBeVisible()
       }
     )
 
@@ -168,7 +175,11 @@ unsubscribedTest.describe(
       'Cleanup prevents stale subscription state after dialog close',
       async ({ comfyPage, subscriptionHelper }) => {
         await clickPopoverSubscribe(comfyPage.page)
-        const dialog = comfyPage.page.getByRole('dialog')
+        // Use the aria-labelledby key to target only the subscription dialog —
+        // avoids strict-mode violations when a second GlobalDialog is stacked.
+        const dialog = comfyPage.page.locator(
+          '[aria-labelledby="subscription-required"]'
+        )
         await expect(dialog).toBeVisible()
 
         await dialog.getByRole('button', { name: /close/i }).first().click()

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -11,7 +11,12 @@ import type { Locator, Page } from '@playwright/test'
 import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelper'
 
 async function openUserPopover(page: Page): Promise<Locator> {
-  await page.getByTestId(TestIds.user.currentUserButton).click()
+  // Use dispatchEvent instead of click() to bypass Playwright's actionability
+  // check — in the cloud environment a subscription dialog backdrop can be
+  // present during initial page load and would block a standard click.
+  await page
+    .getByTestId(TestIds.user.currentUserButton)
+    .dispatchEvent('click')
   const popover = page.getByTestId(TestIds.user.currentUserPopover)
   await expect(popover).toBeVisible()
   return popover

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -14,9 +14,7 @@ async function openUserPopover(page: Page): Promise<Locator> {
   // Use dispatchEvent instead of click() to bypass Playwright's actionability
   // check — in the cloud environment a subscription dialog backdrop can be
   // present during initial page load and would block a standard click.
-  await page
-    .getByTestId(TestIds.user.currentUserButton)
-    .dispatchEvent('click')
+  await page.getByTestId(TestIds.user.currentUserButton).dispatchEvent('click')
   const popover = page.getByTestId(TestIds.user.currentUserPopover)
   await expect(popover).toBeVisible()
   return popover

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -7,66 +7,11 @@ import {
   withFreeTier,
   withUnsubscribed
 } from '@e2e/fixtures/helpers/SubscriptionHelper'
-import type { Locator, Page } from '@playwright/test'
 import type { SubscriptionHelper } from '@e2e/fixtures/helpers/SubscriptionHelper'
-
-async function openUserPopover(page: Page): Promise<Locator> {
-  // Use dispatchEvent instead of click() to bypass Playwright's actionability
-  // check — in the cloud environment a subscription dialog backdrop can be
-  // present during initial page load and would block a standard click.
-  await page.getByTestId(TestIds.user.currentUserButton).dispatchEvent('click')
-  const popover = page.getByTestId(TestIds.user.currentUserPopover)
-  await expect(popover).toBeVisible()
-  return popover
-}
-
-async function clickPopoverSubscribe(page: Page): Promise<void> {
-  const popover = await openUserPopover(page)
-  // Use dispatchEvent instead of click() because the click opens the
-  // subscription dialog whose backdrop appears mid-action; Playwright's
-  // actionability re-check would otherwise see the mask intercepting and
-  // retry until timeout. The button is already known-visible from
-  // openUserPopover, so dispatching a synthetic click is safe here.
-  await popover
-    .getByRole('button', { name: /subscribe/i })
-    .first()
-    .dispatchEvent('click')
-}
-
-// Closes the auto-opened subscription-required dialog if present.
-// Polls briefly because the dialog opens asynchronously after the
-// `isLoggedIn` watcher fires on app boot.
-async function dismissSubscriptionDialogIfOpen(page: Page): Promise<void> {
-  // Target only the subscription-required dialog by its known aria-labelledby
-  // key — avoids strict-mode violations when multiple GlobalDialog items are
-  // on the stack simultaneously.
-  const dialog = page.locator('[aria-labelledby="subscription-required"]')
-  // Use expect with a short timeout: this is intentionally a "dismiss if open"
-  // helper, so absence of the dialog (TimeoutError) is not a failure — we
-  // discard only the timeout error, not any other unexpected exception.
-  const appeared = await expect(dialog)
-    .toBeVisible({ timeout: 2000 })
-    .then(() => true)
-    .catch((e: Error) => {
-      if (e.message.includes('Timeout')) return false
-      throw e
-    })
-  if (!appeared) return
-  const closeButton = dialog.getByRole('button', { name: /close/i }).first()
-  if (await closeButton.isVisible()) {
-    await closeButton.click()
-  } else {
-    await page.keyboard.press('Escape')
-  }
-  await expect(dialog).toBeHidden()
-}
 
 // Installs subscription mocks AFTER comfyPage.setup() and reloads the page
 // so `addInitScript` (which sets `window.__CONFIG__.subscription_required`)
 // applies before module-level reads in `ComfyRunButton/index.ts` evaluate.
-// Depending on `comfyPage` here forces ordering: comfyPage's auth + setup
-// runs first, then mocks are installed, then the page reloads with the
-// mocked config + intercepted endpoints in place.
 function createSubscriptionTest(
   ...defaultOps: Parameters<typeof createSubscriptionHelper>[1][]
 ) {
@@ -77,25 +22,19 @@ function createSubscriptionTest(
       async ({ comfyPage }, use) => {
         const helper = createSubscriptionHelper(comfyPage.page, ...defaultOps)
         await helper.mock()
-        // Disable the cloud-subscription extension so its `requireActive
-        // Subscription` watcher doesn't auto-open the subscription dialog
-        // on app boot. The PrimeVue Dialog mask would otherwise intercept
-        // pointer events on every topbar button these tests interact with.
+        // Disable the cloud-subscription extension so its `requireActiveSubscription`
+        // watcher doesn't auto-open the subscription dialog on app boot.
         await comfyPage.setupSettings({
           'Comfy.Extension.Disabled': ['Comfy.Cloud.Subscription']
         })
         await comfyPage.page.reload()
-        // Wait for Firebase auth to resolve: the user button is v-if="isLoggedIn"
-        // and only renders after onAuthStateChanged fires with the mock user from
-        // IndexedDB. waitForAppReady() does not wait for this — Firebase resolves
-        // asynchronously after app boot. Waiting here ensures the button is
-        // present before any test body tries to click it.
+        // Firebase auth resolves asynchronously after app boot — wait for the
+        // user button (v-if="isLoggedIn") before any test body interacts with it.
         await expect(
           comfyPage.page.getByTestId(TestIds.user.currentUserButton)
         ).toBeVisible()
-        // Defense-in-depth: if the dialog still surfaces (e.g. via a
-        // different code path), dismiss it before the test runs.
-        await dismissSubscriptionDialogIfOpen(comfyPage.page)
+        // Defense-in-depth: dismiss the dialog if it surfaces via a different code path.
+        await helper.dismissSubscriptionDialogIfOpen()
         await use(helper)
         await helper.clearMocks()
       },
@@ -135,6 +74,7 @@ unsubscribedTest.describe(
 
     unsubscribedTest(
       'SubscribeToRun shows short label at narrow viewport',
+      { tag: '@mobile' },
       async ({ comfyPage }) => {
         await comfyPage.page.setViewportSize({ width: 393, height: 851 })
         const btn = comfyPage.page.getByTestId(
@@ -147,8 +87,8 @@ unsubscribedTest.describe(
 
     unsubscribedTest(
       'User popover shows subscribe when unsubscribed',
-      async ({ comfyPage }) => {
-        const popover = await openUserPopover(comfyPage.page)
+      async ({ comfyPage, subscriptionHelper }) => {
+        const popover = await subscriptionHelper.openUserPopover()
         await expect(
           popover.getByRole('button', { name: /subscribe/i })
         ).toBeVisible()
@@ -157,8 +97,8 @@ unsubscribedTest.describe(
 
     unsubscribedTest(
       'User popover subscribe click opens dialog',
-      async ({ comfyPage }) => {
-        await clickPopoverSubscribe(comfyPage.page)
+      async ({ comfyPage, subscriptionHelper }) => {
+        await subscriptionHelper.clickPopoverSubscribe()
         await expect(
           comfyPage.page.locator('[aria-labelledby="subscription-required"]')
         ).toBeVisible()
@@ -172,8 +112,6 @@ unsubscribedTest.describe(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).toBeVisible()
 
-        // Simulate returning from Stripe checkout: seed pending checkout,
-        // mutate mock to return active subscription, trigger re-fetch.
         await subscriptionHelper.seedPendingCheckout('standard', 'monthly')
         subscriptionHelper.setStatus({
           is_active: true,
@@ -191,9 +129,7 @@ unsubscribedTest.describe(
     unsubscribedTest(
       'Cleanup prevents stale subscription state after dialog close',
       async ({ comfyPage, subscriptionHelper }) => {
-        await clickPopoverSubscribe(comfyPage.page)
-        // Use the aria-labelledby key to target only the subscription dialog —
-        // avoids strict-mode violations when a second GlobalDialog is stacked.
+        await subscriptionHelper.clickPopoverSubscribe()
         const dialog = comfyPage.page.locator(
           '[aria-labelledby="subscription-required"]'
         )
@@ -211,6 +147,9 @@ unsubscribedTest.describe(
         await subscriptionHelper.triggerSubscriptionRefetch()
 
         await expect(dialog).toBeHidden()
+        await expect(
+          comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
+        ).toBeHidden()
       }
     )
   }
@@ -221,7 +160,7 @@ subscribedTest.describe(
   { tag: '@cloud' },
   () => {
     subscribedTest(
-      'SubscribeToRun hidden when subscribed',
+      'Queue button visible and subscribe buttons hidden when subscribed',
       async ({ comfyPage }) => {
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.queueButton)
@@ -229,15 +168,6 @@ subscribedTest.describe(
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeToRunButton)
         ).toBeHidden()
-      }
-    )
-
-    subscribedTest(
-      'Topbar subscribe button hidden for paid tier',
-      async ({ comfyPage }) => {
-        await expect(
-          comfyPage.page.getByTestId(TestIds.topbar.queueButton)
-        ).toBeVisible()
         await expect(
           comfyPage.page.getByTestId(TestIds.topbar.subscribeButton)
         ).toBeHidden()

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -87,7 +87,7 @@ unsubscribedTest.describe(
 
     unsubscribedTest(
       'User popover shows subscribe when unsubscribed',
-      async ({ comfyPage, subscriptionHelper }) => {
+      async ({ subscriptionHelper }) => {
         const popover = await subscriptionHelper.openUserPopover()
         await expect(
           popover.getByRole('button', { name: /subscribe/i })

--- a/browser_tests/tests/subscription.spec.ts
+++ b/browser_tests/tests/subscription.spec.ts
@@ -74,7 +74,6 @@ unsubscribedTest.describe(
 
     unsubscribedTest(
       'SubscribeToRun shows short label at narrow viewport',
-      { tag: '@mobile' },
       async ({ comfyPage }) => {
         await comfyPage.page.setViewportSize({ width: 393, height: 851 })
         const btn = comfyPage.page.getByTestId(

--- a/src/components/topbar/CurrentUserButton.vue
+++ b/src/components/topbar/CurrentUserButton.vue
@@ -6,6 +6,7 @@
       class="p-1 hover:bg-transparent"
       variant="muted-textonly"
       :aria-label="$t('g.currentUser')"
+      data-testid="current-user-button"
       @click="popover?.toggle($event)"
     >
       <div

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -1,6 +1,7 @@
 <!-- A popover that shows current user information and actions -->
 <template>
   <div
+    data-testid="current-user-popover"
     class="current-user-popover -m-3 w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
   >
     <!-- User Info Section -->

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -1,6 +1,7 @@
 <!-- A popover that shows current user information and actions -->
 <template>
   <div
+    data-testid="current-user-popover"
     class="current-user-popover -m-3 w-fit max-w-96 min-w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
   >
     <!-- User Info Section -->


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Adds E2E Playwright tests for the untested `SubscribeButton.vue` and `SubscribeToRun.vue` components, plus a reusable subscription mock fixture module following the existing `AssetHelper` pattern.

## New Files

### `browser_tests/fixtures/data/subscriptionFixtures.ts`
Typed factory functions and named presets for subscription status and balance API responses, using `operations` types from `@comfyorg/registry-types`.

### `browser_tests/fixtures/helpers/SubscriptionHelper.ts`
Operator composition pattern mirroring `AssetHelper` — operators like `withActiveSubscription()`, `withFreeTier()`, `withCredits()`. Mocks `/customers/cloud-subscription-status`, `/customers/balance`, `/customers/cloud-subscription-checkout`. Supports mid-test mock mutation via `setStatus()` and Stripe checkout simulation via `seedPendingCheckout()` + `triggerSubscriptionRefetch()`.

### `browser_tests/tests/subscription.spec.ts`
10 test cases tagged `@cloud`:
- SubscribeToRun visibility, click-to-dialog, responsive label
- User popover subscribe button visibility and click-to-dialog
- Topbar subscribe button for free tier vs paid tier
- Subscription state transition (mock mutation + visibilitychange re-fetch)
- onBeforeUnmount cleanup (dialog close prevents stale watcher)

## Verification
- `pnpm typecheck:browser` ✅
- `pnpm exec eslint` ✅
- `pnpm exec oxlint` ✅
- `pnpm format:check` ✅
- Pre-commit hooks passed ✅
- Tests require `DISTRIBUTION=cloud` CI build

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11379-test-add-E2E-Playwright-tests-for-SubscribeButton-and-SubscribeToRun-3476d73d365081829180d339ddb6b790) by [Unito](https://www.unito.io)

---

## 🔀 Rebase & handoff status (2026-07-13)

**Status: APPROVED + green months ago → rotted on `main` (merge-skew) → now rebased onto current `main` → ready to merge.**

- Rebase resolved a popover `data-testid` conflict.
- **Fixed knip**: removed 9 dead fixture exports that `main`'s new knip gate now flags (they were unused).

- [x] Rebased onto current `main`
- [x] Popover data-testid conflict resolved
- [x] knip fixed (9 dead fixture exports removed)
- [x] Ready to merge — assigned to @christian-byrne