### PR TITLE
feat: add download service abstraction with functional composition

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -54,6 +54,7 @@ const config: KnipConfig = {
     '.github/workflows/ci-oss-assets-validation.yaml',
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
+    'src/platform/downloads/downloadServiceStore.ts',
     // Marketing media tooling — adopted by pages in a follow-up PR
     'apps/website/src/components/common/SiteVideo.vue',
     'apps/website/src/utils/marketingImage.ts',

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,6 +55,7 @@ const config: KnipConfig = {
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
     'src/platform/downloads/downloadServiceStore.ts',
+    'src/platform/downloads/types.ts',
     // Marketing media tooling — adopted by pages in a follow-up PR
     'apps/website/src/components/common/SiteVideo.vue',
     'apps/website/src/utils/marketingImage.ts',

--- a/src/platform/downloads/downloadServiceStore.ts
+++ b/src/platform/downloads/downloadServiceStore.ts
@@ -37,8 +37,13 @@ export const useDownloadServiceStore = defineStore('downloadService', () => {
     if (!_initPromise) {
       _initPromise = createDownloadServiceProvider()
     }
-    _service = await _initPromise
-    service.value = _service
+    try {
+      _service = await _initPromise
+      service.value = _service
+    } catch (error) {
+      _initPromise = null
+      throw error
+    }
   }
 
   return { service, initialize }

--- a/src/platform/downloads/downloadServiceStore.ts
+++ b/src/platform/downloads/downloadServiceStore.ts
@@ -3,48 +3,33 @@ import { shallowRef } from 'vue'
 
 import type { DownloadService } from './types'
 
-let _service: DownloadService | null = null
-let _initPromise: Promise<DownloadService> | null = null
-
 async function createDownloadServiceProvider(): Promise<DownloadService> {
   if (__DISTRIBUTION__ === 'desktop') {
-    const { createElectronDownloadService } =
-      await import('./providers/createElectronDownloadService')
-    const electronService = createElectronDownloadService()
-    await electronService.initialize()
-    return electronService
+    const { createElectronDownloadService } = await import(
+      './providers/createElectronDownloadService'
+    )
+    return createElectronDownloadService()
   }
 
   if (__DISTRIBUTION__ === 'cloud') {
-    const { createCloudDownloadService } =
-      await import('./providers/createCloudDownloadService')
+    const { createCloudDownloadService } = await import(
+      './providers/createCloudDownloadService'
+    )
     return createCloudDownloadService()
   }
 
-  const { createBrowserDownloadService } =
-    await import('./providers/createBrowserDownloadService')
+  const { createBrowserDownloadService } = await import(
+    './providers/createBrowserDownloadService'
+  )
   return createBrowserDownloadService()
 }
 
 export const useDownloadServiceStore = defineStore('downloadService', () => {
   const service = shallowRef<DownloadService | null>(null)
 
-  async function initialize() {
-    if (_service) {
-      service.value = _service
-      return
-    }
-    if (!_initPromise) {
-      _initPromise = createDownloadServiceProvider()
-    }
-    try {
-      _service = await _initPromise
-      service.value = _service
-    } catch (error) {
-      _initPromise = null
-      throw error
-    }
-  }
+  const ready = createDownloadServiceProvider().then((provider) => {
+    service.value = provider
+  })
 
-  return { service, initialize }
+  return { service, ready }
 })

--- a/src/platform/downloads/downloadServiceStore.ts
+++ b/src/platform/downloads/downloadServiceStore.ts
@@ -4,6 +4,7 @@ import { shallowRef } from 'vue'
 import type { DownloadService } from './types'
 
 let _service: DownloadService | null = null
+let _initPromise: Promise<DownloadService> | null = null
 
 async function createDownloadServiceProvider(): Promise<DownloadService> {
   if (__DISTRIBUTION__ === 'desktop') {
@@ -33,7 +34,10 @@ export const useDownloadServiceStore = defineStore('downloadService', () => {
       service.value = _service
       return
     }
-    _service = await createDownloadServiceProvider()
+    if (!_initPromise) {
+      _initPromise = createDownloadServiceProvider()
+    }
+    _service = await _initPromise
     service.value = _service
   }
 

--- a/src/platform/downloads/downloadServiceStore.ts
+++ b/src/platform/downloads/downloadServiceStore.ts
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia'
+import { shallowRef } from 'vue'
+
+import type { DownloadService } from './types'
+
+let _service: DownloadService | null = null
+
+async function createDownloadServiceProvider(): Promise<DownloadService> {
+  if (__DISTRIBUTION__ === 'desktop') {
+    const { createElectronDownloadService } =
+      await import('./providers/createElectronDownloadService')
+    const electronService = createElectronDownloadService()
+    await electronService.initialize()
+    return electronService
+  }
+
+  if (__DISTRIBUTION__ === 'cloud') {
+    const { createCloudDownloadService } =
+      await import('./providers/createCloudDownloadService')
+    return createCloudDownloadService()
+  }
+
+  const { createBrowserDownloadService } =
+    await import('./providers/createBrowserDownloadService')
+  return createBrowserDownloadService()
+}
+
+export const useDownloadServiceStore = defineStore('downloadService', () => {
+  const service = shallowRef<DownloadService | null>(null)
+
+  async function initialize() {
+    if (_service) {
+      service.value = _service
+      return
+    }
+    _service = await createDownloadServiceProvider()
+    service.value = _service
+  }
+
+  return { service, initialize }
+})

--- a/src/platform/downloads/downloadServiceStore.ts
+++ b/src/platform/downloads/downloadServiceStore.ts
@@ -5,22 +5,19 @@ import type { DownloadService } from './types'
 
 async function createDownloadServiceProvider(): Promise<DownloadService> {
   if (__DISTRIBUTION__ === 'desktop') {
-    const { createElectronDownloadService } = await import(
-      './providers/createElectronDownloadService'
-    )
+    const { createElectronDownloadService } =
+      await import('./providers/createElectronDownloadService')
     return createElectronDownloadService()
   }
 
   if (__DISTRIBUTION__ === 'cloud') {
-    const { createCloudDownloadService } = await import(
-      './providers/createCloudDownloadService'
-    )
+    const { createCloudDownloadService } =
+      await import('./providers/createCloudDownloadService')
     return createCloudDownloadService()
   }
 
-  const { createBrowserDownloadService } = await import(
-    './providers/createBrowserDownloadService'
-  )
+  const { createBrowserDownloadService } =
+    await import('./providers/createBrowserDownloadService')
   return createBrowserDownloadService()
 }
 

--- a/src/platform/downloads/providers/createBrowserDownloadService.test.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { createBrowserDownloadService } from './createBrowserDownloadService'
+
+describe('createBrowserDownloadService', () => {
+  let clickSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    clickSpy = vi.fn()
+    vi.spyOn(document, 'createElement').mockReturnValue({
+      set href(_: string) {},
+      set download(_: string) {},
+      set target(_: string) {},
+      set rel(_: string) {},
+      click: clickSpy
+    } as unknown as HTMLAnchorElement)
+  })
+
+  it('returns a completed entry after triggering a browser download', async () => {
+    const service = createBrowserDownloadService()
+
+    const entry = await service.start({
+      url: 'https://example.com/model.safetensors',
+      savePath: '/models/checkpoints',
+      filename: 'model.safetensors'
+    })
+
+    expect(clickSpy).toHaveBeenCalledOnce()
+    expect(entry).toMatchObject({
+      id: 'https://example.com/model.safetensors',
+      url: 'https://example.com/model.safetensors',
+      filename: 'model.safetensors',
+      savePath: '/models/checkpoints',
+      status: 'completed',
+      progress: 1
+    })
+  })
+
+  it('does not support pause/resume', () => {
+    const service = createBrowserDownloadService()
+    expect(service.supportsPauseResume).toBe(false)
+  })
+
+  it('getAll returns empty array', () => {
+    const service = createBrowserDownloadService()
+    expect(service.getAll()).toEqual([])
+  })
+
+  it('getById returns null', () => {
+    const service = createBrowserDownloadService()
+    expect(service.getById('anything')).toBeNull()
+  })
+
+  it('onProgress returns a no-op unsubscribe', () => {
+    const service = createBrowserDownloadService()
+    const unsubscribe = service.onProgress('id', () => {})
+    expect(typeof unsubscribe).toBe('function')
+    unsubscribe()
+  })
+})

--- a/src/platform/downloads/providers/createBrowserDownloadService.test.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.test.ts
@@ -48,7 +48,8 @@ describe('createBrowserDownloadService', () => {
 
   it('getById returns null', () => {
     const service = createBrowserDownloadService()
-    expect(service.getById('anything')).toBeNull()
+    const entry = service.getById('anything')
+    expect(entry).toBeNull()
   })
 
   it('onProgress returns a no-op unsubscribe', () => {

--- a/src/platform/downloads/providers/createBrowserDownloadService.test.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.test.ts
@@ -1,19 +1,32 @@
+import type { Mock } from 'vitest'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import { createBrowserDownloadService } from './createBrowserDownloadService'
 
 describe('createBrowserDownloadService', () => {
-  let clickSpy: ReturnType<typeof vi.fn>
+  let anchorElement: HTMLAnchorElement
+  let clickSpy: Mock<() => void>
 
   beforeEach(() => {
-    clickSpy = vi.fn()
-    vi.spyOn(document, 'createElement').mockReturnValue({
-      set href(_: string) {},
-      set download(_: string) {},
-      set target(_: string) {},
-      set rel(_: string) {},
-      click: clickSpy
-    } as unknown as HTMLAnchorElement)
+    anchorElement = document.createElement('a')
+    clickSpy = vi.fn<() => void>()
+    anchorElement.click = clickSpy
+    vi.spyOn(document, 'createElement').mockReturnValue(anchorElement)
+  })
+
+  it('configures the anchor before clicking it', async () => {
+    const service = createBrowserDownloadService()
+
+    await service.start({
+      url: 'https://example.com/model.safetensors',
+      savePath: '/models/checkpoints',
+      filename: 'model.safetensors'
+    })
+
+    expect(anchorElement.href).toBe('https://example.com/model.safetensors')
+    expect(anchorElement.download).toBe('model.safetensors')
+    expect(anchorElement.target).toBe('_blank')
+    expect(anchorElement.rel).toBe('noopener noreferrer')
   })
 
   it('returns a completed entry after triggering a browser download', async () => {

--- a/src/platform/downloads/providers/createBrowserDownloadService.test.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.test.ts
@@ -1,5 +1,5 @@
 import type { Mock } from 'vitest'
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
 
 import { createBrowserDownloadService } from './createBrowserDownloadService'
 
@@ -12,6 +12,10 @@ describe('createBrowserDownloadService', () => {
     clickSpy = vi.fn<() => void>()
     anchorElement.click = clickSpy
     vi.spyOn(document, 'createElement').mockReturnValue(anchorElement)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('configures the anchor before clicking it', async () => {

--- a/src/platform/downloads/providers/createBrowserDownloadService.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.ts
@@ -1,11 +1,11 @@
-import type { DownloadEntry, DownloadService } from '../types'
+import type {
+  DownloadEntry,
+  DownloadService,
+  DownloadStartParams
+} from '../types'
 
 export function createBrowserDownloadService(): DownloadService {
-  async function start(params: {
-    url: string
-    savePath: string
-    filename: string
-  }): Promise<DownloadEntry> {
+  async function start(params: DownloadStartParams): Promise<DownloadEntry> {
     const anchorElement = document.createElement('a')
     anchorElement.href = params.url
     anchorElement.download = params.filename

--- a/src/platform/downloads/providers/createBrowserDownloadService.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.ts
@@ -1,0 +1,52 @@
+import type { DownloadEntry, DownloadService } from '../types'
+
+export function createBrowserDownloadService(): DownloadService {
+  async function start(params: {
+    url: string
+    savePath: string
+    filename: string
+  }): Promise<DownloadEntry> {
+    const anchorElement = document.createElement('a')
+    anchorElement.href = params.url
+    anchorElement.download = params.filename
+    anchorElement.target = '_blank'
+    anchorElement.rel = 'noopener noreferrer'
+    anchorElement.click()
+
+    return {
+      id: params.url,
+      url: params.url,
+      filename: params.filename,
+      savePath: params.savePath,
+      status: 'completed',
+      progress: 1
+    }
+  }
+
+  async function pause() {}
+  async function resume() {}
+  async function cancel() {}
+
+  function getAll(): DownloadEntry[] {
+    return []
+  }
+
+  function getById(): null {
+    return null
+  }
+
+  function onProgress(): () => void {
+    return () => {}
+  }
+
+  return {
+    supportsPauseResume: false,
+    start,
+    pause,
+    resume,
+    cancel,
+    getAll,
+    getById,
+    onProgress
+  }
+}

--- a/src/platform/downloads/providers/createBrowserDownloadService.ts
+++ b/src/platform/downloads/providers/createBrowserDownloadService.ts
@@ -1,10 +1,10 @@
 import type {
   DownloadEntry,
-  DownloadService,
-  DownloadStartParams
+  DownloadStartParams,
+  NonPausableDownloadService
 } from '../types'
 
-export function createBrowserDownloadService(): DownloadService {
+export function createBrowserDownloadService(): NonPausableDownloadService {
   async function start(params: DownloadStartParams): Promise<DownloadEntry> {
     const anchorElement = document.createElement('a')
     anchorElement.href = params.url
@@ -23,8 +23,6 @@ export function createBrowserDownloadService(): DownloadService {
     }
   }
 
-  async function pause() {}
-  async function resume() {}
   async function cancel() {}
 
   function getAll(): DownloadEntry[] {
@@ -42,8 +40,6 @@ export function createBrowserDownloadService(): DownloadService {
   return {
     supportsPauseResume: false,
     start,
-    pause,
-    resume,
     cancel,
     getAll,
     getById,

--- a/src/platform/downloads/providers/createCloudDownloadService.test.ts
+++ b/src/platform/downloads/providers/createCloudDownloadService.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { createCloudDownloadService } from './createCloudDownloadService'
+
+const mockUploadAssetAsync = vi.fn()
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    uploadAssetAsync: (...args: unknown[]) => mockUploadAssetAsync(...args)
+  }
+}))
+
+describe('createCloudDownloadService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an in_progress entry when the upload is async', async () => {
+    mockUploadAssetAsync.mockResolvedValueOnce({
+      type: 'async',
+      task: { task_id: 'task-123', status: 'running' }
+    })
+
+    const service = createCloudDownloadService()
+    const entry = await service.start({
+      url: 'https://example.com/model.safetensors',
+      savePath: '/models/checkpoints',
+      filename: 'model.safetensors'
+    })
+
+    expect(entry).toMatchObject({
+      id: 'task-123',
+      url: 'https://example.com/model.safetensors',
+      status: 'in_progress',
+      progress: 0
+    })
+    expect(service.getById('task-123')).toEqual(entry)
+  })
+
+  it('returns a completed entry when the upload resolves synchronously', async () => {
+    mockUploadAssetAsync.mockResolvedValueOnce({
+      type: 'sync',
+      asset: { id: 'asset-456', name: 'model.safetensors' }
+    })
+
+    const service = createCloudDownloadService()
+    const entry = await service.start({
+      url: 'https://example.com/model.safetensors',
+      savePath: '/models/checkpoints',
+      filename: 'model.safetensors'
+    })
+
+    expect(entry).toMatchObject({
+      id: 'https://example.com/model.safetensors',
+      status: 'completed',
+      progress: 1
+    })
+  })
+
+  it('passes custom tags to uploadAssetAsync', async () => {
+    mockUploadAssetAsync.mockResolvedValueOnce({
+      type: 'sync',
+      asset: { id: 'asset-789' }
+    })
+
+    const service = createCloudDownloadService()
+    await service.start({
+      url: 'https://example.com/lora.safetensors',
+      savePath: '/models/loras',
+      filename: 'lora.safetensors',
+      tags: ['models', 'loras']
+    })
+
+    expect(mockUploadAssetAsync).toHaveBeenCalledWith({
+      source_url: 'https://example.com/lora.safetensors',
+      tags: ['models', 'loras']
+    })
+  })
+
+  it('falls back to [models] when no tags provided', async () => {
+    mockUploadAssetAsync.mockResolvedValueOnce({
+      type: 'sync',
+      asset: { id: 'asset-000' }
+    })
+
+    const service = createCloudDownloadService()
+    await service.start({
+      url: 'https://example.com/model.safetensors',
+      savePath: '/models',
+      filename: 'model.safetensors'
+    })
+
+    expect(mockUploadAssetAsync).toHaveBeenCalledWith({
+      source_url: 'https://example.com/model.safetensors',
+      tags: ['models']
+    })
+  })
+
+  it('does not support pause/resume', () => {
+    const service = createCloudDownloadService()
+    expect(service.supportsPauseResume).toBe(false)
+  })
+
+  it('tracks entries in getAll after start', async () => {
+    mockUploadAssetAsync.mockResolvedValueOnce({
+      type: 'async',
+      task: { task_id: 'task-track', status: 'running' }
+    })
+
+    const service = createCloudDownloadService()
+    await service.start({
+      url: 'https://example.com/a.safetensors',
+      savePath: '/models',
+      filename: 'a.safetensors'
+    })
+
+    expect(service.getAll()).toHaveLength(1)
+    expect(service.getAll()[0].id).toBe('task-track')
+  })
+})

--- a/src/platform/downloads/providers/createCloudDownloadService.ts
+++ b/src/platform/downloads/providers/createCloudDownloadService.ts
@@ -1,0 +1,71 @@
+import type { DownloadEntry, DownloadService } from '../types'
+
+export function createCloudDownloadService(): DownloadService {
+  const entries = new Map<string, DownloadEntry>()
+  const progressListeners = new Map<
+    string,
+    Set<(entry: DownloadEntry) => void>
+  >()
+
+  async function start(params: {
+    url: string
+    savePath: string
+    filename: string
+  }): Promise<DownloadEntry> {
+    const { assetService } =
+      await import('@/platform/assets/services/assetService')
+
+    const result = await assetService.uploadAssetAsync({
+      source_url: params.url,
+      tags: ['models']
+    })
+
+    const id = result.type === 'async' ? result.task.task_id : params.url
+    const entry: DownloadEntry = {
+      id,
+      url: params.url,
+      filename: params.filename,
+      savePath: params.savePath,
+      status: result.type === 'async' ? 'in_progress' : 'completed',
+      progress: result.type === 'async' ? 0 : 1
+    }
+    entries.set(id, entry)
+    return entry
+  }
+
+  async function pause() {}
+  async function resume() {}
+  async function cancel() {}
+
+  function getAll(): DownloadEntry[] {
+    return [...entries.values()]
+  }
+
+  function getById(id: string): DownloadEntry | null {
+    return entries.get(id) ?? null
+  }
+
+  function onProgress(
+    id: string,
+    cb: (entry: DownloadEntry) => void
+  ): () => void {
+    if (!progressListeners.has(id)) {
+      progressListeners.set(id, new Set())
+    }
+    progressListeners.get(id)!.add(cb)
+    return () => {
+      progressListeners.get(id)?.delete(cb)
+    }
+  }
+
+  return {
+    supportsPauseResume: false,
+    start,
+    pause,
+    resume,
+    cancel,
+    getAll,
+    getById,
+    onProgress
+  }
+}

--- a/src/platform/downloads/providers/createCloudDownloadService.ts
+++ b/src/platform/downloads/providers/createCloudDownloadService.ts
@@ -1,4 +1,8 @@
-import type { DownloadEntry, DownloadService } from '../types'
+import type {
+  DownloadEntry,
+  DownloadService,
+  DownloadStartParams
+} from '../types'
 
 export function createCloudDownloadService(): DownloadService {
   const entries = new Map<string, DownloadEntry>()
@@ -7,17 +11,13 @@ export function createCloudDownloadService(): DownloadService {
     Set<(entry: DownloadEntry) => void>
   >()
 
-  async function start(params: {
-    url: string
-    savePath: string
-    filename: string
-  }): Promise<DownloadEntry> {
+  async function start(params: DownloadStartParams): Promise<DownloadEntry> {
     const { assetService } =
       await import('@/platform/assets/services/assetService')
 
     const result = await assetService.uploadAssetAsync({
       source_url: params.url,
-      tags: ['models']
+      tags: params.tags ?? ['models']
     })
 
     const id = result.type === 'async' ? result.task.task_id : params.url

--- a/src/platform/downloads/providers/createCloudDownloadService.ts
+++ b/src/platform/downloads/providers/createCloudDownloadService.ts
@@ -1,10 +1,10 @@
 import type {
   DownloadEntry,
-  DownloadService,
-  DownloadStartParams
+  DownloadStartParams,
+  NonPausableDownloadService
 } from '../types'
 
-export function createCloudDownloadService(): DownloadService {
+export function createCloudDownloadService(): NonPausableDownloadService {
   const entries = new Map<string, DownloadEntry>()
   const progressListeners = new Map<
     string,
@@ -33,8 +33,6 @@ export function createCloudDownloadService(): DownloadService {
     return entry
   }
 
-  async function pause() {}
-  async function resume() {}
   async function cancel() {}
 
   function getAll(): DownloadEntry[] {
@@ -61,8 +59,6 @@ export function createCloudDownloadService(): DownloadService {
   return {
     supportsPauseResume: false,
     start,
-    pause,
-    resume,
     cancel,
     getAll,
     getById,

--- a/src/platform/downloads/providers/createElectronDownloadService.test.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.test.ts
@@ -1,0 +1,157 @@
+import { DownloadStatus } from '@comfyorg/comfyui-electron-types'
+import type { DownloadProgressUpdate } from '@comfyorg/comfyui-electron-types'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { createElectronDownloadService } from './createElectronDownloadService'
+
+let progressCallback: ((update: DownloadProgressUpdate) => void) | null = null
+
+const mockDownloadManager = {
+  getAllDownloads: vi.fn().mockResolvedValue([]),
+  startDownload: vi.fn().mockResolvedValue(true),
+  pauseDownload: vi.fn().mockResolvedValue(undefined),
+  resumeDownload: vi.fn().mockResolvedValue(undefined),
+  cancelDownload: vi.fn().mockResolvedValue(undefined),
+  deleteModel: vi.fn().mockResolvedValue(true),
+  onDownloadProgress: vi.fn((cb: (update: DownloadProgressUpdate) => void) => {
+    progressCallback = cb
+  })
+}
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: () => ({ DownloadManager: mockDownloadManager })
+}))
+
+describe('createElectronDownloadService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    progressCallback = null
+  })
+
+  it('initializes with existing downloads from DownloadManager', async () => {
+    mockDownloadManager.getAllDownloads.mockResolvedValueOnce([
+      {
+        url: 'https://example.com/model.safetensors',
+        filename: 'model.safetensors',
+        state: 'in_progress',
+        receivedBytes: 500,
+        totalBytes: 1000,
+        isPaused: false
+      }
+    ])
+
+    const service = createElectronDownloadService()
+    await service.initialize()
+
+    const allDownloads = service.getAll()
+    expect(allDownloads).toHaveLength(1)
+    expect(allDownloads[0]).toMatchObject({
+      id: 'https://example.com/model.safetensors',
+      filename: 'model.safetensors',
+      status: 'in_progress',
+      progress: 0.5
+    })
+  })
+
+  it('start delegates to DownloadManager and returns a pending entry', async () => {
+    const service = createElectronDownloadService()
+    await service.initialize()
+
+    const entry = await service.start({
+      url: 'https://example.com/new-model.safetensors',
+      savePath: '/models/checkpoints',
+      filename: 'new-model.safetensors'
+    })
+
+    expect(mockDownloadManager.startDownload).toHaveBeenCalledWith(
+      'https://example.com/new-model.safetensors',
+      '/models/checkpoints',
+      'new-model.safetensors'
+    )
+    expect(entry).toMatchObject({
+      status: 'pending',
+      progress: 0
+    })
+    expect(service.getById(entry.id)).toEqual(entry)
+  })
+
+  it('updates entries on progress callbacks from DownloadManager', async () => {
+    const service = createElectronDownloadService()
+    await service.initialize()
+
+    await service.start({
+      url: 'https://example.com/dl.safetensors',
+      savePath: '/models',
+      filename: 'dl.safetensors'
+    })
+
+    progressCallback!({
+      url: 'https://example.com/dl.safetensors',
+      filename: 'dl.safetensors',
+      savePath: '/models',
+      progress: 0.75,
+      status: DownloadStatus.IN_PROGRESS
+    })
+
+    const updated = service.getById('https://example.com/dl.safetensors')
+    expect(updated?.progress).toBe(0.75)
+    expect(updated?.status).toBe('in_progress')
+  })
+
+  it('onProgress notifies subscribers when entries update', async () => {
+    const service = createElectronDownloadService()
+    await service.initialize()
+
+    const url = 'https://example.com/sub.safetensors'
+    await service.start({
+      url,
+      savePath: '/models',
+      filename: 'sub.safetensors'
+    })
+
+    const listener = vi.fn()
+    const unsubscribe = service.onProgress(url, listener)
+
+    progressCallback!({
+      url,
+      filename: 'sub.safetensors',
+      savePath: '/models',
+      progress: 0.5,
+      status: DownloadStatus.IN_PROGRESS
+    })
+
+    expect(listener).toHaveBeenCalledOnce()
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ progress: 0.5 })
+    )
+
+    unsubscribe()
+    progressCallback!({
+      url,
+      filename: 'sub.safetensors',
+      savePath: '/models',
+      progress: 1,
+      status: DownloadStatus.COMPLETED
+    })
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('pause/resume/cancel delegate to DownloadManager', async () => {
+    const service = createElectronDownloadService()
+    await service.initialize()
+
+    await service.pause('url1')
+    expect(mockDownloadManager.pauseDownload).toHaveBeenCalledWith('url1')
+
+    await service.resume('url2')
+    expect(mockDownloadManager.resumeDownload).toHaveBeenCalledWith('url2')
+
+    await service.cancel('url3')
+    expect(mockDownloadManager.cancelDownload).toHaveBeenCalledWith('url3')
+  })
+
+  it('supports pause/resume', () => {
+    const service = createElectronDownloadService()
+    expect(service.supportsPauseResume).toBe(true)
+  })
+})

--- a/src/platform/downloads/providers/createElectronDownloadService.test.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.test.ts
@@ -40,8 +40,7 @@ describe('createElectronDownloadService', () => {
       }
     ])
 
-    const service = createElectronDownloadService()
-    await service.initialize()
+    const service = await createElectronDownloadService()
 
     const allDownloads = service.getAll()
     expect(allDownloads).toHaveLength(1)
@@ -54,8 +53,7 @@ describe('createElectronDownloadService', () => {
   })
 
   it('start delegates to DownloadManager and returns a pending entry', async () => {
-    const service = createElectronDownloadService()
-    await service.initialize()
+    const service = await createElectronDownloadService()
 
     const entry = await service.start({
       url: 'https://example.com/new-model.safetensors',
@@ -76,8 +74,7 @@ describe('createElectronDownloadService', () => {
   })
 
   it('updates entries on progress callbacks from DownloadManager', async () => {
-    const service = createElectronDownloadService()
-    await service.initialize()
+    const service = await createElectronDownloadService()
 
     await service.start({
       url: 'https://example.com/dl.safetensors',
@@ -99,8 +96,7 @@ describe('createElectronDownloadService', () => {
   })
 
   it('onProgress notifies subscribers when entries update', async () => {
-    const service = createElectronDownloadService()
-    await service.initialize()
+    const service = await createElectronDownloadService()
 
     const url = 'https://example.com/sub.safetensors'
     await service.start({
@@ -137,8 +133,7 @@ describe('createElectronDownloadService', () => {
   })
 
   it('pause/resume/cancel delegate to DownloadManager', async () => {
-    const service = createElectronDownloadService()
-    await service.initialize()
+    const service = await createElectronDownloadService()
 
     await service.pause('url1')
     expect(mockDownloadManager.pauseDownload).toHaveBeenCalledWith('url1')
@@ -150,8 +145,8 @@ describe('createElectronDownloadService', () => {
     expect(mockDownloadManager.cancelDownload).toHaveBeenCalledWith('url3')
   })
 
-  it('supports pause/resume', () => {
-    const service = createElectronDownloadService()
+  it('supports pause/resume', async () => {
+    const service = await createElectronDownloadService()
     expect(service.supportsPauseResume).toBe(true)
   })
 })

--- a/src/platform/downloads/providers/createElectronDownloadService.test.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.test.ts
@@ -73,6 +73,19 @@ describe('createElectronDownloadService', () => {
     expect(service.getById(entry.id)).toEqual(entry)
   })
 
+  it('throws when startDownload returns false', async () => {
+    mockDownloadManager.startDownload.mockResolvedValueOnce(false)
+    const service = await createElectronDownloadService()
+
+    await expect(
+      service.start({
+        url: 'https://example.com/fail.safetensors',
+        savePath: '/models',
+        filename: 'fail.safetensors'
+      })
+    ).rejects.toThrow('Download could not be started')
+  })
+
   it('updates entries on progress callbacks from DownloadManager', async () => {
     const service = await createElectronDownloadService()
 

--- a/src/platform/downloads/providers/createElectronDownloadService.test.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.test.ts
@@ -162,4 +162,40 @@ describe('createElectronDownloadService', () => {
     const service = await createElectronDownloadService()
     expect(service.supportsPauseResume).toBe(true)
   })
+
+  it.each([
+    ['completed', DownloadStatus.COMPLETED],
+    ['cancelled', DownloadStatus.CANCELLED],
+    ['error', DownloadStatus.ERROR]
+  ])(
+    'prunes terminal entries (%s) after notifying listeners',
+    async (_label, terminalStatus) => {
+      const service = await createElectronDownloadService()
+
+      const url = 'https://example.com/terminal.safetensors'
+      await service.start({
+        url,
+        savePath: '/models',
+        filename: 'terminal.safetensors'
+      })
+
+      const listener = vi.fn()
+      service.onProgress(url, listener)
+
+      progressCallback!({
+        url,
+        filename: 'terminal.safetensors',
+        savePath: '/models',
+        progress: 1,
+        status: terminalStatus
+      })
+
+      // Listener still receives the final notification
+      expect(listener).toHaveBeenCalledOnce()
+      // Entry pruned to bound memory growth
+      const prunedEntry = service.getById(url)
+      expect(prunedEntry).toBeNull()
+      expect(service.getAll()).toHaveLength(0)
+    }
+  )
 })

--- a/src/platform/downloads/providers/createElectronDownloadService.test.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.test.ts
@@ -1,5 +1,8 @@
 import { DownloadStatus } from '@comfyorg/comfyui-electron-types'
-import type { DownloadProgressUpdate } from '@comfyorg/comfyui-electron-types'
+import type {
+  DownloadProgressUpdate,
+  DownloadState
+} from '@comfyorg/comfyui-electron-types'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import { createElectronDownloadService } from './createElectronDownloadService'
@@ -7,12 +10,12 @@ import { createElectronDownloadService } from './createElectronDownloadService'
 let progressCallback: ((update: DownloadProgressUpdate) => void) | null = null
 
 const mockDownloadManager = {
-  getAllDownloads: vi.fn().mockResolvedValue([]),
-  startDownload: vi.fn().mockResolvedValue(true),
-  pauseDownload: vi.fn().mockResolvedValue(undefined),
-  resumeDownload: vi.fn().mockResolvedValue(undefined),
-  cancelDownload: vi.fn().mockResolvedValue(undefined),
-  deleteModel: vi.fn().mockResolvedValue(true),
+  getAllDownloads: vi.fn(async (): Promise<DownloadState[]> => []),
+  startDownload: vi.fn(async () => true),
+  pauseDownload: vi.fn(async () => undefined),
+  resumeDownload: vi.fn(async () => undefined),
+  cancelDownload: vi.fn(async () => undefined),
+  deleteModel: vi.fn(async () => true),
   onDownloadProgress: vi.fn((cb: (update: DownloadProgressUpdate) => void) => {
     progressCallback = cb
   })
@@ -33,7 +36,7 @@ describe('createElectronDownloadService', () => {
       {
         url: 'https://example.com/model.safetensors',
         filename: 'model.safetensors',
-        state: 'in_progress',
+        state: DownloadStatus.IN_PROGRESS,
         receivedBytes: 500,
         totalBytes: 1000,
         isPaused: false

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -1,6 +1,11 @@
 import type { DownloadProgressUpdate } from '@comfyorg/comfyui-electron-types'
 
-import type { DownloadEntry, DownloadService, DownloadStatus } from '../types'
+import type {
+  DownloadEntry,
+  DownloadService,
+  DownloadStartParams,
+  DownloadStatus
+} from '../types'
 
 import { electronAPI } from '@/utils/envUtil'
 
@@ -32,7 +37,12 @@ export function createElectronDownloadService(): DownloadService & {
     notifyListeners(update.url, entry)
   }
 
+  let initialized = false
+
   async function initialize() {
+    if (initialized) return
+    initialized = true
+
     const existingDownloads = await downloadManager.getAllDownloads()
     for (const download of existingDownloads) {
       entries.set(download.url, {
@@ -49,11 +59,7 @@ export function createElectronDownloadService(): DownloadService & {
     downloadManager.onDownloadProgress(upsertFromProgress)
   }
 
-  async function start(params: {
-    url: string
-    savePath: string
-    filename: string
-  }): Promise<DownloadEntry> {
+  async function start(params: DownloadStartParams): Promise<DownloadEntry> {
     await downloadManager.startDownload(
       params.url,
       params.savePath,

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -18,6 +18,11 @@ export function createElectronDownloadService(): DownloadService & {
     Set<(entry: DownloadEntry) => void>
   >()
   const downloadManager = electronAPI().DownloadManager
+  if (!downloadManager) {
+    throw new Error(
+      'DownloadManager is unavailable. Verify Electron preload exposes DownloadManager.'
+    )
+  }
 
   function notifyListeners(id: string, entry: DownloadEntry) {
     progressListeners.get(id)?.forEach((cb) => cb(entry))
@@ -42,21 +47,25 @@ export function createElectronDownloadService(): DownloadService & {
   async function initialize() {
     if (initialized) return
     initialized = true
-
-    const existingDownloads = await downloadManager.getAllDownloads()
-    for (const download of existingDownloads) {
-      entries.set(download.url, {
-        id: download.url,
-        url: download.url,
-        filename: download.filename,
-        savePath: '',
-        status: download.state as DownloadStatus,
-        progress: download.totalBytes
-          ? download.receivedBytes / download.totalBytes
-          : 0
-      })
+    try {
+      const existingDownloads = await downloadManager.getAllDownloads()
+      for (const download of existingDownloads) {
+        entries.set(download.url, {
+          id: download.url,
+          url: download.url,
+          filename: download.filename,
+          savePath: '',
+          status: download.state as DownloadStatus,
+          progress: download.totalBytes
+            ? download.receivedBytes / download.totalBytes
+            : 0
+        })
+      }
+      downloadManager.onDownloadProgress(upsertFromProgress)
+    } catch (error) {
+      initialized = false
+      throw error
     }
-    downloadManager.onDownloadProgress(upsertFromProgress)
   }
 
   async function start(params: DownloadStartParams): Promise<DownloadEntry> {
@@ -106,7 +115,12 @@ export function createElectronDownloadService(): DownloadService & {
     }
     progressListeners.get(id)!.add(cb)
     return () => {
-      progressListeners.get(id)?.delete(cb)
+      const listeners = progressListeners.get(id)
+      if (!listeners) return
+      listeners.delete(cb)
+      if (listeners.size === 0) {
+        progressListeners.delete(id)
+      }
     }
   }
 

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -1,0 +1,118 @@
+import type { DownloadProgressUpdate } from '@comfyorg/comfyui-electron-types'
+
+import type { DownloadEntry, DownloadService, DownloadStatus } from '../types'
+
+import { electronAPI } from '@/utils/envUtil'
+
+export function createElectronDownloadService(): DownloadService & {
+  initialize(): Promise<void>
+} {
+  const entries = new Map<string, DownloadEntry>()
+  const progressListeners = new Map<
+    string,
+    Set<(entry: DownloadEntry) => void>
+  >()
+  const downloadManager = electronAPI().DownloadManager
+
+  function notifyListeners(id: string, entry: DownloadEntry) {
+    progressListeners.get(id)?.forEach((cb) => cb(entry))
+  }
+
+  function upsertFromProgress(update: DownloadProgressUpdate) {
+    const existing = entries.get(update.url)
+    const entry: DownloadEntry = {
+      id: update.url,
+      url: update.url,
+      filename: update.filename ?? existing?.filename ?? '',
+      savePath: update.savePath ?? existing?.savePath ?? '',
+      status: (update.status as DownloadStatus) ?? 'in_progress',
+      progress: update.progress ?? 0
+    }
+    entries.set(update.url, entry)
+    notifyListeners(update.url, entry)
+  }
+
+  async function initialize() {
+    const existingDownloads = await downloadManager.getAllDownloads()
+    for (const download of existingDownloads) {
+      entries.set(download.url, {
+        id: download.url,
+        url: download.url,
+        filename: download.filename,
+        savePath: '',
+        status: download.state as DownloadStatus,
+        progress: download.totalBytes
+          ? download.receivedBytes / download.totalBytes
+          : 0
+      })
+    }
+    downloadManager.onDownloadProgress(upsertFromProgress)
+  }
+
+  async function start(params: {
+    url: string
+    savePath: string
+    filename: string
+  }): Promise<DownloadEntry> {
+    await downloadManager.startDownload(
+      params.url,
+      params.savePath,
+      params.filename
+    )
+    const entry: DownloadEntry = {
+      id: params.url,
+      url: params.url,
+      filename: params.filename,
+      savePath: params.savePath,
+      status: 'pending',
+      progress: 0
+    }
+    entries.set(params.url, entry)
+    return entry
+  }
+
+  async function pause(id: string) {
+    await downloadManager.pauseDownload(id)
+  }
+
+  async function resume(id: string) {
+    await downloadManager.resumeDownload(id)
+  }
+
+  async function cancel(id: string) {
+    await downloadManager.cancelDownload(id)
+  }
+
+  function getAll(): DownloadEntry[] {
+    return [...entries.values()]
+  }
+
+  function getById(id: string): DownloadEntry | null {
+    return entries.get(id) ?? null
+  }
+
+  function onProgress(
+    id: string,
+    cb: (entry: DownloadEntry) => void
+  ): () => void {
+    if (!progressListeners.has(id)) {
+      progressListeners.set(id, new Set())
+    }
+    progressListeners.get(id)!.add(cb)
+    return () => {
+      progressListeners.get(id)?.delete(cb)
+    }
+  }
+
+  return {
+    supportsPauseResume: true,
+    initialize,
+    start,
+    pause,
+    resume,
+    cancel,
+    getAll,
+    getById,
+    onProgress
+  }
+}

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -9,14 +9,27 @@ import type {
 
 import { electronAPI } from '@/utils/envUtil'
 
-export function createElectronDownloadService(): DownloadService & {
-  initialize(): Promise<void>
-} {
-  const entries = new Map<string, DownloadEntry>()
-  const progressListeners = new Map<
-    string,
-    Set<(entry: DownloadEntry) => void>
-  >()
+const VALID_STATUSES: ReadonlySet<string> = new Set([
+  'pending',
+  'in_progress',
+  'paused',
+  'completed',
+  'cancelled',
+  'error'
+])
+
+function isDownloadStatus(value: unknown): value is DownloadStatus {
+  return typeof value === 'string' && VALID_STATUSES.has(value)
+}
+
+function toDownloadStatus(
+  value: unknown,
+  fallback: DownloadStatus = 'error'
+): DownloadStatus {
+  return isDownloadStatus(value) ? value : fallback
+}
+
+export async function createElectronDownloadService(): Promise<DownloadService> {
   const api = electronAPI()
   const downloadManager = api?.DownloadManager
   if (!downloadManager) {
@@ -25,29 +38,11 @@ export function createElectronDownloadService(): DownloadService & {
     )
   }
 
-  const VALID_STATUSES: ReadonlySet<string> = new Set([
-    'pending',
-    'in_progress',
-    'paused',
-    'completed',
-    'cancelled',
-    'error'
-  ])
-
-  function isDownloadStatus(value: unknown): value is DownloadStatus {
-    return typeof value === 'string' && VALID_STATUSES.has(value)
-  }
-
-  function toDownloadStatus(
-    value: unknown,
-    fallback: DownloadStatus = 'error'
-  ): DownloadStatus {
-    return isDownloadStatus(value) ? value : fallback
-  }
-
-  function notifyListeners(id: string, entry: DownloadEntry) {
-    progressListeners.get(id)?.forEach((cb) => cb(entry))
-  }
+  const entries = new Map<string, DownloadEntry>()
+  const progressListeners = new Map<
+    string,
+    Set<(entry: DownloadEntry) => void>
+  >()
 
   function upsertFromProgress(update: DownloadProgressUpdate) {
     const existing = entries.get(update.url)
@@ -60,40 +55,23 @@ export function createElectronDownloadService(): DownloadService & {
       progress: update.progress ?? 0
     }
     entries.set(update.url, entry)
-    notifyListeners(update.url, entry)
+    progressListeners.get(update.url)?.forEach((cb) => cb(entry))
   }
 
-  let initialized = false
-  let initPromise: Promise<void> | null = null
-
-  async function initialize() {
-    if (initialized) return
-    if (initPromise) return initPromise
-
-    initPromise = (async () => {
-      try {
-        const existingDownloads = await downloadManager.getAllDownloads()
-        for (const download of existingDownloads) {
-          entries.set(download.url, {
-            id: download.url,
-            url: download.url,
-            filename: download.filename,
-            savePath: '',
-            status: toDownloadStatus(download.state),
-            progress: download.totalBytes
-              ? download.receivedBytes / download.totalBytes
-              : 0
-          })
-        }
-        downloadManager.onDownloadProgress(upsertFromProgress)
-        initialized = true
-      } finally {
-        initPromise = null
-      }
-    })()
-
-    return initPromise
+  const existingDownloads = await downloadManager.getAllDownloads()
+  for (const download of existingDownloads) {
+    entries.set(download.url, {
+      id: download.url,
+      url: download.url,
+      filename: download.filename,
+      savePath: '',
+      status: toDownloadStatus(download.state),
+      progress: download.totalBytes
+        ? download.receivedBytes / download.totalBytes
+        : 0
+    })
   }
+  downloadManager.onDownloadProgress(upsertFromProgress)
 
   async function start(params: DownloadStartParams): Promise<DownloadEntry> {
     const started = await downloadManager.startDownload(
@@ -128,6 +106,7 @@ export function createElectronDownloadService(): DownloadService & {
 
   async function cancel(id: string) {
     await downloadManager.cancelDownload(id)
+    entries.delete(id)
   }
 
   function getAll(): DownloadEntry[] {
@@ -158,7 +137,6 @@ export function createElectronDownloadService(): DownloadService & {
 
   return {
     supportsPauseResume: true,
-    initialize,
     start,
     pause,
     resume,

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -25,7 +25,7 @@ export function createElectronDownloadService(): DownloadService & {
     )
   }
 
-  const VALID_STATUSES = new Set<DownloadStatus>([
+  const VALID_STATUSES: ReadonlySet<string> = new Set([
     'pending',
     'in_progress',
     'paused',
@@ -34,13 +34,15 @@ export function createElectronDownloadService(): DownloadService & {
     'error'
   ])
 
+  function isDownloadStatus(value: unknown): value is DownloadStatus {
+    return typeof value === 'string' && VALID_STATUSES.has(value)
+  }
+
   function toDownloadStatus(
     value: unknown,
     fallback: DownloadStatus = 'error'
   ): DownloadStatus {
-    return VALID_STATUSES.has(value as DownloadStatus)
-      ? (value as DownloadStatus)
-      : fallback
+    return isDownloadStatus(value) ? value : fallback
   }
 
   function notifyListeners(id: string, entry: DownloadEntry) {

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -17,7 +17,8 @@ export function createElectronDownloadService(): DownloadService & {
     string,
     Set<(entry: DownloadEntry) => void>
   >()
-  const downloadManager = electronAPI().DownloadManager
+  const api = electronAPI()
+  const downloadManager = api?.DownloadManager
   if (!downloadManager) {
     throw new Error(
       'DownloadManager is unavailable. Verify Electron preload exposes DownloadManager.'
@@ -43,29 +44,35 @@ export function createElectronDownloadService(): DownloadService & {
   }
 
   let initialized = false
+  let initPromise: Promise<void> | null = null
 
   async function initialize() {
     if (initialized) return
-    initialized = true
-    try {
-      const existingDownloads = await downloadManager.getAllDownloads()
-      for (const download of existingDownloads) {
-        entries.set(download.url, {
-          id: download.url,
-          url: download.url,
-          filename: download.filename,
-          savePath: '',
-          status: download.state as DownloadStatus,
-          progress: download.totalBytes
-            ? download.receivedBytes / download.totalBytes
-            : 0
-        })
+    if (initPromise) return initPromise
+
+    initPromise = (async () => {
+      try {
+        const existingDownloads = await downloadManager.getAllDownloads()
+        for (const download of existingDownloads) {
+          entries.set(download.url, {
+            id: download.url,
+            url: download.url,
+            filename: download.filename,
+            savePath: '',
+            status: download.state as DownloadStatus,
+            progress: download.totalBytes
+              ? download.receivedBytes / download.totalBytes
+              : 0
+          })
+        }
+        downloadManager.onDownloadProgress(upsertFromProgress)
+        initialized = true
+      } finally {
+        initPromise = null
       }
-      downloadManager.onDownloadProgress(upsertFromProgress)
-    } catch (error) {
-      initialized = false
-      throw error
-    }
+    })()
+
+    return initPromise
   }
 
   async function start(params: DownloadStartParams): Promise<DownloadEntry> {

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -25,6 +25,24 @@ export function createElectronDownloadService(): DownloadService & {
     )
   }
 
+  const VALID_STATUSES = new Set<DownloadStatus>([
+    'pending',
+    'in_progress',
+    'paused',
+    'completed',
+    'cancelled',
+    'error'
+  ])
+
+  function toDownloadStatus(
+    value: unknown,
+    fallback: DownloadStatus = 'error'
+  ): DownloadStatus {
+    return VALID_STATUSES.has(value as DownloadStatus)
+      ? (value as DownloadStatus)
+      : fallback
+  }
+
   function notifyListeners(id: string, entry: DownloadEntry) {
     progressListeners.get(id)?.forEach((cb) => cb(entry))
   }
@@ -36,7 +54,7 @@ export function createElectronDownloadService(): DownloadService & {
       url: update.url,
       filename: update.filename ?? existing?.filename ?? '',
       savePath: update.savePath ?? existing?.savePath ?? '',
-      status: (update.status as DownloadStatus) ?? 'in_progress',
+      status: toDownloadStatus(update.status, 'in_progress'),
       progress: update.progress ?? 0
     }
     entries.set(update.url, entry)
@@ -59,7 +77,7 @@ export function createElectronDownloadService(): DownloadService & {
             url: download.url,
             filename: download.filename,
             savePath: '',
-            status: download.state as DownloadStatus,
+            status: toDownloadStatus(download.state),
             progress: download.totalBytes
               ? download.receivedBytes / download.totalBytes
               : 0
@@ -76,11 +94,16 @@ export function createElectronDownloadService(): DownloadService & {
   }
 
   async function start(params: DownloadStartParams): Promise<DownloadEntry> {
-    await downloadManager.startDownload(
+    const started = await downloadManager.startDownload(
       params.url,
       params.savePath,
       params.filename
     )
+    if (started === false) {
+      throw new Error(
+        `Download could not be started for ${params.url}. Verify the URL and try again.`
+      )
+    }
     const entry: DownloadEntry = {
       id: params.url,
       url: params.url,

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -18,6 +18,12 @@ const VALID_STATUSES: ReadonlySet<string> = new Set([
   'error'
 ])
 
+const TERMINAL_STATUSES: ReadonlySet<DownloadStatus> = new Set([
+  'completed',
+  'cancelled',
+  'error'
+])
+
 function isDownloadStatus(value: unknown): value is DownloadStatus {
   return typeof value === 'string' && VALID_STATUSES.has(value)
 }
@@ -56,6 +62,13 @@ export async function createElectronDownloadService(): Promise<PausableDownloadS
     }
     entries.set(update.url, entry)
     progressListeners.get(update.url)?.forEach((cb) => cb(entry))
+
+    // Prune terminal entries to bound memory growth. Consumers that need
+    // final state should snapshot it in their onProgress callback above.
+    if (TERMINAL_STATUSES.has(entry.status)) {
+      entries.delete(update.url)
+      progressListeners.delete(update.url)
+    }
   }
 
   const existingDownloads = await downloadManager.getAllDownloads()

--- a/src/platform/downloads/providers/createElectronDownloadService.ts
+++ b/src/platform/downloads/providers/createElectronDownloadService.ts
@@ -2,9 +2,9 @@ import type { DownloadProgressUpdate } from '@comfyorg/comfyui-electron-types'
 
 import type {
   DownloadEntry,
-  DownloadService,
   DownloadStartParams,
-  DownloadStatus
+  DownloadStatus,
+  PausableDownloadService
 } from '../types'
 
 import { electronAPI } from '@/utils/envUtil'
@@ -29,7 +29,7 @@ function toDownloadStatus(
   return isDownloadStatus(value) ? value : fallback
 }
 
-export async function createElectronDownloadService(): Promise<DownloadService> {
+export async function createElectronDownloadService(): Promise<PausableDownloadService> {
   const api = electronAPI()
   const downloadManager = api?.DownloadManager
   if (!downloadManager) {

--- a/src/platform/downloads/types.ts
+++ b/src/platform/downloads/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Download service abstraction types.
+ *
+ * Provides a unified contract for model downloads across all distributions
+ * (Desktop/Electron, Browser/Localhost, Cloud). Components depend only on
+ * this interface — platform-specific implementations are injected at build
+ * time via {@link __DISTRIBUTION__} and tree-shaken from other builds.
+ */
+
+export type DownloadStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
+  | 'error'
+
+export interface DownloadEntry {
+  /** Unique key — URL for electron, taskId for cloud */
+  readonly id: string
+  readonly url: string
+  readonly filename: string
+  readonly savePath: string
+  status: DownloadStatus
+  progress: number
+  error?: string
+}
+
+export interface DownloadService {
+  /** Resolves once the download is accepted, not when it completes. */
+  start(params: {
+    url: string
+    savePath: string
+    filename: string
+  }): Promise<DownloadEntry>
+
+  pause(id: string): Promise<void>
+  resume(id: string): Promise<void>
+  cancel(id: string): Promise<void>
+
+  getAll(): DownloadEntry[]
+  getById(id: string): DownloadEntry | null
+
+  /** Returns an unsubscribe function. */
+  onProgress(id: string, cb: (entry: DownloadEntry) => void): () => void
+
+  readonly supportsPauseResume: boolean
+}

--- a/src/platform/downloads/types.ts
+++ b/src/platform/downloads/types.ts
@@ -26,13 +26,17 @@ export interface DownloadEntry {
   error?: string
 }
 
+export interface DownloadStartParams {
+  url: string
+  savePath: string
+  filename: string
+  /** Cloud-specific metadata tags (e.g. ['models', 'checkpoints']). */
+  tags?: string[]
+}
+
 export interface DownloadService {
   /** Resolves once the download is accepted, not when it completes. */
-  start(params: {
-    url: string
-    savePath: string
-    filename: string
-  }): Promise<DownloadEntry>
+  start(params: DownloadStartParams): Promise<DownloadEntry>
 
   pause(id: string): Promise<void>
   resume(id: string): Promise<void>

--- a/src/platform/downloads/types.ts
+++ b/src/platform/downloads/types.ts
@@ -34,12 +34,10 @@ export interface DownloadStartParams {
   tags?: string[]
 }
 
-export interface DownloadService {
+interface BaseDownloadService {
   /** Resolves once the download is accepted, not when it completes. */
   start(params: DownloadStartParams): Promise<DownloadEntry>
 
-  pause(id: string): Promise<void>
-  resume(id: string): Promise<void>
   cancel(id: string): Promise<void>
 
   getAll(): DownloadEntry[]
@@ -47,6 +45,23 @@ export interface DownloadService {
 
   /** Returns an unsubscribe function. */
   onProgress(id: string, cb: (entry: DownloadEntry) => void): () => void
-
-  readonly supportsPauseResume: boolean
 }
+
+export interface PausableDownloadService extends BaseDownloadService {
+  readonly supportsPauseResume: true
+  pause(id: string): Promise<void>
+  resume(id: string): Promise<void>
+}
+
+export interface NonPausableDownloadService extends BaseDownloadService {
+  readonly supportsPauseResume: false
+}
+
+/**
+ * Discriminated union by {@link supportsPauseResume}. Callers must narrow
+ * on the discriminant before calling {@link PausableDownloadService.pause}
+ * or {@link PausableDownloadService.resume}; the compiler enforces this.
+ */
+export type DownloadService =
+  | PausableDownloadService
+  | NonPausableDownloadService


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary
- Unified `DownloadService` interface with per-distribution providers (Electron, Browser, Cloud) selected at build time via `__DISTRIBUTION__`
- PR 1 of incremental migration — new files only, no existing code changes

## Motivation
Desktop download code regressed twice (DESK2-47, DESK2-48). Platform-specific branching (`isDesktop`, `isCloud`) leaks into components. This encapsulates all platform-specific download logic behind a single contract.

## Design
- Functional composition matching `createAssetService()` / `createTaskService()` — closure-based factories, no classes
- Build-time DI via `__DISTRIBUTION__` + dynamic `import()` — tree-shaking eliminates unused providers
- Pinia store (`useDownloadServiceStore`) as single public API

## Test coverage
17 unit tests: browser (5), electron (6), cloud (6)

## Follow-up PRs
1. Migrate `electronDownloadStore.ts` consumers
2. Migrate `missingModelDownload.ts` platform branches
3. Add `@desktop` Playwright E2E tests
4. Wire cloud provider to WebSocket events

Refs: DESK2-47, DESK2-48

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11437-feat-add-download-service-abstraction-with-functional-composition-3486d73d36508132b1f0fb8fc54098d9) by [Unito](https://www.unito.io)
