### PR TITLE
test: add unit tests for layoutStore setter and query paths

### DIFF
--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -646,3 +646,186 @@ describe('layoutStore CRDT operations', () => {
     }
   )
 })
+
+describe('layoutStore getNodeLayoutRef setter', () => {
+  beforeEach(() => {
+    layoutStore.initializeFromLiteGraph([])
+  })
+
+  const baseLayout = (): NodeLayout => ({
+    id: 'ref-node',
+    position: { x: 10, y: 20 },
+    size: { width: 100, height: 50 },
+    zIndex: 0,
+    visible: true,
+    bounds: { x: 10, y: 20, width: 100, height: 50 }
+  })
+
+  it('creates a node when setter receives a layout for an unknown id', () => {
+    const ref = layoutStore.getNodeLayoutRef('ref-node')
+    expect(ref.value).toBeNull()
+
+    ref.value = baseLayout()
+
+    expect(ref.value).toEqual(baseLayout())
+  })
+
+  it('emits a moveNode operation when only position changes', () => {
+    const ref = layoutStore.getNodeLayoutRef('ref-node')
+    ref.value = baseLayout()
+    const before = Date.now()
+    const moved = { ...baseLayout(), position: { x: 99, y: 88 } }
+
+    ref.value = moved
+
+    const ops = layoutStore.getOperationsSince(before - 1)
+    expect(ops.some((op) => op.type === 'moveNode')).toBe(true)
+    expect(ref.value?.position).toEqual({ x: 99, y: 88 })
+  })
+
+  it('emits a resizeNode operation when only size changes', () => {
+    const ref = layoutStore.getNodeLayoutRef('ref-node')
+    ref.value = baseLayout()
+    const before = Date.now()
+    const resized = { ...baseLayout(), size: { width: 200, height: 80 } }
+
+    ref.value = resized
+
+    const ops = layoutStore.getOperationsSince(before - 1)
+    expect(ops.some((op) => op.type === 'resizeNode')).toBe(true)
+  })
+
+  it('emits a setNodeZIndex operation when only zIndex changes', () => {
+    const ref = layoutStore.getNodeLayoutRef('ref-node')
+    ref.value = baseLayout()
+    const before = Date.now()
+    const restacked = { ...baseLayout(), zIndex: 5 }
+
+    ref.value = restacked
+
+    const ops = layoutStore.getOperationsSince(before - 1)
+    expect(ops.some((op) => op.type === 'setNodeZIndex')).toBe(true)
+  })
+
+  it('emits a deleteNode operation when setter receives null', () => {
+    const ref = layoutStore.getNodeLayoutRef('ref-node')
+    ref.value = baseLayout()
+    const before = Date.now()
+
+    ref.value = null
+
+    const ops = layoutStore.getOperationsSince(before - 1)
+    expect(ops.some((op) => op.type === 'deleteNode')).toBe(true)
+    expect(ref.value).toBeNull()
+  })
+})
+
+describe('layoutStore queries', () => {
+  beforeEach(() => {
+    layoutStore.initializeFromLiteGraph([])
+  })
+
+  const seedNode = (id: string, x: number, y: number, z = 0) => {
+    const layout: NodeLayout = {
+      id,
+      position: { x, y },
+      size: { width: 100, height: 50 },
+      zIndex: z,
+      visible: true,
+      bounds: { x, y, width: 100, height: 50 }
+    }
+    layoutStore.applyOperation({
+      type: 'createNode',
+      entity: 'node',
+      nodeId: id,
+      layout,
+      timestamp: Date.now(),
+      source: LayoutSource.External,
+      actor: 'test'
+    })
+  }
+
+  it('getNodesInBounds returns reactive node IDs that intersect bounds', () => {
+    seedNode('inside', 0, 0)
+    seedNode('outside', 1000, 1000)
+
+    const inBounds = layoutStore.getNodesInBounds({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200
+    })
+
+    expect(inBounds.value).toContain('inside')
+    expect(inBounds.value).not.toContain('outside')
+  })
+
+  it('queryNodeAtPoint returns the top-zIndex node containing the point', () => {
+    seedNode('low', 0, 0, 0)
+    seedNode('high', 0, 0, 10)
+
+    const hit = layoutStore.queryNodeAtPoint({ x: 25, y: 25 })
+
+    expect(hit).toBe('high')
+  })
+
+  it('queryNodeAtPoint returns null when no node contains the point', () => {
+    seedNode('only', 0, 0)
+
+    const hit = layoutStore.queryNodeAtPoint({ x: 999, y: 999 })
+
+    expect(hit).toBeNull()
+  })
+})
+
+describe('layoutStore link layout updates', () => {
+  beforeEach(() => {
+    layoutStore.initializeFromLiteGraph([])
+  })
+
+  const stubPath = () => ({}) as unknown as Path2D
+  const baseLink = (path = stubPath()) => ({
+    id: 1 as const,
+    path,
+    bounds: { x: 0, y: 0, width: 50, height: 50 },
+    centerPos: { x: 25, y: 25 },
+    sourceNodeId: 'a',
+    targetNodeId: 'b',
+    sourceSlot: 0,
+    targetSlot: 0
+  })
+
+  it('updateLinkLayout short-circuits when bounds and centerPos are unchanged', () => {
+    layoutStore.updateLinkLayout(1, baseLink())
+    const newPath = stubPath()
+
+    layoutStore.updateLinkLayout(1, baseLink(newPath))
+
+    expect(layoutStore.getLinkLayout(1)?.path).toBe(newPath)
+  })
+
+  it('updateLinkLayout replaces stored layout when bounds change', () => {
+    layoutStore.updateLinkLayout(1, baseLink())
+    const moved = {
+      ...baseLink(),
+      bounds: { x: 10, y: 10, width: 50, height: 50 }
+    }
+
+    layoutStore.updateLinkLayout(1, moved)
+
+    expect(layoutStore.getLinkLayout(1)?.bounds.x).toBe(10)
+  })
+
+  it('deleteLinkLayout removes the link and its segment layouts', () => {
+    layoutStore.updateLinkLayout(1, baseLink())
+    layoutStore.updateLinkSegmentLayout(1, null, {
+      path: stubPath(),
+      bounds: { x: 0, y: 0, width: 5, height: 5 },
+      centerPos: { x: 1, y: 1 }
+    })
+
+    layoutStore.deleteLinkLayout(1)
+
+    expect(layoutStore.getLinkLayout(1)).toBeNull()
+  })
+})

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -6,9 +6,24 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
 import type {
   LayoutChange,
+  LayoutOperation,
   NodeLayout,
   SlotLayout
 } from '@/renderer/core/layout/types'
+
+function getOperationsAddedBy(action: () => void): LayoutOperation[] {
+  const operationCount = layoutStore.getOperationsSince(0).length
+  action()
+  return layoutStore.getOperationsSince(0).slice(operationCount)
+}
+
+function expectSingleOperation(
+  operations: LayoutOperation[],
+  expectedOperation: Record<string, unknown>
+): void {
+  expect(operations).toHaveLength(1)
+  expect(operations[0]).toEqual(expect.objectContaining(expectedOperation))
+}
 
 describe('layoutStore CRDT operations', () => {
   beforeEach(() => {
@@ -576,9 +591,15 @@ describe('layoutStore CRDT operations', () => {
       actor: 'test'
     })
 
-    const originalTitleHeight = LiteGraph.NODE_TITLE_HEIGHT
-    // @ts-expect-error – intentionally simulate undefined runtime value
-    LiteGraph.NODE_TITLE_HEIGHT = undefined
+    const originalTitleHeightDescriptor = Object.getOwnPropertyDescriptor(
+      LiteGraph,
+      'NODE_TITLE_HEIGHT'
+    )
+    Object.defineProperty(LiteGraph, 'NODE_TITLE_HEIGHT', {
+      configurable: true,
+      value: undefined,
+      writable: true
+    })
 
     try {
       layoutStore.setSource(LayoutSource.DOM)
@@ -597,7 +618,13 @@ describe('layoutStore CRDT operations', () => {
       const nodeRef = layoutStore.getNodeLayoutRef(nodeId)
       expect(nodeRef.value?.size.height).toBe(layout.size.height)
     } finally {
-      LiteGraph.NODE_TITLE_HEIGHT = originalTitleHeight
+      if (originalTitleHeightDescriptor) {
+        Object.defineProperty(
+          LiteGraph,
+          'NODE_TITLE_HEIGHT',
+          originalTitleHeightDescriptor
+        )
+      }
     }
   })
 
@@ -652,70 +679,106 @@ describe('layoutStore getNodeLayoutRef setter', () => {
     layoutStore.initializeFromLiteGraph([])
   })
 
-  const baseLayout = (): NodeLayout => ({
-    id: 'ref-node',
-    position: { x: 10, y: 20 },
-    size: { width: 100, height: 50 },
-    zIndex: 0,
-    visible: true,
-    bounds: { x: 10, y: 20, width: 100, height: 50 }
-  })
+  function baseLayout(): NodeLayout {
+    return {
+      id: 'ref-node',
+      position: { x: 10, y: 20 },
+      size: { width: 100, height: 50 },
+      zIndex: 0,
+      visible: true,
+      bounds: { x: 10, y: 20, width: 100, height: 50 }
+    }
+  }
 
   it('creates a node when setter receives a layout for an unknown id', () => {
     const ref = layoutStore.getNodeLayoutRef('ref-node')
+    const layout = baseLayout()
     expect(ref.value).toBeNull()
 
-    ref.value = baseLayout()
+    const operations = getOperationsAddedBy(() => {
+      ref.value = layout
+    })
 
-    expect(ref.value).toEqual(baseLayout())
+    expectSingleOperation(operations, {
+      type: 'createNode',
+      nodeId: 'ref-node',
+      layout
+    })
+    expect(ref.value).toEqual(layout)
   })
 
-  it('emits a moveNode operation when only position changes', () => {
-    const ref = layoutStore.getNodeLayoutRef('ref-node')
-    ref.value = baseLayout()
-    const before = Date.now()
-    const moved = { ...baseLayout(), position: { x: 99, y: 88 } }
+  it.for<{
+    name: string
+    nextLayout: NodeLayout
+    expectedOperation: Record<string, unknown>
+  }>([
+    {
+      name: 'moveNode',
+      nextLayout: {
+        ...baseLayout(),
+        position: { x: 99, y: 88 },
+        bounds: { x: 99, y: 88, width: 100, height: 50 }
+      },
+      expectedOperation: {
+        type: 'moveNode',
+        nodeId: 'ref-node',
+        position: { x: 99, y: 88 },
+        previousPosition: baseLayout().position
+      }
+    },
+    {
+      name: 'resizeNode',
+      nextLayout: {
+        ...baseLayout(),
+        size: { width: 200, height: 80 },
+        bounds: { x: 10, y: 20, width: 200, height: 80 }
+      },
+      expectedOperation: {
+        type: 'resizeNode',
+        nodeId: 'ref-node',
+        size: { width: 200, height: 80 },
+        previousSize: baseLayout().size
+      }
+    },
+    {
+      name: 'setNodeZIndex',
+      nextLayout: { ...baseLayout(), zIndex: 5 },
+      expectedOperation: {
+        type: 'setNodeZIndex',
+        nodeId: 'ref-node',
+        zIndex: 5,
+        previousZIndex: 0
+      }
+    }
+  ])(
+    'emits a $name operation for layout-only updates',
+    ({ nextLayout, expectedOperation }) => {
+      const ref = layoutStore.getNodeLayoutRef('ref-node')
+      ref.value = baseLayout()
 
-    ref.value = moved
+      const operations = getOperationsAddedBy(() => {
+        ref.value = nextLayout
+      })
 
-    const ops = layoutStore.getOperationsSince(before - 1)
-    expect(ops.some((op) => op.type === 'moveNode')).toBe(true)
-    expect(ref.value?.position).toEqual({ x: 99, y: 88 })
-  })
-
-  it('emits a resizeNode operation when only size changes', () => {
-    const ref = layoutStore.getNodeLayoutRef('ref-node')
-    ref.value = baseLayout()
-    const before = Date.now()
-    const resized = { ...baseLayout(), size: { width: 200, height: 80 } }
-
-    ref.value = resized
-
-    const ops = layoutStore.getOperationsSince(before - 1)
-    expect(ops.some((op) => op.type === 'resizeNode')).toBe(true)
-  })
-
-  it('emits a setNodeZIndex operation when only zIndex changes', () => {
-    const ref = layoutStore.getNodeLayoutRef('ref-node')
-    ref.value = baseLayout()
-    const before = Date.now()
-    const restacked = { ...baseLayout(), zIndex: 5 }
-
-    ref.value = restacked
-
-    const ops = layoutStore.getOperationsSince(before - 1)
-    expect(ops.some((op) => op.type === 'setNodeZIndex')).toBe(true)
-  })
+      expectSingleOperation(operations, expectedOperation)
+      expect(ref.value).toEqual(nextLayout)
+    }
+  )
 
   it('emits a deleteNode operation when setter receives null', () => {
     const ref = layoutStore.getNodeLayoutRef('ref-node')
-    ref.value = baseLayout()
-    const before = Date.now()
+    const layout = baseLayout()
+    ref.value = layout
 
-    ref.value = null
+    const operations = getOperationsAddedBy(() => {
+      ref.value = null
+    })
 
-    const ops = layoutStore.getOperationsSince(before - 1)
-    expect(ops.some((op) => op.type === 'deleteNode')).toBe(true)
+    expectSingleOperation(operations, {
+      type: 'deleteNode',
+      nodeId: 'ref-node',
+      previousLayout: layout
+    })
     expect(ref.value).toBeNull()
   })
 })
@@ -824,8 +887,14 @@ describe('layoutStore link layout updates', () => {
       centerPos: { x: 1, y: 1 }
     })
 
+    expect(layoutStore.queryLinkSegmentAtPoint({ x: 1, y: 1 })).toEqual({
+      linkId: 1,
+      rerouteId: null
+    })
+
     layoutStore.deleteLinkLayout(1)
 
     expect(layoutStore.getLinkLayout(1)).toBeNull()
+    expect(layoutStore.queryLinkSegmentAtPoint({ x: 1, y: 1 })).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Adds 11 tests for \`src/renderer/core/layout/store/layoutStore.ts\` covering paths previously uncovered by the existing 17-test suite. Targets the customRef setter machinery, reactive queries, and link-layout updates that are reachable through the public API.

## Test Coverage

\`getNodeLayoutRef\` setter:
- Setter on a fresh ref triggers \`createNode\`.
- Position-only change triggers \`moveNode\`.
- Size-only change triggers \`resizeNode\`.
- zIndex-only change triggers \`setNodeZIndex\`.
- Setting to \`null\` triggers \`deleteNode\`.

Queries:
- \`getNodesInBounds\` returns reactive node IDs intersecting the bounds.
- \`queryNodeAtPoint\` returns the top-zIndex node containing the point.
- \`queryNodeAtPoint\` returns \`null\` when no node contains the point.

Link layouts:
- \`updateLinkLayout\` short-circuits when bounds and centerPos unchanged but still updates the path.
- \`updateLinkLayout\` replaces stored layout when bounds change.
- \`deleteLinkLayout\` removes the link and its segment layouts.

## Testing

\`\`\`bash
pnpm vitest run src/renderer/core/layout/store/layoutStore.test.ts
\`\`\`

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11747-test-add-unit-tests-for-layoutStore-setter-and-query-paths-3516d73d365081d9bc1de336ff7258ea) by [Unito](https://www.unito.io)
