### PR TITLE
test: add e2e specs for float and combo Vue widgets

### DIFF
--- a/browser_tests/fixtures/utils/litegraphUtils.ts
+++ b/browser_tests/fixtures/utils/litegraphUtils.ts
@@ -171,7 +171,7 @@ class NodeSlotReference {
   }
 }
 
-class NodeWidgetReference {
+export class NodeWidgetReference {
   constructor(
     readonly index: number,
     readonly node: NodeReference
@@ -368,6 +368,25 @@ export class NodeReference {
     return new NodeSlotReference('input', index, this)
   }
   async getWidget(index: number) {
+    return new NodeWidgetReference(index, this)
+  }
+  async getWidgetByName(name: string) {
+    const index = await this.comfyPage.page.evaluate(
+      ([id, widgetName]) => {
+        const node = window.app!.canvas.graph!.getNodeById(id)
+        if (!node) throw new Error(`Node ${id} not found`)
+
+        const widgetIndex =
+          node.widgets?.findIndex((widget) => widget.name === widgetName) ?? -1
+        if (widgetIndex < 0) {
+          throw new Error(`Widget "${widgetName}" not found on node ${id}`)
+        }
+
+        return widgetIndex
+      },
+      [this.id, name] as const
+    )
+
     return new NodeWidgetReference(index, this)
   }
   async click(

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -56,6 +56,9 @@ test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
     await comfyPage.workflow.loadGraphData(serialized)
     await comfyPage.vueNodes.waitForNodes()
 
+    // Verify both the internal widget state and the visible Vue combobox
+    // after reload. A broken rehydration path could keep the widget object
+    // correct while rendering the old selection (or vice versa).
     const schedulerValueAfterReload = await comfyPage.page.evaluate(() => {
       const graph = window.graph as unknown as TestGraphAccess | undefined
       if (!graph) return null
@@ -64,7 +67,11 @@ test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
       )
       return node?.widgets?.find((w) => w.name === 'scheduler')?.value ?? null
     })
-
     expect(schedulerValueAfterReload).toBe('karras')
+
+    const schedulerComboAfterReload = comfyPage.vueNodes
+      .getNodeByTitle('KSampler')
+      .getByRole('combobox', { name: 'scheduler', exact: true })
+    await expect(schedulerComboAfterReload).toContainText('karras')
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import type { TestGraphAccess } from '@e2e/types/globals'
 
 test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
   test('opens a dropdown that lists sampler options', async ({ comfyPage }) => {
@@ -56,18 +55,13 @@ test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
     await comfyPage.workflow.loadGraphData(serialized)
     await comfyPage.vueNodes.waitForNodes()
 
-    // Verify both the internal widget state and the visible Vue combobox
-    // after reload. A broken rehydration path could keep the widget object
-    // correct while rendering the old selection (or vice versa).
-    const schedulerValueAfterReload = await comfyPage.page.evaluate(() => {
-      const graph = window.graph as unknown as TestGraphAccess | undefined
-      if (!graph) return null
-      const node = Object.values(graph._nodes_by_id).find(
-        (n) => n.type === 'KSampler'
-      )
-      return node?.widgets?.find((w) => w.name === 'scheduler')?.value ?? null
-    })
-    expect(schedulerValueAfterReload).toBe('karras')
+    const [ksamplerNode] = await comfyPage.nodeOps.getNodeRefsByType('KSampler')
+    if (!ksamplerNode) {
+      throw new Error('KSampler node not found after reload')
+    }
+
+    const schedulerWidget = await ksamplerNode.getWidgetByName('scheduler')
+    await expect.poll(() => schedulerWidget.getValue()).toBe('karras')
 
     const schedulerComboAfterReload = comfyPage.vueNodes
       .getNodeByTitle('KSampler')

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -1,0 +1,66 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import type { TestGraphAccess } from '@e2e/types/globals'
+
+test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
+  test('opens a dropdown that lists sampler options', async ({ comfyPage }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    const samplerCombo = comfyPage.vueNodes
+      .getNodeByTitle('KSampler')
+      .getByRole('combobox', { name: 'sampler_name', exact: true })
+
+    await samplerCombo.click()
+
+    // The option list should include at least a few known samplers
+    await expect(
+      comfyPage.page.getByRole('option', { name: 'euler', exact: true })
+    ).toBeVisible()
+    await expect(
+      comfyPage.page.getByRole('option', { name: 'dpmpp_2m', exact: true })
+    ).toBeVisible()
+  })
+
+  test('updates the combo value after a new option is selected', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    await comfyPage.vueNodes.selectComboOption(
+      'KSampler',
+      'sampler_name',
+      'dpmpp_2m'
+    )
+
+    const samplerCombo = comfyPage.vueNodes
+      .getNodeByTitle('KSampler')
+      .getByRole('combobox', { name: 'sampler_name', exact: true })
+
+    await expect(samplerCombo).toContainText('dpmpp_2m')
+  })
+
+  test('persists the selected combo value in the serialized workflow', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    await comfyPage.vueNodes.selectComboOption(
+      'KSampler',
+      'scheduler',
+      'karras'
+    )
+
+    const schedulerValue = await comfyPage.page.evaluate(() => {
+      const graph = window.graph as unknown as TestGraphAccess | undefined
+      if (!graph) return null
+      const node = Object.values(graph._nodes_by_id).find(
+        (n) => n.type === 'KSampler'
+      )
+      return node?.widgets?.find((w) => w.name === 'scheduler')?.value ?? null
+    })
+
+    expect(schedulerValue).toBe('karras')
+  })
+})

--- a/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts
@@ -41,7 +41,7 @@ test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
     await expect(samplerCombo).toContainText('dpmpp_2m')
   })
 
-  test('persists the selected combo value in the serialized workflow', async ({
+  test('persists the selected combo value across a serialize and reload round-trip', async ({
     comfyPage
   }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
@@ -52,7 +52,11 @@ test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
       'karras'
     )
 
-    const schedulerValue = await comfyPage.page.evaluate(() => {
+    const serialized = await comfyPage.workflow.getExportedWorkflow()
+    await comfyPage.workflow.loadGraphData(serialized)
+    await comfyPage.vueNodes.waitForNodes()
+
+    const schedulerValueAfterReload = await comfyPage.page.evaluate(() => {
       const graph = window.graph as unknown as TestGraphAccess | undefined
       if (!graph) return null
       const node = Object.values(graph._nodes_by_id).find(
@@ -61,6 +65,6 @@ test.describe('Vue Combo Widget', { tag: '@vue-nodes' }, () => {
       return node?.widgets?.find((w) => w.name === 'scheduler')?.value ?? null
     })
 
-    expect(schedulerValue).toBe('karras')
+    expect(schedulerValueAfterReload).toBe('karras')
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
@@ -14,7 +14,9 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
       .first()
     const { input } = comfyPage.vueNodes.getInputNumberControls(cfgWidget)
 
-    await input.fill('1.5 + 1.75')
+    // 2.1 + 1.23 = 3.33 — well away from any half-point, so the expected
+    // value is the same under half-up, half-even, and half-away-from-zero.
+    await input.fill('2.1 + 1.23')
     await input.blur()
 
     await expect(input).toHaveValue('3.3')
@@ -72,5 +74,10 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
 
     const cfgWidgetAfterReload = await ksamplerNode.getWidgetByName('cfg')
     await expect.poll(() => cfgWidgetAfterReload.getValue()).toBe(7.5)
+
+    // Also assert the Vue input mirrors the persisted value, so a broken
+    // rehydration path that keeps litegraph state correct but renders stale
+    // UI (or vice versa) still fails this test.
+    await expect(input).toHaveValue('7.5')
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
@@ -1,0 +1,71 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import type { TestGraphAccess } from '@e2e/types/globals'
+
+test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
+  test('allows changing value via the number input', async ({ comfyPage }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    const cfgWidget = comfyPage.vueNodes
+      .getWidgetByName('KSampler', 'cfg')
+      .first()
+    const { input } = comfyPage.vueNodes.getInputNumberControls(cfgWidget)
+
+    await input.fill('3.5')
+    await input.blur()
+
+    await expect(input).toHaveValue('3.5')
+  })
+
+  test('increment and decrement buttons update the value', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    const denoiseWidget = comfyPage.vueNodes
+      .getWidgetByName('KSampler', 'denoise')
+      .first()
+    const controls = comfyPage.vueNodes.getInputNumberControls(denoiseWidget)
+
+    const initial = Number(await controls.input.inputValue())
+
+    await controls.incrementButton.click()
+    await expect(controls.input).not.toHaveValue(initial.toString())
+
+    const afterIncrement = Number(await controls.input.inputValue())
+    expect(afterIncrement).toBeGreaterThan(initial)
+
+    await controls.decrementButton.click()
+    await expect
+      .poll(() => Number(controls.input.inputValue().then(Number)))
+      .toBeLessThanOrEqual(afterIncrement)
+  })
+
+  test('persists value after the workflow is serialized and reloaded', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
+
+    const cfgWidget = comfyPage.vueNodes
+      .getWidgetByName('KSampler', 'cfg')
+      .first()
+    const { input } = comfyPage.vueNodes.getInputNumberControls(cfgWidget)
+
+    await input.fill('7.25')
+    await input.blur()
+    await expect(input).toHaveValue('7.25')
+
+    const cfgValue = await comfyPage.page.evaluate(() => {
+      const graph = window.graph as unknown as TestGraphAccess | undefined
+      if (!graph) return null
+      const node = Object.values(graph._nodes_by_id).find(
+        (n) => n.type === 'KSampler'
+      )
+      return node?.widgets?.find((w) => w.name === 'cfg')?.value ?? null
+    })
+
+    expect(cfgValue).toBe(7.25)
+  })
+})

--- a/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
@@ -32,18 +32,18 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
     const initial = Number(await controls.input.inputValue())
 
     await controls.incrementButton.click()
-    await expect(controls.input).not.toHaveValue(initial.toString())
-
+    await expect
+      .poll(async () => Number(await controls.input.inputValue()))
+      .toBeGreaterThan(initial)
     const afterIncrement = Number(await controls.input.inputValue())
-    expect(afterIncrement).toBeGreaterThan(initial)
 
     await controls.decrementButton.click()
     await expect
-      .poll(() => Number(controls.input.inputValue().then(Number)))
-      .toBeLessThanOrEqual(afterIncrement)
+      .poll(async () => Number(await controls.input.inputValue()))
+      .toBeLessThan(afterIncrement)
   })
 
-  test('persists value after the workflow is serialized and reloaded', async ({
+  test('persists value across a serialize and reload round-trip', async ({
     comfyPage
   }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
@@ -57,7 +57,11 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
     await input.blur()
     await expect(input).toHaveValue('7.25')
 
-    const cfgValue = await comfyPage.page.evaluate(() => {
+    const serialized = await comfyPage.workflow.getExportedWorkflow()
+    await comfyPage.workflow.loadGraphData(serialized)
+    await comfyPage.vueNodes.waitForNodes()
+
+    const cfgValueAfterReload = await comfyPage.page.evaluate(() => {
       const graph = window.graph as unknown as TestGraphAccess | undefined
       if (!graph) return null
       const node = Object.values(graph._nodes_by_id).find(
@@ -66,6 +70,6 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
       return node?.widgets?.find((w) => w.name === 'cfg')?.value ?? null
     })
 
-    expect(cfgValue).toBe(7.25)
+    expect(cfgValueAfterReload).toBe(7.25)
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
@@ -24,10 +24,12 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
   }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
 
-    const denoiseWidget = comfyPage.vueNodes
-      .getWidgetByName('KSampler', 'denoise')
+    // cfg has room to grow (initial 8, max 100); denoise is at its max (1)
+    // so its increment button is disabled and can't be used here.
+    const cfgWidget = comfyPage.vueNodes
+      .getWidgetByName('KSampler', 'cfg')
       .first()
-    const controls = comfyPage.vueNodes.getInputNumberControls(denoiseWidget)
+    const controls = comfyPage.vueNodes.getInputNumberControls(cfgWidget)
 
     const initial = Number(await controls.input.inputValue())
 
@@ -53,9 +55,10 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
       .first()
     const { input } = comfyPage.vueNodes.getInputNumberControls(cfgWidget)
 
-    await input.fill('7.25')
+    // KSampler's cfg is precision=1, so pick a value that lands on the grid
+    await input.fill('7.5')
     await input.blur()
-    await expect(input).toHaveValue('7.25')
+    await expect(input).toHaveValue('7.5')
 
     const serialized = await comfyPage.workflow.getExportedWorkflow()
     await comfyPage.workflow.loadGraphData(serialized)
@@ -70,6 +73,6 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
       return node?.widgets?.find((w) => w.name === 'cfg')?.value ?? null
     })
 
-    expect(cfgValueAfterReload).toBe(7.25)
+    expect(cfgValueAfterReload).toBe(7.5)
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts
@@ -2,10 +2,11 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import type { TestGraphAccess } from '@e2e/types/globals'
 
 test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
-  test('allows changing value via the number input', async ({ comfyPage }) => {
+  test('evaluates expression input using the widget precision', async ({
+    comfyPage
+  }) => {
     await comfyPage.workflow.loadWorkflow('vueNodes/linked-int-widget')
 
     const cfgWidget = comfyPage.vueNodes
@@ -13,10 +14,10 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
       .first()
     const { input } = comfyPage.vueNodes.getInputNumberControls(cfgWidget)
 
-    await input.fill('3.5')
+    await input.fill('1.5 + 1.75')
     await input.blur()
 
-    await expect(input).toHaveValue('3.5')
+    await expect(input).toHaveValue('3.3')
   })
 
   test('increment and decrement buttons update the value', async ({
@@ -64,15 +65,12 @@ test.describe('Vue Float Widget', { tag: '@vue-nodes' }, () => {
     await comfyPage.workflow.loadGraphData(serialized)
     await comfyPage.vueNodes.waitForNodes()
 
-    const cfgValueAfterReload = await comfyPage.page.evaluate(() => {
-      const graph = window.graph as unknown as TestGraphAccess | undefined
-      if (!graph) return null
-      const node = Object.values(graph._nodes_by_id).find(
-        (n) => n.type === 'KSampler'
-      )
-      return node?.widgets?.find((w) => w.name === 'cfg')?.value ?? null
-    })
+    const [ksamplerNode] = await comfyPage.nodeOps.getNodeRefsByType('KSampler')
+    if (!ksamplerNode) {
+      throw new Error('KSampler node not found after reload')
+    }
 
-    expect(cfgValueAfterReload).toBe(7.5)
+    const cfgWidgetAfterReload = await ksamplerNode.getWidgetByName('cfg')
+    await expect.poll(() => cfgWidgetAfterReload.getValue()).toBe(7.5)
   })
 })


### PR DESCRIPTION
## Summary

Adds two Playwright specs extending \`browser_tests/tests/vueNodes/widgets/\` to cover float and combo value types, following the existing \`integerWidget.spec.ts\` / \`multilineStringWidget.spec.ts\` pattern. Part of a widget-test-coverage sequence.

## Changes

- **What**:
  - \`browser_tests/tests/vueNodes/widgets/float/floatWidget.spec.ts\` (3) — number-input value change, increment/decrement on \`denoise\`, and persistence through litegraph widget state after user edit.
  - \`browser_tests/tests/vueNodes/widgets/combo/comboWidget.spec.ts\` (3) — dropdown lists known sampler options, combo value updates on select, \`scheduler\` value persists.

Reuses the existing \`vueNodes/linked-int-widget.json\` fixture (KSampler exposes \`cfg\` / \`denoise\` floats and \`sampler_name\` / \`scheduler\` combos). No new fixture files.

## Review Focus

- Specs tagged \`@vue-nodes\`, consistent with the sibling suites.
- Persistence assertions read widget state via \`window.graph._nodes_by_id[...].widgets\` (typed through \`TestGraphAccess\` from \`@e2e/types/globals\`) rather than JSON-serializing the whole graph — avoids \`unknown\` typing on \`window.graph.serialize()\`.
- Boolean and color e2e specs are intentionally NOT in this PR — they'd need new workflow fixtures, which I'd prefer to design with you before writing.
- \`pnpm typecheck:browser\` is clean locally; CI run needed to validate the Playwright behaviour since I couldn't run the full e2e suite locally.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11447-test-add-e2e-specs-for-float-and-combo-Vue-widgets-3486d73d365081f79302edc87595130c) by [Unito](https://www.unito.io)
