### PR TITLE
test: add unit tests for useMaskEditor composable

### DIFF
--- a/src/composables/maskeditor/useMaskEditor.test.ts
+++ b/src/composables/maskeditor/useMaskEditor.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+
+const mockDialogStore = vi.hoisted(() => ({
+  showDialog: vi.fn()
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => mockDialogStore
+}))
+
+vi.mock('@/components/maskeditor/dialog/TopBarHeader.vue', () => ({
+  default: { name: 'TopBarHeaderStub' }
+}))
+
+vi.mock('@/components/maskeditor/MaskEditorContent.vue', () => ({
+  default: { name: 'MaskEditorContentStub' }
+}))
+
+import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
+
+type NodeShape = {
+  imgs?: unknown[]
+  previewMediaType?: string
+}
+
+const nodeWithImage = (overrides: NodeShape = {}): LGraphNode =>
+  ({
+    imgs: [new Image()],
+    previewMediaType: undefined,
+    ...overrides
+  }) as unknown as LGraphNode
+
+describe('useMaskEditor', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('openMaskEditor', () => {
+    it('should open the dialog with the node forwarded as a prop', () => {
+      const node = nodeWithImage()
+
+      useMaskEditor().openMaskEditor(node)
+
+      expect(mockDialogStore.showDialog).toHaveBeenCalledTimes(1)
+      expect(mockDialogStore.showDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'global-mask-editor',
+          props: { node }
+        })
+      )
+    })
+
+    it('should pass header and content components to the dialog', () => {
+      useMaskEditor().openMaskEditor(nodeWithImage())
+
+      expect(mockDialogStore.showDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headerComponent: expect.anything(),
+          component: expect.anything()
+        })
+      )
+    })
+
+    it('should configure modal dialog with maximizable and closable flags', () => {
+      useMaskEditor().openMaskEditor(nodeWithImage())
+
+      expect(mockDialogStore.showDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dialogComponentProps: expect.objectContaining({
+            modal: true,
+            maximizable: true,
+            closable: true
+          })
+        })
+      )
+    })
+
+    it('should accept a node whose previewMediaType is "image" without imgs', () => {
+      const node = nodeWithImage({
+        imgs: undefined,
+        previewMediaType: 'image'
+      })
+
+      useMaskEditor().openMaskEditor(node)
+
+      expect(mockDialogStore.showDialog).toHaveBeenCalledTimes(1)
+    })
+
+    it('should log and bail when node is null', () => {
+      useMaskEditor().openMaskEditor(null as unknown as LGraphNode)
+
+      expect(errorSpy).toHaveBeenCalledWith('[MaskEditor] No node provided')
+      expect(mockDialogStore.showDialog).not.toHaveBeenCalled()
+    })
+
+    it('should log and bail when node has neither imgs nor image preview', () => {
+      const node = nodeWithImage({ imgs: [], previewMediaType: undefined })
+
+      useMaskEditor().openMaskEditor(node)
+
+      expect(errorSpy).toHaveBeenCalledWith('[MaskEditor] Node has no images')
+      expect(mockDialogStore.showDialog).not.toHaveBeenCalled()
+    })
+
+    it('should bail when node has empty imgs and a non-image preview type', () => {
+      const node = nodeWithImage({ imgs: [], previewMediaType: 'video' })
+
+      useMaskEditor().openMaskEditor(node)
+
+      expect(mockDialogStore.showDialog).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for `useMaskEditor` composable, raising coverage from 0% to 100% (statements / branches / functions / lines).

## Changes

- **What**: Add `src/composables/maskeditor/useMaskEditor.test.ts` (7 tests) covering `openMaskEditor`:
  - Happy path: dialog opened once, `node` forwarded as a prop, header / content components attached.
  - Modal dialog config (`modal` / `maximizable` / `closable` flags) forwarded to PrimeVue dialog props.
  - Acceptance path for nodes with no `imgs` but `previewMediaType === 'image'`.
  - Three guard paths that should log and bail: `node` is null, node with empty `imgs` and no image preview, node with empty `imgs` and a non-image preview type (e.g. `'video'`).

## Review Focus

- Mocked `useDialogStore` with a single shared `showDialog` spy — the only contract under test is "we forwarded these props to the store action", so instantiating Pinia would just add noise.
- `TopBarHeader.vue` and `MaskEditorContent.vue` are stubbed because they pull in the full mask-editor render tree; we only assert they're forwarded as `headerComponent` / `component`, not what they render.
- `console.error` is spied per-test so the bail messages are observable but don't pollute runner output.
- `nodeWithImage` factory uses a structural `NodeShape` (`{ imgs?, previewMediaType? }`) rather than `Partial<LGraphNode>` because the real `LGraphNode` type requires a `LGraphNodeConstructor`-shaped `constructor` field, which would force every test to construct a full graph node — irrelevant to the contract being tested.
- Style aligned with sibling tests: `should ...` naming, `describe` grouped by exposed function (`openMaskEditor`), helper factory.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11644-test-add-unit-tests-for-useMaskEditor-composable-34e6d73d365081e98336db0a92c37ccf) by [Unito](https://www.unito.io)
