### PR TITLE
refactor: deduplicate Civitai hostname logic in getSourceName

### DIFF
--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -8,6 +8,7 @@ import {
   getPathDetails,
   highlightQuery,
   isCivitaiModelUrl,
+  isCivitaiUrl,
   isPreviewableMediaType,
   truncateFilename
 } from './formatUtil'
@@ -378,6 +379,19 @@ describe('formatUtil', () => {
     it('returns false for text/other', () => {
       expect(isPreviewableMediaType('text')).toBe(false)
       expect(isPreviewableMediaType('other')).toBe(false)
+    })
+  })
+
+  describe('isCivitaiUrl', () => {
+    it.for([
+      { url: 'https://civitai.com/models/123', expected: true },
+      { url: 'https://civitai.red/models/123', expected: true },
+      { url: 'https://sub.civitai.com/models/123', expected: true },
+      { url: 'https://sub.civitai.red/models/123', expected: true },
+      { url: 'https://example.com/model', expected: false },
+      { url: 'not-a-url', expected: false }
+    ])('$url → $expected', ({ url, expected }) => {
+      expect(isCivitaiUrl(url)).toBe(expected)
     })
   })
 

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -355,6 +355,22 @@ export const generateUUID = (): string => {
   })
 }
 
+const isCivitaiHost = (hostname: string): boolean =>
+  hostname === 'civitai.com' ||
+  hostname.endsWith('.civitai.com') ||
+  hostname === 'civitai.red' ||
+  hostname.endsWith('.civitai.red')
+
+/**
+ * Checks if a URL belongs to any Civitai domain (civitai.com or civitai.red).
+ * Use this for source-name detection; use `isCivitaiModelUrl` when the URL
+ * must also match a specific model API path format.
+ */
+export const isCivitaiUrl = (url: string): boolean => {
+  if (!isValidUrl(url)) return false
+  return isCivitaiHost(new URL(url).hostname.toLowerCase())
+}
+
 /**
  * Checks if a URL is a Civitai model URL
  * @example
@@ -367,17 +383,9 @@ export const isCivitaiModelUrl = (url: string): boolean => {
   if (!isValidUrl(url)) return false
 
   const urlObj = new URL(url)
-  const hostname = urlObj.hostname.toLowerCase()
-  const isCivitaiHost =
-    hostname === 'civitai.com' ||
-    hostname.endsWith('.civitai.com') ||
-    hostname === 'civitai.red' ||
-    hostname.endsWith('.civitai.red')
-  if (!isCivitaiHost) {
-    return false
-  }
-  const pathname = urlObj.pathname
+  if (!isCivitaiHost(urlObj.hostname.toLowerCase())) return false
 
+  const pathname = urlObj.pathname
   return (
     /^\/api\/download\/models\/(\d+)$/.test(pathname) ||
     /^\/api\/v1\/models\/(\d+)$/.test(pathname) ||

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -1,4 +1,5 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { isCivitaiUrl } from '@/utils/formatUtil'
 
 /**
  * Type-safe utilities for extracting metadata from assets.
@@ -126,16 +127,9 @@ export function getAssetAdditionalTags(asset: AssetItem): string[] {
  * @returns Human-readable source name
  */
 export function getSourceName(url: string): string {
+  if (isCivitaiUrl(url)) return 'Civitai'
   try {
     const hostname = new URL(url).hostname.toLowerCase()
-    if (
-      hostname === 'civitai.com' ||
-      hostname.endsWith('.civitai.com') ||
-      hostname === 'civitai.red' ||
-      hostname.endsWith('.civitai.red')
-    ) {
-      return 'Civitai'
-    }
     if (hostname === 'huggingface.co' || hostname.endsWith('.huggingface.co')) {
       return 'Hugging Face'
     }


### PR DESCRIPTION
## Summary

- Extract `isCivitaiHost` private helper from `isCivitaiModelUrl` in `formatUtil.ts` for DRY hostname checking
- Add `isCivitaiUrl` exported function for hostname-only Civitai URL detection (distinct from `isCivitaiModelUrl` which also validates the path format)
- Refactor `getSourceName` in `assetMetadataUtils.ts` to use the shared `isCivitaiUrl` instead of inline duplicate hostname checks
- Add tests for `isCivitaiUrl` covering `.com`, `.red`, subdomain, and invalid URL cases

## Changes

- `packages/shared-frontend-utils/src/formatUtil.ts` — add `isCivitaiHost` private helper + export `isCivitaiUrl`; refactor `isCivitaiModelUrl` to use helper
- `packages/shared-frontend-utils/src/formatUtil.test.ts` — add `isCivitaiUrl` test suite
- `src/platform/assets/utils/assetMetadataUtils.ts` — import `isCivitaiUrl` from `@/utils/formatUtil`; remove inline hostname logic from `getSourceName`

## Testing

### Automated

- Added `isCivitaiUrl` test suite (6 cases: `.com`, `.red`, subdomains, non-Civitai, invalid URL)
- All 71 existing `formatUtil` tests pass
- All 53 existing `assetMetadataUtils` tests pass (behavior preserved)
- TypeScript typecheck passes

### E2E Verification Steps

1. Run unit tests: `npx vitest run packages/shared-frontend-utils/src/formatUtil.test.ts src/platform/assets/utils/assetMetadataUtils.test.ts`
2. Expected: all tests pass
3. Verify `getSourceName('https://civitai.red/models/123')` returns `'Civitai'`
4. Verify `isCivitaiUrl('https://civitai.com/models/any-path')` returns `true`
5. Verify `isCivitaiModelUrl` still rejects non-API paths while `isCivitaiUrl` accepts them

## Review Focus

`isCivitaiUrl` (new, hostname-only) vs `isCivitaiModelUrl` (existing, hostname+path format): `getSourceName` needs to recognize ANY Civitai URL as a source, so using `isCivitaiModelUrl` directly would incorrectly reject valid browse URLs like `civitai.com/models/123`.

Closes #11357

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11822-refactor-deduplicate-Civitai-hostname-logic-in-getSourceName-3546d73d36508110974ccc3b7384d82b) by [Unito](https://www.unito.io)
