### PR TITLE
test: add unit tests for assetService

### DIFF
--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assetService } from '@/platform/assets/services/assetService'
+import { api } from '@/scripts/api'
 
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 const mockSettingStoreGet = vi.hoisted(() => vi.fn(() => false))
@@ -39,6 +40,25 @@ vi.mock('@/scripts/api', () => ({
 vi.mock('@/i18n', () => ({
   st: vi.fn((_key: string, fallback: string) => fallback)
 }))
+
+const fetchApiMock = vi.mocked(api.fetchApi)
+
+const buildResponse = (
+  body: unknown,
+  init: { ok?: boolean; status?: number } = {}
+): Response =>
+  ({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: vi.fn().mockResolvedValue(body)
+  }) as unknown as Response
+
+const validAsset = (overrides: Record<string, unknown> = {}) => ({
+  id: 'asset-1',
+  name: 'model.safetensors',
+  tags: ['models'],
+  ...overrides
+})
 
 describe(assetService.shouldUseAssetBrowser, () => {
   beforeEach(() => {
@@ -102,5 +122,196 @@ describe(assetService.shouldUseAssetBrowser, () => {
         'wrong_input'
       )
     ).toBe(false)
+  })
+})
+
+describe(assetService.getAssetMetadata, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws a localized message when the response is not ok', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({ code: 'FILE_TOO_LARGE' }, { ok: false, status: 413 })
+    )
+
+    await expect(
+      assetService.getAssetMetadata('https://example.com/model.safetensors')
+    ).rejects.toThrow('File too large')
+  })
+
+  it('throws a localized message when validation reports is_valid=false', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({
+        content_length: 100,
+        final_url: 'https://example.com/model.safetensors',
+        validation: {
+          is_valid: false,
+          errors: [{ code: 'UNSAFE_VIRUS_SCAN', message: 'bad', field: 'file' }]
+        }
+      })
+    )
+
+    await expect(
+      assetService.getAssetMetadata('https://example.com/model.safetensors')
+    ).rejects.toThrow('Unsafe virus scan')
+  })
+
+  it('encodes the URL in the query string', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({
+        content_length: 1,
+        final_url: 'https://example.com/x'
+      })
+    )
+
+    await assetService.getAssetMetadata('https://example.com/foo bar?x=1')
+
+    expect(fetchApiMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/assets/remote-metadata?url=' +
+          encodeURIComponent('https://example.com/foo bar?x=1')
+      )
+    )
+  })
+})
+
+describe(assetService.uploadAssetFromBase64, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws before calling the network when data is not a data URL', async () => {
+    await expect(
+      assetService.uploadAssetFromBase64({
+        data: 'not-a-data-url',
+        name: 'image.png'
+      })
+    ).rejects.toThrow('Invalid data URL')
+
+    expect(fetchApiMock).not.toHaveBeenCalled()
+  })
+})
+
+describe(assetService.uploadAssetAsync, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an async result when the server responds 202', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse(
+        { task_id: 'task-1', status: 'running' },
+        { ok: true, status: 202 }
+      )
+    )
+
+    const result = await assetService.uploadAssetAsync({
+      source_url: 'https://example.com/model.safetensors'
+    })
+
+    expect(result).toEqual({
+      type: 'async',
+      task: { task_id: 'task-1', status: 'running' }
+    })
+  })
+
+  it('returns a sync result when the server responds 200', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse(validAsset({ id: 'asset-2', name: 'sync.safetensors' }))
+    )
+
+    const result = await assetService.uploadAssetAsync({
+      source_url: 'https://example.com/model.safetensors'
+    })
+
+    expect(result).toEqual({
+      type: 'sync',
+      asset: expect.objectContaining({ id: 'asset-2' })
+    })
+  })
+})
+
+describe(assetService.deleteAsset, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws an error containing the status code when the response is not ok', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse(null, { ok: false, status: 503 })
+    )
+
+    await expect(assetService.deleteAsset('asset-1')).rejects.toThrow(/503/)
+  })
+})
+
+describe(assetService.getAssetModelFolders, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('filters out missing-tagged assets and blacklisted directories, returning alphabetical unique folders without include_public', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({
+        assets: [
+          validAsset({ id: 'a', tags: ['models', 'loras'] }),
+          validAsset({ id: 'b', tags: ['models', 'checkpoints'] }),
+          validAsset({ id: 'c', tags: ['models', 'configs'] }),
+          validAsset({ id: 'd', tags: ['models', 'missing', 'controlnet'] }),
+          validAsset({ id: 'e', tags: ['models', 'loras'] })
+        ]
+      })
+    )
+
+    const folders = await assetService.getAssetModelFolders()
+
+    expect(folders).toEqual([
+      { name: 'checkpoints', folders: [] },
+      { name: 'loras', folders: [] }
+    ])
+
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    expect(requestedUrl).not.toContain('include_public')
+  })
+})
+
+describe(assetService.updateAsset, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws when the response body fails schema validation', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({ name: 'no-id-field.safetensors' })
+    )
+
+    await expect(
+      assetService.updateAsset('asset-1', { name: 'renamed.safetensors' })
+    ).rejects.toThrow(/Invalid response/)
+  })
+})
+
+describe(assetService.getAssetsByTag, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards include_public=true by default and excludes missing-tagged assets', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({
+        assets: [
+          validAsset({ id: 'visible', tags: ['input'] }),
+          validAsset({ id: 'hidden', tags: ['input', 'missing'] })
+        ]
+      })
+    )
+
+    const assets = await assetService.getAssetsByTag('input')
+
+    expect(assets.map((a) => a.id)).toEqual(['visible'])
+
+    const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
+    expect(requestedUrl).toContain('include_public=true')
   })
 })

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { assetService } from '@/platform/assets/services/assetService'
 import { api } from '@/scripts/api'
 
@@ -43,22 +44,25 @@ vi.mock('@/i18n', () => ({
 
 const fetchApiMock = vi.mocked(api.fetchApi)
 
-const buildResponse = (
+function buildResponse(
   body: unknown,
   init: { ok?: boolean; status?: number } = {}
-): Response =>
-  ({
+): Response {
+  return {
     ok: init.ok ?? true,
     status: init.status ?? 200,
     json: vi.fn().mockResolvedValue(body)
-  }) as unknown as Response
+  } as unknown as Response
+}
 
-const validAsset = (overrides: Record<string, unknown> = {}) => ({
-  id: 'asset-1',
-  name: 'model.safetensors',
-  tags: ['models'],
-  ...overrides
-})
+function validAsset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'asset-1',
+    name: 'model.safetensors',
+    tags: ['models'],
+    ...overrides
+  }
+}
 
 describe(assetService.shouldUseAssetBrowser, () => {
   beforeEach(() => {
@@ -244,6 +248,17 @@ describe(assetService.deleteAsset, () => {
 
     await expect(assetService.deleteAsset('asset-1')).rejects.toThrow(/503/)
   })
+
+  it('issues a DELETE to the asset endpoint when the response is ok', async () => {
+    fetchApiMock.mockResolvedValueOnce(buildResponse(null))
+
+    await assetService.deleteAsset('asset-1')
+
+    expect(fetchApiMock).toHaveBeenCalledWith(
+      '/assets/asset-1',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
 })
 
 describe(assetService.getAssetModelFolders, () => {
@@ -272,7 +287,8 @@ describe(assetService.getAssetModelFolders, () => {
     ])
 
     const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
-    expect(requestedUrl).not.toContain('include_public')
+    const params = new URL(requestedUrl, 'http://localhost').searchParams
+    expect(params.has('include_public')).toBe(false)
   })
 })
 
@@ -289,6 +305,28 @@ describe(assetService.updateAsset, () => {
     await expect(
       assetService.updateAsset('asset-1', { name: 'renamed.safetensors' })
     ).rejects.toThrow(/Invalid response/)
+  })
+
+  it('PUTs the JSON payload and returns the parsed asset', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse(validAsset({ id: 'asset-1', name: 'renamed.safetensors' }))
+    )
+
+    const result = await assetService.updateAsset('asset-1', {
+      name: 'renamed.safetensors'
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({ id: 'asset-1', name: 'renamed.safetensors' })
+    )
+    expect(fetchApiMock).toHaveBeenCalledWith(
+      '/assets/asset-1',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'renamed.safetensors' })
+      })
+    )
   })
 })
 
@@ -312,6 +350,7 @@ describe(assetService.getAssetsByTag, () => {
     expect(assets.map((a) => a.id)).toEqual(['visible'])
 
     const requestedUrl = fetchApiMock.mock.calls[0]?.[0] as string
-    expect(requestedUrl).toContain('include_public=true')
+    const params = new URL(requestedUrl, 'http://localhost').searchParams
+    expect(params.get('include_public')).toBe('true')
   })
 })


### PR DESCRIPTION
## Summary

Extends `assetService.test.ts` (which previously only covered `shouldUseAssetBrowser`) with behavioral tests for the network-bound methods: metadata fetch error mapping, base64 upload validation, async-vs-sync upload routing, delete error propagation, model-folder filtering, update validation, and tag-filtered list defaults.

## Changes

- **What**: Adds 10 Vitest cases across `getAssetMetadata`, `uploadAssetFromBase64`, `uploadAssetAsync`, `deleteAsset`, `getAssetModelFolders`, `updateAsset`, and `getAssetsByTag`. Reuses the existing hoisted `mockDistributionState` / `mockSettingStoreGet` setup and the existing `vi.mock('@/scripts/api')` boundary; adds local `buildResponse` and `validAsset` helpers scoped to this file.

## Review Focus

- The localized error path is covered through public methods (`getAssetMetadata`) rather than reaching for the internal `getLocalizedErrorMessage`.
- `getAssetModelFolders` test asserts that the request URL omits `include_public` (the internal call site passes no `includePublic`), matching the conditional in `handleAssetRequest`.
- `uploadAssetAsync` tests pin the discriminated-union shape (`type: 'async' | 'sync'`) for both 202 and 200 responses.

## Testing

\`\`\`bash
pnpm exec vitest run src/platform/assets/services/assetService.test.ts
pnpm format -- src/platform/assets/services/assetService.test.ts
pnpm lint
pnpm typecheck
pnpm knip
\`\`\`

All 16 tests pass (6 prior + 10 new).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11670-test-add-unit-tests-for-assetService-34f6d73d36508117b1aafaf463e9c820) by [Unito](https://www.unito.io)
