### PR TITLE
fix(website): point Install via GitHub buttons to install docs anchor

### DIFF
--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -46,7 +46,7 @@ test.describe('Download page @smoke', () => {
     await expect(githubBtn).toBeVisible()
     await expect(githubBtn).toHaveAttribute(
       'href',
-      'https://github.com/Comfy-Org/ComfyUI'
+      'https://github.com/Comfy-Org/ComfyUI#installing'
     )
 
     await context.close()

--- a/apps/website/src/components/product/local/EcoSystemSection.vue
+++ b/apps/website/src/components/product/local/EcoSystemSection.vue
@@ -28,7 +28,11 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
         <!-- CTA buttons -->
         <div class="mt-10 flex flex-col gap-4 lg:flex-row">
           <DownloadLocalButton :locale />
-          <BrandButton :href="externalLinks.github" variant="outline" size="lg">
+          <BrandButton
+            :href="externalLinks.githubInstall"
+            variant="outline"
+            size="lg"
+          >
             <span class="inline-flex items-center gap-2">
               <i
                 class="icon-mask size-5 -translate-y-px mask-[url('/icons/social/github.svg')]"

--- a/apps/website/src/components/product/local/HeroSection.vue
+++ b/apps/website/src/components/product/local/HeroSection.vue
@@ -323,7 +323,7 @@ onUnmounted(() => {
       <div class="mt-8 flex flex-col gap-4 lg:flex-row">
         <DownloadLocalButton :locale class="lg:min-w-60 lg:p-4" />
         <BrandButton
-          :href="externalLinks.github"
+          :href="externalLinks.githubInstall"
           variant="outline"
           size="lg"
           class="lg:min-w-60 lg:p-4"

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -34,6 +34,7 @@ export const externalLinks = {
   docs: 'https://docs.comfy.org/',
   docsApi: 'https://docs.comfy.org/api-reference/cloud',
   github: 'https://github.com/Comfy-Org/ComfyUI',
+  githubInstall: 'https://github.com/Comfy-Org/ComfyUI#installing',
   platform: 'https://platform.comfy.org',
   workflows: 'https://comfy.org/workflows',
   youtube: 'https://www.youtube.com/@ComfyOrg'


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Updates the "Install via GitHub" CTA buttons on the `/download` page to deep-link to the install instructions section of the ComfyUI README (`#installing`) instead of the repo root, so users land directly on setup steps.

## Changes

- `apps/website/src/config/routes.ts`: add `externalLinks.githubInstall = 'https://github.com/Comfy-Org/ComfyUI#installing'` (separate from `externalLinks.github`, which is still used by the navbar/footer/star badge for the generic repo link).
- `apps/website/src/components/product/local/HeroSection.vue`: switch the secondary CTA next to "Download Local" from `externalLinks.github` to `externalLinks.githubInstall`.
- `apps/website/src/components/product/local/EcoSystemSection.vue`: same swap on the ecosystem-section CTA.

The platform-aware `Download Local` button (Windows/macOS installers via `useDownloadUrl`) and the generic GitHub social/repo links elsewhere on the site are unchanged.

## Verification

- `pnpm --filter @comfyorg/website typecheck` — 0 errors
- `pnpm --filter @comfyorg/website test:unit` — 23/23 passing
- `pnpm exec eslint` on changed files — clean
- `pnpm exec oxfmt --check` — clean
- Manual via `pnpm dev` + Playwright DOM assertion on `/download`:
  - Hero "INSTALL FROM GITHUB" → `https://github.com/Comfy-Org/ComfyUI#installing` ✓
  - EcoSystem "INSTALL FROM GITHUB" → `https://github.com/Comfy-Org/ComfyUI#installing` ✓
  - Other "GitHub" links (nav, footer, star badge) → unchanged at `https://github.com/Comfy-Org/ComfyUI` ✓

Per request from #website-and-docs: the local download surfaces should at least link to the ComfyUI install instructions on GitHub. Companion change to comfy-org/website#227.

## Screenshots

![Download page hero with INSTALL FROM GITHUB button now linking to install docs anchor](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3c608b478e1150f3fc43b6092811c93ff3cd90a253263ab05ac43fe8ce7a0843/pr-images/1777761785467-060efddb-f5a0-44a8-8bbe-287c991171ee.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11852-fix-website-point-Install-via-GitHub-buttons-to-install-docs-anchor-3546d73d365081fe8370cd675ae8f896) by [Unito](https://www.unito.io)
