### PR TITLE
fix: guard workspace auth refresh races

### DIFF
--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -67,6 +67,7 @@ describe('useWorkspaceAuthStore', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   describe('initial state', () => {
@@ -671,14 +672,7 @@ describe('useWorkspaceAuthStore', () => {
   })
 
   describe('refreshToken retry/race paths', () => {
-    // NOTE: This test documents the CURRENT behavior — exhausted refresh
-    // retries clear the workspace context unconditionally, even when the
-    // existing workspace token is still within its expiry window. That is a
-    // UX gap (transient backend outage manifests as forced logout) and the
-    // store should preserve a still-valid token across transient
-    // TOKEN_EXCHANGE_FAILED errors. Update the assertion alongside any source
-    // change that tracks token expiry to skip the context clear.
-    it('retries up to 3 times with exponential backoff on TOKEN_EXCHANGE_FAILED, then clears context', async () => {
+    it('retries up to 3 times with exponential backoff on TOKEN_EXCHANGE_FAILED, then preserves valid context', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
 
       // Initial successful switchWorkspace establishes context.
@@ -689,7 +683,7 @@ describe('useWorkspaceAuthStore', () => {
       vi.stubGlobal('fetch', mockFetch)
 
       const store = useWorkspaceAuthStore()
-      const { currentWorkspace } = storeToRefs(store)
+      const { currentWorkspace, workspaceToken } = storeToRefs(store)
 
       await store.switchWorkspace('workspace-123')
       expect(currentWorkspace.value).not.toBeNull()
@@ -711,31 +705,32 @@ describe('useWorkspaceAuthStore', () => {
 
       const refreshPromise = store.refreshToken()
 
-      // Drain the four attempts (initial + 3 retries) and their backoff delays.
-      await vi.runAllTimersAsync()
+      // 1 initial switchWorkspace + 1 immediate refresh attempt.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
+
+      await vi.advanceTimersByTimeAsync(4000)
+      expect(mockFetch).toHaveBeenCalledTimes(5)
+
       await refreshPromise
 
       // 1 initial switchWorkspace + 4 refresh attempts = 5 total fetch calls.
       expect(mockFetch).toHaveBeenCalledTimes(5)
-      // Backoff: 1s + 2s + 4s = 7s of cumulative warn-logged delays.
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(3)
+      expect(currentWorkspace.value).toEqual(mockWorkspaceWithRole)
+      expect(workspaceToken.value).toBe('workspace-token-abc')
       expect(
-        consoleWarnSpy.mock.calls.some((c) =>
-          /retrying in 1000ms/.test(String(c[0]))
-        )
-      ).toBe(true)
-      expect(
-        consoleWarnSpy.mock.calls.some((c) =>
-          /retrying in 2000ms/.test(String(c[0]))
-        )
-      ).toBe(true)
-      expect(
-        consoleWarnSpy.mock.calls.some((c) =>
-          /retrying in 4000ms/.test(String(c[0]))
-        )
-      ).toBe(true)
-
-      // After the final failure the context is cleared.
-      expect(currentWorkspace.value).toBeNull()
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+      ).toBe(JSON.stringify(mockWorkspaceWithRole))
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBe(
+        'workspace-token-abc'
+      )
 
       consoleErrorSpy.mockRestore()
       consoleWarnSpy.mockRestore()
@@ -776,16 +771,7 @@ describe('useWorkspaceAuthStore', () => {
       consoleErrorSpy.mockRestore()
     })
 
-    // KNOWN BUG (.fails): when an in-flight refresh's switchWorkspace call is
-    // already past its requestId-staleness check and awaiting the token-exchange
-    // fetch, switchWorkspace has no post-await commit guard. If the user
-    // switches workspaces and the stale refresh's fetch resolves AFTER the new
-    // switch has committed, the stale response will overwrite the new
-    // workspace's currentWorkspace/workspaceToken/sessionStorage. Mark this
-    // expected-fail until switchWorkspace gains a commit-time staleness check
-    // (e.g. compare captured requestId or expected workspaceId before
-    // assigning state). Removing `.fails` once fixed will catch regressions.
-    it.fails('the new workspace wins when the stale refresh resolves last', async () => {
+    it('the new workspace wins when the stale refresh resolves last', async () => {
       mockGetIdToken.mockResolvedValue('firebase-token-xyz')
 
       const mockFetch = vi.fn().mockResolvedValueOnce({
@@ -810,6 +796,10 @@ describe('useWorkspaceAuthStore', () => {
 
       // User switches workspace AND its fetch resolves first.
       const newWorkspace = { ...mockWorkspace, id: 'workspace-other' }
+      const newWorkspaceWithRole = {
+        ...newWorkspace,
+        role: 'owner' as const
+      }
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -824,10 +814,15 @@ describe('useWorkspaceAuthStore', () => {
       // New workspace is committed at this point.
       expect(currentWorkspace.value?.id).toBe('workspace-other')
       expect(workspaceToken.value).toBe('new-workspace-token')
+      expect(
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+      ).toBe(JSON.stringify(newWorkspaceWithRole))
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBe(
+        'new-workspace-token'
+      )
 
-      // Now resolve the stale refresh fetch — it carries an OLD-workspace
-      // token, and the source has no commit-time staleness check, so it
-      // clobbers the new workspace state.
+      // Now resolve the stale refresh fetch. It carries an old-workspace token
+      // and must not be allowed to commit over the newer workspace context.
       resolveRefreshFetch({
         ok: true,
         json: () =>
@@ -835,10 +830,14 @@ describe('useWorkspaceAuthStore', () => {
       })
       await refreshPromise
 
-      // Once the source-side guard is added, both of these become true
-      // (the test stops failing) and `.fails` should be dropped.
       expect(currentWorkspace.value?.id).toBe('workspace-other')
       expect(workspaceToken.value).toBe('new-workspace-token')
+      expect(
+        sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.CURRENT_WORKSPACE)
+      ).toBe(JSON.stringify(newWorkspaceWithRole))
+      expect(sessionStorage.getItem(WORKSPACE_STORAGE_KEYS.TOKEN)).toBe(
+        'new-workspace-token'
+      )
     })
   })
 
@@ -853,11 +852,21 @@ describe('useWorkspaceAuthStore', () => {
         })
       )
 
-      const setItemSpy = vi
-        .spyOn(sessionStorage, 'setItem')
-        .mockImplementation(() => {
-          throw new Error('QuotaExceededError')
-        })
+      const setItemSpy = vi.fn((_key: string, _value: string) => {
+        throw new Error('QuotaExceededError')
+      })
+      const originalSessionStorage = sessionStorage
+      const failingSessionStorage = {
+        get length() {
+          return originalSessionStorage.length
+        },
+        clear: () => originalSessionStorage.clear(),
+        getItem: (key: string) => originalSessionStorage.getItem(key),
+        key: (index: number) => originalSessionStorage.key(index),
+        removeItem: (key: string) => originalSessionStorage.removeItem(key),
+        setItem: setItemSpy
+      } satisfies Storage
+      vi.stubGlobal('sessionStorage', failingSessionStorage)
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => {})
@@ -868,11 +877,11 @@ describe('useWorkspaceAuthStore', () => {
       await store.switchWorkspace('workspace-123')
 
       expect(workspaceToken.value).toBe('workspace-token-abc')
+      expect(setItemSpy).toHaveBeenCalled()
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         'Failed to persist workspace context to sessionStorage'
       )
 
-      setItemSpy.mockRestore()
       consoleWarnSpy.mockRestore()
     })
   })

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -49,6 +49,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   // State
   const currentWorkspace = shallowRef<WorkspaceWithRole | null>(null)
   const workspaceToken = ref<string | null>(null)
+  const workspaceTokenExpiresAt = ref<number | null>(null)
   const isLoading = ref(false)
   const error = ref<Error | null>(null)
 
@@ -80,6 +81,26 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     refreshTimerId = setTimeout(() => {
       void refreshToken()
     }, delay)
+  }
+
+  function scheduleWorkspaceContextClear(expiresAt: number): void {
+    stopRefreshTimer()
+    const delay = Math.max(0, expiresAt - Date.now())
+
+    refreshTimerId = setTimeout(() => {
+      if (workspaceTokenExpiresAt.value === expiresAt) {
+        clearWorkspaceContext()
+      }
+    }, delay)
+  }
+
+  function hasValidWorkspaceContext(): boolean {
+    return (
+      currentWorkspace.value !== null &&
+      workspaceToken.value !== null &&
+      workspaceTokenExpiresAt.value !== null &&
+      workspaceTokenExpiresAt.value > Date.now()
+    )
   }
 
   function persistToSession(
@@ -155,6 +176,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
       currentWorkspace.value = parseResult.data
       workspaceToken.value = token
+      workspaceTokenExpiresAt.value = expiresAt
       error.value = null
 
       scheduleTokenRefresh(expiresAt)
@@ -176,6 +198,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     if (currentWorkspace.value?.id !== workspaceId) {
       refreshRequestId++
     }
+    const capturedRequestId = refreshRequestId
 
     isLoading.value = true
     error.value = null
@@ -257,16 +280,29 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
         role: data.role
       }
 
+      if (capturedRequestId !== refreshRequestId) {
+        return
+      }
+
       currentWorkspace.value = workspaceWithRole
       workspaceToken.value = data.token
+      workspaceTokenExpiresAt.value = expiresAt
 
       persistToSession(workspaceWithRole, data.token, expiresAt)
       scheduleTokenRefresh(expiresAt)
     } catch (err) {
-      error.value = err instanceof Error ? err : new Error(String(err))
-      throw error.value
+      const normalizedError =
+        err instanceof Error ? err : new Error(String(err))
+
+      if (capturedRequestId === refreshRequestId) {
+        error.value = normalizedError
+      }
+
+      throw normalizedError
     } finally {
-      isLoading.value = false
+      if (capturedRequestId === refreshRequestId) {
+        isLoading.value = false
+      }
     }
   }
 
@@ -327,8 +363,24 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
 
         // Only clear context if this refresh is still for the current workspace
         if (capturedRequestId === refreshRequestId) {
-          console.error('Failed to refresh workspace token after retries:', err)
-          clearWorkspaceContext()
+          const currentTokenExpiresAt = workspaceTokenExpiresAt.value
+          if (
+            isTransientError &&
+            currentTokenExpiresAt !== null &&
+            hasValidWorkspaceContext()
+          ) {
+            console.error(
+              'Failed to refresh workspace token after retries; preserving current workspace token until expiry:',
+              err
+            )
+            scheduleWorkspaceContextClear(currentTokenExpiresAt)
+          } else {
+            console.error(
+              'Failed to refresh workspace token after retries:',
+              err
+            )
+            clearWorkspaceContext()
+          }
         }
       }
     }
@@ -353,6 +405,7 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     stopRefreshTimer()
     currentWorkspace.value = null
     workspaceToken.value = null
+    workspaceTokenExpiresAt.value = null
     error.value = null
     clearSessionStorage()
   }


### PR DESCRIPTION
## Summary

Fix workspace auth refresh races so stale token exchanges cannot overwrite a newer workspace context, and transient refresh outages preserve still-valid workspace tokens.

## Changes

- **What**: Add a commit-time request staleness guard before workspace auth state/sessionStorage writes, track token expiry in memory, and preserve valid context after exhausted transient token-exchange retries.
- **Dependencies**: None.

## Review Focus

Check the request-id guard around async `switchWorkspace()` commits and the fallback behavior when `TOKEN_EXCHANGE_FAILED` retries are exhausted before the existing token expires.

Linear: FE-485

Validation:
- `pnpm exec vitest run src/platform/workspace/stores/useWorkspaceAuth.test.ts`
- `pnpm exec vue-tsc --noEmit --pretty false`
- `pnpm exec eslint src/platform/workspace/stores/workspaceAuthStore.ts src/platform/workspace/stores/useWorkspaceAuth.test.ts`
- `pnpm exec oxlint src/platform/workspace/stores/workspaceAuthStore.ts src/platform/workspace/stores/useWorkspaceAuth.test.ts --type-aware`
- `pnpm format -- src/platform/workspace/stores/workspaceAuthStore.ts src/platform/workspace/stores/useWorkspaceAuth.test.ts`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11722-fix-guard-workspace-auth-refresh-races-3506d73d36508101b35cd7a78765aaa3) by [Unito](https://www.unito.io)
