### PR TITLE
Fix core node detection for missing nodes

### DIFF
--- a/src/workbench/extensions/manager/composables/nodePack/useWorkflowPacks.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/useWorkflowPacks.ts
@@ -61,7 +61,7 @@ const _useWorkflowPacks = () => {
 
     // Check if node is a core node
     const nodeDef = nodeDefStore.nodeDefsByName[nodeName]
-    if (nodeDef?.nodeSource.type === 'core') {
+    if (nodeDef?.isCoreNode) {
       if (!systemStatsStore.systemStats) {
         await systemStatsStore.refetchSystemStats()
       }


### PR DESCRIPTION
Nodes in the 'essentials' category do not have type 'core'. The check has been updated to instead use the dedicated `isCoreNode` prop.

No tests currently. The existing tests for this code section all mock out the relevant code path and properly writing a test for this would take far more time than I can allocate right now.

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11809-Fix-core-node-detection-for-missing-nodes-3536d73d3650815aabb2deb54c4ecec4) by [Unito](https://www.unito.io)
