### PR TITLE
test: add unit tests for mask editor settings panels

### DIFF
--- a/src/components/maskeditor/BrushSettingsPanel.test.ts
+++ b/src/components/maskeditor/BrushSettingsPanel.test.ts
@@ -1,0 +1,230 @@
+/* eslint-disable testing-library/no-container, testing-library/no-node-access -- shape buttons are unlabeled divs and number inputs have no aria labels */
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { reactive } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import BrushSettingsPanel from '@/components/maskeditor/BrushSettingsPanel.vue'
+import { BrushShape } from '@/extensions/core/maskeditor/types'
+
+const initialMock = () => ({
+  brushSettings: reactive({
+    type: BrushShape.Arc,
+    size: 10,
+    opacity: 0.7,
+    hardness: 1,
+    stepSize: 5
+  }),
+  rgbColor: '#FF0000',
+  colorInput: null as HTMLInputElement | null,
+  setBrushSize: vi.fn(),
+  setBrushOpacity: vi.fn(),
+  setBrushHardness: vi.fn(),
+  setBrushStepSize: vi.fn(),
+  resetBrushToDefault: vi.fn()
+})
+
+let mockStore: ReturnType<typeof initialMock>
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: () => mockStore
+}))
+
+vi.mock('@/components/maskeditor/controls/SliderControl.vue', () => ({
+  default: {
+    name: 'SliderControlStub',
+    props: ['label', 'min', 'max', 'step', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: `<button data-slider="true" @click="$emit('update:modelValue', 0.5)">{{ modelValue }}</button>`
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      maskEditor: {
+        brushSettings: 'Brush Settings',
+        brushShape: 'Brush Shape',
+        colorSelector: 'Color Selector',
+        thickness: 'Thickness',
+        opacity: 'Opacity',
+        hardness: 'Hardness',
+        stepSize: 'Step Size',
+        resetToDefault: 'Reset to Default'
+      }
+    }
+  }
+})
+
+const renderPanel = () =>
+  render(BrushSettingsPanel, { global: { plugins: [i18n] } })
+
+const setNumberInput = (input: HTMLInputElement, value: string): void => {
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('BrushSettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStore = initialMock()
+  })
+
+  describe('brush shape buttons', () => {
+    it('should set brushSettings.type to Arc when arc button clicked', async () => {
+      mockStore.brushSettings.type = BrushShape.Rect
+      const { container } = renderPanel()
+      const user = userEvent.setup()
+
+      const arcEl = container.querySelector(
+        '.maskEditor_sidePanelBrushShapeCircle'
+      )
+      await user.click(arcEl as Element)
+
+      expect(mockStore.brushSettings.type).toBe(BrushShape.Arc)
+    })
+
+    it('should set brushSettings.type to Rect when rect button clicked', async () => {
+      const { container } = renderPanel()
+      const user = userEvent.setup()
+
+      const rectEl = container.querySelector(
+        '.maskEditor_sidePanelBrushShapeSquare'
+      )
+      await user.click(rectEl as Element)
+
+      expect(mockStore.brushSettings.type).toBe(BrushShape.Rect)
+    })
+  })
+
+  describe('reset button', () => {
+    it('should call resetBrushToDefault when clicked', async () => {
+      const user = userEvent.setup()
+      renderPanel()
+
+      await user.click(screen.getByRole('button', { name: 'Reset to Default' }))
+
+      expect(mockStore.resetBrushToDefault).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('numeric inputs', () => {
+    it('should call setBrushSize when size number input changes', () => {
+      const { container } = renderPanel()
+      const sizeInput = container.querySelectorAll(
+        'input[type="number"]'
+      )[0] as HTMLInputElement
+
+      setNumberInput(sizeInput, '50')
+
+      expect(mockStore.setBrushSize).toHaveBeenCalledWith(50)
+    })
+
+    it('should call setBrushOpacity when opacity number input changes', () => {
+      const { container } = renderPanel()
+      const opacityInput = container.querySelectorAll(
+        'input[type="number"]'
+      )[1] as HTMLInputElement
+
+      setNumberInput(opacityInput, '0.4')
+
+      expect(mockStore.setBrushOpacity).toHaveBeenCalledWith(0.4)
+    })
+
+    it('should call setBrushHardness when hardness number input changes', () => {
+      const { container } = renderPanel()
+      const hardnessInput = container.querySelectorAll(
+        'input[type="number"]'
+      )[2] as HTMLInputElement
+
+      setNumberInput(hardnessInput, '0.6')
+
+      expect(mockStore.setBrushHardness).toHaveBeenCalledWith(0.6)
+    })
+
+    it('should call setBrushStepSize when step number input changes', () => {
+      const { container } = renderPanel()
+      const stepInput = container.querySelectorAll(
+        'input[type="number"]'
+      )[3] as HTMLInputElement
+
+      setNumberInput(stepInput, '20')
+
+      expect(mockStore.setBrushStepSize).toHaveBeenCalledWith(20)
+    })
+  })
+
+  describe('size slider (logarithmic)', () => {
+    it('should call setBrushSize with Math.round(Math.pow(250, value))', () => {
+      const { container } = renderPanel()
+      const sizeSlider = container.querySelectorAll(
+        '[data-slider="true"]'
+      )[0] as HTMLElement
+
+      sizeSlider.click()
+      // value = 0.5 → Math.round(Math.pow(250, 0.5)) = 16
+      expect(mockStore.setBrushSize).toHaveBeenCalledWith(16)
+    })
+
+    it('should map size 250 to slider value 1', () => {
+      mockStore.brushSettings.size = 250
+      const { container } = renderPanel()
+      const sizeSlider = container.querySelectorAll(
+        '[data-slider="true"]'
+      )[0] as HTMLElement
+
+      // Math.log(250) / Math.log(250) = 1
+      expect(sizeSlider.textContent).toContain('1')
+    })
+
+    it('should return cached raw slider value when size matches the mapping', async () => {
+      mockStore.setBrushSize.mockImplementation((size: number) => {
+        mockStore.brushSettings.size = size
+      })
+      const { container } = renderPanel()
+      const sizeSlider = container.querySelectorAll(
+        '[data-slider="true"]'
+      )[0] as HTMLElement
+
+      // Click sets rawSliderValue=0.5 → setBrushSize(16) → size=16
+      // → next getter run sees cached match → returns 0.5
+      sizeSlider.click()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(sizeSlider.textContent).toContain('0.5')
+    })
+  })
+
+  describe('color input', () => {
+    it('should v-model rgbColor on the color input', () => {
+      const { container } = renderPanel()
+      const colorInput = container.querySelector(
+        'input[type="color"]'
+      ) as HTMLInputElement
+
+      colorInput.value = '#00ff00'
+      colorInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(mockStore.rgbColor).toBe('#00ff00')
+    })
+
+    it('should expose color input ref to the store on mount', () => {
+      const { container } = renderPanel()
+      const colorInput = container.querySelector('input[type="color"]')
+
+      expect(mockStore.colorInput).toBe(colorInput)
+    })
+
+    it('should clear store.colorInput on unmount', () => {
+      const { unmount } = renderPanel()
+      expect(mockStore.colorInput).not.toBeNull()
+
+      unmount()
+
+      expect(mockStore.colorInput).toBeNull()
+    })
+  })
+})

--- a/src/components/maskeditor/ColorSelectSettingsPanel.test.ts
+++ b/src/components/maskeditor/ColorSelectSettingsPanel.test.ts
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import ColorSelectSettingsPanel from '@/components/maskeditor/ColorSelectSettingsPanel.vue'
+import { ColorComparisonMethod } from '@/extensions/core/maskeditor/types'
+
+const mockStore = vi.hoisted(() => ({
+  colorSelectTolerance: 20,
+  selectionOpacity: 100,
+  colorSelectLivePreview: false,
+  applyWholeImage: false,
+  colorComparisonMethod: 'simple' as ColorComparisonMethod,
+  maskBoundary: false,
+  maskTolerance: 0,
+  setColorSelectTolerance: vi.fn(),
+  setSelectionOpacity: vi.fn(),
+  setMaskTolerance: vi.fn()
+}))
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: () => mockStore
+}))
+
+vi.mock('@/components/maskeditor/controls/SliderControl.vue', () => ({
+  default: {
+    name: 'SliderControlStub',
+    props: ['label', 'min', 'max', 'step', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: `<button data-control="slider" :aria-label="label" @click="$emit('update:modelValue', 99)">{{ modelValue }}</button>`
+  }
+}))
+
+vi.mock('@/components/maskeditor/controls/ToggleControl.vue', () => ({
+  default: {
+    name: 'ToggleControlStub',
+    props: ['label', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: `<button data-control="toggle" :aria-label="label" @click="$emit('update:modelValue', !modelValue)">{{ modelValue }}</button>`
+  }
+}))
+
+vi.mock('@/components/maskeditor/controls/DropdownControl.vue', () => ({
+  default: {
+    name: 'DropdownControlStub',
+    props: ['label', 'options', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: `<button data-control="dropdown" :aria-label="label" @click="$emit('update:modelValue', 'lab')">{{ modelValue }}</button>`
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      maskEditor: {
+        colorSelectSettings: 'Color Select Settings',
+        tolerance: 'Tolerance',
+        selectionOpacity: 'Selection Opacity',
+        livePreview: 'Live Preview',
+        applyToWholeImage: 'Apply to Whole Image',
+        method: 'Method',
+        stopAtMask: 'Stop at mask',
+        maskTolerance: 'Mask Tolerance'
+      }
+    }
+  }
+})
+
+const renderPanel = () =>
+  render(ColorSelectSettingsPanel, { global: { plugins: [i18n] } })
+
+describe('ColorSelectSettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStore.colorSelectTolerance = 20
+    mockStore.selectionOpacity = 100
+    mockStore.colorSelectLivePreview = false
+    mockStore.applyWholeImage = false
+    mockStore.colorComparisonMethod = ColorComparisonMethod.Simple
+    mockStore.maskBoundary = false
+    mockStore.maskTolerance = 0
+  })
+
+  it('should call setColorSelectTolerance when tolerance slider emits', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Tolerance' }))
+
+    expect(mockStore.setColorSelectTolerance).toHaveBeenCalledWith(99)
+  })
+
+  it('should call setSelectionOpacity when selection opacity slider emits', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Selection Opacity' }))
+
+    expect(mockStore.setSelectionOpacity).toHaveBeenCalledWith(99)
+  })
+
+  it('should toggle colorSelectLivePreview when live preview toggle emits', async () => {
+    const user = userEvent.setup()
+    mockStore.colorSelectLivePreview = false
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Live Preview' }))
+
+    expect(mockStore.colorSelectLivePreview).toBe(true)
+  })
+
+  it('should toggle applyWholeImage when whole-image toggle emits', async () => {
+    const user = userEvent.setup()
+    mockStore.applyWholeImage = false
+    renderPanel()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Apply to Whole Image' })
+    )
+
+    expect(mockStore.applyWholeImage).toBe(true)
+  })
+
+  it('should set comparison method when dropdown emits', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Method' }))
+
+    expect(mockStore.colorComparisonMethod).toBe(ColorComparisonMethod.LAB)
+  })
+
+  it('should toggle maskBoundary when stop-at-mask toggle emits', async () => {
+    const user = userEvent.setup()
+    mockStore.maskBoundary = false
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Stop at mask' }))
+
+    expect(mockStore.maskBoundary).toBe(true)
+  })
+
+  it('should call setMaskTolerance when mask tolerance slider emits', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Mask Tolerance' }))
+
+    expect(mockStore.setMaskTolerance).toHaveBeenCalledWith(99)
+  })
+
+  it('should reflect store values on the controls', () => {
+    mockStore.colorSelectTolerance = 77
+    mockStore.colorComparisonMethod = ColorComparisonMethod.HSL
+
+    renderPanel()
+
+    expect(
+      screen.getByRole('button', { name: 'Tolerance' }).textContent
+    ).toContain('77')
+    expect(
+      screen.getByRole('button', { name: 'Method' }).textContent
+    ).toContain('hsl')
+  })
+})

--- a/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
+++ b/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
@@ -1,0 +1,281 @@
+/* eslint-disable testing-library/no-container, testing-library/no-node-access -- layer rows have unlabeled checkboxes and the blend-mode select has no role-friendly label */
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { reactive } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { useToolManager } from '@/composables/maskeditor/useToolManager'
+import ImageLayerSettingsPanel from '@/components/maskeditor/ImageLayerSettingsPanel.vue'
+import { MaskBlendMode, Tools } from '@/extensions/core/maskeditor/types'
+
+type ToolManager = ReturnType<typeof useToolManager>
+
+const initialMock = () =>
+  reactive({
+    maskOpacity: 0.8,
+    maskBlendMode: MaskBlendMode.Black,
+    activeLayer: 'mask' as 'mask' | 'rgb',
+    currentTool: Tools.MaskPen,
+    image: { src: 'https://example.com/base.png' } as { src: string } | null,
+    maskCanvas: null as HTMLCanvasElement | null,
+    rgbCanvas: null as HTMLCanvasElement | null,
+    imgCanvas: null as HTMLCanvasElement | null,
+    setMaskOpacity: vi.fn()
+  })
+
+let mockStore: ReturnType<typeof initialMock>
+const mockUpdateMaskColor = vi.fn().mockResolvedValue(undefined)
+const mockSetActiveLayer = vi.fn()
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: () => mockStore
+}))
+
+vi.mock('@/composables/maskeditor/useCanvasManager', () => ({
+  useCanvasManager: () => ({ updateMaskColor: mockUpdateMaskColor })
+}))
+
+vi.mock('@/components/maskeditor/controls/SliderControl.vue', () => ({
+  default: {
+    name: 'SliderControlStub',
+    props: ['label', 'min', 'max', 'step', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: `<button data-slider="true" @click="$emit('update:modelValue', 0.3)">{{ modelValue }}</button>`
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      maskEditor: {
+        layers: 'Layers',
+        maskOpacity: 'Mask Opacity',
+        maskBlendingOptions: 'Mask Blending Options',
+        black: 'Black',
+        white: 'White',
+        negative: 'Negative',
+        maskLayer: 'Mask Layer',
+        paintLayer: 'Paint Layer',
+        baseImageLayer: 'Base Image Layer',
+        activateLayer: 'Activate Layer',
+        baseLayerPreview: 'Base layer preview'
+      }
+    }
+  }
+})
+
+const renderPanel = (props?: Record<string, unknown>) =>
+  render(ImageLayerSettingsPanel, {
+    global: { plugins: [i18n] },
+    props
+  })
+
+const makeCanvas = (): HTMLCanvasElement => document.createElement('canvas')
+
+describe('ImageLayerSettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStore = initialMock()
+  })
+
+  describe('mask opacity slider', () => {
+    it('should call setMaskOpacity and update mask canvas opacity', async () => {
+      const user = userEvent.setup()
+      const canvas = makeCanvas()
+      mockStore.maskCanvas = canvas
+      const { container } = renderPanel()
+
+      await user.click(
+        container.querySelector('[data-slider="true"]') as HTMLElement
+      )
+
+      expect(mockStore.setMaskOpacity).toHaveBeenCalledWith(0.3)
+      expect(canvas.style.opacity).toBe('0.3')
+    })
+
+    it('should leave canvas alone when no maskCanvas is set', async () => {
+      const user = userEvent.setup()
+      const { container } = renderPanel()
+
+      await expect(
+        user.click(
+          container.querySelector('[data-slider="true"]') as HTMLElement
+        )
+      ).resolves.not.toThrow()
+
+      expect(mockStore.setMaskOpacity).toHaveBeenCalledWith(0.3)
+    })
+  })
+
+  describe('blend mode select', () => {
+    it.each([
+      ['black', MaskBlendMode.Black],
+      ['white', MaskBlendMode.White],
+      ['negative', MaskBlendMode.Negative],
+      ['unknown-fallback', MaskBlendMode.Black]
+    ] as const)('should map %s to MaskBlendMode.%s', async (raw, expected) => {
+      const { container } = renderPanel()
+      const select = container.querySelector('select') as HTMLSelectElement
+
+      Object.defineProperty(select, 'value', {
+        value: raw,
+        configurable: true
+      })
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(mockStore.maskBlendMode).toBe(expected)
+      expect(mockUpdateMaskColor).toHaveBeenCalled()
+    })
+  })
+
+  describe('layer visibility checkboxes', () => {
+    it('should toggle mask canvas opacity to maskOpacity when checked, 0 when unchecked', async () => {
+      const user = userEvent.setup()
+      const canvas = makeCanvas()
+      mockStore.maskCanvas = canvas
+      mockStore.maskOpacity = 0.5
+
+      const { container } = renderPanel()
+      const checkbox = container.querySelectorAll(
+        'input[type="checkbox"]'
+      )[0] as HTMLInputElement
+
+      await user.click(checkbox)
+      expect(canvas.style.opacity).toBe('0')
+
+      await user.click(checkbox)
+      expect(canvas.style.opacity).toBe('0.5')
+    })
+
+    it('should toggle paint (rgb) canvas opacity between 0 and 1', async () => {
+      const user = userEvent.setup()
+      const canvas = makeCanvas()
+      mockStore.rgbCanvas = canvas
+
+      const { container } = renderPanel()
+      const checkbox = container.querySelectorAll(
+        'input[type="checkbox"]'
+      )[1] as HTMLInputElement
+
+      await user.click(checkbox)
+      expect(canvas.style.opacity).toBe('0')
+
+      await user.click(checkbox)
+      expect(canvas.style.opacity).toBe('1')
+    })
+
+    it('should toggle base image canvas opacity between 0 and 1', async () => {
+      const user = userEvent.setup()
+      const canvas = makeCanvas()
+      mockStore.imgCanvas = canvas
+
+      const { container } = renderPanel()
+      const checkbox = container.querySelectorAll(
+        'input[type="checkbox"]'
+      )[2] as HTMLInputElement
+
+      await user.click(checkbox)
+      expect(canvas.style.opacity).toBe('0')
+    })
+
+    it('should not throw when toggling visibility for missing canvases', async () => {
+      const user = userEvent.setup()
+      const { container } = renderPanel()
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]')
+
+      for (const cb of checkboxes) {
+        await expect(user.click(cb as HTMLInputElement)).resolves.not.toThrow()
+      }
+    })
+  })
+
+  describe('activate layer buttons', () => {
+    it('should forward the layer to toolManager.setActiveLayer when clicked', async () => {
+      const user = userEvent.setup()
+      mockStore.activeLayer = 'rgb'
+
+      renderPanel({
+        toolManager: {
+          setActiveLayer: mockSetActiveLayer
+        } as unknown as ToolManager
+      })
+
+      const [maskBtn] = screen.getAllByRole('button', {
+        name: 'Activate Layer'
+      })
+      await user.click(maskBtn)
+
+      expect(mockSetActiveLayer).toHaveBeenCalledWith('mask')
+    })
+
+    it('should not throw when toolManager prop is omitted', async () => {
+      const user = userEvent.setup()
+      mockStore.activeLayer = 'rgb'
+
+      renderPanel()
+      const [maskBtn] = screen.getAllByRole('button', {
+        name: 'Activate Layer'
+      })
+
+      await expect(user.click(maskBtn)).resolves.not.toThrow()
+    })
+
+    it('should mark the active-layer button disabled', () => {
+      mockStore.activeLayer = 'mask'
+
+      renderPanel()
+      const [maskBtn] = screen.getAllByRole('button', {
+        name: 'Activate Layer'
+      })
+
+      expect(maskBtn.hasAttribute('disabled')).toBe(true)
+    })
+  })
+
+  describe('paint layer activate visibility', () => {
+    const styleOf = (el: Element): string => el.getAttribute('style') ?? ''
+
+    it('should hide paint activate button when current tool is not Eraser', () => {
+      mockStore.currentTool = Tools.MaskPen
+      const { container } = renderPanel()
+      const buttons = Array.from(container.querySelectorAll('button'))
+      const paintBtn = buttons.find((b) => styleOf(b).includes('display:'))
+
+      expect(paintBtn).toBeDefined()
+      expect(styleOf(paintBtn as Element)).toContain('display: none')
+    })
+
+    it('should show paint activate button when current tool is Eraser', () => {
+      mockStore.currentTool = Tools.Eraser
+      const { container } = renderPanel()
+      const buttons = Array.from(container.querySelectorAll('button'))
+      const paintBtn = buttons.find((b) => styleOf(b).includes('display:'))
+
+      expect(paintBtn).toBeDefined()
+      expect(styleOf(paintBtn as Element)).toContain('display: block')
+    })
+  })
+
+  describe('base image preview', () => {
+    it('should render base image src from store', () => {
+      mockStore.image = { src: 'https://example.com/img.png' }
+      renderPanel()
+      const img = screen.getByAltText('Base layer preview')
+
+      expect((img as HTMLImageElement).src).toBe('https://example.com/img.png')
+    })
+
+    it('should render empty src when no image', () => {
+      mockStore.image = null
+      renderPanel()
+      const img = screen.getByAltText('Base layer preview')
+
+      expect(img.getAttribute('src')).toBe('')
+    })
+  })
+})

--- a/src/components/maskeditor/PaintBucketSettingsPanel.test.ts
+++ b/src/components/maskeditor/PaintBucketSettingsPanel.test.ts
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import PaintBucketSettingsPanel from '@/components/maskeditor/PaintBucketSettingsPanel.vue'
+
+const mockStore = vi.hoisted(() => ({
+  paintBucketTolerance: 5,
+  fillOpacity: 100,
+  setPaintBucketTolerance: vi.fn(),
+  setFillOpacity: vi.fn()
+}))
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: () => mockStore
+}))
+
+vi.mock('@/components/maskeditor/controls/SliderControl.vue', () => ({
+  default: {
+    name: 'SliderControlStub',
+    props: ['label', 'min', 'max', 'step', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: `<button :aria-label="label" @click="$emit('update:modelValue', 42)">{{ modelValue }}</button>`
+  }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      maskEditor: {
+        paintBucketSettings: 'Paint Bucket Settings',
+        tolerance: 'Tolerance',
+        fillOpacity: 'Fill Opacity'
+      }
+    }
+  }
+})
+
+const renderPanel = () =>
+  render(PaintBucketSettingsPanel, { global: { plugins: [i18n] } })
+
+describe('PaintBucketSettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStore.paintBucketTolerance = 5
+    mockStore.fillOpacity = 100
+  })
+
+  it('should bind tolerance slider to store value', () => {
+    mockStore.paintBucketTolerance = 87
+    renderPanel()
+
+    expect(
+      screen.getByRole('button', { name: 'Tolerance' }).textContent
+    ).toContain('87')
+  })
+
+  it('should bind fill opacity slider to store value', () => {
+    mockStore.fillOpacity = 33
+    renderPanel()
+
+    expect(
+      screen.getByRole('button', { name: 'Fill Opacity' }).textContent
+    ).toContain('33')
+  })
+
+  it('should call setPaintBucketTolerance when tolerance slider emits', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Tolerance' }))
+
+    expect(mockStore.setPaintBucketTolerance).toHaveBeenCalledWith(42)
+  })
+
+  it('should call setFillOpacity when fill opacity slider emits', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Fill Opacity' }))
+
+    expect(mockStore.setFillOpacity).toHaveBeenCalledWith(42)
+  })
+})

--- a/src/components/maskeditor/SettingsPanelContainer.test.ts
+++ b/src/components/maskeditor/SettingsPanelContainer.test.ts
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SettingsPanelContainer from '@/components/maskeditor/SettingsPanelContainer.vue'
+import { Tools } from '@/extensions/core/maskeditor/types'
+
+const mockStore = vi.hoisted(() => ({
+  currentTool: 'pen' as Tools
+}))
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: () => mockStore
+}))
+
+vi.mock('@/components/maskeditor/BrushSettingsPanel.vue', () => ({
+  default: {
+    name: 'BrushSettingsPanelStub',
+    template: '<div>brush-panel</div>'
+  }
+}))
+
+vi.mock('@/components/maskeditor/ColorSelectSettingsPanel.vue', () => ({
+  default: {
+    name: 'ColorSelectSettingsPanelStub',
+    template: '<div>color-panel</div>'
+  }
+}))
+
+vi.mock('@/components/maskeditor/PaintBucketSettingsPanel.vue', () => ({
+  default: {
+    name: 'PaintBucketSettingsPanelStub',
+    template: '<div>bucket-panel</div>'
+  }
+}))
+
+describe('SettingsPanelContainer', () => {
+  beforeEach(() => {
+    mockStore.currentTool = Tools.MaskPen
+  })
+
+  it('should render PaintBucketSettingsPanel when current tool is MaskBucket', () => {
+    mockStore.currentTool = Tools.MaskBucket
+    const { container } = render(SettingsPanelContainer)
+    expect(container.textContent).toContain('bucket-panel')
+  })
+
+  it('should render ColorSelectSettingsPanel when current tool is MaskColorFill', () => {
+    mockStore.currentTool = Tools.MaskColorFill
+    const { container } = render(SettingsPanelContainer)
+    expect(container.textContent).toContain('color-panel')
+  })
+
+  it('should render BrushSettingsPanel for any other tool', () => {
+    mockStore.currentTool = Tools.MaskPen
+    const { container } = render(SettingsPanelContainer)
+    expect(container.textContent).toContain('brush-panel')
+  })
+
+  it('should render BrushSettingsPanel for Eraser', () => {
+    mockStore.currentTool = Tools.Eraser
+    const { container } = render(SettingsPanelContainer)
+    expect(container.textContent).toContain('brush-panel')
+  })
+
+  it('should render BrushSettingsPanel for PaintPen', () => {
+    mockStore.currentTool = Tools.PaintPen
+    const { container } = render(SettingsPanelContainer)
+    expect(container.textContent).toContain('brush-panel')
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for the five mask editor settings panel components, raising each from 0–35% to ~98–100% across coverage dimensions.

## Changes

- **What**: Add 5 sibling test files under `src/components/maskeditor/` (47 tests total):
  - `PaintBucketSettingsPanel.test.ts` (4): both sliders bind to / write through to `setPaintBucketTolerance` / `setFillOpacity`. **100%**.
  - `ColorSelectSettingsPanel.test.ts` (8): all 7 controls (4 sliders, 2 toggles, 1 dropdown) bind to and write through to the right store fields/setters; method dropdown casts to `ColorComparisonMethod`. **100%**.
  - `BrushSettingsPanel.test.ts` (13): shape buttons (Arc/Rect), reset to default, four numeric inputs (size/opacity/hardness/step), logarithmic size slider including the cached-raw-value path (`Math.round(Math.pow(250, x))`), color input v-model, color input ref forwarded to / cleared from store on mount/unmount.
  - `ImageLayerSettingsPanel.test.ts` (17): mask opacity slider + canvas style sync, blend-mode select with all 3 enum values + default fallback, three layer-visibility checkboxes (with and without canvas refs), activate-layer button forwarding to `toolManager.setActiveLayer`, disabled-when-active and "show paint button only when Eraser" branches, base image preview src binding.
  - `SettingsPanelContainer.test.ts` (5): tool → component routing (`MaskBucket` → bucket panel, `MaskColorFill` → color panel, anything else → brush panel).

## Review Focus

- Stack matches sibling control tests (`@testing-library/vue` + `userEvent` + stub child controls). Each panel's child `SliderControl` / `ToggleControl` / `DropdownControl` is replaced by a minimal `<button>` stub that emits `update:modelValue` on click, so panel logic is decoupled from control internals (already covered by their own tests).
- Two panels (`Brush`, `ImageLayer`) need real reactivity (`brushSettings.size` changes through a setter must propagate to the slider's modelValue computed; `currentTool` / `activeLayer` mutations between tests). They use `reactive()` from Vue at top level + a `let mockStore` reset in `beforeEach`. Plain object mocks would either silently no-op or leak state between tests.
- The two reactive panels enable file-level `eslint-disable testing-library/no-container, testing-library/no-node-access` because the unlabeled DOM (shape divs, unlabeled `<input type="number">`/`<input type="color">`/`<input type="checkbox">`/`<select>`) genuinely can't be queried via `screen.getByRole/Label`. Each disable has a comment explaining why.
- `BrushSettingsPanel` has a non-trivial cached-value branch in `brushSizeSliderValue` computed: when `rawSliderValue` and `brushSize` are in sync, the getter returns the raw float instead of recomputing `log(size)/log(250)`. Test stubs `setBrushSize` to actually write back so the next read takes the cached path.
- `ImageLayerSettingsPanel` has a `display: 'block' | 'none'` style binding. happy-dom doesn't populate `el.style.display` from inline style strings reliably, so the test asserts via `el.getAttribute('style')` instead.
- `SettingsPanelContainer` uses inline component stubs that render unique text — assertion is just `textContent.toContain('brush-panel')` etc. No need for component-instance probing.
- Style aligned with sibling tests: `should ...` naming, `describe` grouped by feature (button group, slider, etc.), `vi.hoisted` for mock state where reactivity isn't required.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11647-test-add-unit-tests-for-mask-editor-settings-panels-34e6d73d36508117911bc0850ce085e1) by [Unito](https://www.unito.io)
