### PR TITLE
refactor: consolidate NodeId type aliases (pre-work for adr008)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -98,6 +98,21 @@ import type { WidgetTypeMap } from './widgets/widgetMap'
 
 // #region Types
 
+/**
+ * Canonical identifier type for a litegraph node.
+ *
+ * This is the single source of truth for node IDs across the litegraph
+ * library and the workflow schema layer. Other modules SHOULD import
+ * `NodeId` from here (or via the workflow schema re-export) rather than
+ * declaring local `string` / `number | string` aliases.
+ *
+ * Note: `src/renderer/core/layout/types.ts` deliberately defines a
+ * narrower `NodeId = string` for the Vue-node renderer, where IDs are
+ * normalized to strings. That is a separate, intentionally-narrower
+ * layered alias — see the JSDoc there.
+ *
+ * Tracking issue for full migration: #11428.
+ */
 export type NodeId = number | string
 
 export type NodeProperty = string | number | boolean | object

--- a/src/platform/workflow/validation/schemas/workflowSchema.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod'
 import type { SafeParseReturnType } from 'zod'
 import { fromZodError } from 'zod-validation-error'
+
 import type { RendererType } from '@/lib/litegraph/src/LGraph'
+import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 
 const zRendererType = z.enum([
   'LG',
@@ -12,9 +14,20 @@ const zRendererType = z.enum([
 // GroupNode is hacking node id to be a string, so we need to allow that.
 // innerNode.id = `${this.node.id}:${i}`
 // Remove it after GroupNode is redesigned.
-export const zNodeId = z.union([z.number().int(), z.string()])
+export const zNodeId = z.union([
+  z.number().int(),
+  z.string()
+]) satisfies z.ZodType<NodeId>
 const zNodeInputName = z.string()
-export type NodeId = z.infer<typeof zNodeId>
+
+/**
+ * Re-export of the canonical {@link NodeId} type defined in
+ * `src/lib/litegraph/src/LGraphNode.ts`. Kept here for ergonomic imports
+ * alongside `zNodeId` (the runtime validator) and historical call sites.
+ *
+ * See issue #11428 for the consolidation rationale.
+ */
+export type { NodeId }
 
 /**
  * UUID identifier for a saved workflow.

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -37,6 +37,20 @@ export interface NodeBoundsUpdate {
   bounds: Bounds
 }
 
+/**
+ * Renderer-internal node identifier.
+ *
+ * Intentionally narrower than the canonical {@link NodeId} in
+ * `src/lib/litegraph/src/LGraphNode.ts` (which is `number | string`).
+ * The Vue-node renderer normalizes all incoming IDs to strings before
+ * they enter the layout system, so this layered alias documents and
+ * enforces that contract at the renderer boundary.
+ *
+ * If you need a node ID at the litegraph or workflow-schema layer,
+ * import `NodeId` from `@/lib/litegraph/src/LGraphNode` instead.
+ *
+ * See issue #11428 for the layered-types decision.
+ */
 export type NodeId = string
 export type LinkId = number
 export type RerouteId = number


### PR DESCRIPTION
## Summary

Consolidate the three competing \`NodeId\` type aliases identified in #11428 into a single canonical definition, with a back-compat re-export and a runtime/type drift guard. No behavior change.

## Changes

- **What**:
  - Mark \`src/lib/litegraph/src/LGraphNode.ts\` \`NodeId = number | string\` as the canonical source (45+ existing import sites).
  - \`src/platform/workflow/validation/schemas/workflowSchema.ts\` now \`export type { NodeId }\` from the canonical location instead of declaring its own \`z.infer\` alias. Add \`zNodeId\` \`satisfies z.ZodType<NodeId>\` so the validator and the type can never silently drift.
  - \`src/renderer/core/layout/types.ts\` keeps its narrower \`NodeId = string\` (the Vue-node renderer normalizes to strings at the boundary), but is now documented as an intentional layered variant per the issue's \"layered set\" suggestion.
- **Breaking**: None. Both \`@/lib/litegraph/src/LGraphNode\` and \`@/platform/workflow/validation/schemas/workflowSchema\` continue to export \`NodeId\` with the same shape.

## Review Focus

- Is the canonical home (\`LGraphNode.ts\`) the right one? It currently has the most importers (~45); \`workflowSchema.ts\` (~24) and \`renderer/core/layout/types.ts\` (~6) are the alternatives.
- Is keeping the renderer's narrower \`string\`-only alias correct, or should it be unified with the canonical \`number | string\` (would touch many call sites — explicitly out of scope for this PR)?

## Follow-ups

The issue describes ~151 sites where \`nodeId\` is typed as bare \`string\` / Vue prop \`String\`. Those will land in scoped follow-up PRs (litegraph internals, renderer, stores, Vue props) so each stays under the 300-LOC guideline. A CI guard (lint rule) is also a candidate for a follow-up.

Refs #11428

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11839-refactor-consolidate-NodeId-type-aliases-pre-work-for-adr008-3546d73d3650814697a0da8026a3e701) by [Unito](https://www.unito.io)
