### PR TITLE
test: add E2E tests for ActionBarButtons toolbar component

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -89,7 +89,8 @@ export const TestIds = {
     subscribeButton: 'topbar-subscribe-button',
     loginButton: 'login-button',
     loginButtonPopover: 'login-button-popover',
-    loginButtonPopoverLearnMore: 'login-button-popover-learn-more'
+    loginButtonPopoverLearnMore: 'login-button-popover-learn-more',
+    actionBarButtons: 'action-bar-buttons'
   },
   nodeLibrary: {
     bookmarksSection: 'node-library-bookmarks-section'

--- a/browser_tests/tests/actionBarButtons.spec.ts
+++ b/browser_tests/tests/actionBarButtons.spec.ts
@@ -1,0 +1,167 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+const ICON_CLASS = 'icon-[lucide--star]'
+const BUTTON_LABEL = 'Test Action'
+const BUTTON_TOOLTIP = 'Test action tooltip'
+
+test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.setup()
+  })
+
+  test.describe('Empty state', () => {
+    test('container is hidden when no extension registers buttons', async ({
+      comfyPage
+    }) => {
+      const container = comfyPage.page.getByTestId(
+        TestIds.topbar.actionBarButtons
+      )
+      await expect(container).toBeHidden()
+    })
+  })
+
+  test.describe('Button rendering', () => {
+    test('registered button is visible with correct label', async ({
+      comfyPage
+    }) => {
+      await comfyPage.page.evaluate(
+        ({ icon, label, tooltip }) => {
+          window.app!.registerExtension({
+            name: 'TestActionBarButton',
+            actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
+          })
+        },
+        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
+      )
+
+      const container = comfyPage.page.getByTestId(
+        TestIds.topbar.actionBarButtons
+      )
+      await expect(container).toBeVisible()
+      await expect(
+        container.getByRole('button', { name: BUTTON_TOOLTIP })
+      ).toBeVisible()
+      await expect(container.getByText(BUTTON_LABEL)).toBeVisible()
+    })
+
+    test('button icon is rendered', async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(
+        ({ icon, label, tooltip }) => {
+          window.app!.registerExtension({
+            name: 'TestActionBarButton',
+            actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
+          })
+        },
+        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
+      )
+
+      const container = comfyPage.page.getByTestId(
+        TestIds.topbar.actionBarButtons
+      )
+      const icon = container
+        .getByRole('button', { name: BUTTON_TOOLTIP })
+        .locator('i')
+      await expect(icon).toHaveClass(new RegExp(ICON_CLASS))
+    })
+
+    test('multiple registered buttons all appear', async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(() => {
+        window.app!.registerExtension({
+          name: 'TestActionBarButtons',
+          actionBarButtons: [
+            {
+              icon: 'icon-[lucide--star]',
+              label: 'First',
+              tooltip: 'First action',
+              onClick: () => {}
+            },
+            {
+              icon: 'icon-[lucide--heart]',
+              label: 'Second',
+              tooltip: 'Second action',
+              onClick: () => {}
+            }
+          ]
+        })
+      })
+
+      const container = comfyPage.page.getByTestId(
+        TestIds.topbar.actionBarButtons
+      )
+      await expect(
+        container.getByRole('button', { name: 'First action' })
+      ).toBeVisible()
+      await expect(
+        container.getByRole('button', { name: 'Second action' })
+      ).toBeVisible()
+    })
+  })
+
+  test.describe('Click handler', () => {
+    test('clicking a button fires its onClick handler', async ({
+      comfyPage
+    }) => {
+      await comfyPage.page.evaluate(
+        ({ icon, label, tooltip }) => {
+          ;(
+            window as typeof window & { __testClicked: boolean }
+          ).__testClicked = false
+          window.app!.registerExtension({
+            name: 'TestActionBarButton',
+            actionBarButtons: [
+              {
+                icon,
+                label,
+                tooltip,
+                onClick: () => {
+                  ;(
+                    window as typeof window & { __testClicked: boolean }
+                  ).__testClicked = true
+                }
+              }
+            ]
+          })
+        },
+        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
+      )
+
+      const button = comfyPage.page
+        .getByTestId(TestIds.topbar.actionBarButtons)
+        .getByRole('button', { name: BUTTON_TOOLTIP })
+      await button.click()
+
+      await expect
+        .poll(() =>
+          comfyPage.page.evaluate(
+            () =>
+              (window as typeof window & { __testClicked: boolean })
+                .__testClicked
+          )
+        )
+        .toBe(true)
+    })
+  })
+
+  test.describe('Mobile layout', { tag: ['@mobile'] }, () => {
+    test('button label is hidden on mobile viewport', async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(
+        ({ icon, label, tooltip }) => {
+          window.app!.registerExtension({
+            name: 'TestActionBarButton',
+            actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
+          })
+        },
+        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
+      )
+
+      const container = comfyPage.page.getByTestId(
+        TestIds.topbar.actionBarButtons
+      )
+      await expect(container).toBeVisible()
+      await expect(container.getByText(BUTTON_LABEL)).toBeHidden()
+    })
+  })
+})

--- a/browser_tests/tests/actionBarButtons.spec.ts
+++ b/browser_tests/tests/actionBarButtons.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
@@ -6,6 +7,32 @@ import { TestIds } from '@e2e/fixtures/selectors'
 const ICON_CLASS = 'icon-[lucide--star]'
 const BUTTON_LABEL = 'Test Action'
 const BUTTON_TOOLTIP = 'Test action tooltip'
+
+async function registerTestButton(
+  page: Page,
+  opts: {
+    name?: string
+    icon?: string
+    label?: string
+    tooltip?: string
+    onClick?: () => void
+  } = {}
+): Promise<void> {
+  await page.evaluate(
+    ({ name, icon, label, tooltip }) => {
+      window.app!.registerExtension({
+        name,
+        actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
+      })
+    },
+    {
+      name: opts.name ?? 'TestActionBarButton',
+      icon: opts.icon ?? ICON_CLASS,
+      label: opts.label ?? BUTTON_LABEL,
+      tooltip: opts.tooltip ?? BUTTON_TOOLTIP
+    }
+  )
+}
 
 test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -16,10 +43,9 @@ test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
     test('container is hidden when no extension registers buttons', async ({
       comfyPage
     }) => {
-      const container = comfyPage.page.getByTestId(
-        TestIds.topbar.actionBarButtons
-      )
-      await expect(container).toBeHidden()
+      await expect(
+        comfyPage.page.getByTestId(TestIds.topbar.actionBarButtons)
+      ).toBeHidden()
     })
   })
 
@@ -27,16 +53,7 @@ test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
     test('registered button is visible with correct label', async ({
       comfyPage
     }) => {
-      await comfyPage.page.evaluate(
-        ({ icon, label, tooltip }) => {
-          window.app!.registerExtension({
-            name: 'TestActionBarButton',
-            actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
-          })
-        },
-        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
-      )
-
+      await registerTestButton(comfyPage.page)
       const container = comfyPage.page.getByTestId(
         TestIds.topbar.actionBarButtons
       )
@@ -48,23 +65,12 @@ test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
     })
 
     test('button icon is rendered', async ({ comfyPage }) => {
-      await comfyPage.page.evaluate(
-        ({ icon, label, tooltip }) => {
-          window.app!.registerExtension({
-            name: 'TestActionBarButton',
-            actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
-          })
-        },
-        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
-      )
-
-      const container = comfyPage.page.getByTestId(
-        TestIds.topbar.actionBarButtons
-      )
-      const icon = container
+      await registerTestButton(comfyPage.page)
+      const icon = comfyPage.page
+        .getByTestId(TestIds.topbar.actionBarButtons)
         .getByRole('button', { name: BUTTON_TOOLTIP })
         .locator('i')
-      await expect(icon).toHaveClass(new RegExp(ICON_CLASS))
+      await expect(icon).toHaveClass(ICON_CLASS)
     })
 
     test('multiple registered buttons all appear', async ({ comfyPage }) => {
@@ -147,16 +153,7 @@ test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
 
   test.describe('Mobile layout', { tag: ['@mobile'] }, () => {
     test('button label is hidden on mobile viewport', async ({ comfyPage }) => {
-      await comfyPage.page.evaluate(
-        ({ icon, label, tooltip }) => {
-          window.app!.registerExtension({
-            name: 'TestActionBarButton',
-            actionBarButtons: [{ icon, label, tooltip, onClick: () => {} }]
-          })
-        },
-        { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
-      )
-
+      await registerTestButton(comfyPage.page)
       const container = comfyPage.page.getByTestId(
         TestIds.topbar.actionBarButtons
       )

--- a/browser_tests/tests/actionBarButtons.spec.ts
+++ b/browser_tests/tests/actionBarButtons.spec.ts
@@ -15,7 +15,6 @@ async function registerTestButton(
     icon?: string
     label?: string
     tooltip?: string
-    onClick?: () => void
   } = {}
 ): Promise<void> {
   await page.evaluate(
@@ -35,10 +34,6 @@ async function registerTestButton(
 }
 
 test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
-  test.beforeEach(async ({ comfyPage }) => {
-    await comfyPage.setup()
-  })
-
   test.describe('Empty state', () => {
     test('container is hidden when no extension registers buttons', async ({
       comfyPage
@@ -110,27 +105,16 @@ test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
     test('clicking a button fires its onClick handler', async ({
       comfyPage
     }) => {
-      await comfyPage.page.evaluate(
-        ({ icon, label, tooltip }) => {
-          ;(
-            window as typeof window & { __testClicked: boolean }
-          ).__testClicked = false
-          window.app!.registerExtension({
-            name: 'TestActionBarButton',
-            actionBarButtons: [
-              {
-                icon,
-                label,
-                tooltip,
-                onClick: () => {
-                  ;(
-                    window as typeof window & { __testClicked: boolean }
-                  ).__testClicked = true
-                }
-              }
-            ]
-          })
-        },
+      const onClickFired = comfyPage.page.evaluate(
+        ({ icon, label, tooltip }) =>
+          new Promise<boolean>((resolve) => {
+            window.app!.registerExtension({
+              name: 'TestActionBarButton',
+              actionBarButtons: [
+                { icon, label, tooltip, onClick: () => resolve(true) }
+              ]
+            })
+          }),
         { icon: ICON_CLASS, label: BUTTON_LABEL, tooltip: BUTTON_TOOLTIP }
       )
 
@@ -139,15 +123,7 @@ test.describe('ActionBar Buttons', { tag: ['@ui'] }, () => {
         .getByRole('button', { name: BUTTON_TOOLTIP })
       await button.click()
 
-      await expect
-        .poll(() =>
-          comfyPage.page.evaluate(
-            () =>
-              (window as typeof window & { __testClicked: boolean })
-                .__testClicked
-          )
-        )
-        .toBe(true)
+      await expect(onClickFired).resolves.toBe(true)
     })
   })
 

--- a/src/components/topbar/ActionBarButtons.vue
+++ b/src/components/topbar/ActionBarButtons.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="flex h-full shrink-0 items-center gap-1 empty:hidden">
+  <div
+    data-testid="action-bar-buttons"
+    class="flex h-full shrink-0 items-center gap-1 empty:hidden"
+  >
     <Button
       v-for="(button, index) in actionBarButtonStore.buttons"
       :key="index"


### PR DESCRIPTION
## Summary

- Add E2E tests for the `ActionBarButtons` toolbar component (FE-111)
- Add `data-testid="action-bar-buttons"` to the container div for stable test targeting
- Register `TestIds.topbar.actionBarButtons` in `selectors.ts`

## Changes

- `browser_tests/tests/actionBarButtons.spec.ts` — 6 tests across 5 scenarios: empty state, button rendering, icon rendering, multiple buttons, click handler, mobile label hiding
- `src/components/topbar/ActionBarButtons.vue` — adds `data-testid` to container
- `browser_tests/fixtures/selectors.ts` — registers new test ID

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds Playwright coverage and a `data-testid` attribute; runtime behavior is unchanged aside from an extra DOM attribute.
> 
> **Overview**
> Adds a new Playwright spec (`actionBarButtons.spec.ts`) that verifies the ActionBarButtons container empty state, rendering (label/icon), multiple buttons, click handler execution, and mobile label-hiding behavior by registering buttons via `window.app!.registerExtension`.
> 
> Updates the UI and test selector plumbing by adding `data-testid="action-bar-buttons"` to `ActionBarButtons.vue` and exposing it as `TestIds.topbar.actionBarButtons` for stable E2E targeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f90d1f1d97ccff04ce4e3d088750a36198122e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11561-test-add-E2E-tests-for-ActionBarButtons-toolbar-component-34b6d73d36508153874fda856a78817f) by [Unito](https://www.unito.io)
