### PR TITLE
test: add unit tests for media widgets (chart, record audio)

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
@@ -1,0 +1,125 @@
+/* eslint-disable vue/one-component-per-file */
+import { render, screen } from '@testing-library/vue'
+import type { ChartData } from 'chart.js'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { ChartInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+import WidgetChart from './WidgetChart.vue'
+import { createMockWidget } from './widgetTestUtils'
+
+type ChartWidgetOptions = NonNullable<ChartInputSpec['options']>
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: { g: { chart: 'Chart', chartLowercase: 'chart' } } }
+})
+
+const ChartStub = defineComponent({
+  name: 'Chart',
+  props: {
+    type: { type: String, default: '' },
+    data: { type: Object, default: () => ({}) },
+    options: { type: Object, default: () => ({}) }
+  },
+  template:
+    '<div data-testid="chart" :data-chart-type="type" :data-chart-data="JSON.stringify(data)" v-bind="$attrs" />'
+})
+
+function makeWidget(
+  options: Partial<ChartWidgetOptions> = {}
+): SimplifiedWidget<ChartData, ChartWidgetOptions> {
+  return createMockWidget<ChartData>({
+    value: { labels: [], datasets: [] },
+    name: 'test_chart',
+    type: 'chart',
+    options: options as ChartWidgetOptions
+  }) as SimplifiedWidget<ChartData, ChartWidgetOptions>
+}
+
+function renderChart(
+  widget: SimplifiedWidget<ChartData, ChartWidgetOptions>,
+  modelValue: ChartData
+) {
+  const value = ref<ChartData>(modelValue)
+  const Harness = defineComponent({
+    components: { WidgetChart },
+    setup: () => ({ widget, value }),
+    template: '<WidgetChart :widget="widget" v-model="value" />'
+  })
+  const utils = render(Harness, {
+    global: { plugins: [i18n], stubs: { Chart: ChartStub } }
+  })
+  return { ...utils, value }
+}
+
+describe('WidgetChart', () => {
+  describe('Chart type selection', () => {
+    it('defaults to "line" when no type option is set', () => {
+      renderChart(makeWidget(), { labels: [], datasets: [] })
+      expect(screen.getByTestId('chart')).toHaveAttribute(
+        'data-chart-type',
+        'line'
+      )
+    })
+
+    it('uses the type from widget.options when provided', () => {
+      renderChart(makeWidget({ type: 'bar' }), { labels: [], datasets: [] })
+      expect(screen.getByTestId('chart')).toHaveAttribute(
+        'data-chart-type',
+        'bar'
+      )
+    })
+  })
+
+  describe('Chart data binding', () => {
+    it('passes model value through to the Chart component', () => {
+      const data: ChartData = {
+        labels: ['a', 'b'],
+        datasets: [{ label: 'x', data: [1, 2] }]
+      }
+      renderChart(makeWidget(), data)
+      const parsed = JSON.parse(
+        screen.getByTestId('chart').dataset.chartData!
+      )
+      expect(parsed.labels).toEqual(['a', 'b'])
+      expect(parsed.datasets[0].label).toBe('x')
+    })
+
+    it('falls back to empty labels/datasets when value is an empty object', () => {
+      const { value } = renderChart(
+        makeWidget(),
+        { labels: [], datasets: [] }
+      )
+      value.value = {} as ChartData
+      // value mutation happens after initial render; re-read the latest state
+      // by triggering a re-render via the same mount assertion
+      const parsed = JSON.parse(
+        screen.getByTestId('chart').dataset.chartData!
+      )
+      expect(Array.isArray(parsed.labels)).toBe(true)
+      expect(Array.isArray(parsed.datasets)).toBe(true)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('sets an aria-label that includes the widget name and chart type', () => {
+      renderChart(makeWidget({ type: 'pie' }), { labels: [], datasets: [] })
+      const chart = screen.getByTestId('chart')
+      expect(chart.getAttribute('aria-label')).toContain('test_chart')
+      expect(chart.getAttribute('aria-label')).toContain('pie')
+    })
+
+    it('uses the translated "Chart" label when the widget has no name', () => {
+      const widget = makeWidget()
+      widget.name = ''
+      renderChart(widget, { labels: [], datasets: [] })
+      const chart = screen.getByTestId('chart')
+      expect(chart.getAttribute('aria-label')).toContain('Chart')
+    })
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
@@ -2,7 +2,7 @@
 import { render, screen } from '@testing-library/vue'
 import type { ChartData } from 'chart.js'
 import { describe, expect, it } from 'vitest'
-import { defineComponent, ref } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { ChartInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -90,19 +90,34 @@ describe('WidgetChart', () => {
       expect(parsed.datasets[0].label).toBe('x')
     })
 
-    it('falls back to empty labels/datasets when value is an empty object', () => {
+    it('falls back to empty labels/datasets when value becomes null', async () => {
       const { value } = renderChart(
         makeWidget(),
-        { labels: [], datasets: [] }
+        { labels: ['a'], datasets: [{ label: 'x', data: [1] }] }
       )
-      value.value = {} as ChartData
-      // value mutation happens after initial render; re-read the latest state
-      // by triggering a re-render via the same mount assertion
+      value.value = null as unknown as ChartData
+      await nextTick()
+
       const parsed = JSON.parse(
         screen.getByTestId('chart').dataset.chartData!
       )
-      expect(Array.isArray(parsed.labels)).toBe(true)
-      expect(Array.isArray(parsed.datasets)).toBe(true)
+      expect(parsed).toEqual({ labels: [], datasets: [] })
+    })
+
+    it('reactively updates the chart when model value changes', async () => {
+      const { value } = renderChart(
+        makeWidget(),
+        { labels: ['a'], datasets: [{ label: 'x', data: [1] }] }
+      )
+
+      value.value = { labels: ['b', 'c'], datasets: [{ label: 'y', data: [2, 3] }] }
+      await nextTick()
+
+      const parsed = JSON.parse(
+        screen.getByTestId('chart').dataset.chartData!
+      )
+      expect(parsed.labels).toEqual(['b', 'c'])
+      expect(parsed.datasets[0].label).toBe('y')
     })
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
@@ -85,39 +85,36 @@ describe('WidgetChart', () => {
         datasets: [{ label: 'x', data: [1, 2] }]
       }
       renderChart(makeWidget(), data)
-      const parsed = JSON.parse(
-        screen.getByTestId('chart').dataset.chartData!
-      )
+      const parsed = JSON.parse(screen.getByTestId('chart').dataset.chartData!)
       expect(parsed.labels).toEqual(['a', 'b'])
       expect(parsed.datasets[0].label).toBe('x')
     })
 
     it('falls back to empty labels/datasets when value becomes null', async () => {
-      const { value } = renderChart(
-        makeWidget(),
-        { labels: ['a'], datasets: [{ label: 'x', data: [1] }] }
-      )
+      const { value } = renderChart(makeWidget(), {
+        labels: ['a'],
+        datasets: [{ label: 'x', data: [1] }]
+      })
       value.value = null as unknown as ChartData
       await nextTick()
 
-      const parsed = JSON.parse(
-        screen.getByTestId('chart').dataset.chartData!
-      )
+      const parsed = JSON.parse(screen.getByTestId('chart').dataset.chartData!)
       expect(parsed).toEqual({ labels: [], datasets: [] })
     })
 
     it('reactively updates the chart when model value changes', async () => {
-      const { value } = renderChart(
-        makeWidget(),
-        { labels: ['a'], datasets: [{ label: 'x', data: [1] }] }
-      )
+      const { value } = renderChart(makeWidget(), {
+        labels: ['a'],
+        datasets: [{ label: 'x', data: [1] }]
+      })
 
-      value.value = { labels: ['b', 'c'], datasets: [{ label: 'y', data: [2, 3] }] }
+      value.value = {
+        labels: ['b', 'c'],
+        datasets: [{ label: 'y', data: [2, 3] }]
+      }
       await nextTick()
 
-      const parsed = JSON.parse(
-        screen.getByTestId('chart').dataset.chartData!
-      )
+      const parsed = JSON.parse(screen.getByTestId('chart').dataset.chartData!)
       expect(parsed.labels).toEqual(['b', 'c'])
       expect(parsed.datasets[0].label).toBe('y')
     })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetChart.test.ts
@@ -5,13 +5,15 @@ import { describe, expect, it } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import type { IWidgetOptions } from '@/lib/litegraph/src/types/widgets'
 import type { ChartInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 import WidgetChart from './WidgetChart.vue'
 import { createMockWidget } from './widgetTestUtils'
 
-type ChartWidgetOptions = NonNullable<ChartInputSpec['options']>
+type ChartWidgetOptions = NonNullable<ChartInputSpec['options']> &
+  IWidgetOptions
 
 const i18n = createI18n({
   legacy: false,
@@ -123,10 +125,10 @@ describe('WidgetChart', () => {
 
   describe('Accessibility', () => {
     it('sets an aria-label that includes the widget name and chart type', () => {
-      renderChart(makeWidget({ type: 'pie' }), { labels: [], datasets: [] })
+      renderChart(makeWidget({ type: 'bar' }), { labels: [], datasets: [] })
       const chart = screen.getByTestId('chart')
       expect(chart.getAttribute('aria-label')).toContain('test_chart')
-      expect(chart.getAttribute('aria-label')).toContain('pie')
+      expect(chart.getAttribute('aria-label')).toContain('bar')
     })
 
     it('uses the translated "Chart" label when the widget has no name', () => {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -26,9 +26,9 @@ type MockPlaybackState = {
   onMetadataLoaded: ReturnType<typeof vi.fn>
 }
 
-const recorderState = vi.hoisted(() => ({} as Record<string, unknown>))
-const playbackState = vi.hoisted(() => ({} as Record<string, unknown>))
-const waveformState = vi.hoisted(() => ({} as Record<string, unknown>))
+const recorderState = vi.hoisted(() => ({}) as Record<string, unknown>)
+const playbackState = vi.hoisted(() => ({}) as Record<string, unknown>)
+const waveformState = vi.hoisted(() => ({}) as Record<string, unknown>)
 const capturedOptions = vi.hoisted(
   () =>
     ({
@@ -190,9 +190,7 @@ describe('WidgetRecordAudio', () => {
     it('calls startRecording when Start button is clicked', async () => {
       renderWidget()
       const user = userEvent.setup()
-      await user.click(
-        screen.getByRole('button', { name: /Start Recording/i })
-      )
+      await user.click(screen.getByRole('button', { name: /Start Recording/i }))
       expect(recorder.startRecording).toHaveBeenCalledTimes(1)
     })
 
@@ -224,9 +222,7 @@ describe('WidgetRecordAudio', () => {
       setRecorderMocks({ isRecording: ref(true) })
       renderWidget()
       const user = userEvent.setup()
-      await user.click(
-        screen.getByRole('button', { name: /Stop Recording/i })
-      )
+      await user.click(screen.getByRole('button', { name: /Stop Recording/i }))
       expect(recorder.stopRecording).toHaveBeenCalledTimes(1)
     })
 
@@ -278,9 +274,7 @@ describe('WidgetRecordAudio', () => {
     it('calls playback.stop when the stop playback button is clicked', async () => {
       renderWidget()
       const user = userEvent.setup()
-      await user.click(
-        screen.getByRole('button', { name: /Stop Playback/i })
-      )
+      await user.click(screen.getByRole('button', { name: /Stop Playback/i }))
       expect(playback.stop).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -29,25 +29,46 @@ type MockPlaybackState = {
 const recorderState = vi.hoisted(() => ({} as Record<string, unknown>))
 const playbackState = vi.hoisted(() => ({} as Record<string, unknown>))
 const waveformState = vi.hoisted(() => ({} as Record<string, unknown>))
+const capturedOptions = vi.hoisted(
+  () =>
+    ({
+      recorder: null as unknown,
+      playback: null as unknown
+    }) as { recorder: unknown; playback: unknown }
+)
+const appMock = vi.hoisted(() => ({
+  app: {
+    canvas: {
+      graph: {
+        getNodeById: (_: unknown) => null as unknown
+      }
+    }
+  }
+}))
+const isDOMWidgetMock = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('../composables/audio/useAudioRecorder', () => ({
-  useAudioRecorder: () => recorderState
+  useAudioRecorder: (options: unknown) => {
+    capturedOptions.recorder = options
+    return recorderState
+  }
 }))
 
 vi.mock('../composables/audio/useAudioPlayback', () => ({
-  useAudioPlayback: () => playbackState
+  useAudioPlayback: (_el: unknown, options: unknown) => {
+    capturedOptions.playback = options
+    return playbackState
+  }
 }))
 
 vi.mock('../composables/audio/useAudioWaveform', () => ({
   useAudioWaveform: () => waveformState
 }))
 
-vi.mock('@/scripts/app', () => ({
-  app: { canvas: { graph: { getNodeById: () => null } } }
-}))
+vi.mock('@/scripts/app', () => appMock)
 
 vi.mock('@/scripts/domWidget', () => ({
-  isDOMWidget: () => false
+  isDOMWidget: isDOMWidgetMock
 }))
 
 import WidgetRecordAudio from './WidgetRecordAudio.vue'
@@ -261,6 +282,84 @@ describe('WidgetRecordAudio', () => {
         screen.getByRole('button', { name: /Stop Playback/i })
       )
       expect(playback.stop).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Recording persistence via onRecordingComplete', () => {
+    function createAudioWidget(initialSrc = '') {
+      const element = document.createElement('audio') as HTMLAudioElement
+      element.src = initialSrc
+      return {
+        name: 'audioUI',
+        type: 'audio',
+        element
+      }
+    }
+
+    function primeAudioWidgetInNode(widgets: { element: HTMLAudioElement }[]) {
+      appMock.app.canvas.graph.getNodeById = () =>
+        ({
+          widgets
+        }) as unknown
+      isDOMWidgetMock.mockReturnValue(true)
+    }
+
+    it('replaces the audio widget element src with a new blob URL when a recording completes', async () => {
+      const originalCreateObjectURL = URL.createObjectURL
+      URL.createObjectURL = vi.fn((blob: Blob) => `blob:fake/${blob.size}`)
+
+      const audioWidget = createAudioWidget()
+      primeAudioWidgetInNode([audioWidget])
+      renderWidget()
+
+      const options = capturedOptions.recorder as {
+        onRecordingComplete: (blob: Blob) => Promise<void> | void
+      }
+      const blob = new Blob(['audio-bytes'], { type: 'audio/webm' })
+      await options.onRecordingComplete(blob)
+
+      expect(audioWidget.element.src).toContain('blob:fake/')
+      URL.createObjectURL = originalCreateObjectURL
+    })
+
+    it('revokes the previous blob URL before replacing it', async () => {
+      const originalCreateObjectURL = URL.createObjectURL
+      const originalRevoke = URL.revokeObjectURL
+      URL.createObjectURL = vi.fn(() => 'blob:fake/new')
+      URL.revokeObjectURL = vi.fn()
+
+      const audioWidget = createAudioWidget('blob:stale-existing')
+      primeAudioWidgetInNode([audioWidget])
+      renderWidget()
+
+      const options = capturedOptions.recorder as {
+        onRecordingComplete: (blob: Blob) => Promise<void> | void
+      }
+      await options.onRecordingComplete(new Blob(['x']))
+
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:stale-existing')
+      expect(audioWidget.element.src).toBe('blob:fake/new')
+
+      URL.createObjectURL = originalCreateObjectURL
+      URL.revokeObjectURL = originalRevoke
+    })
+
+    it('does not write to non-DOM widgets on the host node', async () => {
+      const originalCreateObjectURL = URL.createObjectURL
+      URL.createObjectURL = vi.fn(() => 'blob:fake/new')
+
+      const audioWidget = createAudioWidget('originally-empty')
+      primeAudioWidgetInNode([audioWidget])
+      isDOMWidgetMock.mockReturnValue(false)
+      renderWidget()
+
+      const options = capturedOptions.recorder as {
+        onRecordingComplete: (blob: Blob) => Promise<void> | void
+      }
+      await options.onRecordingComplete(new Blob(['x']))
+
+      expect(audioWidget.element.src).not.toBe('blob:fake/new')
+      URL.createObjectURL = originalCreateObjectURL
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -2,45 +2,21 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-type MockRecorderState = {
-  isRecording: ReturnType<typeof ref<boolean>>
-  recordedURL: ReturnType<typeof ref<string | null>>
-  startRecording: ReturnType<typeof vi.fn>
-  stopRecording: ReturnType<typeof vi.fn>
-  mediaRecorder: ReturnType<typeof ref<unknown>>
-}
-type MockPlaybackState = {
-  isPlaying: ReturnType<typeof ref<boolean>>
-  audioElementKey: ReturnType<typeof ref<number>>
-  resetAudioElement: ReturnType<typeof vi.fn>
-  play: ReturnType<typeof vi.fn>
-  stop: ReturnType<typeof vi.fn>
-  getCurrentTime: ReturnType<typeof vi.fn>
-  getDuration: ReturnType<typeof vi.fn>
-  playbackTimerInterval: ReturnType<typeof ref<number | null>>
-  onPlaybackEnded: ReturnType<typeof vi.fn>
-  onMetadataLoaded: ReturnType<typeof vi.fn>
-}
-
-const recorderState = vi.hoisted(() => ({}) as Record<string, unknown>)
-const playbackState = vi.hoisted(() => ({}) as Record<string, unknown>)
-const waveformState = vi.hoisted(() => ({}) as Record<string, unknown>)
-const capturedOptions = vi.hoisted(
-  () =>
-    ({
-      recorder: null as unknown,
-      playback: null as unknown
-    }) as { recorder: unknown; playback: unknown }
-)
+const { useAudioRecorderMock, useAudioPlaybackMock, useAudioWaveformMock } =
+  vi.hoisted(() => ({
+    useAudioRecorderMock: vi.fn(),
+    useAudioPlaybackMock: vi.fn(),
+    useAudioWaveformMock: vi.fn()
+  }))
 const appMock = vi.hoisted(() => ({
   app: {
     canvas: {
       graph: {
-        getNodeById: (_: unknown) => null as unknown
+        getNodeById: vi.fn<(id: string) => unknown>(() => null)
       }
     }
   }
@@ -48,21 +24,15 @@ const appMock = vi.hoisted(() => ({
 const isDOMWidgetMock = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('../composables/audio/useAudioRecorder', () => ({
-  useAudioRecorder: (options: unknown) => {
-    capturedOptions.recorder = options
-    return recorderState
-  }
+  useAudioRecorder: useAudioRecorderMock
 }))
 
 vi.mock('../composables/audio/useAudioPlayback', () => ({
-  useAudioPlayback: (_el: unknown, options: unknown) => {
-    capturedOptions.playback = options
-    return playbackState
-  }
+  useAudioPlayback: useAudioPlaybackMock
 }))
 
 vi.mock('../composables/audio/useAudioWaveform', () => ({
-  useAudioWaveform: () => waveformState
+  useAudioWaveform: useAudioWaveformMock
 }))
 
 vi.mock('@/scripts/app', () => appMock)
@@ -71,7 +41,49 @@ vi.mock('@/scripts/domWidget', () => ({
   isDOMWidget: isDOMWidgetMock
 }))
 
+import type { useAudioPlayback } from '../composables/audio/useAudioPlayback'
+import { useAudioRecorder } from '../composables/audio/useAudioRecorder'
+import type { useAudioWaveform } from '../composables/audio/useAudioWaveform'
 import WidgetRecordAudio from './WidgetRecordAudio.vue'
+
+type RecorderOptions = NonNullable<Parameters<typeof useAudioRecorder>[0]>
+
+const recorder = {
+  isRecording: ref(false),
+  recordedURL: ref<string | null>(null),
+  mediaRecorder: ref<MediaRecorder | null>(null),
+  startRecording: vi.fn(async () => {}),
+  stopRecording: vi.fn(),
+  dispose: vi.fn()
+} satisfies ReturnType<typeof useAudioRecorder>
+
+const playback = {
+  isPlaying: ref(false),
+  audioElementKey: ref(0),
+  play: vi.fn(async () => true),
+  stop: vi.fn(),
+  onPlaybackEnded: vi.fn(),
+  onMetadataLoaded: vi.fn(),
+  resetAudioElement: vi.fn(async () => {}),
+  getCurrentTime: vi.fn(() => 0),
+  getDuration: vi.fn(() => 0),
+  playbackTimerInterval: ref<ReturnType<typeof setInterval> | null>(null)
+} satisfies ReturnType<typeof useAudioPlayback>
+
+const waveform = {
+  waveformBars: ref<{ height: number }[]>([]),
+  initWaveform: vi.fn(),
+  updateWaveform: vi.fn(),
+  setupAudioContext: vi.fn(async () => {}),
+  setupRecordingVisualization: vi.fn(async () => {}),
+  setupPlaybackVisualization: vi.fn(async () => true),
+  stopWaveform: vi.fn(),
+  dispose: vi.fn()
+} satisfies ReturnType<typeof useAudioWaveform>
+
+useAudioRecorderMock.mockImplementation(() => recorder)
+useAudioPlaybackMock.mockImplementation(() => playback)
+useAudioWaveformMock.mockImplementation(() => waveform)
 
 const i18n = createI18n({
   legacy: false,
@@ -100,55 +112,6 @@ const ButtonStub = defineComponent({
     '<button v-bind="$attrs" :disabled="disabled" type="button"><slot /></button>'
 })
 
-let recorder: MockRecorderState
-let playback: MockPlaybackState
-
-function setRecorderMocks(overrides: Partial<MockRecorderState> = {}) {
-  recorder = {
-    isRecording: ref(false),
-    recordedURL: ref<string | null>(null),
-    startRecording: vi.fn(async () => {}),
-    stopRecording: vi.fn(),
-    mediaRecorder: ref(null),
-    ...overrides
-  } as MockRecorderState
-  Object.keys(recorderState).forEach((k) => delete recorderState[k])
-  Object.assign(recorderState, recorder)
-}
-
-function setPlaybackMocks(overrides: Partial<MockPlaybackState> = {}) {
-  playback = {
-    isPlaying: ref(false),
-    audioElementKey: ref(0),
-    resetAudioElement: vi.fn(async () => {}),
-    play: vi.fn(async () => {}),
-    stop: vi.fn(),
-    getCurrentTime: vi.fn(() => 0),
-    getDuration: vi.fn(() => 0),
-    playbackTimerInterval: ref<number | null>(null),
-    onPlaybackEnded: vi.fn(),
-    onMetadataLoaded: vi.fn(),
-    ...overrides
-  } as MockPlaybackState
-  Object.keys(playbackState).forEach((k) => delete playbackState[k])
-  Object.assign(playbackState, playback)
-}
-
-function setWaveformMocks() {
-  const waveform = {
-    waveformBars: ref<{ height: number }[]>([]),
-    initWaveform: vi.fn(),
-    stopWaveform: vi.fn(),
-    dispose: vi.fn(),
-    setupAudioContext: vi.fn(async () => {}),
-    setupRecordingVisualization: vi.fn(async () => {}),
-    setupPlaybackVisualization: vi.fn(async () => true),
-    updateWaveform: vi.fn()
-  }
-  Object.keys(waveformState).forEach((k) => delete waveformState[k])
-  Object.assign(waveformState, waveform)
-}
-
 function renderWidget(props: { readonly?: boolean; nodeId?: string } = {}) {
   return render(WidgetRecordAudio, {
     global: {
@@ -159,11 +122,35 @@ function renderWidget(props: { readonly?: boolean; nodeId?: string } = {}) {
   })
 }
 
+function getRecorderOptions(): RecorderOptions {
+  const options = vi.mocked(useAudioRecorder).mock.calls.at(-1)?.[0]
+  if (!options) throw new Error('useAudioRecorder has not been called yet')
+  return options
+}
+
 describe('WidgetRecordAudio', () => {
   beforeEach(() => {
-    setRecorderMocks()
-    setPlaybackMocks()
-    setWaveformMocks()
+    recorder.isRecording.value = false
+    recorder.recordedURL.value = null
+    recorder.mediaRecorder.value = null
+    recorder.startRecording.mockClear()
+    recorder.stopRecording.mockClear()
+    recorder.dispose.mockClear()
+
+    playback.isPlaying.value = false
+    playback.audioElementKey.value = 0
+    playback.playbackTimerInterval.value = null
+    playback.play.mockClear()
+    playback.stop.mockClear()
+
+    waveform.waveformBars.value = []
+
+    useAudioRecorderMock.mockClear()
+    useAudioPlaybackMock.mockClear()
+    useAudioWaveformMock.mockClear()
+
+    appMock.app.canvas.graph.getNodeById.mockReset().mockReturnValue(null)
+    isDOMWidgetMock.mockReset().mockReturnValue(false)
   })
 
   describe('Idle state', () => {
@@ -198,20 +185,22 @@ describe('WidgetRecordAudio', () => {
       renderWidget({ readonly: true })
       const user = userEvent.setup()
       const btn = screen.getByRole('button', { name: /Start Recording/i })
-      await user.click(btn).catch(() => {})
+      await user.click(btn)
       expect(recorder.startRecording).not.toHaveBeenCalled()
     })
   })
 
   describe('Recording state', () => {
+    beforeEach(() => {
+      recorder.isRecording.value = true
+    })
+
     it('shows "Listening..." text while recording', () => {
-      setRecorderMocks({ isRecording: ref(true) })
       renderWidget()
       expect(screen.getByText('Listening...')).toBeInTheDocument()
     })
 
     it('renders a stop button while recording', () => {
-      setRecorderMocks({ isRecording: ref(true) })
       renderWidget()
       expect(
         screen.getByRole('button', { name: /Stop Recording/i })
@@ -219,7 +208,6 @@ describe('WidgetRecordAudio', () => {
     })
 
     it('calls stopRecording when the stop button is clicked', async () => {
-      setRecorderMocks({ isRecording: ref(true) })
       renderWidget()
       const user = userEvent.setup()
       await user.click(screen.getByRole('button', { name: /Stop Recording/i }))
@@ -227,7 +215,6 @@ describe('WidgetRecordAudio', () => {
     })
 
     it('disables the Start Recording button while recording', () => {
-      setRecorderMocks({ isRecording: ref(true) })
       renderWidget()
       expect(
         screen.getByRole('button', { name: /Start Recording/i })
@@ -237,7 +224,7 @@ describe('WidgetRecordAudio', () => {
 
   describe('Ready state (has recording, not playing)', () => {
     beforeEach(() => {
-      setRecorderMocks({ recordedURL: ref('blob:fake-url') })
+      recorder.recordedURL.value = 'blob:fake-url'
     })
 
     it('shows "Ready" text', () => {
@@ -255,8 +242,8 @@ describe('WidgetRecordAudio', () => {
 
   describe('Playing state', () => {
     beforeEach(() => {
-      setRecorderMocks({ recordedURL: ref('blob:fake-url') })
-      setPlaybackMocks({ isPlaying: ref(true) })
+      recorder.recordedURL.value = 'blob:fake-url'
+      playback.isPlaying.value = true
     })
 
     it('shows "Playing..." text', () => {
@@ -291,69 +278,58 @@ describe('WidgetRecordAudio', () => {
     }
 
     function primeAudioWidgetInNode(widgets: { element: HTMLAudioElement }[]) {
-      appMock.app.canvas.graph.getNodeById = () =>
-        ({
-          widgets
-        }) as unknown
+      appMock.app.canvas.graph.getNodeById.mockReturnValue({ widgets })
       isDOMWidgetMock.mockReturnValue(true)
     }
 
-    it('replaces the audio widget element src with a new blob URL when a recording completes', async () => {
-      const originalCreateObjectURL = URL.createObjectURL
-      URL.createObjectURL = vi.fn((blob: Blob) => `blob:fake/${blob.size}`)
+    beforeEach(() => {
+      vi.spyOn(URL, 'createObjectURL').mockImplementation(
+        (blob: Blob | MediaSource) =>
+          blob instanceof Blob ? `blob:fake/${blob.size}` : 'blob:fake/media'
+      )
+      vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    })
 
+    afterEach(() => {
+      vi.mocked(URL.createObjectURL).mockRestore()
+      vi.mocked(URL.revokeObjectURL).mockRestore()
+    })
+
+    it('replaces the audio widget element src with a new blob URL when a recording completes', async () => {
       const audioWidget = createAudioWidget()
       primeAudioWidgetInNode([audioWidget])
       renderWidget()
 
-      const options = capturedOptions.recorder as {
-        onRecordingComplete: (blob: Blob) => Promise<void> | void
-      }
       const blob = new Blob(['audio-bytes'], { type: 'audio/webm' })
-      await options.onRecordingComplete(blob)
+      await getRecorderOptions().onRecordingComplete?.(blob)
 
       expect(audioWidget.element.src).toContain('blob:fake/')
-      URL.createObjectURL = originalCreateObjectURL
     })
 
     it('revokes the previous blob URL before replacing it', async () => {
-      const originalCreateObjectURL = URL.createObjectURL
-      const originalRevoke = URL.revokeObjectURL
-      URL.createObjectURL = vi.fn(() => 'blob:fake/new')
-      URL.revokeObjectURL = vi.fn()
+      vi.mocked(URL.createObjectURL).mockReturnValue('blob:fake/new')
 
       const audioWidget = createAudioWidget('blob:stale-existing')
       primeAudioWidgetInNode([audioWidget])
       renderWidget()
 
-      const options = capturedOptions.recorder as {
-        onRecordingComplete: (blob: Blob) => Promise<void> | void
-      }
-      await options.onRecordingComplete(new Blob(['x']))
+      await getRecorderOptions().onRecordingComplete?.(new Blob(['x']))
 
       expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:stale-existing')
       expect(audioWidget.element.src).toBe('blob:fake/new')
-
-      URL.createObjectURL = originalCreateObjectURL
-      URL.revokeObjectURL = originalRevoke
     })
 
     it('does not write to non-DOM widgets on the host node', async () => {
-      const originalCreateObjectURL = URL.createObjectURL
-      URL.createObjectURL = vi.fn(() => 'blob:fake/new')
+      vi.mocked(URL.createObjectURL).mockReturnValue('blob:fake/new')
 
       const audioWidget = createAudioWidget('originally-empty')
       primeAudioWidgetInNode([audioWidget])
       isDOMWidgetMock.mockReturnValue(false)
       renderWidget()
 
-      const options = capturedOptions.recorder as {
-        onRecordingComplete: (blob: Blob) => Promise<void> | void
-      }
-      await options.onRecordingComplete(new Blob(['x']))
+      await getRecorderOptions().onRecordingComplete?.(new Blob(['x']))
 
       expect(audioWidget.element.src).not.toBe('blob:fake/new')
-      URL.createObjectURL = originalCreateObjectURL
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetRecordAudio.test.ts
@@ -1,0 +1,266 @@
+/* eslint-disable vue/no-reserved-component-names */
+import { createTestingPinia } from '@pinia/testing'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+type MockRecorderState = {
+  isRecording: ReturnType<typeof ref<boolean>>
+  recordedURL: ReturnType<typeof ref<string | null>>
+  startRecording: ReturnType<typeof vi.fn>
+  stopRecording: ReturnType<typeof vi.fn>
+  mediaRecorder: ReturnType<typeof ref<unknown>>
+}
+type MockPlaybackState = {
+  isPlaying: ReturnType<typeof ref<boolean>>
+  audioElementKey: ReturnType<typeof ref<number>>
+  resetAudioElement: ReturnType<typeof vi.fn>
+  play: ReturnType<typeof vi.fn>
+  stop: ReturnType<typeof vi.fn>
+  getCurrentTime: ReturnType<typeof vi.fn>
+  getDuration: ReturnType<typeof vi.fn>
+  playbackTimerInterval: ReturnType<typeof ref<number | null>>
+  onPlaybackEnded: ReturnType<typeof vi.fn>
+  onMetadataLoaded: ReturnType<typeof vi.fn>
+}
+
+const recorderState = vi.hoisted(() => ({} as Record<string, unknown>))
+const playbackState = vi.hoisted(() => ({} as Record<string, unknown>))
+const waveformState = vi.hoisted(() => ({} as Record<string, unknown>))
+
+vi.mock('../composables/audio/useAudioRecorder', () => ({
+  useAudioRecorder: () => recorderState
+}))
+
+vi.mock('../composables/audio/useAudioPlayback', () => ({
+  useAudioPlayback: () => playbackState
+}))
+
+vi.mock('../composables/audio/useAudioWaveform', () => ({
+  useAudioWaveform: () => waveformState
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: { graph: { getNodeById: () => null } } }
+}))
+
+vi.mock('@/scripts/domWidget', () => ({
+  isDOMWidget: () => false
+}))
+
+import WidgetRecordAudio from './WidgetRecordAudio.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: {
+        startRecording: 'Start Recording',
+        stopRecording: 'Stop Recording',
+        playRecording: 'Play Recording',
+        stopPlayback: 'Stop Playback',
+        listening: 'Listening...',
+        playing: 'Playing...',
+        ready: 'Ready',
+        micPermissionDenied: 'Microphone permission denied'
+      }
+    }
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  inheritAttrs: false,
+  props: { disabled: { type: Boolean, default: false } },
+  template:
+    '<button v-bind="$attrs" :disabled="disabled" type="button"><slot /></button>'
+})
+
+let recorder: MockRecorderState
+let playback: MockPlaybackState
+
+function setRecorderMocks(overrides: Partial<MockRecorderState> = {}) {
+  recorder = {
+    isRecording: ref(false),
+    recordedURL: ref<string | null>(null),
+    startRecording: vi.fn(async () => {}),
+    stopRecording: vi.fn(),
+    mediaRecorder: ref(null),
+    ...overrides
+  } as MockRecorderState
+  Object.keys(recorderState).forEach((k) => delete recorderState[k])
+  Object.assign(recorderState, recorder)
+}
+
+function setPlaybackMocks(overrides: Partial<MockPlaybackState> = {}) {
+  playback = {
+    isPlaying: ref(false),
+    audioElementKey: ref(0),
+    resetAudioElement: vi.fn(async () => {}),
+    play: vi.fn(async () => {}),
+    stop: vi.fn(),
+    getCurrentTime: vi.fn(() => 0),
+    getDuration: vi.fn(() => 0),
+    playbackTimerInterval: ref<number | null>(null),
+    onPlaybackEnded: vi.fn(),
+    onMetadataLoaded: vi.fn(),
+    ...overrides
+  } as MockPlaybackState
+  Object.keys(playbackState).forEach((k) => delete playbackState[k])
+  Object.assign(playbackState, playback)
+}
+
+function setWaveformMocks() {
+  const waveform = {
+    waveformBars: ref<{ height: number }[]>([]),
+    initWaveform: vi.fn(),
+    stopWaveform: vi.fn(),
+    dispose: vi.fn(),
+    setupAudioContext: vi.fn(async () => {}),
+    setupRecordingVisualization: vi.fn(async () => {}),
+    setupPlaybackVisualization: vi.fn(async () => true),
+    updateWaveform: vi.fn()
+  }
+  Object.keys(waveformState).forEach((k) => delete waveformState[k])
+  Object.assign(waveformState, waveform)
+}
+
+function renderWidget(props: { readonly?: boolean; nodeId?: string } = {}) {
+  return render(WidgetRecordAudio, {
+    global: {
+      plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
+      stubs: { Button: ButtonStub }
+    },
+    props: { readonly: false, nodeId: 'n1', ...props }
+  })
+}
+
+describe('WidgetRecordAudio', () => {
+  beforeEach(() => {
+    setRecorderMocks()
+    setPlaybackMocks()
+    setWaveformMocks()
+  })
+
+  describe('Idle state', () => {
+    it('renders the Start Recording button', () => {
+      renderWidget()
+      expect(
+        screen.getByRole('button', { name: /Start Recording/i })
+      ).toBeInTheDocument()
+    })
+
+    it('does not render status area when idle', () => {
+      renderWidget()
+      expect(screen.queryByText('Listening...')).toBeNull()
+      expect(screen.queryByText('Ready')).toBeNull()
+    })
+
+    it('disables the Start Recording button when readonly is true', () => {
+      renderWidget({ readonly: true })
+      expect(
+        screen.getByRole('button', { name: /Start Recording/i })
+      ).toBeDisabled()
+    })
+
+    it('calls startRecording when Start button is clicked', async () => {
+      renderWidget()
+      const user = userEvent.setup()
+      await user.click(
+        screen.getByRole('button', { name: /Start Recording/i })
+      )
+      expect(recorder.startRecording).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not start recording when readonly', async () => {
+      renderWidget({ readonly: true })
+      const user = userEvent.setup()
+      const btn = screen.getByRole('button', { name: /Start Recording/i })
+      await user.click(btn).catch(() => {})
+      expect(recorder.startRecording).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Recording state', () => {
+    it('shows "Listening..." text while recording', () => {
+      setRecorderMocks({ isRecording: ref(true) })
+      renderWidget()
+      expect(screen.getByText('Listening...')).toBeInTheDocument()
+    })
+
+    it('renders a stop button while recording', () => {
+      setRecorderMocks({ isRecording: ref(true) })
+      renderWidget()
+      expect(
+        screen.getByRole('button', { name: /Stop Recording/i })
+      ).toBeInTheDocument()
+    })
+
+    it('calls stopRecording when the stop button is clicked', async () => {
+      setRecorderMocks({ isRecording: ref(true) })
+      renderWidget()
+      const user = userEvent.setup()
+      await user.click(
+        screen.getByRole('button', { name: /Stop Recording/i })
+      )
+      expect(recorder.stopRecording).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables the Start Recording button while recording', () => {
+      setRecorderMocks({ isRecording: ref(true) })
+      renderWidget()
+      expect(
+        screen.getByRole('button', { name: /Start Recording/i })
+      ).toBeDisabled()
+    })
+  })
+
+  describe('Ready state (has recording, not playing)', () => {
+    beforeEach(() => {
+      setRecorderMocks({ recordedURL: ref('blob:fake-url') })
+    })
+
+    it('shows "Ready" text', () => {
+      renderWidget()
+      expect(screen.getByText('Ready')).toBeInTheDocument()
+    })
+
+    it('renders the play button', () => {
+      renderWidget()
+      expect(
+        screen.getByRole('button', { name: /Play Recording/i })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('Playing state', () => {
+    beforeEach(() => {
+      setRecorderMocks({ recordedURL: ref('blob:fake-url') })
+      setPlaybackMocks({ isPlaying: ref(true) })
+    })
+
+    it('shows "Playing..." text', () => {
+      renderWidget()
+      expect(screen.getByText('Playing...')).toBeInTheDocument()
+    })
+
+    it('renders the stop playback button', () => {
+      renderWidget()
+      expect(
+        screen.getByRole('button', { name: /Stop Playback/i })
+      ).toBeInTheDocument()
+    })
+
+    it('calls playback.stop when the stop playback button is clicked', async () => {
+      renderWidget()
+      const user = userEvent.setup()
+      await user.click(
+        screen.getByRole('button', { name: /Stop Playback/i })
+      )
+      expect(playback.stop).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds 20 unit tests across 2 files covering WidgetChart and WidgetRecordAudio. Part of a widget-test-coverage sequence.

## Changes

- **What**:
  - \`WidgetChart.test.ts\` (6) — default type 'line', honours \`widget.options.type\`, passes model value through to the PrimeVue Chart stub, empty-object fallback for labels/datasets, aria-label includes widget name + type.
  - \`WidgetRecordAudio.test.ts\` (14) — idle state renders Start Recording button and disables it on \`readonly\`; recording state shows "Listening..." and a stop button wired to \`recorder.stopRecording\`; ready state shows Play button; playing state shows Stop-playback wired to \`playback.stop\`.

## Review Focus

- \`WidgetRecordAudio\` mocks \`useAudioRecorder\` / \`useAudioPlayback\` / \`useAudioWaveform\` at their module boundary (follows "don't mock what you don't own" — MediaRecorder is behind those composables).
- \`useAudioRecorder\` already has its own composable-level test; this PR tests the orchestration only.
- \`WidgetLegacy\` is intentionally NOT covered here — 100+ LoC of litegraph/canvas integration, already covered by e2e \`widget.spec.ts\`.
- No changes to any source component.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11444-test-add-unit-tests-for-media-widgets-chart-record-audio-3486d73d365081c5b438e104d0e3b0df) by [Unito](https://www.unito.io)
