### PR TITLE
Add audio/video preview tests

### DIFF
--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -202,7 +202,7 @@ Most common testing needs are already addressed by these helpers, which will mak
    await comfyPage.setSetting('Comfy.NodeBadge.NodeIdBadgeMode', 'None')
 
    // Clean up uploaded files if needed
-   await comfyPage.request.delete(`${comfyPage.url}/api/delete/image.png`)
+   comfyPage.deleteFileAfterTest({ filename: 'image.png' })
    ```
 
 6. **Prefer functional assertions over screenshots**:

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -429,9 +429,7 @@ export class ComfyPage {
     type?: string
   }) {
     const url = `${this.url}/api/devtools/view?${new URLSearchParams(file)}`
-    this.onTeardown(async () => {
-      this.request.delete(url)
-    })
+    this.onTeardown(() => this.request.delete(url))
   }
 }
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -184,8 +184,6 @@ export class ComfyPage {
   /** Worker index to test user ID */
   public readonly userIds: string[] = []
 
-  protected teardownCallbacks: (() => Promise<unknown>)[] = []
-
   /** Test user ID for the current context */
   get id() {
     return this.userIds[comfyPageFixture.info().parallelIndex]
@@ -416,20 +414,27 @@ export class ComfyPage {
     }, focusMode)
     await this.nextFrame()
   }
+}
+
+class ComfyFiles {
+  protected teardownCallbacks: (() => Promise<unknown>)[] = []
+
+  constructor(protected readonly comfyPage: ComfyPage) {}
 
   async teardown() {
     await Promise.all(this.teardownCallbacks.map((cb) => cb()))
   }
-  onTeardown(cb: () => Promise<unknown>) {
-    this.teardownCallbacks.push(cb)
-  }
-  deleteFileAfterTest(file: {
+
+  deleteAfterTest(file: {
     filename: string
     subfolder?: string
     type?: string
   }) {
-    const url = `${this.url}/api/devtools/view?${new URLSearchParams(file)}`
-    this.onTeardown(() => this.request.delete(url))
+    this.teardownCallbacks.push(() =>
+      this.comfyPage.request.delete(
+        `${this.comfyPage.url}/api/devtools/view?${new URLSearchParams(file)}`
+      )
+    )
   }
 }
 
@@ -440,6 +445,7 @@ const COLLECT_COVERAGE = process.env.COLLECT_COVERAGE === 'true'
 export const comfyPageFixture = base.extend<{
   comfyPage: ComfyPage
   comfyMouse: ComfyMouse
+  comfyFiles: ComfyFiles
 }>({
   page: async ({ page, browserName }, use) => {
     if (browserName !== 'chromium' || !COLLECT_COVERAGE) {
@@ -513,12 +519,15 @@ export const comfyPageFixture = base.extend<{
     await use(comfyPage)
 
     if (needsPerf) await comfyPage.perf.dispose()
-
-    await comfyPage.teardown()
   },
   comfyMouse: async ({ comfyPage }, use) => {
     const comfyMouse = new ComfyMouse(comfyPage)
     await use(comfyMouse)
+  },
+  comfyFiles: async ({ comfyPage }, use) => {
+    const comfyFiles = new ComfyFiles(comfyPage)
+    await use(comfyFiles)
+    await comfyFiles.teardown()
   }
 })
 

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -184,6 +184,8 @@ export class ComfyPage {
   /** Worker index to test user ID */
   public readonly userIds: string[] = []
 
+  protected teardownCallbacks: (() => Promise<unknown>)[] = []
+
   /** Test user ID for the current context */
   get id() {
     return this.userIds[comfyPageFixture.info().parallelIndex]
@@ -414,6 +416,23 @@ export class ComfyPage {
     }, focusMode)
     await this.nextFrame()
   }
+
+  async teardown() {
+    await Promise.all(this.teardownCallbacks.map((cb) => cb()))
+  }
+  onTeardown(cb: () => Promise<unknown>) {
+    this.teardownCallbacks.push(cb)
+  }
+  deleteFileAfterTest(file: {
+    filename: string
+    subfolder?: string
+    type?: string
+  }) {
+    const url = `${this.url}/api/devtools/view?${new URLSearchParams(file)}`
+    this.onTeardown(async () => {
+      this.request.delete(url)
+    })
+  }
 }
 
 export const testComfySnapToGridGridSize = 50
@@ -496,6 +515,8 @@ export const comfyPageFixture = base.extend<{
     await use(comfyPage)
 
     if (needsPerf) await comfyPage.perf.dispose()
+
+    await comfyPage.teardown()
   },
   comfyMouse: async ({ comfyPage }, use) => {
     const comfyMouse = new ComfyMouse(comfyPage)

--- a/browser_tests/fixtures/components/AudioPreview.ts
+++ b/browser_tests/fixtures/components/AudioPreview.ts
@@ -1,0 +1,39 @@
+import type { Locator } from '@playwright/test'
+
+export class AudioPreview {
+  public readonly download: Locator
+  public readonly play: Locator
+  public readonly upload: Locator
+  public readonly volume: Locator
+  public readonly audio: Locator
+
+  constructor(node: Locator) {
+    this.download = node.getByLabel('Download audio')
+    this.play = node.getByLabel('Play/Pause')
+    this.upload = node.locator('input')
+    this.volume = node.getByLabel('Volume')
+    this.audio = node.locator('audio')
+  }
+  async isPlaying() {
+    return await this.audio.evaluate((audio: HTMLAudioElement) => !audio.paused)
+  }
+  async isMuted() {
+    return await this.audio.evaluate((audio: HTMLAudioElement) => audio.muted)
+  }
+}
+
+/*
+ * Generates a buffer of a 20 second wav file for testing with
+ */
+export function getWav() {
+  const header = 'UklGRixxAgBXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQBxAgA='
+  const notes = [8 / 9, 1, 9 / 8, 6 / 5, 4 / 3, 3 / 2, 0]
+  const buffer = Buffer.alloc(160_044, header, 'base64')
+  for (let t = 0; t < 160000; t++) {
+    const measure = [0xd2d2c8, 0xce4088, 0xca32c8, 0x8e4009][(t >> 14) & 3]
+    const beat = ((t >> 10) & 15) > 9 ? 18 : (t >> 10) & 15
+    const noteIndex = (measure >> (((0x3dbe4688 >> (beat * 3)) & 7) * 3)) & 7
+    buffer.writeInt8(((t << 3) * notes[noteIndex]) & 127, t + 44)
+  }
+  return buffer
+}

--- a/browser_tests/fixtures/components/VideoPreview.ts
+++ b/browser_tests/fixtures/components/VideoPreview.ts
@@ -1,0 +1,24 @@
+import type { Locator } from '@playwright/test'
+
+export class VideoPreview {
+  public readonly navigationDots: Locator
+  public readonly preview: Locator
+  public readonly upload: Locator
+  public readonly video: Locator
+  public readonly download: Locator
+
+  constructor(loadVideoNode: Locator) {
+    this.preview = loadVideoNode.locator('.video-preview')
+    this.navigationDots = this.preview.getByRole('button', {
+      name: 'View video'
+    })
+    this.upload = loadVideoNode.locator('input')
+    this.video = this.preview.locator('video')
+    this.download = loadVideoNode.getByRole('button', {
+      name: 'Download video'
+    })
+  }
+  async videoSrc() {
+    return await this.video.getAttribute('src')
+  }
+}

--- a/browser_tests/tests/vueNodes/videoPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/videoPreview.spec.ts
@@ -22,7 +22,7 @@ test('Load Video', async ({ comfyPage }) => {
 
     await comfyPage.page.mouse.dblclick(500, 300, { delay: 5 })
     await comfyPage.searchBox.fillAndSelectFirstNode('Load Video')
-    //await new Promise(r => setTimeout(r, 5000))
+
     await expect(loadVideoNode).toHaveCount(1)
     await expect(loadVideoNode).toBeVisible()
   })

--- a/browser_tests/tests/vueNodes/videoPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/videoPreview.spec.ts
@@ -25,7 +25,6 @@ test('Load Video', async ({ comfyPage }) => {
     //await new Promise(r => setTimeout(r, 5000))
     await expect(loadVideoNode).toHaveCount(1)
     await expect(loadVideoNode).toBeVisible()
-    await expect(loadVideoNode.locator('video')).toBeVisible()
   })
 
   await test.step('Can upload a video file', async () => {

--- a/browser_tests/tests/vueNodes/videoPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/videoPreview.spec.ts
@@ -5,18 +5,16 @@ import {
 import { VideoPreview } from '@e2e/fixtures/components/VideoPreview'
 import { assetPath } from '@e2e/fixtures/utils/paths'
 
-test('Load Video', async ({ comfyPage }) => {
-  const file1 = 'workflow.mp4'
-  const file2 = 'workflow.webm'
+const file1 = 'workflow.mp4' as const
+const file2 = 'workflow.webm' as const
 
-  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+test('@vue-nodes Load Video', async ({ comfyPage, comfyFiles }) => {
   await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'v1 (legacy)')
-  await comfyPage.vueNodes.waitForNodes()
 
   const loadVideoNode = comfyPage.vueNodes.getNodeByTitle('Load Video')
   const loadVideo = new VideoPreview(loadVideoNode)
 
-  await test.step('Can add node', async () => {
+  await test.step('Add node', async () => {
     await comfyPage.menu.topbar.newWorkflowButton.click()
     await comfyPage.nextFrame()
 
@@ -27,22 +25,22 @@ test('Load Video', async ({ comfyPage }) => {
     await expect(loadVideoNode).toBeVisible()
   })
 
-  await test.step('Can upload a video file', async () => {
+  await test.step('Upload a video file', async () => {
     await loadVideo.upload.setInputFiles(assetPath(`workflowInMedia/${file1}`))
-    comfyPage.deleteFileAfterTest({ filename: file1, type: 'input' })
+    comfyFiles.deleteAfterTest({ filename: file1, type: 'input' })
     await expect(loadVideoNode).toContainText(file1)
     await expect(loadVideo.video).toBeVisible()
   })
 
-  await test.step('Can update displayed video', async () => {
+  await test.step('Update displayed video', async () => {
     const initialSrc = await loadVideo.videoSrc()
     await loadVideo.upload.setInputFiles(assetPath(`workflowInMedia/${file2}`))
-    comfyPage.deleteFileAfterTest({ filename: file2, type: 'input' })
+    comfyFiles.deleteAfterTest({ filename: file2, type: 'input' })
     await expect(loadVideoNode).toContainText(file2)
     await expect.poll(() => loadVideo.videoSrc()).not.toEqual(initialSrc)
   })
 
-  await test.step('Can display multiple video', async () => {
+  await test.step('Display multiple videmus', async () => {
     await expect(loadVideo.navigationDots).toBeHidden()
 
     //forcibly display multiple video files at once

--- a/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
@@ -1,0 +1,57 @@
+import { AudioPreview, getWav } from '@e2e/fixtures/components/AudioPreview'
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test('Audio Widget', async ({ comfyPage }) => {
+  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+  await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'v1 (legacy)')
+  await comfyPage.vueNodes.waitForNodes()
+
+  const loadAudioNode = comfyPage.vueNodes.getNodeByTitle('Load Audio')
+  const audioPreview = new AudioPreview(loadAudioNode)
+
+  await test.step('Can add node', async () => {
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+    await comfyPage.nextFrame()
+
+    //await comfyPage.canvasOps.doubleClick()
+    await comfyPage.page.mouse.dblclick(500, 500, { delay: 5 })
+    await comfyPage.searchBox.fillAndSelectFirstNode('Load Audio')
+    await expect(loadAudioNode).toBeVisible()
+  })
+
+  const fileName = `audio-${Date.now()}.wav`
+
+  await test.step('Can upload an audio file', async () => {
+    const file = { name: fileName, buffer: getWav(), mimeType: 'audio/x-wav' }
+    await audioPreview.upload.setInputFiles(file)
+    await expect(loadAudioNode).toContainText(fileName)
+    //dnd is bugged
+    expect(await comfyPage.vueNodes.getNodeCount()).toBe(1)
+  })
+
+  await test.step('Previews audio files', async () => {
+    expect(loadAudioNode).toContainText('0:00 / 0:20')
+
+    expect(await audioPreview.isPlaying()).toBe(false)
+    await audioPreview.play.click()
+    await expect.poll(() => audioPreview.isPlaying()).toBe(true)
+    await audioPreview.play.click()
+    await expect.poll(() => audioPreview.isPlaying()).toBe(false)
+
+    expect(await audioPreview.isMuted()).toBe(false)
+    await audioPreview.volume.click()
+    await expect.poll(() => audioPreview.isMuted()).toBe(true)
+    await audioPreview.volume.click()
+    await expect.poll(() => audioPreview.isMuted()).toBe(false)
+  })
+
+  await test.step('Can redownload uploaded file', async () => {
+    const downloadPromise = comfyPage.page.waitForEvent('download')
+    await audioPreview.download.click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe(fileName)
+  })
+})

--- a/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
@@ -33,7 +33,7 @@ test('Audio Widget', async ({ comfyPage }) => {
   })
 
   await test.step('Previews audio files', async () => {
-    expect(loadAudioNode).toContainText('0:00 / 0:20')
+    await expect(loadAudioNode).toContainText('0:00 / 0:20')
 
     expect(await audioPreview.isPlaying()).toBe(false)
     await audioPreview.play.click()
@@ -43,9 +43,12 @@ test('Audio Widget', async ({ comfyPage }) => {
 
     expect(await audioPreview.isMuted()).toBe(false)
     await audioPreview.volume.click()
+    const volumeIcon = audioPreview.volume.locator('i')
+    await expect(volumeIcon).toContainClass('icon-[lucide--volume-x]')
     await expect.poll(() => audioPreview.isMuted()).toBe(true)
     await audioPreview.volume.click()
     await expect.poll(() => audioPreview.isMuted()).toBe(false)
+    await expect(volumeIcon).not.toContainClass('icon-[lucide--volume-x]')
   })
 
   await test.step('Can redownload uploaded file', async () => {

--- a/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
@@ -4,15 +4,13 @@ import {
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
 
-test('Audio Widget', async ({ comfyPage }) => {
-  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+test('@vue-nodes Audio Widget', async ({ comfyPage, comfyFiles }) => {
   await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'v1 (legacy)')
-  await comfyPage.vueNodes.waitForNodes()
 
   const loadAudioNode = comfyPage.vueNodes.getNodeByTitle('Load Audio')
   const audioPreview = new AudioPreview(loadAudioNode)
 
-  await test.step('Can add node', async () => {
+  await test.step('Add node', async () => {
     await comfyPage.menu.topbar.newWorkflowButton.click()
     await comfyPage.nextFrame()
 
@@ -24,14 +22,14 @@ test('Audio Widget', async ({ comfyPage }) => {
 
   const filename = `audio-${Date.now()}.wav`
 
-  await test.step('Can upload an audio file', async () => {
+  await test.step('Upload an audio file', async () => {
     const file = { name: filename, buffer: getWav(), mimeType: 'audio/x-wav' }
     await audioPreview.upload.setInputFiles(file)
-    comfyPage.deleteFileAfterTest({ filename, type: 'input' })
+    comfyFiles.deleteAfterTest({ filename, type: 'input' })
     await expect(loadAudioNode).toContainText(filename)
   })
 
-  await test.step('Previews audio files', async () => {
+  await test.step('Preview audio file', async () => {
     await expect(loadAudioNode).toContainText('0:00 / 0:20')
 
     expect(await audioPreview.isPlaying()).toBe(false)
@@ -50,7 +48,7 @@ test('Audio Widget', async ({ comfyPage }) => {
     await expect(volumeIcon).not.toContainClass('icon-[lucide--volume-x]')
   })
 
-  await test.step('Can redownload uploaded file', async () => {
+  await test.step('Redownload uploaded file', async () => {
     const downloadPromise = comfyPage.page.waitForEvent('download')
     await audioPreview.download.click()
     const download = await downloadPromise

--- a/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/audioWidget.spec.ts
@@ -22,14 +22,13 @@ test('Audio Widget', async ({ comfyPage }) => {
     await expect(loadAudioNode).toBeVisible()
   })
 
-  const fileName = `audio-${Date.now()}.wav`
+  const filename = `audio-${Date.now()}.wav`
 
   await test.step('Can upload an audio file', async () => {
-    const file = { name: fileName, buffer: getWav(), mimeType: 'audio/x-wav' }
+    const file = { name: filename, buffer: getWav(), mimeType: 'audio/x-wav' }
     await audioPreview.upload.setInputFiles(file)
-    await expect(loadAudioNode).toContainText(fileName)
-    //dnd is bugged
-    expect(await comfyPage.vueNodes.getNodeCount()).toBe(1)
+    comfyPage.deleteFileAfterTest({ filename, type: 'input' })
+    await expect(loadAudioNode).toContainText(filename)
   })
 
   await test.step('Previews audio files', async () => {
@@ -55,6 +54,6 @@ test('Audio Widget', async ({ comfyPage }) => {
     const downloadPromise = comfyPage.page.waitForEvent('download')
     await audioPreview.download.click()
     const download = await downloadPromise
-    expect(download.suggestedFilename()).toBe(fileName)
+    expect(download.suggestedFilename()).toBe(filename)
   })
 })

--- a/browser_tests/tests/vueNodes/widgets/videoPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/videoPreview.spec.ts
@@ -44,7 +44,7 @@ test('Load Video', async ({ comfyPage }) => {
   })
 
   await test.step('Can display multiple video', async () => {
-    expect(loadVideo.navigationDots).toBeHidden()
+    await expect(loadVideo.navigationDots).toBeHidden()
 
     //forcibly display multiple video files at once
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', false)
@@ -74,7 +74,7 @@ test('Load Video', async ({ comfyPage }) => {
 
   await test.step('Can redownload uploaded file', async () => {
     await loadVideo.video.hover()
-    expect(loadVideo.download).toBeVisible()
+    await expect(loadVideo.download).toBeVisible()
 
     const downloadPromise = comfyPage.page.waitForEvent('download')
     await loadVideo.download.click()

--- a/browser_tests/tests/vueNodes/widgets/videoPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/videoPreview.spec.ts
@@ -1,0 +1,82 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { VideoPreview } from '@e2e/fixtures/components/VideoPreview'
+import { assetPath } from '@e2e/fixtures/utils/paths'
+
+test('Load Video', async ({ comfyPage }) => {
+  const file1 = 'workflow.mp4'
+  const file2 = 'workflow.webm'
+
+  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+  await comfyPage.settings.setSetting('Comfy.NodeSearchBoxImpl', 'v1 (legacy)')
+  await comfyPage.vueNodes.waitForNodes()
+
+  const loadVideoNode = comfyPage.vueNodes.getNodeByTitle('Load Video')
+  const loadVideo = new VideoPreview(loadVideoNode)
+
+  await test.step('Can add node', async () => {
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+    await comfyPage.nextFrame()
+
+    await comfyPage.page.mouse.dblclick(500, 300, { delay: 5 })
+    await comfyPage.searchBox.fillAndSelectFirstNode('Load Video')
+    //await new Promise(r => setTimeout(r, 5000))
+    await expect(loadVideoNode).toHaveCount(1)
+    await expect(loadVideoNode).toBeVisible()
+    await expect(loadVideoNode.locator('video')).toBeVisible()
+  })
+
+  await test.step('Can upload a video file', async () => {
+    await loadVideo.upload.setInputFiles(assetPath(`workflowInMedia/${file1}`))
+    await expect(loadVideoNode).toContainText(file1)
+    await expect(loadVideo.video).toBeVisible()
+  })
+
+  await test.step('Can update displayed video', async () => {
+    const initialSrc = await loadVideo.videoSrc()
+    await loadVideo.upload.setInputFiles(assetPath(`workflowInMedia/${file2}`))
+    await expect(loadVideoNode).toContainText(file2)
+    await expect.poll(() => loadVideo.videoSrc()).not.toEqual(initialSrc)
+  })
+
+  await test.step('Can display multiple video', async () => {
+    expect(loadVideo.navigationDots).toBeHidden()
+
+    //forcibly display multiple video files at once
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', false)
+    await comfyPage.nextFrame()
+    await comfyPage.page.evaluate(
+      (names) => {
+        graph!.nodes[0].images.splice(
+          0,
+          1,
+          ...names.map((filename) => ({
+            type: 'input',
+            filename,
+            subfolder: ''
+          }))
+        )
+      },
+      [file1, file2]
+    )
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
+    await expect(loadVideo.navigationDots).toHaveCount(2)
+    await loadVideo.navigationDots.nth(0).click()
+    await expect.poll(() => loadVideo.videoSrc()).toContain(file1)
+    await loadVideo.navigationDots.nth(1).click()
+    await expect.poll(() => loadVideo.videoSrc()).toContain(file2)
+  })
+
+  await test.step('Can redownload uploaded file', async () => {
+    await loadVideo.video.hover()
+    expect(loadVideo.download).toBeVisible()
+
+    const downloadPromise = comfyPage.page.waitForEvent('download')
+    await loadVideo.download.click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe(file2)
+  })
+})

--- a/browser_tests/tests/vueNodes/widgets/videoPreview.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/videoPreview.spec.ts
@@ -30,6 +30,7 @@ test('Load Video', async ({ comfyPage }) => {
 
   await test.step('Can upload a video file', async () => {
     await loadVideo.upload.setInputFiles(assetPath(`workflowInMedia/${file1}`))
+    comfyPage.deleteFileAfterTest({ filename: file1, type: 'input' })
     await expect(loadVideoNode).toContainText(file1)
     await expect(loadVideo.video).toBeVisible()
   })
@@ -37,6 +38,7 @@ test('Load Video', async ({ comfyPage }) => {
   await test.step('Can update displayed video', async () => {
     const initialSrc = await loadVideo.videoSrc()
     await loadVideo.upload.setInputFiles(assetPath(`workflowInMedia/${file2}`))
+    comfyPage.deleteFileAfterTest({ filename: file2, type: 'input' })
     await expect(loadVideoNode).toContainText(file2)
     await expect.poll(() => loadVideo.videoSrc()).not.toEqual(initialSrc)
   })

--- a/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/audio/AudioPreviewPlayer.vue
@@ -184,7 +184,7 @@ const progressPercentage = computed(() => {
 const modelValue = defineModel<string>()
 
 const showVolumeTwo = computed(() => !isMuted.value && volume.value > 0.5)
-const showVolumeOne = computed(() => isMuted.value && volume.value > 0)
+const showVolumeOne = computed(() => !isMuted.value && volume.value > 0)
 
 // Playback controls
 const togglePlayPause = () => {

--- a/tools/devtools/__init__.py
+++ b/tools/devtools/__init__.py
@@ -96,5 +96,27 @@ async def set_settings(request: Request):
     except Exception as e:
         return web.Response(status=500, text=f"Error: {str(e)}")
 
+@server.PromptServer.instance.routes.delete("/devtools/view")
+async def set_settings(request: Request):
+    print(request.rel_url.query)
+    try:
+        filename = request.rel_url.query['filename']
+        type = request.rel_url.query.get('type', 'output')
+        output_dir = folder_paths.get_directory_by_type(type)
+        if "subfolder" in request.rel_url.query:
+            full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
+            if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                return web.Response(status=403)
+            output_dir = full_output_dir
+        filename = os.path.basename(filename)
+        file = os.path.join(output_dir, filename)
+        print(file)
+        if (os.path.exists(file)):
+            os.remove(file)
+        return web.Response(status=200)
+    except Exception as e:
+        print(e)
+        return web.Response(status=500, text=f"Error: {str(e)}")
+
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/tools/devtools/__init__.py
+++ b/tools/devtools/__init__.py
@@ -97,25 +97,19 @@ async def set_settings(request: Request):
         return web.Response(status=500, text=f"Error: {str(e)}")
 
 @server.PromptServer.instance.routes.delete("/devtools/view")
-async def set_settings(request: Request):
-    print(request.rel_url.query)
+async def delete_file(request: Request):
     try:
         filename = request.rel_url.query['filename']
         type = request.rel_url.query.get('type', 'output')
         output_dir = folder_paths.get_directory_by_type(type)
-        if "subfolder" in request.rel_url.query:
-            full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-            if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
-                return web.Response(status=403)
-            output_dir = full_output_dir
-        filename = os.path.basename(filename)
-        file = os.path.join(output_dir, filename)
-        print(file)
-        if (os.path.exists(file)):
-            os.remove(file)
+        subfolder = request.rel_url.query.get('subfolder', '')
+        filepath = os.path.join(output_dir, subfolder, filename)
+        if os.path.commonpath(output_dir, filepath) != output_dir:
+            return web.Response(status=403)
+        if (os.path.exists(filepath)):
+            os.remove(filepath)
         return web.Response(status=200)
     except Exception as e:
-        print(e)
         return web.Response(status=500, text=f"Error: {str(e)}")
 
 

--- a/tools/devtools/__init__.py
+++ b/tools/devtools/__init__.py
@@ -104,7 +104,7 @@ async def delete_file(request: Request):
         output_dir = folder_paths.get_directory_by_type(type)
         subfolder = request.rel_url.query.get('subfolder', '')
         filepath = os.path.join(output_dir, subfolder, filename)
-        if os.path.commonpath(output_dir, filepath) != output_dir:
+        if os.path.commonpath([output_dir, filepath]) != output_dir:
             return web.Response(status=403)
         if (os.path.exists(filepath)):
             os.remove(filepath)


### PR DESCRIPTION
Adds tests for the vue audio preview widget and vue video previews (which are not widgets).

Also
- Fixes a bug where muted audio previews would incorrectly display a 'low volume' indicator instead of a muted indicator.
- Add test helper for deleting uploaded files after a test completes

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11523-Add-audio-preview-tests-3496d73d365081be8630ede6dae1726a) by [Unito](https://www.unito.io)
