### PR TITLE
fix: add assetsPrefix to avoid /_astro collision with workflows site

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -6,6 +6,9 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',
+  build: {
+    assetsPrefix: '/_website'
+  },
   devToolbar: { enabled: !process.env.NO_TOOLBAR },
   integrations: [vue(), sitemap()],
   vite: {

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',
   build: {
+    assets: '_website',
     assetsPrefix: '/_website'
   },
   devToolbar: { enabled: !process.env.NO_TOOLBAR },

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -7,8 +7,7 @@ export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',
   build: {
-    assets: '_website',
-    assetsPrefix: '/_website'
+    assets: '_website'
   },
   devToolbar: { enabled: !process.env.NO_TOOLBAR },
   integrations: [vue(), sitemap()],


### PR DESCRIPTION
## Problem

The website and workflows sites both emit build assets under `/_astro/`. The comfy-router sends all `/_astro/*` requests to the workflows Vercel project, so when a page from the website references `/_astro/SiteNav.xxx.js`, it 404s because that file only exists on the website's Vercel deployment.

## Fix

Add `build.assetsPrefix: '/_website'` to the Astro config. This makes Astro emit asset references as `/_website/SiteNav.xxx.js` instead of `/_astro/SiteNav.xxx.js`.

The comfy-router already routes `/_website/*` to the website origin, so these assets will resolve correctly.

## Why this matters

**This is blocking the comfy.org cutover from Framer → new site.** Without it, the homepage loads but all CSS/JS 404s and nothing renders.

## Change

One line in `apps/website/astro.config.ts`:
```ts
build: {
  assetsPrefix: '/_website'
}
```

## Verification

After merge + Vercel deploy:
- Homepage HTML should reference `/_website/*.js` and `/_website/*.css` instead of `/_astro/*`
- `/workflows` page should still reference `/_astro/*` (unaffected)
- Both sites render correctly through the proxy

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11584-fix-add-assetsPrefix-to-avoid-_astro-collision-with-workflows-site-34c6d73d36508101a932caa2905f0a2b) by [Unito](https://www.unito.io)
