### PR TITLE
ci: stabilize Vercel website preview URLs per PR

### DIFF
--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -85,6 +85,8 @@ jobs:
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Alias deployment to stable PR hostname
+        id: alias-set
+        continue-on-error: true
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
@@ -96,20 +98,31 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
           ALIAS_HOST: ${{ steps.alias.outputs.host }}
+          ALIAS_OK: ${{ steps.alias-set.outcome == 'success' }}
         run: |
           {
-            echo "**Preview:** https://$ALIAS_HOST"
-            echo "**This commit:** $DEPLOY_URL"
+            if [[ "$ALIAS_OK" == "true" ]]; then
+              echo "**Preview:** https://$ALIAS_HOST"
+              echo "**This commit:** $DEPLOY_URL"
+            else
+              echo "**Preview:** $DEPLOY_URL"
+              echo "_Stable alias update failed — URL reflects this commit only._"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save PR metadata
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
           ALIAS_HOST: ${{ steps.alias.outputs.host }}
+          ALIAS_OK: ${{ steps.alias-set.outcome == 'success' }}
         run: |
           mkdir -p temp/vercel-preview
           echo "$DEPLOY_URL" > temp/vercel-preview/url.txt
-          echo "https://$ALIAS_HOST" > temp/vercel-preview/stable-url.txt
+          if [[ "$ALIAS_OK" == "true" ]]; then
+            echo "https://$ALIAS_HOST" > temp/vercel-preview/stable-url.txt
+          else
+            echo "$DEPLOY_URL" > temp/vercel-preview/stable-url.txt
+          fi
 
       - name: Upload preview metadata
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -21,6 +21,10 @@ env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
   VERCEL_SCOPE: comfyui
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-preview:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -33,6 +33,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
@@ -40,9 +45,11 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
+        working-directory: apps/website
         run: vercel pull --yes --environment=preview
 
       - name: Build project artifacts
+        working-directory: apps/website
         run: vercel build
 
       - name: Fetch head commit metadata
@@ -62,6 +69,7 @@ jobs:
 
       - name: Deploy project artifacts to Vercel
         id: deploy
+        working-directory: apps/website
         env:
           GIT_COMMIT_REF: ${{ github.event.pull_request.head.ref }}
           GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -122,6 +130,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
@@ -129,13 +142,16 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
+        working-directory: apps/website
         run: vercel pull --yes --environment=production
 
       - name: Build project artifacts
+        working-directory: apps/website
         run: vercel build --prod
 
       - name: Deploy project artifacts to Vercel
         id: deploy
+        working-directory: apps/website
         run: |
           URL=$(vercel deploy --prebuilt --prod)
           echo "url=$URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -78,17 +78,23 @@ jobs:
           vercel alias set "$DEPLOY_URL" "$ALIAS_HOST" --token="$VERCEL_TOKEN"
 
       - name: Add deployment URLs to summary
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+          ALIAS_HOST: ${{ steps.alias.outputs.host }}
         run: |
           {
-            echo "**Preview:** https://${{ steps.alias.outputs.host }}"
-            echo "**This commit:** ${{ steps.deploy.outputs.url }}"
+            echo "**Preview:** https://$ALIAS_HOST"
+            echo "**This commit:** $DEPLOY_URL"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save PR metadata
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+          ALIAS_HOST: ${{ steps.alias.outputs.host }}
         run: |
           mkdir -p temp/vercel-preview
-          echo "${{ steps.deploy.outputs.url }}" > temp/vercel-preview/url.txt
-          echo "https://${{ steps.alias.outputs.host }}" > temp/vercel-preview/stable-url.txt
+          echo "$DEPLOY_URL" > temp/vercel-preview/url.txt
+          echo "https://$ALIAS_HOST" > temp/vercel-preview/stable-url.txt
 
       - name: Upload preview metadata
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -33,13 +33,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
@@ -130,13 +130,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -19,6 +19,7 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_WEBSITE_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}
   VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
+  VERCEL_SCOPE: comfyui
 
 jobs:
   deploy-preview:
@@ -84,7 +85,7 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
         run: |
-          vercel alias set "$DEPLOY_URL" "$ALIAS_HOST"
+          vercel alias set "$DEPLOY_URL" "$ALIAS_HOST" --scope="$VERCEL_SCOPE"
 
       - name: Publish preview outputs
         env:

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -45,11 +45,9 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        working-directory: apps/website
         run: vercel pull --yes --environment=preview
 
       - name: Build project artifacts
-        working-directory: apps/website
         run: vercel build
 
       - name: Fetch head commit metadata
@@ -69,7 +67,6 @@ jobs:
 
       - name: Deploy project artifacts to Vercel
         id: deploy
-        working-directory: apps/website
         env:
           GIT_COMMIT_REF: ${{ github.event.pull_request.head.ref }}
           GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -142,16 +139,13 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        working-directory: apps/website
         run: vercel pull --yes --environment=production
 
       - name: Build project artifacts
-        working-directory: apps/website
         run: vercel build --prod
 
       - name: Deploy project artifacts to Vercel
         id: deploy
-        working-directory: apps/website
         run: |
           URL=$(vercel deploy --prebuilt --prod)
           echo "url=$URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -18,6 +18,7 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_WEBSITE_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
   PREVIEW_ALIAS_PREFIX: comfy-website-preview
 
 jobs:
@@ -37,10 +38,10 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_WEBSITE_TOKEN }}
+        run: vercel pull --yes --environment=preview
 
       - name: Build project artifacts
-        run: vercel build --token=${{ secrets.VERCEL_WEBSITE_TOKEN }}
+        run: vercel build
 
       - name: Compute stable alias hostname
         id: alias
@@ -66,7 +67,6 @@ jobs:
       - name: Deploy project artifacts to Vercel
         id: deploy
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
           GIT_COMMIT_REF: ${{ github.event.pull_request.head.ref }}
           GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           GIT_AUTHOR_LOGIN: ${{ steps.head-commit.outputs.author }}
@@ -75,7 +75,6 @@ jobs:
           GIT_REPO: ${{ github.repository }}
         run: |
           URL=$(vercel deploy --prebuilt \
-            --token="$VERCEL_TOKEN" \
             --meta githubCommitRef="$GIT_COMMIT_REF" \
             --meta githubCommitSha="$GIT_COMMIT_SHA" \
             --meta githubCommitAuthorLogin="$GIT_AUTHOR_LOGIN" \
@@ -88,11 +87,10 @@ jobs:
         id: alias-set
         continue-on-error: true
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
           ALIAS_HOST: ${{ steps.alias.outputs.host }}
         run: |
-          vercel alias set "$DEPLOY_URL" "$ALIAS_HOST" --token="$VERCEL_TOKEN"
+          vercel alias set "$DEPLOY_URL" "$ALIAS_HOST"
 
       - name: Add deployment URLs to summary
         env:
@@ -144,15 +142,15 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel environment information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_WEBSITE_TOKEN }}
+        run: vercel pull --yes --environment=production
 
       - name: Build project artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_WEBSITE_TOKEN }}
+        run: vercel build --prod
 
       - name: Deploy project artifacts to Vercel
         id: deploy
         run: |
-          URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_WEBSITE_TOKEN }})
+          URL=$(vercel deploy --prebuilt --prod)
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Add deployment URL to summary

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -48,14 +48,29 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: echo "host=${PREVIEW_ALIAS_PREFIX}-pr-${PR_NUMBER}.vercel.app" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch head commit metadata
+        id: head-commit
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+            })
+            const author = data.author?.login || data.commit.author?.name || ''
+            const message = (data.commit.message || '').split('\n', 1)[0]
+            core.setOutput('author', author)
+            core.setOutput('message', message)
+
       - name: Deploy project artifacts to Vercel
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
           GIT_COMMIT_REF: ${{ github.event.pull_request.head.ref }}
           GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-          GIT_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
-          GIT_COMMIT_MESSAGE: ${{ github.event.pull_request.title }}
+          GIT_AUTHOR_LOGIN: ${{ steps.head-commit.outputs.author }}
+          GIT_COMMIT_MESSAGE: ${{ steps.head-commit.outputs.message }}
           GIT_PR_ID: ${{ github.event.pull_request.number }}
           GIT_REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -19,7 +19,6 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_WEBSITE_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}
   VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
-  PREVIEW_ALIAS_PREFIX: comfy-website-preview
 
 jobs:
   deploy-preview:
@@ -27,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      ALIAS_HOST: comfy-website-preview-pr-${{ github.event.pull_request.number }}.vercel.app
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -42,12 +43,6 @@ jobs:
 
       - name: Build project artifacts
         run: vercel build
-
-      - name: Compute stable alias hostname
-        id: alias
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: echo "host=${PREVIEW_ALIAS_PREFIX}-pr-${PR_NUMBER}.vercel.app" >> "$GITHUB_OUTPUT"
 
       - name: Fetch head commit metadata
         id: head-commit
@@ -88,39 +83,30 @@ jobs:
         continue-on-error: true
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
-          ALIAS_HOST: ${{ steps.alias.outputs.host }}
         run: |
           vercel alias set "$DEPLOY_URL" "$ALIAS_HOST"
 
-      - name: Add deployment URLs to summary
+      - name: Publish preview outputs
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
-          ALIAS_HOST: ${{ steps.alias.outputs.host }}
           ALIAS_OK: ${{ steps.alias-set.outcome == 'success' }}
         run: |
+          if [[ "$ALIAS_OK" == "true" ]]; then
+            STABLE_URL="https://$ALIAS_HOST"
+          else
+            STABLE_URL="$DEPLOY_URL"
+          fi
+          mkdir -p temp/vercel-preview
+          echo "$DEPLOY_URL" > temp/vercel-preview/url.txt
+          echo "$STABLE_URL" > temp/vercel-preview/stable-url.txt
           {
+            echo "**Preview:** $STABLE_URL"
             if [[ "$ALIAS_OK" == "true" ]]; then
-              echo "**Preview:** https://$ALIAS_HOST"
               echo "**This commit:** $DEPLOY_URL"
             else
-              echo "**Preview:** $DEPLOY_URL"
               echo "_Stable alias update failed — URL reflects this commit only._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Save PR metadata
-        env:
-          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
-          ALIAS_HOST: ${{ steps.alias.outputs.host }}
-          ALIAS_OK: ${{ steps.alias-set.outcome == 'success' }}
-        run: |
-          mkdir -p temp/vercel-preview
-          echo "$DEPLOY_URL" > temp/vercel-preview/url.txt
-          if [[ "$ALIAS_OK" == "true" ]]; then
-            echo "https://$ALIAS_HOST" > temp/vercel-preview/stable-url.txt
-          else
-            echo "$DEPLOY_URL" > temp/vercel-preview/stable-url.txt
-          fi
 
       - name: Upload preview metadata
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -18,6 +18,7 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_WEBSITE_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}
+  PREVIEW_ALIAS_PREFIX: comfy-website-preview
 
 jobs:
   deploy-preview:
@@ -41,19 +42,53 @@ jobs:
       - name: Build project artifacts
         run: vercel build --token=${{ secrets.VERCEL_WEBSITE_TOKEN }}
 
+      - name: Compute stable alias hostname
+        id: alias
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "host=${PREVIEW_ALIAS_PREFIX}-pr-${PR_NUMBER}.vercel.app" >> "$GITHUB_OUTPUT"
+
       - name: Deploy project artifacts to Vercel
         id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
+          GIT_COMMIT_REF: ${{ github.event.pull_request.head.ref }}
+          GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          GIT_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          GIT_COMMIT_MESSAGE: ${{ github.event.pull_request.title }}
+          GIT_PR_ID: ${{ github.event.pull_request.number }}
+          GIT_REPO: ${{ github.repository }}
         run: |
-          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_WEBSITE_TOKEN }})
+          URL=$(vercel deploy --prebuilt \
+            --token="$VERCEL_TOKEN" \
+            --meta githubCommitRef="$GIT_COMMIT_REF" \
+            --meta githubCommitSha="$GIT_COMMIT_SHA" \
+            --meta githubCommitAuthorLogin="$GIT_AUTHOR_LOGIN" \
+            --meta githubCommitMessage="$GIT_COMMIT_MESSAGE" \
+            --meta githubPrId="$GIT_PR_ID" \
+            --meta githubRepo="$GIT_REPO")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
-      - name: Add deployment URL to summary
-        run: echo "**Preview:** ${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Alias deployment to stable PR hostname
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_WEBSITE_TOKEN }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+          ALIAS_HOST: ${{ steps.alias.outputs.host }}
+        run: |
+          vercel alias set "$DEPLOY_URL" "$ALIAS_HOST" --token="$VERCEL_TOKEN"
+
+      - name: Add deployment URLs to summary
+        run: |
+          {
+            echo "**Preview:** https://${{ steps.alias.outputs.host }}"
+            echo "**This commit:** ${{ steps.deploy.outputs.url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save PR metadata
         run: |
           mkdir -p temp/vercel-preview
           echo "${{ steps.deploy.outputs.url }}" > temp/vercel-preview/url.txt
+          echo "https://${{ steps.alias.outputs.host }}" > temp/vercel-preview/stable-url.txt
 
       - name: Upload preview metadata
         uses: actions/upload-artifact@v6

--- a/.github/workflows/pr-vercel-website-preview.yaml
+++ b/.github/workflows/pr-vercel-website-preview.yaml
@@ -37,16 +37,27 @@ jobs:
         id: pr-meta
         uses: ./.github/actions/resolve-pr-from-workflow-run
 
-      - name: Read preview URL
+      - name: Read preview URLs
         if: steps.pr-meta.outputs.skip != 'true'
         id: meta
         run: |
           echo "url=$(cat temp/vercel-preview/url.txt)" >> "$GITHUB_OUTPUT"
+          echo "stable_url=$(cat temp/vercel-preview/stable-url.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Write report
         if: steps.pr-meta.outputs.skip != 'true'
+        env:
+          DEPLOYED_AT: ${{ github.event.workflow_run.updated_at }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          echo "**Website Preview:** ${{ steps.meta.outputs.url }}" > preview-report.md
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          {
+            echo "**Website Preview:** ${{ steps.meta.outputs.stable_url }}"
+            echo ""
+            echo "<sub>This commit: ${{ steps.meta.outputs.url }}</sub>"
+            echo ""
+            echo "<sub>Last updated: $DEPLOYED_AT for \`$SHORT_SHA\`</sub>"
+          } > preview-report.md
 
       - name: Post PR comment
         if: steps.pr-meta.outputs.skip != 'true'

--- a/.github/workflows/pr-vercel-website-preview.yaml
+++ b/.github/workflows/pr-vercel-website-preview.yaml
@@ -47,14 +47,16 @@ jobs:
       - name: Write report
         if: steps.pr-meta.outputs.skip != 'true'
         env:
+          STABLE_URL: ${{ steps.meta.outputs.stable_url }}
+          UNIQUE_URL: ${{ steps.meta.outputs.url }}
           DEPLOYED_AT: ${{ github.event.workflow_run.updated_at }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           SHORT_SHA="${HEAD_SHA:0:7}"
           cat > preview-report.md <<EOF
-          **Website Preview:** ${{ steps.meta.outputs.stable_url }}
+          **Website Preview:** $STABLE_URL
 
-          <sub>This commit: ${{ steps.meta.outputs.url }}</sub>
+          <sub>This commit: $UNIQUE_URL</sub>
 
           <sub>Last updated: $DEPLOYED_AT for \`$SHORT_SHA\`</sub>
           EOF

--- a/.github/workflows/pr-vercel-website-preview.yaml
+++ b/.github/workflows/pr-vercel-website-preview.yaml
@@ -37,21 +37,14 @@ jobs:
         id: pr-meta
         uses: ./.github/actions/resolve-pr-from-workflow-run
 
-      - name: Read preview URLs
-        if: steps.pr-meta.outputs.skip != 'true'
-        id: meta
-        run: |
-          echo "url=$(cat temp/vercel-preview/url.txt)" >> "$GITHUB_OUTPUT"
-          echo "stable_url=$(cat temp/vercel-preview/stable-url.txt)" >> "$GITHUB_OUTPUT"
-
       - name: Write report
         if: steps.pr-meta.outputs.skip != 'true'
         env:
-          STABLE_URL: ${{ steps.meta.outputs.stable_url }}
-          UNIQUE_URL: ${{ steps.meta.outputs.url }}
           DEPLOYED_AT: ${{ github.event.workflow_run.updated_at }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
+          STABLE_URL=$(cat temp/vercel-preview/stable-url.txt)
+          UNIQUE_URL=$(cat temp/vercel-preview/url.txt)
           SHORT_SHA="${HEAD_SHA:0:7}"
           cat > preview-report.md <<EOF
           **Website Preview:** $STABLE_URL

--- a/.github/workflows/pr-vercel-website-preview.yaml
+++ b/.github/workflows/pr-vercel-website-preview.yaml
@@ -51,13 +51,13 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           SHORT_SHA="${HEAD_SHA:0:7}"
-          {
-            echo "**Website Preview:** ${{ steps.meta.outputs.stable_url }}"
-            echo ""
-            echo "<sub>This commit: ${{ steps.meta.outputs.url }}</sub>"
-            echo ""
-            echo "<sub>Last updated: $DEPLOYED_AT for \`$SHORT_SHA\`</sub>"
-          } > preview-report.md
+          cat > preview-report.md <<EOF
+          **Website Preview:** ${{ steps.meta.outputs.stable_url }}
+
+          <sub>This commit: ${{ steps.meta.outputs.url }}</sub>
+
+          <sub>Last updated: $DEPLOYED_AT for \`$SHORT_SHA\`</sub>
+          EOF
 
       - name: Post PR comment
         if: steps.pr-meta.outputs.skip != 'true'

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -23,6 +23,10 @@
       "destination": "https://blog.comfy.org/",
       "permanent": true
     },
-    { "source": "/press", "destination": "/about", "permanent": true }
+    {
+      "source": "/press",
+      "destination": "/about",
+      "permanent": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Make the website preview URL stable per PR and make deployments show up correctly in the Vercel dashboard.

## Changes

- **What**:
  - Pass git metadata (`githubCommitRef`, `githubCommitSha`, `githubCommitAuthorLogin`, `githubCommitMessage`, `githubPrId`, `githubRepo`) via `vercel deploy --meta` so deployments group by branch/PR in the dashboard and pick up branch-scoped env vars.
  - Alias each preview deploy to a stable per-PR hostname: `comfy-website-preview-pr-<N>.vercel.app`. URL no longer changes between pushes on the same PR.
  - PR comment now shows the stable URL prominently, the per-commit URL as subtext, plus a last-updated timestamp and short SHA so reviewers can tell if the preview is current.
  - User-controlled PR fields routed through env vars (no shell interpolation of untrusted strings).

## Review Focus

- `PREVIEW_ALIAS_PREFIX` is set to `comfy-website-preview` — confirm this subdomain pattern is free within the Vercel team (first deploy will claim it).
- Production job is untouched.
- `vercel.json` keeps `github.enabled: false` — intentional, we stay CLI-driven.

### Known limitation (out of scope)

Vercel Shareable Links are bound to a specific deployment ID. Aliasing the stable hostname to a new deployment does **not** carry over previously-issued share links. If the team needs share links to persist across pushes, follow-up options: Protection Bypass for Automation (project-level token) or Deployment Protection Exceptions (Pro+).

### Follow-ups

- Optional `vercel alias rm` on PR close to clean up stale aliases.

## Screenshots (if applicable)

N/A — CI config only. Verification will land on this PR's own preview run.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11478-ci-stabilize-Vercel-website-preview-URLs-per-PR-3486d73d3650815ab24be1f7895cecc5) by [Unito](https://www.unito.io)
