### PR TITLE
chore: add 301 redirects for old Framer case study URLs

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',
   prefetch: { prefetchAll: true },
+  redirects: {
+    '/cloud/enterprise-case-studies/comfyui-at-architectural-scale-how-moment-factory-reimagined-3d-projection-mapping':
+      '/customers/moment-factory/',
+    '/cloud/enterprise-case-studies/how-series-entertainment-rebuilt-game-and-video-production-with-comfyui':
+      '/customers/series-entertainment/'
+  },
   build: {
     assets: '_website'
   },


### PR DESCRIPTION
## Summary

Add 301 redirects for old Framer case study URLs to new `/customers/` pages.

## Changes

- Add `redirects` config to `apps/website/astro.config.ts` mapping two old Framer enterprise case study URLs to their new Astro customer pages

## Testing

### Automated

- Website build succeeds with redirect pages generated
- Lint, typecheck, and format checks pass

### E2E Verification Steps

1. Deploy to preview
2. Visit `/cloud/enterprise-case-studies/comfyui-at-architectural-scale-how-moment-factory-reimagined-3d-projection-mapping` — should 301 redirect to `/customers/moment-factory/`
3. Visit `/cloud/enterprise-case-studies/how-series-entertainment-rebuilt-game-and-video-production-with-comfyui` — should 301 redirect to `/customers/series-entertainment/`

Fixes #11583

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11654-chore-add-301-redirects-for-old-Framer-case-study-URLs-34e6d73d36508187a386eed3e25cf1b2) by [Unito](https://www.unito.io)
