### PR TITLE
test(subgraph): pin #10849 promoted-widget-value corruption with it.fails

### DIFF
--- a/src/lib/litegraph/src/subgraph/SubgraphNode.multiInstance.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.multiInstance.test.ts
@@ -259,17 +259,8 @@ describe('SubgraphNode multi-instance widget isolation', () => {
     expect(serialized.widgets_values).toBeUndefined()
   })
 
-  // Pins the open #10849 regression: the post-#10849 SubgraphNode.configure
-  // applies `widgets_values` positionally to promoted widgets, which corrupts
-  // pre-#10849 templates (e.g. Z-Image-Turbo) where `widgets_values` was
-  // leftover from older serialization and never represented promoted-widget
-  // values. The fix on the unmerged inline-proxyWidgets-state branch
-  // distinguishes legacy entries (plain 2-tuples) from new-format entries
-  // (entries carrying inline state), and falls back to the source widget's
-  // value for the legacy shape.
-  //
-  // Uses it.fails so the suite stays green while the bug is present and
-  // flips to failing when the fix lands. Drop the `.fails` marker then.
+  // it.fails pins the open #10849 SubgraphNode.configure regression on Main;
+  // drop the marker once the inline-proxyWidgets-state fix lands.
   it.fails('falls back to source widget value when proxyWidgets is in legacy 2-tuple shape (regression for #10849)', () => {
     const subgraph = createTestSubgraph({
       inputs: [{ name: 'value', type: 'number' }]

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.multiInstance.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.multiInstance.test.ts
@@ -258,4 +258,80 @@ describe('SubgraphNode multi-instance widget isolation', () => {
     const serialized = instance.serialize()
     expect(serialized.widgets_values).toBeUndefined()
   })
+
+  // Pins the open #10849 regression: the post-#10849 SubgraphNode.configure
+  // applies `widgets_values` positionally to promoted widgets, which corrupts
+  // pre-#10849 templates (e.g. Z-Image-Turbo) where `widgets_values` was
+  // leftover from older serialization and never represented promoted-widget
+  // values. The fix on the unmerged inline-proxyWidgets-state branch
+  // distinguishes legacy entries (plain 2-tuples) from new-format entries
+  // (entries carrying inline state), and falls back to the source widget's
+  // value for the legacy shape.
+  //
+  // Uses it.fails so the suite stays green while the bug is present and
+  // flips to failing when the fix lands. Drop the `.fails` marker then.
+  it.fails('falls back to source widget value when proxyWidgets is in legacy 2-tuple shape (regression for #10849)', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'value', type: 'number' }]
+    })
+
+    const SOURCE_DEFAULT = 42
+    const LEGACY_NOISE = 999
+
+    const { node } = createNodeWithWidget('TestNode', SOURCE_DEFAULT)
+    subgraph.add(node)
+    subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+
+    const instance = createTestSubgraphNode(subgraph, { id: 801 })
+    instance.configure({
+      id: 801,
+      type: subgraph.id,
+      pos: [100, 100],
+      size: [200, 100],
+      inputs: [],
+      outputs: [],
+      mode: 0,
+      order: 0,
+      flags: {},
+      properties: { proxyWidgets: [['-1', 'widget']] },
+      widgets_values: [LEGACY_NOISE]
+    })
+
+    const widget = instance.widgets?.[0]
+    expect(widget?.value).toBe(SOURCE_DEFAULT)
+    expect(widget?.serializeValue?.(instance, 0)).toBe(SOURCE_DEFAULT)
+  })
+
+  it.fails('does not corrupt unbound promoted widgets when widgets_values length mismatches view count (regression for #10849)', () => {
+    const subgraph = createTestSubgraph({
+      inputs: [{ name: 'value', type: 'number' }]
+    })
+
+    const SOURCE_DEFAULT = 42
+    const LEGACY_NOISE_A = 111
+    const LEGACY_NOISE_B = 222
+
+    const { node } = createNodeWithWidget('TestNode', SOURCE_DEFAULT)
+    subgraph.add(node)
+    subgraph.inputNode.slots[0].connect(node.inputs[0], node)
+
+    const instance = createTestSubgraphNode(subgraph, { id: 802 })
+    instance.configure({
+      id: 802,
+      type: subgraph.id,
+      pos: [100, 100],
+      size: [200, 100],
+      inputs: [],
+      outputs: [],
+      mode: 0,
+      order: 0,
+      flags: {},
+      properties: { proxyWidgets: [['-1', 'widget']] },
+      widgets_values: [LEGACY_NOISE_A, LEGACY_NOISE_B]
+    })
+
+    const widget = instance.widgets?.[0]
+    expect(widget?.value).toBe(SOURCE_DEFAULT)
+    expect(widget?.value).not.toBe(LEGACY_NOISE_A)
+  })
 })


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

#11579 restored *categorical* test coverage for subgraph serialization but didn't reproduce the specific Z-Image-Turbo regression introduced by #10849 — pre-#10849 templates whose `widgets_values` is leftover noise get corrupted on load because the new code applies that array positionally to promoted widget views.

This PR adds two **vitest** cases that pin the user-visible symptom directly: after loading a misaligned legacy payload, the promoted widget value should reflect the source default, not the legacy `widgets_values[i]`.

Both use `it.fails` so the suite stays green while the bug is present and flips to failing the moment the fix on `fix/subgraph-promoted-widget-inline-state` lands.

## Tests

1. `falls back to source widget value when proxyWidgets is in legacy 2-tuple shape` — configure() with `proxyWidgets: [['-1', 'widget']]` + `widgets_values: [999]` should leave the widget at the source default (42), not 999.
2. `does not corrupt unbound promoted widgets when widgets_values length mismatches view count` — same shape with longer/wrong-length array.

## Verification

- All 8 cases in the file pass under `it.fails` (CI green).
- Removing `.fails` locally produces the expected failures: `expected 42, received 999` and `expected 42, received 111` — confirming both tests catch the regression.
- `pnpm typecheck`, `pnpm exec eslint`, `pnpm exec oxlint` all clean.

## Why `it.fails` and not plain failing tests

The actual fix (`fix/subgraph-promoted-widget-inline-state`) is unmerged. Landing genuinely-failing tests on main would break CI for everyone. `it.fails` documents the bug runnably, keeps CI green, and signals when the fix lands so the marker can be dropped.

## Why these assertions, not "widgets_values must be undefined"

A first draft asserted that `serialize()` should not write `widgets_values` at all. That conflicts with existing coverage in the same file (`preserves per-instance widget values after configure`, `round-trips per-instance widget values`) which deliberately uses `widgets_values` for round-trip persistence. These rewritten assertions target the load-time corruption symptom directly without contradicting the per-instance contract — feedback from Oracle review.

## Coordination

Mirrors the failing tests already on commit `6a982675e` of the unmerged `fix/subgraph-promoted-widget-inline-state` branch, with the addition of `.fails` markers and a clarifying comment so they can land on main first.

Follow-up to #11579.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11697-test-subgraph-pin-10849-promoted-widget-value-corruption-with-it-fails-34f6d73d365081d7a04dcf48ebeceafe) by [Unito](https://www.unito.io)
