### PR TITLE
fix(load3d): dispose THREE.Points GPU resources in clearModel()

### DIFF
--- a/src/extensions/core/load3d/SceneModelManager.test.ts
+++ b/src/extensions/core/load3d/SceneModelManager.test.ts
@@ -102,6 +102,16 @@ function createMeshModel(name = 'TestModel'): THREE.Group {
   return group
 }
 
+function createPointsModel(name = 'TestModel'): THREE.Group {
+  const geometry = new THREE.BufferGeometry()
+  const material = new THREE.PointsMaterial({ color: 0xff0000 })
+  const points = new THREE.Points(geometry, material)
+  const group = new THREE.Group()
+  group.name = name
+  group.add(points)
+  return group
+}
+
 describe('SceneModelManager', () => {
   describe('constructor', () => {
     it('initializes default state', () => {
@@ -304,6 +314,20 @@ describe('SceneModelManager', () => {
       const mesh = model.children[0] as THREE.Mesh
       const geoDispose = vi.spyOn(mesh.geometry, 'dispose')
       const matDispose = vi.spyOn(mesh.material as THREE.Material, 'dispose')
+
+      await manager.setupModel(model)
+      manager.clearModel()
+
+      expect(geoDispose).toHaveBeenCalled()
+      expect(matDispose).toHaveBeenCalled()
+    })
+
+    it('disposes points geometry and materials', async () => {
+      const { manager } = createManager()
+      const model = createPointsModel()
+      const points = model.children[0] as THREE.Points
+      const geoDispose = vi.spyOn(points.geometry, 'dispose')
+      const matDispose = vi.spyOn(points.material as THREE.Material, 'dispose')
 
       await manager.setupModel(model)
       manager.clearModel()

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -328,7 +328,7 @@ export class SceneModelManager implements ModelManagerInterface {
       this.scene.remove(obj)
 
       obj.traverse((child) => {
-        if (child instanceof THREE.Mesh) {
+        if (child instanceof THREE.Mesh || child instanceof THREE.Points) {
           child.geometry?.dispose()
           if (Array.isArray(child.material)) {
             child.material.forEach((material) => material.dispose())


### PR DESCRIPTION
Fixes #11345

## Summary

`clearModel()` in `SceneModelManager` only traversed and disposed `THREE.Mesh` instances, leaving `THREE.Points` objects (created by `handlePLYModeSwitch()` for point-cloud mode) leaking GPU geometry and material memory on repeated point-cloud loads/clears.

## Changes

- `SceneModelManager.ts`: extend the dispose traversal in `clearModel()` to also handle `THREE.Points`, mirroring the pattern already used by `removeAllMainModelsFromScene()`.
- `SceneModelManager.test.ts`: add regression test verifying `geometry.dispose()` and `material.dispose()` are called for `THREE.Points` children on `clearModel()`.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11836-fix-load3d-dispose-THREE-Points-GPU-resources-in-clearModel-3546d73d365081718338e824bc3e737d) by [Unito](https://www.unito.io)
