### PR TITLE
fix(load3d): snapshot original materials before reapplying materialMode

### DIFF
--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -201,20 +201,40 @@ describe('SceneModelManager', () => {
       expect(setupCamera).toHaveBeenCalled()
     })
 
-    it('does not skip materialMode when it differs from original', async () => {
+    it('reapplies non-original materialMode after snapshotting', async () => {
       const { manager } = createManager()
       const model = createMeshModel()
 
-      // setupModel checks materialMode !== 'original' and calls
-      // setMaterialMode, but the guard `mode === this.materialMode`
-      // causes it to no-op. Then setupModelMaterials resets to 'original'.
+      // setupModel calls setupModelMaterials first (which internally calls
+      // setMaterialMode('original') to reset), then reapplies the stored mode.
       manager.materialMode = 'wireframe'
       const spy = vi.spyOn(manager, 'setMaterialMode')
       await manager.setupModel(model)
 
-      // setMaterialMode is called with the stored mode and then 'original'
-      expect(spy).toHaveBeenCalledWith('wireframe')
       expect(spy).toHaveBeenCalledWith('original')
+      expect(spy).toHaveBeenCalledWith('wireframe')
+      // The final material mode visible on the mesh should be wireframe.
+      const mesh = model.children[0] as THREE.Mesh
+      expect((mesh.material as THREE.MeshBasicMaterial).wireframe).toBe(true)
+    })
+
+    it('snapshots original materials before applying materialMode so restore is correct', async () => {
+      const { manager } = createManager()
+      const model = createMeshModel()
+      const mesh = model.children[0] as THREE.Mesh
+      const originalMat = mesh.material
+
+      // Set a non-original mode before loading — this was the bug:
+      // originalMaterials would capture the wireframe material instead of the real one.
+      manager.materialMode = 'wireframe'
+      await manager.setupModel(model)
+
+      // The snapshot must hold the *pre-mutation* material.
+      expect(manager.originalMaterials.get(mesh)).toBe(originalMat)
+
+      // Restoring to 'original' must give back the true original, not wireframe.
+      manager.setMaterialMode('original')
+      expect(mesh.material).toBe(originalMat)
     })
 
     it('applies current up direction if not original', async () => {

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -447,15 +447,16 @@ export class SceneModelManager implements ModelManagerInterface {
     }
 
     this.scene.add(model)
+    const pendingMaterialMode = this.materialMode
+    this.setupModelMaterials(model)
 
-    if (this.materialMode !== 'original') {
-      this.setMaterialMode(this.materialMode)
+    if (pendingMaterialMode !== 'original') {
+      this.setMaterialMode(pendingMaterialMode)
     }
 
     if (this.currentUpDirection !== 'original') {
       this.setUpDirection(this.currentUpDirection)
     }
-    this.setupModelMaterials(model)
 
     const box = this.computeWorldBounds(model)
     const size = box.getSize(new THREE.Vector3())


### PR DESCRIPTION
## Summary

Fixes a bug where models reloaded in wireframe/normal/depth modes would not restore to their original materials correctly, because the material snapshot was being taken *after* the mode was applied.

## Changes

- Move `setupModelMaterials(model)` to immediately after `scene.add(model)` and before `setMaterialMode()` / `setUpDirection()` in `SceneModelManager.setupModel()`
- Save `materialMode` into `pendingMaterialMode` before calling `setupModelMaterials()`, since the latter internally calls `setMaterialMode('original')` which resets `this.materialMode` — preserving the value ensures the subsequent reapplication guard works correctly
- Update stale test assertion that reflected the old (incorrect) call order
- Add regression test: verifies that `originalMaterials` captures the pre-mutation material and that restoring to `'original'` after a non-original load gives back the true original mesh material

## Testing

### Automated

- `src/extensions/core/load3d/SceneModelManager.test.ts` — 44 tests, all pass
- Full load3d test suite — 401 tests, all pass

### E2E Verification Steps

1. Open ComfyUI with a Load3D node
2. Load any GLB/OBJ model
3. Switch Material Mode to **Wireframe** (or Normal/Depth)
4. Load a different model (or reload the same one)
5. Switch Material Mode back to **Original**
6. Verify the model renders with its original diffuse/PBR materials (not wireframe)

## Review Focus

The key invariant: `setupModelMaterials()` must snapshot mesh materials in their *unmodified* state. It must run before any `setMaterialMode()` call that mutates them. The `pendingMaterialMode` variable is needed because `setupModelMaterials()` internally calls `setMaterialMode('original')`, which updates `this.materialMode`, making the subsequent guard `if (this.materialMode !== 'original')` silently skip reapplication without it.

Fixes #11344

<!-- Pipeline-Ticket: pick-issue-3417 -->

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11825-fix-load3d-snapshot-original-materials-before-reapplying-materialMode-3546d73d3650818b9c35fa60c15f17a3) by [Unito](https://www.unito.io)
