### PR TITLE
ci: add e2e-status gate job for required checks

### DIFF
--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -223,6 +223,24 @@ jobs:
           path: ./playwright-report/
           retention-days: 30
 
+  # Gate job — single required check that passes whether the matrix ran or was
+  # skipped. Branch rulesets require this instead of the individual matrix-
+  # expanded check names so PRs with no e2e-relevant changes aren't stuck.
+  e2e-status:
+    if: ${{ always() }}
+    needs: [changes, playwright-tests-chromium-sharded, playwright-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check E2E results
+        env:
+          SHOULD_RUN: ${{ needs.changes.outputs.should_run }}
+          SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
+          BROWSERS: ${{ needs.playwright-tests.result }}
+        run: |
+          [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
+          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" ]] && echo "E2E failed" && exit 1
+          echo "E2E passed"
+
   #### BEGIN Deployment and commenting (non-forked PRs only)
   # when using pull_request event, we have permission to comment directly
   # if its a forked repo, we need to use workflow_run event in a separate workflow (pr-playwright-deploy.yaml)


### PR DESCRIPTION
## Summary

Follow-up to #11568. Fixes Playwright required checks hanging as "Waiting for status to be reported" on PRs with no e2e-relevant file changes.

## Problem

PR #11568 added a `changes` filter to skip E2E when only docs/apps/storybook files are touched. The E2E workflow skips correctly, but branch rulesets require the 11 matrix-expanded check names (e.g. `playwright-tests-chromium-sharded (1, 8)`). When a matrix job is skipped via dependency, GitHub only reports the parent job name — the individual matrix entries are never reported, so required checks hang forever.

## Fix

Add a single `e2e-status` gate job that:
- Uses `if: always()` so it always runs regardless of skipped dependencies
- Passes when E2E was intentionally skipped (no relevant changes)
- Passes when all matrix jobs succeeded
- Fails when any matrix job failed

**After merging**, the ProtectMain and Core release branches rulesets should be updated to require `e2e-status` instead of the 11 individual matrix check names.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11587-ci-add-e2e-status-gate-job-for-required-checks-34c6d73d365081b59c01e8d61d0b808d) by [Unito](https://www.unito.io)
