### PR TITLE
test: reset queue history cap in browser tests

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -505,6 +505,7 @@ export const comfyPageFixture = base.extend<{
         'Comfy.userId': userId,
         // Set tutorial completed to true to avoid loading the tutorial workflow.
         'Comfy.TutorialCompleted': true,
+        'Comfy.Queue.MaxHistoryItems': 64,
         'Comfy.SnapToGrid.GridSize': testComfySnapToGridGridSize,
         'Comfy.VueNodes.AutoScaleLayout': false,
         // Disable toast warning about version compatibility, as they may or

--- a/browser_tests/tests/queue/queueSettings.spec.ts
+++ b/browser_tests/tests/queue/queueSettings.spec.ts
@@ -15,6 +15,7 @@ import { webSocketFixture } from '@e2e/fixtures/ws'
 const test = mergeTests(comfyPageFixture, webSocketFixture)
 
 const TOTAL_MOCK_JOBS = 20
+const MAX_HISTORY_ITEMS_SETTING = 'Comfy.Queue.MaxHistoryItems'
 const overflowJobsListRoutePattern = '**/api/jobs?*'
 
 function isHistoryJobsRequest(url: string): boolean {
@@ -59,7 +60,7 @@ test.describe('Queue settings', { tag: '@canvas' }, () => {
       }) => {
         const TARGET_LIMIT = 6
         await comfyPage.settings.setSetting(
-          'Comfy.Queue.MaxHistoryItems',
+          MAX_HISTORY_ITEMS_SETTING,
           TARGET_LIMIT
         )
 
@@ -106,7 +107,7 @@ test.describe('Queue settings', { tag: '@canvas' }, () => {
 
       const VISIBLE_LIMIT = 6
       await comfyPage.settings.setSetting(
-        'Comfy.Queue.MaxHistoryItems',
+        MAX_HISTORY_ITEMS_SETTING,
         VISIBLE_LIMIT
       )
       const exec = new ExecutionHelper(comfyPage, await getWebSocket())


### PR DESCRIPTION
## Summary
- Reset `Comfy.Queue.MaxHistoryItems` in the shared browser-test `comfyPage` setup so worker-persisted queue settings cannot leak between tests.
- Keep the queue settings spec focused on asserting the setting behavior without local cleanup scaffolding.

## Validation
- `PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://127.0.0.1:65419 PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:65400 TEST_COMFYUI_DIR=/Users/ben/.codex/comfyui-preview-env/runtime/worktrees/fe-500-maxhistoryitems pnpm exec playwright test browser_tests/tests/queue/queueSettings.spec.ts --project=chromium --workers=1`
- `pnpm exec eslint browser_tests/tests/queue/queueSettings.spec.ts browser_tests/fixtures/ComfyPage.ts`
- `pnpm exec oxlint browser_tests/tests/queue/queueSettings.spec.ts browser_tests/fixtures/ComfyPage.ts`
- `pnpm typecheck:browser`
- `git diff --check`
- commit hook: staged oxfmt, oxlint, eslint, `pnpm typecheck`, `pnpm typecheck:browser`

Linear: FE-500