### PR TITLE
fix(keybindings): respect Reka DismissableLayer state for Escape

### DIFF
--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -108,6 +108,41 @@ describe('keybindingService - Escape key handling', () => {
     expect(mockCommandExecute).not.toHaveBeenCalled()
   })
 
+  it('should NOT execute Escape keybinding when a Reka dismissable layer is open', async () => {
+    const layer = document.createElement('div')
+    layer.setAttribute('data-dismissable-layer', '')
+    layer.setAttribute('data-state', 'open')
+    document.body.appendChild(layer)
+
+    try {
+      const event = createKeyboardEvent('Escape')
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).not.toHaveBeenCalled()
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    } finally {
+      document.body.removeChild(layer)
+    }
+  })
+
+  it('should execute Escape keybinding when a closed dismissable layer is in the DOM', async () => {
+    const layer = document.createElement('div')
+    layer.setAttribute('data-dismissable-layer', '')
+    layer.setAttribute('data-state', 'closed')
+    document.body.appendChild(layer)
+
+    try {
+      const event = createKeyboardEvent('Escape')
+      await keybindingService.keybindHandler(event)
+
+      expect(mockCommandExecute).toHaveBeenCalledWith(
+        'Comfy.Graph.ExitSubgraph'
+      )
+    } finally {
+      document.body.removeChild(layer)
+    }
+  })
+
   it('should execute Escape keybinding with modifiers regardless of dialog state', async () => {
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.push(createTestDialogInstance('test-dialog'))

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -10,6 +10,8 @@ import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import type { DialogInstance } from '@/stores/dialogStore'
 import { useDialogStore } from '@/stores/dialogStore'
+import type { Subgraph } from '@/lib/litegraph/src/litegraph'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
 function createTestDialogInstance(
   key: string,
@@ -45,6 +47,18 @@ vi.mock('@/scripts/app', () => ({
   }
 }))
 
+vi.mock('@/stores/subgraphNavigationStore', () => {
+  // Pinia setup stores auto-unwrap top-level refs when accessed via the
+  // store proxy, so the production code sees `activeSubgraph` directly
+  // as `Subgraph | undefined`. Mirror that with a plain object.
+  const state: { activeSubgraph: Subgraph | undefined } = {
+    activeSubgraph: undefined
+  }
+  return {
+    useSubgraphNavigationStore: () => state
+  }
+})
+
 describe('keybindingService - Escape key handling', () => {
   let keybindingService: ReturnType<typeof useKeybindingService>
   let mockCommandExecute: ReturnType<typeof useCommandStore>['execute']
@@ -60,9 +74,17 @@ describe('keybindingService - Escape key handling', () => {
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.length = 0
 
+    const subgraphNavigationStore = useSubgraphNavigationStore()
+    subgraphNavigationStore.activeSubgraph = undefined
+
     keybindingService = useKeybindingService()
     keybindingService.registerCoreKeybindings()
   })
+
+  function setInSubgraph() {
+    const subgraphNavigationStore = useSubgraphNavigationStore()
+    subgraphNavigationStore.activeSubgraph = {} as Subgraph
+  }
 
   function createKeyboardEvent(
     key: string,
@@ -89,14 +111,26 @@ describe('keybindingService - Escape key handling', () => {
     return event
   }
 
-  it('should execute Escape keybinding when no dialogs are open', async () => {
+  it('should execute ExitSubgraph when in a subgraph and no dialogs are open', async () => {
+    setInSubgraph()
+
     const event = createKeyboardEvent('Escape')
     await keybindingService.keybindHandler(event)
 
     expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.Graph.ExitSubgraph')
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('should NOT execute ExitSubgraph or preventDefault at top level', async () => {
+    const event = createKeyboardEvent('Escape')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+    expect(event.preventDefault).not.toHaveBeenCalled()
   })
 
   it('should NOT execute Escape keybinding when dialogs are open', async () => {
+    setInSubgraph()
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.push(createTestDialogInstance('test-dialog'))
 
@@ -106,41 +140,6 @@ describe('keybindingService - Escape key handling', () => {
     await keybindingService.keybindHandler(event)
 
     expect(mockCommandExecute).not.toHaveBeenCalled()
-  })
-
-  it('should NOT execute Escape keybinding when a Reka dismissable layer is open', async () => {
-    const layer = document.createElement('div')
-    layer.setAttribute('data-dismissable-layer', '')
-    layer.setAttribute('data-state', 'open')
-    document.body.appendChild(layer)
-
-    try {
-      const event = createKeyboardEvent('Escape')
-      await keybindingService.keybindHandler(event)
-
-      expect(mockCommandExecute).not.toHaveBeenCalled()
-      expect(event.preventDefault).not.toHaveBeenCalled()
-    } finally {
-      document.body.removeChild(layer)
-    }
-  })
-
-  it('should execute Escape keybinding when a closed dismissable layer is in the DOM', async () => {
-    const layer = document.createElement('div')
-    layer.setAttribute('data-dismissable-layer', '')
-    layer.setAttribute('data-state', 'closed')
-    document.body.appendChild(layer)
-
-    try {
-      const event = createKeyboardEvent('Escape')
-      await keybindingService.keybindHandler(event)
-
-      expect(mockCommandExecute).toHaveBeenCalledWith(
-        'Comfy.Graph.ExitSubgraph'
-      )
-    } finally {
-      document.body.removeChild(layer)
-    }
   })
 
   it('should execute Escape keybinding with modifiers regardless of dialog state', async () => {

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -2,6 +2,7 @@ import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCommandStore } from '@/stores/commandStore'
 import { useDialogStore } from '@/stores/dialogStore'
+import { useSubgraphNavigationStore } from '@/stores/subgraphNavigationStore'
 
 import { CORE_KEYBINDINGS } from './defaults'
 import { KeyComboImpl } from './keyCombo'
@@ -13,6 +14,7 @@ export function useKeybindingService() {
   const commandStore = useCommandStore()
   const settingStore = useSettingStore()
   const dialogStore = useDialogStore()
+  const subgraphNavigationStore = useSubgraphNavigationStore()
 
   async function keybindHandler(event: KeyboardEvent) {
     const keyCombo = KeyComboImpl.fromEvent(event)
@@ -53,11 +55,14 @@ export function useKeybindingService() {
         if (dialogStore.dialogStack.length > 0) {
           return
         }
-        // Reka's DismissableLayer (Popover, DropdownMenu, etc.) skips
-        // its own `dismiss` when defaultPrevented. Bail before
-        // preventDefault() so the open layer can close itself.
+        // `Comfy.Graph.ExitSubgraph` is a no-op at the top level.
+        // preventDefault() then eats the Escape that Reka's
+        // DismissableLayer (Popover, DropdownMenu, etc.) needs to
+        // dismiss; DismissableLayer skips its own dismiss when
+        // defaultPrevented.
         if (
-          document.querySelector('[data-dismissable-layer][data-state="open"]')
+          keybinding.commandId === 'Comfy.Graph.ExitSubgraph' &&
+          !subgraphNavigationStore.activeSubgraph
         ) {
           return
         }

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -53,6 +53,20 @@ export function useKeybindingService() {
         if (dialogStore.dialogStack.length > 0) {
           return
         }
+        // Reka's DismissableLayer (Popover, DropdownMenu, ContextMenu,
+        // HoverCard, Combobox, Select, etc.) checks `defaultPrevented`
+        // before emitting `dismiss`. Calling preventDefault() below for
+        // a no-op `Comfy.Graph.ExitSubgraph` at root level silently
+        // swallows Escape-to-close for every Reka surface in the app.
+        // Bail when one is open so the layer's own listener can dismiss
+        // it. The `data-dismissable-layer` + `data-state="open"` pair
+        // is Reka's stable contract; the codebase already relies on it
+        // in tests (e.g. SingleSelect.test.ts, MultiSelect.test.ts).
+        if (
+          document.querySelector('[data-dismissable-layer][data-state="open"]')
+        ) {
+          return
+        }
       }
 
       event.preventDefault()

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -53,15 +53,9 @@ export function useKeybindingService() {
         if (dialogStore.dialogStack.length > 0) {
           return
         }
-        // Reka's DismissableLayer (Popover, DropdownMenu, ContextMenu,
-        // HoverCard, Combobox, Select, etc.) checks `defaultPrevented`
-        // before emitting `dismiss`. Calling preventDefault() below for
-        // a no-op `Comfy.Graph.ExitSubgraph` at root level silently
-        // swallows Escape-to-close for every Reka surface in the app.
-        // Bail when one is open so the layer's own listener can dismiss
-        // it. The `data-dismissable-layer` + `data-state="open"` pair
-        // is Reka's stable contract; the codebase already relies on it
-        // in tests (e.g. SingleSelect.test.ts, MultiSelect.test.ts).
+        // Reka's DismissableLayer (Popover, DropdownMenu, etc.) skips
+        // its own `dismiss` when defaultPrevented. Bail before
+        // preventDefault() so the open layer can close itself.
         if (
           document.querySelector('[data-dismissable-layer][data-state="open"]')
         ) {


### PR DESCRIPTION
`keybindHandler` registers a window-level keydown listener that calls
`event.preventDefault()` on every matched keybinding, including the
no-op `Comfy.Graph.ExitSubgraph` for bare Escape outside subgraphs.
That listener fires before Reka's `DismissableLayer` listener (both
are bound to window/keydown/bubble; ours registers first via
`GraphView.vue:272`). Reka checks `event.defaultPrevented` before
emitting `dismiss`, so it skips the close path and the popover stays
open silently.

Net effect: every Reka surface in the app — Popover, DropdownMenu,
ContextMenu, HoverCard, Combobox, Select, anything wrapping
DismissableLayer — fails to close on Escape. Components with explicit
`@escape-key-down` handlers are unaffected because Reka emits that
event before checking `defaultPrevented`; only the auto-dismiss path
is broken.

Extend the existing dialogStore bail to also cover any open
dismissable layer. The `data-dismissable-layer` + `data-state="open"`
attribute pair is Reka's stable contract — already relied on by tests
in `SingleSelect.test.ts` and `MultiSelect.test.ts`.

Adds two regression tests covering open-layer (bail) and
closed-layer-in-DOM (don't bail) cases.

## E2E coverage rationale

This is a contract fix on the boundary between `keybindingService`
and Reka's `DismissableLayer`. The unit test
(`keybindingService.escape.test.ts`) covers the contract directly
via the same `[data-dismissable-layer][data-state="open"]` selector
that the production code reads. The codebase already relies on that
selector pattern in unit form (`SingleSelect.test.ts`,
`MultiSelect.test.ts`). The Reka components themselves are
unit-tested upstream by Reka; the only project-specific contract is
the bail logic, which is fully covered at the function boundary.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11686-fix-keybindings-respect-Reka-DismissableLayer-state-for-Escape-34f6d73d36508147bb6cc31324c172d1) by [Unito](https://www.unito.io)

