### PR TITLE
test: add WidgetRange unit tests

### DIFF
--- a/src/components/range/WidgetRange.test.ts
+++ b/src/components/range/WidgetRange.test.ts
@@ -58,7 +58,9 @@ const RangeEditorStub = defineComponent({
 
 function makeWidget(
   options: Partial<IWidgetRangeOptions> = {},
-  widgetOverrides: Partial<SimplifiedWidget<RangeValue, IWidgetRangeOptions>> = {}
+  widgetOverrides: Partial<
+    SimplifiedWidget<RangeValue, IWidgetRangeOptions>
+  > = {}
 ): SimplifiedWidget<RangeValue, IWidgetRangeOptions> {
   return {
     name: 'range_w',
@@ -132,10 +134,9 @@ describe('WidgetRange', () => {
     it('shows upstream value when disabled with a valid upstream', () => {
       setUpstream({ min: 0.3, max: 0.7 })
       renderWidget(
-        makeWidget(
-          { disabled: true } as IWidgetRangeOptions,
-          { linkedUpstream: { nodeId: 'n1' } }
-        ),
+        makeWidget({ disabled: true } as IWidgetRangeOptions, {
+          linkedUpstream: { nodeId: 'n1' }
+        }),
         { min: 0, max: 1 }
       )
       const el = screen.getByTestId('range-editor')
@@ -144,10 +145,10 @@ describe('WidgetRange', () => {
 
     it('ignores upstream value when not disabled', () => {
       setUpstream({ min: 0.3, max: 0.7 })
-      renderWidget(
-        makeWidget({}, { linkedUpstream: { nodeId: 'n1' } }),
-        { min: 0, max: 1 }
-      )
+      renderWidget(makeWidget({}, { linkedUpstream: { nodeId: 'n1' } }), {
+        min: 0,
+        max: 1
+      })
       const el = screen.getByTestId('range-editor')
       expect(JSON.parse(el.dataset.model!)).toEqual({ min: 0, max: 1 })
     })
@@ -165,9 +166,7 @@ describe('WidgetRange', () => {
       outputsHolder.nodeOutputs = {
         loc1: { histogram_range_w: [1, 2, 3, 4] }
       }
-      renderWidget(
-        makeWidget({}, { nodeLocatorId: 'loc1' })
-      )
+      renderWidget(makeWidget({}, { nodeLocatorId: 'loc1' }))
       expect(screen.getByTestId('range-editor').dataset.hasHistogram).toBe(
         'true'
       )
@@ -177,9 +176,7 @@ describe('WidgetRange', () => {
       outputsHolder.nodeOutputs = {
         loc1: { histogram_range_w: [] }
       }
-      renderWidget(
-        makeWidget({}, { nodeLocatorId: 'loc1' })
-      )
+      renderWidget(makeWidget({}, { nodeLocatorId: 'loc1' }))
       expect(screen.getByTestId('range-editor').dataset.hasHistogram).toBe(
         'false'
       )

--- a/src/components/range/WidgetRange.test.ts
+++ b/src/components/range/WidgetRange.test.ts
@@ -1,0 +1,188 @@
+/* eslint-disable vue/one-component-per-file */
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import type {
+  IWidgetRangeOptions,
+  RangeValue
+} from '@/lib/litegraph/src/types/widgets'
+import type { SimplifiedWidget } from '@/types/simplifiedWidget'
+
+const upstreamHolder = vi.hoisted(() => ({
+  ref: null as { value: unknown } | null
+}))
+
+vi.mock('@/composables/useUpstreamValue', async () => {
+  const { ref } = await import('vue')
+  return {
+    useUpstreamValue: () => {
+      upstreamHolder.ref = upstreamHolder.ref ?? ref<unknown>(undefined)
+      return upstreamHolder.ref
+    },
+    singleValueExtractor: () => () => undefined
+  }
+})
+
+const outputsHolder = vi.hoisted(() => ({
+  nodeOutputs: {} as Record<string, unknown>
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => outputsHolder
+}))
+
+import WidgetRange from './WidgetRange.vue'
+
+const RangeEditorStub = defineComponent({
+  name: 'RangeEditor',
+  props: {
+    modelValue: { type: Object, default: () => ({ min: 0, max: 1 }) },
+    disabled: { type: Boolean, default: false },
+    histogram: { type: Object, default: null },
+    display: { type: String, default: '' }
+  },
+  // eslint-disable-next-line vue/no-unused-emit-declarations
+  emits: ['update:modelValue'],
+  template: `
+    <div data-testid="range-editor"
+      :data-disabled="String(disabled)"
+      :data-has-histogram="String(!!histogram)"
+      :data-model="JSON.stringify(modelValue)"
+      :data-display="display"
+      @click="$emit('update:modelValue', { min: 5, max: 10 })"
+    />
+  `
+})
+
+function makeWidget(
+  options: Partial<IWidgetRangeOptions> = {},
+  widgetOverrides: Partial<SimplifiedWidget<RangeValue, IWidgetRangeOptions>> = {}
+): SimplifiedWidget<RangeValue, IWidgetRangeOptions> {
+  return {
+    name: 'range_w',
+    type: 'range',
+    value: { min: 0, max: 1 },
+    options: options as IWidgetRangeOptions,
+    ...widgetOverrides
+  } as SimplifiedWidget<RangeValue, IWidgetRangeOptions>
+}
+
+function setUpstream(value: RangeValue | undefined) {
+  if (!upstreamHolder.ref) upstreamHolder.ref = { value: undefined }
+  upstreamHolder.ref.value = value
+}
+
+function renderWidget(
+  widget: SimplifiedWidget<RangeValue, IWidgetRangeOptions>,
+  initialModel: RangeValue = { min: 0, max: 1 }
+) {
+  const value = ref<RangeValue>(initialModel)
+  const Harness = defineComponent({
+    components: { WidgetRange },
+    setup: () => ({ value, widget }),
+    template: '<WidgetRange v-model="value" :widget="widget" />'
+  })
+  const utils = render(Harness, {
+    global: { stubs: { RangeEditor: RangeEditorStub } }
+  })
+  return { ...utils, value }
+}
+
+describe('WidgetRange', () => {
+  beforeEach(() => {
+    upstreamHolder.ref = null
+    outputsHolder.nodeOutputs = {}
+  })
+
+  describe('Value pass-through', () => {
+    it('forwards modelValue to the RangeEditor', () => {
+      renderWidget(makeWidget(), { min: 0.2, max: 0.8 })
+      const el = screen.getByTestId('range-editor')
+      expect(JSON.parse(el.dataset.model!)).toEqual({ min: 0.2, max: 0.8 })
+    })
+
+    it('propagates editor updates back to v-model', async () => {
+      const { value } = renderWidget(makeWidget())
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('range-editor'))
+      expect(value.value).toEqual({ min: 5, max: 10 })
+    })
+
+    it('forwards the display option to the RangeEditor', () => {
+      renderWidget(makeWidget({ display: 'histogram' }))
+      expect(screen.getByTestId('range-editor').dataset.display).toBe(
+        'histogram'
+      )
+    })
+  })
+
+  describe('Disabled state', () => {
+    it('passes disabled=true when widget.options.disabled is set', () => {
+      renderWidget(makeWidget({ disabled: true }))
+      expect(screen.getByTestId('range-editor').dataset.disabled).toBe('true')
+    })
+
+    it('passes disabled=false by default', () => {
+      renderWidget(makeWidget())
+      expect(screen.getByTestId('range-editor').dataset.disabled).toBe('false')
+    })
+
+    it('shows upstream value when disabled with a valid upstream', () => {
+      setUpstream({ min: 0.3, max: 0.7 })
+      renderWidget(
+        makeWidget(
+          { disabled: true } as IWidgetRangeOptions,
+          { linkedUpstream: { nodeId: 'n1' } }
+        ),
+        { min: 0, max: 1 }
+      )
+      const el = screen.getByTestId('range-editor')
+      expect(JSON.parse(el.dataset.model!)).toEqual({ min: 0.3, max: 0.7 })
+    })
+
+    it('ignores upstream value when not disabled', () => {
+      setUpstream({ min: 0.3, max: 0.7 })
+      renderWidget(
+        makeWidget({}, { linkedUpstream: { nodeId: 'n1' } }),
+        { min: 0, max: 1 }
+      )
+      const el = screen.getByTestId('range-editor')
+      expect(JSON.parse(el.dataset.model!)).toEqual({ min: 0, max: 1 })
+    })
+  })
+
+  describe('Histogram', () => {
+    it('passes null histogram when nodeLocatorId is absent', () => {
+      renderWidget(makeWidget())
+      expect(screen.getByTestId('range-editor').dataset.hasHistogram).toBe(
+        'false'
+      )
+    })
+
+    it('passes a histogram when node output has a matching histogram entry', () => {
+      outputsHolder.nodeOutputs = {
+        loc1: { histogram_range_w: [1, 2, 3, 4] }
+      }
+      renderWidget(
+        makeWidget({}, { nodeLocatorId: 'loc1' })
+      )
+      expect(screen.getByTestId('range-editor').dataset.hasHistogram).toBe(
+        'true'
+      )
+    })
+
+    it('treats an empty histogram array as null', () => {
+      outputsHolder.nodeOutputs = {
+        loc1: { histogram_range_w: [] }
+      }
+      renderWidget(
+        makeWidget({}, { nodeLocatorId: 'loc1' })
+      )
+      expect(screen.getByTestId('range-editor').dataset.hasHistogram).toBe(
+        'false'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Splits the WidgetRange test coverage out of #11446 so this widget can be reviewed independently.

## Changes

- **What**: Adds WidgetRange unit tests covering value pass-through, display propagation, disabled-state handling, upstream overrides, and histogram derivation.

## Review Focus

Focused test-only PR extracted from #11446.
Validated with `pnpm test:unit -- --run src/components/range/WidgetRange.test.ts`.

## Screenshots (if applicable)

N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11471-test-add-WidgetRange-unit-tests-3486d73d365081d7a684ca3ff02320d6) by [Unito](https://www.unito.io)
