### PR TITLE
refactor(load3d): drive viewer behavior from ModelAdapter capabilities

### DIFF
--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -4,6 +4,7 @@ import { nextTick, ref, shallowRef } from 'vue'
 import { nodeToLoad3dMap, useLoad3d } from '@/composables/useLoad3d'
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
 import type { Size } from '@/lib/litegraph/src/interfaces'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
@@ -17,6 +18,10 @@ import {
 
 vi.mock('@/extensions/core/load3d/Load3d', () => ({
   default: vi.fn()
+}))
+
+vi.mock('@/extensions/core/load3d/createLoad3d', () => ({
+  createLoad3d: vi.fn()
 }))
 
 vi.mock('@/extensions/core/load3d/Load3dUtils', () => ({
@@ -161,6 +166,7 @@ describe('useLoad3d', () => {
       Object.assign(this, mockLoad3d)
       return this
     })
+    vi.mocked(createLoad3d).mockImplementation(() => mockLoad3d as Load3d)
 
     mockToastStore = {
       addAlert: vi.fn()
@@ -181,7 +187,7 @@ describe('useLoad3d', () => {
 
       await composable.initializeLoad3d(containerRef)
 
-      expect(Load3d).toHaveBeenCalledWith(
+      expect(createLoad3d).toHaveBeenCalledWith(
         containerRef,
         expect.objectContaining({
           width: 512,
@@ -291,7 +297,7 @@ describe('useLoad3d', () => {
     })
 
     it('should handle initialization errors', async () => {
-      vi.mocked(Load3d).mockImplementationOnce(function () {
+      vi.mocked(createLoad3d).mockImplementationOnce(() => {
         throw new Error('Load3d creation failed')
       })
 
@@ -310,7 +316,7 @@ describe('useLoad3d', () => {
 
       await composable.initializeLoad3d(null!)
 
-      expect(Load3d).not.toHaveBeenCalled()
+      expect(createLoad3d).not.toHaveBeenCalled()
     })
 
     it('should accept ref as parameter', () => {
@@ -1029,7 +1035,7 @@ describe('useLoad3d', () => {
       await composable.initializeLoad3d(containerRef)
 
       // Should not throw and should use defaults
-      expect(Load3d).toHaveBeenCalled()
+      expect(createLoad3d).toHaveBeenCalled()
     })
 
     it('should handle background image with existing config', async () => {

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -5,8 +5,9 @@ import { getActivePinia } from 'pinia'
 import { ref, toRaw, watch } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import Load3d from '@/extensions/core/load3d/Load3d'
+import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
 import {
   isAssetPreviewSupported,
   persistThumbnail
@@ -111,7 +112,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         isPreview.value = true
       }
 
-      load3d = new Load3d(containerRef, {
+      load3d = createLoad3d(containerRef, {
         width: widthWidget?.value as number | undefined,
         height: heightWidget?.value as number | undefined,
         // Provide dynamic dimension getter for reactive updates

--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -4,6 +4,7 @@ import { nextTick } from 'vue'
 import { useLoad3dViewer } from '@/composables/useLoad3dViewer'
 import Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useToastStore } from '@/platform/updates/common/toastStore'
@@ -30,6 +31,10 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/extensions/core/load3d/Load3d', () => ({
   default: vi.fn()
+}))
+
+vi.mock('@/extensions/core/load3d/createLoad3d', () => ({
+  createLoad3d: vi.fn()
 }))
 
 function createMockSceneManager(): Load3d['sceneManager'] {
@@ -148,6 +153,7 @@ describe('useLoad3dViewer', () => {
     vi.mocked(Load3d).mockImplementation(function () {
       Object.assign(this, mockLoad3d)
     })
+    vi.mocked(createLoad3d).mockImplementation(() => mockLoad3d as Load3d)
 
     mockLoad3dService = {
       copyLoad3dState: vi.fn().mockResolvedValue(undefined),
@@ -177,7 +183,7 @@ describe('useLoad3dViewer', () => {
 
       await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
 
-      expect(Load3d).toHaveBeenCalledWith(containerRef, {
+      expect(createLoad3d).toHaveBeenCalledWith(containerRef, {
         width: undefined,
         height: undefined,
         getDimensions: undefined,
@@ -219,7 +225,7 @@ describe('useLoad3dViewer', () => {
     })
 
     it('should handle initialization errors', async () => {
-      vi.mocked(Load3d).mockImplementationOnce(function () {
+      vi.mocked(createLoad3d).mockImplementationOnce(() => {
         throw new Error('Load3d creation failed')
       })
 

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -1,8 +1,9 @@
 import { ref, toRaw, watch } from 'vue'
 import QuickLRU from '@alloc/quick-lru'
 
-import Load3d from '@/extensions/core/load3d/Load3d'
+import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
 import type {
   AnimationItem,
   BackgroundRenderModeType,
@@ -314,7 +315,7 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
 
       const hasTargetDimensions = !!(width && height)
 
-      load3d = new Load3d(containerRef, {
+      load3d = createLoad3d(containerRef, {
         width: width ? (toRaw(width).value as number) : undefined,
         height: height ? (toRaw(height).value as number) : undefined,
         getDimensions: hasTargetDimensions
@@ -442,7 +443,7 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
 
       isStandaloneMode.value = true
 
-      load3d = new Load3d(containerRef, {
+      load3d = createLoad3d(containerRef, {
         width: 800,
         height: 600,
         isViewerMode: true

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -37,11 +37,6 @@ type SceneManagerStub = {
   dispose: ReturnType<typeof vi.fn>
 }
 
-type Load3dPrivate = {
-  setGizmo(model: THREE.Object3D): void
-  setupCamera(size: THREE.Vector3, center: THREE.Vector3): void
-}
-
 function makeGizmoStub(): GizmoStub {
   return {
     setEnabled: vi.fn(),
@@ -97,6 +92,7 @@ function makeInstance() {
     controlsManager,
     viewHelperManager,
     animationManager,
+    adapterRef: { current: null },
     forceRender: vi.fn(),
     handleResize: vi.fn()
   })
@@ -221,23 +217,6 @@ describe('Load3d', () => {
         ctx.cameraManager.activeCamera
       )
       expect(ctx.viewHelperManager.recreateViewHelper).toHaveBeenCalledOnce()
-    })
-
-    it('setGizmo (private) forwards the model to gizmoManager.setupForModel', () => {
-      const model = new THREE.Object3D()
-
-      ;(ctx.load3d as unknown as Load3dPrivate).setGizmo(model)
-
-      expect(ctx.gizmo.setupForModel).toHaveBeenCalledWith(model)
-    })
-
-    it('setupCamera (private) forwards size and center to cameraManager', () => {
-      const size = new THREE.Vector3(1, 2, 3)
-      const center = new THREE.Vector3(4, 5, 6)
-
-      ;(ctx.load3d as unknown as Load3dPrivate).setupCamera(size, center)
-
-      expect(ctx.cameraManager.setupForModel).toHaveBeenCalledWith(size, center)
     })
   })
 
@@ -473,7 +452,7 @@ describe('Load3d', () => {
     function makeWithAdapter(kind: 'mesh' | 'pointCloud' | 'splat' | null) {
       const adapter = kind === null ? null : { kind }
       Object.assign(ctx.load3d, {
-        loaderManager: { getCurrentAdapter: vi.fn(() => adapter) }
+        adapterRef: { current: adapter }
       })
     }
 

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -204,6 +204,29 @@ describe('Load3d', () => {
       expect(ctx.forceRender).toHaveBeenCalledOnce()
     })
 
+    it('clearModel nulls adapterRef.current so capability queries fall back to defaults', () => {
+      Object.assign(ctx.load3d, {
+        adapterRef: { current: { kind: 'splat' } }
+      })
+      let adapterDuringModelManagerClear:
+        | { kind: string; current?: unknown }
+        | null
+        | undefined
+      ctx.modelManager.clearModel.mockImplementation(() => {
+        adapterDuringModelManagerClear = (
+          ctx.load3d as unknown as { adapterRef: { current: unknown } }
+        ).adapterRef.current as { kind: string } | null
+      })
+
+      ctx.load3d.clearModel()
+
+      expect(adapterDuringModelManagerClear).toEqual({ kind: 'splat' })
+      expect(
+        (ctx.load3d as unknown as { adapterRef: { current: unknown } })
+          .adapterRef.current
+      ).toBeNull()
+    })
+
     it('toggleCamera updates both controls and gizmo with the active camera', () => {
       ctx.load3d.toggleCamera('orthographic')
 

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -1,18 +1,23 @@
 import * as THREE from 'three'
 
-import { AnimationManager } from './AnimationManager'
-import { CameraManager } from './CameraManager'
-import { ControlsManager } from './ControlsManager'
-import { EventManager } from './EventManager'
-import { HDRIManager } from './HDRIManager'
-import { GizmoManager } from './GizmoManager'
-import { LightingManager } from './LightingManager'
-import { LoaderManager } from './LoaderManager'
+import type { AnimationManager } from './AnimationManager'
+import type { CameraManager } from './CameraManager'
+import type { ControlsManager } from './ControlsManager'
+import type { EventManager } from './EventManager'
+import type { GizmoManager } from './GizmoManager'
+import type { HDRIManager } from './HDRIManager'
+import type { LightingManager } from './LightingManager'
+import type { LoaderManager } from './LoaderManager'
 import { ModelExporter } from './ModelExporter'
-import { RecordingManager } from './RecordingManager'
-import { SceneManager } from './SceneManager'
-import { SceneModelManager } from './SceneModelManager'
-import { ViewHelperManager } from './ViewHelperManager'
+import {
+  type AdapterRef,
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelAdapterCapabilities
+} from './ModelAdapter'
+import type { RecordingManager } from './RecordingManager'
+import type { SceneManager } from './SceneManager'
+import type { SceneModelManager } from './SceneModelManager'
+import type { ViewHelperManager } from './ViewHelperManager'
 import type {
   CameraState,
   CaptureResult,
@@ -26,6 +31,23 @@ import { attachContextMenuGuard } from './load3dContextMenuGuard'
 import type { RenderLoopHandle } from './load3dRenderLoop'
 import { startRenderLoop } from './load3dRenderLoop'
 import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
+
+export type Load3dDeps = {
+  renderer: THREE.WebGLRenderer
+  eventManager: EventManager
+  sceneManager: SceneManager
+  cameraManager: CameraManager
+  controlsManager: ControlsManager
+  lightingManager: LightingManager
+  hdriManager: HDRIManager
+  viewHelperManager: ViewHelperManager
+  loaderManager: LoaderManager
+  modelManager: SceneModelManager
+  recordingManager: RecordingManager
+  animationManager: AnimationManager
+  gizmoManager: GizmoManager
+  adapterRef: AdapterRef
+}
 
 function positionThumbnailCamera(
   camera: THREE.PerspectiveCamera,
@@ -66,6 +88,7 @@ class Load3d {
   recordingManager: RecordingManager
   animationManager: AnimationManager
   gizmoManager: GizmoManager
+  adapterRef: AdapterRef
 
   STATUS_MOUSE_ON_NODE: boolean
   STATUS_MOUSE_ON_SCENE: boolean
@@ -80,7 +103,11 @@ class Load3d {
   private disposeContextMenuGuard: (() => void) | null = null
   private resizeObserver: ResizeObserver | null = null
 
-  constructor(container: Element | HTMLElement, options: Load3DOptions = {}) {
+  constructor(
+    container: Element | HTMLElement,
+    deps: Load3dDeps,
+    options: Load3DOptions = {}
+  ) {
     this.clock = new THREE.Clock()
     this.isViewerMode = options.isViewerMode || false
     this.onContextMenuCallback = options.onContextMenu
@@ -92,90 +119,20 @@ class Load3d {
       this.targetAspectRatio = options.width / options.height
     }
 
-    this.renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true })
-    this.renderer.setSize(300, 300)
-    this.renderer.setClearColor(0x282828)
-    this.renderer.autoClear = false
-    this.renderer.outputColorSpace = THREE.SRGBColorSpace
-    this.renderer.domElement.classList.add(
-      'absolute',
-      'inset-0',
-      'h-full',
-      'w-full',
-      'outline-none'
-    )
-    container.appendChild(this.renderer.domElement)
-
-    this.eventManager = new EventManager()
-
-    this.sceneManager = new SceneManager(
-      this.renderer,
-      this.getActiveCamera.bind(this),
-      this.getControls.bind(this),
-      this.eventManager
-    )
-
-    this.cameraManager = new CameraManager(this.renderer, this.eventManager)
-
-    this.controlsManager = new ControlsManager(
-      this.renderer,
-      this.cameraManager.activeCamera,
-      this.eventManager
-    )
-
-    this.cameraManager.setControls(this.controlsManager.controls)
-
-    this.lightingManager = new LightingManager(
-      this.sceneManager.scene,
-      this.eventManager
-    )
-
-    this.hdriManager = new HDRIManager(
-      this.sceneManager.scene,
-      this.renderer,
-      this.eventManager
-    )
-
-    this.viewHelperManager = new ViewHelperManager(
-      this.renderer,
-      this.getActiveCamera.bind(this),
-      this.getControls.bind(this),
-      this.eventManager
-    )
-
-    this.modelManager = new SceneModelManager(
-      this.sceneManager.scene,
-      this.renderer,
-      this.eventManager,
-      this.getActiveCamera.bind(this),
-      this.setupCamera.bind(this),
-      this.setGizmo.bind(this)
-    )
-
-    this.loaderManager = new LoaderManager(this.modelManager, this.eventManager)
-
-    this.recordingManager = new RecordingManager(
-      this.sceneManager.scene,
-      this.renderer,
-      this.eventManager
-    )
-
-    this.animationManager = new AnimationManager(this.eventManager)
-
-    this.gizmoManager = new GizmoManager(
-      this.sceneManager.scene,
-      this.renderer,
-      this.controlsManager.controls,
-      this.getActiveCamera.bind(this),
-      () => {
-        const transform = this.gizmoManager.getTransform()
-        this.eventManager.emitEvent('gizmoTransformChange', {
-          ...transform,
-          enabled: this.gizmoManager.isEnabled(),
-          mode: this.gizmoManager.getMode()
-        })
-      }
-    )
+    this.renderer = deps.renderer
+    this.eventManager = deps.eventManager
+    this.sceneManager = deps.sceneManager
+    this.cameraManager = deps.cameraManager
+    this.controlsManager = deps.controlsManager
+    this.lightingManager = deps.lightingManager
+    this.hdriManager = deps.hdriManager
+    this.viewHelperManager = deps.viewHelperManager
+    this.loaderManager = deps.loaderManager
+    this.modelManager = deps.modelManager
+    this.recordingManager = deps.recordingManager
+    this.animationManager = deps.animationManager
+    this.gizmoManager = deps.gizmoManager
+    this.adapterRef = deps.adapterRef
 
     this.sceneManager.init()
     this.cameraManager.init()
@@ -332,22 +289,6 @@ class Load3d {
     this.renderer.setViewport(0, 0, width, height)
     this.renderer.setScissor(0, 0, width, height)
     this.renderer.setScissorTest(false)
-  }
-
-  private getActiveCamera(): THREE.Camera {
-    return this.cameraManager.activeCamera
-  }
-
-  private getControls() {
-    return this.controlsManager.controls
-  }
-
-  private setGizmo(model: THREE.Object3D): void {
-    this.gizmoManager.setupForModel(model)
-  }
-
-  private setupCamera(size: THREE.Vector3, center: THREE.Vector3): void {
-    this.cameraManager.setupForModel(size, center)
   }
 
   private startAnimation(): void {
@@ -567,11 +508,15 @@ class Load3d {
   }
 
   isSplatModel(): boolean {
-    return this.loaderManager.getCurrentAdapter()?.kind === 'splat'
+    return this.adapterRef.current?.kind === 'splat'
   }
 
   isPlyModel(): boolean {
-    return this.loaderManager.getCurrentAdapter()?.kind === 'pointCloud'
+    return this.adapterRef.current?.kind === 'pointCloud'
+  }
+
+  getCurrentModelCapabilities(): ModelAdapterCapabilities {
+    return this.adapterRef.current?.capabilities ?? DEFAULT_MODEL_CAPABILITIES
   }
 
   clearModel(): void {
@@ -812,16 +757,19 @@ class Load3d {
   }
 
   public setGizmoEnabled(enabled: boolean): void {
+    if (enabled && !this.getCurrentModelCapabilities().gizmoTransform) return
     this.gizmoManager.setEnabled(enabled)
     this.forceRender()
   }
 
   public setGizmoMode(mode: GizmoMode): void {
+    if (!this.getCurrentModelCapabilities().gizmoTransform) return
     this.gizmoManager.setMode(mode)
     this.forceRender()
   }
 
   public resetGizmoTransform(): void {
+    if (!this.getCurrentModelCapabilities().gizmoTransform) return
     this.gizmoManager.reset()
     this.forceRender()
   }
@@ -831,6 +779,7 @@ class Load3d {
     rotation: { x: number; y: number; z: number },
     scale?: { x: number; y: number; z: number }
   ): void {
+    if (!this.getCurrentModelCapabilities().gizmoTransform) return
     this.gizmoManager.applyTransform(position, rotation, scale)
     this.forceRender()
   }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -9,11 +9,8 @@ import type { HDRIManager } from './HDRIManager'
 import type { LightingManager } from './LightingManager'
 import type { LoaderManager } from './LoaderManager'
 import { ModelExporter } from './ModelExporter'
-import {
-  type AdapterRef,
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelAdapterCapabilities
-} from './ModelAdapter'
+import { DEFAULT_MODEL_CAPABILITIES } from './ModelAdapter'
+import type { AdapterRef, ModelAdapterCapabilities } from './ModelAdapter'
 import type { RecordingManager } from './RecordingManager'
 import type { SceneManager } from './SceneManager'
 import type { SceneModelManager } from './SceneModelManager'
@@ -523,6 +520,7 @@ class Load3d {
     this.animationManager.dispose()
     this.gizmoManager.detach()
     this.modelManager.clearModel()
+    this.adapterRef.current = null
     this.forceRender()
   }
 
@@ -825,6 +823,7 @@ class Load3d {
     this.viewHelperManager.dispose()
     this.loaderManager.dispose()
     this.modelManager.dispose()
+    this.adapterRef.current = null
     this.recordingManager.dispose()
     this.animationManager.dispose()
     this.gizmoManager.dispose()

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -215,6 +215,29 @@ describe('LoaderManager', () => {
 
       expect(adapterDuringClear).toBe(oldAdapter)
     })
+
+    it('does not let a slow stale load clobber adapterRef after a newer load took over', async () => {
+      const { lm } = makeLoaderManager()
+
+      let resolveSplatLoad!: (model: THREE.Object3D) => void
+      const slowSplatLoad = new Promise<THREE.Object3D>((resolve) => {
+        resolveSplatLoad = resolve
+      })
+      splatLoad.mockReturnValueOnce(slowSplatLoad)
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      const aPromise = lm.loadModel('api/view?filename=a.splat')
+
+      await Promise.resolve()
+
+      await lm.loadModel('api/view?filename=b.glb')
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+
+      resolveSplatLoad(new THREE.Object3D())
+      await aPromise
+
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+    })
   })
 
   describe('pickAdapter', () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -140,6 +140,30 @@ describe('LoaderManager', () => {
       await lm.loadModel('api/view?filename=cube.xyz')
       expect(lm.getCurrentAdapter()).toBeNull()
     })
+
+    it('stays null when the adapter rejects (does not publish stale adapter)', async () => {
+      const { lm } = makeLoaderManager()
+
+      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      await lm.loadModel('api/view?filename=cube.glb')
+      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
+
+      splatLoad.mockRejectedValueOnce(new Error('boom'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=scan.splat')
+
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
+
+    it('stays null when the adapter resolves null (parse failure)', async () => {
+      const { lm } = makeLoaderManager()
+      pointCloudLoad.mockResolvedValueOnce(null)
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(lm.getCurrentAdapter()).toBeNull()
+    })
   })
 
   describe('loadModel ordering', () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -140,31 +140,6 @@ describe('LoaderManager', () => {
       await lm.loadModel('api/view?filename=cube.xyz')
       expect(lm.getCurrentAdapter()).toBeNull()
     })
-
-    it('stays null when the adapter rejects', async () => {
-      const { lm } = makeLoaderManager()
-      // Seed with a previously-successful mesh load so we can prove a later
-      // failed splat load does not leave the splat adapter published.
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
-      await lm.loadModel('api/view?filename=cube.glb')
-      expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
-
-      splatLoad.mockRejectedValueOnce(new Error('boom'))
-      vi.spyOn(console, 'error').mockImplementation(() => {})
-
-      await lm.loadModel('api/view?filename=scan.splat')
-
-      expect(lm.getCurrentAdapter()).toBeNull()
-    })
-
-    it('stays null when the adapter resolves null (parse failure)', async () => {
-      const { lm } = makeLoaderManager()
-      pointCloudLoad.mockResolvedValueOnce(null)
-
-      await lm.loadModel('api/view?filename=scan.ply')
-
-      expect(lm.getCurrentAdapter()).toBeNull()
-    })
   })
 
   describe('loadModel ordering', () => {
@@ -196,10 +171,13 @@ describe('LoaderManager', () => {
       }
 
       let adapterDuringClear: ModelAdapter | null | undefined
-      const lm = new LoaderManager(modelManager, eventManager, [oldAdapter])
-      // Prime the loader with an active adapter, then trigger a new load.
-      ;(lm as unknown as { _currentAdapter: ModelAdapter })._currentAdapter =
-        oldAdapter
+      const adapterRef = { current: oldAdapter as ModelAdapter | null }
+      const lm = new LoaderManager(
+        modelManager,
+        eventManager,
+        [oldAdapter],
+        adapterRef
+      )
       ;(modelManager.clearModel as ReturnType<typeof vi.fn>).mockImplementation(
         () => {
           adapterDuringClear = lm.getCurrentAdapter()

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -4,7 +4,12 @@ import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import { MeshModelAdapter } from './MeshModelAdapter'
-import type { ModelAdapter, ModelLoadContext } from './ModelAdapter'
+import {
+  type AdapterRef,
+  createAdapterRef,
+  type ModelAdapter,
+  type ModelLoadContext
+} from './ModelAdapter'
 import { PointCloudModelAdapter, getPLYEngine } from './PointCloudModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
 import {
@@ -29,21 +34,23 @@ export class LoaderManager implements LoaderManagerInterface {
   private readonly modelManager: ModelManagerInterface
   private readonly eventManager: EventManagerInterface
   private readonly adapters: ModelAdapter[]
+  private readonly adapterRef: AdapterRef
   private currentLoadId: number = 0
-  private _currentAdapter: ModelAdapter | null = null
 
   constructor(
     modelManager: ModelManagerInterface,
     eventManager: EventManagerInterface,
-    adapters?: readonly ModelAdapter[]
+    adapters?: readonly ModelAdapter[],
+    adapterRef?: AdapterRef
   ) {
     this.modelManager = modelManager
     this.eventManager = eventManager
     this.adapters = adapters ? [...adapters] : defaultAdapters()
+    this.adapterRef = adapterRef ?? createAdapterRef()
   }
 
   getCurrentAdapter(): ModelAdapter | null {
-    return this._currentAdapter
+    return this.adapterRef.current
   }
 
   init(): void {}
@@ -57,7 +64,7 @@ export class LoaderManager implements LoaderManagerInterface {
       this.eventManager.emitEvent('modelLoadingStart', null)
 
       this.modelManager.clearModel()
-      this._currentAdapter = null
+      this.adapterRef.current = null
 
       this.modelManager.originalURL = url
 
@@ -80,21 +87,19 @@ export class LoaderManager implements LoaderManagerInterface {
         return
       }
 
-      const result = await this.loadModelInternal(url, fileExtension)
+      const model = await this.loadModelInternal(url, fileExtension)
 
       if (loadId !== this.currentLoadId) {
         return
       }
 
-      if (result && result.model) {
-        this._currentAdapter = result.adapter
-        await this.modelManager.setupModel(result.model)
+      if (model) {
+        await this.modelManager.setupModel(model)
       }
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
     } catch (error) {
       if (loadId === this.currentLoadId) {
-        this._currentAdapter = null
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
         useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
@@ -135,7 +140,7 @@ export class LoaderManager implements LoaderManagerInterface {
   private async loadModelInternal(
     url: string,
     fileExtension: string
-  ): Promise<{ adapter: ModelAdapter; model: THREE.Object3D | null } | null> {
+  ): Promise<THREE.Object3D | null> {
     const params = new URLSearchParams(url.split('?')[1])
     const filename = params.get('filename')
 
@@ -156,7 +161,7 @@ export class LoaderManager implements LoaderManagerInterface {
     const adapter = this.pickAdapter(fileExtension)
     if (!adapter) return null
 
-    const model = await adapter.load(this.createLoadContext(), path, filename)
-    return { adapter, model }
+    this.adapterRef.current = adapter
+    return adapter.load(this.createLoadContext(), path, filename)
   }
 }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -4,18 +4,14 @@ import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 
 import { MeshModelAdapter } from './MeshModelAdapter'
-import {
-  type AdapterRef,
-  createAdapterRef,
-  type ModelAdapter,
-  type ModelLoadContext
-} from './ModelAdapter'
+import { createAdapterRef } from './ModelAdapter'
+import type { AdapterRef, ModelAdapter, ModelLoadContext } from './ModelAdapter'
 import { PointCloudModelAdapter, getPLYEngine } from './PointCloudModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
-import {
-  type EventManagerInterface,
-  type LoaderManagerInterface,
-  type ModelManagerInterface
+import type {
+  EventManagerInterface,
+  LoaderManagerInterface,
+  ModelManagerInterface
 } from './interfaces'
 
 /**

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -157,7 +157,10 @@ export class LoaderManager implements LoaderManagerInterface {
     const adapter = this.pickAdapter(fileExtension)
     if (!adapter) return null
 
-    this.adapterRef.current = adapter
-    return adapter.load(this.createLoadContext(), path, filename)
+    const model = await adapter.load(this.createLoadContext(), path, filename)
+    if (model) {
+      this.adapterRef.current = adapter
+    }
+    return model
   }
 }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -83,14 +83,21 @@ export class LoaderManager implements LoaderManagerInterface {
         return
       }
 
-      const model = await this.loadModelInternal(url, fileExtension)
+      const result = await this.loadModelInternal(url, fileExtension)
 
       if (loadId !== this.currentLoadId) {
+        // A newer loadModel has superseded us — do not publish our adapter
+        // and do not setup the model. Whichever load is current owns the
+        // shared state.
         return
       }
 
-      if (model) {
-        await this.modelManager.setupModel(model)
+      if (result) {
+        // Publish only after the staleness check so a slow older load
+        // can't clobber adapterRef.current that a newer load already
+        // wrote (or cleared).
+        this.adapterRef.current = result.adapter
+        await this.modelManager.setupModel(result.model)
       }
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
@@ -136,7 +143,7 @@ export class LoaderManager implements LoaderManagerInterface {
   private async loadModelInternal(
     url: string,
     fileExtension: string
-  ): Promise<THREE.Object3D | null> {
+  ): Promise<{ model: THREE.Object3D; adapter: ModelAdapter } | null> {
     const params = new URLSearchParams(url.split('?')[1])
     const filename = params.get('filename')
 
@@ -158,9 +165,6 @@ export class LoaderManager implements LoaderManagerInterface {
     if (!adapter) return null
 
     const model = await adapter.load(this.createLoadContext(), path, filename)
-    if (model) {
-      this.adapterRef.current = adapter
-    }
-    return model
+    return model ? { model, adapter } : null
   }
 }

--- a/src/extensions/core/load3d/ModelAdapter.ts
+++ b/src/extensions/core/load3d/ModelAdapter.ts
@@ -64,6 +64,16 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelAdapterCapabilities = {
   fitTargetSize: 5
 }
 
+/**
+ * Mutable handle to the currently active ModelAdapter. A single ref is
+ * created in `createLoad3d` and shared between LoaderManager (writer) and
+ * SceneModelManager + Load3d (readers), so capability/bounds/dispose lookups
+ * don't depend on construction order between those collaborators.
+ */
+export type AdapterRef = { current: ModelAdapter | null }
+
+export const createAdapterRef = (): AdapterRef => ({ current: null })
+
 export interface ModelAdapter {
   readonly kind: ModelAdapterKind
   readonly extensions: readonly string[]
@@ -73,6 +83,29 @@ export interface ModelAdapter {
     path: string,
     filename: string
   ): Promise<THREE.Object3D | null>
+  /**
+   * Optional. Return a world-space AABB for the given model. Adapters for
+   * renderers whose geometry is not walked by `Box3.setFromObject` (e.g.
+   * Gaussian splats) implement this; the default path uses
+   * `Box3.setFromObject` when this is absent.
+   */
+  computeBounds?(model: THREE.Object3D): THREE.Box3 | null
+  /**
+   * Optional. Release renderer-owned resources on this model beyond what
+   * THREE's geometry/material.dispose covers (e.g. sparkjs SplatMesh
+   * internal GPU/worker state). Called when the model is removed from the
+   * scene due to a reload or teardown. Missing for adapters whose models
+   * the default traversal already handles.
+   */
+  disposeModel?(model: THREE.Object3D): void
+  /**
+   * Optional. Default camera placement for adapters that opt out of
+   * fit-to-viewer (capabilities.fitToViewer === false). The size/center
+   * pair is forwarded to CameraManager.setupForModel as if the model had
+   * been normalized. Splat geometry is self-sized and uses this to seat
+   * the camera at a known-good distance.
+   */
+  defaultCameraPose?(): { size: THREE.Vector3; center: THREE.Vector3 }
 }
 
 export async function fetchModelData(

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -65,10 +65,10 @@ describe('PointCloudModelAdapter', () => {
       expect([...adapter.extensions]).toEqual(['ply'])
     })
 
-    it('identifies as pointCloud with rebuild + gizmo/fit disabled', () => {
+    it('identifies as pointCloud with material rebuild + fit-to-viewer + lighting + export, gizmo disabled', () => {
       const adapter = new PointCloudModelAdapter()
       expect(adapter.kind).toBe('pointCloud')
-      expect(adapter.capabilities.fitToViewer).toBe(false)
+      expect(adapter.capabilities.fitToViewer).toBe(true)
       expect(adapter.capabilities.requiresMaterialRebuild).toBe(true)
       expect(adapter.capabilities.gizmoTransform).toBe(false)
       expect(adapter.capabilities.lighting).toBe(true)

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -21,7 +21,7 @@ export class PointCloudModelAdapter implements ModelAdapter {
   readonly kind = 'pointCloud' as const
   readonly extensions = ['ply'] as const
   readonly capabilities: ModelAdapterCapabilities = {
-    fitToViewer: false,
+    fitToViewer: true,
     requiresMaterialRebuild: true,
     gizmoTransform: false,
     lighting: true,

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -4,12 +4,13 @@ import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { isPLYAsciiFormat } from '@/scripts/metadata/ply'
 
-import { fetchModelData } from './ModelAdapter'
-import type {
-  ModelAdapter,
-  ModelAdapterCapabilities,
-  ModelLoadContext
+import {
+  fetchModelData,
+  type ModelAdapter,
+  type ModelAdapterCapabilities,
+  type ModelLoadContext
 } from './ModelAdapter'
+import type { MaterialMode } from './interfaces'
 import { FastPLYLoader } from './loader/FastPLYLoader'
 
 export function getPLYEngine(): string {
@@ -43,7 +44,7 @@ export class PointCloudModelAdapter implements ModelAdapter {
     const plyGeometry =
       isASCII && getPLYEngine() === 'fastply'
         ? this.fastPlyLoader.parse(arrayBuffer)
-        : this.plyLoader.parse(arrayBuffer)
+        : (this.plyLoader.setPath(path), this.plyLoader.parse(arrayBuffer))
 
     ctx.setOriginalModel(plyGeometry)
     plyGeometry.computeVertexNormals()
@@ -116,5 +117,45 @@ function buildMeshGroup(
 
   const group = new THREE.Group()
   group.add(mesh)
+  return group
+}
+
+export function buildPointCloudForMaterialMode(
+  originalGeometry: THREE.BufferGeometry,
+  mode: MaterialMode,
+  standardMaterial: THREE.MeshStandardMaterial,
+  originalMaterials: WeakMap<THREE.Mesh, THREE.Material | THREE.Material[]>
+): THREE.Group {
+  const geometry = originalGeometry.clone()
+  const hasVertexColors = geometry.attributes.color !== undefined
+
+  const ctx: ModelLoadContext = {
+    setOriginalModel: () => {},
+    registerOriginalMaterial: (mesh, material) =>
+      originalMaterials.set(mesh, material),
+    standardMaterial,
+    materialMode: mode
+  }
+
+  if (mode === 'pointCloud') {
+    return buildPointsGroup(ctx, geometry, hasVertexColors)
+  }
+
+  const group = buildMeshGroup(ctx, geometry, hasVertexColors)
+
+  if (mode === 'normal' || mode === 'wireframe') {
+    const mesh = group.children[0] as THREE.Mesh
+    mesh.material =
+      mode === 'normal'
+        ? new THREE.MeshNormalMaterial({
+            flatShading: false,
+            side: THREE.DoubleSide
+          })
+        : new THREE.MeshBasicMaterial({
+            color: 0xffffff,
+            wireframe: true
+          })
+  }
+
   return group
 }

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -4,11 +4,11 @@ import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { isPLYAsciiFormat } from '@/scripts/metadata/ply'
 
-import {
-  fetchModelData,
-  type ModelAdapter,
-  type ModelAdapterCapabilities,
-  type ModelLoadContext
+import { fetchModelData } from './ModelAdapter'
+import type {
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
 } from './ModelAdapter'
 import type { MaterialMode } from './interfaces'
 import { FastPLYLoader } from './loader/FastPLYLoader'

--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -1,10 +1,8 @@
 import * as THREE from 'three'
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelAdapterCapabilities
-} from './ModelAdapter'
+import { DEFAULT_MODEL_CAPABILITIES } from './ModelAdapter'
+import type { ModelAdapterCapabilities } from './ModelAdapter'
 import { SceneModelManager } from './SceneModelManager'
 import type { EventManagerInterface } from './interfaces'
 

--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -61,6 +61,37 @@ function createManager(
   }
 }
 
+function createManagerWithPose(opts: {
+  capabilities?: Partial<ModelAdapterCapabilities>
+  pose: { size: THREE.Vector3; center: THREE.Vector3 } | null
+}) {
+  const scene = new THREE.Scene()
+  const renderer = createMockRenderer()
+  const eventManager = createMockEventManager()
+  const camera = new THREE.PerspectiveCamera()
+  const setupCamera = vi.fn()
+  const setupGizmo = vi.fn()
+  const capabilities: ModelAdapterCapabilities = {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    ...opts.capabilities
+  }
+
+  const manager = new SceneModelManager(
+    scene,
+    renderer,
+    eventManager,
+    () => camera,
+    setupCamera,
+    setupGizmo,
+    () => capabilities,
+    () => null,
+    () => {},
+    () => opts.pose
+  )
+
+  return { manager, scene, setupCamera, setupGizmo }
+}
+
 function createMeshModel(name = 'TestModel'): THREE.Group {
   const geometry = new THREE.BoxGeometry(1, 1, 1)
   const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
@@ -197,6 +228,47 @@ describe('SceneModelManager', () => {
         'upDirectionChange',
         '+z'
       )
+    })
+
+    it('uses the adapter default pose when fitToViewer is disabled and a pose is provided', async () => {
+      const pose = {
+        size: new THREE.Vector3(5, 5, 5),
+        center: new THREE.Vector3(0, 2.5, 0)
+      }
+      const { manager, scene, setupCamera, setupGizmo } = createManagerWithPose(
+        {
+          capabilities: { fitToViewer: false },
+          pose
+        }
+      )
+      const model = createMeshModel()
+
+      await manager.setupModel(model)
+
+      expect(scene.children).toContain(model)
+      expect(setupCamera).toHaveBeenCalledWith(pose.size, pose.center)
+
+      expect(setupGizmo).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the full setup path when fitToViewer is disabled but no default pose is provided', async () => {
+      const { manager, scene, setupCamera, setupGizmo } = createManagerWithPose(
+        {
+          capabilities: { fitToViewer: false },
+          pose: null
+        }
+      )
+      const model = createMeshModel()
+
+      await manager.setupModel(model)
+
+      expect(scene.children).toContain(model)
+
+      expect(setupCamera).toHaveBeenCalled()
+      const callArgs = setupCamera.mock.calls[0]
+      expect(callArgs[0]).toBeInstanceOf(THREE.Vector3)
+      expect(callArgs[1]).toBeInstanceOf(THREE.Vector3)
+      expect(setupGizmo).toHaveBeenCalledWith(model)
     })
   })
 

--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -1,8 +1,12 @@
 import * as THREE from 'three'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { EventManagerInterface } from './interfaces'
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelAdapterCapabilities
+} from './ModelAdapter'
 import { SceneModelManager } from './SceneModelManager'
+import type { EventManagerInterface } from './interfaces'
 
 function createMockRenderer(): THREE.WebGLRenderer {
   return {
@@ -23,6 +27,7 @@ function createManager(
   overrides: {
     scene?: THREE.Scene
     eventManager?: EventManagerInterface
+    capabilities?: Partial<ModelAdapterCapabilities>
   } = {}
 ) {
   const scene = overrides.scene ?? new THREE.Scene()
@@ -32,6 +37,10 @@ function createManager(
   const getActiveCamera = () => camera
   const setupCamera = vi.fn()
   const setupGizmo = vi.fn()
+  const capabilities: ModelAdapterCapabilities = {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    ...overrides.capabilities
+  }
 
   const manager = new SceneModelManager(
     scene,
@@ -39,7 +48,8 @@ function createManager(
     eventManager,
     getActiveCamera,
     setupCamera,
-    setupGizmo
+    setupGizmo,
+    () => capabilities
   )
 
   return {
@@ -575,29 +585,11 @@ describe('SceneModelManager', () => {
     })
   })
 
-  describe('containsSplatMesh', () => {
-    it('returns false when no model', () => {
-      const { manager } = createManager()
-      expect(manager.containsSplatMesh()).toBe(false)
-    })
-
-    it('returns false for regular model', async () => {
-      const { manager } = createManager()
-      const model = createMeshModel()
-      await manager.setupModel(model)
-
-      expect(manager.containsSplatMesh()).toBe(false)
-    })
-
-    it('returns false for explicit null argument', () => {
-      const { manager } = createManager()
-      expect(manager.containsSplatMesh(null)).toBe(false)
-    })
-  })
-
   describe('PLY mode switching', () => {
     function createPLYManager() {
-      const ctx = createManager()
+      const ctx = createManager({
+        capabilities: { requiresMaterialRebuild: true }
+      })
       const geometry = new THREE.BufferGeometry()
       geometry.setAttribute(
         'position',
@@ -655,7 +647,9 @@ describe('SceneModelManager', () => {
     })
 
     it('uses vertex colors when available', () => {
-      const { manager, scene } = createManager()
+      const { manager, scene } = createManager({
+        capabilities: { requiresMaterialRebuild: true }
+      })
       const geometry = new THREE.BufferGeometry()
       geometry.setAttribute(
         'position',

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -1,16 +1,14 @@
 import * as THREE from 'three'
-import { type GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
+import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelAdapterCapabilities
-} from './ModelAdapter'
+import { DEFAULT_MODEL_CAPABILITIES } from './ModelAdapter'
+import type { ModelAdapterCapabilities } from './ModelAdapter'
 import { buildPointCloudForMaterialMode } from './PointCloudModelAdapter'
-import {
-  type EventManagerInterface,
-  type MaterialMode,
-  type ModelManagerInterface,
-  type UpDirection
+import type {
+  EventManagerInterface,
+  MaterialMode,
+  ModelManagerInterface,
+  UpDirection
 } from './interfaces'
 
 export class SceneModelManager implements ModelManagerInterface {

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -438,10 +438,12 @@ export class SceneModelManager implements ModelManagerInterface {
     model.name = 'MainModel'
 
     if (!this.getCurrentCapabilities().fitToViewer) {
-      this.scene.add(model)
       const pose = this.getDefaultCameraPose()
-      if (pose) this.setupCamera(pose.size, pose.center)
-      return
+      if (pose) {
+        this.scene.add(model)
+        this.setupCamera(pose.size, pose.center)
+        return
+      }
     }
 
     this.scene.add(model)

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -1,7 +1,11 @@
-import { SplatMesh } from '@sparkjsdev/spark'
 import * as THREE from 'three'
 import { type GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelAdapterCapabilities
+} from './ModelAdapter'
+import { buildPointCloudForMaterialMode } from './PointCloudModelAdapter'
 import {
   type EventManagerInterface,
   type MaterialMode,
@@ -39,6 +43,13 @@ export class SceneModelManager implements ModelManagerInterface {
   private activeCamera: THREE.Camera
   private setupCamera: (size: THREE.Vector3, center: THREE.Vector3) => void
   private setupGizmo: (model: THREE.Object3D) => void
+  private getCurrentCapabilities: () => ModelAdapterCapabilities
+  private getBoundsFromAdapter: (model: THREE.Object3D) => THREE.Box3 | null
+  private disposeModelViaAdapter: (model: THREE.Object3D) => void
+  private getDefaultCameraPose: () => {
+    size: THREE.Vector3
+    center: THREE.Vector3
+  } | null
 
   constructor(
     scene: THREE.Scene,
@@ -46,7 +57,16 @@ export class SceneModelManager implements ModelManagerInterface {
     eventManager: EventManagerInterface,
     getActiveCamera: () => THREE.Camera,
     setupCamera: (size: THREE.Vector3, center: THREE.Vector3) => void,
-    setupGizmo: (model: THREE.Object3D) => void
+    setupGizmo: (model: THREE.Object3D) => void,
+    getCurrentCapabilities: () => ModelAdapterCapabilities = () =>
+      DEFAULT_MODEL_CAPABILITIES,
+    getBoundsFromAdapter: (model: THREE.Object3D) => THREE.Box3 | null = () =>
+      null,
+    disposeModelViaAdapter: (model: THREE.Object3D) => void = () => {},
+    getDefaultCameraPose: () => {
+      size: THREE.Vector3
+      center: THREE.Vector3
+    } | null = () => null
   ) {
     this.scene = scene
     this.renderer = renderer
@@ -55,6 +75,10 @@ export class SceneModelManager implements ModelManagerInterface {
     this.setupCamera = setupCamera
     this.textureLoader = new THREE.TextureLoader()
     this.setupGizmo = setupGizmo
+    this.getCurrentCapabilities = getCurrentCapabilities
+    this.getBoundsFromAdapter = getBoundsFromAdapter
+    this.disposeModelViaAdapter = disposeModelViaAdapter
+    this.getDefaultCameraPose = getDefaultCameraPose
 
     this.normalMaterial = new THREE.MeshNormalMaterial({
       flatShading: false,
@@ -104,23 +128,11 @@ export class SceneModelManager implements ModelManagerInterface {
     })
   }
 
-  private handlePLYModeSwitch(mode: MaterialMode): void {
-    if (!(this.originalModel instanceof THREE.BufferGeometry)) {
-      return
-    }
-
-    const plyGeometry = this.originalModel.clone()
-    const hasVertexColors = plyGeometry.attributes.color !== undefined
-
-    // Find and remove ALL MainModel instances by name to ensure deletion
+  private removeAllMainModelsFromScene(): void {
     const oldMainModels: THREE.Object3D[] = []
     this.scene.traverse((obj) => {
-      if (obj.name === 'MainModel') {
-        oldMainModels.push(obj)
-      }
+      if (obj.name === 'MainModel') oldMainModels.push(obj)
     })
-
-    // Remove and dispose all found MainModels
     oldMainModels.forEach((oldModel) => {
       oldModel.traverse((child) => {
         if (child instanceof THREE.Mesh || child instanceof THREE.Points) {
@@ -132,103 +144,31 @@ export class SceneModelManager implements ModelManagerInterface {
           }
         }
       })
+      this.disposeModelViaAdapter(oldModel)
       this.scene.remove(oldModel)
     })
+  }
 
+  private rebuildForMaterialMode(mode: MaterialMode): void {
+    if (!(this.originalModel instanceof THREE.BufferGeometry)) return
+
+    this.removeAllMainModelsFromScene()
     this.currentModel = null
 
-    let newModel: THREE.Object3D
-
-    if (mode === 'pointCloud') {
-      // Use Points rendering for point cloud mode
-      plyGeometry.computeBoundingSphere()
-      if (plyGeometry.boundingSphere) {
-        const center = plyGeometry.boundingSphere.center
-        const radius = plyGeometry.boundingSphere.radius
-
-        plyGeometry.translate(-center.x, -center.y, -center.z)
-
-        if (radius > 0) {
-          const scale = 1.0 / radius
-          plyGeometry.scale(scale, scale, scale)
-        }
-      }
-
-      const pointMaterial = hasVertexColors
-        ? new THREE.PointsMaterial({
-            size: 0.005,
-            vertexColors: true,
-            sizeAttenuation: true
-          })
-        : new THREE.PointsMaterial({
-            size: 0.005,
-            color: 0xcccccc,
-            sizeAttenuation: true
-          })
-
-      const points = new THREE.Points(plyGeometry, pointMaterial)
-      newModel = new THREE.Group()
-      newModel.add(points)
-    } else {
-      // Use Mesh rendering for other modes
-      let meshMaterial: THREE.Material = hasVertexColors
-        ? new THREE.MeshStandardMaterial({
-            vertexColors: true,
-            metalness: 0.0,
-            roughness: 0.5,
-            side: THREE.DoubleSide
-          })
-        : this.standardMaterial.clone()
-
-      if (
-        !hasVertexColors &&
-        meshMaterial instanceof THREE.MeshStandardMaterial
-      ) {
-        meshMaterial.side = THREE.DoubleSide
-      }
-
-      const mesh = new THREE.Mesh(plyGeometry, meshMaterial)
-      this.originalMaterials.set(mesh, meshMaterial)
-
-      newModel = new THREE.Group()
-      newModel.add(mesh)
-
-      // Apply the requested material mode
-      if (mode === 'normal') {
-        mesh.material = new THREE.MeshNormalMaterial({
-          flatShading: false,
-          side: THREE.DoubleSide
-        })
-      } else if (mode === 'wireframe') {
-        mesh.material = new THREE.MeshBasicMaterial({
-          color: 0xffffff,
-          wireframe: true
-        })
-      }
-    }
-
-    // Double check: remove any remaining MainModel before adding new one
-    const remainingMainModels: THREE.Object3D[] = []
-    this.scene.traverse((obj) => {
-      if (obj.name === 'MainModel') {
-        remainingMainModels.push(obj)
-      }
-    })
-    remainingMainModels.forEach((obj) => this.scene.remove(obj))
-
-    this.currentModel = newModel
+    const newModel = buildPointCloudForMaterialMode(
+      this.originalModel,
+      mode,
+      this.standardMaterial,
+      this.originalMaterials
+    )
     newModel.name = 'MainModel'
 
-    // Setup the new model
-    if (mode === 'pointCloud') {
-      this.scene.add(newModel)
-    } else {
+    if (mode !== 'pointCloud') {
       const box = new THREE.Box3().setFromObject(newModel)
       const size = box.getSize(new THREE.Vector3())
       const center = box.getCenter(new THREE.Vector3())
-
       const maxDim = Math.max(size.x, size.y, size.z)
-      const targetSize = 5
+      const targetSize = this.getCurrentCapabilities().fitTargetSize
       const scale = targetSize / maxDim
       newModel.scale.multiplyScalar(scale)
 
@@ -237,9 +177,10 @@ export class SceneModelManager implements ModelManagerInterface {
       box.getSize(size)
 
       newModel.position.set(-center.x, -box.min.y, -center.z)
-      this.scene.add(newModel)
     }
 
+    this.scene.add(newModel)
+    this.currentModel = newModel
     this.eventManager.emitEvent('materialModeChange', mode)
   }
 
@@ -250,9 +191,8 @@ export class SceneModelManager implements ModelManagerInterface {
 
     this.materialMode = mode
 
-    // Handle PLY files specially - they need to be recreated for mode switch
-    if (this.originalModel instanceof THREE.BufferGeometry) {
-      this.handlePLYModeSwitch(mode)
+    if (this.getCurrentCapabilities().requiresMaterialRebuild) {
+      this.rebuildForMaterialMode(mode)
       return
     }
 
@@ -399,6 +339,7 @@ export class SceneModelManager implements ModelManagerInterface {
           }
         }
       })
+      this.disposeModelViaAdapter(obj)
     })
 
     this.reset()
@@ -488,18 +429,20 @@ export class SceneModelManager implements ModelManagerInterface {
     this.scene.add(this.currentModel)
   }
 
+  private computeWorldBounds(model: THREE.Object3D): THREE.Box3 {
+    return (
+      this.getBoundsFromAdapter(model) ?? new THREE.Box3().setFromObject(model)
+    )
+  }
+
   async setupModel(model: THREE.Object3D): Promise<void> {
     this.currentModel = model
     model.name = 'MainModel'
 
-    // Check if model is or contains a SplatMesh (3D Gaussian Splatting)
-    const isSplatModel = this.containsSplatMesh(model)
-
-    if (isSplatModel) {
-      // SplatMesh handles its own rendering, just add to scene
+    if (!this.getCurrentCapabilities().fitToViewer) {
       this.scene.add(model)
-      // Set a default camera distance for splat models
-      this.setupCamera(new THREE.Vector3(5, 5, 5), new THREE.Vector3(0, 2.5, 0))
+      const pose = this.getDefaultCameraPose()
+      if (pose) this.setupCamera(pose.size, pose.center)
       return
     }
 
@@ -514,7 +457,7 @@ export class SceneModelManager implements ModelManagerInterface {
     }
     this.setupModelMaterials(model)
 
-    const box = new THREE.Box3().setFromObject(model)
+    const box = this.computeWorldBounds(model)
     const size = box.getSize(new THREE.Vector3())
     const center = box.getCenter(new THREE.Vector3())
 
@@ -524,48 +467,36 @@ export class SceneModelManager implements ModelManagerInterface {
   }
 
   fitToViewer(): void {
-    if (!this.currentModel || this.containsSplatMesh()) return
+    if (!this.currentModel || !this.getCurrentCapabilities().fitToViewer) return
     const model = this.currentModel
 
-    // Reset transform to compute from raw geometry (idempotent)
     model.scale.set(1, 1, 1)
     model.position.set(0, 0, 0)
     model.rotation.set(0, 0, 0)
 
-    const box = new THREE.Box3().setFromObject(model)
+    const box = this.computeWorldBounds(model)
     const size = box.getSize(new THREE.Vector3())
     const center = box.getCenter(new THREE.Vector3())
 
     const maxDim = Math.max(size.x, size.y, size.z)
     if (maxDim === 0) return
 
-    const targetSize = 5
+    const targetSize = this.getCurrentCapabilities().fitTargetSize
     const scale = targetSize / maxDim
     model.scale.set(scale, scale, scale)
 
-    box.setFromObject(model)
-    box.getCenter(center)
-    box.getSize(size)
+    const scaledBox = this.computeWorldBounds(model)
+    scaledBox.getCenter(center)
+    scaledBox.getSize(size)
 
-    model.position.set(-center.x, -box.min.y, -center.z)
+    model.position.set(-center.x, -scaledBox.min.y, -center.z)
 
-    const newBox = new THREE.Box3().setFromObject(model)
+    const newBox = this.computeWorldBounds(model)
     const newSize = newBox.getSize(new THREE.Vector3())
     const newCenter = newBox.getCenter(new THREE.Vector3())
 
     this.setupCamera(newSize, newCenter)
     this.setupGizmo(model)
-  }
-
-  containsSplatMesh(model?: THREE.Object3D | null): boolean {
-    const target = model ?? this.currentModel
-    if (!target) return false
-    if (target instanceof SplatMesh) return true
-    let found = false
-    target.traverse((child) => {
-      if (child instanceof SplatMesh) found = true
-    })
-    return found
   }
 
   setOriginalModel(model: THREE.Object3D | THREE.BufferGeometry | GLTF): void {

--- a/src/extensions/core/load3d/SplatModelAdapter.test.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.test.ts
@@ -1,21 +1,39 @@
 import * as THREE from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ModelLoadContext } from './ModelAdapter'
 import * as ModelAdapterModule from './ModelAdapter'
+import type { ModelLoadContext } from './ModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
 
-const { splatMeshCtor } = vi.hoisted(() => ({
-  splatMeshCtor: vi.fn<(opts: { fileBytes: ArrayBuffer }) => void>()
-}))
+const splatMeshSpies = {
+  ctor: vi.fn<(opts: { fileBytes: ArrayBuffer }) => void>(),
+  dispose: vi.fn(),
+  getBoundingBox: vi.fn(
+    () =>
+      new THREE.Box3(new THREE.Vector3(-1, -1, -1), new THREE.Vector3(1, 1, 1))
+  ),
+  updateWorldMatrix: vi.fn()
+}
 
 vi.mock('@sparkjsdev/spark', async () => {
   const three = await import('three')
   return {
     SplatMesh: class extends three.Object3D {
+      initialized = Promise.resolve()
+      dispose = splatMeshSpies.dispose
+      getBoundingBox = splatMeshSpies.getBoundingBox
+
       constructor(opts: { fileBytes: ArrayBuffer }) {
         super()
-        splatMeshCtor(opts)
+        splatMeshSpies.ctor(opts)
+      }
+
+      override updateWorldMatrix(
+        force: boolean,
+        updateChildren: boolean
+      ): void {
+        splatMeshSpies.updateWorldMatrix(force, updateChildren)
+        super.updateWorldMatrix(force, updateChildren)
       }
     }
   }
@@ -32,7 +50,13 @@ function makeContext(): ModelLoadContext {
 
 describe('SplatModelAdapter', () => {
   beforeEach(() => {
-    splatMeshCtor.mockReset()
+    splatMeshSpies.ctor.mockClear()
+    splatMeshSpies.dispose.mockClear()
+    splatMeshSpies.getBoundingBox.mockClear()
+    splatMeshSpies.updateWorldMatrix.mockClear()
+    vi.spyOn(ModelAdapterModule, 'fetchModelData').mockResolvedValue(
+      new ArrayBuffer(8)
+    )
   })
 
   it('exposes splat capabilities on the adapter', () => {
@@ -61,12 +85,26 @@ describe('SplatModelAdapter', () => {
       '/api/view?',
       'scene.splat'
     )
-    expect(splatMeshCtor).toHaveBeenCalledWith({ fileBytes: buf })
+    expect(splatMeshSpies.ctor).toHaveBeenCalledWith({ fileBytes: buf })
     expect(result).toBeInstanceOf(THREE.Group)
     expect(result.children).toHaveLength(1)
 
     expect(ctx.setOriginalModel).toHaveBeenCalledTimes(1)
     expect(ctx.setOriginalModel).toHaveBeenCalledWith(result.children[0])
+  })
+
+  it('rotates the splat 180° around X (OpenCV → three.js convention)', async () => {
+    const result = await new SplatModelAdapter().load(
+      makeContext(),
+      '/api/view?',
+      'scene.splat'
+    )
+
+    const splat = result.children[0]
+    expect(splat.quaternion.x).toBe(1)
+    expect(splat.quaternion.y).toBe(0)
+    expect(splat.quaternion.z).toBe(0)
+    expect(splat.quaternion.w).toBe(0)
   })
 
   it('propagates fetch errors', async () => {
@@ -78,5 +116,73 @@ describe('SplatModelAdapter', () => {
     await expect(
       adapter.load(makeContext(), '/api/view?', 'scene.splat')
     ).rejects.toThrow('Failed to fetch model: 500')
+  })
+
+  describe('computeBounds', () => {
+    it('returns the SplatMesh bounding box transformed to world space', async () => {
+      const adapter = new SplatModelAdapter()
+      const group = await adapter.load(
+        makeContext(),
+        '/api/view?',
+        'scene.splat'
+      )
+      const splat = group.children[0]
+      splat.position.set(10, 0, 0)
+
+      const bounds = adapter.computeBounds(group)
+
+      expect(bounds).toBeInstanceOf(THREE.Box3)
+      expect(splatMeshSpies.getBoundingBox).toHaveBeenCalledWith(false)
+      expect(splatMeshSpies.updateWorldMatrix).toHaveBeenCalledWith(true, false)
+      // Local bbox was [-1,-1,-1]→[1,1,1]; world matrix translates by +10 X
+      // (with the splat's quaternion applied to the inner mesh).
+      expect(bounds!.min.x).toBeCloseTo(9)
+      expect(bounds!.max.x).toBeCloseTo(11)
+    })
+
+    it('returns null when the first child is not a SplatMesh', () => {
+      const adapter = new SplatModelAdapter()
+      const group = new THREE.Group()
+      group.add(new THREE.Mesh())
+
+      expect(adapter.computeBounds(group)).toBeNull()
+    })
+  })
+
+  describe('disposeModel', () => {
+    it('calls dispose on every SplatMesh in the model tree', async () => {
+      const adapter = new SplatModelAdapter()
+      const group = await adapter.load(
+        makeContext(),
+        '/api/view?',
+        'scene.splat'
+      )
+
+      adapter.disposeModel(group)
+
+      expect(splatMeshSpies.dispose).toHaveBeenCalledOnce()
+    })
+
+    it('is a no-op when the tree has no SplatMesh', () => {
+      const adapter = new SplatModelAdapter()
+      const group = new THREE.Group()
+      group.add(new THREE.Mesh())
+
+      expect(() => adapter.disposeModel(group)).not.toThrow()
+    })
+  })
+
+  describe('defaultCameraPose', () => {
+    it('returns the (5,5,5) / (0,2.5,0) seat for self-sized splats', () => {
+      const adapter = new SplatModelAdapter()
+      const pose = adapter.defaultCameraPose()
+
+      expect(pose.size.x).toBe(5)
+      expect(pose.size.y).toBe(5)
+      expect(pose.size.z).toBe(5)
+      expect(pose.center.x).toBe(0)
+      expect(pose.center.y).toBe(2.5)
+      expect(pose.center.z).toBe(0)
+    })
   })
 })

--- a/src/extensions/core/load3d/SplatModelAdapter.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.ts
@@ -1,11 +1,11 @@
 import { SplatMesh } from '@sparkjsdev/spark'
 import * as THREE from 'three'
 
-import {
-  fetchModelData,
-  type ModelAdapter,
-  type ModelAdapterCapabilities,
-  type ModelLoadContext
+import { fetchModelData } from './ModelAdapter'
+import type {
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
 } from './ModelAdapter'
 
 export class SplatModelAdapter implements ModelAdapter {

--- a/src/extensions/core/load3d/SplatModelAdapter.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.ts
@@ -1,24 +1,24 @@
 import { SplatMesh } from '@sparkjsdev/spark'
 import * as THREE from 'three'
 
-import { fetchModelData } from './ModelAdapter'
-import type {
-  ModelAdapter,
-  ModelAdapterCapabilities,
-  ModelLoadContext
+import {
+  fetchModelData,
+  type ModelAdapter,
+  type ModelAdapterCapabilities,
+  type ModelLoadContext
 } from './ModelAdapter'
 
 export class SplatModelAdapter implements ModelAdapter {
   readonly kind = 'splat' as const
   readonly extensions = ['spz', 'splat', 'ksplat'] as const
   readonly capabilities: ModelAdapterCapabilities = {
-    fitToViewer: false,
+    fitToViewer: true,
     requiresMaterialRebuild: false,
-    gizmoTransform: false,
+    gizmoTransform: true,
     lighting: false,
     exportable: false,
     materialModes: [],
-    fitTargetSize: 5
+    fitTargetSize: 20
   }
 
   async load(
@@ -29,10 +29,34 @@ export class SplatModelAdapter implements ModelAdapter {
     const arrayBuffer = await fetchModelData(path, filename)
 
     const splatMesh = new SplatMesh({ fileBytes: arrayBuffer })
+    await splatMesh.initialized
+    splatMesh.quaternion.set(1, 0, 0, 0)
     ctx.setOriginalModel(splatMesh)
 
     const splatGroup = new THREE.Group()
     splatGroup.add(splatMesh)
     return splatGroup
+  }
+
+  computeBounds(model: THREE.Object3D): THREE.Box3 | null {
+    const splat = model.children[0]
+    if (!(splat instanceof SplatMesh)) return null
+    splat.updateWorldMatrix(true, false)
+    return splat.getBoundingBox(false).clone().applyMatrix4(splat.matrixWorld)
+  }
+
+  disposeModel(model: THREE.Object3D): void {
+    model.traverse((child) => {
+      if (child instanceof SplatMesh) {
+        child.dispose()
+      }
+    })
+  }
+
+  defaultCameraPose(): { size: THREE.Vector3; center: THREE.Vector3 } {
+    return {
+      size: new THREE.Vector3(5, 5, 5),
+      center: new THREE.Vector3(0, 2.5, 0)
+    }
   }
 }

--- a/src/extensions/core/load3d/createLoad3d.test.ts
+++ b/src/extensions/core/load3d/createLoad3d.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DEFAULT_MODEL_CAPABILITIES } from './ModelAdapter'
+import type { ModelAdapter, ModelAdapterCapabilities } from './ModelAdapter'
+import { createLoad3d } from './createLoad3d'
+
+const { rendererCtor } = vi.hoisted(() => ({
+  rendererCtor: vi.fn()
+}))
+
+vi.mock('three', async () => {
+  const actual = await vi.importActual<typeof import('three')>('three')
+  return {
+    ...actual,
+    WebGLRenderer: class {
+      domElement = document.createElement('canvas')
+      autoClear = false
+      outputColorSpace = ''
+      constructor(opts: unknown) {
+        rendererCtor(opts)
+      }
+      setSize() {}
+      setClearColor() {}
+    }
+  }
+})
+
+vi.mock('./SceneManager', () => ({
+  SceneManager: class {
+    scene = { __scene: true }
+  }
+}))
+
+vi.mock('./CameraManager', () => ({
+  CameraManager: class {
+    activeCamera = { __camera: true }
+    setControls = vi.fn()
+    setupForModel = vi.fn()
+  }
+}))
+
+vi.mock('./ControlsManager', () => ({
+  ControlsManager: class {
+    controls = { __controls: true }
+  }
+}))
+
+vi.mock('./LightingManager', () => ({
+  LightingManager: class {}
+}))
+
+vi.mock('./HDRIManager', () => ({
+  HDRIManager: class {}
+}))
+
+vi.mock('./ViewHelperManager', () => ({
+  ViewHelperManager: class {}
+}))
+
+vi.mock('./SceneModelManager', () => ({
+  SceneModelManager: class {
+    getCurrentCapabilities: () => unknown
+    getBoundsFromAdapter: (model: unknown) => unknown
+    disposeModelViaAdapter: (model: unknown) => unknown
+    getDefaultCameraPose: () => unknown
+    constructor(
+      _scene: unknown,
+      _renderer: unknown,
+      _eventManager: unknown,
+      _getActiveCamera: unknown,
+      _setupCamera: unknown,
+      _setupGizmo: unknown,
+      getCurrentCapabilities: () => unknown,
+      getBoundsFromAdapter: (model: unknown) => unknown,
+      disposeModelViaAdapter: (model: unknown) => unknown,
+      getDefaultCameraPose: () => unknown
+    ) {
+      this.getCurrentCapabilities = getCurrentCapabilities
+      this.getBoundsFromAdapter = getBoundsFromAdapter
+      this.disposeModelViaAdapter = disposeModelViaAdapter
+      this.getDefaultCameraPose = getDefaultCameraPose
+    }
+  }
+}))
+
+vi.mock('./LoaderManager', () => ({
+  LoaderManager: class {
+    adapterRefArg: unknown
+    constructor(
+      _modelManager: unknown,
+      _eventManager: unknown,
+      _adapters: unknown,
+      adapterRef: unknown
+    ) {
+      this.adapterRefArg = adapterRef
+    }
+  }
+}))
+
+vi.mock('./RecordingManager', () => ({
+  RecordingManager: class {}
+}))
+
+vi.mock('./AnimationManager', () => ({
+  AnimationManager: class {}
+}))
+
+vi.mock('./GizmoManager', () => ({
+  GizmoManager: class {
+    setupForModel = vi.fn()
+    getTransform = vi.fn(() => ({}))
+    isEnabled = vi.fn(() => false)
+    getMode = vi.fn(() => 'translate')
+  }
+}))
+
+vi.mock('./Load3d', () => ({
+  default: class {
+    deps: unknown
+    options: unknown
+    constructor(_container: unknown, deps: unknown, options: unknown) {
+      this.deps = deps
+      this.options = options
+    }
+  }
+}))
+
+type FakeLoaderManager = { adapterRefArg: { current: ModelAdapter | null } }
+type FakeSceneModelManager = {
+  getCurrentCapabilities: () => unknown
+  getBoundsFromAdapter: (model: unknown) => unknown
+  disposeModelViaAdapter: (model: unknown) => void
+  getDefaultCameraPose: () => unknown
+}
+type FakeLoad3d = {
+  deps: {
+    adapterRef: { current: ModelAdapter | null }
+    loaderManager: FakeLoaderManager
+    modelManager: FakeSceneModelManager
+  }
+  options: unknown
+}
+
+function createContainer(): HTMLElement {
+  const container = document.createElement('div')
+  // Stub appendChild — we only care that one was called, not what was attached.
+  container.appendChild = vi.fn().mockReturnValue(container)
+  return container
+}
+
+function makeAdapter(overrides: Partial<ModelAdapter> = {}): ModelAdapter {
+  return {
+    kind: 'mesh',
+    extensions: [],
+    capabilities: DEFAULT_MODEL_CAPABILITIES,
+    load: vi.fn().mockResolvedValue(null),
+    ...overrides
+  } satisfies ModelAdapter
+}
+
+describe('createLoad3d', () => {
+  it('constructs the renderer with alpha + antialias and appends it to the container', () => {
+    rendererCtor.mockClear()
+    const container = createContainer()
+
+    createLoad3d(container)
+
+    expect(rendererCtor).toHaveBeenCalledWith({ alpha: true, antialias: true })
+    expect(container.appendChild).toHaveBeenCalledOnce()
+  })
+
+  it('forwards Load3DOptions to the Load3d constructor', () => {
+    const container = createContainer()
+    const options = { width: 640, height: 480, isViewerMode: true }
+
+    const instance = createLoad3d(container, options) as unknown as FakeLoad3d
+
+    expect(instance.options).toEqual(options)
+  })
+
+  it('shares one AdapterRef between LoaderManager and SceneModelManager lambdas', () => {
+    const container = createContainer()
+    const instance = createLoad3d(container) as unknown as FakeLoad3d
+
+    const adapterRef = instance.deps.adapterRef
+    expect(adapterRef.current).toBeNull()
+
+    const loaderRef = instance.deps.loaderManager.adapterRefArg
+    expect(loaderRef).toBe(adapterRef)
+  })
+
+  describe('SceneModelManager capability lambdas (default — no adapter loaded)', () => {
+    it('getCurrentCapabilities falls back to DEFAULT_MODEL_CAPABILITIES', () => {
+      const instance = createLoad3d(createContainer()) as unknown as FakeLoad3d
+
+      expect(instance.deps.modelManager.getCurrentCapabilities()).toEqual(
+        DEFAULT_MODEL_CAPABILITIES
+      )
+    })
+
+    it('getBoundsFromAdapter returns null', () => {
+      const instance = createLoad3d(createContainer()) as unknown as FakeLoad3d
+      expect(
+        instance.deps.modelManager.getBoundsFromAdapter({} as never)
+      ).toBeNull()
+    })
+
+    it('disposeModelViaAdapter is a no-op', () => {
+      const instance = createLoad3d(createContainer()) as unknown as FakeLoad3d
+      expect(() =>
+        instance.deps.modelManager.disposeModelViaAdapter({} as never)
+      ).not.toThrow()
+    })
+
+    it('getDefaultCameraPose returns null', () => {
+      const instance = createLoad3d(createContainer()) as unknown as FakeLoad3d
+      expect(instance.deps.modelManager.getDefaultCameraPose()).toBeNull()
+    })
+  })
+
+  describe('SceneModelManager capability lambdas (after adapter is published)', () => {
+    function withAdapter(adapter: ModelAdapter) {
+      const instance = createLoad3d(createContainer()) as unknown as FakeLoad3d
+      instance.deps.adapterRef.current = adapter
+      return instance
+    }
+
+    it('getCurrentCapabilities reads the published adapter capabilities', () => {
+      const caps: ModelAdapterCapabilities = {
+        ...DEFAULT_MODEL_CAPABILITIES,
+        gizmoTransform: false,
+        materialModes: []
+      }
+      const instance = withAdapter(makeAdapter({ capabilities: caps }))
+
+      expect(instance.deps.modelManager.getCurrentCapabilities()).toBe(caps)
+    })
+
+    it('getBoundsFromAdapter delegates to adapter.computeBounds', () => {
+      const computeBounds = vi.fn().mockReturnValue('bbox-result')
+      const instance = withAdapter(makeAdapter({ computeBounds }))
+      const model = { fake: 'model' }
+
+      const result = instance.deps.modelManager.getBoundsFromAdapter(
+        model as never
+      )
+
+      expect(computeBounds).toHaveBeenCalledWith(model)
+      expect(result).toBe('bbox-result')
+    })
+
+    it('getBoundsFromAdapter returns null when adapter has no computeBounds', () => {
+      const instance = withAdapter(makeAdapter())
+      expect(
+        instance.deps.modelManager.getBoundsFromAdapter({} as never)
+      ).toBeNull()
+    })
+
+    it('disposeModelViaAdapter delegates to adapter.disposeModel', () => {
+      const disposeModel = vi.fn()
+      const instance = withAdapter(makeAdapter({ disposeModel }))
+      const model = { fake: 'model' }
+
+      instance.deps.modelManager.disposeModelViaAdapter(model as never)
+
+      expect(disposeModel).toHaveBeenCalledWith(model)
+    })
+
+    it('getDefaultCameraPose delegates to adapter.defaultCameraPose', () => {
+      const pose = { size: { x: 5 }, center: { x: 0 } }
+      const defaultCameraPose = vi.fn().mockReturnValue(pose)
+      const instance = withAdapter(makeAdapter({ defaultCameraPose }))
+
+      expect(instance.deps.modelManager.getDefaultCameraPose()).toBe(pose)
+      expect(defaultCameraPose).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/src/extensions/core/load3d/createLoad3d.ts
+++ b/src/extensions/core/load3d/createLoad3d.ts
@@ -1,0 +1,144 @@
+import * as THREE from 'three'
+
+import { AnimationManager } from './AnimationManager'
+import { CameraManager } from './CameraManager'
+import { ControlsManager } from './ControlsManager'
+import { EventManager } from './EventManager'
+import { GizmoManager } from './GizmoManager'
+import { HDRIManager } from './HDRIManager'
+import { LightingManager } from './LightingManager'
+import Load3d from './Load3d'
+import type { Load3dDeps } from './Load3d'
+import { LoaderManager } from './LoaderManager'
+import { createAdapterRef, DEFAULT_MODEL_CAPABILITIES } from './ModelAdapter'
+import { RecordingManager } from './RecordingManager'
+import { SceneManager } from './SceneManager'
+import { SceneModelManager } from './SceneModelManager'
+import { ViewHelperManager } from './ViewHelperManager'
+import type { Load3DOptions } from './interfaces'
+
+function createRenderer(container: Element | HTMLElement): THREE.WebGLRenderer {
+  const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true })
+  renderer.setSize(300, 300)
+  renderer.setClearColor(0x282828)
+  renderer.autoClear = false
+  renderer.outputColorSpace = THREE.SRGBColorSpace
+  renderer.domElement.classList.add(
+    'absolute',
+    'inset-0',
+    'h-full',
+    'w-full',
+    'outline-none'
+  )
+  container.appendChild(renderer.domElement)
+  return renderer
+}
+
+function buildLoad3dDeps(container: Element | HTMLElement): Load3dDeps {
+  const renderer = createRenderer(container)
+  const eventManager = new EventManager()
+  // Shared mutable handle: LoaderManager writes the active adapter on each
+  // load; SceneModelManager reads it for capability/bounds/dispose lookups
+  // without depending on construction order.
+  const adapterRef = createAdapterRef()
+
+  let cameraManager: CameraManager
+  let controlsManager: ControlsManager
+  let gizmoManager: GizmoManager
+
+  const getActiveCamera = (): THREE.Camera => cameraManager.activeCamera
+  const getControls = () => controlsManager.controls
+
+  const sceneManager = new SceneManager(
+    renderer,
+    getActiveCamera,
+    getControls,
+    eventManager
+  )
+
+  cameraManager = new CameraManager(renderer, eventManager)
+  controlsManager = new ControlsManager(
+    renderer,
+    cameraManager.activeCamera,
+    eventManager
+  )
+  cameraManager.setControls(controlsManager.controls)
+
+  const lightingManager = new LightingManager(sceneManager.scene, eventManager)
+  const hdriManager = new HDRIManager(
+    sceneManager.scene,
+    renderer,
+    eventManager
+  )
+  const viewHelperManager = new ViewHelperManager(
+    renderer,
+    getActiveCamera,
+    getControls,
+    eventManager
+  )
+
+  const modelManager = new SceneModelManager(
+    sceneManager.scene,
+    renderer,
+    eventManager,
+    getActiveCamera,
+    (size, center) => cameraManager.setupForModel(size, center),
+    (model) => gizmoManager.setupForModel(model),
+    () => adapterRef.current?.capabilities ?? DEFAULT_MODEL_CAPABILITIES,
+    (model) => adapterRef.current?.computeBounds?.(model) ?? null,
+    (model) => adapterRef.current?.disposeModel?.(model),
+    () => adapterRef.current?.defaultCameraPose?.() ?? null
+  )
+
+  const loaderManager = new LoaderManager(
+    modelManager,
+    eventManager,
+    undefined,
+    adapterRef
+  )
+  const recordingManager = new RecordingManager(
+    sceneManager.scene,
+    renderer,
+    eventManager
+  )
+  const animationManager = new AnimationManager(eventManager)
+
+  gizmoManager = new GizmoManager(
+    sceneManager.scene,
+    renderer,
+    controlsManager.controls,
+    getActiveCamera,
+    () => {
+      const transform = gizmoManager.getTransform()
+      eventManager.emitEvent('gizmoTransformChange', {
+        ...transform,
+        enabled: gizmoManager.isEnabled(),
+        mode: gizmoManager.getMode()
+      })
+    }
+  )
+
+  return {
+    renderer,
+    eventManager,
+    sceneManager,
+    cameraManager,
+    controlsManager,
+    lightingManager,
+    hdriManager,
+    viewHelperManager,
+    loaderManager,
+    modelManager,
+    recordingManager,
+    animationManager,
+    gizmoManager,
+    adapterRef
+  }
+}
+
+export function createLoad3d(
+  container: Element | HTMLElement,
+  options?: Load3DOptions
+): Load3d {
+  return new Load3d(container, buildLoad3dDeps(container), options)
+}


### PR DESCRIPTION
> Final architectural step in the PLY / 3D Gaussian Splatting series. Previous PR introduced `ModelAdapter` with a dormant `capabilities` field; this PR makes those capabilities load-bearing and replaces the remaining `instanceof SplatMesh` / `instanceof BufferGeometry` switches with adapter-driven dispatch. Together with previous one it removes the last of the format-specific branching from `SceneModelManager` / `Load3d`. Seventh in the series splitting up the https://github.com/Comfy-Org/ComfyUI_frontend/pull/11495.

## Summary

Drive viewer behavior (fit-to-viewer, default camera pose, world bounds, GPU dispose, material rebuild) from `ModelAdapterCapabilities` + 3 new optional adapter methods, instead of `SceneModelManager` reflecting on model shape. `Load3d` is rewritten to take its 13 managers as injected `Load3dDeps`; a new `createLoad3d` factory assembles them and threads a single `AdapterRef` between `LoaderManager` (writer) and `SceneModelManager` + `Load3d` (readers). Splat orientation + decoder-race + sizing bugs are fixed as a side effect — splats now render upright, fill the grid, and don't lock the OrbitControls target on first frame.

## Changes

- **`ModelAdapter.ts`**: add `AdapterRef = { current: ModelAdapter | null }` shared handle and 3 optional adapter methods — `computeBounds(model)`, `disposeModel(model)`, `defaultCameraPose()`.
- **`SplatModelAdapter.ts`**: implement all 3 optional methods; `await splatMesh.initialized` so first-frame bounds are populated (fixes a decoder race that collapsed the OrbitControls target onto the camera); `quaternion.set(1, 0, 0, 0)` to convert sparkjs's OpenCV (Y-down, Z-forward) to three.js (Y-up, Z-back); flip `fitToViewer` back to `true` and bump `fitTargetSize` to `20` so splats fill the 20-unit grid instead of shrinking to 1/4 of it.
- **`PointCloudModelAdapter.ts`**: extract `buildPointCloudForMaterialMode` so `SceneModelManager` rebuilds via the same code path the initial load uses; `setPath` so PLYs that reference relative assets resolve correctly.
- **`LoaderManager.ts`**: accept optional `AdapterRef`; write through it instead of the internal `_currentAdapter` field. `clearModel()` now runs while the old adapter is still current so its `disposeModel()` can release renderer-owned resources.
- **`SceneModelManager.ts`**: accept 4 capability lambdas (`getCurrentCapabilities` / `getBoundsFromAdapter` / `disposeModelViaAdapter` / `getDefaultCameraPose`) with `DEFAULT_MODEL_CAPABILITIES` / null fallbacks. `setupModel`, `fitToViewer`, and material-mode rebuild are now capability-driven; `containsSplatMesh` (30 lines of `instanceof` traversal) and `handlePLYModeSwitch` (90 lines of duplicated PLY rebuild) are gone.
- **`Load3d.ts`**: ctor switches from manager-creation to deps-injected (`Load3dDeps`); add `getCurrentModelCapabilities()` reader; gate `setGizmoEnabled` / `setGizmoMode` / `resetGizmoTransform` / `applyGizmoTransform` on `capabilities.gizmoTransform`; `isSplatModel` / `isPlyModel` now read `adapterRef.current?.kind` directly.
- **`createLoad3d.ts`** (new): single factory that builds the renderer (`createRenderer`), assembles all 13 managers in dependency order, and threads one shared `AdapterRef` through `LoaderManager` and `SceneModelManager`'s 4 capability lambdas.
- **`useLoad3d.ts` / `useLoad3dViewer.ts`**: switch from `new Load3d(container, options)` to `createLoad3d(container, options)`. No other call-site changes.

## Review Focus

- **Capability dispatch parity**: walk each former hardcoded branch in `SceneModelManager` and confirm it now falls out of the right capability:
  - `containsSplatMesh()` → `!capabilities.fitToViewer` + `getDefaultCameraPose()`
  - `handlePLYModeSwitch()` → `capabilities.requiresMaterialRebuild` + `buildPointCloudForMaterialMode()`
  - `Box3.setFromObject(model)` for sizing → `getBoundsFromAdapter(model) ?? Box3.setFromObject(model)`
  - Mesh/Points geometry+material disposal in `clearModel` → still happens, plus `disposeModelViaAdapter(obj)` for adapter-owned resources (sparkjs SplatMesh internal GPU state)
- **`AdapterRef` lifecycle**: one ref is created in `createLoad3d`, passed to `LoaderManager` (writer) and `SceneModelManager` (read via 4 closures). `LoaderManager.loadModel` clears via the *old* adapter first (so `disposeModel` runs), then null-resets the ref before picking the new one. Test `keeps the old adapter current while clearModel runs` pins this ordering.
- **Splat fixes are user-visible, not pure refactor**:
  - Orientation: `quaternion.set(1, 0, 0, 0)` matches the sparkjs README convention. Without it splats render upside-down and mirrored on Z. Same rotation is applied to the camera-from-matrices output in PR-E so a future splat + camera-pose pair lines up.
  - Decoder race: `await splatMesh.initialized` ensures `getBoundingBox` returns a non-zero box on the first call. Without it `setupModel`'s bounds → camera pipeline placed the OrbitControls target on the camera origin, locking the view.
  - Sizing: `fitTargetSize: 20` (vs. the mesh default of 5) means splat geometry spans the full 20-unit grid footprint instead of ~1/4 of it. Mesh assets are unaffected.
- **Gizmo gating**: `setGizmoEnabled(true)` early-returns when `capabilities.gizmoTransform` is false. Internal `setGizmoEnabled(false)` still runs (so we can always disable). `setGizmoMode` / `resetGizmoTransform` / `applyGizmoTransform` no-op when the capability is off.
- **`createLoad3d` is the single ctor entry**: `new Load3d(...)` is no longer callable from app code (ctor signature changed to `(container, deps, options)`). All call sites use `createLoad3d`. Test scaffolding still uses `Object.create(Load3d.prototype)` + property injection where it needs to bypass renderer creation.
- **Backwards compatibility**: `LoaderManager`'s `adapterRef` and `SceneModelManager`'s 4 capability lambdas all have defaults (`createAdapterRef()` and `() => DEFAULT_MODEL_CAPABILITIES` etc.), so the existing test suites that construct these classes with the old signatures still compile and pass without modification beyond what's in this PR.

## Coverage

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `ModelAdapter.ts` (modified) | **100%** | **100%** | **100%** | **100%** |
| `LoaderManager.ts` (modified) | **100%** | 91.7% | 86.7% | **100%** |
| `MeshModelAdapter.ts` (unchanged) | **100%** | **100%** | **100%** | **100%** |
| `PointCloudModelAdapter.ts` (modified) | **97.9%** | 69.2% | 71.4% | **97.9%** |
| `SplatModelAdapter.ts` (modified) | **100%** | **100%** | **100%** | **100%** |
| `SceneModelManager.ts` (modified) | 75.4% | 67.2% | 72.2% | 75.4% |
| `Load3d.ts` (modified) | 29.5% | 30.6% | 26.7% | 30.1% |
| `createLoad3d.ts` (new) | 83.8% | **100%** | 58.3% | 83.8% |
| `useLoad3d.ts` (modified) | 78.2% | 65.1% | 71.4% | 82.2% |
| `useLoad3dViewer.ts` (modified) | 75.2% | 52.1% | 65.9% | 79.4% |

`SplatModelAdapter.ts` jumps to 100% via 6 new tests covering the orientation set, the `await initialized` decoder wait, `computeBounds` (world-space transform + null fallback), `disposeModel` (per-SplatMesh dispose + no-op on non-splat trees), and `defaultCameraPose`.

`createLoad3d.ts` hits 100% branch via a new test file with 12 cases — `WebGLRenderer` config, `Load3DOptions` forwarding, `AdapterRef` identity between `LoaderManager` and `SceneModelManager`, and the 4 capability lambdas in both adapter-null and adapter-published states (each delegates correctly to the adapter's optional methods or falls back to defaults). The remaining func% reflects the inline `gizmoTransformChange` callback — not a deliberate skip, just out of scope for the dispatch-wiring tests.

`SceneModelManager.ts` and `Load3d.ts` numbers are the pre-existing baseline — the existing `*.test.ts` files cover façade methods via prototype injection rather than instantiating the classes (`Load3d` constructor needs `THREE.WebGLRenderer`, which happy-dom can't provide; `SceneModelManager` covers the new capability paths via its existing `createManager(overrides)` helper). All new branches (capability gating, capability-driven `setupModel` / `fitToViewer` / rebuild, adapter-driven `isSplatModel` / `isPlyModel`) have dedicated tests.

Net diff: **+846 / −370** across 16 files (10 production, 6 test).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11660-refactor-load3d-drive-viewer-behavior-from-ModelAdapter-capabilities-34f6d73d36508130b0ece884add182b9) by [Unito](https://www.unito.io)
