### PR TITLE
fix(11615): LGraphCanvas.maximumFps getter returns FPS not frame-gap

### DIFF
--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -466,7 +466,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
   /** Maximum frames per second to render. 0: unlimited. Default: 0 */
   public get maximumFps() {
     return this._maximumFrameGap > Number.EPSILON
-      ? this._maximumFrameGap / 1000
+      ? 1000 / this._maximumFrameGap
       : 0
   }
 


### PR DESCRIPTION
## Summary

The `maximumFps` getter was returning frame-gap (in seconds) instead of FPS. The setter correctly computes frameGap = 1000 / fps, but the getter was doing frameGap / 1000 instead of the inverse (1000 / frameGap).

## Changes

- Fixed getter to return `1000 / this._maximumFrameGap` instead of `this._maximumFrameGap / 1000`

## Testing

- Typecheck: ✓
- Lint: ✓
- Format: ✓

Fixes #11615