### PR TITLE
fix: add vertical viewport collision detection to job details popover

### DIFF
--- a/src/components/queue/job/JobAssetsList.vue
+++ b/src/components/queue/job/JobAssetsList.vue
@@ -93,10 +93,11 @@
   <Teleport to="body">
     <div
       v-if="activeDetails && popoverPosition"
-      class="job-details-popover fixed z-50"
+      class="job-details-popover fixed z-50 overflow-y-auto"
       :style="{
         top: `${popoverPosition.top}px`,
-        left: `${popoverPosition.left}px`
+        left: `${popoverPosition.left}px`,
+        maxHeight: `${popoverPosition.maxHeight}px`
       }"
       @mouseenter="onPopoverEnter"
       @mouseleave="onPopoverLeave"
@@ -150,7 +151,11 @@ const { t } = useI18n()
 const scrollContainer = ref<HTMLElement | null>(null)
 const hoveredJobId = ref<string | null>(null)
 const activeRowElement = ref<HTMLElement | null>(null)
-const popoverPosition = ref<{ top: number; left: number } | null>(null)
+const popoverPosition = ref<{
+  top: number
+  left: number
+  maxHeight: number
+} | null>(null)
 const flatRows = computed(() => buildVirtualJobRows(displayedJobGroups))
 const virtualizer = useVirtualizer({
   get count(): number {
@@ -237,7 +242,11 @@ function updatePopoverPosition() {
   if (!rowElement) return
 
   const rect = rowElement.getBoundingClientRect()
-  popoverPosition.value = getHoverPopoverPosition(rect, window.innerWidth)
+  popoverPosition.value = getHoverPopoverPosition(
+    rect,
+    window.innerWidth,
+    window.innerHeight
+  )
 }
 
 function onJobLeave(jobId: string) {

--- a/src/components/queue/job/QueueJobItem.vue
+++ b/src/components/queue/job/QueueJobItem.vue
@@ -9,10 +9,11 @@
     <Teleport to="body">
       <div
         v-if="!isPreviewVisible && showDetails && popoverPosition"
-        class="fixed z-50"
+        class="fixed z-50 overflow-y-auto"
         :style="{
           top: `${popoverPosition.top}px`,
-          left: `${popoverPosition.left}px`
+          left: `${popoverPosition.left}px`,
+          maxHeight: `${popoverPosition.maxHeight}px`
         }"
         @mouseenter="onPopoverEnter"
         @mouseleave="onPopoverLeave"
@@ -299,13 +300,21 @@ const onIconLeave = () => scheduleHidePreview()
 const onPreviewEnter = () => scheduleShowPreview()
 const onPreviewLeave = () => scheduleHidePreview()
 
-const popoverPosition = ref<{ top: number; left: number } | null>(null)
+const popoverPosition = ref<{
+  top: number
+  left: number
+  maxHeight: number
+} | null>(null)
 
 const updatePopoverPosition = () => {
   const el = rowRef.value
   if (!el) return
   const rect = el.getBoundingClientRect()
-  popoverPosition.value = getHoverPopoverPosition(rect, window.innerWidth)
+  popoverPosition.value = getHoverPopoverPosition(
+    rect,
+    window.innerWidth,
+    window.innerHeight
+  )
 }
 
 const isAnyPopoverVisible = computed(

--- a/src/components/queue/job/getHoverPopoverPosition.test.ts
+++ b/src/components/queue/job/getHoverPopoverPosition.test.ts
@@ -3,59 +3,95 @@ import { describe, expect, it } from 'vitest'
 import { getHoverPopoverPosition } from './getHoverPopoverPosition'
 
 describe('getHoverPopoverPosition', () => {
+  const viewportHeight = 800
+
   it('places the popover to the right when space is available', () => {
     const position = getHoverPopoverPosition(
       { top: 100, left: 40, right: 240 },
-      1280
+      1280,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 100, left: 248 })
+    expect(position).toEqual({ top: 100, left: 248, maxHeight: 692 })
   })
 
   it('places the popover to the left when right space is insufficient', () => {
     const position = getHoverPopoverPosition(
       { top: 100, left: 980, right: 1180 },
-      1280
+      1280,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 100, left: 672 })
+    expect(position).toEqual({ top: 100, left: 672, maxHeight: 692 })
   })
 
   it('clamps the top to viewport padding when rect.top is near the top edge', () => {
     const position = getHoverPopoverPosition(
       { top: 2, left: 40, right: 240 },
-      1280
+      1280,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 8, left: 248 })
+    expect(position).toEqual({ top: 8, left: 248, maxHeight: 784 })
   })
 
   it('clamps left to viewport padding when fallback would go off-screen', () => {
     const position = getHoverPopoverPosition(
       { top: 100, left: 100, right: 300 },
-      320
+      320,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 100, left: 8 })
+    expect(position).toEqual({ top: 100, left: 8, maxHeight: 692 })
   })
 
   it('prefers right when both sides have equal space', () => {
     const position = getHoverPopoverPosition(
       { top: 200, left: 340, right: 640 },
-      1280
+      1280,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 200, left: 648 })
+    expect(position).toEqual({ top: 200, left: 648, maxHeight: 592 })
   })
 
   it('falls back to left when right space is less than popover width', () => {
     const position = getHoverPopoverPosition(
       { top: 100, left: 600, right: 1000 },
-      1280
+      1280,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 100, left: 292 })
+    expect(position).toEqual({ top: 100, left: 292, maxHeight: 692 })
   })
 
   it('handles narrow viewport where popover barely fits', () => {
     const position = getHoverPopoverPosition(
       { top: 50, left: 8, right: 100 },
-      316
+      316,
+      viewportHeight
     )
-    expect(position).toEqual({ top: 50, left: 8 })
+    expect(position).toEqual({ top: 50, left: 8, maxHeight: 742 })
+  })
+
+  it('constrains maxHeight when anchor is near the bottom of the viewport', () => {
+    const position = getHoverPopoverPosition(
+      { top: 700, left: 40, right: 240 },
+      1280,
+      viewportHeight
+    )
+    expect(position).toEqual({ top: 700, left: 248, maxHeight: 92 })
+  })
+
+  it('provides minimal maxHeight when anchor is at the very bottom', () => {
+    const position = getHoverPopoverPosition(
+      { top: 790, left: 40, right: 240 },
+      1280,
+      viewportHeight
+    )
+    expect(position).toEqual({ top: 790, left: 248, maxHeight: 2 })
+  })
+
+  it('provides full maxHeight when anchor is at the top of the viewport', () => {
+    const position = getHoverPopoverPosition(
+      { top: 8, left: 40, right: 240 },
+      1280,
+      viewportHeight
+    )
+    expect(position).toEqual({ top: 8, left: 248, maxHeight: 784 })
   })
 })

--- a/src/components/queue/job/getHoverPopoverPosition.ts
+++ b/src/components/queue/job/getHoverPopoverPosition.ts
@@ -7,11 +7,13 @@ type AnchorRect = Pick<DOMRect, 'top' | 'left' | 'right'>
 type HoverPopoverPosition = {
   top: number
   left: number
+  maxHeight: number
 }
 
 export function getHoverPopoverPosition(
   rect: AnchorRect,
-  viewportWidth: number
+  viewportWidth: number,
+  viewportHeight: number
 ): HoverPopoverPosition {
   const availableLeft = rect.left - POPOVER_GAP
   const availableRight = viewportWidth - rect.right - POPOVER_GAP
@@ -22,18 +24,23 @@ export function getHoverPopoverPosition(
     viewportWidth - POPOVER_WIDTH - VIEWPORT_PADDING
   )
 
+  const top = Math.max(VIEWPORT_PADDING, rect.top)
+  const maxHeight = viewportHeight - top - VIEWPORT_PADDING
+
   if (
     availableRight >= POPOVER_WIDTH &&
     (availableRight >= availableLeft || availableLeft < POPOVER_WIDTH)
   ) {
     return {
-      top: Math.max(VIEWPORT_PADDING, rect.top),
-      left: Math.min(maxLeft, preferredLeft)
+      top,
+      left: Math.min(maxLeft, preferredLeft),
+      maxHeight
     }
   }
 
   return {
-    top: Math.max(VIEWPORT_PADDING, rect.top),
-    left: Math.max(VIEWPORT_PADDING, Math.min(maxLeft, fallbackLeft))
+    top,
+    left: Math.max(VIEWPORT_PADDING, Math.min(maxLeft, fallbackLeft)),
+    maxHeight
   }
 }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

- Add bottom-of-viewport collision detection to `getHoverPopoverPosition()` so the job details popover no longer gets clipped when hovering over jobs near the bottom of the job list
- Return a `maxHeight` value from the positioning utility and apply `overflow-y: auto` on the popover wrapper, constraining it to available vertical space

## Problem

The job details popover that appears on hover only had horizontal (left/right) collision detection (added in #9679). When a job was near the bottom of the viewport, the popover rendered downward from the anchor point without checking available vertical space, causing it to overflow and clip — hiding critical information like error logs.

## Changes

- **`getHoverPopoverPosition.ts`**: Accept `viewportHeight` parameter, compute and return `maxHeight` (`viewportHeight - top - VIEWPORT_PADDING`)
- **`QueueJobItem.vue`**: Pass `window.innerHeight`, apply `maxHeight` + `overflow-y: auto` on the details popover wrapper
- **`JobAssetsList.vue`**: Same changes as QueueJobItem
- **`getHoverPopoverPosition.test.ts`**: Add 3 test cases for bottom-edge vertical clamping

## Review Focus

Verify that the `maxHeight` constraint with `overflow-y: auto` is the right UX tradeoff vs. flipping the popover upward. The scroll approach was chosen because popover height is dynamic (varies by job state) and unknown at positioning time.

## Screenshots

![Job details popover constrained to viewport when hovering over bottom-most job (400px viewport). Popover shows 'Job Details' header with scrollable content instead of clipping off-screen.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/60fcf0ef6a87f04860948d2761c1bf00c295832230cd693a6074af1018b51dfa/pr-images/1776596364773-0bb5afb2-3b4f-41ab-a6ac-d480ebe4497a.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11424-fix-add-vertical-viewport-collision-detection-to-job-details-popover-3476d73d3650816697f1de53e87c2941) by [Unito](https://www.unito.io)
