### PR TITLE
feat: Node search - Improve category tree on mobile with collapse

### DIFF
--- a/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
@@ -17,6 +17,9 @@ export class ComfyNodeSearchBoxV2 {
   readonly filterChips: Locator
   readonly noResults: Locator
   readonly nodeIdBadge: Locator
+  readonly sidebarToggle: Locator
+  readonly sidebarBackdrop: Locator
+  readonly filterChipsScroll: Locator
 
   constructor(private comfyPage: ComfyPage) {
     const page = comfyPage.page
@@ -28,6 +31,11 @@ export class ComfyNodeSearchBoxV2 {
     this.filterChips = this.dialog.getByTestId(searchBoxV2.filterChip)
     this.noResults = this.dialog.getByTestId(searchBoxV2.noResults)
     this.nodeIdBadge = this.dialog.getByTestId(searchBoxV2.nodeIdBadge)
+    this.sidebarToggle = this.dialog.getByTestId(searchBoxV2.sidebarToggle)
+    this.sidebarBackdrop = this.dialog.getByTestId(searchBoxV2.sidebarBackdrop)
+    this.filterChipsScroll = this.dialog.getByTestId(
+      searchBoxV2.filterChipsScroll
+    )
   }
 
   /** Sidebar category tree button (e.g. `sampling`, `sampling/custom_sampling`). */

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -261,6 +261,9 @@ export const TestIds = {
     chipDelete: 'chip-delete',
     noResults: 'no-results',
     nodeIdBadge: 'node-id-badge',
+    sidebarToggle: 'toggle-category-sidebar',
+    sidebarBackdrop: 'sidebar-backdrop',
+    filterChipsScroll: 'filter-chips-scroll',
     category: (id: string) => `category-${id}`,
     rootCategory: (id: string) => `search-category-${id}`,
     typeFilter: (key: 'input' | 'output') => `search-filter-${key}`

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -125,4 +125,144 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       })
     })
   })
+
+  test.describe('Category sidebar', () => {
+    test('Sidebar toggle hides and shows the category sidebar', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+      await searchBoxV2.open()
+
+      const samplingCategory = searchBoxV2.categoryButton('sampling')
+      await expect(samplingCategory).toBeVisible()
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+
+      await searchBoxV2.sidebarToggle.click()
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+      await expect(samplingCategory).toBeHidden()
+
+      await searchBoxV2.sidebarToggle.click()
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+      await expect(samplingCategory).toBeVisible()
+    })
+
+    test('Filter bar scrolls horizontally while the sidebar toggle stays pinned', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+      // Narrow viewport so the chips overflow the filter bar
+      await comfyPage.page.setViewportSize({ width: 360, height: 800 })
+      await searchBoxV2.open()
+
+      const scrollEl = searchBoxV2.filterChipsScroll
+      const dims = await scrollEl.evaluate((el) => ({
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth
+      }))
+      expect(dims.scrollWidth).toBeGreaterThan(dims.clientWidth)
+
+      await scrollEl.evaluate((el) => {
+        el.scrollLeft = el.scrollWidth
+      })
+
+      // The toggle lives outside the scroll container, so even when the
+      // chips scroll hundreds of px it must remain visible in the viewport.
+      await expect(searchBoxV2.sidebarToggle).toBeInViewport()
+    })
+
+    test('@mobile Sidebar is collapsed by default on mobile', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+      await searchBoxV2.open()
+
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+      await expect(searchBoxV2.categoryButton('sampling')).toBeHidden()
+    })
+
+    test('@mobile Clicking outside the sidebar closes it', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+      await searchBoxV2.open()
+
+      await searchBoxV2.sidebarToggle.click()
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+      await expect(searchBoxV2.categoryButton('sampling')).toBeVisible()
+      await expect(searchBoxV2.sidebarBackdrop).toBeVisible()
+
+      // The backdrop spans the full content area, but the sidebar (z-20)
+      // covers its left ~208px (w-52). Click past that to land on the
+      // backdrop rather than the sidebar.
+      await searchBoxV2.sidebarBackdrop.click({ position: { x: 240, y: 40 } })
+
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+      await expect(searchBoxV2.categoryButton('sampling')).toBeHidden()
+      await expect(searchBoxV2.sidebarBackdrop).toBeHidden()
+    })
+
+    test('@mobile Focusing the search input closes the sidebar', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+      await searchBoxV2.open()
+
+      await searchBoxV2.sidebarToggle.click()
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+
+      await searchBoxV2.input.focus()
+
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+    })
+
+    test('Sidebar collapses on resize to mobile and preserves user state on resize to desktop', async ({
+      comfyPage
+    }) => {
+      const { searchBoxV2 } = comfyPage
+      await comfyPage.page.setViewportSize({ width: 1280, height: 800 })
+      await searchBoxV2.open()
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+
+      await comfyPage.page.setViewportSize({ width: 360, height: 800 })
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+
+      // Returning to desktop must NOT auto-restore the sidebar — the
+      // user's collapsed state is preserved across breakpoint changes.
+      await comfyPage.page.setViewportSize({ width: 1280, height: 800 })
+      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+    })
+  })
 })

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -239,30 +239,37 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
       )
     })
 
-    test('Sidebar collapses on resize to mobile and preserves user state on resize to desktop', async ({
+    test('Sidebar state across mobile/desktop resizes', async ({
       comfyPage
     }) => {
       const { searchBoxV2 } = comfyPage
-      await comfyPage.page.setViewportSize({ width: 1280, height: 800 })
+      const switchToDesktop = () =>
+        comfyPage.page.setViewportSize({ width: 1280, height: 800 })
+      const switchToMobile = () =>
+        comfyPage.page.setViewportSize({ width: 360, height: 800 })
+      const expectExpanded = (value: 'true' | 'false') =>
+        expect(searchBoxV2.sidebarToggle).toHaveAttribute(
+          'aria-expanded',
+          value
+        )
+
+      await switchToDesktop()
       await searchBoxV2.open()
-      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
-        'aria-expanded',
-        'true'
-      )
+      await expectExpanded('true')
 
-      await comfyPage.page.setViewportSize({ width: 360, height: 800 })
-      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
-        'aria-expanded',
-        'false'
-      )
+      await switchToMobile()
+      await expectExpanded('false')
 
-      // Returning to desktop must NOT auto-restore the sidebar — the
-      // user's collapsed state is preserved across breakpoint changes.
-      await comfyPage.page.setViewportSize({ width: 1280, height: 800 })
-      await expect(searchBoxV2.sidebarToggle).toHaveAttribute(
-        'aria-expanded',
-        'false'
-      )
+      await searchBoxV2.sidebarToggle.click()
+      await switchToDesktop()
+      await expectExpanded('true')
+
+      await searchBoxV2.sidebarToggle.click()
+      await switchToMobile()
+      await expectExpanded('false')
+
+      await switchToDesktop()
+      await expectExpanded('false')
     })
   })
 })

--- a/src/components/searchbox/v2/NodeSearchContent.test.ts
+++ b/src/components/searchbox/v2/NodeSearchContent.test.ts
@@ -5,9 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NodeSearchContent from '@/components/searchbox/v2/NodeSearchContent.vue'
 import {
   createMockNodeDef,
+  setViewport,
   setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 }
+const MOBILE_VIEWPORT = { width: 360, height: 800 }
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -19,6 +23,7 @@ describe('NodeSearchContent', () => {
   beforeEach(() => {
     setupTestPinia()
     vi.restoreAllMocks()
+    setViewport(DESKTOP_VIEWPORT)
     const settings = useSettingStore()
     settings.settingValues['Comfy.NodeLibrary.Bookmarks.V2'] = []
     settings.settingValues['Comfy.NodeLibrary.BookmarksCustomization'] = {}
@@ -656,6 +661,89 @@ describe('NodeSearchContent', () => {
       })
       const removedValues = onRemoveFilter.mock.calls.map(([f]) => f.value)
       expect(removedValues).toEqual(expect.arrayContaining(['IMAGE', 'LATENT']))
+    })
+  })
+
+  describe('sidebar toggle', () => {
+    it('should hide and show the category sidebar when the toggle is clicked', async () => {
+      useNodeDefStore().updateNodeDefs([
+        createMockNodeDef({
+          name: 'KSampler',
+          display_name: 'KSampler',
+          category: 'sampling'
+        })
+      ])
+
+      const { user } = renderComponent()
+
+      const sidebar = await screen.findByTestId('category-sampling')
+      expect(sidebar).toBeVisible()
+
+      const toggle = screen.getByTestId('toggle-category-sidebar')
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+      await user.click(toggle)
+      await waitFor(() => {
+        expect(toggle).toHaveAttribute('aria-expanded', 'false')
+        expect(screen.getByTestId('category-sampling')).not.toBeVisible()
+      })
+
+      await user.click(toggle)
+      await waitFor(() => {
+        expect(toggle).toHaveAttribute('aria-expanded', 'true')
+        expect(screen.getByTestId('category-sampling')).toBeVisible()
+      })
+    })
+
+    it('should close the sidebar when the search input gains focus on mobile', async () => {
+      setViewport(MOBILE_VIEWPORT)
+      useNodeDefStore().updateNodeDefs([
+        createMockNodeDef({
+          name: 'KSampler',
+          display_name: 'KSampler',
+          category: 'sampling'
+        })
+      ])
+
+      const { user } = renderComponent()
+
+      const toggle = screen.getByTestId('toggle-category-sidebar')
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+      await user.click(toggle)
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+      await user.click(screen.getByRole('combobox'))
+
+      await waitFor(() => {
+        expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      })
+    })
+
+    it('should collapse on resize to mobile and preserve user state on resize back to desktop', async () => {
+      useNodeDefStore().updateNodeDefs([
+        createMockNodeDef({
+          name: 'KSampler',
+          display_name: 'KSampler',
+          category: 'sampling'
+        })
+      ])
+
+      renderComponent()
+
+      const toggle = screen.getByTestId('toggle-category-sidebar')
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+      setViewport(MOBILE_VIEWPORT)
+      await waitFor(() => {
+        expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      })
+
+      // Returning to desktop should NOT auto-restore — collapsed state is
+      // preserved so a user's earlier explicit toggle isn't undone.
+      setViewport(DESKTOP_VIEWPORT)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
     })
   })
 

--- a/src/components/searchbox/v2/NodeSearchContent.test.ts
+++ b/src/components/searchbox/v2/NodeSearchContent.test.ts
@@ -10,14 +10,15 @@ import {
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
 
-const DESKTOP_VIEWPORT = { width: 1280, height: 800 }
-const MOBILE_VIEWPORT = { width: 360, height: 800 }
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeDefStore, useNodeFrequencyStore } from '@/stores/nodeDefStore'
 import { NodeSourceType } from '@/types/nodeSource'
 import type { FuseFilterWithValue } from '@/utils/fuseUtil'
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 }
+const MOBILE_VIEWPORT = { width: 360, height: 800 }
 
 describe('NodeSearchContent', () => {
   beforeEach(() => {
@@ -552,7 +553,7 @@ describe('NodeSearchContent', () => {
   })
 
   describe('filter integration', () => {
-    it('should display active filters in the input area', () => {
+    it('renders one chip per active filter with the filter value', () => {
       useNodeDefStore().updateNodeDefs([
         createMockNodeDef({
           name: 'ImageNode',
@@ -561,16 +562,20 @@ describe('NodeSearchContent', () => {
         })
       ])
 
+      const inputFilter = useNodeDefStore().nodeSearchService.inputTypeFilter
       renderComponent({
         filters: [
-          {
-            filterDef: useNodeDefStore().nodeSearchService.inputTypeFilter,
-            value: 'IMAGE'
-          }
+          { filterDef: inputFilter, value: 'IMAGE' },
+          { filterDef: inputFilter, value: 'LATENT' }
         ]
       })
 
-      expect(screen.getAllByTestId('filter-chip').length).toBeGreaterThan(0)
+      const chipTexts = screen
+        .getAllByTestId('filter-chip')
+        .map((c) => c.textContent ?? '')
+      expect(chipTexts).toHaveLength(2)
+      expect(chipTexts.some((t) => t.includes('IMAGE'))).toBe(true)
+      expect(chipTexts.some((t) => t.includes('LATENT'))).toBe(true)
     })
   })
 

--- a/src/components/searchbox/v2/NodeSearchContent.test.ts
+++ b/src/components/searchbox/v2/NodeSearchContent.test.ts
@@ -720,7 +720,7 @@ describe('NodeSearchContent', () => {
       })
     })
 
-    it('should collapse on resize to mobile and preserve user state on resize back to desktop', async () => {
+    it('should preserve user state across mobile/desktop resizes', async () => {
       useNodeDefStore().updateNodeDefs([
         createMockNodeDef({
           name: 'KSampler',
@@ -729,21 +729,27 @@ describe('NodeSearchContent', () => {
         })
       ])
 
-      renderComponent()
+      const { user } = renderComponent()
 
       const toggle = screen.getByTestId('toggle-category-sidebar')
-      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+      const expectExpanded = (value: 'true' | 'false') =>
+        waitFor(() => expect(toggle).toHaveAttribute('aria-expanded', value))
+
+      await expectExpanded('true')
 
       setViewport(MOBILE_VIEWPORT)
-      await waitFor(() => {
-        expect(toggle).toHaveAttribute('aria-expanded', 'false')
-      })
+      await expectExpanded('false')
 
-      // Returning to desktop should NOT auto-restore — collapsed state is
-      // preserved so a user's earlier explicit toggle isn't undone.
+      await user.click(toggle)
       setViewport(DESKTOP_VIEWPORT)
-      await new Promise((resolve) => setTimeout(resolve, 0))
-      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      await expectExpanded('true')
+
+      await user.click(toggle)
+      setViewport(MOBILE_VIEWPORT)
+      await expectExpanded('false')
+
+      setViewport(DESKTOP_VIEWPORT)
+      await expectExpanded('false')
     })
   })
 

--- a/src/components/searchbox/v2/NodeSearchContent.vue
+++ b/src/components/searchbox/v2/NodeSearchContent.vue
@@ -90,8 +90,8 @@
               :node-def="node"
               :current-query="searchQuery"
               show-description
-              :show-source-badge="rootFilter !== 'essentials'"
-              :hide-bookmark-icon="selectedCategory === 'favorites'"
+              :show-source-badge="rootFilter !== RootCategory.Essentials"
+              :hide-bookmark-icon="selectedCategory === RootCategory.Favorites"
             />
           </div>
           <div
@@ -119,6 +119,8 @@ import NodeSearchCategorySidebar, {
 } from '@/components/searchbox/v2/NodeSearchCategorySidebar.vue'
 import NodeSearchInput from '@/components/searchbox/v2/NodeSearchInput.vue'
 import NodeSearchListItem from '@/components/searchbox/v2/NodeSearchListItem.vue'
+import { RootCategory } from '@/components/searchbox/v2/rootCategories'
+import type { RootCategoryId } from '@/components/searchbox/v2/rootCategories'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeDefStore, useNodeFrequencyStore } from '@/stores/nodeDefStore'
@@ -134,9 +136,9 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 const sourceCategoryFilters: Record<string, (n: ComfyNodeDefImpl) => boolean> =
   {
-    essentials: isEssentialNode,
-    comfy: (n) => n.nodeSource.type === NodeSourceType.Core,
-    custom: isCustomNode
+    [RootCategory.Essentials]: isEssentialNode,
+    [RootCategory.Comfy]: (n) => n.nodeSource.type === NodeSourceType.Core,
+    [RootCategory.Custom]: isCustomNode
   }
 
 const { filters } = defineProps<{
@@ -192,21 +194,21 @@ function onSearchFocus() {
 }
 
 // Root filter from filter bar category buttons (radio toggle)
-const rootFilter = ref<string | null>(null)
+const rootFilter = ref<RootCategoryId | null>(null)
 
 const rootFilterLabel = computed(() => {
   switch (rootFilter.value) {
-    case 'favorites':
+    case RootCategory.Favorites:
       return t('g.bookmarked')
-    case BLUEPRINT_CATEGORY:
+    case RootCategory.Blueprint:
       return t('g.blueprints')
-    case 'partner-nodes':
+    case RootCategory.PartnerNodes:
       return t('g.partner')
-    case 'essentials':
+    case RootCategory.Essentials:
       return t('g.essentials')
-    case 'comfy':
+    case RootCategory.Comfy:
       return t('g.comfy')
-    case 'custom':
+    case RootCategory.Custom:
       return t('g.extensions')
     default:
       return undefined
@@ -219,11 +221,11 @@ const rootFilteredNodeDefs = computed(() => {
   const sourceFilter = sourceCategoryFilters[rootFilter.value]
   if (sourceFilter) return allNodes.filter(sourceFilter)
   switch (rootFilter.value) {
-    case 'favorites':
+    case RootCategory.Favorites:
       return allNodes.filter((n) => nodeBookmarkStore.isBookmarked(n))
-    case BLUEPRINT_CATEGORY:
-      return allNodes.filter((n) => n.category.startsWith(rootFilter.value!))
-    case 'partner-nodes':
+    case RootCategory.Blueprint:
+      return allNodes.filter((n) => n.category.startsWith(BLUEPRINT_CATEGORY))
+    case RootCategory.PartnerNodes:
       return allNodes.filter((n) => n.api_node)
     default:
       return allNodes
@@ -250,7 +252,7 @@ function onClearFilterGroup(filterId: string) {
   }
 }
 
-function onSelectCategory(category: string) {
+function onSelectCategory(category: RootCategoryId) {
   if (rootFilter.value === category) {
     rootFilter.value = null
   } else {

--- a/src/components/searchbox/v2/NodeSearchContent.vue
+++ b/src/components/searchbox/v2/NodeSearchContent.vue
@@ -13,11 +13,13 @@
         @navigate-down="navigateResults(1)"
         @navigate-up="navigateResults(-1)"
         @select-current="selectCurrentResult"
+        @focusin="onSearchFocus"
       />
 
       <!-- Filter header row -->
       <div class="flex items-center">
         <NodeSearchFilterBar
+          v-model:is-sidebar-open="isSidebarOpen"
           class="flex-1"
           :filters="filters"
           :active-category="rootFilter"
@@ -34,17 +36,27 @@
       </div>
 
       <!-- Content area -->
-      <div class="flex min-h-0 flex-1 overflow-hidden">
-        <!-- Category sidebar -->
+      <div class="relative flex min-h-0 flex-1 overflow-hidden">
         <NodeSearchCategorySidebar
+          v-show="isSidebarOpen"
+          id="node-search-category-sidebar"
           v-model:selected-category="sidebarCategory"
-          class="w-52 shrink-0"
+          :aria-label="isMobile ? t('g.categories') : undefined"
+          class="w-52 shrink-0 max-md:absolute max-md:inset-y-0 max-md:left-0 max-md:z-20 max-md:bg-base-background max-md:shadow-interface"
           :hide-chevrons="!anyTreeCategoryHasChildren"
           :hide-presets="rootFilter !== null"
           :node-defs="rootFilteredNodeDefs"
           :root-label="rootFilterLabel"
           :root-key="rootFilter ?? undefined"
           @auto-expand="selectedCategory = $event"
+        />
+
+        <!-- Mobile overlay backdrop to close sidebar on outside click -->
+        <div
+          v-if="isMobile && isSidebarOpen"
+          data-testid="sidebar-backdrop"
+          class="absolute inset-0 z-10 md:hidden"
+          @click="isSidebarOpen = false"
         />
 
         <!-- Results list -->
@@ -96,6 +108,7 @@
 </template>
 
 <script setup lang="ts">
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import { FocusScope } from 'reka-ui'
 import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -166,6 +179,17 @@ const searchInputRef = ref<InstanceType<typeof NodeSearchInput>>()
 const searchQuery = ref('')
 const selectedCategory = ref(DEFAULT_CATEGORY)
 const selectedIndex = ref(0)
+
+const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
+const isSidebarOpen = ref(!isMobile.value)
+watch(isMobile, (mobile) => {
+  // On transitioning to mobile state, close the sidebar
+  if (mobile) isSidebarOpen.value = false
+})
+
+function onSearchFocus() {
+  if (isMobile.value) isSidebarOpen.value = false
+}
 
 // Root filter from filter bar category buttons (radio toggle)
 const rootFilter = ref<string | null>(null)

--- a/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue'
+import { cleanup, render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -9,23 +9,16 @@ import {
   setupTestPinia,
   testI18n
 } from '@/components/searchbox/v2/__test__/testUtils'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
-
-vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: vi.fn(() => ({
-    get: vi.fn((key: string) => {
-      if (key === 'Comfy.NodeLibrary.Bookmarks.V2') return []
-      if (key === 'Comfy.NodeLibrary.BookmarksCustomization') return {}
-      return undefined
-    }),
-    set: vi.fn()
-  }))
-}))
 
 describe(NodeSearchFilterBar, () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     setupTestPinia()
+    const settings = useSettingStore()
+    settings.settingValues['Comfy.NodeLibrary.Bookmarks.V2'] = []
+    settings.settingValues['Comfy.NodeLibrary.BookmarksCustomization'] = {}
     useNodeDefStore().updateNodeDefs([
       createMockNodeDef({
         name: 'ImageNode',
@@ -59,46 +52,33 @@ describe(NodeSearchFilterBar, () => {
     return { user, onSelectCategory, onUpdateIsSidebarOpen }
   }
 
-  it('should render Extensions button and Input/Output popover triggers', async () => {
-    await createRender({ hasCustomNodes: true })
+  const buttonTexts = () =>
+    screen.getAllByRole('button').map((b) => b.textContent?.trim())
 
-    const buttons = screen.getAllByRole('button')
-    const texts = buttons.map((b) => b.textContent?.trim())
-    expect(texts).toContain('Extensions')
+  it.each([
+    { prop: 'hasFavorites', label: 'Bookmarked' },
+    { prop: 'hasBlueprintNodes', label: 'Blueprints' },
+    { prop: 'hasEssentialNodes', label: 'Essentials' },
+    { prop: 'hasPartnerNodes', label: 'Partner' },
+    { prop: 'hasCustomNodes', label: 'Extensions' }
+  ] as const)(
+    'shows the $label button only when $prop is true',
+    async ({ prop, label }) => {
+      await createRender()
+      expect(buttonTexts()).not.toContain(label)
+
+      cleanup()
+      await createRender({ [prop]: true })
+      expect(buttonTexts()).toContain(label)
+    }
+  )
+
+  it('always renders the Comfy button and Input/Output type filter triggers', async () => {
+    await createRender()
+    const texts = buttonTexts()
+    expect(texts).toContain('Comfy')
     expect(texts).toContain('Input')
     expect(texts).toContain('Output')
-  })
-
-  it('should always render Comfy button', async () => {
-    await createRender()
-    const texts = screen
-      .getAllByRole('button')
-      .map((b) => b.textContent?.trim())
-    expect(texts).toContain('Comfy')
-  })
-
-  it('should render conditional category buttons when matching nodes exist', async () => {
-    await createRender({
-      hasFavorites: true,
-      hasEssentialNodes: true,
-      hasBlueprintNodes: true,
-      hasPartnerNodes: true
-    })
-    const texts = screen
-      .getAllByRole('button')
-      .map((b) => b.textContent?.trim())
-    expect(texts).toContain('Bookmarked')
-    expect(texts).toContain('Blueprints')
-    expect(texts).toContain('Partner')
-    expect(texts).toContain('Essentials')
-  })
-
-  it('should not render Extensions button when no custom nodes exist', async () => {
-    await createRender()
-    const texts = screen
-      .getAllByRole('button')
-      .map((b) => b.textContent?.trim())
-    expect(texts).not.toContain('Extensions')
   })
 
   it('should emit selectCategory when category button is clicked', async () => {

--- a/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
@@ -38,8 +38,13 @@ describe(NodeSearchFilterBar, () => {
   async function createRender(props = {}) {
     const user = userEvent.setup()
     const onSelectCategory = vi.fn()
+    const onUpdateIsSidebarOpen = vi.fn()
     render(NodeSearchFilterBar, {
-      props: { onSelectCategory, ...props },
+      props: {
+        onSelectCategory,
+        'onUpdate:isSidebarOpen': onUpdateIsSidebarOpen,
+        ...props
+      },
       global: {
         plugins: [testI18n],
         stubs: {
@@ -51,7 +56,7 @@ describe(NodeSearchFilterBar, () => {
       }
     })
     await nextTick()
-    return { user, onSelectCategory }
+    return { user, onSelectCategory, onUpdateIsSidebarOpen }
   }
 
   it('should render Extensions button and Input/Output popover triggers', async () => {
@@ -111,6 +116,26 @@ describe(NodeSearchFilterBar, () => {
 
     expect(screen.getByRole('button', { name: 'Extensions' })).toHaveAttribute(
       'aria-pressed',
+      'true'
+    )
+  })
+
+  it('should expose aria-expanded=false and emit update:isSidebarOpen=true when toggled from collapsed', async () => {
+    const { user, onUpdateIsSidebarOpen } = await createRender({
+      isSidebarOpen: false
+    })
+    const toggle = screen.getByTestId('toggle-category-sidebar')
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(toggle)
+    expect(onUpdateIsSidebarOpen).toHaveBeenCalledExactlyOnceWith(true)
+  })
+
+  it('should expose aria-expanded=true when isSidebarOpen prop is true', async () => {
+    await createRender({ isSidebarOpen: true })
+    expect(screen.getByTestId('toggle-category-sidebar')).toHaveAttribute(
+      'aria-expanded',
       'true'
     )
   })

--- a/src/components/searchbox/v2/NodeSearchFilterBar.vue
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.vue
@@ -82,6 +82,7 @@ import { useI18n } from 'vue-i18n'
 
 import NodeSearchTypeFilterPopover from '@/components/searchbox/v2/NodeSearchTypeFilterPopover.vue'
 import { RootCategory } from '@/components/searchbox/v2/rootCategories'
+import type { RootCategoryId } from '@/components/searchbox/v2/rootCategories'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import type { FuseFilterWithValue } from '@/utils/fuseUtil'
 import { getLinkTypeColor } from '@/utils/litegraphUtil'
@@ -111,7 +112,7 @@ const emit = defineEmits<{
   toggleFilter: [filterDef: FuseFilter<ComfyNodeDefImpl, string>, value: string]
   clearFilterGroup: [filterId: string]
   focusSearch: []
-  selectCategory: [category: string]
+  selectCategory: [category: RootCategoryId]
 }>()
 
 const { t } = useI18n()
@@ -120,7 +121,7 @@ const nodeDefStore = useNodeDefStore()
 const MAX_VISIBLE_DOTS = 4
 
 const categoryButtons = computed(() => {
-  const buttons: { id: string; label: string }[] = []
+  const buttons: { id: RootCategoryId; label: string }[] = []
   if (hasFavorites) {
     buttons.push({ id: RootCategory.Favorites, label: t('g.bookmarked') })
   }

--- a/src/components/searchbox/v2/NodeSearchFilterBar.vue
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.vue
@@ -1,48 +1,67 @@
 <template>
-  <div class="flex items-center gap-2.5 px-3">
-    <!-- Category filter buttons -->
+  <div class="flex min-w-0 items-center gap-2.5 pl-3">
     <button
-      v-for="btn in categoryButtons"
-      :key="btn.id"
       type="button"
-      :data-testid="`search-category-${btn.id}`"
-      :aria-pressed="activeCategory === btn.id"
-      :class="chipClass(activeCategory === btn.id)"
-      @click="emit('selectCategory', btn.id)"
+      data-testid="toggle-category-sidebar"
+      aria-controls="node-search-category-sidebar"
+      :aria-expanded="isSidebarOpen"
+      :aria-label="isSidebarOpen ? t('g.hideLeftPanel') : t('g.showLeftPanel')"
+      :class="chipClass(isSidebarOpen)"
+      @click="isSidebarOpen = !isSidebarOpen"
     >
-      {{ btn.label }}
+      <i class="icon-[lucide--panel-left] size-4" />
     </button>
 
     <div class="h-5 w-px shrink-0 bg-border-subtle" />
 
-    <!-- Type filter popovers (Input / Output) -->
-    <NodeSearchTypeFilterPopover
-      v-for="tf in typeFilters"
-      :key="tf.chip.key"
-      :chip="tf.chip"
-      :selected-values="tf.values"
-      @toggle="(v) => emit('toggleFilter', tf.chip.filter, v)"
-      @clear="emit('clearFilterGroup', tf.chip.filter.id)"
-      @escape-close="emit('focusSearch')"
+    <div
+      data-testid="filter-chips-scroll"
+      class="flex min-w-0 flex-1 items-center gap-2.5 overflow-x-auto pr-3"
     >
+      <!-- Category filter buttons -->
       <button
+        v-for="btn in categoryButtons"
+        :key="btn.id"
         type="button"
-        :data-testid="`search-filter-${tf.chip.key}`"
-        :class="chipClass(false, tf.values.length > 0)"
+        :data-testid="`search-category-${btn.id}`"
+        :aria-pressed="activeCategory === btn.id"
+        :class="chipClass(activeCategory === btn.id)"
+        @click="emit('selectCategory', btn.id)"
       >
-        <span v-if="tf.values.length > 0" class="flex items-center">
-          <span
-            v-for="val in tf.values.slice(0, MAX_VISIBLE_DOTS)"
-            :key="val"
-            class="-mx-[2px] text-lg leading-none"
-            :style="{ color: getLinkTypeColor(val) }"
-            >&bull;</span
-          >
-        </span>
-        {{ tf.chip.label }}
-        <i class="icon-[lucide--chevron-down] size-3.5" />
+        {{ btn.label }}
       </button>
-    </NodeSearchTypeFilterPopover>
+
+      <div class="h-5 w-px shrink-0 bg-border-subtle" />
+
+      <!-- Type filter popovers (Input / Output) -->
+      <NodeSearchTypeFilterPopover
+        v-for="tf in typeFilters"
+        :key="tf.chip.key"
+        :chip="tf.chip"
+        :selected-values="tf.values"
+        @toggle="(v) => emit('toggleFilter', tf.chip.filter, v)"
+        @clear="emit('clearFilterGroup', tf.chip.filter.id)"
+        @escape-close="emit('focusSearch')"
+      >
+        <button
+          type="button"
+          :data-testid="`search-filter-${tf.chip.key}`"
+          :class="chipClass(false, tf.values.length > 0)"
+        >
+          <span v-if="tf.values.length > 0" class="flex items-center">
+            <span
+              v-for="val in tf.values.slice(0, MAX_VISIBLE_DOTS)"
+              :key="val"
+              class="-mx-[2px] text-lg leading-none"
+              :style="{ color: getLinkTypeColor(val) }"
+              >&bull;</span
+            >
+          </span>
+          {{ tf.chip.label }}
+          <i class="icon-[lucide--chevron-down] size-3.5" />
+        </button>
+      </NodeSearchTypeFilterPopover>
+    </div>
   </div>
 </template>
 
@@ -86,6 +105,8 @@ const {
   hasCustomNodes?: boolean
 }>()
 
+const isSidebarOpen = defineModel<boolean>('isSidebarOpen', { default: true })
+
 const emit = defineEmits<{
   toggleFilter: [filterDef: FuseFilter<ComfyNodeDefImpl, string>, value: string]
   clearFilterGroup: [filterId: string]
@@ -106,13 +127,13 @@ const categoryButtons = computed(() => {
   if (hasBlueprintNodes) {
     buttons.push({ id: RootCategory.Blueprint, label: t('g.blueprints') })
   }
-  if (hasPartnerNodes) {
-    buttons.push({ id: RootCategory.PartnerNodes, label: t('g.partner') })
-  }
+  buttons.push({ id: RootCategory.Comfy, label: t('g.comfy') })
   if (hasEssentialNodes) {
     buttons.push({ id: RootCategory.Essentials, label: t('g.essentials') })
   }
-  buttons.push({ id: RootCategory.Comfy, label: t('g.comfy') })
+  if (hasPartnerNodes) {
+    buttons.push({ id: RootCategory.PartnerNodes, label: t('g.partner') })
+  }
   if (hasCustomNodes) {
     buttons.push({ id: RootCategory.Custom, label: t('g.extensions') })
   }
@@ -146,7 +167,7 @@ const typeFilters = computed(() => [
 
 function chipClass(isActive: boolean, hasSelections = false) {
   return cn(
-    'flex cursor-pointer items-center justify-center gap-1 rounded-md border border-secondary-background px-3 py-1 font-inter text-sm transition-colors',
+    'flex shrink-0 cursor-pointer items-center justify-center gap-1 rounded-md border border-secondary-background px-3 py-1 font-inter text-sm transition-colors',
     isActive
       ? 'border-base-foreground bg-base-foreground text-base-background'
       : hasSelections

--- a/src/components/searchbox/v2/__test__/testUtils.ts
+++ b/src/components/searchbox/v2/__test__/testUtils.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
+import type { DetachedWindowAPI } from 'happy-dom'
 import { setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 
@@ -35,3 +36,12 @@ export const testI18n = createI18n({
   locale: 'en',
   messages: { en: enMessages }
 })
+
+export function setViewport(viewport: { width: number; height: number }) {
+  const happyDOM = (window as unknown as { happyDOM?: DetachedWindowAPI })
+    .happyDOM
+  if (!happyDOM) {
+    throw new Error('window.happyDOM is unavailable to set viewport')
+  }
+  happyDOM.setViewport(viewport)
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -230,6 +230,7 @@
     "warning": "Warning",
     "name": "Name",
     "category": "Category",
+    "categories": "Categories",
     "sort": "Sort",
     "source": "Source",
     "filter": "Filter",


### PR DESCRIPTION
## Summary

Improves the search experience on mobile by collapsing the category menu & reogranises the filer buttons

## Changes

- **What**: 
- add toggle button to collapse category selection
- auto collapse on mobile
- floating panel on mobile
- re-order filter buttons
- tests

## Screenshots (if applicable)
Closed:
<img width="415" height="373" alt="image" src="https://github.com/user-attachments/assets/c99cd6cd-eb92-4ce3-9844-591dd1e80769" />

Desktop open:
<img width="455" height="328" alt="image" src="https://github.com/user-attachments/assets/df15bdda-f77a-4c12-90e1-8608d67c55b4" />

Mobile open:
<img width="427" height="600" alt="image" src="https://github.com/user-attachments/assets/a2b115ad-bce0-4ed1-9d30-126a35263259" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11687-feat-Node-search-Improve-category-tree-on-mobile-with-collapse-34f6d73d365081729075e8b0071a3bc1) by [Unito](https://www.unito.io)
