### PR TITLE
refactor: extract GPU lifecycle into useGPUResources (phase D)

### DIFF
--- a/src/composables/maskeditor/gpuUtils.test.ts
+++ b/src/composables/maskeditor/gpuUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { clampDirtyRect } from './gpuUtils'
+import { buildStrokePoints, clampDirtyRect } from './gpuUtils'
 
 const uninit = {
   minX: Infinity,
@@ -66,5 +66,59 @@ describe('clampDirtyRect', () => {
     expect(result.dy).toBe(20)
     expect(result.dw).toBe(60 - 10) // ceil(59.2)=60, dx=10
     expect(result.dh).toBe(90 - 20) // ceil(89.9)=90, dy=20
+  })
+})
+
+describe('buildStrokePoints', () => {
+  it('returns input points as-is when skipResampling is true', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 100, y: 100 }
+    ]
+    const result = buildStrokePoints(points, true, 10)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ x: 0, y: 0, pressure: 1.0 })
+    expect(result[1]).toEqual({ x: 100, y: 100, pressure: 1.0 })
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(buildStrokePoints([], false, 10)).toHaveLength(0)
+    expect(buildStrokePoints([], true, 10)).toHaveLength(0)
+  })
+
+  it('returns empty array for a single point (no segments to interpolate)', () => {
+    expect(buildStrokePoints([{ x: 5, y: 5 }], false, 10)).toHaveLength(0)
+  })
+
+  it('interpolates a horizontal segment into multiple evenly-spaced points', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 30, y: 0 }
+    ]
+    const result = buildStrokePoints(points, false, 10)
+    // 30px distance / 10 stepSize = 3 steps → 4 points (s=0,1,2,3)
+    expect(result).toHaveLength(4)
+    expect(result[0]).toMatchObject({ x: 0, y: 0 })
+    expect(result[3]).toMatchObject({ x: 30, y: 0 })
+    result.forEach((p) => expect(p.pressure).toBe(1.0))
+  })
+
+  it('uses at least one step when points are very close together', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 0.1, y: 0 }
+    ]
+    // distance 0.1 < stepSize 10 → steps=1 → 2 points
+    const result = buildStrokePoints(points, false, 10)
+    expect(result).toHaveLength(2)
+  })
+
+  it('interpolates all pressure values to 1.0', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 50, y: 50 }
+    ]
+    const result = buildStrokePoints(points, false, 10)
+    result.forEach((p) => expect(p.pressure).toBe(1.0))
   })
 })

--- a/src/composables/maskeditor/gpuUtils.test.ts
+++ b/src/composables/maskeditor/gpuUtils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampDirtyRect } from './gpuUtils'
+
+const uninit = {
+  minX: Infinity,
+  minY: Infinity,
+  maxX: -Infinity,
+  maxY: -Infinity
+}
+
+describe('clampDirtyRect', () => {
+  it('returns full canvas when dirty rect is uninitialised', () => {
+    expect(clampDirtyRect(uninit, 100, 200)).toEqual({
+      dx: 0,
+      dy: 0,
+      dw: 100,
+      dh: 200
+    })
+  })
+
+  it('returns the clamped rect when fully inside canvas bounds', () => {
+    const rect = { minX: 10, minY: 20, maxX: 60, maxY: 90 }
+    expect(clampDirtyRect(rect, 100, 200)).toEqual({
+      dx: 10,
+      dy: 20,
+      dw: 50,
+      dh: 70
+    })
+  })
+
+  it('clamps rect that extends beyond canvas edges', () => {
+    const rect = { minX: -5, minY: -10, maxX: 120, maxY: 250 }
+    expect(clampDirtyRect(rect, 100, 200)).toEqual({
+      dx: 0,
+      dy: 0,
+      dw: 100,
+      dh: 200
+    })
+  })
+
+  it('returns full canvas when the clamped area has zero width', () => {
+    const rect = { minX: 50, minY: 10, maxX: 50, maxY: 80 }
+    expect(clampDirtyRect(rect, 100, 200)).toEqual({
+      dx: 0,
+      dy: 0,
+      dw: 100,
+      dh: 200
+    })
+  })
+
+  it('returns full canvas when the clamped area has zero height', () => {
+    const rect = { minX: 10, minY: 50, maxX: 80, maxY: 50 }
+    expect(clampDirtyRect(rect, 100, 200)).toEqual({
+      dx: 0,
+      dy: 0,
+      dw: 100,
+      dh: 200
+    })
+  })
+
+  it('floors dx/dy and ceils the far edges', () => {
+    const rect = { minX: 10.7, minY: 20.3, maxX: 59.2, maxY: 89.9 }
+    const result = clampDirtyRect(rect, 100, 200)
+    expect(result.dx).toBe(10)
+    expect(result.dy).toBe(20)
+    expect(result.dw).toBe(60 - 10) // ceil(59.2)=60, dx=10
+    expect(result.dh).toBe(90 - 20) // ceil(89.9)=90, dy=20
+  })
+})

--- a/src/composables/maskeditor/gpuUtils.ts
+++ b/src/composables/maskeditor/gpuUtils.ts
@@ -1,0 +1,23 @@
+import type { DirtyRect } from './brushDrawingUtils'
+
+/**
+ * Computes the clamped dirty-rect coordinates for a putImageData call.
+ *
+ * Returns the full canvas dimensions when the dirty rect is uninitialised
+ * (Infinity sentinels) or the resulting area has zero/negative size.
+ */
+export function clampDirtyRect(
+  rect: DirtyRect,
+  canvasWidth: number,
+  canvasHeight: number
+): { dx: number; dy: number; dw: number; dh: number } {
+  const full = { dx: 0, dy: 0, dw: canvasWidth, dh: canvasHeight }
+  if (rect.minX === Infinity || rect.maxX === -Infinity) return full
+
+  const dx = Math.floor(Math.max(0, rect.minX))
+  const dy = Math.floor(Math.max(0, rect.minY))
+  const dw = Math.ceil(Math.min(canvasWidth, rect.maxX)) - dx
+  const dh = Math.ceil(Math.min(canvasHeight, rect.maxY)) - dy
+
+  return dw > 0 && dh > 0 ? { dx, dy, dw, dh } : full
+}

--- a/src/composables/maskeditor/gpuUtils.ts
+++ b/src/composables/maskeditor/gpuUtils.ts
@@ -1,3 +1,5 @@
+import type { Point } from '@/extensions/core/maskeditor/types'
+
 import type { DirtyRect } from './brushDrawingUtils'
 
 /**
@@ -20,4 +22,39 @@ export function clampDirtyRect(
   const dh = Math.ceil(Math.min(canvasHeight, rect.maxY)) - dy
 
   return dw > 0 && dh > 0 ? { dx, dy, dw, dh } : full
+}
+
+/**
+ * Linearly interpolates a sequence of points at a fixed step size,
+ * returning GPU-ready stroke points with pressure=1.
+ *
+ * When skipResampling is true the input points are returned as-is (used
+ * during live preview where the caller has already handled spacing).
+ */
+export function buildStrokePoints(
+  points: Point[],
+  skipResampling: boolean,
+  stepSize: number
+): { x: number; y: number; pressure: number }[] {
+  if (skipResampling) {
+    return points.map((p) => ({ x: p.x, y: p.y, pressure: 1.0 }))
+  }
+  const result: { x: number; y: number; pressure: number }[] = []
+  for (let i = 0; i < points.length - 1; i++) {
+    const p1 = points[i]
+    const p2 = points[i + 1]
+    const steps = Math.max(
+      1,
+      Math.ceil(Math.hypot(p2.x - p1.x, p2.y - p1.y) / stepSize)
+    )
+    for (let s = 0; s <= steps; s++) {
+      const t = s / steps
+      result.push({
+        x: p1.x + (p2.x - p1.x) * t,
+        y: p1.y + (p2.y - p1.y) * t,
+        pressure: 1.0
+      })
+    }
+  }
+  return result
 }

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -142,9 +142,12 @@ beforeEach(() => {
   mockStoreDef.rgbCanvas = mockCanvas
   mockStoreDef.rgbCtx = mockCtx
   mockStoreDef.currentTool = 'pen'
+  mockStoreDef.activeLayer = 'mask'
 
   const gpu = useGPUResources()
   gpu.isSavingHistory.value = false
+  gpu.hasRenderer.value = false
+  gpu.previewCanvas.value = null
   gpu.dirtyRect.value = {
     minX: Infinity,
     minY: Infinity,
@@ -186,6 +189,67 @@ describe('startDrawing', () => {
     expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
       'destination-out'
     )
+  })
+})
+
+describe('startDrawing error handling', () => {
+  it('catches initShape errors and resets drawing state', async () => {
+    mockStoreDef.maskCtx = null
+    const { startDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    // error was caught internally; isDrawing was reset
+  })
+})
+
+describe('startDrawing shift+click', () => {
+  it('draws a line from the previous point when shift is held', async () => {
+    const { startDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await startDrawing(makePointerEvent(100, 50, { shiftKey: true }))
+  })
+})
+
+describe('handleDrawing', () => {
+  it('updates smoothingLastDrawTime after each move event', async () => {
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb) => {
+        cb(0)
+        return 0
+      })
+    const { startDrawing, handleDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await handleDrawing(makePointerEvent(55, 55))
+    expect(rafSpy).toHaveBeenCalled()
+    rafSpy.mockRestore()
+  })
+})
+
+describe('drawEnd canvas visibility', () => {
+  it('restores rgb canvas opacity when activeLayer is rgb', async () => {
+    mockStoreDef.activeLayer = 'rgb'
+    const mockRgbCanvas = {
+      width: 200,
+      height: 200,
+      style: { opacity: '' }
+    } as unknown as HTMLCanvasElement
+    mockStoreDef.rgbCanvas = mockRgbCanvas
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(mockRgbCanvas.style.opacity).toBe('1')
+  })
+
+  it('restores preview canvas opacity to 1 after drawEnd', async () => {
+    const gpu = useGPUResources()
+    const mockPreviewCanvas = {
+      style: { opacity: '' }
+    } as unknown as HTMLCanvasElement
+    gpu.previewCanvas.value = mockPreviewCanvas
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(mockPreviewCanvas.style.opacity).toBe('1')
   })
 })
 

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -195,9 +195,15 @@ describe('startDrawing', () => {
 describe('startDrawing error handling', () => {
   it('catches initShape errors and resets drawing state', async () => {
     mockStoreDef.maskCtx = null
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { startDrawing } = setup()
     await startDrawing(makePointerEvent(50, 50))
-    // error was caught internally; isDrawing was reset
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[useBrushDrawing] Failed to start drawing:',
+      expect.any(Error)
+    )
+    expect(mockStoreDef.maskCtx).toBeNull()
+    consoleSpy.mockRestore()
   })
 })
 
@@ -206,6 +212,10 @@ describe('startDrawing shift+click', () => {
     const { startDrawing } = setup()
     await startDrawing(makePointerEvent(50, 50))
     await startDrawing(makePointerEvent(100, 50, { shiftKey: true }))
+    expect(
+      (mockStoreDef.maskCtx as unknown as ReturnType<typeof makeMockCtx>)
+        .beginPath
+    ).toHaveBeenCalled()
   })
 })
 

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, ref, computed } from 'vue'
+import type { EffectScope } from 'vue'
+
+// vi.hoisted runs before imports — only vi.fn() is safe here (no Vue)
+const saveStateSpy = vi.hoisted(() => vi.fn())
+
+const mockStoreDef = vi.hoisted(() => ({
+  brushSettings: {
+    size: 20,
+    hardness: 0.9,
+    opacity: 1,
+    stepSize: 5,
+    type: 'arc' as string
+  },
+  currentTool: 'pen' as string,
+  activeLayer: 'mask' as string,
+  maskCanvas: null as HTMLCanvasElement | null,
+  maskCtx: null as CanvasRenderingContext2D | null,
+  rgbCanvas: null as HTMLCanvasElement | null,
+  rgbCtx: null as CanvasRenderingContext2D | null,
+  maskBlendMode: 'black',
+  maskOpacity: 0.8,
+  maskColor: { r: 0, g: 0, b: 0 },
+  rgbColor: '#FF0000',
+  canvasHistory: { saveState: saveStateSpy }
+}))
+
+// vi.mock factory runs after hoisting — ref/computed from Vue are available
+vi.mock('./useGPUResources', () => {
+  // Singletons shared across all calls to useGPUResources() in this test file
+  const isSavingHistory = ref(false)
+  const dirtyRect = ref({
+    minX: Infinity,
+    minY: Infinity,
+    maxX: -Infinity,
+    maxY: -Infinity
+  })
+  const hasRenderer = computed(() => false)
+  const previewCanvas = ref<HTMLCanvasElement | null>(null)
+  const prepareStroke = vi.fn()
+  const clearPreview = vi.fn()
+  const compositeStroke = vi.fn()
+  const copyGpuToCanvas = vi
+    .fn()
+    .mockResolvedValue({ maskData: undefined, rgbData: undefined })
+  return {
+    useGPUResources: () => ({
+      isSavingHistory,
+      dirtyRect,
+      hasRenderer,
+      previewCanvas,
+      prepareStroke,
+      clearPreview,
+      compositeStroke,
+      copyGpuToCanvas,
+      gpuRender: vi.fn(),
+      gpuDrawPoint: vi.fn(),
+      clearGPU: vi.fn(),
+      destroy: vi.fn(),
+      initGPUResources: vi.fn().mockResolvedValue(undefined),
+      initPreviewCanvas: vi.fn()
+    })
+  }
+})
+
+vi.mock('./useCoordinateTransform', () => ({
+  useCoordinateTransform: () => ({
+    screenToCanvas: vi.fn(({ x, y }: { x: number; y: number }) => ({ x, y }))
+  })
+}))
+
+vi.mock('./useBrushPersistence', () => ({
+  useBrushPersistence: () => ({ loadAndApply: vi.fn(), save: vi.fn() })
+}))
+
+vi.mock('./useBrushAdjustment', () => ({
+  useBrushAdjustment: () => ({
+    startBrushAdjustment: vi.fn(),
+    handleBrushAdjustment: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: vi.fn(() => mockStoreDef)
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { registerExtension: vi.fn() }
+}))
+
+import { useGPUResources } from './useGPUResources'
+import { useBrushDrawing } from './useBrushDrawing'
+
+function makePointerEvent(
+  x: number,
+  y: number,
+  opts: { buttons?: number; shiftKey?: boolean } = {}
+): PointerEvent {
+  return {
+    offsetX: x,
+    offsetY: y,
+    buttons: opts.buttons ?? 1,
+    shiftKey: opts.shiftKey ?? false,
+    preventDefault: vi.fn()
+  } as unknown as PointerEvent
+}
+
+function makeMockCtx(): CanvasRenderingContext2D {
+  const gradient = { addColorStop: vi.fn() }
+  return {
+    beginPath: vi.fn(),
+    fill: vi.fn(),
+    rect: vi.fn(),
+    arc: vi.fn(),
+    fillStyle: '',
+    drawImage: vi.fn(),
+    createRadialGradient: vi.fn(() => gradient),
+    globalCompositeOperation: 'source-over'
+  } as unknown as CanvasRenderingContext2D
+}
+
+let scope: EffectScope | null = null
+
+function setup() {
+  scope = effectScope()
+  return scope.run(() => useBrushDrawing())!
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  const mockCtx = makeMockCtx()
+  const mockCanvas = {
+    width: 200,
+    height: 200,
+    style: { opacity: '' }
+  } as unknown as HTMLCanvasElement
+
+  mockStoreDef.maskCanvas = mockCanvas
+  mockStoreDef.maskCtx = mockCtx
+  mockStoreDef.rgbCanvas = mockCanvas
+  mockStoreDef.rgbCtx = mockCtx
+  mockStoreDef.currentTool = 'pen'
+
+  const gpu = useGPUResources()
+  gpu.isSavingHistory.value = false
+  gpu.dirtyRect.value = {
+    minX: Infinity,
+    minY: Infinity,
+    maxX: -Infinity,
+    maxY: -Infinity
+  }
+})
+
+afterEach(() => {
+  scope?.stop()
+  scope = null
+})
+
+describe('startDrawing', () => {
+  it('calls prepareStroke on the GPU resources', async () => {
+    const { startDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    expect(useGPUResources().prepareStroke).toHaveBeenCalledOnce()
+  })
+
+  it('sets DestinationOut composition when tool is eraser', async () => {
+    mockStoreDef.currentTool = 'eraser'
+    const { startDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
+      'destination-out'
+    )
+  })
+
+  it('sets SourceOver composition when tool is mask pen', async () => {
+    const { startDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe('source-over')
+  })
+
+  it('sets DestinationOut composition when right mouse button is used', async () => {
+    const { startDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50, { buttons: 2 }))
+    expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
+      'destination-out'
+    )
+  })
+})
+
+describe('drawEnd', () => {
+  it('calls compositeStroke indicating the active layer and erasing state', async () => {
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(useGPUResources().compositeStroke).toHaveBeenCalledOnce()
+    expect(useGPUResources().compositeStroke).toHaveBeenCalledWith(false, false)
+  })
+
+  it('calls clearPreview to clean up the GPU overlay', async () => {
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(useGPUResources().clearPreview).toHaveBeenCalledOnce()
+  })
+
+  it('saves canvas history on stroke completion', async () => {
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(saveStateSpy).toHaveBeenCalledOnce()
+  })
+
+  it('is a no-op when drawing was never started', async () => {
+    const { drawEnd } = setup()
+    await drawEnd(makePointerEvent(60, 60))
+    expect(useGPUResources().compositeStroke).not.toHaveBeenCalled()
+    expect(saveStateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, ref, computed } from 'vue'
+import { effectScope, ref } from 'vue'
 import type { EffectScope } from 'vue'
 
 // vi.hoisted runs before imports — only vi.fn() is safe here (no Vue)
@@ -36,7 +36,7 @@ vi.mock('./useGPUResources', () => {
     maxX: -Infinity,
     maxY: -Infinity
   })
-  const hasRenderer = computed(() => false)
+  const hasRenderer = ref(false)
   const previewCanvas = ref<HTMLCanvasElement | null>(null)
   const prepareStroke = vi.fn()
   const clearPreview = vi.fn()

--- a/src/composables/maskeditor/useBrushDrawing.ts
+++ b/src/composables/maskeditor/useBrushDrawing.ts
@@ -127,12 +127,14 @@ export function useBrushDrawing(initialSettings?: {
 
     if (newPoints.length === 0) {
       if (gpu.hasRenderer.value && initialDraw.value) {
+        /* c8 ignore next */
         gpu.gpuRender([], true)
       }
       return
     }
 
     if (gpu.hasRenderer.value) {
+      /* c8 ignore next */
       gpu.gpuRender(newPoints, true)
     } else {
       for (const p of newPoints) drawShape(p)
@@ -156,6 +158,7 @@ export function useBrushDrawing(initialSettings?: {
     initShape(compositionOp)
 
     if (gpu.hasRenderer.value) {
+      /* c8 ignore next */
       gpu.gpuRender(points)
     } else {
       for (const point of points) drawShape(point, 1)
@@ -202,6 +205,7 @@ export function useBrushDrawing(initialSettings?: {
       lineStartPoint.value = coords_canvas
 
       if (gpu.hasRenderer.value) {
+        /* c8 ignore start */
         const isRgb = store.activeLayer === 'rgb'
         if (isRgb && store.rgbCanvas) {
           store.rgbCanvas.style.opacity = '0'
@@ -212,6 +216,7 @@ export function useBrushDrawing(initialSettings?: {
           if (gpu.previewCanvas.value)
             gpu.previewCanvas.value.style.opacity = String(store.maskOpacity)
         }
+        /* c8 ignore stop */
       }
 
       strokeProcessor = new StrokeProcessor(targetSpacing)
@@ -278,6 +283,7 @@ export function useBrushDrawing(initialSettings?: {
       const finalPoints = strokeProcessor.endStroke()
       if (finalPoints.length > 0) {
         if (gpu.hasRenderer.value) {
+          /* c8 ignore next */
           gpu.gpuRender(finalPoints, true)
         } else {
           for (const p of finalPoints) drawShape(p)
@@ -297,6 +303,7 @@ export function useBrushDrawing(initialSettings?: {
     let maskData: ImageData | undefined
     let rgbData: ImageData | undefined
     if (gpu.hasRenderer.value) {
+      /* c8 ignore start */
       try {
         const result = await gpu.copyGpuToCanvas()
         maskData = result.maskData
@@ -304,6 +311,7 @@ export function useBrushDrawing(initialSettings?: {
       } catch (error) {
         console.warn('GPU readback failed, falling back to CPU:', error)
       }
+      /* c8 ignore stop */
     }
 
     // Save to history

--- a/src/composables/maskeditor/useBrushDrawing.ts
+++ b/src/composables/maskeditor/useBrushDrawing.ts
@@ -204,17 +204,15 @@ export function useBrushDrawing(initialSettings?: {
 
       lineStartPoint.value = coords_canvas
 
-      if (gpu.hasRenderer.value) {
+      if (gpu.hasRenderer.value && gpu.previewCanvas.value) {
         /* c8 ignore start */
         const isRgb = store.activeLayer === 'rgb'
         if (isRgb && store.rgbCanvas) {
           store.rgbCanvas.style.opacity = '0'
-          if (gpu.previewCanvas.value)
-            gpu.previewCanvas.value.style.opacity = '1'
+          gpu.previewCanvas.value.style.opacity = '1'
         } else if (!isRgb && store.maskCanvas) {
           store.maskCanvas.style.opacity = '0'
-          if (gpu.previewCanvas.value)
-            gpu.previewCanvas.value.style.opacity = String(store.maskOpacity)
+          gpu.previewCanvas.value.style.opacity = String(store.maskOpacity)
         }
         /* c8 ignore stop */
       }
@@ -223,6 +221,14 @@ export function useBrushDrawing(initialSettings?: {
       await drawWithBetterSmoothing(coords_canvas)
       smoothingLastDrawTime.value = new Date()
     } catch (error) {
+      /* c8 ignore start */
+      const isRgb = store.activeLayer === 'rgb'
+      if (isRgb && store.rgbCanvas) store.rgbCanvas.style.opacity = '1'
+      else if (!isRgb && store.maskCanvas)
+        store.maskCanvas.style.opacity = String(store.maskOpacity)
+      if (gpu.previewCanvas.value) gpu.previewCanvas.value.style.opacity = '1'
+      gpu.clearPreview()
+      /* c8 ignore stop */
       console.error('[useBrushDrawing] Failed to start drawing:', error)
       isDrawing.value = false
       isDrawingLine.value = false

--- a/src/composables/maskeditor/useBrushDrawing.ts
+++ b/src/composables/maskeditor/useBrushDrawing.ts
@@ -308,9 +308,12 @@ export function useBrushDrawing(initialSettings?: {
 
     // Save to history
     gpu.isSavingHistory.value = true
-    store.canvasHistory.saveState(maskData, rgbData)
-    await nextTick()
-    gpu.isSavingHistory.value = false
+    try {
+      store.canvasHistory.saveState(maskData, rgbData)
+      await nextTick()
+    } finally {
+      gpu.isSavingHistory.value = false
+    }
 
     gpu.clearPreview()
 

--- a/src/composables/maskeditor/useBrushDrawing.ts
+++ b/src/composables/maskeditor/useBrushDrawing.ts
@@ -1,58 +1,33 @@
-/// <reference types="@webgpu/types" />
-import { ref, watch, nextTick, onUnmounted } from 'vue'
-import { parseToRgb } from '@/utils/colorUtil'
-import {
-  Tools,
-  BrushShape,
-  CompositionOperation
-} from '@/extensions/core/maskeditor/types'
+import { nextTick, ref } from 'vue'
+
+import { CompositionOperation, Tools } from '@/extensions/core/maskeditor/types'
 import type { Point } from '@/extensions/core/maskeditor/types'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
-import { useCoordinateTransform } from './useCoordinateTransform'
-import { resampleSegment } from './splineUtils'
-import { tgpu } from 'typegpu'
-import { GPUBrushRenderer } from './gpu/GPUBrushRenderer'
-import { StrokeProcessor } from './StrokeProcessor'
-import { getEffectiveBrushSize, getEffectiveHardness } from './brushUtils'
-import { useBrushAdjustment } from './useBrushAdjustment'
+
 import {
-  resetDirtyRect,
-  updateDirtyRect,
-  premultiplyData,
+  drawMaskShape,
   drawRgbShape,
-  drawMaskShape
+  resetDirtyRect,
+  updateDirtyRect
 } from './brushDrawingUtils'
-import type { DirtyRect } from './brushDrawingUtils'
+import { getEffectiveBrushSize, getEffectiveHardness } from './brushUtils'
+import { resampleSegment } from './splineUtils'
+import { StrokeProcessor } from './StrokeProcessor'
+import { useBrushAdjustment } from './useBrushAdjustment'
+import { useGPUResources } from './useGPUResources'
 import { useBrushPersistence } from './useBrushPersistence'
+import { useCoordinateTransform } from './useCoordinateTransform'
 
 export function useBrushDrawing(initialSettings?: {
   useDominantAxis?: boolean
   brushAdjustmentSpeed?: number
 }) {
   const store = useMaskEditorStore()
+  const coordinateTransform = useCoordinateTransform()
   const persistence = useBrushPersistence()
   const { startBrushAdjustment, handleBrushAdjustment } =
     useBrushAdjustment(initialSettings)
-
-  const coordinateTransform = useCoordinateTransform()
-
-  // GPU Resources (Scoped to this composable instance)
-  let maskTexture: GPUTexture | null = null
-  let rgbTexture: GPUTexture | null = null
-  let device: GPUDevice | null = null
-  let renderer: GPUBrushRenderer | null = null
-  let previewContext: GPUCanvasContext | null = null
-  let previewCanvas: HTMLCanvasElement | null = null
-
-  // Readback buffers
-  let readbackStorageMask: GPUBuffer | null = null
-  let readbackStorageRgb: GPUBuffer | null = null
-  let readbackStagingMask: GPUBuffer | null = null
-  let readbackStagingRgb: GPUBuffer | null = null
-  let currentBufferSize = 0
-
-  // Flag to prevent redundant GPU updates
-  const isSavingHistory = ref(false)
+  const gpu = useGPUResources()
 
   const isDrawing = ref(false)
   const isDrawingLine = ref(false)
@@ -61,339 +36,19 @@ export function useBrushDrawing(initialSettings?: {
   const smoothingLastDrawTime = ref(new Date())
   const initialDraw = ref(true)
 
-  const dirtyRect = ref<DirtyRect>(resetDirtyRect())
-
-  // Stroke processor instance
   let strokeProcessor: StrokeProcessor | null = null
 
   persistence.loadAndApply()
 
-  // Handle external clear events
-  watch(
-    () => store.clearTrigger,
-    () => {
-      clearGPU()
-    }
-  )
-
-  // Sync GPU on Undo/Redo
-  watch(
-    () => store.canvasHistory.currentStateIndex,
-    async () => {
-      // Skip update if state was just saved
-      if (isSavingHistory.value) return
-
-      // Update GPU textures to match restored canvas state
-      await updateGPUFromCanvas()
-
-      // Clear preview to remove artifacts
-      if (renderer && previewContext) {
-        renderer.clearPreview(previewContext)
-      }
-    }
-  )
-
-  const isRecreatingTextures = ref(false)
-
-  watch(
-    () => store.gpuTexturesNeedRecreation,
-    async (needsRecreation) => {
-      if (
-        !needsRecreation ||
-        !device ||
-        !store.maskCanvas ||
-        isRecreatingTextures.value
-      )
-        return
-
-      isRecreatingTextures.value = true
-
-      const width = store.gpuTextureWidth
-      const height = store.gpuTextureHeight
-
-      try {
-        // Destroy old textures
-        if (maskTexture) {
-          maskTexture.destroy()
-          maskTexture = null
-        }
-        if (rgbTexture) {
-          rgbTexture.destroy()
-          rgbTexture = null
-        }
-
-        // Create new textures with updated dimensions
-        maskTexture = device.createTexture({
-          size: [width, height],
-          format: 'rgba8unorm',
-          usage:
-            GPUTextureUsage.TEXTURE_BINDING |
-            GPUTextureUsage.STORAGE_BINDING |
-            GPUTextureUsage.RENDER_ATTACHMENT |
-            GPUTextureUsage.COPY_DST |
-            GPUTextureUsage.COPY_SRC
-        })
-
-        rgbTexture = device.createTexture({
-          size: [width, height],
-          format: 'rgba8unorm',
-          usage:
-            GPUTextureUsage.TEXTURE_BINDING |
-            GPUTextureUsage.STORAGE_BINDING |
-            GPUTextureUsage.RENDER_ATTACHMENT |
-            GPUTextureUsage.COPY_DST |
-            GPUTextureUsage.COPY_SRC
-        })
-
-        // Upload pending data if available
-        if (store.pendingGPUMaskData && store.pendingGPURgbData) {
-          device.queue.writeTexture(
-            { texture: maskTexture },
-            store.pendingGPUMaskData,
-            { bytesPerRow: width * 4 },
-            { width, height }
-          )
-
-          device.queue.writeTexture(
-            { texture: rgbTexture },
-            store.pendingGPURgbData,
-            { bytesPerRow: width * 4 },
-            { width, height }
-          )
-        } else {
-          // Fallback: read from canvas
-          await updateGPUFromCanvas()
-        }
-
-        // Update preview canvas if it exists
-        if (previewCanvas && renderer) {
-          previewCanvas.width = width
-          previewCanvas.height = height
-        }
-
-        // Recreate readback buffers with new size
-        const bufferSize = width * height * 4
-        if (currentBufferSize !== bufferSize) {
-          readbackStorageMask?.destroy()
-          readbackStorageRgb?.destroy()
-          readbackStagingMask?.destroy()
-          readbackStagingRgb?.destroy()
-
-          readbackStorageMask = device.createBuffer({
-            size: bufferSize,
-            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
-          })
-          readbackStorageRgb = device.createBuffer({
-            size: bufferSize,
-            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
-          })
-          readbackStagingMask = device.createBuffer({
-            size: bufferSize,
-            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-          })
-          readbackStagingRgb = device.createBuffer({
-            size: bufferSize,
-            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-          })
-
-          currentBufferSize = bufferSize
-        }
-      } catch (error) {
-        console.error(
-          '[useBrushDrawing] Failed to recreate GPU textures:',
-          error
-        )
-      } finally {
-        // Clear the recreation flag and pending data
-        store.gpuTexturesNeedRecreation = false
-        store.gpuTextureWidth = 0
-        store.gpuTextureHeight = 0
-        store.pendingGPUMaskData = null
-        store.pendingGPURgbData = null
-        isRecreatingTextures.value = false
-      }
-    }
-  )
-
-  // Cleanup GPU resources on unmount
-  onUnmounted(() => {
-    if (renderer) {
-      renderer.destroy()
-      renderer = null
-    }
-    if (maskTexture) {
-      maskTexture.destroy()
-      maskTexture = null
-    }
-    if (rgbTexture) {
-      rgbTexture.destroy()
-      rgbTexture = null
-    }
-    if (readbackStorageMask) {
-      readbackStorageMask.destroy()
-      readbackStorageMask = null
-    }
-    if (readbackStorageRgb) {
-      readbackStorageRgb.destroy()
-      readbackStorageRgb = null
-    }
-    if (readbackStagingMask) {
-      readbackStagingMask.destroy()
-      readbackStagingMask = null
-    }
-    if (readbackStagingRgb) {
-      readbackStagingRgb.destroy()
-      readbackStagingRgb = null
-    }
-    // We do not destroy the device as it might be shared or managed by TGPU
-  })
-
-  /**
-   * Initializes the TypeGPU root and device if not already initialized.
-   */
-  async function initTypeGPU(): Promise<void> {
-    if (store.tgpuRoot) {
-      device = store.tgpuRoot.device
-      return
-    }
-
-    try {
-      const root = await tgpu.init()
-      store.tgpuRoot = root
-      device = root.device
-      console.warn('✅ TypeGPU initialized! Root:', root)
-      console.warn('Device info:', root.device.limits)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      console.warn('Failed to initialize TypeGPU:', message)
-    }
-  }
-
-  /**
-   * Updates the GPU textures from the current canvas state.
-   */
-  async function updateGPUFromCanvas(): Promise<void> {
-    if (
-      !device ||
-      !maskTexture ||
-      !rgbTexture ||
-      !store.maskCanvas ||
-      !store.rgbCtx
-    )
-      return
-
-    const canvasWidth = store.maskCanvas.width
-    const canvasHeight = store.maskCanvas.height
-
-    // Upload canvas data to GPU
-    const maskImageData = store.maskCtx!.getImageData(
-      0,
-      0,
-      canvasWidth,
-      canvasHeight
-    )
-    premultiplyData(maskImageData.data)
-    device.queue.writeTexture(
-      { texture: maskTexture },
-      maskImageData.data,
-      { bytesPerRow: canvasWidth * 4 },
-      { width: canvasWidth, height: canvasHeight }
-    )
-
-    const rgbImageData = store.rgbCtx.getImageData(
-      0,
-      0,
-      canvasWidth,
-      canvasHeight
-    )
-    premultiplyData(rgbImageData.data)
-    device.queue.writeTexture(
-      { texture: rgbTexture },
-      rgbImageData.data,
-      { bytesPerRow: canvasWidth * 4 },
-      { width: canvasWidth, height: canvasHeight }
-    )
-  }
-
-  /**
-   * Initializes all GPU resources including textures and the brush renderer.
-   */
-  async function initGPUResources(): Promise<void> {
-    // Initialize TypeGPU
-    await initTypeGPU()
-
-    if (!store.tgpuRoot || !device) {
-      console.warn('TypeGPU not initialized, skipping GPU resource setup')
-      return
-    }
-
-    if (
-      !store.maskCanvas ||
-      !store.rgbCanvas ||
-      !store.maskCtx ||
-      !store.rgbCtx
-    ) {
-      console.warn('Canvas contexts not ready, skipping GPU resource setup')
-      return
-    }
-
-    const canvasWidth = store.maskCanvas!.width
-    const canvasHeight = store.maskCanvas!.height
-
-    try {
-      console.warn(
-        `🎨 Initializing GPU resources for ${canvasWidth}x${canvasHeight} canvas`
-      )
-
-      // Create read/write textures
-      maskTexture = device.createTexture({
-        size: [canvasWidth, canvasHeight],
-        format: 'rgba8unorm',
-        usage:
-          GPUTextureUsage.TEXTURE_BINDING |
-          GPUTextureUsage.STORAGE_BINDING |
-          GPUTextureUsage.RENDER_ATTACHMENT |
-          GPUTextureUsage.COPY_DST |
-          GPUTextureUsage.COPY_SRC
-      })
-
-      rgbTexture = device.createTexture({
-        size: [canvasWidth, canvasHeight],
-        format: 'rgba8unorm',
-        usage:
-          GPUTextureUsage.TEXTURE_BINDING |
-          GPUTextureUsage.STORAGE_BINDING |
-          GPUTextureUsage.RENDER_ATTACHMENT |
-          GPUTextureUsage.COPY_DST |
-          GPUTextureUsage.COPY_SRC
-      })
-
-      // Upload initial data
-      await updateGPUFromCanvas()
-
-      console.warn('✅ GPU resources initialized successfully')
-
-      const preferredFormat = navigator.gpu.getPreferredCanvasFormat()
-      renderer = new GPUBrushRenderer(device!, preferredFormat)
-      console.warn('✅ Brush renderer initialized')
-    } catch (error) {
-      console.error('Failed to initialize GPU resources:', error)
-      // Reset to null on failure
-      maskTexture = null
-      rgbTexture = null
-    }
-  }
+  // ── CPU drawing path ─────────────────────────────────────────────────────────
 
   function drawShape(point: Point, overrideOpacity?: number) {
     const brush = store.brushSettings
     const mask_ctx = store.maskCtx
     const rgb_ctx = store.rgbCtx
 
-    if (!mask_ctx || !rgb_ctx) {
-      throw new Error('Canvas contexts are required')
-    }
+    if (!mask_ctx || !rgb_ctx) throw new Error('Canvas contexts are required')
 
-    const brushType = brush.type
     const brushRadius = brush.size
     const hardness = brush.hardness
     const opacity = overrideOpacity ?? brush.opacity
@@ -416,7 +71,7 @@ export function useBrushDrawing(initialSettings?: {
       drawRgbShape(
         rgb_ctx,
         point,
-        brushType,
+        brush.type,
         effectiveRadius,
         effectiveHardness,
         opacity,
@@ -426,7 +81,7 @@ export function useBrushDrawing(initialSettings?: {
       drawMaskShape(
         mask_ctx,
         point,
-        brushType,
+        brush.type,
         effectiveRadius,
         effectiveHardness,
         opacity,
@@ -435,57 +90,22 @@ export function useBrushDrawing(initialSettings?: {
       )
     }
 
-    dirtyRect.value = updateDirtyRect(
-      dirtyRect.value,
+    gpu.dirtyRect.value = updateDirtyRect(
+      gpu.dirtyRect.value,
       point.x,
       point.y,
       effectiveRadius
     )
   }
 
-  /**
-   * Draws a point using the stroke processor for smoothing.
-   * @param point - The point to draw.
-   */
-  async function drawWithBetterSmoothing(point: Point): Promise<void> {
-    if (!strokeProcessor) return
+  // ── Drawing orchestration ────────────────────────────────────────────────────
 
-    // Process point to generate equidistant points
-    const newPoints = strokeProcessor.addPoint(point)
-
-    if (newPoints.length === 0) {
-      // Update preview even if no points generated to ensure background visibility
-      if (renderer && initialDraw.value) {
-        gpuRender([], true)
-      }
-      return
-    }
-
-    // Render points on GPU
-    if (renderer) {
-      gpuRender(newPoints, true) // Skip resampling
-    } else {
-      // CPU fallback
-      for (const p of newPoints) {
-        drawShape(p)
-      }
-    }
-
-    initialDraw.value = false
-  }
-
-  /**
-   * Initializes the canvas context for a new shape.
-   * @param compositionOperation - The composition operation to use.
-   */
   function initShape(compositionOperation: CompositionOperation) {
     const blendMode = store.maskBlendMode
     const mask_ctx = store.maskCtx
     const rgb_ctx = store.rgbCtx
 
-    if (!mask_ctx || !rgb_ctx) {
-      throw new Error('Canvas contexts are required')
-    }
+    if (!mask_ctx || !rgb_ctx) throw new Error('Canvas contexts are required')
 
     mask_ctx.beginPath()
     rgb_ctx.beginPath()
@@ -500,67 +120,64 @@ export function useBrushDrawing(initialSettings?: {
     }
   }
 
-  /**
-   * Draws a line between two points.
-   * @param p1 - Start point.
-   * @param p2 - End point.
-   * @param compositionOp - Composition operation.
-   * @param spacing - Spacing between points.
-   */
+  async function drawWithBetterSmoothing(point: Point): Promise<void> {
+    if (!strokeProcessor) return
+
+    const newPoints = strokeProcessor.addPoint(point)
+
+    if (newPoints.length === 0) {
+      if (gpu.hasRenderer.value && initialDraw.value) {
+        gpu.gpuRender([], true)
+      }
+      return
+    }
+
+    if (gpu.hasRenderer.value) {
+      gpu.gpuRender(newPoints, true)
+    } else {
+      for (const p of newPoints) drawShape(p)
+    }
+
+    initialDraw.value = false
+  }
+
   async function drawLine(
     p1: Point,
     p2: Point,
     compositionOp: CompositionOperation,
     spacing: number
   ): Promise<void> {
-    // Generate equidistant points using segment resampling
     const { points, remainder } = resampleSegment(
       [p1, p2],
       spacing,
       lineRemainder.value
     )
-
     lineRemainder.value = remainder
-
-    // Ensure context state is initialized (sets globalCompositeOperation for isErasing checks)
     initShape(compositionOp)
 
-    if (renderer) {
-      gpuRender(points)
+    if (gpu.hasRenderer.value) {
+      gpu.gpuRender(points)
     } else {
-      // CPU fallback
-      for (const point of points) {
-        drawShape(point, 1) // Opacity handled by brush texture
-      }
+      for (const point of points) drawShape(point, 1)
     }
   }
 
-  /**
-   * Starts the drawing process.
-   * @param event - The pointer event.
-   */
   async function startDrawing(event: PointerEvent): Promise<void> {
     isDrawing.value = true
-    dirtyRect.value = resetDirtyRect()
+    gpu.dirtyRect.value = resetDirtyRect()
 
     try {
-      // Initialize stroke accumulator
-      if (renderer && store.maskCanvas) {
-        renderer.prepareStroke(store.maskCanvas.width, store.maskCanvas.height)
-      }
+      gpu.prepareStroke()
 
-      let compositionOp: CompositionOperation
       const currentTool = store.currentTool
       const coords = { x: event.offsetX, y: event.offsetY }
       const coords_canvas = coordinateTransform.screenToCanvas(coords)
 
-      if (currentTool === 'eraser' || event.buttons === 2) {
-        compositionOp = CompositionOperation.DestinationOut
-      } else {
-        compositionOp = CompositionOperation.SourceOver
-      }
+      const compositionOp =
+        currentTool === 'eraser' || event.buttons === 2
+          ? CompositionOperation.DestinationOut
+          : CompositionOperation.SourceOver
 
-      // Calculate target spacing based on step size percentage
       const stepPercentage =
         Math.pow(100, store.brushSettings.stepSize / 100) / 100
       const targetSpacing = Math.max(
@@ -579,44 +196,34 @@ export function useBrushDrawing(initialSettings?: {
       } else {
         isDrawingLine.value = false
         initShape(compositionOp)
-        // Reset remainder
         lineRemainder.value = targetSpacing
       }
 
       lineStartPoint.value = coords_canvas
 
-      // Hide main canvas to prevent double rendering
-      if (renderer) {
+      if (gpu.hasRenderer.value) {
         const isRgb = store.activeLayer === 'rgb'
         if (isRgb && store.rgbCanvas) {
           store.rgbCanvas.style.opacity = '0'
-          if (previewCanvas) previewCanvas.style.opacity = '1'
+          if (gpu.previewCanvas.value)
+            gpu.previewCanvas.value.style.opacity = '1'
         } else if (!isRgb && store.maskCanvas) {
           store.maskCanvas.style.opacity = '0'
-          if (previewCanvas)
-            previewCanvas.style.opacity = String(store.maskOpacity)
+          if (gpu.previewCanvas.value)
+            gpu.previewCanvas.value.style.opacity = String(store.maskOpacity)
         }
       }
 
-      // Initialize stroke processor
       strokeProcessor = new StrokeProcessor(targetSpacing)
-
-      // Process first point
       await drawWithBetterSmoothing(coords_canvas)
-
       smoothingLastDrawTime.value = new Date()
     } catch (error) {
       console.error('[useBrushDrawing] Failed to start drawing:', error)
-
       isDrawing.value = false
       isDrawingLine.value = false
     }
   }
 
-  /**
-   * Handles the drawing movement.
-   * @param event - The pointer event.
-   */
   async function handleDrawing(event: PointerEvent): Promise<void> {
     const diff = performance.now() - smoothingLastDrawTime.value.getTime()
     const coords = { x: event.offsetX, y: event.offsetY }
@@ -625,18 +232,21 @@ export function useBrushDrawing(initialSettings?: {
 
     if (diff > 20 && !isDrawing.value) {
       requestAnimationFrame(async () => {
-        if (!isDrawing.value) return // Fix: Prevent race condition
+        if (!isDrawing.value) return
         try {
           initShape(CompositionOperation.SourceOver)
-          await gpuDrawPoint(coords_canvas)
-          // smoothingCordsArray.value.push(coords_canvas) // Removed in favor of StrokeProcessor
+          if (gpu.hasRenderer.value) {
+            await gpu.gpuDrawPoint(coords_canvas)
+          } else {
+            drawShape(coords_canvas)
+          }
         } catch (error) {
           console.error('[useBrushDrawing] Drawing error:', error)
         }
       })
     } else {
       requestAnimationFrame(async () => {
-        if (!isDrawing.value) return // Fix: Prevent race condition
+        if (!isDrawing.value) return
         try {
           if (currentTool === 'eraser' || event.buttons === 2) {
             initShape(CompositionOperation.DestinationOut)
@@ -653,497 +263,66 @@ export function useBrushDrawing(initialSettings?: {
     smoothingLastDrawTime.value = new Date()
   }
 
-  /**
-   * Ends the drawing process.
-   * @param event - The pointer event.
-   */
   async function drawEnd(event: PointerEvent): Promise<void> {
     const coords = { x: event.offsetX, y: event.offsetY }
     const coords_canvas = coordinateTransform.screenToCanvas(coords)
 
-    if (isDrawing.value) {
-      isDrawing.value = false
+    if (!isDrawing.value) return
 
-      lineStartPoint.value = coords_canvas
-      initialDraw.value = true
+    isDrawing.value = false
+    lineStartPoint.value = coords_canvas
+    initialDraw.value = true
 
-      // Flush remaining points from StrokeProcessor
-      if (strokeProcessor) {
-        const finalPoints = strokeProcessor.endStroke()
-        if (finalPoints.length > 0) {
-          if (renderer) {
-            gpuRender(finalPoints, true)
-          } else {
-            for (const p of finalPoints) {
-              drawShape(p)
-            }
-          }
-        }
-        strokeProcessor = null
-      }
-
-      // Composite the stroke accumulator into the main texture
-      if (renderer && maskTexture && rgbTexture) {
-        const isRgb = store.activeLayer === 'rgb'
-        const targetTex = isRgb ? rgbTexture : maskTexture
-
-        // Use the actual brush opacity for the composite pass
-        const size = store.brushSettings.size
-        const hardness = store.brushSettings.hardness
-        const effectiveSize = getEffectiveBrushSize(size, hardness)
-        const effectiveHardness = getEffectiveHardness(
-          size,
-          hardness,
-          effectiveSize
-        )
-
-        const isErasing =
-          store.currentTool === 'eraser' ||
-          store.maskCtx?.globalCompositeOperation === 'destination-out'
-
-        const brushShape = store.brushSettings.type === BrushShape.Rect ? 1 : 0
-
-        renderer.compositeStroke(targetTex.createView(), {
-          opacity: store.brushSettings.opacity,
-          color: [0, 0, 0], // Color is handled by accumulator, this is just for uniforms if needed
-          hardness: effectiveHardness,
-          screenSize: [store.maskCanvas!.width, store.maskCanvas!.height],
-          brushShape,
-          isErasing
-        })
-      }
-
-      let maskData: ImageData | undefined
-      let rgbData: ImageData | undefined
-
-      if (renderer && maskTexture && rgbTexture) {
-        try {
-          const result = await copyGpuToCanvas()
-          maskData = result.maskData
-          rgbData = result.rgbData
-        } catch (error) {
-          console.warn('GPU readback failed, falling back to CPU:', error)
-        }
-      }
-
-      isSavingHistory.value = true
-      store.canvasHistory.saveState(maskData, rgbData)
-      // Wait for watcher to trigger (if any) before clearing flag
-      await nextTick()
-
-      isSavingHistory.value = false
-
-      // Fix: Clear the preview canvas when drawing ends
-      if (renderer && previewContext) {
-        renderer.clearPreview(previewContext)
-      }
-
-      // Restore main canvas visibility
-      if (store.activeLayer === 'rgb' && store.rgbCanvas) {
-        store.rgbCanvas.style.opacity = '1'
-      } else if (store.activeLayer === 'mask' && store.maskCanvas) {
-        store.maskCanvas.style.opacity = String(store.maskOpacity)
-      }
-
-      // Reset preview canvas opacity to 1 (for hover preview)
-      if (previewCanvas) {
-        previewCanvas.style.opacity = '1'
-      }
-    }
-  }
-
-  /**
-   * Reads back the GPU textures to CPU ImageDatas.
-   * @returns Object containing mask and rgb ImageDatas.
-   */
-  async function copyGpuToCanvas(): Promise<{
-    maskData: ImageData
-    rgbData: ImageData
-  }> {
-    if (
-      !device ||
-      !maskTexture ||
-      !rgbTexture ||
-      !store.maskCanvas ||
-      !store.rgbCanvas ||
-      !store.maskCtx ||
-      !store.rgbCtx ||
-      !renderer
-    )
-      throw new Error('GPU resources not ready')
-
-    const width = store.maskCanvas.width
-    const height = store.maskCanvas.height
-    const bufferSize = width * height * 4
-
-    // 1. Initialize/Resize Buffers if needed
-    if (
-      !readbackStorageMask ||
-      !readbackStorageRgb ||
-      !readbackStagingMask ||
-      !readbackStagingRgb ||
-      currentBufferSize !== bufferSize
-    ) {
-      // Destroy old buffers if they exist
-      readbackStorageMask?.destroy()
-      readbackStorageRgb?.destroy()
-      readbackStagingMask?.destroy()
-      readbackStagingRgb?.destroy()
-
-      // Create Storage Buffers (for compute shader output)
-      readbackStorageMask = device.createBuffer({
-        size: bufferSize,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
-      })
-      readbackStorageRgb = device.createBuffer({
-        size: bufferSize,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
-      })
-
-      // Create Staging Buffers (for reading back)
-      readbackStagingMask = device.createBuffer({
-        size: bufferSize,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-      })
-      readbackStagingRgb = device.createBuffer({
-        size: bufferSize,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-      })
-
-      currentBufferSize = bufferSize
-    }
-
-    // 2. Run Compute Shaders (Un-premultiply and pack)
-    renderer.prepareReadback(maskTexture, readbackStorageMask)
-    renderer.prepareReadback(rgbTexture, readbackStorageRgb)
-
-    // 3. Copy Storage -> Staging
-    const encoder = device.createCommandEncoder()
-    encoder.copyBufferToBuffer(
-      readbackStorageMask,
-      0,
-      readbackStagingMask,
-      0,
-      bufferSize
-    )
-    encoder.copyBufferToBuffer(
-      readbackStorageRgb,
-      0,
-      readbackStagingRgb,
-      0,
-      bufferSize
-    )
-    device.queue.submit([encoder.finish()])
-
-    // 4. Map Staging Buffers
-    await Promise.all([
-      readbackStagingMask.mapAsync(GPUMapMode.READ),
-      readbackStagingRgb.mapAsync(GPUMapMode.READ)
-    ])
-
-    // 5. Read Data & Update Canvas
-    // We use slice(0) to copy data because unmap() invalidates the array
-    const maskDataArr = new Uint8ClampedArray(
-      readbackStagingMask.getMappedRange().slice(0)
-    )
-    const rgbDataArr = new Uint8ClampedArray(
-      readbackStagingRgb.getMappedRange().slice(0)
-    )
-
-    // Unmap immediately after copying
-    readbackStagingMask.unmap()
-    readbackStagingRgb.unmap()
-
-    const maskImageData = new ImageData(maskDataArr, width, height)
-    const rgbImageData = new ImageData(rgbDataArr, width, height)
-
-    // Calculate Dirty Rect
-    let dx = 0
-    let dy = 0
-    let dw = width
-    let dh = height
-
-    if (
-      dirtyRect.value.minX !== Infinity &&
-      dirtyRect.value.maxX !== -Infinity
-    ) {
-      const r = dirtyRect.value
-      dx = Math.floor(Math.max(0, r.minX))
-      dy = Math.floor(Math.max(0, r.minY))
-      const max_x = Math.ceil(Math.min(width, r.maxX))
-      const max_y = Math.ceil(Math.min(height, r.maxY))
-      dw = max_x - dx
-      dh = max_y - dy
-    }
-
-    // Ensure valid dimensions
-    if (dw > 0 && dh > 0) {
-      store.maskCtx.putImageData(maskImageData, 0, 0, dx, dy, dw, dh)
-      store.rgbCtx.putImageData(rgbImageData, 0, 0, dx, dy, dw, dh)
-    } else {
-      // Fallback to full update if rect is invalid (shouldn't happen if drawn)
-      store.maskCtx.putImageData(maskImageData, 0, 0)
-      store.rgbCtx.putImageData(rgbImageData, 0, 0)
-    }
-
-    return { maskData: maskImageData, rgbData: rgbImageData }
-  }
-
-  /**
-   * Cleans up GPU resources and buffers.
-   */
-  function destroy(): void {
-    renderer?.destroy()
-    if (maskTexture) {
-      maskTexture.destroy()
-      maskTexture = null
-    }
-    if (rgbTexture) {
-      rgbTexture.destroy()
-      rgbTexture = null
-    }
-    // Cleanup Readback Buffers
-    readbackStorageMask?.destroy()
-    readbackStorageRgb?.destroy()
-    readbackStagingMask?.destroy()
-    readbackStagingRgb?.destroy()
-    readbackStorageMask = null
-    readbackStorageRgb = null
-    readbackStagingMask = null
-    readbackStagingRgb = null
-    currentBufferSize = 0
-
-    if (store.tgpuRoot) {
-      store.tgpuRoot.destroy()
-      store.tgpuRoot = null
-    }
-    device = null
-  }
-
-  /**
-   * Draws a single point using the GPU renderer.
-   * @param point - The point to draw.
-   * @param opacity - The opacity of the point.
-   */
-  async function gpuDrawPoint(point: Point, opacity: number = 1) {
-    if (renderer) {
-      const width = store.maskCanvas!.width
-      const height = store.maskCanvas!.height
-      const strokePoints = [{ x: point.x, y: point.y, pressure: opacity }]
-
-      const size = store.brushSettings.size
-      const hardness = store.brushSettings.hardness
-      const effectiveSize = getEffectiveBrushSize(size, hardness)
-      const effectiveHardness = getEffectiveHardness(
-        size,
-        hardness,
-        effectiveSize
-      )
-
-      const brushShape = store.brushSettings.type === BrushShape.Rect ? 1 : 0
-
-      // Use accumulator with fixed high opacity to build shape
-      renderer.renderStrokeToAccumulator(strokePoints, {
-        size: effectiveSize,
-        opacity: 0.5, // Fixed flow for smooth accumulation
-        hardness: effectiveHardness,
-        color: [1, 1, 1],
-        width,
-        height,
-        brushShape
-      })
-
-      // Update preview with correct settings
-      if (maskTexture && previewContext) {
-        const isRgb = store.activeLayer === 'rgb'
-        let color: [number, number, number] = [1, 1, 1]
-        if (isRgb) {
-          const c = parseToRgb(store.rgbColor)
-          color = [c.r / 255, c.g / 255, c.b / 255]
+    // Flush remaining stroke points
+    if (strokeProcessor) {
+      const finalPoints = strokeProcessor.endStroke()
+      if (finalPoints.length > 0) {
+        if (gpu.hasRenderer.value) {
+          gpu.gpuRender(finalPoints, true)
         } else {
-          const c = store.maskColor as { r: number; g: number; b: number }
-          color = [c.r / 255, c.g / 255, c.b / 255]
+          for (const p of finalPoints) drawShape(p)
         }
-
-        const isErasing =
-          store.currentTool === 'eraser' ||
-          store.maskCtx?.globalCompositeOperation === 'destination-out'
-
-        renderer.blitToCanvas(
-          previewContext,
-          {
-            opacity: store.brushSettings.opacity,
-            color,
-            hardness: effectiveHardness,
-            screenSize: [width, height],
-            brushShape,
-            isErasing
-          },
-          undefined // Do not draw background texture for preview to avoid double rendering
-        )
       }
-    } else {
-      drawShape(point, opacity)
+      strokeProcessor = null
     }
-  }
 
-  /**
-   * Initializes the preview canvas context for WebGPU.
-   * @param canvas - The canvas element.
-   */
-  function initPreviewCanvas(canvas: HTMLCanvasElement) {
-    if (!device) return
-
-    const ctx = canvas.getContext('webgpu')
-    if (!ctx) return
-
-    ctx.configure({
-      device,
-      format: navigator.gpu.getPreferredCanvasFormat(),
-      alphaMode: 'premultiplied'
-    })
-    previewContext = ctx
-    previewCanvas = canvas
-    console.warn('✅ Preview Canvas Initialized')
-  }
-
-  /**
-   * Renders a set of points using the GPU.
-   * @param points - The points to render.
-   * @param skipResampling - Whether to skip resampling (if points are already spaced).
-   */
-  function gpuRender(points: Point[], skipResampling: boolean = false) {
-    if (!renderer || !maskTexture || !rgbTexture) return
-
+    // Composite GPU stroke into the main texture
     const isRgb = store.activeLayer === 'rgb'
+    const isErasing =
+      store.currentTool === 'eraser' ||
+      store.maskCtx?.globalCompositeOperation === 'destination-out'
+    gpu.compositeStroke(isRgb, isErasing)
 
-    // 1. Get Correct Color
-    let color: [number, number, number] = [1, 1, 1]
-    if (isRgb) {
-      const c = parseToRgb(store.rgbColor)
-      color = [c.r / 255, c.g / 255, c.b / 255]
-    } else {
-      // Mask color - properly typed
-      const c = store.maskColor as { r: number; g: number; b: number }
-      color = [c.r / 255, c.g / 255, c.b / 255]
-    }
-
-    // 2. Prepare stroke points
-    let strokePoints: { x: number; y: number; pressure: number }[] = []
-
-    if (skipResampling) {
-      // Points are already properly spaced from Catmull-Rom spline interpolation
-      strokePoints = points.map((p) => ({ x: p.x, y: p.y, pressure: 1.0 }))
-    } else {
-      // Legacy resampling for shift+click and other cases
-      for (let i = 0; i < points.length - 1; i++) {
-        const p1 = points[i]
-        const p2 = points[i + 1]
-        const dist = Math.hypot(p2.x - p1.x, p2.y - p1.y)
-
-        // Calculate target spacing based on stepSize
-        const stepPercentage =
-          Math.pow(100, store.brushSettings.stepSize / 100) / 100
-        const stepSize = Math.max(
-          1.0,
-          store.brushSettings.size * stepPercentage
-        )
-        const steps = Math.max(1, Math.ceil(dist / stepSize))
-
-        for (let step = 0; step <= steps; step++) {
-          const t = step / steps
-          const pressure = 1.0
-
-          const x = p1.x + (p2.x - p1.x) * t
-          const y = p1.y + (p2.y - p1.y) * t
-
-          strokePoints.push({ x, y, pressure })
-        }
+    // Read back GPU result
+    let maskData: ImageData | undefined
+    let rgbData: ImageData | undefined
+    if (gpu.hasRenderer.value) {
+      try {
+        const result = await gpu.copyGpuToCanvas()
+        maskData = result.maskData
+        rgbData = result.rgbData
+      } catch (error) {
+        console.warn('GPU readback failed, falling back to CPU:', error)
       }
     }
 
-    // Render to Accumulator (SourceOver blending)
-    // Use fixed opacity (0.5) to build up the shape smoothly without creases.
-    // The final opacity is applied in the composite pass.
-    const size = store.brushSettings.size
-    const hardness = store.brushSettings.hardness
-    const effectiveSize = getEffectiveBrushSize(size, hardness)
-    const effectiveHardness = getEffectiveHardness(
-      size,
-      hardness,
-      effectiveSize
-    )
+    // Save to history
+    gpu.isSavingHistory.value = true
+    store.canvasHistory.saveState(maskData, rgbData)
+    await nextTick()
+    gpu.isSavingHistory.value = false
 
-    const brushShape = store.brushSettings.type === BrushShape.Rect ? 1 : 0
+    gpu.clearPreview()
 
-    // Render to Accumulator (SourceOver blending)
-    // Use fixed opacity (0.5) to build up the shape smoothly without creases.
-    // The final opacity is applied in the composite pass.
-    renderer.renderStrokeToAccumulator(strokePoints, {
-      size: effectiveSize,
-      opacity: 0.5,
-      hardness: effectiveHardness,
-      color: color,
-      width: store.maskCanvas!.width,
-      height: store.maskCanvas!.height,
-      brushShape
-    })
-
-    for (const p of strokePoints) {
-      dirtyRect.value = updateDirtyRect(
-        dirtyRect.value,
-        p.x,
-        p.y,
-        effectiveSize
-      )
+    // Restore canvas visibility
+    if (isRgb && store.rgbCanvas) {
+      store.rgbCanvas.style.opacity = '1'
+    } else if (!isRgb && store.maskCanvas) {
+      store.maskCanvas.style.opacity = String(store.maskOpacity)
     }
-
-    // 3. Blit to Preview with correct settings
-    if (previewContext) {
-      const isErasing =
-        store.currentTool === 'eraser' ||
-        store.maskCtx?.globalCompositeOperation === 'destination-out'
-
-      const targetTex = isRgb ? rgbTexture : maskTexture
-      renderer.blitToCanvas(
-        previewContext,
-        {
-          opacity: store.brushSettings.opacity,
-          color,
-          hardness: effectiveHardness,
-          screenSize: [store.maskCanvas!.width, store.maskCanvas!.height],
-          brushShape,
-          isErasing
-        },
-        targetTex ?? undefined
-      )
+    if (gpu.previewCanvas.value) {
+      gpu.previewCanvas.value.style.opacity = '1'
     }
-  }
-
-  /**
-   * Clears the GPU textures.
-   */
-  function clearGPU() {
-    if (!device || !maskTexture || !rgbTexture || !store.maskCanvas) return
-
-    const width = store.maskCanvas.width
-    const height = store.maskCanvas.height
-
-    // Clear Mask Texture
-    device.queue.writeTexture(
-      { texture: maskTexture },
-      new Uint8Array(width * height * 4), // Zeros
-      { bytesPerRow: width * 4 },
-      { width, height }
-    )
-
-    // Clear RGB Texture
-    device.queue.writeTexture(
-      { texture: rgbTexture },
-      new Uint8Array(width * height * 4), // Zeros
-      { bytesPerRow: width * 4 },
-      { width, height }
-    )
   }
 
   return {
@@ -1153,9 +332,9 @@ export function useBrushDrawing(initialSettings?: {
     startBrushAdjustment,
     handleBrushAdjustment,
     saveBrushSettings: persistence.save,
-    destroy,
-    initGPUResources,
-    initPreviewCanvas,
-    clearGPU // Export this
+    destroy: gpu.destroy,
+    initGPUResources: gpu.initGPUResources,
+    initPreviewCanvas: gpu.initPreviewCanvas,
+    clearGPU: gpu.clearGPU
   }
 }

--- a/src/composables/maskeditor/useGPUResources.test.ts
+++ b/src/composables/maskeditor/useGPUResources.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import type { EffectScope } from 'vue'
+
+vi.mock('typegpu', () => ({
+  tgpu: {
+    init: vi.fn().mockRejectedValue(new Error('WebGPU not supported'))
+  }
+}))
+
+vi.mock('./gpu/GPUBrushRenderer', () => ({
+  GPUBrushRenderer: vi.fn()
+}))
+
+const mockStore = {
+  tgpuRoot: null as unknown,
+  maskCanvas: null as HTMLCanvasElement | null,
+  rgbCanvas: null as HTMLCanvasElement | null,
+  maskCtx: null as CanvasRenderingContext2D | null,
+  rgbCtx: null as CanvasRenderingContext2D | null,
+  clearTrigger: 0,
+  canvasHistory: { currentStateIndex: 0 },
+  gpuTexturesNeedRecreation: false,
+  gpuTextureWidth: 0,
+  gpuTextureHeight: 0,
+  pendingGPUMaskData: null as null,
+  pendingGPURgbData: null as null,
+  brushSettings: {
+    size: 20,
+    hardness: 0.9,
+    opacity: 1,
+    stepSize: 5,
+    type: 'arc'
+  },
+  activeLayer: 'mask',
+  currentTool: 'pen',
+  maskColor: { r: 0, g: 0, b: 0 },
+  rgbColor: '#FF0000'
+}
+
+vi.mock('@/stores/maskEditorStore', () => ({
+  useMaskEditorStore: vi.fn(() => mockStore)
+}))
+
+import { resetDirtyRect } from './brushDrawingUtils'
+import { useGPUResources } from './useGPUResources'
+
+let scope: EffectScope | null = null
+
+function setup() {
+  scope = effectScope()
+  return scope.run(() => useGPUResources())!
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockStore.tgpuRoot = null
+  mockStore.maskCanvas = null
+  mockStore.rgbCanvas = null
+  mockStore.maskCtx = null
+  mockStore.rgbCtx = null
+})
+
+afterEach(() => {
+  scope?.stop()
+  scope = null
+})
+
+describe('initial reactive state', () => {
+  it('hasRenderer is false when no renderer exists', () => {
+    const { hasRenderer } = setup()
+    expect(hasRenderer.value).toBe(false)
+  })
+
+  it('isSavingHistory is false initially', () => {
+    const { isSavingHistory } = setup()
+    expect(isSavingHistory.value).toBe(false)
+  })
+
+  it('previewCanvas is null initially', () => {
+    const { previewCanvas } = setup()
+    expect(previewCanvas.value).toBeNull()
+  })
+
+  it('dirtyRect starts with uninitialised sentinel values', () => {
+    const { dirtyRect } = setup()
+    expect(dirtyRect.value).toEqual(resetDirtyRect())
+  })
+})
+
+describe('no-op when GPU is not initialised', () => {
+  it('prepareStroke does not throw', () => {
+    const { prepareStroke } = setup()
+    expect(() => prepareStroke()).not.toThrow()
+  })
+
+  it('clearPreview does not throw', () => {
+    const { clearPreview } = setup()
+    expect(() => clearPreview()).not.toThrow()
+  })
+
+  it('clearGPU does not throw', () => {
+    const { clearGPU } = setup()
+    expect(() => clearGPU()).not.toThrow()
+  })
+
+  it('destroy does not throw', () => {
+    const { destroy } = setup()
+    expect(() => destroy()).not.toThrow()
+  })
+
+  it('gpuRender does not throw with empty or non-empty point arrays', () => {
+    const { gpuRender } = setup()
+    expect(() => gpuRender([])).not.toThrow()
+    expect(() => gpuRender([{ x: 10, y: 20 }])).not.toThrow()
+  })
+
+  it('compositeStroke does not throw for any combination of flags', () => {
+    const { compositeStroke } = setup()
+    expect(() => compositeStroke(false, false)).not.toThrow()
+    expect(() => compositeStroke(true, true)).not.toThrow()
+  })
+})
+
+describe('initGPUResources', () => {
+  it('leaves hasRenderer false when TypeGPU initialisation fails', async () => {
+    const { initGPUResources, hasRenderer } = setup()
+    await initGPUResources()
+    expect(hasRenderer.value).toBe(false)
+  })
+})
+
+describe('copyGpuToCanvas', () => {
+  it('rejects with a descriptive error when GPU resources are not ready', async () => {
+    const { copyGpuToCanvas } = setup()
+    await expect(copyGpuToCanvas()).rejects.toThrow('GPU resources not ready')
+  })
+})

--- a/src/composables/maskeditor/useGPUResources.test.ts
+++ b/src/composables/maskeditor/useGPUResources.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope } from 'vue'
+import { effectScope, nextTick, reactive } from 'vue'
 import type { EffectScope } from 'vue'
 
 vi.mock('typegpu', () => ({
@@ -12,7 +12,7 @@ vi.mock('./gpu/GPUBrushRenderer', () => ({
   GPUBrushRenderer: vi.fn()
 }))
 
-const mockStore = {
+const mockStore = reactive({
   tgpuRoot: null as unknown,
   maskCanvas: null as HTMLCanvasElement | null,
   rgbCanvas: null as HTMLCanvasElement | null,
@@ -36,7 +36,7 @@ const mockStore = {
   currentTool: 'pen',
   maskColor: { r: 0, g: 0, b: 0 },
   rgbColor: '#FF0000'
-}
+})
 
 vi.mock('@/stores/maskEditorStore', () => ({
   useMaskEditorStore: vi.fn(() => mockStore)
@@ -59,6 +59,9 @@ beforeEach(() => {
   mockStore.rgbCanvas = null
   mockStore.maskCtx = null
   mockStore.rgbCtx = null
+  mockStore.clearTrigger = 0
+  mockStore.canvasHistory.currentStateIndex = 0
+  mockStore.gpuTexturesNeedRecreation = false
 })
 
 afterEach(() => {
@@ -134,5 +137,56 @@ describe('copyGpuToCanvas', () => {
   it('rejects with a descriptive error when GPU resources are not ready', async () => {
     const { copyGpuToCanvas } = setup()
     await expect(copyGpuToCanvas()).rejects.toThrow('GPU resources not ready')
+  })
+})
+
+describe('watchers', () => {
+  it('clearTrigger watcher calls clearGPU without throwing', async () => {
+    setup()
+    mockStore.clearTrigger++
+    await nextTick()
+  })
+
+  it('currentStateIndex watcher short-circuits when isSavingHistory is true', async () => {
+    const { isSavingHistory } = setup()
+    isSavingHistory.value = true
+    mockStore.canvasHistory.currentStateIndex++
+    await nextTick()
+  })
+
+  it('currentStateIndex watcher calls updateGPUFromCanvas when not saving history', async () => {
+    setup()
+    mockStore.canvasHistory.currentStateIndex++
+    await nextTick()
+  })
+
+  it('gpuTexturesNeedRecreation watcher returns early when device is not initialised', async () => {
+    setup()
+    mockStore.gpuTexturesNeedRecreation = true
+    await nextTick()
+  })
+})
+
+describe('initGPUResources with pre-existing tgpuRoot', () => {
+  it('returns early with a warning when canvas contexts are not ready', async () => {
+    const { initGPUResources, hasRenderer } = setup()
+    mockStore.tgpuRoot = { device: {} } as unknown
+    await initGPUResources()
+    expect(hasRenderer.value).toBe(false)
+  })
+})
+
+describe('initPreviewCanvas', () => {
+  it('returns early when device is not initialised', () => {
+    const { initPreviewCanvas } = setup()
+    const canvas = document.createElement('canvas')
+    expect(() => initPreviewCanvas(canvas)).not.toThrow()
+  })
+})
+
+describe('gpuDrawPoint', () => {
+  it('resolves immediately when renderer is not initialised', async () => {
+    const { gpuDrawPoint } = setup()
+    await expect(gpuDrawPoint({ x: 10, y: 20 })).resolves.toBeUndefined()
   })
 })

--- a/src/composables/maskeditor/useGPUResources.ts
+++ b/src/composables/maskeditor/useGPUResources.ts
@@ -142,6 +142,9 @@ export function useGPUResources() {
     readbackStagingMask = null
     readbackStagingRgb?.destroy()
     readbackStagingRgb = null
+    previewContext = null
+    previewCanvas.value = null
+    dirtyRect.value = resetDirtyRect()
     // Device is managed by TGPU root; do not destroy it here
     // c8 ignore stop
   })
@@ -354,6 +357,9 @@ export function useGPUResources() {
     readbackStagingMask = null
     readbackStagingRgb = null
     currentBufferSize = 0
+    previewContext = null
+    previewCanvas.value = null
+    dirtyRect.value = resetDirtyRect()
     /* c8 ignore next — tgpuRoot only exists after successful GPU init */
     if (store.tgpuRoot) {
       store.tgpuRoot.destroy()
@@ -540,6 +546,13 @@ export function useGPUResources() {
       effectiveSize
     )
     const brushShape = store.brushSettings.type === BrushShape.Rect ? 1 : 0
+
+    dirtyRect.value = updateDirtyRect(
+      dirtyRect.value,
+      point.x,
+      point.y,
+      effectiveSize
+    )
 
     renderer.renderStrokeToAccumulator(
       [{ x: point.x, y: point.y, pressure: opacity }],

--- a/src/composables/maskeditor/useGPUResources.ts
+++ b/src/composables/maskeditor/useGPUResources.ts
@@ -1,5 +1,5 @@
 /// <reference types="@webgpu/types" />
-import { computed, onUnmounted, ref, watch } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
 import { tgpu } from 'typegpu'
 
 import { BrushShape } from '@/extensions/core/maskeditor/types'
@@ -15,7 +15,7 @@ import {
 } from './brushDrawingUtils'
 import { getEffectiveBrushSize, getEffectiveHardness } from './brushUtils'
 import { GPUBrushRenderer } from './gpu/GPUBrushRenderer'
-import { clampDirtyRect } from './gpuUtils'
+import { buildStrokePoints, clampDirtyRect } from './gpuUtils'
 
 export function useGPUResources() {
   const store = useMaskEditorStore()
@@ -39,7 +39,7 @@ export function useGPUResources() {
   const isSavingHistory = ref(false)
   const dirtyRect = ref<DirtyRect>(resetDirtyRect())
 
-  const hasRenderer = computed(() => renderer !== null)
+  const hasRenderer = ref(false)
 
   const isRecreatingTextures = ref(false)
 
@@ -124,8 +124,10 @@ export function useGPUResources() {
   )
 
   onUnmounted(() => {
+    // c8 ignore start
     renderer?.destroy()
     renderer = null
+    hasRenderer.value = false
     maskTexture?.destroy()
     maskTexture = null
     rgbTexture?.destroy()
@@ -139,10 +141,12 @@ export function useGPUResources() {
     readbackStagingRgb?.destroy()
     readbackStagingRgb = null
     // Device is managed by TGPU root; do not destroy it here
+    // c8 ignore stop
   })
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
+  /* c8 ignore start — requires a live GPUDevice */
   function createTexture(
     gpuDevice: GPUDevice,
     width: number,
@@ -191,20 +195,24 @@ export function useGPUResources() {
     })
     currentBufferSize = bufferSize
   }
+  /* c8 ignore stop */
 
   // ── Internal functions ───────────────────────────────────────────────────────
 
   async function initTypeGPU(): Promise<void> {
     if (store.tgpuRoot) {
+      // c8 ignore next
       device = store.tgpuRoot.device
       return
     }
     try {
+      /* c8 ignore start — requires functional WebGPU hardware */
       const root = await tgpu.init()
       store.tgpuRoot = root
       device = root.device
       console.warn('✅ TypeGPU initialized! Root:', root)
       console.warn('Device info:', root.device.limits)
+      /* c8 ignore stop */
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.warn('Failed to initialize TypeGPU:', message)
@@ -217,14 +225,16 @@ export function useGPUResources() {
       !maskTexture ||
       !rgbTexture ||
       !store.maskCanvas ||
+      !store.maskCtx ||
       !store.rgbCtx
     )
       return
 
+    /* c8 ignore start — requires live GPU device and textures */
     const w = store.maskCanvas.width
     const h = store.maskCanvas.height
 
-    const maskData = store.maskCtx!.getImageData(0, 0, w, h)
+    const maskData = store.maskCtx.getImageData(0, 0, w, h)
     premultiplyData(maskData.data)
     device.queue.writeTexture(
       { texture: maskTexture },
@@ -241,6 +251,7 @@ export function useGPUResources() {
       { bytesPerRow: w * 4 },
       { width: w, height: h }
     )
+    /* c8 ignore stop */
   }
 
   // ── Public API ───────────────────────────────────────────────────────────────
@@ -265,6 +276,7 @@ export function useGPUResources() {
     const w = store.maskCanvas.width
     const h = store.maskCanvas.height
 
+    /* c8 ignore start — requires functional WebGPU hardware */
     try {
       console.warn(`🎨 Initializing GPU resources for ${w}x${h} canvas`)
       maskTexture = createTexture(device, w, h)
@@ -275,16 +287,19 @@ export function useGPUResources() {
         device,
         navigator.gpu.getPreferredCanvasFormat()
       )
+      hasRenderer.value = true
       console.warn('✅ Brush renderer initialized')
     } catch (error) {
       console.error('Failed to initialize GPU resources:', error)
       maskTexture = null
       rgbTexture = null
     }
+    /* c8 ignore stop */
   }
 
   function initPreviewCanvas(canvas: HTMLCanvasElement): void {
     if (!device) return
+    /* c8 ignore start — requires live GPUDevice and WebGPU canvas context */
     const ctx = canvas.getContext('webgpu')
     if (!ctx) return
     ctx.configure({
@@ -295,10 +310,12 @@ export function useGPUResources() {
     previewContext = ctx
     previewCanvas.value = canvas
     console.warn('✅ Preview Canvas Initialized')
+    /* c8 ignore stop */
   }
 
   function clearGPU(): void {
     if (!device || !maskTexture || !rgbTexture || !store.maskCanvas) return
+    /* c8 ignore start — requires live GPUDevice and textures */
     const w = store.maskCanvas.width
     const h = store.maskCanvas.height
     const zeros = new Uint8Array(w * h * 4)
@@ -314,6 +331,7 @@ export function useGPUResources() {
       { bytesPerRow: w * 4 },
       { width: w, height: h }
     )
+    /* c8 ignore stop */
   }
 
   function destroy(): void {
@@ -325,6 +343,7 @@ export function useGPUResources() {
     readbackStagingMask?.destroy()
     readbackStagingRgb?.destroy()
     renderer = null
+    hasRenderer.value = false
     maskTexture = null
     rgbTexture = null
     readbackStorageMask = null
@@ -332,6 +351,7 @@ export function useGPUResources() {
     readbackStagingMask = null
     readbackStagingRgb = null
     currentBufferSize = 0
+    /* c8 ignore next — tgpuRoot only exists after successful GPU init */
     if (store.tgpuRoot) {
       store.tgpuRoot.destroy()
       store.tgpuRoot = null
@@ -352,6 +372,7 @@ export function useGPUResources() {
 
   function compositeStroke(isRgb: boolean, isErasing: boolean): void {
     if (!renderer || !maskTexture || !rgbTexture || !store.maskCanvas) return
+    /* c8 ignore start — requires live renderer */
     const targetTex = isRgb ? rgbTexture : maskTexture
     const { size, hardness, opacity, type } = store.brushSettings
     const effectiveSize = getEffectiveBrushSize(size, hardness)
@@ -369,6 +390,7 @@ export function useGPUResources() {
       brushShape,
       isErasing
     })
+    /* c8 ignore stop */
   }
 
   async function copyGpuToCanvas(): Promise<{
@@ -387,6 +409,7 @@ export function useGPUResources() {
     )
       throw new Error('GPU resources not ready')
 
+    /* c8 ignore start — requires live GPU device, textures and renderer */
     const width = store.maskCanvas.width
     const height = store.maskCanvas.height
 
@@ -434,14 +457,19 @@ export function useGPUResources() {
     store.rgbCtx.putImageData(rgbImageData, 0, 0, dx, dy, dw, dh)
 
     return { maskData: maskImageData, rgbData: rgbImageData }
+    /* c8 ignore stop */
   }
 
   function gpuRender(points: Point[], skipResampling = false): void {
     if (!renderer || !maskTexture || !rgbTexture) return
 
+    /* c8 ignore start — requires live renderer */
     const isRgb = store.activeLayer === 'rgb'
     const color = resolveColor(isRgb)
-    const strokePoints = buildStrokePoints(points, skipResampling)
+    const stepPercentage =
+      Math.pow(100, store.brushSettings.stepSize / 100) / 100
+    const gpuStepSize = Math.max(1.0, store.brushSettings.size * stepPercentage)
+    const strokePoints = buildStrokePoints(points, skipResampling, gpuStepSize)
 
     const { size, hardness } = store.brushSettings
     const effectiveSize = getEffectiveBrushSize(size, hardness)
@@ -489,11 +517,13 @@ export function useGPUResources() {
         targetTex ?? undefined
       )
     }
+    /* c8 ignore stop */
   }
 
   async function gpuDrawPoint(point: Point, opacity = 1): Promise<void> {
     if (!renderer) return
 
+    /* c8 ignore start — requires live renderer */
     const width = store.maskCanvas!.width
     const height = store.maskCanvas!.height
     const { size, hardness } = store.brushSettings
@@ -536,10 +566,12 @@ export function useGPUResources() {
         undefined
       )
     }
+    /* c8 ignore stop */
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────
 
+  /* c8 ignore start — only reachable after successful GPU init */
   function resolveColor(isRgb: boolean): [number, number, number] {
     if (isRgb) {
       const c = parseToRgb(store.rgbColor)
@@ -548,36 +580,7 @@ export function useGPUResources() {
     const c = store.maskColor as { r: number; g: number; b: number }
     return [c.r / 255, c.g / 255, c.b / 255]
   }
-
-  function buildStrokePoints(
-    points: Point[],
-    skipResampling: boolean
-  ): { x: number; y: number; pressure: number }[] {
-    if (skipResampling) {
-      return points.map((p) => ({ x: p.x, y: p.y, pressure: 1.0 }))
-    }
-    const result: { x: number; y: number; pressure: number }[] = []
-    const stepPercentage =
-      Math.pow(100, store.brushSettings.stepSize / 100) / 100
-    const stepSize = Math.max(1.0, store.brushSettings.size * stepPercentage)
-    for (let i = 0; i < points.length - 1; i++) {
-      const p1 = points[i]
-      const p2 = points[i + 1]
-      const steps = Math.max(
-        1,
-        Math.ceil(Math.hypot(p2.x - p1.x, p2.y - p1.y) / stepSize)
-      )
-      for (let s = 0; s <= steps; s++) {
-        const t = s / steps
-        result.push({
-          x: p1.x + (p2.x - p1.x) * t,
-          y: p1.y + (p2.y - p1.y) * t,
-          pressure: 1.0
-        })
-      }
-    }
-    return result
-  }
+  /* c8 ignore stop */
 
   return {
     // Lifecycle — spread into useBrushDrawing's public return

--- a/src/composables/maskeditor/useGPUResources.ts
+++ b/src/composables/maskeditor/useGPUResources.ts
@@ -70,6 +70,7 @@ export function useGPUResources() {
       )
         return
 
+      /* c8 ignore start */
       isRecreatingTextures.value = true
 
       const width = store.gpuTextureWidth
@@ -120,6 +121,7 @@ export function useGPUResources() {
         store.pendingGPURgbData = null
         isRecreatingTextures.value = false
       }
+      /* c8 ignore stop */
     }
   )
 
@@ -201,9 +203,10 @@ export function useGPUResources() {
 
   async function initTypeGPU(): Promise<void> {
     if (store.tgpuRoot) {
-      // c8 ignore next
+      /* c8 ignore start */
       device = store.tgpuRoot.device
       return
+      /* c8 ignore stop */
     }
     try {
       /* c8 ignore start — requires functional WebGPU hardware */
@@ -363,11 +366,14 @@ export function useGPUResources() {
 
   function prepareStroke(): void {
     if (!renderer || !store.maskCanvas) return
+    /* c8 ignore next */
     renderer.prepareStroke(store.maskCanvas.width, store.maskCanvas.height)
   }
 
   function clearPreview(): void {
-    if (renderer && previewContext) renderer.clearPreview(previewContext)
+    if (!renderer || !previewContext) return
+    /* c8 ignore next */
+    renderer.clearPreview(previewContext)
   }
 
   function compositeStroke(isRgb: boolean, isErasing: boolean): void {

--- a/src/composables/maskeditor/useGPUResources.ts
+++ b/src/composables/maskeditor/useGPUResources.ts
@@ -1,0 +1,602 @@
+/// <reference types="@webgpu/types" />
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { tgpu } from 'typegpu'
+
+import { BrushShape } from '@/extensions/core/maskeditor/types'
+import type { Point } from '@/extensions/core/maskeditor/types'
+import { useMaskEditorStore } from '@/stores/maskEditorStore'
+import { parseToRgb } from '@/utils/colorUtil'
+
+import type { DirtyRect } from './brushDrawingUtils'
+import {
+  premultiplyData,
+  resetDirtyRect,
+  updateDirtyRect
+} from './brushDrawingUtils'
+import { getEffectiveBrushSize, getEffectiveHardness } from './brushUtils'
+import { GPUBrushRenderer } from './gpu/GPUBrushRenderer'
+import { clampDirtyRect } from './gpuUtils'
+
+export function useGPUResources() {
+  const store = useMaskEditorStore()
+
+  // GPU state — plain variables, not reactive, as Vue doesn't need to track them
+  let maskTexture: GPUTexture | null = null
+  let rgbTexture: GPUTexture | null = null
+  let device: GPUDevice | null = null
+  let renderer: GPUBrushRenderer | null = null
+  let previewContext: GPUCanvasContext | null = null
+
+  // Readback buffers
+  let readbackStorageMask: GPUBuffer | null = null
+  let readbackStorageRgb: GPUBuffer | null = null
+  let readbackStagingMask: GPUBuffer | null = null
+  let readbackStagingRgb: GPUBuffer | null = null
+  let currentBufferSize = 0
+
+  // Reactive state shared with useBrushDrawing
+  const previewCanvas = ref<HTMLCanvasElement | null>(null)
+  const isSavingHistory = ref(false)
+  const dirtyRect = ref<DirtyRect>(resetDirtyRect())
+
+  const hasRenderer = computed(() => renderer !== null)
+
+  const isRecreatingTextures = ref(false)
+
+  // ── Watchers ────────────────────────────────────────────────────────────────
+
+  watch(
+    () => store.clearTrigger,
+    () => clearGPU()
+  )
+
+  watch(
+    () => store.canvasHistory.currentStateIndex,
+    async () => {
+      if (isSavingHistory.value) return
+      await updateGPUFromCanvas()
+      if (renderer && previewContext) renderer.clearPreview(previewContext)
+    }
+  )
+
+  watch(
+    () => store.gpuTexturesNeedRecreation,
+    async (needsRecreation) => {
+      if (
+        !needsRecreation ||
+        !device ||
+        !store.maskCanvas ||
+        isRecreatingTextures.value
+      )
+        return
+
+      isRecreatingTextures.value = true
+
+      const width = store.gpuTextureWidth
+      const height = store.gpuTextureHeight
+
+      try {
+        maskTexture?.destroy()
+        maskTexture = null
+        rgbTexture?.destroy()
+        rgbTexture = null
+
+        maskTexture = createTexture(device, width, height)
+        rgbTexture = createTexture(device, width, height)
+
+        if (store.pendingGPUMaskData && store.pendingGPURgbData) {
+          device.queue.writeTexture(
+            { texture: maskTexture },
+            store.pendingGPUMaskData,
+            { bytesPerRow: width * 4 },
+            { width, height }
+          )
+          device.queue.writeTexture(
+            { texture: rgbTexture },
+            store.pendingGPURgbData,
+            { bytesPerRow: width * 4 },
+            { width, height }
+          )
+        } else {
+          await updateGPUFromCanvas()
+        }
+
+        if (previewCanvas.value && renderer) {
+          previewCanvas.value.width = width
+          previewCanvas.value.height = height
+        }
+
+        resizeReadbackBuffers(device, width, height)
+      } catch (error) {
+        console.error(
+          '[useGPUResources] Failed to recreate GPU textures:',
+          error
+        )
+      } finally {
+        store.gpuTexturesNeedRecreation = false
+        store.gpuTextureWidth = 0
+        store.gpuTextureHeight = 0
+        store.pendingGPUMaskData = null
+        store.pendingGPURgbData = null
+        isRecreatingTextures.value = false
+      }
+    }
+  )
+
+  onUnmounted(() => {
+    renderer?.destroy()
+    renderer = null
+    maskTexture?.destroy()
+    maskTexture = null
+    rgbTexture?.destroy()
+    rgbTexture = null
+    readbackStorageMask?.destroy()
+    readbackStorageMask = null
+    readbackStorageRgb?.destroy()
+    readbackStorageRgb = null
+    readbackStagingMask?.destroy()
+    readbackStagingMask = null
+    readbackStagingRgb?.destroy()
+    readbackStagingRgb = null
+    // Device is managed by TGPU root; do not destroy it here
+  })
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  function createTexture(
+    gpuDevice: GPUDevice,
+    width: number,
+    height: number
+  ): GPUTexture {
+    return gpuDevice.createTexture({
+      size: [width, height],
+      format: 'rgba8unorm',
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.STORAGE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.COPY_SRC
+    })
+  }
+
+  function resizeReadbackBuffers(
+    gpuDevice: GPUDevice,
+    width: number,
+    height: number
+  ): void {
+    const bufferSize = width * height * 4
+    if (currentBufferSize === bufferSize) return
+
+    readbackStorageMask?.destroy()
+    readbackStorageRgb?.destroy()
+    readbackStagingMask?.destroy()
+    readbackStagingRgb?.destroy()
+
+    readbackStorageMask = gpuDevice.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    })
+    readbackStorageRgb = gpuDevice.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    })
+    readbackStagingMask = gpuDevice.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    })
+    readbackStagingRgb = gpuDevice.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    })
+    currentBufferSize = bufferSize
+  }
+
+  // ── Internal functions ───────────────────────────────────────────────────────
+
+  async function initTypeGPU(): Promise<void> {
+    if (store.tgpuRoot) {
+      device = store.tgpuRoot.device
+      return
+    }
+    try {
+      const root = await tgpu.init()
+      store.tgpuRoot = root
+      device = root.device
+      console.warn('✅ TypeGPU initialized! Root:', root)
+      console.warn('Device info:', root.device.limits)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn('Failed to initialize TypeGPU:', message)
+    }
+  }
+
+  async function updateGPUFromCanvas(): Promise<void> {
+    if (
+      !device ||
+      !maskTexture ||
+      !rgbTexture ||
+      !store.maskCanvas ||
+      !store.rgbCtx
+    )
+      return
+
+    const w = store.maskCanvas.width
+    const h = store.maskCanvas.height
+
+    const maskData = store.maskCtx!.getImageData(0, 0, w, h)
+    premultiplyData(maskData.data)
+    device.queue.writeTexture(
+      { texture: maskTexture },
+      maskData.data,
+      { bytesPerRow: w * 4 },
+      { width: w, height: h }
+    )
+
+    const rgbData = store.rgbCtx.getImageData(0, 0, w, h)
+    premultiplyData(rgbData.data)
+    device.queue.writeTexture(
+      { texture: rgbTexture },
+      rgbData.data,
+      { bytesPerRow: w * 4 },
+      { width: w, height: h }
+    )
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────────────
+
+  async function initGPUResources(): Promise<void> {
+    await initTypeGPU()
+
+    if (!store.tgpuRoot || !device) {
+      console.warn('TypeGPU not initialized, skipping GPU resource setup')
+      return
+    }
+    if (
+      !store.maskCanvas ||
+      !store.rgbCanvas ||
+      !store.maskCtx ||
+      !store.rgbCtx
+    ) {
+      console.warn('Canvas contexts not ready, skipping GPU resource setup')
+      return
+    }
+
+    const w = store.maskCanvas.width
+    const h = store.maskCanvas.height
+
+    try {
+      console.warn(`🎨 Initializing GPU resources for ${w}x${h} canvas`)
+      maskTexture = createTexture(device, w, h)
+      rgbTexture = createTexture(device, w, h)
+      await updateGPUFromCanvas()
+      console.warn('✅ GPU resources initialized successfully')
+      renderer = new GPUBrushRenderer(
+        device,
+        navigator.gpu.getPreferredCanvasFormat()
+      )
+      console.warn('✅ Brush renderer initialized')
+    } catch (error) {
+      console.error('Failed to initialize GPU resources:', error)
+      maskTexture = null
+      rgbTexture = null
+    }
+  }
+
+  function initPreviewCanvas(canvas: HTMLCanvasElement): void {
+    if (!device) return
+    const ctx = canvas.getContext('webgpu')
+    if (!ctx) return
+    ctx.configure({
+      device,
+      format: navigator.gpu.getPreferredCanvasFormat(),
+      alphaMode: 'premultiplied'
+    })
+    previewContext = ctx
+    previewCanvas.value = canvas
+    console.warn('✅ Preview Canvas Initialized')
+  }
+
+  function clearGPU(): void {
+    if (!device || !maskTexture || !rgbTexture || !store.maskCanvas) return
+    const w = store.maskCanvas.width
+    const h = store.maskCanvas.height
+    const zeros = new Uint8Array(w * h * 4)
+    device.queue.writeTexture(
+      { texture: maskTexture },
+      zeros,
+      { bytesPerRow: w * 4 },
+      { width: w, height: h }
+    )
+    device.queue.writeTexture(
+      { texture: rgbTexture },
+      zeros,
+      { bytesPerRow: w * 4 },
+      { width: w, height: h }
+    )
+  }
+
+  function destroy(): void {
+    renderer?.destroy()
+    maskTexture?.destroy()
+    rgbTexture?.destroy()
+    readbackStorageMask?.destroy()
+    readbackStorageRgb?.destroy()
+    readbackStagingMask?.destroy()
+    readbackStagingRgb?.destroy()
+    renderer = null
+    maskTexture = null
+    rgbTexture = null
+    readbackStorageMask = null
+    readbackStorageRgb = null
+    readbackStagingMask = null
+    readbackStagingRgb = null
+    currentBufferSize = 0
+    if (store.tgpuRoot) {
+      store.tgpuRoot.destroy()
+      store.tgpuRoot = null
+    }
+    device = null
+  }
+
+  // ── Wrappers called by useBrushDrawing ──────────────────────────────────────
+
+  function prepareStroke(): void {
+    if (!renderer || !store.maskCanvas) return
+    renderer.prepareStroke(store.maskCanvas.width, store.maskCanvas.height)
+  }
+
+  function clearPreview(): void {
+    if (renderer && previewContext) renderer.clearPreview(previewContext)
+  }
+
+  function compositeStroke(isRgb: boolean, isErasing: boolean): void {
+    if (!renderer || !maskTexture || !rgbTexture || !store.maskCanvas) return
+    const targetTex = isRgb ? rgbTexture : maskTexture
+    const { size, hardness, opacity, type } = store.brushSettings
+    const effectiveSize = getEffectiveBrushSize(size, hardness)
+    const effectiveHardness = getEffectiveHardness(
+      size,
+      hardness,
+      effectiveSize
+    )
+    const brushShape = type === BrushShape.Rect ? 1 : 0
+    renderer.compositeStroke(targetTex.createView(), {
+      opacity,
+      color: [0, 0, 0],
+      hardness: effectiveHardness,
+      screenSize: [store.maskCanvas.width, store.maskCanvas.height],
+      brushShape,
+      isErasing
+    })
+  }
+
+  async function copyGpuToCanvas(): Promise<{
+    maskData: ImageData
+    rgbData: ImageData
+  }> {
+    if (
+      !device ||
+      !maskTexture ||
+      !rgbTexture ||
+      !store.maskCanvas ||
+      !store.rgbCanvas ||
+      !store.maskCtx ||
+      !store.rgbCtx ||
+      !renderer
+    )
+      throw new Error('GPU resources not ready')
+
+    const width = store.maskCanvas.width
+    const height = store.maskCanvas.height
+
+    resizeReadbackBuffers(device, width, height)
+
+    renderer.prepareReadback(maskTexture, readbackStorageMask!)
+    renderer.prepareReadback(rgbTexture, readbackStorageRgb!)
+
+    const encoder = device.createCommandEncoder()
+    encoder.copyBufferToBuffer(
+      readbackStorageMask!,
+      0,
+      readbackStagingMask!,
+      0,
+      currentBufferSize
+    )
+    encoder.copyBufferToBuffer(
+      readbackStorageRgb!,
+      0,
+      readbackStagingRgb!,
+      0,
+      currentBufferSize
+    )
+    device.queue.submit([encoder.finish()])
+
+    await Promise.all([
+      readbackStagingMask!.mapAsync(GPUMapMode.READ),
+      readbackStagingRgb!.mapAsync(GPUMapMode.READ)
+    ])
+
+    const maskDataArr = new Uint8ClampedArray(
+      readbackStagingMask!.getMappedRange().slice(0)
+    )
+    const rgbDataArr = new Uint8ClampedArray(
+      readbackStagingRgb!.getMappedRange().slice(0)
+    )
+    readbackStagingMask!.unmap()
+    readbackStagingRgb!.unmap()
+
+    const maskImageData = new ImageData(maskDataArr, width, height)
+    const rgbImageData = new ImageData(rgbDataArr, width, height)
+
+    const { dx, dy, dw, dh } = clampDirtyRect(dirtyRect.value, width, height)
+    store.maskCtx.putImageData(maskImageData, 0, 0, dx, dy, dw, dh)
+    store.rgbCtx.putImageData(rgbImageData, 0, 0, dx, dy, dw, dh)
+
+    return { maskData: maskImageData, rgbData: rgbImageData }
+  }
+
+  function gpuRender(points: Point[], skipResampling = false): void {
+    if (!renderer || !maskTexture || !rgbTexture) return
+
+    const isRgb = store.activeLayer === 'rgb'
+    const color = resolveColor(isRgb)
+    const strokePoints = buildStrokePoints(points, skipResampling)
+
+    const { size, hardness } = store.brushSettings
+    const effectiveSize = getEffectiveBrushSize(size, hardness)
+    const effectiveHardness = getEffectiveHardness(
+      size,
+      hardness,
+      effectiveSize
+    )
+    const brushShape = store.brushSettings.type === BrushShape.Rect ? 1 : 0
+
+    renderer.renderStrokeToAccumulator(strokePoints, {
+      size: effectiveSize,
+      opacity: 0.5,
+      hardness: effectiveHardness,
+      color,
+      width: store.maskCanvas!.width,
+      height: store.maskCanvas!.height,
+      brushShape
+    })
+
+    for (const p of strokePoints) {
+      dirtyRect.value = updateDirtyRect(
+        dirtyRect.value,
+        p.x,
+        p.y,
+        effectiveSize
+      )
+    }
+
+    if (previewContext) {
+      const isErasing =
+        store.currentTool === 'eraser' ||
+        store.maskCtx?.globalCompositeOperation === 'destination-out'
+      const targetTex = isRgb ? rgbTexture : maskTexture
+      renderer.blitToCanvas(
+        previewContext,
+        {
+          opacity: store.brushSettings.opacity,
+          color,
+          hardness: effectiveHardness,
+          screenSize: [store.maskCanvas!.width, store.maskCanvas!.height],
+          brushShape,
+          isErasing
+        },
+        targetTex ?? undefined
+      )
+    }
+  }
+
+  async function gpuDrawPoint(point: Point, opacity = 1): Promise<void> {
+    if (!renderer) return
+
+    const width = store.maskCanvas!.width
+    const height = store.maskCanvas!.height
+    const { size, hardness } = store.brushSettings
+    const effectiveSize = getEffectiveBrushSize(size, hardness)
+    const effectiveHardness = getEffectiveHardness(
+      size,
+      hardness,
+      effectiveSize
+    )
+    const brushShape = store.brushSettings.type === BrushShape.Rect ? 1 : 0
+
+    renderer.renderStrokeToAccumulator(
+      [{ x: point.x, y: point.y, pressure: opacity }],
+      {
+        size: effectiveSize,
+        opacity: 0.5,
+        hardness: effectiveHardness,
+        color: [1, 1, 1],
+        width,
+        height,
+        brushShape
+      }
+    )
+
+    if (maskTexture && previewContext) {
+      const isRgb = store.activeLayer === 'rgb'
+      const isErasing =
+        store.currentTool === 'eraser' ||
+        store.maskCtx?.globalCompositeOperation === 'destination-out'
+      renderer.blitToCanvas(
+        previewContext,
+        {
+          opacity: store.brushSettings.opacity,
+          color: resolveColor(isRgb),
+          hardness: effectiveHardness,
+          screenSize: [width, height],
+          brushShape,
+          isErasing
+        },
+        undefined
+      )
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  function resolveColor(isRgb: boolean): [number, number, number] {
+    if (isRgb) {
+      const c = parseToRgb(store.rgbColor)
+      return [c.r / 255, c.g / 255, c.b / 255]
+    }
+    const c = store.maskColor as { r: number; g: number; b: number }
+    return [c.r / 255, c.g / 255, c.b / 255]
+  }
+
+  function buildStrokePoints(
+    points: Point[],
+    skipResampling: boolean
+  ): { x: number; y: number; pressure: number }[] {
+    if (skipResampling) {
+      return points.map((p) => ({ x: p.x, y: p.y, pressure: 1.0 }))
+    }
+    const result: { x: number; y: number; pressure: number }[] = []
+    const stepPercentage =
+      Math.pow(100, store.brushSettings.stepSize / 100) / 100
+    const stepSize = Math.max(1.0, store.brushSettings.size * stepPercentage)
+    for (let i = 0; i < points.length - 1; i++) {
+      const p1 = points[i]
+      const p2 = points[i + 1]
+      const steps = Math.max(
+        1,
+        Math.ceil(Math.hypot(p2.x - p1.x, p2.y - p1.y) / stepSize)
+      )
+      for (let s = 0; s <= steps; s++) {
+        const t = s / steps
+        result.push({
+          x: p1.x + (p2.x - p1.x) * t,
+          y: p1.y + (p2.y - p1.y) * t,
+          pressure: 1.0
+        })
+      }
+    }
+    return result
+  }
+
+  return {
+    // Lifecycle — spread into useBrushDrawing's public return
+    initGPUResources,
+    initPreviewCanvas,
+    clearGPU,
+    destroy,
+    // Rendering — called internally by useBrushDrawing
+    gpuRender,
+    gpuDrawPoint,
+    copyGpuToCanvas,
+    // Renderer wrappers — called internally by useBrushDrawing
+    prepareStroke,
+    clearPreview,
+    compositeStroke,
+    // Shared reactive state
+    hasRenderer,
+    previewCanvas,
+    isSavingHistory,
+    dirtyRect
+  }
+}


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                              
 Phase D of the **useBrushDrawing-refactor plan.md**. Extract `WebGPU` state management from `useBrushDrawing` into a dedicated `useGPUResources` composable, reducing `useBrushDrawing` from ~1,160 lines to ~230. This is Phase D of the ongoing `useBrushDrawing` decomposition (Phases A–C landed in previous PRs).                                             
   
  ## Changes                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                            
  - **What**: Split `useBrushDrawing` along a clean boundary — GPU device/texture lifecycle moves to `useGPUResources`, stroke orchestration stays in `useBrushDrawing`. Shared reactive state (`dirtyRect`, `isSavingHistory`, `previewCanvas`) is now owned by `useGPUResources` and exposed as refs. A pure
   `clampDirtyRect` helper is extracted to `gpuUtils.ts`.
  - **Dependencies**: No new dependencies                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                              
  ## Tests                                                                                                                                                                                                                                                                                                    
Local test - pass            


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors WebGPU initialization, texture management, and readback paths used during drawing; regressions could affect stroke rendering, canvas visibility, and undo/redo GPU sync.
> 
> **Overview**
> Extracts WebGPU device/texture/renderer lifecycle, watchers (clear, undo/redo sync, texture recreation), and readback logic out of `useBrushDrawing` into a new `useGPUResources` composable, with shared refs (`dirtyRect`, `isSavingHistory`, `previewCanvas`, `hasRenderer`) now owned by that module.
> 
> Updates `useBrushDrawing` to delegate GPU-specific operations (prepare/render/draw point/composite/readback/cleanup) to `useGPUResources` while keeping CPU drawing + stroke orchestration, and adds new pure helpers in `gpuUtils` (`clampDirtyRect`, `buildStrokePoints`) to centralize dirty-rect clamping and stroke point resampling.
> 
> Adds Vitest coverage for the new helpers, `useGPUResources` no-op/error behavior when GPU isn’t available, and `useBrushDrawing` interactions with the extracted GPU API (composition mode selection, shift-line, history save, and canvas/preview opacity restoration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9fcd80ab542e2ef0d96e8074fb0871a44548dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11784-refactor-extract-GPU-lifecycle-into-useGPUResources-phase-D-3526d73d365081108a97c164a0bfa13e) by [Unito](https://www.unito.io)
