### PR TITLE
test: harden strict parser coverage for long ISO fractions

### DIFF
--- a/src/utils/dateTimeUtil.test.ts
+++ b/src/utils/dateTimeUtil.test.ts
@@ -53,29 +53,44 @@ describe('parseIsoDateSafe', () => {
   })
 
   it('normalizes fractional seconds longer than 3 digits', () => {
-    const date = parseIsoDateSafe('2026-04-18T10:04:55.6513Z')
-    expect(date?.toISOString()).toBe('2026-04-18T10:04:55.651Z')
+    withStrictMillisecondParser((normalizedValues) => {
+      const date = parseIsoDateSafe('2026-04-18T10:04:55.6513Z')
+      expect(date?.toISOString()).toBe('2026-04-18T10:04:55.651Z')
+      expect(normalizedValues).toEqual(['2026-04-18T10:04:55.651Z'])
+    })
   })
 
   it('handles fractional seconds without timezone suffix', () => {
-    const date = parseIsoDateSafe('2026-04-18T10:04:55.6513')
-    expect(date).not.toBeNull()
-    expect(Number.isNaN(date!.getTime())).toBe(false)
+    withStrictMillisecondParser((normalizedValues) => {
+      const date = parseIsoDateSafe('2026-04-18T10:04:55.6513')
+      expect(date).not.toBeNull()
+      expect(Number.isNaN(date!.getTime())).toBe(false)
+      expect(normalizedValues).toEqual(['2026-04-18T10:04:55.651'])
+    })
   })
 
   it('handles offset timezones with long fractional seconds', () => {
-    const date = parseIsoDateSafe('2026-04-18T10:04:55.6513+09:00')
-    expect(date?.toISOString()).toBe('2026-04-18T01:04:55.651Z')
+    withStrictMillisecondParser((normalizedValues) => {
+      const date = parseIsoDateSafe('2026-04-18T10:04:55.6513+09:00')
+      expect(date?.toISOString()).toBe('2026-04-18T01:04:55.651Z')
+      expect(normalizedValues).toEqual(['2026-04-18T10:04:55.651+09:00'])
+    })
   })
 
   it('handles negative-offset timezones with long fractional seconds', () => {
-    const date = parseIsoDateSafe('2026-04-18T10:04:55.987654-05:00')
-    expect(date?.toISOString()).toBe('2026-04-18T15:04:55.987Z')
+    withStrictMillisecondParser((normalizedValues) => {
+      const date = parseIsoDateSafe('2026-04-18T10:04:55.987654-05:00')
+      expect(date?.toISOString()).toBe('2026-04-18T15:04:55.987Z')
+      expect(normalizedValues).toEqual(['2026-04-18T10:04:55.987-05:00'])
+    })
   })
 
   it('handles the full 9-digit nanosecond precision Go can emit', () => {
-    const date = parseIsoDateSafe('2026-04-18T10:04:55.123456789Z')
-    expect(date?.toISOString()).toBe('2026-04-18T10:04:55.123Z')
+    withStrictMillisecondParser((normalizedValues) => {
+      const date = parseIsoDateSafe('2026-04-18T10:04:55.123456789Z')
+      expect(date?.toISOString()).toBe('2026-04-18T10:04:55.123Z')
+      expect(normalizedValues).toEqual(['2026-04-18T10:04:55.123Z'])
+    })
   })
 
   it('passes through timestamps without any fractional seconds', () => {


### PR DESCRIPTION
## Summary

- run every `parseIsoDateSafe` case with more than 3 fractional-second digits through `withStrictMillisecondParser`
- assert the normalized 3-digit timestamp string passed into `Date` for each long-fraction variant
- keep the follow-up scoped to test coverage only

## Root cause

V8 already accepts and truncates ISO timestamps with more than 3 fractional-second digits, so the existing tests could stay green even if `parseIsoDateSafe` failed to normalize those values before constructing `Date`. Wrapping the long-fraction cases in the strict parser shim makes CI exercise the Safari/WebView-sensitive path the feature is meant to protect.

## Testing

- `pnpm exec vitest run src/utils/dateTimeUtil.test.ts`
- `pnpm exec eslint src/utils/dateTimeUtil.test.ts`

Fixes #11528

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11529-codex-test-harden-strict-parser-coverage-for-long-ISO-fractions-34a6d73d365081119577eb5fb6d4992c) by [Unito](https://www.unito.io)
