### PR TITLE
test: tighten subscription checkout emit typing

### DIFF
--- a/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.test.ts
@@ -122,19 +122,21 @@ vi.mock('vue-i18n', async (importOriginal) => {
 })
 
 describe('useSubscriptionCheckout', () => {
-  let emit: ReturnType<typeof vi.fn>
+  type CloseEmit = (e: 'close', subscribed: boolean) => void
+
+  let emit: ReturnType<typeof vi.fn<CloseEmit>>
 
   async function setup() {
     const { useSubscriptionCheckout } =
       await import('./useSubscriptionCheckout')
-    return useSubscriptionCheckout(emit as never)
+    return useSubscriptionCheckout(emit)
   }
 
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.clearAllMocks()
     mockPlans.value = allPlans()
-    emit = vi.fn()
+    emit = vi.fn<CloseEmit>()
   })
 
   describe('handleSubscribeClick', () => {


### PR DESCRIPTION
## Summary

Tightens the `useSubscriptionCheckout` test emit mock so it matches the composable contract without using `as never`.

## Changes

- **What**: Adds a `CloseEmit` function signature and types `vi.fn<CloseEmit>()` directly.
- **Dependencies**: None.

## Review Focus

Confirm the mock typing remains readable and preserves the existing test behavior.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11832-test-tighten-subscription-checkout-emit-typing-3546d73d3650818eaacec567ff8e519d) by [Unito](https://www.unito.io)
