### PR TITLE
test(load3d): add unit tests for SceneManager

### DIFF
--- a/src/extensions/core/load3d/SceneManager.test.ts
+++ b/src/extensions/core/load3d/SceneManager.test.ts
@@ -1,0 +1,546 @@
+import * as THREE from 'three'
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EventManagerInterface } from './interfaces'
+import Load3dUtils from './Load3dUtils'
+import { SceneManager } from './SceneManager'
+
+const { mockTextureLoad } = vi.hoisted(() => ({
+  mockTextureLoad: vi.fn()
+}))
+
+vi.mock('./Load3dUtils', () => ({
+  default: {
+    splitFilePath: vi.fn(),
+    getResourceURL: vi.fn()
+  }
+}))
+
+vi.mock('three', async (importOriginal) => {
+  const actual = await importOriginal<typeof THREE>()
+  class StubTextureLoader {
+    load = mockTextureLoad
+  }
+  return { ...actual, TextureLoader: StubTextureLoader }
+})
+
+function makeMockEventManager() {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    emitEvent: vi.fn()
+  } satisfies EventManagerInterface
+}
+
+function makeRenderer() {
+  const canvas = document.createElement('canvas')
+  Object.defineProperty(canvas, 'clientWidth', {
+    configurable: true,
+    value: 800
+  })
+  Object.defineProperty(canvas, 'clientHeight', {
+    configurable: true,
+    value: 600
+  })
+  canvas.width = 800
+  canvas.height = 600
+  vi.spyOn(canvas, 'toDataURL').mockReturnValue('data:image/png;base64,FAKE')
+  return {
+    domElement: canvas,
+    setClearColor: vi.fn(),
+    setSize: vi.fn(),
+    render: vi.fn(),
+    clear: vi.fn(),
+    getClearColor: vi.fn().mockReturnValue(new THREE.Color(0xffffff)),
+    getClearAlpha: vi.fn().mockReturnValue(1),
+    toneMapping: THREE.NoToneMapping,
+    toneMappingExposure: 1,
+    outputColorSpace: THREE.SRGBColorSpace
+  } as unknown as THREE.WebGLRenderer
+}
+
+function makeImageTexture(width = 200, height = 100): THREE.Texture {
+  const texture = new THREE.Texture()
+  ;(texture as unknown as { image: { width: number; height: number } }).image =
+    {
+      width,
+      height
+    }
+  return texture
+}
+
+describe('SceneManager', () => {
+  let renderer: THREE.WebGLRenderer
+  let camera: THREE.PerspectiveCamera
+  let events: ReturnType<typeof makeMockEventManager>
+  let manager: SceneManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    renderer = makeRenderer()
+    camera = new THREE.PerspectiveCamera()
+    events = makeMockEventManager()
+    manager = new SceneManager(
+      renderer,
+      () => camera,
+      () => ({}) as unknown as OrbitControls,
+      events
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('construction', () => {
+    it('builds the main scene with a grid helper at the origin', () => {
+      expect(manager.scene).toBeInstanceOf(THREE.Scene)
+      expect(manager.gridHelper).toBeInstanceOf(THREE.GridHelper)
+      expect(manager.scene.children).toContain(manager.gridHelper)
+    })
+
+    it('builds a separate background scene with a tiled mesh', () => {
+      expect(manager.backgroundScene).toBeInstanceOf(THREE.Scene)
+      expect(manager.backgroundMesh).toBeInstanceOf(THREE.Mesh)
+      expect(manager.backgroundScene.children).toContain(manager.backgroundMesh)
+      expect(manager.backgroundColorMaterial).toBeInstanceOf(
+        THREE.MeshBasicMaterial
+      )
+    })
+
+    it('initializes the background to color mode at the default color', () => {
+      expect(manager.currentBackgroundType).toBe('color')
+      expect(manager.currentBackgroundColor).toBe('#282828')
+      expect(manager.backgroundRenderMode).toBe('tiled')
+    })
+  })
+
+  describe('toggleGrid', () => {
+    it('hides and shows the grid and emits showGridChange', () => {
+      manager.toggleGrid(false)
+      expect(manager.gridHelper.visible).toBe(false)
+      expect(events.emitEvent).toHaveBeenCalledWith('showGridChange', false)
+
+      manager.toggleGrid(true)
+      expect(manager.gridHelper.visible).toBe(true)
+      expect(events.emitEvent).toHaveBeenCalledWith('showGridChange', true)
+    })
+  })
+
+  describe('setBackgroundColor', () => {
+    it('updates the material color and emits backgroundColorChange', () => {
+      manager.setBackgroundColor('#ff0000')
+
+      expect(manager.currentBackgroundColor).toBe('#ff0000')
+      expect(manager.currentBackgroundType).toBe('color')
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundColorChange',
+        '#ff0000'
+      )
+    })
+
+    it('clears any prior texture-based scene background', () => {
+      manager.scene.background = makeImageTexture()
+
+      manager.setBackgroundColor('#abcdef')
+
+      expect(manager.scene.background).toBeNull()
+    })
+
+    it('demotes panorama mode back to tiled and emits the change', () => {
+      manager.backgroundRenderMode = 'panorama'
+
+      manager.setBackgroundColor('#abcdef')
+
+      expect(manager.backgroundRenderMode).toBe('tiled')
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundRenderModeChange',
+        'tiled'
+      )
+    })
+
+    it('disposes any prior background texture', () => {
+      const texture = makeImageTexture()
+      const dispose = vi.spyOn(texture, 'dispose')
+      manager.backgroundTexture = texture
+
+      manager.setBackgroundColor('#000000')
+
+      expect(dispose).toHaveBeenCalled()
+      expect(manager.backgroundTexture).toBeNull()
+    })
+  })
+
+  describe('setBackgroundImage', () => {
+    it('falls back to setBackgroundColor when given an empty path', async () => {
+      const setBackgroundColor = vi.spyOn(manager, 'setBackgroundColor')
+
+      await manager.setBackgroundImage('')
+
+      expect(setBackgroundColor).toHaveBeenCalledWith(
+        manager.currentBackgroundColor
+      )
+    })
+
+    it('emits a loading-start event before fetching', async () => {
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/api/view?bg.png')
+      mockTextureLoad.mockImplementation(
+        (_url: string, resolve: (t: THREE.Texture) => void) =>
+          resolve(makeImageTexture())
+      )
+
+      const promise = manager.setBackgroundImage('bg.png')
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundImageLoadingStart',
+        null
+      )
+      await promise
+    })
+
+    it('rewrites temp/output subfolders to a flat path with the right type', async () => {
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['temp', 'out.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view?out.png')
+      mockTextureLoad.mockImplementation(
+        (_url: string, resolve: (t: THREE.Texture) => void) =>
+          resolve(makeImageTexture())
+      )
+
+      await manager.setBackgroundImage('temp/out.png')
+
+      expect(Load3dUtils.getResourceURL).toHaveBeenCalledWith(
+        '',
+        'out.png',
+        'temp'
+      )
+    })
+
+    it('prefixes /api when getResourceURL returns a non-/api URL', async () => {
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view?bg.png')
+      const captured: string[] = []
+      mockTextureLoad.mockImplementation(
+        (url: string, resolve: (t: THREE.Texture) => void) => {
+          captured.push(url)
+          resolve(makeImageTexture())
+        }
+      )
+
+      await manager.setBackgroundImage('bg.png')
+
+      expect(captured[0]).toBe('/api/view?bg.png')
+    })
+
+    it('in tiled mode, swaps the background mesh material to use the new texture', async () => {
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/api/bg')
+      const texture = makeImageTexture()
+      mockTextureLoad.mockImplementation(
+        (_url: string, resolve: (t: THREE.Texture) => void) => resolve(texture)
+      )
+
+      await manager.setBackgroundImage('bg.png')
+
+      expect(manager.currentBackgroundType).toBe('image')
+      expect(manager.backgroundTexture).toBe(texture)
+      expect(manager.backgroundMesh!.material).not.toBe(
+        manager.backgroundColorMaterial
+      )
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundImageChange',
+        'bg.png'
+      )
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundImageLoadingEnd',
+        null
+      )
+    })
+
+    it('in panorama mode, assigns the texture as the scene background with equirectangular mapping', async () => {
+      manager.backgroundRenderMode = 'panorama'
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/api/bg')
+      const texture = makeImageTexture()
+      mockTextureLoad.mockImplementation(
+        (_url: string, resolve: (t: THREE.Texture) => void) => resolve(texture)
+      )
+
+      await manager.setBackgroundImage('bg.png')
+
+      expect(manager.scene.background).toBe(texture)
+      expect(texture.mapping).toBe(THREE.EquirectangularReflectionMapping)
+    })
+
+    it('disposes a previously loaded background texture before assigning the new one', async () => {
+      const previous = makeImageTexture()
+      const disposePrev = vi.spyOn(previous, 'dispose')
+      manager.backgroundTexture = previous
+
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/api/bg')
+      mockTextureLoad.mockImplementation(
+        (_url: string, resolve: (t: THREE.Texture) => void) =>
+          resolve(makeImageTexture())
+      )
+
+      await manager.setBackgroundImage('bg.png')
+
+      expect(disposePrev).toHaveBeenCalled()
+    })
+
+    it('on load failure, emits loading-end and falls back to a color background', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
+      vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/api/bg')
+      mockTextureLoad.mockImplementation(
+        (
+          _url: string,
+          _resolve: unknown,
+          _onProgress: unknown,
+          reject: (e: Error) => void
+        ) => reject(new Error('load failed'))
+      )
+      const setBackgroundColor = vi.spyOn(manager, 'setBackgroundColor')
+
+      await manager.setBackgroundImage('bg.png')
+
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundImageLoadingEnd',
+        null
+      )
+      expect(setBackgroundColor).toHaveBeenCalledWith(
+        manager.currentBackgroundColor
+      )
+    })
+  })
+
+  describe('removeBackgroundImage', () => {
+    it('reverts to the current color and emits loading-end', () => {
+      const setBackgroundColor = vi.spyOn(manager, 'setBackgroundColor')
+
+      manager.removeBackgroundImage()
+
+      expect(setBackgroundColor).toHaveBeenCalledWith(
+        manager.currentBackgroundColor
+      )
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundImageLoadingEnd',
+        null
+      )
+    })
+  })
+
+  describe('setBackgroundRenderMode', () => {
+    it('is a no-op when the requested mode equals the current mode', () => {
+      events.emitEvent.mockClear()
+
+      manager.setBackgroundRenderMode('tiled')
+
+      expect(events.emitEvent).not.toHaveBeenCalled()
+    })
+
+    it('switches to panorama on a color background and just emits the change', () => {
+      manager.setBackgroundRenderMode('panorama')
+
+      expect(manager.backgroundRenderMode).toBe('panorama')
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'backgroundRenderModeChange',
+        'panorama'
+      )
+    })
+
+    it('promotes an image background to scene.background when switching to panorama', () => {
+      manager.currentBackgroundType = 'image'
+      const texture = makeImageTexture()
+      manager.backgroundTexture = texture
+
+      manager.setBackgroundRenderMode('panorama')
+
+      expect(manager.scene.background).toBe(texture)
+      expect(texture.mapping).toBe(THREE.EquirectangularReflectionMapping)
+    })
+
+    it('demotes back to tiled by clearing scene.background and updating the mesh map', () => {
+      manager.currentBackgroundType = 'image'
+      const texture = makeImageTexture()
+      manager.backgroundTexture = texture
+      manager.scene.background = texture
+      manager.backgroundRenderMode = 'panorama'
+
+      manager.setBackgroundRenderMode('tiled')
+
+      expect(manager.scene.background).toBeNull()
+      const mat = manager.backgroundMesh!.material as THREE.MeshBasicMaterial
+      expect(mat.map).toBe(texture)
+      // THREE's `needsUpdate` is a write-only setter — reading is undefined.
+      // Asserting the map swap is sufficient to validate the demote path.
+    })
+  })
+
+  describe('updateBackgroundSize', () => {
+    it('does nothing without a texture or mesh', () => {
+      const mesh = new THREE.Mesh(
+        new THREE.PlaneGeometry(1, 1),
+        new THREE.MeshBasicMaterial()
+      )
+      const before = mesh.scale.toArray()
+
+      manager.updateBackgroundSize(null, mesh, 100, 100)
+
+      expect(mesh.scale.toArray()).toEqual(before)
+    })
+
+    it('does nothing without a mesh', () => {
+      expect(() =>
+        manager.updateBackgroundSize(makeImageTexture(), null, 100, 100)
+      ).not.toThrow()
+    })
+
+    it('does nothing when the mesh material has no map', () => {
+      const texture = makeImageTexture(400, 100)
+      const mesh = new THREE.Mesh(
+        new THREE.PlaneGeometry(1, 1),
+        new THREE.MeshBasicMaterial() // no map
+      )
+      const before = mesh.scale.toArray()
+
+      manager.updateBackgroundSize(texture, mesh, 200, 100)
+
+      expect(mesh.scale.toArray()).toEqual(before)
+    })
+
+    it('scales horizontally when the image is wider than the target', () => {
+      const texture = makeImageTexture(400, 100) // imageAspect = 4
+      const mat = new THREE.MeshBasicMaterial({ map: texture })
+      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat)
+
+      manager.updateBackgroundSize(texture, mesh, 200, 100) // targetAspect = 2
+
+      expect(mesh.scale.x).toBeCloseTo(2)
+      expect(mesh.scale.y).toBe(1)
+    })
+
+    it('scales vertically when the image is taller than the target', () => {
+      const texture = makeImageTexture(100, 400) // imageAspect = 0.25
+      const mat = new THREE.MeshBasicMaterial({ map: texture })
+      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat)
+
+      manager.updateBackgroundSize(texture, mesh, 200, 100) // targetAspect = 2
+
+      expect(mesh.scale.x).toBe(1)
+      expect(mesh.scale.y).toBeCloseTo(8)
+    })
+  })
+
+  describe('handleResize', () => {
+    it('updates background size when an image background is active', () => {
+      const texture = makeImageTexture(400, 100)
+      manager.backgroundTexture = texture
+      manager.currentBackgroundType = 'image'
+      ;(manager.backgroundMesh!.material as THREE.MeshBasicMaterial).map =
+        texture
+      const update = vi.spyOn(manager, 'updateBackgroundSize')
+
+      manager.handleResize(800, 600)
+
+      expect(update).toHaveBeenCalledWith(
+        texture,
+        manager.backgroundMesh,
+        800,
+        600
+      )
+    })
+
+    it('does nothing when only a color background is active', () => {
+      const update = vi.spyOn(manager, 'updateBackgroundSize')
+
+      manager.handleResize(800, 600)
+
+      expect(update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getCurrentBackgroundInfo', () => {
+    it('returns the color when in color mode', () => {
+      manager.setBackgroundColor('#abc123')
+
+      expect(manager.getCurrentBackgroundInfo()).toEqual({
+        type: 'color',
+        value: '#abc123'
+      })
+    })
+
+    it('returns an empty value when in image mode', () => {
+      manager.currentBackgroundType = 'image'
+
+      expect(manager.getCurrentBackgroundInfo()).toEqual({
+        type: 'image',
+        value: ''
+      })
+    })
+  })
+
+  describe('captureScene', () => {
+    it('returns three data URLs and restores the renderer to its original state', async () => {
+      const result = await manager.captureScene(400, 300)
+
+      expect(result.scene).toBe('data:image/png;base64,FAKE')
+      expect(result.mask).toBe('data:image/png;base64,FAKE')
+      expect(result.normal).toBe('data:image/png;base64,FAKE')
+      // Renderer.setSize is called once with the capture size and once to restore.
+      expect(renderer.setSize).toHaveBeenCalledWith(400, 300)
+      expect(renderer.setSize).toHaveBeenLastCalledWith(800, 600)
+    })
+
+    it('restores grid visibility after rendering the normal pass', async () => {
+      manager.gridHelper.visible = true
+
+      await manager.captureScene(100, 100)
+
+      expect(manager.gridHelper.visible).toBe(true)
+    })
+
+    it('rejects when the renderer throws during capture', async () => {
+      vi.mocked(renderer.render).mockImplementationOnce(() => {
+        throw new Error('renderer fail')
+      })
+
+      await expect(manager.captureScene(100, 100)).rejects.toThrow(
+        'renderer fail'
+      )
+    })
+  })
+
+  describe('dispose', () => {
+    it('disposes the texture, color material, and mesh resources, then clears scenes', () => {
+      const texture = makeImageTexture()
+      const disposeTexture = vi.spyOn(texture, 'dispose')
+      manager.backgroundTexture = texture
+      const disposeColorMat = vi.spyOn(
+        manager.backgroundColorMaterial!,
+        'dispose'
+      )
+      const disposeGeometry = vi.spyOn(
+        manager.backgroundMesh!.geometry,
+        'dispose'
+      )
+
+      manager.dispose()
+
+      expect(disposeTexture).toHaveBeenCalled()
+      expect(disposeColorMat).toHaveBeenCalled()
+      expect(disposeGeometry).toHaveBeenCalled()
+      expect(manager.scene.children).toHaveLength(0)
+      expect(manager.backgroundScene.children).toHaveLength(0)
+    })
+
+    it('clears the scene background when one was set', () => {
+      manager.scene.background = makeImageTexture()
+
+      manager.dispose()
+
+      expect(manager.scene.background).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add 35 unit tests for `SceneManager`, the largest remaining gap in the load3d core (452 LOC). Targets only the logic-bearing methods (background mode dispatch, render-mode switching, aspect-ratio scaling, capture pipeline, dispose). Renderer-passthrough internals are intentionally left to E2E. Follow-up to Tier 1 (#11733), Tier 2, Tier 3a, and Tier 3b.

## Changes

- **What**: 35 new tests covering construction (main scene + background scene + grid + tiled mesh + default color mode), `toggleGrid`, `setBackgroundColor` (color update, scene-bg cleanup, panorama-demote, prior-texture dispose), `setBackgroundImage` (empty-path fallback, loading-start emit, temp/output subfolder rewrite, /api prefix, tiled-mesh material swap, panorama scene-background promotion, prior-texture dispose, error-path fallback), `removeBackgroundImage`, `setBackgroundRenderMode` (no-op same-mode, color-only emit, image panorama-promote, image tiled-demote), `updateBackgroundSize` (no-texture/no-mesh/no-map guards, wide vs. tall image scaling), `handleResize` (image-bg active vs. color-only), `getCurrentBackgroundInfo`, `captureScene` (returns 3 data URLs + restores renderer state, restores grid visibility, propagates errors), and `dispose` (resource cleanup + scene-background null).

## Review Focus

- **Coverage**: `SceneManager.ts` 89.5% lines / 74.2% branches / 89.5% funcs. Uncovered lines are concentrated in `renderBackground` and the deep mesh-traversal loop inside `captureScene` — exactly the renderer-passthrough territory deferred per the Tier 3c plan.
- **`THREE.Material.needsUpdate` is a write-only setter** in THREE.js — reading returns `undefined`. The "demote panorama → tiled" test asserts `mat.map === texture` instead of `mat.needsUpdate === true`, with a comment explaining why.
- **happy-dom canvas `clientWidth`/`clientHeight` default to 0** — `makeRenderer()` overrides them via `Object.defineProperty` so production code reading `renderer.domElement.clientWidth` gets the test value.
- **`THREE.TextureLoader` is mocked via `vi.mock('three', ...)` with `importOriginal`**, matching the pattern in `RecordingManager.test.ts` and `HDRIManager.test.ts`. `mockTextureLoad` is hoisted so each test can resolve/reject the load callback independently.
- **`vi.spyOn(manager, 'setBackgroundColor')` in three places** to assert internal delegation (empty-path fallback, error fallback, `removeBackgroundImage`). Defensible because the delegation IS the documented contract for these methods.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11762-test-load3d-add-unit-tests-for-SceneManager-3516d73d365081628ff4c146defebac1) by [Unito](https://www.unito.io)
