### PR TITLE
fix(load3d): suppress error toast on 404 when loading output model file

### DIFF
--- a/browser_tests/assets/3d/load3d_missing_model.json
+++ b/browser_tests/assets/3d/load3d_missing_model.json
@@ -1,0 +1,31 @@
+{
+  "last_node_id": 1,
+  "last_link_id": 0,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "Load3D",
+      "pos": [50, 50],
+      "size": [400, 650],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": null },
+        { "name": "MASK", "type": "MASK", "links": null },
+        { "name": "MESH", "type": "MESH", "links": null }
+      ],
+      "properties": {
+        "Node name for S&R": "Load3D",
+        "Last Time Model File": "nonexistent_model.glb"
+      },
+      "widgets_values": ["", 1024, 1024, "#000000"]
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "config": {},
+  "extra": { "ds": { "offset": [0, 0], "scale": 1 } },
+  "version": 0.4
+}

--- a/browser_tests/assets/3d/load3d_missing_model.json
+++ b/browser_tests/assets/3d/load3d_missing_model.json
@@ -4,23 +4,19 @@
   "nodes": [
     {
       "id": 1,
-      "type": "Load3D",
+      "type": "Preview3D",
       "pos": [50, 50],
-      "size": [400, 650],
+      "size": [450, 600],
       "flags": {},
       "order": 0,
       "mode": 0,
       "inputs": [],
-      "outputs": [
-        { "name": "IMAGE", "type": "IMAGE", "links": null },
-        { "name": "MASK", "type": "MASK", "links": null },
-        { "name": "MESH", "type": "MESH", "links": null }
-      ],
+      "outputs": [],
       "properties": {
-        "Node name for S&R": "Load3D",
+        "Node name for S&R": "Preview3D",
         "Last Time Model File": "nonexistent_model.glb"
       },
-      "widgets_values": ["", 1024, 1024, "#000000"]
+      "widgets_values": ["nonexistent_model.glb"]
     }
   ],
   "links": [],

--- a/browser_tests/tests/load3d/load3d.spec.ts
+++ b/browser_tests/tests/load3d/load3d.spec.ts
@@ -292,8 +292,8 @@ test.describe('Load3D silent 404 on missing output model', () => {
       route.fulfill({ status: 404, body: 'Not Found' })
     )
 
-    // This workflow has Last Time Model File set, which triggers the
-    // loadFolder: 'output' + silentOnNotFound: true path in load3d.ts
+    // This workflow has a Preview3D node with Last Time Model File set,
+    // triggering the loadFolder: 'output' + silentOnNotFound: true path.
     await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
 
     // Wait for the 404 response before asserting — gives the load attempt time
@@ -310,7 +310,7 @@ test.describe('Load3D silent 404 on missing output model', () => {
   test('Shows an error toast when a non-404 error occurs loading the output model', async ({
     comfyPage
   }) => {
-    // Intercept with a 500 to simulate a real server error — toast must appear
+    // Intercept with a 500 to simulate a real server error (not 404) — toast must appear
     await comfyPage.page.route('**/view?**', (route) =>
       route.fulfill({ status: 500, body: 'Internal Server Error' })
     )

--- a/browser_tests/tests/load3d/load3d.spec.ts
+++ b/browser_tests/tests/load3d/load3d.spec.ts
@@ -282,6 +282,57 @@ test.describe('Load3D', () => {
   })
 })
 
+test.describe('Load3D silent 404 on missing output model', () => {
+  test('Does not show an error toast when the output model file is missing (404)', async ({
+    comfyPage
+  }) => {
+    // Intercept model fetch and return 404 to simulate a missing output file
+    // (e.g. shared workflow opened on a machine that never ran it)
+    await comfyPage.page.route('**/view?**', (route) =>
+      route.fulfill({ status: 404, body: 'Not Found' })
+    )
+
+    // This workflow has Last Time Model File set, which triggers the
+    // loadFolder: 'output' + silentOnNotFound: true path in load3d.ts
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
+    // Wait for the 404 response before asserting — gives the load attempt time
+    // to complete without using waitForTimeout
+    const responsePromise = comfyPage.page.waitForResponse('**/view?**')
+    await comfyPage.workflow.loadWorkflow('3d/load3d_missing_model')
+    await responsePromise
+
+    await expect(
+      comfyPage.toast.visibleToasts.filter({ hasText: 'Error loading model' })
+    ).toHaveCount(0)
+  })
+
+  test('Shows an error toast when a non-404 error occurs loading the output model', async ({
+    comfyPage
+  }) => {
+    // Intercept with a 500 to simulate a real server error — toast must appear
+    await comfyPage.page.route('**/view?**', (route) =>
+      route.fulfill({ status: 500, body: 'Internal Server Error' })
+    )
+
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
+    const responsePromise = comfyPage.page.waitForResponse('**/view?**')
+    await comfyPage.workflow.loadWorkflow('3d/load3d_missing_model')
+    await responsePromise
+
+    await expect
+      .poll(
+        () =>
+          comfyPage.toast.visibleToasts
+            .filter({ hasText: 'Error loading model' })
+            .count(),
+        { timeout: 10000 }
+      )
+      .toBeGreaterThan(0)
+  })
+})
+
 test.describe('Load3D initialization failure', () => {
   test('Surfaces a toast when the THREE.WebGLRenderer cannot be created', async ({
     comfyPage

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -497,7 +497,8 @@ useExtensionService().registerExtension({
           const settings = {
             loadFolder: 'output',
             modelWidget: modelWidget,
-            cameraState: cameraState
+            cameraState: cameraState,
+            silentOnNotFound: true
           }
 
           config.configure(settings)
@@ -528,7 +529,8 @@ useExtensionService().registerExtension({
             loadFolder: 'output',
             modelWidget: modelWidget,
             cameraState: cameraState,
-            bgImagePath: bgImagePath
+            bgImagePath: bgImagePath,
+            silentOnNotFound: true
           }
 
           config.configure(settings)

--- a/src/extensions/core/load3d/Load3DConfiguration.test.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
+import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import type {
   GizmoConfig,
   ModelConfig
 } from '@/extensions/core/load3d/interfaces'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import type { Dictionary } from '@/lib/litegraph/src/interfaces'
 import type { NodeProperty } from '@/lib/litegraph/src/LGraphNode'
 
@@ -160,5 +162,90 @@ describe('Load3DConfiguration.loadModelConfig', () => {
     const result = createConfig(properties).loadModelConfig()
 
     expect(result.gizmo).toEqual(fullGizmo)
+  })
+})
+
+describe('Load3DConfiguration.silentOnNotFound propagation', () => {
+  let loadModelSpy: ReturnType<typeof vi.fn>
+
+  function makeLoad3dMock(): Load3d {
+    loadModelSpy = vi.fn().mockResolvedValue(undefined)
+    return {
+      loadModel: loadModelSpy,
+      setUpDirection: vi.fn(),
+      setMaterialMode: vi.fn(),
+      setTargetSize: vi.fn(),
+      setCameraState: vi.fn(),
+      toggleGrid: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setBackgroundImage: vi.fn().mockResolvedValue(undefined),
+      setBackgroundRenderMode: vi.fn(),
+      toggleCamera: vi.fn(),
+      setFOV: vi.fn(),
+      setLightIntensity: vi.fn(),
+      setHDRIIntensity: vi.fn(),
+      setHDRIAsBackground: vi.fn(),
+      setHDRIEnabled: vi.fn()
+    } as unknown as Load3d
+  }
+
+  async function flush() {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+
+  beforeEach(() => {
+    vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'model.glb'])
+    vi.mocked(Load3dUtils.getResourceURL).mockReturnValue(
+      '/view?filename=model.glb'
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('configureForSaveMesh forwards silentOnNotFound: true to loadModel', async () => {
+    const config = new Load3DConfiguration(makeLoad3dMock())
+    config.configureForSaveMesh('output', 'model.glb', {
+      silentOnNotFound: true
+    })
+    await flush()
+    expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
+      silentOnNotFound: true
+    })
+  })
+
+  it('configureForSaveMesh uses silentOnNotFound: false when option is omitted', async () => {
+    const config = new Load3DConfiguration(makeLoad3dMock())
+    config.configureForSaveMesh('output', 'model.glb')
+    await flush()
+    expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
+      silentOnNotFound: false
+    })
+  })
+
+  it('configure forwards silentOnNotFound: true from settings to loadModel', async () => {
+    const config = new Load3DConfiguration(makeLoad3dMock())
+    config.configure({
+      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      loadFolder: 'output',
+      silentOnNotFound: true
+    })
+    await flush()
+    expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
+      silentOnNotFound: true
+    })
+  })
+
+  it('configure uses silentOnNotFound: false when setting is omitted', async () => {
+    const config = new Load3DConfiguration(makeLoad3dMock())
+    config.configure({
+      modelWidget: { value: 'model.glb' } as unknown as IBaseWidget,
+      loadFolder: 'output'
+    })
+    await flush()
+    expect(loadModelSpy).toHaveBeenCalledWith(expect.any(String), 'model.glb', {
+      silentOnNotFound: false
+    })
   })
 })

--- a/src/extensions/core/load3d/Load3DConfiguration.ts
+++ b/src/extensions/core/load3d/Load3DConfiguration.ts
@@ -21,6 +21,7 @@ type Load3DConfigurationSettings = {
   width?: IBaseWidget
   height?: IBaseWidget
   bgImagePath?: string
+  silentOnNotFound?: boolean
 }
 
 class Load3DConfiguration {
@@ -29,8 +30,16 @@ class Load3DConfiguration {
     private properties?: Dictionary<NodeProperty | undefined>
   ) {}
 
-  configureForSaveMesh(loadFolder: 'input' | 'output', filePath: string) {
-    this.setupModelHandlingForSaveMesh(filePath, loadFolder)
+  configureForSaveMesh(
+    loadFolder: 'input' | 'output',
+    filePath: string,
+    options?: { silentOnNotFound?: boolean }
+  ) {
+    this.setupModelHandlingForSaveMesh(
+      filePath,
+      loadFolder,
+      options?.silentOnNotFound ?? false
+    )
     this.setupDefaultProperties()
   }
 
@@ -38,7 +47,8 @@ class Load3DConfiguration {
     this.setupModelHandling(
       setting.modelWidget,
       setting.loadFolder,
-      setting.cameraState
+      setting.cameraState,
+      setting.silentOnNotFound ?? false
     )
     this.setupTargetSize(setting.width, setting.height)
     this.setupDefaultProperties(setting.bgImagePath)
@@ -58,8 +68,16 @@ class Load3DConfiguration {
     }
   }
 
-  private setupModelHandlingForSaveMesh(filePath: string, loadFolder: string) {
-    const onModelWidgetUpdate = this.createModelUpdateHandler(loadFolder)
+  private setupModelHandlingForSaveMesh(
+    filePath: string,
+    loadFolder: string,
+    silentOnNotFound: boolean
+  ) {
+    const onModelWidgetUpdate = this.createModelUpdateHandler(
+      loadFolder,
+      undefined,
+      silentOnNotFound
+    )
 
     if (filePath) {
       onModelWidgetUpdate(filePath)
@@ -69,11 +87,13 @@ class Load3DConfiguration {
   private setupModelHandling(
     modelWidget: IBaseWidget,
     loadFolder: string,
-    cameraState?: CameraState
+    cameraState?: CameraState,
+    silentOnNotFound: boolean = false
   ) {
     const onModelWidgetUpdate = this.createModelUpdateHandler(
       loadFolder,
-      cameraState
+      cameraState,
+      silentOnNotFound
     )
     if (modelWidget.value) {
       onModelWidgetUpdate(modelWidget.value)
@@ -241,7 +261,8 @@ class Load3DConfiguration {
 
   private createModelUpdateHandler(
     loadFolder: string,
-    cameraState?: CameraState
+    cameraState?: CameraState,
+    silentOnNotFound: boolean = false
   ) {
     let isFirstLoad = true
     return async (value: string | number | boolean | object) => {
@@ -258,7 +279,7 @@ class Load3DConfiguration {
         )
       )
 
-      await this.load3d.loadModel(modelUrl, filename)
+      await this.load3d.loadModel(modelUrl, filename, { silentOnNotFound })
 
       const modelConfig = this.loadModelConfig()
       this.applyModelConfig(modelConfig)

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -22,6 +22,7 @@ import type {
   EventCallback,
   GizmoMode,
   Load3DOptions,
+  LoadModelOptions,
   MaterialMode,
   UpDirection
 } from './interfaces'
@@ -500,7 +501,11 @@ class Load3d {
     return this._loadGeneration
   }
 
-  async loadModel(url: string, originalFileName?: string): Promise<void> {
+  async loadModel(
+    url: string,
+    originalFileName?: string,
+    options?: LoadModelOptions
+  ): Promise<void> {
     this._loadGeneration += 1
 
     if (this.loadingPromise) {
@@ -509,7 +514,11 @@ class Load3d {
       } catch (e) {}
     }
 
-    this.loadingPromise = this._loadModelInternal(url, originalFileName)
+    this.loadingPromise = this._loadModelInternal(
+      url,
+      originalFileName,
+      options
+    )
     return this.loadingPromise
   }
 
@@ -525,7 +534,8 @@ class Load3d {
 
   private async _loadModelInternal(
     url: string,
-    originalFileName?: string
+    originalFileName?: string,
+    options?: LoadModelOptions
   ): Promise<void> {
     this.cameraManager.reset()
     this.controlsManager.reset()
@@ -533,7 +543,7 @@ class Load3d {
     this.modelManager.clearModel()
     this.animationManager.dispose()
 
-    await this.loaderManager.loadModel(url, originalFileName)
+    await this.loaderManager.loadModel(url, originalFileName, options)
 
     // Auto-detect and setup animations if present
     if (this.modelManager.currentModel) {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -436,6 +436,55 @@ describe('LoaderManager', () => {
       expect(consoleError).toHaveBeenCalled()
     })
 
+    it('suppresses the alert on a 404 when silentOnNotFound is set', async () => {
+      const { lm } = makeLoaderManager()
+      const notFound = new Error(
+        'fetch for "..." responded with 404: Not Found'
+      )
+      meshLoad.mockRejectedValueOnce(notFound)
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb', undefined, {
+        silentOnNotFound: true
+      })
+
+      expect(consoleError).toHaveBeenCalled()
+      expect(addAlert).not.toHaveBeenCalledWith(
+        'toastMessages.errorLoadingModel'
+      )
+    })
+
+    it('detects a 404 from the response status field on three.js HttpError', async () => {
+      const { lm } = makeLoaderManager()
+      const httpError = Object.assign(new Error('not found'), {
+        response: { status: 404 }
+      })
+      meshLoad.mockRejectedValueOnce(httpError)
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb', undefined, {
+        silentOnNotFound: true
+      })
+
+      expect(addAlert).not.toHaveBeenCalledWith(
+        'toastMessages.errorLoadingModel'
+      )
+    })
+
+    it('still alerts on non-404 errors when silentOnNotFound is set', async () => {
+      const { lm } = makeLoaderManager()
+      meshLoad.mockRejectedValueOnce(new Error('parse failure: bad header'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await lm.loadModel('api/view?filename=cube.glb', undefined, {
+        silentOnNotFound: true
+      })
+
+      expect(addAlert).toHaveBeenCalledWith('toastMessages.errorLoadingModel')
+    })
+
     it('discards the result of a stale load when a newer one has started', async () => {
       const { lm, modelManager, eventManager } = makeLoaderManager()
 

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -10,9 +10,23 @@ import { PointCloudModelAdapter, getPLYEngine } from './PointCloudModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
 import type {
   EventManagerInterface,
+  LoadModelOptions,
   LoaderManagerInterface,
   ModelManagerInterface
 } from './interfaces'
+
+/**
+ * three.js's HttpError attaches the failed `Response` to the thrown Error.
+ * fetchModelData throws a plain Error whose message embeds the status code.
+ * Detect both forms so we can keep the toast for parse / network failures
+ * but stay silent on 404 when the caller opted in.
+ */
+function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const withResponse = error as Error & { response?: { status?: number } }
+  if (withResponse.response?.status === 404) return true
+  return /\b404\b/.test(error.message)
+}
 
 /**
  * Default adapter set: mesh + pointCloud + splat. Each adapter declares the
@@ -53,7 +67,11 @@ export class LoaderManager implements LoaderManagerInterface {
 
   dispose(): void {}
 
-  async loadModel(url: string, originalFileName?: string): Promise<void> {
+  async loadModel(
+    url: string,
+    originalFileName?: string,
+    options?: LoadModelOptions
+  ): Promise<void> {
     const loadId = ++this.currentLoadId
 
     try {
@@ -105,7 +123,9 @@ export class LoaderManager implements LoaderManagerInterface {
       if (loadId === this.currentLoadId) {
         this.eventManager.emitEvent('modelLoadingEnd', null)
         console.error('Error loading model:', error)
-        useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
+        if (!(options?.silentOnNotFound && isNotFoundError(error))) {
+          useToastStore().addAlert(t('toastMessages.errorLoadingModel'))
+        }
       }
     }
   }

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -198,8 +198,23 @@ export interface ModelManagerInterface {
   setupModelMaterials(model: THREE.Object3D): void
 }
 
+export interface LoadModelOptions {
+  /**
+   * When true, suppress the user-facing toast for file-not-found
+   * (HTTP 404) errors. Other errors (parse failures, network drops)
+   * still surface a toast. Use for "preview" surfaces whose model
+   * file is server-produced and may legitimately be absent locally
+   * (e.g. shared workflows on a fresh machine).
+   */
+  silentOnNotFound?: boolean
+}
+
 export interface LoaderManagerInterface {
   init(): void
   dispose(): void
-  loadModel(url: string, originalFileName?: string): Promise<void>
+  loadModel(
+    url: string,
+    originalFileName?: string,
+    options?: LoadModelOptions
+  ): Promise<void>
 }

--- a/src/extensions/core/saveMesh.ts
+++ b/src/extensions/core/saveMesh.ts
@@ -103,7 +103,9 @@ useExtensionService().registerExtension({
 
           const loadFolder = fileInfo.type as 'input' | 'output'
 
-          config.configureForSaveMesh(loadFolder, filePath)
+          config.configureForSaveMesh(loadFolder, filePath, {
+            silentOnNotFound: true
+          })
 
           if (isAssetPreviewSupported()) {
             const filename = fileInfo.filename ?? ''


### PR DESCRIPTION
## Summary

- Adds `silentOnNotFound` option to `LoadModelOptions` interface, threaded through `Load3d.loadModel` → `LoaderManager.loadModel`
- 404 errors (detected via message text or `response.status`) are silently swallowed when `silentOnNotFound: true`; all other errors still surface a toast
- Sets `silentOnNotFound: true` for output-folder loads in `load3d.ts` and `saveMesh.ts` — covers shared workflows opened on a machine that never ran them

## Test plan

- [x] `LoaderManager.test.ts` — 40 unit tests covering 404 suppression, non-404 still toasts, stale load handling
- [x] `Load3DConfiguration.test.ts` — 4 unit tests verifying `silentOnNotFound` propagates correctly through `configureForSaveMesh` and `configure`
- [x] `load3d.spec.ts` — 2 E2E tests: 404 → no toast, 500 → toast appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling behavior in the 3D model loading pipeline and extends method signatures/options; risk is mainly missed call sites or incorrectly classifying non-404 errors as 404 and hiding real failures.
> 
> **Overview**
> Prevents noisy user-facing toasts when an *output* 3D model referenced by `Preview3D`/`SaveGLB` is missing locally by adding a `silentOnNotFound` flag and suppressing the "Error loading model" toast specifically for HTTP 404 failures.
> 
> Threads the new `LoadModelOptions` through `Load3d.loadModel` → `LoaderManager.loadModel` and updates `Load3DConfiguration`/callers to opt in for output-folder loads, with new unit + Playwright coverage (404 stays silent, non-404 still toasts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049f75ef60afef4ad3314e0b39f17e4725fd4e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11807-fix-load3d-suppress-error-toast-on-404-when-loading-output-model-file-3536d73d36508129ac0de1d5b081dcf0) by [Unito](https://www.unito.io)
