### PR TITLE
fix: hide advanced footer button on collapsed Vue nodes

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts
@@ -2,6 +2,10 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+
+const SHOW_ADVANCED_INPUTS = 'Show advanced inputs'
+const HIDE_ADVANCED_INPUTS = 'Hide advanced inputs'
 
 test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -20,15 +24,11 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
     await comfyPage.vueNodes.waitForNodes()
   })
 
-  function getNode(
-    comfyPage: Parameters<Parameters<typeof test>[2]>[0]['comfyPage']
-  ) {
+  function getNode(comfyPage: ComfyPage) {
     return comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
   }
 
-  function getWidgets(
-    comfyPage: Parameters<Parameters<typeof test>[2]>[0]['comfyPage']
-  ) {
+  function getWidgets(comfyPage: ComfyPage) {
     return getNode(comfyPage).locator('.lg-node-widget')
   }
 
@@ -46,7 +46,7 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
     await expect(node.getByLabel('base_shift', { exact: true })).toBeHidden()
 
     // "Show advanced inputs" button should be present
-    await expect(node.getByText('Show advanced inputs')).toBeVisible()
+    await expect(node.getByText(SHOW_ADVANCED_INPUTS)).toBeVisible()
   })
 
   test('should show advanced widgets when per-node toggle is clicked', async ({
@@ -58,18 +58,39 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
     await expect(widgets).toHaveCount(2)
 
     // Click the toggle button to show advanced widgets
-    await node.getByText('Show advanced inputs').click()
+    await node.getByText(SHOW_ADVANCED_INPUTS).click()
 
     await expect(widgets).toHaveCount(4)
     await expect(node.getByLabel('max_shift', { exact: true })).toBeVisible()
     await expect(node.getByLabel('base_shift', { exact: true })).toBeVisible()
 
     // Button text should change to "Hide advanced inputs"
-    await expect(node.getByText('Hide advanced inputs')).toBeVisible()
+    await expect(node.getByText(HIDE_ADVANCED_INPUTS)).toBeVisible()
 
     // Click again to hide
-    await node.getByText('Hide advanced inputs').click()
+    await node.getByText(HIDE_ADVANCED_INPUTS).click()
     await expect(widgets).toHaveCount(2)
+  })
+
+  test('should hide advanced footer button while collapsed', async ({
+    comfyPage
+  }) => {
+    const node = getNode(comfyPage)
+    const showAdvancedButton = node.getByText(SHOW_ADVANCED_INPUTS)
+    const vueNode =
+      await comfyPage.vueNodes.getFixtureByTitle('ModelSamplingFlux')
+
+    await expect(showAdvancedButton).toBeVisible()
+
+    await vueNode.toggleCollapse()
+    await comfyPage.nextFrame()
+
+    await expect(showAdvancedButton).toBeHidden()
+
+    await vueNode.toggleCollapse()
+    await comfyPage.nextFrame()
+
+    await expect(showAdvancedButton).toBeVisible()
   })
 
   test('should show advanced widgets when global setting is enabled', async ({
@@ -92,6 +113,6 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
     await expect(node.getByLabel('base_shift', { exact: true })).toBeVisible()
 
     // The toggle button should not be shown when global setting is active
-    await expect(node.getByText('Show advanced inputs')).toBeHidden()
+    await expect(node.getByText(SHOW_ADVANCED_INPUTS)).toBeHidden()
   })
 })

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -120,6 +120,7 @@ const i18n = createI18n({
         error: 'Error'
       },
       rightSidePanel: {
+        showAdvancedShort: 'Show Advanced',
         showAdvancedInputsButton: 'Show Advanced Inputs'
       },
       'Node Render Error': 'Node Render Error'
@@ -285,7 +286,9 @@ describe('LGraphNode', () => {
       }
     })
 
-    expect(screen.queryByText('Show Advanced Inputs')).toBeNull()
+    expect(
+      screen.queryByRole('button', { name: /show advanced/i })
+    ).not.toBeInTheDocument()
   })
 
   it('should show error-only footer for collapsed nodes with advanced widgets', () => {
@@ -304,8 +307,10 @@ describe('LGraphNode', () => {
       }
     })
 
-    expect(screen.getByText('Error')).toBeTruthy()
-    expect(screen.queryByText(/show advanced/i)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Error' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /show advanced/i })
+    ).not.toBeInTheDocument()
   })
 
   describe('Reroute node sizing', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -11,6 +11,7 @@ import { TitleMode } from '@/lib/litegraph/src/types/globalEnums'
 import LGraphNode from '@/renderer/extensions/vueNodes/components/LGraphNode.vue'
 import { useVueElementTracking } from '@/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { app } from '@/scripts/app'
 
 const mockData = vi.hoisted(() => ({
@@ -115,6 +116,12 @@ const i18n = createI18n({
   locale: 'en',
   messages: {
     en: {
+      g: {
+        error: 'Error'
+      },
+      rightSidePanel: {
+        showAdvancedInputsButton: 'Show Advanced Inputs'
+      },
       'Node Render Error': 'Node Render Error'
     }
   }
@@ -172,6 +179,12 @@ describe('LGraphNode', () => {
     setActivePinia(pinia)
     const canvasStore = useCanvasStore()
     canvasStore.selectedNodeIds.clear()
+    const settingStore = useSettingStore(pinia)
+    vi.mocked(settingStore.get).mockImplementation((key) => {
+      if (key === 'Comfy.RightSidePanel.ShowErrorsTab') return true
+      if (key === 'Comfy.Node.AlwaysShowAdvancedWidgets') return false
+      if (key === 'Comfy.Node.Opacity') return 1
+    })
   })
 
   it('should call resize tracking composable with node ID', () => {
@@ -255,6 +268,44 @@ describe('LGraphNode', () => {
 
     expect(root.style.getPropertyValue('--node-height')).toBe('130px')
     expect(root.style.getPropertyValue('--node-height-x')).toBe('')
+  })
+
+  it('should hide advanced footer button while the node is collapsed', () => {
+    renderLGraphNode({
+      nodeData: {
+        ...mockNodeData,
+        flags: { collapsed: true },
+        widgets: [
+          {
+            name: 'advancedWidget',
+            type: 'number',
+            options: { advanced: true }
+          }
+        ]
+      }
+    })
+
+    expect(screen.queryByText('Show Advanced Inputs')).toBeNull()
+  })
+
+  it('should show error-only footer for collapsed nodes with advanced widgets', () => {
+    renderLGraphNode({
+      nodeData: {
+        ...mockNodeData,
+        flags: { collapsed: true },
+        hasErrors: true,
+        widgets: [
+          {
+            name: 'advancedWidget',
+            type: 'number',
+            options: { advanced: true }
+          }
+        ]
+      }
+    })
+
+    expect(screen.getByText('Error')).toBeTruthy()
+    expect(screen.queryByText('Show Advanced')).toBeNull()
   })
 
   describe('Reroute node sizing', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -305,7 +305,7 @@ describe('LGraphNode', () => {
     })
 
     expect(screen.getByText('Error')).toBeTruthy()
-    expect(screen.queryByText('Show Advanced')).toBeNull()
+    expect(screen.queryByText(/show advanced/i)).toBeNull()
   })
 
   describe('Reroute node sizing', () => {

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -723,6 +723,7 @@ useGLSLPreview(lgraphNode)
 const showAdvancedInputsButton = computed(() => {
   const node = lgraphNode.value
   if (!node) return false
+  if (isCollapsed.value) return false
 
   // For subgraph nodes: check for unpromoted widgets
   if (node instanceof SubgraphNode) {


### PR DESCRIPTION
Before 

https://github.com/user-attachments/assets/82e323d7-0c9b-4303-81eb-87cb7b62f1c1


After 

https://github.com/user-attachments/assets/56f1db45-1b5d-47a9-9960-9a73deb68e78

Fixes the Vue node footer so the Advanced button only appears while a node is expanded.

Root cause: `showAdvancedInputsButton` only checked for advanced widgets and the global setting, so collapsed nodes with advanced widgets could still render the Advanced tab, including the combined error + advanced footer state.

Changes:
- Return `false` for advanced footer visibility when the Vue node is collapsed.
- Add regression coverage for collapsed advanced nodes and collapsed error + advanced nodes.

Validation:
- `pnpm test:unit -- src/renderer/extensions/vueNodes/components/LGraphNode.test.ts`
- Commit hook: format, stylelint, oxlint, eslint, `pnpm typecheck`
- Push hook: `pnpm knip`

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11778-codex-Hide-advanced-footer-on-collapsed-Vue-nodes-3526d73d365081d79399ddda40f2a7f7) by [Unito](https://www.unito.io)
