### PR TITLE
test: add unit tests for pnginfo wrappers and getLatentMetadata

### DIFF
--- a/src/scripts/pnginfo.test.ts
+++ b/src/scripts/pnginfo.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { getWebpMetadata } from './pnginfo'
+import { getFromAvifFile } from './metadata/avif'
+import { getFromFlacFile } from './metadata/flac'
+import { getFromPngFile } from './metadata/png'
+import {
+  getAvifMetadata,
+  getFlacMetadata,
+  getLatentMetadata,
+  getPngMetadata,
+  getWebpMetadata
+} from './pnginfo'
+
+vi.mock('./metadata/png', () => ({
+  getFromPngFile: vi.fn()
+}))
+vi.mock('./metadata/flac', () => ({
+  getFromFlacFile: vi.fn()
+}))
+vi.mock('./metadata/avif', () => ({
+  getFromAvifFile: vi.fn()
+}))
 
 function buildExifPayload(workflowJson: string): Uint8Array {
   const fullStr = `workflow:${workflowJson}\0`
@@ -63,5 +82,71 @@ describe('getWebpMetadata', () => {
     const metadata = await getWebpMetadata(file)
 
     expect(metadata.workflow).toBe(workflow)
+  })
+})
+
+describe('format-specific metadata wrappers', () => {
+  it('getPngMetadata delegates to getFromPngFile', async () => {
+    const file = new File([], 'a.png', { type: 'image/png' })
+    vi.mocked(getFromPngFile).mockResolvedValue({ workflow: '{"png":1}' })
+
+    const result = await getPngMetadata(file)
+
+    expect(getFromPngFile).toHaveBeenCalledWith(file)
+    expect(result).toEqual({ workflow: '{"png":1}' })
+  })
+
+  it('getFlacMetadata delegates to getFromFlacFile', async () => {
+    const file = new File([], 'a.flac', { type: 'audio/flac' })
+    vi.mocked(getFromFlacFile).mockResolvedValue({ workflow: '{"flac":1}' })
+
+    const result = await getFlacMetadata(file)
+
+    expect(getFromFlacFile).toHaveBeenCalledWith(file)
+    expect(result).toEqual({ workflow: '{"flac":1}' })
+  })
+
+  it('getAvifMetadata delegates to getFromAvifFile', async () => {
+    const file = new File([], 'a.avif', { type: 'image/avif' })
+    vi.mocked(getFromAvifFile).mockResolvedValue({ workflow: '{"avif":1}' })
+
+    const result = await getAvifMetadata(file)
+
+    expect(getFromAvifFile).toHaveBeenCalledWith(file)
+    expect(result).toEqual({ workflow: '{"avif":1}' })
+  })
+})
+
+const buildSafetensors = (header: Record<string, unknown>): File => {
+  const headerJson = JSON.stringify(header)
+  const headerBytes = new TextEncoder().encode(headerJson)
+  const buf = new ArrayBuffer(8 + headerBytes.length)
+  const dv = new DataView(buf)
+  dv.setUint32(0, headerBytes.length, true)
+  dv.setUint32(4, 0, true)
+  new Uint8Array(buf, 8).set(headerBytes)
+  return new File([buf], 'x.safetensors')
+}
+
+describe('getLatentMetadata', () => {
+  it('returns the __metadata__ object from a safetensors header', async () => {
+    const file = buildSafetensors({
+      __metadata__: { workflow: '{"nodes":[]}', extra: 'value' },
+      'tensor.weight': { dtype: 'F32', shape: [1], data_offsets: [0, 4] }
+    })
+
+    const result = await getLatentMetadata(file)
+
+    expect(result).toEqual({ workflow: '{"nodes":[]}', extra: 'value' })
+  })
+
+  it('resolves undefined when header has no __metadata__ entry', async () => {
+    const file = buildSafetensors({
+      'tensor.weight': { dtype: 'F32', shape: [1], data_offsets: [0, 4] }
+    })
+
+    const result = await getLatentMetadata(file)
+
+    expect(result).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Extends \`src/scripts/pnginfo.test.ts\` with 5 new tests covering the format-specific delegating wrappers and the safetensors metadata reader. Lifts pnginfo.ts coverage from **17.6% → 23.2%** lines (the remaining gap is \`importA1111\`, which needs a refactor before it can be tested cleanly — left to a follow-up).

## Test Coverage

- \`getPngMetadata\`, \`getFlacMetadata\`, \`getAvifMetadata\` delegate to their respective \`metadata/*\` modules (mocked).
- \`getLatentMetadata\` returns the \`__metadata__\` object from a hand-built safetensors header.
- \`getLatentMetadata\` resolves \`undefined\` when the header has no \`__metadata__\` entry.

## Out of scope

\`importA1111\` (lines 176-542) is a 270-line A1111-prompt → ComfyUI-graph builder. Testing it requires either heavy LiteGraph mocks or a refactor that extracts pure parsing helpers from the graph-mutation code. Tracking separately.

## Testing

\`\`\`bash
pnpm vitest run src/scripts/pnginfo.test.ts
pnpm vitest run src/scripts/pnginfo.test.ts --coverage --coverage.include='src/scripts/pnginfo.ts'
\`\`\`

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11745-test-add-unit-tests-for-pnginfo-wrappers-and-getLatentMetadata-3516d73d365081c080a6c8146aa1bee8) by [Unito](https://www.unito.io)
