### PR TITLE
fix: enable Chrome password autofill on signup form

### DIFF
--- a/src/components/dialog/content/signin/PasswordFields.vue
+++ b/src/components/dialog/content/signin/PasswordFields.vue
@@ -12,6 +12,7 @@
     <Password
       v-model="password"
       input-id="comfy-org-sign-up-password"
+      pt:pc-input-text:root:name="new-password"
       pt:pc-input-text:root:autocomplete="new-password"
       name="password"
       :feedback="false"
@@ -76,6 +77,7 @@
     <Password
       name="confirmPassword"
       input-id="comfy-org-sign-up-confirm-password"
+      pt:pc-input-text:root:name="confirm-password"
       pt:pc-input-text:root:autocomplete="new-password"
       :feedback="false"
       toggle-mask

--- a/src/components/dialog/content/signin/PasswordFields.vue
+++ b/src/components/dialog/content/signin/PasswordFields.vue
@@ -12,7 +12,6 @@
     <Password
       v-model="password"
       input-id="comfy-org-sign-up-password"
-      pt:pc-input-text:root:name="new-password"
       pt:pc-input-text:root:autocomplete="new-password"
       name="password"
       :feedback="false"
@@ -77,7 +76,6 @@
     <Password
       name="confirmPassword"
       input-id="comfy-org-sign-up-confirm-password"
-      pt:pc-input-text:root:name="confirm-password"
       pt:pc-input-text:root:autocomplete="new-password"
       :feedback="false"
       toggle-mask

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -1,0 +1,110 @@
+import { Form, FormField } from '@primevue/forms'
+import { render, screen } from '@testing-library/vue'
+import Button from '@/components/ui/button/Button.vue'
+import PrimeVue from 'primevue/config'
+import InputText from 'primevue/inputtext'
+import Password from 'primevue/password'
+import ProgressSpinner from 'primevue/progressspinner'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import SignUpForm from './SignUpForm.vue'
+
+vi.mock('firebase/app', () => ({
+  initializeApp: vi.fn(),
+  getApp: vi.fn()
+}))
+
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(),
+  setPersistence: vi.fn(),
+  browserLocalPersistence: {},
+  onAuthStateChanged: vi.fn(),
+  signInWithEmailAndPassword: vi.fn(),
+  signOut: vi.fn()
+}))
+
+const mockLoadingRef = ref(false)
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(() => ({
+    get loading() {
+      return mockLoadingRef.value
+    }
+  }))
+}))
+
+describe('SignUpForm', () => {
+  beforeEach(() => {
+    mockLoadingRef.value = false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function renderComponent() {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: enMessages }
+    })
+    return render(SignUpForm, {
+      global: {
+        plugins: [PrimeVue, i18n],
+        components: {
+          Form,
+          FormField,
+          Button,
+          InputText,
+          Password,
+          ProgressSpinner
+        }
+      }
+    })
+  }
+
+  describe('Password manager autofill attributes', () => {
+    it('renders email input with attributes Chrome needs to recognize the field', () => {
+      renderComponent()
+
+      const emailInput = screen.getByPlaceholderText(
+        enMessages.auth.signup.emailPlaceholder
+      )
+      expect(emailInput).toHaveAttribute('id', 'comfy-org-sign-up-email')
+      expect(emailInput).toHaveAttribute('name', 'email')
+      expect(emailInput).toHaveAttribute('autocomplete', 'email')
+      expect(emailInput).toHaveAttribute('type', 'email')
+    })
+
+    it('renders password input with new-password autofill attributes', () => {
+      renderComponent()
+
+      const passwordInput = screen.getByPlaceholderText(
+        enMessages.auth.signup.passwordPlaceholder
+      )
+      expect(passwordInput).toHaveAttribute('id', 'comfy-org-sign-up-password')
+      expect(passwordInput).toHaveAttribute('name', 'password')
+      expect(passwordInput).toHaveAttribute('autocomplete', 'new-password')
+    })
+
+    it('renders confirm-password input with distinct name and new-password autocomplete', () => {
+      renderComponent()
+
+      const confirmPasswordInput = screen.getByPlaceholderText(
+        enMessages.auth.login.confirmPasswordPlaceholder
+      )
+      expect(confirmPasswordInput).toHaveAttribute(
+        'id',
+        'comfy-org-sign-up-confirm-password'
+      )
+      expect(confirmPasswordInput).toHaveAttribute('name', 'confirmPassword')
+      expect(confirmPasswordInput).toHaveAttribute(
+        'autocomplete',
+        'new-password'
+      )
+    })
+  })
+})

--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -18,7 +18,7 @@
         pt:root:name="email"
         pt:root:autocomplete="email"
         class="h-10"
-        type="text"
+        type="email"
         :placeholder="t('auth.signup.emailPlaceholder')"
         :invalid="$field.invalid"
       />

--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -15,6 +15,7 @@
       </label>
       <InputText
         pt:root:id="comfy-org-sign-up-email"
+        pt:root:name="email"
         pt:root:autocomplete="email"
         class="h-10"
         type="text"


### PR DESCRIPTION
## Summary

Add `name` attributes to the signup form's email, password, and confirm-password inputs so Chrome's password manager recognizes the form and offers autofill/save.

## Changes

- **What**: Pass `name` through to the underlying `<input>` on the email field (via `pt:root:name`) and on both password fields (via `pt:pc-input-text:root:name`). Without `name`, Chrome can't pair the email with the password and won't surface the save-password / suggest-strong-password prompts.

## Review Focus

- The PrimeVue passthrough syntax (`pt:root:*` for `InputText`, `pt:pc-input-text:root:*` for `Password`) lands the attribute on the actual `<input>` element — verified in DevTools.
- `confirm-password` is not a standard `autocomplete` token; we keep `autocomplete="new-password"` on both password fields and only differentiate via `name`.

## Screenshots (if applicable)


https://github.com/user-attachments/assets/e1e25ab5-8496-4c84-b5f1-630f31956c80

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11636-fix-enable-Chrome-password-autofill-on-signup-form-34e6d73d36508180882cc9ebafb58417) by [Unito](https://www.unito.io)
