### PR TITLE
feat: add queue progress overlay feature survey

### DIFF
--- a/src/components/queue/JobHistoryActionsMenu.vue
+++ b/src/components/queue/JobHistoryActionsMenu.vue
@@ -98,6 +98,7 @@ import { useQueueFeatureFlags } from '@/composables/queue/useQueueFeatureFlags'
 import { buildTooltipConfig } from '@/composables/useTooltipConfig'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTracking'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
 const emit = defineEmits<{
@@ -107,6 +108,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const settingStore = useSettingStore()
 const sidebarTabStore = useSidebarTabStore()
+const { trackFeatureUsed } = useSurveyFeatureTracking('queue-progress-overlay')
 
 const moreTooltipConfig = computed(() => buildTooltipConfig(t('g.more')))
 const { isQueuePanelV2Enabled, isRunProgressBarEnabled } =
@@ -119,6 +121,7 @@ const onClearHistoryFromMenu = (close: () => void) => {
 }
 
 const onToggleDockedJobHistory = async (close: () => void) => {
+  trackFeatureUsed()
   close()
 
   try {
@@ -138,6 +141,7 @@ const onToggleDockedJobHistory = async (close: () => void) => {
 }
 
 const onToggleRunProgressBar = async () => {
+  trackFeatureUsed()
   await settingStore.set(
     'Comfy.Queue.ShowRunProgressBar',
     !isRunProgressBarEnabled.value

--- a/src/components/queue/QueueOverlayExpanded.vue
+++ b/src/components/queue/QueueOverlayExpanded.vue
@@ -103,14 +103,12 @@ const onUpdateSelectedJobTab = (value: JobTab) => {
 }
 
 const onMenuItem = (item: JobListItem, event: Event) => {
-  trackFeatureUsed()
   currentMenuItem.value = item
   jobContextMenuRef.value?.open(event)
 }
 
 const onJobMenuAction = wrapWithErrorHandlingAsync(async (entry: MenuEntry) => {
   if (entry.kind === 'divider') return
-  trackFeatureUsed()
   if (entry.onClick) await entry.onClick()
   jobContextMenuRef.value?.hide()
 })

--- a/src/components/queue/QueueOverlayExpanded.vue
+++ b/src/components/queue/QueueOverlayExpanded.vue
@@ -13,7 +13,7 @@
       :selected-sort-mode="selectedSortMode"
       :has-failed-jobs="hasFailedJobs"
       @show-assets="$emit('showAssets')"
-      @update:selected-job-tab="$emit('update:selectedJobTab', $event)"
+      @update:selected-job-tab="onUpdateSelectedJobTab"
       @update:selected-workflow-filter="
         $emit('update:selectedWorkflowFilter', $event)
       "
@@ -50,6 +50,7 @@ import type {
 import type { MenuEntry } from '@/composables/queue/useJobMenu'
 import { useJobMenu } from '@/composables/queue/useJobMenu'
 import { useErrorHandling } from '@/composables/useErrorHandling'
+import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTracking'
 
 import QueueOverlayHeader from './QueueOverlayHeader.vue'
 import JobContextMenu from './job/JobContextMenu.vue'
@@ -81,6 +82,7 @@ const emit = defineEmits<{
 const currentMenuItem = ref<JobListItem | null>(null)
 const jobContextMenuRef = ref<InstanceType<typeof JobContextMenu> | null>(null)
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
+const { trackFeatureUsed } = useSurveyFeatureTracking('queue-progress-overlay')
 
 const { jobMenuEntries } = useJobMenu(
   () => currentMenuItem.value,
@@ -95,13 +97,20 @@ const onDeleteItemEvent = (item: JobListItem) => {
   emit('deleteItem', item)
 }
 
+const onUpdateSelectedJobTab = (value: JobTab) => {
+  trackFeatureUsed()
+  emit('update:selectedJobTab', value)
+}
+
 const onMenuItem = (item: JobListItem, event: Event) => {
+  trackFeatureUsed()
   currentMenuItem.value = item
   jobContextMenuRef.value?.open(event)
 }
 
 const onJobMenuAction = wrapWithErrorHandlingAsync(async (entry: MenuEntry) => {
   if (entry.kind === 'divider') return
+  trackFeatureUsed()
   if (entry.onClick) await entry.onClick()
   jobContextMenuRef.value?.hide()
 })

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -66,6 +66,7 @@ import { useResultGallery } from '@/composables/queue/useResultGallery'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useAssetSelectionStore } from '@/platform/assets/composables/useAssetSelectionStore'
 import { isCloud } from '@/platform/distribution/types'
+import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTracking'
 import { api } from '@/scripts/api'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useCommandStore } from '@/stores/commandStore'
@@ -93,6 +94,7 @@ const assetsStore = useAssetsStore()
 const assetSelectionStore = useAssetSelectionStore()
 const { showQueueClearHistoryDialog } = useQueueClearHistoryDialog()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
+const { trackFeatureUsed } = useSurveyFeatureTracking('queue-progress-overlay')
 
 const {
   totalPercentFormatted,
@@ -188,6 +190,7 @@ const {
 const displayedJobGroups = computed(() => groupedJobItems.value)
 
 const onCancelItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
+  trackFeatureUsed()
   const jobId = item.taskRef?.jobId
   if (!jobId) return
 
@@ -209,6 +212,7 @@ const onCancelItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
 })
 
 const onDeleteItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
+  trackFeatureUsed()
   if (!item.taskRef) return
   await queueStore.delete(item.taskRef)
 })
@@ -224,10 +228,12 @@ const setExpanded = (expanded: boolean) => {
 }
 
 const viewAllJobs = () => {
+  trackFeatureUsed()
   setExpanded(true)
 }
 
 const toggleAssetsSidebar = () => {
+  trackFeatureUsed()
   sidebarTabStore.toggleSidebarTab('assets')
 }
 
@@ -257,12 +263,14 @@ const focusAssetInSidebar = async (item: JobListItem) => {
 
 const inspectJobAsset = wrapWithErrorHandlingAsync(
   async (item: JobListItem) => {
+    trackFeatureUsed()
     await openResultGallery(item)
     await focusAssetInSidebar(item)
   }
 )
 
 const cancelQueuedWorkflows = wrapWithErrorHandlingAsync(async () => {
+  trackFeatureUsed()
   // Capture pending jobIds before clearing
   const pendingJobIds = queueStore.pendingTasks
     .map((task) => task.jobId)
@@ -275,6 +283,7 @@ const cancelQueuedWorkflows = wrapWithErrorHandlingAsync(async () => {
 })
 
 const interruptAll = wrapWithErrorHandlingAsync(async () => {
+  trackFeatureUsed()
   const tasks = queueStore.runningTasks
   const jobIds = tasks
     .map((task) => task.jobId)
@@ -298,6 +307,7 @@ const interruptAll = wrapWithErrorHandlingAsync(async () => {
 })
 
 const onClearHistoryFromMenu = () => {
+  trackFeatureUsed()
   showQueueClearHistoryDialog()
 }
 </script>

--- a/src/components/queue/job/JobFilterActions.vue
+++ b/src/components/queue/job/JobFilterActions.vue
@@ -122,6 +122,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { jobSortModes } from '@/composables/queue/useJobList'
 import type { JobSortMode } from '@/composables/queue/useJobList'
 import { buildTooltipConfig } from '@/composables/useTooltipConfig'
+import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTracking'
 
 const {
   hideShowAssetsAction = false,
@@ -147,6 +148,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { trackFeatureUsed } = useSurveyFeatureTracking('queue-progress-overlay')
 
 const filterTooltipConfig = computed(() =>
   buildTooltipConfig(t('sideToolbar.queueProgressOverlay.filterBy'))
@@ -170,6 +172,7 @@ const onSelectWorkflowFilter = (
   value: 'all' | 'current',
   close: () => void
 ) => {
+  trackFeatureUsed()
   selectWorkflowFilter(value)
   close()
 }
@@ -179,6 +182,7 @@ const selectSortMode = (value: JobSortMode) => {
 }
 
 const onSelectSortMode = (value: JobSortMode, close: () => void) => {
+  trackFeatureUsed()
   selectSortMode(value)
   close()
 }

--- a/src/components/sidebar/tabs/JobHistorySidebarTab.vue
+++ b/src/components/sidebar/tabs/JobHistorySidebarTab.vue
@@ -220,14 +220,12 @@ const onDeleteItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
 })
 
 const onMenuItem = (item: JobListItem, event: Event) => {
-  trackFeatureUsed()
   currentMenuItem.value = item
   jobContextMenuRef.value?.open(event)
 }
 
 const onJobMenuAction = wrapWithErrorHandlingAsync(async (entry: MenuEntry) => {
   if (entry.kind === 'divider') return
-  trackFeatureUsed()
   if (entry.onClick) await entry.onClick()
   jobContextMenuRef.value?.hide()
 })

--- a/src/components/sidebar/tabs/JobHistorySidebarTab.vue
+++ b/src/components/sidebar/tabs/JobHistorySidebarTab.vue
@@ -2,15 +2,16 @@
   <SidebarTabTemplate :title="$t('queue.jobHistory')">
     <template #alt-title>
       <div class="ml-auto flex shrink-0 items-center">
-        <JobHistoryActionsMenu @clear-history="showQueueClearHistoryDialog" />
+        <JobHistoryActionsMenu @clear-history="onClearHistory" />
       </div>
     </template>
     <template #header>
       <div class="flex flex-col gap-2 pb-1">
         <div class="px-3 py-2">
           <JobFilterTabs
-            v-model:selected-job-tab="selectedJobTab"
+            :selected-job-tab="selectedJobTab"
             :has-failed-jobs="hasFailedJobs"
+            @update:selected-job-tab="onUpdateSelectedJobTab"
           />
         </div>
         <JobFilterActions
@@ -81,13 +82,14 @@ import JobHistoryActionsMenu from '@/components/queue/JobHistoryActionsMenu.vue'
 import type { MenuEntry } from '@/composables/queue/useJobMenu'
 import { useJobMenu } from '@/composables/queue/useJobMenu'
 import { useJobList } from '@/composables/queue/useJobList'
-import type { JobListItem } from '@/composables/queue/useJobList'
+import type { JobListItem, JobTab } from '@/composables/queue/useJobList'
 import { useQueueClearHistoryDialog } from '@/composables/queue/useQueueClearHistoryDialog'
 import { useResultGallery } from '@/composables/queue/useResultGallery'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import SidebarTabTemplate from '@/components/sidebar/tabs/SidebarTabTemplate.vue'
 import MediaLightbox from '@/components/sidebar/tabs/queue/MediaLightbox.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTracking'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useExecutionStore } from '@/stores/executionStore'
@@ -104,6 +106,17 @@ const executionStore = useExecutionStore()
 const queueStore = useQueueStore()
 const { showQueueClearHistoryDialog } = useQueueClearHistoryDialog()
 const { wrapWithErrorHandlingAsync } = useErrorHandling()
+const { trackFeatureUsed } = useSurveyFeatureTracking('queue-progress-overlay')
+
+const onClearHistory = () => {
+  trackFeatureUsed()
+  showQueueClearHistoryDialog()
+}
+
+const onUpdateSelectedJobTab = (value: JobTab) => {
+  trackFeatureUsed()
+  selectedJobTab.value = value
+}
 const {
   selectedJobTab,
   selectedWorkflowFilter,
@@ -145,6 +158,7 @@ const activeQueueSummary = computed(() => {
 })
 
 const clearQueuedWorkflows = wrapWithErrorHandlingAsync(async () => {
+  trackFeatureUsed()
   const pendingJobIds = queueStore.pendingTasks
     .map((task) => task.jobId)
     .filter((id): id is string => typeof id === 'string' && id.length > 0)
@@ -160,6 +174,7 @@ const {
 } = useResultGallery(() => filteredTasks.value)
 
 const onViewItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
+  trackFeatureUsed()
   const previewOutput = item.taskRef?.previewOutput
 
   if (previewOutput?.is3D) {
@@ -194,21 +209,25 @@ const { jobMenuEntries, cancelJob } = useJobMenu(
 )
 
 const onCancelItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
+  trackFeatureUsed()
   await cancelJob(item)
 })
 
 const onDeleteItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
+  trackFeatureUsed()
   if (!item.taskRef) return
   await queueStore.delete(item.taskRef)
 })
 
 const onMenuItem = (item: JobListItem, event: Event) => {
+  trackFeatureUsed()
   currentMenuItem.value = item
   jobContextMenuRef.value?.open(event)
 }
 
 const onJobMenuAction = wrapWithErrorHandlingAsync(async (entry: MenuEntry) => {
   if (entry.kind === 'divider') return
+  trackFeatureUsed()
   if (entry.onClick) await entry.onClick()
   jobContextMenuRef.value?.hide()
 })

--- a/src/platform/surveys/surveyRegistry.ts
+++ b/src/platform/surveys/surveyRegistry.ts
@@ -11,6 +11,12 @@ export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {
     triggerThreshold: 3,
     delayMs: 5000
   },
+  'queue-progress-overlay': {
+    featureId: 'queue-progress-overlay',
+    typeformId: 'HZ5saxry',
+    triggerThreshold: 16,
+    delayMs: 5000
+  },
   'error-panel': {
     featureId: 'error-panel',
     typeformId: 'iFp4p4mV',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Registers a new nightly feature survey for the Queue Progress Overlay using the existing feature-survey registry (same pattern as the merged node-search survey, PRs #8175/#8355/#9934).

- New registry entry `queue-progress-overlay` → Typeform `HZ5saxry`, threshold **16**, 5s display delay.
- `trackFeatureUsed()` wired at the major user-initiated handlers inside the overlay so the survey triggers regardless of panel location (floating-right v1 or docked-left v2).
- Run button and other ActionBar items that the overlay pops over from are deliberately **not** tracked — tracking is scoped to interactions that originate inside the job panel / queue progress overlay itself.

## Tracked interactions

Both variants share most sub-components, so tracking is instrumented once at each logical surface:

- **`QueueProgressOverlay.vue`** (v1 container): `viewAllJobs`, `interruptAll`, `cancelQueuedWorkflows`, `onClearHistoryFromMenu`, `toggleAssetsSidebar`, `onCancelItem`, `onDeleteItem`, `inspectJobAsset`
- **`QueueOverlayExpanded.vue`**: job tab switches
- **`JobHistorySidebarTab.vue`** (v2 docked): job tab switches, `clearQueuedWorkflows`, `onClearHistory`, `onCancelItem`, `onDeleteItem`, `onViewItem`
- **`JobFilterActions.vue`** (shared): workflow filter + sort mode selections
- **`JobHistoryActionsMenu.vue`** (shared): docked-history toggle + run-progress-bar toggle

Deliberately **not tracked** to keep the signal clean:
- Hover handlers (ambient preview behaviour)
- Search-box keystrokes (debounced typing)
- Context menu open and menu-item dispatch — menu actions either bubble through already-tracked terminal handlers (e.g. inspect-asset → `onViewItem`) or are secondary operations (copy-id, open-workflow, download). Avoids double-counting per code review feedback.

## How it works (inherits from existing infrastructure)

1. `surveyRegistry.ts` drives `NightlySurveyController` → `NightlySurveyPopover`, which handles the Typeform embed.
2. Eligibility already gated on `isNightly && !isCloud && !isDesktop`, once-per-user, 4-day global cooldown across all surveys, and opt-out.
3. Typeform response routing to #C0ALLT6Q3SQ is handled on the Typeform side.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (no new warnings)
- `pnpm knip` ✅
- `pnpm test:unit` on `src/components/queue`, `src/components/sidebar/tabs/JobHistorySidebarTab`, `src/platform/surveys` → **123/123 passing**
- Pre-commit hooks (stylelint, oxfmt, oxlint, eslint, typecheck) all pass
- Manual: dev server + backend boot cleanly, app loads without new runtime errors, `localStorage['Comfy.FeatureUsage']` layout verified to match what `useFeatureUsageTracker` writes

## Notes

- Survey key `queue-progress-overlay` covers both v1 (floating-right) and v2 (docked-sidebar) per product guidance: _"This should trigger regardless of the location of the panel (docked from left or floating on right)."_ Both surfaces are the same product feature — the survey is intentionally scoped to the whole job-panel experience.


## Screenshots

![App loads cleanly with the new survey code in place — empty canvas with Run button and sidebar, no runtime errors](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/fd18977704544ba278ad3fa42c695289ae7e02001550ce38955d6fb47d872146/pr-images/1776914667332-03e4ef0a-4137-47c6-87b8-b554770b8900.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11560-feat-add-queue-progress-overlay-feature-survey-34b6d73d3650819a9a50fd67fd9b5941) by [Unito](https://www.unito.io)
