### PR TITLE
test: harden useKeyboard test setup with vi.hoisted and try/finally

### DIFF
--- a/src/composables/maskeditor/useKeyboard.test.ts
+++ b/src/composables/maskeditor/useKeyboard.test.ts
@@ -11,14 +11,18 @@ type MockStore = {
   canvasHistory: MockCanvasHistory
 }
 
-const mockCanvasHistory: MockCanvasHistory = {
-  undo: vi.fn(),
-  redo: vi.fn()
-}
+const { mockStore, mockCanvasHistory } = vi.hoisted(() => {
+  const mockCanvasHistory: MockCanvasHistory = {
+    undo: vi.fn(),
+    redo: vi.fn()
+  }
 
-const mockStore: MockStore = {
-  canvasHistory: mockCanvasHistory
-}
+  const mockStore: MockStore = {
+    canvasHistory: mockCanvasHistory
+  }
+
+  return { mockStore, mockCanvasHistory }
+})
 
 vi.mock('@/stores/maskEditorStore', () => ({
   useMaskEditorStore: vi.fn(() => mockStore)
@@ -111,9 +115,11 @@ describe('useKeyboard', () => {
         configurable: true
       })
 
-      expect(() => dispatchKeyDown({ key: ' ' })).not.toThrow()
-
-      Reflect.deleteProperty(document, 'activeElement')
+      try {
+        expect(() => dispatchKeyDown({ key: ' ' })).not.toThrow()
+      } finally {
+        Reflect.deleteProperty(document, 'activeElement')
+      }
     })
 
     it('should call undo on Ctrl+Z without shift', () => {


### PR DESCRIPTION
## Summary
- Move `mockCanvasHistory` / `mockStore` into `vi.hoisted()` so the mock state is hoisted before module imports, matching the pattern in `useCanvasTransform.test.ts`.
- Wrap the temporary `document.activeElement` override in `try/finally` so the property is restored even if the assertion throws, preventing state leak into subsequent tests.

- Fixes #11658

## Test plan
- [x] `pnpm test:unit src/composables/maskeditor/useKeyboard.test.ts` — 17/17 pass
- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new warnings)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11659-test-harden-useKeyboard-test-setup-with-vi-hoisted-and-try-finally-34f6d73d36508139be2ddc3095ea6952) by [Unito](https://www.unito.io)
