### PR TITLE
docs: prefer real createI18n over mocking vue-i18n in tests

### DIFF
--- a/docs/testing/unit-testing.md
+++ b/docs/testing/unit-testing.md
@@ -257,6 +257,8 @@ it('should validate node definition', () => {
 
 ## Mocking Composables with Reactive State
 
+> **Don't mock `vue-i18n`.** Mount with a real `createI18n` plugin instance instead — see [Don't Mock `vue-i18n` in `vitest-patterns.md`](./vitest-patterns.md#dont-mock-vue-i18n--use-a-real-plugin). This section applies to composables you own.
+
 When mocking composables that return reactive refs, define the mock implementation inline in `vi.mock()`'s factory function. This ensures stable singleton instances across all test invocations.
 
 ### Rules

--- a/docs/testing/vitest-patterns.md
+++ b/docs/testing/vitest-patterns.md
@@ -30,9 +30,42 @@ describe('MyStore', () => {
 
 **Why `stubActions: false`?** By default, testing pinia stubs all actions. Set to `false` when testing actual store behavior.
 
-## i18n in Component Tests
+## Don't Mock `vue-i18n` — Use a Real Plugin
 
-Use real `createI18n` with empty messages instead of mocking `vue-i18n`. See `SearchBox.test.ts` for example.
+Mount with a real `createI18n` instance instead of mocking `vue-i18n`. The plugin is cheap, owned by a third party (don't mock what you don't own), and a real instance exercises the same translation key resolution and pluralization logic that production uses.
+
+This applies to **all tests** that touch a component or composable calling `useI18n()` — not just component tests.
+
+```typescript
+import { createI18n } from 'vue-i18n'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} } // empty — assertions key off the translation key, not the rendered string
+})
+
+// Component tests: pass via global plugins
+mount(MyComponent, { global: { plugins: [i18n] } })
+
+// Composable tests: provide via a host component (see useMediaAssetActions.test.ts pattern)
+const app = createApp(HostComponent)
+app.use(i18n)
+```
+
+Real example: [`src/components/searchbox/v2/__test__/testUtils.ts`](../../src/components/searchbox/v2/__test__/testUtils.ts) exports a shared `testI18n` instance.
+
+### Asserting on translation keys
+
+With empty messages, `t('foo.bar')` returns `'foo.bar'` (the key). Assert against the key directly — no need to mock `t`:
+
+```typescript
+expect(toastSpy).toHaveBeenCalledWith(
+  expect.objectContaining({ detail: 'mediaAsset.selection.exportStarted' })
+)
+```
+
+For pluralization / interpolation arguments, spy on the consumer (e.g. the toast `add` fn) and inspect the captured payload, rather than spying on `t` itself.
 
 ## Mock Patterns
 


### PR DESCRIPTION
## Summary

Document that `vue-i18n` should not be mocked in tests — mount with a real `createI18n` plugin instance instead.

## Changes

- **What**: Expanded `docs/testing/vitest-patterns.md` "Don't Mock `vue-i18n`" section with a concrete code example (covering both component and composable tests), guidance for asserting on translation keys with empty messages, and a real-example link to `src/components/searchbox/v2/__test__/testUtils.ts`. Added a callout at the top of `docs/testing/unit-testing.md` "Mocking Composables with Reactive State" cross-linking the new section, since that section applies to *owned* composables.

## Review Focus

- The previous `vitest-patterns.md` paragraph pointed at a non-existent `SearchBox.test.ts`; the new link points to the actual shared `testI18n` helper.
- The "Mocking Composables with Reactive State" pattern should not be applied to third-party composables like `useI18n` — the callout makes that explicit.

Surfaced during review of #11737, where the test file mocked `vue-i18n` and then accumulated structural workarounds (hoisted aliases, helper functions, type casts) to interact with the mocked `t`. A real `createI18n` instance avoids the entire ceremony.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11776-docs-prefer-real-createI18n-over-mocking-vue-i18n-in-tests-3526d73d365081d4bc39fbf3c2502e49) by [Unito](https://www.unito.io)
