### PR TITLE
fix: add GLSL live update when custom size is changed

### DIFF
--- a/browser_tests/tests/vueNodes/glslPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/glslPreview.spec.ts
@@ -258,6 +258,84 @@ test.describe('GLSL Shader Preview', { tag: ['@vue-nodes', '@node'] }, () => {
       })
     })
 
+    test('live-updates the preview when size_mode is toggled', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      // Default 512x512 falls out of `getResolution`'s DEFAULT_SIZE when no
+      // upstream image is connected and size_mode is `from_input`.
+      const DEFAULT = { width: 512, height: 512 }
+      const CUSTOM = { width: 64, height: 64 }
+
+      await test.step('initial from_input render uses default size', async () => {
+        await glsl.simulateExecutionOutput(ws)
+        await expect.poll(() => glsl.getPreviewNaturalSize()).toEqual(DEFAULT)
+      })
+
+      await test.step('switching to custom re-renders at the custom size', async () => {
+        await glsl.selectSizeMode('custom')
+        await expect(glsl.widthInput).toBeVisible()
+        await glsl.widthInput.fill(String(CUSTOM.width))
+        await glsl.widthInput.blur()
+        await glsl.heightInput.fill(String(CUSTOM.height))
+        await glsl.heightInput.blur()
+
+        await expect.poll(() => glsl.getPreviewNaturalSize()).toEqual(CUSTOM)
+      })
+
+      await test.step('switching back to from_input restores the default size', async () => {
+        await glsl.selectSizeMode('from_input')
+        await expect.poll(() => glsl.getPreviewNaturalSize()).toEqual(DEFAULT)
+      })
+    })
+
+    test('live-updates the preview when width or height widget changes', async ({
+      comfyPage,
+      getWebSocket
+    }) => {
+      const ws = await getWebSocket()
+      const glsl = new GLSLShaderNode(comfyPage, GLSL_NODE_ID, GLSL_NODE_TITLE)
+
+      await test.step('render initial 16x32 preview in custom mode', async () => {
+        await glsl.selectSizeMode('custom')
+        await expect(glsl.widthInput).toBeVisible()
+        await glsl.widthInput.fill('16')
+        await glsl.widthInput.blur()
+        await glsl.heightInput.fill('32')
+        await glsl.heightInput.blur()
+
+        await glsl.simulateExecutionOutput(ws)
+        await expect
+          .poll(() => glsl.getPreviewNaturalSize())
+          .toEqual({ width: 16, height: 32 })
+      })
+
+      await test.step('editing width widget re-renders at the new resolution', async () => {
+        const beforeSrc = await glsl.getPreviewSrc()
+        await glsl.widthInput.fill('48')
+        await glsl.widthInput.press('Enter')
+
+        await expect.poll(() => glsl.getPreviewSrc()).not.toBe(beforeSrc)
+        await expect
+          .poll(() => glsl.getPreviewNaturalSize())
+          .toEqual({ width: 48, height: 32 })
+      })
+
+      await test.step('editing height widget re-renders at the new resolution', async () => {
+        const beforeSrc = await glsl.getPreviewSrc()
+        await glsl.heightInput.fill('64')
+        await glsl.heightInput.press('Enter')
+
+        await expect.poll(() => glsl.getPreviewSrc()).not.toBe(beforeSrc)
+        await expect
+          .poll(() => glsl.getPreviewNaturalSize())
+          .toEqual({ width: 48, height: 64 })
+      })
+    })
+
     test('logs a compile failure then recovers when shader becomes valid again', async ({
       comfyPage,
       getWebSocket

--- a/src/components/boundingbox/WidgetBoundingBox.test.ts
+++ b/src/components/boundingbox/WidgetBoundingBox.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'

--- a/src/components/graph/widgets/MultiSelectWidget.test.ts
+++ b/src/components/graph/widgets/MultiSelectWidget.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { describe, expect, it } from 'vitest'

--- a/src/components/graph/widgets/TextPreviewWidget.test.ts
+++ b/src/components/graph/widgets/TextPreviewWidget.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/components/imagecrop/WidgetImageCrop.test.ts
+++ b/src/components/imagecrop/WidgetImageCrop.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 /* eslint-disable vue/no-reserved-component-names */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'

--- a/src/components/range/WidgetRange.test.ts
+++ b/src/components/range/WidgetRange.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/glsl/useGLSLPreview.ts
+++ b/src/renderer/glsl/useGLSLPreview.ts
@@ -282,7 +282,7 @@ function createInnerPreview(
     }
   }
 
-  function getCustomResolution(): [number, number] | null {
+  const customResolution = computed((): [number, number] | null => {
     const gId = graphId.value
     if (!gId) return null
 
@@ -314,10 +314,10 @@ function createInnerPreview(
       normalizeDimension(widthWidget.value),
       normalizeDimension(heightWidget.value)
     )
-  }
+  })
 
   function getResolution(): [number, number] {
-    const custom = getCustomResolution()
+    const custom = customResolution.value
     if (custom) return custom
 
     const node = nodeRef.value
@@ -482,7 +482,8 @@ function createInnerPreview(
         floatValues.value,
         intValues.value,
         boolValues.value,
-        curveValues.value
+        curveValues.value,
+        customResolution.value
       ] as const,
     () => {
       if (shouldRender.value) debouncedRender()


### PR DESCRIPTION
## Summary

Changing the custom size mode width & height were not reactive and so did not live update on the FE

## Changes

- **What**: 
- change `customResolution` to be computed, changing width/height then triggers a live update
- add tests

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11517-fix-add-GLSL-live-update-when-custom-size-is-changed-3496d73d3650816e940bf821f4e18db5) by [Unito](https://www.unito.io)
