### PR TITLE
update: robots.txt to point to /sitemap-0.xml

### DIFF
--- a/apps/website/public/robots.txt
+++ b/apps/website/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://comfy.org/sitemap-index.xml
+Sitemap: https://comfy.org/sitemap-0.xml


### PR DESCRIPTION
## Summary

<!-- One sentence describing what changed and why. -->

robots.txt at [comfy.org](https://comfy.org/) references /sitemap-index.xml which returns 404. The actual working sitemap is at /sitemap-0.xml (200, 38 URLs). This blocks search engines from discovering the sitemap.

## Changes

- **What**: <!-- Core functionality added/modified -->
  - Update robots.txt to point to /sitemap-0.xml, OR

## Review Focus

<!-- Critical design decisions or edge cases that need attention -->

<!-- If this PR fixes an issue, uncomment and update the line below -->
<!-- Fixes #ISSUE_NUMBER -->

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11802-update-robots-txt-to-point-to-sitemap-0-xml-3536d73d365081bb9545eb96dd1e8025) by [Unito](https://www.unito.io)
