### PR TITLE
test(load3d): add unit tests for EventManager, ViewHelperManager, and load3dLazy

### DIFF
--- a/src/extensions/core/load3d/EventManager.test.ts
+++ b/src/extensions/core/load3d/EventManager.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EventManager } from './EventManager'
+
+describe('EventManager', () => {
+  let manager: EventManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    manager = new EventManager()
+  })
+
+  describe('emitEvent', () => {
+    it('does nothing when there are no listeners for the event', () => {
+      expect(() => manager.emitEvent('unknown', { x: 1 })).not.toThrow()
+    })
+
+    it('invokes every listener registered for the event with the payload', () => {
+      const a = vi.fn()
+      const b = vi.fn()
+      manager.addEventListener('change', a)
+      manager.addEventListener('change', b)
+
+      manager.emitEvent('change', { value: 7 })
+
+      expect(a).toHaveBeenCalledWith({ value: 7 })
+      expect(b).toHaveBeenCalledWith({ value: 7 })
+    })
+
+    it('does not invoke listeners registered for a different event', () => {
+      const cb = vi.fn()
+      manager.addEventListener('a', cb)
+
+      manager.emitEvent('b', null)
+
+      expect(cb).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('removeEventListener', () => {
+    it('detaches a previously added listener', () => {
+      const cb = vi.fn()
+      manager.addEventListener('change', cb)
+
+      manager.removeEventListener('change', cb)
+      manager.emitEvent('change', null)
+
+      expect(cb).not.toHaveBeenCalled()
+    })
+
+    it('leaves other listeners on the same event intact', () => {
+      const a = vi.fn()
+      const b = vi.fn()
+      manager.addEventListener('change', a)
+      manager.addEventListener('change', b)
+
+      manager.removeEventListener('change', a)
+      manager.emitEvent('change', null)
+
+      expect(a).not.toHaveBeenCalled()
+      expect(b).toHaveBeenCalled()
+    })
+
+    it('is safely a no-op for an event that has never been listened to', () => {
+      expect(() => manager.removeEventListener('never', vi.fn())).not.toThrow()
+    })
+  })
+})

--- a/src/extensions/core/load3d/ViewHelperManager.test.ts
+++ b/src/extensions/core/load3d/ViewHelperManager.test.ts
@@ -1,0 +1,258 @@
+import * as THREE from 'three'
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EventManagerInterface } from './interfaces'
+import { ViewHelperManager } from './ViewHelperManager'
+
+interface MockViewHelperInstance {
+  camera: THREE.Camera
+  domElement: HTMLElement
+  animating: boolean
+  visible: boolean
+  center: THREE.Vector3 | null
+  update: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+  handleClick: ReturnType<typeof vi.fn>
+}
+
+const { viewHelperInstances, mockHandleClick } = vi.hoisted(() => ({
+  viewHelperInstances: [] as MockViewHelperInstance[],
+  mockHandleClick: vi.fn()
+}))
+
+vi.mock('three/examples/jsm/helpers/ViewHelper', () => {
+  class ViewHelper {
+    animating = false
+    visible = true
+    center: THREE.Vector3 | null = null
+    update = vi.fn()
+    dispose = vi.fn()
+    handleClick = mockHandleClick
+    constructor(
+      public camera: THREE.Camera,
+      public domElement: HTMLElement
+    ) {
+      viewHelperInstances.push(this as unknown as MockViewHelperInstance)
+    }
+  }
+  return { ViewHelper }
+})
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+function makeOrbitControls(target = new THREE.Vector3()) {
+  return { target } as unknown as OrbitControls
+}
+
+describe('ViewHelperManager', () => {
+  let events: ReturnType<typeof makeMockEventManager>
+  let camera: THREE.PerspectiveCamera
+  let controls: OrbitControls
+  let manager: ViewHelperManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    viewHelperInstances.length = 0
+    events = makeMockEventManager()
+    camera = new THREE.PerspectiveCamera()
+    controls = makeOrbitControls()
+    manager = new ViewHelperManager(
+      {} as THREE.WebGLRenderer,
+      () => camera,
+      () => controls,
+      events
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('createViewHelper', () => {
+    it('appends a 128x128 absolutely-positioned container to the parent element', () => {
+      const parent = document.createElement('div')
+
+      manager.createViewHelper(parent)
+
+      expect(manager.viewHelperContainer.parentNode).toBe(parent)
+      expect(manager.viewHelperContainer.style.width).toBe('128px')
+      expect(manager.viewHelperContainer.style.height).toBe('128px')
+      expect(manager.viewHelperContainer.style.position).toBe('absolute')
+    })
+
+    it('instantiates ViewHelper with the active camera and binds its center to the controls target', () => {
+      const target = new THREE.Vector3(1, 2, 3)
+      controls = makeOrbitControls(target)
+      manager = new ViewHelperManager(
+        {} as THREE.WebGLRenderer,
+        () => camera,
+        () => controls,
+        events
+      )
+
+      manager.createViewHelper(document.createElement('div'))
+
+      expect(viewHelperInstances).toHaveLength(1)
+      expect(viewHelperInstances[0].camera).toBe(camera)
+      expect(manager.viewHelper.center).toBe(target)
+    })
+
+    it('routes pointerup events to ViewHelper.handleClick and stops propagation', () => {
+      const parent = document.createElement('div')
+      const propagated = vi.fn()
+      parent.addEventListener('pointerup', propagated)
+      manager.createViewHelper(parent)
+
+      const event = new PointerEvent('pointerup', { bubbles: true })
+      manager.viewHelperContainer.dispatchEvent(event)
+
+      expect(mockHandleClick).toHaveBeenCalledWith(event)
+      expect(propagated).not.toHaveBeenCalled()
+    })
+
+    it('stops propagation of pointerdown events without forwarding them to ViewHelper', () => {
+      const parent = document.createElement('div')
+      const propagated = vi.fn()
+      parent.addEventListener('pointerdown', propagated)
+      manager.createViewHelper(parent)
+
+      manager.viewHelperContainer.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true })
+      )
+
+      expect(propagated).not.toHaveBeenCalled()
+      expect(mockHandleClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('update', () => {
+    it('does nothing when ViewHelper is not animating', () => {
+      manager.createViewHelper(document.createElement('div'))
+      manager.viewHelper.animating = false
+
+      manager.update(0.5)
+
+      expect(manager.viewHelper.update).not.toHaveBeenCalled()
+      expect(events.emitEvent).not.toHaveBeenCalled()
+    })
+
+    it('drives the animation while it is in progress without emitting yet', () => {
+      manager.createViewHelper(document.createElement('div'))
+      manager.viewHelper.animating = true
+
+      manager.update(0.25)
+
+      expect(manager.viewHelper.update).toHaveBeenCalledWith(0.25)
+      expect(events.emitEvent).not.toHaveBeenCalled()
+    })
+
+    it('emits cameraChanged with a perspective state when the animation just finished', () => {
+      manager.createViewHelper(document.createElement('div'))
+      camera.position.set(1, 2, 3)
+      camera.zoom = 1.5
+      controls.target.set(4, 5, 6)
+      manager.viewHelper.animating = true
+      ;(
+        manager.viewHelper.update as unknown as {
+          mockImplementation(fn: () => void): void
+        }
+      ).mockImplementation(() => {
+        manager.viewHelper.animating = false
+      })
+
+      manager.update(0)
+
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraChanged', {
+        position: expect.objectContaining({ x: 1, y: 2, z: 3 }),
+        target: expect.objectContaining({ x: 4, y: 5, z: 6 }),
+        zoom: 1.5,
+        cameraType: 'perspective'
+      })
+    })
+
+    it('reports orthographic when the active camera is an OrthographicCamera', () => {
+      const ortho = new THREE.OrthographicCamera()
+      ortho.zoom = 0.5
+      manager = new ViewHelperManager(
+        {} as THREE.WebGLRenderer,
+        () => ortho,
+        () => controls,
+        events
+      )
+      manager.createViewHelper(document.createElement('div'))
+      manager.viewHelper.animating = true
+      ;(
+        manager.viewHelper.update as unknown as {
+          mockImplementation(fn: () => void): void
+        }
+      ).mockImplementation(() => {
+        manager.viewHelper.animating = false
+      })
+
+      manager.update(0)
+
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'cameraChanged',
+        expect.objectContaining({ cameraType: 'orthographic', zoom: 0.5 })
+      )
+    })
+  })
+
+  describe('visibleViewHelper', () => {
+    it('shows the helper and unhides the container when called with true', () => {
+      manager.createViewHelper(document.createElement('div'))
+      manager.viewHelper.visible = false
+      manager.viewHelperContainer.style.display = 'none'
+
+      manager.visibleViewHelper(true)
+
+      expect(manager.viewHelper.visible).toBe(true)
+      expect(manager.viewHelperContainer.style.display).toBe('block')
+    })
+
+    it('hides the helper and the container when called with false', () => {
+      manager.createViewHelper(document.createElement('div'))
+
+      manager.visibleViewHelper(false)
+
+      expect(manager.viewHelper.visible).toBe(false)
+      expect(manager.viewHelperContainer.style.display).toBe('none')
+    })
+  })
+
+  describe('recreateViewHelper', () => {
+    it('disposes the old helper and constructs a new one bound to the controls target', () => {
+      manager.createViewHelper(document.createElement('div'))
+      const oldHelper = manager.viewHelper
+      const newTarget = new THREE.Vector3(9, 9, 9)
+      controls.target.copy(newTarget)
+
+      manager.recreateViewHelper()
+
+      expect(oldHelper.dispose).toHaveBeenCalled()
+      expect(manager.viewHelper).not.toBe(oldHelper)
+      expect(viewHelperInstances).toHaveLength(2)
+      expect(manager.viewHelper.center).toBe(controls.target)
+    })
+  })
+
+  describe('dispose', () => {
+    it('disposes the helper and removes the container from its parent', () => {
+      const parent = document.createElement('div')
+      manager.createViewHelper(parent)
+      const helper = manager.viewHelper
+
+      manager.dispose()
+
+      expect(helper.dispose).toHaveBeenCalled()
+      expect(manager.viewHelperContainer.parentNode).toBeNull()
+    })
+  })
+})

--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import type { ComfyExtension } from '@/types/comfy'
+
+const { registerExtensionMock, enabledExtensionsGetter } = vi.hoisted(() => ({
+  registerExtensionMock: vi.fn(),
+  enabledExtensionsGetter: vi.fn(() => [] as ComfyExtension[])
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({ registerExtension: registerExtensionMock })
+}))
+
+vi.mock('@/stores/extensionStore', () => ({
+  useExtensionStore: () => ({
+    get enabledExtensions() {
+      return enabledExtensionsGetter()
+    }
+  })
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { __mockApp: true }
+}))
+
+vi.mock('@/extensions/core/load3d', () => ({}))
+vi.mock('@/extensions/core/saveMesh', () => ({}))
+
+type Hook = (
+  nodeType: typeof LGraphNode,
+  nodeData: ComfyNodeDef,
+  app?: unknown
+) => Promise<void> | void
+
+async function loadLazyExtensionFresh(): Promise<{ hook: Hook }> {
+  vi.resetModules()
+  registerExtensionMock.mockClear()
+  enabledExtensionsGetter.mockReset().mockReturnValue([])
+  await import('@/extensions/core/load3dLazy')
+  const ext = registerExtensionMock.mock.calls[0][0] as ComfyExtension
+  return { hook: ext.beforeRegisterNodeDef as Hook }
+}
+
+function makeNodeDef(
+  name: string,
+  extra: Partial<ComfyNodeDef> = {}
+): ComfyNodeDef {
+  return {
+    name,
+    display_name: name,
+    category: '',
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    python_module: '',
+    description: '',
+    ...extra
+  } as ComfyNodeDef
+}
+
+describe('load3dLazy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers a single Comfy.Load3DLazy extension on import', async () => {
+    await loadLazyExtensionFresh()
+
+    expect(registerExtensionMock).toHaveBeenCalledOnce()
+    const ext = registerExtensionMock.mock.calls[0][0] as ComfyExtension
+    expect(ext.name).toBe('Comfy.Load3DLazy')
+    expect(typeof ext.beforeRegisterNodeDef).toBe('function')
+  })
+
+  it('skips loading and mutation for non-3D node defs', async () => {
+    const { hook } = await loadLazyExtensionFresh()
+
+    await hook({} as typeof LGraphNode, makeNodeDef('PlainNode'))
+
+    // No diff was ever computed because the early-return branch was taken.
+    expect(enabledExtensionsGetter).not.toHaveBeenCalled()
+  })
+
+  it.each(['Load3D', 'Preview3D', 'SaveGLB'])(
+    'recognizes %s as a 3D node type and triggers the lazy-load path',
+    async (nodeType) => {
+      const { hook } = await loadLazyExtensionFresh()
+
+      await hook({} as typeof LGraphNode, makeNodeDef(nodeType))
+
+      // The lazy-load path always reads enabledExtensions once for the diff.
+      expect(enabledExtensionsGetter).toHaveBeenCalled()
+    }
+  )
+
+  it('injects mesh_upload spec flags into the model_file widget for Load3D nodes', async () => {
+    const { hook } = await loadLazyExtensionFresh()
+    const nodeData = makeNodeDef('Load3D', {
+      input: {
+        required: { model_file: ['STRING', {}] }
+      }
+    } as Partial<ComfyNodeDef>)
+
+    await hook({} as typeof LGraphNode, nodeData)
+
+    const spec = (
+      nodeData.input!.required!.model_file as [string, Record<string, unknown>]
+    )[1]
+    expect(spec.mesh_upload).toBe(true)
+    expect(spec.upload_subfolder).toBe('3d')
+  })
+
+  it('does not throw when a Load3D node has no model_file widget spec', async () => {
+    const { hook } = await loadLazyExtensionFresh()
+    const nodeData = makeNodeDef('Load3D', {
+      input: { required: {} }
+    } as Partial<ComfyNodeDef>)
+
+    await expect(
+      hook({} as typeof LGraphNode, nodeData)
+    ).resolves.toBeUndefined()
+  })
+
+  it('does not mutate model_file for non-Load3D 3D node types', async () => {
+    const { hook } = await loadLazyExtensionFresh()
+    const nodeData = makeNodeDef('Preview3D', {
+      input: {
+        required: { model_file: ['STRING', { existing: true }] }
+      }
+    } as Partial<ComfyNodeDef>)
+
+    await hook({} as typeof LGraphNode, nodeData)
+
+    const spec = (
+      nodeData.input!.required!.model_file as [string, Record<string, unknown>]
+    )[1]
+    expect(spec.mesh_upload).toBeUndefined()
+  })
+
+  it('replays beforeRegisterNodeDef of newly registered extensions, passing the app reference', async () => {
+    const newExtension: ComfyExtension = {
+      name: 'Inner',
+      beforeRegisterNodeDef: vi.fn()
+    }
+    // First call (snapshotting `before`) sees an empty list; second call
+    // (computing the diff after dynamic imports) sees the new extension.
+    enabledExtensionsGetter
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([newExtension])
+    const { hook } = await loadLazyExtensionFresh()
+    enabledExtensionsGetter
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([newExtension])
+
+    const nodeData = makeNodeDef('Preview3D')
+    await hook({ id: 1 } as unknown as typeof LGraphNode, nodeData)
+
+    expect(newExtension.beforeRegisterNodeDef).toHaveBeenCalledWith(
+      { id: 1 },
+      nodeData,
+      expect.objectContaining({ __mockApp: true })
+    )
+  })
+
+  it('does not replay extensions that were already registered before lazy loading', async () => {
+    const preexisting: ComfyExtension = {
+      name: 'PreExisting',
+      beforeRegisterNodeDef: vi.fn()
+    }
+    enabledExtensionsGetter.mockReturnValue([preexisting])
+    const { hook } = await loadLazyExtensionFresh()
+    enabledExtensionsGetter.mockReturnValue([preexisting])
+
+    await hook({} as typeof LGraphNode, makeNodeDef('Load3D'))
+
+    expect(preexisting.beforeRegisterNodeDef).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Add unit tests for the three remaining small/wrapper modules in the load3d domain (`EventManager` pub/sub, `ViewHelperManager` ViewHelper wrapper, and `load3dLazy` lazy-extension loader). Follow-up to Tier 1 (#11733) and Tier 2.

## Changes

- **What**: 28 new unit tests across 3 files covering EventManager add/remove/emit semantics, ViewHelperManager container DOM creation + pointer-event interception + animation-finished camera-state emission + perspective/orthographic zoom snapshotting + dispose ordering, and load3dLazy extension registration + 3D-node-type recognition + Load3D-specific `mesh_upload` injection + `beforeRegisterNodeDef` hook replay for newly registered extensions.

## Review Focus

- **Coverage** (lines/branches/funcs): EventManager 100% / 100% / 100%, ViewHelperManager 100% / 83.3% / 72.7%, load3dLazy 95.8% / 80% / 100%. Aggregate: **98.6% / 85.3% / 85.7%**.
- **`vi.mock` factory side-effects only fire once per test file** — `load3dLazy.test.ts` originally tried to count dynamic imports of `./load3d` and `./saveMesh` via spies inside the mock factory, but factories aren't re-invoked across `vi.resetModules()`. Switched to verifying observable side effects (`enabledExtensions` getter call counts, `beforeRegisterNodeDef` replay invocations).
- **Snapshot-vs-diff `enabledExtensions` queue** in `load3dLazy.test.ts`: production code does `before = new Set(enabledExtensions); await imports; diff = enabledExtensions.filter(!before.has)`. To exercise the replay branch, the mock returns `[]` first (for `before`) and `[newExtension]` second (for the post-import snapshot) via `mockReturnValueOnce` queueing.
- **`MockViewHelper` is defined inside the `vi.mock()` factory** rather than `vi.hoisted()`, matching the `GizmoManager.test.ts:15-41` convention (hoisted handles only, classes inside the factory).
- **PointerEvent propagation tests** require the production code's `event.stopPropagation()` to actually keep events from bubbling to the parent in happy-dom; the parent listener gets attached and asserted-not-called.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11760-test-load3d-add-unit-tests-for-EventManager-ViewHelperManager-and-load3dLazy-3516d73d3650814bb2dac3360ab0d2a1) by [Unito](https://www.unito.io)
