### PR TITLE
refactor: extract normalizeLinearData from pruneLinearData

### DIFF
--- a/src/composables/useWorkflowActionsMenu.test.ts
+++ b/src/composables/useWorkflowActionsMenu.test.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useWorkflowActionsMenu } from '@/composables/useWorkflowActionsMenu'
+import type { LinearData } from '@/platform/workflow/management/stores/comfyWorkflow'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import type { WorkflowMenuAction } from '@/types/workflowMenuItem'
 
@@ -43,15 +44,10 @@ const mockMenuItemStore = vi.hoisted(() => ({
 const mockAppModeStore = vi.hoisted(() => ({
   enterBuilder: vi.fn(),
   pruneLinearData: vi.fn(
-    (
-      data?: Partial<{
-        inputs: [number | string, string][]
-        outputs: (number | string)[]
-      }>
-    ) => ({
-      inputs: data?.inputs ?? [],
-      outputs: data?.outputs ?? []
-    })
+    (data: {
+      inputs: [number | string, string][]
+      outputs: (number | string)[]
+    }) => data
   ),
   selectedInputs: [] as [number | string, string][],
   selectedOutputs: [] as (number | string)[]
@@ -83,6 +79,10 @@ vi.mock('@/stores/menuItemStore', () => ({
 }))
 
 vi.mock('@/stores/appModeStore', () => ({
+  normalizeLinearData: vi.fn((data?: Partial<LinearData>) => ({
+    inputs: data?.inputs ?? [],
+    outputs: data?.outputs ?? []
+  })),
   useAppModeStore: vi.fn(() => mockAppModeStore)
 }))
 

--- a/src/composables/useWorkflowActionsMenu.ts
+++ b/src/composables/useWorkflowActionsMenu.ts
@@ -15,7 +15,7 @@ import {
 import { useCommandStore } from '@/stores/commandStore'
 import { useMenuItemStore } from '@/stores/menuItemStore'
 import { useSubgraphStore } from '@/stores/subgraphStore'
-import { useAppModeStore } from '@/stores/appModeStore'
+import { normalizeLinearData, useAppModeStore } from '@/stores/appModeStore'
 import type {
   WorkflowMenuAction,
   WorkflowMenuItem
@@ -229,7 +229,7 @@ export function useWorkflowActionsMenu(
       : workflow?.changeTracker?.activeState?.extra?.linearData
     let hasLinearData: boolean
     if (rawLd) {
-      const { inputs, outputs } = pruneLinearData(rawLd)
+      const { inputs, outputs } = pruneLinearData(normalizeLinearData(rawLd))
       hasLinearData = inputs.length > 0 || outputs.length > 0
     } else {
       hasLinearData = workflow?.path?.endsWith('.app.json') ?? false

--- a/src/platform/workflow/sharing/composables/useShareDialog.ts
+++ b/src/platform/workflow/sharing/composables/useShareDialog.ts
@@ -4,7 +4,7 @@ import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useWorkflowStore } from '../../management/stores/workflowStore'
-import { useAppModeStore } from '@/stores/appModeStore'
+import { normalizeLinearData, useAppModeStore } from '@/stores/appModeStore'
 import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 import { t } from '@/i18n'
 
@@ -27,7 +27,7 @@ export function useShareDialog() {
 
     const isAppDefault = wf.initialMode === 'app'
     const linearData = wf.changeTracker?.activeState?.extra?.linearData
-    const { outputs } = pruneLinearData(linearData)
+    const { outputs } = pruneLinearData(normalizeLinearData(linearData))
 
     if (isAppDefault && outputs.length === 0) {
       const dialog = showConfirmDialog({

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -66,7 +66,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => mockSettings
 }))
 
-import { useAppModeStore } from './appModeStore'
+import { normalizeLinearData, useAppModeStore } from './appModeStore'
 
 function createBuilderWorkflow(
   activeMode: string = 'builder:inputs'
@@ -99,6 +99,31 @@ function createBuilderWorkflowWithOutputs(
   }
   return workflow
 }
+
+describe('normalizeLinearData', () => {
+  it('returns empty arrays for undefined input', () => {
+    expect(normalizeLinearData(undefined)).toEqual({ inputs: [], outputs: [] })
+  })
+
+  it('fills missing inputs with empty array', () => {
+    expect(normalizeLinearData({ outputs: [1] })).toEqual({
+      inputs: [],
+      outputs: [1]
+    })
+  })
+
+  it('fills missing outputs with empty array', () => {
+    expect(normalizeLinearData({ inputs: [[1, 'prompt']] })).toEqual({
+      inputs: [[1, 'prompt']],
+      outputs: []
+    })
+  })
+
+  it('passes through complete data unchanged', () => {
+    const data = { inputs: [[1, 'prompt']] as [number, string][], outputs: [2] }
+    expect(normalizeLinearData(data)).toEqual(data)
+  })
+})
 
 describe('appModeStore', () => {
   let workflowStore: ReturnType<typeof useWorkflowStore>

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -20,6 +20,12 @@ import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { resolveNode } from '@/utils/litegraphUtil'
 
+export function normalizeLinearData(
+  data: Partial<LinearData> | undefined
+): LinearData {
+  return { inputs: data?.inputs ?? [], outputs: data?.outputs ?? [] }
+}
+
 export function nodeTypeValidForApp(type: string) {
   return !['Note', 'MarkdownNote'].includes(type)
 }
@@ -46,22 +52,16 @@ export const useAppModeStore = defineStore('appMode', () => {
   // Prune entries referencing nodes deleted in workflow mode.
   // Only check node existence, not widgets — dynamic widgets can
   // hide/show other widgets so a missing widget does not mean stale data.
-  function pruneLinearData(data: Partial<LinearData> | undefined): LinearData {
-    const rawInputs = data?.inputs ?? []
-    const rawOutputs = data?.outputs ?? []
-
+  function pruneLinearData(data: LinearData): LinearData {
+    if (!app.rootGraph) return data
     return {
-      inputs: app.rootGraph
-        ? rawInputs.filter(([nodeId]) => resolveNode(nodeId))
-        : rawInputs,
-      outputs: app.rootGraph
-        ? rawOutputs.filter((nodeId) => resolveNode(nodeId))
-        : rawOutputs
+      inputs: data.inputs.filter(([nodeId]) => resolveNode(nodeId)),
+      outputs: data.outputs.filter((nodeId) => resolveNode(nodeId))
     }
   }
 
   function loadSelections(data: Partial<LinearData> | undefined) {
-    const { inputs, outputs } = pruneLinearData(data)
+    const { inputs, outputs } = pruneLinearData(normalizeLinearData(data))
     selectedInputs.value = inputs
     selectedOutputs.value = outputs
   }


### PR DESCRIPTION
## Summary                                                                                                         
                                                                                                                  
  Extracts normalizeLinearData as a standalone exported pure function, separating two concerns that were          
  previously mixed inside pruneLinearData.                                                                        
                                                                                                                  
  ## Changes                                                                                                         
                                                                                                                  
  - What: pruneLinearData previously handled both defaulting undefined/partial LinearData and filtering stale node
   references. This extracts the defaulting logic into a new exported normalizeLinearData function. Callers now
  explicitly compose the two: pruneLinearData(normalizeLinearData(rawData)). pruneLinearData's signature is       
  simplified to accept a full LinearData (not Partial<LinearData> | undefined).

  ## Review Focus

  - normalizeLinearData is now exported from appModeStore.ts, it's a pure function with no store dependency, so
  callers in useWorkflowActionsMenu.ts and useShareDialog.ts can import it directly
  - The early-return in pruneLinearData when app.rootGraph is absent makes the guard explicit instead of buried in
   conditional chaining                                                                                           
  - Tests for normalizeLinearData were added in appModeStore.test.ts covering undefined, partial, and complete
  input cases                                                                                                     
                  
  Fixes #11430

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11582-refactor-extract-normalizeLinearData-from-pruneLinearData-34c6d73d365081beb9ebf24289575c36) by [Unito](https://www.unito.io)
