### PR TITLE
feat(website): add PostHog analytics

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -26,6 +26,7 @@
     "cva": "catalog:",
     "gsap": "catalog:",
     "lenis": "catalog:",
+    "posthog-js": "catalog:",
     "vue": "catalog:",
     "zod": "catalog:"
   },

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -133,8 +133,14 @@ const websiteJsonLd = {
     <script>
       import { initSmoothScroll, cancelScroll } from '../scripts/smoothScroll'
       import { ScrollTrigger } from '../scripts/gsapSetup'
+      import { initPostHog, capturePageview } from '../scripts/posthog'
 
       initSmoothScroll()
+
+      if (import.meta.env.PROD) {
+        initPostHog()
+        document.addEventListener('astro:page-load', capturePageview)
+      }
 
       document.addEventListener('astro:page-load', () => {
         ScrollTrigger.refresh()

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -1,0 +1,24 @@
+import posthog from 'posthog-js'
+
+const POSTHOG_KEY = 'phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO'
+const POSTHOG_API_HOST = 'https://t.comfy.org'
+const POSTHOG_UI_HOST = 'https://us.posthog.com'
+
+let initialized = false
+
+export function initPostHog() {
+  if (initialized || typeof window === 'undefined') return
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_API_HOST,
+    ui_host: POSTHOG_UI_HOST,
+    capture_pageview: false,
+    capture_pageleave: true,
+    person_profiles: 'identified_only'
+  })
+  initialized = true
+}
+
+export function capturePageview() {
+  if (!initialized) return
+  posthog.capture('$pageview')
+}

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -12,17 +12,25 @@ let initialized = false
 
 export function initPostHog() {
   if (initialized || typeof window === 'undefined' || !POSTHOG_KEY) return
-  posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_API_HOST,
-    ui_host: POSTHOG_UI_HOST,
-    capture_pageview: false,
-    capture_pageleave: true,
-    person_profiles: 'identified_only'
-  })
-  initialized = true
+  try {
+    posthog.init(POSTHOG_KEY, {
+      api_host: POSTHOG_API_HOST,
+      ui_host: POSTHOG_UI_HOST,
+      capture_pageview: false,
+      capture_pageleave: true,
+      person_profiles: 'identified_only'
+    })
+    initialized = true
+  } catch (error) {
+    console.error('PostHog init failed', error)
+  }
 }
 
 export function capturePageview() {
   if (!initialized) return
-  posthog.capture('$pageview')
+  try {
+    posthog.capture('$pageview')
+  } catch (error) {
+    console.error('PostHog pageview capture failed', error)
+  }
 }

--- a/apps/website/src/scripts/posthog.ts
+++ b/apps/website/src/scripts/posthog.ts
@@ -1,13 +1,17 @@
 import posthog from 'posthog-js'
 
-const POSTHOG_KEY = 'phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO'
-const POSTHOG_API_HOST = 'https://t.comfy.org'
-const POSTHOG_UI_HOST = 'https://us.posthog.com'
+const POSTHOG_KEY =
+  import.meta.env.PUBLIC_POSTHOG_KEY ??
+  'phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO'
+const POSTHOG_API_HOST =
+  import.meta.env.PUBLIC_POSTHOG_API_HOST ?? 'https://t.comfy.org'
+const POSTHOG_UI_HOST =
+  import.meta.env.PUBLIC_POSTHOG_UI_HOST ?? 'https://us.posthog.com'
 
 let initialized = false
 
 export function initPostHog() {
-  if (initialized || typeof window === 'undefined') return
+  if (initialized || typeof window === 'undefined' || !POSTHOG_KEY) return
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_API_HOST,
     ui_host: POSTHOG_UI_HOST,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,6 +949,9 @@ importers:
       lenis:
         specifier: 'catalog:'
         version: 1.3.21(react@19.2.4)(vue@3.5.13(typescript@5.9.3))
+      posthog-js:
+        specifier: 'catalog:'
+        version: 1.358.1
       vue:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Adds PostHog page analytics to the marketing website (`apps/website/`).

## Changes

- **What**: New `posthog.ts` script with `initPostHog`/`capturePageview`. Wired into `BaseLayout.astro` behind `import.meta.env.PROD` (mirroring the GTM gate). Pageviews are captured on every `astro:page-load` so ClientRouter view-transition navigations are tracked, not just hard reloads.
- **Dependencies**: `posthog-js` (already in the workspace catalog at `^1.358.1`; previously used by the workbench telemetry provider).

## Review Focus

- API host is set to `https://t.comfy.org` to match `src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts` — confirm that proxy is OK to share with the website surface.
- Project token is hard-coded inline. It is a public `phc_…` frontend token (designed to ship to clients); this matches the pattern used for `gtmId` in the same file. Happy to switch to a `PUBLIC_POSTHOG_KEY` env var if preferred.
- `person_profiles: 'identified_only'` to avoid creating profiles for every anonymous visitor — flag if you want full anonymous tracking instead.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11735-feat-website-add-PostHog-analytics-3516d73d3650811189c6d64c3af4ded9) by [Unito](https://www.unito.io)
