### PR TITLE
[backport cloud/1.43] feat: add frontend subscription success recovery

### DIFF
--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -117,7 +117,7 @@ export const useAuthActions = () => {
 
   const accessBillingPortal = wrapWithErrorHandlingAsync<
     [targetTier?: BillingPortalTargetTier, openInNewTab?: boolean],
-    void
+    boolean
   >(async (targetTier, openInNewTab = true) => {
     const response = await authStore.accessBillingPortal(targetTier)
     if (!response.billing_portal_url) {
@@ -128,10 +128,11 @@ export const useAuthActions = () => {
       )
     }
     if (openInNewTab) {
-      window.open(response.billing_portal_url, '_blank')
-    } else {
-      globalThis.location.href = response.billing_portal_url
+      return window.open(response.billing_portal_url, '_blank') !== null
     }
+
+    globalThis.location.href = response.billing_portal_url
+    return true
   }, reportError)
 
   const fetchBalance = wrapWithErrorHandlingAsync(async () => {

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -7,9 +7,19 @@ import { createI18n } from 'vue-i18n'
 
 import PricingTable from '@/platform/cloud/subscription/components/PricingTable.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 
 async function flushPromises() {
   await new Promise((r) => setTimeout(r, 0))
+}
+
+function createDeferredPromise<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
 }
 
 const mockIsActiveSubscription = ref(false)
@@ -25,6 +35,35 @@ const mockGetAuthHeader = vi.fn(() =>
   Promise.resolve({ Authorization: 'Bearer test-token' })
 )
 const mockGetCheckoutAttribution = vi.hoisted(() => vi.fn(() => ({})))
+const mockLocalStorage = vi.hoisted(() => {
+  const store = new Map<string, string>()
+
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value)
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    __reset: () => {
+      store.clear()
+    }
+  }
+})
+
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true
+})
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true
+})
 
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: () => ({
@@ -148,7 +187,20 @@ function renderComponent() {
       },
       stubs: {
         SelectButton: {
-          template: '<div><slot /></div>',
+          template: `
+            <div>
+              <button
+                v-for="option in options"
+                :key="option.value"
+                type="button"
+                @click="$emit('update:modelValue', option.value)"
+              >
+                <slot name="option" :option="option">
+                  {{ option.label }}
+                </slot>
+              </button>
+            </div>
+          `,
           props: ['modelValue', 'options'],
           emits: ['update:modelValue']
         },
@@ -167,7 +219,10 @@ describe('PricingTable', () => {
     mockSubscriptionTier.value = null
     mockIsYearlySubscription.value = false
     mockUserId.value = 'user-123'
+    mockAccessBillingPortal.mockReset()
+    mockAccessBillingPortal.mockResolvedValue(true)
     mockTrackBeginCheckout.mockReset()
+    mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
       json: async () => ({ checkout_url: 'https://checkout.stripe.com/test' })
@@ -215,6 +270,66 @@ describe('PricingTable', () => {
       await flushPromises()
 
       expect(mockAccessBillingPortal).toHaveBeenCalledWith('pro-yearly')
+    })
+
+    it('records the plan snapshot that was actually opened', async () => {
+      mockIsActiveSubscription.value = true
+      mockSubscriptionTier.value = 'STANDARD'
+
+      const portalOpen = createDeferredPromise<boolean>()
+      mockAccessBillingPortal.mockReturnValueOnce(portalOpen.promise)
+
+      renderComponent()
+      await flushPromises()
+
+      const creatorButton = screen
+        .getAllByRole('button')
+        .find((b) => b.textContent?.includes('Creator'))
+
+      await userEvent.click(creatorButton!)
+      await flushPromises()
+
+      const monthlyToggle = screen.getByRole('button', { name: 'Monthly' })
+      await userEvent.click(monthlyToggle)
+      await flushPromises()
+
+      portalOpen.resolve(true)
+      await flushPromises()
+
+      expect(mockAccessBillingPortal).toHaveBeenCalledWith('creator-yearly')
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(
+            PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY
+          ) ?? '{}'
+        )
+      ).toMatchObject({
+        tier: 'creator',
+        cycle: 'yearly',
+        checkout_type: 'change',
+        previous_tier: 'standard',
+        previous_cycle: 'monthly'
+      })
+    })
+
+    it('does not record a pending upgrade when the billing portal does not open', async () => {
+      mockIsActiveSubscription.value = true
+      mockSubscriptionTier.value = 'STANDARD'
+      mockAccessBillingPortal.mockResolvedValueOnce(false)
+
+      renderComponent()
+      await flushPromises()
+
+      const creatorButton = screen
+        .getAllByRole('button')
+        .find((b) => b.textContent?.includes('Creator'))
+
+      await userEvent.click(creatorButton!)
+      await flushPromises()
+
+      expect(
+        window.localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+      ).toBeNull()
     })
 
     it('should use the latest userId value when it changes after mount', async () => {

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -273,6 +273,7 @@ import type {
   TierKey,
   TierPricing
 } from '@/platform/cloud/subscription/constants/tierPricing'
+import { recordPendingSubscriptionCheckoutAttempt } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { performSubscriptionCheckout } from '@/platform/cloud/subscription/utils/subscriptionCheckoutUtil'
 import { isPlanDowngrade } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
@@ -450,29 +451,31 @@ const handleSubscribe = wrapWithErrorHandlingAsync(
 
     try {
       if (hasPaidSubscription.value) {
+        const targetPlan = {
+          tierKey,
+          billingCycle: currentBillingCycle.value
+        } as const
+        const previousPlan = currentPlanDescriptor.value
         const checkoutAttribution = await getCheckoutAttributionForCloud()
         if (userId.value) {
           telemetry?.trackBeginCheckout({
             user_id: userId.value,
-            tier: tierKey,
-            cycle: currentBillingCycle.value,
+            tier: targetPlan.tierKey,
+            cycle: targetPlan.billingCycle,
             checkout_type: 'change',
             ...checkoutAttribution,
-            ...(currentTierKey.value
-              ? { previous_tier: currentTierKey.value }
-              : {})
+            ...(previousPlan ? { previous_tier: previousPlan.tierKey } : {})
           })
         }
         // Pass the target tier to create a deep link to subscription update confirmation
-        const checkoutTier = getCheckoutTier(tierKey, currentBillingCycle.value)
-        const targetPlan = {
-          tierKey,
-          billingCycle: currentBillingCycle.value
-        }
+        const checkoutTier = getCheckoutTier(
+          targetPlan.tierKey,
+          targetPlan.billingCycle
+        )
         const downgrade =
-          currentPlanDescriptor.value &&
+          previousPlan &&
           isPlanDowngrade({
-            current: currentPlanDescriptor.value,
+            current: previousPlan,
             target: targetPlan
           })
 
@@ -480,7 +483,20 @@ const handleSubscribe = wrapWithErrorHandlingAsync(
           // TODO(COMFY-StripeProration): Remove once backend checkout creation mirrors portal proration ("change at billing end")
           await accessBillingPortal()
         } else {
-          await accessBillingPortal(checkoutTier)
+          const didOpenPortal = await accessBillingPortal(checkoutTier)
+          if (!didOpenPortal) {
+            return
+          }
+
+          recordPendingSubscriptionCheckoutAttempt({
+            tier: targetPlan.tierKey,
+            cycle: targetPlan.billingCycle,
+            checkout_type: 'change',
+            ...(previousPlan ? { previous_tier: previousPlan.tierKey } : {}),
+            ...(previousPlan
+              ? { previous_cycle: previousPlan.billingCycle }
+              : {})
+          })
         }
       } else {
         await performSubscriptionCheckout(

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -145,7 +145,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, watch } from 'vue'
+import { computed, watch } from 'vue'
 
 import CloudBadge from '@/components/topbar/CloudBadge.vue'
 import Button from '@/components/ui/button/Button.vue'
@@ -169,7 +169,7 @@ const emit = defineEmits<{
   close: [subscribed: boolean]
 }>()
 
-const { fetchStatus, isActiveSubscription } = useBillingContext()
+const { isActiveSubscription } = useBillingContext()
 
 const isSubscriptionEnabled = (): boolean =>
   Boolean(isCloud && window.__CONFIG__?.subscription_required)
@@ -190,69 +190,10 @@ const telemetry = useTelemetry()
 // Always show custom pricing table for cloud subscriptions
 const showCustomPricingTable = computed(() => isSubscriptionEnabled())
 
-const POLL_INTERVAL_MS = 3000
-const MAX_POLL_ATTEMPTS = 3
-let pollInterval: number | null = null
-let pollAttempts = 0
-
-const stopPolling = () => {
-  if (pollInterval) {
-    clearInterval(pollInterval)
-    pollInterval = null
-  }
-}
-
-const startPolling = () => {
-  stopPolling()
-  pollAttempts = 0
-
-  const poll = async () => {
-    try {
-      await fetchStatus()
-      pollAttempts++
-
-      if (pollAttempts >= MAX_POLL_ATTEMPTS) {
-        stopPolling()
-      }
-    } catch (error) {
-      console.error(
-        '[SubscriptionDialog] Failed to poll subscription status',
-        error
-      )
-      stopPolling()
-    }
-  }
-
-  void poll()
-  pollInterval = window.setInterval(() => {
-    void poll()
-  }, POLL_INTERVAL_MS)
-}
-
-const handleWindowFocus = () => {
-  if (showCustomPricingTable.value) {
-    startPolling()
-  }
-}
-
-watch(
-  showCustomPricingTable,
-  (enabled) => {
-    if (enabled) {
-      window.addEventListener('focus', handleWindowFocus)
-    } else {
-      window.removeEventListener('focus', handleWindowFocus)
-      stopPolling()
-    }
-  },
-  { immediate: true }
-)
-
 watch(
   () => isActiveSubscription.value,
   (isActive) => {
     if (isActive && showCustomPricingTable.value) {
-      telemetry?.trackMonthlySubscriptionSucceeded()
       emit('close', true)
     }
   }
@@ -263,7 +204,6 @@ const handleSubscribed = () => {
 }
 
 const handleChooseTeam = () => {
-  stopPolling()
   if (onChooseTeam) {
     onChooseTeam()
   } else {
@@ -272,7 +212,6 @@ const handleChooseTeam = () => {
 }
 
 const handleClose = () => {
-  stopPolling()
   onClose()
 }
 
@@ -293,11 +232,6 @@ const handleViewEnterprise = () => {
   })
   window.open('https://www.comfy.org/cloud/enterprise', '_blank')
 }
-
-onBeforeUnmount(() => {
-  stopPolling()
-  window.removeEventListener('focus', handleWindowFocus)
-})
 </script>
 
 <style scoped>

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
+import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 
 const {
   mockIsLoggedIn,
@@ -12,10 +13,13 @@ const {
   mockGetCheckoutAttribution,
   mockTelemetry,
   mockUserId,
-  mockIsCloud
+  mockIsCloud,
+  mockAuthStoreInitialized,
+  mockLocalStorage
 } = vi.hoisted(() => ({
   mockIsLoggedIn: { value: false },
   mockIsCloud: { value: true },
+  mockAuthStoreInitialized: { value: true },
   mockReportError: vi.fn(),
   mockAccessBillingPortal: vi.fn(),
   mockShowSubscriptionRequiredDialog: vi.fn(),
@@ -28,9 +32,29 @@ const {
   })),
   mockTelemetry: {
     trackSubscription: vi.fn(),
+    trackMonthlySubscriptionSucceeded: vi.fn(),
     trackMonthlySubscriptionCancelled: vi.fn()
   },
-  mockUserId: { value: 'user-123' }
+  mockUserId: { value: 'user-123' },
+  mockLocalStorage: (() => {
+    const store = new Map<string, string>()
+
+    return {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value)
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key)
+      }),
+      clear: vi.fn(() => {
+        store.clear()
+      }),
+      __reset: () => {
+        store.clear()
+      }
+    }
+  })()
 }))
 
 let scope: ReturnType<typeof effectScope> | undefined
@@ -54,6 +78,16 @@ function useSubscriptionWithScope() {
 
   return subscription
 }
+
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true
+})
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true
+})
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: vi.fn(() => ({
@@ -109,6 +143,9 @@ vi.mock('@/services/dialogService', () => ({
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: vi.fn(() => ({
     getAuthHeader: mockGetAuthHeader,
+    get isInitialized() {
+      return mockAuthStoreInitialized.value
+    },
     get userId() {
       return mockUserId.value
     }
@@ -121,9 +158,11 @@ global.fetch = vi.fn()
 
 describe('useSubscription', () => {
   afterEach(() => {
+    vi.useRealTimers()
     scope?.stop()
     scope = undefined
     setDistribution('localhost')
+    mockLocalStorage.__reset()
   })
 
   beforeEach(() => {
@@ -132,11 +171,16 @@ describe('useSubscription', () => {
     setDistribution('cloud')
 
     vi.clearAllMocks()
+    mockLocalStorage.__reset()
     mockIsLoggedIn.value = false
     mockTelemetry.trackSubscription.mockReset()
+    mockTelemetry.trackMonthlySubscriptionSucceeded.mockReset()
     mockTelemetry.trackMonthlySubscriptionCancelled.mockReset()
+    mockAccessBillingPortal.mockReset()
+    mockAccessBillingPortal.mockResolvedValue(true)
     mockUserId.value = 'user-123'
     mockIsCloud.value = true
+    mockAuthStoreInitialized.value = true
     window.__CONFIG__ = {
       subscription_required: true
     } as typeof window.__CONFIG__
@@ -289,7 +333,7 @@ describe('useSubscription', () => {
       // Mock window.open
       const windowOpenSpy = vi
         .spyOn(window, 'open')
-        .mockImplementation(() => null)
+        .mockImplementation(() => window as unknown as Window)
 
       const { subscribe } = useSubscriptionWithScope()
 
@@ -311,6 +355,16 @@ describe('useSubscription', () => {
       )
 
       expect(windowOpenSpy).toHaveBeenCalledWith(checkoutUrl, '_blank')
+      expect(
+        JSON.parse(
+          localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY) ??
+            '{}'
+        )
+      ).toMatchObject({
+        tier: 'standard',
+        cycle: 'monthly',
+        checkout_type: 'new'
+      })
 
       windowOpenSpy.mockRestore()
     })
@@ -324,6 +378,181 @@ describe('useSubscription', () => {
       const { subscribe } = useSubscriptionWithScope()
 
       await expect(subscribe()).rejects.toThrow()
+    })
+  })
+
+  describe('pending checkout recovery', () => {
+    it('emits subscription_success when a pending new subscription becomes active', async () => {
+      localStorage.setItem(
+        PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+        JSON.stringify({
+          attempt_id: 'attempt-123',
+          started_at_ms: Date.now(),
+          tier: 'creator',
+          cycle: 'yearly',
+          checkout_type: 'new'
+        })
+      )
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          is_active: true,
+          subscription_id: 'sub_123',
+          subscription_tier: 'CREATOR',
+          subscription_duration: 'ANNUAL',
+          renewal_date: '2025-11-16'
+        })
+      } as Response)
+
+      mockIsLoggedIn.value = true
+      useSubscriptionWithScope()
+
+      await vi.waitFor(() => {
+        expect(
+          mockTelemetry.trackMonthlySubscriptionSucceeded
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            user_id: 'user-123',
+            checkout_attempt_id: 'attempt-123',
+            tier: 'creator',
+            cycle: 'yearly',
+            checkout_type: 'new',
+            value: 336,
+            currency: 'USD'
+          })
+        )
+      })
+      expect(
+        localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+      ).toBeNull()
+    })
+
+    it('emits subscription_success when a pending upgrade reaches the target tier', async () => {
+      localStorage.setItem(
+        PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+        JSON.stringify({
+          attempt_id: 'attempt-456',
+          started_at_ms: Date.now(),
+          tier: 'pro',
+          cycle: 'monthly',
+          checkout_type: 'change',
+          previous_tier: 'creator',
+          previous_cycle: 'monthly'
+        })
+      )
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          is_active: true,
+          subscription_id: 'sub_123',
+          subscription_tier: 'PRO',
+          subscription_duration: 'MONTHLY',
+          renewal_date: '2025-11-16'
+        })
+      } as Response)
+
+      mockIsLoggedIn.value = true
+      useSubscriptionWithScope()
+
+      await vi.waitFor(() => {
+        expect(
+          mockTelemetry.trackMonthlySubscriptionSucceeded
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            checkout_attempt_id: 'attempt-456',
+            tier: 'pro',
+            cycle: 'monthly',
+            checkout_type: 'change',
+            previous_tier: 'creator',
+            value: 100
+          })
+        )
+      })
+    })
+
+    it('rechecks pending checkout attempts when the document becomes visible', async () => {
+      mockIsLoggedIn.value = true
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          is_active: false,
+          subscription_id: '',
+          renewal_date: ''
+        })
+      } as Response)
+
+      useSubscriptionWithScope()
+
+      await vi.waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+      })
+
+      vi.mocked(global.fetch).mockClear()
+      localStorage.setItem(
+        PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+        JSON.stringify({
+          attempt_id: 'attempt-visible',
+          started_at_ms: Date.now(),
+          tier: 'standard',
+          cycle: 'monthly',
+          checkout_type: 'new'
+        })
+      )
+
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      await vi.waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('does not clear pending attempts before auth initialization resolves', async () => {
+      mockAuthStoreInitialized.value = false
+      mockIsLoggedIn.value = false
+
+      localStorage.setItem(
+        PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+        JSON.stringify({
+          attempt_id: 'attempt-pre-auth',
+          started_at_ms: Date.now(),
+          tier: 'standard',
+          cycle: 'monthly',
+          checkout_type: 'new'
+        })
+      )
+
+      useSubscriptionWithScope()
+
+      await vi.waitFor(() => {
+        expect(
+          localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+        ).not.toBeNull()
+      })
+    })
+
+    it('clears pending checkout attempts when initialized while logged out', async () => {
+      localStorage.setItem(
+        PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+        JSON.stringify({
+          attempt_id: 'attempt-logout',
+          started_at_ms: Date.now(),
+          tier: 'standard',
+          cycle: 'monthly',
+          checkout_type: 'new'
+        })
+      )
+
+      mockIsLoggedIn.value = false
+      useSubscriptionWithScope()
+
+      await vi.waitFor(() => {
+        expect(
+          localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+        ).toBeNull()
+      })
     })
   })
 
@@ -431,6 +660,40 @@ describe('useSubscription', () => {
       await manageSubscription()
 
       expect(mockAccessBillingPortal).toHaveBeenCalled()
+    })
+
+    it('does not start cancellation watching when the billing portal does not open', async () => {
+      vi.useFakeTimers()
+      mockIsLoggedIn.value = true
+      mockAccessBillingPortal.mockResolvedValueOnce(false)
+
+      const activeResponse = {
+        ok: true,
+        json: async () => ({
+          is_active: true,
+          subscription_id: 'sub_active',
+          renewal_date: '2025-11-16'
+        })
+      }
+
+      vi.mocked(global.fetch).mockResolvedValue(activeResponse as Response)
+
+      try {
+        const { fetchStatus, manageSubscription } = useSubscriptionWithScope()
+
+        await fetchStatus()
+        vi.mocked(global.fetch).mockClear()
+
+        await manageSubscription()
+        await vi.advanceTimersByTimeAsync(5000)
+
+        expect(global.fetch).not.toHaveBeenCalled()
+        expect(
+          mockTelemetry.trackMonthlySubscriptionCancelled
+        ).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('tracks cancellation after manage subscription when status flips', async () => {

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -1,5 +1,10 @@
 import { computed, ref, watch } from 'vue'
-import { createSharedComposable } from '@vueuse/core'
+import {
+  createSharedComposable,
+  defaultDocument,
+  defaultWindow,
+  useEventListener
+} from '@vueuse/core'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
@@ -14,6 +19,14 @@ import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import { useDialogService } from '@/services/dialogService'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { operations } from '@/types/comfyRegistryTypes'
+import {
+  PENDING_SUBSCRIPTION_CHECKOUT_EVENT,
+  PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+  clearPendingSubscriptionCheckoutAttempt,
+  consumePendingSubscriptionCheckoutSuccess,
+  hasPendingSubscriptionCheckoutAttempt,
+  recordPendingSubscriptionCheckoutAttempt
+} from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { useSubscriptionCancellationWatcher } from './useSubscriptionCancellationWatcher'
 
 type CloudSubscriptionCheckoutResponse = NonNullable<
@@ -23,6 +36,8 @@ type CloudSubscriptionCheckoutResponse = NonNullable<
 export type CloudSubscriptionStatusResponse = NonNullable<
   operations['GetCloudSubscriptionStatus']['responses']['200']['content']['application/json']
 >
+
+const PENDING_SUBSCRIPTION_CHECKOUT_RETRY_DELAYS_MS = [3000, 10000, 30000]
 
 function useSubscriptionInternal() {
   const subscriptionStatus = ref<CloudSubscriptionStatusResponse | null>(null)
@@ -111,6 +126,78 @@ function useSubscriptionInternal() {
       return getCheckoutAttribution()
     }
 
+  let pendingCheckoutRecoveryTimeout: number | null = null
+  let pendingCheckoutRecoveryAttempt = 0
+  let isRecoveringPendingCheckout = false
+
+  const stopPendingCheckoutRecovery = () => {
+    if (pendingCheckoutRecoveryTimeout !== null && defaultWindow) {
+      defaultWindow.clearTimeout(pendingCheckoutRecoveryTimeout)
+    }
+
+    pendingCheckoutRecoveryTimeout = null
+    pendingCheckoutRecoveryAttempt = 0
+  }
+
+  const schedulePendingCheckoutRecovery = () => {
+    if (
+      !defaultWindow ||
+      pendingCheckoutRecoveryTimeout !== null ||
+      !isLoggedIn.value ||
+      !hasPendingSubscriptionCheckoutAttempt()
+    ) {
+      return
+    }
+
+    const nextDelay =
+      PENDING_SUBSCRIPTION_CHECKOUT_RETRY_DELAYS_MS[
+        pendingCheckoutRecoveryAttempt
+      ]
+
+    if (nextDelay === undefined) {
+      return
+    }
+
+    pendingCheckoutRecoveryTimeout = defaultWindow.setTimeout(() => {
+      pendingCheckoutRecoveryTimeout = null
+      pendingCheckoutRecoveryAttempt += 1
+      void recoverPendingSubscriptionCheckout('retry')
+    }, nextDelay)
+  }
+
+  const syncPendingSubscriptionSuccess = (
+    statusData: CloudSubscriptionStatusResponse
+  ) => {
+    const metadata = consumePendingSubscriptionCheckoutSuccess(statusData)
+
+    if (!metadata) {
+      if (hasPendingSubscriptionCheckoutAttempt()) {
+        schedulePendingCheckoutRecovery()
+      } else {
+        stopPendingCheckoutRecovery()
+      }
+      return
+    }
+
+    telemetry?.trackMonthlySubscriptionSucceeded({
+      ...(authStore.userId ? { user_id: authStore.userId } : {}),
+      ...metadata
+    })
+    stopPendingCheckoutRecovery()
+  }
+
+  const buildAuthHeaders = async (): Promise<Record<string, string>> => {
+    const authHeader = await getAuthHeader()
+    if (!authHeader) {
+      throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
+    }
+
+    return {
+      ...authHeader,
+      'Content-Type': 'application/json'
+    }
+  }
+
   const fetchStatus = wrapWithErrorHandlingAsync(
     fetchSubscriptionStatus,
     reportError
@@ -127,7 +214,24 @@ function useSubscriptionInternal() {
       )
     }
 
-    window.open(response.checkout_url, '_blank')
+    const checkoutWindow = window.open(response.checkout_url, '_blank')
+    if (!checkoutWindow) {
+      return
+    }
+
+    recordPendingSubscriptionCheckoutAttempt({
+      tier: 'standard',
+      cycle: 'monthly',
+      checkout_type: isSubscribedOrIsNotCloud.value ? 'change' : 'new',
+      ...(subscriptionTier.value
+        ? { previous_tier: TIER_TO_KEY[subscriptionTier.value] }
+        : {}),
+      ...(subscriptionDuration.value === 'ANNUAL'
+        ? { previous_cycle: 'yearly' as const }
+        : subscriptionDuration.value === 'MONTHLY'
+          ? { previous_cycle: 'monthly' as const }
+          : {})
+    })
   }, reportError)
 
   const showSubscriptionDialog = (options?: {
@@ -160,7 +264,11 @@ function useSubscriptionInternal() {
     })
 
   const manageSubscription = async () => {
-    await accessBillingPortal()
+    const didOpenPortal = await accessBillingPortal()
+    if (!didOpenPortal) {
+      return
+    }
+
     startCancellationWatcher()
   }
 
@@ -184,23 +292,44 @@ function useSubscriptionInternal() {
     await accessBillingPortal()
   }
 
+  const recoverPendingSubscriptionCheckout = async (
+    source: 'bootstrap' | 'pageshow' | 'visibilitychange' | 'retry'
+  ) => {
+    if (
+      !isCloud ||
+      !isLoggedIn.value ||
+      !hasPendingSubscriptionCheckoutAttempt() ||
+      isRecoveringPendingCheckout
+    ) {
+      return
+    }
+
+    isRecoveringPendingCheckout = true
+
+    try {
+      await fetchSubscriptionStatus()
+    } catch (error) {
+      console.error(
+        `[Subscription] Failed to recover pending checkout on ${source}:`,
+        error
+      )
+      schedulePendingCheckoutRecovery()
+    } finally {
+      isRecoveringPendingCheckout = false
+    }
+  }
+
   /**
    * Fetch the current cloud subscription status for the authenticated user
    * @returns Subscription status or null if no subscription exists
    */
   async function fetchSubscriptionStatus(): Promise<CloudSubscriptionStatusResponse | null> {
-    const authHeader = await getAuthHeader()
-    if (!authHeader) {
-      throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
-    }
+    const headers = await buildAuthHeaders()
 
     const response = await fetch(
       buildApiUrl('/customers/cloud-subscription-status'),
       {
-        headers: {
-          ...authHeader,
-          'Content-Type': 'application/json'
-        }
+        headers
       }
     )
 
@@ -215,16 +344,55 @@ function useSubscriptionInternal() {
 
     const statusData = await response.json()
     subscriptionStatus.value = statusData
+    syncPendingSubscriptionSuccess(statusData)
 
     return statusData
   }
 
+  const handlePendingSubscriptionCheckoutChange = () => {
+    if (!hasPendingSubscriptionCheckoutAttempt()) {
+      stopPendingCheckoutRecovery()
+      return
+    }
+
+    stopPendingCheckoutRecovery()
+    void recoverPendingSubscriptionCheckout('retry')
+  }
+
+  useEventListener(defaultWindow, PENDING_SUBSCRIPTION_CHECKOUT_EVENT, () => {
+    handlePendingSubscriptionCheckoutChange()
+  })
+
+  useEventListener(defaultWindow, 'storage', (event: StorageEvent) => {
+    if (event.key === PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY) {
+      handlePendingSubscriptionCheckoutChange()
+    }
+  })
+
+  useEventListener(defaultWindow, 'pageshow', () => {
+    void recoverPendingSubscriptionCheckout('pageshow')
+  })
+
+  useEventListener(defaultDocument, 'visibilitychange', () => {
+    if (defaultDocument?.visibilityState === 'visible') {
+      void recoverPendingSubscriptionCheckout('visibilitychange')
+    }
+  })
+
   watch(
-    () => isLoggedIn.value,
-    async (loggedIn) => {
+    () => [authStore.isInitialized, isLoggedIn.value] as const,
+    async ([authInitialized, loggedIn]) => {
+      if (!authInitialized) {
+        return
+      }
+
       if (loggedIn && isCloud) {
         try {
-          await fetchSubscriptionStatus()
+          if (hasPendingSubscriptionCheckoutAttempt()) {
+            await recoverPendingSubscriptionCheckout('bootstrap')
+          } else {
+            await fetchSubscriptionStatus()
+          }
         } catch (error) {
           // Network errors are expected during navigation/component unmount
           // and when offline - log for debugging but don't surface to user
@@ -234,6 +402,8 @@ function useSubscriptionInternal() {
         }
       } else {
         subscriptionStatus.value = null
+        clearPendingSubscriptionCheckoutAttempt()
+        stopPendingCheckoutRecovery()
         stopCancellationWatcher()
         isInitialized.value = true
       }
@@ -243,20 +413,14 @@ function useSubscriptionInternal() {
 
   const initiateSubscriptionCheckout =
     async (): Promise<CloudSubscriptionCheckoutResponse> => {
-      const authHeader = await getAuthHeader()
-      if (!authHeader) {
-        throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
-      }
+      const headers = await buildAuthHeaders()
       const checkoutAttribution = await getCheckoutAttributionForCloud()
 
       const response = await fetch(
         buildApiUrl('/customers/cloud-subscription-checkout'),
         {
           method: 'POST',
-          headers: {
-            ...authHeader,
-            'Content-Type': 'application/json'
-          },
+          headers,
           body: JSON.stringify(checkoutAttribution)
         }
       )

--- a/src/platform/cloud/subscription/constants/tierPricing.ts
+++ b/src/platform/cloud/subscription/constants/tierPricing.ts
@@ -1,7 +1,7 @@
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import type { components } from '@/types/comfyRegistryTypes'
 
-type SubscriptionTier = components['schemas']['SubscriptionTier']
+export type SubscriptionTier = components['schemas']['SubscriptionTier']
 
 export type TierKey = 'free' | 'standard' | 'creator' | 'pro' | 'founder'
 

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutTracker.ts
@@ -1,0 +1,314 @@
+import {
+  TIER_TO_KEY,
+  getTierPrice
+} from '@/platform/cloud/subscription/constants/tierPricing'
+import type {
+  SubscriptionTier,
+  TierKey
+} from '@/platform/cloud/subscription/constants/tierPricing'
+import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
+import type { SubscriptionSuccessMetadata } from '@/platform/telemetry/types'
+
+const PENDING_SUBSCRIPTION_CHECKOUT_MAX_AGE_MS = 6 * 60 * 60 * 1000
+const VALID_TIER_KEYS = new Set<TierKey>([
+  'free',
+  'standard',
+  'creator',
+  'pro',
+  'founder'
+])
+
+export const PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY =
+  'comfy.subscription.pending_checkout_attempt'
+export const PENDING_SUBSCRIPTION_CHECKOUT_EVENT =
+  'comfy:subscription-checkout-attempt-changed'
+
+type CheckoutType = 'new' | 'change'
+type SubscriptionDuration = 'MONTHLY' | 'ANNUAL'
+
+interface SubscriptionStatusSnapshot {
+  is_active?: boolean
+  subscription_tier?: SubscriptionTier | null
+  subscription_duration?: SubscriptionDuration | null
+}
+
+interface PendingSubscriptionCheckoutAttempt {
+  attempt_id: string
+  started_at_ms: number
+  tier: TierKey
+  cycle: BillingCycle
+  checkout_type: CheckoutType
+  previous_tier?: TierKey
+  previous_cycle?: BillingCycle
+}
+
+interface RecordPendingSubscriptionCheckoutAttemptInput {
+  tier: TierKey
+  cycle: BillingCycle
+  checkout_type: CheckoutType
+  previous_tier?: TierKey
+  previous_cycle?: BillingCycle
+}
+
+const dispatchPendingCheckoutChangeEvent = () => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.dispatchEvent(new Event(PENDING_SUBSCRIPTION_CHECKOUT_EVENT))
+}
+
+const createAttemptId = (): string => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+
+  return `attempt-${Date.now()}`
+}
+
+const getStorage = (): Storage | null => {
+  let storage: Storage | null = null
+
+  try {
+    storage = globalThis.localStorage
+  } catch {
+    return null
+  }
+
+  if (
+    !storage ||
+    typeof storage.getItem !== 'function' ||
+    typeof storage.setItem !== 'function' ||
+    typeof storage.removeItem !== 'function'
+  ) {
+    return null
+  }
+
+  return storage
+}
+
+const getAnnualCheckoutValue = (tier: Exclude<TierKey, 'free' | 'founder'>) =>
+  getTierPrice(tier, true) * 12
+
+const getCheckoutValue = (tier: TierKey, cycle: BillingCycle): number => {
+  if (tier === 'free' || tier === 'founder') {
+    return getTierPrice(tier, cycle === 'yearly')
+  }
+
+  return cycle === 'yearly'
+    ? getAnnualCheckoutValue(tier)
+    : getTierPrice(tier, false)
+}
+
+const getTierFromStatus = (
+  status: SubscriptionStatusSnapshot
+): TierKey | null => {
+  const subscriptionTier = status.subscription_tier
+  if (!subscriptionTier) {
+    return null
+  }
+
+  return TIER_TO_KEY[subscriptionTier] ?? null
+}
+
+const getCycleFromStatus = (
+  status: SubscriptionStatusSnapshot
+): BillingCycle | null => {
+  if (status.subscription_duration === 'ANNUAL') {
+    return 'yearly'
+  }
+
+  if (status.subscription_duration === 'MONTHLY') {
+    return 'monthly'
+  }
+
+  return null
+}
+
+const isExpired = (attempt: PendingSubscriptionCheckoutAttempt): boolean =>
+  Date.now() - attempt.started_at_ms > PENDING_SUBSCRIPTION_CHECKOUT_MAX_AGE_MS
+
+const normalizeAttempt = (
+  value: unknown
+): PendingSubscriptionCheckoutAttempt | null => {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = value as Partial<PendingSubscriptionCheckoutAttempt>
+
+  if (
+    typeof candidate.attempt_id !== 'string' ||
+    typeof candidate.started_at_ms !== 'number' ||
+    typeof candidate.tier !== 'string' ||
+    typeof candidate.cycle !== 'string' ||
+    typeof candidate.checkout_type !== 'string'
+  ) {
+    return null
+  }
+
+  if (
+    !VALID_TIER_KEYS.has(candidate.tier as TierKey) ||
+    (candidate.cycle !== 'monthly' && candidate.cycle !== 'yearly') ||
+    (candidate.checkout_type !== 'new' && candidate.checkout_type !== 'change')
+  ) {
+    return null
+  }
+
+  return {
+    attempt_id: candidate.attempt_id,
+    started_at_ms: candidate.started_at_ms,
+    tier: candidate.tier as TierKey,
+    cycle: candidate.cycle,
+    checkout_type: candidate.checkout_type,
+    ...(candidate.previous_tier &&
+    VALID_TIER_KEYS.has(candidate.previous_tier as TierKey)
+      ? { previous_tier: candidate.previous_tier as TierKey }
+      : {}),
+    ...(candidate.previous_cycle === 'monthly' ||
+    candidate.previous_cycle === 'yearly'
+      ? { previous_cycle: candidate.previous_cycle }
+      : {})
+  }
+}
+
+export const clearPendingSubscriptionCheckoutAttempt = (): void => {
+  const storage = getStorage()
+  if (!storage) {
+    return
+  }
+
+  try {
+    storage.removeItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+  } catch {
+    return
+  }
+  dispatchPendingCheckoutChangeEvent()
+}
+
+const getPendingSubscriptionCheckoutAttempt =
+  (): PendingSubscriptionCheckoutAttempt | null => {
+    const storage = getStorage()
+    if (!storage) {
+      return null
+    }
+
+    let rawAttempt: string | null
+
+    try {
+      rawAttempt = storage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+    } catch {
+      return null
+    }
+
+    if (!rawAttempt) {
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(rawAttempt)
+      const attempt = normalizeAttempt(parsed)
+
+      if (!attempt || isExpired(attempt)) {
+        clearPendingSubscriptionCheckoutAttempt()
+        return null
+      }
+
+      return attempt
+    } catch {
+      clearPendingSubscriptionCheckoutAttempt()
+      return null
+    }
+  }
+
+export const hasPendingSubscriptionCheckoutAttempt = (): boolean =>
+  getPendingSubscriptionCheckoutAttempt() !== null
+
+export const recordPendingSubscriptionCheckoutAttempt = (
+  input: RecordPendingSubscriptionCheckoutAttemptInput
+): PendingSubscriptionCheckoutAttempt => {
+  const storage = getStorage()
+  if (!storage) {
+    return {
+      attempt_id: createAttemptId(),
+      started_at_ms: Date.now(),
+      tier: input.tier,
+      cycle: input.cycle,
+      checkout_type: input.checkout_type,
+      ...(input.previous_tier ? { previous_tier: input.previous_tier } : {}),
+      ...(input.previous_cycle ? { previous_cycle: input.previous_cycle } : {})
+    }
+  }
+
+  const attempt: PendingSubscriptionCheckoutAttempt = {
+    attempt_id: createAttemptId(),
+    started_at_ms: Date.now(),
+    tier: input.tier,
+    cycle: input.cycle,
+    checkout_type: input.checkout_type,
+    ...(input.previous_tier ? { previous_tier: input.previous_tier } : {}),
+    ...(input.previous_cycle ? { previous_cycle: input.previous_cycle } : {})
+  }
+
+  try {
+    storage.setItem(
+      PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
+      JSON.stringify(attempt)
+    )
+  } catch {
+    return attempt
+  }
+  dispatchPendingCheckoutChangeEvent()
+
+  return attempt
+}
+
+const didAttemptSucceed = (
+  attempt: PendingSubscriptionCheckoutAttempt,
+  status: SubscriptionStatusSnapshot
+): boolean => {
+  if (!status.is_active) {
+    return false
+  }
+
+  return (
+    getTierFromStatus(status) === attempt.tier &&
+    getCycleFromStatus(status) === attempt.cycle
+  )
+}
+
+export const consumePendingSubscriptionCheckoutSuccess = (
+  status: SubscriptionStatusSnapshot
+): SubscriptionSuccessMetadata | null => {
+  const attempt = getPendingSubscriptionCheckoutAttempt()
+  if (!attempt || !didAttemptSucceed(attempt, status)) {
+    return null
+  }
+
+  clearPendingSubscriptionCheckoutAttempt()
+
+  const value = getCheckoutValue(attempt.tier, attempt.cycle)
+
+  return {
+    checkout_attempt_id: attempt.attempt_id,
+    tier: attempt.tier,
+    cycle: attempt.cycle,
+    checkout_type: attempt.checkout_type,
+    ...(attempt.previous_tier ? { previous_tier: attempt.previous_tier } : {}),
+    value,
+    currency: 'USD',
+    ecommerce: {
+      value,
+      currency: 'USD',
+      items: [
+        {
+          item_name: attempt.tier,
+          item_category: 'subscription',
+          item_variant: attempt.cycle,
+          price: value,
+          quantity: 1
+        }
+      ]
+    }
+  }
+}

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, reactive } from 'vue'
 
+import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { performSubscriptionCheckout } from './subscriptionCheckoutUtil'
 
 const {
@@ -8,7 +9,8 @@ const {
   mockGetAuthHeader,
   mockUserId,
   mockIsCloud,
-  mockGetCheckoutAttribution
+  mockGetCheckoutAttribution,
+  mockLocalStorage
 } = vi.hoisted(() => ({
   mockTelemetry: {
     trackBeginCheckout: vi.fn()
@@ -29,8 +31,37 @@ const {
     gclid: 'gclid-123',
     gbraid: 'gbraid-456',
     wbraid: 'wbraid-789'
-  }))
+  })),
+  mockLocalStorage: (() => {
+    const store = new Map<string, string>()
+
+    return {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value)
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key)
+      }),
+      clear: vi.fn(() => {
+        store.clear()
+      }),
+      __reset: () => {
+        store.clear()
+      }
+    }
+  })()
 }))
+
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true
+})
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true
+})
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => mockTelemetry)
@@ -81,16 +112,20 @@ describe('performSubscriptionCheckout', () => {
     vi.clearAllMocks()
     mockIsCloud.value = true
     mockUserId.value = 'user-123'
+    mockLocalStorage.__reset()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
     setDistribution('localhost')
+    mockLocalStorage.__reset()
   })
 
   it('tracks begin_checkout with user id and tier metadata', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockImplementation(() => window as unknown as Window)
 
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -175,7 +210,9 @@ describe('performSubscriptionCheckout', () => {
 
   it('uses the latest userId when it changes after checkout starts', async () => {
     const checkoutUrl = 'https://checkout.stripe.com/test'
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockImplementation(() => window as unknown as Window)
     const authHeader = createDeferred<{ Authorization: string }>()
 
     mockUserId.value = 'user-early'
@@ -202,5 +239,22 @@ describe('performSubscriptionCheckout', () => {
       })
     )
     expect(openSpy).toHaveBeenCalledWith(checkoutUrl, '_blank')
+  })
+
+  it('does not persist a pending attempt when the checkout popup is blocked', async () => {
+    const checkoutUrl = 'https://checkout.stripe.com/test'
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ checkout_url: checkoutUrl })
+    } as Response)
+
+    await performSubscriptionCheckout('pro', 'monthly', true)
+
+    expect(openSpy).toHaveBeenCalledWith(checkoutUrl, '_blank')
+    expect(
+      window.localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY)
+    ).toBeNull()
   })
 })

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
@@ -7,6 +7,7 @@ import { useTelemetry } from '@/platform/telemetry'
 import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import type { CheckoutAttributionMetadata } from '@/platform/telemetry/types'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import { recordPendingSubscriptionCheckoutAttempt } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import type { BillingCycle } from './subscriptionTierRank'
 
 type CheckoutTier = TierKey | `${TierKey}-yearly`
@@ -113,9 +114,24 @@ export async function performSubscriptionCheckout(
         ...checkoutAttribution
       })
     }
+
     if (openInNewTab) {
-      window.open(data.checkout_url, '_blank')
+      const checkoutWindow = window.open(data.checkout_url, '_blank')
+      if (!checkoutWindow) {
+        return
+      }
+
+      recordPendingSubscriptionCheckoutAttempt({
+        tier: tierKey,
+        cycle: currentBillingCycle,
+        checkout_type: 'new'
+      })
     } else {
+      recordPendingSubscriptionCheckoutAttempt({
+        tier: tierKey,
+        cycle: currentBillingCycle,
+        checkout_type: 'new'
+      })
       globalThis.location.href = data.checkout_url
     }
   }

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -18,6 +18,7 @@ import type {
   PageVisibilityMetadata,
   SettingChangedMetadata,
   SubscriptionMetadata,
+  SubscriptionSuccessMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryDispatcher,
@@ -80,8 +81,12 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackBeginCheckout?.(metadata))
   }
 
-  trackMonthlySubscriptionSucceeded(): void {
-    this.dispatch((provider) => provider.trackMonthlySubscriptionSucceeded?.())
+  trackMonthlySubscriptionSucceeded(
+    metadata?: SubscriptionSuccessMetadata
+  ): void {
+    this.dispatch((provider) =>
+      provider.trackMonthlySubscriptionSucceeded?.(metadata)
+    )
   }
 
   trackMonthlySubscriptionCancelled(): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -98,6 +98,90 @@ describe('GtmTelemetryProvider', () => {
       })
     })
 
+    it('pushes subscription_success metadata with ecommerce reset', () => {
+      const provider = createInitializedProvider()
+
+      provider.trackMonthlySubscriptionSucceeded({
+        checkout_attempt_id: 'attempt-123',
+        tier: 'creator',
+        cycle: 'yearly',
+        checkout_type: 'new',
+        value: 336,
+        currency: 'USD',
+        ecommerce: {
+          currency: 'USD',
+          value: 336,
+          items: [
+            {
+              item_name: 'creator',
+              item_category: 'subscription',
+              item_variant: 'yearly',
+              price: 336,
+              quantity: 1
+            }
+          ]
+        }
+      })
+
+      const dataLayer = window.dataLayer as Record<string, unknown>[]
+
+      expect(dataLayer[dataLayer.length - 2]).toMatchObject({ ecommerce: null })
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'subscription_success',
+        checkout_attempt_id: 'attempt-123',
+        value: 336
+      })
+    })
+
+    it('does not reset ecommerce when GTM is not initialized', () => {
+      window.__CONFIG__ = {
+        ga_measurement_id: 'G-TEST123'
+      }
+
+      const provider = new GtmTelemetryProvider()
+
+      provider.trackMonthlySubscriptionSucceeded({
+        checkout_attempt_id: 'attempt-123',
+        tier: 'creator',
+        cycle: 'yearly',
+        checkout_type: 'new',
+        value: 336,
+        currency: 'USD',
+        ecommerce: {
+          currency: 'USD',
+          value: 336,
+          items: [
+            {
+              item_name: 'creator',
+              item_category: 'subscription',
+              item_variant: 'yearly',
+              price: 336,
+              quantity: 1
+            }
+          ]
+        }
+      })
+
+      const dataLayer = window.dataLayer as unknown[]
+
+      expect(
+        dataLayer.some(
+          (entry) =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            'ecommerce' in (entry as Record<string, unknown>)
+        )
+      ).toBe(false)
+      expect(
+        dataLayer.some(
+          (entry) =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            (entry as Record<string, unknown>).event === 'subscription_success'
+        )
+      ).toBe(false)
+    })
+
     it('pushes run_workflow with trigger_source', () => {
       const provider = createInitializedProvider()
       provider.trackRunButton({ trigger_source: 'button' })

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -16,6 +16,7 @@ import type {
   SettingChangedMetadata,
   ShareFlowMetadata,
   SubscriptionMetadata,
+  SubscriptionSuccessMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryProvider,
@@ -167,8 +168,17 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     this.pushEvent('signup_opened')
   }
 
-  trackMonthlySubscriptionSucceeded(): void {
-    this.pushEvent('subscription_success')
+  trackMonthlySubscriptionSucceeded(
+    metadata?: SubscriptionSuccessMetadata
+  ): void {
+    if (this.initialized && metadata?.ecommerce) {
+      window.dataLayer?.push({ ecommerce: null })
+    }
+
+    this.pushEvent(
+      'subscription_success',
+      metadata ? { ...metadata } : undefined
+    )
   }
 
   trackRunButton(options?: {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -31,6 +31,7 @@ import type {
   RunButtonProperties,
   SettingChangedMetadata,
   SubscriptionMetadata,
+  SubscriptionSuccessMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryEventName,
@@ -235,8 +236,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.ADD_API_CREDIT_BUTTON_CLICKED)
   }
 
-  trackMonthlySubscriptionSucceeded(): void {
-    this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED)
+  trackMonthlySubscriptionSucceeded(
+    metadata?: SubscriptionSuccessMetadata
+  ): void {
+    this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED, metadata)
   }
 
   /**

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -26,6 +26,7 @@ import type {
   RunButtonProperties,
   SettingChangedMetadata,
   SubscriptionMetadata,
+  SubscriptionSuccessMetadata,
   SurveyResponses,
   TabCountMetadata,
   TelemetryEventName,
@@ -255,8 +256,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.ADD_API_CREDIT_BUTTON_CLICKED)
   }
 
-  trackMonthlySubscriptionSucceeded(): void {
-    this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED)
+  trackMonthlySubscriptionSucceeded(
+    metadata?: SubscriptionSuccessMetadata
+  ): void {
+    this.trackEvent(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED, metadata)
   }
 
   trackMonthlySubscriptionCancelled(): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -344,6 +344,32 @@ export interface BeginCheckoutMetadata
   previous_tier?: TierKey
 }
 
+interface EcommerceItemMetadata {
+  item_name: string
+  item_category: string
+  item_variant?: string
+  price: number
+  quantity: number
+}
+
+interface EcommerceMetadata {
+  currency: string
+  value: number
+  items: EcommerceItemMetadata[]
+}
+
+export interface SubscriptionSuccessMetadata extends Record<string, unknown> {
+  user_id?: string
+  checkout_attempt_id: string
+  tier: TierKey
+  cycle: BillingCycle
+  checkout_type: 'new' | 'change'
+  previous_tier?: TierKey
+  value: number
+  currency: string
+  ecommerce: EcommerceMetadata
+}
+
 /**
  * Telemetry provider interface for individual providers.
  * All methods are optional - providers only implement what they need.
@@ -360,7 +386,9 @@ export interface TelemetryProvider {
     metadata?: SubscriptionMetadata
   ): void
   trackBeginCheckout?(metadata: BeginCheckoutMetadata): void
-  trackMonthlySubscriptionSucceeded?(): void
+  trackMonthlySubscriptionSucceeded?(
+    metadata?: SubscriptionSuccessMetadata
+  ): void
   trackMonthlySubscriptionCancelled?(): void
   trackAddApiCreditButtonClicked?(): void
   trackApiCreditTopupButtonPurchaseClicked?(amount: number): void
@@ -559,3 +587,4 @@ export type TelemetryEventProperties =
   | WorkflowSavedMetadata
   | DefaultViewSetMetadata
   | SubscriptionMetadata
+  | SubscriptionSuccessMetadata


### PR DESCRIPTION
Backports #11286

## Summary
- backport frontend subscription success recovery to `cloud/1.43`

## Backport Delta
- `18ef350db` is the cherry-pick of main's `ecb7fd479` from #11286
- the backport-only review surface is intentionally small:
  - `src/platform/cloud/subscription/components/PricingTable.test.ts`: adapt the assertions to `cloud/1.43`'s existing `mount`-based test harness
  - `src/platform/cloud/subscription/constants/tierPricing.ts`: one-line type-only export (`type SubscriptionTier` -> `export type SubscriptionTier`)
- runtime review should therefore mostly follow #11286 rather than treating this as a novel branch-specific implementation

## Why
The automated backport failed because `cloud/1.43` had drifted in `PricingTable.test.ts`. The runtime code itself cherry-picked cleanly; the only non-test branch-local change was the small `SubscriptionTier` export needed to match the API surface expected by the backported code.

## Validation
- `pnpm exec vitest run src/platform/cloud/subscription/composables/useSubscription.test.ts src/platform/cloud/subscription/components/PricingTable.test.ts src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts`
- `pnpm typecheck`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11476-backport-cloud-1-43-feat-add-frontend-subscription-success-recovery-3486d73d3650813ebc87c162a8aa759e) by [Unito](https://www.unito.io)
