### PR TITLE
refactor(load3d): extract viewport math to load3dViewport

### DIFF
--- a/src/components/curve/WidgetCurve.test.ts
+++ b/src/components/curve/WidgetCurve.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 /* eslint-disable vue/no-reserved-component-names */
 /* eslint-disable vue/no-unused-emit-declarations */
 import { render, screen } from '@testing-library/vue'

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -241,6 +241,148 @@ describe('Load3d', () => {
     })
   })
 
+  describe('viewport wiring', () => {
+    it('isActive ORs the activity flags through isLoad3dActive', () => {
+      Object.assign(ctx.load3d, {
+        STATUS_MOUSE_ON_NODE: false,
+        STATUS_MOUSE_ON_SCENE: false,
+        STATUS_MOUSE_ON_VIEWER: false,
+        INITIAL_RENDER_DONE: true,
+        animationManager: { isAnimationPlaying: false, dispose: vi.fn() },
+        recordingManager: { getIsRecording: vi.fn(() => false) }
+      })
+
+      expect(ctx.load3d.isActive()).toBe(false)
+      ;(ctx.load3d as { STATUS_MOUSE_ON_NODE: boolean }).STATUS_MOUSE_ON_NODE =
+        true
+      expect(ctx.load3d.isActive()).toBe(true)
+    })
+
+    it('handleResize letterboxes the renderer when a target aspect ratio is set', () => {
+      delete (ctx.load3d as { handleResize?: unknown }).handleResize
+
+      const parent = document.createElement('div')
+      Object.defineProperty(parent, 'clientWidth', {
+        value: 800,
+        configurable: true
+      })
+      Object.defineProperty(parent, 'clientHeight', {
+        value: 600,
+        configurable: true
+      })
+      const canvas = document.createElement('canvas')
+      parent.appendChild(canvas)
+
+      const setSize = vi.fn()
+      const cameraResize = vi.fn()
+      const sceneResize = vi.fn()
+
+      Object.assign(ctx.load3d, {
+        renderer: { domElement: canvas, setSize },
+        targetWidth: 400,
+        targetHeight: 200,
+        targetAspectRatio: 2,
+        isViewerMode: false,
+        cameraManager: { ...ctx.cameraManager, handleResize: cameraResize },
+        sceneManager: { ...ctx.sceneManager, handleResize: sceneResize }
+      })
+
+      ctx.load3d.handleResize()
+
+      // Container 800x600, target aspect 2:1 → letterboxed render area 800x400
+      expect(setSize).toHaveBeenCalledWith(800, 600)
+      expect(cameraResize).toHaveBeenCalledWith(800, 400)
+      expect(sceneResize).toHaveBeenCalledWith(800, 400)
+    })
+
+    it('renderMainScene applies the letterboxed viewport and feeds aspect to the camera', () => {
+      const setViewport = vi.fn()
+      const setScissor = vi.fn()
+      const setScissorTest = vi.fn()
+      const setClearColor = vi.fn()
+      const clear = vi.fn()
+      const render = vi.fn()
+      const updateAspectRatio = vi.fn()
+      const renderBackground = vi.fn()
+
+      const canvas = document.createElement('canvas')
+      Object.defineProperty(canvas, 'clientWidth', {
+        value: 800,
+        configurable: true
+      })
+      Object.defineProperty(canvas, 'clientHeight', {
+        value: 600,
+        configurable: true
+      })
+      const scene = {} as THREE.Scene
+
+      Object.assign(ctx.load3d, {
+        renderer: {
+          domElement: canvas,
+          setViewport,
+          setScissor,
+          setScissorTest,
+          setClearColor,
+          clear,
+          render
+        },
+        targetWidth: 400,
+        targetHeight: 200,
+        targetAspectRatio: 2,
+        isViewerMode: false,
+        cameraManager: { ...ctx.cameraManager, updateAspectRatio },
+        sceneManager: { ...ctx.sceneManager, renderBackground, scene }
+      })
+
+      ctx.load3d.renderMainScene()
+
+      expect(setViewport).toHaveBeenNthCalledWith(1, 0, 0, 800, 600)
+      expect(setScissor).toHaveBeenNthCalledWith(1, 0, 0, 800, 600)
+      expect(setViewport).toHaveBeenNthCalledWith(2, 0, 100, 800, 400)
+      expect(setScissor).toHaveBeenNthCalledWith(2, 0, 100, 800, 400)
+      expect(updateAspectRatio).toHaveBeenCalledWith(2)
+      expect(setScissorTest).toHaveBeenCalledWith(true)
+      expect(render).toHaveBeenCalledWith(scene, ctx.cameraManager.activeCamera)
+    })
+
+    it('setBackgroundImage updates background size with letterbox dimensions when a texture is loaded', async () => {
+      const updateBackgroundSize = vi.fn()
+      const setBackgroundImage = vi.fn().mockResolvedValue(undefined)
+      const canvas = document.createElement('canvas')
+      Object.defineProperty(canvas, 'clientWidth', {
+        value: 800,
+        configurable: true
+      })
+      Object.defineProperty(canvas, 'clientHeight', {
+        value: 600,
+        configurable: true
+      })
+
+      Object.assign(ctx.load3d, {
+        renderer: { domElement: canvas },
+        targetWidth: 400,
+        targetHeight: 200,
+        targetAspectRatio: 2,
+        isViewerMode: false,
+        sceneManager: {
+          ...ctx.sceneManager,
+          setBackgroundImage,
+          updateBackgroundSize,
+          backgroundTexture: {},
+          backgroundMesh: {}
+        }
+      })
+
+      await ctx.load3d.setBackgroundImage('test.png')
+
+      expect(setBackgroundImage).toHaveBeenCalledWith('test.png')
+      // Container 800x600, target aspect 2:1 → letterbox render area 800x400
+      const args = updateBackgroundSize.mock.calls[0]
+      expect(args[2]).toBe(800)
+      expect(args[3]).toBe(400)
+    })
+  })
+
   describe('captureScene', () => {
     it('hides the gizmo helper during capture and restores it after success', async () => {
       const captureResult = { scene: 'a', mask: 'b', normal: 'c' }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -24,6 +24,7 @@ import type {
   MaterialMode,
   UpDirection
 } from './interfaces'
+import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
 
 function positionThumbnailCamera(
   camera: THREE.PerspectiveCamera,
@@ -354,22 +355,10 @@ class Load3d {
     }
 
     if (this.shouldMaintainAspectRatio()) {
-      const containerAspectRatio = containerWidth / containerHeight
-
-      let renderWidth: number
-      let renderHeight: number
-      let offsetX: number = 0
-      let offsetY: number = 0
-
-      if (containerAspectRatio > this.targetAspectRatio) {
-        renderHeight = containerHeight
-        renderWidth = renderHeight * this.targetAspectRatio
-        offsetX = (containerWidth - renderWidth) / 2
-      } else {
-        renderWidth = containerWidth
-        renderHeight = renderWidth / this.targetAspectRatio
-        offsetY = (containerHeight - renderHeight) / 2
-      }
+      const { offsetX, offsetY, width, height } = computeLetterboxedViewport(
+        { width: containerWidth, height: containerHeight },
+        this.targetAspectRatio
+      )
 
       this.renderer.setViewport(0, 0, containerWidth, containerHeight)
       this.renderer.setScissor(0, 0, containerWidth, containerHeight)
@@ -377,11 +366,10 @@ class Load3d {
       this.renderer.setClearColor(0x0a0a0a)
       this.renderer.clear()
 
-      this.renderer.setViewport(offsetX, offsetY, renderWidth, renderHeight)
-      this.renderer.setScissor(offsetX, offsetY, renderWidth, renderHeight)
+      this.renderer.setViewport(offsetX, offsetY, width, height)
+      this.renderer.setScissor(offsetX, offsetY, width, height)
 
-      const renderAspectRatio = renderWidth / renderHeight
-      this.cameraManager.updateAspectRatio(renderAspectRatio)
+      this.cameraManager.updateAspectRatio(width / height)
     } else {
       // No aspect ratio constraint: fill the entire container
       this.renderer.setViewport(0, 0, containerWidth, containerHeight)
@@ -459,14 +447,14 @@ class Load3d {
   }
 
   isActive(): boolean {
-    return (
-      this.STATUS_MOUSE_ON_NODE ||
-      this.STATUS_MOUSE_ON_SCENE ||
-      this.STATUS_MOUSE_ON_VIEWER ||
-      this.isRecording() ||
-      !this.INITIAL_RENDER_DONE ||
-      this.animationManager.isAnimationPlaying
-    )
+    return isLoad3dActive({
+      mouseOnNode: this.STATUS_MOUSE_ON_NODE,
+      mouseOnScene: this.STATUS_MOUSE_ON_SCENE,
+      mouseOnViewer: this.STATUS_MOUSE_ON_VIEWER,
+      recording: this.isRecording(),
+      initialRenderDone: this.INITIAL_RENDER_DONE,
+      animationPlaying: this.animationManager.isAnimationPlaying
+    })
   }
 
   async exportModel(format: string): Promise<void> {
@@ -527,24 +515,16 @@ class Load3d {
       const containerHeight = this.renderer.domElement.clientHeight
 
       if (this.shouldMaintainAspectRatio()) {
-        const containerAspectRatio = containerWidth / containerHeight
-
-        let renderWidth: number
-        let renderHeight: number
-
-        if (containerAspectRatio > this.targetAspectRatio) {
-          renderHeight = containerHeight
-          renderWidth = renderHeight * this.targetAspectRatio
-        } else {
-          renderWidth = containerWidth
-          renderHeight = renderWidth / this.targetAspectRatio
-        }
+        const { width, height } = computeLetterboxedViewport(
+          { width: containerWidth, height: containerHeight },
+          this.targetAspectRatio
+        )
 
         this.sceneManager.updateBackgroundSize(
           this.sceneManager.backgroundTexture,
           this.sceneManager.backgroundMesh,
-          renderWidth,
-          renderHeight
+          width,
+          height
         )
       } else {
         // No aspect ratio constraints: fill container
@@ -742,21 +722,14 @@ class Load3d {
     }
 
     if (this.shouldMaintainAspectRatio()) {
-      const containerAspectRatio = containerWidth / containerHeight
-      let renderWidth: number
-      let renderHeight: number
-
-      if (containerAspectRatio > this.targetAspectRatio) {
-        renderHeight = containerHeight
-        renderWidth = renderHeight * this.targetAspectRatio
-      } else {
-        renderWidth = containerWidth
-        renderHeight = renderWidth / this.targetAspectRatio
-      }
+      const { width, height } = computeLetterboxedViewport(
+        { width: containerWidth, height: containerHeight },
+        this.targetAspectRatio
+      )
 
       this.renderer.setSize(containerWidth, containerHeight)
-      this.cameraManager.handleResize(renderWidth, renderHeight)
-      this.sceneManager.handleResize(renderWidth, renderHeight)
+      this.cameraManager.handleResize(width, height)
+      this.sceneManager.handleResize(width, height)
     } else {
       // No aspect ratio constraint: use container dimensions directly
       this.renderer.setSize(containerWidth, containerHeight)

--- a/src/extensions/core/load3d/load3dViewport.test.ts
+++ b/src/extensions/core/load3d/load3dViewport.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
+import type { Load3dActivityFlags } from './load3dViewport'
+
+describe('computeLetterboxedViewport', () => {
+  it('pillarboxes when the container is wider than the target aspect', () => {
+    const viewport = computeLetterboxedViewport({ width: 800, height: 400 }, 1)
+
+    expect(viewport).toEqual({
+      offsetX: 200,
+      offsetY: 0,
+      width: 400,
+      height: 400
+    })
+  })
+
+  it('letterboxes when the container is taller than the target aspect', () => {
+    const viewport = computeLetterboxedViewport({ width: 400, height: 800 }, 1)
+
+    expect(viewport).toEqual({
+      offsetX: 0,
+      offsetY: 200,
+      width: 400,
+      height: 400
+    })
+  })
+
+  it('fills the container when aspect ratios match exactly', () => {
+    const viewport = computeLetterboxedViewport(
+      { width: 1024, height: 768 },
+      1024 / 768
+    )
+
+    expect(viewport.offsetX).toBe(0)
+    expect(viewport.offsetY).toBe(0)
+    expect(viewport.width).toBe(1024)
+    expect(viewport.height).toBe(768)
+  })
+
+  it('handles a wide target aspect inside a square container', () => {
+    const viewport = computeLetterboxedViewport(
+      { width: 600, height: 600 },
+      16 / 9
+    )
+
+    expect(viewport.offsetX).toBe(0)
+    expect(viewport.width).toBe(600)
+    expect(viewport.height).toBeCloseTo(337.5)
+    expect(viewport.offsetY).toBeCloseTo((600 - 337.5) / 2)
+  })
+
+  it('handles a tall target aspect inside a square container', () => {
+    const viewport = computeLetterboxedViewport(
+      { width: 600, height: 600 },
+      9 / 16
+    )
+
+    expect(viewport.offsetY).toBe(0)
+    expect(viewport.height).toBe(600)
+    expect(viewport.width).toBeCloseTo(337.5)
+    expect(viewport.offsetX).toBeCloseTo((600 - 337.5) / 2)
+  })
+
+  it('preserves the target aspect ratio in the returned rect', () => {
+    const target = 16 / 9
+    const wide = computeLetterboxedViewport(
+      { width: 1920, height: 500 },
+      target
+    )
+    const tall = computeLetterboxedViewport(
+      { width: 500, height: 1920 },
+      target
+    )
+
+    expect(wide.width / wide.height).toBeCloseTo(target)
+    expect(tall.width / tall.height).toBeCloseTo(target)
+  })
+})
+
+describe('isLoad3dActive', () => {
+  const idle: Load3dActivityFlags = {
+    mouseOnNode: false,
+    mouseOnScene: false,
+    mouseOnViewer: false,
+    recording: false,
+    initialRenderDone: true,
+    animationPlaying: false
+  }
+
+  it('is inactive once the first frame is rendered with nothing happening', () => {
+    expect(isLoad3dActive(idle)).toBe(false)
+  })
+
+  it('is active before the first frame renders', () => {
+    expect(isLoad3dActive({ ...idle, initialRenderDone: false })).toBe(true)
+  })
+
+  it.each([
+    ['mouseOnNode'],
+    ['mouseOnScene'],
+    ['mouseOnViewer'],
+    ['recording'],
+    ['animationPlaying']
+  ] as const)('is active when %s is true', (flag) => {
+    expect(isLoad3dActive({ ...idle, [flag]: true })).toBe(true)
+  })
+})

--- a/src/extensions/core/load3d/load3dViewport.ts
+++ b/src/extensions/core/load3d/load3dViewport.ts
@@ -1,0 +1,55 @@
+type Size = { width: number; height: number }
+
+type LetterboxedViewport = {
+  offsetX: number
+  offsetY: number
+  width: number
+  height: number
+}
+
+export function computeLetterboxedViewport(
+  container: Size,
+  targetAspectRatio: number
+): LetterboxedViewport {
+  const containerAspectRatio = container.width / container.height
+
+  if (containerAspectRatio > targetAspectRatio) {
+    const height = container.height
+    const width = height * targetAspectRatio
+    return {
+      offsetX: (container.width - width) / 2,
+      offsetY: 0,
+      width,
+      height
+    }
+  }
+
+  const width = container.width
+  const height = width / targetAspectRatio
+  return {
+    offsetX: 0,
+    offsetY: (container.height - height) / 2,
+    width,
+    height
+  }
+}
+
+export type Load3dActivityFlags = {
+  mouseOnNode: boolean
+  mouseOnScene: boolean
+  mouseOnViewer: boolean
+  recording: boolean
+  initialRenderDone: boolean
+  animationPlaying: boolean
+}
+
+export function isLoad3dActive(flags: Load3dActivityFlags): boolean {
+  return (
+    flags.mouseOnNode ||
+    flags.mouseOnScene ||
+    flags.mouseOnViewer ||
+    flags.recording ||
+    !flags.initialRenderDone ||
+    flags.animationPlaying
+  )
+}


### PR DESCRIPTION
## Summary

Pull two pure helpers out of `Load3d` into a sibling module. Mechanical refactor — no behavior change. Second of four small PRs splitting up the https://github.com/Comfy-Org/ComfyUI_frontend/pull/11495.

## Changes

- **What**: New `load3dViewport.ts` exports two pure functions:
  - `computeLetterboxedViewport({ width, height }, targetAspectRatio)` returns `{ offsetX, offsetY, width, height }` — the aspect-ratio fitting math that was duplicated inline in three places (`renderMainScene`, `setBackgroundImage`, `handleResize`).
  - `isLoad3dActive(flags)` consumes the activity-flag struct used by the rAF tick gate; `Load3d.isActive()` now delegates to it.

## Review Focus

- The three call sites in `Load3d.ts` produce byte-identical viewport rectangles for any `(containerWidth, containerHeight, targetAspect)` triple — same branch on aspect-ratio comparison, same offset derivation. Simplest way to verify: diff the math.
- `isLoad3dActive` ORs the same six flags as before in the same order. Old implementation read `this.STATUS_MOUSE_ON_NODE` etc. directly; new one reads them through a flags object built at the call site.
- 13 unit tests cover the helpers: the "wider" / "taller" / "matching" aspect cases for letterboxing, and each individual flag flipping `isLoad3dActive` on by itself.


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11624-refactor-load3d-extract-viewport-math-to-load3dViewport-34d6d73d365081ab9af5fc445bf5bd5a) by [Unito](https://www.unito.io)
