### PR TITLE
test: expand load3d unit test coverage

### DIFF
--- a/src/components/load3d/Load3D.test.ts
+++ b/src/components/load3d/Load3D.test.ts
@@ -1,0 +1,254 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import Load3D from '@/components/load3d/Load3D.vue'
+import type { ComponentWidget } from '@/scripts/domWidget'
+
+const { load3dState, resolveNodeMock, settingGetMock } = vi.hoisted(() => ({
+  load3dState: {
+    current: null as ReturnType<typeof buildLoad3dStub> | null
+  },
+  resolveNodeMock: vi.fn(),
+  settingGetMock: vi.fn()
+}))
+
+function buildLoad3dStub() {
+  return {
+    sceneConfig: ref({}),
+    modelConfig: ref({}),
+    cameraConfig: ref({}),
+    lightConfig: ref({}),
+    isRecording: ref(false),
+    isPreview: ref(false),
+    canFitToViewer: ref(true),
+    canUseGizmo: ref(true),
+    canUseLighting: ref(true),
+    canExport: ref(true),
+    materialModes: ref(['original', 'normal', 'wireframe']),
+    hasSkeleton: ref(false),
+    hasRecording: ref(false),
+    recordingDuration: ref(0),
+    animations: ref<Array<{ name: string; index: number }>>([]),
+    playing: ref(false),
+    selectedSpeed: ref(1),
+    selectedAnimation: ref(0),
+    animationProgress: ref(0),
+    animationDuration: ref(0),
+    loading: ref(false),
+    loadingMessage: ref(''),
+    initializeLoad3d: vi.fn(),
+    handleMouseEnter: vi.fn(),
+    handleMouseLeave: vi.fn(),
+    handleStartRecording: vi.fn(),
+    handleStopRecording: vi.fn(),
+    handleExportRecording: vi.fn(),
+    handleClearRecording: vi.fn(),
+    handleSeek: vi.fn(),
+    handleBackgroundImageUpdate: vi.fn(),
+    handleHDRIFileUpdate: vi.fn(),
+    handleExportModel: vi.fn(),
+    handleModelDrop: vi.fn(),
+    handleToggleGizmo: vi.fn(),
+    handleSetGizmoMode: vi.fn(),
+    handleResetGizmoTransform: vi.fn(),
+    handleFitToViewer: vi.fn(),
+    cleanup: vi.fn()
+  }
+}
+
+vi.mock('@/composables/useLoad3d', () => ({
+  useLoad3d: () => load3dState.current
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: settingGetMock })
+}))
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  resolveNode: resolveNodeMock
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      load3d: { fitToViewer: 'Fit to viewer' }
+    }
+  }
+})
+
+type RenderOptions = {
+  widget?: unknown
+  nodeId?: number | string
+  stateOverrides?: Partial<ReturnType<typeof buildLoad3dStub>>
+  enable3DViewer?: boolean
+}
+
+const MOCK_NODE = { id: 'node', type: 'Load3D' }
+
+function renderLoad3D(options: RenderOptions = {}) {
+  const stub = buildLoad3dStub()
+  if (options.stateOverrides) {
+    Object.assign(stub, options.stateOverrides)
+  }
+  load3dState.current = stub
+
+  settingGetMock.mockImplementation((key: string) =>
+    key === 'Comfy.Load3D.3DViewerEnable'
+      ? (options.enable3DViewer ?? false)
+      : undefined
+  )
+
+  return {
+    ...render(Load3D, {
+      props: {
+        widget: (options.widget ?? {
+          node: MOCK_NODE
+        }) as unknown as ComponentWidget<string[]>,
+        nodeId: options.nodeId
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          Load3DControls: {
+            name: 'Load3DControls',
+            template: '<div data-testid="load3d-controls" />'
+          },
+          Load3DScene: {
+            name: 'Load3DScene',
+            template: '<div data-testid="load3d-scene" />'
+          },
+          AnimationControls: {
+            name: 'AnimationControls',
+            template: '<div data-testid="animation-controls" />'
+          },
+          RecordingControls: {
+            name: 'RecordingControls',
+            template: '<div data-testid="recording-controls" />'
+          },
+          ViewerControls: {
+            name: 'ViewerControls',
+            template: '<div data-testid="viewer-controls" />'
+          },
+          Button: {
+            name: 'Button',
+            props: ['ariaLabel'],
+            template:
+              '<button type="button" :aria-label="ariaLabel"><slot /></button>'
+          }
+        },
+        directives: {
+          tooltip: () => {}
+        }
+      }
+    }),
+    stub
+  }
+}
+
+describe('Load3D', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    load3dState.current = null
+  })
+
+  describe('node resolution', () => {
+    it('uses widget.node when the widget is a ComponentWidget', () => {
+      renderLoad3D({ widget: { node: MOCK_NODE } })
+
+      expect(screen.getByTestId('load3d-scene')).toBeInTheDocument()
+      expect(resolveNodeMock).not.toHaveBeenCalled()
+    })
+
+    it('falls back to resolveNode(nodeId) when the widget lacks a node', async () => {
+      resolveNodeMock.mockReturnValue(MOCK_NODE)
+      renderLoad3D({ widget: {}, nodeId: 42 })
+
+      expect(resolveNodeMock).toHaveBeenCalledWith(42)
+      expect(await screen.findByTestId('load3d-scene')).toBeInTheDocument()
+    })
+
+    it('does not render Load3DScene when no node can be resolved', async () => {
+      resolveNodeMock.mockReturnValue(null)
+      renderLoad3D({ widget: {}, nodeId: 99 })
+
+      await Promise.resolve()
+      expect(screen.queryByTestId('load3d-scene')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('capability-driven chrome', () => {
+    it('shows the fit-to-viewer button when canFitToViewer is true', () => {
+      renderLoad3D({ stateOverrides: { canFitToViewer: ref(true) } })
+      expect(
+        screen.getByRole('button', { name: 'Fit to viewer' })
+      ).toBeInTheDocument()
+    })
+
+    it('hides the fit-to-viewer button when canFitToViewer is false', () => {
+      renderLoad3D({ stateOverrides: { canFitToViewer: ref(false) } })
+      expect(
+        screen.queryByRole('button', { name: 'Fit to viewer' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('invokes handleFitToViewer when the fit button is clicked', async () => {
+      const { stub } = renderLoad3D()
+      const user = userEvent.setup()
+
+      await user.click(screen.getByRole('button', { name: 'Fit to viewer' }))
+
+      expect(stub.handleFitToViewer).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('viewer controls', () => {
+    it('renders ViewerControls when the 3D viewer setting is enabled', () => {
+      renderLoad3D({ enable3DViewer: true })
+      expect(screen.getByTestId('viewer-controls')).toBeInTheDocument()
+    })
+
+    it('hides ViewerControls when the 3D viewer setting is disabled', () => {
+      renderLoad3D({ enable3DViewer: false })
+      expect(screen.queryByTestId('viewer-controls')).not.toBeInTheDocument()
+    })
+
+    it('hides ViewerControls when there is no node even if the setting is on', () => {
+      resolveNodeMock.mockReturnValue(null)
+      renderLoad3D({ widget: {}, nodeId: 1, enable3DViewer: true })
+      expect(screen.queryByTestId('viewer-controls')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('recording controls', () => {
+    it('renders RecordingControls in regular (non-preview) mode', () => {
+      renderLoad3D({ stateOverrides: { isPreview: ref(false) } })
+      expect(screen.getByTestId('recording-controls')).toBeInTheDocument()
+    })
+
+    it('hides RecordingControls in preview mode', () => {
+      renderLoad3D({ stateOverrides: { isPreview: ref(true) } })
+      expect(screen.queryByTestId('recording-controls')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('animation controls', () => {
+    it('renders AnimationControls when animations are present', () => {
+      renderLoad3D({
+        stateOverrides: {
+          animations: ref([{ name: 'idle', index: 0 }])
+        }
+      })
+      expect(screen.getByTestId('animation-controls')).toBeInTheDocument()
+    })
+
+    it('hides AnimationControls when the animation list is empty', () => {
+      renderLoad3D()
+      expect(screen.queryByTestId('animation-controls')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/load3d/Load3DControls.test.ts
+++ b/src/components/load3d/Load3DControls.test.ts
@@ -1,0 +1,374 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import Load3DControls from '@/components/load3d/Load3DControls.vue'
+import type {
+  CameraConfig,
+  LightConfig,
+  MaterialMode,
+  ModelConfig,
+  SceneConfig
+} from '@/extensions/core/load3d/interfaces'
+
+vi.mock('@/composables/useDismissableOverlay', () => ({
+  useDismissableOverlay: vi.fn()
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      menu: { showMenu: 'Show menu' },
+      load3d: {
+        scene: 'Scene',
+        model: 'Model',
+        camera: 'Camera',
+        light: 'Light',
+        gizmo: { label: 'Gizmo' },
+        export: 'Export'
+      }
+    }
+  }
+})
+
+const childStubs = {
+  SceneControls: {
+    name: 'SceneControls',
+    emits: ['update-background-image'],
+    template: `<div data-testid="scene-controls">
+      <button data-testid="scene-emit-bg" @click="$emit('update-background-image', null)" />
+    </div>`
+  },
+  ModelControls: {
+    name: 'ModelControls',
+    template: '<div data-testid="model-controls" />'
+  },
+  CameraControls: {
+    name: 'CameraControls',
+    template: '<div data-testid="camera-controls" />'
+  },
+  LightControls: {
+    name: 'LightControls',
+    template: '<div data-testid="light-controls" />'
+  },
+  HDRIControls: {
+    name: 'HDRIControls',
+    emits: ['update-hdri-file'],
+    template: `<div data-testid="hdri-controls">
+      <button data-testid="hdri-emit-file" @click="$emit('update-hdri-file', null)" />
+    </div>`
+  },
+  ExportControls: {
+    name: 'ExportControls',
+    emits: ['export-model'],
+    template: `<div data-testid="export-controls">
+      <button data-testid="export-emit-glb" @click="$emit('export-model', 'glb')" />
+    </div>`
+  },
+  GizmoControls: {
+    name: 'GizmoControls',
+    emits: ['toggle-gizmo', 'set-gizmo-mode', 'reset-gizmo-transform'],
+    template: `<div data-testid="gizmo-controls">
+      <button data-testid="gizmo-emit-toggle" @click="$emit('toggle-gizmo', true)" />
+      <button data-testid="gizmo-emit-mode" @click="$emit('set-gizmo-mode', 'rotate')" />
+      <button data-testid="gizmo-emit-reset" @click="$emit('reset-gizmo-transform')" />
+    </div>`
+  }
+}
+
+const defaultSceneConfig: SceneConfig = {
+  showGrid: true,
+  backgroundColor: '#000000',
+  backgroundImage: '',
+  backgroundRenderMode: 'tiled'
+}
+
+const defaultModelConfig: ModelConfig = {
+  upDirection: 'original',
+  materialMode: 'original',
+  showSkeleton: false,
+  gizmo: {
+    enabled: false,
+    mode: 'translate',
+    position: { x: 0, y: 0, z: 0 },
+    rotation: { x: 0, y: 0, z: 0 },
+    scale: { x: 1, y: 1, z: 1 }
+  }
+}
+
+const defaultCameraConfig: CameraConfig = {
+  cameraType: 'perspective',
+  fov: 75
+}
+
+const defaultLightConfig: LightConfig = {
+  intensity: 5,
+  hdri: {
+    enabled: false,
+    hdriPath: '',
+    showAsBackground: false,
+    intensity: 1
+  }
+}
+
+type RenderProps = {
+  sceneConfig?: SceneConfig
+  modelConfig?: ModelConfig
+  cameraConfig?: CameraConfig
+  lightConfig?: LightConfig
+  canUseGizmo?: boolean
+  canUseLighting?: boolean
+  canExport?: boolean
+  materialModes?: readonly MaterialMode[]
+  hasSkeleton?: boolean
+  onUpdateBackgroundImage?: (file: File | null) => void
+  onExportModel?: (format: string) => void
+  onUpdateHdriFile?: (file: File | null) => void
+  onToggleGizmo?: (enabled: boolean) => void
+  onSetGizmoMode?: (mode: string) => void
+  onResetGizmoTransform?: () => void
+}
+
+function renderControls(overrides: RenderProps = {}) {
+  const result = render(Load3DControls, {
+    props: {
+      sceneConfig: defaultSceneConfig,
+      modelConfig: defaultModelConfig,
+      cameraConfig: defaultCameraConfig,
+      lightConfig: defaultLightConfig,
+      canUseGizmo: true,
+      canUseLighting: true,
+      canExport: true,
+      materialModes: ['original', 'normal', 'wireframe'],
+      hasSkeleton: false,
+      ...overrides
+    },
+    global: {
+      plugins: [i18n],
+      stubs: childStubs,
+      directives: {
+        tooltip: () => {}
+      }
+    }
+  })
+  return { ...result, user: userEvent.setup() }
+}
+
+async function openMenu(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Show menu' }))
+}
+
+describe('Load3DControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('category menu', () => {
+    it('renders SceneControls by default', () => {
+      renderControls()
+      expect(screen.getByTestId('scene-controls')).toBeInTheDocument()
+    })
+
+    it('keeps the category menu closed until the trigger is clicked', async () => {
+      const { user } = renderControls()
+
+      expect(
+        screen.queryByRole('button', { name: 'Scene' })
+      ).not.toBeInTheDocument()
+
+      await openMenu(user)
+
+      expect(screen.getByRole('button', { name: 'Scene' })).toBeInTheDocument()
+    })
+
+    it('shows every category when all capabilities are enabled', async () => {
+      const { user } = renderControls()
+      await openMenu(user)
+
+      for (const label of [
+        'Scene',
+        'Model',
+        'Camera',
+        'Light',
+        'Gizmo',
+        'Export'
+      ]) {
+        expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+      }
+    })
+
+    it('omits the light category when canUseLighting is false', async () => {
+      const { user } = renderControls({ canUseLighting: false })
+      await openMenu(user)
+
+      expect(
+        screen.queryByRole('button', { name: 'Light' })
+      ).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Scene' })).toBeInTheDocument()
+    })
+
+    it('omits the gizmo category when canUseGizmo is false', async () => {
+      const { user } = renderControls({ canUseGizmo: false })
+      await openMenu(user)
+
+      expect(
+        screen.queryByRole('button', { name: 'Gizmo' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('omits the export category when canExport is false', async () => {
+      const { user } = renderControls({ canExport: false })
+      await openMenu(user)
+
+      expect(
+        screen.queryByRole('button', { name: 'Export' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('selecting a category closes the menu and swaps the visible control', async () => {
+      const { user } = renderControls()
+      await openMenu(user)
+
+      await user.click(screen.getByRole('button', { name: 'Model' }))
+
+      expect(
+        screen.queryByRole('button', { name: 'Scene' })
+      ).not.toBeInTheDocument()
+      expect(screen.getByTestId('model-controls')).toBeInTheDocument()
+      expect(screen.queryByTestId('scene-controls')).not.toBeInTheDocument()
+    })
+
+    it('falls back to scene when the active category becomes unavailable', async () => {
+      const { user, rerender } = renderControls()
+      await openMenu(user)
+      await user.click(screen.getByRole('button', { name: 'Light' }))
+      expect(screen.getByTestId('light-controls')).toBeInTheDocument()
+
+      await rerender({
+        sceneConfig: defaultSceneConfig,
+        modelConfig: defaultModelConfig,
+        cameraConfig: defaultCameraConfig,
+        lightConfig: defaultLightConfig,
+        canUseGizmo: true,
+        canUseLighting: false,
+        canExport: true,
+        materialModes: ['original', 'normal', 'wireframe'],
+        hasSkeleton: false
+      })
+
+      expect(screen.queryByTestId('light-controls')).not.toBeInTheDocument()
+      expect(screen.getByTestId('scene-controls')).toBeInTheDocument()
+    })
+  })
+
+  describe('control visibility', () => {
+    async function selectCategory(
+      user: ReturnType<typeof userEvent.setup>,
+      label: string
+    ) {
+      await openMenu(user)
+      await user.click(screen.getByRole('button', { name: label }))
+    }
+
+    it.each([
+      ['Model', 'model-controls'],
+      ['Camera', 'camera-controls']
+    ])('%s category renders only %s', async (label, testId) => {
+      const { user } = renderControls()
+      await selectCategory(user, label)
+
+      expect(screen.getByTestId(testId)).toBeInTheDocument()
+      expect(screen.queryByTestId('scene-controls')).not.toBeInTheDocument()
+    })
+
+    it('Light category renders both LightControls and HDRIControls', async () => {
+      const { user } = renderControls()
+      await selectCategory(user, 'Light')
+
+      expect(screen.getByTestId('light-controls')).toBeInTheDocument()
+      expect(screen.getByTestId('hdri-controls')).toBeInTheDocument()
+    })
+
+    it('Gizmo category renders GizmoControls', async () => {
+      const { user } = renderControls()
+      await selectCategory(user, 'Gizmo')
+
+      expect(screen.getByTestId('gizmo-controls')).toBeInTheDocument()
+    })
+
+    it('Export category renders ExportControls', async () => {
+      const { user } = renderControls()
+      await selectCategory(user, 'Export')
+
+      expect(screen.getByTestId('export-controls')).toBeInTheDocument()
+    })
+
+    it('hides all controls when the corresponding v-model is undefined', () => {
+      renderControls({
+        sceneConfig: undefined,
+        modelConfig: undefined,
+        cameraConfig: undefined,
+        lightConfig: undefined
+      })
+
+      expect(screen.queryByTestId('scene-controls')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('event forwarding', () => {
+    it('forwards updateBackgroundImage from SceneControls', async () => {
+      const onUpdateBackgroundImage = vi.fn()
+      const { user } = renderControls({ onUpdateBackgroundImage })
+
+      await user.click(screen.getByTestId('scene-emit-bg'))
+
+      expect(onUpdateBackgroundImage).toHaveBeenCalledWith(null)
+    })
+
+    it('forwards exportModel from ExportControls', async () => {
+      const onExportModel = vi.fn()
+      const { user } = renderControls({ onExportModel })
+      await openMenu(user)
+      await user.click(screen.getByRole('button', { name: 'Export' }))
+
+      await user.click(screen.getByTestId('export-emit-glb'))
+
+      expect(onExportModel).toHaveBeenCalledWith('glb')
+    })
+
+    it('forwards updateHdriFile from HDRIControls', async () => {
+      const onUpdateHdriFile = vi.fn()
+      const { user } = renderControls({ onUpdateHdriFile })
+      await openMenu(user)
+      await user.click(screen.getByRole('button', { name: 'Light' }))
+
+      await user.click(screen.getByTestId('hdri-emit-file'))
+
+      expect(onUpdateHdriFile).toHaveBeenCalledWith(null)
+    })
+
+    it('forwards gizmo events from GizmoControls', async () => {
+      const onToggleGizmo = vi.fn()
+      const onSetGizmoMode = vi.fn()
+      const onResetGizmoTransform = vi.fn()
+      const { user } = renderControls({
+        onToggleGizmo,
+        onSetGizmoMode,
+        onResetGizmoTransform
+      })
+      await openMenu(user)
+      await user.click(screen.getByRole('button', { name: 'Gizmo' }))
+
+      await user.click(screen.getByTestId('gizmo-emit-toggle'))
+      await user.click(screen.getByTestId('gizmo-emit-mode'))
+      await user.click(screen.getByTestId('gizmo-emit-reset'))
+
+      expect(onToggleGizmo).toHaveBeenCalledWith(true)
+      expect(onSetGizmoMode).toHaveBeenCalledWith('rotate')
+      expect(onResetGizmoTransform).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/components/load3d/Load3dViewerContent.test.ts
+++ b/src/components/load3d/Load3dViewerContent.test.ts
@@ -1,0 +1,360 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import Load3dViewerContent from '@/components/load3d/Load3dViewerContent.vue'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+class NoopMutationObserver {
+  observe() {}
+  disconnect() {}
+  takeRecords(): MutationRecord[] {
+    return []
+  }
+}
+
+const {
+  viewerState,
+  dragState,
+  capturedDragOptions,
+  dialogCloseMock,
+  serviceSourceLoad3d,
+  getLoad3dAsyncMock
+} = vi.hoisted(() => ({
+  viewerState: {
+    current: null as ReturnType<typeof buildViewerStub> | null
+  },
+  dragState: {
+    current: null as ReturnType<typeof buildDragStub> | null
+  },
+  capturedDragOptions: {
+    current: null as { onModelDrop?: (file: File) => Promise<void> } | null
+  },
+  dialogCloseMock: vi.fn(),
+  serviceSourceLoad3d: {
+    current: null as unknown
+  },
+  getLoad3dAsyncMock: vi.fn()
+}))
+
+function buildViewerStub() {
+  return {
+    backgroundColor: ref('#282828'),
+    showGrid: ref(true),
+    cameraType: ref('perspective'),
+    fov: ref(75),
+    lightIntensity: ref(1),
+    backgroundImage: ref(''),
+    hasBackgroundImage: ref(false),
+    backgroundRenderMode: ref('tiled'),
+    upDirection: ref('original'),
+    materialMode: ref('original'),
+    gizmoEnabled: ref(false),
+    gizmoMode: ref('translate'),
+    isPreview: ref(false),
+    isStandaloneMode: ref(false),
+    canUseGizmo: ref(true),
+    canUseLighting: ref(true),
+    canExport: ref(true),
+    materialModes: ref(['original', 'normal', 'wireframe']),
+    animations: ref<Array<{ name: string; index: number }>>([]),
+    playing: ref(false),
+    selectedSpeed: ref(1),
+    selectedAnimation: ref(0),
+    animationProgress: ref(0),
+    animationDuration: ref(0),
+    initializeViewer: vi.fn().mockResolvedValue(undefined),
+    initializeStandaloneViewer: vi.fn().mockResolvedValue(undefined),
+    exportModel: vi.fn(),
+    handleResize: vi.fn(),
+    handleMouseEnter: vi.fn(),
+    handleMouseLeave: vi.fn(),
+    restoreInitialState: vi.fn(),
+    refreshViewport: vi.fn(),
+    handleBackgroundImageUpdate: vi.fn(),
+    handleModelDrop: vi.fn().mockResolvedValue(undefined),
+    handleSeek: vi.fn(),
+    resetGizmoTransform: vi.fn()
+  }
+}
+
+function buildDragStub() {
+  return {
+    isDragging: ref(false),
+    dragMessage: ref(''),
+    handleDragOver: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleDrop: vi.fn()
+  }
+}
+
+vi.mock('@/composables/useLoad3dViewer', () => ({
+  useLoad3dViewer: () => viewerState.current
+}))
+
+vi.mock('@/composables/useLoad3dDrag', () => ({
+  useLoad3dDrag: (opts: { onModelDrop?: (file: File) => Promise<void> }) => {
+    capturedDragOptions.current = opts
+    return dragState.current
+  }
+}))
+
+vi.mock('@/services/load3dService', () => ({
+  useLoad3dService: () => ({
+    getOrCreateViewerSync: () => viewerState.current,
+    getLoad3dAsync: getLoad3dAsyncMock
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ closeDialog: dialogCloseMock })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { cancel: 'Cancel' }
+    }
+  }
+})
+
+type RenderOptions = {
+  node?: LGraphNode
+  modelUrl?: string
+  viewerOverrides?: Partial<ReturnType<typeof buildViewerStub>>
+  dragOverrides?: Partial<ReturnType<typeof buildDragStub>>
+}
+
+const MOCK_NODE = { id: 'node-1', type: 'Load3D' } as unknown as LGraphNode
+
+async function renderViewerContent(options: RenderOptions = {}) {
+  const viewerStub = buildViewerStub()
+  if (options.viewerOverrides) {
+    Object.assign(viewerStub, options.viewerOverrides)
+  }
+  viewerState.current = viewerStub
+
+  const dragStub = buildDragStub()
+  if (options.dragOverrides) {
+    Object.assign(dragStub, options.dragOverrides)
+  }
+  dragState.current = dragStub
+
+  getLoad3dAsyncMock.mockResolvedValue(serviceSourceLoad3d.current)
+
+  const result = render(Load3dViewerContent, {
+    props: {
+      node: options.node,
+      modelUrl: options.modelUrl
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        AnimationControls: {
+          name: 'AnimationControls',
+          template: '<div data-testid="animation-controls" />'
+        },
+        CameraControls: {
+          name: 'CameraControls',
+          template: '<div data-testid="camera-controls" />'
+        },
+        ExportControls: {
+          name: 'ExportControls',
+          template: '<div data-testid="export-controls" />'
+        },
+        GizmoControls: {
+          name: 'GizmoControls',
+          template: '<div data-testid="gizmo-controls" />'
+        },
+        LightControls: {
+          name: 'LightControls',
+          template: '<div data-testid="light-controls" />'
+        },
+        ModelControls: {
+          name: 'ModelControls',
+          template: '<div data-testid="model-controls" />'
+        },
+        SceneControls: {
+          name: 'SceneControls',
+          template: '<div data-testid="scene-controls" />'
+        },
+        Button: {
+          name: 'Button',
+          template: '<button type="button"><slot /></button>'
+        }
+      }
+    }
+  })
+  return {
+    ...result,
+    viewer: viewerStub,
+    drag: dragStub,
+    user: userEvent.setup()
+  }
+}
+
+describe('Load3dViewerContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('MutationObserver', NoopMutationObserver)
+    viewerState.current = null
+    dragState.current = null
+    capturedDragOptions.current = null
+    serviceSourceLoad3d.current = null
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('initialization', () => {
+    it('invokes initializeStandaloneViewer when a modelUrl is provided without a node', async () => {
+      const { viewer } = await renderViewerContent({
+        modelUrl: 'api/view?filename=cube.glb'
+      })
+
+      await vi.waitFor(() =>
+        expect(viewer.initializeStandaloneViewer).toHaveBeenCalledWith(
+          expect.any(HTMLElement),
+          'api/view?filename=cube.glb'
+        )
+      )
+      expect(viewer.initializeViewer).not.toHaveBeenCalled()
+    })
+
+    it('invokes initializeViewer with the source load3d when a node is provided', async () => {
+      const source = { id: 'source-load3d' }
+      serviceSourceLoad3d.current = source
+      const { viewer } = await renderViewerContent({ node: MOCK_NODE })
+
+      await vi.waitFor(() =>
+        expect(viewer.initializeViewer).toHaveBeenCalledWith(
+          expect.any(HTMLElement),
+          source
+        )
+      )
+      expect(getLoad3dAsyncMock).toHaveBeenCalledWith(MOCK_NODE)
+      expect(viewer.initializeStandaloneViewer).not.toHaveBeenCalled()
+    })
+
+    it('skips initializeViewer if the source load3d cannot be resolved', async () => {
+      serviceSourceLoad3d.current = null
+      const { viewer } = await renderViewerContent({ node: MOCK_NODE })
+
+      await vi.waitFor(() =>
+        expect(getLoad3dAsyncMock).toHaveBeenCalledWith(MOCK_NODE)
+      )
+      expect(viewer.initializeViewer).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('capability gating', () => {
+    it('hides LightControls when canUseLighting is false', async () => {
+      await renderViewerContent({
+        node: MOCK_NODE,
+        viewerOverrides: { canUseLighting: ref(false) }
+      })
+
+      expect(screen.queryByTestId('light-controls')).not.toBeInTheDocument()
+    })
+
+    it('hides GizmoControls when canUseGizmo is false', async () => {
+      await renderViewerContent({
+        node: MOCK_NODE,
+        viewerOverrides: { canUseGizmo: ref(false) }
+      })
+
+      expect(screen.queryByTestId('gizmo-controls')).not.toBeInTheDocument()
+    })
+
+    it('hides ExportControls when canExport is false', async () => {
+      await renderViewerContent({
+        node: MOCK_NODE,
+        viewerOverrides: { canExport: ref(false) }
+      })
+
+      expect(screen.queryByTestId('export-controls')).not.toBeInTheDocument()
+    })
+
+    it('renders all capability-gated controls when all flags are true', async () => {
+      await renderViewerContent({ node: MOCK_NODE })
+
+      expect(screen.getByTestId('light-controls')).toBeInTheDocument()
+      expect(screen.getByTestId('gizmo-controls')).toBeInTheDocument()
+      expect(screen.getByTestId('export-controls')).toBeInTheDocument()
+    })
+  })
+
+  describe('animation controls', () => {
+    it('hides AnimationControls when the animation list is empty', async () => {
+      await renderViewerContent({ node: MOCK_NODE })
+      expect(screen.queryByTestId('animation-controls')).not.toBeInTheDocument()
+    })
+
+    it('shows AnimationControls when animations are present', async () => {
+      await renderViewerContent({
+        node: MOCK_NODE,
+        viewerOverrides: {
+          animations: ref([{ name: 'idle', index: 0 }])
+        }
+      })
+      expect(screen.getByTestId('animation-controls')).toBeInTheDocument()
+    })
+  })
+
+  describe('drag overlay', () => {
+    it('is hidden by default', async () => {
+      await renderViewerContent({ node: MOCK_NODE })
+      expect(screen.queryByText(/drag/i)).not.toBeInTheDocument()
+    })
+
+    it('renders the drag message when useLoad3dDrag reports dragging', async () => {
+      await renderViewerContent({
+        node: MOCK_NODE,
+        dragOverrides: {
+          isDragging: ref(true),
+          dragMessage: ref('Drop to load')
+        }
+      })
+
+      expect(screen.getByText('Drop to load')).toBeInTheDocument()
+    })
+  })
+
+  describe('drag integration', () => {
+    it('routes a dropped file through useLoad3dDrag back to viewer.handleModelDrop', async () => {
+      const { viewer } = await renderViewerContent({ node: MOCK_NODE })
+      const file = new File(['cube'], 'cube.glb')
+
+      await capturedDragOptions.current!.onModelDrop!(file)
+
+      expect(viewer.handleModelDrop).toHaveBeenCalledWith(file)
+    })
+  })
+
+  describe('cancel button', () => {
+    it('closes the dialog in node mode and restores initial viewer state', async () => {
+      const { user, viewer } = await renderViewerContent({ node: MOCK_NODE })
+
+      await user.click(screen.getByRole('button', { name: /Cancel/ }))
+
+      expect(viewer.restoreInitialState).toHaveBeenCalledOnce()
+      expect(dialogCloseMock).toHaveBeenCalledOnce()
+    })
+
+    it('closes the dialog in standalone mode without touching initial state', async () => {
+      const { user, viewer } = await renderViewerContent({
+        modelUrl: 'api/view?filename=cube.glb'
+      })
+
+      await user.click(screen.getByRole('button', { name: /Cancel/ }))
+
+      expect(viewer.restoreInitialState).not.toHaveBeenCalled()
+      expect(dialogCloseMock).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/components/load3d/controls/viewer/ViewerModelControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerModelControls.test.ts
@@ -1,0 +1,194 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import ViewerModelControls from '@/components/load3d/controls/viewer/ViewerModelControls.vue'
+import type {
+  MaterialMode,
+  UpDirection
+} from '@/extensions/core/load3d/interfaces'
+
+vi.mock('primevue/select', () => ({
+  default: {
+    name: 'Select',
+    props: ['modelValue', 'options', 'optionLabel', 'optionValue'],
+    emits: ['update:modelValue'],
+    template: `
+      <select
+        :value="modelValue"
+        @change="$emit('update:modelValue', $event.target.value)"
+      >
+        <option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+      </select>
+    `
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      load3d: {
+        upDirection: 'Up direction',
+        materialMode: 'Material mode',
+        upDirections: { original: 'Original' },
+        materialModes: {
+          original: 'Original',
+          normal: 'Normal',
+          wireframe: 'Wireframe',
+          pointCloud: 'Point Cloud',
+          depth: 'Depth'
+        }
+      }
+    }
+  }
+})
+
+type RenderProps = {
+  upDirection?: UpDirection
+  materialMode?: MaterialMode
+  materialModes?: readonly MaterialMode[]
+  'onUpdate:upDirection'?: (value: UpDirection | undefined) => void
+  'onUpdate:materialMode'?: (value: MaterialMode | undefined) => void
+}
+
+function renderControls(overrides: RenderProps = {}) {
+  const result = render(ViewerModelControls, {
+    props: {
+      upDirection: 'original',
+      materialMode: 'original',
+      materialModes: ['original', 'normal', 'wireframe'],
+      ...overrides
+    },
+    global: {
+      plugins: [i18n]
+    }
+  })
+  return { ...result, user: userEvent.setup() }
+}
+
+function getOptions(select: HTMLElement) {
+  return Array.from(select.querySelectorAll('option'))
+}
+
+describe('ViewerModelControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('renders both up direction and material mode selects by default', () => {
+      renderControls()
+      expect(screen.getAllByRole('combobox')).toHaveLength(2)
+      expect(screen.getByText('Up direction')).toBeInTheDocument()
+      expect(screen.getByText('Material mode')).toBeInTheDocument()
+    })
+
+    it('hides the material mode select when materialModes is empty', () => {
+      renderControls({ materialModes: [] })
+      expect(screen.getAllByRole('combobox')).toHaveLength(1)
+      expect(screen.queryByText('Material mode')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('up direction options', () => {
+    it('exposes the seven supported directions', () => {
+      renderControls()
+      const [upDirectionSelect] = screen.getAllByRole('combobox')
+      const options = getOptions(upDirectionSelect)
+
+      expect(options.map((o) => o.getAttribute('value'))).toEqual([
+        'original',
+        '-x',
+        '+x',
+        '-y',
+        '+y',
+        '-z',
+        '+z'
+      ])
+    })
+
+    it('localizes the "original" option label and uses raw axis labels for the rest', () => {
+      renderControls()
+      const [upDirectionSelect] = screen.getAllByRole('combobox')
+      const options = getOptions(upDirectionSelect)
+
+      expect(options.map((o) => o.textContent?.trim())).toEqual([
+        'Original',
+        '-X',
+        '+X',
+        '-Y',
+        '+Y',
+        '-Z',
+        '+Z'
+      ])
+    })
+  })
+
+  describe('material mode options', () => {
+    it('emits one option per materialModes entry with localized labels', () => {
+      renderControls({ materialModes: ['original', 'normal', 'wireframe'] })
+      const [, materialModeSelect] = screen.getAllByRole('combobox')
+      const options = getOptions(materialModeSelect)
+
+      expect(options.map((o) => o.getAttribute('value'))).toEqual([
+        'original',
+        'normal',
+        'wireframe'
+      ])
+      expect(options.map((o) => o.textContent?.trim())).toEqual([
+        'Original',
+        'Normal',
+        'Wireframe'
+      ])
+    })
+
+    it('includes pointCloud when the adapter exposes it (PLY)', () => {
+      renderControls({
+        materialModes: ['original', 'pointCloud', 'normal', 'wireframe']
+      })
+      const [, materialModeSelect] = screen.getAllByRole('combobox')
+      const options = getOptions(materialModeSelect)
+
+      expect(options).toHaveLength(4)
+      expect(options[1].textContent?.trim()).toBe('Point Cloud')
+      expect(options[1].getAttribute('value')).toBe('pointCloud')
+    })
+  })
+
+  describe('v-model binding', () => {
+    it('renders the initial upDirection as the selected option', () => {
+      renderControls({ upDirection: '-z' })
+      const [upDirectionSelect] = screen.getAllByRole('combobox')
+      expect((upDirectionSelect as HTMLSelectElement).value).toBe('-z')
+    })
+
+    it('renders the initial materialMode as the selected option', () => {
+      renderControls({ materialMode: 'normal' })
+      const [, materialModeSelect] = screen.getAllByRole('combobox')
+      expect((materialModeSelect as HTMLSelectElement).value).toBe('normal')
+    })
+
+    it('emits update:upDirection when a new direction is chosen', async () => {
+      const listener = vi.fn()
+      const { user } = renderControls({ 'onUpdate:upDirection': listener })
+      const [upDirectionSelect] = screen.getAllByRole('combobox')
+
+      await user.selectOptions(upDirectionSelect, '+x')
+
+      expect(listener).toHaveBeenCalledWith('+x')
+    })
+
+    it('emits update:materialMode when a new mode is chosen', async () => {
+      const listener = vi.fn()
+      const { user } = renderControls({ 'onUpdate:materialMode': listener })
+      const [, materialModeSelect] = screen.getAllByRole('combobox')
+
+      await user.selectOptions(materialModeSelect, 'wireframe')
+
+      expect(listener).toHaveBeenCalledWith('wireframe')
+    })
+  })
+})

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -2,114 +2,124 @@ import * as THREE from 'three'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Load3d from '@/extensions/core/load3d/Load3d'
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelAdapterCapabilities
+} from '@/extensions/core/load3d/ModelAdapter'
+import { ModelExporter } from '@/extensions/core/load3d/ModelExporter'
+import {
+  makeAnimationManagerStub,
+  makeCameraManagerStub,
+  makeControlsManagerStub,
+  makeEventManagerStub,
+  makeGizmoStub,
+  makeHDRIManagerStub,
+  makeLightingManagerStub,
+  makeLoaderManagerStub,
+  makeModelManagerStub,
+  makeRecordingManagerStub,
+  makeRendererStub,
+  makeSceneManagerStub,
+  makeViewHelperManagerStub
+} from '@/extensions/core/load3d/__test__/managerStubs'
 import type { GizmoMode } from '@/extensions/core/load3d/interfaces'
 
-type GizmoStub = {
-  setEnabled: ReturnType<typeof vi.fn>
-  setMode: ReturnType<typeof vi.fn>
-  reset: ReturnType<typeof vi.fn>
-  applyTransform: ReturnType<typeof vi.fn>
-  getTransform: ReturnType<typeof vi.fn>
-  setupForModel: ReturnType<typeof vi.fn>
-  updateCamera: ReturnType<typeof vi.fn>
-  detach: ReturnType<typeof vi.fn>
-  dispose: ReturnType<typeof vi.fn>
-  removeFromScene: ReturnType<typeof vi.fn>
-  ensureHelperInScene: ReturnType<typeof vi.fn>
-  isEnabled: ReturnType<typeof vi.fn>
-  getMode: ReturnType<typeof vi.fn>
-}
-
-type ModelManagerStub = {
-  fitToViewer: ReturnType<typeof vi.fn>
-  clearModel: ReturnType<typeof vi.fn>
-}
-
-type CameraManagerStub = {
-  toggleCamera: ReturnType<typeof vi.fn>
-  setupForModel: ReturnType<typeof vi.fn>
-  reset: ReturnType<typeof vi.fn>
-  activeCamera: THREE.Camera
-}
-
-type SceneManagerStub = {
-  captureScene: ReturnType<typeof vi.fn>
-  dispose: ReturnType<typeof vi.fn>
-}
-
-function makeGizmoStub(): GizmoStub {
-  return {
-    setEnabled: vi.fn(),
-    setMode: vi.fn(),
-    reset: vi.fn(),
-    applyTransform: vi.fn(),
-    getTransform: vi.fn(() => ({
-      position: { x: 0, y: 0, z: 0 },
-      rotation: { x: 0, y: 0, z: 0 },
-      scale: { x: 1, y: 1, z: 1 }
-    })),
-    setupForModel: vi.fn(),
-    updateCamera: vi.fn(),
-    detach: vi.fn(),
-    dispose: vi.fn(),
-    removeFromScene: vi.fn(),
-    ensureHelperInScene: vi.fn(),
-    isEnabled: vi.fn(() => false),
-    getMode: vi.fn(() => 'translate')
+vi.mock('@/extensions/core/load3d/ModelExporter', () => ({
+  ModelExporter: {
+    exportGLB: vi.fn().mockResolvedValue(undefined),
+    exportOBJ: vi.fn().mockResolvedValue(undefined),
+    exportSTL: vi.fn().mockResolvedValue(undefined)
   }
+}))
+
+type MakeInstanceOptions = {
+  capabilities?: ModelAdapterCapabilities | null
+  adapterKind?: 'mesh' | 'pointCloud' | 'splat' | null
+  stubForceRender?: boolean
+  stubHandleResize?: boolean
+  targetWidth?: number
+  targetHeight?: number
+  getDimensionsCallback?: () => { width: number; height: number } | null
 }
 
-function makeInstance() {
+function makeInstance(opts: MakeInstanceOptions = {}) {
+  const {
+    capabilities = {
+      fitToViewer: true,
+      requiresMaterialRebuild: false,
+      gizmoTransform: true,
+      lighting: true,
+      exportable: true,
+      materialModes: ['original', 'normal', 'wireframe']
+    },
+    adapterKind = 'mesh',
+    stubForceRender = true,
+    stubHandleResize = true,
+    targetWidth = 0,
+    targetHeight = 0,
+    getDimensionsCallback
+  } = opts
+
   const gizmo = makeGizmoStub()
-  const modelManager: ModelManagerStub = {
-    fitToViewer: vi.fn(),
-    clearModel: vi.fn()
-  }
-  const cameraManager: CameraManagerStub = {
-    toggleCamera: vi.fn(),
-    setupForModel: vi.fn(),
-    reset: vi.fn(),
-    activeCamera: new THREE.PerspectiveCamera()
-  }
-  const sceneManager: SceneManagerStub = {
-    captureScene: vi.fn(),
-    dispose: vi.fn()
-  }
-  const controlsManager = { updateCamera: vi.fn() }
-  const viewHelperManager = { recreateViewHelper: vi.fn() }
-  const animationManager = { dispose: vi.fn() }
-  const loaderManager = {
-    getCurrentAdapter: vi.fn().mockReturnValue({
-      kind: 'mesh',
-      extensions: ['glb'],
-      capabilities: {
-        fitToViewer: true,
-        requiresMaterialRebuild: false,
-        gizmoTransform: true,
-        lighting: true,
-        exportable: true,
-        materialModes: ['original', 'normal', 'wireframe']
-      }
-    })
-  }
+  const sceneManager = makeSceneManagerStub()
+  const cameraManager = makeCameraManagerStub()
+  const controlsManager = makeControlsManagerStub()
+  const lightingManager = makeLightingManagerStub()
+  const hdriManager = makeHDRIManagerStub()
+  const viewHelperManager = makeViewHelperManagerStub()
+  const loaderManager = makeLoaderManagerStub(capabilities, adapterKind)
+  const modelManager = makeModelManagerStub()
+  const recordingManager = makeRecordingManagerStub()
+  const animationManager = makeAnimationManagerStub()
+  const eventManager = makeEventManagerStub()
+  const renderer = makeRendererStub()
 
   // Load3d's constructor instantiates THREE.WebGLRenderer, ResizeObserver
   // and ViewHelper, none of which are available in happy-dom. Skip it and
   // inject stubs directly onto the prototype instance so delegation methods
   // can be exercised in isolation.
   const load3d = Object.create(Load3d.prototype) as Load3d
+  const forceRender = vi.fn()
+  const handleResize = vi.fn()
+
   Object.assign(load3d, {
+    clock: new THREE.Clock(),
     gizmoManager: gizmo,
     modelManager,
     cameraManager,
     sceneManager,
     controlsManager,
+    lightingManager,
+    hdriManager,
     viewHelperManager,
-    animationManager,
     loaderManager,
-    forceRender: vi.fn(),
-    handleResize: vi.fn()
+    recordingManager,
+    animationManager,
+    eventManager,
+    renderer,
+    STATUS_MOUSE_ON_NODE: false,
+    STATUS_MOUSE_ON_SCENE: false,
+    STATUS_MOUSE_ON_VIEWER: false,
+    INITIAL_RENDER_DONE: false,
+    targetWidth,
+    targetHeight,
+    targetAspectRatio:
+      targetWidth && targetHeight ? targetWidth / targetHeight : 1,
+    isViewerMode: false,
+    loadingPromise: null,
+    onContextMenuCallback: undefined,
+    getDimensionsCallback,
+    resizeObserver: null,
+    disposeContextMenuGuard: null,
+    renderLoop: null
   })
+
+  if (stubForceRender) {
+    Object.assign(load3d, { forceRender })
+  }
+  if (stubHandleResize) {
+    Object.assign(load3d, { handleResize })
+  }
 
   return {
     load3d,
@@ -118,9 +128,16 @@ function makeInstance() {
     cameraManager,
     sceneManager,
     controlsManager,
+    lightingManager,
+    hdriManager,
     viewHelperManager,
+    loaderManager,
+    recordingManager,
     animationManager,
-    forceRender: load3d.forceRender as ReturnType<typeof vi.fn>
+    eventManager,
+    renderer,
+    forceRender,
+    handleResize
   }
 }
 
@@ -128,6 +145,7 @@ describe('Load3d', () => {
   let ctx: ReturnType<typeof makeInstance>
 
   beforeEach(() => {
+    vi.clearAllMocks()
     ctx = makeInstance()
   })
 
@@ -135,11 +153,52 @@ describe('Load3d', () => {
     vi.restoreAllMocks()
   })
 
-  describe('gizmo delegation', () => {
-    it('getGizmoManager returns the underlying manager', () => {
+  describe('manager getters', () => {
+    it('expose injected managers', () => {
+      expect(ctx.load3d.getEventManager()).toBe(ctx.eventManager)
+      expect(ctx.load3d.getSceneManager()).toBe(ctx.sceneManager)
+      expect(ctx.load3d.getCameraManager()).toBe(ctx.cameraManager)
+      expect(ctx.load3d.getControlsManager()).toBe(ctx.controlsManager)
+      expect(ctx.load3d.getLightingManager()).toBe(ctx.lightingManager)
+      expect(ctx.load3d.getViewHelperManager()).toBe(ctx.viewHelperManager)
+      expect(ctx.load3d.getLoaderManager()).toBe(ctx.loaderManager)
+      expect(ctx.load3d.getModelManager()).toBe(ctx.modelManager)
+      expect(ctx.load3d.getRecordingManager()).toBe(ctx.recordingManager)
       expect(ctx.load3d.getGizmoManager()).toBe(ctx.gizmo)
     })
 
+    it('getTargetSize returns the stored target dimensions', () => {
+      const localCtx = makeInstance({ targetWidth: 640, targetHeight: 480 })
+      expect(localCtx.load3d.getTargetSize()).toEqual({
+        width: 640,
+        height: 480
+      })
+    })
+
+    it('getCurrentModel returns the modelManager current model', () => {
+      const cube = new THREE.Object3D()
+      ctx.modelManager.currentModel = cube
+      expect(ctx.load3d.getCurrentModel()).toBe(cube)
+    })
+
+    it('getCurrentCameraType delegates to cameraManager', () => {
+      ctx.cameraManager.getCurrentCameraType.mockReturnValue('orthographic')
+      expect(ctx.load3d.getCurrentCameraType()).toBe('orthographic')
+    })
+
+    it('getCameraState delegates to cameraManager', () => {
+      const state = {
+        position: new THREE.Vector3(1, 2, 3),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 2,
+        cameraType: 'perspective' as const
+      }
+      ctx.cameraManager.getCameraState.mockReturnValue(state)
+      expect(ctx.load3d.getCameraState()).toBe(state)
+    })
+  })
+
+  describe('gizmo delegation', () => {
     it('setGizmoEnabled delegates to gizmoManager.setEnabled and forces a render', () => {
       ctx.load3d.setGizmoEnabled(true)
 
@@ -203,6 +262,94 @@ describe('Load3d', () => {
     })
   })
 
+  describe('capability gating', () => {
+    function makeNoGizmoCtx() {
+      return makeInstance({
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          gizmoTransform: false
+        },
+        adapterKind: 'splat'
+      })
+    }
+
+    it('setGizmoEnabled(true) is a no-op when gizmoTransform capability is false', () => {
+      const c = makeNoGizmoCtx()
+      c.load3d.setGizmoEnabled(true)
+
+      expect(c.gizmo.setEnabled).not.toHaveBeenCalled()
+      expect(c.forceRender).not.toHaveBeenCalled()
+    })
+
+    it('setGizmoEnabled(false) still delegates even when capability is false', () => {
+      const c = makeNoGizmoCtx()
+      c.load3d.setGizmoEnabled(false)
+
+      expect(c.gizmo.setEnabled).toHaveBeenCalledWith(false)
+    })
+
+    it('setGizmoMode is a no-op when gizmoTransform capability is false', () => {
+      const c = makeNoGizmoCtx()
+      c.load3d.setGizmoMode('rotate')
+
+      expect(c.gizmo.setMode).not.toHaveBeenCalled()
+    })
+
+    it('resetGizmoTransform is a no-op when gizmoTransform capability is false', () => {
+      const c = makeNoGizmoCtx()
+      c.load3d.resetGizmoTransform()
+
+      expect(c.gizmo.reset).not.toHaveBeenCalled()
+    })
+
+    it('applyGizmoTransform is a no-op when gizmoTransform capability is false', () => {
+      const c = makeNoGizmoCtx()
+      c.load3d.applyGizmoTransform({ x: 1, y: 0, z: 0 }, { x: 0, y: 0, z: 0 })
+
+      expect(c.gizmo.applyTransform).not.toHaveBeenCalled()
+    })
+
+    it('isSplatModel returns true only when current adapter.kind === "splat"', () => {
+      expect(makeInstance({ adapterKind: 'splat' }).load3d.isSplatModel()).toBe(
+        true
+      )
+      expect(makeInstance({ adapterKind: 'mesh' }).load3d.isSplatModel()).toBe(
+        false
+      )
+      expect(
+        makeInstance({
+          adapterKind: null,
+          capabilities: null
+        }).load3d.isSplatModel()
+      ).toBe(false)
+    })
+
+    it('isPlyModel returns true only when current adapter.kind === "pointCloud"', () => {
+      expect(
+        makeInstance({ adapterKind: 'pointCloud' }).load3d.isPlyModel()
+      ).toBe(true)
+      expect(makeInstance({ adapterKind: 'mesh' }).load3d.isPlyModel()).toBe(
+        false
+      )
+    })
+
+    it('getCurrentModelCapabilities returns adapter capabilities when present', () => {
+      const caps = {
+        ...DEFAULT_MODEL_CAPABILITIES,
+        exportable: false
+      }
+      const c = makeInstance({ capabilities: caps, adapterKind: 'splat' })
+      expect(c.load3d.getCurrentModelCapabilities()).toEqual(caps)
+    })
+
+    it('getCurrentModelCapabilities falls back to DEFAULT when no adapter is loaded', () => {
+      const c = makeInstance({ capabilities: null, adapterKind: null })
+      expect(c.load3d.getCurrentModelCapabilities()).toEqual(
+        DEFAULT_MODEL_CAPABILITIES
+      )
+    })
+  })
+
   describe('lifecycle interactions', () => {
     it('clearModel detaches the gizmo before clearing the model', () => {
       const order: string[] = []
@@ -231,6 +378,467 @@ describe('Load3d', () => {
         ctx.cameraManager.activeCamera
       )
       expect(ctx.viewHelperManager.recreateViewHelper).toHaveBeenCalledOnce()
+      expect(ctx.handleResize).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('scene / background setters', () => {
+    it('toggleGrid delegates and forces a render', () => {
+      ctx.load3d.toggleGrid(false)
+      expect(ctx.sceneManager.toggleGrid).toHaveBeenCalledWith(false)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setBackgroundColor delegates and forces a render', () => {
+      ctx.load3d.setBackgroundColor('#ff0000')
+      expect(ctx.sceneManager.setBackgroundColor).toHaveBeenCalledWith(
+        '#ff0000'
+      )
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setBackgroundRenderMode delegates and forces a render', () => {
+      ctx.load3d.setBackgroundRenderMode('panorama')
+      expect(ctx.sceneManager.setBackgroundRenderMode).toHaveBeenCalledWith(
+        'panorama'
+      )
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('removeBackgroundImage delegates and forces a render', () => {
+      ctx.load3d.removeBackgroundImage()
+      expect(ctx.sceneManager.removeBackgroundImage).toHaveBeenCalledOnce()
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setBackgroundImage without existing texture only sets and renders', async () => {
+      await ctx.load3d.setBackgroundImage('some/path.png')
+
+      expect(ctx.sceneManager.setBackgroundImage).toHaveBeenCalledWith(
+        'some/path.png'
+      )
+      expect(ctx.sceneManager.updateBackgroundSize).not.toHaveBeenCalled()
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setBackgroundImage updates background size with container dimensions when no aspect ratio is enforced', async () => {
+      ctx.sceneManager.backgroundTexture = {}
+      ctx.sceneManager.backgroundMesh = {}
+
+      await ctx.load3d.setBackgroundImage('some/path.png')
+
+      expect(ctx.sceneManager.updateBackgroundSize).toHaveBeenCalledWith(
+        {},
+        {},
+        ctx.renderer.domElement.clientWidth,
+        ctx.renderer.domElement.clientHeight
+      )
+    })
+
+    it('setBackgroundImage uses letterboxed dimensions when aspect ratio is enforced', async () => {
+      const c = makeInstance({ targetWidth: 400, targetHeight: 400 })
+      c.sceneManager.backgroundTexture = {}
+      c.sceneManager.backgroundMesh = {}
+
+      await c.load3d.setBackgroundImage('bg.png')
+
+      // 800x600 container, 1:1 target → letterbox is 600x600.
+      expect(c.sceneManager.updateBackgroundSize).toHaveBeenCalledWith(
+        {},
+        {},
+        600,
+        600
+      )
+    })
+  })
+
+  describe('camera setters', () => {
+    it('setCameraState delegates and forces a render', () => {
+      const state = {
+        position: new THREE.Vector3(5, 5, 5),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 1,
+        cameraType: 'perspective' as const
+      }
+      ctx.load3d.setCameraState(state)
+
+      expect(ctx.cameraManager.setCameraState).toHaveBeenCalledWith(state)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setFOV delegates and forces a render', () => {
+      ctx.load3d.setFOV(42)
+      expect(ctx.cameraManager.setFOV).toHaveBeenCalledWith(42)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('material, up direction and skeleton', () => {
+    it('setMaterialMode delegates and forces a render', () => {
+      ctx.load3d.setMaterialMode('wireframe')
+      expect(ctx.modelManager.setMaterialMode).toHaveBeenCalledWith('wireframe')
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setUpDirection delegates and forces a render', () => {
+      ctx.load3d.setUpDirection('-z')
+      expect(ctx.modelManager.setUpDirection).toHaveBeenCalledWith('-z')
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setShowSkeleton delegates and forces a render', () => {
+      ctx.load3d.setShowSkeleton(true)
+      expect(ctx.modelManager.setShowSkeleton).toHaveBeenCalledWith(true)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('getShowSkeleton reflects modelManager.showSkeleton', () => {
+      ctx.modelManager.showSkeleton = true
+      expect(ctx.load3d.getShowSkeleton()).toBe(true)
+    })
+
+    it('hasSkeleton delegates to modelManager.hasSkeleton', () => {
+      ctx.modelManager.hasSkeleton.mockReturnValue(true)
+      expect(ctx.load3d.hasSkeleton()).toBe(true)
+      expect(ctx.modelManager.hasSkeleton).toHaveBeenCalled()
+    })
+  })
+
+  describe('light and HDRI', () => {
+    it('setLightIntensity delegates and forces a render', () => {
+      ctx.load3d.setLightIntensity(3)
+      expect(ctx.lightingManager.setLightIntensity).toHaveBeenCalledWith(3)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('loadHDRI awaits hdriManager and forces a render', async () => {
+      await ctx.load3d.loadHDRI('http://example.com/hdr.hdr')
+      expect(ctx.hdriManager.loadHDRI).toHaveBeenCalledWith(
+        'http://example.com/hdr.hdr'
+      )
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setHDRIEnabled toggles hdriManager AND lightingManager hdri mode', () => {
+      ctx.load3d.setHDRIEnabled(true)
+
+      expect(ctx.hdriManager.setEnabled).toHaveBeenCalledWith(true)
+      expect(ctx.lightingManager.setHDRIMode).toHaveBeenCalledWith(true)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setHDRIAsBackground delegates and forces a render', () => {
+      ctx.load3d.setHDRIAsBackground(true)
+      expect(ctx.hdriManager.setShowAsBackground).toHaveBeenCalledWith(true)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('setHDRIIntensity delegates and forces a render', () => {
+      ctx.load3d.setHDRIIntensity(0.5)
+      expect(ctx.hdriManager.setIntensity).toHaveBeenCalledWith(0.5)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('clearHDRI clears hdri and disables lightingManager hdri mode', () => {
+      ctx.load3d.clearHDRI()
+
+      expect(ctx.hdriManager.clear).toHaveBeenCalledOnce()
+      expect(ctx.lightingManager.setHDRIMode).toHaveBeenCalledWith(false)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('target size and viewport refresh', () => {
+    it('setTargetSize updates stored dimensions and triggers a resize', () => {
+      ctx.load3d.setTargetSize(1024, 512)
+
+      expect(ctx.load3d.getTargetSize()).toEqual({ width: 1024, height: 512 })
+      expect(ctx.handleResize).toHaveBeenCalledOnce()
+    })
+
+    it('refreshViewport delegates to handleResize', () => {
+      ctx.load3d.refreshViewport()
+      expect(ctx.handleResize).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('mouse status and isActive', () => {
+    it('updateStatusMouseOnNode/Scene/Viewer set the corresponding flags', () => {
+      ctx.load3d.updateStatusMouseOnNode(true)
+      ctx.load3d.updateStatusMouseOnScene(true)
+      ctx.load3d.updateStatusMouseOnViewer(true)
+
+      expect(ctx.load3d.STATUS_MOUSE_ON_NODE).toBe(true)
+      expect(ctx.load3d.STATUS_MOUSE_ON_SCENE).toBe(true)
+      expect(ctx.load3d.STATUS_MOUSE_ON_VIEWER).toBe(true)
+    })
+
+    it('isActive is true when the mouse is over the node', () => {
+      ctx.load3d.updateStatusMouseOnNode(true)
+      expect(ctx.load3d.isActive()).toBe(true)
+    })
+
+    it('isActive is true when recording', () => {
+      ctx.recordingManager.getIsRecording.mockReturnValue(true)
+      expect(ctx.load3d.isActive()).toBe(true)
+    })
+
+    it('isActive is true when an animation is playing', () => {
+      ctx.animationManager.isAnimationPlaying = true
+      expect(ctx.load3d.isActive()).toBe(true)
+    })
+
+    it('isActive is true until the initial render completes', () => {
+      expect(ctx.load3d.isActive()).toBe(true)
+
+      ctx.load3d.INITIAL_RENDER_DONE = true
+      expect(ctx.load3d.isActive()).toBe(false)
+    })
+  })
+
+  describe('animation delegation', () => {
+    it('setAnimationSpeed forwards to animationManager', () => {
+      ctx.load3d.setAnimationSpeed(2)
+      expect(ctx.animationManager.setAnimationSpeed).toHaveBeenCalledWith(2)
+    })
+
+    it('updateSelectedAnimation forwards to animationManager', () => {
+      ctx.load3d.updateSelectedAnimation(3)
+      expect(ctx.animationManager.updateSelectedAnimation).toHaveBeenCalledWith(
+        3
+      )
+    })
+
+    it.each([undefined, true, false])('toggleAnimation forwards %s', (play) => {
+      ctx.load3d.toggleAnimation(play)
+      expect(ctx.animationManager.toggleAnimation).toHaveBeenCalledWith(play)
+    })
+
+    it('hasAnimations reflects animationManager.animationClips length', () => {
+      expect(ctx.load3d.hasAnimations()).toBe(false)
+      ctx.animationManager.animationClips = [
+        new THREE.AnimationClip('run', 1, [])
+      ]
+      expect(ctx.load3d.hasAnimations()).toBe(true)
+    })
+
+    it('getAnimationTime and getAnimationDuration delegate to animationManager', () => {
+      ctx.animationManager.getAnimationTime.mockReturnValue(1.5)
+      ctx.animationManager.getAnimationDuration.mockReturnValue(5)
+
+      expect(ctx.load3d.getAnimationTime()).toBe(1.5)
+      expect(ctx.load3d.getAnimationDuration()).toBe(5)
+    })
+
+    it('setAnimationTime delegates and forces a render', () => {
+      ctx.load3d.setAnimationTime(2.5)
+      expect(ctx.animationManager.setAnimationTime).toHaveBeenCalledWith(2.5)
+      expect(ctx.forceRender).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('recording delegation', () => {
+    it('startRecording hides the view helper and forwards target dimensions', async () => {
+      const c = makeInstance({ targetWidth: 256, targetHeight: 256 })
+
+      await c.load3d.startRecording()
+
+      expect(c.viewHelperManager.visibleViewHelper).toHaveBeenCalledWith(false)
+      expect(c.recordingManager.startRecording).toHaveBeenCalledWith(256, 256)
+    })
+
+    it('stopRecording restores the view helper and emits a status change', () => {
+      ctx.load3d.stopRecording()
+
+      expect(ctx.viewHelperManager.visibleViewHelper).toHaveBeenCalledWith(true)
+      expect(ctx.recordingManager.stopRecording).toHaveBeenCalledOnce()
+      expect(ctx.eventManager.emitEvent).toHaveBeenCalledWith(
+        'recordingStatusChange',
+        false
+      )
+    })
+
+    it('isRecording, getRecordingDuration, getRecordingData delegate to recordingManager', () => {
+      ctx.recordingManager.getIsRecording.mockReturnValue(true)
+      ctx.recordingManager.getRecordingDuration.mockReturnValue(7)
+      ctx.recordingManager.getRecordingData.mockReturnValue('data:video/mp4')
+
+      expect(ctx.load3d.isRecording()).toBe(true)
+      expect(ctx.load3d.getRecordingDuration()).toBe(7)
+      expect(ctx.load3d.getRecordingData()).toBe('data:video/mp4')
+    })
+
+    it('exportRecording forwards the filename argument', () => {
+      ctx.load3d.exportRecording('video.mp4')
+      expect(ctx.recordingManager.exportRecording).toHaveBeenCalledWith(
+        'video.mp4'
+      )
+    })
+
+    it('clearRecording delegates', () => {
+      ctx.load3d.clearRecording()
+      expect(ctx.recordingManager.clearRecording).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('event listener delegation', () => {
+    it('addEventListener / removeEventListener forward to eventManager', () => {
+      const cb = vi.fn()
+      ctx.load3d.addEventListener('foo', cb)
+      ctx.load3d.removeEventListener('foo', cb)
+
+      expect(ctx.eventManager.addEventListener).toHaveBeenCalledWith('foo', cb)
+      expect(ctx.eventManager.removeEventListener).toHaveBeenCalledWith(
+        'foo',
+        cb
+      )
+    })
+  })
+
+  describe('loadModel flow', () => {
+    it('resets camera/controls/gizmo/model/animation before invoking the loader', async () => {
+      const order: string[] = []
+      ctx.cameraManager.reset.mockImplementation(() => order.push('camera'))
+      ctx.controlsManager.reset.mockImplementation(() => order.push('controls'))
+      ctx.gizmo.detach.mockImplementation(() => order.push('gizmo'))
+      ctx.modelManager.clearModel.mockImplementation(() => order.push('model'))
+      ctx.animationManager.dispose.mockImplementation(() =>
+        order.push('animation')
+      )
+      ctx.loaderManager.loadModel.mockImplementation(() => {
+        order.push('load')
+        return Promise.resolve()
+      })
+
+      await ctx.load3d.loadModel('url', 'file.glb')
+
+      expect(order).toEqual([
+        'camera',
+        'controls',
+        'gizmo',
+        'model',
+        'animation',
+        'load'
+      ])
+      expect(ctx.loaderManager.loadModel).toHaveBeenCalledWith(
+        'url',
+        'file.glb'
+      )
+      expect(ctx.handleResize).toHaveBeenCalledOnce()
+    })
+
+    it('sets up animations when the loader produces a model', async () => {
+      const obj = new THREE.Object3D()
+      const originalModel = { foo: 'bar' }
+      ctx.loaderManager.loadModel.mockImplementation(async () => {
+        ctx.modelManager.currentModel = obj
+        ctx.modelManager.originalModel = originalModel
+      })
+
+      await ctx.load3d.loadModel('url')
+
+      expect(ctx.animationManager.setupModelAnimations).toHaveBeenCalledWith(
+        obj,
+        originalModel
+      )
+    })
+
+    it('skips animation setup when the loader does not produce a model', async () => {
+      await ctx.load3d.loadModel('url')
+      expect(ctx.animationManager.setupModelAnimations).not.toHaveBeenCalled()
+    })
+
+    it('awaits the previous loading promise before starting a new load', async () => {
+      let resolvePrev!: () => void
+      const prev = new Promise<void>((r) => {
+        resolvePrev = r
+      })
+      ;(
+        ctx.load3d as unknown as { loadingPromise: Promise<void> | null }
+      ).loadingPromise = prev
+
+      const loadPromise = ctx.load3d.loadModel('url')
+      expect(ctx.loaderManager.loadModel).not.toHaveBeenCalled()
+
+      resolvePrev()
+      await loadPromise
+
+      expect(ctx.loaderManager.loadModel).toHaveBeenCalledOnce()
+    })
+
+    it('swallows rejections from the previous loading promise', async () => {
+      const prev = Promise.reject(new Error('prev failed'))
+      ;(
+        ctx.load3d as unknown as { loadingPromise: Promise<void> | null }
+      ).loadingPromise = prev
+
+      await expect(ctx.load3d.loadModel('url')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('exportModel', () => {
+    beforeEach(() => {
+      ctx.modelManager.currentModel = new THREE.Object3D()
+      ctx.modelManager.originalFileName = 'cube'
+      ctx.modelManager.originalURL = 'http://example.com/cube.glb'
+    })
+
+    it('throws when no model is loaded', async () => {
+      ctx.modelManager.currentModel = null
+
+      await expect(ctx.load3d.exportModel('glb')).rejects.toThrow(
+        'No model to export'
+      )
+    })
+
+    it('emits exportLoadingStart and Exit events around a GLB export', async () => {
+      await ctx.load3d.exportModel('glb')
+
+      expect(ctx.eventManager.emitEvent).toHaveBeenCalledWith(
+        'exportLoadingStart',
+        'Exporting as GLB...'
+      )
+      expect(ctx.eventManager.emitEvent).toHaveBeenCalledWith(
+        'exportLoadingEnd',
+        null
+      )
+      expect(ModelExporter.exportGLB).toHaveBeenCalledWith(
+        expect.any(THREE.Object3D),
+        'cube.glb',
+        'http://example.com/cube.glb'
+      )
+    })
+
+    it('dispatches to exportOBJ for the obj format', async () => {
+      await ctx.load3d.exportModel('obj')
+      expect(ModelExporter.exportOBJ).toHaveBeenCalled()
+    })
+
+    it('dispatches to exportSTL for the stl format', async () => {
+      await ctx.load3d.exportModel('stl')
+      expect(ModelExporter.exportSTL).toHaveBeenCalled()
+    })
+
+    it('throws for an unsupported format and still emits exportLoadingEnd', async () => {
+      await expect(ctx.load3d.exportModel('abc')).rejects.toThrow(
+        'Unsupported export format: abc'
+      )
+
+      expect(ctx.eventManager.emitEvent).toHaveBeenCalledWith(
+        'exportLoadingEnd',
+        null
+      )
+    })
+
+    it('falls back to "model" as filename base when originalFileName is missing', async () => {
+      ctx.modelManager.originalFileName = null
+      await ctx.load3d.exportModel('glb')
+
+      expect(ModelExporter.exportGLB).toHaveBeenCalledWith(
+        expect.any(THREE.Object3D),
+        'model.glb',
+        'http://example.com/cube.glb'
+      )
     })
   })
 
@@ -257,6 +865,252 @@ describe('Load3d', () => {
 
       expect(ctx.gizmo.removeFromScene).toHaveBeenCalledOnce()
       expect(ctx.gizmo.ensureHelperInScene).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('captureThumbnail', () => {
+    it('throws when no model is loaded', async () => {
+      await expect(ctx.load3d.captureThumbnail()).rejects.toThrow(
+        'No model loaded for thumbnail capture'
+      )
+    })
+
+    it('captures the scene and restores grid visibility after success', async () => {
+      ctx.modelManager.currentModel = new THREE.Object3D()
+      ctx.sceneManager.gridHelper.visible = true
+      ctx.sceneManager.captureScene.mockResolvedValue({
+        scene: 'data:image/png;base64,abc',
+        mask: '',
+        normal: ''
+      })
+
+      const result = await ctx.load3d.captureThumbnail(128, 128)
+
+      expect(ctx.sceneManager.captureScene).toHaveBeenCalledWith(128, 128)
+      expect(ctx.sceneManager.gridHelper.visible).toBe(true)
+      expect(result).toBe('data:image/png;base64,abc')
+    })
+
+    it('temporarily switches to perspective and restores the camera type and state', async () => {
+      ctx.modelManager.currentModel = new THREE.Object3D()
+      ctx.cameraManager.getCurrentCameraType.mockReturnValue('orthographic')
+      const savedState = {
+        position: new THREE.Vector3(0, 0, 0),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 1,
+        cameraType: 'orthographic' as const
+      }
+      ctx.cameraManager.getCameraState.mockReturnValue(savedState)
+      ctx.sceneManager.captureScene.mockResolvedValue({
+        scene: 'img',
+        mask: '',
+        normal: ''
+      })
+
+      await ctx.load3d.captureThumbnail()
+
+      expect(ctx.cameraManager.toggleCamera).toHaveBeenNthCalledWith(
+        1,
+        'perspective'
+      )
+      expect(ctx.cameraManager.toggleCamera).toHaveBeenNthCalledWith(
+        2,
+        'orthographic'
+      )
+      expect(ctx.cameraManager.setCameraState).toHaveBeenCalledWith(savedState)
+    })
+
+    it('restores camera and grid state even when capture fails', async () => {
+      ctx.modelManager.currentModel = new THREE.Object3D()
+      ctx.sceneManager.gridHelper.visible = true
+      ctx.cameraManager.getCurrentCameraType.mockReturnValue('orthographic')
+      const savedState = {
+        position: new THREE.Vector3(0, 0, 0),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 1,
+        cameraType: 'orthographic' as const
+      }
+      ctx.cameraManager.getCameraState.mockReturnValue(savedState)
+      const err = new Error('capture failed')
+      ctx.sceneManager.captureScene.mockRejectedValue(err)
+
+      await expect(ctx.load3d.captureThumbnail()).rejects.toBe(err)
+
+      expect(ctx.sceneManager.gridHelper.visible).toBe(true)
+      expect(ctx.cameraManager.toggleCamera).toHaveBeenNthCalledWith(
+        2,
+        'orthographic'
+      )
+      expect(ctx.cameraManager.setCameraState).toHaveBeenCalledWith(savedState)
+    })
+  })
+
+  describe('handleResize', () => {
+    function makeForResize(
+      opts: Omit<MakeInstanceOptions, 'stubHandleResize'>
+    ) {
+      return makeInstance({ ...opts, stubHandleResize: false })
+    }
+
+    it('warns and returns when the canvas has no parent element', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const c = makeForResize({})
+      c.renderer.domElement.remove()
+
+      c.load3d.handleResize()
+
+      expect(warnSpy).toHaveBeenCalled()
+      expect(c.cameraManager.handleResize).not.toHaveBeenCalled()
+      expect(c.sceneManager.handleResize).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('uses the container dimensions when no aspect ratio is enforced', () => {
+      const c = makeForResize({})
+      c.load3d.handleResize()
+
+      expect(c.renderer.setSize).toHaveBeenCalledWith(800, 600)
+      expect(c.cameraManager.handleResize).toHaveBeenCalledWith(800, 600)
+      expect(c.sceneManager.handleResize).toHaveBeenCalledWith(800, 600)
+      expect(c.forceRender).toHaveBeenCalledOnce()
+    })
+
+    it('letterboxes to the target aspect ratio when one is configured', () => {
+      const c = makeForResize({ targetWidth: 400, targetHeight: 400 })
+      c.load3d.handleResize()
+
+      expect(c.renderer.setSize).toHaveBeenCalledWith(800, 600)
+      expect(c.cameraManager.handleResize).toHaveBeenCalledWith(600, 600)
+      expect(c.sceneManager.handleResize).toHaveBeenCalledWith(600, 600)
+    })
+
+    it('reads target dimensions from the dynamic getDimensions callback', () => {
+      const getDimensions = vi.fn(() => ({ width: 100, height: 100 }))
+      const c = makeForResize({ getDimensionsCallback: getDimensions })
+
+      c.load3d.handleResize()
+
+      expect(getDimensions).toHaveBeenCalled()
+      expect(c.load3d.getTargetSize()).toEqual({ width: 100, height: 100 })
+      expect(c.cameraManager.handleResize).toHaveBeenCalledWith(600, 600)
+    })
+  })
+
+  describe('renderMainScene', () => {
+    function makeForRender(
+      opts: Omit<MakeInstanceOptions, 'stubForceRender'> = {}
+    ) {
+      return makeInstance({ ...opts, stubForceRender: false })
+    }
+
+    it('fills the container when no aspect ratio is enforced', () => {
+      const c = makeForRender()
+
+      c.load3d.renderMainScene()
+
+      expect(c.renderer.setViewport).toHaveBeenCalledWith(0, 0, 800, 600)
+      expect(c.renderer.setScissor).toHaveBeenCalledWith(0, 0, 800, 600)
+      expect(c.renderer.setScissorTest).toHaveBeenCalledWith(true)
+      expect(c.cameraManager.updateAspectRatio).not.toHaveBeenCalled()
+      expect(c.sceneManager.renderBackground).toHaveBeenCalled()
+      expect(c.renderer.render).toHaveBeenCalledWith(
+        c.sceneManager.scene,
+        c.cameraManager.activeCamera
+      )
+    })
+
+    it('letterboxes and updates camera aspect ratio when a target aspect ratio is set', () => {
+      const c = makeForRender({ targetWidth: 400, targetHeight: 400 })
+
+      c.load3d.renderMainScene()
+
+      expect(c.renderer.setClearColor).toHaveBeenCalled()
+      expect(c.renderer.clear).toHaveBeenCalled()
+      expect(c.renderer.setViewport).toHaveBeenLastCalledWith(100, 0, 600, 600)
+      expect(c.cameraManager.updateAspectRatio).toHaveBeenCalledWith(1)
+    })
+
+    it('uses the dynamic getDimensions callback to update the target aspect ratio', () => {
+      const getDimensions = vi.fn(() => ({ width: 320, height: 160 }))
+      const c = makeForRender({ getDimensionsCallback: getDimensions })
+
+      c.load3d.renderMainScene()
+
+      expect(getDimensions).toHaveBeenCalled()
+      expect(c.cameraManager.updateAspectRatio).toHaveBeenCalledWith(2)
+    })
+  })
+
+  describe('forceRender', () => {
+    it('performs a frame and sets the initial-render flag', () => {
+      const c = makeInstance({ stubForceRender: false })
+      expect(c.load3d.INITIAL_RENDER_DONE).toBe(false)
+
+      c.load3d.forceRender()
+
+      expect(c.renderer.render).toHaveBeenCalled()
+      expect(c.viewHelperManager.update).toHaveBeenCalled()
+      expect(c.controlsManager.update).toHaveBeenCalled()
+      expect(c.animationManager.update).toHaveBeenCalled()
+      expect(c.load3d.INITIAL_RENDER_DONE).toBe(true)
+    })
+  })
+
+  describe('remove', () => {
+    it('disposes all managers and tears down the renderer', () => {
+      const canvasRemoveSpy = vi.spyOn(ctx.renderer.domElement, 'remove')
+      const dispatchSpy = vi.spyOn(ctx.renderer.domElement, 'dispatchEvent')
+
+      ctx.load3d.remove()
+
+      expect(ctx.renderer.forceContextLoss).toHaveBeenCalledOnce()
+      expect(dispatchSpy).toHaveBeenCalled()
+      expect(ctx.sceneManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.cameraManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.controlsManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.lightingManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.hdriManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.viewHelperManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.loaderManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.modelManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.recordingManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.animationManager.dispose).toHaveBeenCalledOnce()
+      expect(ctx.gizmo.dispose).toHaveBeenCalledOnce()
+      expect(ctx.renderer.dispose).toHaveBeenCalledOnce()
+      expect(canvasRemoveSpy).toHaveBeenCalledOnce()
+    })
+
+    it('disconnects the ResizeObserver if one was attached', () => {
+      const disconnect = vi.fn()
+      ;(
+        ctx.load3d as unknown as { resizeObserver: { disconnect: () => void } }
+      ).resizeObserver = { disconnect }
+
+      ctx.load3d.remove()
+
+      expect(disconnect).toHaveBeenCalledOnce()
+    })
+
+    it('invokes the context menu guard dispose callback', () => {
+      const disposeGuard = vi.fn()
+      ;(
+        ctx.load3d as unknown as { disposeContextMenuGuard: () => void }
+      ).disposeContextMenuGuard = disposeGuard
+
+      ctx.load3d.remove()
+
+      expect(disposeGuard).toHaveBeenCalledOnce()
+    })
+
+    it('stops the render loop if one was running', () => {
+      const stop = vi.fn()
+      ;(
+        ctx.load3d as unknown as { renderLoop: { stop: () => void } }
+      ).renderLoop = { stop }
+
+      ctx.load3d.remove()
+
+      expect(stop).toHaveBeenCalledOnce()
     })
   })
 })

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -1,34 +1,37 @@
+import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LoaderManager } from './LoaderManager'
-import type { ModelAdapter } from './ModelAdapter'
-import type { EventManagerInterface, ModelManagerInterface } from './interfaces'
+import type { ModelAdapter, ModelLoadContext } from './ModelAdapter'
+import {
+  makeEventManagerStub,
+  makeModelManagerStub
+} from './__test__/managerStubs'
 
-// Each adapter is stubbed with only the fields pickAdapter consults: `kind`
-// for identity assertions and `extensions` for routing. `load` is a vi.fn()
-// so we can assert on call forwarding if we extend the suite later.
+const { meshLoad, splatLoad, pointCloudLoad, getPLYEngineMock, addAlert } =
+  vi.hoisted(() => ({
+    meshLoad: vi.fn(),
+    splatLoad: vi.fn(),
+    pointCloudLoad: vi.fn(),
+    getPLYEngineMock: vi.fn<() => string>(),
+    addAlert: vi.fn()
+  }))
+
 vi.mock('./MeshModelAdapter', () => ({
   MeshModelAdapter: class {
     readonly kind = 'mesh' as const
     readonly extensions = ['stl', 'fbx', 'obj', 'gltf', 'glb'] as const
     readonly capabilities = {}
-    load = vi.fn()
+    load = meshLoad
   }
 }))
 
-const pointCloudInstance = {
-  kind: 'pointCloud' as const,
-  extensions: ['ply'] as const,
-  capabilities: {},
-  load: vi.fn()
-}
-const getPLYEngineMock = vi.fn<() => string>()
 vi.mock('./PointCloudModelAdapter', () => ({
   PointCloudModelAdapter: class {
-    kind = pointCloudInstance.kind
-    extensions = pointCloudInstance.extensions
-    capabilities = pointCloudInstance.capabilities
-    load = pointCloudInstance.load
+    readonly kind = 'pointCloud' as const
+    readonly extensions = ['ply'] as const
+    readonly capabilities = {}
+    load = pointCloudLoad
   },
   getPLYEngine: () => getPLYEngineMock()
 }))
@@ -38,43 +41,70 @@ vi.mock('./SplatModelAdapter', () => ({
     readonly kind = 'splat' as const
     readonly extensions = ['spz', 'splat', 'ksplat'] as const
     readonly capabilities = {}
-    load = vi.fn()
+    load = splatLoad
   }
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert })
 }))
 
 type LoaderManagerInternals = {
   pickAdapter(extension: string): ModelAdapter | null
 }
 
-function makeLoaderManager(): {
-  lm: LoaderManager
-  pick: (ext: string) => ModelAdapter | null
-} {
-  const modelManager = {
-    originalMaterials: new WeakMap(),
-    clearModel: vi.fn(),
-    setupModel: vi.fn()
-  } as unknown as ModelManagerInterface
-  const eventManager: EventManagerInterface = {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    emitEvent: vi.fn()
-  }
-
-  const lm = new LoaderManager(modelManager, eventManager)
+function makeLoaderManager() {
+  const modelManager = makeModelManagerStub()
+  const eventManager = makeEventManagerStub()
+  const lm = new LoaderManager(
+    modelManager as unknown as ConstructorParameters<typeof LoaderManager>[0],
+    eventManager
+  )
   const internals = lm as unknown as LoaderManagerInternals
-  return { lm, pick: internals.pickAdapter.bind(lm) }
+  return {
+    lm,
+    modelManager,
+    eventManager,
+    pick: internals.pickAdapter.bind(lm)
+  }
 }
 
 describe('LoaderManager', () => {
   beforeEach(() => {
-    getPLYEngineMock.mockReset()
+    vi.clearAllMocks()
     getPLYEngineMock.mockReturnValue('three')
+    meshLoad.mockResolvedValue(null)
+    splatLoad.mockResolvedValue(null)
+    pointCloudLoad.mockResolvedValue(null)
   })
 
   describe('getCurrentAdapter', () => {
     it('returns null before any model loads', () => {
       const { lm } = makeLoaderManager()
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
+
+    it('exposes the picked adapter after a successful load', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+    })
+
+    it('resets to null at the start of a new load', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+
+      await lm.loadModel('api/view?filename=cube.xyz')
       expect(lm.getCurrentAdapter()).toBeNull()
     })
   })
@@ -118,6 +148,277 @@ describe('LoaderManager', () => {
       const { pick } = makeLoaderManager()
       expect(pick('xyz')).toBeNull()
       expect(pick('')).toBeNull()
+    })
+  })
+
+  describe('loadModel', () => {
+    it('emits modelLoadingStart and records originalURL before dispatching', async () => {
+      const { lm, eventManager, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingStart',
+        null
+      )
+      expect(modelManager.originalURL).toBe('api/view?filename=cube.glb')
+    })
+
+    it('clears any existing model before routing to the adapter', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      const order: string[] = []
+      modelManager.clearModel.mockImplementation(() => order.push('clear'))
+      meshLoad.mockImplementationOnce(async () => {
+        order.push('load')
+        return null
+      })
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(order).toEqual(['clear', 'load'])
+    })
+
+    it('derives originalFileName from an explicit originalFileName argument', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?filename=ignored.glb', 'uploads/my-cube.glb')
+
+      expect(modelManager.originalFileName).toBe('my-cube')
+    })
+
+    it('derives originalFileName from the URL filename param when no override is given', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(modelManager.originalFileName).toBe('cube')
+    })
+
+    it('falls back to "model" when the URL has no filename param', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?other=1')
+
+      expect(modelManager.originalFileName).toBe('model')
+    })
+
+    it('alerts when the file extension cannot be determined', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?other=1')
+
+      expect(addAlert).toHaveBeenCalledWith(
+        'toastMessages.couldNotDetermineFileType'
+      )
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      expect(meshLoad).not.toHaveBeenCalled()
+    })
+
+    it('passes setupModel the object returned by the adapter', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      const loaded = new THREE.Object3D()
+      meshLoad.mockResolvedValueOnce(loaded)
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(modelManager.setupModel).toHaveBeenCalledWith(loaded)
+    })
+
+    it('skips setupModel when the adapter returns null', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(null)
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+    })
+
+    it('emits modelLoadingEnd when the load completes', async () => {
+      const { lm, eventManager } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
+    })
+
+    it('forwards a decoded path and filename to the adapter', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel(
+        'api/view?type=output&subfolder=nested%2Fdir&filename=cube.glb'
+      )
+
+      expect(meshLoad).toHaveBeenCalledWith(
+        expect.objectContaining({
+          setOriginalModel: expect.any(Function),
+          registerOriginalMaterial: expect.any(Function)
+        }),
+        'api/view?type=output&subfolder=nested%2Fdir&filename=',
+        'cube.glb'
+      )
+    })
+
+    it('defaults the path to type=input when no type param is given', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(meshLoad).toHaveBeenCalledWith(
+        expect.anything(),
+        'api/view?type=input&subfolder=&filename=',
+        'cube.glb'
+      )
+    })
+
+    it('routes .ply through the splat adapter when the engine setting is sparkjs', async () => {
+      getPLYEngineMock.mockReturnValue('sparkjs')
+      const { lm } = makeLoaderManager()
+      splatLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(splatLoad).toHaveBeenCalled()
+      expect(pointCloudLoad).not.toHaveBeenCalled()
+    })
+
+    it('handles adapter errors by alerting and still emitting modelLoadingEnd', async () => {
+      const { lm, eventManager } = makeLoaderManager()
+      const err = new Error('boom')
+      meshLoad.mockRejectedValueOnce(err)
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
+      expect(addAlert).toHaveBeenCalledWith('toastMessages.errorLoadingModel')
+      expect(consoleError).toHaveBeenCalled()
+    })
+
+    it('discards the result of a stale load when a newer one has started', async () => {
+      const { lm, modelManager, eventManager } = makeLoaderManager()
+
+      let resolveFirst!: (value: THREE.Object3D) => void
+      const firstLoad = new Promise<THREE.Object3D>((r) => {
+        resolveFirst = r
+      })
+      const firstModel = new THREE.Object3D()
+      firstModel.name = 'first'
+      const secondModel = new THREE.Object3D()
+      secondModel.name = 'second'
+
+      meshLoad
+        .mockImplementationOnce(() => firstLoad)
+        .mockResolvedValueOnce(secondModel)
+
+      const firstPromise = lm.loadModel('api/view?filename=first.glb')
+      const secondPromise = lm.loadModel('api/view?filename=second.glb')
+
+      resolveFirst(firstModel)
+
+      await Promise.all([firstPromise, secondPromise])
+
+      expect(modelManager.setupModel).toHaveBeenCalledTimes(1)
+      expect(modelManager.setupModel).toHaveBeenCalledWith(secondModel)
+
+      const endEmits = eventManager.emitEvent.mock.calls.filter(
+        ([name]) => name === 'modelLoadingEnd'
+      )
+      expect(endEmits).toHaveLength(1)
+    })
+
+    it('logs and drops the load when the URL is missing a filename param', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await lm.loadModel('api/view?type=output', 'uploads/file.glb')
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Missing filename in URL:',
+        'api/view?type=output'
+      )
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      consoleError.mockRestore()
+    })
+
+    it('proxies setOriginalModel and registerOriginalMaterial through the load context', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      let capturedCtx: ModelLoadContext | undefined
+      meshLoad.mockImplementationOnce(async (ctx: ModelLoadContext) => {
+        capturedCtx = ctx
+        return new THREE.Object3D()
+      })
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      const mesh = new THREE.Mesh(
+        new THREE.BufferGeometry(),
+        new THREE.MeshBasicMaterial()
+      )
+      const mat = new THREE.MeshStandardMaterial()
+      capturedCtx!.setOriginalModel(mesh)
+      capturedCtx!.registerOriginalMaterial(mesh, mat)
+
+      expect(modelManager.setOriginalModel).toHaveBeenCalledWith(mesh)
+      expect(modelManager.originalMaterials.get(mesh)).toBe(mat)
+    })
+
+    it('exposes modelManager.standardMaterial and materialMode via getters on the load context', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      modelManager.materialMode = 'wireframe'
+      let capturedCtx: ModelLoadContext | undefined
+      meshLoad.mockImplementationOnce(async (ctx: ModelLoadContext) => {
+        capturedCtx = ctx
+        return new THREE.Object3D()
+      })
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(capturedCtx!.standardMaterial).toBe(modelManager.standardMaterial)
+      expect(capturedCtx!.materialMode).toBe('wireframe')
+    })
+
+    it('suppresses alerts and modelLoadingEnd when a stale load throws', async () => {
+      const { lm, eventManager } = makeLoaderManager()
+
+      let rejectFirst!: (err: unknown) => void
+      const firstLoad = new Promise<THREE.Object3D>((_, r) => {
+        rejectFirst = r
+      })
+
+      meshLoad
+        .mockImplementationOnce(() => firstLoad)
+        .mockResolvedValueOnce(new THREE.Object3D())
+
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      const firstPromise = lm.loadModel('api/view?filename=first.glb')
+      const secondPromise = lm.loadModel('api/view?filename=second.glb')
+
+      rejectFirst(new Error('stale failure'))
+
+      await Promise.all([firstPromise, secondPromise])
+
+      expect(addAlert).not.toHaveBeenCalled()
+      const endEmits = eventManager.emitEvent.mock.calls.filter(
+        ([name]) => name === 'modelLoadingEnd'
+      )
+      expect(endEmits).toHaveLength(1)
+      consoleError.mockRestore()
     })
   })
 })

--- a/src/extensions/core/load3d/__test__/managerStubs.ts
+++ b/src/extensions/core/load3d/__test__/managerStubs.ts
@@ -1,0 +1,269 @@
+import * as THREE from 'three'
+import { vi } from 'vitest'
+
+import type { ModelAdapterCapabilities } from '@/extensions/core/load3d/ModelAdapter'
+import type {
+  CameraState,
+  CameraType,
+  GizmoMode,
+  MaterialMode
+} from '@/extensions/core/load3d/interfaces'
+
+export function makeGizmoStub() {
+  return {
+    setEnabled: vi.fn(),
+    setMode: vi.fn(),
+    reset: vi.fn(),
+    applyTransform: vi.fn(),
+    getTransform: vi.fn(() => ({
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      scale: { x: 1, y: 1, z: 1 }
+    })),
+    setupForModel: vi.fn(),
+    updateCamera: vi.fn(),
+    detach: vi.fn(),
+    dispose: vi.fn(),
+    removeFromScene: vi.fn(),
+    ensureHelperInScene: vi.fn(),
+    isEnabled: vi.fn(() => false),
+    getMode: vi.fn(() => 'translate' as GizmoMode)
+  }
+}
+
+export function makeSceneManagerStub() {
+  return {
+    captureScene: vi.fn(),
+    dispose: vi.fn(),
+    setBackgroundColor: vi.fn(),
+    setBackgroundImage: vi.fn().mockResolvedValue(undefined),
+    removeBackgroundImage: vi.fn(),
+    toggleGrid: vi.fn(),
+    setBackgroundRenderMode: vi.fn(),
+    handleResize: vi.fn(),
+    renderBackground: vi.fn(),
+    updateBackgroundSize: vi.fn(),
+    scene: new THREE.Scene(),
+    backgroundTexture: null as unknown,
+    backgroundMesh: null as unknown,
+    gridHelper: { visible: true }
+  }
+}
+
+export function makeCameraManagerStub() {
+  const perspective = new THREE.PerspectiveCamera()
+  return {
+    activeCamera: perspective as THREE.Camera,
+    perspectiveCamera: perspective,
+    toggleCamera: vi.fn(),
+    setupForModel: vi.fn(),
+    reset: vi.fn(),
+    setFOV: vi.fn(),
+    setCameraState: vi.fn(),
+    getCameraState: vi.fn<() => CameraState>(() => ({
+      position: new THREE.Vector3(0, 0, 10),
+      target: new THREE.Vector3(0, 0, 0),
+      zoom: 1,
+      cameraType: 'perspective'
+    })),
+    getCurrentCameraType: vi.fn<() => CameraType>(() => 'perspective'),
+    handleResize: vi.fn(),
+    updateAspectRatio: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+export function makeControlsManagerStub() {
+  return {
+    controls: {
+      target: new THREE.Vector3(0, 0, 0),
+      update: vi.fn()
+    },
+    update: vi.fn(),
+    updateCamera: vi.fn(),
+    reset: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+export function makeLightingManagerStub() {
+  return {
+    setLightIntensity: vi.fn(),
+    setHDRIMode: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+export function makeHDRIManagerStub() {
+  return {
+    loadHDRI: vi.fn().mockResolvedValue(undefined),
+    setEnabled: vi.fn(),
+    setShowAsBackground: vi.fn(),
+    setIntensity: vi.fn(),
+    clear: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+export function makeViewHelperManagerStub() {
+  return {
+    viewHelper: { render: vi.fn() },
+    recreateViewHelper: vi.fn(),
+    visibleViewHelper: vi.fn(),
+    update: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+export function makeLoaderManagerStub(
+  capabilities: ModelAdapterCapabilities | null = {
+    fitToViewer: true,
+    requiresMaterialRebuild: false,
+    gizmoTransform: true,
+    lighting: true,
+    exportable: true,
+    materialModes: ['original', 'normal', 'wireframe']
+  },
+  kind: 'mesh' | 'pointCloud' | 'splat' | null = 'mesh'
+) {
+  const adapter =
+    kind === null || capabilities === null
+      ? null
+      : { kind, extensions: [], capabilities, load: vi.fn() }
+  return {
+    loadModel: vi.fn().mockResolvedValue(undefined),
+    getCurrentAdapter: vi.fn(() => adapter),
+    init: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+type ModelManagerStub = {
+  fitToViewer: ReturnType<typeof vi.fn>
+  clearModel: ReturnType<typeof vi.fn>
+  setMaterialMode: ReturnType<typeof vi.fn>
+  setUpDirection: ReturnType<typeof vi.fn>
+  setShowSkeleton: ReturnType<typeof vi.fn>
+  hasSkeleton: ReturnType<typeof vi.fn<() => boolean>>
+  showSkeleton: boolean
+  currentModel: THREE.Object3D | null
+  originalModel: unknown
+  originalFileName: string | null
+  originalURL: string | null
+  dispose: ReturnType<typeof vi.fn>
+  setupModel: ReturnType<typeof vi.fn>
+  setOriginalModel: ReturnType<typeof vi.fn>
+  originalMaterials: WeakMap<THREE.Mesh, THREE.Material | THREE.Material[]>
+  standardMaterial: THREE.MeshStandardMaterial
+  materialMode: MaterialMode
+}
+
+export function makeModelManagerStub(): ModelManagerStub {
+  return {
+    fitToViewer: vi.fn(),
+    clearModel: vi.fn(),
+    setMaterialMode: vi.fn(),
+    setUpDirection: vi.fn(),
+    setShowSkeleton: vi.fn(),
+    hasSkeleton: vi.fn(() => false),
+    showSkeleton: false,
+    currentModel: null,
+    originalModel: null,
+    originalFileName: 'model',
+    originalURL: null,
+    dispose: vi.fn(),
+    setupModel: vi.fn().mockResolvedValue(undefined),
+    setOriginalModel: vi.fn(),
+    originalMaterials: new WeakMap(),
+    standardMaterial: new THREE.MeshStandardMaterial(),
+    materialMode: 'original'
+  }
+}
+
+export function makeRecordingManagerStub() {
+  return {
+    startRecording: vi.fn().mockResolvedValue(undefined),
+    stopRecording: vi.fn(),
+    getIsRecording: vi.fn(() => false),
+    getRecordingDuration: vi.fn(() => 0),
+    getRecordingData: vi.fn<() => string | null>(() => null),
+    exportRecording: vi.fn(),
+    clearRecording: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+type AnimationManagerStub = {
+  setupModelAnimations: ReturnType<typeof vi.fn>
+  setAnimationSpeed: ReturnType<typeof vi.fn>
+  updateSelectedAnimation: ReturnType<typeof vi.fn>
+  toggleAnimation: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+  animationClips: THREE.AnimationClip[]
+  isAnimationPlaying: boolean
+  getAnimationTime: ReturnType<typeof vi.fn<() => number>>
+  getAnimationDuration: ReturnType<typeof vi.fn<() => number>>
+  setAnimationTime: ReturnType<typeof vi.fn>
+  init: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+}
+
+export function makeAnimationManagerStub(): AnimationManagerStub {
+  return {
+    setupModelAnimations: vi.fn(),
+    setAnimationSpeed: vi.fn(),
+    updateSelectedAnimation: vi.fn(),
+    toggleAnimation: vi.fn(),
+    update: vi.fn(),
+    animationClips: [],
+    isAnimationPlaying: false,
+    getAnimationTime: vi.fn(() => 0),
+    getAnimationDuration: vi.fn(() => 0),
+    setAnimationTime: vi.fn(),
+    init: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+export function makeEventManagerStub() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  }
+}
+
+// jsdom/happy-dom report 0 for clientWidth/Height; override with deterministic
+// values so viewport-sensitive code (renderMainScene, handleResize) is testable.
+export function makeRendererStub(containerWidth = 800, containerHeight = 600) {
+  const canvas = document.createElement('canvas')
+  const parent = document.createElement('div')
+  parent.appendChild(canvas)
+
+  const setClientSize = (el: HTMLElement, width: number, height: number) => {
+    Object.defineProperty(el, 'clientWidth', {
+      value: width,
+      configurable: true
+    })
+    Object.defineProperty(el, 'clientHeight', {
+      value: height,
+      configurable: true
+    })
+  }
+  setClientSize(parent, containerWidth, containerHeight)
+  setClientSize(canvas, containerWidth, containerHeight)
+
+  return {
+    domElement: canvas,
+    setViewport: vi.fn(),
+    setScissor: vi.fn(),
+    setScissorTest: vi.fn(),
+    setClearColor: vi.fn(),
+    setSize: vi.fn(),
+    clear: vi.fn(),
+    render: vi.fn(),
+    forceContextLoss: vi.fn(),
+    dispose: vi.fn(),
+    parent
+  }
+}


### PR DESCRIPTION
## Summary
Add behavioural tests for Load3d, LoaderManager and the four Vue components that were effectively uncovered after the capability-driven refactor.

Coverage changes:
- Load3d.ts              9.74%  -> 81.84%
- LoaderManager.ts      27.03%  -> 100%
- Load3DControls.vue     0%     -> 93.93%
- ViewerModelControls    0%     -> 100%
- Load3D.vue             0%     -> ~92%
- Load3dViewerContent    0%     -> ~79%

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11553-test-expand-load3d-unit-test-coverage-34b6d73d365081efb1d6cd2e4ecb2042) by [Unito](https://www.unito.io)
