### PR TITLE
fix(load3d): parse [output]/[input]/[temp] annotation when loading

### DIFF
--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type Load3d from '@/extensions/core/load3d/Load3d'
-import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
+import Load3DConfiguration, {
+  parseAnnotatedFilename
+} from '@/extensions/core/load3d/Load3DConfiguration'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import type {
   GizmoConfig,
@@ -246,6 +248,50 @@ describe('Load3DConfiguration.silentOnNotFound propagation', () => {
     await flush()
     expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
       silentOnNotFound: false
+    })
+  })
+})
+
+describe('parseAnnotatedFilename', () => {
+  it('strips a [output] suffix and switches to the output folder', () => {
+    expect(parseAnnotatedFilename('foo.glb [output]', 'input')).toEqual({
+      filename: 'foo.glb',
+      folder: 'output'
+    })
+  })
+
+  it('strips a [input] suffix and switches to the input folder', () => {
+    expect(parseAnnotatedFilename('sub/foo.glb [input]', 'output')).toEqual({
+      filename: 'sub/foo.glb',
+      folder: 'input'
+    })
+  })
+
+  it('strips a [temp] suffix and switches to the temp folder', () => {
+    expect(parseAnnotatedFilename('foo.glb [temp]', 'input')).toEqual({
+      filename: 'foo.glb',
+      folder: 'temp'
+    })
+  })
+
+  it('returns the value unchanged with the fallback folder when unannotated', () => {
+    expect(parseAnnotatedFilename('foo.glb', 'input')).toEqual({
+      filename: 'foo.glb',
+      folder: 'input'
+    })
+  })
+
+  it('does not strip a non-folder annotation', () => {
+    expect(parseAnnotatedFilename('foo.glb [draft]', 'input')).toEqual({
+      filename: 'foo.glb [draft]',
+      folder: 'input'
+    })
+  })
+
+  it('only matches a trailing annotation, not one in the middle', () => {
+    expect(parseAnnotatedFilename('foo [output] bar.glb', 'input')).toEqual({
+      filename: 'foo [output] bar.glb',
+      folder: 'input'
     })
   })
 })

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -24,6 +24,20 @@ type Load3DConfigurationSettings = {
   silentOnNotFound?: boolean
 }
 
+const ANNOTATED_FILENAME_PATTERN = / \[(input|output|temp)\]$/
+
+export function parseAnnotatedFilename(
+  rawValue: string,
+  fallbackFolder: string
+): { filename: string; folder: string } {
+  const match = ANNOTATED_FILENAME_PATTERN.exec(rawValue)
+  if (!match) return { filename: rawValue, folder: fallbackFolder }
+  return {
+    filename: rawValue.slice(0, match.index),
+    folder: match[1]
+  }
+}
+
 class Load3DConfiguration {
   constructor(
     private load3d: Load3d,
@@ -268,14 +282,17 @@ class Load3DConfiguration {
     return async (value: string | number | boolean | object) => {
       if (!value) return
 
-      const filename = value as string
+      const { filename, folder } = parseAnnotatedFilename(
+        value as string,
+        loadFolder
+      )
 
       this.setResourceFolder(filename)
 
       const modelUrl = api.apiURL(
         Load3dUtils.getResourceURL(
           ...Load3dUtils.splitFilePath(filename),
-          loadFolder
+          folder
         )
       )
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -683,6 +683,95 @@ describe('useWidgetSelectItems', () => {
     })
   })
 
+  describe('output asset subfolder', () => {
+    it('prefixes the subfolder onto the annotated path so the load URL targets the right folder', async () => {
+      mockMediaAssets.media.value = [
+        {
+          id: 'asset-mesh-1',
+          name: 'ComfyUI_00105_.glb',
+          preview_url: '',
+          tags: ['output'],
+          user_metadata: {
+            jobId: 'job-mesh',
+            nodeId: '7',
+            subfolder: '3d'
+          }
+        }
+      ]
+
+      const { dropdownItems, filterSelected } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => [],
+          modelValue: ref(undefined),
+          assetKind: () => 'mesh' as const
+        })
+      )
+      filterSelected.value = 'outputs'
+      await nextTick()
+
+      expect(dropdownItems.value).toHaveLength(1)
+      expect(dropdownItems.value[0].name).toBe('3d/ComfyUI_00105_.glb [output]')
+    })
+
+    it('omits the subfolder prefix when the asset has none', async () => {
+      mockMediaAssets.media.value = [
+        {
+          id: 'asset-mesh-2',
+          name: 'plain.glb',
+          preview_url: '',
+          tags: ['output'],
+          user_metadata: {
+            jobId: 'job-plain',
+            nodeId: '8',
+            subfolder: ''
+          }
+        }
+      ]
+
+      const { dropdownItems, filterSelected } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => [],
+          modelValue: ref(undefined),
+          assetKind: () => 'mesh' as const
+        })
+      )
+      filterSelected.value = 'outputs'
+      await nextTick()
+
+      expect(dropdownItems.value).toHaveLength(1)
+      expect(dropdownItems.value[0].name).toBe('plain.glb [output]')
+    })
+
+    it('does not prefix the subfolder for non-mesh kinds even when present', async () => {
+      mockMediaAssets.media.value = [
+        {
+          id: 'asset-image-1',
+          name: 'photo.png',
+          preview_url: '',
+          tags: ['output'],
+          user_metadata: {
+            jobId: 'job-image',
+            nodeId: '9',
+            subfolder: 'sub'
+          }
+        }
+      ]
+
+      const { dropdownItems, filterSelected } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => [],
+          modelValue: ref(undefined),
+          assetKind: () => 'image' as const
+        })
+      )
+      filterSelected.value = 'outputs'
+      await nextTick()
+
+      expect(dropdownItems.value).toHaveLength(1)
+      expect(dropdownItems.value[0].name).toBe('photo.png [output]')
+    })
+  })
+
   describe('FE-228: output dropdown label uses human-readable filename', () => {
     it('renders metadata.filename in label when asset.name is a hash', async () => {
       mockMediaAssets.media.value = [

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
@@ -180,7 +180,14 @@ export function useWidgetSelectItems(options: UseWidgetSelectItemsOptions) {
       if (getMediaTypeFromFilename(asset.name) !== targetMediaType) continue
       if (seen.has(asset.id)) continue
       seen.add(asset.id)
-      const annotatedPath = `${asset.name} [output]`
+      const subfolder =
+        kind === 'mesh'
+          ? getOutputAssetMetadata(asset.user_metadata)?.subfolder
+          : undefined
+      const pathWithSubfolder = subfolder
+        ? `${subfolder}/${asset.name}`
+        : asset.name
+      const annotatedPath = `${pathWithSubfolder} [output]`
       const displayLabel = `${getAssetDisplayFilename(asset)} [output]`
       items.push({
         id: `output-${asset.id}`,


### PR DESCRIPTION
## Summary
The Vue node model picker mixes output assets into the dropdown with a trailing ' [output]' suffix on the value. Forwarding that string to loadModel as a literal filename under the configured input folder caused a 404 and the model never rendered. Strip the trailing folder annotation per call and use the matching folder so picking an output asset loads correctly while plain values keep the configured folder.

Output assets stored under a subfolder (e.g. 3d/) were exposed in the Vue node dropdown as just '<filename> [output]', so selection produced an /api/view URL with empty subfolder and a 404. Read the subfolder from the asset's OutputAssetMetadata and prefix it onto the annotated path so the downstream load handler can split it back out and target the correct folder.

## Screenshots (if applicable)
https://github.com/user-attachments/assets/463d1071-efdc-46a4-b101-8e1c012d19c7

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11805-fix-load3d-parse-output-input-temp-annotation-when-loading-3536d73d365081a8ac9cf75d14ae29e6) by [Unito](https://www.unito.io)
