### PR TITLE
test: clarify inert getClientFeatureFlags mock in progress_text binary parsing tests

### DIFF
--- a/src/scripts/api.featureFlags.test.ts
+++ b/src/scripts/api.featureFlags.test.ts
@@ -319,7 +319,7 @@ describe('API Feature Flags', () => {
     })
 
     it('should parse legacy format when server does not support progress_text_metadata', () => {
-      // Restore real getClientFeatureFlags (advertises support)
+      // Client advertises support; intentionally inert — parser checks serverFeatureFlags only
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_progress_text_metadata: true
       })
@@ -337,6 +337,7 @@ describe('API Feature Flags', () => {
     })
 
     it('should parse new format when server supports progress_text_metadata', () => {
+      // Client advertises support; intentionally inert — parser checks serverFeatureFlags only
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_progress_text_metadata: true
       })
@@ -359,6 +360,7 @@ describe('API Feature Flags', () => {
       // This is the exact bug scenario: client says it supports the flag,
       // server doesn't, but the decoder checks the client flag and tries
       // to parse a prompt_id that isn't there.
+      // Client advertises support; intentionally inert — parser checks serverFeatureFlags only
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_progress_text_metadata: true
       })


### PR DESCRIPTION
## Summary

Adds inline comments to three `vi.mocked(api.getClientFeatureFlags).mockReturnValue()` calls in the `progress_text binary message parsing` describe block, clarifying they are intentionally inert — the parser checks `serverFeatureFlags` only.

This prevents future readers from being confused about whether the mock has any effect.

- Fixes #11186

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11385-test-clarify-inert-getClientFeatureFlags-mock-in-progress_text-binary-parsing-tests-3476d73d365081a98c06c43c4737fdd9) by [Unito](https://www.unito.io)
