### PR TITLE
update: replace placeholder images in API automation section

### DIFF
--- a/apps/website/src/components/product/api/AutomationSection.vue
+++ b/apps/website/src/components/product/api/AutomationSection.vue
@@ -10,7 +10,7 @@ const features = [
   {
     title: t('api.automation.feature1.title', locale),
     description: t('api.automation.feature1.description', locale),
-    image: 'https://media.comfy.org/website/gallery/desert.webp',
+    image: 'https://media.comfy.org/website/api/infrastructure-nodes.webp',
     description2: t('api.automation.feature1.description2', locale)
   },
   {
@@ -22,7 +22,7 @@ const features = [
   {
     title: t('api.automation.feature3.title', locale),
     description: t('api.automation.feature3.description', locale),
-    image: 'https://media.comfy.org/website/pricing/free.webp'
+    image: 'https://media.comfy.org/website/api/precision-tools.webp'
   }
 ]
 </script>


### PR DESCRIPTION
## Changes

- Replace placeholder images in API automation section with final assets
  - Feature 1: `desert.webp` → `precision-tools.webp`
  - Feature 3: `free.webp` → `infrastructure-nodes.webp`


<img width="1000" height="552" alt="Kapture 2026-04-25 at 00 54 23" src="https://github.com/user-attachments/assets/dd503d2f-56c3-4346-adfa-27b3b92a04a8" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11602-update-replace-placeholder-images-in-API-automation-section-34c6d73d365081319ca4db9b60099835) by [Unito](https://www.unito.io)
