### PR TITLE
fix: localize secret date labels

### DIFF
--- a/src/platform/secrets/components/SecretListItem.stories.ts
+++ b/src/platform/secrets/components/SecretListItem.stories.ts
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { SecretMetadata } from '../types'
+import SecretListItem from './SecretListItem.vue'
+
+const sampleSecret: SecretMetadata = {
+  id: 'secret-huggingface',
+  name: 'HuggingFace API Key',
+  provider: 'huggingface',
+  created_at: '2026-02-06T10:00:00Z',
+  updated_at: '2026-02-06T10:00:00Z',
+  last_used_at: '2026-04-17T10:00:00Z'
+}
+
+const meta: Meta<typeof SecretListItem> = {
+  title: 'Platform/Secrets/SecretListItem',
+  component: SecretListItem,
+  parameters: {
+    layout: 'centered'
+  },
+  decorators: [
+    () => ({
+      template: `
+        <div class="w-[480px] bg-base-background p-8">
+          <story />
+        </div>
+      `
+    })
+  ],
+  args: {
+    secret: sampleSecret,
+    loading: false,
+    disabled: false
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const NeverUsed: Story = {
+  args: {
+    secret: {
+      ...sampleSecret,
+      id: 'secret-civitai',
+      name: 'Civitai Token',
+      provider: 'civitai',
+      last_used_at: undefined
+    }
+  }
+}
+
+export const Loading: Story = {
+  args: {
+    loading: true
+  }
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true
+  }
+}

--- a/src/platform/secrets/components/SecretListItem.test.ts
+++ b/src/platform/secrets/components/SecretListItem.test.ts
@@ -34,6 +34,10 @@ const i18n = createI18n({
   }
 })
 
+function formatExpectedDate(dateString: string): string {
+  return i18n.global.d(new Date(dateString), { dateStyle: 'medium' })
+}
+
 function createMockSecret(
   overrides: Partial<SecretMetadata> = {}
 ): SecretMetadata {
@@ -106,9 +110,7 @@ describe('SecretListItem', () => {
       renderComponent({ secret })
 
       expect(
-        screen.getByText(
-          `Created ${new Date(secret.created_at).toLocaleDateString()}`
-        )
+        screen.getByText(`Created ${formatExpectedDate(secret.created_at)}`)
       ).toBeInTheDocument()
     })
 
@@ -118,7 +120,7 @@ describe('SecretListItem', () => {
 
       expect(
         screen.getByText(
-          `Last used ${new Date(secret.last_used_at!).toLocaleDateString()}`
+          `Last used ${formatExpectedDate(secret.last_used_at!)}`
         )
       ).toBeInTheDocument()
     })
@@ -139,9 +141,7 @@ describe('SecretListItem', () => {
 
       expect(screen.queryByText(/&#x2F;/)).not.toBeInTheDocument()
       expect(
-        screen.getByText(
-          `Created ${new Date(secret.created_at).toLocaleDateString()}`
-        )
+        screen.getByText(`Created ${formatExpectedDate(secret.created_at)}`)
       ).toBeInTheDocument()
     })
 
@@ -152,9 +152,7 @@ describe('SecretListItem', () => {
       renderComponent({ secret })
 
       expect(
-        screen.getByText(
-          `Created ${new Date(secret.created_at).toLocaleDateString()}`
-        )
+        screen.getByText(`Created ${formatExpectedDate(secret.created_at)}`)
       ).toBeInTheDocument()
       expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument()
     })
@@ -166,9 +164,7 @@ describe('SecretListItem', () => {
       renderComponent({ secret })
 
       expect(
-        screen.getByText(
-          `Created ${new Date(secret.created_at).toLocaleDateString()}`
-        )
+        screen.getByText(`Created ${formatExpectedDate(secret.created_at)}`)
       ).toBeInTheDocument()
       expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument()
     })
@@ -177,7 +173,7 @@ describe('SecretListItem', () => {
       const secret = createMockSecret({ created_at: 'not-a-date' })
       renderComponent({ secret })
 
-      expect(screen.queryByText(/secrets\.createdAt/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^Created /)).not.toBeInTheDocument()
       expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument()
     })
 
@@ -185,7 +181,7 @@ describe('SecretListItem', () => {
       const secret = createMockSecret({ last_used_at: 'not-a-date' })
       renderComponent({ secret })
 
-      expect(screen.queryByText(/secrets\.lastUsed/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^Last used /)).not.toBeInTheDocument()
       expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument()
     })
 
@@ -197,7 +193,7 @@ describe('SecretListItem', () => {
 
       expect(
         screen.getByText(
-          `Last used ${new Date(secret.last_used_at!).toLocaleDateString()}`
+          `Last used ${formatExpectedDate(secret.last_used_at!)}`
         )
       ).toBeInTheDocument()
       expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument()

--- a/src/platform/secrets/components/SecretListItem.vue
+++ b/src/platform/secrets/components/SecretListItem.vue
@@ -78,14 +78,14 @@ const emit = defineEmits<{
   delete: []
 }>()
 
-const { t } = useI18n()
+const { d, t } = useI18n()
 
 const providerLabel = computed(() => getProviderLabel(secret.provider))
 const providerLogo = computed(() => getProviderLogo(secret.provider))
 
 function formatIsoDate(iso: string | undefined | null): string {
   const date = parseIsoDateSafe(iso)
-  return date ? date.toLocaleDateString() : ''
+  return date ? d(date, { dateStyle: 'medium' }) : ''
 }
 
 const createdDate = computed(() => formatIsoDate(secret.created_at))


### PR DESCRIPTION
## Summary

Localizes secret list date labels through Vue I18n date formatting instead of the browser default numeric date format, with Storybook coverage for design review.

## Changes

- **What**: Replaces `toLocaleDateString()` with `useI18n().d(..., { dateStyle: 'medium' })` for `SecretListItem` dates.
- **What**: Updates `SecretListItem` expectations to match the Vue I18n date formatter.
- **What**: Adds `SecretListItem` stories for default, never-used, loading, and disabled states.
- **Dependencies**: None.

## Review Focus

Stacked on #11480 to keep the escaping fix scoped. Please confirm whether the localized medium date style matches design/product expectations.

## Screenshots (if applicable)

https://f3ba7229.comfy-storybook.pages.dev/?path=/story/platform-secrets-secretlistitem--default

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11524-fix-localize-secret-date-labels-3496d73d3650814bb70bfb3f870a31cd) by [Unito](https://www.unito.io)
