### PR TITLE
fix: reset file input value after selection to allow same-file reupload

### DIFF
--- a/browser_tests/tests/fileInputReselection.spec.ts
+++ b/browser_tests/tests/fileInputReselection.spec.ts
@@ -3,53 +3,52 @@ import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
 test.describe('File input same-file reselection', () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
-    await comfyPage.settings.setSetting('Comfy.Canvas.BackgroundImage', '')
-  })
-
-  test.afterEach(async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Canvas.BackgroundImage', '')
-  })
-
-  test('should allow uploading the same file twice in a row', async ({
+  test('should allow uploading the same file twice via LoadImage node', async ({
     comfyPage
   }) => {
-    await comfyPage.page.keyboard.press('Control+,')
+    await comfyPage.workflow.loadWorkflow('nodes/load_image_with_ksampler')
 
-    const appearanceOption = comfyPage.page.locator('text=Appearance')
-    await appearanceOption.click()
+    const loadImageNodes =
+      await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+    const loadImageNode = loadImageNodes[0]
+    const uploadWidget = await loadImageNode.getWidget(1)
+    const fileWidget = await loadImageNode.getWidget(0)
 
-    const backgroundImageSetting = comfyPage.page.locator(
-      '#Comfy\\.Canvas\\.BackgroundImage'
+    // First upload
+    const firstUpload = comfyPage.page.waitForResponse(
+      (resp) => resp.url().includes('/upload/') && resp.status() === 200,
+      { timeout: 10_000 }
     )
-    const uploadButton = backgroundImageSetting.getByRole('button', {
-      name: /upload/i
-    })
-
     const firstChooser = comfyPage.page.waitForEvent('filechooser')
-    await uploadButton.click()
-    await (
-      await firstChooser
-    ).setFiles(comfyPage.assetPath('test_upload_image.png'))
+    await uploadWidget.click()
+    await (await firstChooser).setFiles(
+      comfyPage.assetPath('test_upload_image.png')
+    )
+    await firstUpload
 
-    const urlInput = backgroundImageSetting.getByRole('textbox')
-    await expect(urlInput).toHaveValue(/^\/api\/view\?/)
+    await expect
+      .poll(() => fileWidget.getValue(), {
+        message: 'First upload should set widget value'
+      })
+      .toContain('test_upload_image')
 
-    const clearButton = backgroundImageSetting.getByRole('button', {
-      name: /clear/i
-    })
-    await clearButton.click()
-    await expect(urlInput).toHaveValue('')
-
-    // Second upload of the SAME file — this failed before the fix because
-    // the hidden input retained the previous value and onchange did not fire.
+    // Second upload of the SAME file — before the fix, the hidden input
+    // retained the previous value and onchange did not fire.
+    const secondUpload = comfyPage.page.waitForResponse(
+      (resp) => resp.url().includes('/upload/') && resp.status() === 200,
+      { timeout: 10_000 }
+    )
     const secondChooser = comfyPage.page.waitForEvent('filechooser')
-    await uploadButton.click()
-    await (
-      await secondChooser
-    ).setFiles(comfyPage.assetPath('test_upload_image.png'))
+    await uploadWidget.click()
+    await (await secondChooser).setFiles(
+      comfyPage.assetPath('test_upload_image.png')
+    )
+    await secondUpload
 
-    await expect(urlInput).toHaveValue(/^\/api\/view\?/)
+    await expect
+      .poll(() => fileWidget.getValue(), {
+        message: 'Second upload of the same file should still set widget value'
+      })
+      .toContain('test_upload_image')
   })
 })

--- a/browser_tests/tests/fileInputReselection.spec.ts
+++ b/browser_tests/tests/fileInputReselection.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+test.describe('File input same-file reselection', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
+    await comfyPage.settings.setSetting('Comfy.Canvas.BackgroundImage', '')
+  })
+
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.Canvas.BackgroundImage', '')
+  })
+
+  test('should allow uploading the same file twice in a row', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.keyboard.press('Control+,')
+
+    const appearanceOption = comfyPage.page.locator('text=Appearance')
+    await appearanceOption.click()
+
+    const backgroundImageSetting = comfyPage.page.locator(
+      '#Comfy\\.Canvas\\.BackgroundImage'
+    )
+    const uploadButton = backgroundImageSetting.getByRole('button', {
+      name: /upload/i
+    })
+
+    const firstChooser = comfyPage.page.waitForEvent('filechooser')
+    await uploadButton.click()
+    await (
+      await firstChooser
+    ).setFiles(comfyPage.assetPath('test_upload_image.png'))
+
+    const urlInput = backgroundImageSetting.getByRole('textbox')
+    await expect(urlInput).toHaveValue(/^\/api\/view\?/)
+
+    const clearButton = backgroundImageSetting.getByRole('button', {
+      name: /clear/i
+    })
+    await clearButton.click()
+    await expect(urlInput).toHaveValue('')
+
+    // Second upload of the SAME file — this failed before the fix because
+    // the hidden input retained the previous value and onchange did not fire.
+    const secondChooser = comfyPage.page.waitForEvent('filechooser')
+    await uploadButton.click()
+    await (
+      await secondChooser
+    ).setFiles(comfyPage.assetPath('test_upload_image.png'))
+
+    await expect(urlInput).toHaveValue(/^\/api\/view\?/)
+  })
+})

--- a/browser_tests/tests/fileInputReselection.spec.ts
+++ b/browser_tests/tests/fileInputReselection.spec.ts
@@ -21,9 +21,9 @@ test.describe('File input same-file reselection', () => {
     )
     const firstChooser = comfyPage.page.waitForEvent('filechooser')
     await uploadWidget.click()
-    await (await firstChooser).setFiles(
-      comfyPage.assetPath('test_upload_image.png')
-    )
+    await (
+      await firstChooser
+    ).setFiles(comfyPage.assetPath('test_upload_image.png'))
     await firstUpload
 
     await expect
@@ -40,9 +40,9 @@ test.describe('File input same-file reselection', () => {
     )
     const secondChooser = comfyPage.page.waitForEvent('filechooser')
     await uploadWidget.click()
-    await (await secondChooser).setFiles(
-      comfyPage.assetPath('test_upload_image.png')
-    )
+    await (
+      await secondChooser
+    ).setFiles(comfyPage.assetPath('test_upload_image.png'))
     await secondUpload
 
     await expect

--- a/src/composables/node/useNodeDragAndDrop.test.ts
+++ b/src/composables/node/useNodeDragAndDrop.test.ts
@@ -1,0 +1,243 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeDragAndDrop } from './useNodeDragAndDrop'
+
+function createNode(overrides: Record<string, unknown> = {}): LGraphNode {
+  return fromAny<LGraphNode, unknown>({
+    ...overrides
+  })
+}
+
+function createFile(name: string, type = 'image/png'): File {
+  return new File(['data'], name, { type })
+}
+
+function createDragEvent(options: {
+  items?: Array<{ kind: string }>
+  files?: File[]
+  types?: string[]
+  uri?: string
+}): DragEvent {
+  const { items = [], files = [], types = [], uri = '' } = options
+  return fromAny<DragEvent, unknown>({
+    dataTransfer: {
+      items: fromAny<DataTransferItemList, unknown>(items),
+      files: fromAny<FileList, unknown>(files),
+      types,
+      getData: vi.fn((format: string) =>
+        format === 'text/uri-list' ? uri : ''
+      )
+    }
+  })
+}
+
+describe('useNodeDragAndDrop', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('onDragOver detects file items by default', () => {
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+    const isDragging = node.onDragOver?.(
+      createDragEvent({ items: [{ kind: 'file' }] })
+    )
+
+    expect(isDragging).toBe(true)
+  })
+
+  it('onDragOver delegates to custom handler result', () => {
+    const node = createNode()
+    const onDragOver = vi.fn().mockReturnValue(false)
+
+    useNodeDragAndDrop(node, {
+      onDrop: vi.fn().mockResolvedValue([]),
+      onDragOver
+    })
+
+    const isDragging = node.onDragOver?.(
+      createDragEvent({ items: [{ kind: 'file' }] })
+    )
+
+    expect(onDragOver).toHaveBeenCalledTimes(1)
+    expect(isDragging).toBe(false)
+  })
+
+  it('onDragOver returns true for uri list drops without file items', () => {
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+    const isDragging = node.onDragOver?.(
+      createDragEvent({ items: [{ kind: 'string' }], types: ['text/uri-list'] })
+    )
+
+    expect(isDragging).toBe(true)
+  })
+
+  it('onDragOver returns false when drag event has no items', () => {
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+    const isDragging = node.onDragOver?.(fromAny<DragEvent, unknown>({}))
+
+    expect(isDragging).toBe(false)
+  })
+
+  it('onDragDrop calls onDrop with filtered files', async () => {
+    const onDrop = vi.fn().mockResolvedValue([])
+    const node = createNode()
+    const keep = createFile('keep.png')
+    const skip = createFile('skip.jpg', 'image/jpeg')
+
+    useNodeDragAndDrop(node, {
+      onDrop,
+      fileFilter: (file) => file.type === 'image/png'
+    })
+
+    const result = await node.onDragDrop?.(
+      createDragEvent({ files: [keep, skip], items: [{ kind: 'file' }] })
+    )
+
+    expect(result).toBe(true)
+    expect(onDrop).toHaveBeenCalledWith([keep])
+  })
+
+  it('onDragDrop returns false for invalid drops', async () => {
+    const onDrop = vi.fn().mockResolvedValue([])
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop })
+
+    const result = await node.onDragDrop?.(createDragEvent({}))
+
+    expect(result).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('onDragDrop handles same-origin uri drops', async () => {
+    const onDrop = vi.fn().mockResolvedValue([])
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      fromAny<Response, unknown>({
+        ok: true,
+        blob: vi
+          .fn()
+          .mockResolvedValue(new Blob(['uri'], { type: 'image/png' }))
+      })
+    )
+    const uri = `${location.origin}/api/file?filename=uri.png`
+
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop })
+
+    const result = await node.onDragDrop?.(
+      createDragEvent({ uri, types: ['text/uri-list'] })
+    )
+
+    expect(result).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledWith(new URL(uri))
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(onDrop.mock.calls[0][0][0]).toBeInstanceOf(File)
+    expect(onDrop.mock.calls[0][0][0].name).toBe('uri.png')
+  })
+
+  it('onDragDrop returns false for cross-origin uri drops', async () => {
+    const node = createNode()
+    const onDrop = vi.fn().mockResolvedValue([])
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    useNodeDragAndDrop(node, { onDrop })
+
+    const result = await node.onDragDrop?.(
+      createDragEvent({
+        uri: 'https://example.com/api/file?filename=uri.png',
+        types: ['text/uri-list']
+      })
+    )
+
+    expect(result).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('onDragDrop returns false when uri fetch throws', async () => {
+    const onDrop = vi.fn().mockResolvedValue([])
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
+    const uri = `${location.origin}/api/file?filename=uri.png`
+
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop })
+
+    const result = await node.onDragDrop?.(
+      createDragEvent({ uri, types: ['text/uri-list'] })
+    )
+
+    expect(result).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('onDragDrop returns false when uri response is invalid or filtered out', async () => {
+    const onDrop = vi.fn().mockResolvedValue([])
+    const uri = `${location.origin}/api/file?filename=uri.jpg`
+
+    const nodeA = createNode()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      fromAny<Response, unknown>({ ok: false })
+    )
+    useNodeDragAndDrop(nodeA, { onDrop })
+    const badResponseResult = await nodeA.onDragDrop?.(
+      createDragEvent({ uri, types: ['text/uri-list'] })
+    )
+    expect(badResponseResult).toBe(false)
+
+    const nodeB = createNode()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      fromAny<Response, unknown>({
+        ok: true,
+        blob: vi
+          .fn()
+          .mockResolvedValue(new Blob(['uri'], { type: 'image/jpeg' }))
+      })
+    )
+    useNodeDragAndDrop(nodeB, {
+      onDrop,
+      fileFilter: (file) => file.type === 'image/png'
+    })
+    const filteredOutResult = await nodeB.onDragDrop?.(
+      createDragEvent({ uri, types: ['text/uri-list'] })
+    )
+
+    expect(filteredOutResult).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('onRemoved clears handlers and chains existing onRemoved', () => {
+    const previousOnRemoved = vi.fn()
+    const node = createNode({ onRemoved: previousOnRemoved })
+
+    useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+    expect(node.onDragOver).toBeTypeOf('function')
+    expect(node.onDragDrop).toBeTypeOf('function')
+
+    node.onRemoved?.call(node)
+
+    expect(previousOnRemoved).toHaveBeenCalledTimes(1)
+    expect(node.onDragOver).toBeUndefined()
+    expect(node.onDragDrop).toBeUndefined()
+  })
+
+  it('onRemoved preserves handlers replaced by another extension', () => {
+    const node = createNode()
+    useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+    const replacementDragOver = vi.fn()
+    const replacementDragDrop = vi.fn()
+    node.onDragOver = replacementDragOver
+    node.onDragDrop = replacementDragDrop
+
+    node.onRemoved?.call(node)
+
+    expect(node.onDragOver).toBe(replacementDragOver)
+    expect(node.onDragDrop).toBe(replacementDragDrop)
+  })
+})

--- a/src/composables/node/useNodeDragAndDrop.ts
+++ b/src/composables/node/useNodeDragAndDrop.ts
@@ -1,3 +1,4 @@
+import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 type DragHandler = (e: DragEvent) => boolean
@@ -43,9 +44,10 @@ export const useNodeDragAndDrop = <T>(
     return !!e?.dataTransfer?.getData('text/uri-list')
   }
 
-  node.onDragOver = isDraggingFiles
+  const installedDragOver = isDraggingFiles
+  node.onDragOver = installedDragOver
 
-  node.onDragDrop = async function (e: DragEvent) {
+  const installedDragDrop = async function (e: DragEvent) {
     if (!isDraggingValidFiles(e)) return false
 
     const files = filterFiles(e.dataTransfer!.files)
@@ -73,4 +75,10 @@ export const useNodeDragAndDrop = <T>(
     }
     return true
   }
+  node.onDragDrop = installedDragDrop
+
+  node.onRemoved = useChainCallback(node.onRemoved, () => {
+    if (node.onDragOver === installedDragOver) node.onDragOver = undefined
+    if (node.onDragDrop === installedDragDrop) node.onDragDrop = undefined
+  })
 }

--- a/src/composables/node/useNodeFileInput.test.ts
+++ b/src/composables/node/useNodeFileInput.test.ts
@@ -1,0 +1,175 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeFileInput } from './useNodeFileInput'
+
+function createNode(overrides: Record<string, unknown> = {}): LGraphNode {
+  return fromAny<LGraphNode, unknown>({
+    ...overrides
+  })
+}
+
+function createFile(name: string, type = 'image/png'): File {
+  return new File(['data'], name, { type })
+}
+
+function setInputFiles(input: HTMLInputElement, files: File[]) {
+  Object.defineProperty(input, 'files', {
+    configurable: true,
+    value: fromAny<FileList, unknown>(files)
+  })
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  Object.defineProperty(input, 'value', {
+    configurable: true,
+    writable: true,
+    value
+  })
+}
+
+describe('useNodeFileInput', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates a file input with configured attributes and defaults', () => {
+    const fileInput = document.createElement('input')
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockReturnValue(fileInput)
+
+    const node = createNode()
+    useNodeFileInput(node, { onSelect: vi.fn() })
+
+    expect(createElementSpy).toHaveBeenCalledWith('input')
+    expect(fileInput.type).toBe('file')
+    expect(fileInput.accept).toBe('*')
+    expect(fileInput.multiple).toBe(false)
+  })
+
+  it('uses provided accept and allow_batch options', () => {
+    const fileInput = document.createElement('input')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const node = createNode()
+    useNodeFileInput(node, {
+      onSelect: vi.fn(),
+      accept: 'image/*',
+      allow_batch: true
+    })
+
+    expect(fileInput.accept).toBe('image/*')
+    expect(fileInput.multiple).toBe(true)
+  })
+
+  it('calls onSelect with filtered files and resets value on change', () => {
+    const fileInput = document.createElement('input')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const onSelect = vi.fn()
+    const node = createNode()
+    const keep = createFile('keep.png')
+    const skip = createFile('skip.jpg', 'image/jpeg')
+
+    useNodeFileInput(node, {
+      onSelect,
+      fileFilter: (file) => file.type === 'image/png'
+    })
+
+    setInputFiles(fileInput, [keep, skip])
+    setInputValue(fileInput, 'C:\\fakepath\\keep.png')
+
+    fileInput.onchange?.(new Event('change'))
+
+    expect(onSelect).toHaveBeenCalledWith([keep])
+    expect(fileInput.value).toBe('')
+  })
+
+  it('does not call onSelect for empty file list and still resets value', () => {
+    const fileInput = document.createElement('input')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const onSelect = vi.fn()
+    const node = createNode()
+
+    useNodeFileInput(node, { onSelect })
+
+    setInputFiles(fileInput, [])
+    setInputValue(fileInput, 'C:\\fakepath\\empty.png')
+    fileInput.onchange?.(new Event('change'))
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(fileInput.value).toBe('')
+  })
+
+  it('resets value before invoking onSelect so it is cleared even on throw', () => {
+    const fileInput = document.createElement('input')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const node = createNode()
+    const onSelect = vi.fn(() => {
+      throw new Error('boom')
+    })
+
+    useNodeFileInput(node, { onSelect })
+
+    setInputFiles(fileInput, [createFile('test.png')])
+    setInputValue(fileInput, 'C:\\fakepath\\test.png')
+
+    expect(() => fileInput.onchange?.(new Event('change'))).toThrow('boom')
+    expect(fileInput.value).toBe('')
+  })
+
+  it('does not call onSelect when all files are filtered out', () => {
+    const fileInput = document.createElement('input')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const onSelect = vi.fn()
+    const node = createNode()
+
+    useNodeFileInput(node, {
+      onSelect,
+      fileFilter: () => false
+    })
+
+    setInputFiles(fileInput, [createFile('ignored.png')])
+    fileInput.onchange?.(new Event('change'))
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('openFileSelection clicks the generated input', () => {
+    const fileInput = document.createElement('input')
+    const clickSpy = vi.spyOn(fileInput, 'click')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const node = createNode()
+    const { openFileSelection } = useNodeFileInput(node, { onSelect: vi.fn() })
+
+    openFileSelection()
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up on removal, chains existing callback, and no-ops after removal', () => {
+    const fileInput = document.createElement('input')
+    const clickSpy = vi.spyOn(fileInput, 'click')
+    vi.spyOn(document, 'createElement').mockReturnValue(fileInput)
+
+    const previousOnRemoved = vi.fn()
+    const node = createNode({ onRemoved: previousOnRemoved })
+    const { openFileSelection } = useNodeFileInput(node, { onSelect: vi.fn() })
+
+    expect(fileInput.onchange).toBeTypeOf('function')
+
+    node.onRemoved?.call(node)
+
+    expect(previousOnRemoved).toHaveBeenCalledTimes(1)
+    expect(fileInput.onchange).toBeNull()
+
+    openFileSelection()
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/node/useNodeFileInput.ts
+++ b/src/composables/node/useNodeFileInput.ts
@@ -25,10 +25,12 @@ export function useNodeFileInput(node: LGraphNode, options: FileInputOptions) {
   fileInput.multiple = allow_batch
 
   fileInput.onchange = () => {
-    if (fileInput?.files?.length) {
-      const files = Array.from(fileInput.files).filter(fileFilter)
-      if (files.length) onSelect(files)
-    }
+    const files = fileInput?.files?.length
+      ? Array.from(fileInput.files).filter(fileFilter)
+      : []
+    // Reset value so re-selecting the same file triggers onchange
+    if (fileInput) fileInput.value = ''
+    if (files.length) onSelect(files)
   }
 
   node.onRemoved = useChainCallback(node.onRemoved, () => {

--- a/src/composables/node/useNodePaste.test.ts
+++ b/src/composables/node/useNodePaste.test.ts
@@ -1,0 +1,107 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodePaste } from './useNodePaste'
+
+function createNode(overrides: Record<string, unknown> = {}): LGraphNode {
+  return fromAny<LGraphNode, unknown>({
+    ...overrides
+  })
+}
+
+function createFile(name: string, type = 'image/png'): File {
+  return new File(['data'], name, { type })
+}
+
+describe('useNodePaste', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('pasteFiles calls onPaste with filtered files', () => {
+    const onPaste = vi.fn().mockResolvedValue('ok')
+    const node = createNode()
+    const keep = createFile('keep.png')
+    const skip = createFile('skip.jpg', 'image/jpeg')
+
+    useNodePaste(node, {
+      onPaste,
+      fileFilter: (file) => file.type === 'image/png',
+      allow_batch: true
+    })
+
+    const result = node.pasteFiles?.([keep, skip])
+
+    expect(result).toBe(true)
+    expect(onPaste).toHaveBeenCalledWith([keep])
+  })
+
+  it('pasteFiles returns false when no files match filter', () => {
+    const onPaste = vi.fn().mockResolvedValue('ok')
+    const node = createNode()
+
+    useNodePaste(node, {
+      onPaste,
+      fileFilter: () => false
+    })
+
+    const result = node.pasteFiles?.([createFile('ignored.png')])
+
+    expect(result).toBe(false)
+    expect(onPaste).not.toHaveBeenCalled()
+  })
+
+  it('pasteFiles limits to first file when allow_batch is false', () => {
+    const onPaste = vi.fn().mockResolvedValue('ok')
+    const node = createNode()
+    const first = createFile('first.png')
+    const second = createFile('second.png')
+
+    useNodePaste(node, { onPaste, allow_batch: false })
+
+    const result = node.pasteFiles?.([first, second])
+
+    expect(result).toBe(true)
+    expect(onPaste).toHaveBeenCalledWith([first])
+  })
+
+  it('pasteFiles passes all files when allow_batch is true', () => {
+    const onPaste = vi.fn().mockResolvedValue('ok')
+    const node = createNode()
+    const first = createFile('first.png')
+    const second = createFile('second.png')
+
+    useNodePaste(node, { onPaste, allow_batch: true })
+
+    const result = node.pasteFiles?.([first, second])
+
+    expect(result).toBe(true)
+    expect(onPaste).toHaveBeenCalledWith([first, second])
+  })
+
+  it('onRemoved clears pasteFiles and chains existing onRemoved', () => {
+    const previousOnRemoved = vi.fn()
+    const node = createNode({ onRemoved: previousOnRemoved })
+
+    useNodePaste(node, { onPaste: vi.fn().mockResolvedValue('ok') })
+    expect(node.pasteFiles).toBeTypeOf('function')
+
+    node.onRemoved?.call(node)
+
+    expect(previousOnRemoved).toHaveBeenCalledTimes(1)
+    expect(node.pasteFiles).toBeUndefined()
+  })
+
+  it('onRemoved preserves pasteFiles replaced by another extension', () => {
+    const node = createNode()
+    useNodePaste(node, { onPaste: vi.fn().mockResolvedValue('ok') })
+
+    const replacementPasteFiles = vi.fn()
+    node.pasteFiles = replacementPasteFiles
+
+    node.onRemoved?.call(node)
+
+    expect(node.pasteFiles).toBe(replacementPasteFiles)
+  })
+})

--- a/src/composables/node/useNodePaste.ts
+++ b/src/composables/node/useNodePaste.ts
@@ -1,3 +1,4 @@
+import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 type PasteHandler<T> = (files: File[]) => Promise<T>
@@ -17,7 +18,7 @@ export const useNodePaste = <T>(
 ) => {
   const { onPaste, fileFilter = () => true, allow_batch = false } = options
 
-  node.pasteFiles = function (files: File[]) {
+  const installedPasteFiles = function (files: File[]) {
     const filteredFiles = Array.from(files).filter(fileFilter)
     if (!filteredFiles.length) return false
 
@@ -26,4 +27,9 @@ export const useNodePaste = <T>(
     void onPaste(paste)
     return true
   }
+  node.pasteFiles = installedPasteFiles
+
+  node.onRemoved = useChainCallback(node.onRemoved, () => {
+    if (node.pasteFiles === installedPasteFiles) node.pasteFiles = undefined
+  })
 }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fixes the "choose video to upload" button becoming unresponsive after running a workflow with a subgraph a few times.

**Root cause**: The detached input element in `useNodeFileInput` never resets its `value`. The browser's `onchange` only fires when the value *changes* — re-selecting the same file silently drops the event. A page refresh recreates the input with an empty value, which is why refreshing fixes it.

## Changes

- `useNodeFileInput.ts`: Reset `fileInput.value` before invoking callbacks so value is cleared even if a callback throws
- `useNodeDragAndDrop.ts`: Add `onRemoved` cleanup for installed handlers (only clears own handlers; preserves replacements from extensions)
- `useNodePaste.ts`: Add `onRemoved` cleanup for installed `pasteFiles` handler (same reference-safe pattern)
- 3 new colocated test files with 26 test cases covering all branches

## Codebase Audit

Audited all 11 file upload implementations across the codebase. Found 5 using the ghost/virtual input pattern — 3 with the same missing value-reset bug:
- `useNodeFileInput.ts` — fixed in this PR
- `scripts/utils.ts` (`uploadFile()`) — one-shot pattern, lower risk
- `extensions/core/load3d.ts` — partial reset only

The 4 Vue component implementations already reset correctly.

## Future Work

VueUse `useFileDialog` composable handles same-file reselection via `reset: true` and provides automatic lifecycle cleanup. A follow-up PR could migrate the ghost input patterns for a centralized solution.

## Test Plan

- 26 unit tests across 3 new test files (all pass)
- 9 existing useNodeImageUpload tests still pass
- Pre-commit hooks pass (oxfmt, oxlint, eslint, typecheck)
- Oracle code review addressed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11417-fix-reset-file-input-value-after-selection-to-allow-same-file-reupload-3476d73d3650814d95efdab602a3852d) by [Unito](https://www.unito.io)
