### PR TITLE
feat: show loading spinner during template URL loading

### DIFF
--- a/browser_tests/tests/templateUrlLoading.spec.ts
+++ b/browser_tests/tests/templateUrlLoading.spec.ts
@@ -1,0 +1,114 @@
+import { expect } from '@playwright/test'
+
+import type { WorkflowTemplates } from '@/platform/workflow/templates/types/template'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+const MOCK_TEMPLATE_INDEX: WorkflowTemplates[] = [
+  {
+    moduleName: 'default',
+    title: 'Test Templates',
+    type: 'image',
+    templates: [
+      {
+        name: 'test_template',
+        title: 'Test Template',
+        mediaType: 'image',
+        mediaSubtype: 'webp',
+        description: 'A test template for URL loading.'
+      }
+    ]
+  }
+]
+
+const MOCK_WORKFLOW_JSON = {
+  last_node_id: 2,
+  last_link_id: 1,
+  nodes: [
+    {
+      id: 1,
+      type: 'KSampler',
+      pos: [100, 100],
+      size: [300, 200],
+      outputs: [{ name: 'LATENT', type: 'LATENT', links: [1] }],
+      properties: {}
+    },
+    {
+      id: 2,
+      type: 'EmptyLatentImage',
+      pos: [500, 100],
+      size: [300, 200],
+      inputs: [{ name: 'LATENT', type: 'LATENT', link: 1 }],
+      properties: {}
+    }
+  ],
+  links: [[1, 1, 0, 2, 0, 'LATENT']],
+  groups: [],
+  config: {},
+  extra: {},
+  version: 0.4
+}
+
+test.describe('Template URL loading spinner', { tag: ['@workflow'] }, () => {
+  test('shows spinner while loading template from URL param', async ({
+    comfyPage
+  }) => {
+    const blockUIMask = comfyPage.page.locator('.p-blockui-mask')
+
+    await comfyPage.page.route('**/templates/index.json', async (route) => {
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify(MOCK_TEMPLATE_INDEX),
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store'
+        }
+      })
+    })
+
+    let resolveTemplate: (() => void) | undefined
+    const templateDelay = new Promise<void>((resolve) => {
+      resolveTemplate = resolve
+    })
+
+    await comfyPage.page.route(
+      '**/templates/test_template.json',
+      async (route) => {
+        await templateDelay
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify(MOCK_WORKFLOW_JSON),
+          headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store'
+          }
+        })
+      }
+    )
+
+    await comfyPage.page.goto(`${comfyPage.url}?template=test_template`)
+
+    await expect(blockUIMask).toBeVisible({ timeout: 10_000 })
+
+    resolveTemplate?.()
+
+    await expect(blockUIMask).toBeHidden({ timeout: 30_000 })
+
+    await comfyPage.page.waitForFunction(
+      () => window.app && window.app.extensionManager
+    )
+  })
+
+  test('dismisses spinner normally when no template param', async ({
+    comfyPage
+  }) => {
+    const blockUIMask = comfyPage.page.locator('.p-blockui-mask')
+
+    await comfyPage.page.goto(comfyPage.url)
+
+    await comfyPage.page.waitForFunction(
+      () => window.app && window.app.extensionManager
+    )
+
+    await expect(blockUIMask).toBeHidden({ timeout: 30_000 })
+  })
+})

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -114,6 +114,11 @@ export const mergePreservedQueryIntoQuery = (
   return changed ? nextQuery : undefined
 }
 
+export const hasPreservedQuery = (namespace: string): boolean => {
+  if (preservedQueries.has(namespace)) return true
+  return readFromStorage(namespace) !== null
+}
+
 export const clearPreservedQuery = (namespace: string) => {
   if (!preservedQueries.has(namespace)) return
   preservedQueries.delete(namespace)

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -23,7 +23,7 @@ const readFromStorage = (namespace: string): Record<string, string> | null => {
     const raw = sessionStorage.getItem(getStorageKey(namespace))
     if (!raw) return null
 
-    const parsed = JSON.parse(raw)
+    const parsed: unknown = JSON.parse(raw)
     if (!isValidQueryRecord(parsed)) {
       console.warn('[preservedQuery] invalid storage format')
       sessionStorage.removeItem(getStorageKey(namespace))

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -28,7 +28,7 @@ const readFromStorage = (namespace: string): Record<string, string> | null => {
     const raw = sessionStorage.getItem(getStorageKey(namespace))
     if (!raw) return null
 
-    const parsed = JSON.parse(raw)
+    const parsed: unknown = JSON.parse(raw)
     if (!isValidQueryRecord(parsed)) {
       console.warn('[preservedQuery] invalid storage format')
       sessionStorage.removeItem(getStorageKey(namespace))

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -159,6 +159,11 @@ export const mergePreservedQueryIntoQuery = (
   return changed ? nextQuery : undefined
 }
 
+export const hasPreservedQuery = (namespace: string): boolean => {
+  if (preservedQueries.has(namespace)) return true
+  return readFromStorage(namespace) !== null
+}
+
 export const clearPreservedQuery = (namespace: string) => {
   if (!preservedQueries.has(namespace)) return
   preservedQueries.delete(namespace)

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -17,6 +17,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import {
+  hasPreservedQuery,
   hydratePreservedQuery,
   mergePreservedQueryIntoQuery
 } from '@/platform/navigation/preservedQueryManager'
@@ -226,14 +227,7 @@ export function useWorkflowPersistenceV2() {
     if (route.query.template && typeof route.query.template === 'string') {
       return true
     }
-    try {
-      const raw = sessionStorage.getItem('Comfy.PreservedQuery.template')
-      if (!raw) return false
-      const parsed = JSON.parse(raw)
-      return typeof parsed?.template === 'string'
-    } catch {
-      return false
-    }
+    return hasPreservedQuery(TEMPLATE_NAMESPACE)
   }
 
   const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -222,13 +222,16 @@ export function useWorkflowPersistenceV2() {
     }
   }
 
-  const loadTemplateFromUrlIfPresent = async () => {
+  const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {
     const query = await ensureTemplateQueryFromIntent()
     const hasTemplateUrl = query.template && typeof query.template === 'string'
 
     if (hasTemplateUrl) {
       await templateUrlLoader.loadTemplateFromUrl()
+      return true
     }
+
+    return false
   }
 
   const loadSharedWorkflowFromUrlIfPresent = async () => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -222,6 +222,20 @@ export function useWorkflowPersistenceV2() {
     }
   }
 
+  const hasTemplateIntent = (): boolean => {
+    if (route.query.template && typeof route.query.template === 'string') {
+      return true
+    }
+    try {
+      const raw = sessionStorage.getItem('Comfy.PreservedQuery.template')
+      if (!raw) return false
+      const parsed = JSON.parse(raw)
+      return typeof parsed?.template === 'string'
+    } catch {
+      return false
+    }
+  }
+
   const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {
     const query = await ensureTemplateQueryFromIntent()
     const hasTemplateUrl = query.template && typeof query.template === 'string'
@@ -354,6 +368,7 @@ export function useWorkflowPersistenceV2() {
   }
 
   return {
+    hasTemplateIntent,
     initializeWorkflow,
     loadSharedWorkflowFromUrlIfPresent,
     loadTemplateFromUrlIfPresent,

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -283,7 +283,7 @@ export function useWorkflowPersistenceV2() {
     }
   }
 
-  const loadTemplateFromUrlIfPresent = async () => {
+  const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {
     const query = await ensureTemplateQueryFromIntent()
     const hasTemplateUrl = query.template && typeof query.template === 'string'
 

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -291,7 +291,9 @@ export function useWorkflowPersistenceV2() {
     return hasPreservedQuery(TEMPLATE_NAMESPACE)
   }
 
-  const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {
+  const loadTemplateFromUrlIfPresent = async (): Promise<
+    string | undefined
+  > => {
     const query = await ensureTemplateQueryFromIntent()
     const hasTemplateUrl = query.template && typeof query.template === 'string'
 

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -17,6 +17,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import {
+  hasPreservedQuery,
   hydratePreservedQuery,
   mergePreservedQueryIntoQuery
 } from '@/platform/navigation/preservedQueryManager'
@@ -287,14 +288,7 @@ export function useWorkflowPersistenceV2() {
     if (route.query.template && typeof route.query.template === 'string') {
       return true
     }
-    try {
-      const raw = sessionStorage.getItem('Comfy.PreservedQuery.template')
-      if (!raw) return false
-      const parsed = JSON.parse(raw)
-      return typeof parsed?.template === 'string'
-    } catch {
-      return false
-    }
+    return hasPreservedQuery(TEMPLATE_NAMESPACE)
   }
 
   const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {

--- a/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
+++ b/src/platform/workflow/persistence/composables/useWorkflowPersistenceV2.ts
@@ -283,6 +283,20 @@ export function useWorkflowPersistenceV2() {
     }
   }
 
+  const hasTemplateIntent = (): boolean => {
+    if (route.query.template && typeof route.query.template === 'string') {
+      return true
+    }
+    try {
+      const raw = sessionStorage.getItem('Comfy.PreservedQuery.template')
+      if (!raw) return false
+      const parsed = JSON.parse(raw)
+      return typeof parsed?.template === 'string'
+    } catch {
+      return false
+    }
+  }
+
   const loadTemplateFromUrlIfPresent = async (): Promise<boolean> => {
     const query = await ensureTemplateQueryFromIntent()
     const hasTemplateUrl = query.template && typeof query.template === 'string'
@@ -415,6 +429,7 @@ export function useWorkflowPersistenceV2() {
   }
 
   return {
+    hasTemplateIntent,
     initializeWorkflow,
     loadSharedWorkflowFromUrlIfPresent,
     loadTemplateFromUrlIfPresent,

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isReadonly } from 'vue'
 
 import { useTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
 
@@ -397,5 +398,123 @@ describe('useTemplateUrlLoader', () => {
     }
 
     consoleSpy.mockRestore()
+  })
+
+  describe('loading state refs', () => {
+    it('returns readonly refs for isLoading, error, and isReady', () => {
+      const { isLoading, error, isReady } = useTemplateUrlLoader()
+
+      expect(isReadonly(isLoading)).toBe(true)
+      expect(isReadonly(error)).toBe(true)
+      expect(isReadonly(isReady)).toBe(true)
+    })
+
+    it('transitions refs through success lifecycle', async () => {
+      mockQueryParams = { template: 'flux_simple' }
+
+      let resolveLoadTemplates: (() => void) | undefined
+      mockLoadTemplates.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveLoadTemplates = resolve
+          })
+      )
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      const loadPromise = loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(true)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      resolveLoadTemplates?.()
+      await loadPromise
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(true)
+    })
+
+    it('sets isReady after failed template load without setting error', async () => {
+      mockQueryParams = { template: 'invalid-template' }
+      mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      await loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(true)
+    })
+
+    it('sets error and isReady when load throws', async () => {
+      mockQueryParams = { template: 'flux_simple' }
+      const thrownError = new Error('Network error')
+      mockLoadTemplates.mockRejectedValueOnce(thrownError)
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+      const loadPromise = loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(true)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      await loadPromise
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(thrownError)
+      expect(isReady.value).toBe(true)
+    })
+
+    it('keeps refs unchanged when template param is missing', async () => {
+      mockQueryParams = {}
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+
+      await loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+      expect(mockLoadTemplates).not.toHaveBeenCalled()
+      expect(mockLoadWorkflowTemplate).not.toHaveBeenCalled()
+    })
+
+    it('keeps refs unchanged for invalid params before async work', async () => {
+      const invalidQueries: Record<string, string>[] = [
+        { template: '../../../etc/passwd' },
+        { template: 'flux_simple', source: '../malicious' },
+        { template: 'flux_simple', mode: '../malicious' }
+      ]
+
+      for (const query of invalidQueries) {
+        vi.clearAllMocks()
+        mockQueryParams = query
+
+        const { loadTemplateFromUrl, isLoading, error, isReady } =
+          useTemplateUrlLoader()
+
+        await loadTemplateFromUrl()
+
+        expect(isLoading.value).toBe(false)
+        expect(error.value).toBe(null)
+        expect(isReady.value).toBe(false)
+        expect(mockLoadTemplates).not.toHaveBeenCalled()
+      }
+    })
   })
 })

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -516,5 +516,28 @@ describe('useTemplateUrlLoader', () => {
         expect(mockLoadTemplates).not.toHaveBeenCalled()
       }
     })
+
+    it('resets stale state on retry after error', async () => {
+      mockQueryParams = { template: 'flux_simple' }
+      const thrownError = new Error('Network error')
+      mockLoadTemplates.mockRejectedValueOnce(thrownError)
+
+      const { loadTemplateFromUrl, error, isReady } = useTemplateUrlLoader()
+
+      await loadTemplateFromUrl()
+      expect(error.value).toBe(thrownError)
+      expect(isReady.value).toBe(true)
+
+      mockLoadTemplates.mockResolvedValueOnce(true)
+      const retryPromise = loadTemplateFromUrl()
+
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      await retryPromise
+
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(true)
+    })
   })
 })

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -18,13 +18,17 @@ const preservedQueryMocks = vi.hoisted(() => ({
   clearPreservedQuery: vi.fn()
 }))
 
-// Mock vue-router
-let mockQueryParams: Record<string, string | string[] | undefined> = {}
+const routeMocks = vi.hoisted(() => ({
+  query: {} as Record<string, string | string[] | undefined>
+}))
+
 const mockRouterReplace = vi.fn()
 
 vi.mock('vue-router', () => ({
   useRoute: vi.fn(() => ({
-    query: mockQueryParams
+    get query() {
+      return routeMocks.query
+    }
   })),
   useRouter: vi.fn(() => ({
     replace: mockRouterReplace
@@ -84,12 +88,12 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 describe('useTemplateUrlLoader', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockQueryParams = {}
+    routeMocks.query = {}
     mockCanvasStore.linearMode = false
   })
 
   it('does not load template when no query param present', () => {
-    mockQueryParams = {}
+    routeMocks.query = {}
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -99,7 +103,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('loads template when query param is present', async () => {
-    mockQueryParams = { template: 'flux_simple' }
+    routeMocks.query = { template: 'flux_simple' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -113,7 +117,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('uses default source when source param is not provided', async () => {
-    mockQueryParams = { template: 'flux_simple' }
+    routeMocks.query = { template: 'flux_simple' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -125,7 +129,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('uses custom source when source param is provided', async () => {
-    mockQueryParams = { template: 'custom-template', source: 'custom-module' }
+    routeMocks.query = { template: 'custom-template', source: 'custom-module' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -137,7 +141,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('shows error toast when template loading fails', async () => {
-    mockQueryParams = { template: 'invalid-template' }
+    routeMocks.query = { template: 'invalid-template' }
     mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -152,7 +156,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('handles array query params correctly', () => {
     // Vue Router can return string[] for duplicate params
-    mockQueryParams = { template: ['first', 'second'] }
+    routeMocks.query = { template: ['first', 'second'] }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -163,7 +167,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('rejects invalid template parameter with special characters', () => {
     // Test path traversal attempt
-    mockQueryParams = { template: '../../../etc/passwd' }
+    routeMocks.query = { template: '../../../etc/passwd' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -173,7 +177,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('rejects invalid template parameter with slash', () => {
-    mockQueryParams = { template: 'path/to/template' }
+    routeMocks.query = { template: 'path/to/template' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -193,7 +197,7 @@ describe('useTemplateUrlLoader', () => {
 
     for (const template of validTemplates) {
       vi.clearAllMocks()
-      mockQueryParams = { template }
+      routeMocks.query = { template }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
       await loadTemplateFromUrl()
@@ -203,7 +207,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('rejects invalid source parameter with special characters', () => {
-    mockQueryParams = { template: 'flux_simple', source: '../malicious' }
+    routeMocks.query = { template: 'flux_simple', source: '../malicious' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -217,7 +221,7 @@ describe('useTemplateUrlLoader', () => {
 
     for (const source of validSources) {
       vi.clearAllMocks()
-      mockQueryParams = { template: 'flux_simple', source }
+      routeMocks.query = { template: 'flux_simple', source }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
       await loadTemplateFromUrl()
@@ -230,7 +234,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('shows error toast when exception is thrown', async () => {
-    mockQueryParams = { template: 'flux_simple' }
+    routeMocks.query = { template: 'flux_simple' }
     mockLoadTemplates.mockRejectedValueOnce(new Error('Network error'))
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -244,7 +248,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('removes template params from URL after successful load', async () => {
-    mockQueryParams = {
+    routeMocks.query = {
       template: 'flux_simple',
       source: 'custom',
       mode: 'linear',
@@ -260,7 +264,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('removes template params from URL even on error', async () => {
-    mockQueryParams = { template: 'invalid', source: 'custom', other: 'param' }
+    routeMocks.query = { template: 'invalid', source: 'custom', other: 'param' }
     mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -272,7 +276,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('removes template params from URL even on exception', async () => {
-    mockQueryParams = { template: 'flux_simple', other: 'param' }
+    routeMocks.query = { template: 'flux_simple', other: 'param' }
     mockLoadTemplates.mockRejectedValueOnce(new Error('Network error'))
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -284,7 +288,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('sets linear mode when mode=linear and template loads successfully', async () => {
-    mockQueryParams = { template: 'flux_simple', mode: 'linear' }
+    routeMocks.query = { template: 'flux_simple', mode: 'linear' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -297,7 +301,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('does not set linear mode when template loading fails', async () => {
-    mockQueryParams = { template: 'invalid-template', mode: 'linear' }
+    routeMocks.query = { template: 'invalid-template', mode: 'linear' }
     mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -307,7 +311,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('does not set linear mode when mode parameter is not linear', async () => {
-    mockQueryParams = { template: 'flux_simple', mode: 'graph' }
+    routeMocks.query = { template: 'flux_simple', mode: 'graph' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -320,7 +324,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('rejects invalid mode parameter with special characters', () => {
-    mockQueryParams = { template: 'flux_simple', mode: '../malicious' }
+    routeMocks.query = { template: 'flux_simple', mode: '../malicious' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -330,7 +334,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('handles array mode params correctly', () => {
     // Vue Router can return string[] for duplicate params
-    mockQueryParams = {
+    routeMocks.query = {
       template: 'flux_simple',
       mode: ['linear', 'graph']
     }
@@ -344,7 +348,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('warns about unsupported mode values but continues loading', async () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockQueryParams = { template: 'flux_simple', mode: 'unsupported' }
+    routeMocks.query = { template: 'flux_simple', mode: 'unsupported' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -362,7 +366,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('accepts supported mode parameter: linear', async () => {
-    mockQueryParams = { template: 'flux_simple', mode: 'linear' }
+    routeMocks.query = { template: 'flux_simple', mode: 'linear' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -382,7 +386,7 @@ describe('useTemplateUrlLoader', () => {
       vi.clearAllMocks()
       consoleSpy.mockClear()
       mockCanvasStore.linearMode = false
-      mockQueryParams = { template: 'flux_simple', mode }
+      routeMocks.query = { template: 'flux_simple', mode }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
       await loadTemplateFromUrl()
@@ -410,7 +414,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('transitions refs through success lifecycle', async () => {
-      mockQueryParams = { template: 'flux_simple' }
+      routeMocks.query = { template: 'flux_simple' }
 
       let resolveLoadTemplates: (() => void) | undefined
       mockLoadTemplates.mockImplementationOnce(
@@ -442,7 +446,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('sets hasAttempted after failed template load without setting error', async () => {
-      mockQueryParams = { template: 'invalid-template' }
+      routeMocks.query = { template: 'invalid-template' }
       mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
       const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
@@ -460,7 +464,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('sets error and hasAttempted when load throws', async () => {
-      mockQueryParams = { template: 'flux_simple' }
+      routeMocks.query = { template: 'flux_simple' }
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
@@ -480,7 +484,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('keeps refs unchanged when template param is missing', async () => {
-      mockQueryParams = {}
+      routeMocks.query = {}
 
       const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
@@ -503,7 +507,7 @@ describe('useTemplateUrlLoader', () => {
 
       for (const query of invalidQueries) {
         vi.clearAllMocks()
-        mockQueryParams = query
+        routeMocks.query = query
 
         const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
           useTemplateUrlLoader()
@@ -518,7 +522,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('resets stale state on retry after error', async () => {
-      mockQueryParams = { template: 'flux_simple' }
+      routeMocks.query = { template: 'flux_simple' }
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -401,12 +401,12 @@ describe('useTemplateUrlLoader', () => {
   })
 
   describe('loading state refs', () => {
-    it('returns readonly refs for isLoading, error, and isReady', () => {
-      const { isLoading, error, isReady } = useTemplateUrlLoader()
+    it('returns readonly refs for isLoading, error, and hasAttempted', () => {
+      const { isLoading, error, hasAttempted } = useTemplateUrlLoader()
 
       expect(isReadonly(isLoading)).toBe(true)
       expect(isReadonly(error)).toBe(true)
-      expect(isReadonly(isReady)).toBe(true)
+      expect(isReadonly(hasAttempted)).toBe(true)
     })
 
     it('transitions refs through success lifecycle', async () => {
@@ -420,76 +420,76 @@ describe('useTemplateUrlLoader', () => {
           })
       )
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       const loadPromise = loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(true)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       resolveLoadTemplates?.()
       await loadPromise
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
 
-    it('sets isReady after failed template load without setting error', async () => {
+    it('sets hasAttempted after failed template load without setting error', async () => {
       mockQueryParams = { template: 'invalid-template' }
       mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       await loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
 
-    it('sets error and isReady when load throws', async () => {
+    it('sets error and hasAttempted when load throws', async () => {
       mockQueryParams = { template: 'flux_simple' }
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
       const loadPromise = loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(true)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       await loadPromise
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(thrownError)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
 
     it('keeps refs unchanged when template param is missing', async () => {
       mockQueryParams = {}
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
 
       await loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
       expect(mockLoadTemplates).not.toHaveBeenCalled()
       expect(mockLoadWorkflowTemplate).not.toHaveBeenCalled()
     })
@@ -505,14 +505,14 @@ describe('useTemplateUrlLoader', () => {
         vi.clearAllMocks()
         mockQueryParams = query
 
-        const { loadTemplateFromUrl, isLoading, error, isReady } =
+        const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
           useTemplateUrlLoader()
 
         await loadTemplateFromUrl()
 
         expect(isLoading.value).toBe(false)
         expect(error.value).toBe(null)
-        expect(isReady.value).toBe(false)
+        expect(hasAttempted.value).toBe(false)
         expect(mockLoadTemplates).not.toHaveBeenCalled()
       }
     })
@@ -522,22 +522,22 @@ describe('useTemplateUrlLoader', () => {
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
-      const { loadTemplateFromUrl, error, isReady } = useTemplateUrlLoader()
+      const { loadTemplateFromUrl, error, hasAttempted } = useTemplateUrlLoader()
 
       await loadTemplateFromUrl()
       expect(error.value).toBe(thrownError)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
 
       mockLoadTemplates.mockResolvedValueOnce(true)
       const retryPromise = loadTemplateFromUrl()
 
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       await retryPromise
 
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
   })
 })

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -526,7 +526,8 @@ describe('useTemplateUrlLoader', () => {
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
-      const { loadTemplateFromUrl, error, hasAttempted } = useTemplateUrlLoader()
+      const { loadTemplateFromUrl, error, hasAttempted } =
+        useTemplateUrlLoader()
 
       await loadTemplateFromUrl()
       expect(error.value).toBe(thrownError)

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -87,7 +87,6 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 describe('useTemplateUrlLoader', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     routeMocks.query = {}
     mockCanvasStore.linearMode = false
   })
@@ -419,8 +418,8 @@ describe('useTemplateUrlLoader', () => {
       let resolveLoadTemplates: (() => void) | undefined
       mockLoadTemplates.mockImplementationOnce(
         () =>
-          new Promise<void>((resolve) => {
-            resolveLoadTemplates = resolve
+          new Promise<boolean>((resolve) => {
+            resolveLoadTemplates = () => resolve(true)
           })
       )
 

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -18,13 +18,17 @@ const preservedQueryMocks = vi.hoisted(() => ({
   clearPreservedQuery: vi.fn()
 }))
 
-// Mock vue-router
-let mockQueryParams: Record<string, string | string[] | undefined> = {}
+const routeMocks = vi.hoisted(() => ({
+  query: {} as Record<string, string | string[] | undefined>
+}))
+
 const mockRouterReplace = vi.fn()
 
 vi.mock('vue-router', () => ({
   useRoute: vi.fn(() => ({
-    query: mockQueryParams
+    get query() {
+      return routeMocks.query
+    }
   })),
   useRouter: vi.fn(() => ({
     replace: mockRouterReplace
@@ -83,12 +87,13 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 describe('useTemplateUrlLoader', () => {
   beforeEach(() => {
-    mockQueryParams = {}
+    vi.clearAllMocks()
+    routeMocks.query = {}
     mockCanvasStore.linearMode = false
   })
 
   it('does not load template when no query param present', () => {
-    mockQueryParams = {}
+    routeMocks.query = {}
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -98,7 +103,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('loads template when query param is present', async () => {
-    mockQueryParams = { template: 'flux_simple' }
+    routeMocks.query = { template: 'flux_simple' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -112,7 +117,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('uses default source when source param is not provided', async () => {
-    mockQueryParams = { template: 'flux_simple' }
+    routeMocks.query = { template: 'flux_simple' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -124,7 +129,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('uses custom source when source param is provided', async () => {
-    mockQueryParams = { template: 'custom-template', source: 'custom-module' }
+    routeMocks.query = { template: 'custom-template', source: 'custom-module' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -136,7 +141,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('shows error toast when template loading fails', async () => {
-    mockQueryParams = { template: 'invalid-template' }
+    routeMocks.query = { template: 'invalid-template' }
     mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -151,7 +156,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('handles array query params correctly', () => {
     // Vue Router can return string[] for duplicate params
-    mockQueryParams = { template: ['first', 'second'] }
+    routeMocks.query = { template: ['first', 'second'] }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -162,7 +167,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('rejects invalid template parameter with special characters', () => {
     // Test path traversal attempt
-    mockQueryParams = { template: '../../../etc/passwd' }
+    routeMocks.query = { template: '../../../etc/passwd' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -172,7 +177,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('rejects invalid template parameter with slash', () => {
-    mockQueryParams = { template: 'path/to/template' }
+    routeMocks.query = { template: 'path/to/template' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -192,7 +197,7 @@ describe('useTemplateUrlLoader', () => {
 
     for (const template of validTemplates) {
       vi.clearAllMocks()
-      mockQueryParams = { template }
+      routeMocks.query = { template }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
       await loadTemplateFromUrl()
@@ -202,7 +207,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('rejects invalid source parameter with special characters', () => {
-    mockQueryParams = { template: 'flux_simple', source: '../malicious' }
+    routeMocks.query = { template: 'flux_simple', source: '../malicious' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -216,7 +221,7 @@ describe('useTemplateUrlLoader', () => {
 
     for (const source of validSources) {
       vi.clearAllMocks()
-      mockQueryParams = { template: 'flux_simple', source }
+      routeMocks.query = { template: 'flux_simple', source }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
       await loadTemplateFromUrl()
@@ -229,7 +234,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('shows error toast when exception is thrown', async () => {
-    mockQueryParams = { template: 'flux_simple' }
+    routeMocks.query = { template: 'flux_simple' }
     mockLoadTemplates.mockRejectedValueOnce(new Error('Network error'))
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -243,7 +248,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('removes template params from URL after successful load', async () => {
-    mockQueryParams = {
+    routeMocks.query = {
       template: 'flux_simple',
       source: 'custom',
       mode: 'linear',
@@ -259,7 +264,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('removes template params from URL even on error', async () => {
-    mockQueryParams = { template: 'invalid', source: 'custom', other: 'param' }
+    routeMocks.query = { template: 'invalid', source: 'custom', other: 'param' }
     mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -271,7 +276,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('removes template params from URL even on exception', async () => {
-    mockQueryParams = { template: 'flux_simple', other: 'param' }
+    routeMocks.query = { template: 'flux_simple', other: 'param' }
     mockLoadTemplates.mockRejectedValueOnce(new Error('Network error'))
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -283,7 +288,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('sets linear mode when mode=linear and template loads successfully', async () => {
-    mockQueryParams = { template: 'flux_simple', mode: 'linear' }
+    routeMocks.query = { template: 'flux_simple', mode: 'linear' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -296,7 +301,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('does not set linear mode when template loading fails', async () => {
-    mockQueryParams = { template: 'invalid-template', mode: 'linear' }
+    routeMocks.query = { template: 'invalid-template', mode: 'linear' }
     mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
@@ -306,7 +311,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('does not set linear mode when mode parameter is not linear', async () => {
-    mockQueryParams = { template: 'flux_simple', mode: 'graph' }
+    routeMocks.query = { template: 'flux_simple', mode: 'graph' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -319,7 +324,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('rejects invalid mode parameter with special characters', () => {
-    mockQueryParams = { template: 'flux_simple', mode: '../malicious' }
+    routeMocks.query = { template: 'flux_simple', mode: '../malicious' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     void loadTemplateFromUrl()
@@ -329,7 +334,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('handles array mode params correctly', () => {
     // Vue Router can return string[] for duplicate params
-    mockQueryParams = {
+    routeMocks.query = {
       template: 'flux_simple',
       mode: ['linear', 'graph']
     }
@@ -343,7 +348,7 @@ describe('useTemplateUrlLoader', () => {
 
   it('warns about unsupported mode values but continues loading', async () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    mockQueryParams = { template: 'flux_simple', mode: 'unsupported' }
+    routeMocks.query = { template: 'flux_simple', mode: 'unsupported' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -361,7 +366,7 @@ describe('useTemplateUrlLoader', () => {
   })
 
   it('accepts supported mode parameter: linear', async () => {
-    mockQueryParams = { template: 'flux_simple', mode: 'linear' }
+    routeMocks.query = { template: 'flux_simple', mode: 'linear' }
 
     const { loadTemplateFromUrl } = useTemplateUrlLoader()
     await loadTemplateFromUrl()
@@ -381,7 +386,7 @@ describe('useTemplateUrlLoader', () => {
       vi.clearAllMocks()
       consoleSpy.mockClear()
       mockCanvasStore.linearMode = false
-      mockQueryParams = { template: 'flux_simple', mode }
+      routeMocks.query = { template: 'flux_simple', mode }
 
       const { loadTemplateFromUrl } = useTemplateUrlLoader()
       await loadTemplateFromUrl()
@@ -409,7 +414,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('transitions refs through success lifecycle', async () => {
-      mockQueryParams = { template: 'flux_simple' }
+      routeMocks.query = { template: 'flux_simple' }
 
       let resolveLoadTemplates: (() => void) | undefined
       mockLoadTemplates.mockImplementationOnce(
@@ -441,7 +446,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('sets hasAttempted after failed template load without setting error', async () => {
-      mockQueryParams = { template: 'invalid-template' }
+      routeMocks.query = { template: 'invalid-template' }
       mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
       const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
@@ -459,7 +464,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('sets error and hasAttempted when load throws', async () => {
-      mockQueryParams = { template: 'flux_simple' }
+      routeMocks.query = { template: 'flux_simple' }
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
@@ -479,7 +484,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('keeps refs unchanged when template param is missing', async () => {
-      mockQueryParams = {}
+      routeMocks.query = {}
 
       const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
@@ -502,7 +507,7 @@ describe('useTemplateUrlLoader', () => {
 
       for (const query of invalidQueries) {
         vi.clearAllMocks()
-        mockQueryParams = query
+        routeMocks.query = query
 
         const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
           useTemplateUrlLoader()
@@ -517,7 +522,7 @@ describe('useTemplateUrlLoader', () => {
     })
 
     it('resets stale state on retry after error', async () => {
-      mockQueryParams = { template: 'flux_simple' }
+      routeMocks.query = { template: 'flux_simple' }
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isReadonly } from 'vue'
 
 import { useTemplateUrlLoader } from '@/platform/workflow/templates/composables/useTemplateUrlLoader'
 
@@ -396,5 +397,123 @@ describe('useTemplateUrlLoader', () => {
     }
 
     consoleSpy.mockRestore()
+  })
+
+  describe('loading state refs', () => {
+    it('returns readonly refs for isLoading, error, and isReady', () => {
+      const { isLoading, error, isReady } = useTemplateUrlLoader()
+
+      expect(isReadonly(isLoading)).toBe(true)
+      expect(isReadonly(error)).toBe(true)
+      expect(isReadonly(isReady)).toBe(true)
+    })
+
+    it('transitions refs through success lifecycle', async () => {
+      mockQueryParams = { template: 'flux_simple' }
+
+      let resolveLoadTemplates: (() => void) | undefined
+      mockLoadTemplates.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveLoadTemplates = resolve
+          })
+      )
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      const loadPromise = loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(true)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      resolveLoadTemplates?.()
+      await loadPromise
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(true)
+    })
+
+    it('sets isReady after failed template load without setting error', async () => {
+      mockQueryParams = { template: 'invalid-template' }
+      mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      await loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(true)
+    })
+
+    it('sets error and isReady when load throws', async () => {
+      mockQueryParams = { template: 'flux_simple' }
+      const thrownError = new Error('Network error')
+      mockLoadTemplates.mockRejectedValueOnce(thrownError)
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+      const loadPromise = loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(true)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      await loadPromise
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(thrownError)
+      expect(isReady.value).toBe(true)
+    })
+
+    it('keeps refs unchanged when template param is missing', async () => {
+      mockQueryParams = {}
+
+      const { loadTemplateFromUrl, isLoading, error, isReady } =
+        useTemplateUrlLoader()
+
+      await loadTemplateFromUrl()
+
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+      expect(mockLoadTemplates).not.toHaveBeenCalled()
+      expect(mockLoadWorkflowTemplate).not.toHaveBeenCalled()
+    })
+
+    it('keeps refs unchanged for invalid params before async work', async () => {
+      const invalidQueries: Record<string, string>[] = [
+        { template: '../../../etc/passwd' },
+        { template: 'flux_simple', source: '../malicious' },
+        { template: 'flux_simple', mode: '../malicious' }
+      ]
+
+      for (const query of invalidQueries) {
+        vi.clearAllMocks()
+        mockQueryParams = query
+
+        const { loadTemplateFromUrl, isLoading, error, isReady } =
+          useTemplateUrlLoader()
+
+        await loadTemplateFromUrl()
+
+        expect(isLoading.value).toBe(false)
+        expect(error.value).toBe(null)
+        expect(isReady.value).toBe(false)
+        expect(mockLoadTemplates).not.toHaveBeenCalled()
+      }
+    })
   })
 })

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -400,12 +400,12 @@ describe('useTemplateUrlLoader', () => {
   })
 
   describe('loading state refs', () => {
-    it('returns readonly refs for isLoading, error, and isReady', () => {
-      const { isLoading, error, isReady } = useTemplateUrlLoader()
+    it('returns readonly refs for isLoading, error, and hasAttempted', () => {
+      const { isLoading, error, hasAttempted } = useTemplateUrlLoader()
 
       expect(isReadonly(isLoading)).toBe(true)
       expect(isReadonly(error)).toBe(true)
-      expect(isReadonly(isReady)).toBe(true)
+      expect(isReadonly(hasAttempted)).toBe(true)
     })
 
     it('transitions refs through success lifecycle', async () => {
@@ -419,76 +419,76 @@ describe('useTemplateUrlLoader', () => {
           })
       )
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       const loadPromise = loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(true)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       resolveLoadTemplates?.()
       await loadPromise
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
 
-    it('sets isReady after failed template load without setting error', async () => {
+    it('sets hasAttempted after failed template load without setting error', async () => {
       mockQueryParams = { template: 'invalid-template' }
       mockLoadWorkflowTemplate.mockResolvedValueOnce(false)
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       await loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
 
-    it('sets error and isReady when load throws', async () => {
+    it('sets error and hasAttempted when load throws', async () => {
       mockQueryParams = { template: 'flux_simple' }
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
       const loadPromise = loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(true)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       await loadPromise
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(thrownError)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
 
     it('keeps refs unchanged when template param is missing', async () => {
       mockQueryParams = {}
 
-      const { loadTemplateFromUrl, isLoading, error, isReady } =
+      const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
         useTemplateUrlLoader()
 
       await loadTemplateFromUrl()
 
       expect(isLoading.value).toBe(false)
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
       expect(mockLoadTemplates).not.toHaveBeenCalled()
       expect(mockLoadWorkflowTemplate).not.toHaveBeenCalled()
     })
@@ -504,14 +504,14 @@ describe('useTemplateUrlLoader', () => {
         vi.clearAllMocks()
         mockQueryParams = query
 
-        const { loadTemplateFromUrl, isLoading, error, isReady } =
+        const { loadTemplateFromUrl, isLoading, error, hasAttempted } =
           useTemplateUrlLoader()
 
         await loadTemplateFromUrl()
 
         expect(isLoading.value).toBe(false)
         expect(error.value).toBe(null)
-        expect(isReady.value).toBe(false)
+        expect(hasAttempted.value).toBe(false)
         expect(mockLoadTemplates).not.toHaveBeenCalled()
       }
     })
@@ -521,22 +521,22 @@ describe('useTemplateUrlLoader', () => {
       const thrownError = new Error('Network error')
       mockLoadTemplates.mockRejectedValueOnce(thrownError)
 
-      const { loadTemplateFromUrl, error, isReady } = useTemplateUrlLoader()
+      const { loadTemplateFromUrl, error, hasAttempted } = useTemplateUrlLoader()
 
       await loadTemplateFromUrl()
       expect(error.value).toBe(thrownError)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
 
       mockLoadTemplates.mockResolvedValueOnce(true)
       const retryPromise = loadTemplateFromUrl()
 
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(false)
+      expect(hasAttempted.value).toBe(false)
 
       await retryPromise
 
       expect(error.value).toBe(null)
-      expect(isReady.value).toBe(true)
+      expect(hasAttempted.value).toBe(true)
     })
   })
 })

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.test.ts
@@ -515,5 +515,28 @@ describe('useTemplateUrlLoader', () => {
         expect(mockLoadTemplates).not.toHaveBeenCalled()
       }
     })
+
+    it('resets stale state on retry after error', async () => {
+      mockQueryParams = { template: 'flux_simple' }
+      const thrownError = new Error('Network error')
+      mockLoadTemplates.mockRejectedValueOnce(thrownError)
+
+      const { loadTemplateFromUrl, error, isReady } = useTemplateUrlLoader()
+
+      await loadTemplateFromUrl()
+      expect(error.value).toBe(thrownError)
+      expect(isReady.value).toBe(true)
+
+      mockLoadTemplates.mockResolvedValueOnce(true)
+      const retryPromise = loadTemplateFromUrl()
+
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(false)
+
+      await retryPromise
+
+      expect(error.value).toBe(null)
+      expect(isReady.value).toBe(true)
+    })
   })
 })

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -70,6 +70,9 @@ export function useTemplateUrlLoader() {
    * Handles errors internally and shows appropriate user feedback
    */
   const loadTemplateFromUrl = async () => {
+    error.value = null
+    isReady.value = false
+
     const templateParam = route.query.template
 
     if (!templateParam || typeof templateParam !== 'string') {
@@ -111,7 +114,6 @@ export function useTemplateUrlLoader() {
     }
 
     isLoading.value = true
-    error.value = null
 
     try {
       await templateWorkflows.loadTemplates()

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -1,4 +1,5 @@
 import { useToast } from 'primevue/usetoast'
+import { readonly, ref, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -32,6 +33,10 @@ export function useTemplateUrlLoader() {
   const TEMPLATE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.TEMPLATE
   const SUPPORTED_MODES = ['linear'] as const
   type SupportedMode = (typeof SUPPORTED_MODES)[number]
+
+  const isLoading = ref(false)
+  const error = shallowRef<Error | null>(null)
+  const isReady = ref(false)
 
   /**
    * Validates parameter format to prevent path traversal and injection attacks
@@ -105,6 +110,9 @@ export function useTemplateUrlLoader() {
       )
     }
 
+    isLoading.value = true
+    error.value = null
+
     try {
       await templateWorkflows.loadTemplates()
 
@@ -122,14 +130,15 @@ export function useTemplateUrlLoader() {
           })
         })
       } else if (modeParam === 'linear') {
-        // Set linear mode after successful template load
         useTelemetry()?.trackEnterLinear({ source: 'template_url' })
         canvasStore.linearMode = true
       }
-    } catch (error) {
+    } catch (e) {
+      const caught = e instanceof Error ? e : new Error(String(e))
+      error.value = caught
       console.error(
         '[useTemplateUrlLoader] Failed to load template from URL:',
-        error
+        caught
       )
       toast.add({
         severity: 'error',
@@ -137,12 +146,17 @@ export function useTemplateUrlLoader() {
         detail: t('g.errorLoadingTemplate')
       })
     } finally {
+      isLoading.value = false
+      isReady.value = true
       cleanupUrlParams()
       clearPreservedQuery(TEMPLATE_NAMESPACE)
     }
   }
 
   return {
-    loadTemplateFromUrl
+    loadTemplateFromUrl,
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    isReady: readonly(isReady)
   }
 }

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -36,7 +36,7 @@ export function useTemplateUrlLoader() {
 
   const isLoading = ref(false)
   const error = shallowRef<Error | null>(null)
-  const isReady = ref(false)
+  const hasAttempted = ref(false)
 
   /**
    * Validates parameter format to prevent path traversal and injection attacks
@@ -71,7 +71,7 @@ export function useTemplateUrlLoader() {
    */
   const loadTemplateFromUrl = async () => {
     error.value = null
-    isReady.value = false
+    hasAttempted.value = false
 
     const templateParam = route.query.template
 
@@ -149,7 +149,7 @@ export function useTemplateUrlLoader() {
       })
     } finally {
       isLoading.value = false
-      isReady.value = true
+      hasAttempted.value = true
       cleanupUrlParams()
       clearPreservedQuery(TEMPLATE_NAMESPACE)
     }
@@ -159,6 +159,6 @@ export function useTemplateUrlLoader() {
     loadTemplateFromUrl,
     isLoading: readonly(isLoading),
     error: readonly(error),
-    isReady: readonly(isReady)
+    hasAttempted: readonly(hasAttempted)
   }
 }

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -71,6 +71,9 @@ export function useTemplateUrlLoader() {
    * @returns the id of the template that loaded, if one did
    */
   const loadTemplateFromUrl = async (): Promise<string | undefined> => {
+    error.value = null
+    isReady.value = false
+
     const templateParam = route.query.template
 
     if (!templateParam || typeof templateParam !== 'string') {
@@ -112,7 +115,6 @@ export function useTemplateUrlLoader() {
     }
 
     isLoading.value = true
-    error.value = null
 
     try {
       await templateWorkflows.loadTemplates()

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -36,7 +36,7 @@ export function useTemplateUrlLoader() {
 
   const isLoading = ref(false)
   const error = shallowRef<Error | null>(null)
-  const isReady = ref(false)
+  const hasAttempted = ref(false)
 
   /**
    * Validates parameter format to prevent path traversal and injection attacks
@@ -72,7 +72,7 @@ export function useTemplateUrlLoader() {
    */
   const loadTemplateFromUrl = async (): Promise<string | undefined> => {
     error.value = null
-    isReady.value = false
+    hasAttempted.value = false
 
     const templateParam = route.query.template
 
@@ -154,7 +154,7 @@ export function useTemplateUrlLoader() {
       })
     } finally {
       isLoading.value = false
-      isReady.value = true
+      hasAttempted.value = true
       cleanupUrlParams()
       clearPreservedQuery(TEMPLATE_NAMESPACE)
     }
@@ -164,6 +164,6 @@ export function useTemplateUrlLoader() {
     loadTemplateFromUrl,
     isLoading: readonly(isLoading),
     error: readonly(error),
-    isReady: readonly(isReady)
+    hasAttempted: readonly(hasAttempted)
   }
 }

--- a/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
+++ b/src/platform/workflow/templates/composables/useTemplateUrlLoader.ts
@@ -1,4 +1,5 @@
 import { useToast } from 'primevue/usetoast'
+import { readonly, ref, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -32,6 +33,10 @@ export function useTemplateUrlLoader() {
   const TEMPLATE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.TEMPLATE
   const SUPPORTED_MODES = ['linear'] as const
   type SupportedMode = (typeof SUPPORTED_MODES)[number]
+
+  const isLoading = ref(false)
+  const error = shallowRef<Error | null>(null)
+  const isReady = ref(false)
 
   /**
    * Validates parameter format to prevent path traversal and injection attacks
@@ -106,6 +111,9 @@ export function useTemplateUrlLoader() {
       )
     }
 
+    isLoading.value = true
+    error.value = null
+
     try {
       await templateWorkflows.loadTemplates()
 
@@ -126,15 +134,16 @@ export function useTemplateUrlLoader() {
       }
 
       if (modeParam === 'linear') {
-        // Set linear mode after successful template load
         useTelemetry()?.trackEnterLinear({ source: 'template_url' })
         canvasStore.linearMode = true
       }
       return sourceParam === 'default' ? templateParam : undefined
-    } catch (error) {
+    } catch (e) {
+      const caught = e instanceof Error ? e : new Error(String(e))
+      error.value = caught
       console.error(
         '[useTemplateUrlLoader] Failed to load template from URL:',
-        error
+        caught
       )
       toast.add({
         severity: 'error',
@@ -142,12 +151,17 @@ export function useTemplateUrlLoader() {
         detail: t('g.errorLoadingTemplate')
       })
     } finally {
+      isLoading.value = false
+      isReady.value = true
       cleanupUrlParams()
       clearPreservedQuery(TEMPLATE_NAMESPACE)
     }
   }
 
   return {
-    loadTemplateFromUrl
+    loadTemplateFromUrl,
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    isReady: readonly(isReady)
   }
 }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

- Keep the existing `BlockUI` spinner visible while a template is loading from URL parameters (`/?template=flux_simple`), preventing the flash of default/stale workflow
- Add reactive `isLoading`, `error`, `isReady` refs to `useTemplateUrlLoader` composable, matching the `useAsyncState`/VueUse async pattern
- Add `hasTemplateIntent()` to `useWorkflowPersistenceV2` that checks both route query params and preserved query sessionStorage, ensuring the spinner stays up for both direct URL hits and preserved-query-based navigation
- `loadTemplateFromUrlIfPresent()` now returns `boolean` indicating whether a template load was attempted

## Problem

When navigating to `/?template=flux_simple`, `workspaceStore.spinner` (the `BlockUI` full-screen overlay) was dismissed after `comfyApp.setup()` but *before* template loading started. Users saw the default workflow flash briefly before being replaced by the template.

## Approach

Defer spinner dismissal in `GraphCanvas.vue` when a template URL intent is detected via `hasTemplateIntent()`. The spinner stays visible through the full template loading sequence (index fetch → template JSON fetch → graph render) and is dismissed using the stable boolean return from `loadTemplateFromUrlIfPresent()` to avoid timing races with URL cleanup.

## Test Plan

- 30 unit tests for `useTemplateUrlLoader` (7 new: lifecycle transitions, retry reset, readonly guarantees)
- 15 unit tests for `useWorkflowPersistenceV2` (7 new: `loadTemplateFromUrlIfPresent` return values, `hasTemplateIntent` with route query, preserved query, and invalid storage)
- 1 E2E test (`browser_tests/tests/templateUrlLoading.spec.ts`) verifying spinner visibility during delayed template load
- Manual verification: navigated to `/?template=default` and confirmed template loads without stale workflow flash

## Screenshots

![Template loaded via URL param /?template=default — no stale workflow flash](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/bcd356cf58c5c47cb3e28ec215c1358a6e5779e21d0e2f1b36a0efeb3580346b/pr-images/1776654810295-15d83ffe-8a83-4f89-9840-830f6c20adbe.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11457-feat-show-loading-spinner-during-template-URL-loading-3486d73d365081b99402f66958983032) by [Unito](https://www.unito.io)
