### PR TITLE
fix: suppress Preview3D model-load error toasts

### DIFF
--- a/browser_tests/tests/load3d/preview3dExecution.spec.ts
+++ b/browser_tests/tests/load3d/preview3dExecution.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@e2e/fixtures/helpers/Preview3DPipelineFixture'
 
 test.describe('Preview3D execution flow', { tag: ['@slow', '@node'] }, () => {
-  test('Preview3D shows no error toast when execution output has no model file', async ({
+  test('Preview3D shows inline error and no toast when execution output has no model file', async ({
     preview3dPipeline: pipeline
   }) => {
     // nextFrame ensures the nodeCreated nextTick has settled and onExecuted
@@ -22,18 +22,21 @@ test.describe('Preview3D execution flow', { tag: ['@slow', '@node'] }, () => {
 
     await pipeline.comfyPage.nextFrame()
     await expect(
+      pipeline.comfyPage.page.getByTestId('load3d-error-overlay')
+    ).toBeVisible()
+    await expect(
       pipeline.comfyPage.page.locator('.p-toast-message')
     ).toHaveCount(0)
   })
 
-  test('Preview3D shows no error toast when model file cannot be loaded', async ({
+  test('Preview3D shows inline error and no toast when model file cannot be loaded', async ({
     preview3dPipeline: pipeline
   }) => {
     await pipeline.comfyPage.nextFrame()
 
     // Simulate an execution result pointing to a file that does not exist on
-    // the server. The LoaderManager should swallow the load error silently for
-    // preview nodes (suppressErrors = true).
+    // the server. The LoaderManager emits modelLoadError for preview nodes
+    // (suppressErrors = true) so the error appears inline, not as a toast.
     const responsePromise = pipeline.comfyPage.page.waitForResponse((r) =>
       r.url().includes('nonexistent_preview_model.glb')
     )
@@ -45,6 +48,9 @@ test.describe('Preview3D execution flow', { tag: ['@slow', '@node'] }, () => {
 
     await responsePromise
     await pipeline.comfyPage.nextFrame()
+    await expect(
+      pipeline.comfyPage.page.getByTestId('load3d-error-overlay')
+    ).toBeVisible()
     await expect(
       pipeline.comfyPage.page.locator('.p-toast-message')
     ).toHaveCount(0)

--- a/browser_tests/tests/load3d/preview3dExecution.spec.ts
+++ b/browser_tests/tests/load3d/preview3dExecution.spec.ts
@@ -1,9 +1,55 @@
+import { expect } from '@playwright/test'
+
 import {
   preview3dPipelineTest as test,
   Preview3DPipelineContext
 } from '@e2e/fixtures/helpers/Preview3DPipelineFixture'
 
 test.describe('Preview3D execution flow', { tag: ['@slow', '@node'] }, () => {
+  test('Preview3D shows no error toast when execution output has no model file', async ({
+    preview3dPipeline: pipeline
+  }) => {
+    // nextFrame ensures the nodeCreated nextTick has settled and onExecuted
+    // is wired up before we call it.
+    await pipeline.comfyPage.nextFrame()
+
+    // Simulate onExecuted with an empty result — the scenario that previously
+    // produced a spurious warning toast when filePath was missing.
+    await pipeline.comfyPage.page.evaluate((previewId) => {
+      const node = window.app!.graph.getNodeById(Number(previewId))
+      node?.onExecuted?.({ result: [] })
+    }, Preview3DPipelineContext.previewNodeId)
+
+    await pipeline.comfyPage.nextFrame()
+    await expect(
+      pipeline.comfyPage.page.locator('.p-toast-message')
+    ).toHaveCount(0)
+  })
+
+  test('Preview3D shows no error toast when model file cannot be loaded', async ({
+    preview3dPipeline: pipeline
+  }) => {
+    await pipeline.comfyPage.nextFrame()
+
+    // Simulate an execution result pointing to a file that does not exist on
+    // the server. The LoaderManager should swallow the load error silently for
+    // preview nodes (suppressErrors = true).
+    const responsePromise = pipeline.comfyPage.page.waitForResponse((r) =>
+      r.url().includes('nonexistent_preview_model.glb')
+    )
+
+    await pipeline.comfyPage.page.evaluate((previewId) => {
+      const node = window.app!.graph.getNodeById(Number(previewId))
+      node?.onExecuted?.({ result: ['nonexistent_preview_model.glb'] })
+    }, Preview3DPipelineContext.previewNodeId)
+
+    await responsePromise
+    await pipeline.comfyPage.nextFrame()
+    await expect(
+      pipeline.comfyPage.page.locator('.p-toast-message')
+    ).toHaveCount(0)
+  })
+
   test('Preview3D loads model from execution output', async ({
     preview3dPipeline: pipeline
   }) => {

--- a/browser_tests/tests/load3d/preview3dExecution.spec.ts
+++ b/browser_tests/tests/load3d/preview3dExecution.spec.ts
@@ -9,12 +9,8 @@ test.describe('Preview3D execution flow', { tag: ['@slow', '@node'] }, () => {
   test('Preview3D shows inline error and no toast when execution output has no model file', async ({
     preview3dPipeline: pipeline
   }) => {
-    // nextFrame ensures the nodeCreated nextTick has settled and onExecuted
-    // is wired up before we call it.
     await pipeline.comfyPage.nextFrame()
 
-    // Simulate onExecuted with an empty result — the scenario that previously
-    // produced a spurious warning toast when filePath was missing.
     await pipeline.comfyPage.page.evaluate((previewId) => {
       const node = window.app!.graph.getNodeById(Number(previewId))
       node?.onExecuted?.({ result: [] })
@@ -34,9 +30,6 @@ test.describe('Preview3D execution flow', { tag: ['@slow', '@node'] }, () => {
   }) => {
     await pipeline.comfyPage.nextFrame()
 
-    // Simulate an execution result pointing to a file that does not exist on
-    // the server. The LoaderManager emits modelLoadError for preview nodes
-    // (suppressErrors = true) so the error appears inline, not as a toast.
     const responsePromise = pipeline.comfyPage.page.waitForResponse((r) =>
       r.url().includes('nonexistent_preview_model.glb')
     )

--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -13,6 +13,7 @@
       :cleanup="cleanup"
       :loading="loading"
       :loading-message="loadingMessage"
+      :load-error="loadError"
       :on-model-drop="isPreview ? undefined : handleModelDrop"
       :is-preview="isPreview"
     />
@@ -143,6 +144,7 @@ const {
   // other state
   isRecording,
   isPreview,
+  loadError,
   canFitToViewer,
   canUseGizmo,
   canUseLighting,

--- a/src/components/load3d/Load3DScene.test.ts
+++ b/src/components/load3d/Load3DScene.test.ts
@@ -45,6 +45,7 @@ vi.mock('@/components/common/LoadingOverlay.vue', () => ({
 type RenderOpts = {
   loading?: boolean
   loadingMessage?: string
+  loadError?: string | null
   isPreview?: boolean
   onModelDrop?: (file: File) => void | Promise<void>
   initializeLoad3d?: (container: HTMLElement) => Promise<void>
@@ -62,6 +63,7 @@ function renderComponent(opts: RenderOpts = {}) {
       cleanup,
       loading: opts.loading ?? false,
       loadingMessage: opts.loadingMessage ?? '',
+      loadError: opts.loadError ?? null,
       onModelDrop: opts.onModelDrop,
       isPreview: opts.isPreview ?? false
     }
@@ -149,5 +151,32 @@ describe('Load3DScene', () => {
     await expect(
       dragState.capturedOptions!.onModelDrop!(file)
     ).resolves.toBeUndefined()
+  })
+
+  describe('error overlay', () => {
+    it('shows the error overlay when loadError is set and not loading', () => {
+      renderComponent({ loadError: 'No model received from connected node' })
+
+      expect(screen.getByTestId('load3d-error-overlay')).toBeInTheDocument()
+      expect(
+        screen.getByText('No model received from connected node')
+      ).toBeInTheDocument()
+    })
+
+    it('hides the error overlay when loadError is null', () => {
+      renderComponent({ loadError: null })
+
+      expect(
+        screen.queryByTestId('load3d-error-overlay')
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides the error overlay while loading even if loadError is set', () => {
+      renderComponent({ loadError: 'some error', loading: true })
+
+      expect(
+        screen.queryByTestId('load3d-error-overlay')
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/load3d/Load3DScene.vue
+++ b/src/components/load3d/Load3DScene.vue
@@ -16,6 +16,20 @@
     @drop.prevent.stop="handleDrop"
   >
     <LoadingOverlay :loading="loading" :loading-message="loadingMessage" />
+    <Transition name="fade">
+      <div
+        v-if="loadError && !loading"
+        class="pointer-events-none absolute inset-0 z-40 flex items-center justify-center"
+        data-testid="load3d-error-overlay"
+      >
+        <div
+          class="mx-4 flex items-center gap-2 rounded-lg bg-error/10 px-4 py-3 text-sm text-error"
+        >
+          <i class="pi pi-exclamation-triangle shrink-0" />
+          {{ loadError }}
+        </div>
+      </div>
+    </Transition>
     <div
       v-if="!isPreview && isDragging"
       class="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
@@ -40,6 +54,7 @@ const props = defineProps<{
   cleanup: () => void
   loading: boolean
   loadingMessage: string
+  loadError?: string | null
   onModelDrop?: (file: File) => void | Promise<void>
   isPreview: boolean
 }>()

--- a/src/components/load3d/Load3DScene.vue
+++ b/src/components/load3d/Load3DScene.vue
@@ -19,6 +19,7 @@
     <Transition name="fade">
       <div
         v-if="loadError && !loading"
+        role="alert"
         class="pointer-events-none absolute inset-0 z-40 flex items-center justify-center"
         data-testid="load3d-error-overlay"
       >

--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -755,7 +755,8 @@ describe('useLoad3d', () => {
         'recordingStatusChange',
         'animationListChange',
         'animationProgressChange',
-        'cameraChanged'
+        'cameraChanged',
+        'modelLoadError'
       ]
 
       expectedEvents.forEach((event) => {
@@ -813,6 +814,34 @@ describe('useLoad3d', () => {
       modelLoadingEndHandler?.()
       expect(composable.loading.value).toBe(false)
       expect(composable.loadingMessage.value).toBe('')
+    })
+
+    it('modelLoadError event sets loadError and modelLoadingStart clears it', async () => {
+      let modelLoadErrorHandler: ((msg: string) => void) | undefined
+      let modelLoadingStartHandler: (() => void) | undefined
+
+      vi.mocked(mockLoad3d.addEventListener!).mockImplementation(
+        (event: string, handler: unknown) => {
+          if (event === 'modelLoadError') {
+            modelLoadErrorHandler = handler as (msg: string) => void
+          } else if (event === 'modelLoadingStart') {
+            modelLoadingStartHandler = handler as () => void
+          }
+        }
+      )
+
+      const composable = useLoad3d(mockNode)
+      await composable.initializeLoad3d(document.createElement('div'))
+
+      expect(composable.loadError.value).toBeNull()
+
+      modelLoadErrorHandler?.('No model received from connected node')
+      expect(composable.loadError.value).toBe(
+        'No model received from connected node'
+      )
+
+      modelLoadingStartHandler?.()
+      expect(composable.loadError.value).toBeNull()
     })
 
     it('should handle recordingStatusChange event', async () => {

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -94,6 +94,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   const animationDuration = ref(0)
   const loading = ref(false)
   const loadingMessage = ref('')
+  const loadError = ref<string | null>(null)
   const isPreview = ref(false)
   const isSplatModel = ref(false)
   const isPlyModel = ref(false)
@@ -775,6 +776,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     modelLoadingStart: () => {
       loadingMessage.value = t('load3d.loadingModel')
       loading.value = true
+      loadError.value = null
       if (!isFirstModelLoad) {
         modelConfig.value = {
           upDirection: 'original',
@@ -883,6 +885,9 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         modelConfig.value.gizmo.enabled = data.enabled
         modelConfig.value.gizmo.mode = data.mode
       }
+    },
+    modelLoadError: (message: string) => {
+      loadError.value = message
     }
   } as const
 
@@ -943,6 +948,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     lightConfig,
     isRecording,
     isPreview,
+    loadError,
     isSplatModel,
     isPlyModel,
     canFitToViewer,

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -132,6 +132,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
                 height: heightWidget.value as number
               })
             : undefined,
+        suppressLoadErrors: isPreview.value,
         onContextMenu: (event) => {
           const menuOptions = app.canvas.getNodeMenuOptions(node)
           new LiteGraph.ContextMenu(menuOptions, {

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -510,9 +510,7 @@ useExtensionService().registerExtension({
           const filePath = result?.[0]
 
           if (!filePath) {
-            const msg = t('toastMessages.unableToGetModelFilePath')
-            console.error(msg)
-            useToastStore().addAlert(msg)
+            console.error(t('toastMessages.unableToGetModelFilePath'))
           }
 
           const cameraState = result?.[1]

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -511,6 +511,10 @@ useExtensionService().registerExtension({
 
           if (!filePath) {
             console.error(t('toastMessages.unableToGetModelFilePath'))
+            load3d.eventManager.emitEvent(
+              'modelLoadError',
+              t('load3d.noModelReceived')
+            )
           }
 
           const cameraState = result?.[1]

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -521,6 +521,26 @@ describe('LoaderManager', () => {
       expect(capturedCtx!.materialMode).toBe('wireframe')
     })
 
+    it('does not show a toast when suppressErrors is true and the adapter throws', async () => {
+      const modelManager = makeModelManagerStub()
+      const eventManager = makeEventManagerStub()
+      const lm = new LoaderManager(
+        modelManager as unknown as ConstructorParameters<
+          typeof LoaderManager
+        >[0],
+        eventManager,
+        undefined,
+        undefined,
+        true
+      )
+      meshLoad.mockRejectedValueOnce(new Error('boom'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb')
+
+      expect(addAlert).not.toHaveBeenCalled()
+    })
+
     it('suppresses alerts and modelLoadingEnd when a stale load throws', async () => {
       const { lm, eventManager } = makeLoaderManager()
 

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -574,6 +574,10 @@ describe('LoaderManager', () => {
         'modelLoadError',
         expect.any(String)
       )
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
     })
 
     it('suppresses alerts and modelLoadingEnd when a stale load throws', async () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -333,19 +333,23 @@ describe('LoaderManager', () => {
       expect(modelManager.originalFileName).toBe('model')
     })
 
-    it('alerts when the file extension cannot be determined', async () => {
-      const { lm, modelManager } = makeLoaderManager()
+    it('alerts and emits modelLoadingEnd when the file extension cannot be determined', async () => {
+      const { lm, modelManager, eventManager } = makeLoaderManager()
 
       await lm.loadModel('api/view?other=1')
 
       expect(addAlert).toHaveBeenCalledWith(
         'toastMessages.couldNotDetermineFileType'
       )
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
+      )
       expect(modelManager.setupModel).not.toHaveBeenCalled()
       expect(meshLoad).not.toHaveBeenCalled()
     })
 
-    it('emits modelLoadError and skips toast when suppressErrors is true and extension cannot be determined', async () => {
+    it('emits modelLoadError and modelLoadingEnd (no toast) when suppressErrors is true and extension cannot be determined', async () => {
       const modelManager = makeModelManagerStub()
       const eventManager = makeEventManagerStub()
       const lm = new LoaderManager(
@@ -364,6 +368,10 @@ describe('LoaderManager', () => {
       expect(eventManager.emitEvent).toHaveBeenCalledWith(
         'modelLoadError',
         'toastMessages.couldNotDetermineFileType'
+      )
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadingEnd',
+        null
       )
       expect(modelManager.setupModel).not.toHaveBeenCalled()
     })

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -521,7 +521,7 @@ describe('LoaderManager', () => {
       expect(capturedCtx!.materialMode).toBe('wireframe')
     })
 
-    it('does not show a toast when suppressErrors is true and the adapter throws', async () => {
+    it('emits modelLoadError and skips toast when suppressErrors is true and the adapter throws', async () => {
       const modelManager = makeModelManagerStub()
       const eventManager = makeEventManagerStub()
       const lm = new LoaderManager(
@@ -539,6 +539,10 @@ describe('LoaderManager', () => {
       await lm.loadModel('api/view?filename=cube.glb')
 
       expect(addAlert).not.toHaveBeenCalled()
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadError',
+        expect.any(String)
+      )
     })
 
     it('suppresses alerts and modelLoadingEnd when a stale load throws', async () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -345,6 +345,29 @@ describe('LoaderManager', () => {
       expect(meshLoad).not.toHaveBeenCalled()
     })
 
+    it('emits modelLoadError and skips toast when suppressErrors is true and extension cannot be determined', async () => {
+      const modelManager = makeModelManagerStub()
+      const eventManager = makeEventManagerStub()
+      const lm = new LoaderManager(
+        modelManager as unknown as ConstructorParameters<
+          typeof LoaderManager
+        >[0],
+        eventManager,
+        undefined,
+        undefined,
+        true
+      )
+
+      await lm.loadModel('api/view?other=1')
+
+      expect(addAlert).not.toHaveBeenCalled()
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'modelLoadError',
+        'toastMessages.couldNotDetermineFileType'
+      )
+      expect(modelManager.setupModel).not.toHaveBeenCalled()
+    })
+
     it('passes setupModel the object returned by the adapter', async () => {
       const { lm, modelManager } = makeLoaderManager()
       const loaded = new THREE.Object3D()

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -82,14 +82,13 @@ export class LoaderManager implements LoaderManagerInterface {
       }
 
       if (!fileExtension) {
+        const message = t('toastMessages.couldNotDetermineFileType')
         if (this.suppressErrors) {
-          this.eventManager.emitEvent(
-            'modelLoadError',
-            t('toastMessages.couldNotDetermineFileType')
-          )
+          this.eventManager.emitEvent('modelLoadError', message)
         } else {
-          useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
+          useToastStore().addAlert(message)
         }
+        this.eventManager.emitEvent('modelLoadingEnd', null)
         return
       }
 

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -108,7 +108,12 @@ export class LoaderManager implements LoaderManagerInterface {
       if (loadId === this.currentLoadId) {
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
-        if (!this.suppressErrors) {
+        if (this.suppressErrors) {
+          this.eventManager.emitEvent(
+            'modelLoadError',
+            t('toastMessages.errorLoadingModel')
+          )
+        } else {
           useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
         }
       }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -31,18 +31,21 @@ export class LoaderManager implements LoaderManagerInterface {
   private readonly eventManager: EventManagerInterface
   private readonly adapters: ModelAdapter[]
   private readonly adapterRef: AdapterRef
+  private readonly suppressErrors: boolean
   private currentLoadId: number = 0
 
   constructor(
     modelManager: ModelManagerInterface,
     eventManager: EventManagerInterface,
     adapters?: readonly ModelAdapter[],
-    adapterRef?: AdapterRef
+    adapterRef?: AdapterRef,
+    suppressErrors: boolean = false
   ) {
     this.modelManager = modelManager
     this.eventManager = eventManager
     this.adapters = adapters ? [...adapters] : defaultAdapters()
     this.adapterRef = adapterRef ?? createAdapterRef()
+    this.suppressErrors = suppressErrors
   }
 
   getCurrentAdapter(): ModelAdapter | null {
@@ -105,7 +108,9 @@ export class LoaderManager implements LoaderManagerInterface {
       if (loadId === this.currentLoadId) {
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
-        useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
+        if (!this.suppressErrors) {
+          useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
+        }
       }
     }
   }

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -82,7 +82,14 @@ export class LoaderManager implements LoaderManagerInterface {
       }
 
       if (!fileExtension) {
-        useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
+        if (this.suppressErrors) {
+          this.eventManager.emitEvent(
+            'modelLoadError',
+            t('toastMessages.couldNotDetermineFileType')
+          )
+        } else {
+          useToastStore().addAlert(t('toastMessages.couldNotDetermineFileType'))
+        }
         return
       }
 

--- a/src/extensions/core/load3d/createLoad3d.ts
+++ b/src/extensions/core/load3d/createLoad3d.ts
@@ -34,7 +34,10 @@ function createRenderer(container: Element | HTMLElement): THREE.WebGLRenderer {
   return renderer
 }
 
-function buildLoad3dDeps(container: Element | HTMLElement): Load3dDeps {
+function buildLoad3dDeps(
+  container: Element | HTMLElement,
+  options?: Load3DOptions
+): Load3dDeps {
   const renderer = createRenderer(container)
   const eventManager = new EventManager()
   // Shared mutable handle: LoaderManager writes the active adapter on each
@@ -94,7 +97,8 @@ function buildLoad3dDeps(container: Element | HTMLElement): Load3dDeps {
     modelManager,
     eventManager,
     undefined,
-    adapterRef
+    adapterRef,
+    options?.suppressLoadErrors ?? false
   )
   const recordingManager = new RecordingManager(
     sceneManager.scene,
@@ -140,5 +144,5 @@ export function createLoad3d(
   container: Element | HTMLElement,
   options?: Load3DOptions
 ): Load3d {
-  return new Load3d(container, buildLoad3dDeps(container), options)
+  return new Load3d(container, buildLoad3dDeps(container, options), options)
 }

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -82,6 +82,9 @@ export interface Load3DOptions {
 
   // Optional context menu callback
   onContextMenu?: (event: MouseEvent) => void
+
+  // Suppress model-load error toasts (e.g. for preview nodes that don't own their model file)
+  suppressLoadErrors?: boolean
 }
 
 export interface CaptureResult {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1951,6 +1951,7 @@
     "tiledMode": "Tiled",
     "panoramaMode": "Panorama",
     "loadingModel": "Loading 3D Model...",
+    "noModelReceived": "No model received from connected node",
     "upDirection": "Up Direction",
     "materialMode": "Material Mode",
     "showSkeleton": "Show Skeleton",


### PR DESCRIPTION
## Summary

Preview3D nodes do not own their model file — the file is produced by a connected Load3D node at execution time. When execution produced no output, or when the model URL was unreachable, the node incorrectly showed an error toast that confused users.

## Changes

- Add `suppressLoadErrors` option to `Load3DOptions` and `LoaderManager` constructor; preview nodes pass `suppressErrors: true` so load failures are swallowed silently
- Remove `useToastStore().addAlert()` in the `onExecuted` callback when `filePath` is absent (now console-only)
- Wire `suppressLoadErrors: isPreview.value` through `createLoad3d` → `buildLoad3dDeps` → `LoaderManager`
- Add unit test for suppressed-error path in `LoaderManager`
- Add two E2E tests in `preview3dExecution.spec.ts` verifying no toast appears when `onExecuted` fires with an empty result or a nonexistent model file

## Analysis
https://linear.app/comfyorg/issue/FE-409/bug-disable-warning-popup-for-preview-3d-node




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-propagation paths for 3D model loading and Preview3D execution, which could affect how load failures are surfaced or cleared during concurrent loads. No auth/data persistence impact, but touches shared loader/event flow and user-visible UI feedback.
> 
> **Overview**
> Preview3D model-load failures are no longer surfaced as toast alerts; instead, preview nodes suppress loader toasts via a new `suppressLoadErrors` option wired through `createLoad3d`/`LoaderManager` and emit a `modelLoadError` event.
> 
> The Load3D UI now displays an inline error overlay (`load3d-error-overlay`) driven by a new `loadError` state in `useLoad3d`, which is cleared on `modelLoadingStart` and set via the new `modelLoadError` event. Tests were added/updated (unit + E2E) to assert the no-toast behavior and the inline error overlay for missing/unloadable preview outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99890d7d94eb803ab484b380b9cd2e1c508da997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11767-fix-suppress-Preview3D-model-load-error-toasts-3516d73d36508103acafc4c08ed7fee9) by [Unito](https://www.unito.io)
