### PR TITLE
fix: stop duplicate node creation when dropping image on Vue nodes

### DIFF
--- a/src/composables/node/useNodeDragAndDrop.test.ts
+++ b/src/composables/node/useNodeDragAndDrop.test.ts
@@ -86,6 +86,129 @@ describe('useNodeDragAndDrop', () => {
     expect(isDragging).toBe(false)
   })
 
+  describe('claimEvent flag', () => {
+    function createClaimableEvent(
+      options: Parameters<typeof createDragEvent>[0]
+    ) {
+      const event = createDragEvent(options)
+      const preventDefault = vi.fn()
+      const stopPropagation = vi.fn()
+      Object.assign(event, { preventDefault, stopPropagation })
+      return { event, preventDefault, stopPropagation }
+    }
+
+    it('claims the event synchronously before awaiting onDrop for valid file drops', async () => {
+      const { event, preventDefault, stopPropagation } = createClaimableEvent({
+        files: [createFile('a.png')]
+      })
+
+      const onDrop = vi.fn().mockImplementation(async () => {
+        // By the time onDrop runs, the event must already be claimed —
+        // claiming after the await would let document fallback handlers fire.
+        expect(preventDefault).toHaveBeenCalledTimes(1)
+        expect(stopPropagation).toHaveBeenCalledTimes(1)
+        return []
+      })
+
+      const node = createNode()
+      useNodeDragAndDrop(node, { onDrop })
+
+      const result = await node.onDragDrop?.(event, true)
+
+      expect(result).toBe(true)
+      expect(onDrop).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not claim the event when files are filtered out', async () => {
+      const node = createNode()
+      useNodeDragAndDrop(node, {
+        onDrop: vi.fn().mockResolvedValue([]),
+        fileFilter: (file) => file.type === 'image/png'
+      })
+
+      const { event, preventDefault, stopPropagation } = createClaimableEvent({
+        files: [createFile('a.jpg', 'image/jpeg')]
+      })
+
+      const result = await node.onDragDrop?.(event, true)
+
+      expect(result).toBe(false)
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
+    })
+
+    it('claims the event for same-origin uri drops before fetching', async () => {
+      const { event, preventDefault, stopPropagation } = createClaimableEvent({
+        uri: `${location.origin}/api/file?filename=uri.png`,
+        types: ['text/uri-list']
+      })
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+        expect(preventDefault).toHaveBeenCalledTimes(1)
+        expect(stopPropagation).toHaveBeenCalledTimes(1)
+        return fromAny<Response, unknown>({
+          ok: true,
+          blob: vi
+            .fn()
+            .mockResolvedValue(new Blob(['uri'], { type: 'image/png' }))
+        })
+      })
+
+      const node = createNode()
+      useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+      const result = await node.onDragDrop?.(event, true)
+
+      expect(result).toBe(true)
+    })
+
+    it('does not claim the event for cross-origin uri drops', async () => {
+      const node = createNode()
+      useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+      const { event, preventDefault, stopPropagation } = createClaimableEvent({
+        uri: 'https://example.com/api/file?filename=uri.png',
+        types: ['text/uri-list']
+      })
+
+      const result = await node.onDragDrop?.(event, true)
+
+      expect(result).toBe(false)
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
+    })
+
+    it('does not claim the event when drop has no files and no uri', async () => {
+      const node = createNode()
+      useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+      const { event, preventDefault, stopPropagation } = createClaimableEvent(
+        {}
+      )
+
+      const result = await node.onDragDrop?.(event, true)
+
+      expect(result).toBe(false)
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
+    })
+
+    it('does not claim the event when claimEvent is omitted', async () => {
+      const node = createNode()
+      useNodeDragAndDrop(node, { onDrop: vi.fn().mockResolvedValue([]) })
+
+      const { event, preventDefault, stopPropagation } = createClaimableEvent({
+        files: [createFile('a.png')]
+      })
+
+      const result = await node.onDragDrop?.(event)
+
+      expect(result).toBe(true)
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
+    })
+  })
+
   it('onDragDrop calls onDrop with filtered files', async () => {
     const onDrop = vi.fn().mockResolvedValue([])
     const node = createNode()

--- a/src/composables/node/useNodeDragAndDrop.ts
+++ b/src/composables/node/useNodeDragAndDrop.ts
@@ -47,17 +47,26 @@ export const useNodeDragAndDrop = <T>(
   const installedDragOver = isDraggingFiles
   node.onDragOver = installedDragOver
 
-  const installedDragDrop = async function (e: DragEvent) {
+  const installedDragDrop = async function (e: DragEvent, claimEvent = false) {
     if (!isDraggingValidFiles(e)) return false
 
     const files = filterFiles(e.dataTransfer!.files)
     if (files.length) {
+      if (claimEvent) {
+        e.preventDefault()
+        e.stopPropagation()
+      }
       await onDrop(files)
       return true
     }
 
     const uri = URL.parse(e?.dataTransfer?.getData('text/uri-list') ?? '')
     if (!uri || uri.origin !== location.origin) return false
+
+    if (claimEvent) {
+      e.preventDefault()
+      e.stopPropagation()
+    }
 
     try {
       const resp = await fetch(uri)

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -306,8 +306,8 @@ describe('LGraphNode', () => {
   })
 
   describe('handleDrop', () => {
-    it('should stop propagation when onDragDrop returns true', async () => {
-      const onDragDrop = vi.fn().mockReturnValue(true)
+    it('should call onDragDrop with claimEvent=true so the handler can claim the event sync', async () => {
+      const onDragDrop = vi.fn().mockResolvedValue(true)
       mockData.mockLgraphNode = {
         onDragDrop,
         onDragOver: vi.fn(),
@@ -316,25 +316,15 @@ describe('LGraphNode', () => {
 
       const { container } = renderLGraphNode({ nodeData: mockNodeData })
       const nodeEl = getNodeRoot(container)
-      // eslint-disable-next-line testing-library/no-node-access
-      const parent = nodeEl.parentElement!
 
-      const parentListener = vi.fn()
-      expect(parent).not.toBeNull()
-      parent.addEventListener('drop', parentListener)
+      const dropEvent = new Event('drop', { bubbles: true, cancelable: true })
+      nodeEl.dispatchEvent(dropEvent)
 
-      nodeEl.dispatchEvent(
-        new Event('drop', { bubbles: true, cancelable: true })
-      )
-
-      expect(onDragDrop).toHaveBeenCalled()
-      expect(parentListener).not.toHaveBeenCalled()
+      expect(onDragDrop).toHaveBeenCalledWith(dropEvent, true)
     })
 
-    it('should not stop propagation when onDragDrop returns false', async () => {
-      const onDragDrop = vi.fn().mockReturnValue(false)
+    it('should not stop propagation when node has no onDragDrop handler', async () => {
       mockData.mockLgraphNode = {
-        onDragDrop,
         onDragOver: vi.fn(),
         isSubgraphNode: () => false
       }
@@ -352,7 +342,6 @@ describe('LGraphNode', () => {
         new Event('drop', { bubbles: true, cancelable: true })
       )
 
-      expect(onDragDrop).toHaveBeenCalled()
       expect(parentListener).toHaveBeenCalled()
     })
   })

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -813,16 +813,12 @@ function handleDragLeave() {
   isDraggingOver.value = false
 }
 
-function handleDrop(event: DragEvent) {
+async function handleDrop(event: DragEvent) {
   isDraggingOver.value = false
 
   const node = lgraphNode.value
   if (!node?.onDragDrop) return
 
-  const handled = node.onDragDrop(event)
-  if (handled === true) {
-    event.preventDefault()
-    event.stopPropagation()
-  }
+  await node.onDragDrop(event, true)
 }
 </script>

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -144,9 +144,13 @@ declare module '@/lib/litegraph/src/litegraph' {
      * Callback invoked when the node is dropped from an external source, i.e.
      * a file or another HTML element.
      * @param e The drag event
+     * @param claimEvent If true, the handler should call preventDefault and
+     *   stopPropagation synchronously before any await once it has decided to
+     *   accept the drop, so bubbling fallback handlers know not to also process
+     *   the event.
      * @returns {boolean} True if the drag event should be handled by this node, false otherwise
      */
-    onDragDrop?(e: DragEvent): Promise<boolean> | boolean
+    onDragDrop?(e: DragEvent, claimEvent?: boolean): Promise<boolean> | boolean
 
     index?: number
     runningInternalNodeId?: NodeId


### PR DESCRIPTION
## Summary
handleDrop checked `handled === true` to gate stopPropagation, but onDragDrop from useNodeDragAndDrop is async and always returns a Promise, so the check never matched. The drop then bubbled to the document handler in app.ts and spawned a new LoadImage node in addition to the one that accepted the drop.

Updated onDragDrop to take an optional claimEvent flag — when true, it calls preventDefault()/stopPropagation() synchronously inside the handler, only after the sync acceptance check passes (valid files / same-origin URI), and before any await.  
The Vue node now just calls await node.onDragDrop(event, true).
                                                                                                                                                                                                                                                                   
Rejected payloads (cross-origin URI, files filtered out, no valid files) skip the claim and bubble to the document fallback as before. The remaining edge case is async URI fetch failures, which we can't sync-detect without speculatively claiming.  

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/d79a5101-370b-4873-8365-5f9ce188731b



after

https://github.com/user-attachments/assets/8b787474-eab9-4060-8146-c4d8bb24ff9f

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11541-fix-stop-duplicate-node-creation-when-dropping-image-on-Vue-nodes-34a6d73d36508113b153e31768602933) by [Unito](https://www.unito.io)
