### PR TITLE
[backport core/1.43] fix(manager): migrate 4 endpoints GET→POST for CSRF hardening

### DIFF
--- a/browser_tests/tests/dialogs/managerDialog.spec.ts
+++ b/browser_tests/tests/dialogs/managerDialog.spec.ts
@@ -1,0 +1,431 @@
+import { expect } from '@playwright/test'
+
+import type { AlgoliaNodePack } from '@/types/algoliaTypes'
+import type { components as ManagerComponents } from '@/workbench/extensions/manager/types/generatedManagerTypes'
+import type { components as RegistryComponents } from '@comfyorg/registry-types'
+
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
+
+type InstalledPacksResponse =
+  ManagerComponents['schemas']['InstalledPacksResponse']
+type RegistryNodePack = RegistryComponents['schemas']['Node']
+
+interface AlgoliaSearchResult {
+  hits: Partial<AlgoliaNodePack>[]
+  nbHits: number
+  page: number
+  nbPages: number
+  hitsPerPage: number
+}
+
+interface AlgoliaSearchResponse {
+  results: AlgoliaSearchResult[]
+}
+
+const MOCK_PACK_A: RegistryNodePack = {
+  id: 'test-pack-a',
+  name: 'Test Pack A',
+  description: 'A test custom node pack',
+  downloads: 5000,
+  status: 'NodeStatusActive',
+  publisher: { id: 'test-publisher', name: 'Test Publisher' },
+  latest_version: { version: '1.0.0', status: 'NodeVersionStatusActive' },
+  repository: 'https://github.com/test/pack-a',
+  tags: ['image', 'processing']
+}
+
+const MOCK_PACK_B: RegistryNodePack = {
+  id: 'test-pack-b',
+  name: 'Test Pack B',
+  description: 'Another test custom node pack for testing search',
+  downloads: 3000,
+  status: 'NodeStatusActive',
+  publisher: { id: 'another-publisher', name: 'Another Publisher' },
+  latest_version: { version: '2.1.0', status: 'NodeVersionStatusActive' },
+  repository: 'https://github.com/test/pack-b',
+  tags: ['video', 'generation']
+}
+
+const MOCK_PACK_C: RegistryNodePack = {
+  id: 'test-pack-c',
+  name: 'Test Pack C',
+  description: 'Third test pack',
+  downloads: 100,
+  status: 'NodeStatusActive',
+  publisher: { id: 'test-publisher', name: 'Test Publisher' },
+  latest_version: { version: '0.5.0', status: 'NodeVersionStatusActive' },
+  repository: 'https://github.com/test/pack-c'
+}
+
+const MOCK_INSTALLED_PACKS: InstalledPacksResponse = {
+  'test-pack-a': {
+    ver: '1.0.0',
+    cnr_id: 'test-pack-a',
+    enabled: true
+  },
+  'test-pack-c': {
+    ver: '0.5.0',
+    cnr_id: 'test-pack-c',
+    enabled: false
+  }
+}
+
+const MOCK_HIT_A: Partial<AlgoliaNodePack> = {
+  objectID: 'test-pack-a',
+  id: 'test-pack-a',
+  name: 'Test Pack A',
+  description: 'A test custom node pack',
+  total_install: 5000,
+  status: 'NodeStatusActive',
+  publisher_id: 'test-publisher',
+  latest_version: '1.0.0',
+  latest_version_status: 'NodeVersionStatusActive',
+  repository_url: 'https://github.com/test/pack-a',
+  comfy_nodes: ['TestNodeA1', 'TestNodeA2'],
+  create_time: '2024-01-01T00:00:00Z',
+  update_time: '2024-06-01T00:00:00Z',
+  license: 'MIT',
+  tags: ['image', 'processing']
+}
+
+const MOCK_HIT_B: Partial<AlgoliaNodePack> = {
+  objectID: 'test-pack-b',
+  id: 'test-pack-b',
+  name: 'Test Pack B',
+  description: 'Another test custom node pack for testing search',
+  total_install: 3000,
+  status: 'NodeStatusActive',
+  publisher_id: 'another-publisher',
+  latest_version: '2.1.0',
+  latest_version_status: 'NodeVersionStatusActive',
+  repository_url: 'https://github.com/test/pack-b',
+  comfy_nodes: ['TestNodeB1'],
+  create_time: '2024-02-01T00:00:00Z',
+  update_time: '2024-07-01T00:00:00Z',
+  license: 'Apache-2.0',
+  tags: ['video', 'generation']
+}
+
+const MOCK_HIT_C: Partial<AlgoliaNodePack> = {
+  objectID: 'test-pack-c',
+  id: 'test-pack-c',
+  name: 'Test Pack C',
+  description: 'Third test pack',
+  total_install: 100,
+  status: 'NodeStatusActive',
+  publisher_id: 'test-publisher',
+  latest_version: '0.5.0',
+  latest_version_status: 'NodeVersionStatusActive',
+  repository_url: 'https://github.com/test/pack-c',
+  comfy_nodes: ['TestNodeC1'],
+  create_time: '2024-03-01T00:00:00Z',
+  update_time: '2024-05-01T00:00:00Z',
+  license: 'MIT'
+}
+
+const MOCK_ALGOLIA_RESPONSE: AlgoliaSearchResponse = {
+  results: [
+    {
+      hits: [MOCK_HIT_A, MOCK_HIT_B, MOCK_HIT_C],
+      nbHits: 3,
+      page: 0,
+      nbPages: 1,
+      hitsPerPage: 20
+    }
+  ]
+}
+
+const MOCK_ALGOLIA_PACK_B_ONLY: AlgoliaSearchResponse = {
+  results: [
+    {
+      hits: [MOCK_HIT_B],
+      nbHits: 1,
+      page: 0,
+      nbPages: 1,
+      hitsPerPage: 20
+    }
+  ]
+}
+
+const MOCK_ALGOLIA_EMPTY: AlgoliaSearchResponse = {
+  results: [
+    {
+      hits: [],
+      nbHits: 0,
+      page: 0,
+      nbPages: 0,
+      hitsPerPage: 20
+    }
+  ]
+}
+
+test.describe('ManagerDialog', { tag: '@ui' }, () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    const statsWithManager = {
+      ...mockSystemStats,
+      system: {
+        ...mockSystemStats.system,
+        argv: ['main.py', '--enable-manager']
+      }
+    }
+    await comfyPage.page.route('**/system_stats**', async (route) => {
+      await route.fulfill({ json: statsWithManager })
+    })
+
+    await comfyPage.page.route(
+      '**/v2/customnode/installed**',
+      async (route) => {
+        await route.fulfill({ json: MOCK_INSTALLED_PACKS })
+      }
+    )
+
+    await comfyPage.page.route(
+      '**/v2/manager/queue/status**',
+      async (route) => {
+        await route.fulfill({
+          json: {
+            history: {},
+            running_queue: [],
+            pending_queue: [],
+            installed_packs: {}
+          }
+        })
+      }
+    )
+
+    await comfyPage.page.route(
+      '**/v2/manager/queue/history**',
+      async (route) => {
+        await route.fulfill({ json: {} })
+      }
+    )
+
+    await comfyPage.page.route('**/*.algolia.net/**', async (route) => {
+      await route.fulfill({ json: MOCK_ALGOLIA_RESPONSE })
+    })
+
+    await comfyPage.page.route('**/*.algolianet.com/**', async (route) => {
+      await route.fulfill({ json: MOCK_ALGOLIA_RESPONSE })
+    })
+
+    // Mock Comfy Registry API (fallback when Algolia credentials are unavailable)
+    const registryListResponse = {
+      total: 3,
+      nodes: [MOCK_PACK_A, MOCK_PACK_B, MOCK_PACK_C],
+      page: 1,
+      limit: 64,
+      totalPages: 1
+    }
+
+    await comfyPage.page.route(
+      '**/api.comfy.org/nodes/search**',
+      async (route) => {
+        await route.fulfill({ json: registryListResponse })
+      }
+    )
+
+    await comfyPage.page.route(
+      (url) => url.hostname === 'api.comfy.org' && url.pathname === '/nodes',
+      async (route) => {
+        await route.fulfill({ json: registryListResponse })
+      }
+    )
+
+    await comfyPage.page.route(
+      '**/v2/customnode/getmappings**',
+      async (route) => {
+        await route.fulfill({ json: {} })
+      }
+    )
+
+    await comfyPage.page.route(
+      '**/v2/customnode/import_fail_info**',
+      async (route) => {
+        await route.fulfill({ json: {} })
+      }
+    )
+
+    await comfyPage.setup()
+
+    // Seed manager-ready server feature flags AFTER setup so the WebSocket
+    // feature_flags payload can't overwrite them. mockServerFeatures (on
+    // /api/features) does not populate the serverFeatureFlags ref; direct
+    // reactive-ref mutation is the only reliable approach.
+    // See shareWorkflowDialog.spec.ts:34-48 for the canonical pattern.
+    await comfyPage.page.evaluate(() => {
+      const api = window.app!.api
+      api.serverFeatureFlags.value = {
+        ...api.serverFeatureFlags.value,
+        extension: {
+          manager: {
+            supports_v4: true,
+            supports_csrf_post: true
+          }
+        }
+      }
+    })
+  })
+
+  async function openManagerDialog(comfyPage: ComfyPage) {
+    await comfyPage.command.executeCommand('Comfy.OpenManagerDialog')
+  }
+
+  test('Opens the manager dialog via command', async ({ comfyPage }) => {
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+  })
+
+  test('Displays pack cards from search results', async ({ comfyPage }) => {
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await expect(dialog.getByText('Test Pack A')).toBeVisible()
+    await expect(dialog.getByText('Test Pack B')).toBeVisible()
+    await expect(dialog.getByText('Test Pack C')).toBeVisible()
+  })
+
+  test('Search filters displayed packs', async ({ comfyPage }) => {
+    await comfyPage.page.route('**/*.algolia.net/**', async (route) => {
+      await route.fulfill({ json: MOCK_ALGOLIA_PACK_B_ONLY })
+    })
+    await comfyPage.page.route('**/*.algolianet.com/**', async (route) => {
+      await route.fulfill({ json: MOCK_ALGOLIA_PACK_B_ONLY })
+    })
+    await comfyPage.page.route(
+      '**/api.comfy.org/nodes/search**',
+      async (route) => {
+        await route.fulfill({
+          json: {
+            total: 1,
+            nodes: [MOCK_PACK_B],
+            page: 1,
+            limit: 64,
+            totalPages: 1
+          }
+        })
+      }
+    )
+
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const searchInput = dialog.getByPlaceholder(/search/i)
+    await searchInput.fill('Test Pack B')
+
+    await expect(dialog.getByText('Test Pack B')).toBeVisible()
+    await expect(dialog.getByText('Test Pack A')).toBeHidden()
+  })
+
+  test('Clicking a pack card opens the info panel', async ({ comfyPage }) => {
+    await comfyPage.page.route(
+      '**/api.comfy.org/nodes/test-pack-a',
+      async (route) => {
+        await route.fulfill({ json: MOCK_PACK_A })
+      }
+    )
+
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByText('Test Pack A').first().click()
+
+    await expect(dialog.getByText('Test Publisher').first()).toBeVisible()
+  })
+
+  test('Left side panel navigation tabs exist', async ({ comfyPage }) => {
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const nav = dialog.locator('nav')
+    await expect(nav.getByText('All Extensions')).toBeVisible()
+    await expect(nav.getByText('Not Installed')).toBeVisible()
+    await expect(nav.getByText('All Installed')).toBeVisible()
+    await expect(nav.getByText('Updates Available')).toBeVisible()
+  })
+
+  test('Switching tabs changes the content view', async ({ comfyPage }) => {
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const nav = dialog.locator('nav')
+    await nav.getByText('All Installed').click()
+
+    await expect(dialog.getByText('Test Pack A')).toBeVisible()
+  })
+
+  test('Closes via Escape key', async ({ comfyPage }) => {
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await comfyPage.page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+  })
+
+  test('Empty search shows no results message', async ({ comfyPage }) => {
+    await comfyPage.page.route('**/*.algolia.net/**', async (route) => {
+      await route.fulfill({ json: MOCK_ALGOLIA_EMPTY })
+    })
+    await comfyPage.page.route('**/*.algolianet.com/**', async (route) => {
+      await route.fulfill({ json: MOCK_ALGOLIA_EMPTY })
+    })
+    await comfyPage.page.route(
+      '**/api.comfy.org/nodes/search**',
+      async (route) => {
+        await route.fulfill({
+          json: {
+            total: 0,
+            nodes: [],
+            page: 1,
+            limit: 64,
+            totalPages: 0
+          }
+        })
+      }
+    )
+
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const searchInput = dialog.getByPlaceholder(/search/i)
+    await searchInput.fill('nonexistent-pack-xyz-999')
+
+    await expect(
+      dialog.getByText(/no results found|try a different search/i).first()
+    ).toBeVisible()
+  })
+
+  test('Search mode can be switched between packs and nodes', async ({
+    comfyPage
+  }) => {
+    await openManagerDialog(comfyPage)
+
+    const dialog = comfyPage.page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const modeSelector = dialog.getByText('Node Pack').first()
+    await expect(modeSelector).toBeVisible()
+
+    await modeSelector.click()
+    const nodesOption = comfyPage.page.getByRole('option', { name: 'Nodes' })
+    await expect(nodesOption).toBeVisible()
+    await nodesOption.click()
+  })
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -377,6 +377,10 @@
     "actions": "Actions",
     "selected": "Selected",
     "legacyMenuNotAvailable": "Legacy manager menu is not available, defaulting to the new manager menu.",
+    "incompatibleVersion": {
+      "title": "ComfyUI-Manager upgrade required",
+      "message": "Please upgrade ComfyUI-Manager to version 4.2.1 or higher.\n• Desktop: Update the ComfyUI Desktop app\n• Standalone: Run pip install -U comfyui-manager and restart\nLearn more: https://github.com/Comfy-Org/ComfyUI-Manager"
+    },
     "legacyManagerUI": "Use Legacy UI",
     "legacyManagerUIDescription": "To use the legacy Manager UI, start ComfyUI with --enable-manager-legacy-ui",
     "legacyManagerSearchTip": "Looking for ComfyUI-Manager? You can enable the legacy manager UI by starting ComfyUI with the --enable-manager-legacy-ui flag.",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -1798,6 +1798,10 @@
     "gettingInfo": "정보 가져오는 중...",
     "importFailedGenericError": "패키지 가져오기에 실패했습니다. 자세한 내용은 콘솔을 확인하세요.",
     "inWorkflow": "워크플로 내",
+    "incompatibleVersion": {
+      "title": "ComfyUI-Manager 업그레이드 필요",
+      "message": "ComfyUI-Manager를 4.2.1 이상 버전으로 업그레이드해주세요.\n• 데스크톱: ComfyUI Desktop 앱을 업데이트하세요\n• 독립 실행형: pip install -U comfyui-manager 명령 실행 후 재시작하세요\n자세히 보기: https://github.com/Comfy-Org/ComfyUI-Manager"
+    },
     "infoPanelEmpty": "정보를 보려면 항목을 클릭하세요",
     "installAllMissingNodes": "모든 누락된 노드 설치",
     "installError": "설치 오류",

--- a/src/workbench/extensions/manager/composables/useManagerState.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.test.ts
@@ -6,10 +6,13 @@ import { api } from '@/scripts/api'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import {
   ManagerUIState,
+  __resetIncompatibleToastGuard,
   useManagerState
 } from '@/workbench/extensions/manager/composables/useManagerState'
 
 // Mock dependencies that are not stores
+vi.mock('@/i18n', () => ({ t: (key: string) => key }))
+
 vi.mock('@/scripts/api', () => ({
   api: {
     getClientFeatureFlags: vi.fn(),
@@ -42,14 +45,15 @@ vi.mock('@/stores/commandStore', () => ({
   }))
 }))
 
-vi.mock('@/platform/updates/common/toastStore', () => {
-  const add = vi.fn()
-  return {
-    useToastStore: vi.fn(() => ({
-      add
-    }))
-  }
-})
+const { toastAddMock } = vi.hoisted(() => ({
+  toastAddMock: vi.fn()
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: vi.fn(() => ({
+    add: toastAddMock
+  }))
+}))
 
 vi.mock('@/workbench/extensions/manager/composables/useManagerDialog', () => {
   const show = vi.fn()
@@ -61,6 +65,41 @@ vi.mock('@/workbench/extensions/manager/composables/useManagerDialog', () => {
     }))
   }
 })
+
+/**
+ * Helper to build a minimal systemStats argv-only fixture.
+ * Feature-flag values are supplied separately via mocked `api`.
+ */
+const systemStatsFixture = (argv: string[]) => ({
+  system: {
+    os: 'Test OS',
+    python_version: '3.10',
+    embedded_python: false,
+    comfyui_version: '1.0.0',
+    pytorch_version: '2.0.0',
+    argv,
+    ram_total: 16000000000,
+    ram_free: 8000000000
+  },
+  devices: []
+})
+
+/**
+ * Mocks the two server feature flags queried by useManagerState.
+ * `supports_v4`        → `extension.manager.supports_v4`
+ * `supports_csrf_post` → `extension.manager.supports_csrf_post`
+ */
+const mockServerFeatures = (flags: {
+  supports_v4?: boolean
+  supports_csrf_post?: boolean
+}) => {
+  vi.mocked(api.getServerFeature).mockImplementation((name: string) => {
+    if (name === 'extension.manager.supports_v4') return flags.supports_v4
+    if (name === 'extension.manager.supports_csrf_post')
+      return flags.supports_csrf_post
+    return undefined
+  })
+}
 
 describe('useManagerState', () => {
   let systemStatsStore: ReturnType<typeof useSystemStatsStore>
@@ -78,7 +117,8 @@ describe('useManagerState', () => {
     systemStatsStore = useSystemStatsStore()
 
     // Reset all mocks
-    vi.resetAllMocks()
+    vi.clearAllMocks()
+    __resetIncompatibleToastGuard()
 
     // Set default mock returns
     vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
@@ -87,21 +127,8 @@ describe('useManagerState', () => {
 
   describe('managerUIState property', () => {
     it('should return DISABLED state when --enable-manager is NOT present', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py'], // No --enable-manager flag
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture(['python', 'main.py']),
         isInitialized: true
       })
 
@@ -110,26 +137,13 @@ describe('useManagerState', () => {
     })
 
     it('should return LEGACY_UI state when --enable-manager-legacy-ui is present', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: [
-              'python',
-              'main.py',
-              '--enable-manager',
-              '--enable-manager-legacy-ui'
-            ],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager',
+          '--enable-manager-legacy-ui'
+        ]),
         isInitialized: true
       })
 
@@ -137,104 +151,68 @@ describe('useManagerState', () => {
       expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
-    it('should return NEW_UI state when client and server both support v4', () => {
-      // Set up store state
+    it('should return NEW_UI state when client and server both support v4 AND csrf_post', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
 
-    it('should return LEGACY_UI state when server supports v4 but client does not', () => {
-      // Set up store state
+    it('should return LEGACY_UI state when server supports v4 but client does not (and csrf_post present)', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: false
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
     it('should return LEGACY_UI state when server does not support v4', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({})
-      vi.mocked(api.getServerFeature).mockReturnValue(false)
+      mockServerFeatures({ supports_v4: false })
 
       const managerState = useManagerState()
       expect(managerState.managerUIState.value).toBe(ManagerUIState.LEGACY_UI)
     })
 
-    it('should return NEW_UI state when server feature flags are undefined', () => {
-      // Set up store state
+    it('should return NEW_UI state when server feature flags are undefined (transient fallback)', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager'
+        ]),
         isInitialized: true
       })
 
@@ -242,12 +220,10 @@ describe('useManagerState', () => {
       vi.mocked(api.getServerFeature).mockReturnValue(undefined)
 
       const managerState = useManagerState()
-      // When server feature flags haven't loaded yet, default to NEW_UI
       expect(managerState.managerUIState.value).toBe(ManagerUIState.NEW_UI)
     })
 
     it('should handle null systemStats gracefully', () => {
-      // Set up store state
       systemStatsStore.$patch({
         systemStats: null,
         isInitialized: true
@@ -256,59 +232,163 @@ describe('useManagerState', () => {
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
-      // When systemStats is null, we can't check for --enable-manager flag, so manager is disabled
       expect(managerState.managerUIState.value).toBe(ManagerUIState.DISABLED)
     })
   })
 
-  describe('helper properties', () => {
-    it('isManagerEnabled should return true when state is not DISABLED', () => {
-      // Set up store state
+  describe('INCOMPATIBLE state (missing supports_csrf_post)', () => {
+    const enabledManagerStats = () =>
+      systemStatsFixture(['python', 'main.py', '--enable-manager'])
+
+    it('returns INCOMPATIBLE when server supports v4 but csrf_post is false', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(managerState.managerUIState.value).toBe(
+        ManagerUIState.INCOMPATIBLE
+      )
+    })
+
+    it('returns INCOMPATIBLE when server supports v4 but csrf_post is undefined', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: undefined })
+
+      const managerState = useManagerState()
+      expect(managerState.managerUIState.value).toBe(
+        ManagerUIState.INCOMPATIBLE
+      )
+    })
+
+    it('isIncompatibleManager is true only in INCOMPATIBLE state', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(managerState.isIncompatibleManager.value).toBe(true)
+      expect(managerState.isNewManagerUI.value).toBe(false)
+      expect(managerState.isLegacyManagerUI.value).toBe(false)
+    })
+
+    it('shouldShowManagerButtons is false in INCOMPATIBLE state (hide UI)', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(managerState.shouldShowManagerButtons.value).toBe(false)
+      expect(managerState.isManagerEnabled.value).toBe(false)
+    })
+
+    it('fires warn-severity toast exactly once across multiple consumers', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      useManagerState()
+      useManagerState()
+      useManagerState()
+
+      expect(toastAddMock).toHaveBeenCalledTimes(1)
+      expect(toastAddMock).toHaveBeenCalledWith({
+        severity: 'warn',
+        summary: 'manager.incompatibleVersion.title',
+        detail: 'manager.incompatibleVersion.message',
+        life: 15000
+      })
+    })
+
+    it('openManager on INCOMPATIBLE re-emits the upgrade toast without settings redirect', async () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: false })
+
+      const managerState = useManagerState()
+      expect(toastAddMock).toHaveBeenCalledTimes(1)
+
+      await managerState.openManager()
+      expect(toastAddMock).toHaveBeenCalledTimes(2)
+      // second call must still be the upgrade toast, not an error toast
+      expect(toastAddMock).toHaveBeenLastCalledWith({
+        severity: 'warn',
+        summary: 'manager.incompatibleVersion.title',
+        detail: 'manager.incompatibleVersion.message',
+        life: 15000
+      })
+    })
+
+    it('does not fire upgrade toast when state is NEW_UI', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
+
+      useManagerState()
+      expect(toastAddMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('helper properties', () => {
+    const enabledManagerStats = () =>
+      systemStatsFixture(['python', 'main.py', '--enable-manager'])
+
+    it('isManagerEnabled should return true when state is not DISABLED / INCOMPATIBLE', () => {
+      systemStatsStore.$patch({
+        systemStats: enabledManagerStats(),
+        isInitialized: true
+      })
+      vi.mocked(api.getClientFeatureFlags).mockReturnValue({
+        supports_manager_v4_ui: true
+      })
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.isManagerEnabled.value).toBe(true)
     })
 
     it('isManagerEnabled should return false when state is DISABLED', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py'], // No --enable-manager flag
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture(['python', 'main.py']),
         isInitialized: true
       })
 
@@ -317,54 +397,27 @@ describe('useManagerState', () => {
     })
 
     it('isNewManagerUI should return true when state is NEW_UI', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.isNewManagerUI.value).toBe(true)
     })
 
     it('isLegacyManagerUI should return true when state is LEGACY_UI', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: [
-              'python',
-              'main.py',
-              '--enable-manager',
-              '--enable-manager-legacy-ui'
-            ],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: systemStatsFixture([
+          'python',
+          'main.py',
+          '--enable-manager',
+          '--enable-manager-legacy-ui'
+        ]),
         isInitialized: true
       })
 
@@ -373,56 +426,28 @@ describe('useManagerState', () => {
     })
 
     it('shouldShowInstallButton should return true only for NEW_UI', () => {
-      // Set up store state
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.shouldShowInstallButton.value).toBe(true)
     })
 
-    it('shouldShowManagerButtons should return true when not DISABLED', () => {
-      // Set up store state
+    it('shouldShowManagerButtons should return true when state is NEW_UI', () => {
       systemStatsStore.$patch({
-        systemStats: {
-          system: {
-            os: 'Test OS',
-            python_version: '3.10',
-            embedded_python: false,
-            comfyui_version: '1.0.0',
-            pytorch_version: '2.0.0',
-            argv: ['python', 'main.py', '--enable-manager'],
-            ram_total: 16000000000,
-            ram_free: 8000000000
-          },
-          devices: []
-        },
+        systemStats: enabledManagerStats(),
         isInitialized: true
       })
-
       vi.mocked(api.getClientFeatureFlags).mockReturnValue({
         supports_manager_v4_ui: true
       })
-      vi.mocked(api.getServerFeature).mockReturnValue(true)
+      mockServerFeatures({ supports_v4: true, supports_csrf_post: true })
 
       const managerState = useManagerState()
       expect(managerState.shouldShowManagerButtons.value).toBe(true)

--- a/src/workbench/extensions/manager/composables/useManagerState.ts
+++ b/src/workbench/extensions/manager/composables/useManagerState.ts
@@ -1,10 +1,10 @@
 import { storeToRefs } from 'pinia'
-import { computed, readonly } from 'vue'
+import { computed, readonly, watch } from 'vue'
 
 import { t } from '@/i18n'
+import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { api } from '@/scripts/api'
-import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useCommandStore } from '@/stores/commandStore'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 import { useManagerDialog } from '@/workbench/extensions/manager/composables/useManagerDialog'
@@ -13,7 +13,27 @@ import type { ManagerTab } from '@/workbench/extensions/manager/types/comfyManag
 export enum ManagerUIState {
   DISABLED = 'disabled',
   LEGACY_UI = 'legacy',
-  NEW_UI = 'new'
+  NEW_UI = 'new',
+  INCOMPATIBLE = 'incompatible'
+}
+
+/**
+ * Module-level flag to ensure the INCOMPATIBLE upgrade toast fires exactly
+ * once per app session, even when useManagerState() is invoked from many
+ * components. Without this, every consumer would register its own watcher
+ * and stack duplicate toasts on the first transition.
+ */
+let incompatibleToastShown = false
+
+const showIncompatibleToast = (): void => {
+  if (incompatibleToastShown) return
+  incompatibleToastShown = true
+  useToastStore().add({
+    severity: 'warn',
+    summary: t('manager.incompatibleVersion.title'),
+    detail: t('manager.incompatibleVersion.message'),
+    life: 15000
+  })
 }
 
 export function useManagerState() {
@@ -43,6 +63,10 @@ export function useManagerState() {
         'extension.manager.supports_v4'
       )
 
+      const supportsCsrfPost = api.getServerFeature(
+        'extension.manager.supports_csrf_post'
+      )
+
       // Check command line args first (highest priority)
       // --enable-manager flag enables the manager (opposite of old --disable-manager)
       const hasEnableManager =
@@ -57,6 +81,19 @@ export function useManagerState() {
         systemStats.value?.system?.argv?.includes('--enable-manager-legacy-ui')
       ) {
         return ManagerUIState.LEGACY_UI
+      }
+
+      // Server exposes v4 but is missing the CSRF-hardened POST endpoints
+      // (Manager < 4.2.1). Treat as INCOMPATIBLE — hide manager UI and
+      // prompt user to upgrade. csrf_post is an independent axis from v4.
+      //
+      // !== true (not === false) is deliberate: feature_flags arrive atomically
+      // via a single WebSocket payload (src/scripts/api.ts:751-758), so undefined
+      // here means the server did not publish the flag (i.e. Manager 4.2.0),
+      // not a transient partial-delivery state. Using === false would let
+      // flag-less Manager 4.2.0 fall through to NEW_UI → POST → 405 regression.
+      if (serverSupportsV4 === true && supportsCsrfPost !== true) {
+        return ManagerUIState.INCOMPATIBLE
       }
 
       // Both client and server support v4 = NEW_UI
@@ -88,11 +125,16 @@ export function useManagerState() {
   )
 
   /**
-   * Check if manager is enabled (not DISABLED)
+   * Check if manager is enabled (not DISABLED and not INCOMPATIBLE)
+   * INCOMPATIBLE is treated as "not installed" from a UX perspective —
+   * the user must upgrade the Manager backend before the UI becomes usable.
    */
   const isManagerEnabled = readonly(
     computed((): boolean => {
-      return managerUIState.value !== ManagerUIState.DISABLED
+      return (
+        managerUIState.value !== ManagerUIState.DISABLED &&
+        managerUIState.value !== ManagerUIState.INCOMPATIBLE
+      )
     })
   )
 
@@ -115,6 +157,16 @@ export function useManagerState() {
   )
 
   /**
+   * Check if the installed Manager backend is too old to use safely
+   * (lacks the CSRF-hardened POST endpoints introduced in Manager 4.2.1).
+   */
+  const isIncompatibleManager = readonly(
+    computed((): boolean => {
+      return managerUIState.value === ManagerUIState.INCOMPATIBLE
+    })
+  )
+
+  /**
    * Check if install button should be shown (only in NEW_UI mode)
    */
   const shouldShowInstallButton = readonly(
@@ -124,12 +176,26 @@ export function useManagerState() {
   )
 
   /**
-   * Check if manager buttons should be shown (when manager is not disabled)
+   * Check if manager buttons should be shown.
+   * Hidden when DISABLED (flag missing) or INCOMPATIBLE (backend too old).
    */
   const shouldShowManagerButtons = readonly(
     computed((): boolean => {
       return isManagerEnabled.value
     })
+  )
+
+  // Fire the upgrade-required toast once when we first observe the
+  // INCOMPATIBLE state. immediate: true handles the common case where the
+  // composable is mounted after feature flags have already arrived.
+  watch(
+    managerUIState,
+    (state) => {
+      if (state === ManagerUIState.INCOMPATIBLE) {
+        showIncompatibleToast()
+      }
+    },
+    { immediate: true }
   )
 
   /**
@@ -155,6 +221,15 @@ export function useManagerState() {
     switch (state) {
       case ManagerUIState.DISABLED:
         settingsDialog.show('extension')
+        break
+
+      case ManagerUIState.INCOMPATIBLE:
+        // Re-emit the upgrade toast on explicit user action. We intentionally
+        // bypass the once-per-session guard so repeated clicks on a hidden
+        // entry point (e.g. a stale shortcut) still surface guidance,
+        // without redirecting into settings like DISABLED does.
+        incompatibleToastShown = false
+        showIncompatibleToast()
         break
 
       case ManagerUIState.LEGACY_UI: {
@@ -198,8 +273,15 @@ export function useManagerState() {
     isManagerEnabled,
     isNewManagerUI,
     isLegacyManagerUI,
+    isIncompatibleManager,
     shouldShowInstallButton,
     shouldShowManagerButtons,
     openManager
   }
+}
+
+// Test-only export: resets the once-per-session toast guard so unit tests
+// can assert toast firing across multiple `useManagerState()` invocations.
+export const __resetIncompatibleToastGuard = (): void => {
+  incompatibleToastShown = false
 }

--- a/src/workbench/extensions/manager/services/comfyManagerService.ts
+++ b/src/workbench/extensions/manager/services/comfyManagerService.ts
@@ -126,7 +126,7 @@ export const useComfyManagerService = () => {
     }
 
     return executeRequest<null>(
-      () => managerApiClient.get(ManagerRoute.START_QUEUE, { signal }),
+      () => managerApiClient.post(ManagerRoute.START_QUEUE, null, { signal }),
       { errorContext, routeSpecificErrors }
     )
   }
@@ -265,7 +265,7 @@ export const useComfyManagerService = () => {
 
     return executeRequest<null>(
       () =>
-        managerApiClient.get(ManagerRoute.UPDATE_ALL, {
+        managerApiClient.post(ManagerRoute.UPDATE_ALL, null, {
           params: queryParams,
           signal
         }),
@@ -292,7 +292,7 @@ export const useComfyManagerService = () => {
 
     return executeRequest<null>(
       () =>
-        managerApiClient.get(ManagerRoute.UPDATE_COMFYUI, {
+        managerApiClient.post(ManagerRoute.UPDATE_COMFYUI, null, {
           params: queryParams,
           signal
         }),
@@ -307,7 +307,7 @@ export const useComfyManagerService = () => {
     }
 
     return executeRequest<null>(
-      () => managerApiClient.get(ManagerRoute.REBOOT, { signal }),
+      () => managerApiClient.post(ManagerRoute.REBOOT, null, { signal }),
       { errorContext, routeSpecificErrors }
     )
   }


### PR DESCRIPTION
Backport of #11520 to `core/1.43`.

Cherry-picked merge commit `bd96bdf4cc7a8c1460ca5d37cc2c856f4f1654b9`.

**Conflict resolution:**
- `browser_tests/tests/dialogs/managerDialog.spec.ts`: file was deleted in `core/1.43` but modified in the original PR — accepted the PR version per backport policy.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11588-backport-core-1-43-fix-manager-migrate-4-endpoints-GET-POST-for-CSRF-hardening-34c6d73d365081d8b1f4fc9607fa2dbd) by [Unito](https://www.unito.io)
