### PR TITLE
fix: left-align widget actions dropdown menu items

### DIFF
--- a/browser_tests/tests/propertiesPanel/widgetActionsMenu.spec.ts
+++ b/browser_tests/tests/propertiesPanel/widgetActionsMenu.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+
+test.describe('Properties panel - Widget actions menu', { tag: '@ui' }, () => {
+  let panel: PropertiesPanelHelper
+
+  test.beforeEach(async ({ comfyPage }) => {
+    panel = new PropertiesPanelHelper(comfyPage.page)
+    await comfyPage.actionbar.propertiesButton.click()
+    await expect(panel.root).toBeVisible()
+    await comfyPage.nodeOps.selectNodes(['KSampler'])
+  })
+
+  test('menu opens when clicking the more button', async ({ comfyPage }) => {
+    const moreButton = panel.root
+      .getByTestId(TestIds.subgraphEditor.widgetActionsMenuButton)
+      .first()
+    await expect(moreButton).toBeVisible()
+    await moreButton.click()
+
+    const menu = comfyPage.page.getByTestId(TestIds.menu.moreMenuContent)
+    await expect(menu).toBeVisible()
+    await expect(menu.getByText('Rename')).toBeVisible()
+  })
+
+  test('menu items are left-aligned', async ({ comfyPage }) => {
+    const moreButton = panel.root
+      .getByTestId(TestIds.subgraphEditor.widgetActionsMenuButton)
+      .first()
+    await moreButton.click()
+
+    const menu = comfyPage.page.getByTestId(TestIds.menu.moreMenuContent)
+    await expect(menu).toBeVisible()
+
+    const menuButtons = menu.getByRole('button')
+    const count = await menuButtons.count()
+    expect(count).toBeGreaterThan(0)
+
+    for (let i = 0; i < count; i++) {
+      const button = menuButtons.nth(i)
+      await expect
+        .poll(() =>
+          button.evaluate((el) => {
+            const style = getComputedStyle(el)
+            return style.justifyContent
+          })
+        )
+        .toBe('flex-start')
+    }
+  })
+
+  test('menu shows Rename and Favorite actions', async ({ comfyPage }) => {
+    const moreButton = panel.root
+      .getByTestId(TestIds.subgraphEditor.widgetActionsMenuButton)
+      .first()
+    await moreButton.click()
+
+    const menu = comfyPage.page.getByTestId(TestIds.menu.moreMenuContent)
+    await expect(menu).toBeVisible()
+    await expect(menu.getByText('Rename')).toBeVisible()
+    await expect(menu.getByText('Favorite')).toBeVisible()
+  })
+
+  test('menu closes after clicking an action', async ({ comfyPage }) => {
+    const moreButton = panel.root
+      .getByTestId(TestIds.subgraphEditor.widgetActionsMenuButton)
+      .first()
+    await moreButton.click()
+
+    const menu = comfyPage.page.getByTestId(TestIds.menu.moreMenuContent)
+    await expect(menu).toBeVisible()
+
+    await menu.getByText('Favorite').click()
+    await expect(menu).toBeHidden()
+  })
+})

--- a/src/components/rightSidePanel/parameters/WidgetActions.vue
+++ b/src/components/rightSidePanel/parameters/WidgetActions.vue
@@ -130,7 +130,7 @@ function handleResetToDefault() {
       <Button
         variant="textonly"
         size="unset"
-        class="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
+        class="flex w-full items-center justify-start gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
         @click="
           () => {
             handleRename()
@@ -146,7 +146,7 @@ function handleResetToDefault() {
         v-if="canToggleVisibility"
         variant="textonly"
         size="unset"
-        class="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
+        class="flex w-full items-center justify-start gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
         @click="
           () => {
             if (isShownOnParents) handleHideInput()
@@ -168,7 +168,7 @@ function handleResetToDefault() {
       <Button
         variant="textonly"
         size="unset"
-        class="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
+        class="flex w-full items-center justify-start gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
         @click="
           () => {
             handleToggleFavorite()
@@ -190,7 +190,7 @@ function handleResetToDefault() {
         v-if="hasDefault"
         variant="textonly"
         size="unset"
-        class="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
+        class="flex w-full items-center justify-start gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
         :disabled="isCurrentValueDefault"
         @click="
           () => {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Left-align options in the widget actions dropdown popover on the parameter panel. The button base variant (`justify-center`) was causing menu items to be center-aligned.

## Changes

- **What**: Add `justify-start` to each menu button in `WidgetActions.vue` to override the base button variant's `justify-center`, ensuring dropdown options are left-aligned as expected.
- Add e2e tests covering menu open, left-alignment verification, visible actions, and close behavior.

## Review Focus

The fix is minimal — only adding a Tailwind class to 4 existing Button elements. The e2e test verifies `justifyContent === 'flex-start'` on menu buttons, which directly validates the fix.

## Screenshots

See attached screenshot showing the dropdown with left-aligned options after the fix.

## Screenshots

![Widget actions dropdown menu with left-aligned options after fix](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/258d2fc34cc4b5b7256328bff78412ff49555979f6c16ee28213e17ab03fd65e/pr-images/1776590411401-ddf48251-3001-4766-b5c5-f61f13070042.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11414-fix-left-align-widget-actions-dropdown-menu-items-3476d73d365081fa95a5f02a8d931ead) by [Unito](https://www.unito.io)

---

## 🔀 Rebase & handoff status (2026-07-13)

**Status: APPROVED + green months ago → rotted on `main` (merge-skew) → now rebased onto current `main` → ready to merge.**

- Rebased onto current `main`.
- Re-ran the months-old stale e2e suite (now current).

- [x] Rebased onto current `main`
- [x] Stale e2e re-run
- [x] Ready to merge — assigned to @christian-byrne