### PR TITLE
test: extract title editor test component

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -22,6 +22,7 @@ import { MediaLightbox } from '@e2e/fixtures/components/MediaLightbox'
 import { QueuePanel } from '@e2e/fixtures/components/QueuePanel'
 import { SettingDialog } from '@e2e/fixtures/components/SettingDialog'
 import { TemplatesDialog } from '@e2e/fixtures/components/TemplatesDialog'
+import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import {
   AssetsSidebarTab,
   ModelLibrarySidebarTab,
@@ -54,11 +55,13 @@ class ComfyPropertiesPanel {
   readonly root: Locator
   readonly panelTitle: Locator
   readonly searchBox: Locator
+  readonly titleEditor: TitleEditor
 
   constructor(readonly page: Page) {
     this.root = page.getByTestId(TestIds.propertiesPanel.root)
     this.panelTitle = this.root.locator('h3')
     this.searchBox = this.root.getByPlaceholder(/^Search/)
+    this.titleEditor = new TitleEditor(this.root)
   }
 }
 
@@ -160,6 +163,7 @@ export class ComfyPage {
   public readonly settingDialog: SettingDialog
   public readonly confirmDialog: ConfirmDialog
   public readonly templatesDialog: TemplatesDialog
+  public readonly titleEditor: TitleEditor
   public readonly mediaLightbox: MediaLightbox
   public readonly vueNodes: VueNodeHelpers
   public readonly appMode: AppModeHelper
@@ -213,6 +217,7 @@ export class ComfyPage {
     this.settingDialog = new SettingDialog(page, this)
     this.confirmDialog = new ConfirmDialog(page)
     this.templatesDialog = new TemplatesDialog(page)
+    this.titleEditor = new TitleEditor(page)
     this.mediaLightbox = new MediaLightbox(page)
     this.vueNodes = new VueNodeHelpers(page)
     this.appMode = new AppModeHelper(this)

--- a/browser_tests/fixtures/components/TitleEditor.ts
+++ b/browser_tests/fixtures/components/TitleEditor.ts
@@ -1,0 +1,33 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+import { TestIds } from '@e2e/fixtures/selectors'
+
+/**
+ * The node/group title-editing input. Rendered in three scopes: the canvas
+ * overlay (page-wide), the properties panel, and the Vue node itself.
+ */
+export class TitleEditor {
+  public readonly input: Locator
+
+  constructor(scope: Page | Locator) {
+    this.input = scope.getByTestId(TestIds.node.titleInput)
+  }
+
+  async setTitle(title: string): Promise<void> {
+    await this.input.fill(title)
+    await this.input.press('Enter')
+  }
+
+  async cancel(): Promise<void> {
+    await this.input.press('Escape')
+  }
+
+  async expectVisible(): Promise<void> {
+    await expect(this.input).toBeVisible()
+  }
+
+  async expectHidden(): Promise<void> {
+    await expect(this.input).toBeHidden()
+  }
+}

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,12 +1,13 @@
 import type { Locator } from '@playwright/test'
 
+import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 /** DOM-centric helper for a single Vue-rendered node on the canvas. */
 export class VueNodeFixture {
   public readonly header: Locator
   public readonly title: Locator
-  public readonly titleInput: Locator
+  public readonly titleEditor: TitleEditor
   public readonly body: Locator
   public readonly pinIndicator: Locator
   public readonly collapseButton: Locator
@@ -16,7 +17,7 @@ export class VueNodeFixture {
   constructor(private readonly locator: Locator) {
     this.header = locator.locator('[data-testid^="node-header-"]')
     this.title = locator.getByTestId('node-title')
-    this.titleInput = locator.getByTestId('node-title-input')
+    this.titleEditor = new TitleEditor(locator)
     this.body = locator.locator('[data-testid^="node-body-"]')
     this.pinIndicator = locator.getByTestId(TestIds.node.pinIndicator)
     this.collapseButton = locator.getByTestId('node-collapse-button')
@@ -30,17 +31,8 @@ export class VueNodeFixture {
 
   async setTitle(value: string): Promise<void> {
     await this.header.dblclick()
-    const input = this.titleInput
-    await input.waitFor({ state: 'visible' })
-    await input.fill(value)
-    await input.press('Enter')
-  }
-
-  async cancelTitleEdit(): Promise<void> {
-    await this.header.dblclick()
-    const input = this.titleInput
-    await input.waitFor({ state: 'visible' })
-    await input.press('Escape')
+    await this.titleEditor.expectVisible()
+    await this.titleEditor.setTitle(value)
   }
 
   async toggleCollapse(): Promise<void> {

--- a/browser_tests/tests/canvasSettings.spec.ts
+++ b/browser_tests/tests/canvasSettings.spec.ts
@@ -3,7 +3,6 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import { TestIds } from '@e2e/fixtures/selectors'
 import { sleep } from '@e2e/fixtures/utils/timing'
 
 const CLIP_NODE_COUNT = 2
@@ -271,7 +270,6 @@ test.describe('Canvas settings', { tag: '@canvas' }, () => {
         'Default workflow must have CLIPTextEncode nodes'
       ).toHaveLength(CLIP_NODE_COUNT)
       const titlePos = await clipNodes[0].getTitlePosition()
-      const titleInput = comfyPage.page.getByTestId(TestIds.node.titleInput)
       const CLICK_GAP_MS = 200
 
       await test.step(`Gap (${CLICK_GAP_MS}ms) exceeds DoubleClickTime → editor stays hidden`, async () => {
@@ -282,7 +280,7 @@ test.describe('Canvas settings', { tag: '@canvas' }, () => {
         await comfyPage.canvasOps.mouseClickAt(titlePos)
         await sleep(CLICK_GAP_MS)
         await comfyPage.canvasOps.mouseClickAt(titlePos)
-        await expect(titleInput).toBeHidden()
+        await comfyPage.titleEditor.expectHidden()
       })
 
       await test.step(`Gap (${CLICK_GAP_MS}ms) within DoubleClickTime → editor opens`, async () => {
@@ -293,7 +291,7 @@ test.describe('Canvas settings', { tag: '@canvas' }, () => {
         await comfyPage.canvasOps.mouseClickAt(titlePos)
         await sleep(CLICK_GAP_MS)
         await comfyPage.canvasOps.mouseClickAt(titlePos)
-        await expect(titleInput).toBeVisible()
+        await comfyPage.titleEditor.expectVisible()
       })
     })
 

--- a/browser_tests/tests/propertiesPanel/PropertiesPanelHelper.ts
+++ b/browser_tests/tests/propertiesPanel/PropertiesPanelHelper.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
+import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
 
 export class PropertiesPanelHelper {
@@ -8,12 +9,14 @@ export class PropertiesPanelHelper {
   readonly panelTitle: Locator
   readonly searchBox: Locator
   readonly closeButton: Locator
+  readonly titleEditor: TitleEditor
 
   constructor(readonly page: Page) {
     this.root = page.getByTestId(TestIds.propertiesPanel.root)
     this.panelTitle = this.root.locator('h3')
     this.searchBox = this.root.getByPlaceholder(/^Search/)
     this.closeButton = this.root.locator('button[aria-pressed]')
+    this.titleEditor = new TitleEditor(this.root)
   }
 
   get tabs(): Locator {
@@ -26,10 +29,6 @@ export class PropertiesPanelHelper {
 
   get titleEditIcon(): Locator {
     return this.panelTitle.locator('i[class*="lucide--pencil"]')
-  }
-
-  get titleInput(): Locator {
-    return this.root.getByTestId(TestIds.node.titleInput)
   }
 
   getNodeStateButton(state: 'Normal' | 'Bypass' | 'Mute'): Locator {
@@ -86,8 +85,7 @@ export class PropertiesPanelHelper {
 
   async editTitle(newTitle: string): Promise<void> {
     await this.titleEditIcon.click()
-    await this.titleInput.fill(newTitle)
-    await this.titleInput.press('Enter')
+    await this.titleEditor.setTitle(newTitle)
   }
 
   async searchWidgets(query: string): Promise<void> {

--- a/browser_tests/tests/propertiesPanel/PropertiesPanelHelper.ts
+++ b/browser_tests/tests/propertiesPanel/PropertiesPanelHelper.ts
@@ -85,6 +85,7 @@ export class PropertiesPanelHelper {
 
   async editTitle(newTitle: string): Promise<void> {
     await this.titleEditIcon.click()
+    await this.titleEditor.expectVisible()
     await this.titleEditor.setTitle(newTitle)
   }
 

--- a/browser_tests/tests/propertiesPanel/titleEditing.spec.ts
+++ b/browser_tests/tests/propertiesPanel/titleEditing.spec.ts
@@ -18,7 +18,7 @@ test.describe('Properties panel - Title editing', () => {
 
   test('should enter edit mode on pencil click', async () => {
     await panel.titleEditIcon.click()
-    await expect(panel.titleInput).toBeVisible()
+    await panel.titleEditor.expectVisible()
   })
 
   test('should update node title on edit', async () => {

--- a/browser_tests/tests/rightSidePanelTabs.spec.ts
+++ b/browser_tests/tests/rightSidePanelTabs.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyPageFixture as test,
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
-import { TestIds } from '@e2e/fixtures/selectors'
 
 test.describe('Right Side Panel Tabs', { tag: '@ui' }, () => {
   test('Properties panel opens with workflow overview', async ({
@@ -35,11 +34,8 @@ test.describe('Right Side Panel Tabs', { tag: '@ui' }, () => {
 
     // Click on the title to enter edit mode
     await propertiesPanel.panelTitle.click()
-    const titleInput = propertiesPanel.root.getByTestId(TestIds.node.titleInput)
-    await expect(titleInput).toBeVisible()
-
-    await titleInput.fill('My Custom Sampler')
-    await titleInput.press('Enter')
+    await propertiesPanel.titleEditor.expectVisible()
+    await propertiesPanel.titleEditor.setTitle('My Custom Sampler')
 
     await expect(propertiesPanel.panelTitle).toContainText('My Custom Sampler')
   })

--- a/browser_tests/tests/vueNodes/interactions/node/contextMenu.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/contextMenu.spec.ts
@@ -66,10 +66,8 @@ test.describe('Vue Node Context Menu', { tag: '@vue-nodes' }, () => {
       await openContextMenu(comfyPage, 'KSampler')
       await clickExactMenuItem(comfyPage, 'Rename')
 
-      const titleInput = comfyPage.page.getByTestId(TestIds.node.titleInput)
-      await titleInput.waitFor({ state: 'visible' })
-      await titleInput.fill('My Renamed Sampler')
-      await titleInput.press('Enter')
+      await comfyPage.titleEditor.expectVisible()
+      await comfyPage.titleEditor.setTitle('My Renamed Sampler')
       await comfyPage.nextFrame()
 
       const renamedNode =

--- a/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/rename.spec.ts
@@ -2,7 +2,6 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import { TestIds } from '@e2e/fixtures/selectors'
 
 test.describe('Vue Nodes Renaming', { tag: '@vue-nodes' }, () => {
   test('should display node title', async ({ comfyPage }) => {
@@ -22,8 +21,8 @@ test.describe('Vue Nodes Renaming', { tag: '@vue-nodes' }, () => {
     // Test cancel with Escape
     await vueNode.title.dblclick()
     await comfyPage.nextFrame()
-    await vueNode.titleInput.fill('This Should Be Cancelled')
-    await vueNode.titleInput.press('Escape')
+    await vueNode.titleEditor.input.fill('This Should Be Cancelled')
+    await vueNode.titleEditor.cancel()
     await comfyPage.nextFrame()
 
     // Title should remain as the previously saved value
@@ -40,9 +39,6 @@ test.describe('Vue Nodes Renaming', { tag: '@vue-nodes' }, () => {
     if (!nodeBbox) throw new Error('Node not found')
     await loadCheckpointNode.dblclick()
 
-    const editingTitleInput = comfyPage.page.getByTestId(
-      TestIds.node.titleInput
-    )
-    await expect(editingTitleInput).toBeHidden()
+    await comfyPage.titleEditor.expectHidden()
   })
 })


### PR DESCRIPTION
## Summary

Extract shared TitleEditor component and update tests to use it

## Changes

- **What**: 
- add title editor helper
- update locations that used `TestIds.node.titleInput`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11605-test-extract-title-editor-test-component-34c6d73d3650811da6b0ec493b190c3f) by [Unito](https://www.unito.io)
