### PR TITLE
fix(load3d): reapply up-direction after fitToViewer() transform reset

### DIFF
--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -760,4 +760,74 @@ describe('SceneModelManager', () => {
       expect(mainModels).toHaveLength(1)
     })
   })
+
+  describe('fitToViewer', () => {
+    it('does nothing when there is no current model', () => {
+      const { manager, setupCamera, setupGizmo } = createManager()
+
+      manager.fitToViewer()
+
+      expect(setupCamera).not.toHaveBeenCalled()
+      expect(setupGizmo).not.toHaveBeenCalled()
+    })
+
+    it('scales and centers the model', async () => {
+      const { manager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      model.scale.set(0.1, 0.1, 0.1)
+      manager.fitToViewer()
+
+      expect(model.scale.x).toBeGreaterThan(0.1)
+      expect(model.scale.y).toBeGreaterThan(0.1)
+      expect(model.scale.z).toBeGreaterThan(0.1)
+    })
+
+    it('reapplies non-original up-direction after fitting', async () => {
+      const { manager, eventManager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      manager.setUpDirection('+z')
+      vi.mocked(eventManager.emitEvent).mockClear()
+
+      manager.fitToViewer()
+
+      expect(manager.currentUpDirection).toBe('+z')
+      expect(model.rotation.x).toBeCloseTo(-Math.PI / 2)
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'upDirectionChange',
+        '+z'
+      )
+    })
+
+    it('does not call setUpDirection when up-direction is original', async () => {
+      const { manager, eventManager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+      vi.mocked(eventManager.emitEvent).mockClear()
+
+      manager.fitToViewer()
+
+      expect(eventManager.emitEvent).not.toHaveBeenCalledWith(
+        'upDirectionChange',
+        expect.anything()
+      )
+    })
+
+    it('resets originalRotation so up-direction is not compounded after fit', async () => {
+      const { manager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      manager.setUpDirection('+x')
+      const rotationAfterFirstSet = model.rotation.z
+
+      manager.fitToViewer()
+      manager.setUpDirection('+x')
+
+      expect(model.rotation.z).toBeCloseTo(rotationAfterFirstSet)
+    })
+  })
 })

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -491,6 +491,11 @@ export class SceneModelManager implements ModelManagerInterface {
 
     model.position.set(-center.x, -scaledBox.min.y, -center.z)
 
+    if (this.currentUpDirection !== 'original') {
+      this.originalRotation = null
+      this.setUpDirection(this.currentUpDirection)
+    }
+
     const newBox = this.computeWorldBounds(model)
     const newSize = newBox.getSize(new THREE.Vector3())
     const newCenter = newBox.getCenter(new THREE.Vector3())

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -491,8 +491,8 @@ export class SceneModelManager implements ModelManagerInterface {
 
     model.position.set(-center.x, -scaledBox.min.y, -center.z)
 
+    this.originalRotation = null
     if (this.currentUpDirection !== 'original') {
-      this.originalRotation = null
       this.setUpDirection(this.currentUpDirection)
     }
 


### PR DESCRIPTION
## Summary

`fitToViewer()` resets `model.rotation` to `(0, 0, 0)` but never reapplied `currentUpDirection`, causing a state/view mismatch when the user had previously selected a non-default up-axis.

## Changes

- After the scale/center steps in `fitToViewer()`, reset `originalRotation` to `null` (so `setUpDirection` captures the post-fit zero-rotation as the new baseline), then call `setUpDirection(this.currentUpDirection)` when the direction is non-default.
- Added 5 regression tests for `fitToViewer` behavior in `SceneModelManager.test.ts`.

## Testing

### Automated

- `src/extensions/core/load3d/SceneModelManager.test.ts` — 5 new tests in `describe('fitToViewer')`.
- All 48 tests in the file pass.

### E2E Verification Steps

1. Open ComfyUI, add a **Load3D** node, and load any 3D model.
2. In the viewer controls, change **Up Direction** to any non-default value (e.g. `+x` or `-z`).
3. Click **Fit to Viewer**.
4. **Before fix**: model snaps back to raw orientation while UI still shows the chosen up-direction.
5. **After fix**: model retains the chosen up-direction orientation after fitting.

## Review Focus

The key invariant: `fitToViewer()` resets rotation to zero-baseline (scale+position-only normalization), so any active `currentUpDirection` must be re-applied from that new zero baseline. Nulling `originalRotation` before calling `setUpDirection` ensures the direction rotation isn't compounded on top of a stale pre-fit rotation.

Fixes #11347

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11821-fix-load3d-reapply-up-direction-after-fitToViewer-transform-reset-3546d73d3650811ea730c40f26f0d9c8) by [Unito](https://www.unito.io)
