### PR TITLE
[backport cloud/1.43] ci: filter e2e workflow + add e2e-status gate

### DIFF
--- a/.github/workflows/ci-tests-e2e-forks.yaml
+++ b/.github/workflows/ci-tests-e2e-forks.yaml
@@ -64,15 +64,17 @@ jobs:
 
       - name: Download and Deploy Reports
         if: steps.pr.outputs.result != 'null' && github.event.action == 'completed'
-        uses: actions/download-artifact@v7
+        uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-          pattern: playwright-report-*
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: playwright-report-.*
+          name_is_regexp: true
           path: reports
+          if_no_artifact_found: warn
 
       - name: Handle Test Completion
-        if: steps.pr.outputs.result != 'null' && github.event.action == 'completed'
+        if: steps.pr.outputs.result != 'null' && github.event.action == 'completed' && hashFiles('reports/**') != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -7,7 +7,6 @@ on:
     paths-ignore: ['**/*.md']
   pull_request:
     branches-ignore: [wip/*, draft/*, temp/*]
-    paths-ignore: ['**/*.md']
   workflow_dispatch:
 
 concurrency:
@@ -15,7 +14,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            should_run:
+              - '!(**.md)'
+
   setup:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -153,9 +171,9 @@ jobs:
 
   # Merge sharded test reports (no container needed - only runs CLI)
   merge-reports:
-    needs: [playwright-tests-chromium-sharded]
+    needs: [changes, playwright-tests-chromium-sharded]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.should_run == 'true') }}
     steps:
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -190,8 +208,9 @@ jobs:
 
   # Post starting comment for non-forked PRs
   comment-on-pr-start:
+    needs: changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.changes.outputs.should_run == 'true'
     permissions:
       pull-requests: write
     steps:
@@ -210,9 +229,9 @@ jobs:
 
   # Deploy and comment for non-forked PRs only
   deploy-and-comment:
-    needs: [playwright-tests, merge-reports]
+    needs: [changes, playwright-tests, merge-reports]
     runs-on: ubuntu-latest
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.changes.outputs.should_run == 'true'
     permissions:
       pull-requests: write
       contents: read
@@ -237,4 +256,24 @@ jobs:
             "${{ github.event.pull_request.number }}" \
             "${{ github.head_ref }}" \
             "completed"
+
+  e2e-status:
+    if: always()
+    needs: [changes, playwright-tests-chromium-sharded, playwright-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine e2e outcome
+        run: |
+          if [[ "${{ needs.changes.outputs.should_run }}" != "true" && "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "E2E tests skipped (no relevant changes)"
+            exit 0
+          fi
+          if [[ "${{ needs.playwright-tests-chromium-sharded.result }}" == "success" && "${{ needs.playwright-tests.result }}" == "success" ]]; then
+            echo "All E2E tests passed"
+            exit 0
+          fi
+          echo "E2E tests failed or were cancelled"
+          echo "  chromium-sharded: ${{ needs.playwright-tests-chromium-sharded.result }}"
+          echo "  playwright-tests: ${{ needs.playwright-tests.result }}"
+          exit 1
   #### END Deployment and commenting (non-forked PRs only)


### PR DESCRIPTION
Backport of #11568 and #11587 to `cloud/1.43`.

## Changes

**ci-tests-e2e.yaml**
- Remove `paths-ignore` from `pull_request` trigger
- Add `changes` job using `dorny/paths-filter` to skip e2e on markdown-only PRs
- Gate `setup`, `merge-reports`, `comment-on-pr-start`, and `deploy-and-comment` on `should_run`
- Add `e2e-status` gate job that succeeds when tests pass OR when skipped due to no relevant changes

**ci-tests-e2e-forks.yaml**
- Switch artifact download to `dawidd6/action-download-artifact@v12` with regexp matching
- Add `hashFiles('reports/**') != ''` guard to Handle Test Completion step

All cloud/1.43-specific values preserved: container `0.0.16`, cloud build step, 4-browser matrix with `cloud`, conditional artifact download, pnpm-action-setup `v4.4.0`.

- Fixes #11568
- Fixes #11587

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11593-backport-cloud-1-43-ci-filter-e2e-workflow-add-e2e-status-gate-34c6d73d36508138aee2f85acf9d04c8) by [Unito](https://www.unito.io)
