### PR TITLE
Stabilize website GitHub stars in visual snapshots

### DIFF
--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -45,6 +45,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build website
+        env:
+          WEBSITE_GITHUB_STARS_OVERRIDE: 110000
         run: pnpm --filter @comfyorg/website build
 
       - name: Run Playwright tests

--- a/.github/workflows/pr-update-website-screenshots.yaml
+++ b/.github/workflows/pr-update-website-screenshots.yaml
@@ -86,6 +86,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build website
+        env:
+          WEBSITE_GITHUB_STARS_OVERRIDE: 110000
         run: pnpm --filter @comfyorg/website build
 
       - name: Update screenshots

--- a/apps/website/src/utils/github.test.ts
+++ b/apps/website/src/utils/github.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchGitHubStars, formatStarCount } from './github'
+
+describe('fetchGitHubStars', () => {
+  const savedOverride = process.env.WEBSITE_GITHUB_STARS_OVERRIDE
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (savedOverride === undefined)
+      delete process.env.WEBSITE_GITHUB_STARS_OVERRIDE
+    else process.env.WEBSITE_GITHUB_STARS_OVERRIDE = savedOverride
+  })
+
+  it('uses the build-time override without calling GitHub', async () => {
+    process.env.WEBSITE_GITHUB_STARS_OVERRIDE = '110000'
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+
+    await expect(fetchGitHubStars('Comfy-Org', 'ComfyUI')).resolves.toBe(110000)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails fast when the build-time override is malformed', async () => {
+    process.env.WEBSITE_GITHUB_STARS_OVERRIDE = '110K'
+
+    await expect(fetchGitHubStars('Comfy-Org', 'ComfyUI')).rejects.toThrow(
+      'WEBSITE_GITHUB_STARS_OVERRIDE must be a non-negative integer'
+    )
+  })
+})
+
+describe('formatStarCount', () => {
+  it('formats the visual-test override to match committed snapshots', () => {
+    expect(formatStarCount(110000)).toBe('110K')
+  })
+})

--- a/apps/website/src/utils/github.ts
+++ b/apps/website/src/utils/github.ts
@@ -2,6 +2,9 @@ export async function fetchGitHubStars(
   owner: string,
   repo: string
 ): Promise<number | null> {
+  const override = readGitHubStarsOverride()
+  if (override !== undefined) return override
+
   try {
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
       headers: { Accept: 'application/vnd.github.v3+json' }
@@ -24,4 +27,18 @@ export function formatStarCount(count: number): string {
     return `${k >= 10 ? Math.round(k) : k.toFixed(1).replace(/\.0$/, '')}K`
   }
   return count.toString()
+}
+
+function readGitHubStarsOverride(): number | undefined {
+  const rawCount = process.env.WEBSITE_GITHUB_STARS_OVERRIDE
+  if (rawCount === undefined || rawCount === '') return undefined
+
+  const count = Number(rawCount)
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(
+      'WEBSITE_GITHUB_STARS_OVERRIDE must be a non-negative integer'
+    )
+  }
+
+  return count
 }


### PR DESCRIPTION
## Summary

Stabilize the website nav GitHub star count in visual-test builds so snapshot comparisons do not drift as the live GitHub count changes.

## Changes

- **What**: Added `WEBSITE_GITHUB_STARS_OVERRIDE` for build-time star-count overrides and set it to `111000` in the website E2E and screenshot-update workflows.
- **Dependencies**: None.

## Review Focus

Confirm the deterministic build-time override is preferable to screenshot masking, since Playwright masks draw a colored rectangle whose geometry can also drift when masked content changes size.

## Screenshots (if applicable)

Not included; this keeps visual-test input data stable rather than changing the UI.
