### PR TITLE
test: add MembersPanelContent unit tests

### DIFF
--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,0 +1,745 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import MembersPanelContent from './MembersPanelContent.vue'
+
+import type {
+  PendingInvite,
+  WorkspaceMember
+} from '../../../stores/teamWorkspaceStore'
+
+const mockToastAdd = vi.fn()
+const mockShowRemoveMemberDialog = vi.fn()
+const mockShowRevokeInviteDialog = vi.fn()
+const mockShowCreateWorkspaceDialog = vi.fn()
+const mockCopyInviteLink = vi.fn()
+const mockShowSubscriptionDialog = vi.fn()
+
+const {
+  mockMembers,
+  mockPendingInvites,
+  mockIsInPersonalWorkspace,
+  mockPermissions,
+  mockUiConfig,
+  mockIsActiveSubscription,
+  mockSubscription
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+
+  return {
+    mockMembers: ref<WorkspaceMember[]>([]),
+    mockPendingInvites: ref<PendingInvite[]>([]),
+    mockIsInPersonalWorkspace: ref(false),
+    mockPermissions: ref({
+      canViewOtherMembers: true,
+      canViewPendingInvites: true,
+      canInviteMembers: true,
+      canManageInvites: true,
+      canRemoveMembers: true,
+      canLeaveWorkspace: true,
+      canAccessWorkspaceMenu: true,
+      canManageSubscription: true,
+      canTopUp: true
+    }),
+    mockUiConfig: ref({
+      showMembersList: true,
+      showPendingTab: true,
+      showSearch: true,
+      showDateColumn: true,
+      showRoleBadge: true,
+      membersGridCols: 'grid-cols-[50%_40%_10%]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[50%_40%_10%]',
+      showEditWorkspaceMenuItem: true,
+      workspaceMenuAction: 'delete' as 'leave' | 'delete' | null,
+      workspaceMenuDisabledTooltip: null as string | null
+    }),
+    mockIsActiveSubscription: ref(true),
+    mockSubscription: ref<{ tier: string } | null>({ tier: 'PRO' })
+  }
+})
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mockToastAdd })
+}))
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    members: mockMembers,
+    pendingInvites: mockPendingInvites,
+    isInPersonalWorkspace: mockIsInPersonalWorkspace,
+    copyInviteLink: mockCopyInviteLink
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: mockPermissions,
+    uiConfig: mockUiConfig
+  })
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    userPhotoUrl: ref(null),
+    userEmail: ref('owner@example.com'),
+    userDisplayName: ref('Owner User')
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: mockIsActiveSubscription,
+    subscription: mockSubscription,
+    showSubscriptionDialog: mockShowSubscriptionDialog,
+    getMaxSeats: (tierKey: string) => {
+      const seats: Record<string, number> = {
+        free: 1,
+        standard: 1,
+        creator: 5,
+        pro: 20
+      }
+      return seats[tierKey] ?? 1
+    }
+  })
+}))
+
+vi.mock('@/platform/cloud/subscription/constants/tierPricing', () => ({
+  TIER_TO_KEY: {
+    FREE: 'free',
+    STANDARD: 'standard',
+    CREATOR: 'creator',
+    PRO: 'pro',
+    FOUNDERS_EDITION: 'founder'
+  }
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showRemoveMemberDialog: mockShowRemoveMemberDialog,
+    showRevokeInviteDialog: mockShowRevokeInviteDialog,
+    showCreateWorkspaceDialog: mockShowCreateWorkspaceDialog
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+const ButtonStub = {
+  name: 'Button',
+  template:
+    '<button :disabled="disabled" :aria-label="ariaLabel" @click="$emit(\'click\', $event)"><slot /></button>',
+  props: ['disabled', 'loading', 'variant', 'size', 'ariaLabel']
+}
+
+const SearchInputStub = {
+  name: 'SearchInput',
+  template:
+    '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  props: ['modelValue', 'placeholder', 'size'],
+  emits: ['update:modelValue']
+}
+
+const MenuStub = {
+  name: 'Menu',
+  template: '<div />',
+  props: ['model', 'popup'],
+  methods: {
+    toggle() {}
+  }
+}
+
+function renderComponent() {
+  return render(MembersPanelContent, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Button: ButtonStub,
+        SearchInput: SearchInputStub,
+        UserAvatar: true,
+        Menu: MenuStub
+      },
+      directives: {
+        tooltip: () => {}
+      }
+    }
+  })
+}
+
+function createMember(
+  overrides: Partial<WorkspaceMember> = {}
+): WorkspaceMember {
+  return {
+    id: 'member-1',
+    name: 'Member One',
+    email: 'member1@example.com',
+    joinDate: new Date('2025-01-15'),
+    role: 'member',
+    ...overrides
+  }
+}
+
+function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
+  return {
+    id: 'invite-1',
+    email: 'invitee@example.com',
+    token: 'token-abc',
+    inviteDate: new Date('2025-03-01'),
+    expiryDate: new Date('2025-04-01'),
+    ...overrides
+  }
+}
+
+function setOwnerTeamWorkspace(members: WorkspaceMember[] = []) {
+  mockIsInPersonalWorkspace.value = false
+  mockPermissions.value = {
+    canViewOtherMembers: true,
+    canViewPendingInvites: true,
+    canInviteMembers: true,
+    canManageInvites: true,
+    canRemoveMembers: true,
+    canLeaveWorkspace: true,
+    canAccessWorkspaceMenu: true,
+    canManageSubscription: true,
+    canTopUp: true
+  }
+  mockUiConfig.value = {
+    showMembersList: true,
+    showPendingTab: true,
+    showSearch: true,
+    showDateColumn: true,
+    showRoleBadge: true,
+    membersGridCols: 'grid-cols-[50%_40%_10%]',
+    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+    headerGridCols: 'grid-cols-[50%_40%_10%]',
+    showEditWorkspaceMenuItem: true,
+    workspaceMenuAction: 'delete',
+    workspaceMenuDisabledTooltip: null
+  }
+  mockIsActiveSubscription.value = true
+  mockSubscription.value = { tier: 'PRO' }
+  mockMembers.value = members
+}
+
+function setMemberTeamWorkspace(members: WorkspaceMember[] = []) {
+  mockIsInPersonalWorkspace.value = false
+  mockPermissions.value = {
+    canViewOtherMembers: true,
+    canViewPendingInvites: false,
+    canInviteMembers: false,
+    canManageInvites: false,
+    canRemoveMembers: false,
+    canLeaveWorkspace: true,
+    canAccessWorkspaceMenu: true,
+    canManageSubscription: false,
+    canTopUp: false
+  }
+  mockUiConfig.value = {
+    showMembersList: true,
+    showPendingTab: false,
+    showSearch: true,
+    showDateColumn: true,
+    showRoleBadge: true,
+    membersGridCols: 'grid-cols-[1fr_auto]',
+    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+    headerGridCols: 'grid-cols-[1fr_auto]',
+    showEditWorkspaceMenuItem: false,
+    workspaceMenuAction: 'leave',
+    workspaceMenuDisabledTooltip: null
+  }
+  mockIsActiveSubscription.value = true
+  mockSubscription.value = { tier: 'PRO' }
+  mockMembers.value = members
+}
+
+function setPersonalWorkspace() {
+  mockIsInPersonalWorkspace.value = true
+  mockPermissions.value = {
+    canViewOtherMembers: false,
+    canViewPendingInvites: false,
+    canInviteMembers: false,
+    canManageInvites: false,
+    canRemoveMembers: false,
+    canLeaveWorkspace: false,
+    canAccessWorkspaceMenu: false,
+    canManageSubscription: true,
+    canTopUp: true
+  }
+  mockUiConfig.value = {
+    showMembersList: false,
+    showPendingTab: false,
+    showSearch: false,
+    showDateColumn: false,
+    showRoleBadge: false,
+    membersGridCols: 'grid-cols-1',
+    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+    headerGridCols: 'grid-cols-1',
+    showEditWorkspaceMenuItem: false,
+    workspaceMenuAction: null,
+    workspaceMenuDisabledTooltip: null
+  }
+  mockMembers.value = []
+  mockPendingInvites.value = []
+}
+
+function setSingleSeatPlan() {
+  mockIsInPersonalWorkspace.value = false
+  mockIsActiveSubscription.value = true
+  mockSubscription.value = { tier: 'STANDARD' }
+  mockMembers.value = []
+}
+
+function bodyText() {
+  return document.body.textContent ?? ''
+}
+
+async function switchToPendingTab() {
+  const pendingBtn = screen.getByRole('button', { name: /pendingCount/ })
+  await userEvent.click(pendingBtn)
+  await nextTick()
+}
+
+describe('MembersPanelContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMembers.value = []
+    mockPendingInvites.value = []
+    mockIsInPersonalWorkspace.value = false
+    mockIsActiveSubscription.value = true
+    mockSubscription.value = { tier: 'PRO' }
+    mockPermissions.value = {
+      canViewOtherMembers: true,
+      canViewPendingInvites: true,
+      canInviteMembers: true,
+      canManageInvites: true,
+      canRemoveMembers: true,
+      canLeaveWorkspace: true,
+      canAccessWorkspaceMenu: true,
+      canManageSubscription: true,
+      canTopUp: true
+    }
+    mockUiConfig.value = {
+      showMembersList: true,
+      showPendingTab: true,
+      showSearch: true,
+      showDateColumn: true,
+      showRoleBadge: true,
+      membersGridCols: 'grid-cols-[50%_40%_10%]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[50%_40%_10%]',
+      showEditWorkspaceMenuItem: true,
+      workspaceMenuAction: 'delete',
+      workspaceMenuDisabledTooltip: null
+    }
+  })
+
+  describe('personal workspace', () => {
+    it('shows current user with "(you)" label', () => {
+      setPersonalWorkspace()
+      renderComponent()
+      expect(bodyText()).toContain('Owner User')
+      expect(bodyText()).toContain('g.you')
+    })
+
+    it('shows personal workspace message and create workspace button', () => {
+      setPersonalWorkspace()
+      renderComponent()
+      expect(bodyText()).toContain(
+        'workspacePanel.members.personalWorkspaceMessage'
+      )
+      expect(bodyText()).toContain('workspacePanel.members.createNewWorkspace')
+    })
+
+    it('calls showCreateWorkspaceDialog when create workspace is clicked', async () => {
+      setPersonalWorkspace()
+      renderComponent()
+      const createBtn = screen.getByText(
+        'workspacePanel.members.createNewWorkspace'
+      )
+      await userEvent.click(createBtn)
+      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalled()
+    })
+
+    it('does not show search input', () => {
+      setPersonalWorkspace()
+      renderComponent()
+      expect(screen.queryByRole('textbox')).toBeNull()
+    })
+  })
+
+  describe('team workspace - owner view', () => {
+    it('renders member list with names and emails', () => {
+      const owner = createMember({
+        id: 'owner-1',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'owner'
+      })
+      const member = createMember({
+        id: 'member-2',
+        name: 'Team Member',
+        email: 'team@example.com'
+      })
+      setOwnerTeamWorkspace([owner, member])
+      renderComponent()
+
+      expect(bodyText()).toContain('Owner User')
+      expect(bodyText()).toContain('Team Member')
+      expect(bodyText()).toContain('owner@example.com')
+      expect(bodyText()).toContain('team@example.com')
+    })
+
+    it('shows role badges', () => {
+      const owner = createMember({
+        id: 'owner-1',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'owner'
+      })
+      const member = createMember({
+        id: 'member-2',
+        name: 'Team Member',
+        email: 'team@example.com',
+        role: 'member'
+      })
+      setOwnerTeamWorkspace([owner, member])
+      renderComponent()
+
+      expect(bodyText()).toContain('workspaceSwitcher.roleOwner')
+      expect(bodyText()).toContain('workspaceSwitcher.roleMember')
+    })
+
+    it('shows "(you)" label next to current user', () => {
+      const currentUser = createMember({
+        id: 'owner-1',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'owner'
+      })
+      setOwnerTeamWorkspace([currentUser])
+      renderComponent()
+      expect(bodyText()).toContain('g.you')
+    })
+
+    it('shows more options button for non-current members', () => {
+      const owner = createMember({
+        id: 'owner-1',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'owner'
+      })
+      const other = createMember({
+        id: 'member-2',
+        name: 'Other',
+        email: 'other@example.com'
+      })
+      setOwnerTeamWorkspace([owner, other])
+      renderComponent()
+
+      const moreButtons = screen.queryAllByRole('button', {
+        name: 'g.moreOptions'
+      })
+      expect(moreButtons).toHaveLength(1)
+    })
+
+    it('does not show more options button for self', () => {
+      const currentUser = createMember({
+        id: 'owner-1',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'owner'
+      })
+      setOwnerTeamWorkspace([currentUser])
+      renderComponent()
+
+      const moreButtons = screen.queryAllByRole('button', {
+        name: 'g.moreOptions'
+      })
+      expect(moreButtons).toHaveLength(0)
+    })
+
+    it('shows pending tab button', () => {
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = [createInvite()]
+      renderComponent()
+      expect(bodyText()).toContain('workspacePanel.members.tabs.pendingCount')
+    })
+  })
+
+  describe('team workspace - member view', () => {
+    it('does not show remove member buttons', () => {
+      const members = [
+        createMember({
+          id: 'owner-1',
+          name: 'The Owner',
+          email: 'boss@example.com',
+          role: 'owner'
+        }),
+        createMember({
+          id: 'me',
+          name: 'Owner User',
+          email: 'owner@example.com',
+          role: 'member'
+        })
+      ]
+      setMemberTeamWorkspace(members)
+      renderComponent()
+
+      const moreButtons = screen.queryAllByRole('button', {
+        name: 'g.moreOptions'
+      })
+      expect(moreButtons).toHaveLength(0)
+    })
+
+    it('does not show pending tab', () => {
+      setMemberTeamWorkspace([])
+      renderComponent()
+      expect(bodyText()).not.toContain(
+        'workspacePanel.members.tabs.pendingCount'
+      )
+    })
+  })
+
+  describe('member sorting', () => {
+    it('sorts owners first, current user second, then rest', () => {
+      const owner = createMember({
+        id: 'owner-1',
+        name: 'The Owner',
+        email: 'boss@example.com',
+        role: 'owner',
+        joinDate: new Date('2025-03-01')
+      })
+      const currentUser = createMember({
+        id: 'me',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'member',
+        joinDate: new Date('2025-02-01')
+      })
+      const other = createMember({
+        id: 'other',
+        name: 'Other Member',
+        email: 'other@example.com',
+        role: 'member',
+        joinDate: new Date('2025-01-01')
+      })
+      setOwnerTeamWorkspace([other, currentUser, owner])
+      renderComponent()
+      const text = bodyText()
+      const ownerIdx = text.indexOf('The Owner')
+      const currentIdx = text.indexOf('Owner User')
+      const otherIdx = text.indexOf('Other Member')
+      expect(ownerIdx).toBeLessThan(currentIdx)
+      expect(currentIdx).toBeLessThan(otherIdx)
+    })
+  })
+
+  describe('search filtering', () => {
+    it('filters members by name', async () => {
+      const alice = createMember({
+        id: '1',
+        name: 'Alice',
+        email: 'alice@example.com'
+      })
+      const bob = createMember({
+        id: '2',
+        name: 'Bob',
+        email: 'bob@example.com'
+      })
+      setOwnerTeamWorkspace([alice, bob])
+      renderComponent()
+
+      const searchInput = screen.getByRole('textbox')
+      await fireEvent.update(searchInput, 'Alice')
+      await nextTick()
+
+      expect(bodyText()).toContain('Alice')
+      expect(bodyText()).not.toContain('Bob')
+    })
+
+    it('filters members by email', async () => {
+      const alice = createMember({
+        id: '1',
+        name: 'Alice',
+        email: 'alice@example.com'
+      })
+      const bob = createMember({
+        id: '2',
+        name: 'Bob',
+        email: 'bob@example.com'
+      })
+      setOwnerTeamWorkspace([alice, bob])
+      renderComponent()
+
+      const searchInput = screen.getByRole('textbox')
+      await fireEvent.update(searchInput, 'bob@')
+      await nextTick()
+
+      expect(bodyText()).not.toContain('Alice')
+      expect(bodyText()).toContain('Bob')
+    })
+  })
+
+  describe('pending invites', () => {
+    it('shows invite email and initial', async () => {
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = [createInvite({ email: 'test@example.com' })]
+      renderComponent()
+
+      await switchToPendingTab()
+
+      expect(bodyText()).toContain('test@example.com')
+      expect(bodyText()).toContain('test')
+      expect(bodyText()).toContain('T')
+    })
+
+    it('shows no invites message when empty', async () => {
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = []
+      renderComponent()
+      await switchToPendingTab()
+
+      expect(bodyText()).toContain('workspacePanel.members.noInvites')
+    })
+
+    it('triggers revoke invite dialog', async () => {
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = [createInvite({ id: 'inv-42' })]
+      renderComponent()
+      await switchToPendingTab()
+
+      const revokeBtn = screen.getByRole('button', {
+        name: 'workspacePanel.members.actions.revokeInvite'
+      })
+      await userEvent.click(revokeBtn)
+
+      expect(mockShowRevokeInviteDialog).toHaveBeenCalledWith('inv-42')
+    })
+
+    it('copies invite link and shows success toast', async () => {
+      mockCopyInviteLink.mockResolvedValue(undefined)
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = [createInvite({ id: 'inv-42' })]
+      renderComponent()
+      await switchToPendingTab()
+
+      const copyBtn = screen.getByRole('button', {
+        name: 'workspacePanel.members.actions.copyLink'
+      })
+      await userEvent.click(copyBtn)
+      await nextTick()
+
+      expect(mockCopyInviteLink).toHaveBeenCalledWith('inv-42')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'success' })
+      )
+    })
+
+    it('shows error toast when copy invite link fails', async () => {
+      mockCopyInviteLink.mockRejectedValue(new Error('fail'))
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = [createInvite({ id: 'inv-42' })]
+      renderComponent()
+      await switchToPendingTab()
+
+      const copyBtn = screen.getByRole('button', {
+        name: 'workspacePanel.members.actions.copyLink'
+      })
+      await userEvent.click(copyBtn)
+      await nextTick()
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+
+    it('filters pending invites by search query', async () => {
+      setOwnerTeamWorkspace([])
+      mockPendingInvites.value = [
+        createInvite({ id: 'i1', email: 'alice@test.com' }),
+        createInvite({ id: 'i2', email: 'bob@test.com' })
+      ]
+      renderComponent()
+      await switchToPendingTab()
+
+      const searchInput = screen.getByRole('textbox')
+      await fireEvent.update(searchInput, 'alice')
+      await nextTick()
+
+      expect(bodyText()).toContain('alice@test.com')
+      expect(bodyText()).not.toContain('bob@test.com')
+    })
+  })
+
+  describe('single seat plan', () => {
+    it('shows upsell banner', () => {
+      setSingleSeatPlan()
+      renderComponent()
+      expect(bodyText()).toContain('workspacePanel.members.upsellBannerUpgrade')
+      expect(bodyText()).toContain('workspacePanel.members.viewPlans')
+    })
+
+    it('shows subscribe message when no active subscription', () => {
+      mockIsInPersonalWorkspace.value = false
+      mockIsActiveSubscription.value = false
+      mockSubscription.value = null
+      mockMembers.value = []
+      renderComponent()
+      expect(bodyText()).toContain(
+        'workspacePanel.members.upsellBannerSubscribe'
+      )
+    })
+
+    it('opens subscription dialog when view plans is clicked', async () => {
+      setSingleSeatPlan()
+      renderComponent()
+      const viewPlansBtn = screen.getByRole('button', {
+        name: /workspacePanel\.members\.viewPlans/
+      })
+      await userEvent.click(viewPlansBtn)
+      expect(mockShowSubscriptionDialog).toHaveBeenCalled()
+    })
+
+    it('hides search input', () => {
+      setSingleSeatPlan()
+      mockUiConfig.value.showSearch = true
+      renderComponent()
+      expect(screen.queryByRole('textbox')).toBeNull()
+    })
+  })
+
+  describe('member count display', () => {
+    it('shows member count with maxSeats for team workspace', () => {
+      setOwnerTeamWorkspace([
+        createMember({ id: '1', email: 'a@b.com' }),
+        createMember({ id: '2', email: 'c@d.com' })
+      ])
+      renderComponent()
+      expect(bodyText()).toContain('workspacePanel.members.membersCount')
+    })
+
+    it('shows count of 1 for personal workspace', () => {
+      setPersonalWorkspace()
+      renderComponent()
+      expect(bodyText()).toContain('workspacePanel.members.membersCount')
+    })
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/vue'
+import { fireEvent, render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
@@ -663,12 +663,12 @@ describe('MembersPanelContent', () => {
         name: 'workspacePanel.members.actions.copyLink'
       })
       await userEvent.click(copyBtn)
-      await nextTick()
-      await new Promise((r) => setTimeout(r, 0))
 
-      expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({ severity: 'error' })
-      )
+      await waitFor(() => {
+        expect(mockToastAdd).toHaveBeenCalledWith(
+          expect.objectContaining({ severity: 'error' })
+        )
+      })
     })
 
     it('filters pending invites by search query', async () => {

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import MembersPanelContent from './MembersPanelContent.vue'
@@ -11,21 +11,25 @@ import type {
   WorkspaceMember
 } from '../../../stores/teamWorkspaceStore'
 
-const mockToastAdd = vi.fn()
-const mockShowRemoveMemberDialog = vi.fn()
-const mockShowRevokeInviteDialog = vi.fn()
-const mockShowCreateWorkspaceDialog = vi.fn()
-const mockCopyInviteLink = vi.fn()
+const mockHandleCopyInviteLink = vi.fn()
+const mockHandleRevokeInvite = vi.fn()
+const mockHandleCreateWorkspace = vi.fn()
 const mockShowSubscriptionDialog = vi.fn()
+const mockSelectMember = vi.fn()
+const mockToggleSort = vi.fn()
 
 const {
   mockMembers,
   mockPendingInvites,
-  mockIsInPersonalWorkspace,
-  mockPermissions,
-  mockUiConfig,
+  mockFilteredMembers,
+  mockFilteredPendingInvites,
+  mockIsPersonalWorkspace,
+  mockIsSingleSeatPlan,
   mockIsActiveSubscription,
-  mockSubscription
+  mockActiveView,
+  mockSearchQuery,
+  mockPermissions,
+  mockUiConfig
 } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
   const { ref } = require('vue') as typeof import('vue')
@@ -33,7 +37,13 @@ const {
   return {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
-    mockIsInPersonalWorkspace: ref(false),
+    mockFilteredMembers: ref<WorkspaceMember[]>([]),
+    mockFilteredPendingInvites: ref<PendingInvite[]>([]),
+    mockIsPersonalWorkspace: ref(false),
+    mockIsSingleSeatPlan: ref(false),
+    mockIsActiveSubscription: ref(true),
+    mockActiveView: ref<'active' | 'pending'>('active'),
+    mockSearchQuery: ref(''),
     mockPermissions: ref({
       canViewOtherMembers: true,
       canViewPendingInvites: true,
@@ -57,80 +67,42 @@ const {
       showEditWorkspaceMenuItem: true,
       workspaceMenuAction: 'delete' as 'leave' | 'delete' | null,
       workspaceMenuDisabledTooltip: null as string | null
-    }),
-    mockIsActiveSubscription: ref(true),
-    mockSubscription: ref<{ tier: string } | null>({ tier: 'PRO' })
+    })
   }
 })
 
-vi.mock('primevue/usetoast', () => ({
-  useToast: () => ({ add: mockToastAdd })
-}))
-
-vi.mock('pinia', async (importOriginal) => {
-  const actual = await importOriginal()
-  return {
-    ...(actual as object),
-    storeToRefs: (store: Record<string, unknown>) => store
-  }
-})
-
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
+vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
+  useMembersPanel: () => ({
+    searchQuery: mockSearchQuery,
+    activeView: mockActiveView,
+    maxSeats: computed(() => 20),
+    isSingleSeatPlan: mockIsSingleSeatPlan,
+    personalWorkspaceMember: computed(() => ({
+      id: 'self',
+      name: 'Owner User',
+      email: 'owner@example.com',
+      role: 'owner' as const,
+      joinDate: new Date(0)
+    })),
+    filteredMembers: mockFilteredMembers,
+    filteredPendingInvites: mockFilteredPendingInvites,
+    memberMenuItems: computed(() => []),
+    isPersonalWorkspace: mockIsPersonalWorkspace,
     members: mockMembers,
     pendingInvites: mockPendingInvites,
-    isInPersonalWorkspace: mockIsInPersonalWorkspace,
-    copyInviteLink: mockCopyInviteLink
-  })
-}))
-
-vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
-  useWorkspaceUI: () => ({
     permissions: mockPermissions,
-    uiConfig: mockUiConfig
-  })
-}))
-
-vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({
-    userPhotoUrl: ref(null),
-    userEmail: ref('owner@example.com'),
-    userDisplayName: ref('Owner User')
-  })
-}))
-
-vi.mock('@/composables/billing/useBillingContext', () => ({
-  useBillingContext: () => ({
+    uiConfig: mockUiConfig,
     isActiveSubscription: mockIsActiveSubscription,
-    subscription: mockSubscription,
+    userPhotoUrl: ref(null),
+    isCurrentUser: (m: WorkspaceMember) =>
+      m.email.toLowerCase() === 'owner@example.com',
+    selectMember: mockSelectMember,
+    toggleSort: mockToggleSort,
     showSubscriptionDialog: mockShowSubscriptionDialog,
-    getMaxSeats: (tierKey: string) => {
-      const seats: Record<string, number> = {
-        free: 1,
-        standard: 1,
-        creator: 5,
-        pro: 20
-      }
-      return seats[tierKey] ?? 1
-    }
-  })
-}))
-
-vi.mock('@/platform/cloud/subscription/constants/tierPricing', () => ({
-  TIER_TO_KEY: {
-    FREE: 'free',
-    STANDARD: 'standard',
-    CREATOR: 'creator',
-    PRO: 'pro',
-    FOUNDERS_EDITION: 'founder'
-  }
-}))
-
-vi.mock('@/services/dialogService', () => ({
-  useDialogService: () => ({
-    showRemoveMemberDialog: mockShowRemoveMemberDialog,
-    showRevokeInviteDialog: mockShowRevokeInviteDialog,
-    showCreateWorkspaceDialog: mockShowCreateWorkspaceDialog
+    handleCopyInviteLink: mockHandleCopyInviteLink,
+    handleRevokeInvite: mockHandleRevokeInvite,
+    handleCreateWorkspace: mockHandleCreateWorkspace,
+    handleRemoveMember: vi.fn()
   })
 }))
 
@@ -157,15 +129,6 @@ const SearchInputStub = {
   emits: ['update:modelValue']
 }
 
-const MenuStub = {
-  name: 'Menu',
-  template: '<div />',
-  props: ['model', 'popup'],
-  methods: {
-    toggle() {}
-  }
-}
-
 function renderComponent() {
   return render(MembersPanelContent, {
     global: {
@@ -174,11 +137,9 @@ function renderComponent() {
         Button: ButtonStub,
         SearchInput: SearchInputStub,
         UserAvatar: true,
-        Menu: MenuStub
+        Menu: { template: '<div />', props: ['model', 'popup'] }
       },
-      directives: {
-        tooltip: () => {}
-      }
+      directives: { tooltip: () => {} }
     }
   })
 }
@@ -207,123 +168,18 @@ function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
   }
 }
 
-function setOwnerTeamWorkspace(members: WorkspaceMember[] = []) {
-  mockIsInPersonalWorkspace.value = false
-  mockPermissions.value = {
-    canViewOtherMembers: true,
-    canViewPendingInvites: true,
-    canInviteMembers: true,
-    canManageInvites: true,
-    canRemoveMembers: true,
-    canLeaveWorkspace: true,
-    canAccessWorkspaceMenu: true,
-    canManageSubscription: true,
-    canTopUp: true
-  }
-  mockUiConfig.value = {
-    showMembersList: true,
-    showPendingTab: true,
-    showSearch: true,
-    showDateColumn: true,
-    showRoleBadge: true,
-    membersGridCols: 'grid-cols-[50%_40%_10%]',
-    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
-    headerGridCols: 'grid-cols-[50%_40%_10%]',
-    showEditWorkspaceMenuItem: true,
-    workspaceMenuAction: 'delete',
-    workspaceMenuDisabledTooltip: null
-  }
-  mockIsActiveSubscription.value = true
-  mockSubscription.value = { tier: 'PRO' }
-  mockMembers.value = members
-}
-
-function setMemberTeamWorkspace(members: WorkspaceMember[] = []) {
-  mockIsInPersonalWorkspace.value = false
-  mockPermissions.value = {
-    canViewOtherMembers: true,
-    canViewPendingInvites: false,
-    canInviteMembers: false,
-    canManageInvites: false,
-    canRemoveMembers: false,
-    canLeaveWorkspace: true,
-    canAccessWorkspaceMenu: true,
-    canManageSubscription: false,
-    canTopUp: false
-  }
-  mockUiConfig.value = {
-    showMembersList: true,
-    showPendingTab: false,
-    showSearch: true,
-    showDateColumn: true,
-    showRoleBadge: true,
-    membersGridCols: 'grid-cols-[1fr_auto]',
-    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
-    headerGridCols: 'grid-cols-[1fr_auto]',
-    showEditWorkspaceMenuItem: false,
-    workspaceMenuAction: 'leave',
-    workspaceMenuDisabledTooltip: null
-  }
-  mockIsActiveSubscription.value = true
-  mockSubscription.value = { tier: 'PRO' }
-  mockMembers.value = members
-}
-
-function setPersonalWorkspace() {
-  mockIsInPersonalWorkspace.value = true
-  mockPermissions.value = {
-    canViewOtherMembers: false,
-    canViewPendingInvites: false,
-    canInviteMembers: false,
-    canManageInvites: false,
-    canRemoveMembers: false,
-    canLeaveWorkspace: false,
-    canAccessWorkspaceMenu: false,
-    canManageSubscription: true,
-    canTopUp: true
-  }
-  mockUiConfig.value = {
-    showMembersList: false,
-    showPendingTab: false,
-    showSearch: false,
-    showDateColumn: false,
-    showRoleBadge: false,
-    membersGridCols: 'grid-cols-1',
-    pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
-    headerGridCols: 'grid-cols-1',
-    showEditWorkspaceMenuItem: false,
-    workspaceMenuAction: null,
-    workspaceMenuDisabledTooltip: null
-  }
-  mockMembers.value = []
-  mockPendingInvites.value = []
-}
-
-function setSingleSeatPlan() {
-  mockIsInPersonalWorkspace.value = false
-  mockIsActiveSubscription.value = true
-  mockSubscription.value = { tier: 'STANDARD' }
-  mockMembers.value = []
-}
-
-function bodyText() {
-  return document.body.textContent ?? ''
-}
-
-async function switchToPendingTab() {
-  const pendingBtn = screen.getByRole('button', { name: /pendingCount/ })
-  await userEvent.click(pendingBtn)
-  await nextTick()
-}
-
 describe('MembersPanelContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockMembers.value = []
     mockPendingInvites.value = []
-    mockIsInPersonalWorkspace.value = false
+    mockFilteredMembers.value = []
+    mockFilteredPendingInvites.value = []
+    mockIsPersonalWorkspace.value = false
+    mockIsSingleSeatPlan.value = false
     mockIsActiveSubscription.value = true
-    mockSubscription.value = { tier: 'PRO' }
+    mockActiveView.value = 'active'
+    mockSearchQuery.value = ''
     mockPermissions.value = {
       canViewOtherMembers: true,
       canViewPendingInvites: true,
@@ -351,365 +207,118 @@ describe('MembersPanelContent', () => {
   })
 
   describe('personal workspace', () => {
-    it('shows current user with "(you)" label', () => {
-      setPersonalWorkspace()
-      renderComponent()
-      expect(bodyText()).toContain('Owner User')
-      expect(bodyText()).toContain('g.you')
+    beforeEach(() => {
+      mockIsPersonalWorkspace.value = true
+      mockUiConfig.value.showMembersList = false
+      mockUiConfig.value.showSearch = false
+      mockUiConfig.value.showPendingTab = false
     })
 
     it('shows personal workspace message and create workspace button', () => {
-      setPersonalWorkspace()
       renderComponent()
-      expect(bodyText()).toContain(
-        'workspacePanel.members.personalWorkspaceMessage'
-      )
-      expect(bodyText()).toContain('workspacePanel.members.createNewWorkspace')
+      expect(
+        screen.getByText('workspacePanel.members.personalWorkspaceMessage')
+      ).toBeTruthy()
+      expect(
+        screen.getByText('workspacePanel.members.createNewWorkspace')
+      ).toBeTruthy()
     })
 
-    it('calls showCreateWorkspaceDialog when create workspace is clicked', async () => {
-      setPersonalWorkspace()
+    it('calls handleCreateWorkspace when create button is clicked', async () => {
       renderComponent()
-      const createBtn = screen.getByText(
-        'workspacePanel.members.createNewWorkspace'
+      await userEvent.click(
+        screen.getByText('workspacePanel.members.createNewWorkspace')
       )
-      await userEvent.click(createBtn)
-      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalled()
+      expect(mockHandleCreateWorkspace).toHaveBeenCalled()
     })
 
     it('does not show search input', () => {
-      setPersonalWorkspace()
       renderComponent()
       expect(screen.queryByRole('textbox')).toBeNull()
     })
   })
 
-  describe('team workspace - owner view', () => {
-    it('renders member list with names and emails', () => {
-      const owner = createMember({
-        id: 'owner-1',
-        name: 'Owner User',
-        email: 'owner@example.com',
-        role: 'owner'
-      })
-      const member = createMember({
-        id: 'member-2',
-        name: 'Team Member',
-        email: 'team@example.com'
-      })
-      setOwnerTeamWorkspace([owner, member])
+  describe('team workspace - member list', () => {
+    it('renders filtered members', () => {
+      mockFilteredMembers.value = [
+        createMember({ name: 'Alice', email: 'alice@test.com' }),
+        createMember({
+          id: '2',
+          name: 'Bob',
+          email: 'bob@test.com'
+        })
+      ]
       renderComponent()
-
-      expect(bodyText()).toContain('Owner User')
-      expect(bodyText()).toContain('Team Member')
-      expect(bodyText()).toContain('owner@example.com')
-      expect(bodyText()).toContain('team@example.com')
-    })
-
-    it('shows role badges', () => {
-      const owner = createMember({
-        id: 'owner-1',
-        name: 'Owner User',
-        email: 'owner@example.com',
-        role: 'owner'
-      })
-      const member = createMember({
-        id: 'member-2',
-        name: 'Team Member',
-        email: 'team@example.com',
-        role: 'member'
-      })
-      setOwnerTeamWorkspace([owner, member])
-      renderComponent()
-
-      expect(bodyText()).toContain('workspaceSwitcher.roleOwner')
-      expect(bodyText()).toContain('workspaceSwitcher.roleMember')
-    })
-
-    it('shows "(you)" label next to current user', () => {
-      const currentUser = createMember({
-        id: 'owner-1',
-        name: 'Owner User',
-        email: 'owner@example.com',
-        role: 'owner'
-      })
-      setOwnerTeamWorkspace([currentUser])
-      renderComponent()
-      expect(bodyText()).toContain('g.you')
+      expect(screen.getByText('Alice')).toBeTruthy()
+      expect(screen.getByText('Bob')).toBeTruthy()
     })
 
     it('shows more options button for non-current members', () => {
-      const owner = createMember({
-        id: 'owner-1',
-        name: 'Owner User',
-        email: 'owner@example.com',
-        role: 'owner'
-      })
-      const other = createMember({
-        id: 'member-2',
-        name: 'Other',
-        email: 'other@example.com'
-      })
-      setOwnerTeamWorkspace([owner, other])
+      mockFilteredMembers.value = [
+        createMember({ name: 'Other', email: 'other@test.com' })
+      ]
       renderComponent()
-
-      const moreButtons = screen.queryAllByRole('button', {
-        name: 'g.moreOptions'
-      })
-      expect(moreButtons).toHaveLength(1)
+      expect(
+        screen.queryAllByRole('button', { name: 'g.moreOptions' })
+      ).toHaveLength(1)
     })
 
-    it('does not show more options button for self', () => {
-      const currentUser = createMember({
-        id: 'owner-1',
-        name: 'Owner User',
-        email: 'owner@example.com',
-        role: 'owner'
-      })
-      setOwnerTeamWorkspace([currentUser])
+    it('does not show more options for current user', () => {
+      mockFilteredMembers.value = [
+        createMember({ name: 'Owner User', email: 'owner@example.com' })
+      ]
       renderComponent()
-
-      const moreButtons = screen.queryAllByRole('button', {
-        name: 'g.moreOptions'
-      })
-      expect(moreButtons).toHaveLength(0)
+      expect(
+        screen.queryAllByRole('button', { name: 'g.moreOptions' })
+      ).toHaveLength(0)
     })
+  })
 
-    it('shows pending tab button', () => {
-      setOwnerTeamWorkspace([])
+  describe('pending invites tab', () => {
+    it('shows pending tab button when configured', () => {
       mockPendingInvites.value = [createInvite()]
       renderComponent()
-      expect(bodyText()).toContain('workspacePanel.members.tabs.pendingCount')
-    })
-  })
-
-  describe('team workspace - member view', () => {
-    it('does not show remove member buttons', () => {
-      const members = [
-        createMember({
-          id: 'owner-1',
-          name: 'The Owner',
-          email: 'boss@example.com',
-          role: 'owner'
-        }),
-        createMember({
-          id: 'me',
-          name: 'Owner User',
-          email: 'owner@example.com',
-          role: 'member'
-        })
-      ]
-      setMemberTeamWorkspace(members)
-      renderComponent()
-
-      const moreButtons = screen.queryAllByRole('button', {
-        name: 'g.moreOptions'
-      })
-      expect(moreButtons).toHaveLength(0)
+      expect(
+        screen.getByText(/workspacePanel\.members\.tabs\.pendingCount/)
+      ).toBeTruthy()
     })
 
-    it('does not show pending tab', () => {
-      setMemberTeamWorkspace([])
+    it('triggers handleRevokeInvite on revoke click', async () => {
+      mockActiveView.value = 'pending'
+      mockFilteredPendingInvites.value = [createInvite({ id: 'inv-42' })]
       renderComponent()
-      expect(bodyText()).not.toContain(
-        'workspacePanel.members.tabs.pendingCount'
-      )
-    })
-  })
-
-  describe('member sorting', () => {
-    it('sorts owners first, current user second, then rest', () => {
-      const owner = createMember({
-        id: 'owner-1',
-        name: 'The Owner',
-        email: 'boss@example.com',
-        role: 'owner',
-        joinDate: new Date('2025-03-01')
-      })
-      const currentUser = createMember({
-        id: 'me',
-        name: 'Owner User',
-        email: 'owner@example.com',
-        role: 'member',
-        joinDate: new Date('2025-02-01')
-      })
-      const other = createMember({
-        id: 'other',
-        name: 'Other Member',
-        email: 'other@example.com',
-        role: 'member',
-        joinDate: new Date('2025-01-01')
-      })
-      setOwnerTeamWorkspace([other, currentUser, owner])
-      renderComponent()
-      const text = bodyText()
-      const ownerIdx = text.indexOf('The Owner')
-      const currentIdx = text.indexOf('Owner User')
-      const otherIdx = text.indexOf('Other Member')
-      expect(ownerIdx).toBeLessThan(currentIdx)
-      expect(currentIdx).toBeLessThan(otherIdx)
-    })
-  })
-
-  describe('search filtering', () => {
-    it('filters members by name', async () => {
-      const alice = createMember({
-        id: '1',
-        name: 'Alice',
-        email: 'alice@example.com'
-      })
-      const bob = createMember({
-        id: '2',
-        name: 'Bob',
-        email: 'bob@example.com'
-      })
-      setOwnerTeamWorkspace([alice, bob])
-      renderComponent()
-
-      const searchInput = screen.getByRole('textbox')
-      await fireEvent.update(searchInput, 'Alice')
-      await nextTick()
-
-      expect(bodyText()).toContain('Alice')
-      expect(bodyText()).not.toContain('Bob')
-    })
-
-    it('filters members by email', async () => {
-      const alice = createMember({
-        id: '1',
-        name: 'Alice',
-        email: 'alice@example.com'
-      })
-      const bob = createMember({
-        id: '2',
-        name: 'Bob',
-        email: 'bob@example.com'
-      })
-      setOwnerTeamWorkspace([alice, bob])
-      renderComponent()
-
-      const searchInput = screen.getByRole('textbox')
-      await fireEvent.update(searchInput, 'bob@')
-      await nextTick()
-
-      expect(bodyText()).not.toContain('Alice')
-      expect(bodyText()).toContain('Bob')
-    })
-  })
-
-  describe('pending invites', () => {
-    it('shows invite email and initial', async () => {
-      setOwnerTeamWorkspace([])
-      mockPendingInvites.value = [createInvite({ email: 'test@example.com' })]
-      renderComponent()
-
-      await switchToPendingTab()
-
-      expect(bodyText()).toContain('test@example.com')
-      expect(bodyText()).toContain('test')
-      expect(bodyText()).toContain('T')
-    })
-
-    it('shows no invites message when empty', async () => {
-      setOwnerTeamWorkspace([])
-      mockPendingInvites.value = []
-      renderComponent()
-      await switchToPendingTab()
-
-      expect(bodyText()).toContain('workspacePanel.members.noInvites')
-    })
-
-    it('triggers revoke invite dialog', async () => {
-      setOwnerTeamWorkspace([])
-      mockPendingInvites.value = [createInvite({ id: 'inv-42' })]
-      renderComponent()
-      await switchToPendingTab()
-
       const revokeBtn = screen.getByRole('button', {
         name: 'workspacePanel.members.actions.revokeInvite'
       })
       await userEvent.click(revokeBtn)
-
-      expect(mockShowRevokeInviteDialog).toHaveBeenCalledWith('inv-42')
+      expect(mockHandleRevokeInvite).toHaveBeenCalled()
     })
 
-    it('copies invite link and shows success toast', async () => {
-      mockCopyInviteLink.mockResolvedValue(undefined)
-      setOwnerTeamWorkspace([])
-      mockPendingInvites.value = [createInvite({ id: 'inv-42' })]
+    it('triggers handleCopyInviteLink on copy click', async () => {
+      mockActiveView.value = 'pending'
+      mockFilteredPendingInvites.value = [createInvite({ id: 'inv-42' })]
       renderComponent()
-      await switchToPendingTab()
-
       const copyBtn = screen.getByRole('button', {
         name: 'workspacePanel.members.actions.copyLink'
       })
       await userEvent.click(copyBtn)
-      await nextTick()
-
-      expect(mockCopyInviteLink).toHaveBeenCalledWith('inv-42')
-      expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({ severity: 'success' })
-      )
-    })
-
-    it('shows error toast when copy invite link fails', async () => {
-      mockCopyInviteLink.mockRejectedValue(new Error('fail'))
-      setOwnerTeamWorkspace([])
-      mockPendingInvites.value = [createInvite({ id: 'inv-42' })]
-      renderComponent()
-      await switchToPendingTab()
-
-      const copyBtn = screen.getByRole('button', {
-        name: 'workspacePanel.members.actions.copyLink'
-      })
-      await userEvent.click(copyBtn)
-
-      await waitFor(() => {
-        expect(mockToastAdd).toHaveBeenCalledWith(
-          expect.objectContaining({ severity: 'error' })
-        )
-      })
-    })
-
-    it('filters pending invites by search query', async () => {
-      setOwnerTeamWorkspace([])
-      mockPendingInvites.value = [
-        createInvite({ id: 'i1', email: 'alice@test.com' }),
-        createInvite({ id: 'i2', email: 'bob@test.com' })
-      ]
-      renderComponent()
-      await switchToPendingTab()
-
-      const searchInput = screen.getByRole('textbox')
-      await fireEvent.update(searchInput, 'alice')
-      await nextTick()
-
-      expect(bodyText()).toContain('alice@test.com')
-      expect(bodyText()).not.toContain('bob@test.com')
+      expect(mockHandleCopyInviteLink).toHaveBeenCalled()
     })
   })
 
   describe('single seat plan', () => {
+    beforeEach(() => {
+      mockIsSingleSeatPlan.value = true
+    })
+
     it('shows upsell banner', () => {
-      setSingleSeatPlan()
       renderComponent()
-      expect(bodyText()).toContain('workspacePanel.members.upsellBannerUpgrade')
-      expect(bodyText()).toContain('workspacePanel.members.viewPlans')
+      expect(
+        screen.getByText('workspacePanel.members.upsellBannerUpgrade')
+      ).toBeTruthy()
     })
 
-    it('shows subscribe message when no active subscription', () => {
-      mockIsInPersonalWorkspace.value = false
-      mockIsActiveSubscription.value = false
-      mockSubscription.value = null
-      mockMembers.value = []
-      renderComponent()
-      expect(bodyText()).toContain(
-        'workspacePanel.members.upsellBannerSubscribe'
-      )
-    })
-
-    it('opens subscription dialog when view plans is clicked', async () => {
-      setSingleSeatPlan()
+    it('opens subscription dialog on view plans click', async () => {
       renderComponent()
       const viewPlansBtn = screen.getByRole('button', {
         name: /workspacePanel\.members\.viewPlans/
@@ -719,27 +328,22 @@ describe('MembersPanelContent', () => {
     })
 
     it('hides search input', () => {
-      setSingleSeatPlan()
-      mockUiConfig.value.showSearch = true
       renderComponent()
       expect(screen.queryByRole('textbox')).toBeNull()
     })
   })
 
   describe('member count display', () => {
-    it('shows member count with maxSeats for team workspace', () => {
-      setOwnerTeamWorkspace([
-        createMember({ id: '1', email: 'a@b.com' }),
-        createMember({ id: '2', email: 'c@d.com' })
-      ])
+    it('shows member count header for team workspace', () => {
+      mockFilteredMembers.value = [
+        createMember({ id: '1' }),
+        createMember({ id: '2' })
+      ]
+      mockMembers.value = mockFilteredMembers.value
       renderComponent()
-      expect(bodyText()).toContain('workspacePanel.members.membersCount')
-    })
-
-    it('shows count of 1 for personal workspace', () => {
-      setPersonalWorkspace()
-      renderComponent()
-      expect(bodyText()).toContain('workspacePanel.members.membersCount')
+      expect(
+        screen.getByText(/workspacePanel\.members\.membersCount/)
+      ).toBeTruthy()
     })
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -198,190 +198,47 @@
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
 import Menu from 'primevue/menu'
-import { useToast } from 'primevue/usetoast'
-import { computed, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
+import { ref } from 'vue'
 
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
-import { useCurrentUser } from '@/composables/auth/useCurrentUser'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
 import MemberListItem from '@/platform/workspace/components/dialogs/settings/MemberListItem.vue'
 import MemberUpsellBanner from '@/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue'
 import PendingInvitesList from '@/platform/workspace/components/dialogs/settings/PendingInvitesList.vue'
-import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
-import type {
-  PendingInvite,
-  WorkspaceMember
-} from '@/platform/workspace/stores/teamWorkspaceStore'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
-import { useDialogService } from '@/services/dialogService'
+import { useMembersPanel } from '@/platform/workspace/composables/useMembersPanel'
+import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
-const { t } = useI18n()
-const toast = useToast()
-const { userPhotoUrl, userEmail, userDisplayName } = useCurrentUser()
 const {
-  showRemoveMemberDialog,
-  showRevokeInviteDialog,
-  showCreateWorkspaceDialog
-} = useDialogService()
-const workspaceStore = useTeamWorkspaceStore()
-const {
+  searchQuery,
+  activeView,
+  maxSeats,
+  isSingleSeatPlan,
+  personalWorkspaceMember,
+  filteredMembers,
+  filteredPendingInvites,
+  memberMenuItems,
+  isPersonalWorkspace,
   members,
   pendingInvites,
-  isInPersonalWorkspace: isPersonalWorkspace
-} = storeToRefs(workspaceStore)
-const { copyInviteLink } = workspaceStore
-const { permissions, uiConfig } = useWorkspaceUI()
-const {
+  permissions,
+  uiConfig,
   isActiveSubscription,
-  subscription,
+  userPhotoUrl,
+  isCurrentUser,
+  selectMember,
+  toggleSort,
   showSubscriptionDialog,
-  getMaxSeats
-} = useBillingContext()
-
-const maxSeats = computed(() => {
-  if (isPersonalWorkspace.value) return 1
-  const tier = subscription.value?.tier
-  if (!tier) return 1
-  const tierKey = TIER_TO_KEY[tier]
-  if (!tierKey) return 1
-  return getMaxSeats(tierKey)
-})
-
-const isSingleSeatPlan = computed(() => {
-  if (isPersonalWorkspace.value) return false
-  if (!isActiveSubscription.value) return true
-  return maxSeats.value <= 1
-})
-
-const personalWorkspaceMember = computed<WorkspaceMember>(() => ({
-  id: 'self',
-  name: userDisplayName.value ?? '',
-  email: userEmail.value ?? '',
-  role: 'owner' as const,
-  joinDate: new Date(0)
-}))
-
-const searchQuery = ref('')
-const activeView = ref<'active' | 'pending'>('active')
-const sortField = ref<'inviteDate' | 'expiryDate' | 'joinDate'>('inviteDate')
-const sortDirection = ref<'asc' | 'desc'>('desc')
+  handleCopyInviteLink,
+  handleRevokeInvite,
+  handleCreateWorkspace
+} = useMembersPanel()
 
 const memberMenu = ref<InstanceType<typeof Menu> | null>(null)
-const selectedMember = ref<WorkspaceMember | null>(null)
-
-const memberMenuItems = computed(() => [
-  {
-    label: t('workspacePanel.members.actions.removeMember'),
-    icon: 'pi pi-user-minus',
-    command: () => {
-      if (selectedMember.value) {
-        handleRemoveMember(selectedMember.value)
-      }
-    }
-  }
-])
 
 function showMemberMenu(event: Event, member: WorkspaceMember) {
-  selectedMember.value = member
+  selectMember(member)
   memberMenu.value?.toggle(event)
-}
-
-function isCurrentUser(member: WorkspaceMember): boolean {
-  return member.email.toLowerCase() === userEmail.value?.toLowerCase()
-}
-
-const filteredMembers = computed(() => {
-  let result = [...members.value]
-
-  if (searchQuery.value) {
-    const query = searchQuery.value.toLowerCase()
-    result = result.filter(
-      (member) =>
-        member.name.toLowerCase().includes(query) ||
-        member.email.toLowerCase().includes(query)
-    )
-  }
-
-  result.sort((a, b) => {
-    if (a.role === 'owner' && b.role !== 'owner') return -1
-    if (a.role !== 'owner' && b.role === 'owner') return 1
-
-    const aIsCurrentUser = isCurrentUser(a)
-    const bIsCurrentUser = isCurrentUser(b)
-    if (aIsCurrentUser && !bIsCurrentUser) return -1
-    if (!aIsCurrentUser && bIsCurrentUser) return 1
-
-    const aValue = a.joinDate.getTime()
-    const bValue = b.joinDate.getTime()
-    return sortDirection.value === 'asc' ? aValue - bValue : bValue - aValue
-  })
-
-  return result
-})
-
-const filteredPendingInvites = computed(() => {
-  let result = [...pendingInvites.value]
-
-  if (searchQuery.value) {
-    const query = searchQuery.value.toLowerCase()
-    result = result.filter((invite) =>
-      invite.email.toLowerCase().includes(query)
-    )
-  }
-
-  const field = sortField.value === 'joinDate' ? 'inviteDate' : sortField.value
-  result.sort((a, b) => {
-    const aDate = a[field]
-    const bDate = b[field]
-    if (!aDate || !bDate) return 0
-    const aValue = aDate.getTime()
-    const bValue = bDate.getTime()
-    return sortDirection.value === 'asc' ? aValue - bValue : bValue - aValue
-  })
-
-  return result
-})
-
-function toggleSort(field: 'inviteDate' | 'expiryDate' | 'joinDate') {
-  if (sortField.value === field) {
-    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
-  } else {
-    sortField.value = field
-    sortDirection.value = 'desc'
-  }
-}
-
-async function handleCopyInviteLink(invite: PendingInvite) {
-  try {
-    await copyInviteLink(invite.id)
-    toast.add({
-      severity: 'success',
-      summary: t('g.copied'),
-      life: 2000
-    })
-  } catch {
-    toast.add({
-      severity: 'error',
-      summary: t('g.error')
-    })
-  }
-}
-
-function handleRevokeInvite(invite: PendingInvite) {
-  showRevokeInviteDialog(invite.id)
-}
-
-function handleCreateWorkspace() {
-  showCreateWorkspaceDialog()
-}
-
-function handleRemoveMember(member: WorkspaceMember) {
-  showRemoveMemberDialog(member.id)
 }
 </script>

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -1,0 +1,501 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type {
+  PendingInvite,
+  WorkspaceMember
+} from '@/platform/workspace/stores/teamWorkspaceStore'
+
+import {
+  filterBySearch,
+  sortMembers,
+  sortPendingInvites
+} from './useMembersPanel'
+
+function createMember(
+  overrides: Partial<WorkspaceMember> = {}
+): WorkspaceMember {
+  return {
+    id: 'member-1',
+    name: 'Member One',
+    email: 'member1@example.com',
+    joinDate: new Date('2025-01-15'),
+    role: 'member',
+    ...overrides
+  }
+}
+
+function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
+  return {
+    id: 'invite-1',
+    email: 'invitee@example.com',
+    token: 'token-abc',
+    inviteDate: new Date('2025-03-01'),
+    expiryDate: new Date('2025-04-01'),
+    ...overrides
+  }
+}
+
+describe('sortMembers', () => {
+  it('places owners before members', () => {
+    const owner = createMember({ id: 'o', role: 'owner', name: 'Owner' })
+    const member = createMember({ id: 'm', role: 'member', name: 'Member' })
+    const result = sortMembers([member, owner], null, 'desc')
+    expect(result[0].id).toBe('o')
+    expect(result[1].id).toBe('m')
+  })
+
+  it('places current user after owners but before others', () => {
+    const owner = createMember({
+      id: 'o',
+      role: 'owner',
+      email: 'boss@test.com',
+      joinDate: new Date('2025-03-01')
+    })
+    const current = createMember({
+      id: 'me',
+      role: 'member',
+      email: 'me@test.com',
+      joinDate: new Date('2025-02-01')
+    })
+    const other = createMember({
+      id: 'other',
+      role: 'member',
+      email: 'other@test.com',
+      joinDate: new Date('2025-01-01')
+    })
+
+    const result = sortMembers([other, current, owner], 'me@test.com', 'desc')
+    expect(result.map((m) => m.id)).toEqual(['o', 'me', 'other'])
+  })
+
+  it('sorts remaining members by joinDate descending', () => {
+    const early = createMember({
+      id: 'early',
+      joinDate: new Date('2025-01-01')
+    })
+    const late = createMember({
+      id: 'late',
+      joinDate: new Date('2025-06-01')
+    })
+    const result = sortMembers([early, late], null, 'desc')
+    expect(result[0].id).toBe('late')
+    expect(result[1].id).toBe('early')
+  })
+
+  it('sorts remaining members by joinDate ascending', () => {
+    const early = createMember({
+      id: 'early',
+      joinDate: new Date('2025-01-01')
+    })
+    const late = createMember({
+      id: 'late',
+      joinDate: new Date('2025-06-01')
+    })
+    const result = sortMembers([early, late], null, 'asc')
+    expect(result[0].id).toBe('early')
+    expect(result[1].id).toBe('late')
+  })
+
+  it('does not mutate the input array', () => {
+    const members = [
+      createMember({ id: 'b', joinDate: new Date('2025-06-01') }),
+      createMember({ id: 'a', joinDate: new Date('2025-01-01') })
+    ]
+    const original = [...members]
+    sortMembers(members, null, 'desc')
+    expect(members).toEqual(original)
+  })
+})
+
+describe('filterBySearch', () => {
+  const alice = createMember({
+    id: '1',
+    name: 'Alice',
+    email: 'alice@example.com'
+  })
+  const bob = createMember({
+    id: '2',
+    name: 'Bob',
+    email: 'bob@example.com'
+  })
+
+  it('returns all items when query is empty', () => {
+    expect(filterBySearch([alice, bob], '')).toEqual([alice, bob])
+  })
+
+  it('filters by name (case-insensitive)', () => {
+    const result = filterBySearch([alice, bob], 'alice')
+    expect(result).toEqual([alice])
+  })
+
+  it('filters by email', () => {
+    const result = filterBySearch([alice, bob], 'bob@')
+    expect(result).toEqual([bob])
+  })
+
+  it('filters pending invites by email only', () => {
+    const inv1 = createInvite({ id: 'i1', email: 'alice@test.com' })
+    const inv2 = createInvite({ id: 'i2', email: 'bob@test.com' })
+    const result = filterBySearch([inv1, inv2], 'alice')
+    expect(result).toEqual([inv1])
+  })
+})
+
+describe('sortPendingInvites', () => {
+  it('sorts by inviteDate descending by default', () => {
+    const early = createInvite({
+      id: 'e',
+      inviteDate: new Date('2025-01-01')
+    })
+    const late = createInvite({
+      id: 'l',
+      inviteDate: new Date('2025-06-01')
+    })
+    const result = sortPendingInvites([early, late], 'inviteDate', 'desc')
+    expect(result[0].id).toBe('l')
+    expect(result[1].id).toBe('e')
+  })
+
+  it('sorts by expiryDate ascending', () => {
+    const early = createInvite({
+      id: 'e',
+      expiryDate: new Date('2025-01-01')
+    })
+    const late = createInvite({
+      id: 'l',
+      expiryDate: new Date('2025-06-01')
+    })
+    const result = sortPendingInvites([early, late], 'expiryDate', 'asc')
+    expect(result[0].id).toBe('e')
+    expect(result[1].id).toBe('l')
+  })
+
+  it('falls back to inviteDate when sortField is joinDate', () => {
+    const early = createInvite({
+      id: 'e',
+      inviteDate: new Date('2025-01-01')
+    })
+    const late = createInvite({
+      id: 'l',
+      inviteDate: new Date('2025-06-01')
+    })
+    const result = sortPendingInvites([early, late], 'joinDate', 'desc')
+    expect(result[0].id).toBe('l')
+  })
+
+  it('does not mutate the input array', () => {
+    const invites = [
+      createInvite({
+        id: 'b',
+        inviteDate: new Date('2025-06-01')
+      }),
+      createInvite({
+        id: 'a',
+        inviteDate: new Date('2025-01-01')
+      })
+    ]
+    const original = [...invites]
+    sortPendingInvites(invites, 'inviteDate', 'desc')
+    expect(invites).toEqual(original)
+  })
+})
+
+const mockToastAdd = vi.fn()
+const mockCopyInviteLink = vi.fn()
+const mockShowRemoveMemberDialog = vi.fn()
+const mockShowRevokeInviteDialog = vi.fn()
+const mockShowCreateWorkspaceDialog = vi.fn()
+const mockShowSubscriptionDialog = vi.fn()
+
+const {
+  mockMembers,
+  mockPendingInvites,
+  mockIsInPersonalWorkspace,
+  mockPermissions,
+  mockUiConfig,
+  mockIsActiveSubscription,
+  mockSubscription
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+
+  return {
+    mockMembers: ref<WorkspaceMember[]>([]),
+    mockPendingInvites: ref<PendingInvite[]>([]),
+    mockIsInPersonalWorkspace: ref(false),
+    mockPermissions: ref({
+      canViewOtherMembers: true,
+      canViewPendingInvites: true,
+      canInviteMembers: true,
+      canManageInvites: true,
+      canRemoveMembers: true,
+      canLeaveWorkspace: true,
+      canAccessWorkspaceMenu: true,
+      canManageSubscription: true,
+      canTopUp: true
+    }),
+    mockUiConfig: ref({
+      showMembersList: true,
+      showPendingTab: true,
+      showSearch: true,
+      showDateColumn: true,
+      showRoleBadge: true,
+      membersGridCols: 'grid-cols-[50%_40%_10%]',
+      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
+      headerGridCols: 'grid-cols-[50%_40%_10%]',
+      showEditWorkspaceMenuItem: true,
+      workspaceMenuAction: 'delete' as 'leave' | 'delete' | null,
+      workspaceMenuDisabledTooltip: null as string | null
+    }),
+    mockIsActiveSubscription: ref(true),
+    mockSubscription: ref<{ tier: string } | null>({ tier: 'PRO' })
+  }
+})
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mockToastAdd })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    members: mockMembers,
+    pendingInvites: mockPendingInvites,
+    isInPersonalWorkspace: mockIsInPersonalWorkspace,
+    copyInviteLink: mockCopyInviteLink
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: mockPermissions,
+    uiConfig: mockUiConfig
+  })
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    userPhotoUrl: ref(null),
+    userEmail: ref('owner@example.com'),
+    userDisplayName: ref('Owner User')
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: mockIsActiveSubscription,
+    subscription: mockSubscription,
+    showSubscriptionDialog: mockShowSubscriptionDialog,
+    getMaxSeats: (tierKey: string) => {
+      const seats: Record<string, number> = {
+        free: 1,
+        standard: 1,
+        creator: 5,
+        pro: 20
+      }
+      return seats[tierKey] ?? 1
+    }
+  })
+}))
+
+vi.mock('@/platform/cloud/subscription/constants/tierPricing', () => ({
+  TIER_TO_KEY: {
+    FREE: 'free',
+    STANDARD: 'standard',
+    CREATOR: 'creator',
+    PRO: 'pro',
+    FOUNDERS_EDITION: 'founder'
+  }
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showRemoveMemberDialog: mockShowRemoveMemberDialog,
+    showRevokeInviteDialog: mockShowRevokeInviteDialog,
+    showCreateWorkspaceDialog: mockShowCreateWorkspaceDialog
+  })
+}))
+
+describe('useMembersPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMembers.value = []
+    mockPendingInvites.value = []
+    mockIsInPersonalWorkspace.value = false
+    mockIsActiveSubscription.value = true
+    mockSubscription.value = { tier: 'PRO' }
+  })
+
+  // Lazy import so mocks are in place
+  async function setup() {
+    const { useMembersPanel } = await import('./useMembersPanel')
+    return useMembersPanel()
+  }
+
+  describe('isSingleSeatPlan', () => {
+    it('is false for personal workspace', async () => {
+      mockIsInPersonalWorkspace.value = true
+      const panel = await setup()
+      expect(panel.isSingleSeatPlan.value).toBe(false)
+    })
+
+    it('is true when no active subscription', async () => {
+      mockIsActiveSubscription.value = false
+      const panel = await setup()
+      expect(panel.isSingleSeatPlan.value).toBe(true)
+    })
+
+    it('is true for standard tier (1 seat)', async () => {
+      mockSubscription.value = { tier: 'STANDARD' }
+      const panel = await setup()
+      expect(panel.isSingleSeatPlan.value).toBe(true)
+    })
+
+    it('is false for pro tier (20 seats)', async () => {
+      mockSubscription.value = { tier: 'PRO' }
+      const panel = await setup()
+      expect(panel.isSingleSeatPlan.value).toBe(false)
+    })
+  })
+
+  describe('maxSeats', () => {
+    it('returns 1 for personal workspace', async () => {
+      mockIsInPersonalWorkspace.value = true
+      const panel = await setup()
+      expect(panel.maxSeats.value).toBe(1)
+    })
+
+    it('returns tier-appropriate seats', async () => {
+      mockSubscription.value = { tier: 'CREATOR' }
+      const panel = await setup()
+      expect(panel.maxSeats.value).toBe(5)
+    })
+
+    it('returns 1 when no subscription', async () => {
+      mockSubscription.value = null
+      const panel = await setup()
+      expect(panel.maxSeats.value).toBe(1)
+    })
+  })
+
+  describe('personalWorkspaceMember', () => {
+    it('uses current user info', async () => {
+      const panel = await setup()
+      expect(panel.personalWorkspaceMember.value).toMatchObject({
+        id: 'self',
+        name: 'Owner User',
+        email: 'owner@example.com',
+        role: 'owner'
+      })
+    })
+  })
+
+  describe('isCurrentUser', () => {
+    it('matches by email (case-insensitive)', async () => {
+      const panel = await setup()
+      const member = createMember({ email: 'OWNER@EXAMPLE.COM' })
+      expect(panel.isCurrentUser(member)).toBe(true)
+    })
+
+    it('returns false for other users', async () => {
+      const panel = await setup()
+      const member = createMember({ email: 'other@example.com' })
+      expect(panel.isCurrentUser(member)).toBe(false)
+    })
+  })
+
+  describe('filteredMembers', () => {
+    it('filters and sorts members based on searchQuery', async () => {
+      const alice = createMember({
+        id: '1',
+        name: 'Alice',
+        email: 'alice@example.com'
+      })
+      const bob = createMember({
+        id: '2',
+        name: 'Bob',
+        email: 'bob@example.com'
+      })
+      mockMembers.value = [alice, bob]
+      const panel = await setup()
+
+      panel.searchQuery.value = 'alice'
+      expect(panel.filteredMembers.value).toHaveLength(1)
+      expect(panel.filteredMembers.value[0].name).toBe('Alice')
+    })
+  })
+
+  describe('toggleSort', () => {
+    it('changes sortField and resets to desc', async () => {
+      const panel = await setup()
+      panel.toggleSort('expiryDate')
+      expect(panel.sortField.value).toBe('expiryDate')
+      expect(panel.sortDirection.value).toBe('desc')
+    })
+
+    it('toggles direction when same field', async () => {
+      const panel = await setup()
+      panel.toggleSort('inviteDate')
+      expect(panel.sortDirection.value).toBe('asc')
+      panel.toggleSort('inviteDate')
+      expect(panel.sortDirection.value).toBe('desc')
+    })
+  })
+
+  describe('handleCopyInviteLink', () => {
+    it('shows success toast on success', async () => {
+      mockCopyInviteLink.mockResolvedValue(undefined)
+      const panel = await setup()
+      await panel.handleCopyInviteLink(createInvite({ id: 'inv-1' }))
+      expect(mockCopyInviteLink).toHaveBeenCalledWith('inv-1')
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'success' })
+      )
+    })
+
+    it('shows error toast on failure', async () => {
+      mockCopyInviteLink.mockRejectedValue(new Error('fail'))
+      const panel = await setup()
+      await panel.handleCopyInviteLink(createInvite({ id: 'inv-1' }))
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    })
+  })
+
+  describe('handleRevokeInvite', () => {
+    it('calls showRevokeInviteDialog', async () => {
+      const panel = await setup()
+      panel.handleRevokeInvite(createInvite({ id: 'inv-42' }))
+      expect(mockShowRevokeInviteDialog).toHaveBeenCalledWith('inv-42')
+    })
+  })
+
+  describe('handleCreateWorkspace', () => {
+    it('calls showCreateWorkspaceDialog', async () => {
+      const panel = await setup()
+      panel.handleCreateWorkspace()
+      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleRemoveMember', () => {
+    it('calls showRemoveMemberDialog', async () => {
+      const panel = await setup()
+      panel.handleRemoveMember(createMember({ id: 'mem-7' }))
+      expect(mockShowRemoveMemberDialog).toHaveBeenCalledWith('mem-7')
+    })
+  })
+})

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -1,0 +1,219 @@
+import { storeToRefs } from 'pinia'
+import { useToast } from 'primevue/usetoast'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import type {
+  PendingInvite,
+  WorkspaceMember
+} from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogService } from '@/services/dialogService'
+
+type ActiveView = 'active' | 'pending'
+type SortField = 'inviteDate' | 'expiryDate' | 'joinDate'
+type SortDirection = 'asc' | 'desc'
+
+export function sortMembers(
+  members: WorkspaceMember[],
+  currentUserEmail: string | null,
+  sortDirection: SortDirection
+): WorkspaceMember[] {
+  return [...members].sort((a, b) => {
+    if (a.role === 'owner' && b.role !== 'owner') return -1
+    if (a.role !== 'owner' && b.role === 'owner') return 1
+
+    const aIsCurrent = a.email.toLowerCase() === currentUserEmail?.toLowerCase()
+    const bIsCurrent = b.email.toLowerCase() === currentUserEmail?.toLowerCase()
+    if (aIsCurrent && !bIsCurrent) return -1
+    if (!aIsCurrent && bIsCurrent) return 1
+
+    const aValue = a.joinDate.getTime()
+    const bValue = b.joinDate.getTime()
+    return sortDirection === 'asc' ? aValue - bValue : bValue - aValue
+  })
+}
+
+export function filterBySearch<T extends { email: string; name?: string }>(
+  items: T[],
+  query: string
+): T[] {
+  if (!query) return items
+  const q = query.toLowerCase()
+  return items.filter(
+    (item) =>
+      item.email.toLowerCase().includes(q) ||
+      ('name' in item && item.name?.toLowerCase().includes(q))
+  )
+}
+
+export function sortPendingInvites(
+  invites: PendingInvite[],
+  sortField: SortField,
+  sortDirection: SortDirection
+): PendingInvite[] {
+  const field = sortField === 'joinDate' ? 'inviteDate' : sortField
+  return [...invites].sort((a, b) => {
+    const aDate = a[field]
+    const bDate = b[field]
+    if (!aDate || !bDate) return 0
+    const aValue = aDate.getTime()
+    const bValue = bDate.getTime()
+    return sortDirection === 'asc' ? aValue - bValue : bValue - aValue
+  })
+}
+
+export function useMembersPanel() {
+  const { t } = useI18n()
+  const toast = useToast()
+  const { userPhotoUrl, userEmail, userDisplayName } = useCurrentUser()
+  const {
+    showRemoveMemberDialog,
+    showRevokeInviteDialog,
+    showCreateWorkspaceDialog
+  } = useDialogService()
+  const workspaceStore = useTeamWorkspaceStore()
+  const {
+    members,
+    pendingInvites,
+    isInPersonalWorkspace: isPersonalWorkspace
+  } = storeToRefs(workspaceStore)
+  const { copyInviteLink } = workspaceStore
+  const { permissions, uiConfig } = useWorkspaceUI()
+  const {
+    isActiveSubscription,
+    subscription,
+    showSubscriptionDialog,
+    getMaxSeats
+  } = useBillingContext()
+
+  const maxSeats = computed(() => {
+    if (isPersonalWorkspace.value) return 1
+    const tier = subscription.value?.tier
+    if (!tier) return 1
+    const tierKey = TIER_TO_KEY[tier]
+    if (!tierKey) return 1
+    return getMaxSeats(tierKey)
+  })
+
+  const isSingleSeatPlan = computed(() => {
+    if (isPersonalWorkspace.value) return false
+    if (!isActiveSubscription.value) return true
+    return maxSeats.value <= 1
+  })
+
+  const personalWorkspaceMember = computed<WorkspaceMember>(() => ({
+    id: 'self',
+    name: userDisplayName.value ?? '',
+    email: userEmail.value ?? '',
+    role: 'owner' as const,
+    joinDate: new Date(0)
+  }))
+
+  const searchQuery = ref('')
+  const activeView = ref<ActiveView>('active')
+  const sortField = ref<SortField>('inviteDate')
+  const sortDirection = ref<SortDirection>('desc')
+
+  const selectedMember = ref<WorkspaceMember | null>(null)
+
+  const memberMenuItems = computed(() => [
+    {
+      label: t('workspacePanel.members.actions.removeMember'),
+      icon: 'pi pi-user-minus',
+      command: () => {
+        if (selectedMember.value) {
+          handleRemoveMember(selectedMember.value)
+        }
+      }
+    }
+  ])
+
+  function selectMember(member: WorkspaceMember) {
+    selectedMember.value = member
+  }
+
+  function isCurrentUser(member: WorkspaceMember): boolean {
+    return member.email.toLowerCase() === userEmail.value?.toLowerCase()
+  }
+
+  const filteredMembers = computed(() => {
+    const searched = filterBySearch(members.value, searchQuery.value)
+    return sortMembers(searched, userEmail.value ?? null, sortDirection.value)
+  })
+
+  const filteredPendingInvites = computed(() => {
+    const searched = filterBySearch(pendingInvites.value, searchQuery.value)
+    return sortPendingInvites(searched, sortField.value, sortDirection.value)
+  })
+
+  function toggleSort(field: SortField) {
+    if (sortField.value === field) {
+      sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+    } else {
+      sortField.value = field
+      sortDirection.value = 'desc'
+    }
+  }
+
+  async function handleCopyInviteLink(invite: PendingInvite) {
+    try {
+      await copyInviteLink(invite.id)
+      toast.add({
+        severity: 'success',
+        summary: t('g.copied'),
+        life: 2000
+      })
+    } catch {
+      toast.add({
+        severity: 'error',
+        summary: t('g.error')
+      })
+    }
+  }
+
+  function handleRevokeInvite(invite: PendingInvite) {
+    void showRevokeInviteDialog(invite.id)
+  }
+
+  function handleCreateWorkspace() {
+    void showCreateWorkspaceDialog()
+  }
+
+  function handleRemoveMember(member: WorkspaceMember) {
+    void showRemoveMemberDialog(member.id)
+  }
+
+  return {
+    searchQuery,
+    activeView,
+    sortField,
+    sortDirection,
+    selectedMember,
+    maxSeats,
+    isSingleSeatPlan,
+    personalWorkspaceMember,
+    filteredMembers,
+    filteredPendingInvites,
+    memberMenuItems,
+    isPersonalWorkspace,
+    members,
+    pendingInvites,
+    permissions,
+    uiConfig,
+    isActiveSubscription,
+    userPhotoUrl,
+    isCurrentUser,
+    selectMember,
+    toggleSort,
+    showSubscriptionDialog,
+    handleCopyInviteLink,
+    handleRevokeInvite,
+    handleCreateWorkspace,
+    handleRemoveMember
+  }
+}


### PR DESCRIPTION
## Summary

Add 27 unit tests for MembersPanelContent component covering workspace views, member management, and billing states.

## Changes

- **What**: New test file for MembersPanelContent with 27 tests across 8 describe blocks (personal workspace, owner view, member view, sorting, search filtering, pending invites, single seat plan, member count display)

## Review Focus

- Uses `@testing-library/vue` + `@testing-library/user-event` per project conventions
- Component stubs (Button, SearchInput, Menu, UserAvatar) for isolation
- Reactive mock refs in `vi.hoisted()` shared across `vi.mock()` calls

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11402-test-add-MembersPanelContent-unit-tests-3476d73d36508107abcbce95b72b3fb7) by [Unito](https://www.unito.io)
