### PR TITLE
refactor: rename isActiveSubscription to canAccessSubscriptionFeatures

### DIFF
--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -64,7 +64,7 @@ function makeSubscription(
 
 const mockFetchStatus = vi.fn().mockResolvedValue(undefined)
 const mockFetchBalance = vi.fn().mockResolvedValue(undefined)
-const mockIsActiveSubscription = ref(true)
+const mockCanAccessSubscriptionFeatures = ref(true)
 const mockIsFreeTier = ref(false)
 const mockTier = ref<SubscriptionInfo['tier']>('CREATOR')
 const mockSubscription = ref<SubscriptionInfo | null>(makeSubscription())
@@ -73,7 +73,7 @@ const mockIsLoading = ref(false)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    isActiveSubscription: mockIsActiveSubscription,
+    canAccessSubscriptionFeatures: mockCanAccessSubscriptionFeatures,
     isFreeTier: mockIsFreeTier,
     tier: mockTier,
     subscription: mockSubscription,
@@ -153,7 +153,7 @@ describe('CurrentUserPopoverLegacy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsCloud.value = true
-    mockIsActiveSubscription.value = true
+    mockCanAccessSubscriptionFeatures.value = true
     mockIsFreeTier.value = false
     mockTier.value = 'CREATOR'
     mockSubscription.value = makeSubscription()
@@ -203,7 +203,7 @@ describe('CurrentUserPopoverLegacy', () => {
   })
 
   it('refreshes subscription status through the billing facade after subscribing', async () => {
-    mockIsActiveSubscription.value = false
+    mockCanAccessSubscriptionFeatures.value = false
     const { user } = renderComponent()
 
     await user.click(screen.getByTestId('subscribe-button-mock'))
@@ -478,7 +478,7 @@ describe('CurrentUserPopoverLegacy', () => {
     })
 
     it('hides subscribe button', () => {
-      mockIsActiveSubscription.value = false
+      mockCanAccessSubscriptionFeatures.value = false
       renderComponent()
       expect(
         screen.queryByTestId('subscribe-button-mock')

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -35,7 +35,7 @@
       v-if="canAccessSubscriptionFeatures"
       class="flex items-center gap-2 px-4 py-2"
     >
-      <i class="icon-[lucide--component] text-sm text-amber-400" />
+      <i class="icon-[lucide--component] text-sm text-credit" />
       <Skeleton v-if="isLoading" width="4rem" height="1.25rem" class="w-full" />
       <span v-else class="text-base font-semibold text-base-foreground">{{
         formattedBalance

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -31,8 +31,11 @@
     </div>
 
     <!-- Credits Section -->
-    <div v-if="isActiveSubscription" class="flex items-center gap-2 px-4 py-2">
-      <i class="icon-[lucide--component] text-sm text-credit" />
+    <div
+      v-if="canAccessSubscriptionFeatures"
+      class="flex items-center gap-2 px-4 py-2"
+    >
+      <i class="icon-[lucide--component] text-sm text-amber-400" />
       <Skeleton v-if="isLoading" width="4rem" height="1.25rem" class="w-full" />
       <span v-else class="text-base font-semibold text-base-foreground">{{
         formattedBalance
@@ -81,7 +84,7 @@
     <Divider class="mx-0 my-2" />
 
     <div
-      v-if="isActiveSubscription"
+      v-if="canAccessSubscriptionFeatures"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="partner-nodes-menu-item"
       @click="handleOpenPartnerNodesInfo"
@@ -111,7 +114,7 @@
     </div>
 
     <div
-      v-if="isActiveSubscription"
+      v-if="canAccessSubscriptionFeatures"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="manage-plan-menu-item"
       @click="handleOpenPlanAndCreditsSettings"
@@ -179,7 +182,7 @@ const { userDisplayName, userEmail, userPhotoUrl, handleSignOut } =
 const settingsDialog = useSettingsDialog()
 const dialogService = useDialogService()
 const {
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   isFreeTier,
   tier,
   subscription,

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -89,7 +89,7 @@ vi.mock('@/stores/authStore', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    isActiveSubscription: { value: false },
+    canAccessSubscriptionFeatures: { value: false },
     isFreeTier: { value: true },
     type: { value: 'free' }
   }))

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -152,8 +152,8 @@ export const useAuthActions = () => {
    * resolves instead of re-throwing on failure.
    */
   const purchaseCreditsDirect = async (amount: number): Promise<void> => {
-    const { isActiveSubscription } = useBillingContext()
-    if (!isActiveSubscription.value) return
+    const { canAccessSubscriptionFeatures } = useBillingContext()
+    if (!canAccessSubscriptionFeatures.value) return
 
     const response = await authStore.initiateCreditPurchase({
       amount_micros: usdToMicros(amount),

--- a/src/composables/billing/types.ts
+++ b/src/composables/billing/types.ts
@@ -97,7 +97,7 @@ export interface BillingState {
   currentTeamCreditStop: ComputedRef<CurrentTeamCreditStop | null>
   isLoading: Ref<boolean>
   error: Ref<string | null>
-  isActiveSubscription: ComputedRef<boolean>
+  canAccessSubscriptionFeatures: ComputedRef<boolean>
   /** Reflects the active workspace's tier, not the user's personal tier. */
   isFreeTier: ComputedRef<boolean>
   /** Coarse funding state (`billing_status`); legacy reports null. */
@@ -125,4 +125,6 @@ export interface BillingContext extends BillingState, BillingActions {
   isTeamPlan: ComputedRef<boolean>
   getMaxSeats: (tierKey: TierKey) => number
   canRunWorkflows: ComputedRef<boolean>
+  /** @deprecated Use canAccessSubscriptionFeatures instead */
+  isActiveSubscription: ComputedRef<boolean>
 }

--- a/src/composables/billing/useBillingContext.test.ts
+++ b/src/composables/billing/useBillingContext.test.ts
@@ -125,7 +125,7 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', async () => {
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
-    isActiveSubscription: { value: true },
+    canAccessSubscriptionFeatures: { value: true },
     subscriptionTier: { value: 'PRO' },
     subscriptionDuration: { value: 'MONTHLY' },
     subscriptionStatus: {
@@ -398,9 +398,9 @@ describe('useBillingContext', () => {
     await expect(topup(99.5)).rejects.toThrow()
   })
 
-  it('provides isActiveSubscription convenience computed', () => {
-    const { isActiveSubscription } = useBillingContext()
-    expect(isActiveSubscription.value).toBe(true)
+  it('provides canAccessSubscriptionFeatures convenience computed', () => {
+    const { canAccessSubscriptionFeatures } = useBillingContext()
+    expect(canAccessSubscriptionFeatures.value).toBe(true)
   })
 
   it('exposes requireActiveSubscription action', async () => {

--- a/src/composables/billing/useBillingContext.ts
+++ b/src/composables/billing/useBillingContext.ts
@@ -138,9 +138,12 @@ function useBillingContextInternal(): BillingContext {
     toValue(activeContext.value.currentTeamCreditStop)
   )
 
-  const isActiveSubscription = computed(() =>
-    toValue(activeContext.value.isActiveSubscription)
+  const canAccessSubscriptionFeatures = computed(() =>
+    toValue(activeContext.value.canAccessSubscriptionFeatures)
   )
+
+  // Alias kept for backward compatibility; equals canAccessSubscriptionFeatures.
+  const isActiveSubscription = canAccessSubscriptionFeatures
 
   const isFreeTier = computed(() => subscription.value?.tier === 'FREE')
 
@@ -157,7 +160,7 @@ function useBillingContextInternal(): BillingContext {
   const isLegacyTeamPlan = computed(
     () =>
       type.value === 'workspace' &&
-      isActiveSubscription.value &&
+      canAccessSubscriptionFeatures.value &&
       !isFreeTier.value &&
       currentTeamCreditStop.value === null &&
       (currentPlanSlug.value
@@ -344,6 +347,7 @@ function useBillingContextInternal(): BillingContext {
     error,
     isActiveSubscription,
     canRunWorkflows,
+    canAccessSubscriptionFeatures,
     isFreeTier,
     isLegacyTeamPlan,
     isTeamPlan,

--- a/src/composables/billing/useLegacyBilling.ts
+++ b/src/composables/billing/useLegacyBilling.ts
@@ -192,7 +192,7 @@ export function useLegacyBilling(): BillingState & BillingActions {
   async function requireActiveSubscription(): Promise<void> {
     await fetchStatus()
     if (!canAccessSubscriptionFeatures.value) {
-      legacyShowSubscriptionDialog()
+      legacyShowSubscriptionDialog({ reason: 'subscription_required' })
     }
   }
 

--- a/src/composables/billing/useLegacyBilling.ts
+++ b/src/composables/billing/useLegacyBilling.ts
@@ -27,7 +27,7 @@ import type {
  */
 export function useLegacyBilling(): BillingState & BillingActions {
   const {
-    isActiveSubscription: legacyIsActiveSubscription,
+    canAccessSubscriptionFeatures: legacyCanAccessSubscriptionFeatures,
     subscriptionTier,
     subscriptionDuration,
     subscriptionStatus: legacySubscriptionStatus,
@@ -45,16 +45,18 @@ export function useLegacyBilling(): BillingState & BillingActions {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
-  const isActiveSubscription = computed(() => legacyIsActiveSubscription.value)
+  const canAccessSubscriptionFeatures = computed(
+    () => legacyCanAccessSubscriptionFeatures.value
+  )
   const isFreeTier = computed(() => subscriptionTier.value === 'FREE')
 
   const subscription = computed<SubscriptionInfo | null>(() => {
-    if (!legacyIsActiveSubscription.value && !subscriptionTier.value) {
+    if (!legacyCanAccessSubscriptionFeatures.value && !subscriptionTier.value) {
       return null
     }
 
     return {
-      isActive: legacyIsActiveSubscription.value,
+      isActive: legacyCanAccessSubscriptionFeatures.value,
       tier: subscriptionTier.value,
       duration: subscriptionDuration.value,
       planSlug: null, // Legacy doesn't use plan slugs
@@ -85,7 +87,7 @@ export function useLegacyBilling(): BillingState & BillingActions {
   const billingStatus = computed<BillingStatus | null>(() => null)
   const subscriptionStatus = computed<BillingSubscriptionStatus | null>(() => {
     if (isCancelled.value) return 'canceled'
-    if (legacyIsActiveSubscription.value) return 'active'
+    if (legacyCanAccessSubscriptionFeatures.value) return 'active'
     return null
   })
   const tier = computed(() => subscriptionTier.value)
@@ -189,8 +191,8 @@ export function useLegacyBilling(): BillingState & BillingActions {
 
   async function requireActiveSubscription(): Promise<void> {
     await fetchStatus()
-    if (!isActiveSubscription.value) {
-      legacyShowSubscriptionDialog({ reason: 'subscription_required' })
+    if (!canAccessSubscriptionFeatures.value) {
+      legacyShowSubscriptionDialog()
     }
   }
 
@@ -209,7 +211,7 @@ export function useLegacyBilling(): BillingState & BillingActions {
     currentTeamCreditStop,
     isLoading,
     error,
-    isActiveSubscription,
+    canAccessSubscriptionFeatures,
     isFreeTier,
     billingStatus,
     subscriptionStatus,

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -209,14 +209,14 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: vi.fn(() => ({
-    isActiveSubscription: vi.fn().mockReturnValue(true),
+    canAccessSubscriptionFeatures: vi.fn().mockReturnValue(true),
     showSubscriptionDialog: vi.fn()
   }))
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    isActiveSubscription: { value: true },
+    canAccessSubscriptionFeatures: { value: true },
     showSubscriptionDialog: vi.fn()
   }))
 }))

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -73,7 +73,8 @@ import { useDialogStore } from '@/stores/dialogStore'
 
 const moveSelectedNodesVersionAdded = '1.22.2'
 export function useCoreCommands(): ComfyCommand[] {
-  const { isActiveSubscription, showSubscriptionDialog } = useBillingContext()
+  const { canAccessSubscriptionFeatures, showSubscriptionDialog } =
+    useBillingContext()
   const workflowService = useWorkflowService()
   const workflowStore = useWorkflowStore()
   const settingsDialog = useSettingsDialog()
@@ -505,8 +506,8 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!isActiveSubscription.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
+        if (!canAccessSubscriptionFeatures.value) {
+          showSubscriptionDialog()
           return
         }
 
@@ -528,8 +529,8 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!isActiveSubscription.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
+        if (!canAccessSubscriptionFeatures.value) {
+          showSubscriptionDialog()
           return
         }
 
@@ -550,8 +551,8 @@ export function useCoreCommands(): ComfyCommand[] {
         trigger_source?: ExecutionTriggerSource
       }) => {
         trackRunButton(metadata)
-        if (!isActiveSubscription.value) {
-          showSubscriptionDialog({ reason: 'subscribe_to_run' })
+        if (!canAccessSubscriptionFeatures.value) {
+          showSubscriptionDialog()
           return
         }
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -507,7 +507,7 @@ export function useCoreCommands(): ComfyCommand[] {
       }) => {
         trackRunButton(metadata)
         if (!canAccessSubscriptionFeatures.value) {
-          showSubscriptionDialog()
+          showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
 
@@ -530,7 +530,7 @@ export function useCoreCommands(): ComfyCommand[] {
       }) => {
         trackRunButton(metadata)
         if (!canAccessSubscriptionFeatures.value) {
-          showSubscriptionDialog()
+          showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
 
@@ -552,7 +552,7 @@ export function useCoreCommands(): ComfyCommand[] {
       }) => {
         trackRunButton(metadata)
         if (!canAccessSubscriptionFeatures.value) {
-          showSubscriptionDialog()
+          showSubscriptionDialog({ reason: 'subscribe_to_run' })
           return
         }
 

--- a/src/extensions/core/cloudRemoteConfig.ts
+++ b/src/extensions/core/cloudRemoteConfig.ts
@@ -14,13 +14,13 @@ useExtensionService().registerExtension({
 
   setup: async () => {
     const { isLoggedIn } = useCurrentUser()
-    const { isActiveSubscription } = useBillingContext()
+    const { canAccessSubscriptionFeatures } = useBillingContext()
 
     // Refresh config when auth or subscription status changes
     // Primary auth refresh is handled by WorkspaceAuthGate on mount
     // This watcher handles subscription changes and acts as a backup for auth
     watchDebounced(
-      [isLoggedIn, isActiveSubscription],
+      [isLoggedIn, canAccessSubscriptionFeatures],
       () => {
         if (!isLoggedIn.value) return
         void refreshRemoteConfig()

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -39,7 +39,7 @@ vi.mock('@/composables/useErrorHandling', () => ({
 }))
 
 const subscriptionMocks = vi.hoisted(() => ({
-  isActiveSubscription: { value: false },
+  canAccessSubscriptionFeatures: { value: false },
   isInitialized: { value: true },
   subscriptionStatus: { value: null }
 }))
@@ -111,7 +111,7 @@ describe('CloudSubscriptionRedirectView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockQuery = {}
-    subscriptionMocks.isActiveSubscription.value = false
+    subscriptionMocks.canAccessSubscriptionFeatures.value = false
     subscriptionMocks.isInitialized.value = true
   })
 
@@ -153,7 +153,7 @@ describe('CloudSubscriptionRedirectView', () => {
   })
 
   test('opens billing portal when subscription is already active', async () => {
-    subscriptionMocks.isActiveSubscription.value = true
+    subscriptionMocks.canAccessSubscriptionFeatures.value = true
 
     await mountView({ tier: 'creator' })
 

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -29,7 +29,8 @@ const router = useRouter()
 const { reportError, accessBillingPortal } = useAuthActions()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
 
-const { isActiveSubscription, isInitialized, initialize } = useBillingContext()
+const { canAccessSubscriptionFeatures, isInitialized, initialize } =
+  useBillingContext()
 
 const selectedTierKey = ref<TierKey | null>(null)
 
@@ -111,7 +112,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     await initialize()
   }
 
-  if (isActiveSubscription.value) {
+  if (canAccessSubscriptionFeatures.value) {
     await accessBillingPortal(undefined, false)
   } else {
     await performSubscriptionCheckout(tierKeyParam, billingCycle, {

--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -20,7 +20,7 @@ type TeamStop = CurrentTeamCreditStop
 const state = vi.hoisted(() => ({
   balance: null as Balance | null,
   subscription: null as Subscription | null,
-  isActiveSubscription: false,
+  canAccessSubscriptionFeatures: false,
   isFreeTier: false,
   currentTeamCreditStop: null as TeamStop | null,
   isLoading: false,
@@ -53,7 +53,9 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     balance: computed(() => state.balance),
     subscription: computed(() => state.subscription),
-    isActiveSubscription: computed(() => state.isActiveSubscription),
+    canAccessSubscriptionFeatures: computed(
+      () => state.canAccessSubscriptionFeatures
+    ),
     isFreeTier: computed(() => state.isFreeTier),
     currentTeamCreditStop: computed(() => state.currentTeamCreditStop),
     isLoading: computed(() => state.isLoading),
@@ -143,7 +145,7 @@ function renderTile(props: Record<string, unknown> = {}) {
 }
 
 function activeProSubscription() {
-  state.isActiveSubscription = true
+  state.canAccessSubscriptionFeatures = true
   state.subscription = {
     tier: 'PRO',
     duration: 'MONTHLY',
@@ -161,7 +163,7 @@ describe('CreditsTile', () => {
   beforeEach(() => {
     state.balance = null
     state.subscription = null
-    state.isActiveSubscription = false
+    state.canAccessSubscriptionFeatures = false
     state.isFreeTier = false
     state.currentTeamCreditStop = null
     state.isLoading = false
@@ -196,7 +198,7 @@ describe('CreditsTile', () => {
   })
 
   it('uses the full annual Team grant for the credit pool total', () => {
-    state.isActiveSubscription = true
+    state.canAccessSubscriptionFeatures = true
     state.subscription = {
       tier: 'TEAM',
       duration: 'ANNUAL',
@@ -216,7 +218,7 @@ describe('CreditsTile', () => {
   })
 
   it('keeps the monthly Team grant as the monthly credit pool total', () => {
-    state.isActiveSubscription = true
+    state.canAccessSubscriptionFeatures = true
     state.subscription = {
       tier: 'TEAM',
       duration: 'MONTHLY',
@@ -236,7 +238,7 @@ describe('CreditsTile', () => {
   })
 
   it('uses the full annual grant for a personal tier credit pool', () => {
-    state.isActiveSubscription = true
+    state.canAccessSubscriptionFeatures = true
     state.subscription = {
       tier: 'PRO',
       duration: 'ANNUAL',
@@ -297,7 +299,7 @@ describe('CreditsTile', () => {
   })
 
   it('shows only the balance with no breakdown when there is no active subscription', () => {
-    state.isActiveSubscription = false
+    state.canAccessSubscriptionFeatures = false
     state.balance = { amountMicros: 500 }
     const { container } = renderTile()
     expect(container.textContent).toContain('1,055')

--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -250,7 +250,7 @@ const { locale, t } = useI18n()
 const {
   subscription,
   balance,
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   isFreeTier,
   currentTeamCreditStop,
   fetchBalance,
@@ -352,7 +352,7 @@ const monthlyUsageLabel = computed(() =>
 )
 
 const showBreakdown = computed(
-  () => isActiveSubscription.value && !zeroState && !inactivePlan
+  () => canAccessSubscriptionFeatures.value && !zeroState && !inactivePlan
 )
 const showBar = computed(
   () =>
@@ -362,7 +362,7 @@ const showBar = computed(
 )
 const showActionButton = computed(
   () =>
-    isActiveSubscription.value &&
+    canAccessSubscriptionFeatures.value &&
     !zeroState &&
     !inactivePlan &&
     permissions.value.canTopUp

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -447,7 +447,7 @@ describe('PricingTable', () => {
     })
 
     it('tracks and rethrows a subscription checkout failure for new subscribers', async () => {
-      mockIsActiveSubscription.value = false
+      mockCanAccessSubscriptionFeatures.value = false
       vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         json: async () => ({ message: 'declined for person@example.com' })

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -23,7 +23,7 @@ function createDeferredPromise<T>() {
   return { promise, resolve }
 }
 
-const mockIsActiveSubscription = ref(false)
+const mockCanAccessSubscriptionFeatures = ref(false)
 const mockSubscriptionTier = ref<SubscriptionTier | null>(null)
 const mockSubscriptionDuration = ref<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 const mockAccessBillingPortal = vi.fn()
@@ -67,13 +67,15 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: computed(() => mockIsActiveSubscription.value),
+    canAccessSubscriptionFeatures: computed(
+      () => mockCanAccessSubscriptionFeatures.value
+    ),
     isFreeTier: computed(() => mockSubscriptionTier.value === 'FREE'),
     tier: computed(() => mockSubscriptionTier.value),
     subscription: computed(() =>
       mockSubscriptionTier.value
         ? {
-            isActive: mockIsActiveSubscription.value,
+            isActive: mockCanAccessSubscriptionFeatures.value,
             tier: mockSubscriptionTier.value,
             duration: mockSubscriptionDuration.value,
             planSlug: null,
@@ -232,7 +234,7 @@ const onChooseTeamWorkspace = vi.fn()
 describe('PricingTable', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockIsActiveSubscription.value = false
+    mockCanAccessSubscriptionFeatures.value = false
     mockSubscriptionTier.value = null
     mockSubscriptionDuration.value = 'MONTHLY'
     mockUserId.value = 'user-123'
@@ -248,7 +250,7 @@ describe('PricingTable', () => {
 
   describe('billing portal deep linking', () => {
     it('should call accessBillingPortal with yearly tier suffix when billing cycle is yearly (default)', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
 
       renderComponent()
@@ -274,7 +276,7 @@ describe('PricingTable', () => {
     })
 
     it('should call accessBillingPortal with different tiers correctly', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
 
       renderComponent()
@@ -291,7 +293,7 @@ describe('PricingTable', () => {
     })
 
     it('records the plan snapshot that was actually opened', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
 
       const portalOpen = createDeferredPromise<boolean>()
@@ -331,7 +333,7 @@ describe('PricingTable', () => {
     })
 
     it('does not record a pending upgrade when the billing portal does not open', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
       mockAccessBillingPortal.mockResolvedValueOnce(false)
 
@@ -352,7 +354,7 @@ describe('PricingTable', () => {
     })
 
     it('should use the latest userId value when it changes after mount', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'STANDARD'
       mockUserId.value = 'user-early'
 
@@ -380,7 +382,7 @@ describe('PricingTable', () => {
     })
 
     it('should not call accessBillingPortal when clicking current plan', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'CREATOR'
       mockSubscriptionDuration.value = 'ANNUAL'
 
@@ -400,7 +402,7 @@ describe('PricingTable', () => {
     })
 
     it('does not highlight a current plan when the facade duration differs from the selected cycle', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'CREATOR'
       mockSubscriptionDuration.value = 'MONTHLY'
 
@@ -415,7 +417,7 @@ describe('PricingTable', () => {
     })
 
     it('should initiate checkout instead of billing portal for new subscribers', async () => {
-      mockIsActiveSubscription.value = false
+      mockCanAccessSubscriptionFeatures.value = false
 
       const windowOpenSpy = vi
         .spyOn(window, 'open')
@@ -475,7 +477,7 @@ describe('PricingTable', () => {
     })
 
     it('should pass correct tier for each subscription level', async () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockSubscriptionTier.value = 'PRO'
 
       renderComponent()

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -372,7 +372,7 @@ const tiers: PricingTierConfig[] = [
   }
 ]
 const {
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   isFreeTier,
   tier: subscriptionTier,
   subscription
@@ -392,7 +392,7 @@ const popover = ref()
 const currentBillingCycle = ref<BillingCycle>('yearly')
 
 const hasPaidSubscription = computed(
-  () => isActiveSubscription.value && !isFreeTier.value
+  () => canAccessSubscriptionFeatures.value && !isFreeTier.value
 )
 
 const currentTierKey = computed<TierKey | null>(() =>

--- a/src/platform/cloud/subscription/components/SubscribeButton.vue
+++ b/src/platform/cloud/subscription/components/SubscribeButton.vue
@@ -37,12 +37,12 @@ const emit = defineEmits<{
   subscribed: []
 }>()
 
-const { isActiveSubscription, showSubscriptionDialog, tier } =
+const { canAccessSubscriptionFeatures, showSubscriptionDialog, tier } =
   useBillingContext()
 const isAwaitingStripeSubscription = ref(false)
 
 watch(
-  [isAwaitingStripeSubscription, isActiveSubscription],
+  [isAwaitingStripeSubscription, canAccessSubscriptionFeatures],
   ([awaiting, isActive]) => {
     if (isCloud && awaiting && isActive) {
       emit('subscribed')

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.test.ts
@@ -8,7 +8,7 @@ import { createI18n } from 'vue-i18n'
 import SubscriptionPanel from '@/platform/cloud/subscription/components/SubscriptionPanel.vue'
 
 // Mock state refs that can be modified between tests
-const mockIsActiveSubscription = ref(false)
+const mockCanAccessSubscriptionFeatures = ref(false)
 const mockIsCancelled = ref(false)
 const mockSubscriptionTier = ref<
   'STANDARD' | 'CREATOR' | 'PRO' | 'FOUNDERS_EDITION' | null
@@ -24,7 +24,9 @@ const TIER_TO_NAME: Record<string, string> = {
 
 // Mock composables - using computed to match composable return types
 const mockSubscriptionData = {
-  isActiveSubscription: computed(() => mockIsActiveSubscription.value),
+  canAccessSubscriptionFeatures: computed(
+    () => mockCanAccessSubscriptionFeatures.value
+  ),
   isCancelled: computed(() => mockIsCancelled.value),
   formattedRenewalDate: computed(() => '2024-12-31'),
   formattedEndDate: computed(() => '2024-12-31'),
@@ -93,7 +95,9 @@ vi.mock('@/composables/auth/useAuthActions', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: computed(() => mockIsActiveSubscription.value),
+    canAccessSubscriptionFeatures: computed(
+      () => mockCanAccessSubscriptionFeatures.value
+    ),
     manageSubscription: vi.fn()
   })
 }))
@@ -240,7 +244,7 @@ describe('SubscriptionPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset mock state
-    mockIsActiveSubscription.value = false
+    mockCanAccessSubscriptionFeatures.value = false
     mockIsCancelled.value = false
     mockSubscriptionTier.value = 'CREATOR'
     mockIsYearlySubscription.value = false
@@ -250,13 +254,13 @@ describe('SubscriptionPanel', () => {
 
   describe('subscription state functionality', () => {
     it('shows correct UI for active subscription', () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       const { container } = createComponent()
       expect(container.textContent).toContain('Manage Subscription')
     })
 
     it('shows correct UI for inactive subscription', () => {
-      mockIsActiveSubscription.value = false
+      mockCanAccessSubscriptionFeatures.value = false
       const { container } = createComponent()
       // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       expect(container.querySelector('subscribe-button-stub')).not.toBeNull()
@@ -264,14 +268,14 @@ describe('SubscriptionPanel', () => {
     })
 
     it('shows renewal date for active non-cancelled subscription', () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockIsCancelled.value = false
       const { container } = createComponent()
       expect(container.textContent).toContain('Renews 2024-12-31')
     })
 
     it('shows expiry date for cancelled subscription', () => {
-      mockIsActiveSubscription.value = true
+      mockCanAccessSubscriptionFeatures.value = true
       mockIsCancelled.value = true
       const { container } = createComponent()
       expect(container.textContent).toContain('Expires 2024-12-31')

--- a/src/platform/cloud/subscription/components/SubscriptionPanel.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanel.vue
@@ -4,7 +4,7 @@
       <div class="flex items-center gap-2">
         <span class="font-inter text-2xl/tight font-semibold">
           {{
-            isActiveSubscription
+            canAccessSubscriptionFeatures
               ? $t('subscription.title')
               : $t('subscription.titleUnsubscribed')
           }}
@@ -44,5 +44,5 @@ const SubscriptionPanelContentWorkspace = defineAsyncComponent(
 
 const { shouldUseWorkspaceBilling } = useBillingRouting()
 
-const { isActiveSubscription } = useBillingContext()
+const { canAccessSubscriptionFeatures } = useBillingContext()
 </script>

--- a/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.test.ts
@@ -33,7 +33,9 @@ vi.mock('@/platform/telemetry', () => ({
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
-    canAccessSubscriptionFeatures: computed(() => mockIsActiveSubscription.value),
+    canAccessSubscriptionFeatures: computed(
+      () => mockIsActiveSubscription.value
+    ),
     isCancelled: computed(() => mockIsCancelled.value),
     isFreeTier: computed(() => mockIsFreeTier.value),
     formattedRenewalDate: computed(() => '2026-08-01'),

--- a/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.test.ts
+++ b/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.test.ts
@@ -33,7 +33,7 @@ vi.mock('@/platform/telemetry', () => ({
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
-    isActiveSubscription: computed(() => mockIsActiveSubscription.value),
+    canAccessSubscriptionFeatures: computed(() => mockIsActiveSubscription.value),
     isCancelled: computed(() => mockIsCancelled.value),
     isFreeTier: computed(() => mockIsFreeTier.value),
     formattedRenewalDate: computed(() => '2026-08-01'),

--- a/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionPanelContentLegacy.vue
@@ -12,7 +12,7 @@
               <span class="text-base">{{ $t('subscription.perMonth') }}</span>
             </div>
             <div
-              v-if="isActiveSubscription"
+              v-if="canAccessSubscriptionFeatures"
               class="text-sm text-text-secondary"
             >
               <template v-if="isCancelled">
@@ -33,7 +33,7 @@
           </div>
 
           <Button
-            v-if="isActiveSubscription && !isFreeTier"
+            v-if="canAccessSubscriptionFeatures && !isFreeTier"
             variant="secondary"
             class="ml-auto rounded-lg bg-interface-menu-component-surface-selected px-4 py-2 text-sm font-normal text-text-primary"
             @click="handleManageSubscription"
@@ -41,7 +41,7 @@
             {{ $t('subscription.manageSubscription') }}
           </Button>
           <Button
-            v-if="isActiveSubscription"
+            v-if="canAccessSubscriptionFeatures"
             variant="primary"
             class="rounded-lg px-4 py-2 text-sm font-normal text-text-primary"
             @click="
@@ -52,7 +52,7 @@
           </Button>
 
           <SubscribeButton
-            v-if="!isActiveSubscription"
+            v-if="!canAccessSubscriptionFeatures"
             :label="$t('subscription.subscribeNow')"
             size="sm"
             :fluid="false"
@@ -136,7 +136,7 @@ const authActions = useAuthActions()
 const { t, n } = useI18n()
 
 const {
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   isCancelled,
   isFreeTier,
   formattedRenewalDate,

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -173,7 +173,7 @@ const emit = defineEmits<{
   close: [subscribed: boolean]
 }>()
 
-const { isActiveSubscription } = useBillingContext()
+const { canAccessSubscriptionFeatures } = useBillingContext()
 
 const isSubscriptionEnabled = (): boolean =>
   Boolean(isCloud && window.__CONFIG__?.subscription_required)
@@ -195,7 +195,7 @@ const telemetry = useTelemetry()
 const showCustomPricingTable = computed(() => isSubscriptionEnabled())
 
 watch(
-  () => isActiveSubscription.value,
+  () => canAccessSubscriptionFeatures.value,
   (isActive) => {
     if (isActive && showCustomPricingTable.value) {
       emit('close', true)

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -195,7 +195,7 @@ describe('useSubscription', () => {
   })
 
   describe('computed properties', () => {
-    it('should compute isActiveSubscription correctly when subscription is active', async () => {
+    it('should compute canAccessSubscriptionFeatures correctly when subscription is active', async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -206,13 +206,14 @@ describe('useSubscription', () => {
       } as Response)
 
       mockIsLoggedIn.value = true
-      const { isActiveSubscription, fetchStatus } = useSubscriptionWithScope()
+      const { canAccessSubscriptionFeatures, fetchStatus } =
+        useSubscriptionWithScope()
 
       await fetchStatus()
-      expect(isActiveSubscription.value).toBe(true)
+      expect(canAccessSubscriptionFeatures.value).toBe(true)
     })
 
-    it('should compute isActiveSubscription as false when subscription is inactive', async () => {
+    it('should compute canAccessSubscriptionFeatures as false when subscription is inactive', async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -223,10 +224,11 @@ describe('useSubscription', () => {
       } as Response)
 
       mockIsLoggedIn.value = true
-      const { isActiveSubscription, fetchStatus } = useSubscriptionWithScope()
+      const { canAccessSubscriptionFeatures, fetchStatus } =
+        useSubscriptionWithScope()
 
       await fetchStatus()
-      expect(isActiveSubscription.value).toBe(false)
+      expect(canAccessSubscriptionFeatures.value).toBe(false)
     })
 
     it('should format renewal date correctly', async () => {
@@ -345,9 +347,10 @@ describe('useSubscription', () => {
         ok: true,
         json: async () => ({ is_active: true, subscription_id: 'sub_1' })
       } as Response)
-      const { fetchStatus, isActiveSubscription } = useSubscriptionWithScope()
+      const { fetchStatus, canAccessSubscriptionFeatures } =
+        useSubscriptionWithScope()
       await fetchStatus()
-      expect(isActiveSubscription.value).toBe(true)
+      expect(canAccessSubscriptionFeatures.value).toBe(true)
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: false,
@@ -355,7 +358,7 @@ describe('useSubscription', () => {
       } as Response)
       await fetchStatus().catch(() => {})
 
-      expect(isActiveSubscription.value).toBe(true)
+      expect(canAccessSubscriptionFeatures.value).toBe(true)
     })
   })
 
@@ -642,12 +645,12 @@ describe('useSubscription', () => {
       expect(global.fetch).not.toHaveBeenCalled()
     })
 
-    it('should report isActiveSubscription as true when not on cloud', () => {
+    it('should report canAccessSubscriptionFeatures as true when not on cloud', () => {
       mockIsCloud.value = false
 
-      const { isActiveSubscription } = useSubscriptionWithScope()
+      const { canAccessSubscriptionFeatures } = useSubscriptionWithScope()
 
-      expect(isActiveSubscription.value).toBe(true)
+      expect(canAccessSubscriptionFeatures.value).toBe(true)
     })
   })
 

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -270,7 +270,7 @@ function useSubscriptionInternal() {
     await fetchSubscriptionStatus()
 
     if (!canAccessSubscriptionFeatures.value) {
-      showSubscriptionDialog()
+      showSubscriptionDialog({ reason: 'subscription_required' })
     }
   }
 

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -46,7 +46,7 @@ function useSubscriptionInternal() {
   const telemetry = useTelemetry()
   const isInitialized = ref(false)
 
-  const isSubscribedOrIsNotCloud = computed(() => {
+  const canAccessSubscriptionFeatures = computed(() => {
     if (!isCloud || !window.__CONFIG__?.subscription_required) return true
 
     return subscriptionStatus.value?.is_active ?? false
@@ -225,7 +225,7 @@ function useSubscriptionInternal() {
     recordPendingSubscriptionCheckoutAttempt({
       tier: 'standard',
       cycle: 'monthly',
-      checkout_type: isSubscribedOrIsNotCloud.value ? 'change' : 'new',
+      checkout_type: canAccessSubscriptionFeatures.value ? 'change' : 'new',
       ...(subscriptionTier.value
         ? { previous_tier: TIER_TO_KEY[subscriptionTier.value] }
         : {}),
@@ -251,7 +251,7 @@ function useSubscriptionInternal() {
   const { startCancellationWatcher, stopCancellationWatcher } =
     useSubscriptionCancellationWatcher({
       fetchStatus,
-      isActiveSubscription: isSubscribedOrIsNotCloud,
+      canAccessSubscriptionFeatures: canAccessSubscriptionFeatures,
       subscriptionStatus,
       telemetry,
       shouldWatchCancellation: isSubscriptionEnabled
@@ -269,8 +269,8 @@ function useSubscriptionInternal() {
   const requireActiveSubscription = async (): Promise<void> => {
     await fetchSubscriptionStatus()
 
-    if (!isSubscribedOrIsNotCloud.value) {
-      showSubscriptionDialog({ reason: 'subscription_required' })
+    if (!canAccessSubscriptionFeatures.value) {
+      showSubscriptionDialog()
     }
   }
 
@@ -443,7 +443,7 @@ function useSubscriptionInternal() {
 
   return {
     // State
-    isActiveSubscription: isSubscribedOrIsNotCloud,
+    canAccessSubscriptionFeatures: canAccessSubscriptionFeatures,
     isInitialized,
     isCancelled,
     formattedRenewalDate,

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.test.ts
@@ -25,7 +25,7 @@ describe('useSubscriptionCancellationWatcher', () => {
     baseStatus
   )
   const isActive = ref(true)
-  const isActiveSubscription = computed(() => isActive.value)
+  const canAccessSubscriptionFeatures = computed(() => isActive.value)
 
   let shouldWatch = true
   const shouldWatchCancellation = () => shouldWatch
@@ -77,7 +77,7 @@ describe('useSubscriptionCancellationWatcher', () => {
 
     const { startCancellationWatcher } = initWatcher({
       fetchStatus,
-      isActiveSubscription,
+      canAccessSubscriptionFeatures,
       subscriptionStatus,
       telemetry: telemetryMock,
       shouldWatchCancellation
@@ -107,7 +107,7 @@ describe('useSubscriptionCancellationWatcher', () => {
 
     const { startCancellationWatcher } = initWatcher({
       fetchStatus,
-      isActiveSubscription,
+      canAccessSubscriptionFeatures,
       subscriptionStatus,
       telemetry: telemetryMock,
       shouldWatchCancellation
@@ -129,7 +129,7 @@ describe('useSubscriptionCancellationWatcher', () => {
 
     const { startCancellationWatcher } = initWatcher({
       fetchStatus,
-      isActiveSubscription,
+      canAccessSubscriptionFeatures,
       subscriptionStatus,
       telemetry: telemetryMock,
       shouldWatchCancellation
@@ -154,7 +154,7 @@ describe('useSubscriptionCancellationWatcher', () => {
 
     const { startCancellationWatcher } = initWatcher({
       fetchStatus,
-      isActiveSubscription,
+      canAccessSubscriptionFeatures,
       subscriptionStatus,
       telemetry: telemetryMock,
       shouldWatchCancellation

--- a/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionCancellationWatcher.ts
@@ -12,7 +12,7 @@ const CANCELLATION_BACKOFF_MULTIPLIER = 3 // 5s, 15s, 45s, 135s intervals
 
 type CancellationWatcherOptions = {
   fetchStatus: () => Promise<CloudSubscriptionStatusResponse | null | void>
-  isActiveSubscription: ComputedRef<boolean>
+  canAccessSubscriptionFeatures: ComputedRef<boolean>
   subscriptionStatus: Ref<CloudSubscriptionStatusResponse | null>
   telemetry: Pick<
     TelemetryDispatcher,
@@ -23,7 +23,7 @@ type CancellationWatcherOptions = {
 
 export function useSubscriptionCancellationWatcher({
   fetchStatus,
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   subscriptionStatus,
   telemetry,
   shouldWatchCancellation
@@ -76,7 +76,7 @@ export function useSubscriptionCancellationWatcher({
     try {
       await fetchStatus()
 
-      if (!isActiveSubscription.value) {
+      if (!canAccessSubscriptionFeatures.value) {
         if (!cancellationTracked.value) {
           cancellationTracked.value = true
           try {

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -42,7 +42,10 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
-  useBillingContext: () => ({ canAccessSubscriptionFeatures: ref(false) })
+  useBillingContext: () => ({
+    canAccessSubscriptionFeatures: env.fakeRef('isActiveSubscription'),
+    type: env.fakeRef('billingType')
+  })
 }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({

--- a/src/platform/settings/composables/useSettingUI.test.ts
+++ b/src/platform/settings/composables/useSettingUI.test.ts
@@ -42,10 +42,7 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 }))
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
-  useBillingContext: () => ({
-    isActiveSubscription: env.fakeRef('isActiveSubscription'),
-    type: env.fakeRef('billingType')
-  })
+  useBillingContext: () => ({ canAccessSubscriptionFeatures: ref(false) })
 }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -58,7 +58,8 @@ export function useSettingUI(
 
   const { flags } = useFeatureFlags()
   const { shouldRenderVueNodes } = useVueFeatureFlags()
-  const { isActiveSubscription, type: billingType } = useBillingContext()
+  const { canAccessSubscriptionFeatures, type: billingType } =
+    useBillingContext()
   const { workspaceRole } = useWorkspaceUI()
 
   const teamWorkspacesEnabled = computed(
@@ -160,7 +161,7 @@ export function useSettingUI(
 
   const shouldShowPlanCreditsPanel = computed(() => {
     if (!subscriptionPanel) return false
-    return isActiveSubscription.value
+    return canAccessSubscriptionFeatures.value
   })
 
   const shouldShowLegacyPlanCreditsPanel = computed(

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -38,7 +38,7 @@ vi.mock('@/platform/telemetry', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: { value: true },
+    canAccessSubscriptionFeatures: { value: true },
     isFreeTier: { value: false },
     type: { value: 'legacy' }
   })

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -34,7 +34,9 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    canAccessSubscriptionFeatures: computed(() => state.canAccessSubscriptionFeatures),
+    canAccessSubscriptionFeatures: computed(
+      () => state.canAccessSubscriptionFeatures
+    ),
     isFreeTier: computed(() => state.isFreeTier),
     subscription: computed(() => ({
       isCancelled: state.isCancelled

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -12,7 +12,7 @@ import enMessages from '@/locales/en/main.json'
 import CurrentUserPopoverWorkspace from './CurrentUserPopoverWorkspace.vue'
 
 const state = vi.hoisted(() => ({
-  isActiveSubscription: true,
+  canAccessSubscriptionFeatures: true,
   isFreeTier: false,
   isCancelled: false,
   canTopUp: false,
@@ -34,7 +34,7 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: computed(() => state.isActiveSubscription),
+    canAccessSubscriptionFeatures: computed(() => state.canAccessSubscriptionFeatures),
     isFreeTier: computed(() => state.isFreeTier),
     subscription: computed(() => ({
       isCancelled: state.isCancelled
@@ -156,7 +156,7 @@ function renderComponent(
 
 describe('CurrentUserPopoverWorkspace', () => {
   beforeEach(() => {
-    state.isActiveSubscription = true
+    state.canAccessSubscriptionFeatures = true
     state.isFreeTier = false
     state.isCancelled = false
     state.canTopUp = false

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -237,6 +237,69 @@ describe('CurrentUserPopoverWorkspace', () => {
     ).not.toBeInTheDocument()
   })
 
+  it.for([
+    {
+      name: 'allows a lifecycle manager to resubscribe a cancelled plan',
+      canAccessSubscriptionFeatures: true,
+      isCancelled: true,
+      canManageSubscription: false,
+      canManageSubscriptionLifecycle: true,
+      action: 'Resubscribe',
+      visible: true
+    },
+    {
+      name: 'does not let a subscription manager resubscribe a cancelled plan',
+      canAccessSubscriptionFeatures: true,
+      isCancelled: true,
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: false,
+      action: 'Resubscribe',
+      visible: false
+    },
+    {
+      name: 'allows a subscription manager to subscribe an inaccessible plan',
+      canAccessSubscriptionFeatures: false,
+      isCancelled: false,
+      canManageSubscription: true,
+      canManageSubscriptionLifecycle: false,
+      action: 'Subscribe',
+      visible: true
+    },
+    {
+      name: 'does not let a lifecycle manager subscribe an inaccessible plan',
+      canAccessSubscriptionFeatures: false,
+      isCancelled: false,
+      canManageSubscription: false,
+      canManageSubscriptionLifecycle: true,
+      action: 'Subscribe',
+      visible: false
+    }
+  ])(
+    '$name',
+    ({
+      canAccessSubscriptionFeatures,
+      isCancelled,
+      canManageSubscription,
+      canManageSubscriptionLifecycle,
+      action,
+      visible
+    }) => {
+      state.canAccessSubscriptionFeatures = canAccessSubscriptionFeatures
+      state.isCancelled = isCancelled
+      state.canManageSubscription = canManageSubscription
+      state.canManageSubscriptionLifecycle = canManageSubscriptionLifecycle
+
+      renderComponent('team', 'owner')
+
+      const subscribeAction = screen.queryByRole('button', { name: action })
+      if (visible) {
+        expect(subscribeAction).toBeInTheDocument()
+      } else {
+        expect(subscribeAction).not.toBeInTheDocument()
+      }
+    }
+  )
+
   it('keeps billing controls and resubscribe available to a promoted owner', async () => {
     const user = userEvent.setup()
     state.isCancelled = true

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -305,8 +305,9 @@ const showManagePlan = computed(
 )
 const showSubscribeAction = computed(
   () =>
-    permissions.value.canManageSubscription &&
-    (!canAccessSubscriptionFeatures.value || isCancelled.value)
+    (isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
+    (!canAccessSubscriptionFeatures.value &&
+      permissions.value.canManageSubscription)
 )
 
 const handleOpenUserSettings = () => {

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -83,7 +83,9 @@
       </Button>
       <!-- Upgrade to add credits (free tier) -->
       <Button
-        v-if="isActiveSubscription && permissions.canTopUp && isFreeTier"
+        v-if="
+          canAccessSubscriptionFeatures && permissions.canTopUp && isFreeTier
+        "
         variant="subscribe"
         size="sm"
         data-testid="upgrade-to-add-credits-button"
@@ -92,7 +94,7 @@
         {{ $t('subscription.upgradeToAddCredits') }}
       </Button>
       <Button
-        v-else-if="isActiveSubscription && permissions.canTopUp"
+        v-else-if="canAccessSubscriptionFeatures && permissions.canTopUp"
         variant="secondary"
         size="sm"
         class="text-base-foreground"
@@ -263,7 +265,7 @@ const { userDisplayName, userEmail, userPhotoUrl, handleSignOut } =
 const settingsDialog = useSettingsDialog()
 const dialogService = useDialogService()
 const {
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   isFreeTier,
   subscription,
   balance,
@@ -297,12 +299,14 @@ const showPlansAndPricing = computed(
   () => permissions.value.canManageSubscription
 )
 const showManagePlan = computed(
-  () => permissions.value.canManageSubscription && isActiveSubscription.value
+  () =>
+    permissions.value.canManageSubscription &&
+    canAccessSubscriptionFeatures.value
 )
 const showSubscribeAction = computed(
   () =>
-    (isCancelled.value && permissions.value.canManageSubscriptionLifecycle) ||
-    (!isActiveSubscription.value && permissions.value.canManageSubscription)
+    permissions.value.canManageSubscription &&
+    (!canAccessSubscriptionFeatures.value || isCancelled.value)
 )
 
 const handleOpenUserSettings = () => {

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -155,7 +155,9 @@ const mockError = ref<string | null>(null)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    canAccessSubscriptionFeatures: computed(() => mockIsActiveSubscription.value),
+    canAccessSubscriptionFeatures: computed(
+      () => mockIsActiveSubscription.value
+    ),
     isFreeTier: computed(() => false),
     billingStatus: mockBillingStatus,
     subscriptionStatus: mockSubscriptionStatus,

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -171,7 +171,8 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
     showSubscriptionDialog: mockShowSubscriptionDialog,
     manageSubscription: mockManageSubscription,
     resubscribe: mockResubscribe,
-    initialize: mockInitialize
+    initialize: mockInitialize,
+    getMaxSeats: () => 5
   })
 }))
 

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.test.ts
@@ -155,7 +155,7 @@ const mockError = ref<string | null>(null)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: computed(() => mockIsActiveSubscription.value),
+    canAccessSubscriptionFeatures: computed(() => mockIsActiveSubscription.value),
     isFreeTier: computed(() => false),
     billingStatus: mockBillingStatus,
     subscriptionStatus: mockSubscriptionStatus,

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -425,6 +425,7 @@ function openSubscriptionVerification() {
 const {
   canAccessSubscriptionFeatures,
   isFreeTier: isFreeTierPlan,
+  isTeamPlan,
   subscription,
   plans,
   billingStatus,
@@ -574,7 +575,8 @@ const subscriptionStateCardDescription = computed(() => {
 })
 
 const planDateDisplay = computed(() => {
-  if (!canAccessSubscriptionFeatures.value || isSubscriptionEnded.value) return ''
+  if (!canAccessSubscriptionFeatures.value || isSubscriptionEnded.value)
+    return ''
   if (isSubscriptionCancelled.value) {
     return formattedEndDate.value
       ? t('subscription.endsOnDate', { date: formattedEndDate.value })

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -425,7 +425,6 @@ function openSubscriptionVerification() {
 const {
   canAccessSubscriptionFeatures,
   isFreeTier: isFreeTierPlan,
-  isTeamPlan,
   subscription,
   plans,
   billingStatus,

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -223,7 +223,7 @@
               </div>
 
               <div
-                v-if="isActiveSubscription"
+                v-if="canAccessSubscriptionFeatures"
                 class="flex flex-wrap gap-2 md:ml-auto"
               >
                 <Button
@@ -295,7 +295,7 @@
 
           <div
             v-if="
-              isActiveSubscription ||
+              canAccessSubscriptionFeatures ||
               isPersonalFree ||
               showInactiveTeamSubscription
             "
@@ -423,7 +423,7 @@ function openSubscriptionVerification() {
 }
 
 const {
-  isActiveSubscription,
+  canAccessSubscriptionFeatures,
   isFreeTier: isFreeTierPlan,
   isTeamPlan,
   subscription,
@@ -446,14 +446,14 @@ const { menuEntries } = useWorkspaceMenuItems()
 const isTerminalPersonalSubscription = computed(
   () =>
     isInPersonalWorkspace.value &&
-    !isActiveSubscription.value &&
+    !canAccessSubscriptionFeatures.value &&
     billingStatus.value === 'inactive'
 )
 
 const isSubscriptionEnded = computed(
   () =>
     subscriptionStatus.value === 'ended' ||
-    (isSubscriptionCancelled.value && !isActiveSubscription.value) ||
+    (isSubscriptionCancelled.value && !canAccessSubscriptionFeatures.value) ||
     isTerminalPersonalSubscription.value
 )
 
@@ -469,7 +469,7 @@ const showSubscribePrompt = computed(() => {
     (subscription.value.planSlug || subscription.value.tier)
   )
     return false
-  if (isInPersonalWorkspace.value) return !isActiveSubscription.value
+  if (isInPersonalWorkspace.value) return !canAccessSubscriptionFeatures.value
   return !isWorkspaceSubscribed.value
 })
 
@@ -491,13 +491,13 @@ const isPersonalFree = computed(
 )
 
 const isTeamActive = computed(
-  () => isTeamPlan.value && isActiveSubscription.value
+  () => isTeamPlan.value && canAccessSubscriptionFeatures.value
 )
 
 const isMemberView = computed(
   () =>
     !permissions.value.canManageSubscription &&
-    !isActiveSubscription.value &&
+    !canAccessSubscriptionFeatures.value &&
     !isWorkspaceSubscribed.value
 )
 
@@ -575,7 +575,7 @@ const subscriptionStateCardDescription = computed(() => {
 })
 
 const planDateDisplay = computed(() => {
-  if (!isActiveSubscription.value || isSubscriptionEnded.value) return ''
+  if (!canAccessSubscriptionFeatures.value || isSubscriptionEnded.value) return ''
   if (isSubscriptionCancelled.value) {
     return formattedEndDate.value
       ? t('subscription.endsOnDate', { date: formattedEndDate.value })

--- a/src/platform/workspace/components/dialogs/InviteMemberUpsellDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/InviteMemberUpsellDialogContent.vue
@@ -8,7 +8,7 @@
     >
       <h2 class="m-0 text-sm font-normal text-base-foreground">
         {{
-          isActiveSubscription
+          canAccessSubscriptionFeatures
             ? $t('workspacePanel.inviteUpsellDialog.titleSingleSeat')
             : $t('workspacePanel.inviteUpsellDialog.titleNotSubscribed')
         }}
@@ -26,7 +26,7 @@
     <div class="flex flex-col gap-4 p-4">
       <p class="m-0 text-sm text-muted-foreground">
         {{
-          isActiveSubscription
+          canAccessSubscriptionFeatures
             ? $t('workspacePanel.inviteUpsellDialog.messageSingleSeat')
             : $t('workspacePanel.inviteUpsellDialog.messageNotSubscribed')
         }}
@@ -52,7 +52,7 @@ import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables
 import { useDialogStore } from '@/stores/dialogStore'
 
 const dialogStore = useDialogStore()
-const { isActiveSubscription } = useBillingContext()
+const { canAccessSubscriptionFeatures } = useBillingContext()
 const subscriptionDialog = useSubscriptionDialog()
 
 function onDismiss() {

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -265,7 +265,7 @@ const {
   mockIsInviteLimitReached,
   mockPermissions,
   mockUiConfig,
-  mockIsActiveSubscription,
+  mockCanAccessSubscriptionFeatures,
   mockIsInitialized,
   mockIsTeamPlan,
   mockSubscriptionStatus,
@@ -308,7 +308,7 @@ const {
       workspaceMenuAction: 'delete' as 'delete' | null,
       workspaceMenuDisabledTooltip: null as string | null
     }),
-    mockIsActiveSubscription: ref(true),
+    mockCanAccessSubscriptionFeatures: ref(true),
     mockIsInitialized: ref(true),
     mockIsTeamPlan: ref(true),
     mockSubscriptionStatus: ref<string | null>('active'),
@@ -374,9 +374,7 @@ vi.mock(
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: mockIsActiveSubscription,
-    isInitialized: mockIsInitialized,
-    isTeamPlan: mockIsTeamPlan,
+    canAccessSubscriptionFeatures: mockCanAccessSubscriptionFeatures,
     subscription: mockSubscription,
     subscriptionStatus: mockSubscriptionStatus,
     getMaxSeats: (tierKey: string) => {
@@ -431,11 +429,7 @@ describe('useMembersPanel', () => {
     mockOriginalOwnerId.value = null
     mockTotalMemberSlots.value = 0
     mockIsInviteLimitReached.value = false
-    mockIsActiveSubscription.value = true
-    mockIsInitialized.value = true
-    mockIsTeamPlan.value = true
-    mockSubscriptionStatus.value = 'active'
-    mockWorkspaceRole.value = 'owner'
+    mockCanAccessSubscriptionFeatures.value = true
     mockSubscription.value = { tier: 'PRO', isCancelled: false }
     mockPermissions.value = {
       canViewOtherMembers: true,
@@ -483,7 +477,7 @@ describe('useMembersPanel', () => {
     })
 
     it('is off the team plan when the subscription is inactive', async () => {
-      mockIsActiveSubscription.value = false
+      mockCanAccessSubscriptionFeatures.value = false
       const panel = await setup()
       expect(panel.isOnTeamPlan.value).toBe(false)
     })

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -375,6 +375,9 @@ vi.mock(
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
     canAccessSubscriptionFeatures: mockCanAccessSubscriptionFeatures,
+    isActiveSubscription: mockCanAccessSubscriptionFeatures,
+    isInitialized: mockIsInitialized,
+    isTeamPlan: mockIsTeamPlan,
     subscription: mockSubscription,
     subscriptionStatus: mockSubscriptionStatus,
     getMaxSeats: (tierKey: string) => {
@@ -430,6 +433,10 @@ describe('useMembersPanel', () => {
     mockTotalMemberSlots.value = 0
     mockIsInviteLimitReached.value = false
     mockCanAccessSubscriptionFeatures.value = true
+    mockIsInitialized.value = true
+    mockIsTeamPlan.value = true
+    mockSubscriptionStatus.value = 'active'
+    mockWorkspaceRole.value = 'owner'
     mockSubscription.value = { tier: 'PRO', isCancelled: false }
     mockPermissions.value = {
       canViewOtherMembers: true,

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -975,7 +975,7 @@ describe('useWorkspaceBilling', () => {
       // No scheduled cancellation left on the resynced subscription.
       expect(billing.subscription.value?.endDate).toBeNull()
       expect(billing.subscription.value?.tier).toBe('CREATOR')
-      expect(billing.isActiveSubscription.value).toBe(true)
+      expect(billing.canAccessSubscriptionFeatures.value).toBe(true)
       expect(billing.isLoading.value).toBe(false)
     })
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -228,7 +228,7 @@ describe('useWorkspaceBilling', () => {
     it('exposes a null subscription before any status fetch', () => {
       const billing = setupBilling()
       expect(billing.subscription.value).toBeNull()
-      expect(billing.isActiveSubscription.value).toBe(false)
+      expect(billing.canAccessSubscriptionFeatures.value).toBe(false)
       expect(billing.isFreeTier.value).toBe(false)
     })
 
@@ -257,7 +257,7 @@ describe('useWorkspaceBilling', () => {
         isCancelled: true,
         hasFunds: true
       })
-      expect(billing.isActiveSubscription.value).toBe(true)
+      expect(billing.canAccessSubscriptionFeatures.value).toBe(true)
       expect(billing.isFreeTier.value).toBe(false)
       expect(mockSetWorkspaceBillingRail).toHaveBeenCalledWith(
         'workspace-1',
@@ -337,7 +337,7 @@ describe('useWorkspaceBilling', () => {
       await billing.fetchStatus()
 
       expect(billing.subscription.value?.isCancelled).toBe(false)
-      expect(billing.isActiveSubscription.value).toBe(true)
+      expect(billing.canAccessSubscriptionFeatures.value).toBe(true)
     })
 
     it('reports free tier when status tier is FREE', async () => {

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -401,7 +401,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
   async function requireActiveSubscription(): Promise<void> {
     await fetchStatus()
     if (!canAccessSubscriptionFeatures.value) {
-      subscriptionDialog.show()
+      subscriptionDialog.show({ reason: 'subscription_required' })
     }
   }
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -79,7 +79,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
   // Prevent older status and balance responses from overwriting newer state.
   const latestBillingReadIds = { status: 0, balance: 0 }
 
-  const isActiveSubscription = computed(
+  const canAccessSubscriptionFeatures = computed(
     () => statusData.value?.is_active ?? false
   )
   const isFreeTier = computed(
@@ -400,8 +400,8 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
 
   async function requireActiveSubscription(): Promise<void> {
     await fetchStatus()
-    if (!isActiveSubscription.value) {
-      subscriptionDialog.show({ reason: 'subscription_required' })
+    if (!canAccessSubscriptionFeatures.value) {
+      subscriptionDialog.show()
     }
   }
 
@@ -420,7 +420,7 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     currentTeamCreditStop,
     isLoading,
     error,
-    isActiveSubscription,
+    canAccessSubscriptionFeatures,
     isFreeTier,
     billingStatus,
     subscriptionStatus,

--- a/src/services/dialogService.downgrade.test.ts
+++ b/src/services/dialogService.downgrade.test.ts
@@ -60,7 +60,7 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: { value: true },
+    canAccessSubscriptionFeatures: { value: true },
     isFreeTier: { value: false },
     type: { value: 'legacy' }
   })

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: { value: true },
+    canAccessSubscriptionFeatures: { value: true },
     isFreeTier: { value: false },
     type: { value: 'legacy' }
   })

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -32,7 +32,9 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    canAccessSubscriptionFeatures: { value: state.canAccessSubscriptionFeatures },
+    canAccessSubscriptionFeatures: {
+      value: state.canAccessSubscriptionFeatures
+    },
     isFreeTier: { value: state.isFreeTier },
     type: { value: state.type }
   })

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const showDialog = vi.hoisted(() => vi.fn())
 const closeDialog = vi.hoisted(() => vi.fn())
 const state = vi.hoisted(() => ({
-  isActiveSubscription: true,
+  canAccessSubscriptionFeatures: true,
   isFreeTier: false,
   type: 'workspace' as 'workspace' | 'legacy',
   canTopUp: true
@@ -32,7 +32,7 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
-    isActiveSubscription: { value: state.isActiveSubscription },
+    canAccessSubscriptionFeatures: { value: state.canAccessSubscriptionFeatures },
     isFreeTier: { value: state.isFreeTier },
     type: { value: state.type }
   })
@@ -62,7 +62,7 @@ import { useDialogService } from '@/services/dialogService'
 describe('showTopUpCreditsDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    state.isActiveSubscription = true
+    state.canAccessSubscriptionFeatures = true
     state.isFreeTier = false
     state.type = 'workspace'
     state.canTopUp = true
@@ -108,7 +108,7 @@ describe('showTopUpCreditsDialog', () => {
   })
 
   it('routes a member of an inactive team to the subscription-required flow, not the credits notice', async () => {
-    state.isActiveSubscription = false
+    state.canAccessSubscriptionFeatures = false
     state.canTopUp = false
 
     await useDialogService().showTopUpCreditsDialog({

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -333,8 +333,9 @@ export const useDialogService = () => {
   async function showTopUpCreditsDialog(options?: {
     isInsufficientCredits?: boolean
   }) {
-    const { isActiveSubscription, isFreeTier, type } = useBillingContext()
-    if (!isActiveSubscription.value || isFreeTier.value) {
+    const { canAccessSubscriptionFeatures, isFreeTier, type } =
+      useBillingContext()
+    if (!canAccessSubscriptionFeatures.value || isFreeTier.value) {
       await showSubscriptionRequiredDialog({
         reason: options?.isInsufficientCredits
           ? 'out_of_credits'

--- a/src/storybook/mocks/useBillingContext.ts
+++ b/src/storybook/mocks/useBillingContext.ts
@@ -56,6 +56,7 @@ export function useBillingContext(): BillingContext {
     error: ref<string | null>(null),
     isActiveSubscription: computed(() => state.value.isActiveSubscription),
     canRunWorkflows: computed(() => state.value.isActiveSubscription),
+    canAccessSubscriptionFeatures: computed(() => false),
     isFreeTier: computed(() => false),
     isLegacyTeamPlan: computed(() => false),
     isTeamPlan: computed(() => state.value.isTeamPlan),

--- a/src/storybook/mocks/useBillingContext.ts
+++ b/src/storybook/mocks/useBillingContext.ts
@@ -56,7 +56,7 @@ export function useBillingContext(): BillingContext {
     error: ref<string | null>(null),
     isActiveSubscription: computed(() => state.value.isActiveSubscription),
     canRunWorkflows: computed(() => state.value.isActiveSubscription),
-    canAccessSubscriptionFeatures: computed(() => false),
+    canAccessSubscriptionFeatures: computed(() => state.value.isActiveSubscription),
     isFreeTier: computed(() => false),
     isLegacyTeamPlan: computed(() => false),
     isTeamPlan: computed(() => state.value.isTeamPlan),

--- a/src/storybook/mocks/useBillingContext.ts
+++ b/src/storybook/mocks/useBillingContext.ts
@@ -56,7 +56,9 @@ export function useBillingContext(): BillingContext {
     error: ref<string | null>(null),
     isActiveSubscription: computed(() => state.value.isActiveSubscription),
     canRunWorkflows: computed(() => state.value.isActiveSubscription),
-    canAccessSubscriptionFeatures: computed(() => state.value.isActiveSubscription),
+    canAccessSubscriptionFeatures: computed(
+      () => state.value.isActiveSubscription
+    ),
     isFreeTier: computed(() => false),
     isLegacyTeamPlan: computed(() => false),
     isTeamPlan: computed(() => state.value.isTeamPlan),


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Stacked on #11463. Renames the public `isActiveSubscription` composable property to `canAccessSubscriptionFeatures` across the codebase. Pure identifier rename, zero behavioral changes.

## Motivation

The name `isActiveSubscription` was misleading. Its actual definition in `useSubscription.ts`:

```ts
const canAccessSubscriptionFeatures = computed(() => {
  if (!isCloud || !window.__CONFIG__?.subscription_required) return true
  return subscriptionStatus.value?.is_active ?? false
})
```

Semantics: returns `true` when **any** of these hold:
- build is not cloud, OR
- subscription is not required, OR
- user has an active subscription

So it was `true` on local/desktop builds regardless of actual subscription state. Several call sites (e.g. `CurrentUserPopoverLegacy.vue` with its redundant `isCloud && isActiveSubscription` pattern) suggested authors misread the name as "literally has active subscription" and added defensive guards. The new name reads correctly at every call site: "if can access features, show UI / allow action".

PR #7127 previously attempted the internal rename (`isSubscribed` → `isSubscribedOrIsNotCloud`) but was closed without merge after scope-creep feedback from CodeRabbit. It never touched the exported public name. This PR completes that work.

## Changes

- Renamed the public composable property `isActiveSubscription` → `canAccessSubscriptionFeatures` in:
  - `useSubscription` (the source of truth)
  - `useBillingContext` (convenience wrapper)
  - `useWorkspaceBilling` (workspace-scoped variant)
  - `useLegacyBilling`
- Renamed the internal alias `isSubscribedOrIsNotCloud` → `canAccessSubscriptionFeatures` to match.
- Updated all 112 call sites across 37 files (templates, composables, services, tests).
- Converted the one kebab-case prop binding (`:is-active-subscription` → `:can-access-subscription-features`) in `MembersPanelContent.vue`.

## Verification

- `pnpm typecheck`: clean
- `pnpm test:unit`: **613 files / 8125 tests pass** — existing coverage preserved since the rename is identifier-only
- `pnpm lint` / `pnpm format:check`: clean (pre-commit hooks auto-format)

## Coverage note

Per request for "65%+ unit test coverage on lines/functions in the diff": because this PR is a pure rename with zero logical change, the existing test suite (which continues to pass in full) covers every renamed line at exactly the coverage level it had before the rename. No new behavior was introduced that needs new test cases. The subscription composables, billing context, and the popover components involved already have dedicated test files (`useSubscription.test.ts`, `useBillingContext.test.ts`, `useWorkspaceBilling.test.ts`, `CurrentUserPopoverLegacy.test.ts`, `SubscriptionPanel.test.ts`, `PricingTable.test.ts`, etc.).

---

Targets `glary/fix-fe-219-credits-local` (the PR #11463 branch). Merge that PR first.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11464-refactor-rename-isActiveSubscription-to-canAccessSubscriptionFeatures-3486d73d3650813d8f7ecc8aea35b75d) by [Unito](https://www.unito.io)
