### PR TITLE
fix: dedupe keybinding modifier display

### DIFF
--- a/src/platform/keybindings/keyCombo.test.ts
+++ b/src/platform/keybindings/keyCombo.test.ts
@@ -3,6 +3,68 @@ import { describe, expect, it } from 'vitest'
 import { KeyComboImpl } from './keyCombo'
 
 describe('KeyComboImpl', () => {
+  function mockKeyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+    return {
+      key: '',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+      ...overrides
+    } as KeyboardEvent
+  }
+
+  describe('getKeySequences', () => {
+    it.each([
+      {
+        event: { key: 'Shift', shiftKey: true },
+        expected: ['Shift'],
+        label: 'Shift'
+      },
+      {
+        event: { key: 'Control', ctrlKey: true },
+        expected: ['Ctrl'],
+        label: 'Control'
+      },
+      {
+        event: { key: 'Alt', altKey: true },
+        expected: ['Alt'],
+        label: 'Alt'
+      },
+      {
+        event: { key: 'Meta', metaKey: true },
+        expected: ['Ctrl'],
+        label: 'Meta'
+      }
+    ])(
+      'does not duplicate a single $label modifier press',
+      ({ event, expected }) => {
+        const combo = KeyComboImpl.fromEvent(mockKeyEvent(event))
+
+        expect(combo.getKeySequences()).toEqual(expected)
+        expect(combo.toString()).toBe(expected.join(' + '))
+      }
+    )
+
+    it('lists held modifiers once when the pressed key is also a modifier', () => {
+      const combo = KeyComboImpl.fromEvent(
+        mockKeyEvent({ key: 'Shift', ctrlKey: true, shiftKey: true })
+      )
+
+      expect(combo.getKeySequences()).toEqual(['Ctrl', 'Shift'])
+      expect(combo.toString()).toBe('Ctrl + Shift')
+    })
+
+    it('keeps the primary key for non-modifier shortcuts', () => {
+      const combo = KeyComboImpl.fromEvent(
+        mockKeyEvent({ key: 'k', ctrlKey: true, shiftKey: true })
+      )
+
+      expect(combo.getKeySequences()).toEqual(['Ctrl', 'Shift', 'k'])
+      expect(combo.toString()).toBe('Ctrl + Shift + k')
+    })
+  })
+
   describe('isBrowserReserved', () => {
     it.each([
       { key: 't', ctrl: true, label: 'Ctrl + t' },

--- a/src/platform/keybindings/keyCombo.ts
+++ b/src/platform/keybindings/keyCombo.ts
@@ -3,6 +3,13 @@ import { toRaw } from 'vue'
 import { RESERVED_BY_BROWSER, RESERVED_BY_TEXT_INPUT } from './reserved'
 import type { KeyCombo } from './types'
 
+const MODIFIER_KEY_LABELS: Record<string, string> = {
+  Control: 'Ctrl',
+  Meta: 'Ctrl',
+  Alt: 'Alt',
+  Shift: 'Shift'
+}
+
 export class KeyComboImpl implements KeyCombo {
   key: string
   ctrl: boolean
@@ -49,7 +56,7 @@ export class KeyComboImpl implements KeyCombo {
   }
 
   get isModifier(): boolean {
-    return ['Control', 'Meta', 'Alt', 'Shift'].includes(this.key)
+    return this.key in MODIFIER_KEY_LABELS
   }
 
   get modifierCount(): number {
@@ -74,26 +81,37 @@ export class KeyComboImpl implements KeyCombo {
   }
 
   getKeySequences(): string[] {
-    const sequences: string[] = []
-    if (this.ctrl) {
-      sequences.push('Ctrl')
+    const sequences = getModifierSequences(this)
+
+    if (!this.isModifier || sequences.length === 0) {
+      sequences.push(getKeyLabel(this.key))
     }
-    if (this.alt) {
-      sequences.push('Alt')
-    }
-    if (this.shift) {
-      sequences.push('Shift')
-    }
-    sequences.push(this.key)
+
     return sequences
   }
 }
 
 function toNormalizedString(combo: KeyComboImpl): string {
+  const sequences = getModifierSequences(combo)
+
+  if (!combo.isModifier || sequences.length === 0) {
+    sequences.push(getKeyLabel(combo.key, true))
+  }
+
+  return sequences.join(' + ')
+}
+
+function getModifierSequences(combo: KeyComboImpl): string[] {
   const sequences: string[] = []
   if (combo.ctrl) sequences.push('Ctrl')
   if (combo.alt) sequences.push('Alt')
   if (combo.shift) sequences.push('Shift')
-  sequences.push(combo.key.length === 1 ? combo.key.toLowerCase() : combo.key)
-  return sequences.join(' + ')
+  return sequences
+}
+
+function getKeyLabel(key: string, normalizeSingleCharacter = false): string {
+  const label = MODIFIER_KEY_LABELS[key] ?? key
+  return normalizeSingleCharacter && label.length === 1
+    ? label.toLowerCase()
+    : label
 }


### PR DESCRIPTION
## Summary

Fix keybinding display so pressing a modifier key by itself shows that modifier once instead of duplicated text like `Shift + Shift`.

## Changes

- **What**: Centralizes modifier key labels in `KeyComboImpl` and omits the duplicated primary key when the pressed key is itself a modifier.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

The keybinding model still includes active modifiers for normal shortcuts like `Ctrl + Shift + k`, while modifier-only input now renders as a single key. Regression coverage includes single modifier presses, combined held modifiers, and a normal non-modifier shortcut.

Checks run: `pnpm exec vitest run src/platform/keybindings/keyCombo.test.ts`; `pnpm lint:unstaged`; `pnpm exec oxfmt --check src/platform/keybindings/keyCombo.ts src/platform/keybindings/keyCombo.test.ts`; `pnpm exec vitest run src/platform/keybindings/keyCombo.test.ts src/platform/keybindings/keybindingStore.test.ts src/platform/keybindings/keybindingService.escape.test.ts src/platform/keybindings/keybindingService.canvas.test.ts`; `pnpm typecheck`; pre-commit lint-staged checks; pre-push `pnpm knip --cache`.

Linear: FE-240

## Screenshots (if applicable)

Not applicable; covered by keybinding sequence unit tests.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11570-fix-dedupe-keybinding-modifier-display-34b6d73d365081968a88da4465c151de) by [Unito](https://www.unito.io)
