### PR TITLE
refactor: extract Load3d right-click guard to load3dContextMenuGuard

### DIFF
--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -1,7 +1,5 @@
 import * as THREE from 'three'
 
-import { exceedsClickThreshold } from '@/composables/useClickDragGuard'
-
 import { AnimationManager } from './AnimationManager'
 import { CameraManager } from './CameraManager'
 import { ControlsManager } from './ControlsManager'
@@ -24,6 +22,7 @@ import type {
   MaterialMode,
   UpDirection
 } from './interfaces'
+import { attachContextMenuGuard } from './load3dContextMenuGuard'
 import type { RenderLoopHandle } from './load3dRenderLoop'
 import { startRenderLoop } from './load3dRenderLoop'
 import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
@@ -78,10 +77,7 @@ class Load3d {
   targetAspectRatio: number = 1
   isViewerMode: boolean = false
 
-  private rightMouseStart: { x: number; y: number } = { x: 0, y: 0 }
-  private rightMouseMoved: boolean = false
-  private readonly dragThreshold: number = 5
-  private contextMenuAbortController: AbortController | null = null
+  private disposeContextMenuGuard: (() => void) | null = null
   private resizeObserver: ResizeObserver | null = null
 
   constructor(container: Element | HTMLElement, options: Load3DOptions = {}) {
@@ -217,69 +213,12 @@ class Load3d {
     this.resizeObserver.observe(container)
   }
 
-  /**
-   * Initialize context menu on the Three.js canvas
-   * Detects right-click vs right-drag to show menu only on click
-   */
   private initContextMenu(): void {
-    const canvas = this.renderer.domElement
-
-    this.contextMenuAbortController = new AbortController()
-    const { signal } = this.contextMenuAbortController
-
-    const mousedownHandler = (e: MouseEvent) => {
-      if (e.button === 2) {
-        this.rightMouseStart = { x: e.clientX, y: e.clientY }
-        this.rightMouseMoved = false
-      }
-    }
-
-    const mousemoveHandler = (e: MouseEvent) => {
-      if (e.buttons === 2) {
-        if (
-          exceedsClickThreshold(
-            this.rightMouseStart,
-            { x: e.clientX, y: e.clientY },
-            this.dragThreshold
-          )
-        ) {
-          this.rightMouseMoved = true
-        }
-      }
-    }
-
-    const contextmenuHandler = (e: MouseEvent) => {
-      if (this.isViewerMode) return
-
-      const wasDragging =
-        this.rightMouseMoved ||
-        exceedsClickThreshold(
-          this.rightMouseStart,
-          { x: e.clientX, y: e.clientY },
-          this.dragThreshold
-        )
-
-      this.rightMouseMoved = false
-
-      if (wasDragging) {
-        return
-      }
-
-      e.preventDefault()
-      e.stopPropagation()
-
-      this.showNodeContextMenu(e)
-    }
-
-    canvas.addEventListener('mousedown', mousedownHandler, { signal })
-    canvas.addEventListener('mousemove', mousemoveHandler, { signal })
-    canvas.addEventListener('contextmenu', contextmenuHandler, { signal })
-  }
-
-  private showNodeContextMenu(event: MouseEvent): void {
-    if (this.onContextMenuCallback) {
-      this.onContextMenuCallback(event)
-    }
+    this.disposeContextMenuGuard = attachContextMenuGuard(
+      this.renderer.domElement,
+      (event) => this.onContextMenuCallback?.(event),
+      { isDisabled: () => this.isViewerMode }
+    )
   }
 
   getEventManager(): EventManager {
@@ -915,10 +854,8 @@ class Load3d {
       this.resizeObserver = null
     }
 
-    if (this.contextMenuAbortController) {
-      this.contextMenuAbortController.abort()
-      this.contextMenuAbortController = null
-    }
+    this.disposeContextMenuGuard?.()
+    this.disposeContextMenuGuard = null
 
     this.renderer.forceContextLoss()
     const canvas = this.renderer.domElement

--- a/src/extensions/core/load3d/load3dContextMenuGuard.test.ts
+++ b/src/extensions/core/load3d/load3dContextMenuGuard.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { attachContextMenuGuard } from './load3dContextMenuGuard'
+
+function rightMouse(type: string, x: number, y: number, buttons = 2) {
+  const event = new MouseEvent(type, {
+    button: 2,
+    buttons,
+    clientX: x,
+    clientY: y,
+    bubbles: true,
+    cancelable: true
+  })
+  return event
+}
+
+describe('attachContextMenuGuard', () => {
+  let target: HTMLElement
+  let onMenu: ReturnType<typeof vi.fn<(event: MouseEvent) => void>>
+  let dispose: () => void
+
+  beforeEach(() => {
+    target = document.createElement('div')
+    document.body.appendChild(target)
+    onMenu = vi.fn<(event: MouseEvent) => void>()
+  })
+
+  afterEach(() => {
+    dispose?.()
+    target.remove()
+  })
+
+  it('invokes onMenu for a right-click without drag movement', () => {
+    dispose = attachContextMenuGuard(target, onMenu)
+
+    target.dispatchEvent(rightMouse('mousedown', 100, 100))
+    target.dispatchEvent(rightMouse('contextmenu', 100, 100))
+
+    expect(onMenu).toHaveBeenCalledOnce()
+  })
+
+  it('preventDefault is called on the contextmenu event when menu fires', () => {
+    dispose = attachContextMenuGuard(target, onMenu)
+
+    target.dispatchEvent(rightMouse('mousedown', 0, 0))
+    const contextEvent = rightMouse('contextmenu', 0, 0)
+    target.dispatchEvent(contextEvent)
+
+    expect(contextEvent.defaultPrevented).toBe(true)
+  })
+
+  it('suppresses onMenu when the mouse moved past the drag threshold', () => {
+    dispose = attachContextMenuGuard(target, onMenu, { dragThreshold: 5 })
+
+    target.dispatchEvent(rightMouse('mousedown', 100, 100))
+    target.dispatchEvent(rightMouse('mousemove', 120, 120))
+    target.dispatchEvent(rightMouse('contextmenu', 120, 120))
+
+    expect(onMenu).not.toHaveBeenCalled()
+  })
+
+  it('still fires onMenu when the mouse moved within the drag threshold', () => {
+    dispose = attachContextMenuGuard(target, onMenu, { dragThreshold: 10 })
+
+    target.dispatchEvent(rightMouse('mousedown', 100, 100))
+    target.dispatchEvent(rightMouse('mousemove', 103, 104))
+    target.dispatchEvent(rightMouse('contextmenu', 103, 104))
+
+    expect(onMenu).toHaveBeenCalledOnce()
+  })
+
+  it('detects a drag from start to contextmenu even without mousemove events', () => {
+    dispose = attachContextMenuGuard(target, onMenu, { dragThreshold: 5 })
+
+    target.dispatchEvent(rightMouse('mousedown', 100, 100))
+    target.dispatchEvent(rightMouse('contextmenu', 200, 200))
+
+    expect(onMenu).not.toHaveBeenCalled()
+  })
+
+  it('resets drag state between right-clicks', () => {
+    dispose = attachContextMenuGuard(target, onMenu, { dragThreshold: 5 })
+
+    target.dispatchEvent(rightMouse('mousedown', 100, 100))
+    target.dispatchEvent(rightMouse('mousemove', 200, 200))
+    target.dispatchEvent(rightMouse('contextmenu', 200, 200))
+    expect(onMenu).not.toHaveBeenCalled()
+
+    target.dispatchEvent(rightMouse('mousedown', 50, 50))
+    target.dispatchEvent(rightMouse('contextmenu', 50, 50))
+    expect(onMenu).toHaveBeenCalledOnce()
+  })
+
+  it('ignores onMenu when isDisabled returns true', () => {
+    let disabled = true
+    dispose = attachContextMenuGuard(target, onMenu, {
+      isDisabled: () => disabled
+    })
+
+    target.dispatchEvent(rightMouse('mousedown', 10, 10))
+    target.dispatchEvent(rightMouse('contextmenu', 10, 10))
+    expect(onMenu).not.toHaveBeenCalled()
+
+    disabled = false
+    target.dispatchEvent(rightMouse('mousedown', 10, 10))
+    target.dispatchEvent(rightMouse('contextmenu', 10, 10))
+    expect(onMenu).toHaveBeenCalledOnce()
+  })
+
+  it('stops listening after dispose', () => {
+    dispose = attachContextMenuGuard(target, onMenu)
+    dispose()
+
+    target.dispatchEvent(rightMouse('mousedown', 10, 10))
+    target.dispatchEvent(rightMouse('contextmenu', 10, 10))
+
+    expect(onMenu).not.toHaveBeenCalled()
+  })
+
+  it('ignores mousemove events without the right button held', () => {
+    dispose = attachContextMenuGuard(target, onMenu, { dragThreshold: 5 })
+
+    target.dispatchEvent(rightMouse('mousedown', 100, 100))
+    target.dispatchEvent(rightMouse('mousemove', 200, 200, 0))
+    target.dispatchEvent(rightMouse('contextmenu', 100, 100))
+
+    expect(onMenu).toHaveBeenCalledOnce()
+  })
+})

--- a/src/extensions/core/load3d/load3dContextMenuGuard.ts
+++ b/src/extensions/core/load3d/load3dContextMenuGuard.ts
@@ -1,0 +1,72 @@
+import { exceedsClickThreshold } from '@/composables/useClickDragGuard'
+
+type ContextMenuGuardOptions = {
+  isDisabled?: () => boolean
+  dragThreshold?: number
+}
+
+export function attachContextMenuGuard(
+  target: HTMLElement,
+  onMenu: (event: MouseEvent) => void,
+  { isDisabled = () => false, dragThreshold = 5 }: ContextMenuGuardOptions = {}
+): () => void {
+  const abort = new AbortController()
+  const { signal } = abort
+
+  let start = { x: 0, y: 0 }
+  let moved = false
+
+  target.addEventListener(
+    'mousedown',
+    (e) => {
+      if (e.button === 2) {
+        start = { x: e.clientX, y: e.clientY }
+        moved = false
+      }
+    },
+    { signal }
+  )
+
+  target.addEventListener(
+    'mousemove',
+    (e) => {
+      if (
+        e.buttons === 2 &&
+        exceedsClickThreshold(
+          start,
+          { x: e.clientX, y: e.clientY },
+          dragThreshold
+        )
+      ) {
+        moved = true
+      }
+    },
+    { signal }
+  )
+
+  target.addEventListener(
+    'contextmenu',
+    (e) => {
+      if (isDisabled()) return
+
+      const wasDragging =
+        moved ||
+        exceedsClickThreshold(
+          start,
+          { x: e.clientX, y: e.clientY },
+          dragThreshold
+        )
+
+      moved = false
+
+      if (wasDragging) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      onMenu(e)
+    },
+    { signal }
+  )
+
+  return () => abort.abort()
+}


### PR DESCRIPTION
## Summary

Pull the right-click vs right-drag detection out of `Load3d` into a sibling helper. Mechanical refactor — no behavior change. Third of four small PRs splitting up the [`remove-ply-3dgs-nodes-squashed` mega-commit.](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11495.)

## Changes

- **What**: New `load3dContextMenuGuard.ts` exports `attachContextMenuGuard(target, onMenu, { isDisabled, dragThreshold })`. It installs `mousedown` / `mousemove` / `contextmenu` listeners against a single `AbortController` and returns one dispose function.
- `Load3d` now calls `attachContextMenuGuard(this.renderer.domElement, (event) => this.onContextMenuCallback?.(event), { isDisabled: () => this.isViewerMode })` and stores the returned disposer in a single field. Drops four private fields (`rightMouseStart`, `rightMouseMoved`, `dragThreshold`, `contextMenuAbortController`) plus the now-redundant `showNodeContextMenu` private method.
- The 5px drag threshold and `isViewerMode` gating are preserved.

## Review Focus

- The three event handlers (`mousedown`, `mousemove`, `contextmenu`) inside the new helper match the old inline implementations one-for-one — same `e.button === 2` / `e.buttons === 2` checks, same call to `exceedsClickThreshold`, same `preventDefault` + `stopPropagation` ordering.
- `isDisabled: () => this.isViewerMode` replaces the inline `if (this.isViewerMode) return` early-out — same gate, just lifted to a callback.
- A single `AbortController.abort()` (in the returned disposer) replaces the old four-field teardown in `Load3d.remove()`.
- 9 unit tests cover the helper: click vs drag distinction at the threshold, drag-then-click reset, `isDisabled` short-circuit, and the disposer detaching all three listeners.

## Coverage

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `load3dContextMenuGuard.ts` (new) | **100%** | **93.33%** | **100%** | **100%** |
| `Load3d.ts` (modified) | 7.12% | 0% | 13.97% | 7.18% |

The single uncovered branch on `load3dContextMenuGuard.ts` (line 22) is the default-parameter fallback for `dragThreshold` when the caller omits it — `Load3d` always passes `{ isDisabled, dragThreshold: 5 }` through `attachContextMenuGuard`'s second-arg destructure, so the default never fires under the production call path. Adding a test that omits `dragThreshold` would push it to 100%; left as-is to avoid a change-detector test for a default value.

The `Load3d.ts` numbers are the pre-existing baseline on `main` — `Load3d.test.ts` covers façade methods via prototype injection rather than instantiating the class (the constructor needs `THREE.WebGLRenderer`, which happy-dom can't provide). The `initContextMenu` rewrite and the `remove()` teardown change both sit in those same uninstantiated paths and rely on browser e2e for end-to-end coverage, the same as before. Net: the click-vs-drag logic that previously had no unit test is now ≥93% covered through the extracted helper.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11625-refactor-extract-Load3d-right-click-guard-to-load3dContextMenuGuard-34d6d73d36508162aecef46553a3f50d) by [Unito](https://www.unito.io)
