### PR TITLE
fix: harden e2e coverage workflow and fix GH Pages deploy

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend

--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
@@ -109,14 +111,16 @@ jobs:
           if [ ! -s coverage/playwright/coverage.lcov ]; then
             echo "No coverage data; generating placeholder report."
             mkdir -p coverage/html
-            echo '<html><body><h1>No E2E coverage data available for this run.</h1></body></html>' > coverage/html/index.html
+            WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+            echo "<html><body><h1>No E2E coverage data available for this run.</h1><p><a href=\"${WORKFLOW_URL}\">View workflow run</a></p></body></html>" > coverage/html/index.html
             exit 0
           fi
           genhtml coverage/playwright/coverage.lcov \
             -o coverage/html \
             --title "ComfyUI E2E Coverage" \
             --no-function-coverage \
-            --precision 1
+            --precision 1 \
+            --ignore-errors source
 
       - name: Upload HTML report artifact
         if: steps.coverage-shards.outputs.has-coverage == 'true'
@@ -130,7 +134,8 @@ jobs:
     needs: merge
     if: >
       github.event.workflow_run.head_branch == 'main' &&
-      needs.merge.outputs.has-coverage == 'true'
+      needs.merge.outputs.has-coverage == 'true' &&
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Problem

The GH Pages coverage deploy has been failing since #11291 merged — every `CI: E2E Coverage` workflow run errors out and https://comfy-org.github.io/ComfyUI_frontend/ returns 404.

Additionally, two correctness/security issues were identified in the workflow (filed as #11374 and #11375).

## Changes

1. **`--ignore-errors source` on genhtml** — merged LCOV data includes paths like `localhost-8188/assets/main-BRkC1B8m.js` from Playwright V8 coverage instrumented runtime bundles that don't exist as source files in CI, causing genhtml to error out
2. **Pin checkout to `workflow_run.head_sha`** — in `workflow_run` context, the default checkout ref points to the default branch, not the commit that triggered the upstream run; genhtml could annotate against wrong source files (#11375)
3. **Gate deploy on `event == 'push'`** — a fork branch named `main` could satisfy the branch check and overwrite production coverage; adding the event guard prevents this (#11375)
4. **Include workflow run link in placeholder HTML** — when no coverage data is available, the placeholder page now links back to the workflow run for debugging (#11374)

## Fixes

- Fixes the GH Pages 404 caused by #11291
- Fixes #11374
- Fixes #11375