### PR TITLE
fix(manager): migrate 4 endpoints GET→POST for CSRF hardening

### DIFF
--- a/browser_tests/tests/dialogs/managerDialog.spec.ts
+++ b/browser_tests/tests/dialogs/managerDialog.spec.ts
@@ -174,10 +174,6 @@ test.describe('ManagerDialog', { tag: '@ui' }, () => {
       await route.fulfill({ json: statsWithManager })
     })
 
-    await comfyPage.featureFlags.mockServerFeatures({
-      'extension.manager.supports_v4': true
-    })
-
     await comfyPage.page.route(
       '**/v2/customnode/installed**',
       async (route) => {
@@ -252,6 +248,24 @@ test.describe('ManagerDialog', { tag: '@ui' }, () => {
     )
 
     await comfyPage.setup()
+
+    // Seed manager-ready server feature flags AFTER setup so the WebSocket
+    // feature_flags payload can't overwrite them. mockServerFeatures (on
+    // /api/features) does not populate the serverFeatureFlags ref; direct
+    // reactive-ref mutation is the only reliable approach.
+    // See shareWorkflowDialog.spec.ts:34-48 for the canonical pattern.
+    await comfyPage.page.evaluate(() => {
+      const api = window.app!.api
+      api.serverFeatureFlags.value = {
+        ...api.serverFeatureFlags.value,
+        extension: {
+          manager: {
+            supports_v4: true,
+            supports_csrf_post: true
+          }
+        }
+      }
+    })
   })
 
   async function openManagerDialog(comfyPage: ComfyPage) {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -379,6 +379,10 @@
     "actions": "Actions",
     "selected": "Selected",
     "legacyMenuNotAvailable": "Legacy manager menu is not available, defaulting to the new manager menu.",
+    "incompatibleVersion": {
+      "title": "ComfyUI-Manager upgrade required",
+      "message": "Please upgrade ComfyUI-Manager to version 4.2.1 or higher.\n• Desktop: Update the ComfyUI Desktop app\n• Standalone: Run pip install -U comfyui-manager and restart\nLearn more: https://github.com/Comfy-Org/ComfyUI-Manager"
+    },
     "legacyManagerUI": "Use Legacy UI",
     "legacyManagerUIDescription": "To use the legacy Manager UI, start ComfyUI with --enable-manager-legacy-ui",
     "legacyManagerSearchTip": "Looking for ComfyUI-Manager? You can enable the legacy manager UI by starting ComfyUI with the --enable-manager-legacy-ui flag.",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1823,6 +1823,10 @@
     "gettingInfo": "정보 가져오는 중...",
     "importFailedGenericError": "패키지 가져오기에 실패했습니다. 자세한 내용은 콘솔을 확인하세요.",
     "inWorkflow": "워크플로 내",
+    "incompatibleVersion": {
+      "title": "ComfyUI-Manager 업그레이드 필요",
+      "message": "ComfyUI-Manager를 4.2.1 이상 버전으로 업그레이드해주세요.\n• 데스크톱: ComfyUI Desktop 앱을 업데이트하세요\n• 독립 실행형: pip install -U comfyui-manager 명령 실행 후 재시작하세요\n자세히 보기: https://github.com/Comfy-Org/ComfyUI-Manager"
+    },
     "infoPanelEmpty": "정보를 보려면 항목을 클릭하세요",
     "installAllMissingNodes": "모든 누락된 노드 설치",
     "installError": "설치 오류",

--- a/src/workbench/extensions/manager/composables/useManagerState.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.test.ts
@@ -6,10 +6,13 @@ import { api } from '@/scripts/api'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import {
   ManagerUIState,
+  __resetIncompatibleToastGuard,
   useManagerState
 } from '@/workbench/extensions/manager/composables/useManagerState'
 
 // Mock dependencies that are not stores
+vi.mock('@/i18n', () => ({ t: (key: string) => key }))
+
 vi.mock('@/scripts/api', () => ({
   api: {
     getClientFeatureFlags: vi.fn(),
@@ -42,14 +45,15 @@ vi.mock('@/stores/commandStore', () => ({
   }))
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => {
-  const add = vi.fn()
-  return {
-    useToastStore: vi.fn(() => ({
-      add
-    }))
-  }
-})
+const { toastAddMock } = vi.hoisted(() => ({
+  toastAddMock: vi.fn()
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: vi.fn(() => ({
+    add: toastAddMock
+  }))
+}))
 
 vi.mock('@/workbench/extensions/manager/composables/useManagerDialog', () => {
   const show = vi.fn()
@@ -61,6 +65,41 @@ vi.mock('@/workbench/extensions/manager/composables/useManagerDialog', () => {
     }))
   }
 })
+
+/**
+ * Helper to build a minimal systemStats argv-only fixture.
+ * Feature-flag values are supplied separately via mocked `api`.
+ */
+const systemStatsFixture = (argv: string[]) => ({
+  system: {
+    os: 'Test OS',
+    python_version: '3.10',
+    embedded_python: false,
+    comfyui_version: '1.0.0',
+    pytorch_version: '2.0.0',
+    argv,
+    ram_total: 16000000000,
+    ram_free: 8000000000
+  },
+  devices: []
+})
+
+/**
+ * Mocks the two server feature flags queried by useManagerState.
+ * `supports_v4`        → `extension.manager.supports_v4`
+ * `supports_csrf_post` → `extension.manager.supports_csrf_post`
+ */
+const mockServerFeatures = (flags: {
+  supports_v4?: boolean
+  supports_csrf_post?: boolean
+}) => {
+  vi.mocked(api.getServerFeature).mockImplementation((name: string) => {
+    if (name === 'extension.manager.supports_v4') return flags.supports_v4
+    if (name === 'extension.manager.supports_csrf_post')
+      return flags.supports_csrf_post
+    return undefined
+  })
+}
 
 describe('useManagerState', () => {
   let systemStatsStore: ReturnType<typeof useSystemStatsStore>
@@ -78,7 +117,8 @@ describe('useManagerState', () => {
     systemStatsStore = useSystemStatsStore()
 
     // Reset all mocks
-    vi.resetAllMocks()
+    vi.clearAllMocks()
+    __resetIncompatibleToastGuard()
 
     // Set default mock returns
     vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
@@ -87,21 +127,8 @@ describe('useManagerState', () => {
 
   describe('managerUIState property', () => {
     it('should return DISABLED state when --enable-manager is NOT present', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py'], // No --enable-manager flag
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture(['python', 'main.py']),
         isInitialized: true
       })
 
@@ -110,26 +137,13 @@ describe('useManagerState', () => {
     })
 
     it('should return LEGACY_UI state when --enable-manager-legacy-ui is present', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: [
-              'python',
-              'main.py',
-              '--enable-manager',
-              '--enable-manager-legacy-ui'
-            ],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager',
+          '--enable-manager-legacy-ui'
+        ]),
         isInitialized: true
       })
 
@@ -137,104 +151,68 @@ describe('useManagerState', () => {
       expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
-    it('should return NEW_UI state when client and server both support v4', () => {
-      // Set up store state
+    it('should return NEW_UI state when client and server both support v4 AND csrf_post', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
 
-    it('should return LEGACY_UI state when server supports v4 but client does not', () => {
-      // Set up store state
+    it('should return LEGACY_UI state when server supports v4 but client does not (and csrf_post present)', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: false
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return LEGACY_UI state when server does not support v4', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
-      vi.mocked(api.getServerFeature).mockReturnValue(false)
+      mockServerFeatures({ supports_v4: false })
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
-    it('should return NEW_UI state when server feature flags are undefined', () => {
-      // Set up store state
+    it('should return NEW_UI state when server feature flags are undefined (transient fallback)', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
@@ -242,12 +220,10 @@ describe('useManagerState', () => {
       vi.mocked(api.getServerFeature).mockReturnValue(undefined)
 
       const managerState = useManagerState()
-      // When server feature flags haven't loaded yet, default to NEW_UI
       expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should handle null systemStats gracefully', () => {
-      // Set up store state
       systemStatsStore.$patch({
         systemStats: null,
         isInitialized: true
@@ -256,59 +232,163 @@ describe('useManagerState', () => {
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
-      // When systemStats is null, we can't check for --enable-manager flag, so manager is disabled
       expect(managerState.managerUIState.value).toBe(ManagerUIState.DISABLED)
     })
   })
 
-  describe('helper properties', () => {
-    it('isManagerEnabled should return true when state is not DISABLED', () => {
-      // Set up store state
+  describe('INCOMPATIBLE state (missing supports_csrf_post)', () => {
+    const enabledManagerStats = () =>
+      systemStatsFixture(['python', 'main.py', '--enable-manager'])
+
+    it('returns INCOMPATIBLE when server supports v4 but csrf_post is false', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(managerState.managerUIState.value).toBe(
+        ManagerUIState.INCOMPATIBLE
+      )
+    })
+
+    it('returns INCOMPATIBLE when server supports v4 but csrf_post is undefined', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: undefined })
+
+      const managerState = useManagerState()
+      expect(managerState.managerUIState.value).toBe(
+        ManagerUIState.INCOMPATIBLE
+      )
+    })
+
+    it('isIncompatibleManager is true only in INCOMPATIBLE state', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(managerState.isIncompatibleManager.value).toBe(true)
+      expect(managerState.isNewManagerUI.value).toBe(false)
+      expect(managerState.isLegacyManagerUI.value).toBe(false)
+    })
+
+    it('shouldShowManagerButtons is false in INCOMPATIBLE state (hide UI)', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(managerState.shouldShowManagerButtons.value).toBe(false)
+      expect(managerState.isManagerEnabled.value).toBe(false)
+    })
+
+    it('fires warn-severity toast exactly once across multiple consumers', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      useManagerState()
+      useManagerState()
+      useManagerState()
+
+      expect(toastAddMock).toHaveBeenCalledTimes(1)
+      expect(toastAddMock).toHaveBeenCalledWith({
+        severity: 'warn',
+        summary: 'manager.incompatibleVersion.title',
+        detail: 'manager.incompatibleVersion.message',
+        life: 15000
+      })
+    })
+
+    it('openManager on INCOMPATIBLE re-emits the upgrade toast without settings redirect', async () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(toastAddMock).toHaveBeenCalledTimes(1)
+
+      await managerState.openManager()
+      expect(toastAddMock).toHaveBeenCalledTimes(2)
+      // second call must still be the upgrade toast, not an error toast
+      expect(toastAddMock).toHaveBeenLastCalledWith({
+        severity: 'warn',
+        summary: 'manager.incompatibleVersion.title',
+        detail: 'manager.incompatibleVersion.message',
+        life: 15000
+      })
+    })
+
+    it('does not fire upgrade toast when state is NEW_UI', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
+
+      useManagerState()
+      expect(toastAddMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('helper properties', () => {
+    const enabledManagerStats = () =>
+      systemStatsFixture(['python', 'main.py', '--enable-manager'])
+
+    it('isManagerEnabled should return true when state is not DISABLED / INCOMPATIBLE', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.isManagerEnabled.value).toBe(true)
     })
 
     it('isManagerEnabled should return false when state is DISABLED', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py'], // No --enable-manager flag
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture(['python', 'main.py']),
         isInitialized: true
       })
 
@@ -317,54 +397,27 @@ describe('useManagerState', () => {
     })
 
     it('isNewManagerUI should return true when state is NEW_UI', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.isNewManagerUI.value).toBe(true)
     })
 
     it('isLegacyManagerUI should return true when state is LEGACY_UI', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: [
-              'python',
-              'main.py',
-              '--enable-manager',
-              '--enable-manager-legacy-ui'
-            ],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager',
+          '--enable-manager-legacy-ui'
+        ]),
         isInitialized: true
       })
 
@@ -373,56 +426,28 @@ describe('useManagerState', () => {
     })
 
     it('shouldShowInstallButton should return true only for NEW_UI', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.shouldShowInstallButton.value).toBe(true)
     })
 
-    it('shouldShowManagerButtons should return true when not DISABLED', () => {
-      // Set up store state
+    it('shouldShowManagerButtons should return true when state is NEW_UI', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.shouldShowManagerButtons.value).toBe(true)

--- a/src/workbench/extensions/manager/composables/useManagerState.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.ts
@@ -1,10 +1,10 @@
 import { storeToRefs } from 'pinia'
-import { computed, readonly } from 'vue'
+import { computed, readonly, watch } from 'vue'
 
 import { t } from '@/i18n'
+import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
-import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useCommandStore } from '@/stores/commandStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { useManagerDialog } from '@/workbench/extensions/manager/composables/useManagerDialog'
@@ -13,7 +13,27 @@ import type { ManagerTab } from '@/workbench/extensions/manager/types/comfyManag
 export enum ManagerUIState {
   DISABLED = 'disabled',
   LEGACY_UI = 'legacy',
-  NEW_UI = 'new'
+  NEW_UI = 'new',
+  INCOMPATIBLE = 'incompatible'
+}
+
+/**
+ * Module-level flag to ensure the INCOMPATIBLE upgrade toast fires exactly
+ * once per app session, even when useManagerState() is invoked from many
+ * components. Without this, every consumer would register its own watcher
+ * and stack duplicate toasts on the first transition.
+ */
+let incompatibleToastShown = false
+
+const showIncompatibleToast = (): void => {
+  if (incompatibleToastShown) return
+  incompatibleToastShown = true
+  useToastStore().add({
+    severity: 'warn',
+    summary: t('manager.incompatibleVersion.title'),
+    detail: t('manager.incompatibleVersion.message'),
+    life: 15000
+  })
 }
 
 export function useManagerState() {
@@ -43,6 +63,10 @@ export function useManagerState() {
         'extension.manager.supports_v4'
       )
 
+      const supportsCsrfPost = api.getServerFeature(
+        'extension.manager.supports_csrf_post'
+      )
+
       // Check command line args first (highest priority)
       // --enable-manager flag enables the manager (opposite of old --disable-manager)
       const hasEnableManager =
@@ -57,6 +81,19 @@ export function useManagerState() {
         systemStats.value?.system?.argv?.includes('--enable-manager-legacy-ui')
       ) {
         return ManagerUIState.LEGACY_UI
+      }
+
+      // Server exposes v4 but is missing the CSRF-hardened POST endpoints
+      // (Manager < 4.2.1). Treat as INCOMPATIBLE — hide manager UI and
+      // prompt user to upgrade. csrf_post is an independent axis from v4.
+      //
+      // !== true (not === false) is deliberate: feature_flags arrive atomically
+      // via a single WebSocket payload (src/scripts/api.ts:751-758), so undefined
+      // here means the server did not publish the flag (i.e. Manager 4.2.0),
+      // not a transient partial-delivery state. Using === false would let
+      // flag-less Manager 4.2.0 fall through to NEW_UI → POST → 405 regression.
+      if (serverSupportsV4 === true && supportsCsrfPost !== true) {
+        return ManagerUIState.INCOMPATIBLE
       }
 
       // Both client and server support v4 = NEW_UI
@@ -88,11 +125,16 @@ export function useManagerState() {
   )
 
   /**
-   * Check if manager is enabled (not DISABLED)
+   * Check if manager is enabled (not DISABLED and not INCOMPATIBLE)
+   * INCOMPATIBLE is treated as "not installed" from a UX perspective —
+   * the user must upgrade the Manager backend before the UI becomes usable.
    */
   const isManagerEnabled = readonly(
     computed((): boolean => {
-      return managerUIState.value !== ManagerUIState.DISABLED
+      return (
+        managerUIState.value !== ManagerUIState.DISABLED &&
+        managerUIState.value !== ManagerUIState.INCOMPATIBLE
+      )
     })
   )
 
@@ -115,6 +157,16 @@ export function useManagerState() {
   )
 
   /**
+   * Check if the installed Manager backend is too old to use safely
+   * (lacks the CSRF-hardened POST endpoints introduced in Manager 4.2.1).
+   */
+  const isIncompatibleManager = readonly(
+    computed((): boolean => {
+      return managerUIState.value === ManagerUIState.INCOMPATIBLE
+    })
+  )
+
+  /**
    * Check if install button should be shown (only in NEW_UI mode)
    */
   const shouldShowInstallButton = readonly(
@@ -124,12 +176,26 @@ export function useManagerState() {
   )
 
   /**
-   * Check if manager buttons should be shown (when manager is not disabled)
+   * Check if manager buttons should be shown.
+   * Hidden when DISABLED (flag missing) or INCOMPATIBLE (backend too old).
    */
   const shouldShowManagerButtons = readonly(
     computed((): boolean => {
       return isManagerEnabled.value
     })
+  )
+
+  // Fire the upgrade-required toast once when we first observe the
+  // INCOMPATIBLE state. immediate: true handles the common case where the
+  // composable is mounted after feature flags have already arrived.
+  watch(
+    managerUIState,
+    (state) => {
+      if (state === ManagerUIState.INCOMPATIBLE) {
+        showIncompatibleToast()
+      }
+    },
+    { immediate: true }
   )
 
   /**
@@ -155,6 +221,15 @@ export function useManagerState() {
     switch (state) {
       case ManagerUIState.DISABLED:
         settingsDialog.show('extension')
+        break
+
+      case ManagerUIState.INCOMPATIBLE:
+        // Re-emit the upgrade toast on explicit user action. We intentionally
+        // bypass the once-per-session guard so repeated clicks on a hidden
+        // entry point (e.g. a stale shortcut) still surface guidance,
+        // without redirecting into settings like DISABLED does.
+        incompatibleToastShown = false
+        showIncompatibleToast()
         break
 
       case ManagerUIState.LEGACY_UI: {
@@ -198,8 +273,15 @@ export function useManagerState() {
     isManagerEnabled,
     isNewManagerUI,
     isLegacyManagerUI,
+    isIncompatibleManager,
     shouldShowInstallButton,
     shouldShowManagerButtons,
     openManager
   }
+}
+
+// Test-only export: resets the once-per-session toast guard so unit tests
+// can assert toast firing across multiple `useManagerState()` invocations.
+export const __resetIncompatibleToastGuard = (): void => {
+  incompatibleToastShown = false
 }

--- a/src/workbench/extensions/manager/services/comfyManagerService.ts
+++ b/src/workbench/extensions/manager/services/comfyManagerService.ts
@@ -126,7 +126,7 @@ export const useComfyManagerService = () => {
     }
 
     return executeRequest<null>(
-      () => managerApiClient.get(ManagerRoute.START_QUEUE, { signal }),
+      () => managerApiClient.post(ManagerRoute.START_QUEUE, null, { signal }),
       { errorContext, routeSpecificErrors }
     )
   }
@@ -265,7 +265,7 @@ export const useComfyManagerService = () => {
 
     return executeRequest<null>(
       () =>
-        managerApiClient.get(ManagerRoute.UPDATE_ALL, {
+        managerApiClient.post(ManagerRoute.UPDATE_ALL, null, {
           params: queryParams,
           signal
         }),
@@ -292,7 +292,7 @@ export const useComfyManagerService = () => {
 
     return executeRequest<null>(
       () =>
-        managerApiClient.get(ManagerRoute.UPDATE_COMFYUI, {
+        managerApiClient.post(ManagerRoute.UPDATE_COMFYUI, null, {
           params: queryParams,
           signal
         }),
@@ -307,7 +307,7 @@ export const useComfyManagerService = () => {
     }
 
     return executeRequest<null>(
-      () => managerApiClient.get(ManagerRoute.REBOOT, { signal }),
+      () => managerApiClient.post(ManagerRoute.REBOOT, null, { signal }),
       { errorContext, routeSpecificErrors }
     )
   }


### PR DESCRIPTION
## Summary

Align `comfyManagerService` and Manager UI state with CSRF hardening in [Comfy-Org/ComfyUI-Manager#2818](https://github.com/Comfy-Org/ComfyUI-Manager/pull/2818) (4.2.0, Content-Type gate + GET→POST migration) and [Comfy-Org/ComfyUI-Manager#2823](https://github.com/Comfy-Org/ComfyUI-Manager/pull/2823) (4.2.1, `extension.manager.supports_csrf_post` feature flag).

## Changes

- **Service layer**: Convert 4 state-mutation endpoints (`START_QUEUE`, `UPDATE_ALL`, `UPDATE_COMFYUI`, `REBOOT`) from GET to POST. `body=null` + axios default `Content-Type: application/json` is allowed by the backend's `reject_simple_form_post` gate (only the three CORS simple-form types are rejected).
- **UI/state layer**: Add `ManagerUIState.INCOMPATIBLE` triggered when the backend advertises `supports_manager_v4` but not `supports_csrf_post`. Manager UI is treated as "not installed" — buttons hide via `shouldShowManagerButtons` with zero call-site changes across `TopMenuSection`, `MissingNodeCard`, `MissingPackGroupRow`, `TabErrors`.
- **Graceful degraded mode**: One-shot upgrade toast (warn, 15s) dispatched via `watch(immediate:true)` with a module-level guard that survives multiple composable instances. `openManager()` re-emits on explicit user action so stale shortcuts still surface guidance. i18n (en/ko) covering Desktop / standalone pip / Manager UI self-update paths.
- **Breaking**: None. Existing policies preserved (`--enable-manager` absent → `DISABLED`; `--enable-manager-legacy-ui` → `LEGACY_UI`; feature flags not yet loaded → `NEW_UI` transient fallback).

## Review Focus

- Decision-tree ordering in `useManagerState.ts`: `supports_csrf_post` check evaluates before `NEW_UI`/`LEGACY_UI` branches so stale Manager backends never reach the enabled paths.
- Toast guard: module-level `incompatibleToastShown` survives multiple composable instances (tests verify 3× `useManagerState()` = 1 toast call).
- `generatedManagerTypes.ts` still declares the 4 endpoints as GET; regeneration follows once Manager 4.2.1 OpenAPI is published. Runtime is unaffected since axios operates on the route string.

## References

- [Comfy-Org/ComfyUI-Manager#2818](https://github.com/Comfy-Org/ComfyUI-Manager/pull/2818) — CSRF Content-Type gate + GET→POST migration (4.2.0)
- [Comfy-Org/ComfyUI-Manager#2823](https://github.com/Comfy-Org/ComfyUI-Manager/pull/2823) — `supports_csrf_post` feature flag (4.2.1)
- [comfyui-manager 4.2.1 on PyPI](https://pypi.org/project/comfyui-manager/4.2.1) — release package
