### PR TITLE
feat: refresh missing model errors

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -58,6 +58,7 @@ export const TestIds = {
     missingModelLocate: 'missing-model-locate',
     missingModelCopyName: 'missing-model-copy-name',
     missingModelCopyUrl: 'missing-model-copy-url',
+    missingModelActions: 'missing-model-actions',
     missingModelDownload: 'missing-model-download',
     missingModelImportUnsupported: 'missing-model-import-unsupported',
     missingMediaGroup: 'error-group-missing-media',

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
@@ -99,5 +99,52 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
       )
       await expect(downloadButton.first()).toBeVisible()
     })
+
+    test('Should render Download all and Refresh when one model is downloadable', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
+
+      const actions = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingModelActions
+      )
+      await expect(actions).toBeVisible()
+      await expect(
+        actions.getByRole('button', { name: /Download all/ })
+      ).toBeVisible()
+      await expect(
+        actions.getByRole('button', { name: 'Refresh' })
+      ).toBeVisible()
+    })
+
+    test('Should re-fetch object info and model folders when Refresh is clicked', async ({
+      comfyPage
+    }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
+
+      const page = comfyPage.page
+      const actions = page.getByTestId(TestIds.dialogs.missingModelActions)
+      const refreshButton = actions.getByRole('button', { name: 'Refresh' })
+
+      await expect(refreshButton).toBeVisible()
+
+      const objectInfoResponse = page.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname.endsWith('/object_info') &&
+          response.ok()
+      )
+      const modelFoldersResponse = page.waitForResponse((response) => {
+        const pathname = new URL(response.url()).pathname
+        return pathname.endsWith('/experiment/models') && response.ok()
+      })
+
+      await Promise.all([
+        objectInfoResponse,
+        modelFoldersResponse,
+        refreshButton.click()
+      ])
+
+      await expect(refreshButton).toBeEnabled()
+    })
   })
 })

--- a/src/components/curve/WidgetCurve.test.ts
+++ b/src/components/curve/WidgetCurve.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 /* eslint-disable vue/no-reserved-component-names */
 /* eslint-disable vue/no-unused-emit-declarations */
 import { render, screen } from '@testing-library/vue'

--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -102,18 +102,6 @@
                 }}
               </Button>
               <Button
-                v-else-if="
-                  group.type === 'missing_model' &&
-                  downloadableModels.length > 1
-                "
-                variant="secondary"
-                size="sm"
-                class="mr-2 h-8 shrink-0 rounded-lg text-sm"
-                @click.stop="downloadAllModels"
-              >
-                {{ downloadAllLabel }}
-              </Button>
-              <Button
                 v-else-if="group.type === 'swap_nodes'"
                 v-tooltip.top="
                   t(
@@ -238,12 +226,6 @@ import SwapNodesCard from '@/platform/nodeReplacement/components/SwapNodesCard.v
 import MissingModelCard from '@/platform/missingModel/components/MissingModelCard.vue'
 import MissingMediaCard from '@/platform/missingMedia/components/MissingMediaCard.vue'
 import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
-import {
-  downloadModel,
-  isModelDownloadable
-} from '@/platform/missingModel/missingModelDownload'
-import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
-import { formatSize } from '@/utils/formatUtil'
 import Button from '@/components/ui/button/Button.vue'
 import DotSpinner from '@/components/common/DotSpinner.vue'
 import { usePackInstall } from '@/workbench/extensions/manager/composables/nodePack/usePackInstall'
@@ -320,45 +302,6 @@ const singleRuntimeErrorGroup = computed(() => {
 const singleRuntimeErrorCard = computed(
   () => singleRuntimeErrorGroup.value?.cards[0] ?? null
 )
-
-const missingModelStore = useMissingModelStore()
-
-const downloadableModels = computed(() => {
-  if (isCloud) return []
-  return missingModelGroups.value.flatMap((group) =>
-    group.models
-      .filter(
-        (m) =>
-          m.representative.url &&
-          m.representative.directory &&
-          isModelDownloadable({
-            name: m.representative.name,
-            url: m.representative.url,
-            directory: m.representative.directory
-          })
-      )
-      .map((m) => ({
-        name: m.representative.name,
-        url: m.representative.url!,
-        directory: m.representative.directory!
-      }))
-  )
-})
-
-const downloadAllLabel = computed(() => {
-  const base = t('rightSidePanel.missingModels.downloadAll')
-  const total = downloadableModels.value.reduce(
-    (sum, m) => sum + (missingModelStore.fileSizes[m.url] ?? 0),
-    0
-  )
-  return total > 0 ? `${base} (${formatSize(total)})` : base
-})
-
-function downloadAllModels() {
-  for (const model of downloadableModels.value) {
-    downloadModel(model, missingModelStore.folderPaths)
-  }
-}
 
 const isAllCollapsed = computed({
   get() {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3572,7 +3572,10 @@
       "unknownCategory": "Unknown",
       "missingModelsTitle": "Missing Models",
       "assetLoadTimeout": "Model detection timed out. Try reloading the workflow.",
-      "downloadAll": "Download all"
+      "downloadAll": "Download all",
+      "refresh": "Refresh",
+      "refreshFailed": "Failed to refresh missing models. Try again.",
+      "refreshPartiallyFailed": "Some missing models were refreshed, but others could not be verified. Try again."
     },
     "missingMedia": {
       "missingMediaTitle": "Missing Inputs",

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -1,3 +1,4 @@
+import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
@@ -20,6 +21,18 @@ vi.mock('./MissingModelRow.vue', () => ({
   }
 }))
 
+vi.mock('@/platform/missingModel/missingModelStore', () => ({
+  useMissingModelStore: vi.fn(() => ({
+    fileSizes: {},
+    folderPaths: {}
+  }))
+}))
+
+vi.mock('@/platform/missingModel/missingModelDownload', () => ({
+  downloadModel: vi.fn(),
+  isModelDownloadable: vi.fn(() => true)
+}))
+
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -39,7 +52,9 @@ const i18n = createI18n({
           importNotSupported: 'Import Not Supported',
           customNodeDownloadDisabled:
             'Cloud environment does not support model imports for custom nodes.',
-          unknownCategory: 'Unknown Category'
+          unknownCategory: 'Unknown Category',
+          downloadAll: 'Download all',
+          refresh: 'Refresh'
         }
       }
     }
@@ -50,7 +65,11 @@ const i18n = createI18n({
 
 function makeViewModel(
   name: string,
-  nodeId: string = '1'
+  nodeId: string = '1',
+  opts: {
+    directory?: string
+    url?: string
+  } = {}
 ): MissingModelViewModel {
   return {
     name,
@@ -60,7 +79,9 @@ function makeViewModel(
       nodeType: 'CheckpointLoaderSimple',
       widgetName: 'ckpt_name',
       isAssetSupported: true,
-      isMissing: true
+      isMissing: true,
+      directory: opts.directory,
+      url: opts.url
     },
     referencingNodes: [{ nodeId, widgetName: 'ckpt_name' }]
   }
@@ -71,13 +92,21 @@ function makeGroup(
     directory?: string | null
     isAssetSupported?: boolean
     modelNames?: string[]
+    urls?: string[]
   } = {}
 ): MissingModelGroup {
   const names = opts.modelNames ?? ['model.safetensors']
+  const directory =
+    'directory' in opts ? (opts.directory ?? null) : 'checkpoints'
   return {
-    directory: 'directory' in opts ? (opts.directory ?? null) : 'checkpoints',
+    directory,
     isAssetSupported: opts.isAssetSupported ?? true,
-    models: names.map((n, i) => makeViewModel(n, String(i + 1)))
+    models: names.map((n, i) =>
+      makeViewModel(n, String(i + 1), {
+        directory: opts.urls?.[i] && directory ? directory : undefined,
+        url: opts.urls?.[i]
+      })
+    )
   }
 }
 
@@ -96,7 +125,7 @@ function mountCard(
       ...(onLocateModel ? { onLocateModel } : {})
     },
     global: {
-      plugins: [PrimeVue, i18n]
+      plugins: [PrimeVue, i18n, createTestingPinia({ createSpy: vi.fn })]
     }
   })
 }
@@ -244,5 +273,39 @@ describe('MissingModelCard (OSS)', () => {
     })
     expect(container.textContent).toContain('Unknown Category')
     expect(container.textContent).not.toContain('Import Not Supported')
+  })
+
+  it('hides the action section when no models are downloadable', () => {
+    mountCard({
+      missingModelGroups: [
+        makeGroup({
+          modelNames: ['one.safetensors']
+        })
+      ]
+    })
+
+    expect(
+      screen.queryByTestId('missing-model-actions')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Refresh' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the action section when one model is downloadable', () => {
+    mountCard({
+      missingModelGroups: [
+        makeGroup({
+          modelNames: ['one.safetensors'],
+          urls: ['https://huggingface.co/org/repo/resolve/main/one.safetensors']
+        })
+      ]
+    })
+
+    expect(screen.getByTestId('missing-model-actions')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Download all/ })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
   })
 })

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -1,5 +1,41 @@
 <template>
   <div class="px-4 pb-2">
+    <div
+      v-if="downloadableModels.length > 0"
+      data-testid="missing-model-actions"
+      class="flex items-center gap-2 pt-1 pb-2"
+    >
+      <Button
+        variant="secondary"
+        size="lg"
+        class="min-w-0 flex-1"
+        @click="downloadAllModels"
+      >
+        <i aria-hidden="true" class="icon-[lucide--download] size-4 shrink-0" />
+        <span class="truncate">{{ downloadAllLabel }}</span>
+      </Button>
+      <Button
+        variant="secondary"
+        size="lg"
+        class="ml-auto shrink-0"
+        :disabled="isRefreshingMissingModels"
+        @click="refreshMissingModels"
+      >
+        <DotSpinner
+          v-if="isRefreshingMissingModels"
+          aria-hidden="true"
+          duration="1s"
+          :size="16"
+        />
+        <i
+          v-else
+          aria-hidden="true"
+          class="icon-[lucide--refresh-cw] size-4 shrink-0"
+        />
+        {{ t('rightSidePanel.missingModels.refresh') }}
+      </Button>
+    </div>
+
     <!-- Category groups (by directory) -->
     <div
       v-for="group in missingModelGroups"
@@ -67,10 +103,21 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { MissingModelGroup } from '@/platform/missingModel/types'
+import Button from '@/components/ui/button/Button.vue'
+import DotSpinner from '@/components/common/DotSpinner.vue'
 import { isCloud } from '@/platform/distribution/types'
 import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.vue'
+import {
+  downloadModel,
+  isModelDownloadable
+} from '@/platform/missingModel/missingModelDownload'
+import type { ModelWithUrl } from '@/platform/missingModel/missingModelDownload'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useMissingModelRefresh } from '@/platform/missingModel/composables/useMissingModelRefresh'
+import type { MissingModelGroup } from '@/platform/missingModel/types'
+import { formatSize } from '@/utils/formatUtil'
 
 const { missingModelGroups, showNodeIdBadge } = defineProps<{
   missingModelGroups: MissingModelGroup[]
@@ -82,4 +129,47 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const missingModelStore = useMissingModelStore()
+const { isRefreshingMissingModels, refreshMissingModels } =
+  useMissingModelRefresh()
+
+function getDownloadableModel(
+  group: MissingModelGroup,
+  model: MissingModelGroup['models'][number]
+): ModelWithUrl | null {
+  const url = model.representative.url
+  const directory = model.representative.directory ?? group.directory
+  if (!url || !directory) return null
+
+  const downloadableModel = {
+    name: model.representative.name,
+    url,
+    directory
+  }
+  return isModelDownloadable(downloadableModel) ? downloadableModel : null
+}
+
+const downloadableModels = computed<ModelWithUrl[]>(() => {
+  if (isCloud) return []
+  return missingModelGroups.flatMap((group) =>
+    group.models
+      .map((model) => getDownloadableModel(group, model))
+      .filter((model): model is ModelWithUrl => model !== null)
+  )
+})
+
+const downloadAllLabel = computed(() => {
+  const base = t('rightSidePanel.missingModels.downloadAll')
+  const total = downloadableModels.value.reduce(
+    (sum, m) => sum + (missingModelStore.fileSizes[m.url] ?? 0),
+    0
+  )
+  return total > 0 ? `${base} (${formatSize(total)})` : base
+})
+
+function downloadAllModels() {
+  for (const model of downloadableModels.value) {
+    downloadModel(model, missingModelStore.folderPaths)
+  }
+}
 </script>

--- a/src/platform/missingModel/composables/useMissingModelRefresh.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelRefresh.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MissingModelCandidate } from '@/platform/missingModel/types'
+
+const hoisted = vi.hoisted(() => ({
+  app: {
+    rootGraph: {},
+    refreshComboInNodes: vi.fn()
+  },
+  missingModelStore: {
+    missingModelCandidates: null as MissingModelCandidate[] | null,
+    setMissingModels: vi.fn()
+  },
+  toastStore: {
+    add: vi.fn()
+  },
+  activeWorkflow: null as {
+    pendingWarnings: {
+      missingModelCandidates?: MissingModelCandidate[]
+      missingNodeTypes?: string[]
+      missingMediaCandidates?: unknown[]
+    } | null
+  } | null,
+  modelStore: {
+    loadModelFolders: vi.fn(),
+    getLoadedModelFolder: vi.fn()
+  },
+  node: {
+    widgets: [
+      {
+        name: 'ckpt_name',
+        type: 'combo',
+        value: 'missing.safetensors',
+        options: { values: [] as string[] }
+      }
+    ]
+  },
+  getNodeByExecutionId: vi.fn(),
+  resolveComboValues: vi.fn()
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: hoisted.app
+}))
+
+vi.mock('@/platform/missingModel/missingModelStore', () => ({
+  useMissingModelStore: () => hoisted.missingModelStore
+}))
+
+vi.mock('@/stores/modelStore', () => ({
+  useModelStore: () => hoisted.modelStore
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => ({
+    workflow: {
+      activeWorkflow: hoisted.activeWorkflow
+    }
+  })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => hoisted.toastStore
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  getNodeByExecutionId: hoisted.getNodeByExecutionId
+}))
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  resolveComboValues: hoisted.resolveComboValues
+}))
+
+import { useMissingModelRefresh } from './useMissingModelRefresh'
+
+function makeCandidate(
+  overrides: Partial<MissingModelCandidate> = {}
+): MissingModelCandidate {
+  return {
+    nodeId: '1',
+    nodeType: 'CheckpointLoaderSimple',
+    widgetName: 'ckpt_name',
+    isAssetSupported: false,
+    name: 'missing.safetensors',
+    directory: 'checkpoints',
+    isMissing: true,
+    ...overrides
+  }
+}
+
+describe('useMissingModelRefresh', () => {
+  beforeEach(() => {
+    hoisted.app.rootGraph = {}
+    hoisted.app.refreshComboInNodes.mockReset().mockResolvedValue(undefined)
+    hoisted.missingModelStore.missingModelCandidates = [makeCandidate()]
+    hoisted.missingModelStore.setMissingModels.mockReset()
+    hoisted.toastStore.add.mockReset()
+    hoisted.activeWorkflow = { pendingWarnings: null }
+    hoisted.modelStore.loadModelFolders.mockReset().mockResolvedValue(undefined)
+    hoisted.modelStore.getLoadedModelFolder.mockReset().mockResolvedValue({
+      models: {}
+    })
+    hoisted.node.widgets[0].value = 'missing.safetensors'
+    hoisted.node.widgets[0].options.values = []
+    hoisted.getNodeByExecutionId.mockReset().mockReturnValue(hoisted.node)
+    hoisted.resolveComboValues.mockReset().mockReturnValue([])
+  })
+
+  it('refreshes object info silently before checking candidates', async () => {
+    const { refreshMissingModels } = useMissingModelRefresh()
+
+    await refreshMissingModels()
+
+    expect(hoisted.app.refreshComboInNodes).toHaveBeenCalledWith({
+      silent: true
+    })
+    expect(hoisted.modelStore.loadModelFolders).toHaveBeenCalled()
+  })
+
+  it('removes a candidate when refreshed widget options contain the model', async () => {
+    hoisted.resolveComboValues.mockReturnValue(['missing.safetensors'])
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([])
+  })
+
+  it('does not drop candidates added while refresh is in flight', async () => {
+    const staleCandidate = makeCandidate({ name: 'stale.safetensors' })
+    const newCandidate = makeCandidate({
+      nodeId: '2',
+      name: 'newly-added.safetensors'
+    })
+    hoisted.missingModelStore.missingModelCandidates = [staleCandidate]
+    hoisted.resolveComboValues.mockReturnValue(['stale.safetensors'])
+    hoisted.modelStore.loadModelFolders.mockImplementation(() => {
+      hoisted.missingModelStore.missingModelCandidates = [
+        staleCandidate,
+        newCandidate
+      ]
+      return Promise.resolve()
+    })
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([
+      newCandidate
+    ])
+  })
+
+  it('does not re-add candidates removed while refresh is in flight', async () => {
+    const removedCandidate = makeCandidate({ name: 'removed.safetensors' })
+    hoisted.missingModelStore.missingModelCandidates = [removedCandidate]
+    hoisted.resolveComboValues.mockReturnValue(['removed.safetensors'])
+    hoisted.modelStore.loadModelFolders.mockImplementation(() => {
+      hoisted.missingModelStore.missingModelCandidates = null
+      return Promise.resolve()
+    })
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([])
+  })
+
+  it('syncs active workflow pending warnings after refreshing candidates', async () => {
+    hoisted.resolveComboValues.mockReturnValue(['missing.safetensors'])
+    hoisted.activeWorkflow!.pendingWarnings = {
+      missingModelCandidates: [makeCandidate()],
+      missingNodeTypes: ['MissingNode']
+    }
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.activeWorkflow!.pendingWarnings).toEqual({
+      missingModelCandidates: undefined,
+      missingNodeTypes: ['MissingNode']
+    })
+  })
+
+  it('clears active workflow pending warnings when no warnings remain', async () => {
+    hoisted.resolveComboValues.mockReturnValue(['missing.safetensors'])
+    hoisted.activeWorkflow = {
+      pendingWarnings: {
+        missingModelCandidates: [makeCandidate()],
+        missingNodeTypes: [],
+        missingMediaCandidates: []
+      }
+    }
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.activeWorkflow.pendingWarnings).toBeNull()
+  })
+
+  it('skips pending warning sync when there is no active workflow', async () => {
+    hoisted.resolveComboValues.mockReturnValue(['missing.safetensors'])
+    hoisted.activeWorkflow = null
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([])
+  })
+
+  it('removes a candidate when the refreshed model folder contains the model', async () => {
+    hoisted.modelStore.getLoadedModelFolder.mockResolvedValue({
+      models: {
+        '0/missing.safetensors': { file_name: 'missing.safetensors' }
+      }
+    })
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([])
+  })
+
+  it('keeps a candidate when the selected value is still missing', async () => {
+    const candidate = makeCandidate()
+    hoisted.missingModelStore.missingModelCandidates = [candidate]
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).not.toHaveBeenCalled()
+  })
+
+  it('keeps workflow-level candidates unless their directory now contains the model', async () => {
+    const candidate = makeCandidate({ nodeId: undefined, widgetName: '' })
+    hoisted.missingModelStore.missingModelCandidates = [candidate]
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).not.toHaveBeenCalled()
+  })
+
+  it('returns early when there are no candidates', async () => {
+    hoisted.missingModelStore.missingModelCandidates = null
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.app.refreshComboInNodes).not.toHaveBeenCalled()
+    expect(hoisted.missingModelStore.setMissingModels).not.toHaveBeenCalled()
+  })
+
+  it('ignores a second refresh while one is already running', async () => {
+    let resolveRefresh: () => void = () => {}
+    hoisted.app.refreshComboInNodes.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRefresh = resolve
+      })
+    )
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    const firstRefresh = refreshMissingModels()
+    const secondRefresh = refreshMissingModels()
+
+    expect(hoisted.app.refreshComboInNodes).toHaveBeenCalledTimes(1)
+
+    resolveRefresh()
+    await Promise.all([firstRefresh, secondRefresh])
+
+    expect(hoisted.missingModelStore.setMissingModels).not.toHaveBeenCalled()
+  })
+
+  it('shows a toast and keeps existing candidates when refresh fails', async () => {
+    const candidate = makeCandidate()
+    hoisted.missingModelStore.missingModelCandidates = [candidate]
+    hoisted.app.refreshComboInNodes.mockRejectedValue(new Error('failed'))
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).not.toHaveBeenCalled()
+    expect(hoisted.toastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'rightSidePanel.missingModels.refreshFailed'
+    })
+    expect(hoisted.toastStore.add).toHaveBeenCalledTimes(1)
+  })
+
+  it('still removes candidates fixed by object info when model folder refresh fails', async () => {
+    hoisted.resolveComboValues.mockReturnValue(['missing.safetensors'])
+    hoisted.modelStore.loadModelFolders.mockRejectedValue(new Error('failed'))
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([])
+    expect(hoisted.toastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'rightSidePanel.missingModels.refreshPartiallyFailed'
+    })
+    expect(hoisted.toastStore.add).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes resolved candidates and keeps failed candidates when folder checks are mixed', async () => {
+    const resolvedCandidate = makeCandidate({
+      name: 'resolved.safetensors',
+      directory: 'checkpoints'
+    })
+    const failedCandidate = makeCandidate({
+      nodeId: '2',
+      name: 'failed.safetensors',
+      directory: 'loras'
+    })
+    hoisted.missingModelStore.missingModelCandidates = [
+      resolvedCandidate,
+      failedCandidate
+    ]
+    hoisted.getNodeByExecutionId.mockImplementation((_, nodeId: string) => ({
+      widgets: [
+        {
+          name: 'ckpt_name',
+          type: 'combo',
+          value: nodeId === '2' ? 'failed.safetensors' : 'resolved.safetensors',
+          options: { values: [] }
+        }
+      ]
+    }))
+    hoisted.modelStore.getLoadedModelFolder.mockImplementation(
+      (directory: string) => {
+        if (directory === 'checkpoints') {
+          return Promise.resolve({
+            models: {
+              '0/resolved.safetensors': { file_name: 'resolved.safetensors' }
+            }
+          })
+        }
+        return Promise.reject(new Error('failed'))
+      }
+    )
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    expect(hoisted.missingModelStore.setMissingModels).toHaveBeenCalledWith([
+      failedCandidate
+    ])
+    expect(hoisted.toastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'rightSidePanel.missingModels.refreshPartiallyFailed'
+    })
+    expect(hoisted.toastStore.add).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show a stale error toast after a clean second refresh', async () => {
+    hoisted.modelStore.getLoadedModelFolder.mockRejectedValueOnce(
+      new Error('failed')
+    )
+
+    const { refreshMissingModels } = useMissingModelRefresh()
+    await refreshMissingModels()
+
+    hoisted.toastStore.add.mockReset()
+    hoisted.modelStore.getLoadedModelFolder.mockResolvedValueOnce({
+      models: {}
+    })
+
+    await refreshMissingModels()
+
+    expect(hoisted.toastStore.add).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/missingModel/composables/useMissingModelRefresh.ts
+++ b/src/platform/missingModel/composables/useMissingModelRefresh.ts
@@ -1,0 +1,191 @@
+import { ref } from 'vue'
+
+import { t } from '@/i18n'
+import { app } from '@/scripts/app'
+import type {
+  IBaseWidget,
+  IComboWidget
+} from '@/lib/litegraph/src/types/widgets'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import type { MissingModelCandidate } from '@/platform/missingModel/types'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useModelStore } from '@/stores/modelStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
+import { getNodeByExecutionId } from '@/utils/graphTraversalUtil'
+import { resolveComboValues } from '@/utils/litegraphUtil'
+
+function findCandidateWidget(candidate: MissingModelCandidate) {
+  if (candidate.nodeId == null || !app.rootGraph) return undefined
+
+  const node = getNodeByExecutionId(app.rootGraph, String(candidate.nodeId))
+  return node?.widgets?.find((w) => w.name === candidate.widgetName)
+}
+
+function isComboWidget(widget: IBaseWidget): widget is IComboWidget {
+  return widget.type === 'combo'
+}
+
+function isCandidateValueStillSelected(
+  candidate: MissingModelCandidate
+): boolean {
+  return findCandidateWidget(candidate)?.value === candidate.name
+}
+
+function isCandidateInWidgetOptions(candidate: MissingModelCandidate): boolean {
+  const widget = findCandidateWidget(candidate)
+  if (!widget || !isComboWidget(widget)) return false
+
+  return resolveComboValues(widget).includes(candidate.name)
+}
+
+function getCandidateKey(candidate: MissingModelCandidate): string {
+  return [
+    String(candidate.nodeId),
+    candidate.widgetName,
+    candidate.name,
+    candidate.directory ?? ''
+  ].join('::')
+}
+
+function syncActiveWorkflowMissingModels(candidates: MissingModelCandidate[]) {
+  const activeWorkflow = useWorkspaceStore().workflow.activeWorkflow
+  if (!activeWorkflow) return
+
+  activeWorkflow.pendingWarnings = {
+    ...activeWorkflow.pendingWarnings,
+    missingModelCandidates: candidates.length ? candidates : undefined
+  }
+
+  if (
+    !activeWorkflow.pendingWarnings.missingNodeTypes?.length &&
+    !activeWorkflow.pendingWarnings.missingModelCandidates?.length &&
+    !activeWorkflow.pendingWarnings.missingMediaCandidates?.length
+  ) {
+    activeWorkflow.pendingWarnings = null
+  }
+}
+
+/**
+ * Rechecks the currently surfaced missing model candidates against fresh
+ * object_info/model folder data and removes only candidates confirmed fixed.
+ */
+export function useMissingModelRefresh() {
+  const missingModelStore = useMissingModelStore()
+  const modelStore = useModelStore()
+  const toastStore = useToastStore()
+  const isRefreshingMissingModels = ref(false)
+
+  async function isCandidateStillMissing(
+    candidate: MissingModelCandidate
+  ): Promise<{ isStillMissing: boolean; hadError: boolean }> {
+    try {
+      if (candidate.nodeId != null) {
+        if (!isCandidateValueStillSelected(candidate)) {
+          return { isStillMissing: false, hadError: false }
+        }
+        if (isCandidateInWidgetOptions(candidate)) {
+          return { isStillMissing: false, hadError: false }
+        }
+      }
+
+      if (!candidate.directory) {
+        return { isStillMissing: true, hadError: false }
+      }
+
+      const folder = await modelStore.getLoadedModelFolder(candidate.directory)
+      const models = folder?.models
+      if (!models) return { isStillMissing: true, hadError: false }
+
+      return {
+        isStillMissing: !Object.values(models).some(
+          (m) => m.file_name === candidate.name
+        ),
+        hadError: false
+      }
+    } catch (error) {
+      console.error(
+        `[Missing Model] Failed to verify missing model in ${candidate.directory ?? 'unknown directory'}:`,
+        error
+      )
+      return { isStillMissing: true, hadError: true }
+    }
+  }
+
+  function showRefreshFailedToast(resolvedCount: number) {
+    toastStore.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: t(
+        resolvedCount > 0
+          ? 'rightSidePanel.missingModels.refreshPartiallyFailed'
+          : 'rightSidePanel.missingModels.refreshFailed'
+      )
+    })
+  }
+
+  function removeResolvedCandidates(resolvedCandidateKeys: Set<string>) {
+    if (resolvedCandidateKeys.size === 0) return
+
+    const currentCandidates = missingModelStore.missingModelCandidates ?? []
+    const remaining = currentCandidates.filter(
+      (candidate) => !resolvedCandidateKeys.has(getCandidateKey(candidate))
+    )
+
+    missingModelStore.setMissingModels(remaining)
+    syncActiveWorkflowMissingModels(remaining)
+  }
+
+  async function refreshMissingModels() {
+    const candidates = missingModelStore.missingModelCandidates
+    if (!candidates?.length || isRefreshingMissingModels.value) return
+
+    isRefreshingMissingModels.value = true
+    let hadRefreshError = false
+    async function runRefreshStep(label: string, run: () => Promise<unknown>) {
+      try {
+        await run()
+      } catch (error) {
+        hadRefreshError = true
+        console.error(`[Missing Model] Failed to ${label}:`, error)
+      }
+    }
+
+    try {
+      await runRefreshStep('refresh object info', () =>
+        app.refreshComboInNodes({ silent: true })
+      )
+      await runRefreshStep('refresh model folders', () =>
+        modelStore.loadModelFolders()
+      )
+
+      const stillMissingResults = await Promise.all(
+        candidates.map(async (candidate) => ({
+          candidate,
+          ...(await isCandidateStillMissing(candidate))
+        }))
+      )
+      const resolvedCandidateKeys = new Set(
+        stillMissingResults
+          .filter((result) => !result.isStillMissing)
+          .map((result) => getCandidateKey(result.candidate))
+      )
+      const resolvedCount = resolvedCandidateKeys.size
+
+      removeResolvedCandidates(resolvedCandidateKeys)
+
+      if (hadRefreshError || stillMissingResults.some((r) => r.hadError)) {
+        showRefreshFailedToast(resolvedCount)
+      }
+    } catch (error) {
+      console.error('[Missing Model] Failed to refresh missing models:', error)
+      showRefreshFailedToast(0)
+    } finally {
+      isRefreshingMissingModels.value = false
+    }
+  }
+
+  return {
+    isRefreshingMissingModels,
+    refreshMissingModels
+  }
+}

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -26,7 +26,7 @@ const WHITE_LISTED_URLS: ReadonlySet<string> = new Set([
   'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth'
 ])
 
-interface ModelWithUrl {
+export interface ModelWithUrl {
   name: string
   url: string
   directory: string

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -2224,15 +2224,17 @@ export class ComfyApp {
   }
 
   /**
-   * Refresh combo list on whole nodes
+   * Refresh combo list on whole nodes.
+   *
+   * @param options.silent When true, suppress update toast messages.
    */
-  async refreshComboInNodes() {
+  async refreshComboInNodes(options: { silent?: boolean } = {}) {
     const requestToastMessage: ToastMessageOptions = {
       severity: 'info',
       summary: t('g.update'),
       detail: t('toastMessages.updateRequested')
     }
-    if (this.vueAppReady) {
+    if (this.vueAppReady && !options.silent) {
       useToastStore().add(requestToastMessage)
     }
 
@@ -2289,13 +2291,15 @@ export class ComfyApp {
 
     if (this.vueAppReady) {
       this.updateVueAppNodeDefs(defs)
-      useToastStore().remove(requestToastMessage)
-      useToastStore().add({
-        severity: 'success',
-        summary: t('g.updated'),
-        detail: t('toastMessages.nodeDefinitionsUpdated'),
-        life: 1000
-      })
+      if (!options.silent) {
+        useToastStore().remove(requestToastMessage)
+        useToastStore().add({
+          severity: 'success',
+          summary: t('g.updated'),
+          detail: t('toastMessages.nodeDefinitionsUpdated'),
+          life: 1000
+        })
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds an OSS-only Refresh action for missing model errors and keeps the Missing Models bulk actions visible when at least one model can be downloaded.

## Changes

- **What**: Moved Missing Models bulk actions into the Missing Models card so `Download all` and `Refresh` appear next to the affected model rows.
- **What**: Changed the bulk action visibility from "more than one downloadable model" to "at least one downloadable model."
- **What**: Added Refresh for OSS missing-model errors. Refresh silently reloads object info/model folder data, then rechecks only the currently surfaced missing-model candidates and removes candidates confirmed as resolved.
- **What**: Rebased resolved candidates onto the latest store state so refresh does not drop candidates added or removed while the refresh is in flight.
- **What**: Added partial failure handling so unverified candidates remain visible and users see an error toast when refresh cannot fully verify the current candidates.
- **What**: Added unit coverage for candidate reconciliation, pending warning sync, partial failures, and action visibility.
- **What**: Added E2E coverage for the single-downloadable-model bulk action case and for Refresh re-fetching object info/model folder data.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- Refresh intentionally rechecks only the missing-model candidates currently shown in the Errors tab instead of running the full missing-model pipeline. This keeps the action scoped to the user flow it supports: after a user downloads or manually places files, confirm whether the displayed errors have been resolved.
- A full workflow rescan would also discover newly missing models, but that is broader than this action and has more policy questions around surfacing new errors, overlay behavior, bypassed scopes, and pipeline duplication.
- The E2E coverage verifies the OSS Missing Models card wiring, confirms the bulk action area appears for a single downloadable model, and checks that clicking Refresh reloads object info/model folder data. It does not assert that Refresh clears the error because the current browser fixtures provide cleanup for fake models but do not provide a stable devtools helper for creating/installing the fake model mid-test. The candidate reconciliation behavior is covered by focused unit tests instead.
- Follow-up candidates: split `refreshComboInNodes({ silent })` into a quieter object-info refresh/data API and a user-facing command that owns toast behavior.
- Follow-up candidates: consider a full missing-model rescan command if product direction wants Refresh to mean "re-evaluate the entire workflow" instead of "recheck displayed missing-model errors."
- Follow-up candidates: add a backend/devtools test helper for creating fake model files so browser tests can cover end-to-end Refresh clearing behavior.
- Follow-up candidates: revisit Desktop download behavior for model directories that are not present in `folderPaths`; this is pre-existing and outside this PR's refresh scope.

## Screenshots (if applicable)


https://github.com/user-attachments/assets/b6e80404-f5f6-40c3-b607-d5e97f981395



## Tests

- `pnpm vitest src/platform/missingModel/composables/useMissingModelRefresh.test.ts src/platform/missingModel/components/MissingModelCard.test.ts --run`
- `pnpm vitest src/platform/missingModel/missingModelDownload.test.ts --run`
- `pnpm test:browser:local -- browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm lint`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11646-feat-refresh-missing-model-errors-34e6d73d365081e9afddc5b43fd5de34) by [Unito](https://www.unito.io)
