### PR TITLE
Preserve attribution on cloud login redirects

### DIFF
--- a/src/platform/cloud/onboarding/utils/attributionRedirectQuery.test.ts
+++ b/src/platform/cloud/onboarding/utils/attributionRedirectQuery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+import type { LocationQuery } from 'vue-router'
+
+import { buildCloudLoginRedirectQuery } from './attributionRedirectQuery'
+
+describe('buildCloudLoginRedirectQuery', () => {
+  test('preserves attribution as top-level login query params', () => {
+    const query: LocationQuery = {
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      gclid: 'abc123',
+      ignored: 'value'
+    }
+
+    expect(
+      buildCloudLoginRedirectQuery(
+        '/?utm_source=google&utm_medium=cpc&gclid=abc123&ignored=value',
+        query
+      )
+    ).toEqual({
+      previousFullPath: encodeURIComponent(
+        '/?utm_source=google&utm_medium=cpc&gclid=abc123&ignored=value'
+      ),
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      gclid: 'abc123'
+    })
+  })
+
+  test('keeps previousFullPath when no attribution is present', () => {
+    expect(buildCloudLoginRedirectQuery('/cloud/pricing', {})).toEqual({
+      previousFullPath: encodeURIComponent('/cloud/pricing')
+    })
+  })
+
+  test('does not add login query for bare root path', () => {
+    expect(buildCloudLoginRedirectQuery('/', {})).toBeUndefined()
+  })
+})

--- a/src/platform/cloud/onboarding/utils/attributionRedirectQuery.ts
+++ b/src/platform/cloud/onboarding/utils/attributionRedirectQuery.ts
@@ -1,0 +1,48 @@
+import type { LocationQuery, LocationQueryRaw } from 'vue-router'
+
+const CLICK_ID_QUERY_KEYS = new Set([
+  'im_ref',
+  'gclid',
+  'gbraid',
+  'wbraid',
+  'fbclid',
+  'msclkid',
+  'ttclid',
+  'li_fat_id'
+])
+
+function isAttributionQueryKey(key: string): boolean {
+  return key.startsWith('utm_') || CLICK_ID_QUERY_KEYS.has(key)
+}
+
+function attributionQueryFrom(query: LocationQuery): LocationQueryRaw {
+  const attributionQuery: LocationQueryRaw = {}
+
+  for (const [key, value] of Object.entries(query)) {
+    if (isAttributionQueryKey(key) && value !== null) {
+      attributionQuery[key] = value
+    }
+  }
+
+  return attributionQuery
+}
+
+function hasQuery(query: LocationQueryRaw): boolean {
+  return Object.keys(query).length > 0
+}
+
+export function buildCloudLoginRedirectQuery(
+  fullPath: string,
+  query: LocationQuery
+): LocationQueryRaw | undefined {
+  const attributionQuery = attributionQueryFrom(query)
+
+  if (fullPath === '/') {
+    return hasQuery(attributionQuery) ? attributionQuery : undefined
+  }
+
+  return {
+    previousFullPath: encodeURIComponent(fullPath),
+    ...attributionQuery
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,6 +17,7 @@ import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
 
 import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { buildCloudLoginRedirectQuery } from '@/platform/cloud/onboarding/utils/attributionRedirectQuery'
 
 const cloudOnboardingRoutes = isCloud
   ? (await import('./platform/cloud/onboarding/onboardingCloudRoutes'))
@@ -177,10 +178,7 @@ if (isCloud) {
       return next()
     }
 
-    const query =
-      to.fullPath === '/'
-        ? undefined
-        : { previousFullPath: encodeURIComponent(to.fullPath) }
+    const query = buildCloudLoginRedirectQuery(to.fullPath, to.query)
 
     // Check if route requires authentication
     if (to.meta.requiresAuth && !isLoggedIn) {


### PR DESCRIPTION
Stacked on #11799.

Keeps incoming attribution query params visible as top-level params when Cloud redirects an unauthenticated user to `/cloud/login`, while still preserving the original destination in `previousFullPath`.

This handles the case where a user clicks a comfy.org CTA with `utm_*` or ad click IDs, lands on Cloud, and is redirected to login. Without this change, the attribution is only buried in the encoded `previousFullPath`, which is harder for GTM-style validation and query-param based tracking to observe.

Checked with focused Cloud redirect unit tests and pre-commit typecheck/lint hooks.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11800-Preserve-attribution-on-cloud-login-redirects-3536d73d36508173976bff18041ba755) by [Unito](https://www.unito.io)
