### PR TITLE
refactor(load3d): introduce ModelAdapter abstraction for the loader switch

### DIFF
--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -469,6 +469,31 @@ describe('Load3d', () => {
     })
   })
 
+  describe('adapter-driven kind queries', () => {
+    function makeWithAdapter(kind: 'mesh' | 'pointCloud' | 'splat' | null) {
+      const adapter = kind === null ? null : { kind }
+      Object.assign(ctx.load3d, {
+        loaderManager: { getCurrentAdapter: vi.fn(() => adapter) }
+      })
+    }
+
+    it('isSplatModel is true only when the current adapter kind is "splat"', () => {
+      makeWithAdapter('splat')
+      expect(ctx.load3d.isSplatModel()).toBe(true)
+      makeWithAdapter('mesh')
+      expect(ctx.load3d.isSplatModel()).toBe(false)
+      makeWithAdapter(null)
+      expect(ctx.load3d.isSplatModel()).toBe(false)
+    })
+
+    it('isPlyModel is true only when the current adapter kind is "pointCloud"', () => {
+      makeWithAdapter('pointCloud')
+      expect(ctx.load3d.isPlyModel()).toBe(true)
+      makeWithAdapter('mesh')
+      expect(ctx.load3d.isPlyModel()).toBe(false)
+    })
+  })
+
   describe('captureScene', () => {
     it('hides the gizmo helper during capture and restores it after success', async () => {
       const captureResult = { scene: 'a', mask: 'b', normal: 'c' }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -567,11 +567,11 @@ class Load3d {
   }
 
   isSplatModel(): boolean {
-    return this.modelManager.containsSplatMesh()
+    return this.loaderManager.getCurrentAdapter()?.kind === 'splat'
   }
 
   isPlyModel(): boolean {
-    return this.modelManager.originalModel instanceof THREE.BufferGeometry
+    return this.loaderManager.getCurrentAdapter()?.kind === 'pointCloud'
   }
 
   clearModel(): void {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -1,0 +1,505 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  EventManagerInterface,
+  MaterialMode,
+  ModelManagerInterface
+} from './interfaces'
+import { LoaderManager } from './LoaderManager'
+import type { ModelAdapter, ModelLoadContext } from './ModelAdapter'
+
+function makeEventManagerStub() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  }
+}
+
+type ModelManagerStub = {
+  clearModel: ReturnType<typeof vi.fn>
+  setupModel: ReturnType<typeof vi.fn>
+  setOriginalModel: ReturnType<typeof vi.fn>
+  originalMaterials: WeakMap<THREE.Mesh, THREE.Material | THREE.Material[]>
+  standardMaterial: THREE.MeshStandardMaterial
+  materialMode: MaterialMode
+  originalFileName: string | null
+  originalURL: string | null
+}
+
+function makeModelManagerStub(): ModelManagerStub {
+  return {
+    clearModel: vi.fn(),
+    setupModel: vi.fn().mockResolvedValue(undefined),
+    setOriginalModel: vi.fn(),
+    originalMaterials: new WeakMap(),
+    standardMaterial: new THREE.MeshStandardMaterial(),
+    materialMode: 'original',
+    originalFileName: 'model',
+    originalURL: null
+  }
+}
+
+const { meshLoad, splatLoad, pointCloudLoad, getPLYEngineMock, addAlert } =
+  vi.hoisted(() => ({
+    meshLoad: vi.fn(),
+    splatLoad: vi.fn(),
+    pointCloudLoad: vi.fn(),
+    getPLYEngineMock: vi.fn<() => string>(),
+    addAlert: vi.fn()
+  }))
+
+vi.mock('./MeshModelAdapter', () => ({
+  MeshModelAdapter: class {
+    readonly kind = 'mesh' as const
+    readonly extensions = ['stl', 'fbx', 'obj', 'gltf', 'glb'] as const
+    readonly capabilities = {}
+    load = meshLoad
+  }
+}))
+
+vi.mock('./PointCloudModelAdapter', () => ({
+  PointCloudModelAdapter: class {
+    readonly kind = 'pointCloud' as const
+    readonly extensions = ['ply'] as const
+    readonly capabilities = {}
+    load = pointCloudLoad
+  },
+  getPLYEngine: () => getPLYEngineMock()
+}))
+
+vi.mock('./SplatModelAdapter', () => ({
+  SplatModelAdapter: class {
+    readonly kind = 'splat' as const
+    readonly extensions = ['spz', 'splat', 'ksplat'] as const
+    readonly capabilities = {}
+    load = splatLoad
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert })
+}))
+
+type LoaderManagerInternals = {
+  pickAdapter(extension: string): ModelAdapter | null
+}
+
+function makeLoaderManager() {
+  const modelManager = makeModelManagerStub()
+  const eventManager = makeEventManagerStub()
+  const lm = new LoaderManager(
+    modelManager as unknown as ConstructorParameters<typeof LoaderManager>[0],
+    eventManager
+  )
+  const internals = lm as unknown as LoaderManagerInternals
+  return {
+    lm,
+    modelManager,
+    eventManager,
+    pick: internals.pickAdapter.bind(lm)
+  }
+}
+
+describe('LoaderManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPLYEngineMock.mockReturnValue('three')
+    meshLoad.mockResolvedValue(null)
+    splatLoad.mockResolvedValue(null)
+    pointCloudLoad.mockResolvedValue(null)
+  })
+
+  describe('getCurrentAdapter', () => {
+    it('returns null before any model loads', () => {
+      const { lm } = makeLoaderManager()
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
+
+    it('exposes the picked adapter after a successful load', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+    })
+
+    it('resets to null at the start of a new load', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+
+      await lm.loadModel('api/view?filename=cube.xyz')
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
+  })
+
+  describe('loadModel ordering', () => {
+    it('keeps the old adapter current while clearModel runs (so future dispose hooks see it)', async () => {
+      const oldAdapter = {
+        kind: 'splat' as const,
+        extensions: ['splat'] as const,
+        capabilities: {
+          fitToViewer: false,
+          requiresMaterialRebuild: false,
+          gizmoTransform: false,
+          lighting: false,
+          exportable: false,
+          materialModes: [],
+          fitTargetSize: 5
+        },
+        load: vi.fn().mockResolvedValue(null)
+      } satisfies ModelAdapter
+
+      const modelManager = {
+        originalMaterials: new WeakMap(),
+        clearModel: vi.fn(),
+        setupModel: vi.fn()
+      } as unknown as ModelManagerInterface
+      const eventManager: EventManagerInterface = {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        emitEvent: vi.fn()
+      }
+
+      let adapterDuringClear: ModelAdapter | null | undefined
+      const lm = new LoaderManager(modelManager, eventManager, [oldAdapter])
+      // Prime the loader with an active adapter, then trigger a new load.
+      ;(lm as unknown as { _currentAdapter: ModelAdapter })._currentAdapter =
+        oldAdapter
+      ;(modelManager.clearModel as ReturnType<typeof vi.fn>).mockImplementation(
+        () => {
+          adapterDuringClear = lm.getCurrentAdapter()
+        }
+      )
+
+      await lm.loadModel(
+        'api/view?type=input&subfolder=&filename=a.splat',
+        'a.splat'
+      )
+
+      expect(adapterDuringClear).toBe(oldAdapter)
+    })
+  })
+
+  describe('pickAdapter', () => {
+    it.each(['stl', 'fbx', 'obj', 'gltf', 'glb'])(
+      'routes %s to the mesh adapter',
+      (ext) => {
+        const { pick } = makeLoaderManager()
+        expect(pick(ext)?.kind).toBe('mesh')
+      }
+    )
+
+    it.each(['spz', 'splat', 'ksplat'])(
+      'routes %s to the splat adapter',
+      (ext) => {
+        const { pick } = makeLoaderManager()
+        expect(pick(ext)?.kind).toBe('splat')
+      }
+    )
+
+    it('routes .ply to the point-cloud adapter for the default three engine', () => {
+      getPLYEngineMock.mockReturnValue('three')
+      const { pick } = makeLoaderManager()
+      expect(pick('ply')?.kind).toBe('pointCloud')
+    })
+
+    it('routes .ply to the point-cloud adapter for the fastply engine', () => {
+      getPLYEngineMock.mockReturnValue('fastply')
+      const { pick } = makeLoaderManager()
+      expect(pick('ply')?.kind).toBe('pointCloud')
+    })
+
+    it('routes .ply to the splat adapter when the engine setting is sparkjs', () => {
+      getPLYEngineMock.mockReturnValue('sparkjs')
+      const { pick } = makeLoaderManager()
+      expect(pick('ply')?.kind).toBe('splat')
+    })
+
+    it('returns null for unknown extensions', () => {
+      const { pick } = makeLoaderManager()
+      expect(pick('xyz')).toBeNull()
+      expect(pick('')).toBeNull()
+    })
+  })
+
+  describe('loadModel', () => {
+    it('emits modelLoadingStart and records originalURL before dispatching', async () => {
+      const { lm, eventManager, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingStart',
+        null
+      )
+      expect(modelManager.originalURL).toBe('api/view?filename=cube.glb')
+    })
+
+    it('clears any existing model before routing to the adapter', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      const order: string[] = []
+      modelManager.clearModel.mockImplementation(() => order.push('clear'))
+      meshLoad.mockImplementationOnce(async () => {
+        order.push('load')
+        return null
+      })
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(order).toEqual(['clear', 'load'])
+    })
+
+    it('derives originalFileName from an explicit originalFileName argument', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?filename=ignored.glb', 'uploads/my-cube.glb')
+
+      expect(modelManager.originalFileName).toBe('my-cube')
+    })
+
+    it('derives originalFileName from the URL filename param when no override is given', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(modelManager.originalFileName).toBe('cube')
+    })
+
+    it('falls back to "model" when the URL has no filename param', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?other=1')
+
+      expect(modelManager.originalFileName).toBe('model')
+    })
+
+    it('alerts when the file extension cannot be determined', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+
+      await lm.loadModel('api/view?other=1')
+
+      expect(addAlert).toHaveBeenCalledWith(
+        'toastMessages.couldNotDetermineFileType'
+      )
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      expect(meshLoad).not.toHaveBeenCalled()
+    })
+
+    it('passes setupModel the object returned by the adapter', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      const loaded = new THREE.Object3D()
+      meshLoad.mockResolvedValueOnce(loaded)
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(modelManager.setupModel).toHaveBeenCalledWith(loaded)
+    })
+
+    it('skips setupModel when the adapter returns null', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(null)
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+    })
+
+    it('emits modelLoadingEnd when the load completes', async () => {
+      const { lm, eventManager } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
+    })
+
+    it('forwards a decoded path and filename to the adapter', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel(
+        'api/view?type=output&subfolder=nested%2Fdir&filename=cube.glb'
+      )
+
+      expect(meshLoad).toHaveBeenCalledWith(
+        expect.objectContaining({
+          setOriginalModel: expect.any(Function),
+          registerOriginalMaterial: expect.any(Function)
+        }),
+        'api/view?type=output&subfolder=nested%2Fdir&filename=',
+        'cube.glb'
+      )
+    })
+
+    it('defaults the path to type=input when no type param is given', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(meshLoad).toHaveBeenCalledWith(
+        expect.anything(),
+        'api/view?type=input&subfolder=&filename=',
+        'cube.glb'
+      )
+    })
+
+    it('routes .ply through the splat adapter when the engine setting is sparkjs', async () => {
+      getPLYEngineMock.mockReturnValue('sparkjs')
+      const { lm } = makeLoaderManager()
+      splatLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(splatLoad).toHaveBeenCalled()
+      expect(pointCloudLoad).not.toHaveBeenCalled()
+    })
+
+    it('handles adapter errors by alerting and still emitting modelLoadingEnd', async () => {
+      const { lm, eventManager } = makeLoaderManager()
+      const err = new Error('boom')
+      meshLoad.mockRejectedValueOnce(err)
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
+      expect(addAlert).toHaveBeenCalledWith('toastMessages.errorLoadingModel')
+      expect(consoleError).toHaveBeenCalled()
+    })
+
+    it('discards the result of a stale load when a newer one has started', async () => {
+      const { lm, modelManager, eventManager } = makeLoaderManager()
+
+      let resolveFirst!: (value: THREE.Object3D) => void
+      const firstLoad = new Promise<THREE.Object3D>((r) => {
+        resolveFirst = r
+      })
+      const firstModel = new THREE.Object3D()
+      firstModel.name = 'first'
+      const secondModel = new THREE.Object3D()
+      secondModel.name = 'second'
+
+      meshLoad
+        .mockImplementationOnce(() => firstLoad)
+        .mockResolvedValueOnce(secondModel)
+
+      const firstPromise = lm.loadModel('api/view?filename=first.glb')
+      const secondPromise = lm.loadModel('api/view?filename=second.glb')
+
+      resolveFirst(firstModel)
+
+      await Promise.all([firstPromise, secondPromise])
+
+      expect(modelManager.setupModel).toHaveBeenCalledTimes(1)
+      expect(modelManager.setupModel).toHaveBeenCalledWith(secondModel)
+
+      const endEmits = eventManager.emitEvent.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'modelLoadingEnd'
+      )
+      expect(endEmits).toHaveLength(1)
+    })
+
+    it('logs and drops the load when the URL is missing a filename param', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await lm.loadModel('api/view?type=output', 'uploads/file.glb')
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Missing filename in URL:',
+        'api/view?type=output'
+      )
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+      consoleError.mockRestore()
+    })
+
+    it('proxies setOriginalModel and registerOriginalMaterial through the load context', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      let capturedCtx: ModelLoadContext | undefined
+      meshLoad.mockImplementationOnce(async (ctx: ModelLoadContext) => {
+        capturedCtx = ctx
+        return new THREE.Object3D()
+      })
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      const mesh = new THREE.Mesh(
+        new THREE.BufferGeometry(),
+        new THREE.MeshBasicMaterial()
+      )
+      const mat = new THREE.MeshStandardMaterial()
+      capturedCtx!.setOriginalModel(mesh)
+      capturedCtx!.registerOriginalMaterial(mesh, mat)
+
+      expect(modelManager.setOriginalModel).toHaveBeenCalledWith(mesh)
+      expect(modelManager.originalMaterials.get(mesh)).toBe(mat)
+    })
+
+    it('exposes modelManager.standardMaterial and materialMode via getters on the load context', async () => {
+      const { lm, modelManager } = makeLoaderManager()
+      modelManager.materialMode = 'wireframe'
+      let capturedCtx: ModelLoadContext | undefined
+      meshLoad.mockImplementationOnce(async (ctx: ModelLoadContext) => {
+        capturedCtx = ctx
+        return new THREE.Object3D()
+      })
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(capturedCtx!.standardMaterial).toBe(modelManager.standardMaterial)
+      expect(capturedCtx!.materialMode).toBe('wireframe')
+    })
+
+    it('suppresses alerts and modelLoadingEnd when a stale load throws', async () => {
+      const { lm, eventManager } = makeLoaderManager()
+
+      let rejectFirst!: (err: unknown) => void
+      const firstLoad = new Promise<THREE.Object3D>((_, r) => {
+        rejectFirst = r
+      })
+
+      meshLoad
+        .mockImplementationOnce(() => firstLoad)
+        .mockResolvedValueOnce(new THREE.Object3D())
+
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      const firstPromise = lm.loadModel('api/view?filename=first.glb')
+      const secondPromise = lm.loadModel('api/view?filename=second.glb')
+
+      rejectFirst(new Error('stale failure'))
+
+      await Promise.all([firstPromise, secondPromise])
+
+      expect(addAlert).not.toHaveBeenCalled()
+      const endEmits = eventManager.emitEvent.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'modelLoadingEnd'
+      )
+      expect(endEmits).toHaveLength(1)
+      consoleError.mockRestore()
+    })
+  })
+})

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -140,6 +140,31 @@ describe('LoaderManager', () => {
       await lm.loadModel('api/view?filename=cube.xyz')
       expect(lm.getCurrentAdapter()).toBeNull()
     })
+
+    it('stays null when the adapter rejects', async () => {
+      const { lm } = makeLoaderManager()
+      // Seed with a previously-successful mesh load so we can prove a later
+      // failed splat load does not leave the splat adapter published.
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      await lm.loadModel('api/view?filename=cube.glb')
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+
+      splatLoad.mockRejectedValueOnce(new Error('boom'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=scan.splat')
+
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
+
+    it('stays null when the adapter resolves null (parse failure)', async () => {
+      const { lm } = makeLoaderManager()
+      pointCloudLoad.mockResolvedValueOnce(null)
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
   })
 
   describe('loadModel ordering', () => {

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -102,7 +102,7 @@ export class LoaderManager implements LoaderManagerInterface {
 
   private pickAdapter(extension: string): ModelAdapter | null {
     const match = this.adapters.find((adapter) =>
-      adapter.extensions.includes(extension as never)
+      adapter.extensions.includes(extension)
     )
     if (!match) return null
 

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -1,60 +1,49 @@
-import { SplatMesh } from '@sparkjsdev/spark'
-import * as THREE from 'three'
-import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
-import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
-import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
-import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
-import { MtlObjBridge, OBJLoader2Parallel } from 'wwobjloader2'
-// Use pre-bundled worker module (has all dependencies included)
-// The unbundled 'wwobjloader2/worker' has ES imports that fail in production builds
-import OBJLoader2WorkerUrl from 'wwobjloader2/bundle/worker/module?url'
+import type * as THREE from 'three'
 
 import { t } from '@/i18n'
-import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { api } from '@/scripts/api'
-import { isPLYAsciiFormat } from '@/scripts/metadata/ply'
 
+import { MeshModelAdapter } from './MeshModelAdapter'
+import type { ModelAdapter, ModelLoadContext } from './ModelAdapter'
+import { PointCloudModelAdapter, getPLYEngine } from './PointCloudModelAdapter'
+import { SplatModelAdapter } from './SplatModelAdapter'
 import {
   type EventManagerInterface,
   type LoaderManagerInterface,
   type ModelManagerInterface
 } from './interfaces'
-import { FastPLYLoader } from './loader/FastPLYLoader'
+
+/**
+ * Default adapter set: mesh + pointCloud + splat. Each adapter declares the
+ * file extensions it owns; LoaderManager picks one by extension.
+ */
+function defaultAdapters(): ModelAdapter[] {
+  return [
+    new MeshModelAdapter(),
+    new PointCloudModelAdapter(),
+    new SplatModelAdapter()
+  ]
+}
 
 export class LoaderManager implements LoaderManagerInterface {
-  gltfLoader: GLTFLoader
-  objLoader: OBJLoader2Parallel
-  mtlLoader: MTLLoader
-  fbxLoader: FBXLoader
-  stlLoader: STLLoader
-  plyLoader: PLYLoader
-  fastPlyLoader: FastPLYLoader
-
-  private modelManager: ModelManagerInterface
-  private eventManager: EventManagerInterface
+  private readonly modelManager: ModelManagerInterface
+  private readonly eventManager: EventManagerInterface
+  private readonly adapters: ModelAdapter[]
   private currentLoadId: number = 0
+  private _currentAdapter: ModelAdapter | null = null
 
   constructor(
     modelManager: ModelManagerInterface,
-    eventManager: EventManagerInterface
+    eventManager: EventManagerInterface,
+    adapters?: readonly ModelAdapter[]
   ) {
     this.modelManager = modelManager
     this.eventManager = eventManager
+    this.adapters = adapters ? [...adapters] : defaultAdapters()
+  }
 
-    this.gltfLoader = new GLTFLoader()
-    this.objLoader = new OBJLoader2Parallel()
-    // Set worker URL for Vite compatibility
-    this.objLoader.setWorkerUrl(
-      true,
-      new URL(OBJLoader2WorkerUrl, import.meta.url)
-    )
-    this.mtlLoader = new MTLLoader()
-    this.fbxLoader = new FBXLoader()
-    this.stlLoader = new STLLoader()
-    this.plyLoader = new PLYLoader()
-    this.fastPlyLoader = new FastPLYLoader()
+  getCurrentAdapter(): ModelAdapter | null {
+    return this._currentAdapter
   }
 
   init(): void {}
@@ -68,6 +57,7 @@ export class LoaderManager implements LoaderManagerInterface {
       this.eventManager.emitEvent('modelLoadingStart', null)
 
       this.modelManager.clearModel()
+      this._currentAdapter = null
 
       this.modelManager.originalURL = url
 
@@ -80,12 +70,9 @@ export class LoaderManager implements LoaderManagerInterface {
       } else {
         const filename = new URLSearchParams(url.split('?')[1]).get('filename')
         fileExtension = filename?.split('.').pop()?.toLowerCase()
-
-        if (filename) {
-          this.modelManager.originalFileName = filename.split('.')[0] || 'model'
-        } else {
-          this.modelManager.originalFileName = 'model'
-        }
+        this.modelManager.originalFileName = filename
+          ? filename.split('.')[0] || 'model'
+          : 'model'
       }
 
       if (!fileExtension) {
@@ -113,26 +100,50 @@ export class LoaderManager implements LoaderManagerInterface {
     }
   }
 
+  private pickAdapter(extension: string): ModelAdapter | null {
+    const match = this.adapters.find((adapter) =>
+      adapter.extensions.includes(extension as never)
+    )
+    if (!match) return null
+
+    // PLY may be routed through the splat adapter when the PLYEngine setting
+    // is sparkjs. Only honor the routing when both adapters are registered.
+    if (match.kind === 'pointCloud' && getPLYEngine() === 'sparkjs') {
+      const splat = this.adapters.find((adapter) => adapter.kind === 'splat')
+      if (splat) return splat
+    }
+    return match
+  }
+
+  private createLoadContext(): ModelLoadContext {
+    const mm = this.modelManager
+    return {
+      setOriginalModel: (model) => mm.setOriginalModel(model),
+      registerOriginalMaterial: (mesh, material) =>
+        mm.originalMaterials.set(mesh, material),
+      get standardMaterial() {
+        return mm.standardMaterial
+      },
+      get materialMode() {
+        return mm.materialMode
+      }
+    }
+  }
+
   private async loadModelInternal(
     url: string,
     fileExtension: string
   ): Promise<THREE.Object3D | null> {
-    let model: THREE.Object3D | null = null
-
     const params = new URLSearchParams(url.split('?')[1])
-
     const filename = params.get('filename')
 
     if (!filename) {
       console.error('Missing filename in URL:', url)
-
       return null
     }
 
     const loadRootFolder = params.get('type') === 'output' ? 'output' : 'input'
-
     const subfolder = params.get('subfolder') ?? ''
-
     const path =
       'api/view?type=' +
       loadRootFolder +
@@ -140,217 +151,10 @@ export class LoaderManager implements LoaderManagerInterface {
       encodeURIComponent(subfolder) +
       '&filename='
 
-    switch (fileExtension) {
-      case 'stl':
-        this.stlLoader.setPath(path)
-        const geometry = await this.stlLoader.loadAsync(filename)
-        this.modelManager.setOriginalModel(geometry)
-        geometry.computeVertexNormals()
+    const adapter = this.pickAdapter(fileExtension)
+    if (!adapter) return null
 
-        const mesh = new THREE.Mesh(
-          geometry,
-          this.modelManager.standardMaterial
-        )
-
-        const group = new THREE.Group()
-        group.add(mesh)
-        model = group
-        break
-
-      case 'fbx':
-        this.fbxLoader.setPath(path)
-
-        const fbxModel = await this.fbxLoader.loadAsync(filename)
-
-        this.modelManager.setOriginalModel(fbxModel)
-        model = fbxModel
-
-        fbxModel.traverse((child) => {
-          if (child instanceof THREE.Mesh) {
-            this.modelManager.originalMaterials.set(child, child.material)
-
-            if (child instanceof THREE.SkinnedMesh) {
-              child.frustumCulled = false
-            }
-          }
-        })
-        break
-
-      case 'obj':
-        if (this.modelManager.materialMode === 'original') {
-          try {
-            this.mtlLoader.setPath(path)
-
-            const mtlFileName = filename.replace(/\.obj$/, '.mtl')
-
-            const materials = await this.mtlLoader.loadAsync(mtlFileName)
-            materials.preload()
-            const materialsFromMtl =
-              MtlObjBridge.addMaterialsFromMtlLoader(materials)
-            this.objLoader.setMaterials(materialsFromMtl)
-          } catch (e) {
-            console.log(
-              'No MTL file found or error loading it, continuing without materials'
-            )
-          }
-        }
-
-        // OBJLoader2Parallel uses Web Worker for parsing (non-blocking)
-        const objUrl = path + encodeURIComponent(filename)
-        model = await this.objLoader.loadAsync(objUrl)
-
-        model.traverse((child) => {
-          if (child instanceof THREE.Mesh) {
-            this.modelManager.originalMaterials.set(child, child.material)
-          }
-        })
-        break
-
-      case 'gltf':
-      case 'glb':
-        this.gltfLoader.setPath(path)
-        const gltf = await this.gltfLoader.loadAsync(filename)
-
-        this.modelManager.setOriginalModel(gltf)
-        model = gltf.scene
-
-        gltf.scene.traverse((child) => {
-          if (child instanceof THREE.Mesh) {
-            child.geometry.computeVertexNormals()
-            this.modelManager.originalMaterials.set(child, child.material)
-
-            if (child instanceof THREE.SkinnedMesh) {
-              child.frustumCulled = false
-            }
-          }
-        })
-        break
-
-      case 'ply':
-        model = await this.loadPLY(path, filename)
-        break
-
-      case 'spz':
-      case 'splat':
-      case 'ksplat':
-        model = await this.loadSplat(path, filename)
-        break
-    }
-
-    return model
-  }
-
-  private async fetchModelData(path: string, filename: string) {
-    const route =
-      '/' + path.replace(/^api\//, '') + encodeURIComponent(filename)
-    const response = await api.fetchApi(route)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch model: ${response.status}`)
-    }
-    return response.arrayBuffer()
-  }
-
-  private async loadSplat(
-    path: string,
-    filename: string
-  ): Promise<THREE.Object3D> {
-    const arrayBuffer = await this.fetchModelData(path, filename)
-
-    const splatMesh = new SplatMesh({ fileBytes: arrayBuffer })
-    this.modelManager.setOriginalModel(splatMesh)
-    const splatGroup = new THREE.Group()
-    splatGroup.add(splatMesh)
-    return splatGroup
-  }
-
-  private async loadPLY(
-    path: string,
-    filename: string
-  ): Promise<THREE.Object3D | null> {
-    const plyEngine = useSettingStore().get('Comfy.Load3D.PLYEngine') as string
-
-    if (plyEngine === 'sparkjs') {
-      return this.loadSplat(path, filename)
-    }
-
-    // Use Three.js PLYLoader or FastPLYLoader for point cloud PLY files
-    const arrayBuffer = await this.fetchModelData(path, filename)
-
-    const isASCII = isPLYAsciiFormat(arrayBuffer)
-
-    let plyGeometry: THREE.BufferGeometry
-
-    if (isASCII && plyEngine === 'fastply') {
-      plyGeometry = this.fastPlyLoader.parse(arrayBuffer)
-    } else {
-      this.plyLoader.setPath(path)
-      plyGeometry = this.plyLoader.parse(arrayBuffer)
-    }
-
-    this.modelManager.setOriginalModel(plyGeometry)
-    plyGeometry.computeVertexNormals()
-
-    const hasVertexColors = plyGeometry.attributes.color !== undefined
-    const materialMode = this.modelManager.materialMode
-
-    // Use Points rendering for pointCloud mode (better for point clouds)
-    if (materialMode === 'pointCloud') {
-      plyGeometry.computeBoundingSphere()
-      if (plyGeometry.boundingSphere) {
-        const center = plyGeometry.boundingSphere.center
-        const radius = plyGeometry.boundingSphere.radius
-
-        plyGeometry.translate(-center.x, -center.y, -center.z)
-
-        if (radius > 0) {
-          const scale = 1.0 / radius
-          plyGeometry.scale(scale, scale, scale)
-        }
-      }
-
-      const pointMaterial = hasVertexColors
-        ? new THREE.PointsMaterial({
-            size: 0.005,
-            vertexColors: true,
-            sizeAttenuation: true
-          })
-        : new THREE.PointsMaterial({
-            size: 0.005,
-            color: 0xcccccc,
-            sizeAttenuation: true
-          })
-
-      const plyPoints = new THREE.Points(plyGeometry, pointMaterial)
-      this.modelManager.originalMaterials.set(
-        plyPoints as unknown as THREE.Mesh,
-        pointMaterial
-      )
-
-      const plyGroup = new THREE.Group()
-      plyGroup.add(plyPoints)
-      return plyGroup
-    }
-
-    // Use Mesh rendering for other modes
-    let plyMaterial: THREE.Material
-
-    if (hasVertexColors) {
-      plyMaterial = new THREE.MeshStandardMaterial({
-        vertexColors: true,
-        metalness: 0.0,
-        roughness: 0.5,
-        side: THREE.DoubleSide
-      })
-    } else {
-      plyMaterial = this.modelManager.standardMaterial.clone()
-      plyMaterial.side = THREE.DoubleSide
-    }
-
-    const plyMesh = new THREE.Mesh(plyGeometry, plyMaterial)
-    this.modelManager.originalMaterials.set(plyMesh, plyMaterial)
-
-    const plyGroup = new THREE.Group()
-    plyGroup.add(plyMesh)
-    return plyGroup
+    this._currentAdapter = adapter
+    return adapter.load(this.createLoadContext(), path, filename)
   }
 }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -80,19 +80,21 @@ export class LoaderManager implements LoaderManagerInterface {
         return
       }
 
-      const model = await this.loadModelInternal(url, fileExtension)
+      const result = await this.loadModelInternal(url, fileExtension)
 
       if (loadId !== this.currentLoadId) {
         return
       }
 
-      if (model) {
-        await this.modelManager.setupModel(model)
+      if (result && result.model) {
+        this._currentAdapter = result.adapter
+        await this.modelManager.setupModel(result.model)
       }
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
     } catch (error) {
       if (loadId === this.currentLoadId) {
+        this._currentAdapter = null
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
         useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
@@ -133,7 +135,7 @@ export class LoaderManager implements LoaderManagerInterface {
   private async loadModelInternal(
     url: string,
     fileExtension: string
-  ): Promise<THREE.Object3D | null> {
+  ): Promise<{ adapter: ModelAdapter; model: THREE.Object3D | null } | null> {
     const params = new URLSearchParams(url.split('?')[1])
     const filename = params.get('filename')
 
@@ -154,7 +156,7 @@ export class LoaderManager implements LoaderManagerInterface {
     const adapter = this.pickAdapter(fileExtension)
     if (!adapter) return null
 
-    this._currentAdapter = adapter
-    return adapter.load(this.createLoadContext(), path, filename)
+    const model = await adapter.load(this.createLoadContext(), path, filename)
+    return { adapter, model }
   }
 }

--- a/src/extensions/core/load3d/MeshModelAdapter.test.ts
+++ b/src/extensions/core/load3d/MeshModelAdapter.test.ts
@@ -1,0 +1,302 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MeshModelAdapter } from './MeshModelAdapter'
+import type { ModelLoadContext } from './ModelAdapter'
+
+const stlLoaderStub = {
+  setPath: vi.fn(),
+  loadAsync: vi.fn<(filename: string) => Promise<THREE.BufferGeometry>>()
+}
+const fbxLoaderStub = {
+  setPath: vi.fn(),
+  loadAsync: vi.fn<(filename: string) => Promise<THREE.Object3D>>()
+}
+const gltfLoaderStub = {
+  setPath: vi.fn(),
+  loadAsync: vi.fn<(filename: string) => Promise<{ scene: THREE.Object3D }>>()
+}
+const mtlLoaderStub = {
+  setPath: vi.fn(),
+  loadAsync: vi.fn<(filename: string) => Promise<{ preload: () => void }>>()
+}
+const objLoaderStub = {
+  setWorkerUrl: vi.fn(),
+  setMaterials: vi.fn(),
+  loadAsync: vi.fn<(url: string) => Promise<THREE.Object3D>>()
+}
+
+vi.mock('three/examples/jsm/loaders/STLLoader', () => ({
+  STLLoader: class {
+    setPath = stlLoaderStub.setPath
+    loadAsync = stlLoaderStub.loadAsync
+  }
+}))
+
+vi.mock('three/examples/jsm/loaders/FBXLoader', () => ({
+  FBXLoader: class {
+    setPath = fbxLoaderStub.setPath
+    loadAsync = fbxLoaderStub.loadAsync
+  }
+}))
+
+vi.mock('three/examples/jsm/loaders/GLTFLoader', () => ({
+  GLTFLoader: class {
+    setPath = gltfLoaderStub.setPath
+    loadAsync = gltfLoaderStub.loadAsync
+  }
+}))
+
+vi.mock('three/examples/jsm/loaders/MTLLoader', () => ({
+  MTLLoader: class {
+    setPath = mtlLoaderStub.setPath
+    loadAsync = mtlLoaderStub.loadAsync
+  }
+}))
+
+vi.mock('wwobjloader2', () => ({
+  OBJLoader2Parallel: class {
+    setWorkerUrl = objLoaderStub.setWorkerUrl
+    setMaterials = objLoaderStub.setMaterials
+    loadAsync = objLoaderStub.loadAsync
+  },
+  MtlObjBridge: {
+    addMaterialsFromMtlLoader: vi.fn().mockReturnValue([])
+  }
+}))
+
+vi.mock('wwobjloader2/bundle/worker/module?url', () => ({
+  default: 'mock-worker-url'
+}))
+
+function makeContext(
+  materialMode: ModelLoadContext['materialMode'] = 'original'
+): ModelLoadContext {
+  return {
+    setOriginalModel: vi.fn(),
+    registerOriginalMaterial: vi.fn(),
+    standardMaterial: new THREE.MeshStandardMaterial(),
+    materialMode
+  }
+}
+
+function makeFbxLikeGroup(): THREE.Group {
+  const group = new THREE.Group()
+  const mesh = new THREE.Mesh(
+    new THREE.BoxGeometry(),
+    new THREE.MeshStandardMaterial()
+  )
+  group.add(mesh)
+  return group
+}
+
+describe('MeshModelAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('identity', () => {
+    it('identifies as a mesh adapter with full capabilities', () => {
+      const adapter = new MeshModelAdapter()
+      expect(adapter.kind).toBe('mesh')
+      expect(adapter.capabilities.fitToViewer).toBe(true)
+      expect(adapter.capabilities.requiresMaterialRebuild).toBe(false)
+      expect(adapter.capabilities.gizmoTransform).toBe(true)
+      expect(adapter.capabilities.lighting).toBe(true)
+      expect(adapter.capabilities.exportable).toBe(true)
+      expect([...adapter.capabilities.materialModes]).toEqual([
+        'original',
+        'normal',
+        'wireframe'
+      ])
+    })
+
+    it('handles the expected mesh extensions', () => {
+      const adapter = new MeshModelAdapter()
+      expect([...adapter.extensions]).toEqual([
+        'stl',
+        'fbx',
+        'obj',
+        'gltf',
+        'glb'
+      ])
+    })
+  })
+
+  describe('dispatch fallbacks', () => {
+    it('returns null when the filename extension belongs to another adapter', async () => {
+      const adapter = new MeshModelAdapter()
+      const result = await adapter.load(makeContext(), '/path/', 'cloud.ply')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for an unknown extension', async () => {
+      const adapter = new MeshModelAdapter()
+      const result = await adapter.load(makeContext(), '/path/', 'data.xyz')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for a filename without an extension', async () => {
+      const adapter = new MeshModelAdapter()
+      const result = await adapter.load(makeContext(), '/path/', 'noextension')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('STL loader path', () => {
+    it('loads STL geometry and wraps it in a Group with a Mesh child', async () => {
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3)
+      )
+      stlLoaderStub.loadAsync.mockResolvedValue(geometry)
+
+      const adapter = new MeshModelAdapter()
+      const ctx = makeContext()
+
+      const result = await adapter.load(ctx, '/api/view/', 'model.stl')
+
+      expect(stlLoaderStub.setPath).toHaveBeenCalledWith('/api/view/')
+      expect(stlLoaderStub.loadAsync).toHaveBeenCalledWith('model.stl')
+      expect(ctx.setOriginalModel).toHaveBeenCalledWith(geometry)
+      expect(result).toBeInstanceOf(THREE.Group)
+      expect(result!.children[0]).toBeInstanceOf(THREE.Mesh)
+    })
+  })
+
+  describe('FBX loader path', () => {
+    it('loads an FBX model and registers its mesh materials', async () => {
+      const fbxModel = makeFbxLikeGroup()
+      fbxLoaderStub.loadAsync.mockResolvedValue(fbxModel)
+
+      const adapter = new MeshModelAdapter()
+      const ctx = makeContext()
+
+      const result = await adapter.load(ctx, '/api/view/', 'rig.fbx')
+
+      expect(fbxLoaderStub.setPath).toHaveBeenCalledWith('/api/view/')
+      expect(fbxLoaderStub.loadAsync).toHaveBeenCalledWith('rig.fbx')
+      expect(ctx.setOriginalModel).toHaveBeenCalledWith(fbxModel)
+      expect(ctx.registerOriginalMaterial).toHaveBeenCalledTimes(1)
+      expect(result).toBe(fbxModel)
+    })
+
+    it('disables frustum culling on SkinnedMesh children', async () => {
+      const group = new THREE.Group()
+      const skinned = new THREE.SkinnedMesh(
+        new THREE.BoxGeometry(),
+        new THREE.MeshStandardMaterial()
+      )
+      skinned.frustumCulled = true
+      group.add(skinned)
+      fbxLoaderStub.loadAsync.mockResolvedValue(group)
+
+      const adapter = new MeshModelAdapter()
+      await adapter.load(makeContext(), '/api/view/', 'animated.fbx')
+
+      expect(skinned.frustumCulled).toBe(false)
+    })
+  })
+
+  describe('OBJ loader path', () => {
+    it('attempts the MTL sidecar in original material mode', async () => {
+      mtlLoaderStub.loadAsync.mockResolvedValue({ preload: vi.fn() })
+      objLoaderStub.loadAsync.mockResolvedValue(makeFbxLikeGroup())
+
+      const adapter = new MeshModelAdapter()
+      await adapter.load(makeContext('original'), '/api/view/', 'cube.obj')
+
+      expect(mtlLoaderStub.setPath).toHaveBeenCalledWith('/api/view/')
+      expect(mtlLoaderStub.loadAsync).toHaveBeenCalledWith('cube.mtl')
+      expect(objLoaderStub.setMaterials).toHaveBeenCalled()
+      expect(objLoaderStub.loadAsync).toHaveBeenCalledWith('/api/view/cube.obj')
+    })
+
+    it('swallows MTL load errors and continues without materials', async () => {
+      mtlLoaderStub.loadAsync.mockRejectedValue(new Error('no mtl'))
+      objLoaderStub.loadAsync.mockResolvedValue(makeFbxLikeGroup())
+
+      const adapter = new MeshModelAdapter()
+      const result = await adapter.load(
+        makeContext('original'),
+        '/api/view/',
+        'cube.obj'
+      )
+
+      expect(result).toBeInstanceOf(THREE.Group)
+      expect(objLoaderStub.setMaterials).not.toHaveBeenCalled()
+    })
+
+    it('skips the MTL attempt for non-original material modes', async () => {
+      objLoaderStub.loadAsync.mockResolvedValue(makeFbxLikeGroup())
+
+      const adapter = new MeshModelAdapter()
+      await adapter.load(makeContext('wireframe'), '/api/view/', 'cube.obj')
+
+      expect(mtlLoaderStub.loadAsync).not.toHaveBeenCalled()
+      expect(objLoaderStub.loadAsync).toHaveBeenCalledWith('/api/view/cube.obj')
+    })
+
+    it('registers materials for each mesh child', async () => {
+      objLoaderStub.loadAsync.mockResolvedValue(makeFbxLikeGroup())
+
+      const adapter = new MeshModelAdapter()
+      const ctx = makeContext('wireframe')
+      await adapter.load(ctx, '/api/view/', 'cube.obj')
+
+      expect(ctx.registerOriginalMaterial).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('GLTF loader path', () => {
+    it('loads a .glb and returns the scene with vertex normals computed', async () => {
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(),
+        new THREE.MeshStandardMaterial()
+      )
+      const computeNormals = vi.spyOn(mesh.geometry, 'computeVertexNormals')
+      const scene = new THREE.Group()
+      scene.add(mesh)
+      const gltf = { scene }
+      gltfLoaderStub.loadAsync.mockResolvedValue(gltf)
+
+      const adapter = new MeshModelAdapter()
+      const ctx = makeContext()
+
+      const result = await adapter.load(ctx, '/api/view/', 'scene.glb')
+
+      expect(gltfLoaderStub.setPath).toHaveBeenCalledWith('/api/view/')
+      expect(gltfLoaderStub.loadAsync).toHaveBeenCalledWith('scene.glb')
+      expect(ctx.setOriginalModel).toHaveBeenCalledWith(gltf)
+      expect(computeNormals).toHaveBeenCalled()
+      expect(ctx.registerOriginalMaterial).toHaveBeenCalledTimes(1)
+      expect(result).toBe(scene)
+    })
+
+    it('also handles .gltf filenames', async () => {
+      gltfLoaderStub.loadAsync.mockResolvedValue({ scene: new THREE.Group() })
+
+      const adapter = new MeshModelAdapter()
+      await adapter.load(makeContext(), '/api/view/', 'scene.gltf')
+
+      expect(gltfLoaderStub.loadAsync).toHaveBeenCalledWith('scene.gltf')
+    })
+
+    it('disables frustum culling on SkinnedMesh children inside the scene', async () => {
+      const scene = new THREE.Group()
+      const skinned = new THREE.SkinnedMesh(
+        new THREE.BoxGeometry(),
+        new THREE.MeshStandardMaterial()
+      )
+      skinned.frustumCulled = true
+      scene.add(skinned)
+      gltfLoaderStub.loadAsync.mockResolvedValue({ scene })
+
+      const adapter = new MeshModelAdapter()
+      await adapter.load(makeContext(), '/api/view/', 'rigged.glb')
+
+      expect(skinned.frustumCulled).toBe(false)
+    })
+  })
+})

--- a/src/extensions/core/load3d/MeshModelAdapter.ts
+++ b/src/extensions/core/load3d/MeshModelAdapter.ts
@@ -106,7 +106,7 @@ export class MeshModelAdapter implements ModelAdapter {
     if (ctx.materialMode === 'original') {
       try {
         this.mtlLoader.setPath(path)
-        const mtlFileName = filename.replace(/\.obj$/, '.mtl')
+        const mtlFileName = filename.replace(/\.obj$/i, '.mtl')
         const materials = await this.mtlLoader.loadAsync(mtlFileName)
         materials.preload()
         const materialsFromMtl =

--- a/src/extensions/core/load3d/MeshModelAdapter.ts
+++ b/src/extensions/core/load3d/MeshModelAdapter.ts
@@ -1,0 +1,155 @@
+import * as THREE from 'three'
+import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+import { MtlObjBridge, OBJLoader2Parallel } from 'wwobjloader2'
+// Use pre-bundled worker module (has all dependencies included).
+// The unbundled 'wwobjloader2/worker' has ES imports that fail in production builds.
+import OBJLoader2WorkerUrl from 'wwobjloader2/bundle/worker/module?url'
+
+import type {
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
+} from './ModelAdapter'
+
+export class MeshModelAdapter implements ModelAdapter {
+  readonly kind = 'mesh' as const
+  readonly extensions = ['stl', 'fbx', 'obj', 'gltf', 'glb'] as const
+  readonly capabilities: ModelAdapterCapabilities = {
+    fitToViewer: true,
+    requiresMaterialRebuild: false,
+    gizmoTransform: true,
+    lighting: true,
+    exportable: true,
+    materialModes: ['original', 'normal', 'wireframe'],
+    fitTargetSize: 5
+  }
+
+  private readonly gltfLoader = new GLTFLoader()
+  private readonly objLoader: OBJLoader2Parallel
+  private readonly mtlLoader = new MTLLoader()
+  private readonly fbxLoader = new FBXLoader()
+  private readonly stlLoader = new STLLoader()
+
+  constructor() {
+    this.objLoader = new OBJLoader2Parallel()
+    this.objLoader.setWorkerUrl(
+      true,
+      new URL(OBJLoader2WorkerUrl, import.meta.url)
+    )
+  }
+
+  async load(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D | null> {
+    const extension = filename.split('.').pop()?.toLowerCase()
+    switch (extension) {
+      case 'stl':
+        return this.loadSTL(ctx, path, filename)
+      case 'fbx':
+        return this.loadFBX(ctx, path, filename)
+      case 'obj':
+        return this.loadOBJ(ctx, path, filename)
+      case 'gltf':
+      case 'glb':
+        return this.loadGLTF(ctx, path, filename)
+    }
+    return null
+  }
+
+  private async loadSTL(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D> {
+    this.stlLoader.setPath(path)
+    const geometry = await this.stlLoader.loadAsync(filename)
+    ctx.setOriginalModel(geometry)
+    geometry.computeVertexNormals()
+
+    const mesh = new THREE.Mesh(geometry, ctx.standardMaterial)
+    const group = new THREE.Group()
+    group.add(mesh)
+    return group
+  }
+
+  private async loadFBX(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D> {
+    this.fbxLoader.setPath(path)
+    const fbxModel = await this.fbxLoader.loadAsync(filename)
+    ctx.setOriginalModel(fbxModel)
+
+    fbxModel.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        ctx.registerOriginalMaterial(child, child.material)
+        if (child instanceof THREE.SkinnedMesh) {
+          child.frustumCulled = false
+        }
+      }
+    })
+
+    return fbxModel
+  }
+
+  private async loadOBJ(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D> {
+    if (ctx.materialMode === 'original') {
+      try {
+        this.mtlLoader.setPath(path)
+        const mtlFileName = filename.replace(/\.obj$/, '.mtl')
+        const materials = await this.mtlLoader.loadAsync(mtlFileName)
+        materials.preload()
+        const materialsFromMtl =
+          MtlObjBridge.addMaterialsFromMtlLoader(materials)
+        this.objLoader.setMaterials(materialsFromMtl)
+      } catch {
+        console.log(
+          'No MTL file found or error loading it, continuing without materials'
+        )
+      }
+    }
+
+    const objUrl = path + encodeURIComponent(filename)
+    const model = await this.objLoader.loadAsync(objUrl)
+
+    model.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        ctx.registerOriginalMaterial(child, child.material)
+      }
+    })
+
+    return model
+  }
+
+  private async loadGLTF(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D> {
+    this.gltfLoader.setPath(path)
+    const gltf = await this.gltfLoader.loadAsync(filename)
+    ctx.setOriginalModel(gltf)
+
+    gltf.scene.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.geometry.computeVertexNormals()
+        ctx.registerOriginalMaterial(child, child.material)
+        if (child instanceof THREE.SkinnedMesh) {
+          child.frustumCulled = false
+        }
+      }
+    })
+
+    return gltf.scene
+  }
+}

--- a/src/extensions/core/load3d/ModelAdapter.test.ts
+++ b/src/extensions/core/load3d/ModelAdapter.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/scripts/api'
+
+import { DEFAULT_MODEL_CAPABILITIES, fetchModelData } from './ModelAdapter'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: vi.fn()
+  }
+}))
+
+describe('DEFAULT_MODEL_CAPABILITIES', () => {
+  it('enables fit-to-viewer / gizmo / lighting / export by default', () => {
+    expect(DEFAULT_MODEL_CAPABILITIES.fitToViewer).toBe(true)
+    expect(DEFAULT_MODEL_CAPABILITIES.requiresMaterialRebuild).toBe(false)
+    expect(DEFAULT_MODEL_CAPABILITIES.gizmoTransform).toBe(true)
+    expect(DEFAULT_MODEL_CAPABILITIES.lighting).toBe(true)
+    expect(DEFAULT_MODEL_CAPABILITIES.exportable).toBe(true)
+    expect([...DEFAULT_MODEL_CAPABILITIES.materialModes]).toEqual([
+      'original',
+      'normal',
+      'wireframe'
+    ])
+  })
+})
+
+describe('fetchModelData', () => {
+  const mockFetchApi = vi.mocked(api.fetchApi)
+
+  beforeEach(() => {
+    mockFetchApi.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the arrayBuffer on a successful response', async () => {
+    const buf = new ArrayBuffer(8)
+    mockFetchApi.mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: vi.fn().mockResolvedValue(buf)
+    } as unknown as Response)
+
+    const result = await fetchModelData('api/view?...&filename=', 'model.glb')
+
+    expect(result).toBe(buf)
+  })
+
+  it('throws with status code when the response is not ok', async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: false,
+      status: 404
+    } as unknown as Response)
+
+    await expect(
+      fetchModelData('api/view?type=input&subfolder=&filename=', 'missing.glb')
+    ).rejects.toThrow('Failed to fetch model: 404')
+  })
+
+  it('strips the leading api/ prefix and encodes the filename', async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0))
+    } as unknown as Response)
+
+    await fetchModelData(
+      'api/view?type=input&subfolder=&filename=',
+      'a b c.ply'
+    )
+
+    expect(mockFetchApi).toHaveBeenCalledWith(
+      '/view?type=input&subfolder=&filename=a%20b%20c.ply'
+    )
+  })
+
+  it('prepends a single slash when the path has no api/ prefix', async () => {
+    mockFetchApi.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0))
+    } as unknown as Response)
+
+    await fetchModelData('custom?filename=', 'scene.splat')
+
+    expect(mockFetchApi).toHaveBeenCalledWith('/custom?filename=scene.splat')
+  })
+})

--- a/src/extensions/core/load3d/ModelAdapter.ts
+++ b/src/extensions/core/load3d/ModelAdapter.ts
@@ -1,0 +1,88 @@
+import type * as THREE from 'three'
+import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
+
+import { api } from '@/scripts/api'
+
+import type { MaterialMode } from './interfaces'
+
+export interface ModelLoadContext {
+  setOriginalModel(model: THREE.Object3D | THREE.BufferGeometry | GLTF): void
+  registerOriginalMaterial(
+    mesh: THREE.Mesh,
+    material: THREE.Material | THREE.Material[]
+  ): void
+  readonly standardMaterial: THREE.MeshStandardMaterial
+  readonly materialMode: MaterialMode
+}
+
+export type ModelAdapterKind = 'mesh' | 'pointCloud' | 'splat'
+
+export interface ModelAdapterCapabilities {
+  /**
+   * Whether auto-normalize/centering on load and the explicit fit-to-viewer
+   * action should run. Splats render self-sized and are placed at a fixed
+   * camera distance instead.
+   */
+  fitToViewer: boolean
+  /**
+   * Whether a material mode change must rebuild the scene object instead of
+   * traversing the existing mesh tree. True for point-cloud PLY (Mesh <->
+   * Points swap); false for regular meshes and self-rendering splats.
+   */
+  requiresMaterialRebuild: boolean
+  /**
+   * Whether the gizmo transform UI (translate/rotate/scale) should be
+   * exposed for this model type. False for adapters whose already-normalized
+   * output makes user transforms meaningless (PLY point cloud).
+   */
+  gizmoTransform: boolean
+  /** Whether scene-lighting controls apply. False for self-lit formats. */
+  lighting: boolean
+  /** Whether the model can be exported (GLB/OBJ/STL). */
+  exportable: boolean
+  /**
+   * Material modes offered in the UI for this format. An empty array hides
+   * the material-mode dropdown entirely.
+   */
+  materialModes: readonly MaterialMode[]
+  /**
+   * World-space target size along the largest dimension after
+   * fit-to-viewer normalization. Controls how large the model ends up
+   * relative to the 20-unit scene grid; splats use a larger value so they
+   * don't shrink to a quarter of the floor.
+   */
+  fitTargetSize: number
+}
+
+export const DEFAULT_MODEL_CAPABILITIES: ModelAdapterCapabilities = {
+  fitToViewer: true,
+  requiresMaterialRebuild: false,
+  gizmoTransform: true,
+  lighting: true,
+  exportable: true,
+  materialModes: ['original', 'normal', 'wireframe'],
+  fitTargetSize: 5
+}
+
+export interface ModelAdapter {
+  readonly kind: ModelAdapterKind
+  readonly extensions: readonly string[]
+  readonly capabilities: ModelAdapterCapabilities
+  load(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D | null>
+}
+
+export async function fetchModelData(
+  path: string,
+  filename: string
+): Promise<ArrayBuffer> {
+  const route = '/' + path.replace(/^api\//, '') + encodeURIComponent(filename)
+  const response = await api.fetchApi(route)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch model: ${response.status}`)
+  }
+  return response.arrayBuffer()
+}

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -1,0 +1,116 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ModelLoadContext } from './ModelAdapter'
+import * as ModelAdapterModule from './ModelAdapter'
+import { PointCloudModelAdapter } from './PointCloudModelAdapter'
+
+const mockSettingGet = vi.fn<(key: string) => unknown>()
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: mockSettingGet })
+}))
+
+vi.mock('@/scripts/metadata/ply', () => ({
+  isPLYAsciiFormat: vi.fn().mockReturnValue(false)
+}))
+
+vi.mock('three/examples/jsm/loaders/PLYLoader', () => ({
+  PLYLoader: class {
+    setPath = vi.fn()
+    parse = vi.fn(() => makePLYGeometry(false))
+  }
+}))
+
+vi.mock('./loader/FastPLYLoader', () => ({
+  FastPLYLoader: class {
+    parse = vi.fn(() => makePLYGeometry(false))
+  }
+}))
+
+function makePLYGeometry(withColors: boolean): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3)
+  )
+  if (withColors) {
+    geometry.setAttribute(
+      'color',
+      new THREE.Float32BufferAttribute([1, 0, 0, 0, 1, 0, 0, 0, 1], 3)
+    )
+  }
+  return geometry
+}
+
+function makeContext(
+  materialMode: ModelLoadContext['materialMode'] = 'original'
+): ModelLoadContext {
+  return {
+    setOriginalModel: vi.fn(),
+    registerOriginalMaterial: vi.fn(),
+    standardMaterial: new THREE.MeshStandardMaterial(),
+    materialMode
+  }
+}
+
+describe('PointCloudModelAdapter', () => {
+  beforeEach(() => {
+    mockSettingGet.mockReset()
+  })
+
+  describe('identity', () => {
+    it('handles the ply extension', () => {
+      const adapter = new PointCloudModelAdapter()
+      expect([...adapter.extensions]).toEqual(['ply'])
+    })
+
+    it('identifies as pointCloud with rebuild + gizmo/fit disabled', () => {
+      const adapter = new PointCloudModelAdapter()
+      expect(adapter.kind).toBe('pointCloud')
+      expect(adapter.capabilities.fitToViewer).toBe(false)
+      expect(adapter.capabilities.requiresMaterialRebuild).toBe(true)
+      expect(adapter.capabilities.gizmoTransform).toBe(false)
+      expect(adapter.capabilities.lighting).toBe(true)
+      expect(adapter.capabilities.exportable).toBe(true)
+      expect([...adapter.capabilities.materialModes]).toEqual([
+        'original',
+        'pointCloud',
+        'normal',
+        'wireframe'
+      ])
+    })
+  })
+
+  describe('load', () => {
+    beforeEach(() => {
+      mockSettingGet.mockReturnValue('three')
+      vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(
+        new ArrayBuffer(0)
+      )
+    })
+
+    it('returns a Group containing a Mesh for non-pointCloud modes', async () => {
+      const adapter = new PointCloudModelAdapter()
+      const ctx = makeContext('original')
+
+      const result = await adapter.load(ctx, '/api/view?', 'cloud.ply')
+
+      expect(result).toBeInstanceOf(THREE.Group)
+      const child = result!.children[0]
+      expect(child).toBeInstanceOf(THREE.Mesh)
+      expect(ctx.setOriginalModel).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns a Group containing Points when materialMode is pointCloud', async () => {
+      const adapter = new PointCloudModelAdapter()
+      const ctx = makeContext('pointCloud')
+
+      const result = await adapter.load(ctx, '/api/view?', 'cloud.ply')
+
+      expect(result).toBeInstanceOf(THREE.Group)
+      const child = result!.children[0]
+      expect(child).toBeInstanceOf(THREE.Points)
+    })
+  })
+})

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -4,11 +4,11 @@ import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { isPLYAsciiFormat } from '@/scripts/metadata/ply'
 
-import {
-  fetchModelData,
-  type ModelAdapter,
-  type ModelAdapterCapabilities,
-  type ModelLoadContext
+import { fetchModelData } from './ModelAdapter'
+import type {
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
 } from './ModelAdapter'
 import { FastPLYLoader } from './loader/FastPLYLoader'
 

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -1,0 +1,120 @@
+import * as THREE from 'three'
+import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
+
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { isPLYAsciiFormat } from '@/scripts/metadata/ply'
+
+import {
+  fetchModelData,
+  type ModelAdapter,
+  type ModelAdapterCapabilities,
+  type ModelLoadContext
+} from './ModelAdapter'
+import { FastPLYLoader } from './loader/FastPLYLoader'
+
+export function getPLYEngine(): string {
+  return useSettingStore().get('Comfy.Load3D.PLYEngine') as string
+}
+
+export class PointCloudModelAdapter implements ModelAdapter {
+  readonly kind = 'pointCloud' as const
+  readonly extensions = ['ply'] as const
+  readonly capabilities: ModelAdapterCapabilities = {
+    fitToViewer: false,
+    requiresMaterialRebuild: true,
+    gizmoTransform: false,
+    lighting: true,
+    exportable: true,
+    materialModes: ['original', 'pointCloud', 'normal', 'wireframe'],
+    fitTargetSize: 5
+  }
+
+  private readonly plyLoader = new PLYLoader()
+  private readonly fastPlyLoader = new FastPLYLoader()
+
+  async load(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D | null> {
+    const arrayBuffer = await fetchModelData(path, filename)
+    const isASCII = isPLYAsciiFormat(arrayBuffer)
+
+    const plyGeometry =
+      isASCII && getPLYEngine() === 'fastply'
+        ? this.fastPlyLoader.parse(arrayBuffer)
+        : (this.plyLoader.setPath(path), this.plyLoader.parse(arrayBuffer))
+
+    ctx.setOriginalModel(plyGeometry)
+    plyGeometry.computeVertexNormals()
+
+    const hasVertexColors = plyGeometry.attributes.color !== undefined
+
+    if (ctx.materialMode === 'pointCloud') {
+      return buildPointsGroup(ctx, plyGeometry, hasVertexColors)
+    }
+
+    return buildMeshGroup(ctx, plyGeometry, hasVertexColors)
+  }
+}
+
+function buildPointsGroup(
+  ctx: ModelLoadContext,
+  geometry: THREE.BufferGeometry,
+  hasVertexColors: boolean
+): THREE.Group {
+  geometry.computeBoundingSphere()
+  if (geometry.boundingSphere) {
+    const { center, radius } = geometry.boundingSphere
+    geometry.translate(-center.x, -center.y, -center.z)
+    if (radius > 0) {
+      const scale = 1.0 / radius
+      geometry.scale(scale, scale, scale)
+    }
+  }
+
+  const pointMaterial = hasVertexColors
+    ? new THREE.PointsMaterial({
+        size: 0.005,
+        vertexColors: true,
+        sizeAttenuation: true
+      })
+    : new THREE.PointsMaterial({
+        size: 0.005,
+        color: 0xcccccc,
+        sizeAttenuation: true
+      })
+
+  const points = new THREE.Points(geometry, pointMaterial)
+  ctx.registerOriginalMaterial(points as unknown as THREE.Mesh, pointMaterial)
+
+  const group = new THREE.Group()
+  group.add(points)
+  return group
+}
+
+function buildMeshGroup(
+  ctx: ModelLoadContext,
+  geometry: THREE.BufferGeometry,
+  hasVertexColors: boolean
+): THREE.Group {
+  const material = hasVertexColors
+    ? new THREE.MeshStandardMaterial({
+        vertexColors: true,
+        metalness: 0.0,
+        roughness: 0.5,
+        side: THREE.DoubleSide
+      })
+    : ctx.standardMaterial.clone()
+
+  if (!hasVertexColors && material instanceof THREE.MeshStandardMaterial) {
+    material.side = THREE.DoubleSide
+  }
+
+  const mesh = new THREE.Mesh(geometry, material)
+  ctx.registerOriginalMaterial(mesh, material)
+
+  const group = new THREE.Group()
+  group.add(mesh)
+  return group
+}

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -43,7 +43,7 @@ export class PointCloudModelAdapter implements ModelAdapter {
     const plyGeometry =
       isASCII && getPLYEngine() === 'fastply'
         ? this.fastPlyLoader.parse(arrayBuffer)
-        : (this.plyLoader.setPath(path), this.plyLoader.parse(arrayBuffer))
+        : this.plyLoader.parse(arrayBuffer)
 
     ctx.setOriginalModel(plyGeometry)
     plyGeometry.computeVertexNormals()

--- a/src/extensions/core/load3d/SplatModelAdapter.test.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.test.ts
@@ -1,0 +1,82 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ModelLoadContext } from './ModelAdapter'
+import * as ModelAdapterModule from './ModelAdapter'
+import { SplatModelAdapter } from './SplatModelAdapter'
+
+const { splatMeshCtor } = vi.hoisted(() => ({
+  splatMeshCtor: vi.fn<(opts: { fileBytes: ArrayBuffer }) => void>()
+}))
+
+vi.mock('@sparkjsdev/spark', async () => {
+  const three = await import('three')
+  return {
+    SplatMesh: class extends three.Object3D {
+      constructor(opts: { fileBytes: ArrayBuffer }) {
+        super()
+        splatMeshCtor(opts)
+      }
+    }
+  }
+})
+
+function makeContext(): ModelLoadContext {
+  return {
+    setOriginalModel: vi.fn(),
+    registerOriginalMaterial: vi.fn(),
+    standardMaterial: new THREE.MeshStandardMaterial(),
+    materialMode: 'original'
+  }
+}
+
+describe('SplatModelAdapter', () => {
+  beforeEach(() => {
+    splatMeshCtor.mockReset()
+  })
+
+  it('exposes splat capabilities on the adapter', () => {
+    const adapter = new SplatModelAdapter()
+    expect(adapter.kind).toBe('splat')
+    expect(adapter.capabilities.lighting).toBe(false)
+    expect(adapter.capabilities.exportable).toBe(false)
+    expect([...adapter.capabilities.materialModes]).toEqual([])
+  })
+
+  it('handles the Gaussian splat extensions', () => {
+    const adapter = new SplatModelAdapter()
+    expect([...adapter.extensions]).toEqual(['spz', 'splat', 'ksplat'])
+  })
+
+  it('fetches the file, builds a SplatMesh, and wraps it in a Group', async () => {
+    const buf = new ArrayBuffer(128)
+    vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(buf)
+
+    const adapter = new SplatModelAdapter()
+    const ctx = makeContext()
+
+    const result = await adapter.load(ctx, '/api/view?', 'scene.splat')
+
+    expect(ModelAdapterModule.fetchModelData).toHaveBeenCalledWith(
+      '/api/view?',
+      'scene.splat'
+    )
+    expect(splatMeshCtor).toHaveBeenCalledWith({ fileBytes: buf })
+    expect(result).toBeInstanceOf(THREE.Group)
+    expect(result.children).toHaveLength(1)
+
+    expect(ctx.setOriginalModel).toHaveBeenCalledTimes(1)
+    expect(ctx.setOriginalModel).toHaveBeenCalledWith(result.children[0])
+  })
+
+  it('propagates fetch errors', async () => {
+    vi.spyOn(ModelAdapterModule, 'fetchModelData').mockRejectedValue(
+      new Error('Failed to fetch model: 500')
+    )
+
+    const adapter = new SplatModelAdapter()
+    await expect(
+      adapter.load(makeContext(), '/api/view?', 'scene.splat')
+    ).rejects.toThrow('Failed to fetch model: 500')
+  })
+})

--- a/src/extensions/core/load3d/SplatModelAdapter.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.ts
@@ -1,11 +1,11 @@
 import { SplatMesh } from '@sparkjsdev/spark'
 import * as THREE from 'three'
 
-import {
-  fetchModelData,
-  type ModelAdapter,
-  type ModelAdapterCapabilities,
-  type ModelLoadContext
+import { fetchModelData } from './ModelAdapter'
+import type {
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
 } from './ModelAdapter'
 
 export class SplatModelAdapter implements ModelAdapter {

--- a/src/extensions/core/load3d/SplatModelAdapter.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.ts
@@ -1,0 +1,38 @@
+import { SplatMesh } from '@sparkjsdev/spark'
+import * as THREE from 'three'
+
+import {
+  fetchModelData,
+  type ModelAdapter,
+  type ModelAdapterCapabilities,
+  type ModelLoadContext
+} from './ModelAdapter'
+
+export class SplatModelAdapter implements ModelAdapter {
+  readonly kind = 'splat' as const
+  readonly extensions = ['spz', 'splat', 'ksplat'] as const
+  readonly capabilities: ModelAdapterCapabilities = {
+    fitToViewer: false,
+    requiresMaterialRebuild: false,
+    gizmoTransform: false,
+    lighting: false,
+    exportable: false,
+    materialModes: [],
+    fitTargetSize: 5
+  }
+
+  async load(
+    ctx: ModelLoadContext,
+    path: string,
+    filename: string
+  ): Promise<THREE.Object3D> {
+    const arrayBuffer = await fetchModelData(path, filename)
+
+    const splatMesh = new SplatMesh({ fileBytes: arrayBuffer })
+    ctx.setOriginalModel(splatMesh)
+
+    const splatGroup = new THREE.Group()
+    splatGroup.add(splatMesh)
+    return splatGroup
+  }
+}

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -3,11 +3,7 @@
 import type * as THREE from 'three'
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import type { ViewHelper } from 'three/examples/jsm/helpers/ViewHelper'
-import type { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
-import type { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
-import type { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
-import type { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
-import type { OBJLoader2Parallel } from 'wwobjloader2'
+import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 
 export type MaterialMode =
   | 'original'
@@ -203,12 +199,6 @@ export interface ModelManagerInterface {
 }
 
 export interface LoaderManagerInterface {
-  gltfLoader: GLTFLoader
-  objLoader: OBJLoader2Parallel
-  mtlLoader: MTLLoader
-  fbxLoader: FBXLoader
-  stlLoader: STLLoader
-
   init(): void
   dispose(): void
   loadModel(url: string, originalFileName?: string): Promise<void>


### PR DESCRIPTION
> Prerequisite work for improved PLY / 3D Gaussian Splatting support — the per-format loader logic needs to live behind a stable seam before splat-specific fixes (orientation, async-decoder waits, GPU dispose, custom bounds) and capability-driven UX gating can be added without touching `LoaderManager`'s switch every time.

## Summary

Pure refactor. Extracts the per-extension switch inside `LoaderManager` into three `ModelAdapter` implementations and wires the manager to dispatch through them. **No behavior change** — same loader code paths, same outputs, same fallbacks. Sixth in the series splitting up the https://github.com/Comfy-Org/ComfyUI_frontend/pull/11495.

## Changes

- **What**:
  - `ModelAdapter.ts` (new): defines the `ModelAdapter` interface (`kind`, `extensions`, `capabilities`, `load`), a `ModelLoadContext` that exposes only the `SceneModelManager` surface adapters need (`setOriginalModel`, `registerOriginalMaterial`, `standardMaterial`, `materialMode`), and a shared `fetchModelData(path, filename)` helper.
  - `MeshModelAdapter.ts` (new): owns `stl`, `fbx`, `obj`, `gltf`, `glb`. Each branch is a 1:1 lift of the corresponding `case` from `LoaderManager.loadModelInternal` on `main`.
  - `PointCloudModelAdapter.ts` (new): owns `ply`. Includes the existing `FastPLYLoader` / `PLYLoader` fallback and the `pointCloud` vs mesh branching logic.
  - `SplatModelAdapter.ts` (new): owns `spz`, `splat`, `ksplat`. Wraps the `SplatMesh` in a `Group` exactly like the previous `loadSplat` did.
  - `LoaderManager.ts`: now owns just an adapter array (default = the three above) and a small dispatch path. `pickAdapter` matches by extension and routes PLY → splat when the `Comfy.Load3D.PLYEngine` setting is `sparkjs` (preserving the previous routing). `getCurrentAdapter()` is the new public reader used by `Load3d`.
  - `Load3d.isSplatModel` / `isPlyModel` now query `loaderManager.getCurrentAdapter()?.kind` instead of doing tree-introspection (`containsSplatMesh`) or `instanceof THREE.BufferGeometry` checks. Same return values, decoupled from the model shape.
  - `LoaderManagerInterface` no longer exposes the per-format loader fields (`gltfLoader`, `objLoader`, etc.); those are now adapter-internal.
  - `SceneModelManager` is **unchanged** in this PR. Its existing `containsSplatMesh()` traversal and PLY material-mode rebuild stay put; a follow-up PR refactors them once capability gating is in place.

## Review Focus

- **Loader equivalence**: the body of every `case` in `main`'s `LoaderManager.loadModelInternal` is now in the corresponding adapter's `load()` method. Easiest way to verify: diff `main`'s `LoaderManager.loadModelInternal` against the four `load()` bodies and confirm each branch's behavior (file fetch + parse + material wiring + group wrapping) is byte-identical.
- **Dispatch parity**: `pickAdapter` produces the same routing as `main` — extension match first, then the PLYEngine === 'sparkjs' override hoisted up from inside the old `loadPLY`.
- **Capability fields are dormant**: the `ModelAdapterCapabilities` record (`fitToViewer`, `materialModes`, `fitTargetSize`, …) is declared on every adapter but **not consumed anywhere in this PR**. SceneModelManager / Load3d / Load3DControls still read no capability data. The follow-up PR turns these on.
- **`setOriginalModel` / `registerOriginalMaterial`**: adapters now go through the `ModelLoadContext` getter rather than reaching into `modelManager` directly. The context's `standardMaterial` and `materialMode` are exposed via getters so a late-bound `materialMode` is read at the actual call site, not snapshotted at context creation.

## Coverage

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `ModelAdapter.ts` (new) | **100%** | **100%** | **100%** | **100%** |
| `MeshModelAdapter.ts` (new) | **100%** | **100%** | **100%** | **100%** |
| `PointCloudModelAdapter.ts` (new) | 97.22% | 61.11% | 75% | 97.22% |
| `SplatModelAdapter.ts` (new) | **100%** | **100%** | **100%** | **100%** |
| `LoaderManager.ts` (modified) | **100%** | 91.17% | 86.66% | **100%** |
| `Load3d.ts` (modified) | 6.63% | 0% | 13.68% | 6.7% |

All four new files are at or near 100% via dedicated unit tests for each adapter (load happy path, error propagation, extension declarations, capability shape). `LoaderManager.test.ts` exercises the dispatch logic — extension matching, the `ply → splat` sparkjs override, the stale-load discard, the load-context proxying — across 34 cases. The two changed `Load3d.ts` methods (`isSplatModel`, `isPlyModel`) get dedicated tests verifying they read the current adapter's `kind` and fall back to `false` when none is loaded.

`Load3d.ts`'s overall 6.7% number is the pre-existing baseline — the existing `Load3d.test.ts` covers façade methods via prototype injection rather than instantiating the class (the constructor needs `THREE.WebGLRenderer`, which happy-dom can't provide). PR-F's surface in `Load3d.ts` is two method bodies, both covered by the new adapter-driven kind queries test.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11627-refactor-load3d-introduce-ModelAdapter-abstraction-for-the-loader-switch-34d6d73d3650811b8a1ccc55b45100f2) by [Unito](https://www.unito.io)
