### PR TITLE
update: API page links to keys and docs

### DIFF
--- a/apps/website/src/components/product/api/HeroSection.vue
+++ b/apps/website/src/components/product/api/HeroSection.vue
@@ -223,7 +223,7 @@ onUnmounted(() => {
 
       <div class="mt-8 flex flex-col gap-4 lg:flex-row">
         <BrandButton
-          :href="externalLinks.platform"
+          :href="externalLinks.apiKeys"
           size="lg"
           class="text-center lg:min-w-60 lg:p-4"
         >

--- a/apps/website/src/components/product/api/StepsSection.vue
+++ b/apps/website/src/components/product/api/StepsSection.vue
@@ -61,7 +61,7 @@ const steps = [
         class="mt-12 flex flex-col items-center gap-4 lg:flex-row lg:justify-center"
       >
         <BrandButton
-          :href="externalLinks.cloud"
+          :href="externalLinks.apiKeys"
           variant="solid"
           size="lg"
           class="w-full text-center lg:w-auto lg:min-w-48"
@@ -69,7 +69,7 @@ const steps = [
           {{ t('api.hero.getApiKeys', locale) }}
         </BrandButton>
         <BrandButton
-          :href="externalLinks.docs"
+          :href="externalLinks.docsApi"
           variant="outline"
           size="lg"
           class="w-full text-center lg:w-auto lg:min-w-48"

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -27,6 +27,7 @@ export function getRoutes(locale: Locale = 'en'): Routes {
 }
 
 export const externalLinks = {
+  apiKeys: 'https://platform.comfy.org/profile/api-keys',
   blog: 'https://blog.comfy.org/',
   cloud: 'https://cloud.comfy.org',
   discord: 'https://discord.com/invite/comfyorg',


### PR DESCRIPTION
## Summary

Update API page CTA buttons to link directly to the API keys page and API docs instead of generic platform/cloud/docs links.

## Changes

- **What**: Point "Get API Keys" buttons in HeroSection and StepsSection to `platform.comfy.org/profile/api-keys`; point "Read the Docs" button to `docsApi` route; add `apiKeys` entry to `externalLinks` config.

## Review Focus

Straightforward link target updates — verify the new URLs are correct.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11606-update-API-page-links-to-keys-and-docs-34c6d73d365081268bb5dd55c33646c8) by [Unito](https://www.unito.io)
