### PR TITLE
fix: detect V1/V2 draft storage keys in new-user check

### DIFF
--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -26,9 +26,6 @@ vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => mockSettingStore
 }))
 
-//@ts-expect-error Define global for the test
-global.__COMFYUI_FRONTEND_VERSION__ = '1.24.0'
-
 import { useNewUserService } from '@/services/useNewUserService'
 
 describe('useNewUserService', () => {

--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -120,6 +120,46 @@ describe('useNewUserService', () => {
       expect(service.isNewUser()).toBe(false)
     })
 
+    it('should identify existing user when V1 draft store keys exist', async () => {
+      mockSettingStore.settingValues = {}
+      mockSettingStore.get.mockReturnValue(undefined)
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === 'Comfy.Workflow.Drafts') return '{}'
+        return null
+      })
+
+      await service.initializeIfNewUser()
+
+      expect(service.isNewUser()).toBe(false)
+    })
+
+    it('should identify existing user when V1 draft order key exists', async () => {
+      mockSettingStore.settingValues = {}
+      mockSettingStore.get.mockReturnValue(undefined)
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === 'Comfy.Workflow.DraftOrder') return '[]'
+        return null
+      })
+
+      await service.initializeIfNewUser()
+
+      expect(service.isNewUser()).toBe(false)
+    })
+
+    it('should identify existing user when V2 draft index key exists', async () => {
+      mockSettingStore.settingValues = {}
+      mockSettingStore.get.mockReturnValue(undefined)
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === 'Comfy.Workflow.DraftIndex.v2:personal')
+          return '{"v":2,"updatedAt":1,"order":[],"entries":{}}'
+        return null
+      })
+
+      await service.initializeIfNewUser()
+
+      expect(service.isNewUser()).toBe(false)
+    })
+
     it('should identify new user when tutorial is explicitly false', async () => {
       mockSettingStore.settingValues = { 'Comfy.TutorialCompleted': false }
       mockSettingStore.get.mockImplementation((key: string) => {

--- a/src/services/useNewUserService.test.ts
+++ b/src/services/useNewUserService.test.ts
@@ -146,7 +146,21 @@ describe('useNewUserService', () => {
       expect(service.isNewUser()).toBe(false)
     })
 
-    it('should identify existing user when V2 draft index key exists', async () => {
+    it('should identify existing user when V2 draft index has entries', async () => {
+      mockSettingStore.settingValues = {}
+      mockSettingStore.get.mockReturnValue(undefined)
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === 'Comfy.Workflow.DraftIndex.v2:personal')
+          return '{"v":2,"updatedAt":1,"order":["abc"],"entries":{"abc":{"path":"workflows/Untitled.json","name":"Untitled","isTemporary":true,"updatedAt":1}}}'
+        return null
+      })
+
+      await service.initializeIfNewUser()
+
+      expect(service.isNewUser()).toBe(false)
+    })
+
+    it('should identify new user when V2 draft index exists but is empty', async () => {
       mockSettingStore.settingValues = {}
       mockSettingStore.get.mockReturnValue(undefined)
       mockLocalStorage.getItem.mockImplementation((key: string) => {
@@ -157,7 +171,20 @@ describe('useNewUserService', () => {
 
       await service.initializeIfNewUser()
 
-      expect(service.isNewUser()).toBe(false)
+      expect(service.isNewUser()).toBe(true)
+    })
+
+    it('should identify new user when V2 draft index is malformed', async () => {
+      mockSettingStore.settingValues = {}
+      mockSettingStore.get.mockReturnValue(undefined)
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === 'Comfy.Workflow.DraftIndex.v2:personal') return 'not json'
+        return null
+      })
+
+      await service.initializeIfNewUser()
+
+      expect(service.isNewUser()).toBe(true)
     })
 
     it('should identify new user when tutorial is explicitly false', async () => {

--- a/src/services/useNewUserService.ts
+++ b/src/services/useNewUserService.ts
@@ -18,12 +18,29 @@ function _useNewUserService() {
     const isNewUserSettings =
       Object.keys(settingStore.settingValues).length === 0 ||
       !settingStore.get('Comfy.TutorialCompleted')
-    const hasNoWorkflow = !localStorage.getItem('workflow')
-    const hasNoPreviousWorkflow = !localStorage.getItem(
-      'Comfy.PreviousWorkflow'
+
+    // Legacy keys (pre-V1 and V1 persistence)
+    const hasNoLegacyWorkflow =
+      !localStorage.getItem('workflow') &&
+      !localStorage.getItem('Comfy.PreviousWorkflow')
+
+    // V1 draft store keys
+    const hasNoV1Drafts =
+      !localStorage.getItem('Comfy.Workflow.Drafts') &&
+      !localStorage.getItem('Comfy.Workflow.DraftOrder')
+
+    // V2 draft index key (scoped to personal workspace; cloud workspace id
+    // comes from sessionStorage which may not be set yet at this point)
+    const hasNoV2DraftIndex = !localStorage.getItem(
+      'Comfy.Workflow.DraftIndex.v2:personal'
     )
 
-    return isNewUserSettings && hasNoWorkflow && hasNoPreviousWorkflow
+    return (
+      isNewUserSettings &&
+      hasNoLegacyWorkflow &&
+      hasNoV1Drafts &&
+      hasNoV2DraftIndex
+    )
   }
 
   async function registerInitCallback(callback: () => Promise<void>) {

--- a/src/services/useNewUserService.ts
+++ b/src/services/useNewUserService.ts
@@ -2,6 +2,24 @@ import { ref, shallowRef } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 import { useSettingStore } from '@/platform/settings/settingStore'
 
+function hasV2DraftHistory(raw: string | null): boolean {
+  if (!raw) return false
+  try {
+    const parsed = JSON.parse(raw) as {
+      order?: unknown
+      entries?: unknown
+    }
+    const orderLength = Array.isArray(parsed.order) ? parsed.order.length : 0
+    const entriesCount =
+      parsed.entries && typeof parsed.entries === 'object'
+        ? Object.keys(parsed.entries as Record<string, unknown>).length
+        : 0
+    return orderLength > 0 || entriesCount > 0
+  } catch {
+    return false
+  }
+}
+
 function _useNewUserService() {
   const settingStore = useSettingStore()
   const pendingCallbacks = shallowRef<Array<() => Promise<void>>>([])
@@ -30,9 +48,12 @@ function _useNewUserService() {
       !localStorage.getItem('Comfy.Workflow.DraftOrder')
 
     // V2 draft index key (scoped to personal workspace; cloud workspace id
-    // comes from sessionStorage which may not be set yet at this point)
-    const hasNoV2DraftIndex = !localStorage.getItem(
-      'Comfy.Workflow.DraftIndex.v2:personal'
+    // comes from sessionStorage which may not be set yet at this point).
+    // Check for actual draft history rather than key existence: an empty
+    // index is written by `migrateV1toV2()` for genuine new users during
+    // startup, so key presence alone is not evidence of prior usage.
+    const hasNoV2DraftIndex = !hasV2DraftHistory(
+      localStorage.getItem('Comfy.Workflow.DraftIndex.v2:personal')
     )
 
     return (


### PR DESCRIPTION
## Problem

`checkIsNewUser()` in `useNewUserService` only checked legacy pre-V1 localStorage keys (`workflow`, `Comfy.PreviousWorkflow`) to determine if a user had prior workflow history. A returning user who had only ever used the V1 or V2 draft persistence system would have neither of those keys set, causing `isNewUser()` to return `true` and the getting-started tab to appear in the workflow templates dialog after a settings reset.

## Solution

Extend the check to also cover:
- **V1 draft store keys**: `Comfy.Workflow.Drafts`, `Comfy.Workflow.DraftOrder`
- **V2 draft index key**: `Comfy.Workflow.DraftIndex.v2:personal`

The `personal` scope is hardcoded for the V2 check because at the time `checkIsNewUser()` runs, the cloud workspace ID (stored in sessionStorage) may not be set yet. This is fine — any genuine new user will have no personal workspace index regardless.

The original legacy keys are preserved for users who may still have them from older installs.

## Tests

Added three new test cases covering V1 draft store keys, V1 draft order key, and V2 draft index key.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11728-fix-detect-V1-V2-draft-storage-keys-in-new-user-check-3506d73d3650819ca4cfc8e83d95c258) by [Unito](https://www.unito.io)
