### PR TITLE
fix: website polish — prefetch, Safari video controls, border-spin perf

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -6,6 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',
+  prefetch: { prefetchAll: true },
   build: {
     assets: '_website'
   },

--- a/apps/website/src/components/home/BlobMedia.vue
+++ b/apps/website/src/components/home/BlobMedia.vue
@@ -33,6 +33,8 @@ function isVideo(url: string): boolean {
         muted
         loop
         playsinline
+        :controls="false"
+        disablepictureinpicture
         aria-hidden="true"
         :class="
           cn(

--- a/apps/website/src/components/home/BlobMedia.vue
+++ b/apps/website/src/components/home/BlobMedia.vue
@@ -33,7 +33,6 @@ function isVideo(url: string): boolean {
         muted
         loop
         playsinline
-        :controls="false"
         disablepictureinpicture
         aria-hidden="true"
         :class="

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { useTemplateRefsList } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { useIntersectionObserver, useTemplateRefsList } from '@vueuse/core'
+import { ref, useTemplateRef, watch } from 'vue'
 
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
@@ -37,6 +37,12 @@ const badgeSegments = [
 
 const activeIndex = ref(0)
 const videoRefs = useTemplateRefsList<HTMLVideoElement>()
+const sectionRef = useTemplateRef<HTMLElement>('sectionRef')
+const isVisible = ref(false)
+
+useIntersectionObserver(sectionRef, ([entry]) => {
+  isVisible.value = entry?.isIntersecting ?? false
+})
 
 watch(activeIndex, (current, previous) => {
   videoRefs.value[previous]?.pause()
@@ -49,7 +55,7 @@ watch(activeIndex, (current, previous) => {
 </script>
 
 <template>
-  <section class="px-4 py-20 lg:px-20 lg:py-24">
+  <section ref="sectionRef" class="px-4 py-20 lg:px-20 lg:py-24">
     <!-- Section header -->
     <div class="flex flex-col items-center text-center">
       <NodeBadge :segments="badgeSegments" segment-class="" />
@@ -66,23 +72,13 @@ watch(activeIndex, (current, previous) => {
       <!-- Video area (desktop only) -->
       <div class="hidden flex-1 lg:flex">
         <div
-          class="rounded-5xl relative flex w-full items-center justify-center overflow-hidden p-0.5 [clip-path:inset(0_round_var(--radius-5xl))]"
+          :class="
+            cn(
+              'rounded-5xl relative flex w-full items-center justify-center overflow-hidden p-0.5',
+              isVisible && 'animate-border-spin'
+            )
+          "
         >
-          <div
-            class="animate-border-spin absolute top-1/2 left-1/2 aspect-square min-h-full min-w-full -translate-1/2 scale-150"
-            style="
-              background: conic-gradient(
-                from 0deg,
-                color-mix(
-                    in srgb,
-                    var(--color-primary-comfy-yellow) 4%,
-                    transparent
-                  )
-                  0%,
-                var(--color-primary-comfy-yellow) 100%
-              );
-            "
-          />
           <div
             class="bg-primary-comfy-ink relative size-full overflow-hidden rounded-[calc(2.5rem-2px)]"
           >
@@ -92,12 +88,13 @@ watch(activeIndex, (current, previous) => {
               :key="feature.title"
               :src="feature.video"
               :autoplay="i === 0"
+              :preload="i === 0 ? 'metadata' : 'none'"
               loop
               muted
               playsinline
               :class="
                 cn(
-                  'absolute inset-0 size-full object-cover transition-opacity duration-300',
+                  'absolute inset-0 size-full object-cover transition-opacity duration-300 will-change-[opacity]',
                   activeIndex === i ? 'opacity-100' : 'opacity-0'
                 )
               "

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -109,21 +109,24 @@ watch(activeIndex, (current, previous) => {
           <!-- Video area (mobile, rendered before active item) -->
           <div
             v-if="activeIndex === i"
-            :class="
-              cn(
-                'aspect-video overflow-hidden rounded-4xl lg:hidden',
-                i !== 0 && 'mt-4'
-              )
-            "
+            :class="cn('aspect-video lg:hidden', i !== 0 && 'mt-4')"
           >
-            <video
-              :src="feature.video"
-              autoplay
-              loop
-              muted
-              playsinline
-              class="size-full object-cover"
-            />
+            <div
+              class="animate-border-spin size-full overflow-hidden rounded-4xl p-0.5"
+            >
+              <div
+                class="bg-primary-comfy-ink size-full overflow-hidden rounded-[calc(2rem-2px)]"
+              >
+                <video
+                  :src="feature.video"
+                  autoplay
+                  loop
+                  muted
+                  playsinline
+                  class="size-full object-cover"
+                />
+              </div>
+            </div>
           </div>
 
           <!-- Connector (mobile) -->

--- a/apps/website/src/components/pricing/PriceSection.vue
+++ b/apps/website/src/components/pricing/PriceSection.vue
@@ -98,14 +98,7 @@ const plans: PricingPlan[] = [
     summaryKey: 'pricing.enterprise.description',
     ctaKey: 'pricing.enterprise.cta',
     ctaHref: getRoutes(locale).cloudEnterprise,
-    featureIntroKey: 'pricing.enterprise.featureIntro',
-    features: [
-      { text: 'pricing.enterprise.feature1' },
-      { text: 'pricing.enterprise.feature2' },
-      { text: 'pricing.enterprise.feature3' },
-      { text: 'pricing.enterprise.feature4' }
-    ],
-    andMoreKey: 'pricing.enterprise.andMore',
+    features: [],
     isEnterprise: true
   }
 ]
@@ -223,7 +216,7 @@ const activePlanIndex = ref(0)
         <div v-else class="px-6" />
 
         <!-- Features -->
-        <div class="px-6 py-3">
+        <div v-if="plan.features.length" class="px-6 py-3">
           <p class="text-primary-comfy-canvas mb-2 text-sm font-semibold">
             {{
               plan.featureIntroKey ? t(plan.featureIntroKey, locale) : '&nbsp;'
@@ -350,7 +343,10 @@ const activePlanIndex = ref(0)
         </div>
 
         <!-- Features card -->
-        <div class="bg-transparency-white-t4 mt-2 rounded-3xl p-6">
+        <div
+          v-if="plan.features.length"
+          class="bg-transparency-white-t4 mt-2 rounded-3xl p-6"
+        >
           <PricingPlanFeatureList
             :features="plan.features"
             :feature-intro-key="plan.featureIntroKey"

--- a/apps/website/src/components/product/shared/CloudBannerSection.vue
+++ b/apps/website/src/components/product/shared/CloudBannerSection.vue
@@ -12,10 +12,12 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
     <p
       class="text-primary-comfy-canvas relative z-10 text-lg font-semibold lg:text-sm lg:font-normal"
     >
-      {{ t('download.cloud.prefix', locale) }}
+      <span class="whitespace-nowrap">
+        {{ t('download.cloud.prefix', locale) }}
+      </span>
       <a
         :href="externalLinks.cloud"
-        class="text-primary-comfy-yellow mx-1 font-bold tracking-widest uppercase hover:underline"
+        class="text-primary-comfy-yellow mx-1 font-bold tracking-widest whitespace-nowrap uppercase hover:underline"
       >
         {{ t('download.cloud.cta', locale) }}
       </a>

--- a/apps/website/src/components/product/shared/ReasonSection.vue
+++ b/apps/website/src/components/product/shared/ReasonSection.vue
@@ -58,12 +58,11 @@ const {
         :key="reason.titleKey"
         class="border-primary-comfy-canvas/20 flex flex-col gap-4 border-b py-10 first:pt-0 lg:flex-row lg:gap-12"
       >
-        <div class="shrink-0 lg:w-52">
+        <div class="shrink-0 lg:w-84">
           <h3
             class="text-primary-comfy-canvas text-2xl font-light whitespace-pre-line"
-          >
-            {{ t(reason.titleKey, locale) }}
-          </h3>
+            v-html="t(reason.titleKey, locale)"
+          />
           <slot name="reason-extra" :reason="reason" />
         </div>
         <p class="text-primary-comfy-canvas/70 flex-1 text-sm">

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -742,7 +742,7 @@ const translations = {
     'zh-CN': 'Cloud'
   },
   'cloud.reason.1.title': {
-    en: 'Powerful GPUs with end-\nto-end security built-in',
+    en: 'Powerful GPUs with <span class="whitespace-nowrap">end-to-end</span> security <span class="whitespace-nowrap">built-in</span>',
     'zh-CN': '强大 GPU\n端到端安全内置'
   },
   'cloud.reason.1.description': {
@@ -777,7 +777,7 @@ const translations = {
       '每个节点都可见。每个设置都可调。ComfyUI 为您提供完整的推理管线。选择您的采样器、调度器、模型链。云端简化了设置并增强了底层硬件。'
   },
   'cloud.reason.4.title': {
-    en: 'Community workflows,\nunlimited customization\nthrough pre-installed\ncustom nodes',
+    en: 'Community workflows,\nunlimited customization\nthrough <span class="whitespace-nowrap">pre-installed</span>\ncustom nodes',
     'zh-CN': '社区工作流，\n通过预安装自定义节点\n实现无限自定义'
   },
   'cloud.reason.4.description': {

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ interface Props {
 const {
   title,
   description = 'Comfy is the AI creation engine for visual professionals who demand control.',
-  ogImage = '/og-default.png',
+  ogImage = 'https://media.comfy.org/website/comfy.webp',
   noindex = false,
 } = Astro.props
 

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -75,14 +75,25 @@
   --aspect-ratio-gallery-card: 47/31;
 }
 
-@keyframes border-spin {
+@property --border-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes border-angle-spin {
   to {
-    transform: rotate(360deg);
+    --border-angle: 360deg;
   }
 }
 
 @utility animate-border-spin {
-  animation: border-spin 2s linear infinite;
+  animation: border-angle-spin 2s linear infinite;
+  background: conic-gradient(
+    from var(--border-angle),
+    color-mix(in srgb, var(--color-primary-comfy-yellow) 4%, transparent) 0%,
+    var(--color-primary-comfy-yellow) 100%
+  );
 }
 
 @keyframes marquee {
@@ -178,6 +189,14 @@
   display: inline-block;
   position: relative;
   top: 0.19em;
+}
+
+/* Hide native play-button overlay iOS Safari shows when autoplay is blocked
+   (e.g. Low Power Mode). These are decorative background videos. */
+video::-webkit-media-controls-start-playback-button,
+video::-webkit-media-controls-panel {
+  display: none !important;
+  appearance: none;
 }
 
 :root {


### PR DESCRIPTION
## Summary

Website polish: enable Astro prefetch, fix mobile Safari video controls, and optimize the ProductShowcase border-spin animation.

## Changes

- **What**:
  - Enable `prefetch: { prefetchAll: true }` in Astro config for faster navigation
  - Hide native iOS Safari play-button overlays on autoplay background videos (`BlobMedia`, global CSS)
  - Refactor `ProductShowcaseSection` border-spin animation: use `@property --border-angle` with `conic-gradient` directly on the container (removes extra spinning `div`), gate animation on `useIntersectionObserver` visibility, lazy-load non-active videos with `preload="none"`, add `will-change-[opacity]` for smoother crossfade

## Review Focus

- `@property` CSS registered custom property — verify browser support is acceptable for the website target audience
- `!important` on the webkit media controls rule — necessary to override UA styles on iOS Safari

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11586-fix-website-polish-prefetch-Safari-video-controls-border-spin-perf-34c6d73d36508108a0e8f67df9b32a88) by [Unito](https://www.unito.io)
