### PR TITLE
chore: remove unused glslUtils helpers 

### DIFF
--- a/src/renderer/glsl/glslUtils.test.ts
+++ b/src/renderer/glsl/glslUtils.test.ts
@@ -1,46 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  detectOutputCount,
-  detectPassCount,
-  hasVersionDirective
-} from '@/renderer/glsl/glslUtils'
-
-describe('detectOutputCount', () => {
-  it('returns 1 when no fragColor declarations found', () => {
-    expect(detectOutputCount('void main() { gl_FragColor = vec4(1); }')).toBe(1)
-  })
-
-  it('returns 1 for fragColor0 only', () => {
-    expect(detectOutputCount('fragColor0 = vec4(1.0);')).toBe(1)
-  })
-
-  it('returns 2 for fragColor0 and fragColor1', () => {
-    expect(
-      detectOutputCount('fragColor0 = vec4(1.0);\nfragColor1 = vec4(0.0);')
-    ).toBe(2)
-  })
-
-  it('returns 4 for all four outputs', () => {
-    const src = `
-      fragColor0 = vec4(1.0);
-      fragColor1 = vec4(0.5);
-      fragColor2 = vec4(0.3);
-      fragColor3 = vec4(0.0);
-    `
-    expect(detectOutputCount(src)).toBe(4)
-  })
-
-  it('caps at 4 even if higher indices appear', () => {
-    expect(detectOutputCount('fragColor5 = vec4(1.0);')).toBe(4)
-  })
-
-  it('handles non-sequential output indices', () => {
-    expect(
-      detectOutputCount('fragColor0 = vec4(1.0); fragColor3 = vec4(0.0);')
-    ).toBe(4)
-  })
-})
+import { detectPassCount } from '@/renderer/glsl/glslUtils'
 
 describe('detectPassCount', () => {
   it('returns 1 when no pragma found', () => {
@@ -57,21 +17,5 @@ describe('detectPassCount', () => {
 
   it('handles extra whitespace in pragma', () => {
     expect(detectPassCount('#pragma   passes   10')).toBe(10)
-  })
-})
-
-describe('hasVersionDirective', () => {
-  it('returns true for #version 300 es', () => {
-    expect(hasVersionDirective('#version 300 es\nprecision highp float;')).toBe(
-      true
-    )
-  })
-
-  it('returns false for desktop GLSL', () => {
-    expect(hasVersionDirective('#version 330 core\nvoid main() {}')).toBe(false)
-  })
-
-  it('returns false for no version directive', () => {
-    expect(hasVersionDirective('void main() { }')).toBe(false)
   })
 })

--- a/src/renderer/glsl/glslUtils.ts
+++ b/src/renderer/glsl/glslUtils.ts
@@ -1,20 +1,4 @@
 /**
- * Detect how many fragColor outputs are used in a GLSL shader source.
- * Mirrors backend _detect_output_count() in nodes_glsl.py.
- */
-export function detectOutputCount(source: string): number {
-  const matches = source.match(/fragColor(\d+)/g)
-  if (!matches) return 1
-
-  let maxIndex = 0
-  for (const match of matches) {
-    const index = parseInt(match.replace('fragColor', ''), 10)
-    if (index > maxIndex) maxIndex = index
-  }
-  return Math.min(maxIndex + 1, 4)
-}
-
-/**
  * Parse `#pragma passes N` to get multi-pass count.
  * Mirrors backend _detect_pass_count() in nodes_glsl.py.
  */
@@ -22,11 +6,4 @@ export function detectPassCount(source: string): number {
   const match = source.match(/#pragma\s+passes\s+(\d+)/)
   if (match) return Math.max(1, parseInt(match[1], 10))
   return 1
-}
-
-/**
- * Check if a shader source string contains a GLSL ES 3.00 version directive.
- */
-export function hasVersionDirective(source: string): boolean {
-  return /^#version\s+300\s+es\s*$/m.test(source)
 }


### PR DESCRIPTION
## Summary

These look to have been added as part of the initial phased implementation to align with the backend code, however they are unused:
- `detectOutputCount` - The frontend only shows a single output preview which imo is fine, we can add multi display in future if required
- `hasVersionDirective` - The backend needs this as it can execute other version shaders, the web browser will automatically validate and throw an error if it is not a valid shader, this gets surfaced to the user already.

## Changes

- **What**:  
- remove unused functions & tests

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11597-chore-remove-unused-glslUtils-helpers-34c6d73d365081eab784d205b8a0053e) by [Unito](https://www.unito.io)
