### PR TITLE
fix: update zh-CN translations to match English copy changes

### DIFF
--- a/apps/website/src/components/common/SiteNav.vue
+++ b/apps/website/src/components/common/SiteNav.vue
@@ -53,7 +53,7 @@ const navLinks: NavLink[] = [
     label: t('nav.resources', locale),
     items: [
       {
-        label: t('nav.blogs', locale),
+        label: t('nav.blog', locale),
         href: externalLinks.blog,
         external: true
       },

--- a/apps/website/src/components/product/api/StepsSection.vue
+++ b/apps/website/src/components/product/api/StepsSection.vue
@@ -13,13 +13,13 @@ const steps = [
     number: '01',
     titleKey: 'api.steps.step1.title' as const,
     descriptionKey: 'api.steps.step1.description' as const,
-    image: 'https://media.comfy.org/website/api/logo-purple.webp'
+    image: 'https://media.comfy.org/website/enterprise/enterprise_node_1.webp'
   },
   {
     number: '02',
     titleKey: 'api.steps.step2.title' as const,
     descriptionKey: 'api.steps.step2.description' as const,
-    image: 'https://media.comfy.org/website/api/logo-yellow.webp'
+    image: 'https://media.comfy.org/website/enterprise/enterprise_node_2.webp'
   },
   {
     number: '03',

--- a/apps/website/src/components/product/enterprise/BYOKeySection.vue
+++ b/apps/website/src/components/product/enterprise/BYOKeySection.vue
@@ -10,12 +10,12 @@ const cards = [
   {
     titleKey: 'enterprise.byoKey.card1.title' as const,
     descriptionKey: 'enterprise.byoKey.card1.description' as const,
-    image: 'https://media.comfy.org/website/api/logo-purple.webp'
+    image: 'https://media.comfy.org/website/enterprise/enterprise_node_1.webp'
   },
   {
     titleKey: 'enterprise.byoKey.card2.title' as const,
     descriptionKey: 'enterprise.byoKey.card2.description' as const,
-    image: 'https://media.comfy.org/website/api/logo-yellow.webp'
+    image: 'https://media.comfy.org/website/enterprise/enterprise_node_2.webp'
   }
 ]
 </script>

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1600,7 +1600,7 @@ const translations = {
   },
   'nav.comfyHub': { en: 'Comfy Hub', 'zh-CN': 'Comfy Hub' },
   'nav.gallery': { en: 'Gallery', 'zh-CN': '画廊' },
-  'nav.blogs': { en: 'Blogs', 'zh-CN': '博客' },
+  'nav.blog': { en: 'Blog', 'zh-CN': '博客' },
   'nav.github': { en: 'GitHub', 'zh-CN': 'GitHub' },
   'nav.discord': { en: 'Discord', 'zh-CN': 'Discord' },
   'nav.docs': { en: 'Docs', 'zh-CN': '文档' },

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -332,9 +332,9 @@ const translations = {
     'zh-CN': '商业许可保障'
   },
   'enterprise.reason.5.description': {
-    en: 'Every model available through Comfy Cloud is cleared for commercial use. No license ambiguity for your legal team.',
+    en: 'Every major model available through Comfy Cloud is cleared for commercial use. No license ambiguity for your legal team.',
     'zh-CN':
-      '通过 Comfy Cloud 提供的每个模型均已获得商业使用许可。法务团队无需担心许可歧义。'
+      '通过 Comfy Cloud 提供的每个主流模型均已获得商业使用许可。法务团队无需担心许可歧义。'
   },
 
   // Enterprise – HeroSection

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -332,9 +332,9 @@ const translations = {
     'zh-CN': '商业许可保障'
   },
   'enterprise.reason.5.description': {
-    en: 'Every major model available through Comfy Cloud is cleared for commercial use. No license ambiguity for your legal team.',
+    en: 'Every model available through Comfy Cloud is cleared for commercial use. No license ambiguity for your legal team.',
     'zh-CN':
-      '通过 Comfy Cloud 提供的每个主流模型均已获得商业使用许可。法务团队无需担心许可歧义。'
+      '通过 Comfy Cloud 提供的每个模型均已获得商业使用许可。法务团队无需担心许可歧义。'
   },
 
   // Enterprise – HeroSection
@@ -781,9 +781,9 @@ const translations = {
     'zh-CN': '社区工作流，\n通过预安装自定义节点\n实现无限自定义'
   },
   'cloud.reason.4.description': {
-    en: 'Browse, run, and remix workflows built by thousands of creators. Start from proven templates instead of blank canvases. Upload custom LoRAs or finetuned foundational models from CivitAI and Hugging Face. The nodes powering ~90% of local ComfyUI workflows are now in the cloud.',
+    en: 'Browse, run, and remix workflows built by thousands of creators. Start from proven templates instead of blank canvases. Upload custom LoRAs or finetuned foundational models from CivitAI and Hugging Face. The most popular local custom nodes are pre-installed on cloud.',
     'zh-CN':
-      '浏览、运行和混搭由数千名创作者构建的工作流。从经过验证的模板开始，而非空白画布。上传自定义 LoRA 或来自 CivitAI 和 Hugging Face 的微调基础模型。驱动约 90% 本地 ComfyUI 工作流的节点现已上云。'
+      '浏览、运行和混搭由数千名创作者构建的工作流。从经过验证的模板开始，而非空白画布。上传自定义 LoRA 或来自 CivitAI 和 Hugging Face 的微调基础模型。最受欢迎的本地自定义节点已预装在云端。'
   },
 
   // Cloud – AIModelsSection


### PR DESCRIPTION
## Summary

Update zh-CN translations to match recent English copy changes on the website.

## Changes

- **What**: Sync zh-CN translations for enterprise and cloud page descriptions to match updated English text ("Every major model", custom nodes pre-installed copy)

## Review Focus

Translation accuracy for zh-CN strings.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11617-fix-update-zh-CN-translations-to-match-English-copy-changes-34c6d73d36508137adccfcf8e4d69dc6) by [Unito](https://www.unito.io)
