### PR TITLE
test: combine duplicated undo/redo and settings dialog E2E tests with test.step

### DIFF
--- a/browser_tests/tests/keyboardShortcutActions.spec.ts
+++ b/browser_tests/tests/keyboardShortcutActions.spec.ts
@@ -13,45 +13,35 @@ test.describe('Keyboard shortcut actions', { tag: '@keyboard' }, () => {
     await comfyPage.setup()
   })
 
-  test('Ctrl+Z undoes the last graph change', async ({ comfyPage }) => {
+  test('Ctrl+Z undoes and Ctrl+Shift+Z redoes the last graph change', async ({
+    comfyPage
+  }) => {
     const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
 
-    await comfyPage.page.evaluate(() => {
-      const node = window.LiteGraph!.createNode('Note')
-      window.app!.graph!.add(node)
+    await test.step('Ctrl+Z undoes the last graph change', async () => {
+      await comfyPage.page.evaluate(() => {
+        const node = window.LiteGraph!.createNode('Note')
+        window.app!.graph!.add(node)
+      })
+      await comfyPage.nextFrame()
+      await expect
+        .poll(() => comfyPage.nodeOps.getNodeCount())
+        .toBe(initialNodeCount + 1)
+
+      await comfyPage.canvas.click()
+      await comfyPage.page.keyboard.press('ControlOrMeta+z')
+
+      await expect
+        .poll(() => comfyPage.nodeOps.getNodeCount())
+        .toBe(initialNodeCount)
     })
-    await comfyPage.nextFrame()
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount + 1)
 
-    await comfyPage.canvas.click()
-    await comfyPage.page.keyboard.press('ControlOrMeta+z')
-
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount)
-  })
-
-  test('Ctrl+Shift+Z redoes after undo', async ({ comfyPage }) => {
-    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
-
-    await comfyPage.page.evaluate(() => {
-      const node = window.LiteGraph!.createNode('Note')
-      window.app!.graph!.add(node)
+    await test.step('Ctrl+Shift+Z redoes after undo', async () => {
+      await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
+      await expect
+        .poll(() => comfyPage.nodeOps.getNodeCount())
+        .toBe(initialNodeCount + 1)
     })
-    await comfyPage.nextFrame()
-
-    await comfyPage.canvas.click()
-    await comfyPage.page.keyboard.press('ControlOrMeta+z')
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount)
-
-    await comfyPage.page.keyboard.press('ControlOrMeta+Shift+z')
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount + 1)
   })
 
   test('Ctrl+S opens save dialog', async ({ comfyPage }) => {
@@ -62,25 +52,23 @@ test.describe('Keyboard shortcut actions', { tag: '@keyboard' }, () => {
     await expect(saveDialog).toBeVisible()
   })
 
-  test('Ctrl+, opens settings dialog', async ({ comfyPage }) => {
-    await comfyPage.page.keyboard.down('ControlOrMeta')
-    await comfyPage.page.keyboard.press(',')
-    await comfyPage.page.keyboard.up('ControlOrMeta')
-
+  test('Ctrl+, opens and Escape closes settings dialog', async ({
+    comfyPage
+  }) => {
     const settingsDialog = comfyPage.page.getByTestId('settings-dialog')
-    await expect(settingsDialog).toBeVisible()
-  })
 
-  test('Escape closes settings dialog', async ({ comfyPage }) => {
-    await comfyPage.page.keyboard.down('ControlOrMeta')
-    await comfyPage.page.keyboard.press(',')
-    await comfyPage.page.keyboard.up('ControlOrMeta')
+    await test.step('Ctrl+, opens settings dialog', async () => {
+      await comfyPage.page.keyboard.down('ControlOrMeta')
+      await comfyPage.page.keyboard.press(',')
+      await comfyPage.page.keyboard.up('ControlOrMeta')
 
-    const settingsDialog = comfyPage.page.getByTestId('settings-dialog')
-    await expect(settingsDialog).toBeVisible()
+      await expect(settingsDialog).toBeVisible()
+    })
 
-    await comfyPage.page.keyboard.press('Escape')
-    await expect(settingsDialog).toBeHidden()
+    await test.step('Escape closes settings dialog', async () => {
+      await comfyPage.page.keyboard.press('Escape')
+      await expect(settingsDialog).toBeHidden()
+    })
   })
 
   test('Delete key removes selected nodes', async ({ comfyPage }) => {

--- a/browser_tests/tests/topbarMenuCommands.spec.ts
+++ b/browser_tests/tests/topbarMenuCommands.spec.ts
@@ -22,44 +22,35 @@ test.describe('Topbar menu commands', { tag: '@ui' }, () => {
     await expect.poll(() => topbar.getTabNames()).toHaveLength(2)
   })
 
-  test('Edit > Undo undoes the last action', async ({ comfyPage }) => {
+  test('Edit > Undo undoes and Edit > Redo restores the last action', async ({
+    comfyPage
+  }) => {
     const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
 
-    await comfyPage.page.evaluate(() => {
-      const node = window.LiteGraph!.createNode('Note')
-      window.app!.graph!.add(node)
+    await test.step('Edit > Undo undoes the last action', async () => {
+      await comfyPage.page.evaluate(() => {
+        const node = window.LiteGraph!.createNode('Note')
+        window.app!.graph!.add(node)
+      })
+      await comfyPage.nextFrame()
+
+      await expect
+        .poll(() => comfyPage.nodeOps.getNodeCount())
+        .toBe(initialNodeCount + 1)
+
+      await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Undo'])
+
+      await expect
+        .poll(() => comfyPage.nodeOps.getNodeCount())
+        .toBe(initialNodeCount)
     })
-    await comfyPage.nextFrame()
 
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount + 1)
-
-    await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Undo'])
-
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount)
-  })
-
-  test('Edit > Redo restores an undone action', async ({ comfyPage }) => {
-    const initialNodeCount = await comfyPage.nodeOps.getNodeCount()
-
-    await comfyPage.page.evaluate(() => {
-      const node = window.LiteGraph!.createNode('Note')
-      window.app!.graph!.add(node)
+    await test.step('Edit > Redo restores an undone action', async () => {
+      await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Redo'])
+      await expect
+        .poll(() => comfyPage.nodeOps.getNodeCount())
+        .toBe(initialNodeCount + 1)
     })
-    await comfyPage.nextFrame()
-
-    await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Undo'])
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount)
-
-    await comfyPage.menu.topbar.triggerTopbarCommand(['Edit', 'Redo'])
-    await expect
-      .poll(() => comfyPage.nodeOps.getNodeCount())
-      .toBe(initialNodeCount + 1)
   })
 
   test('File > Save opens save dialog', async ({ comfyPage }) => {


### PR DESCRIPTION
## Summary

Refactor E2E tests added in #11210 that repeated full prior-test bodies as setup, combining duplicate pairs into single tests with named `test.step()` blocks.

## Changes

- **What**: In [`browser_tests/tests/keyboardShortcutActions.spec.ts`](../blob/batch-dispatch/cr-11556/browser_tests/tests/keyboardShortcutActions.spec.ts):
  - Merge `Ctrl+Z undoes` + `Ctrl+Shift+Z redoes` → single test with two `test.step()` blocks.
  - Merge `Ctrl+, opens settings dialog` + `Escape closes settings dialog` → single test with two `test.step()` blocks.
- **What**: In [`browser_tests/tests/topbarMenuCommands.spec.ts`](../blob/batch-dispatch/cr-11556/browser_tests/tests/topbarMenuCommands.spec.ts):
  - Merge `Edit > Undo` + `Edit > Redo` → single test with two `test.step()` blocks.

The redo step now reuses the post-undo state from its preceding step instead of re-creating and re-undoing the node, removing the duplicated setup the reviewer flagged.

## Review Focus

- Naming of combined tests and `test.step()` labels.
- Note: per @AustinMroz's [comment thread](https://github.com/Comfy-Org/ComfyUI_frontend/pull/11210#discussion_r3113526265), location 2 in the issue refers to the `Escape closes settings dialog` test (which duplicated the `Ctrl+,` test body), not the `Delete` test (which has unique logic). Treated accordingly.

Fixes #11556

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11835-test-combine-duplicated-undo-redo-and-settings-dialog-E2E-tests-with-test-step-3546d73d365081689df3c56bfbb6f4e4) by [Unito](https://www.unito.io)
