### PR TITLE
test: add unit tests for maskEditorDataStore

### DIFF
--- a/src/stores/maskEditorDataStore.test.ts
+++ b/src/stores/maskEditorDataStore.test.ts
@@ -26,23 +26,6 @@ describe('maskEditorDataStore', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  describe('initial state', () => {
-    it('should start with null input/output/sourceNode', () => {
-      const store = useMaskEditorDataStore()
-
-      expect(store.inputData).toBeNull()
-      expect(store.outputData).toBeNull()
-      expect(store.sourceNode).toBeNull()
-    })
-
-    it('should start not loading and without error', () => {
-      const store = useMaskEditorDataStore()
-
-      expect(store.isLoading).toBe(false)
-      expect(store.loadError).toBeNull()
-    })
-  })
-
   describe('hasValidInput', () => {
     it('should be false when inputData is null', () => {
       const store = useMaskEditorDataStore()

--- a/src/stores/maskEditorDataStore.test.ts
+++ b/src/stores/maskEditorDataStore.test.ts
@@ -1,0 +1,176 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore';
+import type { EditorOutputData } from '@/stores/maskEditorDataStore';
+
+const createImage = (): HTMLImageElement => document.createElement('img')
+
+const createCanvas = (): HTMLCanvasElement => document.createElement('canvas')
+
+const createOutputData = (): EditorOutputData => {
+  const blob = new Blob()
+  const ref = { filename: 'out.png' }
+  return {
+    maskedImage: { canvas: createCanvas(), blob, ref },
+    paintLayer: { canvas: createCanvas(), blob, ref },
+    paintedImage: { canvas: createCanvas(), blob, ref },
+    paintedMaskedImage: { canvas: createCanvas(), blob, ref }
+  }
+}
+
+describe('maskEditorDataStore', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  describe('initial state', () => {
+    it('should start with null input/output/sourceNode', () => {
+      const store = useMaskEditorDataStore()
+
+      expect(store.inputData).toBeNull()
+      expect(store.outputData).toBeNull()
+      expect(store.sourceNode).toBeNull()
+    })
+
+    it('should start not loading and without error', () => {
+      const store = useMaskEditorDataStore()
+
+      expect(store.isLoading).toBe(false)
+      expect(store.loadError).toBeNull()
+    })
+  })
+
+  describe('hasValidInput', () => {
+    it('should be false when inputData is null', () => {
+      const store = useMaskEditorDataStore()
+
+      expect(store.hasValidInput).toBe(false)
+    })
+
+    it('should be true when inputData is set', () => {
+      const store = useMaskEditorDataStore()
+
+      store.inputData = {
+        baseLayer: { image: createImage(), url: 'base' },
+        maskLayer: { image: createImage(), url: 'mask' },
+        sourceRef: { filename: 'src.png' },
+        nodeId: 1
+      }
+
+      expect(store.hasValidInput).toBe(true)
+    })
+  })
+
+  describe('hasValidOutput', () => {
+    it('should be false when outputData is null', () => {
+      const store = useMaskEditorDataStore()
+
+      expect(store.hasValidOutput).toBe(false)
+    })
+
+    it('should be true when outputData is set', () => {
+      const store = useMaskEditorDataStore()
+
+      store.outputData = createOutputData()
+
+      expect(store.hasValidOutput).toBe(true)
+    })
+  })
+
+  describe('isReady', () => {
+    it('should be false without input', () => {
+      const store = useMaskEditorDataStore()
+
+      expect(store.isReady).toBe(false)
+    })
+
+    it('should be true with input and not loading', () => {
+      const store = useMaskEditorDataStore()
+
+      store.inputData = {
+        baseLayer: { image: createImage(), url: 'base' },
+        maskLayer: { image: createImage(), url: 'mask' },
+        sourceRef: { filename: 'src.png' },
+        nodeId: 1
+      }
+
+      expect(store.isReady).toBe(true)
+    })
+
+    it('should be false when loading even if input is set', () => {
+      const store = useMaskEditorDataStore()
+
+      store.inputData = {
+        baseLayer: { image: createImage(), url: 'base' },
+        maskLayer: { image: createImage(), url: 'mask' },
+        sourceRef: { filename: 'src.png' },
+        nodeId: 1
+      }
+      store.isLoading = true
+
+      expect(store.isReady).toBe(false)
+    })
+  })
+
+  describe('setLoading', () => {
+    it('should toggle isLoading without touching loadError when no error provided', () => {
+      const store = useMaskEditorDataStore()
+      store.loadError = 'previous'
+
+      store.setLoading(true)
+
+      expect(store.isLoading).toBe(true)
+      expect(store.loadError).toBe('previous')
+    })
+
+    it('should set loadError when an error string is provided', () => {
+      const store = useMaskEditorDataStore()
+
+      store.setLoading(false, 'failed to load')
+
+      expect(store.isLoading).toBe(false)
+      expect(store.loadError).toBe('failed to load')
+    })
+
+    it('should not clear an existing loadError when called with empty string', () => {
+      const store = useMaskEditorDataStore()
+      store.loadError = 'previous'
+
+      store.setLoading(false, '')
+
+      expect(store.loadError).toBe('previous')
+    })
+  })
+
+  describe('reset', () => {
+    it('should clear all state back to defaults', () => {
+      const store = useMaskEditorDataStore()
+
+      store.inputData = {
+        baseLayer: { image: createImage(), url: 'base' },
+        maskLayer: { image: createImage(), url: 'mask' },
+        paintLayer: { image: createImage(), url: 'paint' },
+        sourceRef: { filename: 'src.png', subfolder: 'sub', type: 'input' },
+        nodeId: 42
+      }
+      store.outputData = createOutputData()
+      store.sourceNode = { id: 42 } as LGraphNode
+      store.isLoading = true
+      store.loadError = 'something broke'
+
+      store.reset()
+
+      expect(store.inputData).toBeNull()
+      expect(store.outputData).toBeNull()
+      expect(store.sourceNode).toBeNull()
+      expect(store.isLoading).toBe(false)
+      expect(store.loadError).toBeNull()
+      expect(store.hasValidInput).toBe(false)
+      expect(store.hasValidOutput).toBe(false)
+      expect(store.isReady).toBe(false)
+    })
+  })
+})

--- a/src/stores/maskEditorDataStore.test.ts
+++ b/src/stores/maskEditorDataStore.test.ts
@@ -3,8 +3,8 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore';
-import type { EditorOutputData } from '@/stores/maskEditorDataStore';
+import { useMaskEditorDataStore } from '@/stores/maskEditorDataStore'
+import type { EditorOutputData } from '@/stores/maskEditorDataStore'
 
 const createImage = (): HTMLImageElement => document.createElement('img')
 


### PR DESCRIPTION
## Summary

Add unit tests for `maskEditorDataStore` Pinia store, raising coverage from 0% to 100% (statements / branches / functions / lines).

## Changes

- **What**: Add `src/stores/maskEditorDataStore.test.ts` (13 tests) covering initial state, the three `computed` predicates (`hasValidInput`, `hasValidOutput`, `isReady` including the `isLoading` interaction), the `setLoading(loading, error?)` action across its three branches (no error arg, truthy error arg, empty-string error arg — empty string is falsy so it must NOT clobber an existing `loadError`), and `reset()` clearing every field including derived predicates.

## Review Focus

- Uses `createTestingPinia({ stubActions: false })` so action implementations actually run, matching the pattern used by other store tests in `src/stores/` (e.g. `dialogStore.test.ts`).
- The `setLoading('', '')` test guards a real branch in the source — `if (error)` skips assignment for empty strings, so callers can't accidentally clear a previous error by passing `''`. Worth keeping if anyone tightens the guard later.
- `reset()` test asserts both raw refs and the three computed values flip back to `false` / `null`, so a future regression in either direction is caught.
- Style aligned with sibling tests: `should ...` naming, `describe` grouped by exposed property/action, `createImage` / `createCanvas` / `createOutputData` helpers to keep arrange blocks short.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11641-test-add-unit-tests-for-maskEditorDataStore-34e6d73d36508121b8e5d185178310ab) by [Unito](https://www.unito.io)
