### PR TITLE
refactor: remove dedup complexity from reportInactiveTrackerCall

### DIFF
--- a/src/scripts/changeTracker.ts
+++ b/src/scripts/changeTracker.ts
@@ -24,20 +24,12 @@ function isActiveTracker(tracker: ChangeTracker): boolean {
   return useWorkflowStore().activeWorkflow?.changeTracker === tracker
 }
 
-const reportedInactiveCalls = new Set<string>()
-
 /**
  * Report a ChangeTracker method being called on an inactive tracker —
  * a lifecycle violation that usually indicates stale extension state or
- * an incorrect call ordering. Reports once per method per workflow per
- * session so the signal is not drowned out by hot-path invocations while
- * still distinguishing between workflows.
+ * an incorrect call ordering.
  */
 function reportInactiveTrackerCall(method: string, workflowPath: string) {
-  const key = `${method}:${workflowPath}`
-  if (reportedInactiveCalls.has(key)) return
-  reportedInactiveCalls.add(key)
-
   console.warn(`${method}() called on inactive tracker for: ${workflowPath}`)
 
   if (isDesktop) {


### PR DESCRIPTION
## Summary

Remove the module-level `reportedInactiveCalls: Set<string>` and the early-return dedup check from `reportInactiveTrackerCall()` in `src/scripts/changeTracker.ts`. Every invocation now emits `console.warn` and (on Desktop) `Sentry.captureMessage` unconditionally.

## Why

The dedup was added in #11328 but is unnecessary:
- Every first-party call site already goes through the `activeWorkflow?.changeTracker` guard, so flooding from in-repo code is unlikely.
- Repeated identical alerts may actually provide more diagnostic signal than the first-only approach suppresses.

## Changes

- Drop `reportedInactiveCalls` Set
- Drop the per-`(method, workflowPath)` early-return
- Trim the JSDoc accordingly

No behavior change for callers (`deactivate`, `captureCanvasState`); only the reporting frequency increases.

## Verification

- `pnpm test:unit -- src/scripts/changeTracker.test.ts` — 16/16 passing
- `pnpm typecheck` — clean
- ESLint / oxfmt — clean

- Fixes #11372

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11833-refactor-remove-dedup-complexity-from-reportInactiveTrackerCall-3546d73d365081fabf57cbf1fa17051f) by [Unito](https://www.unito.io)
