### PR TITLE
fix: use capitalize for keybinding badges

### DIFF
--- a/src/components/dialog/content/setting/keybinding/KeyComboDisplay.vue
+++ b/src/components/dialog/content/setting/keybinding/KeyComboDisplay.vue
@@ -2,7 +2,7 @@
   <span class="flex flex-row gap-0.5">
     <template v-for="(sequence, index) in keySequences" :key="index">
       <Tag
-        class="min-w-6 justify-center gap-1 bg-interface-menu-keybind-surface-default text-center font-normal text-base-foreground uppercase"
+        class="min-w-6 justify-center gap-1 bg-interface-menu-keybind-surface-default text-center font-normal text-base-foreground capitalize"
         :severity="isModified ? 'info' : 'secondary'"
       >
         {{ sequence }}


### PR DESCRIPTION
## Summary

Render keybinding badges in sentence case (`Ctrl + Shift + A`) instead of UPPERCASE (`CTRL + SHIFT + A`) by swapping the `uppercase` Tailwind class for `capitalize` in `KeyComboDisplay.vue`.

`KeyComboImpl.getKeySequences()` already returns labels in their canonical form (`Ctrl`, `Alt`, `Shift`, plus the raw key). The badge styling was forcing them all to UPPER, which is what FE-524 calls out. `text-transform: capitalize` cleanly handles every case: lower modifier, upper modifier, and single character keys.

- Fixes FE-524

## Before / After

| Before (`uppercase`) | After (`capitalize`) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/c6bb96fce/docs/screenshots/fe-524/before.png" width="480"> | <img src="https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/c6bb96fce/docs/screenshots/fe-524/after.png" width="480"> |

## Test plan

- [ ] Open Settings → Keybinding panel and confirm modifier badges render as `Ctrl`, `Alt`, `Shift` instead of `CTRL`, `ALT`, `SHIFT`
- [ ] Confirm single-letter keys (e.g. `A`, `S`) still render uppercase
- [ ] Edit a keybinding and verify the live preview badges in the dialog also render in sentence case
