### PR TITLE
test: achieve 100% coverage on keybinding presetService

### DIFF
--- a/src/platform/keybindings/presetService.test.ts
+++ b/src/platform/keybindings/presetService.test.ts
@@ -207,6 +207,29 @@ describe('useKeybindingPresetService', () => {
         'g.keybindingPresets.deletePresetFailed'
       )
     })
+
+    it('does nothing when user cancels confirmation', async () => {
+      mockConfirm.mockResolvedValueOnce(false)
+
+      const service = await getPresetService()
+      await service.deletePreset('vim')
+
+      expect(mockApi.deleteUserData).not.toHaveBeenCalled()
+    })
+
+    it('does not reset to default when deleting a non-active preset', async () => {
+      mockApi.deleteUserData.mockResolvedValue(
+        new Response(null, { status: 200 })
+      )
+
+      store.currentPresetName = 'emacs'
+
+      const service = await getPresetService()
+      await service.deletePreset('vim')
+
+      expect(store.currentPresetName).toBe('emacs')
+      expect(mockPersistUserKeybindings).not.toHaveBeenCalled()
+    })
   })
 
   describe('exportPreset', () => {
@@ -233,6 +256,19 @@ describe('useKeybindingPresetService', () => {
 
       const service = await getPresetService()
       await expect(service.importPreset()).rejects.toThrow()
+    })
+
+    it('throws when file contains non-JSON content', async () => {
+      mockUploadFile.mockResolvedValue(
+        new File(['not valid json {{'], 'bad.json', {
+          type: 'application/json'
+        })
+      )
+
+      const service = await getPresetService()
+      await expect(service.importPreset()).rejects.toThrow(
+        'g.keybindingPresets.invalidPresetFile'
+      )
     })
 
     it('saves preset to storage and switches to it', async () => {
@@ -395,6 +431,31 @@ describe('useKeybindingPresetService', () => {
       const bindings = Object.values(store.getUserKeybindings())
       expect(bindings[0].commandId).toBe('new.cmd')
     })
+
+    it('applies unset bindings from preset', async () => {
+      store.addDefaultKeybinding(
+        new KeybindingImpl({
+          commandId: 'test.selectAll',
+          combo: { key: 'a', ctrl: true }
+        })
+      )
+
+      const preset: KeybindingPreset = {
+        name: 'vim',
+        newBindings: [],
+        unsetBindings: [
+          { commandId: 'test.selectAll', combo: { key: 'a', ctrl: true } }
+        ]
+      }
+
+      const service = await getPresetService()
+      service.applyPreset(preset)
+
+      expect(store.currentPresetName).toBe('vim')
+      const unset = Object.values(store.getUserUnsetKeybindings())
+      expect(unset).toHaveLength(1)
+      expect(unset[0].commandId).toBe('test.selectAll')
+    })
   })
 
   describe('switchPreset', () => {
@@ -513,6 +574,84 @@ describe('useKeybindingPresetService', () => {
 
       expect(mockShowSmallLayoutDialog).not.toHaveBeenCalled()
       expect(store.currentPresetName).toBe('vim')
+    })
+
+    it('prompts save-as-new when modified default preset and user chooses save', async () => {
+      store.addUserKeybinding(
+        new KeybindingImpl({
+          commandId: 'dirty.cmd',
+          combo: { key: 'X', ctrl: true }
+        })
+      )
+
+      // promptAndSaveNewPreset succeeds
+      mockApi.listUserDataFullInfo.mockResolvedValueOnce([])
+      mockApi.storeUserData.mockResolvedValueOnce(new Response())
+
+      const targetPreset: KeybindingPreset = {
+        name: 'vim',
+        newBindings: [
+          { commandId: 'vim.cmd', combo: { key: 'J', ctrl: false } }
+        ],
+        unsetBindings: []
+      }
+      mockApi.getUserData.mockResolvedValueOnce(
+        new Response(JSON.stringify(targetPreset), { status: 200 })
+      )
+
+      const service = await getPresetService()
+      await service.switchPreset('vim')
+
+      expect(mockPrompt).toHaveBeenCalled()
+      expect(store.currentPresetName).toBe('vim')
+    })
+
+    it('cancels switch when modified default preset and save-as-new is cancelled', async () => {
+      store.addUserKeybinding(
+        new KeybindingImpl({
+          commandId: 'dirty.cmd',
+          combo: { key: 'X', ctrl: true }
+        })
+      )
+
+      // promptAndSaveNewPreset returns false (user cancels prompt)
+      mockPrompt.mockResolvedValueOnce(null)
+
+      const service = await getPresetService()
+      await service.switchPreset('vim')
+
+      expect(mockApi.getUserData).not.toHaveBeenCalled()
+      expect(store.currentPresetName).toBe('default')
+    })
+
+    it('switches to default target after unsaved changes dialog', async () => {
+      store.currentPresetName = 'my-preset'
+      store.savedPresetData = {
+        name: 'my-preset',
+        newBindings: [],
+        unsetBindings: []
+      }
+      store.addUserKeybinding(
+        new KeybindingImpl({
+          commandId: 'dirty.cmd',
+          combo: { key: 'X', ctrl: true }
+        })
+      )
+
+      // Dialog returns false (discard)
+      mockShowSmallLayoutDialog.mockImplementationOnce(
+        (options: Record<string, unknown>) => {
+          const props = options.props as Record<string, unknown> | undefined
+          const onResult = props?.onResult as ((v: boolean) => void) | undefined
+          onResult?.(false)
+        }
+      )
+
+      const service = await getPresetService()
+      await service.switchPreset('default')
+
+      expect(store.currentPresetName).toBe('default')
+      expect(store.savedPresetData).toBeNull()
     })
   })
 


### PR DESCRIPTION
## Summary

Add 7 new unit tests to achieve 100% statement/branch/function/line coverage on `src/platform/keybindings/presetService.ts`.

## Changes

- **What**: 7 new tests in `presetService.test.ts` covering previously-uncovered paths: importPreset JSON parse error, deletePreset cancel/non-active preset, applyPreset with unset bindings, switchPreset save-as-new flow (success and cancel), switchPreset to default after unsaved changes dialog. Cherry-picked source files from 944f78adf since they did not exist on this branch.

## Review Focus

Test quality and mock setup correctness. The source files are unchanged from 944f78adf.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11399-test-achieve-100-coverage-on-keybinding-presetService-3476d73d36508196b78dfd8f0f6f751c) by [Unito](https://www.unito.io)
