### PR TITLE
[backport core/1.42] fix: show credits in legacy user popover on non-cloud distributions

### DIFF
--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -1,7 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { h } from 'vue'
+import { h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
@@ -103,11 +103,13 @@ vi.mock('@/stores/firebaseAuthStore', () => ({
 
 // Mock the useSubscription composable
 const mockFetchStatus = vi.fn().mockResolvedValue(undefined)
+const mockIsFreeTier = ref(false)
 vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   useSubscription: vi.fn(() => ({
-    isActiveSubscription: { value: true },
-    subscriptionTierName: { value: 'Creator' },
-    subscriptionTier: { value: 'CREATOR' },
+    isActiveSubscription: ref(true),
+    isFreeTier: mockIsFreeTier,
+    subscriptionTierName: ref('Creator'),
+    subscriptionTier: ref('CREATOR'),
     fetchStatus: mockFetchStatus
   }))
 }))
@@ -188,6 +190,7 @@ describe('CurrentUserPopoverLegacy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsCloud.value = true
+    mockIsFreeTier.value = false
     mockAuthStoreState.balance = {
       amount_micros: 100_000,
       effective_balance_micros: 100_000,
@@ -430,16 +433,49 @@ describe('CurrentUserPopoverLegacy', () => {
     })
   })
 
+  describe('cloud free tier', () => {
+    beforeEach(() => {
+      mockIsCloud.value = true
+      mockIsFreeTier.value = true
+    })
+
+    it('shows upgrade-to-add-credits button and hides add-credits button', () => {
+      const wrapper = mountComponent()
+      expect(
+        wrapper.find('[data-testid="upgrade-to-add-credits-button"]').exists()
+      ).toBe(true)
+      expect(
+        wrapper.find('[data-testid="add-credits-button"]').exists()
+      ).toBe(false)
+    })
+  })
+
   describe('non-cloud distribution', () => {
     beforeEach(() => {
       mockIsCloud.value = false
     })
 
-    it('hides credits section', () => {
+    it('still shows credits balance', () => {
       const wrapper = mountComponent()
-      expect(wrapper.find('[data-testid="add-credits-button"]').exists()).toBe(
-        false
-      )
+      expect(wrapper.text()).toContain('1000')
+    })
+
+    it('shows add-credits button and hides upgrade-to-add-credits button', () => {
+      const wrapper = mountComponent()
+      expect(
+        wrapper.find('[data-testid="add-credits-button"]').exists()
+      ).toBe(true)
+      expect(
+        wrapper.find('[data-testid="upgrade-to-add-credits-button"]').exists()
+      ).toBe(false)
+    })
+
+    it('hides upgrade-to-add-credits button even when on free tier', () => {
+      mockIsFreeTier.value = true
+      const wrapper = mountComponent()
+      expect(
+        wrapper.find('[data-testid="add-credits-button"]').exists()
+      ).toBe(true)
       expect(
         wrapper.find('[data-testid="upgrade-to-add-credits-button"]').exists()
       ).toBe(false)
@@ -450,11 +486,11 @@ describe('CurrentUserPopoverLegacy', () => {
       expect(wrapper.text()).not.toContain('Subscribe Button')
     })
 
-    it('hides partner nodes menu item', () => {
+    it('still shows partner nodes menu item', () => {
       const wrapper = mountComponent()
       expect(
         wrapper.find('[data-testid="partner-nodes-menu-item"]').exists()
-      ).toBe(false)
+      ).toBe(true)
     })
 
     it('hides plans & pricing menu item', () => {
@@ -464,11 +500,11 @@ describe('CurrentUserPopoverLegacy', () => {
       ).toBe(false)
     })
 
-    it('hides manage plan menu item', () => {
+    it('still shows manage plan menu item', () => {
       const wrapper = mountComponent()
       expect(
         wrapper.find('[data-testid="manage-plan-menu-item"]').exists()
-      ).toBe(false)
+      ).toBe(true)
     })
 
     it('still shows user settings menu item', () => {

--- a/src/components/topbar/CurrentUserPopoverLegacy.test.ts
+++ b/src/components/topbar/CurrentUserPopoverLegacy.test.ts
@@ -444,9 +444,9 @@ describe('CurrentUserPopoverLegacy', () => {
       expect(
         wrapper.find('[data-testid="upgrade-to-add-credits-button"]').exists()
       ).toBe(true)
-      expect(
-        wrapper.find('[data-testid="add-credits-button"]').exists()
-      ).toBe(false)
+      expect(wrapper.find('[data-testid="add-credits-button"]').exists()).toBe(
+        false
+      )
     })
   })
 
@@ -462,9 +462,9 @@ describe('CurrentUserPopoverLegacy', () => {
 
     it('shows add-credits button and hides upgrade-to-add-credits button', () => {
       const wrapper = mountComponent()
-      expect(
-        wrapper.find('[data-testid="add-credits-button"]').exists()
-      ).toBe(true)
+      expect(wrapper.find('[data-testid="add-credits-button"]').exists()).toBe(
+        true
+      )
       expect(
         wrapper.find('[data-testid="upgrade-to-add-credits-button"]').exists()
       ).toBe(false)
@@ -473,9 +473,9 @@ describe('CurrentUserPopoverLegacy', () => {
     it('hides upgrade-to-add-credits button even when on free tier', () => {
       mockIsFreeTier.value = true
       const wrapper = mountComponent()
-      expect(
-        wrapper.find('[data-testid="add-credits-button"]').exists()
-      ).toBe(true)
+      expect(wrapper.find('[data-testid="add-credits-button"]').exists()).toBe(
+        true
+      )
       expect(
         wrapper.find('[data-testid="upgrade-to-add-credits-button"]').exists()
       ).toBe(false)

--- a/src/components/topbar/CurrentUserPopoverLegacy.vue
+++ b/src/components/topbar/CurrentUserPopoverLegacy.vue
@@ -29,11 +29,8 @@
       </span>
     </div>
 
-    <!-- Credits Section (cloud only) -->
-    <div
-      v-if="isCloud && isActiveSubscription"
-      class="flex items-center gap-2 px-4 py-2"
-    >
+    <!-- Credits Section -->
+    <div v-if="isActiveSubscription" class="flex items-center gap-2 px-4 py-2">
       <i class="icon-[lucide--component] text-sm text-amber-400" />
       <Skeleton
         v-if="authStore.isFetchingBalance"
@@ -49,7 +46,7 @@
         class="mr-auto icon-[lucide--circle-help] cursor-help text-base text-muted-foreground"
       />
       <Button
-        v-if="isFreeTier"
+        v-if="isCloud && isFreeTier"
         variant="gradient"
         size="sm"
         data-testid="upgrade-to-add-credits-button"
@@ -82,7 +79,7 @@
     <Divider class="mx-0 my-2" />
 
     <div
-      v-if="isCloud && isActiveSubscription"
+      v-if="isActiveSubscription"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="partner-nodes-menu-item"
       @click="handleOpenPartnerNodesInfo"
@@ -112,7 +109,7 @@
     </div>
 
     <div
-      v-if="isCloud && isActiveSubscription"
+      v-if="isActiveSubscription"
       class="flex cursor-pointer items-center gap-2 px-4 py-2 hover:bg-secondary-background-hover"
       data-testid="manage-plan-menu-item"
       @click="handleOpenPlanAndCreditsSettings"


### PR DESCRIPTION
Manual backport of #11463 to core/1.42.

Cherry-pick of 4b5c15fc7 with test adapted for `@vue/test-utils` (core/1.42 does not have the `@testing-library/vue` migration or the authStore rename).

**Changes:**
- `.vue`: identical to main (remove `isCloud` gate from credits row, add `isCloud && isFreeTier` for upgrade button)
- `.test.ts`: equivalent assertions written in `@vue/test-utils` style (`wrapper.find`/`wrapper.text` instead of `screen.getByTestId`)

- Fixes FE-219

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11503-backport-core-1-42-fix-show-credits-in-legacy-user-popover-on-non-cloud-distributions-3496d73d365081dd87fff12f850b1c93) by [Unito](https://www.unito.io)
