### PR TITLE
test: e2e coverage for node templates

### DIFF
--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -20,8 +20,16 @@ export class ContextMenu {
     await this.page.getByRole('menuitem', { name, exact: true }).click()
   }
 
+  /**
+   * Click a litegraph menu entry. Selects the most recently opened matching
+   * entry so nested submenu items can be reached without being shadowed by
+   * the parent menu still visible behind them.
+   */
   async clickLitegraphMenuItem(name: string): Promise<void> {
-    await this.page.locator(`.litemenu-entry:has-text("${name}")`).click()
+    await this.page
+      .locator('.litemenu-entry:visible', { hasText: name })
+      .last()
+      .click()
   }
 
   async isVisible(): Promise<boolean> {

--- a/browser_tests/fixtures/components/NodeTemplatesManageDialog.ts
+++ b/browser_tests/fixtures/components/NodeTemplatesManageDialog.ts
@@ -1,0 +1,27 @@
+import type { Locator, Page } from '@playwright/test'
+
+import { BaseDialog } from '@e2e/fixtures/components/BaseDialog'
+import { TestIds } from '@e2e/fixtures/selectors'
+
+export class NodeTemplatesManageDialog extends BaseDialog {
+  public readonly rows: Locator
+  /**
+   * Hidden `<input type="file">` used by the Import button. Attached to
+   * `document.body` (not inside the dialog) by the legacy extension, so it
+   * cannot be scoped via `this.root`.
+   */
+  public readonly importInput: Locator
+
+  constructor(page: Page) {
+    super(page, TestIds.nodeTemplates.manageDialog)
+    this.rows = this.root.locator('.templateManagerRow')
+    this.importInput = page.locator('input[type="file"][accept=".json"]')
+  }
+
+  rowByName(name: string): Locator {
+    const escaped = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+    return this.rows.filter({
+      has: this.page.locator(`input[data-name="${escaped}"]`)
+    })
+  }
+}

--- a/browser_tests/fixtures/constants/defaultGraphPositions.ts
+++ b/browser_tests/fixtures/constants/defaultGraphPositions.ts
@@ -1,7 +1,7 @@
 import type { Position } from '@e2e/fixtures/constants/types'
 
 /**
- * Hardcoded positions for the default graph loaded in tests.
+ * Hardcoded positions for the default graph loaded in tests with the legacy menu.
  * These coordinates are specific to the default workflow viewport.
  */
 export const DefaultGraphPositions = {
@@ -50,4 +50,14 @@ export const DefaultGraphPositions = {
   ksampler: { pos: Position; size: { width: number; height: number } }
   loadCheckpoint: { pos: Position; size: { width: number; height: number } }
   emptyLatent: { pos: Position; size: { width: number; height: number } }
+}
+
+/**
+ * Hardcoded positions for the default graph loaded in tests with the new default menu.
+ * These coordinates are specific to the default workflow viewport.
+ */
+export const DefaultGraphNewMenuPositions = {
+  emptyCanvasClick: { x: 200, y: 200 }
+} as const satisfies {
+  emptyCanvasClick: Position
 }

--- a/browser_tests/fixtures/helpers/NodeTemplatesHelper.ts
+++ b/browser_tests/fixtures/helpers/NodeTemplatesHelper.ts
@@ -1,0 +1,64 @@
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { NodeTemplatesManageDialog } from '@e2e/fixtures/components/NodeTemplatesManageDialog'
+import { DefaultGraphNewMenuPositions } from '@e2e/fixtures/constants/defaultGraphPositions'
+import type { UserDataHelper } from '@e2e/fixtures/helpers/UserDataHelper'
+
+const TEMPLATES_FILE = 'comfy.templates.json'
+
+export class NodeTemplatesHelper {
+  public readonly manageDialog: NodeTemplatesManageDialog
+
+  constructor(
+    private readonly comfyPage: ComfyPage,
+    private readonly userData: UserDataHelper
+  ) {
+    this.manageDialog = new NodeTemplatesManageDialog(comfyPage.page)
+  }
+
+  /**
+   * Delete the per-user template store server-side.
+   */
+  async reset(): Promise<void> {
+    await this.userData.delete(TEMPLATES_FILE)
+  }
+
+  private async openCanvasMenu(): Promise<void> {
+    await this.comfyPage.canvasOps.mouseClickAt(
+      DefaultGraphNewMenuPositions.emptyCanvasClick,
+      { button: 'right' }
+    )
+  }
+
+  private async openTemplateSubmenu(): Promise<void> {
+    await this.openCanvasMenu()
+    await this.comfyPage.contextMenu.clickLitegraphMenuItem('Node Templates')
+  }
+
+  async saveKSamplerAsTemplate(name: string): Promise<void> {
+    const ksampler = (
+      await this.comfyPage.nodeOps.getNodeRefsByType('KSampler')
+    )[0]
+    await ksampler.click('title')
+    await this.saveSelectionAsTemplate(name)
+  }
+
+  async saveSelectionAsTemplate(name: string): Promise<void> {
+    await this.openCanvasMenu()
+    await this.comfyPage.contextMenu.clickLitegraphMenuItem(
+      'Save Selected as Template'
+    )
+    await this.comfyPage.nodeOps.fillPromptDialog(name)
+  }
+
+  async insertTemplate(name: string): Promise<void> {
+    await this.openTemplateSubmenu()
+    await this.comfyPage.contextMenu.clickLitegraphMenuItem(name)
+    await this.comfyPage.contextMenu.waitForHidden()
+  }
+
+  async openManageDialog(): Promise<void> {
+    await this.openTemplateSubmenu()
+    await this.comfyPage.contextMenu.clickLitegraphMenuItem('Manage')
+    await this.manageDialog.waitForVisible()
+  }
+}

--- a/browser_tests/fixtures/helpers/UserDataHelper.ts
+++ b/browser_tests/fixtures/helpers/UserDataHelper.ts
@@ -1,0 +1,26 @@
+import type { APIRequestContext } from '@playwright/test'
+
+/**
+ * Interact with the ComfyUI per-user storage (`/api/userdata/...`) from
+ * outside the browser context. Useful for test setup/teardown that needs
+ * to reset server-persisted state (node templates, keybinding presets, etc.)
+ * without reloading the app.
+ */
+export class UserDataHelper {
+  constructor(
+    private readonly request: APIRequestContext,
+    private readonly userId: string,
+    private readonly baseUrl: string
+  ) {}
+
+  async delete(file: string): Promise<void> {
+    const res = await this.request.fetch(
+      `${this.baseUrl}/api/userdata/${encodeURIComponent(file)}`,
+      { method: 'DELETE', headers: { 'Comfy-User': this.userId } }
+    )
+    if (!res.ok() && res.status() !== 404)
+      throw new Error(
+        `Failed to delete userdata file "${file}": HTTP ${res.status()}`
+      )
+  }
+}

--- a/browser_tests/fixtures/nodeTemplatesFixture.ts
+++ b/browser_tests/fixtures/nodeTemplatesFixture.ts
@@ -1,0 +1,18 @@
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { NodeTemplatesHelper } from '@e2e/fixtures/helpers/NodeTemplatesHelper'
+import { UserDataHelper } from '@e2e/fixtures/helpers/UserDataHelper'
+
+export const nodeTemplatesFixture = comfyPageFixture.extend<{
+  nodeTemplates: NodeTemplatesHelper
+}>({
+  nodeTemplates: async ({ comfyPage }, use) => {
+    const userData = new UserDataHelper(
+      comfyPage.request,
+      comfyPage.id,
+      comfyPage.url
+    )
+    const helper = new NodeTemplatesHelper(comfyPage, userData)
+    await helper.reset()
+    await use(helper)
+  }
+})

--- a/browser_tests/fixtures/nodeTemplatesFixture.ts
+++ b/browser_tests/fixtures/nodeTemplatesFixture.ts
@@ -13,6 +13,7 @@ export const nodeTemplatesFixture = comfyPageFixture.extend<{
     )
     const helper = new NodeTemplatesHelper(comfyPage, userData)
     await helper.reset()
+    await comfyPage.workflow.reloadAndWaitForApp()
     await use(helper)
   }
 })

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -76,6 +76,9 @@ export const TestIds = {
   keybindings: {
     presetMenu: 'keybinding-preset-menu'
   },
+  nodeTemplates: {
+    manageDialog: 'manage-node-templates-dialog'
+  },
   topbar: {
     queueButton: 'queue-button',
     queueModeMenuTrigger: 'queue-mode-menu-trigger',

--- a/browser_tests/tests/nodeTemplates.spec.ts
+++ b/browser_tests/tests/nodeTemplates.spec.ts
@@ -68,12 +68,16 @@ function defineNodeTemplatesTests(mode: NodeMode) {
       const row = manageDialog.rowByName(name)
       await expect(row).toHaveCount(1)
 
-      const storeRequest = comfyPage.page.waitForRequest((req) =>
-        isStoreTemplatesRequest(req.url(), req.method())
+      const storeResponse = comfyPage.page.waitForResponse((res) =>
+        isStoreTemplatesRequest(res.url(), res.request().method())
       )
       await row.getByRole('button', { name: 'Delete' }).click()
-      const body = (await storeRequest).postData() ?? ''
-      const stored = JSON.parse(body) as { name: string; data: string }[]
+      const response = await storeResponse
+      expect(response.ok()).toBe(true)
+      const stored = JSON.parse(response.request().postData() ?? '') as {
+        name: string
+        data: string
+      }[]
       expect(stored.map((t) => t.name)).not.toContain(name)
 
       await expect(row).toHaveCount(0)
@@ -141,18 +145,15 @@ test.describe('Node Templates', { tag: ['@canvas'] }, () => {
       await nodeTemplates.openManageDialog()
       await expect(manageDialog.rowByName(name)).toHaveCount(0)
 
-      // Arm the store-request wait BEFORE triggering the upload so we can
-      // safely re-open the dialog only after the imported template has been
-      // pushed to in-memory state AND persisted server-side.
-      const storeRequest = comfyPage.page.waitForRequest((req) =>
-        isStoreTemplatesRequest(req.url(), req.method())
+      const storeResponse = comfyPage.page.waitForResponse((res) =>
+        isStoreTemplatesRequest(res.url(), res.request().method())
       )
       await manageDialog.importInput.setInputFiles({
         name: 'templates.json',
         mimeType: 'application/json',
         buffer: Buffer.from(JSON.stringify(payload))
       })
-      await storeRequest
+      expect((await storeResponse).ok()).toBe(true)
       await manageDialog.waitForHidden()
 
       await nodeTemplates.openManageDialog()

--- a/browser_tests/tests/nodeTemplates.spec.ts
+++ b/browser_tests/tests/nodeTemplates.spec.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs'
+
+import type { TestInfo } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import { nodeTemplatesFixture as test } from '@e2e/fixtures/nodeTemplatesFixture'
+
+type NodeMode = 'vue' | 'litegraph'
+
+function templateName(mode: NodeMode | 'shared', testInfo: TestInfo) {
+  return `tpl-${mode}-${testInfo.parallelIndex}-${testInfo.title.replace(/\W+/g, '-')}`
+}
+
+function isStoreTemplatesRequest(url: string, method: string): boolean {
+  return method === 'POST' && url.includes('/api/userdata/comfy.templates.json')
+}
+
+function defineNodeTemplatesTests(mode: NodeMode) {
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.canvasOps.resetView()
+  })
+
+  test('Save Selected as Template persists the selection under the given name', async ({
+    nodeTemplates
+  }, testInfo) => {
+    const name = templateName(mode, testInfo)
+    const { manageDialog } = nodeTemplates
+
+    await nodeTemplates.saveKSamplerAsTemplate(name)
+
+    await test.step('Manage dialog lists the saved template', async () => {
+      await nodeTemplates.openManageDialog()
+      await expect(manageDialog.rowByName(name)).toHaveCount(1)
+      await manageDialog.close()
+    })
+  })
+
+  test('Saved template appears in the submenu and pastes nodes on click', async ({
+    comfyPage,
+    nodeTemplates
+  }, testInfo) => {
+    const name = templateName(mode, testInfo)
+
+    await nodeTemplates.saveKSamplerAsTemplate(name)
+
+    const initialNodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+
+    await test.step('Insert template from canvas submenu', async () => {
+      await nodeTemplates.insertTemplate(name)
+    })
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+      .toBe(initialNodeCount + 1)
+  })
+
+  test('Deleting a template in the manage dialog removes it from the list', async ({
+    comfyPage,
+    nodeTemplates
+  }, testInfo) => {
+    const name = templateName(mode, testInfo)
+    const { manageDialog } = nodeTemplates
+
+    await nodeTemplates.saveKSamplerAsTemplate(name)
+
+    await test.step('Delete the template and assert it is persisted server-side', async () => {
+      await nodeTemplates.openManageDialog()
+      const row = manageDialog.rowByName(name)
+      await expect(row).toHaveCount(1)
+
+      const storeRequest = comfyPage.page.waitForRequest((req) =>
+        isStoreTemplatesRequest(req.url(), req.method())
+      )
+      await row.getByRole('button', { name: 'Delete' }).click()
+      const body = (await storeRequest).postData() ?? ''
+      const stored = JSON.parse(body) as { name: string; data: string }[]
+      expect(stored.map((t) => t.name)).not.toContain(name)
+
+      await expect(row).toHaveCount(0)
+      await manageDialog.close()
+    })
+  })
+}
+
+test.describe('Node Templates', { tag: ['@canvas'] }, () => {
+  test.describe('Vue nodes', { tag: ['@vue-nodes'] }, () => {
+    defineNodeTemplatesTests('vue')
+  })
+
+  test.describe('Litegraph nodes', () => {
+    defineNodeTemplatesTests('litegraph')
+  })
+
+  // Import/Export are dialog-only flows unaffected by node rendering mode;
+  // run once outside the Vue/Litegraph matrix.
+  test.describe('Dialog import/export', () => {
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.canvasOps.resetView()
+    })
+
+    test('Export downloads a JSON file containing the saved template', async ({
+      comfyPage,
+      nodeTemplates
+    }, testInfo) => {
+      const name = templateName('shared', testInfo)
+      const { manageDialog } = nodeTemplates
+
+      await nodeTemplates.saveKSamplerAsTemplate(name)
+
+      await test.step('Export and verify the downloaded file contents', async () => {
+        await nodeTemplates.openManageDialog()
+        const downloadPromise = comfyPage.page.waitForEvent('download')
+        await manageDialog
+          .rowByName(name)
+          .getByRole('button', { name: 'Export' })
+          .click()
+        const download = await downloadPromise
+
+        expect(download.suggestedFilename()).toContain(name)
+        const downloadPath = await download.path()
+        if (!downloadPath) throw new Error('Download path unavailable')
+        const parsed = JSON.parse(fs.readFileSync(downloadPath, 'utf-8')) as {
+          templates: { name: string; data: string }[]
+        }
+        expect(parsed.templates.map((t) => t.name)).toEqual([name])
+
+        await manageDialog.close()
+      })
+    })
+
+    test('Import adds templates from a JSON file', async ({
+      comfyPage,
+      nodeTemplates
+    }, testInfo) => {
+      const name = templateName('shared', testInfo)
+      const { manageDialog } = nodeTemplates
+      const payload = {
+        templates: [{ name, data: JSON.stringify({ nodes: [] }) }]
+      }
+
+      await nodeTemplates.openManageDialog()
+
+      // Arm the store-request wait BEFORE triggering the upload so we can
+      // safely re-open the dialog only after the imported template has been
+      // pushed to in-memory state AND persisted server-side.
+      const storeRequest = comfyPage.page.waitForRequest((req) =>
+        isStoreTemplatesRequest(req.url(), req.method())
+      )
+      await manageDialog.importInput.setInputFiles({
+        name: 'templates.json',
+        mimeType: 'application/json',
+        buffer: Buffer.from(JSON.stringify(payload))
+      })
+      await storeRequest
+      await manageDialog.waitForHidden()
+
+      await nodeTemplates.openManageDialog()
+      await expect(manageDialog.rowByName(name)).toHaveCount(1)
+      await manageDialog.close()
+    })
+  })
+})

--- a/browser_tests/tests/nodeTemplates.spec.ts
+++ b/browser_tests/tests/nodeTemplates.spec.ts
@@ -139,6 +139,7 @@ test.describe('Node Templates', { tag: ['@canvas'] }, () => {
       }
 
       await nodeTemplates.openManageDialog()
+      await expect(manageDialog.rowByName(name)).toHaveCount(0)
 
       // Arm the store-request wait BEFORE triggering the upload so we can
       // safely re-open the dialog only after the imported template has been

--- a/src/extensions/core/nodeTemplates.ts
+++ b/src/extensions/core/nodeTemplates.ts
@@ -51,6 +51,7 @@ class ManageTemplates extends ComfyDialog {
     })
 
     this.element.classList.add('comfy-manage-templates')
+    this.element.dataset.testid = 'manage-node-templates-dialog'
     this.draggedEl = null
     this.saveVisualCue = null
     this.emptyImg = new Image()


### PR DESCRIPTION
## Summary

Add E2E tests for node templates

## Changes

- **What**: 
- add tests for save, insert, delete, import export
- vue and litegraph
- add testid to dialog
- update `clickLitegraphMenuItem` to enable clicking children with the same name as parent

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11564-test-e2e-coverage-for-node-templates-34b6d73d365081a39ce5c713f05a2a92) by [Unito](https://www.unito.io)
