### PR TITLE
Refactor/brush drawing utils

### DIFF
--- a/src/composables/maskeditor/brushDrawingUtils.test.ts
+++ b/src/composables/maskeditor/brushDrawingUtils.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BrushShape } from '@/extensions/core/maskeditor/types'
+import type { Point } from '@/extensions/core/maskeditor/types'
+
+import {
+  drawMaskShape,
+  drawRgbShape,
+  premultiplyData,
+  resetDirtyRect,
+  updateDirtyRect
+} from './brushDrawingUtils'
+
+function makeMockCtx() {
+  const gradient = { addColorStop: vi.fn() }
+  return {
+    beginPath: vi.fn(),
+    fill: vi.fn(),
+    rect: vi.fn(),
+    arc: vi.fn(),
+    fillStyle: '',
+    drawImage: vi.fn(),
+    createRadialGradient: vi.fn(() => gradient)
+  } as unknown as CanvasRenderingContext2D
+}
+
+function makeMockCanvas() {
+  const imageData = { data: new Uint8ClampedArray(40 * 40 * 4) }
+  const ctx2d = {
+    createImageData: vi.fn(() => imageData),
+    putImageData: vi.fn()
+  }
+  return {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => ctx2d)
+  } as unknown as HTMLCanvasElement
+}
+
+const point: Point = { x: 10, y: 10 }
+
+describe('premultiplyData', () => {
+  it('leaves RGB unchanged when alpha=255', () => {
+    const data = new Uint8ClampedArray([100, 150, 200, 255])
+    premultiplyData(data)
+    expect(data[0]).toBe(100)
+    expect(data[1]).toBe(150)
+    expect(data[2]).toBe(200)
+  })
+
+  it('halves RGB values when alpha=128', () => {
+    const data = new Uint8ClampedArray([200, 200, 200, 128])
+    premultiplyData(data)
+    expect(data[0]).toBeCloseTo(100, 0)
+  })
+
+  it('zeroes RGB when alpha=0', () => {
+    const data = new Uint8ClampedArray([255, 255, 255, 0])
+    premultiplyData(data)
+    expect(data[0]).toBe(0)
+    expect(data[1]).toBe(0)
+    expect(data[2]).toBe(0)
+  })
+})
+
+describe('updateDirtyRect', () => {
+  it('expands bounds on first call', () => {
+    const rect = updateDirtyRect(resetDirtyRect(), 50, 50, 10)
+    expect(rect.minX).toBeLessThan(50)
+    expect(rect.maxX).toBeGreaterThan(50)
+  })
+
+  it('never shrinks existing bounds on subsequent calls', () => {
+    let rect = updateDirtyRect(resetDirtyRect(), 50, 50, 10)
+    rect = updateDirtyRect(rect, 10, 10, 2)
+    expect(rect.minX).toBeLessThanOrEqual(10 - 2)
+    expect(rect.maxX).toBeGreaterThanOrEqual(50 + 10)
+  })
+
+  it('includes padding in the expanded bounds', () => {
+    const rect = updateDirtyRect(resetDirtyRect(), 50, 50, 10)
+    expect(rect.minX).toBe(50 - 10 - 2)
+    expect(rect.maxX).toBe(50 + 10 + 2)
+  })
+})
+
+describe('resetDirtyRect', () => {
+  it('returns infinite bounds so first updateDirtyRect always expands', () => {
+    const rect = resetDirtyRect()
+    expect(rect.minX).toBe(Infinity)
+    expect(rect.minY).toBe(Infinity)
+    expect(rect.maxX).toBe(-Infinity)
+    expect(rect.maxY).toBe(-Infinity)
+  })
+})
+
+describe('drawRgbShape', () => {
+  it('sets fillStyle and calls arc for Arc brush at hardness=1', () => {
+    const ctx = makeMockCtx()
+    drawRgbShape(ctx, point, BrushShape.Arc, 10, 1, 0.8, '#ff0000')
+    expect(ctx.arc).toHaveBeenCalledWith(10, 10, 10, 0, Math.PI * 2, false)
+  })
+
+  it('sets fillStyle and calls rect for Rect brush at hardness=1', () => {
+    const ctx = makeMockCtx()
+    drawRgbShape(ctx, point, BrushShape.Rect, 10, 1, 0.8, '#ff0000')
+    expect(ctx.rect).toHaveBeenCalledWith(0, 0, 20, 20)
+  })
+
+  it('uses radial gradient for Arc brush at hardness < 1', () => {
+    const ctx = makeMockCtx()
+    drawRgbShape(ctx, point, BrushShape.Arc, 10, 0.5, 0.8, '#ff0000')
+    expect(ctx.createRadialGradient).toHaveBeenCalled()
+  })
+
+  describe('Rect brush with soft hardness (uses brush texture cache)', () => {
+    const originalCreateElement = document.createElement.bind(document)
+
+    beforeEach(() => {
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'canvas') return makeMockCanvas()
+        return originalCreateElement(tag)
+      })
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('calls drawImage with the cached texture', () => {
+      const ctx = makeMockCtx()
+      drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#ff0000')
+      expect(ctx.drawImage).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('drawMaskShape', () => {
+  const maskColor = { r: 255, g: 0, b: 0 }
+
+  it('calls arc when not erasing, Arc brush, hardness=1', () => {
+    const ctx = makeMockCtx()
+    drawMaskShape(ctx, point, BrushShape.Arc, 10, 1, 0.8, false, maskColor)
+    expect(ctx.arc).toHaveBeenCalledWith(10, 10, 10, 0, Math.PI * 2, false)
+  })
+
+  it('sets white fillStyle when erasing at hardness=1', () => {
+    const ctx = makeMockCtx()
+    drawMaskShape(ctx, point, BrushShape.Arc, 10, 1, 0.8, true, maskColor)
+    expect(ctx.fillStyle).toContain('255, 255, 255')
+  })
+
+  it('uses radial gradient when hardness < 1 and not erasing', () => {
+    const ctx = makeMockCtx()
+    drawMaskShape(ctx, point, BrushShape.Arc, 10, 0.5, 0.8, false, maskColor)
+    expect(ctx.createRadialGradient).toHaveBeenCalled()
+  })
+
+  it('uses radial gradient when hardness < 1 and erasing', () => {
+    const ctx = makeMockCtx()
+    drawMaskShape(ctx, point, BrushShape.Arc, 10, 0.5, 0.8, true, maskColor)
+    expect(ctx.createRadialGradient).toHaveBeenCalled()
+  })
+
+  describe('Rect brush with soft hardness (uses brush texture cache)', () => {
+    const originalCreateElement = document.createElement.bind(document)
+
+    beforeEach(() => {
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'canvas') return makeMockCanvas()
+        return originalCreateElement(tag)
+      })
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('calls drawImage when not erasing', () => {
+      const ctx = makeMockCtx()
+      drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, false, maskColor)
+      expect(ctx.drawImage).toHaveBeenCalled()
+    })
+
+    it('calls drawImage when erasing', () => {
+      const ctx = makeMockCtx()
+      drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, true, maskColor)
+      expect(ctx.drawImage).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/composables/maskeditor/brushDrawingUtils.test.ts
+++ b/src/composables/maskeditor/brushDrawingUtils.test.ts
@@ -24,17 +24,24 @@ function makeMockCtx() {
   } as unknown as CanvasRenderingContext2D
 }
 
-function makeMockCanvas() {
+function makeMockCanvas(nullCtx = false) {
   const imageData = { data: new Uint8ClampedArray(40 * 40 * 4) }
-  const ctx2d = {
-    createImageData: vi.fn(() => imageData),
-    putImageData: vi.fn()
-  }
+  const ctx2d = nullCtx
+    ? null
+    : { createImageData: vi.fn(() => imageData), putImageData: vi.fn() }
   return {
     width: 0,
     height: 0,
     getContext: vi.fn(() => ctx2d)
   } as unknown as HTMLCanvasElement
+}
+
+function spyOnCreateElement(nullCtx = false) {
+  const originalCreateElement = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'canvas') return makeMockCanvas(nullCtx)
+    return originalCreateElement(tag)
+  })
 }
 
 const point: Point = { x: 10, y: 10 }
@@ -98,23 +105,31 @@ describe('drawRgbShape', () => {
   })
 
   describe('Rect brush with soft hardness', () => {
-    const originalCreateElement = document.createElement.bind(document)
+    beforeEach(() => spyOnCreateElement())
+    afterEach(() => vi.restoreAllMocks())
 
-    beforeEach(() => {
-      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        if (tag === 'canvas') return makeMockCanvas()
-        return originalCreateElement(tag)
-      })
-    })
-
-    afterEach(() => {
-      vi.restoreAllMocks()
-    })
-
-    it('draws the cached brush texture at the correct offset', () => {
+    it('draws the cached brush texture at the correct offset without using a gradient', () => {
       const ctx = makeMockCtx()
-      drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#ff0000')
+      drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#00ff00')
       expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0)
+      expect(ctx.createRadialGradient).not.toHaveBeenCalled()
+    })
+
+    it('reuses the cached texture on a second call with identical parameters', () => {
+      const ctx = makeMockCtx()
+      drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#00ff00')
+      drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#00ff00')
+      const [firstCall, secondCall] = vi.mocked(ctx.drawImage).mock.calls
+      expect(firstCall[0]).toBe(secondCall[0])
+    })
+
+    it('throws when the canvas context is unavailable', () => {
+      vi.restoreAllMocks()
+      spyOnCreateElement(true)
+      const ctx = makeMockCtx()
+      expect(() =>
+        drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#aabbcc')
+      ).toThrow('Unable to create 2D canvas context for brush texture')
     })
   })
 })
@@ -141,29 +156,43 @@ describe('drawMaskShape', () => {
   })
 
   describe('Rect brush with soft hardness', () => {
-    const originalCreateElement = document.createElement.bind(document)
+    beforeEach(() => spyOnCreateElement())
+    afterEach(() => vi.restoreAllMocks())
 
-    beforeEach(() => {
-      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        if (tag === 'canvas') return makeMockCanvas()
-        return originalCreateElement(tag)
-      })
-    })
-
-    afterEach(() => {
-      vi.restoreAllMocks()
-    })
-
-    it('draws the cached brush texture at the correct offset when not erasing', () => {
+    it('draws the cached texture without a gradient when not erasing', () => {
       const ctx = makeMockCtx()
-      drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, false, maskColor)
+      drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, false, {
+        r: 0,
+        g: 255,
+        b: 0
+      })
       expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0)
+      expect(ctx.createRadialGradient).not.toHaveBeenCalled()
     })
 
-    it('draws the cached brush texture at the correct offset when erasing', () => {
+    it('draws the cached texture without a gradient when erasing', () => {
       const ctx = makeMockCtx()
       drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, true, maskColor)
       expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0)
+      expect(ctx.createRadialGradient).not.toHaveBeenCalled()
+    })
+
+    it('uses a different cached texture for erase vs paint', () => {
+      const paintCtx = makeMockCtx()
+      const eraseCtx = makeMockCtx()
+      drawMaskShape(paintCtx, point, BrushShape.Rect, 10, 0.5, 0.8, false, {
+        r: 0,
+        g: 0,
+        b: 255
+      })
+      drawMaskShape(eraseCtx, point, BrushShape.Rect, 10, 0.5, 0.8, true, {
+        r: 0,
+        g: 0,
+        b: 255
+      })
+      const paintTexture = vi.mocked(paintCtx.drawImage).mock.calls[0][0]
+      const eraseTexture = vi.mocked(eraseCtx.drawImage).mock.calls[0][0]
+      expect(paintTexture).not.toBe(eraseTexture)
     })
   })
 })

--- a/src/composables/maskeditor/brushDrawingUtils.test.ts
+++ b/src/composables/maskeditor/brushDrawingUtils.test.ts
@@ -64,10 +64,10 @@ describe('premultiplyData', () => {
 })
 
 describe('updateDirtyRect', () => {
-  it('expands bounds on first call', () => {
+  it('includes padding around the point', () => {
     const rect = updateDirtyRect(resetDirtyRect(), 50, 50, 10)
-    expect(rect.minX).toBeLessThan(50)
-    expect(rect.maxX).toBeGreaterThan(50)
+    expect(rect.minX).toBe(50 - 10 - 2)
+    expect(rect.maxX).toBe(50 + 10 + 2)
   })
 
   it('never shrinks existing bounds on subsequent calls', () => {
@@ -76,44 +76,28 @@ describe('updateDirtyRect', () => {
     expect(rect.minX).toBeLessThanOrEqual(10 - 2)
     expect(rect.maxX).toBeGreaterThanOrEqual(50 + 10)
   })
-
-  it('includes padding in the expanded bounds', () => {
-    const rect = updateDirtyRect(resetDirtyRect(), 50, 50, 10)
-    expect(rect.minX).toBe(50 - 10 - 2)
-    expect(rect.maxX).toBe(50 + 10 + 2)
-  })
-})
-
-describe('resetDirtyRect', () => {
-  it('returns infinite bounds so first updateDirtyRect always expands', () => {
-    const rect = resetDirtyRect()
-    expect(rect.minX).toBe(Infinity)
-    expect(rect.minY).toBe(Infinity)
-    expect(rect.maxX).toBe(-Infinity)
-    expect(rect.maxY).toBe(-Infinity)
-  })
 })
 
 describe('drawRgbShape', () => {
-  it('sets fillStyle and calls arc for Arc brush at hardness=1', () => {
+  it('draws arc at the correct center and radius for Arc brush at hardness=1', () => {
     const ctx = makeMockCtx()
     drawRgbShape(ctx, point, BrushShape.Arc, 10, 1, 0.8, '#ff0000')
     expect(ctx.arc).toHaveBeenCalledWith(10, 10, 10, 0, Math.PI * 2, false)
   })
 
-  it('sets fillStyle and calls rect for Rect brush at hardness=1', () => {
+  it('draws rect at the correct position for Rect brush at hardness=1', () => {
     const ctx = makeMockCtx()
     drawRgbShape(ctx, point, BrushShape.Rect, 10, 1, 0.8, '#ff0000')
     expect(ctx.rect).toHaveBeenCalledWith(0, 0, 20, 20)
   })
 
-  it('uses radial gradient for Arc brush at hardness < 1', () => {
+  it('creates radial gradient centered on the point for Arc brush at hardness < 1', () => {
     const ctx = makeMockCtx()
     drawRgbShape(ctx, point, BrushShape.Arc, 10, 0.5, 0.8, '#ff0000')
-    expect(ctx.createRadialGradient).toHaveBeenCalled()
+    expect(ctx.createRadialGradient).toHaveBeenCalledWith(10, 10, 0, 10, 10, 10)
   })
 
-  describe('Rect brush with soft hardness (uses brush texture cache)', () => {
+  describe('Rect brush with soft hardness', () => {
     const originalCreateElement = document.createElement.bind(document)
 
     beforeEach(() => {
@@ -127,10 +111,10 @@ describe('drawRgbShape', () => {
       vi.restoreAllMocks()
     })
 
-    it('calls drawImage with the cached texture', () => {
+    it('draws the cached brush texture at the correct offset', () => {
       const ctx = makeMockCtx()
       drawRgbShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, '#ff0000')
-      expect(ctx.drawImage).toHaveBeenCalled()
+      expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0)
     })
   })
 })
@@ -138,31 +122,25 @@ describe('drawRgbShape', () => {
 describe('drawMaskShape', () => {
   const maskColor = { r: 255, g: 0, b: 0 }
 
-  it('calls arc when not erasing, Arc brush, hardness=1', () => {
+  it('draws arc at the correct center and radius when not erasing, hardness=1', () => {
     const ctx = makeMockCtx()
     drawMaskShape(ctx, point, BrushShape.Arc, 10, 1, 0.8, false, maskColor)
     expect(ctx.arc).toHaveBeenCalledWith(10, 10, 10, 0, Math.PI * 2, false)
   })
 
-  it('sets white fillStyle when erasing at hardness=1', () => {
+  it('uses white fill color when erasing at hardness=1', () => {
     const ctx = makeMockCtx()
     drawMaskShape(ctx, point, BrushShape.Arc, 10, 1, 0.8, true, maskColor)
     expect(ctx.fillStyle).toContain('255, 255, 255')
   })
 
-  it('uses radial gradient when hardness < 1 and not erasing', () => {
+  it('creates radial gradient centered on the point when hardness < 1', () => {
     const ctx = makeMockCtx()
     drawMaskShape(ctx, point, BrushShape.Arc, 10, 0.5, 0.8, false, maskColor)
-    expect(ctx.createRadialGradient).toHaveBeenCalled()
+    expect(ctx.createRadialGradient).toHaveBeenCalledWith(10, 10, 0, 10, 10, 10)
   })
 
-  it('uses radial gradient when hardness < 1 and erasing', () => {
-    const ctx = makeMockCtx()
-    drawMaskShape(ctx, point, BrushShape.Arc, 10, 0.5, 0.8, true, maskColor)
-    expect(ctx.createRadialGradient).toHaveBeenCalled()
-  })
-
-  describe('Rect brush with soft hardness (uses brush texture cache)', () => {
+  describe('Rect brush with soft hardness', () => {
     const originalCreateElement = document.createElement.bind(document)
 
     beforeEach(() => {
@@ -176,16 +154,16 @@ describe('drawMaskShape', () => {
       vi.restoreAllMocks()
     })
 
-    it('calls drawImage when not erasing', () => {
+    it('draws the cached brush texture at the correct offset when not erasing', () => {
       const ctx = makeMockCtx()
       drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, false, maskColor)
-      expect(ctx.drawImage).toHaveBeenCalled()
+      expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0)
     })
 
-    it('calls drawImage when erasing', () => {
+    it('draws the cached brush texture at the correct offset when erasing', () => {
       const ctx = makeMockCtx()
       drawMaskShape(ctx, point, BrushShape.Rect, 10, 0.5, 0.8, true, maskColor)
-      expect(ctx.drawImage).toHaveBeenCalled()
+      expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0)
     })
   })
 })

--- a/src/composables/maskeditor/brushDrawingUtils.ts
+++ b/src/composables/maskeditor/brushDrawingUtils.ts
@@ -102,17 +102,22 @@ function getCachedBrushTexture(
   color: string,
   opacity: number
 ): HTMLCanvasElement {
-  const cacheKey = `${radius}_${hardness}_${color}_${opacity}`
+  const cacheKey = `${radius}_${hardness}_${color}`
+  const cached = brushTextureCache.get(cacheKey)
+  if (cached) return cached
 
-  if (brushTextureCache.has(cacheKey)) {
-    return brushTextureCache.get(cacheKey)!
+  const size = Math.max(1, Math.ceil(radius * 2))
+  if (!Number.isFinite(size)) {
+    throw new Error(`Invalid brush radius: ${radius}`)
   }
 
-  const size = Math.ceil(radius * 2)
   const tempCanvas = document.createElement('canvas')
-  const tempCtx = tempCanvas.getContext('2d')!
   tempCanvas.width = size
   tempCanvas.height = size
+  const tempCtx = tempCanvas.getContext('2d')
+  if (!tempCtx) {
+    throw new Error('Unable to create 2D canvas context for brush texture')
+  }
 
   const centerX = size / 2
   const centerY = size / 2

--- a/src/composables/maskeditor/brushDrawingUtils.ts
+++ b/src/composables/maskeditor/brushDrawingUtils.ts
@@ -1,0 +1,242 @@
+import QuickLRU from '@alloc/quick-lru'
+
+import { hexToRgb, parseToRgb } from '@/utils/colorUtil'
+import { BrushShape } from '@/extensions/core/maskeditor/types'
+import type { Point } from '@/extensions/core/maskeditor/types'
+
+export type DirtyRect = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+type MaskColor = { r: number; g: number; b: number }
+
+const brushTextureCache = new QuickLRU<string, HTMLCanvasElement>({
+  maxSize: 20
+})
+
+export function resetDirtyRect(): DirtyRect {
+  return { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+}
+
+export function updateDirtyRect(
+  rect: DirtyRect,
+  x: number,
+  y: number,
+  radius: number
+): DirtyRect {
+  const padding = 2
+  return {
+    minX: Math.min(rect.minX, x - radius - padding),
+    minY: Math.min(rect.minY, y - radius - padding),
+    maxX: Math.max(rect.maxX, x + radius + padding),
+    maxY: Math.max(rect.maxY, y + radius + padding)
+  }
+}
+
+function formatRgba(hex: string, alpha: number): string {
+  const { r, g, b } = hexToRgb(hex)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+export function premultiplyData(data: Uint8ClampedArray): void {
+  for (let i = 0; i < data.length; i += 4) {
+    const a = data[i + 3] / 255
+    data[i] = Math.round(data[i] * a)
+    data[i + 1] = Math.round(data[i + 1] * a)
+    data[i + 2] = Math.round(data[i + 2] * a)
+  }
+}
+
+function drawShapeOnContext(
+  ctx: CanvasRenderingContext2D,
+  brushType: BrushShape,
+  x: number,
+  y: number,
+  radius: number
+): void {
+  ctx.beginPath()
+  if (brushType === BrushShape.Rect) {
+    ctx.rect(x - radius, y - radius, radius * 2, radius * 2)
+  } else {
+    ctx.arc(x, y, radius, 0, Math.PI * 2, false)
+  }
+  ctx.fill()
+}
+
+function createBrushGradient(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  hardness: number,
+  color: string,
+  opacity: number,
+  isErasing: boolean
+): CanvasGradient {
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(radius)) {
+    return ctx.createRadialGradient(0, 0, 0, 0, 0, 0)
+  }
+
+  const gradient = ctx.createRadialGradient(x, y, 0, x, y, radius)
+
+  if (isErasing) {
+    gradient.addColorStop(0, `rgba(255, 255, 255, ${opacity})`)
+    gradient.addColorStop(hardness, `rgba(255, 255, 255, ${opacity})`)
+    gradient.addColorStop(1, `rgba(255, 255, 255, 0)`)
+  } else {
+    const { r, g, b } = parseToRgb(color)
+    gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, ${opacity})`)
+    gradient.addColorStop(hardness, `rgba(${r}, ${g}, ${b}, ${opacity})`)
+    gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`)
+  }
+
+  return gradient
+}
+
+function getCachedBrushTexture(
+  radius: number,
+  hardness: number,
+  color: string,
+  opacity: number
+): HTMLCanvasElement {
+  const cacheKey = `${radius}_${hardness}_${color}_${opacity}`
+
+  if (brushTextureCache.has(cacheKey)) {
+    return brushTextureCache.get(cacheKey)!
+  }
+
+  const size = Math.ceil(radius * 2)
+  const tempCanvas = document.createElement('canvas')
+  const tempCtx = tempCanvas.getContext('2d')!
+  tempCanvas.width = size
+  tempCanvas.height = size
+
+  const centerX = size / 2
+  const centerY = size / 2
+  const hardRadius = radius * hardness
+  const imageData = tempCtx.createImageData(size, size)
+  const data = imageData.data
+  const { r, g, b } = parseToRgb(color)
+  const fadeRange = radius - hardRadius
+
+  for (let y = 0; y < size; y++) {
+    const dy = y + 0.5 - centerY
+    for (let x = 0; x < size; x++) {
+      const dx = x + 0.5 - centerX
+      const index = (y * size + x) * 4
+      const distFromEdge = Math.max(Math.abs(dx), Math.abs(dy))
+
+      let pixelOpacity = 0
+      if (distFromEdge <= hardRadius) {
+        pixelOpacity = opacity
+      } else if (distFromEdge <= radius) {
+        const fadeProgress = (distFromEdge - hardRadius) / fadeRange
+        pixelOpacity = opacity * Math.pow(1 - fadeProgress, 2)
+      }
+
+      data[index] = r
+      data[index + 1] = g
+      data[index + 2] = b
+      data[index + 3] = pixelOpacity * 255
+    }
+  }
+
+  tempCtx.putImageData(imageData, 0, 0)
+  brushTextureCache.set(cacheKey, tempCanvas)
+  return tempCanvas
+}
+
+export function drawRgbShape(
+  ctx: CanvasRenderingContext2D,
+  point: Point,
+  brushType: BrushShape,
+  brushRadius: number,
+  hardness: number,
+  opacity: number,
+  rgbColor: string
+): void {
+  const { x, y } = point
+
+  if (brushType === BrushShape.Rect && hardness < 1) {
+    const rgbaColor = formatRgba(rgbColor, opacity)
+    const brushTexture = getCachedBrushTexture(
+      brushRadius,
+      hardness,
+      rgbaColor,
+      opacity
+    )
+    ctx.drawImage(brushTexture, x - brushRadius, y - brushRadius)
+    return
+  }
+
+  if (hardness === 1) {
+    ctx.fillStyle = formatRgba(rgbColor, opacity)
+    drawShapeOnContext(ctx, brushType, x, y, brushRadius)
+    return
+  }
+
+  const gradient = createBrushGradient(
+    ctx,
+    x,
+    y,
+    brushRadius,
+    hardness,
+    rgbColor,
+    opacity,
+    false
+  )
+  ctx.fillStyle = gradient
+  drawShapeOnContext(ctx, brushType, x, y, brushRadius)
+}
+
+export function drawMaskShape(
+  ctx: CanvasRenderingContext2D,
+  point: Point,
+  brushType: BrushShape,
+  brushRadius: number,
+  hardness: number,
+  opacity: number,
+  isErasing: boolean,
+  maskColor: MaskColor
+): void {
+  const { x, y } = point
+
+  if (brushType === BrushShape.Rect && hardness < 1) {
+    const baseColor = isErasing
+      ? `rgba(255, 255, 255, ${opacity})`
+      : `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`
+    const brushTexture = getCachedBrushTexture(
+      brushRadius,
+      hardness,
+      baseColor,
+      opacity
+    )
+    ctx.drawImage(brushTexture, x - brushRadius, y - brushRadius)
+    return
+  }
+
+  if (hardness === 1) {
+    ctx.fillStyle = isErasing
+      ? `rgba(255, 255, 255, ${opacity})`
+      : `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`
+    drawShapeOnContext(ctx, brushType, x, y, brushRadius)
+    return
+  }
+
+  const maskColorHex = `rgb(${maskColor.r}, ${maskColor.g}, ${maskColor.b})`
+  const gradient = createBrushGradient(
+    ctx,
+    x,
+    y,
+    brushRadius,
+    hardness,
+    maskColorHex,
+    opacity,
+    isErasing
+  )
+  ctx.fillStyle = gradient
+  drawShapeOnContext(ctx, brushType, x, y, brushRadius)
+}

--- a/src/composables/maskeditor/useBrushDrawing.ts
+++ b/src/composables/maskeditor/useBrushDrawing.ts
@@ -1,8 +1,7 @@
 /// <reference types="@webgpu/types" />
 import { ref, watch, nextTick, onUnmounted } from 'vue'
-import QuickLRU from '@alloc/quick-lru'
 import { debounce } from 'es-toolkit/compat'
-import { hexToRgb, parseToRgb } from '@/utils/colorUtil'
+import { parseToRgb } from '@/utils/colorUtil'
 import { getStorageValue, setStorageValue } from '@/scripts/utils'
 import {
   Tools,
@@ -17,6 +16,14 @@ import { tgpu } from 'typegpu'
 import { GPUBrushRenderer } from './gpu/GPUBrushRenderer'
 import { StrokeProcessor } from './StrokeProcessor'
 import { getEffectiveBrushSize, getEffectiveHardness } from './brushUtils'
+import {
+  resetDirtyRect,
+  updateDirtyRect,
+  premultiplyData,
+  drawRgbShape,
+  drawMaskShape
+} from './brushDrawingUtils'
+import type { DirtyRect } from './brushDrawingUtils'
 
 /**
  * Saves the brush settings to local storage with a debounce.
@@ -77,80 +84,6 @@ export function useBrushDrawing(initialSettings?: {
   // Flag to prevent redundant GPU updates
   const isSavingHistory = ref(false)
 
-  // Brush texture cache
-  const brushTextureCache = new QuickLRU<string, HTMLCanvasElement>({
-    maxSize: 20
-  })
-
-  /**
-   * Retrieves a cached brush texture or creates a new one if not found.
-   * @param radius - The radius of the brush.
-   * @param hardness - The hardness of the brush (0 to 1).
-   * @param color - The color of the brush.
-   * @param opacity - The opacity of the brush (0 to 1).
-   * @returns The canvas element containing the brush texture.
-   */
-  function getCachedBrushTexture(
-    radius: number,
-    hardness: number,
-    color: string,
-    opacity: number
-  ): HTMLCanvasElement {
-    const cacheKey = `${radius}_${hardness}_${color}_${opacity}`
-
-    if (brushTextureCache.has(cacheKey)) {
-      return brushTextureCache.get(cacheKey)!
-    }
-
-    // Use integer dimensions
-    const size = Math.ceil(radius * 2)
-    const tempCanvas = document.createElement('canvas')
-    const tempCtx = tempCanvas.getContext('2d')!
-    tempCanvas.width = size
-    tempCanvas.height = size
-
-    const centerX = size / 2
-    const centerY = size / 2
-    const hardRadius = radius * hardness
-
-    const imageData = tempCtx.createImageData(size, size)
-    const data = imageData.data
-    const { r, g, b } = parseToRgb(color)
-
-    const fadeRange = radius - hardRadius
-
-    for (let y = 0; y < size; y++) {
-      // Calculate distance from pixel center
-      const dy = y + 0.5 - centerY
-      for (let x = 0; x < size; x++) {
-        const dx = x + 0.5 - centerX
-        const index = (y * size + x) * 4
-
-        // Calculate Chebyshev distance
-        const distFromEdge = Math.max(Math.abs(dx), Math.abs(dy))
-
-        let pixelOpacity = 0
-        if (distFromEdge <= hardRadius) {
-          pixelOpacity = opacity
-        } else if (distFromEdge <= radius) {
-          const fadeProgress = (distFromEdge - hardRadius) / fadeRange
-          // Apply quadratic falloff
-          pixelOpacity = opacity * Math.pow(1 - fadeProgress, 2)
-        }
-
-        data[index] = r
-        data[index + 1] = g
-        data[index + 2] = b
-        data[index + 3] = pixelOpacity * 255
-      }
-    }
-
-    tempCtx.putImageData(imageData, 0, 0)
-    brushTextureCache.set(cacheKey, tempCanvas)
-
-    return tempCanvas
-  }
-
   const isDrawing = ref(false)
   const isDrawingLine = ref(false)
   const lineStartPoint = ref<Point | null>(null)
@@ -158,40 +91,7 @@ export function useBrushDrawing(initialSettings?: {
   const smoothingLastDrawTime = ref(new Date())
   const initialDraw = ref(true)
 
-  // Dirty rectangle tracking
-  const dirtyRect = ref({
-    minX: Infinity,
-    minY: Infinity,
-    maxX: -Infinity,
-    maxY: -Infinity
-  })
-
-  /**
-   * Resets the dirty rectangle to its initial infinite state.
-   */
-  function resetDirtyRect() {
-    dirtyRect.value = {
-      minX: Infinity,
-      minY: Infinity,
-      maxX: -Infinity,
-      maxY: -Infinity
-    }
-  }
-
-  /**
-   * Updates the dirty rectangle to include the specified area.
-   * @param x - The x-coordinate of the center.
-   * @param y - The y-coordinate of the center.
-   * @param radius - The radius of the area.
-   */
-  function updateDirtyRect(x: number, y: number, radius: number) {
-    // Add padding for anti-aliasing
-    const padding = 2
-    dirtyRect.value.minX = Math.min(dirtyRect.value.minX, x - radius - padding)
-    dirtyRect.value.minY = Math.min(dirtyRect.value.minY, y - radius - padding)
-    dirtyRect.value.maxX = Math.max(dirtyRect.value.maxX, x + radius + padding)
-    dirtyRect.value.maxY = Math.max(dirtyRect.value.maxY, y + radius + padding)
-  }
+  const dirtyRect = ref<DirtyRect>(resetDirtyRect())
 
   // Stroke processor instance
   let strokeProcessor: StrokeProcessor | null = null
@@ -411,19 +311,6 @@ export function useBrushDrawing(initialSettings?: {
   }
 
   /**
-   * Premultiplies the alpha of an ImageData array in place.
-   * @param data - The Uint8ClampedArray to modify.
-   */
-  function premultiplyData(data: Uint8ClampedArray) {
-    for (let i = 0; i < data.length; i += 4) {
-      const a = data[i + 3] / 255
-      data[i] = Math.round(data[i] * a)
-      data[i + 1] = Math.round(data[i + 1] * a)
-      data[i + 2] = Math.round(data[i + 2] * a)
-    }
-  }
-
-  /**
    * Updates the GPU textures from the current canvas state.
    */
   async function updateGPUFromCanvas(): Promise<void> {
@@ -538,11 +425,6 @@ export function useBrushDrawing(initialSettings?: {
     }
   }
 
-  /**
-   * Draws a shape on the appropriate canvas based on the current tool and layer.
-   * @param point - The center point of the shape.
-   * @param overrideOpacity - Optional opacity override.
-   */
   function drawShape(point: Point, overrideOpacity?: number) {
     const brush = store.brushSettings
     const mask_ctx = store.maskCtx
@@ -556,6 +438,12 @@ export function useBrushDrawing(initialSettings?: {
     const brushRadius = brush.size
     const hardness = brush.hardness
     const opacity = overrideOpacity ?? brush.opacity
+    const effectiveRadius = getEffectiveBrushSize(brushRadius, hardness)
+    const effectiveHardness = getEffectiveHardness(
+      brushRadius,
+      hardness,
+      effectiveRadius
+    )
 
     const isErasing = mask_ctx.globalCompositeOperation === 'destination-out'
     const currentTool = store.currentTool
@@ -566,244 +454,34 @@ export function useBrushDrawing(initialSettings?: {
       currentTool &&
       (currentTool === Tools.Eraser || currentTool === Tools.PaintPen)
     ) {
-      // Calculate effective size and hardness
-      const effectiveRadius = getEffectiveBrushSize(brushRadius, hardness)
-      const effectiveHardness = getEffectiveHardness(
-        brushRadius,
-        hardness,
-        effectiveRadius
-      )
-
       drawRgbShape(
         rgb_ctx,
         point,
         brushType,
         effectiveRadius,
         effectiveHardness,
-        opacity
+        opacity,
+        store.rgbColor
       )
-      return
+    } else {
+      drawMaskShape(
+        mask_ctx,
+        point,
+        brushType,
+        effectiveRadius,
+        effectiveHardness,
+        opacity,
+        isErasing,
+        store.maskColor
+      )
     }
 
-    // Calculate effective size and hardness
-    const effectiveRadius = getEffectiveBrushSize(brushRadius, hardness)
-    const effectiveHardness = getEffectiveHardness(
-      brushRadius,
-      hardness,
+    dirtyRect.value = updateDirtyRect(
+      dirtyRect.value,
+      point.x,
+      point.y,
       effectiveRadius
     )
-
-    drawMaskShape(
-      mask_ctx,
-      point,
-      brushType,
-      effectiveRadius,
-      effectiveHardness,
-      opacity,
-      isErasing
-    )
-
-    updateDirtyRect(point.x, point.y, effectiveRadius)
-  }
-
-  /**
-   * Draws a shape on the RGB canvas.
-   * @param ctx - The canvas rendering context.
-   * @param point - The center point.
-   * @param brushType - The type of brush (circle/rect).
-   * @param brushRadius - The radius of the brush.
-   * @param hardness - The hardness of the brush.
-   * @param opacity - The opacity of the brush.
-   */
-  function drawRgbShape(
-    ctx: CanvasRenderingContext2D,
-    point: Point,
-    brushType: BrushShape,
-    brushRadius: number,
-    hardness: number,
-    opacity: number
-  ): void {
-    const { x, y } = point
-    const rgbColor = store.rgbColor
-
-    if (brushType === BrushShape.Rect && hardness < 1) {
-      const rgbaColor = formatRgba(rgbColor, opacity)
-      const brushTexture = getCachedBrushTexture(
-        brushRadius,
-        hardness,
-        rgbaColor,
-        opacity
-      )
-      ctx.drawImage(brushTexture, x - brushRadius, y - brushRadius)
-      updateDirtyRect(x, y, brushRadius)
-      return
-    }
-
-    if (hardness === 1) {
-      const rgbaColor = formatRgba(rgbColor, opacity)
-      ctx.fillStyle = rgbaColor
-      drawShapeOnContext(ctx, brushType, x, y, brushRadius)
-      updateDirtyRect(x, y, brushRadius)
-      return
-    }
-
-    const gradient = createBrushGradient(
-      ctx,
-      x,
-      y,
-      brushRadius,
-      hardness,
-      rgbColor,
-      opacity,
-      false
-    )
-    ctx.fillStyle = gradient
-    drawShapeOnContext(ctx, brushType, x, y, brushRadius)
-    updateDirtyRect(x, y, brushRadius)
-  }
-
-  /**
-   * Draws a shape on the Mask canvas.
-   * @param ctx - The canvas rendering context.
-   * @param point - The center point.
-   * @param brushType - The type of brush (circle/rect).
-   * @param brushRadius - The radius of the brush.
-   * @param hardness - The hardness of the brush.
-   * @param opacity - The opacity of the brush.
-   * @param isErasing - Whether the operation is erasing.
-   */
-  function drawMaskShape(
-    ctx: CanvasRenderingContext2D,
-    point: Point,
-    brushType: BrushShape,
-    brushRadius: number,
-    hardness: number,
-    opacity: number,
-    isErasing: boolean
-  ): void {
-    const { x, y } = point
-    const maskColor = store.maskColor
-
-    if (brushType === BrushShape.Rect && hardness < 1) {
-      const baseColor = isErasing
-        ? `rgba(255, 255, 255, ${opacity})`
-        : `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`
-
-      const brushTexture = getCachedBrushTexture(
-        brushRadius,
-        hardness,
-        baseColor,
-        opacity
-      )
-      ctx.drawImage(brushTexture, x - brushRadius, y - brushRadius)
-      updateDirtyRect(x, y, brushRadius)
-      return
-    }
-
-    if (hardness === 1) {
-      ctx.fillStyle = isErasing
-        ? `rgba(255, 255, 255, ${opacity})`
-        : `rgba(${maskColor.r}, ${maskColor.g}, ${maskColor.b}, ${opacity})`
-      drawShapeOnContext(ctx, brushType, x, y, brushRadius)
-      updateDirtyRect(x, y, brushRadius)
-      return
-    }
-
-    const maskColorHex = `rgb(${maskColor.r}, ${maskColor.g}, ${maskColor.b})`
-    const gradient = createBrushGradient(
-      ctx,
-      x,
-      y,
-      brushRadius,
-      hardness,
-      maskColorHex,
-      opacity,
-      isErasing
-    )
-    ctx.fillStyle = gradient
-    drawShapeOnContext(ctx, brushType, x, y, brushRadius)
-    updateDirtyRect(x, y, brushRadius)
-  }
-
-  /**
-   * Helper to draw the path of the shape on the context.
-   * @param ctx - The canvas rendering context.
-   * @param brushType - The type of brush.
-   * @param x - Center x.
-   * @param y - Center y.
-   * @param radius - Radius.
-   */
-  function drawShapeOnContext(
-    ctx: CanvasRenderingContext2D,
-    brushType: BrushShape,
-    x: number,
-    y: number,
-    radius: number
-  ): void {
-    ctx.beginPath()
-    if (brushType === BrushShape.Rect) {
-      ctx.rect(x - radius, y - radius, radius * 2, radius * 2)
-    } else {
-      ctx.arc(x, y, radius, 0, Math.PI * 2, false)
-    }
-    ctx.fill()
-  }
-
-  /**
-   * Formats a hex color and alpha into an rgba string.
-   * @param hex - The hex color string.
-   * @param alpha - The alpha value (0-1).
-   * @returns The rgba string.
-   */
-  function formatRgba(hex: string, alpha: number): string {
-    const { r, g, b } = hexToRgb(hex)
-    return `rgba(${r}, ${g}, ${b}, ${alpha})`
-  }
-
-  /**
-   * Creates a radial gradient for soft brushes.
-   * @param ctx - The canvas context.
-   * @param x - Center x.
-   * @param y - Center y.
-   * @param radius - Radius.
-   * @param hardness - Hardness (0-1).
-   * @param color - Color string.
-   * @param opacity - Opacity (0-1).
-   * @param isErasing - Whether erasing.
-   * @returns The canvas gradient.
-   */
-  function createBrushGradient(
-    ctx: CanvasRenderingContext2D,
-    x: number,
-    y: number,
-    radius: number,
-    hardness: number,
-    color: string,
-    opacity: number,
-    isErasing: boolean
-  ): CanvasGradient {
-    if (
-      !Number.isFinite(x) ||
-      !Number.isFinite(y) ||
-      !Number.isFinite(radius)
-    ) {
-      return ctx.createRadialGradient(0, 0, 0, 0, 0, 0)
-    }
-
-    const gradient = ctx.createRadialGradient(x, y, 0, x, y, radius)
-
-    if (isErasing) {
-      gradient.addColorStop(0, `rgba(255, 255, 255, ${opacity})`)
-      gradient.addColorStop(hardness, `rgba(255, 255, 255, ${opacity})`)
-      gradient.addColorStop(1, `rgba(255, 255, 255, 0)`)
-    } else {
-      const { r, g, b } = parseToRgb(color)
-      gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, ${opacity})`)
-      gradient.addColorStop(hardness, `rgba(${r}, ${g}, ${b}, ${opacity})`)
-      gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`)
-    }
-
-    return gradient
   }
 
   /**
@@ -904,7 +582,7 @@ export function useBrushDrawing(initialSettings?: {
    */
   async function startDrawing(event: PointerEvent): Promise<void> {
     isDrawing.value = true
-    resetDirtyRect()
+    dirtyRect.value = resetDirtyRect()
 
     try {
       // Initialize stroke accumulator
@@ -1531,9 +1209,13 @@ export function useBrushDrawing(initialSettings?: {
       brushShape
     })
 
-    // Update Dirty Rect
     for (const p of strokePoints) {
-      updateDirtyRect(p.x, p.y, effectiveSize)
+      dirtyRect.value = updateDirtyRect(
+        dirtyRect.value,
+        p.x,
+        p.y,
+        effectiveSize
+      )
     }
 
     // 3. Blit to Preview with correct settings


### PR DESCRIPTION
## Summary

PR A of this https://github.com/Comfy-Org/ComfyUI_frontend/pull/11388

## Changes

* **`src/composables/maskeditor/brushDrawingUtils.ts` (New)** — Extracted `premultiplyData`, `formatRgba`, `drawShapeOnContext`, `createBrushGradient`, `getCachedBrushTexture`, `drawRgbShape`, `drawMaskShape`, `resetDirtyRect`, and `updateDirtyRect`; also exports `DirtyRect` / `MaskColor` types.
* **`src/composables/maskeditor/brushDrawingUtils.test.ts` (New)** — 11 unit tests with zero module mocking.
* **`src/composables/maskeditor/useBrushDrawing.ts`** — Replaced logic with imports; updated all `updateDirtyRect` call sites to use pure function calls, eliminating redundant calculations in `drawShape`.

## Test locally
1. Draw a few strokes on the canvas — verify brush marks appear correctly- ok
2. Switch to the eraser tool and erase part of the stroke — verify erasure works - ok
3. Press Ctrl+Z to undo — verify the canvas state is restored - ok
4. Alt+drag to adjust brush size/hardness — verify the brush parameters update correctly - ok

https://github.com/user-attachments/assets/ba4ca54d-e1a9-4985-bc46-b996bbf13eee


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core brush rendering and dirty-rect tracking used during interactive drawing, so subtle regressions in brush appearance/performance or cache behavior are possible. Adds new error paths when brush texture canvas context/radius are invalid.
> 
> **Overview**
> Extracts CPU brush rendering utilities into new `brushDrawingUtils.ts`, including **shape drawing**, **soft brush gradients/rect textures with an LRU cache**, **alpha premultiplication**, and **dirty-rect reset/update** helpers.
> 
> Updates `useBrushDrawing.ts` to import and use these helpers, switching dirty-rect tracking to a pure-function style (`dirtyRect.value = updateDirtyRect(...)`) and simplifying `drawShape` by computing effective radius/hardness once.
> 
> Adds `brushDrawingUtils.test.ts` with focused unit coverage for premultiplication, dirty-rect bounds behavior, and RGB/mask drawing paths (including cached soft-rect textures and error handling when a 2D context can’t be created).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abbc6813a68ce81e3a716fa6177b8f9a94996b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11531-Refactor-brush-drawing-utils-34a6d73d365081e1b404c384e099d1a9) by [Unito](https://www.unito.io)
