### PR TITLE
refactor(litegraph): centralize _version counter via incrementVersion()

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -845,6 +845,15 @@ export class LGraph
   }
 
   /**
+   * Increments the internal version counter.
+   * Currently only read for debug display in {@link LGraphCanvas.renderInfo}.
+   * Centralized so a future VersionSystem can intercept, batch, or replace it.
+   */
+  incrementVersion(): void {
+    this._version++
+  }
+
+  /**
    * @deprecated Will be removed in 0.9
    * Sends an event to all the nodes, useful to trigger stuff
    * @param eventname the name of the event (function to be called)
@@ -957,7 +966,7 @@ export class LGraph
       this.setDirtyCanvas(true)
       this.change()
       node.graph = this
-      this._version++
+      this.incrementVersion()
       return
     }
 
@@ -990,7 +999,7 @@ export class LGraph
     }
 
     node.graph = this
-    this._version++
+    this.incrementVersion()
 
     // Register all widgets with the WidgetValueStore now that node has a
     // valid ID and graph reference.
@@ -1043,7 +1052,7 @@ export class LGraph
         this._groups.splice(index, 1)
       }
       node.graph = undefined
-      this._version++
+      this.incrementVersion()
       this.setDirtyCanvas(true, true)
       this.change()
       return
@@ -1110,7 +1119,7 @@ export class LGraph
     node.onRemoved?.()
 
     node.graph = null
-    this._version++
+    this.incrementVersion()
 
     // remove from canvas render
     const { list_of_graphcanvas } = this
@@ -2720,7 +2729,7 @@ export class LGraph
       this.updateExecutionOrder()
 
       this.onConfigure?.(data)
-      this._version++
+      this.incrementVersion()
 
       // Ensure the primary canvas is set to the correct graph
       const { primaryCanvas } = this

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -3082,7 +3082,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     if (oldValue != widget.value) {
       node.onWidgetChanged?.(widget.name, widget.value, oldValue, widget)
       if (!node.graph) throw new NullGraphError()
-      node.graph._version++
+      node.graph.incrementVersion()
     }
 
     // Clean up state var
@@ -7897,7 +7897,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       }
       node.properties[property] = value
       if (node.graph) {
-        node.graph._version++
+        node.graph.incrementVersion()
       }
       node.onPropertyChanged?.(property, value)
       options.onclose?.()

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -830,7 +830,7 @@ export class LGraphNode
    */
   configure(info: ISerialisedNode): void {
     if (this.graph) {
-      this.graph._version++
+      this.graph.incrementVersion()
     }
     if (info.id === -1) info.id = this.id
     for (const j in info) {
@@ -2989,7 +2989,7 @@ export class LGraphNode
         }
       }
     }
-    graph._version++
+    graph.incrementVersion()
 
     // link has been created now, so its updated
     this.onConnectionsChange?.(
@@ -3138,7 +3138,7 @@ export class LGraphNode
 
         // remove the link from the links pool
         link_info.disconnect(graph, 'input')
-        graph._version++
+        graph.incrementVersion()
 
         // link_info hasn't been modified so its ok
         target.onConnectionsChange?.(
@@ -3176,7 +3176,7 @@ export class LGraphNode
         }
 
         const target = graph.getNodeById(link_info.target_id)
-        graph._version++
+        graph.incrementVersion()
 
         if (target) {
           const input = target.inputs[link_info.target_slot]
@@ -3304,7 +3304,7 @@ export class LGraphNode
         }
 
         link_info.disconnect(graph, keepReroutes ? 'output' : undefined)
-        if (graph) graph._version++
+        if (graph) graph.incrementVersion()
 
         this.onConnectionsChange?.(
           NodeSlotType.INPUT,
@@ -3539,7 +3539,7 @@ export class LGraphNode
   collapse(force?: boolean): void {
     if (!this.collapsible && !force) return
     if (!this.graph) throw new NullGraphError()
-    this.graph._version++
+    this.graph.incrementVersion()
     this.flags.collapsed = !this.flags.collapsed
     this.setDirtyCanvas(true, true)
   }
@@ -3550,7 +3550,7 @@ export class LGraphNode
   toggleAdvanced() {
     if (!this.hasAdvancedWidgets()) return
     if (!this.graph) throw new NullGraphError()
-    this.graph._version++
+    this.graph.incrementVersion()
     this.showAdvanced = !this.showAdvanced
     this.expandToFitContent()
     this.setDirtyCanvas(true, true)
@@ -3567,7 +3567,7 @@ export class LGraphNode
   pin(v?: boolean): void {
     if (!this.graph) throw new NullGraphError()
 
-    this.graph._version++
+    this.graph.incrementVersion()
     this.flags.pinned = v ?? !this.flags.pinned
     this.resizable = !this.pinned
     if (!this.pinned) this.flags.pinned = undefined

--- a/src/lib/litegraph/src/subgraph/SubgraphInput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInput.ts
@@ -134,7 +134,7 @@ export class SubgraphInput extends SubgraphSlot {
         }
       }
     }
-    subgraph._version++
+    subgraph.incrementVersion()
 
     node.onConnectionsChange?.(NodeSlotType.INPUT, inputIndex, true, link, slot)
 

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -187,7 +187,7 @@ export class SubgraphInputNode
 
     const subgraphInputIndex = link.origin_slot
     link.disconnect(subgraph, 'output')
-    subgraph._version++
+    subgraph.incrementVersion()
 
     const subgraphInput = this.slots.at(subgraphInputIndex)
     if (!subgraphInput) {

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -99,7 +99,7 @@ export class SubgraphOutput extends SubgraphSlot {
         }
       }
     }
-    subgraph._version++
+    subgraph.incrementVersion()
 
     node.onConnectionsChange?.(
       NodeSlotType.OUTPUT,

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -436,7 +436,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this.callback?.(this.value, canvas, node, pos, e)
 
     node.onWidgetChanged?.(this.name ?? '', v, oldValue, this)
-    if (node.graph) node.graph._version++
+    if (node.graph) node.graph.incrementVersion()
   }
 
   /**


### PR DESCRIPTION
## Summary

Centralize all `LGraph._version` increments behind a single `incrementVersion()` method to create the seam for a future `VersionSystem` (ECS Migration Phase 0a).

## Changes

- **What**: Added `LGraph.incrementVersion()` and replaced all 19 direct `graph._version++` writes across 7 files. Existing null guards at call sites are preserved. Zero behavioral change — the counter is still only read by `LGraphCanvas.renderInfo()` for debug display.

## Review Focus

- The new method is mechanical: `incrementVersion(): void { this._version++ }`. Look for any sites I missed or null-guard regressions.
- Files updated: `LGraph.ts`, `LGraphNode.ts`, `LGraphCanvas.ts`, `widgets/BaseWidget.ts`, `subgraph/SubgraphInput.ts`, `subgraph/SubgraphInputNode.ts`, `subgraph/SubgraphOutput.ts`.

Part of the [ECS Migration Plan](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/architecture/ecs-migration-plan.md). Linear: FE-165.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11698-refactor-litegraph-centralize-_version-counter-via-incrementVersion-34f6d73d3650810992f8fa3adbae3f38) by [Unito](https://www.unito.io)
