### PR TITLE
fix: rewrite session workflow paths on rename to preserve run history

### DIFF
--- a/browser_tests/tests/appModeSaveRunPersistence.spec.ts
+++ b/browser_tests/tests/appModeSaveRunPersistence.spec.ts
@@ -1,0 +1,78 @@
+import { mergeTests } from '@playwright/test'
+
+import {
+  comfyPageFixture,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const test = mergeTests(comfyPageFixture, webSocketFixture)
+
+const SAVE_IMAGE_NODE = '9'
+const KSAMPLER_NODE = '3'
+
+async function startExecution(comfyPage: ComfyPage, exec: ExecutionHelper) {
+  const jobId = await exec.run()
+  await comfyPage.nextFrame()
+  exec.executionStart(jobId)
+  return jobId
+}
+
+function imageOutput(filename: string) {
+  return {
+    images: [{ filename, subfolder: '', type: 'output' }]
+  }
+}
+
+test.describe('App mode save keeps run history', { tag: '@ui' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.appMode.enableLinearMode()
+    await comfyPage.appMode.suppressVueNodeSwitchPopup()
+    await comfyPage.workflow.loadWorkflow('default')
+    await comfyPage.appMode.enterAppModeWithInputs([[KSAMPLER_NODE, 'seed']])
+    await expect(comfyPage.appMode.linearWidgets).toBeVisible()
+  })
+
+  test('first save as app does not clear previously generated outputs', async ({
+    comfyPage,
+    getWebSocket
+  }) => {
+    const ws = await getWebSocket()
+    const exec = new ExecutionHelper(comfyPage, ws)
+    const jobId = await startExecution(comfyPage, exec)
+
+    await expect(
+      comfyPage.appMode.outputHistory.inProgressItems.first()
+    ).toBeVisible()
+
+    exec.executed(jobId, SAVE_IMAGE_NODE, imageOutput('persist-output.png'))
+
+    await expect(
+      comfyPage.appMode.outputHistory.imageOutputs.first()
+    ).toBeVisible()
+
+    await comfyPage.appMode.enterBuilder()
+    await expect(comfyPage.appMode.steps.toolbar).toBeVisible()
+
+    await comfyPage.appMode.footer.saveAsButton.click()
+    await expect(comfyPage.appMode.saveAs.nameInput).toBeVisible()
+    await comfyPage.appMode.saveAs.fillAndSave(
+      `${Date.now()} run-history-persist`,
+      'App'
+    )
+    await expect(comfyPage.appMode.saveAs.successMessage).toBeVisible()
+
+    await comfyPage.appMode.saveAs.viewAppButton.click()
+    await expect(comfyPage.appMode.saveAs.successDialog).toBeHidden()
+    await expect(comfyPage.appMode.linearWidgets).toBeVisible()
+
+    await expect(
+      comfyPage.appMode.outputHistory.inProgressItems.first()
+    ).toBeVisible()
+    await expect(
+      comfyPage.appMode.outputHistory.imageOutputs.first()
+    ).toBeVisible()
+  })
+})

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -11,6 +11,7 @@ import type { NodeLocatorId } from '@/types/nodeIdentification'
 import type { SerializedNodeId } from '@/types/nodeId'
 import type { AppMode } from '@/utils/appMode'
 import type { WidgetId } from '@/types/widgetId'
+import { generateUUID } from '@/utils/formatUtil'
 
 export interface InputWidgetConfig {
   height?: number
@@ -35,6 +36,8 @@ export interface PendingWarnings {
 export class ComfyWorkflow extends UserFile {
   static readonly basePath: string = 'workflows/'
   readonly tintCanvasBg?: string
+  /** Unique, stable identity for this workflow instance in the current session. */
+  readonly instanceId = generateUUID()
 
   /**
    * The change tracker for the workflow. Non-reactive raw object.

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -16,6 +16,7 @@ import { useWorkflowDraftStore } from '@/platform/workflow/persistence/stores/wo
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { defaultGraph, defaultGraphJSON } from '@/scripts/defaultGraph'
+import { useExecutionStore } from '@/stores/executionStore'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 import {
   createMockCanvas,
@@ -434,6 +435,38 @@ describe('useWorkflowStore', () => {
       // Check that no bookmarks were affected
       expect(bookmarkStore.isBookmarked(workflow.path)).toBe(false)
       expect(bookmarkStore.isBookmarked('test.json')).toBe(false)
+    })
+
+    it('renameWorkflow updates executionStore session path map scoped by workflowId', async () => {
+      const workflow = store.createTemporary('app-to-save.json')
+      const loaded = await workflow.load()
+      const executionStore = useExecutionStore()
+      const workflowId = String(
+        loaded.activeState?.id ?? loaded.initialState?.id
+      )
+
+      executionStore.ensureSessionWorkflowPath('job-1', workflow.path)
+      executionStore.registerJobWorkflowIdMapping('job-1', workflowId)
+      executionStore.ensureSessionWorkflowPath('job-other', workflow.path)
+      executionStore.registerJobWorkflowIdMapping('job-other', 'different-wf')
+
+      vi.spyOn(Object.getPrototypeOf(workflow), 'rename').mockImplementation(
+        async function (this: unknown, ...args: unknown[]) {
+          const renamedPath = args[0] as string
+          ;(this as typeof workflow).path = renamedPath
+          return this as typeof workflow
+        }
+      )
+
+      const newPath = 'workflows/saved-app.app.json'
+      await store.renameWorkflow(workflow, newPath)
+
+      expect(executionStore.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+        newPath
+      )
+      expect(executionStore.jobIdToSessionWorkflowPath.get('job-other')).toBe(
+        'workflows/app-to-save.json'
+      )
     })
   })
 

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -207,6 +207,17 @@ describe('useWorkflowStore', () => {
       expect(workflow2.path).toBe('workflows/Unsaved Workflow (2).json')
     })
 
+    it('assigns each workflow a stable unique session identity', async () => {
+      const workflow = store.createTemporary()
+      const otherWorkflow = store.createTemporary()
+      const instanceId = workflow.instanceId
+
+      await workflow.rename('workflows/renamed.json')
+
+      expect(workflow.instanceId).toBe(instanceId)
+      expect(otherWorkflow.instanceId).not.toBe(instanceId)
+    })
+
     it('should create a temporary workflow not clashing with persisted workflows', async () => {
       await syncRemoteWorkflows(['a.json'])
       const workflow = store.createTemporary('a.json')

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -635,8 +635,7 @@ describe('useWorkflowStore', () => {
       )
 
       vi.spyOn(workflow, 'rename').mockImplementation(
-        async (...args: unknown[]) => {
-          const renamedPath = args[0] as string
+        async (renamedPath: string) => {
           workflow.path = renamedPath
           return workflow
         }

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -613,11 +613,11 @@ describe('useWorkflowStore', () => {
       executionStore.ensureSessionWorkflowPath('job-other', workflow.path)
       executionStore.registerJobWorkflowIdMapping('job-other', 'different-wf')
 
-      vi.spyOn(Object.getPrototypeOf(workflow), 'rename').mockImplementation(
-        async function (this: unknown, ...args: unknown[]) {
+      vi.spyOn(workflow, 'rename').mockImplementation(
+        async (...args: unknown[]) => {
           const renamedPath = args[0] as string
-          ;(this as typeof workflow).path = renamedPath
-          return this as typeof workflow
+          workflow.path = renamedPath
+          return workflow
         }
       )
 

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -16,6 +16,7 @@ import { useWorkflowDraftStoreV2 } from '@/platform/workflow/persistence/stores/
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { defaultGraph, defaultGraphJSON } from '@/scripts/defaultGraph'
+import { useExecutionStore } from '@/stores/executionStore'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
@@ -597,6 +598,38 @@ describe('useWorkflowStore', () => {
       // Check that no bookmarks were affected
       expect(bookmarkStore.isBookmarked(workflow.path)).toBe(false)
       expect(bookmarkStore.isBookmarked('test.json')).toBe(false)
+    })
+
+    it('renameWorkflow updates executionStore session path map scoped by workflowId', async () => {
+      const workflow = store.createTemporary('app-to-save.json')
+      const loaded = await workflow.load()
+      const executionStore = useExecutionStore()
+      const workflowId = String(
+        loaded.activeState?.id ?? loaded.initialState?.id
+      )
+
+      executionStore.ensureSessionWorkflowPath('job-1', workflow.path)
+      executionStore.registerJobWorkflowIdMapping('job-1', workflowId)
+      executionStore.ensureSessionWorkflowPath('job-other', workflow.path)
+      executionStore.registerJobWorkflowIdMapping('job-other', 'different-wf')
+
+      vi.spyOn(Object.getPrototypeOf(workflow), 'rename').mockImplementation(
+        async function (this: unknown, ...args: unknown[]) {
+          const renamedPath = args[0] as string
+          ;(this as typeof workflow).path = renamedPath
+          return this as typeof workflow
+        }
+      )
+
+      const newPath = 'workflows/saved-app.app.json'
+      await store.renameWorkflow(workflow, newPath)
+
+      expect(executionStore.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+        newPath
+      )
+      expect(executionStore.jobIdToSessionWorkflowPath.get('job-other')).toBe(
+        'workflows/app-to-save.json'
+      )
     })
   })
 

--- a/src/platform/workflow/management/stores/workflowStore.test.ts
+++ b/src/platform/workflow/management/stores/workflowStore.test.ts
@@ -611,18 +611,28 @@ describe('useWorkflowStore', () => {
       expect(bookmarkStore.isBookmarked('test.json')).toBe(false)
     })
 
-    it('renameWorkflow updates executionStore session path map scoped by workflowId', async () => {
-      const workflow = store.createTemporary('app-to-save.json')
-      const loaded = await workflow.load()
+    it('renames only jobs from the matching workflow instance', async () => {
+      const duplicateId = 'duplicate-workflow-id'
+      const workflow = store.createTemporary('app-to-save.json', {
+        ...defaultGraph,
+        id: duplicateId
+      })
+      const otherWorkflow = store.createTemporary('other.json', {
+        ...defaultGraph,
+        id: duplicateId
+      })
       const executionStore = useExecutionStore()
-      const workflowId = String(
-        loaded.activeState?.id ?? loaded.initialState?.id
-      )
 
-      executionStore.ensureSessionWorkflowPath('job-1', workflow.path)
-      executionStore.registerJobWorkflowIdMapping('job-1', workflowId)
-      executionStore.ensureSessionWorkflowPath('job-other', workflow.path)
-      executionStore.registerJobWorkflowIdMapping('job-other', 'different-wf')
+      executionStore.ensureSessionWorkflowPath(
+        'job-1',
+        workflow.path,
+        workflow.instanceId
+      )
+      executionStore.ensureSessionWorkflowPath(
+        'job-other',
+        workflow.path,
+        otherWorkflow.instanceId
+      )
 
       vi.spyOn(workflow, 'rename').mockImplementation(
         async (...args: unknown[]) => {

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -19,6 +19,7 @@ import { useWorkflowThumbnail } from '@/renderer/core/thumbnail/useWorkflowThumb
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { defaultGraphJSON } from '@/scripts/defaultGraph'
+import { useExecutionStore } from '@/stores/executionStore'
 import type { NodeExecutionId, NodeLocatorId } from '@/types/nodeIdentification'
 import {
   createNodeExecutionId,
@@ -498,7 +499,13 @@ export const useWorkflowStore = defineStore('workflow', () => {
       const wasBookmarked = bookmarkStore.isBookmarked(oldPath)
       const draftStore = useWorkflowDraftStore()
 
+      const workflowId = workflow.activeState?.id ?? workflow.initialState?.id
       await workflow.rename(newPath)
+      useExecutionStore().rewriteSessionWorkflowPaths(
+        oldPath,
+        workflow.path,
+        workflowId ? String(workflowId) : undefined
+      )
 
       // Synchronously swap old path for new path in lookup and open paths
       // to avoid a tab flicker caused by an async gap between detach/attach.

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -494,12 +494,10 @@ export const useWorkflowStore = defineStore('workflow', () => {
       const wasBookmarked = bookmarkStore.isBookmarked(oldPath)
       const draftStore = useWorkflowDraftStoreV2()
 
-      const workflowId = workflow.activeState?.id ?? workflow.initialState?.id
       await workflow.rename(newPath)
       useExecutionStore().rewriteSessionWorkflowPaths(
-        oldPath,
-        workflow.path,
-        workflowId ? String(workflowId) : undefined
+        workflow.instanceId,
+        workflow.path
       )
 
       // Synchronously swap old path for new path in lookup and open paths

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -21,6 +21,7 @@ import { useWorkflowThumbnail } from '@/renderer/core/thumbnail/useWorkflowThumb
 import { api } from '@/scripts/api'
 import { app as comfyApp } from '@/scripts/app'
 import { defaultGraph } from '@/scripts/defaultGraph'
+import { useExecutionStore } from '@/stores/executionStore'
 import type { NodeExecutionId, NodeLocatorId } from '@/types/nodeIdentification'
 import {
   createNodeExecutionId,
@@ -493,7 +494,13 @@ export const useWorkflowStore = defineStore('workflow', () => {
       const wasBookmarked = bookmarkStore.isBookmarked(oldPath)
       const draftStore = useWorkflowDraftStoreV2()
 
+      const workflowId = workflow.activeState?.id ?? workflow.initialState?.id
       await workflow.rename(newPath)
+      useExecutionStore().rewriteSessionWorkflowPaths(
+        oldPath,
+        workflow.path,
+        workflowId ? String(workflowId) : undefined
+      )
 
       // Synchronously swap old path for new path in lookup and open paths
       // to avoid a tab flicker caused by an async gap between detach/attach.

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -490,6 +490,107 @@ describe('useExecutionStore - progress_text startup guard', () => {
   })
 })
 
+describe('rewriteSessionWorkflowPaths', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('rewrites all entries matching old path when no workflowId filter', () => {
+    store.ensureSessionWorkflowPath('job-1', 'workflows/old.app.json')
+    store.ensureSessionWorkflowPath('job-2', 'workflows/keep.app.json')
+    store.ensureSessionWorkflowPath('job-3', 'workflows/old.app.json')
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+      'workflows/new.app.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-2')).toBe(
+      'workflows/keep.app.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-3')).toBe(
+      'workflows/new.app.json'
+    )
+  })
+
+  it('only rewrites entries matching both path and workflowId', () => {
+    store.ensureSessionWorkflowPath('job-1', 'workflows/old.app.json')
+    store.ensureSessionWorkflowPath('job-2', 'workflows/old.app.json')
+    store.registerJobWorkflowIdMapping('job-1', 'wf-A')
+    store.registerJobWorkflowIdMapping('job-2', 'wf-B')
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json',
+      'wf-A'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+      'workflows/new.app.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-2')).toBe(
+      'workflows/old.app.json'
+    )
+  })
+
+  it('does not rewrite entries from a different workflow sharing the same temp path', () => {
+    store.ensureSessionWorkflowPath(
+      'job-old',
+      'workflows/Unsaved Workflow.json'
+    )
+    store.ensureSessionWorkflowPath(
+      'job-new',
+      'workflows/Unsaved Workflow.json'
+    )
+    store.registerJobWorkflowIdMapping('job-old', 'wf-OLD')
+    store.registerJobWorkflowIdMapping('job-new', 'wf-NEW')
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/Unsaved Workflow.json',
+      'workflows/saved.app.json',
+      'wf-NEW'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.get('job-old')).toBe(
+      'workflows/Unsaved Workflow.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-new')).toBe(
+      'workflows/saved.app.json'
+    )
+  })
+
+  it('does not trigger reactivity when no entries match', () => {
+    store.ensureSessionWorkflowPath('job-1', 'workflows/keep.app.json')
+    const originalMap = store.jobIdToSessionWorkflowPath
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath).toBe(originalMap)
+  })
+
+  it('handles empty map', () => {
+    const originalMap = store.jobIdToSessionWorkflowPath
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.size).toBe(0)
+    expect(store.jobIdToSessionWorkflowPath).toBe(originalMap)
+  })
+})
+
 describe('useExecutionErrorStore - Node Error Lookups', () => {
   let store: ReturnType<typeof useExecutionErrorStore>
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1101,6 +1101,107 @@ describe('useExecutionStore - progress_text startup guard', () => {
   })
 })
 
+describe('rewriteSessionWorkflowPaths', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+  })
+
+  it('rewrites all entries matching old path when no workflowId filter', () => {
+    store.ensureSessionWorkflowPath('job-1', 'workflows/old.app.json')
+    store.ensureSessionWorkflowPath('job-2', 'workflows/keep.app.json')
+    store.ensureSessionWorkflowPath('job-3', 'workflows/old.app.json')
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+      'workflows/new.app.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-2')).toBe(
+      'workflows/keep.app.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-3')).toBe(
+      'workflows/new.app.json'
+    )
+  })
+
+  it('only rewrites entries matching both path and workflowId', () => {
+    store.ensureSessionWorkflowPath('job-1', 'workflows/old.app.json')
+    store.ensureSessionWorkflowPath('job-2', 'workflows/old.app.json')
+    store.registerJobWorkflowIdMapping('job-1', 'wf-A')
+    store.registerJobWorkflowIdMapping('job-2', 'wf-B')
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json',
+      'wf-A'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+      'workflows/new.app.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-2')).toBe(
+      'workflows/old.app.json'
+    )
+  })
+
+  it('does not rewrite entries from a different workflow sharing the same temp path', () => {
+    store.ensureSessionWorkflowPath(
+      'job-old',
+      'workflows/Unsaved Workflow.json'
+    )
+    store.ensureSessionWorkflowPath(
+      'job-new',
+      'workflows/Unsaved Workflow.json'
+    )
+    store.registerJobWorkflowIdMapping('job-old', 'wf-OLD')
+    store.registerJobWorkflowIdMapping('job-new', 'wf-NEW')
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/Unsaved Workflow.json',
+      'workflows/saved.app.json',
+      'wf-NEW'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.get('job-old')).toBe(
+      'workflows/Unsaved Workflow.json'
+    )
+    expect(store.jobIdToSessionWorkflowPath.get('job-new')).toBe(
+      'workflows/saved.app.json'
+    )
+  })
+
+  it('does not trigger reactivity when no entries match', () => {
+    store.ensureSessionWorkflowPath('job-1', 'workflows/keep.app.json')
+    const originalMap = store.jobIdToSessionWorkflowPath
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath).toBe(originalMap)
+  })
+
+  it('handles empty map', () => {
+    const originalMap = store.jobIdToSessionWorkflowPath
+
+    store.rewriteSessionWorkflowPaths(
+      'workflows/old.app.json',
+      'workflows/new.app.json'
+    )
+
+    expect(store.jobIdToSessionWorkflowPath.size).toBe(0)
+    expect(store.jobIdToSessionWorkflowPath).toBe(originalMap)
+  })
+})
+
 describe('useExecutionErrorStore - Node Error Lookups', () => {
   let store: ReturnType<typeof useExecutionErrorStore>
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1110,15 +1110,24 @@ describe('rewriteSessionWorkflowPaths', () => {
     store = useExecutionStore()
   })
 
-  it('rewrites all entries matching old path when no workflowId filter', () => {
-    store.ensureSessionWorkflowPath('job-1', 'workflows/old.app.json')
-    store.ensureSessionWorkflowPath('job-2', 'workflows/keep.app.json')
-    store.ensureSessionWorkflowPath('job-3', 'workflows/old.app.json')
-
-    store.rewriteSessionWorkflowPaths(
+  it('rewrites all entries associated with the workflow instance', () => {
+    store.ensureSessionWorkflowPath(
+      'job-1',
       'workflows/old.app.json',
-      'workflows/new.app.json'
+      'instance-A'
     )
+    store.ensureSessionWorkflowPath(
+      'job-2',
+      'workflows/keep.app.json',
+      'instance-B'
+    )
+    store.ensureSessionWorkflowPath(
+      'job-3',
+      'workflows/old.app.json',
+      'instance-A'
+    )
+
+    store.rewriteSessionWorkflowPaths('instance-A', 'workflows/new.app.json')
 
     expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
       'workflows/new.app.json'
@@ -1131,17 +1140,19 @@ describe('rewriteSessionWorkflowPaths', () => {
     )
   })
 
-  it('only rewrites entries matching both path and workflowId', () => {
-    store.ensureSessionWorkflowPath('job-1', 'workflows/old.app.json')
-    store.ensureSessionWorkflowPath('job-2', 'workflows/old.app.json')
-    store.registerJobWorkflowIdMapping('job-1', 'wf-A')
-    store.registerJobWorkflowIdMapping('job-2', 'wf-B')
-
-    store.rewriteSessionWorkflowPaths(
+  it('only rewrites entries matching the workflow instance', () => {
+    store.ensureSessionWorkflowPath(
+      'job-1',
       'workflows/old.app.json',
-      'workflows/new.app.json',
-      'wf-A'
+      'instance-A'
     )
+    store.ensureSessionWorkflowPath(
+      'job-2',
+      'workflows/old.app.json',
+      'instance-B'
+    )
+
+    store.rewriteSessionWorkflowPaths('instance-A', 'workflows/new.app.json')
 
     expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
       'workflows/new.app.json'
@@ -1154,19 +1165,18 @@ describe('rewriteSessionWorkflowPaths', () => {
   it('does not rewrite entries from a different workflow sharing the same temp path', () => {
     store.ensureSessionWorkflowPath(
       'job-old',
-      'workflows/Unsaved Workflow.json'
+      'workflows/Unsaved Workflow.json',
+      'instance-OLD'
     )
     store.ensureSessionWorkflowPath(
       'job-new',
-      'workflows/Unsaved Workflow.json'
+      'workflows/Unsaved Workflow.json',
+      'instance-NEW'
     )
-    store.registerJobWorkflowIdMapping('job-old', 'wf-OLD')
-    store.registerJobWorkflowIdMapping('job-new', 'wf-NEW')
 
     store.rewriteSessionWorkflowPaths(
-      'workflows/Unsaved Workflow.json',
-      'workflows/saved.app.json',
-      'wf-NEW'
+      'instance-NEW',
+      'workflows/saved.app.json'
     )
 
     expect(store.jobIdToSessionWorkflowPath.get('job-old')).toBe(
@@ -1181,10 +1191,7 @@ describe('rewriteSessionWorkflowPaths', () => {
     store.ensureSessionWorkflowPath('job-1', 'workflows/keep.app.json')
     const originalMap = store.jobIdToSessionWorkflowPath
 
-    store.rewriteSessionWorkflowPaths(
-      'workflows/old.app.json',
-      'workflows/new.app.json'
-    )
+    store.rewriteSessionWorkflowPaths('instance-A', 'workflows/new.app.json')
 
     expect(store.jobIdToSessionWorkflowPath).toBe(originalMap)
   })
@@ -1192,10 +1199,7 @@ describe('rewriteSessionWorkflowPaths', () => {
   it('handles empty map', () => {
     const originalMap = store.jobIdToSessionWorkflowPath
 
-    store.rewriteSessionWorkflowPaths(
-      'workflows/old.app.json',
-      'workflows/new.app.json'
-    )
+    store.rewriteSessionWorkflowPaths('instance-A', 'workflows/new.app.json')
 
     expect(store.jobIdToSessionWorkflowPath.size).toBe(0)
     expect(store.jobIdToSessionWorkflowPath).toBe(originalMap)

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1105,8 +1105,6 @@ describe('rewriteSessionWorkflowPaths', () => {
   let store: ReturnType<typeof useExecutionStore>
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
   })
 

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -576,6 +576,24 @@ export const useExecutionStore = defineStore('execution', () => {
     jobIdToSessionWorkflowPath.value = next
   }
 
+  function rewriteSessionWorkflowPaths(
+    oldPath: string,
+    newPath: string,
+    workflowId?: string
+  ) {
+    let rewritten = false
+    const next = new Map(jobIdToSessionWorkflowPath.value)
+    for (const [jobId, path] of next) {
+      if (path !== oldPath) continue
+      if (workflowId && jobIdToWorkflowId.value.get(jobId) !== workflowId) {
+        continue
+      }
+      next.set(jobId, newPath)
+      rewritten = true
+    }
+    if (rewritten) jobIdToSessionWorkflowPath.value = next
+  }
+
   /**
    * Register or update a mapping from job ID to workflow ID.
    */
@@ -652,6 +670,7 @@ export const useExecutionStore = defineStore('execution', () => {
     nodeLocatorIdToExecutionId,
     jobIdToWorkflowId,
     jobIdToSessionWorkflowPath,
-    ensureSessionWorkflowPath
+    ensureSessionWorkflowPath,
+    rewriteSessionWorkflowPaths
   }
 })

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -920,6 +920,24 @@ export const useExecutionStore = defineStore('execution', () => {
     jobIdToSessionWorkflowPath.value = next
   }
 
+  function rewriteSessionWorkflowPaths(
+    oldPath: string,
+    newPath: string,
+    workflowId?: string
+  ) {
+    let rewritten = false
+    const next = new Map(jobIdToSessionWorkflowPath.value)
+    for (const [jobId, path] of next) {
+      if (path !== oldPath) continue
+      if (workflowId && jobIdToWorkflowId.value.get(jobId) !== workflowId) {
+        continue
+      }
+      next.set(jobId, newPath)
+      rewritten = true
+    }
+    if (rewritten) jobIdToSessionWorkflowPath.value = next
+  }
+
   /**
    * Register or update a mapping from job ID to workflow ID.
    */
@@ -999,6 +1017,7 @@ export const useExecutionStore = defineStore('execution', () => {
     jobIdToSessionWorkflowPath,
     ensureSessionWorkflowPath,
     getWorkflowStatus,
-    clearWorkflowStatus
+    clearWorkflowStatus,
+    rewriteSessionWorkflowPaths
   }
 })

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -940,15 +940,14 @@ export const useExecutionStore = defineStore('execution', () => {
     workflowInstanceId: string,
     newPath: string
   ) {
-    let rewritten = false
-    const next = new Map(jobIdToSessionWorkflowPath.value)
-    for (const [jobId, path] of next) {
+    let next: Map<string, string> | undefined
+    for (const [jobId, path] of jobIdToSessionWorkflowPath.value) {
       if (path === newPath) continue
       if (jobIdToWorkflowInstanceId.get(jobId) !== workflowInstanceId) continue
+      next ??= new Map(jobIdToSessionWorkflowPath.value)
       next.set(jobId, newPath)
-      rewritten = true
     }
-    if (rewritten) jobIdToSessionWorkflowPath.value = next
+    if (next) jobIdToSessionWorkflowPath.value = next
   }
 
   /**

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -154,6 +154,7 @@ export const useExecutionStore = defineStore('execution', () => {
    * Only populated for jobs that are queued in this browser tab.
    */
   const jobIdToSessionWorkflowPath = shallowRef<Map<JobId, string>>(new Map())
+  const jobIdToWorkflowInstanceId = new Map<JobId, string>()
 
   const initializingJobIds = ref<Set<JobId>>(new Set())
 
@@ -462,8 +463,14 @@ export const useExecutionStore = defineStore('execution', () => {
     // Ensure path mapping exists — execution_start can arrive via WebSocket
     // before the HTTP response from queuePrompt triggers storeJob.
     if (!jobIdToSessionWorkflowPath.value.has(activeJobId.value)) {
-      const path = queuedJobs.value[activeJobId.value]?.workflow?.path
-      if (path) ensureSessionWorkflowPath(activeJobId.value, path)
+      const workflow = queuedJobs.value[activeJobId.value]?.workflow
+      if (workflow) {
+        ensureSessionWorkflowPath(
+          activeJobId.value,
+          workflow.path,
+          workflow.instanceId
+        )
+      }
     }
     queuedJobs.value[activeJobId.value].executionStartedAt ??= performance.now()
     setWorkflowStatus(activeJobId.value, {
@@ -880,7 +887,7 @@ export const useExecutionStore = defineStore('execution', () => {
       jobIdToWorkflowId.value.set(id, wid)
     }
     if (workflow?.path) {
-      ensureSessionWorkflowPath(id, workflow.path)
+      ensureSessionWorkflowPath(id, workflow.path, workflow.instanceId)
     }
     flushPendingWorkflowStatus(String(id), workflow)
   }
@@ -908,30 +915,36 @@ export const useExecutionStore = defineStore('execution', () => {
   // ~0.65 MB at capacity (32 char GUID key + 50 char path value)
   const MAX_SESSION_PATH_ENTRIES = 4000
 
-  function ensureSessionWorkflowPath(jobId: JobId, path: string) {
+  function ensureSessionWorkflowPath(
+    jobId: JobId,
+    path: string,
+    workflowInstanceId?: string
+  ) {
+    if (workflowInstanceId) {
+      jobIdToWorkflowInstanceId.set(jobId, workflowInstanceId)
+    }
     if (jobIdToSessionWorkflowPath.value.get(jobId) === path) return
     const next = new Map(jobIdToSessionWorkflowPath.value)
     next.set(jobId, path)
     while (next.size > MAX_SESSION_PATH_ENTRIES) {
       const oldest = next.keys().next().value
-      if (oldest !== undefined) next.delete(oldest)
-      else break
+      if (oldest !== undefined) {
+        next.delete(oldest)
+        jobIdToWorkflowInstanceId.delete(oldest)
+      } else break
     }
     jobIdToSessionWorkflowPath.value = next
   }
 
   function rewriteSessionWorkflowPaths(
-    oldPath: string,
-    newPath: string,
-    workflowId?: string
+    workflowInstanceId: string,
+    newPath: string
   ) {
     let rewritten = false
     const next = new Map(jobIdToSessionWorkflowPath.value)
     for (const [jobId, path] of next) {
-      if (path !== oldPath) continue
-      if (workflowId && jobIdToWorkflowId.value.get(jobId) !== workflowId) {
-        continue
-      }
+      if (path === newPath) continue
+      if (jobIdToWorkflowInstanceId.get(jobId) !== workflowInstanceId) continue
       next.set(jobId, newPath)
       rewritten = true
     }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

- Fixes app mode bug where the first Save-As of a temporary workflow wipes all previously generated runs from the UI
- Root cause: `renameWorkflow()` changes `workflow.path` but `executionStore.jobIdToSessionWorkflowPath` still holds the old temporary path, causing all path-filtered output consumers to return empty
- Adds `rewriteSessionWorkflowPaths()` to executionStore, called from `workflowStore.renameWorkflow()`, scoped by workflow ID to prevent cross-workflow contamination

## Changes

- `executionStore.ts`: New `rewriteSessionWorkflowPaths(oldPath, newPath, workflowId?)` method that rewrites matching entries in the session path map
- `workflowStore.ts`: Call `rewriteSessionWorkflowPaths` after `workflow.rename()` in `renameWorkflow()`
- Unit tests: 5 tests for `rewriteSessionWorkflowPaths` (path-only, scoped, reused-temp isolation, no-match, empty map) + 1 integration test in workflowStore
- E2E test: Full lifecycle test — enter app mode → run execution → save-as → verify outputs persist

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11419-fix-rewrite-session-workflow-paths-on-rename-to-preserve-run-history-3476d73d365081cebb8cdde2204c4a85) by [Unito](https://www.unito.io)
