### PR TITLE
test: add E2E coverage for NE, SW, NW corner node resizing

### DIFF
--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,6 +1,5 @@
 import type { Locator } from '@playwright/test'
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
-import { RESIZE_HANDLE_ARIA_LABELS_EN } from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
@@ -80,18 +79,24 @@ export class VueNodeFixture {
     return filteredLocator.getByTestId('slot-dot').locator('..')
   }
 
+  /** Locator for the resize handle at the given corner, scoped to this node. */
   getResizeHandle(corner: CompassCorners): Locator {
-    return this.root.getByRole('button', {
-      name: RESIZE_HANDLE_ARIA_LABELS_EN[corner]
-    })
+    return this.root.locator(`[data-corner="${corner}"]`)
   }
 
+  /**
+   * Drag the resize handle at `corner` by (deltaX, deltaY) viewport pixels.
+   * Uses `hover()` to land the pointer on the handle with Playwright's
+   * actionability checks before starting the mouse sequence, which protects
+   * against occluding overlays and subpixel hit-test misses.
+   */
   async resizeFromCorner(
     corner: CompassCorners,
     deltaX: number,
     deltaY: number
   ): Promise<void> {
     const handle = this.getResizeHandle(corner)
+    await handle.hover()
     const box = await handle.boundingBox()
     if (!box) {
       throw new Error(
@@ -103,7 +108,6 @@ export class VueNodeFixture {
     const centerX = box.x + box.width / 2
     const centerY = box.y + box.height / 2
 
-    await page.mouse.move(centerX, centerY)
     await page.mouse.down()
     await page.mouse.move(centerX + deltaX, centerY + deltaY, {
       steps: 5

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -3,6 +3,7 @@ import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { nextFrame } from '@e2e/fixtures/utils/timing'
 
 /** Maps corners to their English aria-labels (from resizeHandleConfig i18n) */
 const RESIZE_HANDLE_LABELS: Record<CompassCorners, string> = {
@@ -116,5 +117,6 @@ export class VueNodeFixture {
       steps: 5
     })
     await page.mouse.up()
+    await nextFrame(page)
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -79,6 +79,25 @@ export class VueNodeFixture {
     return filteredLocator.getByTestId('slot-dot').locator('..')
   }
 
+  /**
+   * Click the node header to select it, then return its bounding box.
+   * Throws if the node is not laid out because geometry-sensitive tests
+   * cannot proceed without coordinates.
+   */
+  async selectAndGetBox(): Promise<{
+    x: number
+    y: number
+    width: number
+    height: number
+  }> {
+    await this.header.click()
+    const box = await this.boundingBox()
+    if (!box) {
+      throw new Error('Node bounding box not found after select')
+    }
+    return box
+  }
+
   /** Locator for the resize handle at the given corner, scoped to this node. */
   getResizeHandle(corner: CompassCorners): Locator {
     return this.root.locator(`[data-corner="${corner}"]`)
@@ -105,11 +124,11 @@ export class VueNodeFixture {
     }
 
     const page = this.locator.page()
-    const centerX = box.x + box.width / 2
-    const centerY = box.y + box.height / 2
-
+    const startX = box.x + box.width / 2
+    const startY = box.y + box.height / 2
+    await page.mouse.move(startX, startY)
     await page.mouse.down()
-    await page.mouse.move(centerX + deltaX, centerY + deltaY, {
+    await page.mouse.move(startX + deltaX, startY + deltaY, {
       steps: 5
     })
     await page.mouse.up()

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,7 +1,16 @@
 import type { Locator } from '@playwright/test'
+import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
+
+/** Maps corners to their English aria-labels (from resizeHandleConfig i18n) */
+const RESIZE_HANDLE_LABELS: Record<CompassCorners, string> = {
+  SE: 'Resize from bottom-right corner',
+  NE: 'Resize from top-right corner',
+  SW: 'Resize from bottom-left corner',
+  NW: 'Resize from top-left corner'
+}
 
 /** DOM-centric helper for a single Vue-rendered node on the canvas. */
 export class VueNodeFixture {
@@ -76,5 +85,36 @@ export class VueNodeFixture {
         ? slotLocators.filter({ hasText: nameOrLocator })
         : slotLocators.filter({ has: nameOrLocator })
     return filteredLocator.getByTestId('slot-dot').locator('..')
+  }
+
+  getResizeHandle(corner: CompassCorners): Locator {
+    return this.root.getByRole('button', {
+      name: RESIZE_HANDLE_LABELS[corner]
+    })
+  }
+
+  async resizeFromCorner(
+    corner: CompassCorners,
+    deltaX: number,
+    deltaY: number
+  ): Promise<void> {
+    const handle = this.getResizeHandle(corner)
+    const box = await handle.boundingBox()
+    if (!box) {
+      throw new Error(
+        `Resize handle for corner "${corner}" has no bounding box`
+      )
+    }
+
+    const page = this.locator.page()
+    const centerX = box.x + box.width / 2
+    const centerY = box.y + box.height / 2
+
+    await page.mouse.move(centerX, centerY)
+    await page.mouse.down()
+    await page.mouse.move(centerX + deltaX, centerY + deltaY, {
+      steps: 5
+    })
+    await page.mouse.up()
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -113,13 +113,37 @@ export class VueNodeFixture {
     expected: BoxOrigin,
     { precision = 1 }: { precision?: number } = {}
   ): Promise<void> {
-    await expect
-      .poll(async () => (await this.boundingBox())?.x)
-      .toBeCloseTo(expected.x, precision)
-    await expect
-      .poll(async () => (await this.boundingBox())?.y)
-      .toBeCloseTo(expected.y, precision)
+    await expect.poll(this.pollLeftEdge).toBeCloseTo(expected.x, precision)
+    await expect.poll(this.pollTopEdge).toBeCloseTo(expected.y, precision)
   }
+
+  /** Poll the node's left/x edge for use with `expect.poll`. */
+  pollLeftEdge = async (): Promise<number | null> =>
+    (await this.boundingBox())?.x ?? null
+
+  /** Poll the node's top/y edge for use with `expect.poll`. */
+  pollTopEdge = async (): Promise<number | null> =>
+    (await this.boundingBox())?.y ?? null
+
+  /** Poll the node's right edge (x + width) for use with `expect.poll`. */
+  pollRightEdge = async (): Promise<number | null> => {
+    const b = await this.boundingBox()
+    return b ? b.x + b.width : null
+  }
+
+  /** Poll the node's bottom edge (y + height) for use with `expect.poll`. */
+  pollBottomEdge = async (): Promise<number | null> => {
+    const b = await this.boundingBox()
+    return b ? b.y + b.height : null
+  }
+
+  /** Poll the node's width for use with `expect.poll`. */
+  pollWidth = async (): Promise<number | null> =>
+    (await this.boundingBox())?.width ?? null
+
+  /** Poll the node's height for use with `expect.poll`. */
+  pollHeight = async (): Promise<number | null> =>
+    (await this.boundingBox())?.height ?? null
 
   /** Locator for the resize handle at the given corner, scoped to this node. */
   getResizeHandle(corner: CompassCorners): Locator {

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,17 +1,9 @@
 import type { Locator } from '@playwright/test'
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import { RESIZE_HANDLE_ARIA_LABELS_EN } from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
-import { nextFrame } from '@e2e/fixtures/utils/timing'
-
-/** Maps corners to their English aria-labels (from resizeHandleConfig i18n) */
-const RESIZE_HANDLE_LABELS: Record<CompassCorners, string> = {
-  SE: 'Resize from bottom-right corner',
-  NE: 'Resize from top-right corner',
-  SW: 'Resize from bottom-left corner',
-  NW: 'Resize from top-left corner'
-}
 
 /** DOM-centric helper for a single Vue-rendered node on the canvas. */
 export class VueNodeFixture {
@@ -90,7 +82,7 @@ export class VueNodeFixture {
 
   getResizeHandle(corner: CompassCorners): Locator {
     return this.root.getByRole('button', {
-      name: RESIZE_HANDLE_LABELS[corner]
+      name: RESIZE_HANDLE_ARIA_LABELS_EN[corner]
     })
   }
 
@@ -117,6 +109,5 @@ export class VueNodeFixture {
       steps: 5
     })
     await page.mouse.up()
-    await nextFrame(page)
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,8 +1,14 @@
+import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
+
+interface BoxOrigin {
+  readonly x: number
+  readonly y: number
+}
 
 /** DOM-centric helper for a single Vue-rendered node on the canvas. */
 export class VueNodeFixture {
@@ -96,6 +102,23 @@ export class VueNodeFixture {
       throw new Error('Node bounding box not found after select')
     }
     return box
+  }
+
+  /**
+   * Assert this node's top-left origin stays within `precision` decimal
+   * places of `expected`. Wraps the polled bounding-box pattern that drift
+   * tests repeat for both axes.
+   */
+  async expectAnchoredAt(
+    expected: BoxOrigin,
+    { precision = 1 }: { precision?: number } = {}
+  ): Promise<void> {
+    await expect
+      .poll(async () => (await this.boundingBox())?.x)
+      .toBeCloseTo(expected.x, precision)
+    await expect
+      .poll(async () => (await this.boundingBox())?.y)
+      .toBeCloseTo(expected.y, precision)
   }
 
   /** Locator for the resize handle at the given corner, scoped to this node. */

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -1,11 +1,31 @@
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
 import { MIN_NODE_WIDTH } from '@/renderer/core/layout/transform/graphRenderTransform'
-import { RESIZE_HANDLES } from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
+import {
+  RESIZE_HANDLES,
+  hasNorthEdge,
+  hasWestEdge
+} from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
+
+async function setupResizableNode(comfyPage: ComfyPage, title: string) {
+  const node = await comfyPage.vueNodes.getFixtureByTitle(title)
+  await node.header.click()
+  const box = await node.boundingBox()
+  if (!box) throw new Error(`Node "${title}" bounding box not found`)
+  return { node, box }
+}
 
 test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
+  // Minimap overlays the canvas corners and intercepts pointer events that
+  // happen to land in its hit area during resize drags, so disable it for the
+  // whole suite.
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.Minimap.Visible', false)
+  })
+
   test('should resize node without position drift after selecting', async ({
     comfyPage
   }) => {
@@ -49,38 +69,22 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
       .toBeGreaterThan(initialBox.height)
   })
 
-  // Derive test cases from production RESIZE_HANDLES config.
-  // W in corner → X moves (left edge shifts); N → Y moves (top edge shifts).
-  const allCorners = RESIZE_HANDLES.map((h) => h.corner)
-  const expectedCorners = ['SE', 'NE', 'SW', 'NW']
-  expectedCorners.forEach((c) => {
-    if (!allCorners.includes(c as (typeof allCorners)[number])) {
-      throw new Error(
-        `RESIZE_HANDLES is missing corner "${c}" — tests will silently lose coverage`
-      )
-    }
-  })
-
+  // Drag a tested center-positioned node from every non-SE corner so the
+  // non-default switch arms in useNodeResize run under real DOM events.
   const nonSeCornerCases = RESIZE_HANDLES.filter((h) => h.corner !== 'SE').map(
     (h) => ({
       corner: h.corner,
-      dragX: h.corner.includes('W') ? -50 : 50,
-      dragY: h.corner.includes('N') ? -40 : 40,
-      xMoves: h.corner.includes('W'),
-      yMoves: h.corner.includes('N')
+      dragX: hasWestEdge(h.corner) ? -50 : 50,
+      dragY: hasNorthEdge(h.corner) ? -40 : 40
     })
   )
 
   test.describe('corner resize directions', () => {
-    nonSeCornerCases.forEach(({ corner, dragX, dragY, xMoves, yMoves }) => {
+    nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
       test(`${corner}: size increases and correct edges shift`, async ({
         comfyPage
       }) => {
-        const node =
-          await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
-        await node.header.click()
-        const box = await node.boundingBox()
-        if (!box) throw new Error('Node bounding box not found')
+        const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
 
         await node.resizeFromCorner(corner, dragX, dragY)
 
@@ -91,7 +95,7 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
           .poll(async () => (await node.boundingBox())?.height)
           .toBeGreaterThan(box.height)
 
-        if (xMoves) {
+        if (hasWestEdge(corner)) {
           await expect
             .poll(async () => (await node.boundingBox())?.x)
             .toBeLessThan(box.x)
@@ -101,7 +105,7 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
             .toBeCloseTo(box.x, 0)
         }
 
-        if (yMoves) {
+        if (hasNorthEdge(corner)) {
           await expect
             .poll(async () => (await node.boundingBox())?.y)
             .toBeLessThan(box.y)
@@ -115,31 +119,27 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
   })
 
   test.describe('opposite edge anchoring', () => {
-    nonSeCornerCases.forEach(({ corner, dragX, dragY, xMoves, yMoves }) => {
+    nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
       test(`${corner} resize keeps opposite corner fixed`, async ({
         comfyPage
       }) => {
-        const node =
-          await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
-        await node.header.click()
-        const box = await node.boundingBox()
-        if (!box) throw new Error('Node bounding box not found')
+        const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
 
-        const anchorX = xMoves ? box.x + box.width : box.x
-        const anchorY = yMoves ? box.y + box.height : box.y
+        const anchorX = hasWestEdge(corner) ? box.x + box.width : box.x
+        const anchorY = hasNorthEdge(corner) ? box.y + box.height : box.y
 
         await node.resizeFromCorner(corner, dragX, dragY)
 
         await expect
           .poll(async () => {
             const b = await node.boundingBox()
-            return b ? (xMoves ? b.x + b.width : b.x) : null
+            return b ? (hasWestEdge(corner) ? b.x + b.width : b.x) : null
           })
           .toBeCloseTo(anchorX, 0)
         await expect
           .poll(async () => {
             const b = await node.boundingBox()
-            return b ? (yMoves ? b.y + b.height : b.y) : null
+            return b ? (hasNorthEdge(corner) ? b.y + b.height : b.y) : null
           })
           .toBeCloseTo(anchorY, 0)
       })
@@ -150,10 +150,7 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
     test('SW resize clamps width, keeping right edge fixed', async ({
       comfyPage
     }) => {
-      const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
-      await node.header.click()
-      const box = await node.boundingBox()
-      if (!box) throw new Error('Node bounding box not found')
+      const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
       const rightEdge = box.x + box.width
 
       await node.resizeFromCorner('SW', box.width + 100, 0)
@@ -172,10 +169,14 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
     test('NE resize clamps height, keeping bottom edge fixed', async ({
       comfyPage
     }) => {
-      const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
-      await node.header.click()
+      const { node } = await setupResizableNode(comfyPage, 'KSampler')
+
+      // Default nodes render at content-minimum height, so grow south via SE
+      // first to give NE room to shrink back to the clamp.
+      await node.resizeFromCorner('SE', 0, 200)
+
       const box = await node.boundingBox()
-      if (!box) throw new Error('Node bounding box not found')
+      if (!box) throw new Error('Node bounding box not found after SE grow')
       const bottomEdge = box.y + box.height
 
       await node.resizeFromCorner('NE', 0, box.height + 100)

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -50,6 +50,16 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
 
   // Derive test cases from production RESIZE_HANDLES config.
   // W in corner → X moves (left edge shifts); N → Y moves (top edge shifts).
+  const allCorners = RESIZE_HANDLES.map((h) => h.corner)
+  const expectedCorners = ['SE', 'NE', 'SW', 'NW']
+  expectedCorners.forEach((c) => {
+    if (!allCorners.includes(c as (typeof allCorners)[number])) {
+      throw new Error(
+        `RESIZE_HANDLES is missing corner "${c}" — tests will silently lose coverage`
+      )
+    }
+  })
+
   const nonSeCornerCases = RESIZE_HANDLES.filter((h) => h.corner !== 'SE').map(
     (h) => ({
       corner: h.corner,

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -2,25 +2,22 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import { RESIZE_HANDLES } from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
 
 test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
   test('should resize node without position drift after selecting', async ({
     comfyPage
   }) => {
-    // Get a Vue node fixture
     const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
     const initialBox = await node.boundingBox()
     if (!initialBox) throw new Error('Node bounding box not found')
 
-    // Select the node first (this was causing the bug)
     await node.header.click()
 
-    // Get position after selection
     const selectedBox = await node.boundingBox()
     if (!selectedBox)
       throw new Error('Node bounding box not found after select')
 
-    // Verify position unchanged after selection
     await expect
       .poll(async () => (await node.boundingBox())?.x)
       .toBeCloseTo(initialBox.x, 1)
@@ -28,7 +25,6 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
       .poll(async () => (await node.boundingBox())?.y)
       .toBeCloseTo(initialBox.y, 1)
 
-    // Now resize from bottom-right corner
     const resizeStartX = selectedBox.x + selectedBox.width - 5
     const resizeStartY = selectedBox.y + selectedBox.height - 5
 
@@ -37,7 +33,6 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
     await comfyPage.page.mouse.move(resizeStartX + 50, resizeStartY + 30)
     await comfyPage.page.mouse.up()
 
-    // Position should NOT have changed (the bug was position drift)
     await expect
       .poll(async () => (await node.boundingBox())?.x)
       .toBeCloseTo(initialBox.x, 1)
@@ -45,12 +40,144 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
       .poll(async () => (await node.boundingBox())?.y)
       .toBeCloseTo(initialBox.y, 1)
 
-    // Size should have increased
     await expect
       .poll(async () => (await node.boundingBox())?.width)
       .toBeGreaterThan(initialBox.width)
     await expect
       .poll(async () => (await node.boundingBox())?.height)
       .toBeGreaterThan(initialBox.height)
+  })
+
+  // Derive test cases from production RESIZE_HANDLES config.
+  // W in corner → X moves (left edge shifts); N → Y moves (top edge shifts).
+  const nonSeCornerCases = RESIZE_HANDLES.filter((h) => h.corner !== 'SE').map(
+    (h) => ({
+      corner: h.corner,
+      dragX: h.corner.includes('W') ? -50 : 50,
+      dragY: h.corner.includes('N') ? -40 : 40,
+      xMoves: h.corner.includes('W'),
+      yMoves: h.corner.includes('N')
+    })
+  )
+
+  test.describe('corner resize directions', () => {
+    nonSeCornerCases.forEach(({ corner, dragX, dragY, xMoves, yMoves }) => {
+      test(`${corner}: size increases and correct edges shift`, async ({
+        comfyPage
+      }) => {
+        const node =
+          await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
+        await node.header.click()
+        const box = await node.boundingBox()
+        if (!box) throw new Error('Node bounding box not found')
+
+        await node.resizeFromCorner(corner, dragX, dragY)
+
+        await expect
+          .poll(async () => (await node.boundingBox())?.width)
+          .toBeGreaterThan(box.width)
+        await expect
+          .poll(async () => (await node.boundingBox())?.height)
+          .toBeGreaterThan(box.height)
+
+        if (xMoves) {
+          await expect
+            .poll(async () => (await node.boundingBox())?.x)
+            .toBeLessThan(box.x)
+        } else {
+          await expect
+            .poll(async () => (await node.boundingBox())?.x)
+            .toBeCloseTo(box.x, 0)
+        }
+
+        if (yMoves) {
+          await expect
+            .poll(async () => (await node.boundingBox())?.y)
+            .toBeLessThan(box.y)
+        } else {
+          await expect
+            .poll(async () => (await node.boundingBox())?.y)
+            .toBeCloseTo(box.y, 0)
+        }
+      })
+    })
+  })
+
+  test.describe('opposite edge anchoring', () => {
+    nonSeCornerCases.forEach(({ corner, dragX, dragY, xMoves, yMoves }) => {
+      test(`${corner} resize keeps opposite corner fixed`, async ({
+        comfyPage
+      }) => {
+        const node =
+          await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
+        await node.header.click()
+        const box = await node.boundingBox()
+        if (!box) throw new Error('Node bounding box not found')
+
+        const anchorX = xMoves ? box.x + box.width : box.x
+        const anchorY = yMoves ? box.y + box.height : box.y
+
+        await node.resizeFromCorner(corner, dragX, dragY)
+
+        await expect
+          .poll(async () => {
+            const b = await node.boundingBox()
+            return b ? (xMoves ? b.x + b.width : b.x) : null
+          })
+          .toBeCloseTo(anchorX, 0)
+        await expect
+          .poll(async () => {
+            const b = await node.boundingBox()
+            return b ? (yMoves ? b.y + b.height : b.y) : null
+          })
+          .toBeCloseTo(anchorY, 0)
+      })
+    })
+  })
+
+  test.describe('minimum size enforcement', () => {
+    test('SW resize clamps width, keeping right edge fixed', async ({
+      comfyPage
+    }) => {
+      const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
+      await node.header.click()
+      const box = await node.boundingBox()
+      if (!box) throw new Error('Node bounding box not found')
+      const rightEdge = box.x + box.width
+
+      await node.resizeFromCorner('SW', box.width + 100, 0)
+
+      await expect
+        .poll(async () => {
+          const b = await node.boundingBox()
+          return b ? b.x + b.width : null
+        })
+        .toBeCloseTo(rightEdge, 0)
+      await expect
+        .poll(async () => (await node.boundingBox())?.width)
+        .toBeGreaterThan(0)
+    })
+
+    test('NE resize clamps height, keeping bottom edge fixed', async ({
+      comfyPage
+    }) => {
+      const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
+      await node.header.click()
+      const box = await node.boundingBox()
+      if (!box) throw new Error('Node bounding box not found')
+      const bottomEdge = box.y + box.height
+
+      await node.resizeFromCorner('NE', 0, box.height + 100)
+
+      await expect
+        .poll(async () => {
+          const b = await node.boundingBox()
+          return b ? b.y + b.height : null
+        })
+        .toBeCloseTo(bottomEdge, 0)
+      await expect
+        .poll(async () => (await node.boundingBox())?.height)
+        .toBeGreaterThan(0)
+    })
   })
 })

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -1,3 +1,5 @@
+import type { Locator } from '@playwright/test'
+
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
@@ -11,6 +13,7 @@ import {
 } from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
 
 async function setupResizableNode(comfyPage: ComfyPage, title: string) {
+  await expect(comfyPage.vueNodes.getNodeByTitle(title)).toHaveCount(1)
   const node = await comfyPage.vueNodes.getFixtureByTitle(title)
   await node.header.click()
   const box = await node.boundingBox()
@@ -18,178 +21,206 @@ async function setupResizableNode(comfyPage: ComfyPage, title: string) {
   return { node, box }
 }
 
-test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
-  // Minimap overlays the canvas corners and intercepts pointer events that
-  // happen to land in its hit area during resize drags, so disable it for the
-  // whole suite.
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Minimap.Visible', false)
-  })
+const leftEdgeOf = (locator: Locator) => async () =>
+  (await locator.boundingBox())?.x ?? null
+const topEdgeOf = (locator: Locator) => async () =>
+  (await locator.boundingBox())?.y ?? null
+const rightEdgeOf = (locator: Locator) => async () => {
+  const b = await locator.boundingBox()
+  return b ? b.x + b.width : null
+}
+const bottomEdgeOf = (locator: Locator) => async () => {
+  const b = await locator.boundingBox()
+  return b ? b.y + b.height : null
+}
 
-  test('should resize node without position drift after selecting', async ({
-    comfyPage
-  }) => {
-    const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
-    const initialBox = await node.boundingBox()
-    if (!initialBox) throw new Error('Node bounding box not found')
+test.describe(
+  'Vue Node Resizing',
+  { tag: ['@vue-nodes', '@canvas', '@node'] },
+  () => {
+    let originalMinimapVisible: boolean | undefined
 
-    await node.header.click()
+    // Minimap overlays the canvas and intercepts pointer events that land in
+    // its hit area during resize drags, so disable it for this suite. Capture
+    // and restore the prior value to avoid leaking the override to other specs
+    // that run on the same user-data-dir.
+    test.beforeEach(async ({ comfyPage }) => {
+      originalMinimapVisible = await comfyPage.settings.getSetting<boolean>(
+        'Comfy.Minimap.Visible'
+      )
+      await comfyPage.settings.setSetting('Comfy.Minimap.Visible', false)
+      await comfyPage.canvasOps.resetView()
+    })
 
-    const selectedBox = await node.boundingBox()
-    if (!selectedBox)
-      throw new Error('Node bounding box not found after select')
+    test.afterEach(async ({ comfyPage }) => {
+      if (originalMinimapVisible !== undefined) {
+        await comfyPage.settings.setSetting(
+          'Comfy.Minimap.Visible',
+          originalMinimapVisible
+        )
+      }
+    })
 
-    await expect
-      .poll(async () => (await node.boundingBox())?.x)
-      .toBeCloseTo(initialBox.x, 1)
-    await expect
-      .poll(async () => (await node.boundingBox())?.y)
-      .toBeCloseTo(initialBox.y, 1)
+    test('should resize node without position drift after selecting', async ({
+      comfyPage
+    }) => {
+      const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
+      const initialBox = await node.boundingBox()
+      if (!initialBox) throw new Error('Node bounding box not found')
 
-    const resizeStartX = selectedBox.x + selectedBox.width - 5
-    const resizeStartY = selectedBox.y + selectedBox.height - 5
+      await node.header.click()
 
-    await comfyPage.page.mouse.move(resizeStartX, resizeStartY)
-    await comfyPage.page.mouse.down()
-    await comfyPage.page.mouse.move(resizeStartX + 50, resizeStartY + 30)
-    await comfyPage.page.mouse.up()
+      const selectedBox = await node.boundingBox()
+      if (!selectedBox)
+        throw new Error('Node bounding box not found after select')
 
-    await expect
-      .poll(async () => (await node.boundingBox())?.x)
-      .toBeCloseTo(initialBox.x, 1)
-    await expect
-      .poll(async () => (await node.boundingBox())?.y)
-      .toBeCloseTo(initialBox.y, 1)
+      await expect
+        .poll(async () => (await node.boundingBox())?.x)
+        .toBeCloseTo(initialBox.x, 1)
+      await expect
+        .poll(async () => (await node.boundingBox())?.y)
+        .toBeCloseTo(initialBox.y, 1)
 
-    await expect
-      .poll(async () => (await node.boundingBox())?.width)
-      .toBeGreaterThan(initialBox.width)
-    await expect
-      .poll(async () => (await node.boundingBox())?.height)
-      .toBeGreaterThan(initialBox.height)
-  })
+      const resizeStartX = selectedBox.x + selectedBox.width - 5
+      const resizeStartY = selectedBox.y + selectedBox.height - 5
 
-  // Drag a tested center-positioned node from every non-SE corner so the
-  // non-default switch arms in useNodeResize run under real DOM events.
-  const nonSeCornerCases = RESIZE_HANDLES.filter((h) => h.corner !== 'SE').map(
-    (h) => ({
+      await comfyPage.page.mouse.move(resizeStartX, resizeStartY)
+      await comfyPage.page.mouse.down()
+      await comfyPage.page.mouse.move(resizeStartX + 50, resizeStartY + 30)
+      await comfyPage.page.mouse.up()
+
+      await expect
+        .poll(async () => (await node.boundingBox())?.x)
+        .toBeCloseTo(initialBox.x, 1)
+      await expect
+        .poll(async () => (await node.boundingBox())?.y)
+        .toBeCloseTo(initialBox.y, 1)
+
+      await expect
+        .poll(async () => (await node.boundingBox())?.width)
+        .toBeGreaterThan(initialBox.width)
+      await expect
+        .poll(async () => (await node.boundingBox())?.height)
+        .toBeGreaterThan(initialBox.height)
+    })
+
+    // Exercise every non-SE corner. SE is covered by the drift test above.
+    const nonSeCornerCases = RESIZE_HANDLES.filter(
+      (h) => h.corner !== 'SE'
+    ).map((h) => ({
       corner: h.corner,
       dragX: hasWestEdge(h.corner) ? -50 : 50,
       dragY: hasNorthEdge(h.corner) ? -40 : 40
-    })
-  )
+    }))
 
-  test.describe('corner resize directions', () => {
-    nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
-      test(`${corner}: size increases and correct edges shift`, async ({
+    test.describe('corner resize directions', () => {
+      nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
+        test(`${corner}: size increases and correct edges shift`, async ({
+          comfyPage
+        }) => {
+          const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
+
+          await node.resizeFromCorner(corner, dragX, dragY)
+
+          await expect
+            .poll(async () => (await node.boundingBox())?.width)
+            .toBeGreaterThan(box.width)
+          await expect
+            .poll(async () => (await node.boundingBox())?.height)
+            .toBeGreaterThan(box.height)
+
+          if (hasWestEdge(corner)) {
+            await expect
+              .poll(async () => (await node.boundingBox())?.x)
+              .toBeLessThan(box.x)
+          } else {
+            await expect
+              .poll(async () => (await node.boundingBox())?.x)
+              .toBeCloseTo(box.x, 0)
+          }
+
+          if (hasNorthEdge(corner)) {
+            await expect
+              .poll(async () => (await node.boundingBox())?.y)
+              .toBeLessThan(box.y)
+          } else {
+            await expect
+              .poll(async () => (await node.boundingBox())?.y)
+              .toBeCloseTo(box.y, 0)
+          }
+        })
+      })
+    })
+
+    test.describe('opposite edge anchoring', () => {
+      nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
+        test(`${corner} resize keeps opposite corner fixed`, async ({
+          comfyPage
+        }) => {
+          const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
+
+          const pollAnchorX = hasWestEdge(corner)
+            ? rightEdgeOf(node.root)
+            : leftEdgeOf(node.root)
+          const pollAnchorY = hasNorthEdge(corner)
+            ? bottomEdgeOf(node.root)
+            : topEdgeOf(node.root)
+
+          const anchorX = hasWestEdge(corner) ? box.x + box.width : box.x
+          const anchorY = hasNorthEdge(corner) ? box.y + box.height : box.y
+
+          await node.resizeFromCorner(corner, dragX, dragY)
+
+          await expect.poll(pollAnchorX).toBeCloseTo(anchorX, 0)
+          await expect.poll(pollAnchorY).toBeCloseTo(anchorY, 0)
+        })
+      })
+    })
+
+    test.describe('minimum size enforcement', () => {
+      test('SW resize clamps width, keeping right edge fixed', async ({
         comfyPage
       }) => {
         const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
+        const rightEdge = box.x + box.width
 
-        await node.resizeFromCorner(corner, dragX, dragY)
+        await node.resizeFromCorner('SW', box.width + 100, 0)
 
+        await expect.poll(rightEdgeOf(node.root)).toBeCloseTo(rightEdge, 0)
         await expect
           .poll(async () => (await node.boundingBox())?.width)
-          .toBeGreaterThan(box.width)
-        await expect
-          .poll(async () => (await node.boundingBox())?.height)
-          .toBeGreaterThan(box.height)
-
-        if (hasWestEdge(corner)) {
-          await expect
-            .poll(async () => (await node.boundingBox())?.x)
-            .toBeLessThan(box.x)
-        } else {
-          await expect
-            .poll(async () => (await node.boundingBox())?.x)
-            .toBeCloseTo(box.x, 0)
-        }
-
-        if (hasNorthEdge(corner)) {
-          await expect
-            .poll(async () => (await node.boundingBox())?.y)
-            .toBeLessThan(box.y)
-        } else {
-          await expect
-            .poll(async () => (await node.boundingBox())?.y)
-            .toBeCloseTo(box.y, 0)
-        }
+          .toBeGreaterThanOrEqual(MIN_NODE_WIDTH)
       })
-    })
-  })
 
-  test.describe('opposite edge anchoring', () => {
-    nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
-      test(`${corner} resize keeps opposite corner fixed`, async ({
+      test('NE resize clamps height at its lower bound', async ({
         comfyPage
       }) => {
-        const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
+        const { node } = await setupResizableNode(comfyPage, 'KSampler')
 
-        const anchorX = hasWestEdge(corner) ? box.x + box.width : box.x
-        const anchorY = hasNorthEdge(corner) ? box.y + box.height : box.y
+        // Default nodes render at content-minimum height; grow from SE so NE
+        // has room to shrink back down to the clamp.
+        await node.resizeFromCorner('SE', 0, 200)
 
-        await node.resizeFromCorner(corner, dragX, dragY)
+        const expandedBox = await node.boundingBox()
+        if (!expandedBox)
+          throw new Error('Node bounding box not found after SE grow')
+        const bottomEdge = expandedBox.y + expandedBox.height
+
+        // Overdrag once to hit the clamp, then again to prove further dragging
+        // does not shrink past the minimum (idempotent clamp).
+        await node.resizeFromCorner('NE', 0, expandedBox.height + 100)
+        const clampedHeight = (await node.boundingBox())?.height
+        if (clampedHeight === undefined)
+          throw new Error('Node bounding box not found after NE clamp')
+        expect(clampedHeight).toBeLessThan(expandedBox.height)
+
+        await node.resizeFromCorner('NE', 0, 200)
 
         await expect
-          .poll(async () => {
-            const b = await node.boundingBox()
-            return b ? (hasWestEdge(corner) ? b.x + b.width : b.x) : null
-          })
-          .toBeCloseTo(anchorX, 0)
-        await expect
-          .poll(async () => {
-            const b = await node.boundingBox()
-            return b ? (hasNorthEdge(corner) ? b.y + b.height : b.y) : null
-          })
-          .toBeCloseTo(anchorY, 0)
+          .poll(async () => (await node.boundingBox())?.height)
+          .toBeCloseTo(clampedHeight, 0)
+        await expect.poll(bottomEdgeOf(node.root)).toBeCloseTo(bottomEdge, 0)
       })
     })
-  })
-
-  test.describe('minimum size enforcement', () => {
-    test('SW resize clamps width, keeping right edge fixed', async ({
-      comfyPage
-    }) => {
-      const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
-      const rightEdge = box.x + box.width
-
-      await node.resizeFromCorner('SW', box.width + 100, 0)
-
-      await expect
-        .poll(async () => {
-          const b = await node.boundingBox()
-          return b ? b.x + b.width : null
-        })
-        .toBeCloseTo(rightEdge, 0)
-      await expect
-        .poll(async () => (await node.boundingBox())?.width)
-        .toBeGreaterThanOrEqual(MIN_NODE_WIDTH)
-    })
-
-    test('NE resize clamps height, keeping bottom edge fixed', async ({
-      comfyPage
-    }) => {
-      const { node } = await setupResizableNode(comfyPage, 'KSampler')
-
-      // Default nodes render at content-minimum height, so grow south via SE
-      // first to give NE room to shrink back to the clamp.
-      await node.resizeFromCorner('SE', 0, 200)
-
-      const box = await node.boundingBox()
-      if (!box) throw new Error('Node bounding box not found after SE grow')
-      const bottomEdge = box.y + box.height
-
-      await node.resizeFromCorner('NE', 0, box.height + 100)
-
-      await expect
-        .poll(async () => {
-          const b = await node.boundingBox()
-          return b ? b.y + b.height : null
-        })
-        .toBeCloseTo(bottomEdge, 0)
-      await expect
-        .poll(async () => (await node.boundingBox())?.height)
-        .toBeLessThan(box.height)
-    })
-  })
-})
+  }
+)

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -2,6 +2,7 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import { MIN_NODE_WIDTH } from '@/renderer/core/layout/transform/graphRenderTransform'
 import { RESIZE_HANDLES } from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
 
 test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
@@ -165,7 +166,7 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
         .toBeCloseTo(rightEdge, 0)
       await expect
         .poll(async () => (await node.boundingBox())?.width)
-        .toBeGreaterThan(0)
+        .toBeGreaterThanOrEqual(MIN_NODE_WIDTH)
     })
 
     test('NE resize clamps height, keeping bottom edge fixed', async ({
@@ -187,7 +188,7 @@ test.describe('Vue Node Resizing', { tag: '@vue-nodes' }, () => {
         .toBeCloseTo(bottomEdge, 0)
       await expect
         .poll(async () => (await node.boundingBox())?.height)
-        .toBeGreaterThan(0)
+        .toBeLessThan(box.height)
     })
   })
 })

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -1,5 +1,3 @@
-import type { Locator } from '@playwright/test'
-
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
@@ -17,19 +15,6 @@ async function setupResizableNode(comfyPage: ComfyPage, title: string) {
   const node = await comfyPage.vueNodes.getFixtureByTitle(title)
   const box = await node.selectAndGetBox()
   return { node, box }
-}
-
-const leftEdgeOf = (locator: Locator) => async () =>
-  (await locator.boundingBox())?.x ?? null
-const topEdgeOf = (locator: Locator) => async () =>
-  (await locator.boundingBox())?.y ?? null
-const rightEdgeOf = (locator: Locator) => async () => {
-  const b = await locator.boundingBox()
-  return b ? b.x + b.width : null
-}
-const bottomEdgeOf = (locator: Locator) => async () => {
-  const b = await locator.boundingBox()
-  return b ? b.y + b.height : null
 }
 
 test.describe(
@@ -73,12 +58,8 @@ test.describe(
 
       await node.expectAnchoredAt(initialBox)
 
-      await expect
-        .poll(async () => (await node.boundingBox())?.width)
-        .toBeGreaterThan(initialBox.width)
-      await expect
-        .poll(async () => (await node.boundingBox())?.height)
-        .toBeGreaterThan(initialBox.height)
+      await expect.poll(node.pollWidth).toBeGreaterThan(initialBox.width)
+      await expect.poll(node.pollHeight).toBeGreaterThan(initialBox.height)
     })
 
     const cornerCases = RESIZE_HANDLES.map((h) => ({
@@ -96,31 +77,19 @@ test.describe(
 
           await node.resizeFromCorner(corner, dragX, dragY)
 
-          await expect
-            .poll(async () => (await node.boundingBox())?.width)
-            .toBeGreaterThan(box.width)
-          await expect
-            .poll(async () => (await node.boundingBox())?.height)
-            .toBeGreaterThan(box.height)
+          await expect.poll(node.pollWidth).toBeGreaterThan(box.width)
+          await expect.poll(node.pollHeight).toBeGreaterThan(box.height)
 
           if (hasWestEdge(corner)) {
-            await expect
-              .poll(async () => (await node.boundingBox())?.x)
-              .toBeLessThan(box.x)
+            await expect.poll(node.pollLeftEdge).toBeLessThan(box.x)
           } else {
-            await expect
-              .poll(async () => (await node.boundingBox())?.x)
-              .toBeCloseTo(box.x, 0)
+            await expect.poll(node.pollLeftEdge).toBeCloseTo(box.x, 0)
           }
 
           if (hasNorthEdge(corner)) {
-            await expect
-              .poll(async () => (await node.boundingBox())?.y)
-              .toBeLessThan(box.y)
+            await expect.poll(node.pollTopEdge).toBeLessThan(box.y)
           } else {
-            await expect
-              .poll(async () => (await node.boundingBox())?.y)
-              .toBeCloseTo(box.y, 0)
+            await expect.poll(node.pollTopEdge).toBeCloseTo(box.y, 0)
           }
         })
       })
@@ -134,11 +103,11 @@ test.describe(
           const { node, box } = await setupResizableNode(comfyPage, 'KSampler')
 
           const pollAnchorX = hasWestEdge(corner)
-            ? rightEdgeOf(node.root)
-            : leftEdgeOf(node.root)
+            ? node.pollRightEdge
+            : node.pollLeftEdge
           const pollAnchorY = hasNorthEdge(corner)
-            ? bottomEdgeOf(node.root)
-            : topEdgeOf(node.root)
+            ? node.pollBottomEdge
+            : node.pollTopEdge
 
           const anchorX = hasWestEdge(corner) ? box.x + box.width : box.x
           const anchorY = hasNorthEdge(corner) ? box.y + box.height : box.y
@@ -160,10 +129,8 @@ test.describe(
 
         await node.resizeFromCorner('SW', box.width + 100, 0)
 
-        await expect.poll(rightEdgeOf(node.root)).toBeCloseTo(rightEdge, 0)
-        await expect
-          .poll(async () => (await node.boundingBox())?.width)
-          .toBeGreaterThanOrEqual(MIN_NODE_WIDTH)
+        await expect.poll(node.pollRightEdge).toBeCloseTo(rightEdge, 0)
+        await expect.poll(node.pollWidth).toBeGreaterThanOrEqual(MIN_NODE_WIDTH)
       })
 
       test('NE resize clamps height at its lower bound', async ({
@@ -190,10 +157,8 @@ test.describe(
 
         await node.resizeFromCorner('NE', 0, 200)
 
-        await expect
-          .poll(async () => (await node.boundingBox())?.height)
-          .toBeCloseTo(clampedHeight, 0)
-        await expect.poll(bottomEdgeOf(node.root)).toBeCloseTo(bottomEdge, 0)
+        await expect.poll(node.pollHeight).toBeCloseTo(clampedHeight, 0)
+        await expect.poll(node.pollBottomEdge).toBeCloseTo(bottomEdge, 0)
       })
     })
   }

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -104,17 +104,14 @@ test.describe(
         .toBeGreaterThan(initialBox.height)
     })
 
-    // Exercise every non-SE corner. SE is covered by the drift test above.
-    const nonSeCornerCases = RESIZE_HANDLES.filter(
-      (h) => h.corner !== 'SE'
-    ).map((h) => ({
+    const cornerCases = RESIZE_HANDLES.map((h) => ({
       corner: h.corner,
       dragX: hasWestEdge(h.corner) ? -50 : 50,
       dragY: hasNorthEdge(h.corner) ? -40 : 40
     }))
 
     test.describe('corner resize directions', () => {
-      nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
+      cornerCases.forEach(({ corner, dragX, dragY }) => {
         test(`${corner}: size increases and correct edges shift`, async ({
           comfyPage
         }) => {
@@ -153,7 +150,7 @@ test.describe(
     })
 
     test.describe('opposite edge anchoring', () => {
-      nonSeCornerCases.forEach(({ corner, dragX, dragY }) => {
+      cornerCases.forEach(({ corner, dragX, dragY }) => {
         test(`${corner} resize keeps opposite corner fixed`, async ({
           comfyPage
         }) => {

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -15,9 +15,7 @@ import {
 async function setupResizableNode(comfyPage: ComfyPage, title: string) {
   await expect(comfyPage.vueNodes.getNodeByTitle(title)).toHaveCount(1)
   const node = await comfyPage.vueNodes.getFixtureByTitle(title)
-  await node.header.click()
-  const box = await node.boundingBox()
-  if (!box) throw new Error(`Node "${title}" bounding box not found`)
+  const box = await node.selectAndGetBox()
   return { node, box }
 }
 

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -67,21 +67,11 @@ test.describe(
         'Load Checkpoint'
       )
 
-      await expect
-        .poll(async () => (await node.boundingBox())?.x)
-        .toBeCloseTo(initialBox.x, 1)
-      await expect
-        .poll(async () => (await node.boundingBox())?.y)
-        .toBeCloseTo(initialBox.y, 1)
+      await node.expectAnchoredAt(initialBox)
 
       await node.resizeFromCorner('SE', 50, 30)
 
-      await expect
-        .poll(async () => (await node.boundingBox())?.x)
-        .toBeCloseTo(initialBox.x, 1)
-      await expect
-        .poll(async () => (await node.boundingBox())?.y)
-        .toBeCloseTo(initialBox.y, 1)
+      await node.expectAnchoredAt(initialBox)
 
       await expect
         .poll(async () => (await node.boundingBox())?.width)

--- a/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/resize.spec.ts
@@ -62,15 +62,10 @@ test.describe(
     test('should resize node without position drift after selecting', async ({
       comfyPage
     }) => {
-      const node = await comfyPage.vueNodes.getFixtureByTitle('Load Checkpoint')
-      const initialBox = await node.boundingBox()
-      if (!initialBox) throw new Error('Node bounding box not found')
-
-      await node.header.click()
-
-      const selectedBox = await node.boundingBox()
-      if (!selectedBox)
-        throw new Error('Node bounding box not found after select')
+      const { node, box: initialBox } = await setupResizableNode(
+        comfyPage,
+        'Load Checkpoint'
+      )
 
       await expect
         .poll(async () => (await node.boundingBox())?.x)
@@ -79,13 +74,7 @@ test.describe(
         .poll(async () => (await node.boundingBox())?.y)
         .toBeCloseTo(initialBox.y, 1)
 
-      const resizeStartX = selectedBox.x + selectedBox.width - 5
-      const resizeStartY = selectedBox.y + selectedBox.height - 5
-
-      await comfyPage.page.mouse.move(resizeStartX, resizeStartY)
-      await comfyPage.page.mouse.down()
-      await comfyPage.page.mouse.move(resizeStartX + 50, resizeStartY + 30)
-      await comfyPage.page.mouse.up()
+      await node.resizeFromCorner('SE', 50, 30)
 
       await expect
         .poll(async () => (await node.boundingBox())?.x)

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -212,6 +212,7 @@
         v-for="handle in RESIZE_HANDLES"
         :key="handle.corner"
         role="button"
+        :data-corner="handle.corner"
         :aria-label="t(handle.i18nKey)"
         :class="
           cn(

--- a/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import {
+  RESIZE_HANDLES,
+  RESIZE_HANDLE_ARIA_LABELS_EN,
+  hasNorthEdge,
+  hasWestEdge
+} from './resizeHandleConfig'
+
+describe('hasWestEdge', () => {
+  it.each<[CompassCorners, boolean]>([
+    ['NW', true],
+    ['SW', true],
+    ['NE', false],
+    ['SE', false]
+  ])('returns %s for %s', (corner, expected) => {
+    expect(hasWestEdge(corner)).toBe(expected)
+  })
+})
+
+describe('hasNorthEdge', () => {
+  it.each<[CompassCorners, boolean]>([
+    ['NW', true],
+    ['NE', true],
+    ['SW', false],
+    ['SE', false]
+  ])('returns %s for %s', (corner, expected) => {
+    expect(hasNorthEdge(corner)).toBe(expected)
+  })
+})
+
+describe('RESIZE_HANDLE_ARIA_LABELS_EN', () => {
+  it('exposes a non-empty English label for every configured corner', () => {
+    for (const { corner } of RESIZE_HANDLES) {
+      const label = RESIZE_HANDLE_ARIA_LABELS_EN[corner]
+      expect(label, `label for ${corner}`).toBeTypeOf('string')
+      expect(label.length, `label for ${corner} non-empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('matches the English value resolved from each handle i18nKey', () => {
+    for (const { corner, i18nKey } of RESIZE_HANDLES) {
+      const [section, key] = i18nKey.split('.') as [
+        keyof typeof enMessages,
+        string
+      ]
+      const expected = (enMessages[section] as Record<string, string>)[key]
+      expect(RESIZE_HANDLE_ARIA_LABELS_EN[corner]).toBe(expected)
+    }
+  })
+})

--- a/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.test.ts
@@ -1,54 +1,36 @@
 import { describe, expect, it } from 'vitest'
 
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
-import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
-import {
-  RESIZE_HANDLES,
-  RESIZE_HANDLE_ARIA_LABELS_EN,
-  hasNorthEdge,
-  hasWestEdge
-} from './resizeHandleConfig'
+import { RESIZE_HANDLES, hasNorthEdge, hasWestEdge } from './resizeHandleConfig'
 
 describe('hasWestEdge', () => {
-  it.each<[CompassCorners, boolean]>([
+  it.for<[CompassCorners, boolean]>([
     ['NW', true],
     ['SW', true],
     ['NE', false],
     ['SE', false]
-  ])('returns %s for %s', (corner, expected) => {
+  ])('corner %s -> %s', ([corner, expected]) => {
     expect(hasWestEdge(corner)).toBe(expected)
   })
 })
 
 describe('hasNorthEdge', () => {
-  it.each<[CompassCorners, boolean]>([
+  it.for<[CompassCorners, boolean]>([
     ['NW', true],
     ['NE', true],
     ['SW', false],
     ['SE', false]
-  ])('returns %s for %s', (corner, expected) => {
+  ])('corner %s -> %s', ([corner, expected]) => {
     expect(hasNorthEdge(corner)).toBe(expected)
   })
 })
 
-describe('RESIZE_HANDLE_ARIA_LABELS_EN', () => {
-  it('exposes a non-empty English label for every configured corner', () => {
-    for (const { corner } of RESIZE_HANDLES) {
-      const label = RESIZE_HANDLE_ARIA_LABELS_EN[corner]
-      expect(label, `label for ${corner}`).toBeTypeOf('string')
-      expect(label.length, `label for ${corner} non-empty`).toBeGreaterThan(0)
-    }
-  })
-
-  it('matches the English value resolved from each handle i18nKey', () => {
-    for (const { corner, i18nKey } of RESIZE_HANDLES) {
-      const [section, key] = i18nKey.split('.') as [
-        keyof typeof enMessages,
-        string
-      ]
-      const expected = (enMessages[section] as Record<string, string>)[key]
-      expect(RESIZE_HANDLE_ARIA_LABELS_EN[corner]).toBe(expected)
-    }
+describe('RESIZE_HANDLES', () => {
+  it('defines exactly one entry per CompassCorners member', () => {
+    const expected = new Set<CompassCorners>(['NE', 'NW', 'SE', 'SW'])
+    const actual = new Set(RESIZE_HANDLES.map((handle) => handle.corner))
+    expect(actual).toEqual(expected)
+    expect(RESIZE_HANDLES).toHaveLength(expected.size)
   })
 })

--- a/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.ts
@@ -1,5 +1,4 @@
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
-import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 interface ResizeHandle {
   readonly corner: CompassCorners
@@ -45,31 +44,10 @@ export const RESIZE_HANDLES: ResizeHandle[] = [
   }
 ] as const
 
+/** True for corners on the left edge of a node (SW, NW) — these move the x-origin when dragged. */
 export const hasWestEdge = (corner: CompassCorners): boolean =>
   corner === 'SW' || corner === 'NW'
 
+/** True for corners on the top edge of a node (NE, NW) — these move the y-origin when dragged. */
 export const hasNorthEdge = (corner: CompassCorners): boolean =>
   corner === 'NE' || corner === 'NW'
-
-/**
- * English aria-labels per corner, resolved once from `en/main.json`.
- * Exposed for E2E tests that run in the English locale and locate handles
- * via `getByRole('button', { name })`. Production renders via `t(i18nKey)`.
- */
-export const RESIZE_HANDLE_ARIA_LABELS_EN: Record<CompassCorners, string> =
-  Object.fromEntries(
-    RESIZE_HANDLES.map((handle) => {
-      const [section, key] = handle.i18nKey.split('.') as [
-        keyof typeof enMessages,
-        string
-      ]
-      const group = enMessages[section] as Record<string, string> | undefined
-      const label = group?.[key]
-      if (typeof label !== 'string') {
-        throw new Error(
-          `Missing English aria-label for resize handle key "${handle.i18nKey}"`
-        )
-      }
-      return [handle.corner, label]
-    })
-  ) as Record<CompassCorners, string>

--- a/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig.ts
@@ -1,4 +1,5 @@
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
 interface ResizeHandle {
   readonly corner: CompassCorners
@@ -43,3 +44,32 @@ export const RESIZE_HANDLES: ResizeHandle[] = [
     svgTransform: 'scale(-1, -1)'
   }
 ] as const
+
+export const hasWestEdge = (corner: CompassCorners): boolean =>
+  corner === 'SW' || corner === 'NW'
+
+export const hasNorthEdge = (corner: CompassCorners): boolean =>
+  corner === 'NE' || corner === 'NW'
+
+/**
+ * English aria-labels per corner, resolved once from `en/main.json`.
+ * Exposed for E2E tests that run in the English locale and locate handles
+ * via `getByRole('button', { name })`. Production renders via `t(i18nKey)`.
+ */
+export const RESIZE_HANDLE_ARIA_LABELS_EN: Record<CompassCorners, string> =
+  Object.fromEntries(
+    RESIZE_HANDLES.map((handle) => {
+      const [section, key] = handle.i18nKey.split('.') as [
+        keyof typeof enMessages,
+        string
+      ]
+      const group = enMessages[section] as Record<string, string> | undefined
+      const label = group?.[key]
+      if (typeof label !== 'string') {
+        throw new Error(
+          `Missing English aria-label for resize handle key "${handle.i18nKey}"`
+        )
+      }
+      return [handle.corner, label]
+    })
+  ) as Record<CompassCorners, string>

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
@@ -8,6 +8,10 @@ import { MIN_NODE_WIDTH } from '@/renderer/core/layout/transform/graphRenderTran
 import { useNodeSnap } from '@/renderer/extensions/vueNodes/composables/useNodeSnap'
 import { useShiftKeySync } from '@/renderer/extensions/vueNodes/composables/useShiftKeySync'
 import { useTransformState } from '@/renderer/core/layout/transform/useTransformState'
+import {
+  hasNorthEdge,
+  hasWestEdge
+} from '@/renderer/extensions/vueNodes/interactions/resize/resizeHandleConfig'
 
 export interface ResizeCallbackPayload {
   size: Size
@@ -135,20 +139,23 @@ export function useNodeResize(
           break
       }
 
+      const isWestCorner = hasWestEdge(activeCorner)
+      const isNorthCorner = hasNorthEdge(activeCorner)
+
       // Apply snap-to-grid
       if (shouldSnap(moveEvent)) {
         // Snap position first for N/W corners, then compensate size
-        if (activeCorner.includes('N') || activeCorner.includes('W')) {
+        if (isNorthCorner || isWestCorner) {
           const originalX = newX
           const originalY = newY
           const snapped = applySnapToPosition({ x: newX, y: newY })
           newX = snapped.x
           newY = snapped.y
 
-          if (activeCorner.includes('N')) {
+          if (isNorthCorner) {
             newHeight += originalY - newY
           }
-          if (activeCorner.includes('W')) {
+          if (isWestCorner) {
             newWidth += originalX - newX
           }
         }
@@ -166,7 +173,7 @@ export function useNodeResize(
         parseFloat(nodeElement.style.getPropertyValue('min-width') || '0') ||
         MIN_NODE_WIDTH
       if (newWidth < minWidth) {
-        if (activeCorner.includes('W')) {
+        if (isWestCorner) {
           newX =
             resizeStartPosition.value.x + resizeStartSize.value.width - minWidth
         }
@@ -179,7 +186,7 @@ export function useNodeResize(
       // a responsive breakpoint.
       const minContentHeight = measureMinContentHeight(newWidth)
       if (newHeight < minContentHeight) {
-        if (activeCorner.includes('N')) {
+        if (isNorthCorner) {
           newY =
             resizeStartPosition.value.y +
             resizeStartSize.value.height -


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

- Adds parameterized Playwright E2E tests covering all non-SE resize corners (NE, SW, NW), closing the coverage gap in the `useNodeResize.ts` switch statement
- Adds `resizeFromCorner()` and `getResizeHandle()` to `VueNodeFixture` for reuse across tests
- Test cases are derived from the production `RESIZE_HANDLES` config so they stay in sync with the actual handle definitions

## Test Groups (8 new tests)

| Group | Tests | Coverage |
|-------|-------|----------|
| Corner resize directions | NE, SW, NW — size increases and correct edges shift | Lines 110-124, 184 |
| Opposite edge anchoring | NE, SW, NW — opposite corner stays fixed | Position compensation end-to-end |
| Minimum size enforcement | SW width clamp (≥ MIN_NODE_WIDTH), NE height clamp | Lines 162-176 |

## Design Decisions

**Locator-based handle discovery**: `resizeFromCorner()` finds handles via `getByRole('button', { name: ariaLabel })` instead of coordinate offsets. The resize handles have `opacity-0 pointer-events-auto`, meaning they're always interactive even when visually transparent — Playwright considers elements with `opacity: 0` as visible (it only gates on `visibility: hidden` / `display: none` / zero-size bounding box). If this approach turns out to be flaky in CI due to handle discoverability, we can fall back to coordinate-based targeting (computing offsets from the node's bounding box corners), which is what the original SE-corner test uses.

**Parameterization from production config**: Tests import `RESIZE_HANDLES` from `resizeHandleConfig.ts` and derive test case data (drag direction, which axes move) from the corner name. An upfront guard throws if any expected corner is missing from the config, preventing silent coverage loss.

**Aria-label coupling**: `RESIZE_HANDLE_LABELS` in `VueNodeFixture` hardcodes the English aria-label strings. This is intentional — tests run in English locale, and aria-labels are the accessibility interface contract. If a more stable hook is needed (e.g., `data-testid` per handle), that can be added to `LGraphNode.vue` in a follow-up.

**Frame settlement**: `resizeFromCorner()` calls `nextFrame()` after the mouse-up to ensure layout settles before assertions run, per `FLAKE_PREVENTION_RULES.md`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11408-test-add-E2E-coverage-for-NE-SW-NW-corner-node-resizing-3476d73d3650818d8a5ce5d6d535b38c) by [Unito](https://www.unito.io)
