### PR TITLE
feat: enable node replacement by default

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1272,9 +1272,10 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'When enabled, missing nodes with known replacements will be shown as replaceable in the missing nodes dialog, allowing you to review and apply replacements.',
     type: 'boolean',
-    defaultValue: false,
-    experimental: true,
-    versionAdded: '1.40.0'
+    defaultValue: true,
+    experimental: false,
+    versionAdded: '1.40.0',
+    versionModified: '1.44.5'
   },
   {
     id: 'Comfy.Graph.DeduplicateSubgraphNodeIds',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Enable node replacement suggestions by default so users see Quick Fix options for deprecated/renamed nodes without toggling an experimental setting.

- Change `Comfy.NodeReplacement.Enabled` default from `false` to `true` and remove `experimental` flag
- Add `versionModified` metadata for release tracking
- No breaking change — users who previously disabled this setting keep their preference

## Safety gates

This is an intentional global rollout, gated by two additional server-side checks:

1. Server must provide `node_replacements` feature flag as true (PostHog controlled)
2. `GET /api/node_replacements` must return data (cloud PR Comfy-Org/cloud#2686)

Without both, changing this default alone has no effect. The three gates ensure safe rollout.

## Companion PRs

- Comfy-Org/cloud#2686 — backend `GET /api/node_replacements` endpoint + server-side validation bypass

Replicate of #11246, retargeted to `main` for backport automation.

Labels: `needs-backport`, `cloud/1.42`, `cloud/1.43`, `core/1.42`, `core/1.43`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11439-feat-enable-node-replacement-by-default-3486d73d36508192b77aea9640986106) by [Unito](https://www.unito.io)
