### PR TITLE
test: add unit tests for linkFixer

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -17,6 +17,9 @@ const config: KnipConfig = {
       entry: ['src/i18n.ts'],
       project: ['src/**/*.{js,ts,vue}']
     },
+    'packages/design-system': {
+      project: ['src/**/*.{css,js,ts}']
+    },
     'packages/tailwind-utils': {
       project: ['src/**/*.{js,ts}']
     },

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
+import type {
+  ISerialisedGraph,
+  ISerialisedNode
+} from '@/lib/litegraph/src/types/serialisation'
+
+import { fixBadLinks } from './linkFixer'
+
+type SerialisedInput = NonNullable<ISerialisedNode['inputs']>[number]
+type SerialisedOutput = NonNullable<ISerialisedNode['outputs']>[number]
+
+function createInput(link: number | null): SerialisedInput {
+  return {
+    name: 'input',
+    type: '*',
+    link
+  } satisfies Partial<SerialisedInput> as SerialisedInput
+}
+
+function createOutput(links: number[]): SerialisedOutput {
+  return {
+    name: 'output',
+    type: '*',
+    links
+  } satisfies Partial<SerialisedOutput> as SerialisedOutput
+}
+
+function createNode({
+  id,
+  inputs = [],
+  outputs = []
+}: {
+  id: number
+  inputs?: SerialisedInput[]
+  outputs?: SerialisedOutput[]
+}): ISerialisedNode {
+  return {
+    id,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [100, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    inputs,
+    outputs
+  }
+}
+
+function createGraph({
+  nodes,
+  links
+}: {
+  nodes: ISerialisedNode[]
+  links: SerialisedLLinkArray[]
+}): ISerialisedGraph {
+  return {
+    id: 'b4e984f1-b421-4d24-b8b4-ff895793af13',
+    revision: 0,
+    version: 0.4,
+    last_node_id: Math.max(...nodes.map((node) => Number(node.id)), 0),
+    last_link_id: Math.max(...links.map((link) => link[0]), 0),
+    nodes,
+    links,
+    groups: []
+  }
+}
+
+describe('fixBadLinks', () => {
+  it('leaves a valid serialized graph unchanged', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2, inputs: [createInput(1)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+    const logger = { log: vi.fn() }
+
+    const result = fixBadLinks(graph, { logger })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: false,
+      patched: 0,
+      deleted: 0
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
+    expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(1)
+    expect(logger.log).not.toHaveBeenCalled()
+  })
+
+  it('reports a missing origin output link during a dry run', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([])] }),
+        createNode({ id: 2, inputs: [createInput(1)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+    const logger = { log: vi.fn() }
+
+    const result = fixBadLinks(graph, { logger })
+
+    expect(result).toMatchObject({
+      hasBadLinks: true,
+      fixed: false,
+      patched: 1,
+      deleted: 0
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
+    expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(1)
+    expect(logger.log).toHaveBeenCalled()
+  })
+
+  it('adds a missing origin output link in fix mode', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([])] }),
+        createNode({ id: 2, inputs: [createInput(1)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 0
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
+    expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(1)
+  })
+
+  it('sets a missing target input link in fix mode', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2, inputs: [createInput(null)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 0
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
+    expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(1)
+  })
+
+  it('removes a stale origin reference instead of overwriting another target link', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2, inputs: [createInput(2)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
+    expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(2)
+    expect(graph.links).toEqual([])
+  })
+
+  it('cleans dangling references when a linked node is missing', () => {
+    const graph = createGraph({
+      nodes: [createNode({ id: 2, inputs: [createInput(1)] })],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.inputs?.[0]?.link).toBeNull()
+    expect(graph.links).toEqual([])
+  })
+
+  it('cleans dangling origin references when the target node is missing', () => {
+    const graph = createGraph({
+      nodes: [createNode({ id: 1, outputs: [createOutput([1])] })],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
+    expect(graph.links).toEqual([])
+  })
+
+  it('deletes a stale link that neither endpoint references', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([])] }),
+        createNode({ id: 2, inputs: [createInput(null)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 0,
+      deleted: 1
+    })
+    expect(graph.links).toEqual([])
+  })
+
+  it('suppresses logger calls in silent mode while still applying fixes', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([])] }),
+        createNode({ id: 2, inputs: [createInput(1)] })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+    const logger = { log: vi.fn() }
+
+    const result = fixBadLinks(graph, { fix: true, silent: true, logger })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 0
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([1])
+    expect(logger.log).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -157,6 +157,28 @@ describe('fixBadLinks', () => {
     expect(graph.nodes[1]?.inputs?.[0]?.link).toBe(1)
   })
 
+  it('removes the origin reference when the target input slot is missing', () => {
+    const graph = createGraph({
+      nodes: [
+        createNode({ id: 1, outputs: [createOutput([1])] }),
+        createNode({ id: 2 })
+      ],
+      links: [[1, 1, 0, 2, 0, '*']]
+    })
+
+    const result = fixBadLinks(graph, { fix: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 1
+    })
+    expect(graph.nodes[0]?.outputs?.[0]?.links).toEqual([])
+    expect(graph.nodes[1]?.inputs).toEqual([])
+    expect(graph.links).toEqual([])
+  })
+
   it('removes a stale origin reference instead of overwriting another target link', () => {
     const graph = createGraph({
       nodes: [

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -24,7 +24,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
+import type {
+  INodeInputSlot,
+  INodeOutputSlot
+} from '@/lib/litegraph/src/interfaces'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
@@ -138,7 +141,11 @@ export function fixBadLinks(
       const linkIdToSet = op === 'REMOVE' ? null : linkId
       patchedNode['inputs']![slot] = linkIdToSet
       if (fix) {
-        // node.inputs[slot]!.link = linkIdToSet;
+        node.inputs = node.inputs || []
+        node.inputs[slot] =
+          node.inputs[slot] ||
+          ({} satisfies Partial<INodeInputSlot> as INodeInputSlot)
+        node.inputs[slot]!.link = linkIdToSet
       }
     } else {
       patchedNode['outputs'] = patchedNode['outputs'] || {}
@@ -461,18 +468,17 @@ export function fixBadLinks(
     } stale link removals.`
   )
 
-  let hasBadLinks: boolean = !!(
-    data.patchedNodes.length || data.deletedLinks.length
-  )
+  const hasChanges = !!(data.patchedNodes.length || data.deletedLinks.length)
+  let hasBadLinks: boolean = hasChanges
   // If we're fixing, then let's run it again to see if there are no more bad links.
-  if (fix && !silent) {
+  if (fix) {
     const rerun = fixBadLinks(graph, { fix: false, silent: true })
     hasBadLinks = rerun.hasBadLinks
   }
 
   return {
     hasBadLinks,
-    fixed: !!hasBadLinks && fix,
+    fixed: fix && hasChanges && !hasBadLinks,
     graph,
     patched: data.patchedNodes.length,
     deleted: data.deletedLinks.length

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -24,10 +24,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import type {
-  INodeInputSlot,
-  INodeOutputSlot
-} from '@/lib/litegraph/src/interfaces'
+import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
@@ -139,13 +136,16 @@ export function fixBadLinks(
         return false
       }
       const linkIdToSet = op === 'REMOVE' ? null : linkId
+      const inputSlot = node.inputs?.[slot]
+      if (fix && !inputSlot) {
+        logger.log(
+          ` > Cannot patch ${node.id}.inputs[${slot}] because the input slot is missing.`
+        )
+        return false
+      }
       patchedNode['inputs']![slot] = linkIdToSet
       if (fix) {
-        node.inputs = node.inputs || []
-        node.inputs[slot] =
-          node.inputs[slot] ||
-          ({} satisfies Partial<INodeInputSlot> as INodeInputSlot)
-        node.inputs[slot]!.link = linkIdToSet
+        inputSlot!.link = linkIdToSet
       }
     } else {
       patchedNode['outputs'] = patchedNode['outputs'] || {}


### PR DESCRIPTION
## Summary

Adds unit coverage for `linkFixer` serialized graph repair paths and fixes input-slot repairs being tracked without mutating the serialized workflow data.

## Changes

- **What**: Adds 10 Vitest cases for valid links, dry-run reporting, origin/target repair, missing input-slot cleanup, dangling node cleanup, stale link deletion, and silent mode.
- **What**: Applies serialized input slot mutations in fix mode and reports `fixed` only after a rerun confirms the graph is clean.
- **What**: Adds the design-system package to knip workspace config so the pre-push hook recognizes its exported CSS dependency usage.
- **Dependencies**: None.

## Review Focus

The workflow validation path calls `fixBadLinks` with serialized workflow JSON, so the new tests stay at that boundary and assert the repaired graph shape directly.

## Test Coverage

- CI snapshot for `src/utils/linkFixer.ts`: unit lines 1.8%.
- Local targeted coverage: unit lines 83.9%, functions 94.11%, branches 75.15%.

## Testing

```bash
pnpm format -- src/utils/linkFixer.ts src/utils/linkFixer.test.ts
pnpm test:unit -- src/utils/linkFixer.test.ts
pnpm test:unit -- src/utils/linkFixer.test.ts --coverage
pnpm typecheck
pnpm lint
pnpm knip
```


## screenshoot
<img width="1691" height="927" alt="Screenshot 2026-04-28 at 10 09 26 AM" src="https://github.com/user-attachments/assets/ff59888f-bde3-48f5-853a-60df69e84492" />
