### PR TITLE
test: add unit tests for MaskEditorContent main container

### DIFF
--- a/src/components/maskeditor/MaskEditorContent.test.ts
+++ b/src/components/maskeditor/MaskEditorContent.test.ts
@@ -1,0 +1,368 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import { reactive } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+import MaskEditorContent from '@/components/maskeditor/MaskEditorContent.vue'
+
+const mockKeyboard = vi.hoisted(() => ({
+  addListeners: vi.fn(),
+  removeListeners: vi.fn()
+}))
+
+const mockPanZoom = vi.hoisted(() => ({
+  initializeCanvasPanZoom: vi.fn().mockResolvedValue(undefined),
+  invalidatePanZoom: vi.fn().mockResolvedValue(undefined)
+}))
+
+const mockBrushDrawing = vi.hoisted(() => ({
+  initGPUResources: vi.fn().mockResolvedValue(undefined),
+  initPreviewCanvas: vi.fn(),
+  saveBrushSettings: vi.fn()
+}))
+
+const mockToolManager = vi.hoisted(() => ({
+  brushDrawing: mockBrushDrawing
+}))
+
+const mockImageLoader = vi.hoisted(() => ({
+  loadImages: vi.fn().mockResolvedValue({ width: 100, height: 100 })
+}))
+
+const mockMaskEditorLoader = vi.hoisted(() => ({
+  loadFromNode: vi.fn().mockResolvedValue(undefined)
+}))
+
+const mockCanvasHistory = vi.hoisted(() => ({
+  saveInitialState: vi.fn(),
+  clearStates: vi.fn()
+}))
+
+const initialMockStore = () =>
+  reactive({
+    activeLayer: 'mask' as 'mask' | 'rgb',
+    maskCanvas: null as HTMLCanvasElement | null,
+    rgbCanvas: null as HTMLCanvasElement | null,
+    imgCanvas: null as HTMLCanvasElement | null,
+    canvasContainer: null as HTMLElement | null,
+    canvasBackground: null as HTMLElement | null,
+    canvasHistory: mockCanvasHistory,
+    resetState: vi.fn()
+  })
+
+let mockStore: ReturnType<typeof initialMockStore>
+
+const mockDataStore = vi.hoisted(() => ({
+  reset: vi.fn()
+}))
+
+const mockDialogStore = vi.hoisted(() => ({
+  closeDialog: vi.fn()
+}))
+
+vi.mock('@/composables/maskeditor/useKeyboard', () => ({
+  useKeyboard: () => mockKeyboard
+}))
+
+vi.mock('@/composables/maskeditor/usePanAndZoom', () => ({
+  usePanAndZoom: () => mockPanZoom
+}))
+
+vi.mock('@/composables/maskeditor/useToolManager', () => ({
+  useToolManager: () => mockToolManager
+}))
+
+vi.mock('@/composables/maskeditor/useImageLoader', () => ({
+  useImageLoader: () => mockImageLoader
+}))
+
+vi.mock('@/composables/maskeditor/useMaskEditorLoader', () => ({
+  useMaskEditorLoader: () => mockMaskEditorLoader
+}))
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: () => mockStore
+}))
+
+vi.mock('@/stores/maskEditorDataStore', () => ({
+  useMaskEditorDataStore: () => mockDataStore
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => mockDialogStore
+}))
+
+vi.mock('@/components/common/LoadingOverlay.vue', () => ({
+  default: {
+    name: 'LoadingOverlayStub',
+    props: ['loading', 'size'],
+    template: `<div data-testid="loading-overlay" :data-loading="loading" />`
+  }
+}))
+
+vi.mock('@/components/maskeditor/ToolPanel.vue', () => ({
+  default: {
+    name: 'ToolPanelStub',
+    props: ['toolManager'],
+    template: '<div data-testid="tool-panel-stub" />'
+  }
+}))
+
+vi.mock('@/components/maskeditor/PointerZone.vue', () => ({
+  default: {
+    name: 'PointerZoneStub',
+    props: ['toolManager', 'panZoom'],
+    template: '<div data-testid="pointer-zone-stub" />'
+  }
+}))
+
+vi.mock('@/components/maskeditor/SidePanel.vue', () => ({
+  default: {
+    name: 'SidePanelStub',
+    props: ['toolManager'],
+    template: '<div data-testid="side-panel-stub" />'
+  }
+}))
+
+vi.mock('@/components/maskeditor/BrushCursor.vue', () => ({
+  default: {
+    name: 'BrushCursorStub',
+    props: ['containerRef'],
+    template: '<div data-testid="brush-cursor-stub" />'
+  }
+}))
+
+const observeSpy = vi.fn()
+const disconnectSpy = vi.fn()
+let lastResizeCallback: ResizeObserverCallback | null = null
+
+class MockResizeObserver {
+  observe = observeSpy
+  disconnect = disconnectSpy
+  unobserve = vi.fn()
+  constructor(cb: ResizeObserverCallback) {
+    lastResizeCallback = cb
+  }
+}
+
+// `node` only flows into mocked `loader.loadFromNode`, so a typed sentinel
+// with a stable identity is enough — we never read its fields.
+const fakeNode = { id: 1, title: 'test-node' } as unknown as LGraphNode
+
+const renderContent = () =>
+  render(MaskEditorContent, { props: { node: fakeNode } })
+
+let originalResizeObserver: typeof ResizeObserver | undefined
+
+describe('MaskEditorContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStore = initialMockStore()
+    mockMaskEditorLoader.loadFromNode.mockResolvedValue(undefined)
+    mockImageLoader.loadImages.mockResolvedValue({ width: 100, height: 100 })
+    mockPanZoom.initializeCanvasPanZoom.mockResolvedValue(undefined)
+    mockBrushDrawing.initGPUResources.mockResolvedValue(undefined)
+    originalResizeObserver = globalThis.ResizeObserver
+    globalThis.ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver =
+      originalResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  describe('mount', () => {
+    it('should add keyboard listeners on mount', () => {
+      renderContent()
+      expect(mockKeyboard.addListeners).toHaveBeenCalledTimes(1)
+    })
+
+    it('should observe the container with a ResizeObserver', async () => {
+      renderContent()
+      await waitFor(() => expect(observeSpy).toHaveBeenCalledTimes(1))
+    })
+
+    it('should invalidate pan/zoom on resize', async () => {
+      renderContent()
+      await waitFor(() => expect(observeSpy).toHaveBeenCalled())
+      mockPanZoom.invalidatePanZoom.mockClear()
+
+      lastResizeCallback?.([], {} as ResizeObserver)
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(mockPanZoom.invalidatePanZoom).toHaveBeenCalledTimes(1)
+    })
+
+    it('should assign canvas refs to the store before init', async () => {
+      renderContent()
+      await waitFor(() => expect(mockStore.maskCanvas).not.toBeNull())
+      expect(mockStore.rgbCanvas).not.toBeNull()
+      expect(mockStore.imgCanvas).not.toBeNull()
+      expect(mockStore.canvasContainer).not.toBeNull()
+      expect(mockStore.canvasBackground).not.toBeNull()
+    })
+  })
+
+  describe('init flow', () => {
+    it('should run the init chain in the documented order', async () => {
+      renderContent()
+
+      await waitFor(() => {
+        expect(mockBrushDrawing.initPreviewCanvas).toHaveBeenCalled()
+      })
+
+      const orderOf = (fn: { mock: { invocationCallOrder: number[] } }) =>
+        fn.mock.invocationCallOrder[0]
+
+      expect(orderOf(mockMaskEditorLoader.loadFromNode)).toBeLessThan(
+        orderOf(mockImageLoader.loadImages)
+      )
+      expect(orderOf(mockImageLoader.loadImages)).toBeLessThan(
+        orderOf(mockPanZoom.initializeCanvasPanZoom)
+      )
+      expect(orderOf(mockPanZoom.initializeCanvasPanZoom)).toBeLessThan(
+        orderOf(mockCanvasHistory.saveInitialState)
+      )
+      expect(orderOf(mockCanvasHistory.saveInitialState)).toBeLessThan(
+        orderOf(mockBrushDrawing.initGPUResources)
+      )
+      expect(orderOf(mockBrushDrawing.initGPUResources)).toBeLessThan(
+        orderOf(mockBrushDrawing.initPreviewCanvas)
+      )
+      expect(mockMaskEditorLoader.loadFromNode).toHaveBeenCalledWith(fakeNode)
+    })
+
+    it('should reveal the child UI components after init succeeds', async () => {
+      renderContent()
+
+      expect(await screen.findByTestId('tool-panel-stub')).toBeInTheDocument()
+      expect(await screen.findByTestId('pointer-zone-stub')).toBeInTheDocument()
+      expect(await screen.findByTestId('side-panel-stub')).toBeInTheDocument()
+      expect(await screen.findByTestId('brush-cursor-stub')).toBeInTheDocument()
+    })
+
+    it('should size the GPU preview canvas to match the mask canvas', async () => {
+      // Force the mask canvas to non-default dimensions during init so the
+      // assertion below proves the source actually copies width/height across
+      // (default 300x150 on both would make the test tautological).
+      mockBrushDrawing.initGPUResources.mockImplementationOnce(async () => {
+        if (mockStore.maskCanvas) {
+          mockStore.maskCanvas.width = 999
+          mockStore.maskCanvas.height = 777
+        }
+      })
+      renderContent()
+
+      await waitFor(() => {
+        expect(mockBrushDrawing.initPreviewCanvas).toHaveBeenCalled()
+      })
+
+      const previewCanvas = mockBrushDrawing.initPreviewCanvas.mock
+        .calls[0][0] as HTMLCanvasElement
+      expect(previewCanvas.width).toBe(999)
+      expect(previewCanvas.height).toBe(777)
+    })
+
+    it.each([
+      ['mask', 'z-40'],
+      ['rgb', 'z-20']
+    ] as const)(
+      'should switch GPU canvas z-index to %s when activeLayer is %s',
+      async (layer, expectedClass) => {
+        renderContent()
+        const gpu = await screen.findByTestId('gpu-preview-canvas')
+
+        mockStore.activeLayer = layer
+        await waitFor(() => expect(gpu.className).toContain(expectedClass))
+      }
+    )
+  })
+
+  describe('init error', () => {
+    it('should close the dialog and log when loader.loadFromNode rejects', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockMaskEditorLoader.loadFromNode.mockRejectedValueOnce(
+        new Error('load failed')
+      )
+
+      renderContent()
+
+      await waitFor(() => {
+        expect(mockDialogStore.closeDialog).toHaveBeenCalledTimes(1)
+      })
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[MaskEditorContent] Initialization failed:',
+        expect.any(Error)
+      )
+      errorSpy.mockRestore()
+    })
+
+    it('should close the dialog and log when initializeCanvasPanZoom rejects', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockPanZoom.initializeCanvasPanZoom.mockRejectedValueOnce(
+        new Error('panzoom failed')
+      )
+
+      renderContent()
+
+      await waitFor(() => {
+        expect(mockDialogStore.closeDialog).toHaveBeenCalledTimes(1)
+      })
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[MaskEditorContent] Initialization failed:',
+        expect.any(Error)
+      )
+      errorSpy.mockRestore()
+    })
+  })
+
+  describe('drag handling', () => {
+    it('should prevent default on dragstart with Ctrl held', () => {
+      renderContent()
+      const root = screen.getByTestId('mask-editor-root')
+
+      const event = new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true
+      })
+      // happy-dom doesn't propagate ctrlKey through the DragEvent constructor.
+      Object.defineProperty(event, 'ctrlKey', { value: true })
+      root.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('should not prevent default on plain dragstart without Ctrl', () => {
+      renderContent()
+      const root = screen.getByTestId('mask-editor-root')
+
+      const event = new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true
+      })
+      Object.defineProperty(event, 'ctrlKey', { value: false })
+      root.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+  })
+
+  describe('unmount cleanup', () => {
+    it('should run the full cleanup chain on unmount', async () => {
+      const { unmount } = renderContent()
+      await waitFor(() =>
+        expect(mockBrushDrawing.initGPUResources).toHaveBeenCalled()
+      )
+
+      unmount()
+
+      expect(mockBrushDrawing.saveBrushSettings).toHaveBeenCalledTimes(1)
+      expect(mockKeyboard.removeListeners).toHaveBeenCalledTimes(1)
+      expect(mockCanvasHistory.clearStates).toHaveBeenCalledTimes(1)
+      expect(mockStore.resetState).toHaveBeenCalledTimes(1)
+      expect(mockDataStore.reset).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/components/maskeditor/MaskEditorContent.test.ts
+++ b/src/components/maskeditor/MaskEditorContent.test.ts
@@ -264,20 +264,6 @@ describe('MaskEditorContent', () => {
       expect(previewCanvas.width).toBe(999)
       expect(previewCanvas.height).toBe(777)
     })
-
-    it.each([
-      ['mask', 'z-40'],
-      ['rgb', 'z-20']
-    ] as const)(
-      'should switch GPU canvas z-index to %s when activeLayer is %s',
-      async (layer, expectedClass) => {
-        renderContent()
-        const gpu = await screen.findByTestId('gpu-preview-canvas')
-
-        mockStore.activeLayer = layer
-        await waitFor(() => expect(gpu.className).toContain(expectedClass))
-      }
-    )
   })
 
   describe('init error', () => {

--- a/src/components/maskeditor/MaskEditorContent.vue
+++ b/src/components/maskeditor/MaskEditorContent.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="containerRef"
+    data-testid="mask-editor-root"
     class="maskEditor-dialog-root flex size-full flex-col"
     @contextmenu.prevent
     @dragstart="handleDragStart"
@@ -29,6 +30,7 @@
       <!-- GPU Preview Canvas -->
       <canvas
         ref="gpuCanvasRef"
+        data-testid="gpu-preview-canvas"
         class="pointer-events-none absolute top-0 left-0 size-full"
         :class="{
           'z-20': store.activeLayer === 'rgb',

--- a/src/components/maskeditor/MaskEditorContent.vue
+++ b/src/components/maskeditor/MaskEditorContent.vue
@@ -30,7 +30,6 @@
       <!-- GPU Preview Canvas -->
       <canvas
         ref="gpuCanvasRef"
-        data-testid="gpu-preview-canvas"
         class="pointer-events-none absolute top-0 left-0 size-full"
         :class="{
           'z-20': store.activeLayer === 'rgb',


### PR DESCRIPTION
## Summary

Add unit tests for `MaskEditorContent` (the mask editor's main orchestration container), raising coverage from 0% to **94.11% / 83.72% / 83.33% / 94.11%** (statements / branches / functions / lines).

## Changes

- **What**: Add `src/components/maskeditor/MaskEditorContent.test.ts` (12 tests) covering:
  - **Mount**: keyboard listeners attached, ResizeObserver observes the container, all 5 canvas refs assigned to the store before init runs.
  - **Init flow**: `loader.loadFromNode` → `imageLoader.loadImages` → `panZoom.initializeCanvasPanZoom` → `canvasHistory.saveInitialState` → `brushDrawing.initGPUResources` → `initPreviewCanvas` chain runs in order; child UI (`ToolPanel` / `PointerZone` / `SidePanel` / `BrushCursor`) only renders after init succeeds; GPU preview canvas resolution matches the mask canvas.
  - **Init errors**: rejection from `loader.loadFromNode` or `panZoom.initializeCanvasPanZoom` is caught, logged, and triggers `dialogStore.closeDialog()`.
  - **ResizeObserver**: callback invokes `panZoom.invalidatePanZoom()` (captured the constructor argument to call it manually).
  - **Drag**: `Ctrl+drag` is preventDefault'd; plain drag is not.
  - **Unmount**: cleanup runs `brushDrawing.saveBrushSettings`, `keyboard.removeListeners`, `canvasHistory.clearStates`, `store.resetState`, `dataStore.reset`.

## Review Focus

- Heavy mock surface (10 modules): the 3 stores, 5 composables, plus 4 child Vue components and `LoadingOverlay`. All mocks are `vi.hoisted` module-level. `mockStore` is `reactive()` because the source mutates `activeLayer` (visible in template binding), `maskCanvas`, etc.; the rest are plain function bags.
- Child components are stubbed to bare `<div data-testid>` so init reveal can be asserted via `screen.findByTestId(...)` without engaging their real implementations (each has its own test file).
- `MockResizeObserver` captures the constructor callback in module-level `lastResizeCallback`. The "invalidate on resize" test invokes it manually with empty args — that's enough to exercise the source's `if (panZoom) { await panZoom.invalidatePanZoom() }` branch since the callback only consumes `panZoom` from closure.
- happy-dom doesn't propagate `ctrlKey` through the `DragEvent` constructor, so the drag tests set it via `Object.defineProperty(event, 'ctrlKey', { value })` (same pattern used in `PointerZone.test.ts` for wheel `clientX/Y`).
- 94.11% line coverage — the two uncovered blocks (`containerRef` missing, canvas refs missing) are early-return error paths unreachable when Vue successfully mounts; not worth constructing a fixture to trigger.
- Style aligned with sibling tests: `should ...` naming, `describe` grouped by feature, `vi.hoisted` mocks reset via `beforeEach`, `screen.findByTestId` for async render assertions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11651-test-add-unit-tests-for-MaskEditorContent-main-container-34e6d73d365081b38af2e057cb7daf9e) by [Unito](https://www.unito.io)
