### PR TITLE
fix: skip Preview3D model restore when persisted file is missing

### DIFF
--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -484,23 +484,31 @@ useExtensionService().registerExtension({
       const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
 
       if (modelWidget) {
-        const lastTimeModelFile = node.properties['Last Time Model File']
+        const lastTimeModelFile = node.properties['Last Time Model File'] as
+          | string
+          | undefined
 
         if (lastTimeModelFile) {
-          modelWidget.value = lastTimeModelFile
+          void Load3dUtils.resourceExists(lastTimeModelFile, 'output').then(
+            (exists) => {
+              if (!exists) return
 
-          const cameraConfig = node.properties['Camera Config'] as
-            | CameraConfig
-            | undefined
-          const cameraState = cameraConfig?.state
+              modelWidget.value = lastTimeModelFile
 
-          const settings = {
-            loadFolder: 'output',
-            modelWidget: modelWidget,
-            cameraState: cameraState
-          }
+              const cameraConfig = node.properties['Camera Config'] as
+                | CameraConfig
+                | undefined
+              const cameraState = cameraConfig?.state
 
-          config.configure(settings)
+              const settings = {
+                loadFolder: 'output',
+                modelWidget: modelWidget,
+                cameraState: cameraState
+              }
+
+              config.configure(settings)
+            }
+          )
         }
 
         node.onExecuted = function (output: Load3dPreviewOutput) {

--- a/src/extensions/core/load3d/Load3dUtils.test.ts
+++ b/src/extensions/core/load3d/Load3dUtils.test.ts
@@ -1,6 +1,76 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
+
+const { fetchApiMock } = vi.hoisted(() => ({
+  fetchApiMock: vi.fn()
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: fetchApiMock
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    getRandParam: () => '&rand=1'
+  }
+}))
+
+describe('Load3dUtils.resourceExists', () => {
+  beforeEach(() => {
+    fetchApiMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns true when the HEAD probe is ok', async () => {
+    fetchApiMock.mockResolvedValueOnce({ ok: true })
+
+    const exists = await Load3dUtils.resourceExists('sub/model.glb', 'output')
+
+    expect(exists).toBe(true)
+    expect(fetchApiMock).toHaveBeenCalledTimes(1)
+    const [url, options] = fetchApiMock.mock.calls[0]
+    expect(options).toEqual({ method: 'HEAD' })
+    expect(url).toContain('filename=model.glb')
+    expect(url).toContain('subfolder=sub')
+    expect(url).toContain('type=output')
+  })
+
+  it('returns false when the HEAD probe is a 404', async () => {
+    fetchApiMock.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const exists = await Load3dUtils.resourceExists(
+      'missing/model.glb',
+      'output'
+    )
+
+    expect(exists).toBe(false)
+  })
+
+  it('returns false when fetchApi throws', async () => {
+    fetchApiMock.mockRejectedValueOnce(new Error('network down'))
+
+    const exists = await Load3dUtils.resourceExists('any/model.glb', 'output')
+
+    expect(exists).toBe(false)
+  })
+
+  it('handles paths with no subfolder', async () => {
+    fetchApiMock.mockResolvedValueOnce({ ok: true })
+
+    await Load3dUtils.resourceExists('model.glb', 'input')
+
+    const [url] = fetchApiMock.mock.calls[0]
+    expect(url).toContain('filename=model.glb')
+    expect(url).toContain('subfolder=')
+    expect(url).toContain('type=input')
+  })
+})
 
 describe('Load3dUtils.mapSceneLightIntensityToHdri', () => {
   it('maps scene slider low end to a small positive HDRI intensity', () => {

--- a/src/extensions/core/load3d/Load3dUtils.ts
+++ b/src/extensions/core/load3d/Load3dUtils.ts
@@ -124,6 +124,20 @@ class Load3dUtils {
     return `/view?${params}`
   }
 
+  static async resourceExists(
+    filePath: string,
+    type: 'input' | 'output' | 'temp'
+  ): Promise<boolean> {
+    try {
+      const [subfolder, filename] = this.splitFilePath(filePath)
+      const url = this.getResourceURL(subfolder, filename, type)
+      const resp = await api.fetchApi(url, { method: 'HEAD' })
+      return resp.ok
+    } catch {
+      return false
+    }
+  }
+
   static async uploadMultipleFiles(files: FileList, subfolder: string = '3d') {
     const uploadPromises = Array.from(files).map((file) =>
       this.uploadFile(file, subfolder)


### PR DESCRIPTION
## Summary
When a workflow shared from another machine carries a persisted 'Last Time Model File' property, the local output folder usually does not contain that file and the restore attempt surfaced an error toast. Pre-flight HEAD check the resource and silently skip restoration when absent so user-initiated loads remain the only path that warns on error.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11803-fix-skip-Preview3D-model-restore-when-persisted-file-is-missing-3536d73d36508164b8a5e50ae893b84e) by [Unito](https://www.unito.io)
