### PR TITLE
fix: silence useImage onError rethrow at every call site

### DIFF
--- a/src/components/common/ComfyImage.vue
+++ b/src/components/common/ComfyImage.vue
@@ -51,5 +51,8 @@ const {
   alt?: string
 }>()
 
-const { error } = useImage(computed(() => ({ src, alt })))
+const { error } = useImage(
+  computed(() => ({ src, alt })),
+  { onError: () => {} }
+)
 </script>

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -184,10 +184,13 @@ const tooltipDelay = computed<number>(() =>
   settingStore.get('LiteGraph.Node.TooltipDelay')
 )
 
-const { isLoading, error } = useImage({
-  src: asset.preview_url ?? '',
-  alt: displayName.value
-})
+const { isLoading, error } = useImage(
+  {
+    src: asset.preview_url ?? '',
+    alt: displayName.value
+  },
+  { onError: () => {} }
+)
 
 function handleSelect() {
   acknowledgeAsset(asset.id)

--- a/src/platform/assets/components/MediaImageTop.vue
+++ b/src/platform/assets/components/MediaImageTop.vue
@@ -34,10 +34,13 @@ const emit = defineEmits<{
   view: []
 }>()
 
-const { state, error, isReady } = useImage({
-  src: asset.src ?? '',
-  alt: getAssetDisplayName(asset)
-})
+const { state, error, isReady } = useImage(
+  {
+    src: asset.src ?? '',
+    alt: getAssetDisplayName(asset)
+  },
+  { onError: () => {} }
+)
 
 whenever(
   () =>

--- a/src/platform/workflow/sharing/components/ShareAssetThumbnail.vue
+++ b/src/platform/workflow/sharing/components/ShareAssetThumbnail.vue
@@ -63,5 +63,7 @@ const imageOptions = computed(() => ({
   src: normalizedPreviewUrl.value ?? ''
 }))
 
-const { isReady, isLoading, error } = useImage(imageOptions)
+const { isReady, isLoading, error } = useImage(imageOptions, {
+  onError: () => {}
+})
 </script>


### PR DESCRIPTION
## Summary

Pass `onError: () => {}` to every `useImage` call site — silences the VueUse default `reportError` rethrow that has been our top Datadog RUM issue on prod-v2 for 30+ days.

## Changes

- **What**: 4 call sites of `useImage` now pass an explicit noop `onError` option to opt out of the default `globalThis.reportError` rethrow.

## Review Focus

Each call site already surfaces image failures via the returned `error` ref and handles it in-template (placeholder icon, fallback state). The rethrow was never providing any value to the UI — it was only reaching Datadog RUM.

### Root cause

VueUse `useImage` is built on `useAsyncState`, whose `onError` defaults to `globalThis.reportError`. When `img.onerror` fires, the Promise rejects with a raw DOM `Event` and `reportError` dispatches it to `window`, where Datadog RUM's browser integration picks it up as an uncaught error:

```
Uncaught {"type":"error","isTrusted":true,"currentTarget":"[HTMLImageElement]","target":"[HTMLImageElement]"}
```

### Scope (last 24h, prod-v2)

- 192,243 events across 3,270 unique sessions
- Two drivers:
  - ~86% real 404s on valid preview URLs (expired GCS signed URLs, deleted objects)
  - ~14% structural — audio/json/model assets legitimately have no preview; backend serializes `preview_url` as empty string; empty-src `<img>` always errors

Fix covers both — the browser still emits `error`, `error.value` is still true, UI fallbacks still render. Only the RUM noise goes away.

### Follow-ups (not in this PR)

- Optional: guard empty-src at call sites so we don't kick off known-doomed image loads. Second layer, not required.
- Datadog RUM sourcemap upload isn't configured (Sentry's is). Separate hygiene item — would make future RUM stacks readable instead of pointing at minified vendor chunks.

Fixes FE-224

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11486-fix-silence-useImage-onError-rethrow-at-every-call-site-3496d73d3650816ca257dbc5241b42d1) by [Unito](https://www.unito.io)
