### PR TITLE
Fix nodeReplacement not triggering onRemoved

### DIFF
--- a/src/platform/nodeReplacement/useNodeReplacement.test.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.test.ts
@@ -297,6 +297,7 @@ describe('useNodeReplacement', () => {
 
     it('should apply set_value to widget', () => {
       const placeholder = createPlaceholderNode(1, 'ImageScaleBy')
+      placeholder.onRemoved = vi.fn()
       const graph = createMockGraph([placeholder])
       placeholder.graph = graph
       Object.assign(app, { rootGraph: graph })
@@ -331,6 +332,10 @@ describe('useNodeReplacement', () => {
 
       // set_value should be applied to the widget
       expect(newNode.widgets![0].value).toBe('scale by multiplier')
+      expect(
+        placeholder.onRemoved,
+        'call onRemoved on old node'
+      ).toHaveBeenCalledTimes(1)
     })
 
     it('should transfer widget values using old_widget_ids', () => {

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -159,6 +159,7 @@ function replaceWithMapping(
   nodeGraph: LGraph,
   idx: number
 ): void {
+  node.onRemoved?.()
   newNode.id = node.id
   newNode.pos = [...node.pos]
   newNode.size = [...node.size]
@@ -219,7 +220,6 @@ function replaceWithMapping(
   }
 
   newNode.has_errors = false
-  node.onRemoved?.()
 }
 
 export function useNodeReplacement() {

--- a/src/platform/nodeReplacement/useNodeReplacement.ts
+++ b/src/platform/nodeReplacement/useNodeReplacement.ts
@@ -219,6 +219,7 @@ function replaceWithMapping(
   }
 
   newNode.has_errors = false
+  node.onRemoved?.()
 }
 
 export function useNodeReplacement() {


### PR DESCRIPTION
Node Replacement failed to call onRemoved on the old node. This would cause domWidgets to persist after a node is replaced.

<img width="474" height="257" alt="image" src="https://github.com/user-attachments/assets/51641de7-81e9-4355-88d9-d1605f397076" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11509-Fix-nodeReplacement-not-triggering-onRemoved-3496d73d365081e19a4ae252aa87172d) by [Unito](https://www.unito.io)
