### PR TITLE
test(load3d): add unit tests for AnimationManager, CameraManager, RecordingManager, and load3dService

### DIFF
--- a/src/extensions/core/load3d/AnimationManager.test.ts
+++ b/src/extensions/core/load3d/AnimationManager.test.ts
@@ -1,0 +1,324 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AnimationManager } from './AnimationManager'
+import type { EventManagerInterface } from './interfaces'
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+function makeClip(name: string, duration: number): THREE.AnimationClip {
+  return new THREE.AnimationClip(name, duration, [])
+}
+
+function makeAnimatedModel(
+  clips: THREE.AnimationClip[] = []
+): THREE.Object3D & { animations: THREE.AnimationClip[] } {
+  const obj = new THREE.Object3D() as THREE.Object3D & {
+    animations: THREE.AnimationClip[]
+  }
+  obj.animations = clips
+  return obj
+}
+
+describe('AnimationManager', () => {
+  let events: ReturnType<typeof makeMockEventManager>
+  let manager: AnimationManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    events = makeMockEventManager()
+    manager = new AnimationManager(events)
+  })
+
+  describe('setupModelAnimations', () => {
+    it('creates a mixer and selects the first clip when the model has animations', () => {
+      const clips = [makeClip('walk', 2), makeClip('run', 3)]
+      const model = makeAnimatedModel(clips)
+
+      manager.setupModelAnimations(model, null)
+
+      expect(manager.currentAnimation).not.toBeNull()
+      expect(manager.animationClips).toEqual(clips)
+      expect(manager.selectedAnimationIndex).toBe(0)
+      expect(manager.animationActions).toHaveLength(1)
+    })
+
+    it('falls back to originalModel.animations when the model itself has none', () => {
+      const clips = [makeClip('idle', 1.5)]
+      const model = makeAnimatedModel([])
+      const originalModel = { animations: clips } as unknown as THREE.Object3D
+
+      manager.setupModelAnimations(model, originalModel)
+
+      expect(manager.animationClips).toEqual(clips)
+      expect(manager.currentAnimation).not.toBeNull()
+    })
+
+    it('emits the localized animation list with default names when clips are unnamed', () => {
+      const clips = [makeClip('', 1), makeClip('named', 1)]
+      const model = makeAnimatedModel(clips)
+
+      manager.setupModelAnimations(model, null)
+
+      expect(events.emitEvent).toHaveBeenCalledWith('animationListChange', [
+        { name: 'Animation 1', index: 0 },
+        { name: 'named', index: 1 }
+      ])
+    })
+
+    it('emits an empty list and leaves no actions when neither source has animations', () => {
+      const model = makeAnimatedModel([])
+
+      manager.setupModelAnimations(model, null)
+
+      expect(manager.animationClips).toEqual([])
+      expect(manager.animationActions).toEqual([])
+      expect(events.emitEvent).toHaveBeenLastCalledWith(
+        'animationListChange',
+        []
+      )
+    })
+
+    it('stops previously running actions before loading a new model', () => {
+      const firstClips = [makeClip('a', 1)]
+      manager.setupModelAnimations(makeAnimatedModel(firstClips), null)
+      const firstAction = manager.animationActions[0]
+      const stopSpy = vi.spyOn(firstAction, 'stop')
+
+      const secondClips = [makeClip('b', 1)]
+      manager.setupModelAnimations(makeAnimatedModel(secondClips), null)
+
+      expect(stopSpy).toHaveBeenCalled()
+      expect(manager.animationClips).toEqual(secondClips)
+    })
+  })
+
+  describe('updateSelectedAnimation', () => {
+    it('warns and does nothing when called before any setup', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      manager.updateSelectedAnimation(0)
+
+      expect(warn).toHaveBeenCalled()
+      expect(manager.animationActions).toEqual([])
+      warn.mockRestore()
+    })
+
+    it('warns when the index is out of bounds', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      manager.setupModelAnimations(
+        makeAnimatedModel([makeClip('only', 1)]),
+        null
+      )
+
+      manager.updateSelectedAnimation(5)
+
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('switches to the requested clip and emits an initial progress event', () => {
+      const clips = [makeClip('a', 2), makeClip('b', 4)]
+      manager.setupModelAnimations(makeAnimatedModel(clips), null)
+      events.emitEvent.mockClear()
+
+      manager.updateSelectedAnimation(1)
+
+      expect(manager.selectedAnimationIndex).toBe(1)
+      expect(manager.animationActions).toHaveLength(1)
+      expect(events.emitEvent).toHaveBeenCalledWith('animationProgressChange', {
+        progress: 0,
+        currentTime: 0,
+        duration: 4
+      })
+    })
+
+    it('starts the action paused when the manager is not currently playing', () => {
+      const clips = [makeClip('a', 2)]
+      manager.setupModelAnimations(makeAnimatedModel(clips), null)
+
+      const action = manager.animationActions[0]
+      expect(action.paused).toBe(true)
+    })
+
+    it('starts the action running when the manager is already playing', () => {
+      const clips = [makeClip('a', 2), makeClip('b', 2)]
+      manager.setupModelAnimations(makeAnimatedModel(clips), null)
+      manager.toggleAnimation(true)
+
+      manager.updateSelectedAnimation(1)
+
+      expect(manager.animationActions[0].paused).toBe(false)
+    })
+  })
+
+  describe('toggleAnimation', () => {
+    it('warns and is a no-op when there is no animation loaded', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      manager.toggleAnimation(true)
+
+      expect(warn).toHaveBeenCalled()
+      expect(manager.isAnimationPlaying).toBe(false)
+      warn.mockRestore()
+    })
+
+    it('flips the playing state when called without an explicit value', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 1)]), null)
+
+      manager.toggleAnimation()
+      expect(manager.isAnimationPlaying).toBe(true)
+      manager.toggleAnimation()
+      expect(manager.isAnimationPlaying).toBe(false)
+    })
+
+    it('resets time to zero when starting from the end of the clip', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 2)]), null)
+      const action = manager.animationActions[0]
+      action.time = action.getClip().duration
+
+      manager.toggleAnimation(true)
+
+      expect(action.time).toBe(0)
+      expect(action.paused).toBe(false)
+    })
+  })
+
+  describe('setAnimationSpeed', () => {
+    it('records the speed and propagates it to all current actions', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 1)]), null)
+      const action = manager.animationActions[0]
+      const setEffectiveTimeScale = vi.spyOn(action, 'setEffectiveTimeScale')
+
+      manager.setAnimationSpeed(2.5)
+
+      expect(manager.animationSpeed).toBe(2.5)
+      expect(setEffectiveTimeScale).toHaveBeenCalledWith(2.5)
+    })
+  })
+
+  describe('setAnimationTime', () => {
+    it('clamps the requested time to [0, duration]', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 4)]), null)
+      events.emitEvent.mockClear()
+
+      manager.setAnimationTime(-5)
+      expect(events.emitEvent).toHaveBeenLastCalledWith(
+        'animationProgressChange',
+        { progress: 0, currentTime: 0, duration: 4 }
+      )
+
+      manager.setAnimationTime(99)
+      expect(events.emitEvent).toHaveBeenLastCalledWith(
+        'animationProgressChange',
+        { progress: 100, currentTime: 4, duration: 4 }
+      )
+    })
+
+    it('preserves the paused state across the seek', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 4)]), null)
+      const action = manager.animationActions[0]
+      action.paused = true
+
+      manager.setAnimationTime(2)
+
+      expect(action.paused).toBe(true)
+      expect(action.time).toBe(2)
+    })
+
+    it('emits a progress event reflecting the seek target', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 4)]), null)
+      events.emitEvent.mockClear()
+
+      manager.setAnimationTime(1)
+
+      expect(events.emitEvent).toHaveBeenCalledWith('animationProgressChange', {
+        progress: 25,
+        currentTime: 1,
+        duration: 4
+      })
+    })
+
+    it('is a no-op when no actions are loaded', () => {
+      expect(() => manager.setAnimationTime(1)).not.toThrow()
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'animationProgressChange',
+        expect.anything()
+      )
+    })
+  })
+
+  describe('update', () => {
+    it('does not advance the mixer when not playing', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 4)]), null)
+      const updateSpy = vi.spyOn(manager.currentAnimation!, 'update')
+
+      manager.update(0.5)
+
+      expect(updateSpy).not.toHaveBeenCalled()
+    })
+
+    it('advances the mixer and emits progress while playing', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 4)]), null)
+      manager.toggleAnimation(true)
+      const updateSpy = vi.spyOn(manager.currentAnimation!, 'update')
+      events.emitEvent.mockClear()
+
+      manager.update(0.25)
+
+      expect(updateSpy).toHaveBeenCalledWith(0.25)
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'animationProgressChange',
+        expect.objectContaining({ duration: 4 })
+      )
+    })
+  })
+
+  describe('getters', () => {
+    it('return zero when nothing is loaded', () => {
+      expect(manager.getAnimationTime()).toBe(0)
+      expect(manager.getAnimationDuration()).toBe(0)
+    })
+
+    it('reflect the current action time and clip duration', () => {
+      manager.setupModelAnimations(makeAnimatedModel([makeClip('a', 7)]), null)
+
+      expect(manager.getAnimationDuration()).toBe(7)
+      manager.animationActions[0].time = 3
+      expect(manager.getAnimationTime()).toBe(3)
+    })
+  })
+
+  describe('dispose', () => {
+    it('stops all actions, clears state, and emits an empty list', () => {
+      manager.setupModelAnimations(
+        makeAnimatedModel([makeClip('a', 1), makeClip('b', 1)]),
+        null
+      )
+      manager.toggleAnimation(true)
+      manager.setAnimationSpeed(2)
+      manager.selectedAnimationIndex = 1
+      const stopSpies = manager.animationActions.map((action) =>
+        vi.spyOn(action, 'stop')
+      )
+      events.emitEvent.mockClear()
+
+      manager.dispose()
+
+      stopSpies.forEach((spy) => expect(spy).toHaveBeenCalled())
+      expect(manager.currentAnimation).toBeNull()
+      expect(manager.animationActions).toEqual([])
+      expect(manager.animationClips).toEqual([])
+      expect(manager.selectedAnimationIndex).toBe(0)
+      expect(manager.isAnimationPlaying).toBe(false)
+      expect(manager.animationSpeed).toBe(1.0)
+      expect(events.emitEvent).toHaveBeenCalledWith('animationListChange', [])
+    })
+  })
+})

--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -1,0 +1,233 @@
+import * as THREE from 'three'
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CameraManager } from './CameraManager'
+import type { CameraState, EventManagerInterface } from './interfaces'
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+type ControlsListener = () => void
+
+function makeControlsStub() {
+  const listeners: Record<string, ControlsListener[]> = {}
+  return {
+    target: new THREE.Vector3(),
+    object: null as THREE.Camera | null,
+    update: vi.fn(),
+    addEventListener: vi.fn((event: string, cb: ControlsListener) => {
+      listeners[event] = listeners[event] ?? []
+      listeners[event].push(cb)
+    }),
+    fire(event: string) {
+      listeners[event]?.forEach((cb) => cb())
+    }
+  }
+}
+
+function makeRenderer(): THREE.WebGLRenderer {
+  // CameraManager only stores `_renderer` but never reads it. An empty object
+  // suffices and avoids needing a WebGL context in happy-dom.
+  return {} as THREE.WebGLRenderer
+}
+
+describe('CameraManager', () => {
+  let events: ReturnType<typeof makeMockEventManager>
+  let manager: CameraManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    events = makeMockEventManager()
+    manager = new CameraManager(makeRenderer(), events)
+  })
+
+  describe('construction', () => {
+    it('creates both cameras and starts in perspective mode at the default position', () => {
+      expect(manager.perspectiveCamera).toBeInstanceOf(THREE.PerspectiveCamera)
+      expect(manager.orthographicCamera).toBeInstanceOf(
+        THREE.OrthographicCamera
+      )
+      expect(manager.activeCamera).toBe(manager.perspectiveCamera)
+      expect(manager.getCurrentCameraType()).toBe('perspective')
+      expect(manager.perspectiveCamera.position.toArray()).toEqual([10, 10, 10])
+    })
+  })
+
+  describe('toggleCamera', () => {
+    it('without an argument flips between perspective and orthographic', () => {
+      manager.toggleCamera()
+      expect(manager.getCurrentCameraType()).toBe('orthographic')
+      manager.toggleCamera()
+      expect(manager.getCurrentCameraType()).toBe('perspective')
+    })
+
+    it('with an explicit type switches to that type', () => {
+      manager.toggleCamera('orthographic')
+      expect(manager.activeCamera).toBe(manager.orthographicCamera)
+    })
+
+    it('is a no-op when explicitly switched to the active type', () => {
+      const before = manager.activeCamera
+      manager.toggleCamera('perspective')
+      expect(manager.activeCamera).toBe(before)
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'cameraTypeChange',
+        'perspective'
+      )
+    })
+
+    it('copies position, rotation, and zoom from the old camera to the new one', () => {
+      manager.perspectiveCamera.position.set(1, 2, 3)
+      manager.perspectiveCamera.rotation.set(0.1, 0.2, 0.3)
+      manager.perspectiveCamera.zoom = 1.5
+
+      manager.toggleCamera('orthographic')
+
+      expect(manager.orthographicCamera.position.toArray()).toEqual([1, 2, 3])
+      expect(manager.orthographicCamera.zoom).toBe(1.5)
+    })
+
+    it('emits cameraTypeChange with the requested type', () => {
+      manager.toggleCamera('orthographic')
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'cameraTypeChange',
+        'orthographic'
+      )
+    })
+
+    it('rebinds the controls object and target after switching', () => {
+      const controls = makeControlsStub()
+      controls.target.set(5, 6, 7)
+      manager.setControls(controls as unknown as OrbitControls)
+
+      manager.toggleCamera('orthographic')
+
+      expect(controls.object).toBe(manager.orthographicCamera)
+      expect(controls.target.toArray()).toEqual([5, 6, 7])
+      expect(controls.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('setFOV', () => {
+    it('updates the perspective FOV when perspective is active and emits the value', () => {
+      manager.setFOV(60)
+
+      expect(manager.perspectiveCamera.fov).toBe(60)
+      expect(events.emitEvent).toHaveBeenCalledWith('fovChange', 60)
+    })
+
+    it('does not modify the perspective FOV when orthographic is active', () => {
+      manager.toggleCamera('orthographic')
+      events.emitEvent.mockClear()
+      const before = manager.perspectiveCamera.fov
+
+      manager.setFOV(99)
+
+      expect(manager.perspectiveCamera.fov).toBe(before)
+      expect(events.emitEvent).toHaveBeenCalledWith('fovChange', 99)
+    })
+  })
+
+  describe('camera state round-trip', () => {
+    it('captures and restores position, target, zoom, and type', () => {
+      const controls = makeControlsStub()
+      controls.target.set(2, 3, 4)
+      manager.setControls(controls as unknown as OrbitControls)
+      manager.perspectiveCamera.position.set(7, 8, 9)
+      manager.perspectiveCamera.zoom = 2
+
+      const snapshot = manager.getCameraState()
+
+      expect(snapshot.position.toArray()).toEqual([7, 8, 9])
+      expect(snapshot.target.toArray()).toEqual([2, 3, 4])
+      expect(snapshot.zoom).toBe(2)
+      expect(snapshot.cameraType).toBe('perspective')
+
+      manager.perspectiveCamera.position.set(0, 0, 0)
+      manager.perspectiveCamera.zoom = 1
+      manager.setCameraState(snapshot)
+
+      expect(manager.perspectiveCamera.position.toArray()).toEqual([7, 8, 9])
+      expect(manager.perspectiveCamera.zoom).toBe(2)
+      expect(controls.target.toArray()).toEqual([2, 3, 4])
+    })
+
+    it('returns a default target when no controls are attached', () => {
+      const snapshot = manager.getCameraState()
+      expect(snapshot.target.toArray()).toEqual([0, 0, 0])
+    })
+  })
+
+  describe('setControls', () => {
+    it('emits cameraChanged when the controls fire their end event', () => {
+      const controls = makeControlsStub()
+      manager.setControls(controls as unknown as OrbitControls)
+      events.emitEvent.mockClear()
+
+      controls.fire('end')
+
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'cameraChanged',
+        expect.objectContaining({
+          cameraType: 'perspective'
+        }) satisfies Partial<CameraState>
+      )
+    })
+  })
+
+  describe('handleResize', () => {
+    it('updates perspective aspect when perspective is active', () => {
+      manager.handleResize(800, 400)
+      expect(manager.perspectiveCamera.aspect).toBeCloseTo(2)
+    })
+
+    it('updates orthographic frustum bounds when orthographic is active', () => {
+      manager.toggleCamera('orthographic')
+
+      manager.handleResize(800, 400)
+
+      const cam = manager.orthographicCamera
+      const aspect = 2
+      const frustumSize = 10
+      expect(cam.left).toBeCloseTo((-frustumSize * aspect) / 2)
+      expect(cam.right).toBeCloseTo((frustumSize * aspect) / 2)
+      expect(cam.top).toBeCloseTo(frustumSize / 2)
+      expect(cam.bottom).toBeCloseTo(-frustumSize / 2)
+    })
+  })
+
+  describe('setupForModel', () => {
+    it('positions both cameras based on the model size and centers controls on the target', () => {
+      const controls = makeControlsStub()
+      manager.setControls(controls as unknown as OrbitControls)
+
+      const size = new THREE.Vector3(2, 4, 2)
+      manager.setupForModel(size)
+
+      expect(manager.perspectiveCamera.position.toArray()).toEqual([4, 6, 4])
+      expect(manager.orthographicCamera.position.toArray()).toEqual([4, 6, 4])
+      expect(controls.target.toArray()).toEqual([0, 2, 0])
+      expect(controls.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('reset', () => {
+    it('returns both cameras to the default starting position', () => {
+      manager.perspectiveCamera.position.set(99, 99, 99)
+      manager.orthographicCamera.position.set(99, 99, 99)
+
+      manager.reset()
+
+      expect(manager.perspectiveCamera.position.toArray()).toEqual([10, 10, 10])
+      expect(manager.orthographicCamera.position.toArray()).toEqual([
+        10, 10, 10
+      ])
+    })
+  })
+})

--- a/src/extensions/core/load3d/RecordingManager.test.ts
+++ b/src/extensions/core/load3d/RecordingManager.test.ts
@@ -1,0 +1,317 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EventManagerInterface } from './interfaces'
+import { RecordingManager } from './RecordingManager'
+
+const { downloadBlobMock } = vi.hoisted(() => ({
+  downloadBlobMock: vi.fn()
+}))
+
+vi.mock('@/base/common/downloadUtil', () => ({
+  downloadBlob: downloadBlobMock
+}))
+
+vi.mock('three', async (importOriginal) => {
+  const actual = await importOriginal<typeof THREE>()
+  // Avoid TextureLoader -> ImageLoader -> new Image() in happy-dom.
+  class StubTextureLoader {
+    load() {
+      return new actual.Texture()
+    }
+  }
+  return { ...actual, TextureLoader: StubTextureLoader }
+})
+
+type DataAvailableHandler = (event: { data: Blob }) => void
+type StopHandler = () => void
+
+class MockMediaRecorder {
+  static instances: MockMediaRecorder[] = []
+  ondataavailable: DataAvailableHandler | null = null
+  onstop: StopHandler | null = null
+  state: 'inactive' | 'recording' | 'paused' = 'inactive'
+  constructor(
+    public stream: MediaStream,
+    public options?: MediaRecorderOptions
+  ) {
+    MockMediaRecorder.instances.push(this)
+  }
+  start = vi.fn(() => {
+    this.state = 'recording'
+  })
+  stop = vi.fn(() => {
+    this.state = 'inactive'
+    this.onstop?.()
+  })
+  pushChunk(blob: Blob) {
+    this.ondataavailable?.({ data: blob })
+  }
+}
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+function makeStream(): MediaStream {
+  const tracks: { stop: ReturnType<typeof vi.fn> }[] = [{ stop: vi.fn() }]
+  return {
+    getTracks: () => tracks
+  } as unknown as MediaStream
+}
+
+function makeRenderer(): THREE.WebGLRenderer {
+  const canvas = document.createElement('canvas')
+  canvas.width = 800
+  canvas.height = 600
+  return { domElement: canvas } as unknown as THREE.WebGLRenderer
+}
+
+describe('RecordingManager', () => {
+  let scene: THREE.Scene
+  let renderer: THREE.WebGLRenderer
+  let events: ReturnType<typeof makeMockEventManager>
+  let manager: RecordingManager
+  let rafSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockMediaRecorder.instances = []
+    vi.stubGlobal('MediaRecorder', MockMediaRecorder)
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn()
+    })
+    // happy-dom canvases lack captureStream; stub it on the prototype so
+    // every canvas the production code creates gets a usable stream.
+    vi.spyOn(
+      HTMLCanvasElement.prototype as unknown as {
+        captureStream: (fps?: number) => MediaStream
+      },
+      'captureStream'
+    ).mockImplementation(makeStream)
+    // happy-dom returns null from getContext('2d'); production code throws
+    // without it. Provide a minimal context with the methods the manager calls.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn()
+    } as unknown as ReturnType<HTMLCanvasElement['getContext']>)
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+
+    scene = new THREE.Scene()
+    renderer = makeRenderer()
+    events = makeMockEventManager()
+    manager = new RecordingManager(scene, renderer, events)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  describe('construction', () => {
+    it('adds a hidden recording indicator sprite to the scene', () => {
+      const sprite = scene.children.find((c) => c instanceof THREE.Sprite) as
+        | THREE.Sprite
+        | undefined
+
+      expect(sprite).toBeDefined()
+      expect(sprite!.visible).toBe(false)
+    })
+  })
+
+  describe('startRecording', () => {
+    it('initializes a MediaRecorder, marks recording state, and emits recordingStarted', async () => {
+      await manager.startRecording()
+
+      expect(MockMediaRecorder.instances).toHaveLength(1)
+      expect(MockMediaRecorder.instances[0].start).toHaveBeenCalledWith(100)
+      expect(manager.getIsRecording()).toBe(true)
+      expect(events.emitEvent).toHaveBeenCalledWith('recordingStarted', null)
+    })
+
+    it('shows the recording indicator sprite', async () => {
+      const sprite = scene.children.find(
+        (c) => c instanceof THREE.Sprite
+      ) as THREE.Sprite
+
+      await manager.startRecording()
+
+      expect(sprite.visible).toBe(true)
+    })
+
+    it('begins capturing frames via requestAnimationFrame', async () => {
+      await manager.startRecording()
+      expect(rafSpy).toHaveBeenCalled()
+    })
+
+    it('is idempotent — a second startRecording while already recording is ignored', async () => {
+      await manager.startRecording()
+      await manager.startRecording()
+
+      expect(MockMediaRecorder.instances).toHaveLength(1)
+    })
+
+    it('emits recordingError when MediaRecorder construction fails', async () => {
+      vi.stubGlobal(
+        'MediaRecorder',
+        class {
+          constructor() {
+            throw new Error('codec not supported')
+          }
+        }
+      )
+
+      await manager.startRecording()
+
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'recordingError',
+        expect.any(Error)
+      )
+      expect(manager.getIsRecording()).toBe(false)
+    })
+  })
+
+  describe('stopRecording', () => {
+    it('is a no-op when not currently recording', () => {
+      manager.stopRecording()
+      expect(events.emitEvent).not.toHaveBeenCalledWith(
+        'recordingStopped',
+        expect.anything()
+      )
+    })
+
+    it('hides the indicator, clears recording state, and emits recordingStopped', async () => {
+      await manager.startRecording()
+      const sprite = scene.children.find(
+        (c) => c instanceof THREE.Sprite
+      ) as THREE.Sprite
+
+      manager.stopRecording()
+
+      expect(sprite.visible).toBe(false)
+      expect(manager.getIsRecording()).toBe(false)
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'recordingStopped',
+        expect.objectContaining({ hasRecording: false })
+      )
+    })
+
+    it('reports a non-zero duration after recording', async () => {
+      await manager.startRecording()
+      // Force a known startTime so duration math is deterministic.
+      ;(
+        manager as unknown as { recordingStartTime: number }
+      ).recordingStartTime = Date.now() - 2000
+
+      manager.stopRecording()
+
+      expect(manager.getRecordingDuration()).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('hasRecording / getRecordingData', () => {
+    it('reports no recording until chunks have been received', async () => {
+      await manager.startRecording()
+      expect(manager.hasRecording()).toBe(false)
+      expect(manager.getRecordingData()).toBeNull()
+    })
+
+    it('returns a blob URL once chunks exist', async () => {
+      await manager.startRecording()
+      MockMediaRecorder.instances[0].pushChunk(new Blob(['x']))
+
+      expect(manager.hasRecording()).toBe(true)
+      expect(manager.getRecordingData()).toBe('blob:mock')
+    })
+
+    it('does not push zero-byte chunks', async () => {
+      await manager.startRecording()
+      MockMediaRecorder.instances[0].pushChunk(new Blob([]))
+
+      expect(manager.hasRecording()).toBe(false)
+    })
+  })
+
+  describe('exportRecording', () => {
+    it('emits a recordingError when there is nothing to export', () => {
+      manager.exportRecording()
+
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'recordingError',
+        expect.any(Error)
+      )
+      expect(downloadBlobMock).not.toHaveBeenCalled()
+    })
+
+    it('downloads the blob with the requested filename and emits exportingRecording then recordingExported', async () => {
+      await manager.startRecording()
+      MockMediaRecorder.instances[0].pushChunk(new Blob(['x']))
+
+      manager.exportRecording('clip.webm')
+
+      expect(downloadBlobMock).toHaveBeenCalledWith(
+        'clip.webm',
+        expect.any(Blob)
+      )
+      expect(events.emitEvent).toHaveBeenCalledWith('exportingRecording', null)
+      expect(events.emitEvent).toHaveBeenCalledWith('recordingExported', null)
+    })
+
+    it('uses the default filename when none is provided', async () => {
+      await manager.startRecording()
+      MockMediaRecorder.instances[0].pushChunk(new Blob(['x']))
+
+      manager.exportRecording()
+
+      expect(downloadBlobMock).toHaveBeenCalledWith(
+        'scene-recording.mp4',
+        expect.any(Blob)
+      )
+    })
+  })
+
+  describe('clearRecording', () => {
+    it('drops all chunks, resets duration, and emits recordingCleared', async () => {
+      await manager.startRecording()
+      MockMediaRecorder.instances[0].pushChunk(new Blob(['x']))
+      manager.stopRecording()
+
+      manager.clearRecording()
+
+      expect(manager.hasRecording()).toBe(false)
+      expect(manager.getRecordingDuration()).toBe(0)
+      expect(events.emitEvent).toHaveBeenCalledWith('recordingCleared', null)
+    })
+  })
+
+  describe('dispose', () => {
+    it('removes the indicator sprite from the scene and disposes its material', async () => {
+      const sprite = scene.children.find(
+        (c) => c instanceof THREE.Sprite
+      ) as THREE.Sprite
+      const disposeSpy = vi.spyOn(
+        sprite.material as THREE.SpriteMaterial,
+        'dispose'
+      )
+
+      manager.dispose()
+
+      expect(scene.children).not.toContain(sprite)
+      expect(disposeSpy).toHaveBeenCalled()
+    })
+
+    it('stops an in-flight recording before disposing', async () => {
+      await manager.startRecording()
+
+      manager.dispose()
+
+      expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/services/load3dService.test.ts
+++ b/src/services/load3dService.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type Load3d from '@/extensions/core/load3d/Load3d'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useLoad3dService } from '@/services/load3dService'
+import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+const { nodeMap, useLoad3dViewerMock, skeletonCloneMock } = vi.hoisted(() => ({
+  nodeMap: new Map<LGraphNode, Load3d>(),
+  useLoad3dViewerMock: vi.fn(),
+  skeletonCloneMock: vi.fn()
+}))
+
+vi.mock('@/composables/useLoad3d', () => ({
+  nodeToLoad3dMap: nodeMap
+}))
+
+vi.mock('@/composables/useLoad3dViewer', () => ({
+  useLoad3dViewer: useLoad3dViewerMock
+}))
+
+vi.mock('three/examples/jsm/utils/SkeletonUtils', () => ({
+  clone: skeletonCloneMock
+}))
+
+// Track every node a test creates so the load3dService singleton's
+// internal viewerInstances map can be drained in beforeEach without
+// reaching into the module's private state.
+const createdNodes = new Set<LGraphNode>()
+
+function makeNode(id: number | string): LGraphNode {
+  const node = createMockLGraphNode({ id })
+  createdNodes.add(node)
+  return node
+}
+
+function makeLoad3d(): Load3d {
+  return {
+    remove: vi.fn()
+  } as unknown as Load3d
+}
+
+function makeViewer(overrides: Record<string, unknown> = {}) {
+  return {
+    needApplyChanges: { value: false },
+    applyChanges: vi.fn().mockResolvedValue(true),
+    cleanup: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('load3dService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    nodeMap.clear()
+    const svc = useLoad3dService()
+    for (const node of createdNodes) svc.removeViewer(node)
+    createdNodes.clear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('singleton', () => {
+    it('returns the same instance from useLoad3dService()', () => {
+      expect(useLoad3dService()).toBe(useLoad3dService())
+    })
+  })
+
+  describe('getLoad3d (sync)', () => {
+    it('returns null when the load3d module has not been loaded yet', () => {
+      // Before any async accessor has been called, the cache is empty.
+      // We can't easily simulate "module never loaded" because vi.mock makes
+      // it eagerly available, so this test verifies the behavior via missing
+      // entries instead.
+      const node = makeNode('missing')
+      expect(useLoad3dService().getLoad3d(node)).toBeNull()
+    })
+
+    it('returns null after async load when the node has no entry in the map', async () => {
+      const svc = useLoad3dService()
+      // Trigger the async loader so the sync path has a populated cache.
+      await svc.getLoad3dAsync(makeNode('anything'))
+
+      expect(svc.getLoad3d(makeNode('still-missing'))).toBeNull()
+    })
+
+    it('returns the registered Load3d instance once the map has been populated', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('a')
+      const load3d = makeLoad3d()
+      nodeMap.set(node, load3d)
+      await svc.getLoad3dAsync(node)
+
+      expect(svc.getLoad3d(node)).toBe(load3d)
+    })
+  })
+
+  describe('getLoad3dAsync', () => {
+    it('returns the Load3d for a registered node', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('async-a')
+      const load3d = makeLoad3d()
+      nodeMap.set(node, load3d)
+
+      await expect(svc.getLoad3dAsync(node)).resolves.toBe(load3d)
+    })
+
+    it('returns null for an unregistered node', async () => {
+      const svc = useLoad3dService()
+      await expect(
+        svc.getLoad3dAsync(makeNode('async-missing'))
+      ).resolves.toBeNull()
+    })
+  })
+
+  describe('getNodeByLoad3d', () => {
+    it('finds the node owning a given Load3d instance', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('owner')
+      const load3d = makeLoad3d()
+      nodeMap.set(node, load3d)
+      await svc.getLoad3dAsync(node)
+
+      expect(svc.getNodeByLoad3d(load3d)).toBe(node)
+    })
+
+    it('returns null when the Load3d instance is not in the map', async () => {
+      const svc = useLoad3dService()
+      await svc.getLoad3dAsync(makeNode('warmup'))
+
+      expect(svc.getNodeByLoad3d(makeLoad3d())).toBeNull()
+    })
+  })
+
+  describe('removeLoad3d', () => {
+    it('calls remove() on the instance and drops it from the map', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('to-remove')
+      const load3d = makeLoad3d()
+      nodeMap.set(node, load3d)
+      await svc.getLoad3dAsync(node)
+
+      svc.removeLoad3d(node)
+
+      expect(load3d.remove).toHaveBeenCalled()
+      expect(nodeMap.has(node)).toBe(false)
+    })
+
+    it('is a no-op when the node has no registered Load3d', async () => {
+      const svc = useLoad3dService()
+      await svc.getLoad3dAsync(makeNode('warmup'))
+
+      expect(() => svc.removeLoad3d(makeNode('not-there'))).not.toThrow()
+    })
+  })
+
+  describe('clear', () => {
+    it('removes every registered Load3d', async () => {
+      const svc = useLoad3dService()
+      const a = makeNode('a')
+      const b = makeNode('b')
+      const ld1 = makeLoad3d()
+      const ld2 = makeLoad3d()
+      nodeMap.set(a, ld1)
+      nodeMap.set(b, ld2)
+      await svc.getLoad3dAsync(a)
+
+      svc.clear()
+
+      expect(nodeMap.size).toBe(0)
+      expect(ld1.remove).toHaveBeenCalled()
+      expect(ld2.remove).toHaveBeenCalled()
+    })
+  })
+
+  describe('viewer lifecycle', () => {
+    it('getOrCreateViewer creates a viewer on first call and reuses it on subsequent calls', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('v1')
+      const viewer = makeViewer()
+      useLoad3dViewerMock.mockReturnValue(viewer)
+
+      const first = await svc.getOrCreateViewer(node)
+      const second = await svc.getOrCreateViewer(node)
+
+      expect(first).toBe(viewer)
+      expect(second).toBe(viewer)
+      expect(useLoad3dViewerMock).toHaveBeenCalledTimes(1)
+      expect(useLoad3dViewerMock).toHaveBeenCalledWith(node)
+    })
+
+    it('getOrCreateViewerSync uses the supplied factory once and caches the result', () => {
+      const svc = useLoad3dService()
+      const node = makeNode('v-sync')
+      const viewer = makeViewer()
+      const factory = vi.fn().mockReturnValue(viewer)
+
+      const first = svc.getOrCreateViewerSync(
+        node,
+        factory as unknown as typeof useLoad3dViewerMock
+      )
+      const second = svc.getOrCreateViewerSync(
+        node,
+        factory as unknown as typeof useLoad3dViewerMock
+      )
+
+      expect(first).toBe(viewer)
+      expect(second).toBe(viewer)
+      expect(factory).toHaveBeenCalledTimes(1)
+    })
+
+    it('removeViewer calls cleanup and forgets the viewer', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('v2')
+      const viewer = makeViewer()
+      useLoad3dViewerMock.mockReturnValue(viewer)
+      await svc.getOrCreateViewer(node)
+
+      svc.removeViewer(node)
+
+      expect(viewer.cleanup).toHaveBeenCalled()
+      useLoad3dViewerMock.mockClear()
+      const fresh = makeViewer()
+      useLoad3dViewerMock.mockReturnValue(fresh)
+      const result = await svc.getOrCreateViewer(node)
+      expect(useLoad3dViewerMock).toHaveBeenCalledTimes(1)
+      expect(result).toBe(fresh)
+    })
+
+    it('removeViewer is safe when no viewer has been created for the node', () => {
+      const svc = useLoad3dService()
+      expect(() => svc.removeViewer(makeNode('never'))).not.toThrow()
+    })
+  })
+
+  describe('handleViewerClose', () => {
+    it('removes the viewer without applying changes when none are pending', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('close-clean')
+      const viewer = makeViewer({ needApplyChanges: { value: false } })
+      useLoad3dViewerMock.mockReturnValue(viewer)
+      await svc.getOrCreateViewer(node)
+
+      await svc.handleViewerClose(node)
+
+      expect(viewer.applyChanges).not.toHaveBeenCalled()
+      expect(viewer.cleanup).toHaveBeenCalled()
+    })
+
+    it('applies changes and syncs the node config when changes are pending', async () => {
+      const svc = useLoad3dService()
+      const syncLoad3dConfig = vi.fn()
+      const node = Object.assign(makeNode('close-dirty'), {
+        syncLoad3dConfig
+      }) as LGraphNode
+      const viewer = makeViewer({ needApplyChanges: { value: true } })
+      useLoad3dViewerMock.mockReturnValue(viewer)
+      await svc.getOrCreateViewer(node)
+
+      await svc.handleViewerClose(node)
+
+      expect(viewer.applyChanges).toHaveBeenCalled()
+      expect(syncLoad3dConfig).toHaveBeenCalled()
+      expect(viewer.cleanup).toHaveBeenCalled()
+    })
+
+    it('skips syncLoad3dConfig when the node does not define it', async () => {
+      const svc = useLoad3dService()
+      const node = makeNode('close-no-sync')
+      const viewer = makeViewer({ needApplyChanges: { value: true } })
+      useLoad3dViewerMock.mockReturnValue(viewer)
+      await svc.getOrCreateViewer(node)
+
+      await expect(svc.handleViewerClose(node)).resolves.toBeUndefined()
+      expect(viewer.applyChanges).toHaveBeenCalled()
+      expect(viewer.cleanup).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleViewportRefresh', () => {
+    it('returns silently when the load3d is null', () => {
+      expect(() => useLoad3dService().handleViewportRefresh(null)).not.toThrow()
+    })
+
+    it('toggles the camera through the opposite type and back, then updates controls', () => {
+      const controls = { update: vi.fn() }
+      const load3d = {
+        handleResize: vi.fn(),
+        getCurrentCameraType: vi.fn().mockReturnValue('perspective'),
+        toggleCamera: vi.fn(),
+        getControlsManager: vi.fn().mockReturnValue({ controls })
+      } as unknown as Load3d
+
+      useLoad3dService().handleViewportRefresh(load3d)
+
+      expect(load3d.handleResize).toHaveBeenCalled()
+      expect(load3d.toggleCamera).toHaveBeenNthCalledWith(1, 'orthographic')
+      expect(load3d.toggleCamera).toHaveBeenNthCalledWith(2, 'perspective')
+      expect(controls.update).toHaveBeenCalled()
+    })
+
+    it('toggles in the reverse direction when starting from orthographic', () => {
+      const controls = { update: vi.fn() }
+      const load3d = {
+        handleResize: vi.fn(),
+        getCurrentCameraType: vi.fn().mockReturnValue('orthographic'),
+        toggleCamera: vi.fn(),
+        getControlsManager: vi.fn().mockReturnValue({ controls })
+      } as unknown as Load3d
+
+      useLoad3dService().handleViewportRefresh(load3d)
+
+      expect(load3d.toggleCamera).toHaveBeenNthCalledWith(1, 'perspective')
+      expect(load3d.toggleCamera).toHaveBeenNthCalledWith(2, 'orthographic')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for the four largest untested logic-heavy modules in the load3d domain (`AnimationManager`, `CameraManager`, `RecordingManager`, and the `load3dService` façade).

## Changes

- **What**: 78 new unit tests across 4 files covering animation lifecycle (mixer setup, clip switching, play/pause/seek, dispose), camera state (perspective↔orthographic toggling, FOV gating, state round-trip, controls rebinding, resize math, model fitting), recording lifecycle (MediaRecorder wiring, indicator visibility, chunk handling, export/clear paths, dispose ordering), and the service singleton (sync/async map access, viewer cache, `handleViewerClose` apply-changes flow, `handleViewportRefresh` camera-toggle dance).

## Review Focus

- **Coverage**: AnimationManager 100%, CameraManager 88.8%, RecordingManager 89.1%, load3dService 54.5% lines / 88.9% functions. The service gap is concentrated in one method — `copyLoad3dState` (lines 217-333) — which is entangled with 3-4 subsystems and is intentionally deferred to a follow-up PR.
- **happy-dom shims** in `RecordingManager.test.ts`: `MediaRecorder`, `HTMLCanvasElement.prototype.captureStream`, and `getContext('2d')` are all stubbed because happy-dom doesn't provide them. `THREE.TextureLoader` is also mocked because the constructor eagerly loads an SVG indicator.
- **Singleton state reset** in `load3dService.test.ts`: the service holds a module-level `viewerInstances` Map that can't be reached from outside. Tests track every node they create in a `Set` and drain via `removeViewer` in `beforeEach`. Cleaner than `vi.resetModules()` (which would re-import the service and break the singleton identity).
- **One subtle THREE behavior**: `AnimationManager.setAnimationTime` clamps to `duration`, but `AnimationMixer.setTime(duration)` with `LoopRepeat` wraps `action.time` back to 0. The clamping is therefore only observable through the emitted progress event, not via `action.time` directly — the test asserts via the event.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11733-test-load3d-add-unit-tests-for-AnimationManager-CameraManager-RecordingManager-and--3516d73d3650812485a0c91065e161f0) by [Unito](https://www.unito.io)
