### PR TITLE
fix(load3d): reapply up-direction after fitToViewer() transform reset

### DIFF
--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -655,6 +655,80 @@ describe('SceneModelManager', () => {
     })
   })
 
+  describe('fitToViewer', () => {
+    it('does nothing when no current model', () => {
+      const { manager, setupCamera, setupGizmo } = createManager()
+
+      manager.fitToViewer()
+
+      expect(setupCamera).not.toHaveBeenCalled()
+      expect(setupGizmo).not.toHaveBeenCalled()
+    })
+
+    it('reapplies currentUpDirection after fitting', async () => {
+      const { manager, eventManager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      manager.setUpDirection('+z')
+      vi.mocked(eventManager.emitEvent).mockClear()
+
+      manager.fitToViewer()
+
+      // rotation.x should reflect +z direction (-PI/2) applied to the post-fit base (0,0,0)
+      expect(model.rotation.x).toBeCloseTo(-Math.PI / 2)
+      expect(eventManager.emitEvent).toHaveBeenCalledWith(
+        'upDirectionChange',
+        '+z'
+      )
+    })
+
+    it('does not compound rotations when fitToViewer is called multiple times', async () => {
+      const { manager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      manager.setUpDirection('-x')
+
+      manager.fitToViewer()
+      const rotationAfterFirst = model.rotation.z
+
+      manager.fitToViewer()
+      expect(model.rotation.z).toBeCloseTo(rotationAfterFirst)
+    })
+
+    it('leaves rotation at zero when currentUpDirection is original', async () => {
+      const { manager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      manager.fitToViewer()
+
+      expect(model.rotation.x).toBeCloseTo(0)
+      expect(model.rotation.y).toBeCloseTo(0)
+      expect(model.rotation.z).toBeCloseTo(0)
+    })
+
+    it('does not compound rotation when fitToViewer is called after manual rotation override', async () => {
+      const { manager } = createManager()
+      const model = createMeshModel()
+      await manager.setupModel(model)
+
+      // Set an up direction, then manually override originalRotation to simulate
+      // a prior state where the base rotation was non-zero before fit
+      manager.setUpDirection('+x')
+      // Simulate that originalRotation was captured at a non-zero rotation
+      manager.originalRotation = new THREE.Euler(0.5, 0.3, 0.1)
+
+      manager.fitToViewer()
+
+      // After fit, the rotation should be correct for +x direction applied to (0,0,0) base
+      // Not compounded with the stale originalRotation
+      expect(model.rotation.x).toBeCloseTo(0)
+      expect(model.rotation.z).toBeCloseTo(-Math.PI / 2)
+    })
+  })
+
   describe('PLY mode switching', () => {
     function createPLYManager() {
       const ctx = createManager({

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -491,6 +491,13 @@ export class SceneModelManager implements ModelManagerInterface {
 
     model.position.set(-center.x, -scaledBox.min.y, -center.z)
 
+    // fitToViewer resets rotation to (0,0,0), so originalRotation must be cleared
+    // before reapplying currentUpDirection to avoid compounding rotations.
+    this.originalRotation = null
+    if (this.currentUpDirection !== 'original') {
+      this.setUpDirection(this.currentUpDirection)
+    }
+
     const newBox = this.computeWorldBounds(model)
     const newSize = newBox.getSize(new THREE.Vector3())
     const newCenter = newBox.getCenter(new THREE.Vector3())


### PR DESCRIPTION
## Summary

`fitToViewer()` in `SceneModelManager` resets the model rotation to `(0,0,0)` as part of its normalize-and-scale flow, but does not reapply `currentUpDirection` afterward. This causes a state/view mismatch when the user has previously selected a non-default up-axis (e.g. `+x`, `-z`): the model snaps back to its raw orientation while the Up Direction control still shows the previously selected value.

## Changes

- In `fitToViewer()`, clear `originalRotation` (to avoid compounding with the stale pre-fit base) then reapply `currentUpDirection` if it is not `'original'`
- Add 5 unit tests covering: no-op when no model, reapplication of direction, no rotation compounding on repeated calls, zero rotation for `'original'` direction, and stale `originalRotation` guard

## Testing

### Automated

- `src/extensions/core/load3d/SceneModelManager.test.ts` — 5 new tests in `describe('fitToViewer')`
- All 48 unit tests pass

### E2E Verification Steps

1. Open the Load3D viewer with any 3D model
2. Change **Up Direction** to any non-default value (e.g. `+x` or `-z`) — observe model rotates correctly
3. Click **Fit to Viewer** — model should remain in the chosen up-direction orientation, not snap back to raw orientation
4. Click **Fit to Viewer** again — rotation should remain stable (no compounding)
5. Change Up Direction back to `original` then click **Fit to Viewer** — model should return to neutral orientation `(0,0,0)`

## Review Focus

The key invariant: `fitToViewer()` resets `rotation.set(0,0,0)` explicitly, so we must clear `originalRotation = null` before calling `setUpDirection`. Otherwise `setUpDirection` restores the stale pre-fit rotation as a base and then adds the direction offset on top, compounding incorrectly.

Fixes #11347

<!-- Pipeline-Ticket: pick-issue-3414 -->

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11826-fix-load3d-reapply-up-direction-after-fitToViewer-transform-reset-3546d73d36508166b9bcecc9949c4952) by [Unito](https://www.unito.io)
