### PR TITLE
a11y: add aria-expanded and aria-controls to ProductShowcaseSection accordion

### DIFF
--- a/apps/website/e2e/homepage.spec.ts
+++ b/apps/website/e2e/homepage.spec.ts
@@ -159,15 +159,18 @@ test.describe('Product showcase accordion @interaction', () => {
     await secondFeature.click()
 
     await expect(
-      secondFeature.getByText(/If you are new to ComfyUI/)
+      page
+        .getByRole('region', { name: /App mode/i })
+        .first()
+        .getByText(/If you are new to ComfyUI/)
     ).toBeVisible()
 
     const firstFeature = page
       .getByRole('button', { name: /Full Control with Nodes/i })
       .first()
 
-    await expect(firstFeature).not.toHaveClass(/bg-primary-comfy-yellow/)
-    await expect(secondFeature).toHaveClass(/bg-primary-comfy-yellow/)
+    await expect(firstFeature).toHaveAttribute('aria-expanded', 'false')
+    await expect(secondFeature).toHaveAttribute('aria-expanded', 'true')
   })
 
   test('third feature shows the mask scene on mobile @mobile', async ({

--- a/apps/website/src/components/home/ProductShowcaseSection.test.ts
+++ b/apps/website/src/components/home/ProductShowcaseSection.test.ts
@@ -1,0 +1,61 @@
+import { renderToString } from 'vue/server-renderer'
+import { createSSRApp } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import ProductShowcaseSection from './ProductShowcaseSection.vue'
+
+function renderComponent(props = {}) {
+  const app = createSSRApp(ProductShowcaseSection, props)
+  return renderToString(app)
+}
+
+describe('ProductShowcaseSection', () => {
+  describe('aria-expanded', () => {
+    it('sets aria-expanded="true" on the active accordion button', async () => {
+      const html = await renderComponent()
+      const buttons = html.match(/<button[^>]*>/g) ?? []
+
+      expect(buttons.length).toBe(3)
+      expect(buttons[0]).toContain('aria-expanded="true"')
+    })
+
+    it('sets aria-expanded="false" on inactive accordion buttons', async () => {
+      const html = await renderComponent()
+      const buttons = html.match(/<button[^>]*>/g) ?? []
+
+      expect(buttons[1]).toContain('aria-expanded="false"')
+      expect(buttons[2]).toContain('aria-expanded="false"')
+    })
+  })
+
+  describe('aria-controls', () => {
+    it('sets aria-controls linking each button to its panel', async () => {
+      const html = await renderComponent()
+      const buttons = html.match(/<button[^>]*>/g) ?? []
+
+      expect(buttons[0]).toContain('aria-controls="feature-panel-0"')
+      expect(buttons[1]).toContain('aria-controls="feature-panel-1"')
+      expect(buttons[2]).toContain('aria-controls="feature-panel-2"')
+    })
+
+    it('renders matching panel ids for aria-controls references', async () => {
+      const html = await renderComponent()
+
+      expect(html).toContain('id="feature-panel-0"')
+      expect(html).toContain('id="feature-panel-1"')
+      expect(html).toContain('id="feature-panel-2"')
+    })
+  })
+
+  describe('panel role', () => {
+    it('marks each panel with role="region"', async () => {
+      const html = await renderComponent()
+      const panels = html.match(/id="feature-panel-\d+"[^>]*/g) ?? []
+
+      expect(panels.length).toBe(3)
+      for (const panel of panels) {
+        expect(panel).toContain('role="region"')
+      }
+    })
+  })
+})

--- a/apps/website/src/components/home/ProductShowcaseSection.test.ts
+++ b/apps/website/src/components/home/ProductShowcaseSection.test.ts
@@ -2,7 +2,8 @@
 /* eslint-disable testing-library/no-node-access */
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+import { createSSRApp, nextTick } from 'vue'
+import { renderToString } from 'vue/server-renderer'
 
 import { stubIntersectionObserver } from '../../test/fakeIntersectionObserver'
 import ProductShowcaseSection from './ProductShowcaseSection.vue'
@@ -19,6 +20,11 @@ function sceneSources(): (string | null)[] {
   return [
     ...document.querySelectorAll('lottie-scene-stub, video-mask-scene-stub')
   ].map((el) => el.getAttribute('src'))
+}
+
+function renderComponent(props = {}) {
+  const app = createSSRApp(ProductShowcaseSection, props)
+  return renderToString(app)
 }
 
 describe('ProductShowcaseSection', () => {
@@ -55,5 +61,54 @@ describe('ProductShowcaseSection', () => {
         (src) => src === '/animations/scene-1/scene-01.json'
       )
     ).toHaveLength(1)
+  })
+
+  describe('aria-expanded', () => {
+    it('sets aria-expanded="true" on the active accordion button', async () => {
+      const html = await renderComponent()
+      const buttons = html.match(/<button[^>]*>/g) ?? []
+
+      expect(buttons.length).toBe(3)
+      expect(buttons[0]).toContain('aria-expanded="true"')
+    })
+
+    it('sets aria-expanded="false" on inactive accordion buttons', async () => {
+      const html = await renderComponent()
+      const buttons = html.match(/<button[^>]*>/g) ?? []
+
+      expect(buttons[1]).toContain('aria-expanded="false"')
+      expect(buttons[2]).toContain('aria-expanded="false"')
+    })
+  })
+
+  describe('aria-controls', () => {
+    it('sets aria-controls linking each button to its panel', async () => {
+      const html = await renderComponent()
+      const buttons = html.match(/<button[^>]*>/g) ?? []
+
+      expect(buttons[0]).toContain('aria-controls="feature-panel-0"')
+      expect(buttons[1]).toContain('aria-controls="feature-panel-1"')
+      expect(buttons[2]).toContain('aria-controls="feature-panel-2"')
+    })
+
+    it('renders matching panel ids for aria-controls references', async () => {
+      const html = await renderComponent()
+
+      expect(html).toContain('id="feature-panel-0"')
+      expect(html).toContain('id="feature-panel-1"')
+      expect(html).toContain('id="feature-panel-2"')
+    })
+  })
+
+  describe('panel role', () => {
+    it('marks each panel with role="region"', async () => {
+      const html = await renderComponent()
+      const panels = html.match(/id="feature-panel-\d+"[^>]*/g) ?? []
+
+      expect(panels.length).toBe(3)
+      for (const panel of panels) {
+        expect(panel).toContain('role="region"')
+      }
+    })
   })
 })

--- a/apps/website/src/components/home/ProductShowcaseSection.test.ts
+++ b/apps/website/src/components/home/ProductShowcaseSection.test.ts
@@ -2,8 +2,7 @@
 /* eslint-disable testing-library/no-node-access */
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { createSSRApp, nextTick } from 'vue'
-import { renderToString } from 'vue/server-renderer'
+import { nextTick } from 'vue'
 
 import { stubIntersectionObserver } from '../../test/fakeIntersectionObserver'
 import ProductShowcaseSection from './ProductShowcaseSection.vue'
@@ -22,9 +21,17 @@ function sceneSources(): (string | null)[] {
   ].map((el) => el.getAttribute('src'))
 }
 
-function renderComponent(props = {}) {
-  const app = createSSRApp(ProductShowcaseSection, props)
-  return renderToString(app)
+function accordionTriggers(): HTMLElement[] {
+  return screen
+    .getAllByRole('button')
+    .filter((button) => button.hasAttribute('aria-controls'))
+}
+
+function panelControlledBy(trigger: HTMLElement): HTMLElement | undefined {
+  const panelsById = new Map(
+    screen.getAllByRole('region').map((panel) => [panel.id, panel])
+  )
+  return panelsById.get(trigger.getAttribute('aria-controls') ?? '')
 }
 
 describe('ProductShowcaseSection', () => {
@@ -63,52 +70,35 @@ describe('ProductShowcaseSection', () => {
     ).toHaveLength(1)
   })
 
-  describe('aria-expanded', () => {
-    it('sets aria-expanded="true" on the active accordion button', async () => {
-      const html = await renderComponent()
-      const buttons = html.match(/<button[^>]*>/g) ?? []
+  describe('accordion semantics', () => {
+    it('pairs every trigger with a region it does not contain', () => {
+      renderSection()
 
-      expect(buttons.length).toBe(3)
-      expect(buttons[0]).toContain('aria-expanded="true"')
-    })
+      const triggers = accordionTriggers()
+      expect(triggers).toHaveLength(3)
 
-    it('sets aria-expanded="false" on inactive accordion buttons', async () => {
-      const html = await renderComponent()
-      const buttons = html.match(/<button[^>]*>/g) ?? []
+      for (const trigger of triggers) {
+        const panel = panelControlledBy(trigger)
 
-      expect(buttons[1]).toContain('aria-expanded="false"')
-      expect(buttons[2]).toContain('aria-expanded="false"')
-    })
-  })
-
-  describe('aria-controls', () => {
-    it('sets aria-controls linking each button to its panel', async () => {
-      const html = await renderComponent()
-      const buttons = html.match(/<button[^>]*>/g) ?? []
-
-      expect(buttons[0]).toContain('aria-controls="feature-panel-0"')
-      expect(buttons[1]).toContain('aria-controls="feature-panel-1"')
-      expect(buttons[2]).toContain('aria-controls="feature-panel-2"')
-    })
-
-    it('renders matching panel ids for aria-controls references', async () => {
-      const html = await renderComponent()
-
-      expect(html).toContain('id="feature-panel-0"')
-      expect(html).toContain('id="feature-panel-1"')
-      expect(html).toContain('id="feature-panel-2"')
-    })
-  })
-
-  describe('panel role', () => {
-    it('marks each panel with role="region"', async () => {
-      const html = await renderComponent()
-      const panels = html.match(/id="feature-panel-\d+"[^>]*/g) ?? []
-
-      expect(panels.length).toBe(3)
-      for (const panel of panels) {
-        expect(panel).toContain('role="region"')
+        expect(panel).toBeDefined()
+        expect(trigger.contains(panel!)).toBe(false)
+        expect(panel!.getAttribute('aria-labelledby')).toBe(trigger.id)
+        expect(trigger.id).not.toBe('')
       }
+    })
+
+    it('expands only the selected feature', async () => {
+      renderSection()
+
+      const [first, second] = accordionTriggers()
+      expect(first!.getAttribute('aria-expanded')).toBe('true')
+      expect(second!.getAttribute('aria-expanded')).toBe('false')
+
+      second!.click()
+      await nextTick()
+
+      expect(first!.getAttribute('aria-expanded')).toBe('false')
+      expect(second!.getAttribute('aria-expanded')).toBe('true')
     })
   })
 })

--- a/apps/website/src/components/home/ProductShowcaseSection.test.ts
+++ b/apps/website/src/components/home/ProductShowcaseSection.test.ts
@@ -27,11 +27,8 @@ function accordionTriggers(): HTMLElement[] {
     .filter((button) => button.hasAttribute('aria-controls'))
 }
 
-function panelControlledBy(trigger: HTMLElement): HTMLElement | undefined {
-  const panelsById = new Map(
-    screen.getAllByRole('region').map((panel) => [panel.id, panel])
-  )
-  return panelsById.get(trigger.getAttribute('aria-controls') ?? '')
+function accordionPanels(): HTMLElement[] {
+  return screen.getAllByRole('region', { hidden: true })
 }
 
 describe('ProductShowcaseSection', () => {
@@ -71,34 +68,45 @@ describe('ProductShowcaseSection', () => {
   })
 
   describe('accordion semantics', () => {
-    it('pairs every trigger with a region it does not contain', () => {
+    it('pairs every trigger with a distinct region it does not contain', () => {
       renderSection()
 
       const triggers = accordionTriggers()
+      const panels = accordionPanels()
+
       expect(triggers).toHaveLength(3)
+      expect(panels).toHaveLength(3)
+      expect(new Set(triggers.map((trigger) => trigger.id)).size).toBe(3)
+      expect(new Set(panels.map((panel) => panel.id)).size).toBe(3)
 
-      for (const trigger of triggers) {
-        const panel = panelControlledBy(trigger)
+      expect(
+        triggers.map((trigger) => trigger.getAttribute('aria-controls'))
+      ).toEqual(panels.map((panel) => panel.id))
+      expect(
+        panels.map((panel) => panel.getAttribute('aria-labelledby'))
+      ).toEqual(triggers.map((trigger) => trigger.id))
 
-        expect(panel).toBeDefined()
-        expect(trigger.contains(panel!)).toBe(false)
-        expect(panel!.getAttribute('aria-labelledby')).toBe(trigger.id)
-        expect(trigger.id).not.toBe('')
-      }
+      const selfNesting = triggers.filter((trigger, index) =>
+        trigger.contains(panels[index] ?? null)
+      )
+      expect(selfNesting).toEqual([])
     })
 
-    it('expands only the selected feature', async () => {
+    it('exposes exactly the expanded panel and no other', async () => {
       renderSection()
 
-      const [first, second] = accordionTriggers()
-      expect(first!.getAttribute('aria-expanded')).toBe('true')
-      expect(second!.getAttribute('aria-expanded')).toBe('false')
+      const triggers = accordionTriggers()
+      const expandedStates = () =>
+        triggers.map((trigger) => trigger.getAttribute('aria-expanded'))
 
-      second!.click()
+      expect(expandedStates()).toEqual(['true', 'false', 'false'])
+      expect(screen.getAllByRole('region')).toEqual([accordionPanels()[0]])
+
+      triggers[1]?.click()
       await nextTick()
 
-      expect(first!.getAttribute('aria-expanded')).toBe('false')
-      expect(second!.getAttribute('aria-expanded')).toBe('true')
+      expect(expandedStates()).toEqual(['false', 'true', 'false'])
+      expect(screen.getAllByRole('region')).toEqual([accordionPanels()[1]])
     })
   })
 })

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -157,6 +157,8 @@ watch(activeIndex, (current, previous) => {
             />
             <button
               type="button"
+              :aria-expanded="activeIndex === i"
+              :aria-controls="`feature-panel-${i}`"
               :class="
                 cn(
                   'rounded-5xl w-full cursor-pointer p-8 text-left transition-colors duration-300',
@@ -186,6 +188,8 @@ watch(activeIndex, (current, previous) => {
 
               <!-- Animated description (stacked for constant height) -->
               <div
+                :id="`feature-panel-${i}`"
+                role="region"
                 :class="
                   cn(
                     'grid transition-[grid-template-rows] duration-300',

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -173,6 +173,8 @@ useIntersectionObserver(sectionRef, ([entry]) => {
             />
             <button
               type="button"
+              :aria-expanded="activeIndex === i"
+              :aria-controls="`feature-panel-${i}`"
               :class="
                 cn(
                   'rounded-5xl w-full cursor-pointer p-8 text-left transition-colors duration-300',
@@ -202,6 +204,8 @@ useIntersectionObserver(sectionRef, ([entry]) => {
 
               <!-- Animated description (stacked for constant height) -->
               <div
+                :id="`feature-panel-${i}`"
+                role="region"
                 :class="
                   cn(
                     'grid transition-[grid-template-rows] duration-300',

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -212,6 +212,7 @@ useIntersectionObserver(sectionRef, ([entry]) => {
                 :id="`feature-panel-${i}`"
                 role="region"
                 :aria-labelledby="`feature-trigger-${i}`"
+                :aria-hidden="activeIndex !== i"
                 :class="
                   cn(
                     'grid px-8 pb-8 transition-[grid-template-rows] duration-300',

--- a/apps/website/src/components/home/ProductShowcaseSection.vue
+++ b/apps/website/src/components/home/ProductShowcaseSection.vue
@@ -171,44 +171,50 @@ useIntersectionObserver(sectionRef, ([entry]) => {
               class="hidden self-center lg:block"
               aria-hidden="true"
             />
-            <button
-              type="button"
-              :aria-expanded="activeIndex === i"
-              :aria-controls="`feature-panel-${i}`"
+            <div
               :class="
                 cn(
-                  'rounded-5xl w-full cursor-pointer p-8 text-left transition-colors duration-300',
+                  'rounded-5xl w-full transition-colors duration-300',
                   activeIndex === i
                     ? 'bg-primary-comfy-yellow text-primary-comfy-ink'
                     : 'bg-transparency-white-t4 text-primary-comfy-canvas lg:ml-5'
                 )
               "
-              @click="activeIndex = i"
             >
-              <div class="flex items-center justify-between gap-3">
-                <h3 class="text-2xl/tight font-medium">
-                  {{ feature.title }}
-                </h3>
-                <img
-                  src="/icons/plus.svg"
-                  alt=""
-                  :class="
-                    cn(
-                      'size-5 shrink-0 transition-opacity duration-300',
-                      activeIndex === i ? 'opacity-0' : 'opacity-100'
-                    )
-                  "
-                  aria-hidden="true"
-                />
-              </div>
+              <button
+                :id="`feature-trigger-${i}`"
+                type="button"
+                :aria-expanded="activeIndex === i"
+                :aria-controls="`feature-panel-${i}`"
+                class="w-full cursor-pointer px-8 pt-8 text-left"
+                @click="activeIndex = i"
+              >
+                <div class="flex items-center justify-between gap-3">
+                  <h3 class="text-2xl/tight font-medium">
+                    {{ feature.title }}
+                  </h3>
+                  <img
+                    src="/icons/plus.svg"
+                    alt=""
+                    :class="
+                      cn(
+                        'size-5 shrink-0 transition-opacity duration-300',
+                        activeIndex === i ? 'opacity-0' : 'opacity-100'
+                      )
+                    "
+                    aria-hidden="true"
+                  />
+                </div>
+              </button>
 
               <!-- Animated description (stacked for constant height) -->
               <div
                 :id="`feature-panel-${i}`"
                 role="region"
+                :aria-labelledby="`feature-trigger-${i}`"
                 :class="
                   cn(
-                    'grid transition-[grid-template-rows] duration-300',
+                    'grid px-8 pb-8 transition-[grid-template-rows] duration-300',
                     activeIndex === i ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
                   )
                 "
@@ -228,7 +234,7 @@ useIntersectionObserver(sectionRef, ([entry]) => {
                   </p>
                 </div>
               </div>
-            </button>
+            </div>
           </div>
         </template>
       </div>

--- a/apps/website/vitest.config.ts
+++ b/apps/website/vitest.config.ts
@@ -1,6 +1,8 @@
+import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],


### PR DESCRIPTION
## Summary

Add ARIA attributes to ProductShowcaseSection accordion buttons for screen reader accessibility.

## Changes

- **What**: Add `aria-expanded`, `aria-controls`, panel `id`, and `role="region"` to the accordion in `ProductShowcaseSection.vue`. Add Vue plugin to website vitest config. Add SSR-based accessibility tests.

## Review Focus

Straightforward a11y attribute additions following WAI-ARIA accordion pattern.

Fixes #11312

┆Issue is synchronized with this [Notion page](https://app.notion.com/p/PR-11828-a11y-add-aria-expanded-and-aria-controls-to-ProductShowcaseSection-accordion-3546d73d36508149af9cc5c062c7b48d) by [Unito](https://www.unito.io)
