### PR TITLE
fix: hide blueprint node id in search

### DIFF
--- a/src/components/searchbox/v2/NodeSearchListItem.test.ts
+++ b/src/components/searchbox/v2/NodeSearchListItem.test.ts
@@ -57,6 +57,19 @@ describe('NodeSearchListItem', () => {
       })
       expect(screen.queryByText('KSamplerNode')).not.toBeInTheDocument()
     })
+
+    it('hides id name for subgraph blueprints even when ShowIdName is enabled', () => {
+      useSettingStore().settingValues['Comfy.NodeSearchBoxImpl.ShowIdName'] =
+        true
+      renderItem({
+        nodeDef: createMockNodeDef({
+          name: 'SubgraphBlueprint.e21be61fc452df75e1324e3cc97c41fb0c01a08a5dad4dcd3a2ac118d8907025',
+          display_name: 'My Blueprint',
+          python_module: 'blueprint'
+        })
+      })
+      expect(screen.queryByTestId('node-id-badge')).not.toBeInTheDocument()
+    })
   })
 
   describe('showDescription mode', () => {

--- a/src/components/searchbox/v2/NodeSearchListItem.vue
+++ b/src/components/searchbox/v2/NodeSearchListItem.vue
@@ -155,8 +155,10 @@ const settingStore = useSettingStore()
 const showCategory = computed(() =>
   settingStore.get('Comfy.NodeSearchBoxImpl.ShowCategory')
 )
-const showIdName = computed(() =>
-  settingStore.get('Comfy.NodeSearchBoxImpl.ShowIdName')
+const showIdName = computed(
+  () =>
+    settingStore.get('Comfy.NodeSearchBoxImpl.ShowIdName') &&
+    nodeDef.nodeSource.type !== NodeSourceType.Blueprint
 )
 const showNodeFrequency = computed(() =>
   settingStore.get('Comfy.NodeSearchBoxImpl.ShowNodeFrequency')


### PR DESCRIPTION
There is a setting that enables Node IDs to display on the search results.
Subgraphs have long non-user friendly IDs which cause this to render badly for the built in blueprints (and user published). This update hides the IDs for blueprint nodes.

## Changes

- **What**: 
- hide if blueprint
- add test

## Screenshots (if applicable)

Before:
<img width="910" height="504" alt="image" src="https://github.com/user-attachments/assets/9eea9fd7-8f72-4e1b-9522-46efba0ef71a" />

After:
<img width="797" height="552" alt="image" src="https://github.com/user-attachments/assets/43d6fc62-4102-41c3-b9bb-a3efd244580d" />

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11759-fix-hide-blueprint-node-id-in-search-3516d73d365081baa055d12c6a31fadd) by [Unito](https://www.unito.io)
