### PR TITLE
fix(graph-traversal,minimap): cycle guards and callback chain-wrap survival

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphEdgeCases.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphEdgeCases.test.ts
@@ -27,15 +27,15 @@ describe('SubgraphEdgeCases - Recursion Detection', () => {
     const sub1 = createTestSubgraph({ name: 'Sub1' })
     const sub2 = createTestSubgraph({ name: 'Sub2' })
 
-    // Create circular reference
     const node1 = createTestSubgraphNode(sub1, { id: 1 })
     const node2 = createTestSubgraphNode(sub2, { id: 2 })
 
-    // Current limitation: adding a circular reference overflows recursion depth.
+    // Cycle guard in forEachNode (used by LGraph.add for subgraph registry
+    // tracking) keeps cyclic references from overflowing the stack.
     sub1.add(node2)
     expect(() => {
       sub2.add(node1)
-    }).toThrow(RangeError)
+    }).not.toThrow()
   })
 
   it('should handle deep nesting scenarios', () => {
@@ -52,14 +52,15 @@ describe('SubgraphEdgeCases - Recursion Detection', () => {
     expect(firstLevel.isSubgraphNode()).toBe(true)
   })
 
-  it('should throw RangeError for self-referential subgraph', () => {
-    // Current limitation: creating self-referential subgraph instances overflows recursion depth.
+  it('should not crash on self-referential subgraph', () => {
     const subgraph = createTestSubgraph({ nodeCount: 1 })
     const subgraphNode = createTestSubgraphNode(subgraph)
 
+    // forEachNode's cycle guard skips re-entering an already-visited subgraph
+    // when a subgraph node points back at its containing subgraph.
     expect(() => {
       subgraph.add(subgraphNode)
-    }).toThrow(RangeError)
+    }).not.toThrow()
   })
 
   it('should respect MAX_NESTED_SUBGRAPHS constant', () => {

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.test.ts
@@ -611,16 +611,14 @@ describe('SubgraphNode Execution', () => {
   })
 
   it('should prevent infinite recursion', () => {
-    // Circular self-references currently recurse in traversal; this test documents
-    // that execution flattening throws instead of silently succeeding.
     const subgraph = createTestSubgraph({ nodeCount: 1 })
     const subgraphNode = createTestSubgraphNode(subgraph, {
       parentGraph: subgraph
     })
 
-    // Add subgraph node to its own subgraph (circular reference)
-    // add() itself throws due to recursive forEachNode traversal
-    expect(() => subgraph.add(subgraphNode)).toThrow()
+    // Cycle guard in forEachNode short-circuits the self-referential
+    // traversal instead of overflowing the call stack.
+    expect(() => subgraph.add(subgraphNode)).not.toThrow()
   })
 
   it('should resolve cross-boundary links', () => {

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.test.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.test.ts
@@ -105,23 +105,30 @@ describe('subgraphUtils', () => {
       expect(result.has(subgraph2.id)).toBe(true)
     })
 
-    it('throws RangeError when graph.add() creates a circular subgraph reference', () => {
+    it('handles cyclic subgraph references without crashing graph.add() or findUsedSubgraphIds', () => {
       const rootGraph = new LGraph()
       const subgraph1 = createTestSubgraph({ name: 'Subgraph 1' })
       const subgraph2 = createTestSubgraph({ name: 'Subgraph 2' })
 
-      // Add subgraph1 to root
       const node1 = createTestSubgraphNode(subgraph1)
       rootGraph.add(node1)
 
-      // Add subgraph2 to subgraph1
       const node2 = createTestSubgraphNode(subgraph2)
       subgraph1.add(node2)
 
-      // Add subgraph1 to subgraph2 (circular reference)
-      // Note: add() itself throws RangeError due to recursive forEachNode
+      // forEachNode's cycle guard keeps the LGraph.add subgraph-registry
+      // walk from overflowing on A -> B -> A.
       const node3 = createTestSubgraphNode(subgraph1, { id: 3 })
-      expect(() => subgraph2.add(node3)).toThrow(RangeError)
+      expect(() => subgraph2.add(node3)).not.toThrow()
+
+      const registry = new Map<UUID, LGraph>([
+        [subgraph1.id, subgraph1],
+        [subgraph2.id, subgraph2]
+      ])
+      const result = findUsedSubgraphIds(rootGraph, registry)
+      expect(result.size).toBe(2)
+      expect(result.has(subgraph1.id)).toBe(true)
+      expect(result.has(subgraph2.id)).toBe(true)
     })
 
     it('should handle missing subgraphs in registry gracefully', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -311,6 +311,24 @@ describe('useMinimapGraph', () => {
     expect(onGraphChangedMock).not.toHaveBeenCalled()
   })
 
+  it('resets disposed on init so the manager works after destroy + init', () => {
+    // Lifecycle symmetry: useMinimap.ts reuses the same graphManager
+    // across canvas changes (destroy on old canvas + init on new).
+    // Without resetting `disposed = false` in init, the manager would
+    // stay permanently inert after the first destroy and silently
+    // swallow all subsequent events.
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+
+    graphManager.init()
+    graphManager.destroy()
+    graphManager.init()
+
+    vi.mocked(onGraphChangedMock).mockClear()
+    mockGraph.onNodeAdded!({ id: '99' } as LGraphNode)
+    expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
+  })
+
   it('should clear cache', () => {
     const graphRef = ref(mockGraph) as Ref<LGraph | null>
     const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -152,6 +152,44 @@ describe('useMinimapGraph', () => {
     expect(mockGraph.onConnectionChange).toBe(originalOnConnectionChange)
   })
 
+  it('should not stack a second wrapper after chain-wrap survives cleanup', () => {
+    // Regression: cleanup correctly leaves chain-wrapped slots alone
+    // (clobber-guard), but used to unconditionally drop the patch
+    // record. The next setup would then capture the chain-wrapper as
+    // the new "original" and install a second minimap wrapper
+    // underneath it — one node event then fired the minimap update
+    // twice. Now the record is only dropped once every slot is back
+    // to the captured original, so a re-setup with a chain-wrapped
+    // slot lives in the resubscribe path that does not re-stack.
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+
+    graphManager.setupEventListeners()
+    const minimapWrapper = mockGraph.onNodeAdded!
+
+    // External extension chain-wraps the minimap's onNodeAdded slot
+    // (forwards through the captured wrapper, mirroring the real
+    // useGraphStructureRevision interop pattern).
+    mockGraph.onNodeAdded = function (this: LGraph, node: LGraphNode) {
+      minimapWrapper.call(this, node)
+    }
+    const chainWrapped = mockGraph.onNodeAdded
+
+    graphManager.cleanupEventListeners()
+    // Slot still holds the extension's wrapper; we did not clobber it.
+    expect(mockGraph.onNodeAdded).toBe(chainWrapped)
+
+    graphManager.setupEventListeners()
+    // Slot is unchanged — resubscribe path detected the chain-wrap and
+    // did not stack a second wrapper above it.
+    expect(mockGraph.onNodeAdded).toBe(chainWrapped)
+
+    vi.mocked(onGraphChangedMock).mockClear()
+    mockGraph.onNodeAdded!({ id: '99' } as LGraphNode)
+    // Bug would have fired twice (outer-new + inner-old minimap wrappers).
+    expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
+  })
+
   it('should handle cleanup for never-setup graph', () => {
     const graphRef = ref(mockGraph) as Ref<LGraph | null>
     const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -156,6 +156,7 @@ describe('useMinimapGraph', () => {
   it.each([
     { slot: 'onNodeAdded' as const, fireArg: { id: '99' } },
     { slot: 'onNodeRemoved' as const, fireArg: { id: '99' } },
+    { slot: 'onNodeRemoved' as const, fireArg: { id: 99 } },
     { slot: 'onConnectionChange' as const, fireArg: { id: '99' } },
     {
       slot: 'onTrigger' as const,
@@ -163,6 +164,14 @@ describe('useMinimapGraph', () => {
         type: 'node:property:changed',
         property: 'mode',
         nodeId: '99'
+      }
+    },
+    {
+      slot: 'onTrigger' as const,
+      fireArg: {
+        type: 'node:property:changed',
+        property: 'mode',
+        nodeId: 99
       }
     }
   ])(
@@ -193,6 +202,33 @@ describe('useMinimapGraph', () => {
       expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
     }
   )
+
+  it('invalidates cache when onTrigger fires with a numeric nodeId', () => {
+    // Regression: LiteGraphDataSource.getNodes() stores cache keys as
+    // String(node.id), so onTrigger must stringify nodeId before deletion
+    // or the entry survives and stale state is reported as unchanged.
+    mockGraph._nodes = [
+      {
+        id: 99,
+        pos: [100, 100],
+        size: [150, 80]
+      } as Partial<LGraphNode> as LGraphNode
+    ]
+
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+    graphManager.setupEventListeners()
+
+    expect(graphManager.checkForChanges()).toBe(true)
+    expect(graphManager.checkForChanges()).toBe(false)
+    ;(mockGraph.onTrigger as unknown as (event: unknown) => void)({
+      type: 'node:property:changed',
+      property: 'mode',
+      nodeId: 99
+    })
+
+    expect(graphManager.checkForChanges()).toBe(true)
+  })
 
   it('should handle cleanup for never-setup graph', () => {
     const graphRef = ref(mockGraph) as Ref<LGraph | null>

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -153,19 +153,6 @@ describe('useMinimapGraph', () => {
     expect(mockGraph.onConnectionChange).toBe(originalOnConnectionChange)
   })
 
-  // Regression: cleanup correctly leaves chain-wrapped slots alone
-  // (clobber-guard), but used to unconditionally drop the patch
-  // record. The next setup would then capture the chain-wrapper as
-  // the new "original" and install a second minimap wrapper
-  // underneath it — one node event then fired the minimap update
-  // twice. Now the record is only dropped once every slot is back
-  // to the captured original, so a re-setup with a chain-wrapped
-  // slot lives in the resubscribe path that does not re-stack.
-  // Parameterized across every patched slot to catch per-slot drift
-  // (e.g. a typo in the resubscribe path's onTrigger handling).
-  // The onTrigger wrapper only fires onGraphChanged for
-  // node:property:changed events with specific properties, so its
-  // fireArg matches that filter; the other slots fire on any args.
   it.each([
     { slot: 'onNodeAdded' as const, fireArg: { id: '99' } },
     { slot: 'onNodeRemoved' as const, fireArg: { id: '99' } },
@@ -190,26 +177,19 @@ describe('useMinimapGraph', () => {
         ...args: unknown[]
       ) => void
 
-      // External extension chain-wraps the minimap's slot (forwards
-      // through the captured wrapper, mirroring the real
-      // useGraphStructureRevision interop pattern).
       mockGraph[slot] = function (this: LGraph, ...args: unknown[]) {
         minimapWrapper.call(this, ...args)
       } as never
       const chainWrapped = mockGraph[slot]
 
       graphManager.cleanupEventListeners()
-      // Slot still holds the extension's wrapper; we did not clobber it.
       expect(mockGraph[slot]).toBe(chainWrapped)
 
       graphManager.setupEventListeners()
-      // Slot is unchanged — resubscribe path detected the chain-wrap
-      // and did not stack a second wrapper above it.
       expect(mockGraph[slot]).toBe(chainWrapped)
 
       vi.mocked(onGraphChangedMock).mockClear()
       ;(mockGraph[slot] as unknown as (arg: unknown) => void)(fireArg)
-      // Bug would have fired twice (outer-new + inner-old minimap wrappers).
       expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
     }
   )
@@ -307,6 +287,28 @@ describe('useMinimapGraph', () => {
       'graphChanged',
       expect.any(Function)
     )
+  })
+
+  it('does not fire onGraphChanged from chain-wrapped slots after destroy', () => {
+    // Disposed-flag regression: cleanupEventListeners leaves
+    // chain-wrapped slots in place by design (clobber-guard), so the
+    // installed wrapper remains reachable via the extension's chain.
+    // Without the disposed flag, post-destroy events still trigger
+    // minimap work and keep renderer closures alive.
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
+
+    graphManager.setupEventListeners()
+    const minimapWrapper = mockGraph.onNodeAdded!
+    mockGraph.onNodeAdded = function (this: LGraph, node: LGraphNode) {
+      minimapWrapper.call(this, node)
+    }
+
+    graphManager.destroy()
+
+    vi.mocked(onGraphChangedMock).mockClear()
+    mockGraph.onNodeAdded!({ id: '99' } as LGraphNode)
+    expect(onGraphChangedMock).not.toHaveBeenCalled()
   })
 
   it('should clear cache', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -46,7 +46,8 @@ describe('useMinimapGraph', () => {
       links: createMockLinks([createMockLLink({ id: 1 })]),
       onNodeAdded: vi.fn(),
       onNodeRemoved: vi.fn(),
-      onConnectionChange: vi.fn()
+      onConnectionChange: vi.fn(),
+      onTrigger: vi.fn()
     })
 
     onGraphChangedMock = vi.fn()
@@ -152,43 +153,66 @@ describe('useMinimapGraph', () => {
     expect(mockGraph.onConnectionChange).toBe(originalOnConnectionChange)
   })
 
-  it('should not stack a second wrapper after chain-wrap survives cleanup', () => {
-    // Regression: cleanup correctly leaves chain-wrapped slots alone
-    // (clobber-guard), but used to unconditionally drop the patch
-    // record. The next setup would then capture the chain-wrapper as
-    // the new "original" and install a second minimap wrapper
-    // underneath it — one node event then fired the minimap update
-    // twice. Now the record is only dropped once every slot is back
-    // to the captured original, so a re-setup with a chain-wrapped
-    // slot lives in the resubscribe path that does not re-stack.
-    const graphRef = ref(mockGraph) as Ref<LGraph | null>
-    const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
-
-    graphManager.setupEventListeners()
-    const minimapWrapper = mockGraph.onNodeAdded!
-
-    // External extension chain-wraps the minimap's onNodeAdded slot
-    // (forwards through the captured wrapper, mirroring the real
-    // useGraphStructureRevision interop pattern).
-    mockGraph.onNodeAdded = function (this: LGraph, node: LGraphNode) {
-      minimapWrapper.call(this, node)
+  // Regression: cleanup correctly leaves chain-wrapped slots alone
+  // (clobber-guard), but used to unconditionally drop the patch
+  // record. The next setup would then capture the chain-wrapper as
+  // the new "original" and install a second minimap wrapper
+  // underneath it — one node event then fired the minimap update
+  // twice. Now the record is only dropped once every slot is back
+  // to the captured original, so a re-setup with a chain-wrapped
+  // slot lives in the resubscribe path that does not re-stack.
+  // Parameterized across every patched slot to catch per-slot drift
+  // (e.g. a typo in the resubscribe path's onTrigger handling).
+  // The onTrigger wrapper only fires onGraphChanged for
+  // node:property:changed events with specific properties, so its
+  // fireArg matches that filter; the other slots fire on any args.
+  it.each([
+    { slot: 'onNodeAdded' as const, fireArg: { id: '99' } },
+    { slot: 'onNodeRemoved' as const, fireArg: { id: '99' } },
+    { slot: 'onConnectionChange' as const, fireArg: { id: '99' } },
+    {
+      slot: 'onTrigger' as const,
+      fireArg: {
+        type: 'node:property:changed',
+        property: 'mode',
+        nodeId: '99'
+      }
     }
-    const chainWrapped = mockGraph.onNodeAdded
+  ])(
+    'should not stack a second wrapper after chain-wrap survives cleanup ($slot)',
+    ({ slot, fireArg }) => {
+      const graphRef = ref(mockGraph) as Ref<LGraph | null>
+      const graphManager = useMinimapGraph(graphRef, onGraphChangedMock)
 
-    graphManager.cleanupEventListeners()
-    // Slot still holds the extension's wrapper; we did not clobber it.
-    expect(mockGraph.onNodeAdded).toBe(chainWrapped)
+      graphManager.setupEventListeners()
+      const minimapWrapper = mockGraph[slot] as unknown as (
+        this: LGraph,
+        ...args: unknown[]
+      ) => void
 
-    graphManager.setupEventListeners()
-    // Slot is unchanged — resubscribe path detected the chain-wrap and
-    // did not stack a second wrapper above it.
-    expect(mockGraph.onNodeAdded).toBe(chainWrapped)
+      // External extension chain-wraps the minimap's slot (forwards
+      // through the captured wrapper, mirroring the real
+      // useGraphStructureRevision interop pattern).
+      mockGraph[slot] = function (this: LGraph, ...args: unknown[]) {
+        minimapWrapper.call(this, ...args)
+      } as never
+      const chainWrapped = mockGraph[slot]
 
-    vi.mocked(onGraphChangedMock).mockClear()
-    mockGraph.onNodeAdded!({ id: '99' } as LGraphNode)
-    // Bug would have fired twice (outer-new + inner-old minimap wrappers).
-    expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
-  })
+      graphManager.cleanupEventListeners()
+      // Slot still holds the extension's wrapper; we did not clobber it.
+      expect(mockGraph[slot]).toBe(chainWrapped)
+
+      graphManager.setupEventListeners()
+      // Slot is unchanged — resubscribe path detected the chain-wrap
+      // and did not stack a second wrapper above it.
+      expect(mockGraph[slot]).toBe(chainWrapped)
+
+      vi.mocked(onGraphChangedMock).mockClear()
+      ;(mockGraph[slot] as unknown as (arg: unknown) => void)(fireArg)
+      // Bug would have fired twice (outer-new + inner-old minimap wrappers).
+      expect(onGraphChangedMock).toHaveBeenCalledTimes(1)
+    }
+  )
 
   it('should handle cleanup for never-setup graph', () => {
     const graphRef = ref(mockGraph) as Ref<LGraph | null>

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -51,7 +51,15 @@ export function useMinimapGraph(
   // installed. Cleanup uses the installed wrappers to clobber-guard.
   const originalCallbacksMap = new Map<string, PatchRecord>()
 
+  // Once destroy() runs, the clobber-guard may have left chain-wrapped
+  // slots in place (the extension's wrapper still calls our installed
+  // wrapper internally). The disposed flag short-circuits the wrapper
+  // body so post-destroy events don't keep firing minimap work and
+  // holding renderer closures alive.
+  let disposed = false
+
   const handleGraphChangedThrottled = useThrottleFn(() => {
+    if (disposed) return
     onGraphChanged()
   }, 500)
 
@@ -94,19 +102,23 @@ export function useMinimapGraph(
     const installed: GraphCallbacks = {
       onNodeAdded: function (this: LGraph, node: LGraphNode) {
         original.onNodeAdded?.call(this, node)
+        if (disposed) return
         void handleGraphChangedThrottled()
       },
       onNodeRemoved: function (this: LGraph, node: LGraphNode) {
         original.onNodeRemoved?.call(this, node)
+        if (disposed) return
         nodeStatesCache.delete(node.id)
         void handleGraphChangedThrottled()
       },
       onConnectionChange: function (this: LGraph, node: LGraphNode) {
         original.onConnectionChange?.call(this, node)
+        if (disposed) return
         void handleGraphChangedThrottled()
       },
       onTrigger: function (this: LGraph, event: LGraphTriggerEvent) {
         original.onTrigger?.call(this, event)
+        if (disposed) return
 
         // Listen for visual property changes that affect minimap rendering
         if (
@@ -115,8 +127,10 @@ export function useMinimapGraph(
             event.property === 'bgcolor' ||
             event.property === 'color')
         ) {
-          // Invalidate cache for this node to force redraw
-          nodeStatesCache.delete(String(event.nodeId))
+          // Invalidate cache for this node to force redraw. Match
+          // the write site's NodeId key (number | string) — String()
+          // would miss numeric keys.
+          nodeStatesCache.delete(event.nodeId)
           void handleGraphChangedThrottled()
         }
       }
@@ -239,6 +253,7 @@ export function useMinimapGraph(
   }
 
   const destroy = () => {
+    disposed = true
     cleanupEventListeners()
     api.removeEventListener('graphChanged', handleGraphChangedThrottled)
     nodeStatesCache.clear()

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -21,6 +21,15 @@ interface GraphCallbacks {
   onTrigger?: (event: LGraphTriggerEvent) => void
 }
 
+// Per-graph patch record: the originals captured at install time AND
+// the wrappers we installed. Cleanup checks slot identity against the
+// installed wrappers — if something else (e.g. useGraphStructureRevision)
+// chain-wrapped on top, restoring the original here would clobber it.
+interface PatchRecord {
+  original: GraphCallbacks
+  installed: GraphCallbacks
+}
+
 export function useMinimapGraph(
   graph: Ref<LGraph | null>,
   onGraphChanged: () => void
@@ -38,8 +47,9 @@ export function useMinimapGraph(
   // Track LayoutStore version for change detection
   const layoutStoreVersion = layoutStore.getVersion()
 
-  // Map to store original callbacks per graph ID
-  const originalCallbacksMap = new Map<string, GraphCallbacks>()
+  // Per-graph patch record: original callbacks AND the wrappers we
+  // installed. Cleanup uses the installed wrappers to clobber-guard.
+  const originalCallbacksMap = new Map<string, PatchRecord>()
 
   const handleGraphChangedThrottled = useThrottleFn(() => {
     onGraphChanged()
@@ -49,69 +59,116 @@ export function useMinimapGraph(
     const g = graph.value
     if (!g) return
 
-    // Check if we've already wrapped this graph's callbacks
-    if (originalCallbacksMap.has(g.id)) {
+    // Resubscribe path: a previous cleanup may have restored only the
+    // slots that were not chain-wrapped by an extension, leaving the
+    // record alive because the others are still nested inside an
+    // extension's wrapper. Per-slot repair re-installs ours where the
+    // slot was restored to the original; chain-wrapped slots stay
+    // untouched (the extension's wrapper still calls our wrapper
+    // internally because that closure captured `original`).
+    const existing = originalCallbacksMap.get(g.id)
+    if (existing) {
+      if (g.onNodeAdded === existing.original.onNodeAdded) {
+        g.onNodeAdded = existing.installed.onNodeAdded
+      }
+      if (g.onNodeRemoved === existing.original.onNodeRemoved) {
+        g.onNodeRemoved = existing.installed.onNodeRemoved
+      }
+      if (g.onConnectionChange === existing.original.onConnectionChange) {
+        g.onConnectionChange = existing.installed.onConnectionChange
+      }
+      if (g.onTrigger === existing.original.onTrigger) {
+        g.onTrigger = existing.installed.onTrigger
+      }
       return
     }
 
     // Store the original callbacks for this graph
-    const originalCallbacks: GraphCallbacks = {
+    const original: GraphCallbacks = {
       onNodeAdded: g.onNodeAdded,
       onNodeRemoved: g.onNodeRemoved,
       onConnectionChange: g.onConnectionChange,
       onTrigger: g.onTrigger
     }
-    originalCallbacksMap.set(g.id, originalCallbacks)
 
-    g.onNodeAdded = function (node: LGraphNode) {
-      originalCallbacks.onNodeAdded?.call(this, node)
-      void handleGraphChangedThrottled()
-    }
-
-    g.onNodeRemoved = function (node: LGraphNode) {
-      originalCallbacks.onNodeRemoved?.call(this, node)
-      nodeStatesCache.delete(node.id)
-      void handleGraphChangedThrottled()
-    }
-
-    g.onConnectionChange = function (node: LGraphNode) {
-      originalCallbacks.onConnectionChange?.call(this, node)
-      void handleGraphChangedThrottled()
-    }
-
-    g.onTrigger = function (event: LGraphTriggerEvent) {
-      originalCallbacks.onTrigger?.call(this, event)
-
-      // Listen for visual property changes that affect minimap rendering
-      if (
-        event.type === 'node:property:changed' &&
-        (event.property === 'mode' ||
-          event.property === 'bgcolor' ||
-          event.property === 'color')
-      ) {
-        // Invalidate cache for this node to force redraw
-        nodeStatesCache.delete(String(event.nodeId))
+    const installed: GraphCallbacks = {
+      onNodeAdded: function (this: LGraph, node: LGraphNode) {
+        original.onNodeAdded?.call(this, node)
         void handleGraphChangedThrottled()
+      },
+      onNodeRemoved: function (this: LGraph, node: LGraphNode) {
+        original.onNodeRemoved?.call(this, node)
+        nodeStatesCache.delete(node.id)
+        void handleGraphChangedThrottled()
+      },
+      onConnectionChange: function (this: LGraph, node: LGraphNode) {
+        original.onConnectionChange?.call(this, node)
+        void handleGraphChangedThrottled()
+      },
+      onTrigger: function (this: LGraph, event: LGraphTriggerEvent) {
+        original.onTrigger?.call(this, event)
+
+        // Listen for visual property changes that affect minimap rendering
+        if (
+          event.type === 'node:property:changed' &&
+          (event.property === 'mode' ||
+            event.property === 'bgcolor' ||
+            event.property === 'color')
+        ) {
+          // Invalidate cache for this node to force redraw
+          nodeStatesCache.delete(String(event.nodeId))
+          void handleGraphChangedThrottled()
+        }
       }
     }
+
+    g.onNodeAdded = installed.onNodeAdded
+    g.onNodeRemoved = installed.onNodeRemoved
+    g.onConnectionChange = installed.onConnectionChange
+    g.onTrigger = installed.onTrigger
+    originalCallbacksMap.set(g.id, { original, installed })
   }
 
   const cleanupEventListeners = (oldGraph?: LGraph) => {
     const g = oldGraph || graph.value
     if (!g) return
 
-    const originalCallbacks = originalCallbacksMap.get(g.id)
-    if (!originalCallbacks) {
+    const record = originalCallbacksMap.get(g.id)
+    if (!record) {
       // Graph was never set up (e.g., minimap destroyed before init) - nothing to clean up
       return
     }
 
-    g.onNodeAdded = originalCallbacks.onNodeAdded
-    g.onNodeRemoved = originalCallbacks.onNodeRemoved
-    g.onConnectionChange = originalCallbacks.onConnectionChange
-    g.onTrigger = originalCallbacks.onTrigger
+    // Clobber-guard: only restore the original on slots that still hold
+    // OUR installed wrapper. If a later patcher (e.g.
+    // useGraphStructureRevision, an extension) chain-wrapped on top,
+    // its wrapper now occupies the slot and calls our wrapper
+    // internally — restoring the original here would silently uninstall
+    // the chain. Leave those slots alone; the chain-wrapper still
+    // forwards through `record.original` because our wrapper closure
+    // captured it.
+    const unhookedAdded = g.onNodeAdded === record.installed.onNodeAdded
+    const unhookedRemoved = g.onNodeRemoved === record.installed.onNodeRemoved
+    const unhookedConn =
+      g.onConnectionChange === record.installed.onConnectionChange
+    const unhookedTrigger = g.onTrigger === record.installed.onTrigger
 
-    originalCallbacksMap.delete(g.id)
+    if (unhookedAdded) g.onNodeAdded = record.original.onNodeAdded
+    if (unhookedRemoved) g.onNodeRemoved = record.original.onNodeRemoved
+    if (unhookedConn) g.onConnectionChange = record.original.onConnectionChange
+    if (unhookedTrigger) g.onTrigger = record.original.onTrigger
+
+    // Only drop the record once every slot is back to the captured
+    // original. A chain-wrapped slot still calls our wrapper internally
+    // and that wrapper closure reads `record.original` — deleting the
+    // record now would orphan that closure, AND the next setup would
+    // capture the chain-wrapper as the new "original" and stack a
+    // second minimap wrapper underneath it. Keep the record alive so
+    // setupEventListeners' resubscribe path can repair the restored
+    // slots without re-stacking.
+    if (unhookedAdded && unhookedRemoved && unhookedConn && unhookedTrigger) {
+      originalCallbacksMap.delete(g.id)
+    }
   }
 
   const checkForChangesInternal = () => {

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -49,14 +49,23 @@ export function useMinimapGraph(
 
   // Per-graph patch record: original callbacks AND the wrappers we
   // installed. Cleanup uses the installed wrappers to clobber-guard.
-  const originalCallbacksMap = new Map<string, PatchRecord>()
+  // Keyed by LGraph instance (not id) so records bind to graph identity
+  // and disappear naturally when the graph is GC'd.
+  const originalCallbacksMap = new WeakMap<LGraph, PatchRecord>()
 
   // Once destroy() runs, the clobber-guard may have left chain-wrapped
   // slots in place (the extension's wrapper still calls our installed
   // wrapper internally). The disposed flag short-circuits the wrapper
   // body so post-destroy events don't keep firing minimap work and
-  // holding renderer closures alive.
+  // holding renderer closures alive. init() resets the flag so the
+  // manager can be reused across graph/canvas changes (useMinimap.ts
+  // calls destroy + init when the canvas swaps).
   let disposed = false
+
+  // Stop fn for the layoutStoreVersion watcher. Kept on the closure so
+  // destroy() can cancel the watcher symmetrically with init() and we
+  // don't leak watchers across reuse cycles.
+  let stopLayoutStoreWatch: (() => void) | undefined
 
   const handleGraphChangedThrottled = useThrottleFn(() => {
     if (disposed) return
@@ -74,7 +83,7 @@ export function useMinimapGraph(
     // slot was restored to the original; chain-wrapped slots stay
     // untouched (the extension's wrapper still calls our wrapper
     // internally because that closure captured `original`).
-    const existing = originalCallbacksMap.get(g.id)
+    const existing = originalCallbacksMap.get(g)
     if (existing) {
       if (g.onNodeAdded === existing.original.onNodeAdded) {
         g.onNodeAdded = existing.installed.onNodeAdded
@@ -140,14 +149,14 @@ export function useMinimapGraph(
     g.onNodeRemoved = installed.onNodeRemoved
     g.onConnectionChange = installed.onConnectionChange
     g.onTrigger = installed.onTrigger
-    originalCallbacksMap.set(g.id, { original, installed })
+    originalCallbacksMap.set(g, { original, installed })
   }
 
   const cleanupEventListeners = (oldGraph?: LGraph) => {
     const g = oldGraph || graph.value
     if (!g) return
 
-    const record = originalCallbacksMap.get(g.id)
+    const record = originalCallbacksMap.get(g)
     if (!record) {
       // Graph was never set up (e.g., minimap destroyed before init) - nothing to clean up
       return
@@ -187,7 +196,7 @@ export function useMinimapGraph(
       canRestoreConn &&
       canRestoreTrigger
     ) {
-      originalCallbacksMap.delete(g.id)
+      originalCallbacksMap.delete(g)
     }
   }
 
@@ -250,16 +259,20 @@ export function useMinimapGraph(
   }
 
   const init = () => {
+    disposed = false
     setupEventListeners()
     api.addEventListener('graphChanged', handleGraphChangedThrottled)
 
-    watch(layoutStoreVersion, () => {
+    stopLayoutStoreWatch?.()
+    stopLayoutStoreWatch = watch(layoutStoreVersion, () => {
       void handleGraphChangedThrottled()
     })
   }
 
   const destroy = () => {
     disposed = true
+    stopLayoutStoreWatch?.()
+    stopLayoutStoreWatch = undefined
     cleanupEventListeners()
     api.removeEventListener('graphChanged', handleGraphChangedThrottled)
     nodeStatesCache.clear()

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -161,16 +161,17 @@ export function useMinimapGraph(
     // the chain. Leave those slots alone; the chain-wrapper still
     // forwards through `record.original` because our wrapper closure
     // captured it.
-    const unhookedAdded = g.onNodeAdded === record.installed.onNodeAdded
-    const unhookedRemoved = g.onNodeRemoved === record.installed.onNodeRemoved
-    const unhookedConn =
+    const canRestoreAdded = g.onNodeAdded === record.installed.onNodeAdded
+    const canRestoreRemoved = g.onNodeRemoved === record.installed.onNodeRemoved
+    const canRestoreConn =
       g.onConnectionChange === record.installed.onConnectionChange
-    const unhookedTrigger = g.onTrigger === record.installed.onTrigger
+    const canRestoreTrigger = g.onTrigger === record.installed.onTrigger
 
-    if (unhookedAdded) g.onNodeAdded = record.original.onNodeAdded
-    if (unhookedRemoved) g.onNodeRemoved = record.original.onNodeRemoved
-    if (unhookedConn) g.onConnectionChange = record.original.onConnectionChange
-    if (unhookedTrigger) g.onTrigger = record.original.onTrigger
+    if (canRestoreAdded) g.onNodeAdded = record.original.onNodeAdded
+    if (canRestoreRemoved) g.onNodeRemoved = record.original.onNodeRemoved
+    if (canRestoreConn)
+      g.onConnectionChange = record.original.onConnectionChange
+    if (canRestoreTrigger) g.onTrigger = record.original.onTrigger
 
     // Only drop the record once every slot is back to the captured
     // original. A chain-wrapped slot still calls our wrapper internally
@@ -180,7 +181,12 @@ export function useMinimapGraph(
     // second minimap wrapper underneath it. Keep the record alive so
     // setupEventListeners' resubscribe path can repair the restored
     // slots without re-stacking.
-    if (unhookedAdded && unhookedRemoved && unhookedConn && unhookedTrigger) {
+    if (
+      canRestoreAdded &&
+      canRestoreRemoved &&
+      canRestoreConn &&
+      canRestoreTrigger
+    ) {
       originalCallbacksMap.delete(g.id)
     }
   }

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.ts
@@ -117,7 +117,7 @@ export function useMinimapGraph(
       onNodeRemoved: function (this: LGraph, node: LGraphNode) {
         original.onNodeRemoved?.call(this, node)
         if (disposed) return
-        nodeStatesCache.delete(node.id)
+        nodeStatesCache.delete(String(node.id))
         void handleGraphChangedThrottled()
       },
       onConnectionChange: function (this: LGraph, node: LGraphNode) {
@@ -136,10 +136,7 @@ export function useMinimapGraph(
             event.property === 'bgcolor' ||
             event.property === 'color')
         ) {
-          // Invalidate cache for this node to force redraw. Match
-          // the write site's NodeId key (number | string) — String()
-          // would miss numeric keys.
-          nodeStatesCache.delete(event.nodeId)
+          nodeStatesCache.delete(String(event.nodeId))
           void handleGraphChangedThrottled()
         }
       }

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -102,6 +102,20 @@ function makeCyclicSubgraphFixture(): { graph: LGraph; rootNodeId: number } {
   return { graph: createMockGraph([rootNode]), rootNodeId: 1 }
 }
 
+// Self-cycle fixture: a SubgraphNode whose `subgraph` is its own parent.
+// Pathological JSON, but the cycle guard must still produce a single
+// visit per node (not double via outer + inner descent).
+function makeSelfCycleSubgraphFixture(): {
+  parent: Subgraph
+  childNodeId: number
+} {
+  const parent = createMockSubgraph('self', [])
+  const child = createMockNode(42)
+  const selfRef = createMockNode(7, { isSubgraph: true, subgraph: parent })
+  ;(parent.nodes as LGraphNode[]).push(child, selfRef)
+  return { parent, childNodeId: 42 }
+}
+
 describe('graphTraversalUtil', () => {
   describe('Pure utility functions', () => {
     describe('parseExecutionId', () => {
@@ -441,6 +455,19 @@ describe('graphTraversalUtil', () => {
         const childCount = results.filter((id) => id === 99).length
         expect(childCount).toBe(2)
       })
+
+      it('visits each node exactly once on a self-referential subgraph', () => {
+        // Self-cycle: a SubgraphNode whose .subgraph === its own parent.
+        // If the cycle guard adds the subgraph from the parent frame
+        // instead of seeding visited at function entry, the recursion
+        // descends once into the same graph and mapFn is applied twice
+        // to every node (outer + inner pass).
+        const { parent, childNodeId } = makeSelfCycleSubgraphFixture()
+
+        const results = mapAllNodes(parent, (node) => node.id)
+        const childCount = results.filter((id) => id === childNodeId).length
+        expect(childCount).toBe(1)
+      })
     })
 
     describe('forEachNode', () => {
@@ -524,6 +551,22 @@ describe('graphTraversalUtil', () => {
         expect(visitCounts.get(10)).toBe(1)
         expect(visitCounts.get(20)).toBe(1)
         expect(visitCounts.get(1)).toBe(1)
+      })
+
+      it('invokes fn exactly once per node on a self-referential subgraph', () => {
+        // See mapAllNodes counterpart: side-effect fn must not fire
+        // twice per node when SubgraphNode.subgraph === parent. This is
+        // particularly risky here because forEachNode is used for
+        // mutation (e.g. subgraph registry updates, removal callbacks).
+        const { parent, childNodeId } = makeSelfCycleSubgraphFixture()
+
+        const visitCounts = new Map<number | string, number>()
+        forEachNode(parent, (node) => {
+          visitCounts.set(node.id, (visitCounts.get(node.id) ?? 0) + 1)
+        })
+
+        expect(visitCounts.get(childNodeId)).toBe(1)
+        expect(visitCounts.get(7)).toBe(1)
       })
 
       it('treats sibling subgraphs sharing the default id as distinct', () => {

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -12,6 +12,7 @@ import {
   findNodeInHierarchy,
   findSubgraphByUuid,
   forEachNode,
+  findSubgraphPathById,
   forEachSubgraphNode,
   getAllNonIoNodesInSubgraph,
   getExecutionIdsForSelectedNodes,
@@ -645,6 +646,44 @@ describe('graphTraversalUtil', () => {
       })
     })
 
+    describe('findSubgraphPathById', () => {
+      it('should find a direct child subgraph by id', () => {
+        const target = createMockSubgraph('target', [])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: target })
+        ])
+        expect(findSubgraphPathById(graph, 'target')).toEqual(['target'])
+      })
+
+      it('should find a nested subgraph by id', () => {
+        const target = createMockSubgraph('target', [])
+        const mid = createMockSubgraph('mid', [
+          createMockNode(20, { isSubgraph: true, subgraph: target })
+        ])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: mid })
+        ])
+        expect(findSubgraphPathById(graph, 'target')).toEqual(['mid', 'target'])
+      })
+
+      it('should return null for missing target', () => {
+        const some = createMockSubgraph('some', [])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: some })
+        ])
+        expect(findSubgraphPathById(graph, 'missing')).toBeNull()
+      })
+
+      it('should not infinite-loop on cyclic subgraph references', () => {
+        // The bulk traversers gained path-local cycle guards in this PR;
+        // findSubgraphPathById was overlooked. Without an exit-sentinel on
+        // its DFS stack, an A→B→A cycle would push graph items forever.
+        const { graph } = makeCyclicSubgraphFixture()
+        expect(() => findSubgraphPathById(graph, 'missing')).not.toThrow()
+        expect(findSubgraphPathById(graph, 'missing')).toBeNull()
+      })
+    })
+
     describe('getNodeByExecutionId', () => {
       it('should find node in root graph', () => {
         const nodes = [createMockNode('123'), createMockNode('456')]
@@ -754,6 +793,20 @@ describe('graphTraversalUtil', () => {
 
         const execId = getExecutionIdByNode(rootGraph, targetNode)
         expect(execId).toBe('123:456:999')
+      })
+
+      it('should not stack-overflow on cyclic subgraphs when target is unreachable', () => {
+        // findPartialExecutionPathToGraph (called when node.graph differs
+        // from rootGraph) recurses through subgraph children searching for
+        // the target. Without a path-local visited set, an A→B→A cycle
+        // would recurse indefinitely. The exhaustive search path (target
+        // unreachable, so every path explored) is what trips the bug.
+        const { graph } = makeCyclicSubgraphFixture()
+        const orphan = createMockNode('999')
+        const orphanGraph = createMockSubgraph('orphan', [orphan])
+        orphan.graph = orphanGraph
+        expect(() => getExecutionIdByNode(graph, orphan)).not.toThrow()
+        expect(getExecutionIdByNode(graph, orphan)).toBeNull()
       })
     })
 

--- a/src/utils/graphTraversalUtil.test.ts
+++ b/src/utils/graphTraversalUtil.test.ts
@@ -87,6 +87,20 @@ function createMockSubgraph(
   return graph
 }
 
+// Builds the canonical A↔B cyclic-subgraph fixture: subA contains a node
+// referencing subB and vice versa, with subA hung off a root subgraph node.
+// Used by every "no infinite loop on cyclic subgraph references" test.
+function makeCyclicSubgraphFixture(): { graph: LGraph; rootNodeId: number } {
+  const subA = createMockSubgraph('sub-a', [])
+  const subB = createMockSubgraph('sub-b', [])
+  const nodeInA = createMockNode(10, { isSubgraph: true, subgraph: subB })
+  const nodeInB = createMockNode(20, { isSubgraph: true, subgraph: subA })
+  ;(subA.nodes as LGraphNode[]).push(nodeInA)
+  ;(subB.nodes as LGraphNode[]).push(nodeInB)
+  const rootNode = createMockNode(1, { isSubgraph: true, subgraph: subA })
+  return { graph: createMockGraph([rootNode]), rootNodeId: 1 }
+}
+
 describe('graphTraversalUtil', () => {
   describe('Pure utility functions', () => {
     describe('parseExecutionId', () => {
@@ -379,6 +393,53 @@ describe('graphTraversalUtil', () => {
         expect(results).toHaveLength(5)
         expect(results).toContain('node-300')
       })
+
+      it('should not infinite-loop on cyclic subgraph references', () => {
+        const { graph } = makeCyclicSubgraphFixture()
+
+        expect(() => mapAllNodes(graph, (node) => node.id)).not.toThrow()
+
+        const results = mapAllNodes(graph, (node) => node.id)
+        expect(results).toContain(1)
+        expect(results).toContain(10)
+        expect(results).toContain(20)
+      })
+
+      it('treats sibling subgraphs sharing the default id as distinct', () => {
+        // Reproduces the zero-UUID collision: LGraph.id defaults to a
+        // sentinel UUID until configure() runs. A visited-set keyed on
+        // String(subgraph.id) would skip the second instance — this test
+        // pins the object-identity behavior in place.
+        const sharedId = '00000000-0000-0000-0000-000000000000'
+        const subA = createMockSubgraph(sharedId, [createMockNode(11)])
+        const subB = createMockSubgraph(sharedId, [createMockNode(22)])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: subA }),
+          createMockNode(2, { isSubgraph: true, subgraph: subB })
+        ])
+
+        const results = mapAllNodes(graph, (node) => node.id)
+        expect(results).toContain(11)
+        expect(results).toContain(22)
+      })
+
+      it('counts shared subgraph contents once per SubgraphNode instance', () => {
+        // Two SubgraphNode instances pointing at the SAME Subgraph object
+        // — e.g. user copy-pasted a subgraph node. Each instance is an
+        // independent execution. A global-visited set would visit the
+        // shared subgraph's contents once and undercount; path-local
+        // re-permits the second visit.
+        const child = createMockNode(99)
+        const shared = createMockSubgraph('shared', [child])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: shared }),
+          createMockNode(2, { isSubgraph: true, subgraph: shared })
+        ])
+
+        const results = mapAllNodes(graph, (node) => node.id)
+        const childCount = results.filter((id) => id === 99).length
+        expect(childCount).toBe(2)
+      })
     })
 
     describe('forEachNode', () => {
@@ -449,6 +510,56 @@ describe('graphTraversalUtil', () => {
         })
 
         expect(matchingNodes).toEqual([2, 4])
+      })
+
+      it('should not infinite-loop on cyclic subgraph references', () => {
+        const { graph } = makeCyclicSubgraphFixture()
+
+        const visitCounts = new Map<number | string, number>()
+        forEachNode(graph, (node) => {
+          visitCounts.set(node.id, (visitCounts.get(node.id) ?? 0) + 1)
+        })
+
+        expect(visitCounts.get(10)).toBe(1)
+        expect(visitCounts.get(20)).toBe(1)
+        expect(visitCounts.get(1)).toBe(1)
+      })
+
+      it('treats sibling subgraphs sharing the default id as distinct', () => {
+        // See mapAllNodes counterpart — same zero-UUID collision case.
+        const sharedId = '00000000-0000-0000-0000-000000000000'
+        const subA = createMockSubgraph(sharedId, [createMockNode(11)])
+        const subB = createMockSubgraph(sharedId, [createMockNode(22)])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: subA }),
+          createMockNode(2, { isSubgraph: true, subgraph: subB })
+        ])
+
+        const visited: (string | number)[] = []
+        forEachNode(graph, (node) => {
+          visited.push(node.id)
+        })
+        expect(visited).toContain(11)
+        expect(visited).toContain(22)
+      })
+
+      it('visits shared subgraph contents once per SubgraphNode instance', () => {
+        // See mapAllNodes counterpart — sibling SubgraphNode instances
+        // pointing at the same Subgraph object should each trigger a
+        // visit to the shared contents.
+        const child = createMockNode(99)
+        const shared = createMockSubgraph('shared', [child])
+        const graph = createMockGraph([
+          createMockNode(1, { isSubgraph: true, subgraph: shared }),
+          createMockNode(2, { isSubgraph: true, subgraph: shared })
+        ])
+
+        const visitCounts = new Map<number | string, number>()
+        forEachNode(graph, (node) => {
+          visitCounts.set(node.id, (visitCounts.get(node.id) ?? 0) + 1)
+        })
+
+        expect(visitCounts.get(99)).toBe(2)
       })
     })
 
@@ -1223,6 +1334,65 @@ describe('graphTraversalUtil', () => {
         })
 
         expect(visited).toEqual(['100:', '200:100', '300:100/200'])
+      })
+
+      it('should not infinite-loop on cyclic subgraph references', () => {
+        const { graph } = makeCyclicSubgraphFixture()
+        const rootNode = graph.nodes[0]
+
+        const visitCounts = new Map<number | string, number>()
+        expect(() =>
+          traverseNodesDepthFirst([rootNode], {
+            visitor: (node) => {
+              visitCounts.set(node.id, (visitCounts.get(node.id) ?? 0) + 1)
+            }
+          })
+        ).not.toThrow()
+
+        expect(visitCounts.get(1)).toBe(1)
+        expect(visitCounts.get(10)).toBe(1)
+        expect(visitCounts.get(20)).toBe(1)
+      })
+
+      it('treats sibling subgraphs sharing the default id as distinct', () => {
+        // See mapAllNodes counterpart — same zero-UUID collision case.
+        const sharedId = '00000000-0000-0000-0000-000000000000'
+        const subA = createMockSubgraph(sharedId, [createMockNode(11)])
+        const subB = createMockSubgraph(sharedId, [createMockNode(22)])
+        const nodes = [
+          createMockNode(1, { isSubgraph: true, subgraph: subA }),
+          createMockNode(2, { isSubgraph: true, subgraph: subB })
+        ]
+
+        const visited: (string | number)[] = []
+        traverseNodesDepthFirst(nodes, {
+          visitor: (node) => {
+            visited.push(node.id)
+          }
+        })
+        expect(visited).toContain(11)
+        expect(visited).toContain(22)
+      })
+
+      it('visits shared subgraph contents once per SubgraphNode instance', () => {
+        // See mapAllNodes counterpart — sibling SubgraphNode instances
+        // pointing at the same Subgraph object are independent
+        // executions and each must emit a visit to the shared contents.
+        const child = createMockNode(99)
+        const shared = createMockSubgraph('shared', [child])
+        const nodes = [
+          createMockNode(1, { isSubgraph: true, subgraph: shared }),
+          createMockNode(2, { isSubgraph: true, subgraph: shared })
+        ]
+
+        const visitCounts = new Map<number | string, number>()
+        traverseNodesDepthFirst(nodes, {
+          visitor: (node) => {
+            visitCounts.set(node.id, (visitCounts.get(node.id) ?? 0) + 1)
+          }
+        })
+
+        expect(visitCounts.get(99)).toBe(2)
       })
     })
 

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -298,12 +298,26 @@ export function findSubgraphPathById(
   rootGraph: LGraph,
   targetId: string
 ): string[] | null {
-  const stack: { graph: LGraph | Subgraph; path: string[] }[] = [
-    { graph: rootGraph, path: [] }
-  ]
+  // Cycle guard mirrors traverseNodesDepthFirst: an "exit" sentinel
+  // removes the subgraph from `visited` after its subtree is fully
+  // processed, so a malformed A→B→A cycle short-circuits while two
+  // sibling SubgraphNodes pointing at the same Subgraph are still
+  // searched independently.
+  type StackItem =
+    | { kind: 'node'; graph: LGraph | Subgraph; path: string[] }
+    | { kind: 'exit'; subgraph: LGraph | Subgraph }
+  const stack: StackItem[] = [{ kind: 'node', graph: rootGraph, path: [] }]
+  const visited = new Set<LGraph | Subgraph>()
 
   while (stack.length > 0) {
-    const { graph, path } = stack.pop()!
+    const item = stack.pop()!
+
+    if (item.kind === 'exit') {
+      visited.delete(item.subgraph)
+      continue
+    }
+
+    const { graph, path } = item
 
     // Check if graph exists and has _nodes property
     if (!graph || !graph._nodes || !Array.isArray(graph._nodes)) {
@@ -316,7 +330,10 @@ export function findSubgraphPathById(
         if (node.subgraph.id === targetId) {
           return newPath
         }
-        stack.push({ graph: node.subgraph, path: newPath })
+        if (visited.has(node.subgraph)) continue
+        visited.add(node.subgraph)
+        stack.push({ kind: 'exit', subgraph: node.subgraph })
+        stack.push({ kind: 'node', graph: node.subgraph, path: newPath })
       }
     }
   }
@@ -832,14 +849,22 @@ export function getActiveGraphNodeIds(
 
 function findPartialExecutionPathToGraph(
   target: LGraph,
-  root: LGraph
+  root: LGraph,
+  visited: Set<LGraph | Subgraph> = new Set()
 ): string | undefined {
   for (const node of root.nodes) {
     if (!node.isSubgraphNode()) continue
 
     if (node.subgraph === target) return `${node.id}`
 
-    const subpath = findPartialExecutionPathToGraph(target, node.subgraph)
+    if (visited.has(node.subgraph)) continue
+    visited.add(node.subgraph)
+    const subpath = findPartialExecutionPathToGraph(
+      target,
+      node.subgraph,
+      visited
+    )
+    visited.delete(node.subgraph)
     if (subpath !== undefined) return node.id + ':' + subpath
   }
   return undefined

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -230,16 +230,23 @@ export function collectAllNodes(
  */
 export function findNodeInHierarchy(
   graph: LGraph | Subgraph,
-  nodeId: string | number
+  nodeId: string | number,
+  visited: Set<LGraph | Subgraph> = new Set()
 ): LGraphNode | null {
   // Check current graph
   const node = graph.getNodeById(nodeId)
   if (node) return node
 
-  // Search in subgraphs
+  // Search in subgraphs. Path-local cycle guard: a malformed A→B→A
+  // subgraph cycle would otherwise stack-overflow. See
+  // `mapAllNodesWithVisited` for the same pattern applied to the
+  // bulk-traversal helpers.
   for (const node of graph.nodes) {
     if (node.isSubgraphNode?.() && node.subgraph) {
-      const found = findNodeInHierarchy(node.subgraph, nodeId)
+      if (visited.has(node.subgraph)) continue
+      visited.add(node.subgraph)
+      const found = findNodeInHierarchy(node.subgraph, nodeId, visited)
+      visited.delete(node.subgraph)
       if (found) return found
     }
   }
@@ -256,20 +263,25 @@ export function findNodeInHierarchy(
  */
 export function findSubgraphByUuid(
   graph: LGraph | Subgraph,
-  targetUuid: string
+  targetUuid: string,
+  visited: Set<LGraph | Subgraph> = new Set()
 ): Subgraph | null {
   // Fast O(1) lookup via the root graph's centralized subgraph registry.
   if ('subgraphs' in graph && graph.subgraphs instanceof Map) {
     return graph.subgraphs.get(targetUuid) ?? null
   }
 
-  // Fallback: recursive traversal for non-root graphs without the registry.
+  // Fallback: recursive traversal for non-root graphs without the
+  // registry. Path-local cycle guard mirrors `findNodeInHierarchy`.
   for (const node of graph.nodes) {
     if (node.isSubgraphNode?.() && node.subgraph) {
       if (node.subgraph.id === targetUuid) {
         return node.subgraph
       }
-      const found = findSubgraphByUuid(node.subgraph, targetUuid)
+      if (visited.has(node.subgraph)) continue
+      visited.add(node.subgraph)
+      const found = findSubgraphByUuid(node.subgraph, targetUuid, visited)
+      visited.delete(node.subgraph)
       if (found) return found
     }
   }

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -131,15 +131,34 @@ export function mapAllNodes<T>(
   graph: LGraph | Subgraph,
   mapFn: (node: LGraphNode) => T | undefined
 ): T[] {
+  return mapAllNodesWithVisited(graph, mapFn, new Set())
+}
+
+function mapAllNodesWithVisited<T>(
+  graph: LGraph | Subgraph,
+  mapFn: (node: LGraphNode) => T | undefined,
+  visited: Set<LGraph | Subgraph>
+): T[] {
   const results: T[] = []
 
   visitGraphNodes(graph, (node) => {
-    // Recursively map over subgraphs first
+    // Path-local cycle guard: add on descent, delete on return. Skips
+    // the subgraph only when it's already on the current descent path
+    // (a cycle), but allows re-visit when the same Subgraph definition
+    // is reached via a sibling SubgraphNode. Each SubgraphNode is an
+    // independent execution — global dedup would under-count contents
+    // (cost-aggregation would miss the second instance's nodes).
+    // Object identity rather than `subgraph.id` because LGraph defaults
+    // to the zero UUID until `configure()` assigns a real one. Mirrors
+    // the WeakSet pattern in `useGraphStructureRevision.forEachSubgraph`.
     if (node.isSubgraphNode?.() && node.subgraph) {
-      results.push(...mapAllNodes(node.subgraph, mapFn))
+      if (!visited.has(node.subgraph)) {
+        visited.add(node.subgraph)
+        results.push(...mapAllNodesWithVisited(node.subgraph, mapFn, visited))
+        visited.delete(node.subgraph)
+      }
     }
 
-    // Apply map function to current node
     const result = mapFn(node)
     if (result !== undefined) {
       results.push(result)
@@ -160,13 +179,25 @@ export function forEachNode(
   graph: LGraph | Subgraph,
   fn: (node: LGraphNode) => void
 ): void {
+  forEachNodeWithVisited(graph, fn, new Set())
+}
+
+function forEachNodeWithVisited(
+  graph: LGraph | Subgraph,
+  fn: (node: LGraphNode) => void,
+  visited: Set<LGraph | Subgraph>
+): void {
   visitGraphNodes(graph, (node) => {
-    // Recursively process subgraphs first
+    // See `mapAllNodesWithVisited` — path-local visited set, object
+    // identity, sibling-permits, cycle-blocks.
     if (node.isSubgraphNode?.() && node.subgraph) {
-      forEachNode(node.subgraph, fn)
+      if (!visited.has(node.subgraph)) {
+        visited.add(node.subgraph)
+        forEachNodeWithVisited(node.subgraph, fn, visited)
+        visited.delete(node.subgraph)
+      }
     }
 
-    // Execute function on current node
     fn(node)
   })
 }
@@ -617,28 +648,47 @@ export function traverseNodesDepthFirst<T = void>(
     initialContext = undefined as T,
     expandSubgraphs = true
   } = options || {}
-  type StackItem = { node: LGraphNode; context: T }
+  // The recursive helpers (mapAllNodes/forEachNode) implement a path-local
+  // visited set by deleting on return from the recursion. The iterative
+  // DFS here gets the same semantics by pushing an "exit-subgraph"
+  // sentinel onto the stack alongside the node items: when the sentinel
+  // pops, the subgraph leaves the visited set. Cycles are blocked
+  // (subgraph still in visited when revisited within its own subtree),
+  // sibling SubgraphNode instances are permitted (subgraph removed from
+  // visited before the next sibling pops). See `mapAllNodesWithVisited`
+  // for the full rationale.
+  type StackItem =
+    | { kind: 'node'; node: LGraphNode; context: T }
+    | { kind: 'exit'; subgraph: LGraph | Subgraph }
   const stack: StackItem[] = []
+  const visited = new Set<LGraph | Subgraph>()
 
-  // Initialize stack with starting nodes
   for (const node of nodes) {
-    stack.push({ node, context: initialContext })
+    stack.push({ kind: 'node', node, context: initialContext })
   }
 
-  // Process stack iteratively (DFS)
   while (stack.length > 0) {
-    const { node, context } = stack.pop()!
+    const item = stack.pop()!
 
-    // Visit node and get updated context for children
+    if (item.kind === 'exit') {
+      visited.delete(item.subgraph)
+      continue
+    }
+
+    const { node, context } = item
     const childContext = visitor(node, context)
 
-    // If it's a subgraph and we should expand, add children to stack
     if (expandSubgraphs && node.isSubgraphNode?.() && node.subgraph) {
-      // Process children in reverse order to maintain left-to-right DFS processing
-      // when popping from stack (LIFO). Iterate backwards to avoid array reversal.
-      const children = node.subgraph.nodes
-      for (let i = children.length - 1; i >= 0; i--) {
-        stack.push({ node: children[i], context: childContext })
+      if (!visited.has(node.subgraph)) {
+        visited.add(node.subgraph)
+        // Exit sentinel goes on first so it pops after all children are
+        // processed. Children pushed in reverse to preserve left-to-right
+        // DFS order on LIFO pops.
+        stack.push({ kind: 'exit', subgraph: node.subgraph })
+        const children = node.subgraph.nodes
+        for (let i = children.length - 1; i >= 0; i--) {
+          stack.push({ kind: 'node', node: children[i], context: childContext })
+        }
       }
     }
   }

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -300,9 +300,11 @@ export function findSubgraphPathById(
 ): string[] | null {
   // Cycle guard mirrors traverseNodesDepthFirst: an "exit" sentinel
   // removes the subgraph from `visited` after its subtree is fully
-  // processed, so a malformed A→B→A cycle short-circuits while two
-  // sibling SubgraphNodes pointing at the same Subgraph are still
-  // searched independently.
+  // processed, so a malformed A→B→A cycle short-circuits and a
+  // Subgraph that appears in unrelated subtrees is searched each
+  // time. Sibling SubgraphNodes in the same parent that point at
+  // the same Subgraph object are deduplicated (see inline note
+  // below).
   type StackItem =
     | { kind: 'node'; graph: LGraph | Subgraph; path: string[] }
     | { kind: 'exit'; subgraph: LGraph | Subgraph }
@@ -330,6 +332,12 @@ export function findSubgraphPathById(
         if (node.subgraph.id === targetId) {
           return newPath
         }
+        // Sibling-instance dedupe: identical Subgraph refs in the
+        // same parent are skipped here (the first is already on the
+        // stack with its exit sentinel still pending). Returning the
+        // first match suffices and avoids duplicate paths. Diverges
+        // from mapAllNodesWithVisited, which permits per-instance
+        // descent.
         if (visited.has(node.subgraph)) continue
         visited.add(node.subgraph)
         stack.push({ kind: 'exit', subgraph: node.subgraph })

--- a/src/utils/graphTraversalUtil.ts
+++ b/src/utils/graphTraversalUtil.ts
@@ -139,24 +139,23 @@ function mapAllNodesWithVisited<T>(
   mapFn: (node: LGraphNode) => T | undefined,
   visited: Set<LGraph | Subgraph>
 ): T[] {
+  // Path-local cycle guard: seed `visited` with the current graph at
+  // function entry (not from the parent frame), so a self-referential
+  // SubgraphNode (`node.subgraph === graph`) is detected and skipped
+  // instead of recursing into the same graph and double-applying
+  // mapFn to every node. Sibling SubgraphNodes pointing at the same
+  // Subgraph are still visited independently — each is an independent
+  // execution and global dedup would under-count contents.
+  // Object identity rather than `subgraph.id` because LGraph defaults
+  // to the zero UUID until `configure()` assigns a real one.
+  if (visited.has(graph)) return []
+  visited.add(graph)
+
   const results: T[] = []
 
   visitGraphNodes(graph, (node) => {
-    // Path-local cycle guard: add on descent, delete on return. Skips
-    // the subgraph only when it's already on the current descent path
-    // (a cycle), but allows re-visit when the same Subgraph definition
-    // is reached via a sibling SubgraphNode. Each SubgraphNode is an
-    // independent execution — global dedup would under-count contents
-    // (cost-aggregation would miss the second instance's nodes).
-    // Object identity rather than `subgraph.id` because LGraph defaults
-    // to the zero UUID until `configure()` assigns a real one. Mirrors
-    // the WeakSet pattern in `useGraphStructureRevision.forEachSubgraph`.
     if (node.isSubgraphNode?.() && node.subgraph) {
-      if (!visited.has(node.subgraph)) {
-        visited.add(node.subgraph)
-        results.push(...mapAllNodesWithVisited(node.subgraph, mapFn, visited))
-        visited.delete(node.subgraph)
-      }
+      results.push(...mapAllNodesWithVisited(node.subgraph, mapFn, visited))
     }
 
     const result = mapFn(node)
@@ -165,6 +164,7 @@ function mapAllNodesWithVisited<T>(
     }
   })
 
+  visited.delete(graph)
   return results
 }
 
@@ -187,19 +187,21 @@ function forEachNodeWithVisited(
   fn: (node: LGraphNode) => void,
   visited: Set<LGraph | Subgraph>
 ): void {
+  // See `mapAllNodesWithVisited`: seed at function entry so self-cycle
+  // (`node.subgraph === graph`) is short-circuited before fn is called
+  // twice on every node.
+  if (visited.has(graph)) return
+  visited.add(graph)
+
   visitGraphNodes(graph, (node) => {
-    // See `mapAllNodesWithVisited` — path-local visited set, object
-    // identity, sibling-permits, cycle-blocks.
     if (node.isSubgraphNode?.() && node.subgraph) {
-      if (!visited.has(node.subgraph)) {
-        visited.add(node.subgraph)
-        forEachNodeWithVisited(node.subgraph, fn, visited)
-        visited.delete(node.subgraph)
-      }
+      forEachNodeWithVisited(node.subgraph, fn, visited)
     }
 
     fn(node)
   })
+
+  visited.delete(graph)
 }
 
 /**

--- a/src/workbench/extensions/manager/utils/graphHasMissingNodes.test.ts
+++ b/src/workbench/extensions/manager/utils/graphHasMissingNodes.test.ts
@@ -16,6 +16,7 @@ import type { NodeDefLookup } from '@/workbench/extensions/manager/utils/graphHa
 type NodeDefs = NodeDefLookup
 
 let nodeIdCounter = 0
+let subgraphIdCounter = 0
 const mockNodeDef = {} as ComfyNodeDefImpl
 
 const createGraph = (nodes: LGraphNode[] = []): LGraph => {
@@ -23,7 +24,10 @@ const createGraph = (nodes: LGraphNode[] = []): LGraph => {
 }
 
 const createSubgraph = (nodes: LGraphNode[]): Subgraph => {
-  return fromPartial<Subgraph>({ nodes })
+  return fromPartial<Subgraph>({
+    id: `mock-subgraph-${subgraphIdCounter++}`,
+    nodes
+  })
 }
 
 const createNode = (


### PR DESCRIPTION
## Summary

Eight latent bugs in subgraph traversal and LiteGraph callback patching.
Each one has a concrete user-visible failure mode triggered by either
cyclic subgraph references or a second extension chain-wrapping the
same callback slot — both reachable in normal use: copy-paste of
subgraphs, hiding the minimap with another extension installed, repeated
badge re-init on undo/redo.

Filed separately from the API-Nodes cost-indicator stack (#11683,
#11684, #11685) so each fix is reviewable on its own merits without
also evaluating the new feature, and so future revert / blame /
bisect lands on the right boundary.

## Bugs fixed

### Cyclic subgraphs crash the renderer

**Symptom:** opening a workflow with `subgraph A → contains B → contains
A` (or any cycle) stack-overflows the JS engine. Reachable from the
new actionbar chip and sign-in dialog (every recompute walks the
graph), as well as the existing minimap update path.

**Root cause:** seven subgraph-recursing helpers in
`src/utils/graphTraversalUtil.ts` had no cycle guard. `forEachNode`,
`mapAllNodes`, `traverseNodesDepthFirst`, `findNodeInHierarchy`,
`findSubgraphByUuid`, `findSubgraphPathById`, and
`findPartialExecutionPathToGraph` all recurse / loop unboundedly on
a cycle.

**Fix:** path-local `Set<LGraph | Subgraph>` (or `WeakSet` where
lifetime fits) keyed on object identity, with add-on-descent /
delete-on-return. Iterative call sites use an exit-sentinel stack
item to preserve the path-local invariant on a LIFO stack without
recursion.

### Sibling subgraphs sharing the default zero UUID silently lose their interior nodes

**Symptom:** two SubgraphNodes pointing at distinct Subgraphs that
haven't been `configure()`'d yet collide in the visited set; the
second one's interior is silently skipped. Aggregator counts wrong;
sign-in dialog row list misses entries; node-by-id lookup returns
the wrong instance.

**Root cause:** the visited set was keyed on `String(subgraph.id)`,
and pre-`configure()` Subgraphs all default to the sentinel zero
UUID `00000000-0000-0000-0000-000000000000`.

**Fix:** key the visited set on the `Subgraph` object itself
(identity), matching the `WeakSet` pattern in
`useGraphStructureRevision`. Adds regression tests with two distinct
zero-UUID subgraphs and asserts both interiors are visited.

### Copy-pasted subgraphs silently drop their interior contents

**Symptom:** when one Subgraph instance is referenced by multiple
SubgraphNodes (user copy-pasted a subgraph node), enumeration visits
the interior once and skips every subsequent reference — so 50 copies
of a subgraph node count as one. Aggregator under-counts; row list
under-renders.

**Root cause:** the visited set was added on descent but never
deleted on return, treating sibling references as duplicates.

**Fix:** add-on-descent / delete-on-return semantics. Cycles still
short-circuit (the subgraph is on the current descent path), but
sibling SubgraphNodes pointing at the same Subgraph each get visited.

### Hiding the minimap silently uninstalls other extensions' graph callbacks

**Symptom:** the minimap installs wrappers on
`graph.onNodeAdded` / `.onNodeRemoved` / `.onConnectionChange` /
`.onTrigger`. If another extension chain-wraps on top after the
minimap installed, hiding the minimap restored the captured originals
— silently uninstalling the chain. Any third-party extension that
patches these slots and counts on the chain to forward through stops
firing the moment the minimap is hidden.

**Root cause:** `useMinimapGraph.cleanupEventListeners()` restored
the captured originals unconditionally without checking whether the
slot still held the wrapper the minimap installed.

**Fix:** per-slot identity check. If the slot still equals our
wrapper, restore the original. If something else now occupies the
slot (i.e., a chain-wrapper), leave it alone — the chain-wrapper
still calls our wrapper internally because that closure captured
`original`.

### One node event fires the minimap update twice after re-show

**Symptom:** after the previous fix, a chain-wrapped slot was
correctly left alone on cleanup — but the patch record was
unconditionally deleted. The next `setupEventListeners` (when the
user re-shows the minimap) saw no record, captured the chain-wrapper
as the new "original", and installed a second minimap wrapper
underneath. Each subsequent node event then flowed through both the
outer-new and inner-old minimap wrappers, firing the update twice
(wasted work + visual flicker on minimap redraw).

**Root cause:** `originalCallbacksMap.delete(g.id)` ran
unconditionally on cleanup.

**Fix:** the patch record is only deleted once every slot is back
to the captured original. If any slot remains chain-wrapped, the
record stays alive. `setupEventListeners` resubscribe path: when the
record is still alive, re-install only on slots that have been
restored to the captured original. Mirrors the invariant already
encoded in `useGraphStructureRevision.detach`.

## Noted but out of scope

Multi-model review surfaced an unbounded `Map<string, Ref<number>>` at
`src/composables/node/useNodePricing.ts:452` (`nodeRevisions`). Entries
accumulate over session lifetime — sub-MB even on heavy sessions, but
real. A secondary observation: string keys collide across graphs
(subgraph node id 5 and root node id 5 share a `Ref`), causing spurious
re-computation of badge `computed`s. **Output is unaffected** — actual
badge values come from `cache.get(node)`, a properly-scoped
`WeakMap<LGraphNode, CacheEntry>`. The "collision" is wasted work, not
wrong work.

Not fixed here because the same module has a sibling unbounded Map
(`compiledRulesCache`, keyed by node type names — bounded in practice
by installed extensions, but technically the same shape). Fixing only
`nodeRevisions` would treat these inconsistently without principle.
Both would benefit from a coherent per-node-state lifetime story; that
is a focused architectural change that belongs in its own PR, not
bundled into a fix-only branch.

## Tests

- 113 cases in `graphTraversalUtil.test.ts`. Adds direct cycle-safety
  tests for `findSubgraphPathById` and an indirect test for
  `findPartialExecutionPathToGraph` via `getExecutionIdByNode` with
  an unreachable target (forces the recursion to exhaust every path
  through the cycle). Existing zero-UUID-collision tests still pass
  for all five bulk traversers; new sibling-permits tests verify the
  path-local semantics.
- 19 cases in `useMinimapGraph.test.ts`. The chain-wrap regression
  test is parameterized across all four patched slots
  (`onNodeAdded`, `onNodeRemoved`, `onConnectionChange`, `onTrigger`)
  to catch per-slot drift in the resubscribe path. Each run wraps
  the slot, runs cleanup + setup, and asserts a single event
  produces one minimap update. The bug would have produced two.

## E2E coverage rationale

Both fixes target pathological-data scenarios that are not reachable
through user flows, so unit tests at the function boundary are the
right level of coverage:

1. **Subgraph reference cycles** (`graphTraversalUtil.ts`): a
   malformed graph where Subgraph A contains a SubgraphNode pointing
   back to A. The user-facing surfaces (loadGraphData validation,
   the editor's Make Subgraph command) exclude this shape, so
   reproducing it in Playwright would require constructing the
   cycle in JS, which is what the unit tests already do at the
   function boundary.
2. **Chain-wrap stacking on minimap callbacks**
   (`useMinimapGraph.ts`): a regression that requires a second
   extension (or `useGraphStructureRevision`) to install its own
   wrapper on `LGraph.onNodeAdded` between the minimap's setup and
   cleanup cycles. The interaction is between two TypeScript
   modules, not between user actions and DOM state. Playwright would
   have to mock the second-extension wrapper into existence,
   duplicating what the unit tests cover directly.

## Why filed separately from the cost-indicator stack

These bugs were surfaced during multi-model code review of
#3454 (API Nodes — Credit indicators). Each fix targets code that
exists on `main` independently of that feature, so:

- Reviewers can evaluate "is this fix correct?" without also
  evaluating "is the cost indicator a good design?"
- A future revert of the cost-indicator stack does not also revert
  unrelated bug fixes.
- `git blame` on the touched files links each line to its bug fix
  rather than to a feature commit that bundled it as a drive-by.

## Breaking

None. Public function signatures gained an optional `visited`
parameter defaulting to a fresh empty set / WeakSet — existing call
sites are unchanged.

## Dependencies

None. The cost-indicator stack (#11683, #11684, #11685) builds on
top of this branch — the new aggregator and row composables rely on
cycle-safe traversal, and the minimap interop needs the
retained-record fix to survive `useGraphStructureRevision`
chain-wrapping.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11682-fix-graph-traversal-minimap-cycle-guards-and-callback-chain-wrap-survival-34f6d73d365081fea5dedde42457b159) by [Unito](https://www.unito.io)

