### PR TITLE
refactor: extract Load3d render loop to load3dRenderLoop

### DIFF
--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -383,6 +383,92 @@ describe('Load3d', () => {
     })
   })
 
+  describe('render loop wiring', () => {
+    it('startAnimation registers a render loop whose tick body runs the per-frame managers when active', () => {
+      const animationUpdate = vi.fn()
+      const viewHelperUpdate = vi.fn()
+      const viewHelperRender = vi.fn()
+      const controlsUpdate = vi.fn()
+      const renderMainScene = vi.fn()
+      const resetViewport = vi.fn()
+
+      Object.assign(ctx.load3d, {
+        STATUS_MOUSE_ON_NODE: true,
+        STATUS_MOUSE_ON_SCENE: false,
+        STATUS_MOUSE_ON_VIEWER: false,
+        INITIAL_RENDER_DONE: false,
+        clock: new THREE.Clock(),
+        animationManager: {
+          update: animationUpdate,
+          isAnimationPlaying: false,
+          dispose: vi.fn()
+        },
+        viewHelperManager: {
+          update: viewHelperUpdate,
+          viewHelper: { render: viewHelperRender }
+        },
+        controlsManager: { update: controlsUpdate },
+        recordingManager: { getIsRecording: vi.fn(() => false) },
+        renderMainScene,
+        resetViewport,
+        renderer: {}
+      })
+
+      ;(ctx.load3d as unknown as { startAnimation(): void }).startAnimation()
+
+      const loop = (ctx.load3d as unknown as { renderLoop: { stop(): void } })
+        .renderLoop
+      expect(loop).not.toBeNull()
+      expect(typeof loop.stop).toBe('function')
+
+      // The first loop() ran synchronously; isActive() returned true
+      // (STATUS_MOUSE_ON_NODE), so the tick body executed once.
+      expect(animationUpdate).toHaveBeenCalledOnce()
+      expect(viewHelperUpdate).toHaveBeenCalledOnce()
+      expect(controlsUpdate).toHaveBeenCalledOnce()
+      expect(renderMainScene).toHaveBeenCalledOnce()
+      expect(resetViewport).toHaveBeenCalledOnce()
+      expect(viewHelperRender).toHaveBeenCalledOnce()
+
+      // Cancel the queued rAF so the test doesn't leak frames.
+      loop.stop()
+    })
+
+    it('remove() stops the active render loop and clears the handle', () => {
+      const stop = vi.fn()
+      const canvas = document.createElement('canvas')
+
+      Object.assign(ctx.load3d, {
+        renderLoop: { stop },
+        resizeObserver: null,
+        contextMenuAbortController: null,
+        renderer: {
+          forceContextLoss: vi.fn(),
+          dispose: vi.fn(),
+          domElement: canvas
+        },
+        sceneManager: { ...ctx.sceneManager, dispose: vi.fn() },
+        cameraManager: { ...ctx.cameraManager, dispose: vi.fn() },
+        controlsManager: { ...ctx.controlsManager, dispose: vi.fn() },
+        lightingManager: { dispose: vi.fn() },
+        hdriManager: { dispose: vi.fn() },
+        viewHelperManager: { dispose: vi.fn() },
+        loaderManager: { dispose: vi.fn() },
+        modelManager: { ...ctx.modelManager, dispose: vi.fn() },
+        recordingManager: { dispose: vi.fn() },
+        animationManager: { ...ctx.animationManager, dispose: vi.fn() },
+        gizmoManager: { ...ctx.gizmo, dispose: vi.fn() }
+      })
+
+      ctx.load3d.remove()
+
+      expect(stop).toHaveBeenCalledOnce()
+      expect(
+        (ctx.load3d as unknown as { renderLoop: unknown }).renderLoop
+      ).toBeNull()
+    })
+  })
+
   describe('captureScene', () => {
     it('hides the gizmo helper during capture and restores it after success', async () => {
       const captureResult = { scene: 'a', mask: 'b', normal: 'c' }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -24,6 +24,8 @@ import type {
   MaterialMode,
   UpDirection
 } from './interfaces'
+import type { RenderLoopHandle } from './load3dRenderLoop'
+import { startRenderLoop } from './load3dRenderLoop'
 import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
 
 function positionThumbnailCamera(
@@ -48,7 +50,7 @@ function positionThumbnailCamera(
 class Load3d {
   renderer: THREE.WebGLRenderer
   protected clock: THREE.Clock
-  protected animationFrameId: number | null = null
+  private renderLoop: RenderLoopHandle | null = null
   private loadingPromise: Promise<void> | null = null
   private onContextMenuCallback?: (event: MouseEvent) => void
   private getDimensionsCallback?: () => { width: number; height: number } | null
@@ -410,28 +412,23 @@ class Load3d {
   }
 
   private startAnimation(): void {
-    const animate = () => {
-      this.animationFrameId = requestAnimationFrame(animate)
+    this.renderLoop = startRenderLoop({
+      tick: () => {
+        const delta = this.clock.getDelta()
+        this.animationManager.update(delta)
+        this.viewHelperManager.update(delta)
+        this.controlsManager.update()
 
-      if (!this.isActive()) {
-        return
-      }
+        this.renderMainScene()
 
-      const delta = this.clock.getDelta()
-      this.animationManager.update(delta)
-      this.viewHelperManager.update(delta)
-      this.controlsManager.update()
+        this.resetViewport()
 
-      this.renderMainScene()
-
-      this.resetViewport()
-
-      if (this.viewHelperManager.viewHelper.render) {
-        this.viewHelperManager.viewHelper.render(this.renderer)
-      }
-    }
-
-    animate()
+        if (this.viewHelperManager.viewHelper.render) {
+          this.viewHelperManager.viewHelper.render(this.renderer)
+        }
+      },
+      isActive: () => this.isActive()
+    })
   }
 
   updateStatusMouseOnNode(onNode: boolean): void {
@@ -931,9 +928,8 @@ class Load3d {
     })
     canvas.dispatchEvent(event)
 
-    if (this.animationFrameId !== null) {
-      cancelAnimationFrame(this.animationFrameId)
-    }
+    this.renderLoop?.stop()
+    this.renderLoop = null
 
     this.sceneManager.dispose()
     this.cameraManager.dispose()

--- a/src/extensions/core/load3d/load3dRenderLoop.test.ts
+++ b/src/extensions/core/load3d/load3dRenderLoop.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { startRenderLoop } from './load3dRenderLoop'
+
+describe('startRenderLoop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runs tick on each frame while isActive returns true', () => {
+    const tick = vi.fn()
+    const handle = startRenderLoop({ tick, isActive: () => true })
+
+    vi.advanceTimersToNextTimer()
+    vi.advanceTimersToNextTimer()
+    vi.advanceTimersToNextTimer()
+
+    expect(tick.mock.calls.length).toBeGreaterThanOrEqual(3)
+    handle.stop()
+  })
+
+  it('skips tick on frames where isActive returns false', () => {
+    let active = false
+    const tick = vi.fn()
+    const handle = startRenderLoop({ tick, isActive: () => active })
+
+    vi.advanceTimersToNextTimer()
+    vi.advanceTimersToNextTimer()
+    expect(tick).not.toHaveBeenCalled()
+
+    active = true
+    vi.advanceTimersToNextTimer()
+    expect(tick).toHaveBeenCalledOnce()
+
+    handle.stop()
+  })
+
+  it('stop halts further ticks', () => {
+    const tick = vi.fn()
+    const handle = startRenderLoop({ tick, isActive: () => true })
+
+    vi.advanceTimersToNextTimer()
+    const callsBeforeStop = tick.mock.calls.length
+
+    handle.stop()
+    vi.advanceTimersToNextTimer()
+    vi.advanceTimersToNextTimer()
+
+    expect(tick.mock.calls.length).toBe(callsBeforeStop)
+  })
+
+  it('is safe to call stop multiple times', () => {
+    const handle = startRenderLoop({ tick: vi.fn(), isActive: () => true })
+
+    handle.stop()
+    expect(() => handle.stop()).not.toThrow()
+  })
+})

--- a/src/extensions/core/load3d/load3dRenderLoop.ts
+++ b/src/extensions/core/load3d/load3dRenderLoop.ts
@@ -1,0 +1,32 @@
+type RenderLoopOptions = {
+  tick: () => void
+  isActive: () => boolean
+}
+
+export type RenderLoopHandle = {
+  stop: () => void
+}
+
+export function startRenderLoop({
+  tick,
+  isActive
+}: RenderLoopOptions): RenderLoopHandle {
+  let frameId: number | null = null
+
+  const loop = () => {
+    frameId = requestAnimationFrame(loop)
+    if (!isActive()) return
+    tick()
+  }
+
+  loop()
+
+  return {
+    stop() {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId)
+        frameId = null
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pull the `requestAnimationFrame` loop and its activity-gated tick body out of `Load3d` into a small `startRenderLoop({ tick, isActive })` helper. Pure mechanical refactor — no behavior change. First of four small PRs splitting up the https://github.com/Comfy-Org/ComfyUI_frontend/pull/11495.

## Changes

- **What**: New `load3dRenderLoop.ts` exports `startRenderLoop` (returns a `{ stop }` handle). `Load3d.startAnimation()` now constructs a loop through it; `Load3d.remove()` calls `stop()` instead of `cancelAnimationFrame`. Field `animationFrameId: number | null` becomes `renderLoop: RenderLoopHandle | null`.

## Review Focus

- The tick body inside `startAnimation()` is byte-identical to the previous inline body — only the rAF scheduling has moved.
- `isActive()` is now invoked through a `() => this.isActive()` closure instead of a direct call inside the inline `animate` function, so the activity check still fires once per frame and reads the same fields.
- The new helper has 4 unit tests covering: ticks while active, skip while inactive, stop halts ticks, stop is idempotent.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11623-refactor-extract-Load3d-render-loop-to-load3dRenderLoop-34d6d73d3650815c9c4ec7713e912e37) by [Unito](https://www.unito.io)
