### PR TITLE
[backport cloud/1.43] fix: fix webcam node not showing preview in nodes 2.0

### DIFF
--- a/src/extensions/core/webcamCapture.ts
+++ b/src/extensions/core/webcamCapture.ts
@@ -1,6 +1,7 @@
 import { t } from '@/i18n'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 
 import { api } from '../../scripts/api'
 import { app } from '../../scripts/app'
@@ -84,6 +85,7 @@ app.registerExtension({
     )
 
     const canvas = document.createElement('canvas')
+    const nodeOutputStore = useNodeOutputStore()
 
     const capture = () => {
       // @ts-expect-error widget value type narrow down
@@ -98,6 +100,7 @@ app.registerExtension({
       const img = new Image()
       img.onload = () => {
         node.imgs = [img]
+        nodeOutputStore.setNodePreviewsByNodeId(node.id, [data])
         app.canvas.setDirty(true)
       }
       img.src = data


### PR DESCRIPTION
Backport of #11549 to `cloud/1.43`.

Cherry-picked only the `src/extensions/core/webcamCapture.ts` change from merge commit ac728b92ae60606943abcf17db0d41ea66074e2b. The new tests and test-file modifications from the original PR were intentionally excluded per backport instructions.

## Summary
- call `setNodePreviewsByNodeId` alongside `node.imgs = [img]` so the captured image renders in nodes 2.0

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11598-backport-cloud-1-43-fix-fix-webcam-node-not-showing-preview-in-nodes-2-0-34c6d73d365081eeb853f5377c50776c) by [Unito](https://www.unito.io)
