### PR TITLE
feat: add Run your first workflow button to home hero

### DIFF
--- a/apps/website/src/components/home/HeroSection.vue
+++ b/apps/website/src/components/home/HeroSection.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import type { Locale } from '../../i18n/translations'
+import { externalLinks } from '../../config/routes'
 import { t } from '../../i18n/translations'
+import BrandButton from '../common/BrandButton.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 </script>
@@ -32,6 +34,15 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
       >
         {{ t('hero.subtitle', locale) }}
       </p>
+
+      <BrandButton
+        :href="externalLinks.workflows"
+        variant="outline"
+        size="lg"
+        class="mt-8 w-full p-4 uppercase lg:w-auto lg:min-w-60"
+      >
+        {{ t('hero.runFirstWorkflow', locale) }}
+      </BrandButton>
     </div>
   </section>
 </template>

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -11,6 +11,10 @@ const translations = {
     'zh-CN':
       'Comfy 是面向专业视觉人士的 AI 创作引擎。您可以精确掌控每个模型、每个参数和每个输出。'
   },
+  'hero.runFirstWorkflow': {
+    en: 'Run your first workflow',
+    'zh-CN': '运行你的第一个工作流'
+  },
 
   // ProductShowcaseSection
   'showcase.subtitle1': {


### PR DESCRIPTION
## Summary

Add an outline-style `BrandButton` to the right side of the home page hero section linking to the workflows page.

## Changes

- **What**: 
  - Added a `Run your first workflow` outline button below the subtitle in `apps/website/src/components/home/HeroSection.vue`, linking to `externalLinks.workflows`. Mirrors the button pattern from `product/local/HeroSection.vue`.
  - Added `hero.runFirstWorkflow` i18n entry (en + zh-CN) in `apps/website/src/i18n/translations.ts`.

## Review Focus

- Confirmed alignment with design spec.

<img width="1505" height="776" alt="image" src="https://github.com/user-attachments/assets/215e667d-1827-447b-99b8-eba8cb5ec7e3" />
<img width="335" height="700" alt="image" src="https://github.com/user-attachments/assets/aeac0876-74c3-4e12-a4b3-203f9e541bc2" />


┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11848-feat-add-Run-your-first-workflow-button-to-home-hero-3546d73d365081358d54eddfda71111e) by [Unito](https://www.unito.io)
