### PR TITLE
test(load3d): add unit tests for LightingManager, ControlsManager, exportMenuHelper, and ModelExporter

### DIFF
--- a/src/extensions/core/load3d/ControlsManager.test.ts
+++ b/src/extensions/core/load3d/ControlsManager.test.ts
@@ -1,0 +1,168 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ControlsManager } from './ControlsManager'
+import type { EventManagerInterface } from './interfaces'
+
+const { mockOrbitControls } = vi.hoisted(() => ({
+  mockOrbitControls: vi.fn()
+}))
+
+vi.mock('three/examples/jsm/controls/OrbitControls', () => {
+  type Listener = () => void
+  class OrbitControls {
+    object: THREE.Camera
+    domElement: HTMLElement
+    enableDamping = false
+    target = new THREE.Vector3()
+    update = vi.fn()
+    dispose = vi.fn()
+    private listeners = new Map<string, Listener[]>()
+    constructor(camera: THREE.Camera, domElement: HTMLElement) {
+      this.object = camera
+      this.domElement = domElement
+      mockOrbitControls(camera, domElement)
+    }
+    addEventListener(event: string, cb: Listener) {
+      if (!this.listeners.has(event)) this.listeners.set(event, [])
+      this.listeners.get(event)!.push(cb)
+    }
+    fire(event: string) {
+      this.listeners.get(event)?.forEach((cb) => cb())
+    }
+  }
+  return { OrbitControls }
+})
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+function makeRenderer(opts: { withParent?: boolean } = {}) {
+  const canvas = document.createElement('canvas')
+  if (opts.withParent) {
+    const parent = document.createElement('div')
+    parent.appendChild(canvas)
+  }
+  return { domElement: canvas } as unknown as THREE.WebGLRenderer
+}
+
+describe('ControlsManager', () => {
+  let events: ReturnType<typeof makeMockEventManager>
+  let camera: THREE.PerspectiveCamera
+  let manager: ControlsManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    events = makeMockEventManager()
+    camera = new THREE.PerspectiveCamera()
+  })
+
+  describe('construction', () => {
+    it('attaches OrbitControls to the canvas parent when one exists', () => {
+      const renderer = makeRenderer({ withParent: true })
+
+      manager = new ControlsManager(renderer, camera, events)
+
+      expect(mockOrbitControls).toHaveBeenCalledWith(
+        camera,
+        renderer.domElement.parentElement
+      )
+      expect(manager.controls.enableDamping).toBe(true)
+    })
+
+    it('falls back to the canvas itself when there is no parent', () => {
+      const renderer = makeRenderer({ withParent: false })
+
+      manager = new ControlsManager(renderer, camera, events)
+
+      expect(mockOrbitControls).toHaveBeenCalledWith(
+        camera,
+        renderer.domElement
+      )
+    })
+  })
+
+  describe('init', () => {
+    it('emits cameraChanged with a perspective state when the controls fire end', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+      camera.position.set(1, 2, 3)
+      camera.zoom = 1.25
+      manager.controls.target.set(4, 5, 6)
+      manager.init()
+
+      ;(manager.controls as unknown as { fire(e: string): void }).fire('end')
+
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraChanged', {
+        position: expect.objectContaining({ x: 1, y: 2, z: 3 }),
+        target: expect.objectContaining({ x: 4, y: 5, z: 6 }),
+        zoom: 1.25,
+        cameraType: 'perspective'
+      })
+    })
+
+    it('reports orthographic camera type when initialized with one', () => {
+      const ortho = new THREE.OrthographicCamera()
+      ortho.zoom = 0.5
+      manager = new ControlsManager(makeRenderer(), ortho, events)
+      manager.init()
+
+      ;(manager.controls as unknown as { fire(e: string): void }).fire('end')
+
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'cameraChanged',
+        expect.objectContaining({ cameraType: 'orthographic', zoom: 0.5 })
+      )
+    })
+  })
+
+  describe('updateCamera', () => {
+    it('rebinds controls to the new camera, copies position from the previous one, and preserves the target', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+      camera.position.set(7, 8, 9)
+      manager.controls.target.set(1, 1, 1)
+
+      const newCamera = new THREE.PerspectiveCamera()
+      manager.updateCamera(newCamera)
+
+      expect(manager.controls.object).toBe(newCamera)
+      expect(newCamera.position.toArray()).toEqual([7, 8, 9])
+      expect(manager.controls.target.toArray()).toEqual([1, 1, 1])
+      expect(manager.controls.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('update / reset', () => {
+    it('update delegates to controls.update', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+
+      manager.update()
+
+      expect(manager.controls.update).toHaveBeenCalled()
+    })
+
+    it('reset clears the target back to the origin and refreshes', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+      manager.controls.target.set(5, 6, 7)
+
+      manager.reset()
+
+      expect(manager.controls.target.toArray()).toEqual([0, 0, 0])
+      expect(manager.controls.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('dispose', () => {
+    it('disposes the underlying OrbitControls', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+
+      manager.dispose()
+
+      expect(manager.controls.dispose).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/extensions/core/load3d/LightingManager.test.ts
+++ b/src/extensions/core/load3d/LightingManager.test.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EventManagerInterface } from './interfaces'
+import { LightingManager } from './LightingManager'
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+describe('LightingManager', () => {
+  let scene: THREE.Scene
+  let events: ReturnType<typeof makeMockEventManager>
+  let manager: LightingManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    scene = new THREE.Scene()
+    events = makeMockEventManager()
+    manager = new LightingManager(scene, events)
+  })
+
+  describe('init / setupLights', () => {
+    it('adds six lights — one ambient and five directionals — to the scene', () => {
+      manager.init()
+
+      expect(manager.lights).toHaveLength(6)
+      const ambient = manager.lights.filter(
+        (l) => l instanceof THREE.AmbientLight
+      )
+      const directional = manager.lights.filter(
+        (l) => l instanceof THREE.DirectionalLight
+      )
+      expect(ambient).toHaveLength(1)
+      expect(directional).toHaveLength(5)
+      manager.lights.forEach((light) => {
+        expect(scene.children).toContain(light)
+      })
+    })
+
+    it('positions the directional lights to surround the model', () => {
+      manager.init()
+
+      const positions = manager.lights
+        .filter(
+          (l): l is THREE.DirectionalLight =>
+            l instanceof THREE.DirectionalLight
+        )
+        .map((l) => l.position.toArray())
+
+      expect(positions).toEqual(
+        expect.arrayContaining([
+          [0, 10, 10],
+          [0, 10, -10],
+          [-10, 0, 0],
+          [10, 0, 0],
+          [0, -10, 0]
+        ])
+      )
+    })
+  })
+
+  describe('setLightIntensity', () => {
+    it('scales each light by its stored multiplier and records the requested intensity', () => {
+      manager.init()
+      const ambient = manager.lights.find(
+        (l): l is THREE.AmbientLight => l instanceof THREE.AmbientLight
+      )!
+      const mainLight = manager.lights.find(
+        (l): l is THREE.DirectionalLight =>
+          l instanceof THREE.DirectionalLight &&
+          l.position.y === 10 &&
+          l.position.z === 10
+      )!
+
+      manager.setLightIntensity(2)
+
+      expect(manager.currentIntensity).toBe(2)
+      expect(ambient.intensity).toBeCloseTo(2 * 0.5)
+      expect(mainLight.intensity).toBeCloseTo(2 * 0.8)
+    })
+
+    it('emits lightIntensityChange with the new intensity', () => {
+      manager.init()
+
+      manager.setLightIntensity(1.5)
+
+      expect(events.emitEvent).toHaveBeenCalledWith('lightIntensityChange', 1.5)
+    })
+
+    it('is a no-op (no error) when called before init', () => {
+      expect(() => manager.setLightIntensity(1)).not.toThrow()
+      expect(events.emitEvent).toHaveBeenCalledWith('lightIntensityChange', 1)
+    })
+  })
+
+  describe('setHDRIMode', () => {
+    it('hides every light when HDRI is active', () => {
+      manager.init()
+
+      manager.setHDRIMode(true)
+
+      manager.lights.forEach((light) => {
+        expect(light.visible).toBe(false)
+      })
+    })
+
+    it('restores visibility when HDRI is turned off', () => {
+      manager.init()
+      manager.setHDRIMode(true)
+
+      manager.setHDRIMode(false)
+
+      manager.lights.forEach((light) => {
+        expect(light.visible).toBe(true)
+      })
+    })
+  })
+
+  describe('dispose', () => {
+    it('removes every light from the scene and clears internal state', () => {
+      manager.init()
+      const lightCount = manager.lights.length
+
+      manager.dispose()
+
+      expect(manager.lights).toEqual([])
+      expect(
+        scene.children.filter((c) => c instanceof THREE.Light)
+      ).toHaveLength(0)
+      expect(lightCount).toBeGreaterThan(0)
+    })
+
+    it('resets multipliers so subsequent setLightIntensity calls are no-ops', () => {
+      manager.init()
+      manager.dispose()
+
+      manager.setLightIntensity(5)
+
+      expect(events.emitEvent).toHaveBeenLastCalledWith(
+        'lightIntensityChange',
+        5
+      )
+    })
+  })
+})

--- a/src/extensions/core/load3d/ModelExporter.test.ts
+++ b/src/extensions/core/load3d/ModelExporter.test.ts
@@ -1,0 +1,303 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ModelExporter } from './ModelExporter'
+
+const {
+  downloadBlobMock,
+  addAlertMock,
+  gltfParseMock,
+  objParseMock,
+  stlParseMock
+} = vi.hoisted(() => ({
+  downloadBlobMock: vi.fn(),
+  addAlertMock: vi.fn(),
+  gltfParseMock: vi.fn(),
+  objParseMock: vi.fn(),
+  stlParseMock: vi.fn()
+}))
+
+vi.mock('@/base/common/downloadUtil', () => ({
+  downloadBlob: downloadBlobMock
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert: addAlertMock })
+}))
+
+vi.mock('three/examples/jsm/exporters/GLTFExporter', () => ({
+  GLTFExporter: class {
+    parse = gltfParseMock
+  }
+}))
+
+vi.mock('three/examples/jsm/exporters/OBJExporter', () => ({
+  OBJExporter: class {
+    parse = objParseMock
+  }
+}))
+
+vi.mock('three/examples/jsm/exporters/STLExporter', () => ({
+  STLExporter: class {
+    parse = stlParseMock
+  }
+}))
+
+describe('ModelExporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('detectFormatFromURL', () => {
+    it('extracts the lowercase extension from the filename query parameter', () => {
+      expect(
+        ModelExporter.detectFormatFromURL(
+          'http://example.com/api/view?filename=model.GLB'
+        )
+      ).toBe('glb')
+    })
+
+    it('returns null when there is no filename parameter', () => {
+      expect(
+        ModelExporter.detectFormatFromURL('http://example.com/api/view?foo=bar')
+      ).toBeNull()
+    })
+
+    it('returns null when there is no query string at all', () => {
+      expect(
+        ModelExporter.detectFormatFromURL('http://example.com/file.glb')
+      ).toBeNull()
+    })
+
+    it('returns the whole basename when the filename has no dotted extension', () => {
+      // split('.').pop() returns the only segment when no dot is present.
+      expect(
+        ModelExporter.detectFormatFromURL(
+          'http://example.com/api/view?filename=cube'
+        )
+      ).toBe('cube')
+    })
+  })
+
+  describe('canUseDirectURL', () => {
+    it('returns false for a null URL', () => {
+      expect(ModelExporter.canUseDirectURL(null, 'glb')).toBe(false)
+    })
+
+    it('returns true when the URL extension matches the requested format (case-insensitive)', () => {
+      expect(
+        ModelExporter.canUseDirectURL(
+          'http://example.com/api/view?filename=cube.GLB',
+          'glb'
+        )
+      ).toBe(true)
+    })
+
+    it('returns false when the URL extension does not match', () => {
+      expect(
+        ModelExporter.canUseDirectURL(
+          'http://example.com/api/view?filename=cube.obj',
+          'glb'
+        )
+      ).toBe(false)
+    })
+
+    it('returns false when the URL has no detectable format', () => {
+      expect(
+        ModelExporter.canUseDirectURL('http://example.com/file.glb', 'glb')
+      ).toBe(false)
+    })
+  })
+
+  describe('downloadFromURL', () => {
+    it('fetches the URL and downloads the resulting blob', async () => {
+      const blob = new Blob(['x'])
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) })
+      )
+
+      await ModelExporter.downloadFromURL(
+        'http://example.com/cube.glb',
+        'cube.glb'
+      )
+
+      expect(downloadBlobMock).toHaveBeenCalledWith('cube.glb', blob)
+      vi.unstubAllGlobals()
+    })
+
+    it('rethrows and shows a toast alert when fetch fails', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+
+      await expect(
+        ModelExporter.downloadFromURL('http://example.com/cube.glb', 'cube.glb')
+      ).rejects.toThrow('network')
+      expect(addAlertMock).toHaveBeenCalledWith(
+        'toastMessages.failedToDownloadFile'
+      )
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('exportGLB', () => {
+    it('takes the direct-URL fast path when the original URL is already a .glb', async () => {
+      const blob = new Blob(['x'])
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) })
+      )
+      const model = new THREE.Object3D()
+
+      await ModelExporter.exportGLB(
+        model,
+        'out.glb',
+        'http://example.com/api/view?filename=src.glb'
+      )
+
+      expect(downloadBlobMock).toHaveBeenCalledWith('out.glb', blob)
+      expect(gltfParseMock).not.toHaveBeenCalled()
+      vi.unstubAllGlobals()
+    })
+
+    it('falls through to GLTFExporter when there is no direct URL', async () => {
+      gltfParseMock.mockImplementation(
+        (
+          _model: unknown,
+          onDone: (gltf: ArrayBuffer) => void,
+          _onError: unknown,
+          options: { binary: boolean }
+        ) => {
+          expect(options.binary).toBe(true)
+          onDone(new ArrayBuffer(8))
+        }
+      )
+
+      const promise = ModelExporter.exportGLB(new THREE.Object3D(), 'out.glb')
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(gltfParseMock).toHaveBeenCalled()
+      expect(downloadBlobMock).toHaveBeenCalledWith('out.glb', expect.any(Blob))
+    })
+
+    it('alerts and rethrows when GLTFExporter rejects', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      gltfParseMock.mockImplementation(
+        (_model: unknown, _onDone: unknown, onError: (e: Error) => void) =>
+          onError(new Error('parse fail'))
+      )
+
+      const promise = ModelExporter.exportGLB(new THREE.Object3D(), 'out.glb')
+      const assertion = expect(promise).rejects.toThrow('parse fail')
+      await vi.runAllTimersAsync()
+      await assertion
+      expect(addAlertMock).toHaveBeenCalledWith(
+        'toastMessages.failedToExportModel:{"format":"GLB"}'
+      )
+    })
+  })
+
+  describe('exportOBJ', () => {
+    it('uses the direct-URL fast path for matching .obj URLs', async () => {
+      const blob = new Blob(['x'])
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) })
+      )
+
+      await ModelExporter.exportOBJ(
+        new THREE.Object3D(),
+        'out.obj',
+        'http://example.com/api/view?filename=src.obj'
+      )
+
+      expect(downloadBlobMock).toHaveBeenCalledWith('out.obj', blob)
+      expect(objParseMock).not.toHaveBeenCalled()
+      vi.unstubAllGlobals()
+    })
+
+    it('serializes via OBJExporter and downloads as text when there is no direct URL', async () => {
+      objParseMock.mockReturnValue('# obj data')
+
+      const promise = ModelExporter.exportOBJ(new THREE.Object3D(), 'out.obj')
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(objParseMock).toHaveBeenCalled()
+      expect(downloadBlobMock).toHaveBeenCalledWith('out.obj', expect.any(Blob))
+    })
+
+    it('alerts and rethrows when OBJExporter throws', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      objParseMock.mockImplementation(() => {
+        throw new Error('obj fail')
+      })
+
+      const promise = ModelExporter.exportOBJ(new THREE.Object3D(), 'out.obj')
+      const assertion = expect(promise).rejects.toThrow('obj fail')
+      await vi.runAllTimersAsync()
+      await assertion
+      expect(addAlertMock).toHaveBeenCalledWith(
+        'toastMessages.failedToExportModel:{"format":"OBJ"}'
+      )
+    })
+  })
+
+  describe('exportSTL', () => {
+    it('uses the direct-URL fast path for matching .stl URLs', async () => {
+      const blob = new Blob(['x'])
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) })
+      )
+
+      await ModelExporter.exportSTL(
+        new THREE.Object3D(),
+        'out.stl',
+        'http://example.com/api/view?filename=src.stl'
+      )
+
+      expect(downloadBlobMock).toHaveBeenCalledWith('out.stl', blob)
+      expect(stlParseMock).not.toHaveBeenCalled()
+      vi.unstubAllGlobals()
+    })
+
+    it('serializes via STLExporter and downloads as text when there is no direct URL', async () => {
+      stlParseMock.mockReturnValue('solid model')
+
+      const promise = ModelExporter.exportSTL(new THREE.Object3D(), 'out.stl')
+      await vi.runAllTimersAsync()
+      await promise
+
+      expect(stlParseMock).toHaveBeenCalled()
+      expect(downloadBlobMock).toHaveBeenCalledWith('out.stl', expect.any(Blob))
+    })
+
+    it('alerts and rethrows when STLExporter throws', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      stlParseMock.mockImplementation(() => {
+        throw new Error('stl fail')
+      })
+
+      const promise = ModelExporter.exportSTL(new THREE.Object3D(), 'out.stl')
+      const assertion = expect(promise).rejects.toThrow('stl fail')
+      await vi.runAllTimersAsync()
+      await assertion
+      expect(addAlertMock).toHaveBeenCalledWith(
+        'toastMessages.failedToExportModel:{"format":"STL"}'
+      )
+    })
+  })
+})

--- a/src/extensions/core/load3d/exportMenuHelper.test.ts
+++ b/src/extensions/core/load3d/exportMenuHelper.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type Load3d from './Load3d'
+import { createExportMenuItems } from './exportMenuHelper'
+
+const { contextMenuMock, addToastMock, addAlertMock } = vi.hoisted(() => ({
+  contextMenuMock: vi.fn(),
+  addToastMock: vi.fn(),
+  addAlertMock: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: addToastMock, addAlert: addAlertMock })
+}))
+
+vi.mock(import('@/lib/litegraph/src/litegraph'), async (importOriginal) => {
+  const actual = await importOriginal()
+  class MockContextMenu {
+    constructor(...args: unknown[]) {
+      contextMenuMock(...args)
+    }
+  }
+  // Replace ContextMenu in-place on the real LiteGraph singleton so consumers
+  // that import other members keep getting the real implementations.
+  ;(actual.LiteGraph as unknown as { ContextMenu: unknown }).ContextMenu =
+    MockContextMenu
+  return actual
+})
+
+function makeLoad3d(
+  exportImpl: (format: string) => Promise<void> = vi
+    .fn()
+    .mockResolvedValue(undefined)
+): Load3d {
+  return { exportModel: exportImpl } as unknown as Load3d
+}
+
+describe('createExportMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns a separator followed by a Save submenu', () => {
+    const items = createExportMenuItems(makeLoad3d())
+
+    expect(items).toHaveLength(2)
+    expect(items[0]).toBeNull()
+    expect(items[1]).toMatchObject({
+      content: 'Save',
+      has_submenu: true
+    })
+  })
+
+  it('opens a submenu with GLB, OBJ, STL when the Save item is invoked', () => {
+    const items = createExportMenuItems(makeLoad3d())
+    const saveItem = items[1]!
+
+    ;(saveItem.callback as (...args: unknown[]) => void)(
+      undefined,
+      {},
+      undefined,
+      undefined
+    )
+
+    expect(contextMenuMock).toHaveBeenCalledOnce()
+    const submenuOptions = contextMenuMock.mock.calls[0][0]
+    expect(submenuOptions.map((o: { content: string }) => o.content)).toEqual([
+      'GLB',
+      'OBJ',
+      'STL'
+    ])
+  })
+
+  it('forwards the parent menu and event when opening the submenu', () => {
+    const items = createExportMenuItems(makeLoad3d())
+    const event = { x: 100 } as unknown as MouseEvent
+    const parentMenu = { id: 'prev' }
+
+    ;(items[1]!.callback as (...args: unknown[]) => void)(
+      undefined,
+      {},
+      event,
+      parentMenu
+    )
+
+    expect(contextMenuMock).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ event, parentMenu })
+    )
+  })
+
+  it.each([
+    ['GLB', 'glb'],
+    ['OBJ', 'obj'],
+    ['STL', 'stl']
+  ])(
+    'invokes load3d.exportModel(%s) and shows a success toast when the %s submenu item is clicked',
+    async (label, value) => {
+      const exportModel = vi.fn().mockResolvedValue(undefined)
+      const items = createExportMenuItems(makeLoad3d(exportModel))
+      ;(items[1]!.callback as (...args: unknown[]) => void)(
+        undefined,
+        {},
+        undefined,
+        undefined
+      )
+      const submenuOptions = contextMenuMock.mock.calls[0][0]
+      const item = submenuOptions.find(
+        (o: { content: string }) => o.content === label
+      )
+
+      item.callback()
+      await vi.waitFor(() => expect(exportModel).toHaveBeenCalledWith(value))
+      await vi.waitFor(() =>
+        expect(addToastMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            severity: 'success',
+            summary: `toastMessages.exportSuccess:${JSON.stringify({ format: label })}`
+          })
+        )
+      )
+      expect(addAlertMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it('shows an alert toast and logs when exportModel rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const exportModel = vi.fn().mockRejectedValue(new Error('boom'))
+    const items = createExportMenuItems(makeLoad3d(exportModel))
+    ;(items[1]!.callback as (...args: unknown[]) => void)(
+      undefined,
+      {},
+      undefined,
+      undefined
+    )
+    const glb = contextMenuMock.mock.calls[0][0].find(
+      (o: { content: string }) => o.content === 'GLB'
+    )
+
+    glb.callback()
+
+    await vi.waitFor(() =>
+      expect(addAlertMock).toHaveBeenCalledWith(
+        `toastMessages.failedToExportModel:${JSON.stringify({ format: 'GLB' })}`
+      )
+    )
+    expect(consoleError).toHaveBeenCalledWith(
+      'Export failed:',
+      expect.any(Error)
+    )
+    expect(addToastMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for the four Tier 2 untested logic modules in the load3d domain (`LightingManager`, `ControlsManager`, `exportMenuHelper`, and `ModelExporter`). Follow-up to the Tier 1 PR (#11733).

## Changes

- **What**: 43 new unit tests across 4 files covering light setup/intensity scaling/HDRI mode/disposal, OrbitControls construction (including DOM-parent fallback) and camera-state event emission, the export submenu builder (item structure, submenu opening, format dispatch, success/error toasts), and the static `ModelExporter` (URL parsing, direct-URL fast paths for matching extensions, GLB/OBJ/STL serialization branches, error toast paths).

## Review Focus

- **Coverage** (lines/branches/funcs): LightingManager 100% / 50% / 90.9%, ControlsManager 100% / 100% / 87.5%, exportMenuHelper 100% / 100% / 100%, ModelExporter 98.4% / 95.7% / 100%. Aggregate: **99.2% / 93.5% / 95.1%**.
- **`vi.mock(import('@/lib/litegraph/src/litegraph'), ...)` in `exportMenuHelper.test.ts`** uses the dynamic-import form so `importOriginal()` is auto-typed. Required because `apiSchema.ts` transitively imports `LinkMarkerShape` from the same module — replacing the whole module breaks the build. The mock replaces only `LiteGraph.ContextMenu` in-place on the real singleton.
- **`MockContextMenu` must be a class**, not an arrow function — production code does `new LiteGraph.ContextMenu(...)`. Initial arrow-function mock failed with "is not a constructor".
- **Fake-timer rejection pattern in `ModelExporter.test.ts`**: rejection assertions are attached *before* `vi.runAllTimersAsync()` (`const assertion = expect(p).rejects.toThrow(...); await drain; await assertion`) to avoid unhandled-rejection warnings.
- **Surprising `detectFormatFromURL` behavior**: `detectFormatFromURL('?filename=cube')` returns `'cube'`, not `null`, because `'cube'.split('.').pop()` returns the whole basename when no dot is present. Test documents this rather than asserting an incorrect expectation.
- **Two unreachable lines left uncovered**: `LightingManager:65` (`?? 1` fallback in the `setLightIntensity` multiplier lookup — every light is registered in the map at construction, so the fallback is dead) and `ModelExporter:21` (a `try/catch` around `URLSearchParams` whose constructor cannot throw on the inputs the production code passes).

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11758-test-load3d-add-unit-tests-for-LightingManager-ControlsManager-exportMenuHelper-and-3516d73d365081cb96fff33672503822) by [Unito](https://www.unito.io)
