### PR TITLE
Fix legacy widget width in app mode

### DIFF
--- a/browser_tests/fixtures/ComfyMouse.ts
+++ b/browser_tests/fixtures/ComfyMouse.ts
@@ -1,4 +1,4 @@
-import type { Mouse } from '@playwright/test'
+import type { Locator, Mouse } from '@playwright/test'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import type { Position } from '@e2e/fixtures/types'
@@ -70,6 +70,22 @@ export class ComfyMouse implements Omit<Mouse, 'move'> {
   async move(to: Position, options = ComfyMouse.defaultOptions) {
     await this.mouse.move(to.x, to.y, options)
     await this.nextFrame()
+  }
+
+  async resizeByDragging(
+    element: Locator,
+    { x, y }: { x?: number; y?: number }
+  ) {
+    const elementBox = await element.boundingBox()
+    if (!elementBox) throw new Error('element should have layout')
+
+    const cx = elementBox.x + elementBox.width / 2
+    const cy = elementBox.y + elementBox.height / 2
+
+    await this.dragAndDrop(
+      { x: cx, y: cy },
+      { x: cx + (x ?? 0), y: cy + (y ?? 0) }
+    )
   }
 
   //#region Pass-through

--- a/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
@@ -1,0 +1,48 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '@e2e/fixtures/ComfyPage'
+
+test('In App Mode, widget width updates with panel size', async ({
+  comfyPage,
+  comfyMouse
+}) => {
+  await test.step('setup', async () => {
+    //This tests breaks basically every assumption made by every fixture
+    //A minimal widget is created since no core nodes use WidgetLegacy
+    //No fixture exists for grabbing a widget's width
+    //enterAppModeWithInputs serializes the graph, must setup widget after
+    await comfyPage.appMode.enterAppModeWithInputs([['5', 'testWidget']])
+    await comfyPage.page.evaluate(() => {
+      graph!.getNodeById(5)!.widgets!.push({
+        name: 'testWidget',
+        type: 'TESTWIDGET',
+        options: {},
+        y: 0
+      })
+    })
+
+    await comfyPage.appMode.toggleAppMode()
+    await expect(comfyPage.appMode.linearWidgets).toBeHidden()
+    await comfyPage.appMode.toggleAppMode()
+    await expect(comfyPage.appMode.linearWidgets).toBeVisible()
+  })
+
+  const getWidth = () =>
+    comfyPage.page.evaluate(() => {
+      console.log(graph!.getNodeById(5)!.widgets![3])
+      return graph!.getNodeById(5)!.widgets![3].width ?? 0
+    })
+  const initialWidth = await getWidth()
+  expect(initialWidth).toBeGreaterThan(0)
+
+  const gutter = comfyPage.page.getByRole('separator')
+
+  await expect(gutter).toBeVisible()
+  await comfyMouse.resizeByDragging(gutter, { x: -200 })
+  await expect.poll(getWidth).toBeGreaterThan(initialWidth)
+  const intermediateWidth = await getWidth()
+
+  await comfyMouse.resizeByDragging(gutter, { x: 100 })
+  await expect.poll(getWidth).toBeLessThan(intermediateWidth)
+})

--- a/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
@@ -3,33 +3,22 @@ import {
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
 
-test('In App Mode, widget width updates with panel size', async ({
+test('@vue-nodes In App Mode, widget width updates with panel size', async ({
   comfyPage,
   comfyMouse
 }) => {
   await test.step('setup', async () => {
-    //This tests breaks basically every assumption made by every fixture
-    //A minimal widget is created since no core nodes use WidgetLegacy
-    //No fixture exists for grabbing a widget's width
-    //enterAppModeWithInputs serializes the graph, must setup widget after
-    await comfyPage.appMode.enterAppModeWithInputs([['5', 'testWidget']])
-    await comfyPage.page.evaluate(() => {
-      graph!.getNodeById(5)!.widgets!.push({
-        name: 'testWidget',
-        type: 'TESTWIDGET',
-        options: {},
-        y: 0
-      })
+    await comfyPage.nodeOps.addNode('DevToolsNodeWithLegacyWidget', undefined, {
+      x: 0,
+      y: 0
     })
-
-    await comfyPage.appMode.toggleAppMode()
-    await expect(comfyPage.appMode.linearWidgets).toBeHidden()
-    await comfyPage.appMode.toggleAppMode()
-    await expect(comfyPage.appMode.linearWidgets).toBeVisible()
+    await comfyPage.appMode.enterAppModeWithInputs([['10', 'legacy_widget']])
   })
 
-  const getWidth = () =>
-    comfyPage.page.evaluate(() => graph!.getNodeById(5)!.widgets![3].width ?? 0)
+  const getWidth = () => comfyPage.page.evaluate(
+    () => graph!.getNodeById(10)!.widgets![0].width ?? 0
+  )
+  console.error(await comfyPage.page.evaluate(() => graph.nodes.map(n => n.serialize())))
   const initialWidth = await getWidth()
   expect(initialWidth).toBeGreaterThan(0)
 

--- a/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
@@ -15,20 +15,36 @@ test('@vue-nodes In App Mode, widget width updates with panel size', async ({
     await comfyPage.appMode.enterAppModeWithInputs([['10', 'legacy_widget']])
   })
 
-  const getWidth = () => comfyPage.page.evaluate(
-    () => graph!.getNodeById(10)!.widgets![0].width ?? 0
-  )
-  console.error(await comfyPage.page.evaluate(() => graph.nodes.map(n => n.serialize())))
-  const initialWidth = await getWidth()
-  expect(initialWidth).toBeGreaterThan(0)
+  const getWidth = () =>
+    comfyPage.page.evaluate(
+      () => graph!.getNodeById(10)!.widgets![0].width ?? 0
+    )
 
-  const gutter = comfyPage.page.getByRole('separator')
+  await test.step('Mouse clicks resolve to button regions', async () => {
+    const legacyWidget = comfyPage.appMode.linearWidgets.locator('canvas')
+    const { width, height } = (await legacyWidget.boundingBox())!
 
-  await expect(gutter).toBeVisible()
-  await comfyMouse.resizeByDragging(gutter, { x: -200 })
-  await expect.poll(getWidth).toBeGreaterThan(initialWidth)
-  const intermediateWidth = await getWidth()
+    const nodeRef = await comfyPage.nodeOps.getNodeRefById(10)
+    const legacyWidgetRef = await nodeRef.getWidget(0)
+    expect(await legacyWidgetRef.getValue()).toBe(0)
+    await legacyWidget.click({ position: { x: 20, y: height / 2 } })
+    await expect.poll(() => legacyWidgetRef.getValue()).toBe(-1)
+    await legacyWidget.click({ position: { x: width - 20, y: height / 2 } })
+    await expect.poll(() => legacyWidgetRef.getValue()).toBe(0)
+  })
 
-  await comfyMouse.resizeByDragging(gutter, { x: 100 })
-  await expect.poll(getWidth).toBeLessThan(intermediateWidth)
+  await test.step('Resize to update width', async () => {
+    const initialWidth = await getWidth()
+    expect(initialWidth).toBeGreaterThan(0)
+
+    const gutter = comfyPage.page.getByRole('separator')
+
+    await expect(gutter).toBeVisible()
+    await comfyMouse.resizeByDragging(gutter, { x: -200 })
+    await expect.poll(getWidth).toBeGreaterThan(initialWidth)
+    const intermediateWidth = await getWidth()
+
+    await comfyMouse.resizeByDragging(gutter, { x: 100 })
+    await expect.poll(getWidth).toBeLessThan(intermediateWidth)
+  })
 })

--- a/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
@@ -29,10 +29,7 @@ test('In App Mode, widget width updates with panel size', async ({
   })
 
   const getWidth = () =>
-    comfyPage.page.evaluate(() => {
-      console.log(graph!.getNodeById(5)!.widgets![3])
-      return graph!.getNodeById(5)!.widgets![3].width ?? 0
-    })
+    comfyPage.page.evaluate(() => graph!.getNodeById(5)!.widgets![3].width ?? 0)
   const initialWidth = await getWidth()
   expect(initialWidth).toBeGreaterThan(0)
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,7 +55,9 @@ const config: KnipConfig = {
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
     // Agent review check config, not part of the build
-    '.agents/checks/eslint.strict.config.js'
+    '.agents/checks/eslint.strict.config.js',
+    // Devtools extensions, included dynamically
+    'tools/devtools/web/**'
   ],
   vite: {
     config: ['vite?(.*).config.mts']

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
@@ -92,6 +92,7 @@ function draw() {
   // @ts-expect-error canvasHeight is a custom property used by some extensions
   node.canvasHeight = height
   widgetInstance.y = 0
+  widgetInstance.width = width
   canvasEl.value.height = (height + 2) * scaleFactor
   canvasEl.value.width = width * scaleFactor
   const ctx = canvasEl.value?.getContext('2d')

--- a/tools/devtools/__init__.py
+++ b/tools/devtools/__init__.py
@@ -113,4 +113,5 @@ async def delete_file(request: Request):
         return web.Response(status=500, text=f"Error: {str(e)}")
 
 
-__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
+WEB_DIRECTORY = "./web"
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/tools/devtools/nodes/inputs.py
+++ b/tools/devtools/nodes/inputs.py
@@ -302,6 +302,21 @@ class NodeWithV2ComboInput:
     def node_with_v2_combo_input(self, combo_input: str):
         return (combo_input,)
 
+class NodeWithLegacyWidget:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": { "legacy_widget": ("STRING", { "widgetType":  "DEVTOOLSLEGACYWIDGET" }) }
+        }
+
+    RETURN_TYPES = ()
+    FUNCTION = "node_with_legacy_widget"
+    CATEGORY = "DevTools"
+    DESCRIPTION = ("A node with a legacy widget")
+
+    def node_with_legacy_widget(self):
+        return ()
+
 
 NODE_CLASS_MAPPINGS = {
     "DevToolsLongComboDropdown": LongComboDropdown,
@@ -318,6 +333,7 @@ NODE_CLASS_MAPPINGS = {
     "DevToolsNodeWithSeedInput": NodeWithSeedInput,
     "DevToolsNodeWithValidation": NodeWithValidation,
     "DevToolsNodeWithV2ComboInput": NodeWithV2ComboInput,
+    "DevToolsNodeWithLegacyWidget": NodeWithLegacyWidget,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -335,6 +351,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DevToolsNodeWithSeedInput": "Node With Seed Input",
     "DevToolsNodeWithValidation": "Node With Validation",
     "DevToolsNodeWithV2ComboInput": "Node With V2 Combo Input",
+    "DevToolsNodeWithLegacyWidget": "Node With Legacy Widget",
 }
 
 __all__ = [

--- a/tools/devtools/nodes/inputs.py
+++ b/tools/devtools/nodes/inputs.py
@@ -306,7 +306,7 @@ class NodeWithLegacyWidget:
     @classmethod
     def INPUT_TYPES(cls):
         return {
-            "required": { "legacy_widget": ("STRING", { "widgetType":  "DEVTOOLSLEGACYWIDGET" }) }
+            "required": { "legacy_widget": ("INT", { "widgetType":  "DEVTOOLSLEGACYWIDGET" }) }
         }
 
     RETURN_TYPES = ()

--- a/tools/devtools/web/legacyWidget.js
+++ b/tools/devtools/web/legacyWidget.js
@@ -1,0 +1,25 @@
+import { app } from '../../scripts/app.js'
+
+function legacyWidget(node, inputName, inputData) {
+  if (!node.widgets) node.widgets = []
+  node.widgets.push({
+    draw : function(ctx, node, widget_width, y, H) {
+      ctx.save()
+      ctx.fillStyle = "#7F7"
+      ctx.fillRect(15, y, widget_width - 15 * 2, H)
+      ctx.restore()
+    },
+    name: inputName,
+    options: {},
+    type: 'DEVTOOLS.LEGACYWIDGET',
+    value: 'test',
+    y: 0
+  })
+}
+
+app.registerExtension({
+  name: "DevTools.LegacyWidget",
+  async getCustomWidgets() {
+    return { DEVTOOLSLEGACYWIDGET: legacyWidget }
+  }
+})

--- a/tools/devtools/web/legacyWidget.js
+++ b/tools/devtools/web/legacyWidget.js
@@ -1,24 +1,34 @@
+//es
+// eslint-disable-next-line import-x/no-unresolved -- import is correct at time of test execution
 import { app } from '../../scripts/app.js'
 
 function legacyWidget(node, inputName, inputData) {
   if (!node.widgets) node.widgets = []
   node.widgets.push({
-    draw : function(ctx, node, widget_width, y, H) {
+    draw: function (ctx, node, widget_width, y, H) {
       ctx.save()
-      ctx.fillStyle = "#7F7"
+      ctx.fillStyle = '#7F7'
       ctx.fillRect(15, y, widget_width - 15 * 2, H)
       ctx.restore()
+    },
+    mouse: function mouseAnnotated(event, [x, y], node) {
+      const widget_width = this.width || node.size[0]
+      if (x < 30) {
+        this.value--
+      } else if (x > widget_width - 30 && x < widget_width) {
+        this.value++
+      }
     },
     name: inputName,
     options: {},
     type: 'DEVTOOLS.LEGACYWIDGET',
-    value: 'test',
+    value: 0,
     y: 0
   })
 }
 
 app.registerExtension({
-  name: "DevTools.LegacyWidget",
+  name: 'DevTools.LegacyWidget',
   async getCustomWidgets() {
     return { DEVTOOLSLEGACYWIDGET: legacyWidget }
   }


### PR DESCRIPTION
When in app mode, widgets can be drawn with size different from the size of the parent node. Mouse events on legacy canvas widgets require that the client code query the current state of the node and widget to determine if any elements are being interacted with. This PR sets the `widget.width` property when a legacy canvas widget draw operation occurs so that custom nodes can properly resolve subsequent mouse events.

At current, no core nodes exist that utilize legacy widgets. As a result the setup code to test this bug fix is slightly involved.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11574-Fix-legacy-widget-width-in-app-mode-34b6d73d365081caaa34c6204f8361f6) by [Unito](https://www.unito.io)
