### PR TITLE
fix: render edit pencil icon correctly in properties panel header

### DIFF
--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -299,14 +299,16 @@ function handleTitleCancel() {
               @cancel="handleTitleCancel"
               @click="isEditing = true"
             />
-            <button
+            <Button
               v-if="!isEditing"
+              variant="link"
+              size="unset"
               :aria-label="t('rightSidePanel.editTitle')"
-              class="relative top-[2px] ml-2 inline-flex shrink-0 cursor-pointer items-center justify-center text-muted-foreground hover:text-base-foreground"
+              class="relative top-[2px] ml-2 shrink-0"
               @click="isEditing = true"
             >
               <i aria-hidden="true" class="icon-[lucide--pencil] size-4" />
-            </button>
+            </Button>
           </template>
           <template v-else>
             {{ panelTitle }}

--- a/src/components/rightSidePanel/RightSidePanel.vue
+++ b/src/components/rightSidePanel/RightSidePanel.vue
@@ -302,7 +302,7 @@ function handleTitleCancel() {
             <button
               v-if="!isEditing"
               :aria-label="t('rightSidePanel.editTitle')"
-              class="relative top-[2px] ml-2 size-4 shrink-0 cursor-pointer content-center text-muted-foreground hover:text-base-foreground"
+              class="relative top-[2px] ml-2 inline-flex shrink-0 cursor-pointer items-center justify-center text-muted-foreground hover:text-base-foreground"
               @click="isEditing = true"
             >
               <i aria-hidden="true" class="icon-[lucide--pencil] size-4" />


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The edit pencil button next to the selected node's name at the top of the properties panel (rightSidePanel) rendered as a dark filled square instead of a pencil icon.

## Root cause

The button was given `size-4` (16×16) while the inner iconify `<i class="icon-[lucide--pencil] size-4">` was also 16×16. The icon overflowed the button and was clipped, and `content-center` has no effect on a default `<button>` element, so the icon wasn't centered either. Since iconify icons render via `background-color` masked by the SVG, a clipped mask rendered as a partial/solid block that reads as a dark square.

## Fix

Remove `size-4` and `content-center` from the button; use `inline-flex items-center justify-center` so the button sizes naturally around the 16×16 icon and centers it properly.

```diff
-class="relative top-[2px] ml-2 size-4 shrink-0 cursor-pointer content-center text-muted-foreground hover:text-base-foreground"
+class="relative top-[2px] ml-2 inline-flex shrink-0 cursor-pointer items-center justify-center text-muted-foreground hover:text-base-foreground"
```

One-line change in `src/components/rightSidePanel/RightSidePanel.vue`. No behavior change — clicking the button still switches the title into edit mode via `isEditing = true`. Existing e2e coverage in `browser_tests/tests/propertiesPanel/titleEditing.spec.ts` exercises click behavior.

## Visual verification

Before — dark filled square:

![before](.glary/screenshots/before-fix-zoom.png)

After — pencil icon renders correctly:

![after](.glary/screenshots/after-fix-zoom.png)

Full panel view after the fix:

![after-full](.glary/screenshots/after-fix-full.png)

## Quality gates

- `pnpm lint` — clean (pre-existing unrelated warning in a test file)
- `pnpm typecheck` — clean
- `pnpm format` — no-op
- Manual verification: clicking the pencil still opens the editable title input

## Context

Reported by Alex in Slack `#bug-dump`. Present in `main`, unrelated to #11414.

Bug tracker: [Notion — Icon next to node name in properties panel is broken](https://www.notion.so/Bug-Icon-next-to-node-name-in-properties-panel-is-broken-3486d73d365081919d7ae96dbe260ab4)

## Screenshots

![Before: broken dark filled square icon next to node name](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1e2499fbb5b130c2c7403202f49833ad5fa53cb7abf567f419708a2800935bec/pr-images/1776732250120-e64882bb-c47e-4163-ba0b-4d5a204dba3c.png)

![After: pencil icon renders correctly next to node name](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1e2499fbb5b130c2c7403202f49833ad5fa53cb7abf567f419708a2800935bec/pr-images/1776732250445-45ab977f-3572-43d9-a9fb-211055383573.png)

![After: full properties panel view with pencil icon](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1e2499fbb5b130c2c7403202f49833ad5fa53cb7abf567f419708a2800935bec/pr-images/1776732250814-6cadec99-1d8d-461d-8811-2ca01864d1a6.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11487-fix-render-edit-pencil-icon-correctly-in-properties-panel-header-3496d73d36508157ba08f4a7a6e31fdd) by [Unito](https://www.unito.io)
