### PR TITLE
test: add GLSL execution e2e test

### DIFF
--- a/browser_tests/assets/nodes/glsl_shader_in_subgraph.json
+++ b/browser_tests/assets/nodes/glsl_shader_in_subgraph.json
@@ -1,0 +1,135 @@
+{
+  "id": "ee111111-2222-4333-8444-000000000001",
+  "revision": 0,
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "aa999999-8888-4777-a666-555555555555",
+      "pos": [400, 200],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": null }],
+      "title": "GLSL Subgraph",
+      "properties": {},
+      "widgets_values": []
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "aa999999-8888-4777-a666-555555555555",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 1,
+          "lastLinkId": 1,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "GLSL Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [50, 200, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [900, 200, 120, 60]
+        },
+        "inputs": [],
+        "outputs": [
+          {
+            "id": "bb888888-7777-4666-a555-444444444444",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [1],
+            "pos": { "0": 920, "1": 220 }
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1,
+            "type": "GLSLShader",
+            "pos": [250, 180],
+            "size": [460, 320],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "fragment_shader",
+                "name": "fragment_shader",
+                "type": "STRING",
+                "widget": { "name": "fragment_shader" },
+                "link": null
+              },
+              {
+                "localized_name": "size_mode",
+                "name": "size_mode",
+                "type": "COMFY_DYNAMICCOMBO_V3",
+                "widget": { "name": "size_mode" },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE0",
+                "name": "IMAGE0",
+                "type": "IMAGE",
+                "links": [1]
+              },
+              {
+                "localized_name": "IMAGE1",
+                "name": "IMAGE1",
+                "type": "IMAGE",
+                "links": null
+              },
+              {
+                "localized_name": "IMAGE2",
+                "name": "IMAGE2",
+                "type": "IMAGE",
+                "links": null
+              },
+              {
+                "localized_name": "IMAGE3",
+                "name": "IMAGE3",
+                "type": "IMAGE",
+                "links": null
+              }
+            ],
+            "properties": { "Node name for S&R": "GLSLShader" },
+            "widgets_values": [
+              "#version 300 es\nprecision highp float;\nuniform vec2 u_resolution;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = vec4(1.0, 0.0, 0.0, 1.0);\n}\n",
+              "from_input"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/nodes/glsl_shader_standalone.json
+++ b/browser_tests/assets/nodes/glsl_shader_standalone.json
@@ -1,0 +1,69 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "GLSLShader",
+      "pos": [200, 200],
+      "size": [460, 320],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "fragment_shader",
+          "name": "fragment_shader",
+          "type": "STRING",
+          "widget": { "name": "fragment_shader" },
+          "link": null
+        },
+        {
+          "localized_name": "size_mode",
+          "name": "size_mode",
+          "type": "COMFY_DYNAMICCOMBO_V3",
+          "widget": { "name": "size_mode" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE0",
+          "name": "IMAGE0",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE1",
+          "name": "IMAGE1",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE2",
+          "name": "IMAGE2",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE3",
+          "name": "IMAGE3",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "GLSLShader" },
+      "widgets_values": [
+        "#version 300 es\nprecision highp float;\nuniform vec2 u_resolution;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = vec4(v_texCoord.x, v_texCoord.y, 0.5, 1.0);\n}\n",
+        "from_input"
+      ]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/nodes/glsl_shader_subgraph_with_float.json
+++ b/browser_tests/assets/nodes/glsl_shader_subgraph_with_float.json
@@ -1,0 +1,179 @@
+{
+  "id": "ee111111-2222-4333-8444-000000000002",
+  "revision": 0,
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "aa999999-8888-4777-a666-555555555556",
+      "pos": [400, 200],
+      "size": [400, 200],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": null }],
+      "title": "GLSL Subgraph With Float",
+      "properties": {},
+      "widgets_values": []
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "aa999999-8888-4777-a666-555555555556",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 2,
+          "lastLinkId": 2,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "GLSL Subgraph With Float",
+        "inputNode": {
+          "id": -10,
+          "bounding": [50, 200, 120, 60]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [900, 200, 120, 60]
+        },
+        "inputs": [],
+        "outputs": [
+          {
+            "id": "bb888888-7777-4666-a555-444444444445",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [1],
+            "pos": { "0": 920, "1": 220 }
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1,
+            "type": "GLSLShader",
+            "pos": [400, 180],
+            "size": [460, 320],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "u_float0",
+                "localized_name": "floats.u_float0",
+                "name": "floats.u_float0",
+                "shape": 7,
+                "type": "FLOAT",
+                "link": 2
+              },
+              {
+                "localized_name": "fragment_shader",
+                "name": "fragment_shader",
+                "type": "STRING",
+                "widget": { "name": "fragment_shader" },
+                "link": null
+              },
+              {
+                "localized_name": "size_mode",
+                "name": "size_mode",
+                "type": "COMFY_DYNAMICCOMBO_V3",
+                "widget": { "name": "size_mode" },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE0",
+                "name": "IMAGE0",
+                "type": "IMAGE",
+                "links": [1]
+              },
+              {
+                "localized_name": "IMAGE1",
+                "name": "IMAGE1",
+                "type": "IMAGE",
+                "links": null
+              },
+              {
+                "localized_name": "IMAGE2",
+                "name": "IMAGE2",
+                "type": "IMAGE",
+                "links": null
+              },
+              {
+                "localized_name": "IMAGE3",
+                "name": "IMAGE3",
+                "type": "IMAGE",
+                "links": null
+              }
+            ],
+            "properties": { "Node name for S&R": "GLSLShader" },
+            "widgets_values": [
+              "#version 300 es\nprecision highp float;\nuniform float u_float0;\nuniform vec2 u_resolution;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = vec4(u_float0, 0.0, 0.0, 1.0);\n}\n",
+              "from_input"
+            ]
+          },
+          {
+            "id": 2,
+            "type": "PrimitiveFloat",
+            "pos": [80, 200],
+            "size": [270, 58],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "FLOAT",
+                "widget": { "name": "value" },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [2]
+              }
+            ],
+            "properties": { "Node name for S&R": "PrimitiveFloat" },
+            "widgets_values": [1.0]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 2,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/nodes/glsl_shader_with_bool.json
+++ b/browser_tests/assets/nodes/glsl_shader_with_bool.json
@@ -1,0 +1,105 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "GLSLShader",
+      "pos": [400, 200],
+      "size": [460, 320],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "u_bool0",
+          "localized_name": "bools.u_bool0",
+          "name": "bools.u_bool0",
+          "shape": 7,
+          "type": "BOOLEAN",
+          "link": 1
+        },
+        {
+          "localized_name": "fragment_shader",
+          "name": "fragment_shader",
+          "type": "STRING",
+          "widget": { "name": "fragment_shader" },
+          "link": null
+        },
+        {
+          "localized_name": "size_mode",
+          "name": "size_mode",
+          "type": "COMFY_DYNAMICCOMBO_V3",
+          "widget": { "name": "size_mode" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE0",
+          "name": "IMAGE0",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE1",
+          "name": "IMAGE1",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE2",
+          "name": "IMAGE2",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE3",
+          "name": "IMAGE3",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "GLSLShader" },
+      "widgets_values": [
+        "#version 300 es\nprecision highp float;\nuniform bool u_bool0;\nuniform vec2 u_resolution;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = u_bool0 ? vec4(1.0, 0.0, 0.0, 1.0) : vec4(0.0, 0.0, 1.0, 1.0);\n}\n",
+        "from_input"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "PrimitiveBoolean",
+      "pos": [80, 200],
+      "size": [270, 58],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "value",
+          "name": "value",
+          "type": "BOOLEAN",
+          "widget": { "name": "value" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "BOOLEAN",
+          "name": "BOOLEAN",
+          "type": "BOOLEAN",
+          "links": [1]
+        }
+      ],
+      "properties": { "Node name for S&R": "PrimitiveBoolean" },
+      "widgets_values": [false]
+    }
+  ],
+  "links": [[1, 2, 0, 1, 0, "BOOLEAN"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/nodes/glsl_shader_with_float.json
+++ b/browser_tests/assets/nodes/glsl_shader_with_float.json
@@ -1,0 +1,105 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "GLSLShader",
+      "pos": [400, 200],
+      "size": [460, 320],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "u_float0",
+          "localized_name": "floats.u_float0",
+          "name": "floats.u_float0",
+          "shape": 7,
+          "type": "FLOAT",
+          "link": 1
+        },
+        {
+          "localized_name": "fragment_shader",
+          "name": "fragment_shader",
+          "type": "STRING",
+          "widget": { "name": "fragment_shader" },
+          "link": null
+        },
+        {
+          "localized_name": "size_mode",
+          "name": "size_mode",
+          "type": "COMFY_DYNAMICCOMBO_V3",
+          "widget": { "name": "size_mode" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE0",
+          "name": "IMAGE0",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE1",
+          "name": "IMAGE1",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE2",
+          "name": "IMAGE2",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE3",
+          "name": "IMAGE3",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "GLSLShader" },
+      "widgets_values": [
+        "#version 300 es\nprecision highp float;\nuniform float u_float0;\nuniform vec2 u_resolution;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = vec4(u_float0, v_texCoord.y, 0.5, 1.0);\n}\n",
+        "from_input"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "PrimitiveFloat",
+      "pos": [80, 200],
+      "size": [270, 58],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "value",
+          "name": "value",
+          "type": "FLOAT",
+          "widget": { "name": "value" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "FLOAT",
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [1]
+        }
+      ],
+      "properties": { "Node name for S&R": "PrimitiveFloat" },
+      "widgets_values": [0.25]
+    }
+  ],
+  "links": [[1, 2, 0, 1, 0, "FLOAT"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/nodes/glsl_shader_with_int.json
+++ b/browser_tests/assets/nodes/glsl_shader_with_int.json
@@ -1,0 +1,105 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "GLSLShader",
+      "pos": [400, 200],
+      "size": [460, 320],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "u_int0",
+          "localized_name": "ints.u_int0",
+          "name": "ints.u_int0",
+          "shape": 7,
+          "type": "INT",
+          "link": 1
+        },
+        {
+          "localized_name": "fragment_shader",
+          "name": "fragment_shader",
+          "type": "STRING",
+          "widget": { "name": "fragment_shader" },
+          "link": null
+        },
+        {
+          "localized_name": "size_mode",
+          "name": "size_mode",
+          "type": "COMFY_DYNAMICCOMBO_V3",
+          "widget": { "name": "size_mode" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE0",
+          "name": "IMAGE0",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE1",
+          "name": "IMAGE1",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE2",
+          "name": "IMAGE2",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE3",
+          "name": "IMAGE3",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "GLSLShader" },
+      "widgets_values": [
+        "#version 300 es\nprecision highp float;\nuniform int u_int0;\nuniform vec2 u_resolution;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = vec4(float(u_int0) / 100.0, 0.0, 0.0, 1.0);\n}\n",
+        "from_input"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "PrimitiveInt",
+      "pos": [80, 200],
+      "size": [270, 82],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "value",
+          "name": "value",
+          "type": "INT",
+          "widget": { "name": "value" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "INT",
+          "name": "INT",
+          "type": "INT",
+          "links": [1]
+        }
+      ],
+      "properties": { "Node name for S&R": "PrimitiveInt" },
+      "widgets_values": [25, "randomize"]
+    }
+  ],
+  "links": [[1, 2, 0, 1, 0, "INT"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/assets/nodes/glsl_shader_with_loadimage.json
+++ b/browser_tests/assets/nodes/glsl_shader_with_loadimage.json
@@ -1,0 +1,92 @@
+{
+  "last_node_id": 2,
+  "last_link_id": 1,
+  "nodes": [
+    {
+      "id": 2,
+      "type": "LoadImage",
+      "pos": [50, 200],
+      "size": [315, 314],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [1] },
+        { "name": "MASK", "type": "MASK", "links": null }
+      ],
+      "properties": { "Node name for S&R": "LoadImage" },
+      "widgets_values": ["example.png", "image"]
+    },
+    {
+      "id": 1,
+      "type": "GLSLShader",
+      "pos": [400, 200],
+      "size": [460, 320],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "image0",
+          "localized_name": "images.image0",
+          "name": "images.image0",
+          "type": "IMAGE",
+          "link": 1
+        },
+        {
+          "localized_name": "fragment_shader",
+          "name": "fragment_shader",
+          "type": "STRING",
+          "widget": { "name": "fragment_shader" },
+          "link": null
+        },
+        {
+          "localized_name": "size_mode",
+          "name": "size_mode",
+          "type": "COMFY_DYNAMICCOMBO_V3",
+          "widget": { "name": "size_mode" },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE0",
+          "name": "IMAGE0",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE1",
+          "name": "IMAGE1",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE2",
+          "name": "IMAGE2",
+          "type": "IMAGE",
+          "links": null
+        },
+        {
+          "localized_name": "IMAGE3",
+          "name": "IMAGE3",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": { "Node name for S&R": "GLSLShader" },
+      "widgets_values": [
+        "#version 300 es\nprecision highp float;\nuniform sampler2D u_image0;\nin vec2 v_texCoord;\nlayout(location = 0) out vec4 fragColor0;\nvoid main() {\n    fragColor0 = texture(u_image0, v_texCoord);\n}\n",
+        "from_input"
+      ]
+    }
+  ],
+  "links": [[1, 2, 0, 1, 0, "IMAGE"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": { "offset": [0, 0], "scale": 1 }
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/vueNodes/glslPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/glslPreview.spec.ts
@@ -28,6 +28,17 @@ const RED_SHADER = [
   '}'
 ].join('\n')
 
+/** Shader that drives every pixel's red channel from `u_float0` alone. */
+const FLOAT_RED_SHADER = [
+  '#version 300 es',
+  'precision highp float;',
+  'uniform float u_float0;',
+  'layout(location = 0) out vec4 fragColor0;',
+  'void main() {',
+  '    fragColor0 = vec4(u_float0, 0.0, 0.0, 1.0);',
+  '}'
+].join('\n')
+
 /** Wait until an `<img>` locator has finished decoding. */
 async function waitForImageDecoded(image: Locator): Promise<void> {
   await expect
@@ -213,6 +224,7 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
 
         await expect.poll(() => glsl.getPreviewSrc()).not.toBe(initialSrc)
         await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+        await glsl.expectEveryPixelToBe([255, 0, 0, 255])
       })
     })
 
@@ -270,6 +282,7 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
       await glsl.shaderTextbox.fill(RED_SHADER)
       await expect.poll(() => glsl.getPreviewSrc()).not.toBe(goodSrc)
       await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+      await glsl.expectEveryPixelToBe([255, 0, 0, 255])
     })
   })
 
@@ -292,16 +305,22 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
       const { input: floatValueInput } =
         comfyPage.vueNodes.getInputNumberControls(floatValueWidget)
 
+      // Drive every pixel's red channel directly from u_float0 so the
+      // before/after refresh is visually obvious (dim red → pure red).
+      await glsl.shaderTextbox.fill(FLOAT_RED_SHADER)
       await glsl.simulateExecutionOutput(ws)
       const initialSrc = await glsl.waitForBlobSrc()
+      // Workflow default is 0.25 → ~64; RGBA16F → PNG round-trip can drift.
+      await glsl.expectEveryPixelToBe([64, 0, 0, 255], 2)
 
       await test.step('changing the upstream float value re-renders the preview', async () => {
         await expect(floatValueInput).toBeVisible()
-        await floatValueInput.fill('0.9')
+        await floatValueInput.fill('1.0')
         await floatValueInput.blur()
 
         await expect.poll(() => glsl.getPreviewSrc()).not.toBe(initialSrc)
         await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+        await glsl.expectEveryPixelToBe([255, 0, 0, 255])
       })
     })
   })

--- a/browser_tests/tests/vueNodes/glslPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/glslPreview.spec.ts
@@ -28,6 +28,17 @@ const RED_SHADER = [
   '}'
 ].join('\n')
 
+/** Wait until an `<img>` locator has finished decoding. */
+async function waitForImageDecoded(image: Locator): Promise<void> {
+  await expect
+    .poll(() =>
+      image.evaluate(
+        (el: HTMLImageElement) => el.complete && el.naturalWidth > 0
+      )
+    )
+    .toBe(true)
+}
+
 /** Page-object helper bound to the GLSLShader node under test. */
 class GLSLShaderNode {
   readonly node: Locator
@@ -106,6 +117,7 @@ class GLSLShaderNode {
     expected: [number, number, number, number],
     tolerance = 1
   ): Promise<void> {
+    await waitForImageDecoded(this.previewImage)
     const mismatch = await this.previewImage.evaluate(
       (
         img: HTMLImageElement,
@@ -155,7 +167,9 @@ async function dropImageOntoLoadImage(
   await comfyPage.dragDrop.dragAndDropFile(filename, {
     dropPosition: { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 }
   })
-  await expect(node.locator('.image-preview img')).toBeVisible()
+  const preview = node.locator('.image-preview img')
+  await expect(preview).toBeVisible()
+  await waitForImageDecoded(preview)
 }
 
 test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
@@ -300,7 +314,7 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
 
     const LOAD_IMAGE_NODE_ID = '2'
 
-    test('uses upstream image dimensions and binds it as u_image0', async ({
+    test('uses upstream image dimensions', async ({
       comfyPage,
       getWebSocket
     }) => {

--- a/browser_tests/tests/vueNodes/glslPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/glslPreview.spec.ts
@@ -14,6 +14,8 @@ const test = mergeTests(comfyPageFixture, webSocketFixture)
 const GLSL_NODE_ID = '1'
 const GLSL_NODE_TITLE = 'GLSL Shader'
 const PRIMITIVE_FLOAT_NODE_TITLE = 'Float'
+const PRIMITIVE_INT_NODE_TITLE = 'Int'
+const PRIMITIVE_BOOLEAN_NODE_TITLE = 'Boolean'
 
 const RED_SHADER = [
   '#version 300 es',
@@ -98,13 +100,17 @@ class GLSLShaderNode {
   }
 
   /**
-   * Draw the preview blob to a 2D canvas and verify every pixel matches
+   * Draw the preview blob to a 2D canvas and verify every pixel matches.
    */
   async expectEveryPixelToBe(
-    expected: [number, number, number, number]
+    expected: [number, number, number, number],
+    tolerance = 1
   ): Promise<void> {
     const mismatch = await this.previewImage.evaluate(
-      (img: HTMLImageElement, exp: [number, number, number, number]) => {
+      (
+        img: HTMLImageElement,
+        args: { exp: [number, number, number, number]; tol: number }
+      ) => {
         const canvas = document.createElement('canvas')
         canvas.width = img.naturalWidth
         canvas.height = img.naturalHeight
@@ -113,7 +119,7 @@ class GLSLShaderNode {
         const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height)
         for (let i = 0; i < data.length; i += 4) {
           for (let c = 0; c < 4; c++) {
-            if (Math.abs(data[i + c] - exp[c]) > 1) {
+            if (Math.abs(data[i + c] - args.exp[c]) > args.tol) {
               return {
                 index: i / 4,
                 actual: [data[i], data[i + 1], data[i + 2], data[i + 3]]
@@ -123,10 +129,10 @@ class GLSLShaderNode {
         }
         return null
       },
-      expected
+      { exp: expected, tol: tolerance }
     )
     const message = mismatch
-      ? `expected every pixel ≈ [${expected.join(',')}]; pixel ${mismatch.index} was [${mismatch.actual.join(',')}]`
+      ? `expected every pixel ≈ [${expected.join(',')}] ±${tolerance}; pixel ${mismatch.index} was [${mismatch.actual.join(',')}]`
       : undefined
     expect(mismatch, message).toBeNull()
   }
@@ -337,6 +343,79 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
     })
   })
 
+  test.describe('with primitive int source', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/glsl_shader_with_int')
+      await comfyPage.vueNodes.waitForNodes(2)
+    })
+
+    test('refreshes preview when upstream PrimitiveInt value changes', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+      const intValueWidget = comfyPage.vueNodes.getWidgetByName(
+        PRIMITIVE_INT_NODE_TITLE,
+        'value'
+      )
+      const { input: intValueInput } =
+        comfyPage.vueNodes.getInputNumberControls(intValueWidget)
+
+      await glsl.simulateExecutionOutput(ws)
+      const initialSrc = await glsl.waitForBlobSrc()
+
+      await test.step('changing the upstream int value re-renders the preview', async () => {
+        await expect(intValueInput).toBeVisible()
+        await intValueInput.fill('100')
+        await intValueInput.blur()
+
+        await expect.poll(() => glsl.getPreviewSrc()).not.toBe(initialSrc)
+        await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+      })
+
+      await test.step('upstream int value flows through as the u_int0 uniform', async () => {
+        // Shader writes vec4(float(u_int0) / 100.0, 0, 0, 1); value 100 → red.
+        await glsl.expectEveryPixelToBe([255, 0, 0, 255])
+      })
+    })
+  })
+
+  test.describe('with primitive boolean source', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/glsl_shader_with_bool')
+      await comfyPage.vueNodes.waitForNodes(2)
+    })
+
+    test('upstream PrimitiveBoolean value flows through as the u_bool0 uniform', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+      const booleanToggle = comfyPage.vueNodes
+        .getNodeByTitle(PRIMITIVE_BOOLEAN_NODE_TITLE)
+        .getByRole('switch', { name: 'value' })
+
+      await test.step('boolean=false renders blue', async () => {
+        await glsl.simulateExecutionOutput(ws)
+        await glsl.waitForBlobSrc()
+        // Blue (non-max channel) through RGBA16F → PNG round-trip can drift by 2.
+        await glsl.expectEveryPixelToBe([0, 0, 255, 255], 2)
+      })
+
+      await test.step('toggling boolean=true re-renders red', async () => {
+        const blueSrc = (await glsl.getPreviewSrc())!
+        await expect(booleanToggle).toBeVisible()
+        await booleanToggle.click()
+
+        await expect.poll(() => glsl.getPreviewSrc()).not.toBe(blueSrc)
+        await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+        await glsl.expectEveryPixelToBe([255, 0, 0, 255])
+      })
+    })
+  })
+
   test.describe('GLSL inside a subgraph', () => {
     const SUBGRAPH_NODE_ID = '1'
 
@@ -358,6 +437,37 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
         comfyPage,
         SUBGRAPH_NODE_ID,
         'GLSL Subgraph'
+      )
+
+      await subgraph.simulateExecutionOutput(ws)
+      await expect(subgraph.previewImage).toBeVisible()
+      await subgraph.waitForBlobSrc()
+      await subgraph.expectEveryPixelToBe([255, 0, 0, 255])
+    })
+  })
+
+  test.describe('GLSL inside a subgraph with uniform source', () => {
+    const SUBGRAPH_NODE_ID = '1'
+
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow(
+        'nodes/glsl_shader_subgraph_with_float'
+      )
+      await comfyPage.vueNodes.waitForNodes(1)
+    })
+
+    test('extracts uniform sources from inner upstream widgets', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      // Inner PrimitiveFloat is wired to the inner GLSLShader's floats.u_float0
+      // input. useGLSLUniforms.extractUniformSources should pick it up and feed
+      // 1.0 as u_float0 — shader outputs vec4(u_float0, 0, 0, 1) → red.
+      const subgraph = new GLSLShaderNode(
+        comfyPage,
+        SUBGRAPH_NODE_ID,
+        'GLSL Subgraph With Float'
       )
 
       await subgraph.simulateExecutionOutput(ws)

--- a/browser_tests/tests/vueNodes/glslPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/glslPreview.spec.ts
@@ -1,0 +1,369 @@
+import type { Locator, WebSocketRoute } from '@playwright/test'
+import { mergeTests } from '@playwright/test'
+
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  comfyPageFixture,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const test = mergeTests(comfyPageFixture, webSocketFixture)
+
+const GLSL_NODE_ID = '1'
+const GLSL_NODE_TITLE = 'GLSL Shader'
+const PRIMITIVE_FLOAT_NODE_TITLE = 'Float'
+
+const RED_SHADER = [
+  '#version 300 es',
+  'precision highp float;',
+  'uniform vec2 u_resolution;',
+  'in vec2 v_texCoord;',
+  'layout(location = 0) out vec4 fragColor0;',
+  'void main() {',
+  '    fragColor0 = vec4(1.0, 0.0, 0.0, 1.0);',
+  '}'
+].join('\n')
+
+/** Page-object helper bound to the GLSLShader node under test. */
+class GLSLShaderNode {
+  readonly node: Locator
+  /**
+   * Any `<img>` inside the node whose src is a `blob:` URL. Covers both
+   * the standalone-node `LivePreview` path and the subgraph-wrapped
+   * promoted-preview path (where the blob surfaces via `ImagePreview`).
+   */
+  readonly previewImage: Locator
+  readonly shaderTextbox: Locator
+  readonly widthInput: Locator
+  readonly heightInput: Locator
+
+  constructor(
+    private readonly comfyPage: ComfyPage,
+    readonly nodeId: string,
+    readonly title: string
+  ) {
+    this.node = comfyPage.vueNodes.getNodeLocator(nodeId)
+    this.previewImage = this.node.locator('img[src^="blob:"]')
+    this.shaderTextbox = this.node.getByRole('textbox', {
+      name: 'fragment_shader'
+    })
+    this.widthInput = this.node
+      .getByLabel('size_mode.width', { exact: true })
+      .locator('input')
+    this.heightInput = this.node
+      .getByLabel('size_mode.height', { exact: true })
+      .locator('input')
+  }
+
+  /**
+   * Fire `execution_start` + `executed` with an image output for this node,
+   * which satisfies the `hasExecutionOutput` gate in `useGLSLPreview`.
+   */
+  async simulateExecutionOutput(ws: WebSocketRoute) {
+    const exec = new ExecutionHelper(this.comfyPage, ws)
+    const jobId = await exec.run()
+    await this.comfyPage.nextFrame()
+    exec.executionStart(jobId)
+    exec.executed(jobId, this.nodeId, {
+      images: [{ filename: 'glsl_test.png', subfolder: '', type: 'output' }]
+    })
+    exec.executionSuccess(jobId)
+  }
+
+  async getPreviewSrc(): Promise<string | null> {
+    return this.previewImage.getAttribute('src')
+  }
+
+  async getPreviewNaturalSize(): Promise<{ width: number; height: number }> {
+    return this.previewImage.evaluate((el: HTMLImageElement) => ({
+      width: el.naturalWidth,
+      height: el.naturalHeight
+    }))
+  }
+
+  async selectSizeMode(option: 'from_input' | 'custom'): Promise<void> {
+    await this.comfyPage.vueNodes.selectComboOption(
+      this.title,
+      'size_mode',
+      option
+    )
+  }
+
+  /** Wait until the preview image has a blob: URL and return it. */
+  async waitForBlobSrc(): Promise<string> {
+    await expect.poll(() => this.getPreviewSrc()).toMatch(/^blob:/)
+    return (await this.getPreviewSrc())!
+  }
+
+  /**
+   * Draw the preview blob to a 2D canvas and verify every pixel matches
+   */
+  async expectEveryPixelToBe(
+    expected: [number, number, number, number]
+  ): Promise<void> {
+    const mismatch = await this.previewImage.evaluate(
+      (img: HTMLImageElement, exp: [number, number, number, number]) => {
+        const canvas = document.createElement('canvas')
+        canvas.width = img.naturalWidth
+        canvas.height = img.naturalHeight
+        const ctx = canvas.getContext('2d')!
+        ctx.drawImage(img, 0, 0)
+        const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height)
+        for (let i = 0; i < data.length; i += 4) {
+          for (let c = 0; c < 4; c++) {
+            if (Math.abs(data[i + c] - exp[c]) > 1) {
+              return {
+                index: i / 4,
+                actual: [data[i], data[i + 1], data[i + 2], data[i + 3]]
+              }
+            }
+          }
+        }
+        return null
+      },
+      expected
+    )
+    const message = mismatch
+      ? `expected every pixel ≈ [${expected.join(',')}]; pixel ${mismatch.index} was [${mismatch.actual.join(',')}]`
+      : undefined
+    expect(mismatch, message).toBeNull()
+  }
+}
+
+/**
+ * Drop an image file onto a LoadImage node and wait for its preview to render.
+ */
+async function dropImageOntoLoadImage(
+  comfyPage: ComfyPage,
+  nodeId: string,
+  filename: string
+): Promise<void> {
+  const node = comfyPage.vueNodes.getNodeLocator(nodeId)
+  const box = await node.boundingBox()
+  expect(
+    box,
+    `LoadImage node ${nodeId} must have a bounding box`
+  ).not.toBeNull()
+  await comfyPage.dragDrop.dragAndDropFile(filename, {
+    dropPosition: { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 }
+  })
+  await expect(node.locator('.image-preview img')).toBeVisible()
+}
+
+test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
+  test.describe('standalone node', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/glsl_shader_standalone')
+      await comfyPage.vueNodes.waitForNodes(1)
+    })
+
+    test('renders a blob preview into the node after execution', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      await test.step('no preview is present before execution', async () => {
+        await expect(glsl.previewImage).toHaveCount(0)
+      })
+
+      await test.step('execution populates preview with a blob URL', async () => {
+        await glsl.simulateExecutionOutput(ws)
+
+        await expect(glsl.previewImage).toBeVisible()
+        await glsl.waitForBlobSrc()
+      })
+    })
+
+    test('refreshes the preview when the fragment shader is edited', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      await glsl.simulateExecutionOutput(ws)
+      const initialSrc = await glsl.waitForBlobSrc()
+
+      await test.step('editing the shader replaces the blob URL', async () => {
+        await glsl.shaderTextbox.fill(RED_SHADER)
+
+        await expect.poll(() => glsl.getPreviewSrc()).not.toBe(initialSrc)
+        await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+      })
+    })
+
+    test('custom size_mode controls rendered resolution', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      await test.step('switch size_mode to custom and set width/height', async () => {
+        await glsl.selectSizeMode('custom')
+
+        await expect(glsl.widthInput).toBeVisible()
+        await expect(glsl.heightInput).toBeVisible()
+
+        await glsl.widthInput.fill('16')
+        await glsl.widthInput.blur()
+        await glsl.heightInput.fill('32')
+        await glsl.heightInput.blur()
+      })
+
+      await test.step('executed preview uses the custom resolution', async () => {
+        await glsl.simulateExecutionOutput(ws)
+
+        await expect(glsl.previewImage).toBeVisible()
+        await glsl.waitForBlobSrc()
+        await expect
+          .poll(() => glsl.getPreviewNaturalSize())
+          .toEqual({ width: 16, height: 32 })
+      })
+    })
+
+    test('logs a compile failure then recovers when shader becomes valid again', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      // Captures every `[GLSL] shader compilation failed` warning emitted
+      // by `useGLSLPreview.ts` during this test.
+      const compileFailure = comfyPage.page.waitForEvent('console', {
+        predicate: (msg) =>
+          msg.type() === 'warning' &&
+          msg.text().includes('[GLSL] shader compilation failed')
+      })
+
+      await glsl.simulateExecutionOutput(ws)
+      const goodSrc = await glsl.waitForBlobSrc()
+
+      await glsl.shaderTextbox.fill('not valid glsl at all')
+      await compileFailure // ensures the invalid shader actually hit the compiler
+
+      await glsl.shaderTextbox.fill(RED_SHADER)
+      await expect.poll(() => glsl.getPreviewSrc()).not.toBe(goodSrc)
+      await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+    })
+  })
+
+  test.describe('with primitive float source', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/glsl_shader_with_float')
+      await comfyPage.vueNodes.waitForNodes(2)
+    })
+
+    test('refreshes preview when upstream PrimitiveFloat value changes', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+      const floatValueWidget = comfyPage.vueNodes.getWidgetByName(
+        PRIMITIVE_FLOAT_NODE_TITLE,
+        'value'
+      )
+      const { input: floatValueInput } =
+        comfyPage.vueNodes.getInputNumberControls(floatValueWidget)
+
+      await glsl.simulateExecutionOutput(ws)
+      const initialSrc = await glsl.waitForBlobSrc()
+
+      await test.step('changing the upstream float value re-renders the preview', async () => {
+        await expect(floatValueInput).toBeVisible()
+        await floatValueInput.fill('0.9')
+        await floatValueInput.blur()
+
+        await expect.poll(() => glsl.getPreviewSrc()).not.toBe(initialSrc)
+        await expect.poll(() => glsl.getPreviewSrc()).toMatch(/^blob:/)
+      })
+    })
+  })
+
+  test.describe('with upstream LoadImage', () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/glsl_shader_with_loadimage')
+      await comfyPage.vueNodes.waitForNodes(2)
+    })
+
+    const LOAD_IMAGE_NODE_ID = '2'
+
+    test('uses upstream image dimensions and binds it as u_image0', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      await dropImageOntoLoadImage(
+        comfyPage,
+        LOAD_IMAGE_NODE_ID,
+        'image64x64.webp'
+      )
+
+      await glsl.simulateExecutionOutput(ws)
+      await glsl.waitForBlobSrc()
+      await expect
+        .poll(() => glsl.getPreviewNaturalSize())
+        .toEqual({ width: 64, height: 64 })
+    })
+
+    test('ensures shaders are correctly executed', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      await dropImageOntoLoadImage(
+        comfyPage,
+        LOAD_IMAGE_NODE_ID,
+        'image64x64.webp'
+      )
+      await glsl.shaderTextbox.fill(RED_SHADER)
+      await glsl.simulateExecutionOutput(ws)
+      await glsl.waitForBlobSrc()
+
+      await expect
+        .poll(() => glsl.getPreviewNaturalSize())
+        .toEqual({ width: 64, height: 64 })
+      await glsl.expectEveryPixelToBe([255, 0, 0, 255])
+    })
+  })
+
+  test.describe('GLSL inside a subgraph', () => {
+    const SUBGRAPH_NODE_ID = '1'
+
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.workflow.loadWorkflow('nodes/glsl_shader_in_subgraph')
+      await comfyPage.vueNodes.waitForNodes(1)
+    })
+
+    test('renders a GLSL blob preview on the outer subgraph node', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      // Inside a subgraph, the GLSL renderer writes the blob preview to the
+      // INNER GLSLShader's locator; the outer subgraph node surfaces it via
+      // the promoted-preview path (ImagePreview component), not LivePreview.
+      // Either way, the observable signal is an <img> with a blob: src.
+      const subgraph = new GLSLShaderNode(
+        comfyPage,
+        SUBGRAPH_NODE_ID,
+        'GLSL Subgraph'
+      )
+
+      await subgraph.simulateExecutionOutput(ws)
+      await expect(subgraph.previewImage).toBeVisible()
+      await subgraph.waitForBlobSrc()
+      await subgraph.expectEveryPixelToBe([255, 0, 0, 255])
+    })
+  })
+})

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -410,6 +410,7 @@ function createInnerPreview(
       const result = r.compileFragment(source)
       if (!result.success) {
         lastError.value = result.log
+        console.warn('[GLSL] shader compilation failed:', result.log)
         return
       }
       lastError.value = null


### PR DESCRIPTION
## Summary

Add e2e tests for GLSL shader execution

## Changes

- **What**: 
- add test workflows containing GLSL nodes 
- tests execution, value propagation, error, subgraph handling
- adds console warn on invalid shader to surface error and allow test to detect

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11516-tst-add-GLSL-execution-e2e-test-3496d73d36508199a8e0fa341186ee4d) by [Unito](https://www.unito.io)
