### PR TITLE
fix: load3d used wrong i18n key, add test

### DIFF
--- a/browser_tests/tests/load3d/load3d.spec.ts
+++ b/browser_tests/tests/load3d/load3d.spec.ts
@@ -281,3 +281,33 @@ test.describe('Load3D', () => {
     })
   })
 })
+
+test.describe('Load3D initialization failure', () => {
+  test('Surfaces a toast when the THREE.WebGLRenderer cannot be created', async ({
+    comfyPage
+  }) => {
+    // Force `new THREE.WebGLRenderer(...)` inside Load3d to throw by making
+    // WebGL getContext() calls return null.
+    await comfyPage.page.evaluate(() => {
+      const proto = HTMLCanvasElement.prototype as {
+        getContext: (
+          this: HTMLCanvasElement,
+          type: string,
+          options?: unknown
+        ) => unknown
+      }
+      const original = proto.getContext
+      proto.getContext = function (type, options) {
+        if (type === 'webgl' || type === 'webgl2') return null
+        return original.call(this, type, options)
+      }
+    })
+    await comfyPage.workflow.loadWorkflow('3d/load3d_node')
+
+    await expect(
+      comfyPage.toast.visibleToasts.filter({
+        hasText: 'Failed to initialize 3D Viewer'
+      })
+    ).not.toHaveCount(0)
+  })
+})

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -301,7 +301,7 @@ describe('useLoad3d', () => {
       await composable.initializeLoad3d(containerRef)
 
       expect(mockToastStore.addAlert).toHaveBeenCalledWith(
-        'toastMessages.failedToInitializeLoad3d'
+        'toastMessages.failedToInitializeLoad3dViewer'
       )
     })
 

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -177,7 +177,9 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       handleEvents('add')
     } catch (error) {
       console.error('Error initializing Load3d:', error)
-      useToastStore().addAlert(t('toastMessages.failedToInitializeLoad3d'))
+      useToastStore().addAlert(
+        t('toastMessages.failedToInitializeLoad3dViewer')
+      )
     }
   }
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'


### PR DESCRIPTION
## Summary

Toast for Load3D initialization failure was using the wrong key and so showed an untranslated key to the user.

## Changes

- **What**: 
- Update to use correct existing key
- Add test that forces init failure

## Screenshots (if applicable)
Fixed
<img width="482" height="121" alt="image" src="https://github.com/user-attachments/assets/f89eef99-c1a6-463a-a711-7e9c16d0e89a" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11546-fix-load3d-used-wrong-i18n-key-add-test-34a6d73d36508159aab9f042d3e9c4f0) by [Unito](https://www.unito.io)
