### PR TITLE
feat: add inline-CTA nightly survey for error panel

### DIFF
--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -183,6 +183,8 @@
       </TransitionGroup>
     </div>
 
+    <ErrorPanelSurveyCta v-if="ErrorPanelSurveyCta" />
+
     <!-- Fixed Footer: Help Links -->
     <div class="min-w-0 shrink-0 border-t border-interface-stroke p-4">
       <i18n-t
@@ -216,7 +218,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
@@ -235,7 +237,7 @@ import MissingNodeCard from './MissingNodeCard.vue'
 import SwapNodesCard from '@/platform/nodeReplacement/components/SwapNodesCard.vue'
 import MissingModelCard from '@/platform/missingModel/components/MissingModelCard.vue'
 import MissingMediaCard from '@/platform/missingMedia/components/MissingMediaCard.vue'
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
 import {
   downloadModel,
   isModelDownloadable
@@ -251,6 +253,13 @@ import { useErrorGroups } from './useErrorGroups'
 import type { SwapNodeGroup } from './useErrorGroups'
 import type { ErrorGroup } from './types'
 import { useNodeReplacement } from '@/platform/nodeReplacement/useNodeReplacement'
+
+const ErrorPanelSurveyCta =
+  isNightly && !isCloud && !isDesktop
+    ? defineAsyncComponent(
+        () => import('@/platform/surveys/ErrorPanelSurveyCta.vue')
+      )
+    : undefined
 
 const { t } = useI18n()
 const { copyToClipboard } = useCopyToClipboard()

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2775,6 +2775,10 @@
     "dontAskAgain": "Don't Ask Again",
     "loadError": "Failed to load survey. Please try again later."
   },
+  "errorPanelSurvey": {
+    "ctaText": "How's the new error panel?",
+    "ctaButton": "Give feedback"
+  },
   "cloudOnboarding": {
     "skipToCloudApp": "Skip to the cloud app",
     "survey": {

--- a/src/platform/surveys/ErrorPanelSurveyCta.test.ts
+++ b/src/platform/surveys/ErrorPanelSurveyCta.test.ts
@@ -1,0 +1,193 @@
+import { render, screen, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+const FEATURE_USAGE_KEY = 'Comfy.FeatureUsage'
+const SURVEY_STATE_KEY = 'Comfy.SurveyState'
+const FEATURE_ID = 'error-panel'
+const PRESENTATION_INLINE_CTA = 'inline-cta'
+const CTA_TEST_ID = 'error-panel-survey-cta'
+const CTA_BUTTON_NAME = /errorPanelSurvey.ctaButton/
+const CLOSE_BUTTON_NAME = 'g.close'
+
+const mockIsNightly = vi.hoisted(() => ({ value: true }))
+const mockIsCloud = vi.hoisted(() => ({ value: false }))
+const mockIsDesktop = vi.hoisted(() => ({ value: false }))
+const mockSurveyConfig = vi.hoisted(() => ({
+  value: {
+    featureId: 'error-panel',
+    typeformId: 'iFp4p4mV',
+    triggerThreshold: 3,
+    presentation: 'inline-cta'
+  } as
+    | {
+        featureId: string
+        typeformId: string
+        triggerThreshold?: number
+        presentation?: string
+      }
+    | undefined
+}))
+const mockOpen = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isNightly() {
+    return mockIsNightly.value
+  },
+  get isCloud() {
+    return mockIsCloud.value
+  },
+  get isDesktop() {
+    return mockIsDesktop.value
+  }
+}))
+
+vi.mock('./surveyRegistry', () => ({
+  getSurveyConfig: (id: string) =>
+    id === FEATURE_ID ? mockSurveyConfig.value : undefined
+}))
+
+vi.mock('./useErrorSurveyPopoverState', () => ({
+  useErrorSurveyPopoverState: () => ({
+    isPopoverOpen: ref(false),
+    hasOpenedOnce: ref(false),
+    open: mockOpen,
+    close: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: vi.fn(() => ({
+    t: (key: string) => key
+  }))
+}))
+
+describe('ErrorPanelSurveyCta', () => {
+  function setFeatureUsage(featureId: string, useCount: number) {
+    const existing = JSON.parse(localStorage.getItem(FEATURE_USAGE_KEY) ?? '{}')
+    existing[featureId] = {
+      useCount,
+      firstUsed: Date.now() - 1000,
+      lastUsed: Date.now()
+    }
+    localStorage.setItem(FEATURE_USAGE_KEY, JSON.stringify(existing))
+  }
+
+  function readSurveyState() {
+    return JSON.parse(
+      localStorage.getItem(SURVEY_STATE_KEY) ??
+        '{"optedOut":false,"seenSurveys":{}}'
+    )
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+    mockOpen.mockReset()
+
+    mockIsNightly.value = true
+    mockIsCloud.value = false
+    mockIsDesktop.value = false
+    mockSurveyConfig.value = {
+      featureId: FEATURE_ID,
+      typeformId: 'iFp4p4mV',
+      triggerThreshold: 3,
+      presentation: PRESENTATION_INLINE_CTA
+    }
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  async function renderComponent() {
+    const { default: ErrorPanelSurveyCta } =
+      await import('./ErrorPanelSurveyCta.vue')
+    return render(ErrorPanelSurveyCta)
+  }
+
+  it('does not render CTA below threshold', async () => {
+    setFeatureUsage(FEATURE_ID, 1)
+
+    await renderComponent()
+    await nextTick()
+
+    expect(screen.queryByTestId(CTA_TEST_ID)).not.toBeInTheDocument()
+  })
+
+  it('renders CTA when eligible (threshold met, nightly localhost)', async () => {
+    setFeatureUsage(FEATURE_ID, 5)
+
+    await renderComponent()
+    await nextTick()
+
+    expect(screen.getByTestId(CTA_TEST_ID)).toBeInTheDocument()
+  })
+
+  it('does not render CTA on cloud build', async () => {
+    mockIsCloud.value = true
+    setFeatureUsage(FEATURE_ID, 5)
+
+    await renderComponent()
+    await nextTick()
+
+    expect(screen.queryByTestId(CTA_TEST_ID)).not.toBeInTheDocument()
+  })
+
+  it('does not render CTA on desktop build', async () => {
+    mockIsDesktop.value = true
+    setFeatureUsage(FEATURE_ID, 5)
+
+    await renderComponent()
+    await nextTick()
+
+    expect(screen.queryByTestId(CTA_TEST_ID)).not.toBeInTheDocument()
+  })
+
+  it('does not render CTA when typeformId is invalid', async () => {
+    mockSurveyConfig.value = {
+      featureId: FEATURE_ID,
+      typeformId: 'invalid id with spaces!',
+      triggerThreshold: 3,
+      presentation: PRESENTATION_INLINE_CTA
+    }
+    setFeatureUsage(FEATURE_ID, 5)
+
+    await renderComponent()
+    await nextTick()
+
+    expect(screen.queryByTestId(CTA_TEST_ID)).not.toBeInTheDocument()
+  })
+
+  it('invokes shared popover open() when CTA button clicked', async () => {
+    setFeatureUsage(FEATURE_ID, 5)
+    const user = userEvent.setup()
+
+    await renderComponent()
+    await nextTick()
+
+    await user.click(screen.getByRole('button', { name: CTA_BUTTON_NAME }))
+
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+    expect(readSurveyState().seenSurveys[FEATURE_ID]).toBeUndefined()
+  })
+
+  it('dismisses CTA and marks seen when × on CTA clicked', async () => {
+    setFeatureUsage(FEATURE_ID, 5)
+    const user = userEvent.setup()
+
+    await renderComponent()
+    await nextTick()
+
+    const cta = screen.getByTestId(CTA_TEST_ID)
+    const dismissButton = within(cta).getByRole('button', {
+      name: CLOSE_BUTTON_NAME
+    })
+    await user.click(dismissButton)
+    await nextTick()
+
+    expect(screen.queryByTestId(CTA_TEST_ID)).not.toBeInTheDocument()
+    expect(readSurveyState().seenSurveys[FEATURE_ID]).toBeGreaterThan(0)
+  })
+})

--- a/src/platform/surveys/ErrorPanelSurveyCta.vue
+++ b/src/platform/surveys/ErrorPanelSurveyCta.vue
@@ -1,0 +1,54 @@
+<template>
+  <div
+    v-if="shouldRenderCta"
+    data-testid="error-panel-survey-cta"
+    class="flex min-w-0 shrink-0 items-center justify-between gap-2 border-t border-interface-stroke px-4 py-3"
+  >
+    <span class="min-w-0 flex-1 text-sm/tight text-muted-foreground">
+      {{ t('errorPanelSurvey.ctaText') }}
+    </span>
+    <div class="flex shrink-0 items-center gap-1">
+      <Button variant="overlay-white" size="sm" @click="open">
+        {{ t('errorPanelSurvey.ctaButton') }}
+      </Button>
+      <Button
+        variant="muted-textonly"
+        size="icon-sm"
+        :aria-label="t('g.close')"
+        @click="markSeen"
+      >
+        <i class="icon-[lucide--x] size-4" />
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+
+import { getSurveyConfig } from './surveyRegistry'
+import { useErrorSurveyPopoverState } from './useErrorSurveyPopoverState'
+import { useSurveyEligibility } from './useSurveyEligibility'
+import { isTypeformIdValid } from './useTypeformEmbed'
+
+const { t } = useI18n()
+
+const config = getSurveyConfig('error-panel')
+
+const { isEligible, markSurveyShown } = useSurveyEligibility(
+  () => config ?? { featureId: 'error-panel', typeformId: '' }
+)
+
+const { open } = useErrorSurveyPopoverState()
+
+const shouldRenderCta = computed(
+  () => !!config && isEligible.value && isTypeformIdValid(config.typeformId)
+)
+
+function markSeen() {
+  markSurveyShown()
+}
+</script>

--- a/src/platform/surveys/NightlySurveyController.vue
+++ b/src/platform/surveys/NightlySurveyController.vue
@@ -1,14 +1,32 @@
+<template>
+  <template v-for="config in enabledSurveys" :key="config.featureId">
+    <NightlySurveyPopover :config />
+  </template>
+  <NightlySurveyPopover
+    v-if="errorPanelConfig"
+    v-model:open="isErrorPopoverOpen"
+    :config="errorPanelConfig"
+    mode="manual"
+  />
+</template>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
 import NightlySurveyPopover from './NightlySurveyPopover.vue'
-import { getEnabledSurveys } from './surveyRegistry'
+import { getFloatingSurveys, getSurveyConfig } from './surveyRegistry'
+import { useErrorSurveyPopoverState } from './useErrorSurveyPopoverState'
+import { useErrorSurveyTracking } from './useErrorSurveyTracking'
 
-const enabledSurveys = computed(() => getEnabledSurveys())
+useErrorSurveyTracking()
+
+const { isPopoverOpen: isErrorPopoverOpen } = useErrorSurveyPopoverState()
+
+const enabledSurveys = computed(() => getFloatingSurveys())
+const errorPanelConfig = computed(() => {
+  const config = getSurveyConfig('error-panel')
+  if (!config || config.enabled === false) return undefined
+  if (config.presentation !== 'inline-cta') return undefined
+  return config
+})
 </script>
-
-<template>
-  <template v-for="config in enabledSurveys" :key="config.featureId">
-    <NightlySurveyPopover :config="config" />
-  </template>
-</template>

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -171,6 +171,83 @@ describe('NightlySurveyPopover', () => {
     })
   })
 
+  describe('manual mode', () => {
+    async function renderManual(open = false) {
+      const { default: NightlySurveyPopover } =
+        await import('./NightlySurveyPopover.vue')
+      return render(NightlySurveyPopover, {
+        props: {
+          config: defaultConfig,
+          mode: 'manual',
+          open
+        },
+        global: {
+          stubs: {
+            Teleport: true
+          }
+        }
+      })
+    }
+
+    it('does not auto-open via eligibility watcher', async () => {
+      setFeatureUsage('test-feature', 5)
+
+      await renderManual(false)
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(1000)
+      await nextTick()
+
+      expect(
+        screen.queryByTestId('nightly-survey-popover')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows when parent sets open=true regardless of delay', async () => {
+      await renderManual(true)
+      await nextTick()
+
+      expect(screen.getByTestId('nightly-survey-popover')).toBeInTheDocument()
+    })
+
+    it('does not render the Not Now button', async () => {
+      await renderManual(true)
+      await nextTick()
+
+      expect(
+        screen.queryByRole('button', { name: /nightlySurvey.notNow/ })
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not call markSurveyShown automatically', async () => {
+      await renderManual(true)
+      await nextTick()
+
+      const state = JSON.parse(
+        localStorage.getItem('Comfy.SurveyState') ??
+          '{"optedOut":false,"seenSurveys":{}}'
+      )
+      expect(state.seenSurveys['test-feature']).toBeUndefined()
+    })
+
+    it("still persists optedOut when Don't Ask Again clicked", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      await renderManual(true)
+      await nextTick()
+
+      const optOutButton = screen.getByRole('button', {
+        name: /nightlySurvey.dontAskAgain/
+      })
+      await user.click(optOutButton)
+      await nextTick()
+
+      const state = JSON.parse(
+        localStorage.getItem('Comfy.SurveyState') ?? '{}'
+      )
+      expect(state.optedOut).toBe(true)
+    })
+  })
+
   describe('config', () => {
     it('uses custom delay from config', async () => {
       setFeatureUsage('test-feature', 5)

--- a/src/platform/surveys/NightlySurveyPopover.vue
+++ b/src/platform/surveys/NightlySurveyPopover.vue
@@ -127,6 +127,7 @@ watch(
     showTimeout = setTimeout(() => {
       showTimeout = null
       if (!isValidTypeformId.value) return
+      if (openModel.value) return
       openModel.value = true
       markSurveyShown()
       emit('shown')
@@ -142,12 +143,20 @@ onUnmounted(() => {
 })
 
 function handleDismiss() {
+  if (showTimeout) {
+    clearTimeout(showTimeout)
+    showTimeout = null
+  }
   openModel.value = false
   emit('dismissed')
 }
 
 function handleOptOut() {
   optOut()
+  if (showTimeout) {
+    clearTimeout(showTimeout)
+    showTimeout = null
+  }
   openModel.value = false
   emit('optedOut')
 }

--- a/src/platform/surveys/NightlySurveyPopover.vue
+++ b/src/platform/surveys/NightlySurveyPopover.vue
@@ -1,101 +1,7 @@
-<script setup lang="ts">
-import { whenever } from '@vueuse/core'
-import { computed, onUnmounted, ref, useTemplateRef, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-
-import Button from '@/components/ui/button/Button.vue'
-
-import type { FeatureSurveyConfig } from './useSurveyEligibility'
-import { useSurveyEligibility } from './useSurveyEligibility'
-
-const { config } = defineProps<{
-  config: FeatureSurveyConfig
-}>()
-
-const emit = defineEmits<{
-  shown: []
-  dismissed: []
-  optedOut: []
-}>()
-
-const { t } = useI18n()
-
-const { isEligible, delayMs, markSurveyShown, optOut } = useSurveyEligibility(
-  () => config
-)
-
-const TYPEFORM_SRC = 'https://embed.typeform.com/next/embed.js'
-
-const isVisible = ref(false)
-const typeformError = ref(false)
-const typeformRef = useTemplateRef<HTMLDivElement>('typeformRef')
-
-let showTimeout: ReturnType<typeof setTimeout> | null = null
-
-const isValidTypeformId = computed(() =>
-  /^[A-Za-z0-9]+$/.test(config.typeformId)
-)
-const typeformId = computed(() =>
-  isValidTypeformId.value ? config.typeformId : ''
-)
-
-watch(
-  isEligible,
-  (eligible) => {
-    if (!eligible) {
-      if (showTimeout) {
-        clearTimeout(showTimeout)
-        showTimeout = null
-      }
-      return
-    }
-
-    if (isVisible.value || showTimeout) return
-
-    showTimeout = setTimeout(() => {
-      showTimeout = null
-      if (!isValidTypeformId.value) return
-      isVisible.value = true
-      markSurveyShown()
-      emit('shown')
-    }, delayMs.value)
-  },
-  { immediate: true }
-)
-
-onUnmounted(() => {
-  if (showTimeout) {
-    clearTimeout(showTimeout)
-  }
-})
-
-whenever(typeformRef, () => {
-  if (document.querySelector(`script[src="${TYPEFORM_SRC}"]`)) return
-
-  const scriptEl = document.createElement('script')
-  scriptEl.src = TYPEFORM_SRC
-  scriptEl.async = true
-  scriptEl.onerror = () => {
-    typeformError.value = true
-  }
-  document.head.appendChild(scriptEl)
-})
-
-function handleDismiss() {
-  isVisible.value = false
-  emit('dismissed')
-}
-
-function handleOptOut() {
-  optOut()
-  isVisible.value = false
-  emit('optedOut')
-}
-</script>
-
 <template>
-  <Teleport to="body">
+  <Teleport v-if="hasOpenedOnce" to="body">
     <Transition
+      appear
       enter-active-class="transition duration-300 ease-out"
       enter-from-class="translate-x-full opacity-0"
       enter-to-class="translate-x-0 opacity-100"
@@ -104,7 +10,7 @@ function handleOptOut() {
       leave-to-class="translate-x-full opacity-0"
     >
       <div
-        v-if="isVisible"
+        v-show="openModel"
         data-testid="nightly-survey-popover"
         class="fixed right-4 bottom-4 z-10000 w-80 rounded-lg border border-border-subtle bg-base-background p-4 shadow-lg"
       >
@@ -124,15 +30,23 @@ function handleOptOut() {
         </div>
 
         <div
-          v-show="isVisible && !typeformError && isValidTypeformId"
+          v-show="!typeformError && isValidTypeformId"
           ref="typeformRef"
           data-tf-auto-resize
           :data-tf-widget="typeformId"
           class="min-h-[300px]"
         />
 
-        <div class="mt-3 flex items-center justify-center gap-2">
-          <Button variant="textonly" size="sm" @click="handleDismiss">
+        <div
+          class="mt-3 flex items-center gap-2"
+          :class="mode === 'eligible' ? 'justify-center' : 'justify-end'"
+        >
+          <Button
+            v-if="mode === 'eligible'"
+            variant="textonly"
+            size="sm"
+            @click="handleDismiss"
+          >
             {{ t('nightlySurvey.notNow') }}
           </Button>
           <Button variant="muted-textonly" size="sm" @click="handleOptOut">
@@ -143,3 +57,98 @@ function handleOptOut() {
     </Transition>
   </Teleport>
 </template>
+
+<script setup lang="ts">
+import { onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+
+import type { FeatureSurveyConfig } from './useSurveyEligibility'
+import { useSurveyEligibility } from './useSurveyEligibility'
+import { useTypeformEmbed } from './useTypeformEmbed'
+
+const { config, mode = 'eligible' } = defineProps<{
+  config: FeatureSurveyConfig
+  /**
+   * `eligible` (default): auto-opens after threshold + delay, marks seen on
+   * show, renders "Not Now" button. Used by the global controller for
+   * floating surveys.
+   * `manual`: parent drives visibility via `v-model:open`. Feature site
+   * decides when to mark seen / dismiss. Used by inline-CTA surveys.
+   */
+  mode?: 'eligible' | 'manual'
+}>()
+
+const openModel = defineModel<boolean>('open', { default: false })
+
+const emit = defineEmits<{
+  shown: []
+  dismissed: []
+  optedOut: []
+}>()
+
+const { t } = useI18n()
+
+const { isEligible, delayMs, markSurveyShown, optOut } = useSurveyEligibility(
+  () => config
+)
+
+const hasOpenedOnce = ref(openModel.value)
+const typeformRef = useTemplateRef<HTMLDivElement>('typeformRef')
+
+const { typeformError, isValidTypeformId, typeformId } = useTypeformEmbed(
+  typeformRef,
+  () => config.typeformId
+)
+
+// Teleport stays mounted after the first open so the Typeform iframe
+// persists across consumer-side lifecycle changes.
+watch(openModel, (open) => {
+  if (open) hasOpenedOnce.value = true
+})
+
+let showTimeout: ReturnType<typeof setTimeout> | null = null
+
+watch(
+  isEligible,
+  (eligible) => {
+    if (mode !== 'eligible') return
+    if (!eligible) {
+      if (showTimeout) {
+        clearTimeout(showTimeout)
+        showTimeout = null
+      }
+      return
+    }
+
+    if (openModel.value || showTimeout) return
+
+    showTimeout = setTimeout(() => {
+      showTimeout = null
+      if (!isValidTypeformId.value) return
+      openModel.value = true
+      markSurveyShown()
+      emit('shown')
+    }, delayMs.value)
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  if (showTimeout) {
+    clearTimeout(showTimeout)
+  }
+})
+
+function handleDismiss() {
+  openModel.value = false
+  emit('dismissed')
+}
+
+function handleOptOut() {
+  optOut()
+  openModel.value = false
+  emit('optedOut')
+}
+</script>

--- a/src/platform/surveys/surveyRegistry.test.ts
+++ b/src/platform/surveys/surveyRegistry.test.ts
@@ -5,6 +5,7 @@ import type { FeatureSurveyConfig } from './useSurveyEligibility'
 import {
   FEATURE_SURVEYS,
   getEnabledSurveys,
+  getFloatingSurveys,
   getSurveyConfig
 } from './surveyRegistry'
 
@@ -70,6 +71,47 @@ describe('surveyRegistry', () => {
 
       const enabled = getEnabledSurveys()
       expect(enabled).not.toContainEqual(disabledConfig)
+    })
+  })
+
+  describe('getFloatingSurveys', () => {
+    it('includes entries without a presentation field (defaults to floating)', () => {
+      const floating = getFloatingSurveys()
+      expect(floating).toContainEqual(TEST_CONFIG)
+    })
+
+    it('includes entries with presentation: "floating"', () => {
+      const explicitFloating: FeatureSurveyConfig = {
+        featureId: '__explicit-floating__',
+        typeformId: 'form-1',
+        presentation: 'floating'
+      }
+      FEATURE_SURVEYS['__explicit-floating__'] = explicitFloating
+
+      expect(getFloatingSurveys()).toContainEqual(explicitFloating)
+    })
+
+    it('excludes entries with presentation: "inline-cta"', () => {
+      const inlineCta: FeatureSurveyConfig = {
+        featureId: '__inline__',
+        typeformId: 'form-2',
+        presentation: 'inline-cta'
+      }
+      FEATURE_SURVEYS['__inline__'] = inlineCta
+
+      expect(getFloatingSurveys()).not.toContainEqual(inlineCta)
+    })
+
+    it('excludes entries with enabled: false even when presentation is floating', () => {
+      const disabledFloating: FeatureSurveyConfig = {
+        featureId: '__disabled-floating__',
+        typeformId: 'form-3',
+        presentation: 'floating',
+        enabled: false
+      }
+      FEATURE_SURVEYS['__disabled-floating__'] = disabledFloating
+
+      expect(getFloatingSurveys()).not.toContainEqual(disabledFloating)
     })
   })
 })

--- a/src/platform/surveys/surveyRegistry.ts
+++ b/src/platform/surveys/surveyRegistry.ts
@@ -10,6 +10,12 @@ export const FEATURE_SURVEYS: Record<string, FeatureSurveyConfig> = {
     typeformId: 'goZLqjKL',
     triggerThreshold: 3,
     delayMs: 5000
+  },
+  'error-panel': {
+    featureId: 'error-panel',
+    typeformId: 'iFp4p4mV',
+    triggerThreshold: 3,
+    presentation: 'inline-cta'
   }
 }
 
@@ -22,5 +28,15 @@ export function getSurveyConfig(
 export function getEnabledSurveys(): FeatureSurveyConfig[] {
   return Object.values(FEATURE_SURVEYS).filter(
     (config) => config.enabled !== false
+  )
+}
+
+/**
+ * Surveys that should auto-popup via the global controller.
+ * Inline-CTA surveys are excluded because their feature-site renders them.
+ */
+export function getFloatingSurveys(): FeatureSurveyConfig[] {
+  return getEnabledSurveys().filter(
+    (config) => (config.presentation ?? 'floating') === 'floating'
   )
 }

--- a/src/platform/surveys/useErrorSurveyPopoverState.test.ts
+++ b/src/platform/surveys/useErrorSurveyPopoverState.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('useErrorSurveyPopoverState', () => {
+  beforeEach(async () => {
+    const { useErrorSurveyPopoverState } =
+      await import('./useErrorSurveyPopoverState')
+    useErrorSurveyPopoverState().isPopoverOpen.value = false
+  })
+
+  it('returns a singleton shared across callers', async () => {
+    const { useErrorSurveyPopoverState } =
+      await import('./useErrorSurveyPopoverState')
+    const first = useErrorSurveyPopoverState()
+    const second = useErrorSurveyPopoverState()
+
+    expect(first.isPopoverOpen).toBe(second.isPopoverOpen)
+  })
+
+  it('open() sets isPopoverOpen to true', async () => {
+    const { useErrorSurveyPopoverState } =
+      await import('./useErrorSurveyPopoverState')
+    const { isPopoverOpen, open } = useErrorSurveyPopoverState()
+
+    expect(isPopoverOpen.value).toBe(false)
+    open()
+    expect(isPopoverOpen.value).toBe(true)
+  })
+
+  it('state persists across multiple invocations', async () => {
+    const { useErrorSurveyPopoverState } =
+      await import('./useErrorSurveyPopoverState')
+    useErrorSurveyPopoverState().open()
+
+    const { isPopoverOpen } = useErrorSurveyPopoverState()
+    expect(isPopoverOpen.value).toBe(true)
+  })
+})

--- a/src/platform/surveys/useErrorSurveyPopoverState.ts
+++ b/src/platform/surveys/useErrorSurveyPopoverState.ts
@@ -1,0 +1,26 @@
+import type { Ref } from 'vue'
+import { ref } from 'vue'
+
+/**
+ * Singleton state for the error panel survey popover visibility.
+ * Kept at module scope so popover visibility survives the lifecycle of
+ * individual host components (e.g. the error tab being destroyed when no
+ * errors remain). Together with the popover component keeping its
+ * Teleport mounted after the first open, this is what preserves the
+ * Typeform iframe across workflow switches.
+ */
+const isPopoverOpen = ref(false)
+
+export function useErrorSurveyPopoverState(): {
+  isPopoverOpen: Ref<boolean>
+  open: () => void
+} {
+  function open() {
+    isPopoverOpen.value = true
+  }
+
+  return {
+    isPopoverOpen,
+    open
+  }
+}

--- a/src/platform/surveys/useErrorSurveyTracking.test.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.test.ts
@@ -1,0 +1,98 @@
+import { createPinia, defineStore, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+
+const trackFeatureUsed = vi.hoisted(() => vi.fn())
+
+vi.mock('./useSurveyFeatureTracking', () => ({
+  useSurveyFeatureTracking: () => ({
+    trackFeatureUsed,
+    useCount: ref(0)
+  })
+}))
+
+const useFakeExecutionErrorStore = defineStore('fakeExecutionError', () => {
+  const hasAnyError = ref(false)
+  return { hasAnyError }
+})
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => useFakeExecutionErrorStore()
+}))
+
+import { useErrorSurveyTracking } from './useErrorSurveyTracking'
+
+describe('useErrorSurveyTracking', () => {
+  let scope: ReturnType<typeof effectScope>
+  let store: ReturnType<typeof useFakeExecutionErrorStore>
+
+  function setup() {
+    scope = effectScope()
+    scope.run(() => useErrorSurveyTracking())
+  }
+
+  beforeEach(() => {
+    trackFeatureUsed.mockReset()
+    setActivePinia(createPinia())
+    store = useFakeExecutionErrorStore()
+  })
+
+  afterEach(() => {
+    scope?.stop()
+  })
+
+  it('counts false → true transition once', async () => {
+    setup()
+    store.hasAnyError = true
+    await nextTick()
+
+    expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
+  })
+
+  it('counts initial true state on mount', async () => {
+    store.hasAnyError = true
+    setup()
+    await nextTick()
+
+    expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not count initial false state on mount', async () => {
+    setup()
+    await nextTick()
+
+    expect(trackFeatureUsed).not.toHaveBeenCalled()
+  })
+
+  it('does not count true → false transition', async () => {
+    setup()
+    store.hasAnyError = true
+    await nextTick()
+    store.hasAnyError = false
+    await nextTick()
+
+    expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
+  })
+
+  it('counts a fresh error after clear as a second use', async () => {
+    setup()
+    store.hasAnyError = true
+    await nextTick()
+    store.hasAnyError = false
+    await nextTick()
+    store.hasAnyError = true
+    await nextTick()
+
+    expect(trackFeatureUsed).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not double-count when state stays true', async () => {
+    setup()
+    store.hasAnyError = true
+    await nextTick()
+    store.hasAnyError = true
+    await nextTick()
+
+    expect(trackFeatureUsed).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/platform/surveys/useErrorSurveyTracking.ts
+++ b/src/platform/surveys/useErrorSurveyTracking.ts
@@ -1,0 +1,29 @@
+import { storeToRefs } from 'pinia'
+import { watch } from 'vue'
+
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+
+import { useSurveyFeatureTracking } from './useSurveyFeatureTracking'
+
+const FEATURE_ID = 'error-panel'
+
+/**
+ * Counts error panel occurrences for nightly survey eligibility.
+ * Each transition into an error state (from "no errors anywhere" to
+ * "at least one error somewhere") increments the counter. This treats
+ * a workflow load with multiple simultaneous error types as one event.
+ * `immediate: true` ensures a workflow that loads already in an error
+ * state (e.g. missing nodes/models on startup) counts on initial mount.
+ */
+export function useErrorSurveyTracking() {
+  const { trackFeatureUsed } = useSurveyFeatureTracking(FEATURE_ID)
+  const { hasAnyError } = storeToRefs(useExecutionErrorStore())
+
+  watch(
+    hasAnyError,
+    (next, prev) => {
+      if (!prev && next) trackFeatureUsed()
+    },
+    { immediate: true }
+  )
+}

--- a/src/platform/surveys/useSurveyEligibility.ts
+++ b/src/platform/surveys/useSurveyEligibility.ts
@@ -13,6 +13,13 @@ export interface FeatureSurveyConfig {
   triggerThreshold?: number
   delayMs?: number
   enabled?: boolean
+  /**
+   * How the survey is presented.
+   * - `floating` (default): auto-popup in the lower-right once eligible.
+   * - `inline-cta`: a feature-site component renders its own CTA and decides
+   *   when to open the survey — the global controller ignores it.
+   */
+  presentation?: 'floating' | 'inline-cta'
 }
 
 interface SurveyState {

--- a/src/platform/surveys/useTypeformEmbed.test.ts
+++ b/src/platform/surveys/useTypeformEmbed.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { effectScope, ref } from 'vue'
+
+import { useTypeformEmbed } from './useTypeformEmbed'
+
+describe('useTypeformEmbed', () => {
+  let scope: ReturnType<typeof effectScope>
+
+  function runInScope<T>(fn: () => T): T {
+    scope = effectScope()
+    return scope.run(fn) as T
+  }
+
+  beforeEach(() => {
+    scope = effectScope()
+  })
+
+  afterEach(() => {
+    scope?.stop()
+  })
+
+  it('marks alphanumeric ids as valid', () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const result = runInScope(() => useTypeformEmbed(containerRef, 'goZLqjKL'))
+
+    expect(result.isValidTypeformId.value).toBe(true)
+    expect(result.typeformId.value).toBe('goZLqjKL')
+  })
+
+  it('marks ids with non-alphanumeric characters as invalid', () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const result = runInScope(() =>
+      useTypeformEmbed(containerRef, 'bad id with spaces!')
+    )
+
+    expect(result.isValidTypeformId.value).toBe(false)
+    expect(result.typeformId.value).toBe('')
+  })
+
+  it('marks undefined id as invalid', () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const result = runInScope(() => useTypeformEmbed(containerRef, undefined))
+
+    expect(result.isValidTypeformId.value).toBe(false)
+    expect(result.typeformId.value).toBe('')
+  })
+
+  it('marks empty string id as invalid', () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const result = runInScope(() => useTypeformEmbed(containerRef, ''))
+
+    expect(result.isValidTypeformId.value).toBe(false)
+    expect(result.typeformId.value).toBe('')
+  })
+
+  it('exposes a reactive typeformError ref initialized to false', () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const result = runInScope(() => useTypeformEmbed(containerRef, 'goZLqjKL'))
+
+    expect(result.typeformError.value).toBe(false)
+  })
+})

--- a/src/platform/surveys/useTypeformEmbed.ts
+++ b/src/platform/surveys/useTypeformEmbed.ts
@@ -1,0 +1,125 @@
+import { whenever } from '@vueuse/core'
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import { computed, ref, toValue } from 'vue'
+
+const TYPEFORM_SRC = 'https://embed.typeform.com/next/embed.js'
+const VALID_ID_PATTERN = /^[A-Za-z0-9]+$/
+const SCRIPT_LOAD_TIMEOUT_MS = 10_000
+
+interface TypeformGlobal {
+  load?: () => void
+}
+
+declare global {
+  interface Window {
+    tf?: TypeformGlobal
+  }
+}
+
+/** Pure validator for Typeform form IDs. Exported so feature sites can
+ *  gate rendering before mounting the embed container. */
+export function isTypeformIdValid(id: string | undefined | null): boolean {
+  return !!id && VALID_ID_PATTERN.test(id)
+}
+
+/**
+ * Module-level singleton so every consumer shares one script load.
+ * Resets to `null` on failure so a later consumer can retry.
+ */
+let scriptPromise: Promise<void> | null = null
+
+function ensureScriptLoaded(): Promise<void> {
+  if (scriptPromise) return scriptPromise
+
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${TYPEFORM_SRC}"]`
+    )
+
+    if (existing && typeof window.tf?.load === 'function') {
+      resolve()
+      return
+    }
+
+    const scriptEl = existing ?? document.createElement('script')
+
+    const timeoutId = window.setTimeout(() => {
+      scriptEl.remove()
+      scriptPromise = null
+      reject(new Error('Typeform embed script load timed out'))
+    }, SCRIPT_LOAD_TIMEOUT_MS)
+
+    scriptEl.addEventListener(
+      'load',
+      () => {
+        window.clearTimeout(timeoutId)
+        resolve()
+      },
+      { once: true }
+    )
+    scriptEl.addEventListener(
+      'error',
+      () => {
+        window.clearTimeout(timeoutId)
+        scriptEl.remove()
+        scriptPromise = null
+        reject(new Error('Typeform embed script failed to load'))
+      },
+      { once: true }
+    )
+
+    if (!existing) {
+      scriptEl.src = TYPEFORM_SRC
+      scriptEl.async = true
+      document.head.appendChild(scriptEl)
+    }
+  })
+
+  return scriptPromise
+}
+
+/**
+ * Loads the Typeform embed script on first consumer mount and exposes
+ * validation + error state for an inline form container. After the
+ * script is ready, `window.tf.load()` is called each time a new
+ * container appears so Typeform re-scans for the new `data-tf-widget`
+ * element — the embed's DOMContentLoaded auto-scan only runs once and
+ * its MutationObserver does not reliably catch elements added by later
+ * consumers (e.g. a second popover opening later in the session).
+ * `load()` with `forceReload: false` is idempotent for already-
+ * initialized elements.
+ */
+export function useTypeformEmbed(
+  typeformRef: Ref<HTMLElement | null>,
+  typeformIdInput: MaybeRefOrGetter<string | undefined>
+) {
+  const typeformError = ref(false)
+
+  const isValidTypeformId = computed(() =>
+    isTypeformIdValid(toValue(typeformIdInput))
+  )
+
+  const typeformId = computed(() =>
+    isValidTypeformId.value ? (toValue(typeformIdInput) ?? '') : ''
+  )
+
+  whenever(typeformRef, async () => {
+    try {
+      await ensureScriptLoaded()
+      const tf = window.tf
+      if (typeof tf?.load !== 'function') {
+        throw new Error('Typeform API unavailable after script load')
+      }
+      tf.load()
+    } catch (err) {
+      console.error('[useTypeformEmbed]', err)
+      typeformError.value = true
+    }
+  })
+
+  return {
+    typeformError,
+    isValidTypeformId,
+    typeformId
+  }
+}


### PR DESCRIPTION
## Summary

Adds an inline-CTA Typeform survey for the redesigned error panel, targeting nightly localhost users. Reuses the existing node-search survey infrastructure rather than introducing a parallel stack.

## Changes

- **What**:
  - `surveyRegistry` gains optional `presentation: 'floating' | 'inline-cta'` and a `getFloatingSurveys()` helper; controller filters by it.
  - `NightlySurveyPopover` accepts `mode` + `v-model:open`. Manual mode skips the eligibility watcher, drops the "Not Now" button, and leaves open/close/markSeen to the parent.
  - New `ErrorPanelSurveyCta.vue` renders a CTA in the error tab footer once `useExecutionErrorStore.hasAnyError` has transitioned `null → value` at least 3 times.
  - Popover lives in `NightlySurveyController` (session-persistent). Shared state via module-level singleton (`useErrorSurveyPopoverState`) so the iframe survives error-tab unmounts during workflow switches.
  - `useTypeformEmbed` centralises script loading (singleton Promise, 10s timeout, explicit `window.tf.load()` on each new container). Necessary because the embed's DOMContentLoaded auto-scan only fires once; late consumers need an explicit re-scan to render.
  - CTA and feedback-gate strings added under `errorPanelSurvey.*`.

## Review Focus

- Manual-mode flow in `NightlySurveyPopover.vue` — CTA click is routed through the module singleton; popover stays mounted after the first open (`hasOpenedOnce` + `v-show`) to preserve the iframe across repeated open/close cycles and workflow switches.
- `useTypeformEmbed.ts` — the `window.tf.load()` trick (verified against the CDN `embed.js`) is what lets two surveys coexist; without it Typeform's one-shot DOM scan misses whichever element mounts second.
- `NightlySurveyController.vue` guards against double-mount by requiring `presentation === 'inline-cta'` on `errorPanelConfig`.
- Scope is nightly+localhost only (`isNightlyLocalhost` in `useSurveyEligibility`); async component gate in `TabErrors.vue` keeps this out of Cloud/Desktop/stable bundles.

## Test plan

- [x] `IS_NIGHTLY=true pnpm dev`, clear `Comfy.SurveyState` + `Comfy.FeatureUsage`, trigger 3 failed runs → CTA appears in error tab footer.
- [x] Click "Give feedback" → Typeform popover opens and renders the form.
- [x] Close popover, switch workflow (error tab unmounts), trigger a new error → CTA reappears and reopening the popover shows the same iframe.
- [x] Open error-panel popover, close, then trigger 3 node searches → node-search auto-popup renders its own iframe correctly (two surveys coexist).
- [x] CTA × dismisses and persists (`seenSurveys['error-panel']`).
- [x] "Don't ask again" inside popover sets `optedOut: true` and hides all nightly surveys.
- [x] Cloud/Desktop/stable builds: CTA never renders, controller's manual popover doesn't mount.

## Screenshot

https://github.com/user-attachments/assets/91145f23-fd1e-4caf-b6cc-4b97d33ed6b7

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11591-feat-add-inline-CTA-nightly-survey-for-error-panel-34c6d73d3650817d9f95fddcf64633de) by [Unito](https://www.unito.io)
