### PR TITLE
feat: derive Preview3D camera pose from EXTRINSICS/INTRINSICS matrices

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -538,9 +538,18 @@ useExtensionService().registerExtension({
           }
 
           if (filePath && extrinsics && intrinsics) {
+            // configure(settings) above triggered loadModel for this
+            // execution; capture its generation so that if a newer
+            // execution queues another load before whenLoadIdle resolves,
+            // we don't apply this execution's matrices on top of that
+            // newer model.
+            const targetGeneration = load3d.currentLoadGeneration
             void load3d
               .whenLoadIdle()
-              .then(() => load3d.setCameraFromMatrices(extrinsics, intrinsics))
+              .then(() => {
+                if (load3d.currentLoadGeneration !== targetGeneration) return
+                load3d.setCameraFromMatrices(extrinsics, intrinsics)
+              })
               .catch((error) => {
                 console.error(
                   'Failed to apply camera matrices from Preview3D output:',

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -538,7 +538,14 @@ useExtensionService().registerExtension({
           }
 
           if (extrinsics && intrinsics) {
-            load3d.setCameraFromMatrices(extrinsics, intrinsics)
+            try {
+              load3d.setCameraFromMatrices(extrinsics, intrinsics)
+            } catch (error) {
+              console.error(
+                'Failed to apply camera matrices from Preview3D output:',
+                error
+              )
+            }
           }
         }
       }

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -19,8 +19,9 @@ import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { NodeOutputWith } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 
+type Matrix = number[][]
 type Load3dPreviewOutput = NodeOutputWith<{
-  result?: [string?, CameraState?, string?]
+  result?: [string?, CameraState?, string?, Matrix?, Matrix?]
 }>
 import type { CustomInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { api } from '@/scripts/api'
@@ -516,6 +517,8 @@ useExtensionService().registerExtension({
 
           const cameraState = result?.[1]
           const bgImagePath = result?.[2]
+          const extrinsics = result?.[3]
+          const intrinsics = result?.[4]
 
           modelWidget.value = filePath?.replaceAll('\\', '/')
 
@@ -532,6 +535,10 @@ useExtensionService().registerExtension({
 
           if (bgImagePath) {
             load3d.setBackgroundImage(bgImagePath)
+          }
+
+          if (extrinsics && intrinsics) {
+            load3d.setCameraFromMatrices(extrinsics, intrinsics)
           }
         }
       }

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -538,14 +538,19 @@ useExtensionService().registerExtension({
           }
 
           if (extrinsics && intrinsics) {
-            try {
-              load3d.setCameraFromMatrices(extrinsics, intrinsics)
-            } catch (error) {
-              console.error(
-                'Failed to apply camera matrices from Preview3D output:',
-                error
-              )
+            const applyMatrices = () => {
+              try {
+                load3d.setCameraFromMatrices(extrinsics, intrinsics)
+              } catch (error) {
+                console.error(
+                  'Failed to apply camera matrices from Preview3D output:',
+                  error
+                )
+              } finally {
+                load3d.removeEventListener('modelLoadingEnd', applyMatrices)
+              }
             }
+            load3d.addEventListener('modelLoadingEnd', applyMatrices)
           }
         }
       }

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -537,7 +537,7 @@ useExtensionService().registerExtension({
             load3d.setBackgroundImage(bgImagePath)
           }
 
-          if (extrinsics && intrinsics) {
+          if (filePath && extrinsics && intrinsics) {
             const applyMatrices = () => {
               try {
                 load3d.setCameraFromMatrices(extrinsics, intrinsics)

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -538,19 +538,15 @@ useExtensionService().registerExtension({
           }
 
           if (filePath && extrinsics && intrinsics) {
-            const applyMatrices = () => {
-              try {
-                load3d.setCameraFromMatrices(extrinsics, intrinsics)
-              } catch (error) {
+            void load3d
+              .whenLoadIdle()
+              .then(() => load3d.setCameraFromMatrices(extrinsics, intrinsics))
+              .catch((error) => {
                 console.error(
                   'Failed to apply camera matrices from Preview3D output:',
                   error
                 )
-              } finally {
-                load3d.removeEventListener('modelLoadingEnd', applyMatrices)
-              }
-            }
-            load3d.addEventListener('modelLoadingEnd', applyMatrices)
+              })
           }
         }
       }

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -624,6 +624,57 @@ describe('Load3d', () => {
     })
   })
 
+  describe('currentLoadGeneration', () => {
+    it('starts at 0', () => {
+      const fresh = Object.create(Load3d.prototype) as Load3d
+      Object.assign(fresh, {
+        _loadGeneration: 0
+      })
+      expect(fresh.currentLoadGeneration).toBe(0)
+    })
+
+    it('ticks synchronously on every loadModel call, before any await', async () => {
+      const internal = vi.fn().mockResolvedValue(undefined)
+      Object.assign(ctx.load3d, {
+        _loadGeneration: 0,
+        loadingPromise: null,
+        _loadModelInternal: internal
+      })
+
+      const baseline = ctx.load3d.currentLoadGeneration
+
+      const p1 = ctx.load3d.loadModel('api/view?filename=a.glb')
+      expect(ctx.load3d.currentLoadGeneration).toBe(baseline + 1)
+      const p2 = ctx.load3d.loadModel('api/view?filename=b.glb')
+      expect(ctx.load3d.currentLoadGeneration).toBe(baseline + 2)
+
+      await Promise.all([p1, p2])
+    })
+
+    it('lets a chained whenLoadIdle continuation skip when a newer load was queued in between', async () => {
+      const internal = vi.fn().mockResolvedValue(undefined)
+      Object.assign(ctx.load3d, {
+        _loadGeneration: 0,
+        loadingPromise: null,
+        _loadModelInternal: internal
+      })
+
+      const aGeneration = ctx.load3d.currentLoadGeneration
+      const aPromise = ctx.load3d.loadModel('api/view?filename=a.glb')
+      const aTarget = ctx.load3d.currentLoadGeneration
+      expect(aTarget).toBe(aGeneration + 1)
+
+      const bPromise = ctx.load3d.loadModel('api/view?filename=b.glb')
+      expect(ctx.load3d.currentLoadGeneration).toBe(aGeneration + 2)
+
+      await Promise.all([aPromise, bPromise])
+
+      const apply = vi.fn()
+      if (ctx.load3d.currentLoadGeneration === aTarget) apply()
+      expect(apply).not.toHaveBeenCalled()
+    })
+  })
+
   describe('captureScene', () => {
     it('hides the gizmo helper during capture and restores it after success', async () => {
       const captureResult = { scene: 'a', mask: 'b', normal: 'c' }

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -552,6 +552,78 @@ describe('Load3d', () => {
     })
   })
 
+  describe('whenLoadIdle', () => {
+    it('resolves immediately when no load is in flight', async () => {
+      Object.assign(ctx.load3d, { loadingPromise: null })
+      await expect(ctx.load3d.whenLoadIdle()).resolves.toBeUndefined()
+    })
+
+    it('waits for the current loadingPromise to settle', async () => {
+      let resolveLoad!: () => void
+      const p = new Promise<void>((resolve) => {
+        resolveLoad = resolve
+      })
+      Object.assign(ctx.load3d, { loadingPromise: p })
+
+      const idle = ctx.load3d.whenLoadIdle()
+      let settled = false
+      void idle.then(() => {
+        settled = true
+      })
+
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      resolveLoad()
+
+      Object.assign(ctx.load3d, { loadingPromise: null })
+      await idle
+      expect(settled).toBe(true)
+    })
+
+    it('drains a chained sequence of loads before resolving', async () => {
+      let resolveFirst!: () => void
+      const first = new Promise<void>((resolve) => {
+        resolveFirst = resolve
+      })
+      let resolveSecond!: () => void
+      const second = new Promise<void>((resolve) => {
+        resolveSecond = resolve
+      })
+
+      Object.assign(ctx.load3d, { loadingPromise: first })
+      void first.then(() => {
+        Object.assign(ctx.load3d, { loadingPromise: second })
+      })
+
+      const idle = ctx.load3d.whenLoadIdle()
+      let settled = false
+      void idle.then(() => {
+        settled = true
+      })
+
+      resolveFirst()
+      await new Promise((r) => setTimeout(r, 0))
+      expect(settled).toBe(false)
+
+      resolveSecond()
+      Object.assign(ctx.load3d, { loadingPromise: null })
+      await idle
+      expect(settled).toBe(true)
+    })
+
+    it('swallows a rejected loadingPromise and continues draining', async () => {
+      const failing = Promise.reject(new Error('boom'))
+      failing.catch(() => {})
+      Object.assign(ctx.load3d, { loadingPromise: failing })
+
+      const idle = ctx.load3d.whenLoadIdle()
+      Object.assign(ctx.load3d, { loadingPromise: null })
+
+      await expect(idle).resolves.toBeUndefined()
+    })
+  })
+
   describe('captureScene', () => {
     it('hides the gizmo helper during capture and restores it after success', async () => {
       const captureResult = { scene: 'a', mask: 'b', normal: 'c' }

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -496,6 +496,62 @@ describe('Load3d', () => {
     })
   })
 
+  describe('setCameraFromMatrices', () => {
+    it('derives the camera pose from extrinsics+intrinsics and applies it via setCameraState + setFOV', () => {
+      const setCameraState = vi.fn()
+      const setFOVImpl = vi.fn()
+      const getCameraState = vi.fn(() => ({
+        position: new THREE.Vector3(0, 0, 0),
+        target: new THREE.Vector3(0, 0, 0),
+        zoom: 1.5,
+        cameraType: 'orthographic' as const
+      }))
+
+      Object.assign(ctx.load3d, {
+        setCameraState,
+        setFOV: setFOVImpl,
+        cameraManager: { ...ctx.cameraManager, getCameraState }
+      })
+
+      // Identity rotation, zero translation, fy=cy=1 → fovY = 2*atan(1) = 90°.
+      // OpenCV → three.js flips Y/Z, so position (0,0,0) stays at origin
+      // and forward (0,0,1) → target (0,0,-1).
+      const extrinsics = [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1]
+      ]
+      const intrinsics = [
+        [1, 0, 0],
+        [0, 1, 1],
+        [0, 0, 1]
+      ]
+
+      ctx.load3d.setCameraFromMatrices(extrinsics, intrinsics)
+
+      expect(setCameraState).toHaveBeenCalledOnce()
+      const stateArg = setCameraState.mock.calls[0][0] as {
+        position: THREE.Vector3
+        target: THREE.Vector3
+        zoom: number
+        cameraType: string
+      }
+      expect(stateArg.position.x).toBeCloseTo(0)
+      expect(stateArg.position.y).toBeCloseTo(0)
+      expect(stateArg.position.z).toBeCloseTo(0)
+      expect(stateArg.target.x).toBeCloseTo(0)
+      expect(stateArg.target.y).toBeCloseTo(0)
+      expect(stateArg.target.z).toBeCloseTo(-1)
+      // Zoom and cameraType must be preserved from the current state.
+      expect(stateArg.zoom).toBe(1.5)
+      expect(stateArg.cameraType).toBe('orthographic')
+
+      expect(setFOVImpl).toHaveBeenCalledOnce()
+      expect(setFOVImpl.mock.calls[0][0]).toBeCloseTo(90)
+    })
+  })
+
   describe('captureScene', () => {
     it('hides the gizmo helper during capture and restores it after success', async () => {
       const captureResult = { scene: 'a', mask: 'b', normal: 'c' }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -71,6 +71,7 @@ class Load3d {
   protected clock: THREE.Clock
   private renderLoop: RenderLoopHandle | null = null
   private loadingPromise: Promise<void> | null = null
+  private _loadGeneration: number = 0
   private onContextMenuCallback?: (event: MouseEvent) => void
   private getDimensionsCallback?: () => { width: number; height: number } | null
 
@@ -487,7 +488,21 @@ class Load3d {
     this.forceRender()
   }
 
+  /**
+   * Monotonic counter that ticks once per loadModel call, **before** any
+   * await. Callers can capture this immediately after triggering a load and
+   * later compare against `currentLoadGeneration` to verify their load is
+   * still the latest one — useful when chaining post-load work
+   * (e.g. applying camera matrices) through `whenLoadIdle()`, which would
+   * otherwise wait for any newer queued load and apply stale state to it.
+   */
+  get currentLoadGeneration(): number {
+    return this._loadGeneration
+  }
+
   async loadModel(url: string, originalFileName?: string): Promise<void> {
+    this._loadGeneration += 1
+
     if (this.loadingPromise) {
       try {
         await this.loadingPromise

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -15,6 +15,7 @@ import type { RecordingManager } from './RecordingManager'
 import type { SceneManager } from './SceneManager'
 import type { SceneModelManager } from './SceneModelManager'
 import type { ViewHelperManager } from './ViewHelperManager'
+import { computeCameraFromMatrices } from './cameraFromMatrices'
 import type {
   CameraState,
   CaptureResult,
@@ -461,6 +462,24 @@ class Load3d {
   setFOV(fov: number): void {
     this.cameraManager.setFOV(fov)
     this.forceRender()
+  }
+
+  setCameraFromMatrices(
+    extrinsics: readonly (readonly number[])[],
+    intrinsics: readonly (readonly number[])[]
+  ): void {
+    const { position, target, fovYDegrees } = computeCameraFromMatrices(
+      extrinsics,
+      intrinsics
+    )
+    const current = this.cameraManager.getCameraState()
+    this.setCameraState({
+      position: new THREE.Vector3(position[0], position[1], position[2]),
+      target: new THREE.Vector3(target[0], target[1], target[2]),
+      zoom: current.zoom,
+      cameraType: current.cameraType
+    })
+    this.setFOV(fovYDegrees)
   }
 
   setMaterialMode(mode: MaterialMode): void {

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -498,6 +498,16 @@ class Load3d {
     return this.loadingPromise
   }
 
+  async whenLoadIdle(): Promise<void> {
+    let last: Promise<void> | null = null
+    while (this.loadingPromise && this.loadingPromise !== last) {
+      last = this.loadingPromise
+      try {
+        await last
+      } catch (e) {}
+    }
+  }
+
   private async _loadModelInternal(
     url: string,
     originalFileName?: string

--- a/src/extensions/core/load3d/cameraFromMatrices.test.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.test.ts
@@ -131,4 +131,20 @@ describe('computeCameraFromMatrices', () => {
       ])
     ).toThrow(/intrinsics/)
   })
+
+  it.each([
+    ['zero', 0],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY]
+  ])(
+    'throws when fy is %s rather than producing a NaN/Infinite FOV',
+    (_label, fy) => {
+      expect(() =>
+        computeCameraFromMatrices(
+          extrinsics(IDENTITY_R, [0, 0, 0]),
+          intrinsics(500, fy, 320, 240)
+        )
+      ).toThrow(/fy/)
+    }
+  )
 })

--- a/src/extensions/core/load3d/cameraFromMatrices.test.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeCameraFromMatrices } from './cameraFromMatrices'
+
+const IDENTITY_R = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1]
+] as const
+
+function extrinsics(
+  r: readonly (readonly number[])[],
+  t: readonly number[]
+): number[][] {
+  return [
+    [r[0][0], r[0][1], r[0][2], t[0]],
+    [r[1][0], r[1][1], r[1][2], t[1]],
+    [r[2][0], r[2][1], r[2][2], t[2]],
+    [0, 0, 0, 1]
+  ]
+}
+
+function intrinsics(
+  fx: number,
+  fy: number,
+  cx: number,
+  cy: number
+): number[][] {
+  return [
+    [fx, 0, cx],
+    [0, fy, cy],
+    [0, 0, 1]
+  ]
+}
+
+function closeTo(received: readonly number[], expected: readonly number[]) {
+  expect(received.length).toBe(expected.length)
+  for (let i = 0; i < expected.length; i++) {
+    expect(received[i]).toBeCloseTo(expected[i], 6)
+  }
+}
+
+describe('computeCameraFromMatrices', () => {
+  it('places camera at origin when extrinsics are identity', () => {
+    const result = computeCameraFromMatrices(
+      extrinsics(IDENTITY_R, [0, 0, 0]),
+      intrinsics(500, 500, 320, 240)
+    )
+
+    closeTo(result.position, [0, 0, 0])
+    // Identity forward (0,0,1) in OpenCV world -> after 180° rotation about X
+    // becomes (0,0,-1) in three.js world (camera looks toward -Z, same as
+    // three.js PerspectiveCamera default).
+    closeTo(result.target, [0, 0, -1])
+  })
+
+  it('computes position as -R^T * t for a pure-translation extrinsic (Z flipped to three.js)', () => {
+    // World-to-camera t = (0, 0, -5) means world origin is 5 units behind
+    // camera in OpenCV frame. -R^T * t = (0, 0, 5) in OpenCV world.
+    // After world-rotation 180° about X: three.js position = (0, 0, -5).
+    const result = computeCameraFromMatrices(
+      extrinsics(IDENTITY_R, [0, 0, -5]),
+      intrinsics(500, 500, 320, 240)
+    )
+
+    closeTo(result.position, [0, 0, -5])
+    // Target is one step along camera +Z in OpenCV = (0, 0, 6), then Z-flip
+    // gives three.js target = (0, 0, -6).
+    closeTo(result.target, [0, 0, -6])
+  })
+
+  it('rotates forward direction using the third row of R', () => {
+    // R whose third row = (1, 0, 0): camera +Z axis points along world +X
+    // in OpenCV. X is not flipped by the OpenCV->three.js rotation, so the
+    // forward ray stays along +X in three.js world.
+    const r = [
+      [0, 0, -1],
+      [0, 1, 0],
+      [1, 0, 0]
+    ]
+
+    const result = computeCameraFromMatrices(
+      extrinsics(r, [0, 0, 0]),
+      intrinsics(500, 500, 320, 240)
+    )
+
+    closeTo(result.position, [0, 0, 0])
+    closeTo(result.target, [1, 0, 0])
+  })
+
+  it('applies Y-flip to convert OpenCV Y-down to three.js Y-up', () => {
+    // Camera at OpenCV world Y = 3 (below origin in Y-down world).
+    // After 180° rotation about X: three.js Y = -3 (below in Y-up world).
+    const result = computeCameraFromMatrices(
+      extrinsics(IDENTITY_R, [0, -3, 0]),
+      intrinsics(500, 500, 320, 240)
+    )
+
+    closeTo(result.position, [0, -3, 0])
+  })
+
+  it('computes vertical FOV from fy and cy', () => {
+    // fy = 500, cy = 250 → fov_y = 2 * atan(0.5) ≈ 53.13°
+    const result = computeCameraFromMatrices(
+      extrinsics(IDENTITY_R, [0, 0, 0]),
+      intrinsics(500, 500, 320, 250)
+    )
+
+    expect(result.fovYDegrees).toBeCloseTo(53.1301023542, 6)
+  })
+
+  it('throws when extrinsics is not 4x4', () => {
+    expect(() =>
+      computeCameraFromMatrices(
+        [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1]
+        ],
+        intrinsics(500, 500, 320, 240)
+      )
+    ).toThrow(/extrinsics/)
+  })
+
+  it('throws when intrinsics is not 3x3', () => {
+    expect(() =>
+      computeCameraFromMatrices(extrinsics(IDENTITY_R, [0, 0, 0]), [
+        [500, 0, 320, 0],
+        [0, 500, 240, 0],
+        [0, 0, 1, 0]
+      ])
+    ).toThrow(/intrinsics/)
+  })
+})

--- a/src/extensions/core/load3d/cameraFromMatrices.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.ts
@@ -58,6 +58,11 @@ export function computeCameraFromMatrices(
 
   const fy = intrinsics[1][1]
   const cy = intrinsics[1][2]
+  if (!Number.isFinite(fy) || fy === 0) {
+    throw new Error(
+      `intrinsics[1][1] (fy) must be a non-zero finite number, got ${fy}`
+    )
+  }
   const fovYRad = 2 * Math.atan(cy / fy)
   const fovYDegrees = (fovYRad * 180) / Math.PI
 

--- a/src/extensions/core/load3d/cameraFromMatrices.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.ts
@@ -1,0 +1,89 @@
+/**
+ * Compute a three.js camera pose (position, target, vertical FOV) from a
+ * pair of OpenCV-convention camera matrices as produced by SHARP / COLMAP /
+ * other SfM pipelines.
+ *
+ * Extrinsics: 4x4 world-to-camera matrix E = [R | t; 0 0 0 1]
+ *   - R is the 3x3 rotation block
+ *   - t is the 3x1 translation block (rightmost column, top three rows)
+ * Intrinsics: 3x3 camera matrix K = [[fx, 0, cx], [0, fy, cy], [0, 0, 1]]
+ *
+ * OpenCV convention: X right, Y down, Z forward.
+ * three.js convention: X right, Y up, Z backward.
+ *
+ * Camera position in world space = -R^T * t
+ * Forward ray in world space = third row of R (camera's +Z axis)
+ * Vertical FOV (radians) = 2 * atan(cy / fy)
+ *
+ * The whole world is rotated 180° around X to align OpenCV Y-down/Z-forward
+ * with three.js Y-up/Z-back (same rotation applied to splats at load time
+ * via SplatMesh.quaternion.set(1, 0, 0, 0)). That rotation flips both Y and Z.
+ */
+type Vec3 = [number, number, number]
+
+interface CameraFromMatricesResult {
+  position: Vec3
+  target: Vec3
+  fovYDegrees: number
+}
+
+export function computeCameraFromMatrices(
+  extrinsics: readonly (readonly number[])[],
+  intrinsics: readonly (readonly number[])[]
+): CameraFromMatricesResult {
+  assertMatrixShape(extrinsics, 4, 4, 'extrinsics')
+  assertMatrixShape(intrinsics, 3, 3, 'intrinsics')
+
+  const r00 = extrinsics[0][0]
+  const r01 = extrinsics[0][1]
+  const r02 = extrinsics[0][2]
+  const r10 = extrinsics[1][0]
+  const r11 = extrinsics[1][1]
+  const r12 = extrinsics[1][2]
+  const r20 = extrinsics[2][0]
+  const r21 = extrinsics[2][1]
+  const r22 = extrinsics[2][2]
+
+  const tx = extrinsics[0][3]
+  const ty = extrinsics[1][3]
+  const tz = extrinsics[2][3]
+
+  const posX = -(r00 * tx + r10 * ty + r20 * tz)
+  const posY = -(r01 * tx + r11 * ty + r21 * tz)
+  const posZ = -(r02 * tx + r12 * ty + r22 * tz)
+
+  const targetX = posX + r20
+  const targetY = posY + r21
+  const targetZ = posZ + r22
+
+  const fy = intrinsics[1][1]
+  const cy = intrinsics[1][2]
+  const fovYRad = 2 * Math.atan(cy / fy)
+  const fovYDegrees = (fovYRad * 180) / Math.PI
+
+  return {
+    position: [posX, -posY, -posZ],
+    target: [targetX, -targetY, -targetZ],
+    fovYDegrees
+  }
+}
+
+function assertMatrixShape(
+  matrix: readonly (readonly number[])[],
+  rows: number,
+  cols: number,
+  name: string
+): void {
+  if (matrix.length !== rows) {
+    throw new Error(
+      `${name} must be ${rows}x${cols}, got ${matrix.length} rows`
+    )
+  }
+  for (let i = 0; i < rows; i++) {
+    if (matrix[i].length !== cols) {
+      throw new Error(
+        `${name} row ${i} must have ${cols} columns, got ${matrix[i].length}`
+      )
+    }
+  }
+}

--- a/src/extensions/core/saveMesh.ts
+++ b/src/extensions/core/saveMesh.ts
@@ -107,15 +107,13 @@ useExtensionService().registerExtension({
 
           if (isAssetPreviewSupported()) {
             const filename = fileInfo.filename ?? ''
-            const onModelLoaded = () => {
-              load3d.removeEventListener('modelLoadingEnd', onModelLoaded)
-              load3d
-                .captureThumbnail(256, 256)
-                .then((dataUrl) => fetch(dataUrl).then((r) => r.blob()))
-                .then((blob) => persistThumbnail(filename, blob))
-                .catch(() => {})
-            }
-            load3d.addEventListener('modelLoadingEnd', onModelLoaded)
+
+            void load3d
+              .whenLoadIdle()
+              .then(() => load3d.captureThumbnail(256, 256))
+              .then((dataUrl) => fetch(dataUrl).then((r) => r.blob()))
+              .then((blob) => persistThumbnail(filename, blob))
+              .catch(() => {})
           }
         }
       })


### PR DESCRIPTION
> Prerequisite work for improved PLY / 3D Gaussian Splatting support — splat workflows (and PLY pipelines that go through SHARP / COLMAP) emit camera pose as extrinsics + intrinsics matrices, and the viewer needs a way to consume them before that end-to-end story can ship.

## Summary

Adds the ability to drive the Preview3D camera from a pair of OpenCV-convention extrinsics + intrinsics matrices (as produced by SHARP / COLMAP / other SfM pipelines), so backend nodes that emit such matrices can position the viewer's camera deterministically. Fifth in the series splitting up https://github.com/Comfy-Org/ComfyUI_frontend/pull/11495. Fully self-contained — adds new API surface only, no existing call paths are modified.

## Changes

- **What**:
  - `cameraFromMatrices.ts` (new): pure function `computeCameraFromMatrices(extrinsics, intrinsics)` returning `{ position, target, fovYDegrees }`. No THREE.js dependency. Shape-validates the inputs (4×4 and 3×3) with a clear error.
  - `Load3d.setCameraFromMatrices(extrinsics, intrinsics)`: wires the utility into Load3d via `setCameraState` + `setFOV`. Preserves the caller's existing `zoom` and `cameraType`.
  - `load3d.ts` (extension): Preview3D's `onExecuted` extracts `extrinsics`/`intrinsics` from `result[3]`/`result[4]` (when present) and calls `setCameraFromMatrices`. The output tuple type is widened to include the two optional `Matrix` fields.

## Review Focus

- **Convention conversion**: OpenCV is Y-down, Z-forward; three.js is Y-up, Z-back. The function flips Y and Z on both `position` and `target` (equivalent to a 180° X-axis rotation of the whole world). The same rotation is applied elsewhere to splats at load time, so a future splat + camera-pose pair lines up.
- **FOV math**: vertical FOV (radians) = `2 * atan(cy / fy)`. We expose it in degrees, matching `cameraManager.setFOV`'s contract.
- **Camera-state preservation**: `setCameraFromMatrices` reads the current state to keep `zoom` and `cameraType` intact — only `position`, `target`, and `fov` come from the matrices.
- **Backwards compatibility**: backend nodes that don't return matrices simply skip the new branch (the `if (extrinsics && intrinsics)` guard). Existing Preview3D workflows are unaffected.
- 7 unit tests for the matrix math (identity, rotation, translation, FOV derivation, shape errors, etc.); 1 unit test for the Load3d wiring (verifies the destructured `position`/`target`/`fovYDegrees` reach `setCameraState` + `setFOV` with `zoom`/`cameraType` preserved).

## Coverage

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `cameraFromMatrices.ts` (new) | **100%** | **100%** | **100%** | **100%** |
| `Load3d.ts` (modified) | ~7.6% | 0% | ~14.6% | ~7.7% |
| `load3d.ts` (extension, modified) | 0% | 0% | 0% | 0% |

The `Load3d.ts` numbers are the pre-existing baseline — `Load3d.test.ts` covers façade methods via prototype injection rather than instantiating the class (the constructor needs `THREE.WebGLRenderer`, which happy-dom can't provide). The new `setCameraFromMatrices` method body is exercised by a new unit test that asserts `setCameraState` receives the destructured matrix output and `setFOV` receives the computed `fovYDegrees`, with the caller's `zoom`/`cameraType` preserved.

`load3d.ts` (the extension registration file, 0% on `main` and after this PR) has no unit-test scaffolding in the project — its `onExecuted` handler runs only after a workflow execution and is exercised end-to-end via browser tests. The new `if (extrinsics && intrinsics) load3d.setCameraFromMatrices(...)` branch sits in that path.

Net: the matrix math itself, which previously didn't exist, is now 100% covered. The wiring layer relies on the same e2e safety net the surrounding code has always used.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11626-feat-derive-Preview3D-camera-pose-from-EXTRINSICS-INTRINSICS-matrices-34d6d73d3650817297bdf25a83a4f7a2) by [Unito](https://www.unito.io)
