### PR TITLE
fix: route progress_text feature flag check through getDevOverride

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -638,9 +638,7 @@ export class ComfyApi extends EventTarget {
                 let promptId: string | undefined
 
                 if (
-                  this.serverSupportsFeature(
-                    'supports_progress_text_metadata'
-                  )
+                  this.serverSupportsFeature('supports_progress_text_metadata')
                 ) {
                   const promptIdLength = rawView.getUint32(offset)
                   offset += 4

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -638,7 +638,9 @@ export class ComfyApi extends EventTarget {
                 let promptId: string | undefined
 
                 if (
-                  this.serverFeatureFlags.value?.supports_progress_text_metadata
+                  this.serverSupportsFeature(
+                    'supports_progress_text_metadata'
+                  )
                 ) {
                   const promptIdLength = rawView.getUint32(offset)
                   offset += 4


### PR DESCRIPTION
## Summary

Route the `progress_text` binary parser's feature-flag check through `serverSupportsFeature()` so dev overrides via `localStorage` take effect.

## Changes

- **What**: Replace `this.getClientFeatureFlags()?.supports_progress_text_metadata` with `this.serverSupportsFeature('supports_progress_text_metadata')` in the `case 3` binary message handler, consistent with all other feature-flag checks in the class.

## Review Focus

Minimal one-line change. The key consideration is that `serverSupportsFeature()` routes through `getDevOverride()` first, enabling `localStorage` overrides (`ff:supports_progress_text_metadata`) for dev testing of the binary wire format.

Fixes #11187

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11384-fix-route-progress_text-feature-flag-check-through-getDevOverride-3476d73d36508161bca0d6c2ea7c3c55) by [Unito](https://www.unito.io)
