### PR TITLE
fix: resolve mesh widget thumbnails via asset preview API

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
 import type { ComputedRef } from 'vue'
 import { createI18n } from 'vue-i18n'
@@ -10,6 +10,27 @@ import type { AssetKind } from '@/types/widgetTypes'
 import FormDropdownMenuItem from './FormDropdownMenuItem.vue'
 import { AssetKindKey } from './types'
 import type { FormDropdownMenuItemProps } from './types'
+
+const mockFindServerPreviewUrl = vi.hoisted(() => vi.fn())
+const mockIsAssetPreviewSupported = vi.hoisted(() => vi.fn(() => true))
+const intersectionCallbacks = vi.hoisted(
+  () => [] as Array<(entries: Array<{ isIntersecting: boolean }>) => void>
+)
+
+vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
+  findServerPreviewUrl: (name: string) => mockFindServerPreviewUrl(name),
+  isAssetPreviewSupported: () => mockIsAssetPreviewSupported()
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useIntersectionObserver: (
+    _ref: unknown,
+    cb: (entries: Array<{ isIntersecting: boolean }>) => void
+  ) => {
+    intersectionCallbacks.push(cb)
+    return { stop: vi.fn() }
+  }
+}))
 
 const selectedLabel = 'Selected'
 
@@ -48,7 +69,23 @@ function renderItem(
   })
 }
 
+function fireIntersection(isIntersecting = true) {
+  for (const cb of intersectionCallbacks) {
+    cb([{ isIntersecting }])
+  }
+}
+
+async function flushPromises() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe('FormDropdownMenuItem', () => {
+  beforeEach(() => {
+    intersectionCallbacks.length = 0
+    mockFindServerPreviewUrl.mockReset()
+    mockIsAssetPreviewSupported.mockReset().mockReturnValue(true)
+  })
+
   describe('Label and name', () => {
     it('renders name when no label is provided', () => {
       renderItem({ name: 'alpha' })
@@ -88,6 +125,85 @@ describe('FormDropdownMenuItem', () => {
         { assetKind: 'image' }
       )
       expect(screen.queryByRole('img', { name: 'item_name' })).toBeNull()
+    })
+
+    it('does not look up mesh preview when kind is image', async () => {
+      renderItem({ previewUrl: '/preview.png' }, { assetKind: 'image' })
+      fireIntersection(true)
+      await flushPromises()
+      expect(mockFindServerPreviewUrl).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Mesh thumbnail resolution', () => {
+    it('shows 3D placeholder icon when mesh preview is unresolved', () => {
+      renderItem({ name: '3d/model.glb' }, { assetKind: 'mesh' })
+      expect(screen.getByTestId('dropdown-item-mesh-placeholder')).toBeTruthy()
+    })
+
+    it('looks up preview with basename after intersection fires', async () => {
+      mockFindServerPreviewUrl.mockResolvedValue('/api/view?preview=1')
+      renderItem({ name: '3d/sub/model.glb' }, { assetKind: 'mesh' })
+      fireIntersection(true)
+      await flushPromises()
+      expect(mockFindServerPreviewUrl).toHaveBeenCalledWith('model.glb')
+    })
+
+    it('strips [output] suffix before taking basename', async () => {
+      mockFindServerPreviewUrl.mockResolvedValue(null)
+      renderItem({ name: 'mesh/scene.glb [output]' }, { assetKind: 'mesh' })
+      fireIntersection(true)
+      await flushPromises()
+      expect(mockFindServerPreviewUrl).toHaveBeenCalledWith('scene.glb')
+    })
+
+    it('renders resolved URL in img once findServerPreviewUrl returns', async () => {
+      mockFindServerPreviewUrl.mockResolvedValue('/api/preview/resolved.png')
+      renderItem({ name: '3d/model.glb' }, { assetKind: 'mesh' })
+      fireIntersection(true)
+      const img = (await screen.findByAltText(
+        '3d/model.glb'
+      )) as HTMLImageElement
+      expect(img.getAttribute('src')).toBe('/api/preview/resolved.png')
+    })
+
+    it('skips lookup when asset preview is unsupported', async () => {
+      mockIsAssetPreviewSupported.mockReturnValue(false)
+      renderItem({ name: '3d/model.glb' }, { assetKind: 'mesh' })
+      fireIntersection(true)
+      await flushPromises()
+      expect(mockFindServerPreviewUrl).not.toHaveBeenCalled()
+    })
+
+    it('only looks up once for repeated intersection events', async () => {
+      mockFindServerPreviewUrl.mockResolvedValue(null)
+      renderItem({ name: '3d/model.glb' }, { assetKind: 'mesh' })
+      fireIntersection(true)
+      fireIntersection(true)
+      fireIntersection(true)
+      await flushPromises()
+      expect(mockFindServerPreviewUrl).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not look up when not yet intersecting', async () => {
+      renderItem({ name: '3d/model.glb' }, { assetKind: 'mesh' })
+      fireIntersection(false)
+      await flushPromises()
+      expect(mockFindServerPreviewUrl).not.toHaveBeenCalled()
+    })
+
+    it('ignores the previewUrl prop for mesh kind', async () => {
+      mockFindServerPreviewUrl.mockResolvedValue(null)
+      renderItem(
+        {
+          name: '3d/model.glb',
+          previewUrl: '/api/view?filename=model.glb&type=input'
+        },
+        { assetKind: 'mesh' }
+      )
+      fireIntersection(true)
+      await flushPromises()
+      expect(screen.queryByAltText('3d/model.glb')).toBeNull()
     })
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuItem.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
-import { computed, inject, ref } from 'vue'
+import { useIntersectionObserver } from '@vueuse/core'
+import { computed, inject, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { cn } from '@comfyorg/tailwind-utils'
+
+import {
+  findServerPreviewUrl,
+  isAssetPreviewSupported
+} from '@/platform/assets/utils/assetPreviewUtil'
 
 import { AssetKindKey } from './types'
 import type { FormDropdownMenuItemProps } from './types'
@@ -21,6 +27,42 @@ const actualDimensions = ref<string | null>(null)
 const assetKind = inject(AssetKindKey)
 
 const isVideo = computed(() => assetKind?.value === 'video')
+const isMesh = computed(() => assetKind?.value === 'mesh')
+
+const mediaContainerRef = ref<HTMLElement>()
+const resolvedMeshPreview = ref<string | null>(null)
+const meshPreviewAttempted = ref(false)
+
+function toLookupName(name: string): string {
+  const stripped = name.replace(/ \[output\]$/, '')
+  const slash = stripped.lastIndexOf('/')
+  return slash === -1 ? stripped : stripped.substring(slash + 1)
+}
+
+async function resolveMeshPreview() {
+  if (!isAssetPreviewSupported()) return
+  const url = await findServerPreviewUrl(toLookupName(props.name))
+  if (url) resolvedMeshPreview.value = url
+}
+
+useIntersectionObserver(mediaContainerRef, ([entry]) => {
+  if (!entry?.isIntersecting) return
+  if (!isMesh.value || meshPreviewAttempted.value) return
+  meshPreviewAttempted.value = true
+  void resolveMeshPreview()
+})
+
+watch(
+  () => props.name,
+  () => {
+    meshPreviewAttempted.value = false
+    resolvedMeshPreview.value = null
+  }
+)
+
+const displayedPreviewUrl = computed(() =>
+  isMesh.value ? resolvedMeshPreview.value : props.previewUrl
+)
 
 function handleClick() {
   emit('click', props.index)
@@ -68,6 +110,7 @@ function handleVideoLoad(event: Event) {
     <!-- Image -->
     <div
       v-if="layout !== 'list-small'"
+      ref="mediaContainerRef"
       :class="
         cn(
           'relative',
@@ -106,15 +149,23 @@ function handleVideoLoad(event: Event) {
         @loadeddata="handleVideoLoad"
       />
       <img
-        v-else-if="previewUrl"
-        :src="previewUrl"
+        v-else-if="displayedPreviewUrl"
+        :src="displayedPreviewUrl"
         :alt="name"
         draggable="false"
         class="size-full object-cover"
         @load="handleImageLoad"
       />
       <div
+        v-else-if="isMesh"
+        data-testid="dropdown-item-mesh-placeholder"
+        class="flex size-full items-center justify-center bg-modal-card-placeholder-background"
+      >
+        <i class="icon-[lucide--box] text-3xl text-muted-foreground" />
+      </div>
+      <div
         v-else
+        data-testid="dropdown-item-media-placeholder"
         class="size-full bg-linear-to-tr from-blue-400 via-teal-500 to-green-400"
       />
     </div>

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -241,6 +241,59 @@ describe('useWidgetSelectItems', () => {
     })
   })
 
+  describe('mesh preview URL handling', () => {
+    it('leaves input preview_url empty for mesh kind', () => {
+      const { dropdownItems } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => ['3d/model.glb', 'other.fbx'],
+          modelValue: ref('3d/model.glb'),
+          assetKind: () => 'mesh'
+        })
+      )
+      expect(dropdownItems.value).toHaveLength(2)
+      expect(dropdownItems.value[0].preview_url).toBe('')
+      expect(dropdownItems.value[1].preview_url).toBe('')
+    })
+
+    it('leaves output preview_url empty for mesh kind even when asset has one', async () => {
+      mockMediaAssets.media.value = [
+        {
+          id: 'asset-mesh-1',
+          name: 'scene.glb',
+          preview_url: '/api/view?filename=scene.glb&type=output',
+          tags: ['output']
+        }
+      ]
+
+      const { dropdownItems, filterSelected } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => [],
+          modelValue: ref(undefined),
+          assetKind: () => 'mesh'
+        })
+      )
+      filterSelected.value = 'outputs'
+      await nextTick()
+
+      expect(dropdownItems.value).toHaveLength(1)
+      expect(dropdownItems.value[0].preview_url).toBe('')
+    })
+
+    it('still uses getMediaUrl for image kind inputs', () => {
+      const { dropdownItems } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => ['img_001.png'],
+          modelValue: ref('img_001.png'),
+          assetKind: () => 'image'
+        })
+      )
+      expect(dropdownItems.value[0].preview_url).toContain(
+        'filename=img_001.png'
+      )
+      expect(dropdownItems.value[0].preview_url).toContain('type=input')
+    })
+  })
+
   describe('cloud asset mode', () => {
     const createTestAsset = (
       id: string,

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
@@ -50,7 +50,7 @@ function getMediaUrl(
   type: 'input' | 'output',
   assetKind: AssetKind | undefined
 ): string {
-  if (!['image', 'video', 'audio', 'mesh'].includes(assetKind ?? '')) return ''
+  if (!['image', 'video', 'audio'].includes(assetKind ?? '')) return ''
   const params = new URLSearchParams({ filename, type })
   appendCloudResParam(params, filename)
   return `/api/view?${params}`
@@ -183,7 +183,9 @@ export function useWidgetSelectItems(options: UseWidgetSelectItemsOptions) {
       items.push({
         id: `output-${asset.id}`,
         preview_url:
-          asset.preview_url || getMediaUrl(asset.name, 'output', kind),
+          kind === 'mesh'
+            ? ''
+            : asset.preview_url || getMediaUrl(asset.name, 'output', kind),
         name: annotatedPath,
         label: getDisplayLabel(annotatedPath, labelFn)
       })


### PR DESCRIPTION
## Summary
The Load3d select-model widget was passing the raw .glb URL as the item preview_url, which browsers can't render as an image, producing the broken-image icon on cloud/local asset-enabled servers.

Resolve thumbnails lazily from the asset API using the preview_id link (matching Media3DTop's behavior), look up by basename to stay consistent with the write path in useLoad3d, and fall back to a 3D-box placeholder when no preview exists yet.

## Screenshots
before
<img width="1112" height="1333" alt="image" src="https://github.com/user-attachments/assets/a8fa88ad-ab82-4951-be03-d28111322e30" />

after
with asset-enable on BE
https://github.com/user-attachments/assets/34b416af-5729-4ad0-bf17-722461ffc659

without asset-enable on BE
<img width="1026" height="1201" alt="image" src="https://github.com/user-attachments/assets/71fd463f-ca77-4d63-85ed-01261d032d53" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11538-fix-resolve-mesh-widget-thumbnails-via-asset-preview-API-34a6d73d365081d2aefac044dab0dfc3) by [Unito](https://www.unito.io)
