### PR TITLE
test: cover error branch in useWorkflowThumbnail (+6.1%)

### DIFF
--- a/src/renderer/core/thumbnail/useWorkflowThumbnail.test.ts
+++ b/src/renderer/core/thumbnail/useWorkflowThumbnail.test.ts
@@ -267,4 +267,28 @@ describe('useWorkflowThumbnail', () => {
     expect(workflowThumbnails.value.size).toBe(1)
     expect(getThumbnail('test-key')).toBe('data:image/png;base64,test')
   })
+
+  it('should return null when createGraphThumbnail throws', async () => {
+    vi.mocked(createGraphThumbnail).mockImplementation(() => {
+      throw new Error('Canvas not available')
+    })
+
+    const { createMinimapPreview } = useWorkflowThumbnail()
+    const result = await createMinimapPreview()
+
+    expect(result).toBeNull()
+  })
+
+  it('should not store thumbnail when createGraphThumbnail throws', async () => {
+    vi.mocked(createGraphThumbnail).mockImplementation(() => {
+      throw new Error('Canvas not available')
+    })
+
+    const { storeThumbnail, getThumbnail } = useWorkflowThumbnail()
+    const mockWorkflow = { key: 'error-workflow' } as ComfyWorkflow
+
+    await storeThumbnail(mockWorkflow)
+
+    expect(getThumbnail('error-workflow')).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary

Cover the remaining uncovered error-handling branch in `useWorkflowThumbnail`, bringing unit test coverage from 93.9% to 100%.

## Changes

- **What**: Add 2 unit tests for `createMinimapPreview` error path and `storeThumbnail` null-thumbnail branch

## Review Focus

Tests verify that when `createGraphThumbnail` throws, `createMinimapPreview` returns `null` and `storeThumbnail` does not persist anything.

## Coverage Delta

| File | Before | After | Delta | Missed |
|------|--------|-------|-------|--------|
| `useWorkflowThumbnail.ts` | 93.9% | 100.0% | 🟢 +6.1% | 0 |

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11404-test-cover-error-branch-in-useWorkflowThumbnail-6-1-3476d73d36508148a135ee29f7abf22e) by [Unito](https://www.unito.io)
