### PR TITLE
fix: remove deleted workflow from search results in sidebar

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -144,7 +144,7 @@ export class WorkflowsSidebarTab extends SidebarTab {
     this.activeWorkflowLabel = this.root.locator(
       '.comfyui-workflows-open .p-tree-node-selected .node-label'
     )
-    this.searchInput = page.getByPlaceholder('Search Workflow...')
+    this.searchInput = this.root.getByRole('combobox').first()
   }
 
   async getOpenedWorkflowNames() {

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -136,6 +136,7 @@ export class NodeLibrarySidebarTabV2 extends SidebarTab {
 export class WorkflowsSidebarTab extends SidebarTab {
   public readonly root: Locator
   public readonly activeWorkflowLabel: Locator
+  public readonly searchInput: Locator
 
   constructor(public override readonly page: Page) {
     super(page, 'workflows')
@@ -143,6 +144,7 @@ export class WorkflowsSidebarTab extends SidebarTab {
     this.activeWorkflowLabel = this.root.locator(
       '.comfyui-workflows-open .p-tree-node-selected .node-label'
     )
+    this.searchInput = page.getByPlaceholder('Search Workflow...')
   }
 
   async getOpenedWorkflowNames() {

--- a/browser_tests/tests/sidebar/workflowSearch.spec.ts
+++ b/browser_tests/tests/sidebar/workflowSearch.spec.ts
@@ -55,3 +55,77 @@ test.describe('Workflow sidebar - search', () => {
     await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeHidden()
   })
 })
+
+test.describe('Workflow sidebar - search + deletion', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.workflow.setupWorkflowsDirectory({
+      'alpha-workflow.json': 'default.json',
+      'beta-workflow.json': 'default.json',
+      'gamma-workflow.json': 'default.json'
+    })
+    await comfyPage.settings.setSetting('Comfy.Workflow.ConfirmDelete', false)
+  })
+
+  test('Deleting a workflow while search is active removes it from results', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.open()
+
+    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
+    await searchInput.fill('alpha')
+    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
+
+    await findWorkflow(comfyPage.page, 'alpha-workflow').click({
+      button: 'right'
+    })
+    await comfyPage.contextMenu.clickMenuItem('Delete')
+
+    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
+  })
+
+  test('Deleting during search does not affect other matched results', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.open()
+
+    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
+    await searchInput.fill('workflow')
+
+    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
+    await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeVisible()
+    await expect(findWorkflow(comfyPage.page, 'gamma-workflow')).toBeVisible()
+
+    await findWorkflow(comfyPage.page, 'alpha-workflow').click({
+      button: 'right'
+    })
+    await comfyPage.contextMenu.clickMenuItem('Delete')
+
+    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
+    await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeVisible()
+    await expect(findWorkflow(comfyPage.page, 'gamma-workflow')).toBeVisible()
+  })
+
+  test('Clearing search after deleting during search shows correct workflows', async ({
+    comfyPage
+  }) => {
+    const tab = comfyPage.menu.workflowsTab
+    await tab.open()
+
+    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
+    await searchInput.fill('alpha')
+    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
+
+    await findWorkflow(comfyPage.page, 'alpha-workflow').click({
+      button: 'right'
+    })
+    await comfyPage.contextMenu.clickMenuItem('Delete')
+
+    // Clear search — browse view should not show deleted workflow
+    await searchInput.fill('')
+    await expect(tab.getPersistedItem('beta-workflow')).toBeVisible()
+    await expect(tab.getPersistedItem('gamma-workflow')).toBeVisible()
+    await expect(tab.getPersistedItem('alpha-workflow')).toBeHidden()
+  })
+})

--- a/browser_tests/tests/sidebar/workflowSearch.spec.ts
+++ b/browser_tests/tests/sidebar/workflowSearch.spec.ts
@@ -17,11 +17,11 @@ test.describe('Workflow sidebar - search', () => {
       'alpha-workflow.json': 'default.json',
       'beta-workflow.json': 'default.json'
     })
+    await comfyPage.menu.workflowsTab.open()
   })
 
   test('Search filters saved workflows by name', async ({ comfyPage }) => {
     const tab = comfyPage.menu.workflowsTab
-    await tab.open()
 
     await tab.searchInput.fill('alpha')
 
@@ -31,7 +31,6 @@ test.describe('Workflow sidebar - search', () => {
 
   test('Clearing search restores all workflows', async ({ comfyPage }) => {
     const tab = comfyPage.menu.workflowsTab
-    await tab.open()
 
     await tab.searchInput.fill('alpha')
     await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeHidden()
@@ -44,7 +43,6 @@ test.describe('Workflow sidebar - search', () => {
 
   test('Search with no matches shows empty results', async ({ comfyPage }) => {
     const tab = comfyPage.menu.workflowsTab
-    await tab.open()
 
     await tab.searchInput.fill('nonexistent_xyz')
 
@@ -60,13 +58,13 @@ test.describe('Workflow sidebar - search', () => {
         'gamma-workflow.json': 'default.json'
       })
       await comfyPage.settings.setSetting('Comfy.Workflow.ConfirmDelete', false)
+      await comfyPage.menu.workflowsTab.open()
     })
 
     test('Deleting a workflow while search is active removes it from results', async ({
       comfyPage
     }) => {
       const tab = comfyPage.menu.workflowsTab
-      await tab.open()
 
       await tab.searchInput.fill('alpha')
       await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
@@ -83,7 +81,6 @@ test.describe('Workflow sidebar - search', () => {
       comfyPage
     }) => {
       const tab = comfyPage.menu.workflowsTab
-      await tab.open()
 
       await tab.searchInput.fill('workflow')
 
@@ -105,7 +102,6 @@ test.describe('Workflow sidebar - search', () => {
       comfyPage
     }) => {
       const tab = comfyPage.menu.workflowsTab
-      await tab.open()
 
       await tab.searchInput.fill('alpha')
       await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()

--- a/browser_tests/tests/sidebar/workflowSearch.spec.ts
+++ b/browser_tests/tests/sidebar/workflowSearch.spec.ts
@@ -23,8 +23,7 @@ test.describe('Workflow sidebar - search', () => {
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
 
-    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
-    await searchInput.fill('alpha')
+    await tab.searchInput.fill('alpha')
 
     await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
     await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeHidden()
@@ -34,11 +33,10 @@ test.describe('Workflow sidebar - search', () => {
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
 
-    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
-    await searchInput.fill('alpha')
+    await tab.searchInput.fill('alpha')
     await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeHidden()
 
-    await searchInput.fill('')
+    await tab.searchInput.fill('')
 
     await expect(tab.getPersistedItem('alpha-workflow')).toBeVisible()
     await expect(tab.getPersistedItem('beta-workflow')).toBeVisible()
@@ -48,84 +46,79 @@ test.describe('Workflow sidebar - search', () => {
     const tab = comfyPage.menu.workflowsTab
     await tab.open()
 
-    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
-    await searchInput.fill('nonexistent_xyz')
+    await tab.searchInput.fill('nonexistent_xyz')
 
     await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
     await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeHidden()
   })
-})
 
-test.describe('Workflow sidebar - search + deletion', () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.workflow.setupWorkflowsDirectory({
-      'alpha-workflow.json': 'default.json',
-      'beta-workflow.json': 'default.json',
-      'gamma-workflow.json': 'default.json'
+  test.describe('deletion', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.setupWorkflowsDirectory({
+        'alpha-workflow.json': 'default.json',
+        'beta-workflow.json': 'default.json',
+        'gamma-workflow.json': 'default.json'
+      })
+      await comfyPage.settings.setSetting('Comfy.Workflow.ConfirmDelete', false)
     })
-    await comfyPage.settings.setSetting('Comfy.Workflow.ConfirmDelete', false)
-  })
 
-  test('Deleting a workflow while search is active removes it from results', async ({
-    comfyPage
-  }) => {
-    const tab = comfyPage.menu.workflowsTab
-    await tab.open()
+    test('Deleting a workflow while search is active removes it from results', async ({
+      comfyPage
+    }) => {
+      const tab = comfyPage.menu.workflowsTab
+      await tab.open()
 
-    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
-    await searchInput.fill('alpha')
-    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
+      await tab.searchInput.fill('alpha')
+      await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
 
-    await findWorkflow(comfyPage.page, 'alpha-workflow').click({
-      button: 'right'
+      await findWorkflow(comfyPage.page, 'alpha-workflow').click({
+        button: 'right'
+      })
+      await comfyPage.contextMenu.clickMenuItem('Delete')
+
+      await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
     })
-    await comfyPage.contextMenu.clickMenuItem('Delete')
 
-    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
-  })
+    test('Deleting during search does not affect other matched results', async ({
+      comfyPage
+    }) => {
+      const tab = comfyPage.menu.workflowsTab
+      await tab.open()
 
-  test('Deleting during search does not affect other matched results', async ({
-    comfyPage
-  }) => {
-    const tab = comfyPage.menu.workflowsTab
-    await tab.open()
+      await tab.searchInput.fill('workflow')
 
-    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
-    await searchInput.fill('workflow')
+      await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
+      await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeVisible()
+      await expect(findWorkflow(comfyPage.page, 'gamma-workflow')).toBeVisible()
 
-    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
-    await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeVisible()
-    await expect(findWorkflow(comfyPage.page, 'gamma-workflow')).toBeVisible()
+      await findWorkflow(comfyPage.page, 'alpha-workflow').click({
+        button: 'right'
+      })
+      await comfyPage.contextMenu.clickMenuItem('Delete')
 
-    await findWorkflow(comfyPage.page, 'alpha-workflow').click({
-      button: 'right'
+      await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
+      await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeVisible()
+      await expect(findWorkflow(comfyPage.page, 'gamma-workflow')).toBeVisible()
     })
-    await comfyPage.contextMenu.clickMenuItem('Delete')
 
-    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeHidden()
-    await expect(findWorkflow(comfyPage.page, 'beta-workflow')).toBeVisible()
-    await expect(findWorkflow(comfyPage.page, 'gamma-workflow')).toBeVisible()
-  })
+    test('Clearing search after deleting during search shows correct workflows', async ({
+      comfyPage
+    }) => {
+      const tab = comfyPage.menu.workflowsTab
+      await tab.open()
 
-  test('Clearing search after deleting during search shows correct workflows', async ({
-    comfyPage
-  }) => {
-    const tab = comfyPage.menu.workflowsTab
-    await tab.open()
+      await tab.searchInput.fill('alpha')
+      await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
 
-    const searchInput = comfyPage.page.getByPlaceholder('Search Workflow...')
-    await searchInput.fill('alpha')
-    await expect(findWorkflow(comfyPage.page, 'alpha-workflow')).toBeVisible()
+      await findWorkflow(comfyPage.page, 'alpha-workflow').click({
+        button: 'right'
+      })
+      await comfyPage.contextMenu.clickMenuItem('Delete')
 
-    await findWorkflow(comfyPage.page, 'alpha-workflow').click({
-      button: 'right'
+      await tab.searchInput.fill('')
+      await expect(tab.getPersistedItem('beta-workflow')).toBeVisible()
+      await expect(tab.getPersistedItem('gamma-workflow')).toBeVisible()
+      await expect(tab.getPersistedItem('alpha-workflow')).toBeHidden()
     })
-    await comfyPage.contextMenu.clickMenuItem('Delete')
-
-    // Clear search — browse view should not show deleted workflow
-    await searchInput.fill('')
-    await expect(tab.getPersistedItem('beta-workflow')).toBeVisible()
-    await expect(tab.getPersistedItem('gamma-workflow')).toBeVisible()
-    await expect(tab.getPersistedItem('alpha-workflow')).toBeHidden()
   })
 })

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
@@ -1,0 +1,305 @@
+import { createTestingPinia } from '@pinia/testing'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { nextTick, reactive, ref, watchEffect } from 'vue'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import type { TreeExplorerNode } from '@/types/treeExplorerTypes'
+import { flattenTree } from '@/utils/treeUtil'
+
+import BaseWorkflowsSidebarTab from '@/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue'
+
+const {
+  setSearchQuery,
+  emitSearch,
+  captureSearchRoot,
+  getSearchRoot,
+  resetCapturedSearchRoot,
+  mockExpandNode,
+  mockToggleNodeOnEvent,
+  mockLoadBookmarks,
+  mockWorkflowService,
+  mockWorkflowStoreState,
+  registerSearchHandlers
+} = vi.hoisted(() => {
+  let updateQuery = (_query: string) => {}
+  let triggerSearch = (_query: string) => {}
+  let capturedSearchRoot: TreeExplorerNode<ComfyWorkflow> | null = null
+
+  const workflowStore = {
+    workflows: [] as ComfyWorkflow[],
+    persistedWorkflows: [] as ComfyWorkflow[],
+    bookmarkedWorkflows: [] as ComfyWorkflow[],
+    openWorkflows: [] as ComfyWorkflow[],
+    activeWorkflow: null as ComfyWorkflow | null,
+    syncWorkflows: vi.fn().mockResolvedValue(undefined)
+  }
+
+  return {
+    setSearchQuery: (query: string) => {
+      updateQuery(query)
+    },
+    emitSearch: (query: string) => {
+      triggerSearch(query)
+    },
+    captureSearchRoot: (root: TreeExplorerNode<ComfyWorkflow>) => {
+      capturedSearchRoot = root
+    },
+    getSearchRoot: () => capturedSearchRoot,
+    resetCapturedSearchRoot: () => {
+      capturedSearchRoot = null
+    },
+    mockExpandNode: vi.fn(),
+    mockToggleNodeOnEvent: vi.fn(),
+    mockLoadBookmarks: vi.fn().mockResolvedValue(undefined),
+    mockWorkflowService: {
+      openWorkflow: vi.fn().mockResolvedValue(undefined),
+      closeWorkflow: vi.fn().mockResolvedValue(undefined),
+      renameWorkflow: vi.fn().mockResolvedValue(undefined),
+      deleteWorkflow: vi.fn().mockResolvedValue(undefined),
+      insertWorkflow: vi.fn().mockResolvedValue(undefined),
+      duplicateWorkflow: vi.fn().mockResolvedValue(undefined)
+    },
+    mockWorkflowStoreState: workflowStore,
+    registerSearchHandlers: (
+      updateHandler: (query: string) => void,
+      searchHandler: (query: string) => void
+    ) => {
+      updateQuery = updateHandler
+      triggerSearch = searchHandler
+    }
+  }
+})
+
+const mockWorkflowStore = reactive(mockWorkflowStoreState)
+
+vi.mock('@/components/common/NoResultsPlaceholder.vue', () => ({
+  default: { name: 'NoResultsPlaceholder', template: '<div />' }
+}))
+
+vi.mock('@/components/ui/search-input/SearchInput.vue', () => ({
+  default: {
+    name: 'SearchInput',
+    template: '<div data-testid="search-input" />',
+    props: ['modelValue', 'placeholder'],
+    setup(
+      _props: { modelValue: string; placeholder?: string },
+      {
+        emit,
+        expose
+      }: {
+        emit: (event: 'update:modelValue' | 'search', value: string) => void
+        expose: (value: { focus: () => void }) => void
+      }
+    ) {
+      const focus = vi.fn()
+      expose({ focus })
+      registerSearchHandlers(
+        (query: string) => emit('update:modelValue', query),
+        (query: string) => emit('search', query)
+      )
+      return {}
+    }
+  }
+}))
+
+vi.mock('@/components/sidebar/tabs/SidebarTopArea.vue', () => ({
+  default: { name: 'SidebarTopArea', template: '<div><slot /></div>' }
+}))
+
+vi.mock('@/components/common/TextDivider.vue', () => ({
+  default: { name: 'TextDivider', template: '<div />' }
+}))
+
+vi.mock('@/components/common/TreeExplorer.vue', () => ({
+  default: {
+    name: 'TreeExplorer',
+    template: '<div data-testid="tree-explorer" />',
+    props: ['root', 'selectionKeys', 'expandedKeys'],
+    setup(props: {
+      root: TreeExplorerNode<ComfyWorkflow>
+      selectionKeys?: Record<string, boolean>
+    }) {
+      watchEffect(() => {
+        if (props.selectionKeys === undefined) {
+          captureSearchRoot(props.root)
+        }
+      })
+    }
+  }
+}))
+
+vi.mock('@/components/common/TreeExplorerTreeNode.vue', () => ({
+  default: {
+    name: 'TreeExplorerTreeNode',
+    template:
+      '<div><slot name="before-label" :node="node" /><slot /><slot name="actions" :node="node" /></div>',
+    props: ['node']
+  }
+}))
+
+vi.mock('@/components/sidebar/tabs/SidebarTabTemplate.vue', () => ({
+  default: {
+    name: 'SidebarTabTemplate',
+    template:
+      '<div><slot name="alt-title" /><slot name="tool-buttons" /><slot name="header" /><slot name="body" /></div>'
+  }
+}))
+
+vi.mock('@/components/sidebar/tabs/workflows/WorkflowTreeLeaf.vue', () => ({
+  default: { name: 'WorkflowTreeLeaf', template: '<div />', props: ['node'] }
+}))
+
+vi.mock('@/components/ui/button/Button.vue', () => ({
+  default: { name: 'Button', template: '<button><slot /></button>' }
+}))
+
+vi.mock('@/composables/useTreeExpansion', () => ({
+  useTreeExpansion: () => ({
+    expandNode: mockExpandNode,
+    toggleNodeOnEvent: mockToggleNodeOnEvent
+  })
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ isAppMode: ref(false) })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: vi.fn((key: string) => {
+      if (key === 'Comfy.Workflow.WorkflowTabsPosition') return 'Sidebar'
+      return undefined
+    })
+  })
+}))
+
+vi.mock('@/platform/workflow/core/services/workflowService', () => ({
+  useWorkflowService: () => mockWorkflowService
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => ({ shiftDown: false })
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => mockWorkflowStore,
+  useWorkflowBookmarkStore: () => ({ loadBookmarks: mockLoadBookmarks }),
+  ComfyWorkflow: class {
+    static basePath = 'workflows/'
+  }
+}))
+
+vi.mock('primevue/confirmdialog', () => ({
+  default: { name: 'ConfirmDialog', template: '<div />' }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
+const createMockWorkflow = (path: string) =>
+  fromPartial<ComfyWorkflow>({
+    path,
+    key: path.replace('workflows/', ''),
+    isModified: false,
+    isPersisted: true,
+    isTemporary: false,
+    suffix: 'json',
+    directory: 'workflows'
+  })
+
+const getLeafPaths = (
+  root: TreeExplorerNode<ComfyWorkflow> | null
+): string[] => {
+  if (!root) return []
+  return flattenTree<ComfyWorkflow>(root)
+    .map((w) => w.path)
+    .sort()
+}
+
+describe('BaseWorkflowsSidebarTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetCapturedSearchRoot()
+
+    mockWorkflowStore.workflows = []
+    mockWorkflowStore.persistedWorkflows = []
+    mockWorkflowStore.bookmarkedWorkflows = []
+    mockWorkflowStore.openWorkflows = []
+    mockWorkflowStore.activeWorkflow = null
+  })
+
+  const renderComponent = () =>
+    render(BaseWorkflowsSidebarTab, {
+      props: {
+        title: 'Workflows',
+        searchSubject: 'Workflow',
+        dataTestid: 'workflows-sidebar'
+      },
+      global: {
+        plugins: [createTestingPinia({ stubActions: false }), i18n],
+        stubs: { teleport: true }
+      }
+    })
+
+  it('returns an empty filtered workflow set when searchQuery is empty', async () => {
+    mockWorkflowStore.workflows = [
+      createMockWorkflow('workflows/test-alpha.json'),
+      createMockWorkflow('workflows/test-beta.json')
+    ]
+
+    renderComponent()
+    emitSearch('alpha')
+    await nextTick()
+
+    expect(mockExpandNode).toHaveBeenCalledTimes(1)
+    const expandedRoot = mockExpandNode.mock.calls[0]?.[0] as
+      | TreeExplorerNode<ComfyWorkflow>
+      | undefined
+    expect(getLeafPaths(expandedRoot ?? null)).toHaveLength(0)
+  })
+
+  it('filters workflows by case-insensitive path match', async () => {
+    mockWorkflowStore.workflows = [
+      createMockWorkflow('workflows/test-alpha.json'),
+      createMockWorkflow('workflows/other-workflow.json'),
+      createMockWorkflow('workflows/TEST-gamma.json')
+    ]
+
+    renderComponent()
+
+    setSearchQuery('ALPHA')
+    await nextTick()
+
+    expect(getLeafPaths(getSearchRoot())).toEqual(['workflows/test-alpha.json'])
+  })
+
+  it('reactively updates filtered workflows when a workflow is removed', async () => {
+    mockWorkflowStore.workflows = [
+      createMockWorkflow('workflows/test-alpha.json'),
+      createMockWorkflow('workflows/TEST-alpha-2.json'),
+      createMockWorkflow('workflows/test-beta.json')
+    ]
+
+    renderComponent()
+
+    setSearchQuery('alpha')
+    await nextTick()
+    expect(getLeafPaths(getSearchRoot())).toEqual([
+      'workflows/TEST-alpha-2.json',
+      'workflows/test-alpha.json'
+    ])
+
+    mockWorkflowStore.workflows = mockWorkflowStore.workflows.filter(
+      (workflow) => workflow.path !== 'workflows/TEST-alpha-2.json'
+    )
+    await nextTick()
+
+    expect(getLeafPaths(getSearchRoot())).toEqual(['workflows/test-alpha.json'])
+  })
+})

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue
@@ -194,22 +194,21 @@ const searchBoxRef = ref()
 
 const searchQuery = ref('')
 const isSearching = computed(() => searchQuery.value.length > 0)
-const filteredWorkflows = ref<ComfyWorkflow[]>([])
+const filteredWorkflows = computed(() => {
+  if (searchQuery.value.length === 0) return []
+  const lowerQuery = searchQuery.value.toLocaleLowerCase()
+  return applyFilter(workflowStore.workflows).filter((workflow) =>
+    workflow.path.toLocaleLowerCase().includes(lowerQuery)
+  )
+})
 const filteredRoot = computed<TreeNode>(() => {
   return buildWorkflowTree(filteredWorkflows.value as ComfyWorkflow[])
 })
 const handleSearch = async (query: string) => {
   if (query.length === 0) {
-    filteredWorkflows.value = []
     expandedKeys.value = {}
     return
   }
-  const lowerQuery = query.toLocaleLowerCase()
-  filteredWorkflows.value = applyFilter(workflowStore.workflows).filter(
-    (workflow) => {
-      return workflow.path.toLocaleLowerCase().includes(lowerQuery)
-    }
-  )
   await nextTick()
   expandNode(filteredRoot.value)
 }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Deleting a workflow in the sidebar while search is active left the deleted workflow visible in the search results. Interacting with the stale entry (e.g. duplicate) caused undefined behavior.

## Root Cause

`filteredWorkflows` in `BaseWorkflowsSidebarTab.vue` was a `ref` populated once per search event — a static snapshot that never reacted to store mutations. When `workflowStore.deleteWorkflow()` removed a workflow from `workflowLookup`, the search-panel's `filteredWorkflows` still held a stale reference.

## Fix

Convert `filteredWorkflows` from a `ref` to a `computed` that reactively derives from `searchQuery` and `workflowStore.workflows`. This follows the same pattern already used by `filteredPersistedWorkflows` and `filteredBookmarkedWorkflows` in the same component. `handleSearch` is simplified to only manage tree expansion (its only remaining side effect).

## Test Plan

Three e2e regression tests added to `workflowSearch.spec.ts`:
- **Delete during search removes from results** — deletes a workflow while search is active, asserts it disappears
- **Delete during search preserves siblings** — asserts all other matched workflows remain visible after one is deleted
- **Clear search after delete shows correct browse view** — deletes during search, clears search, verifies browse view is consistent

## Screenshots

![Search active with 3 workflows visible](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3a9cc4daaaf582a87638fc62ec96258cea63981a28bcb282dd625956286c582c/pr-images/1776596412591-c8cc80fb-e57e-4c76-b574-8ab776076105.png)

![After deleting test-alpha during search — removed from results correctly](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3a9cc4daaaf582a87638fc62ec96258cea63981a28bcb282dd625956286c582c/pr-images/1776596412913-23eebf62-aac8-4848-8468-8ecb56c0dc8f.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11425-fix-remove-deleted-workflow-from-search-results-in-sidebar-3476d73d365081f19ef6c6b9261a1ee9) by [Unito](https://www.unito.io)
