### PR TITLE
feat: boost SaveImageAdvanced node frequency for search ranking

### DIFF
--- a/public/assets/sorted-custom-node-map.json
+++ b/public/assets/sorted-custom-node-map.json
@@ -3,6 +3,7 @@
   "LoadImage": 3474,
   "CLIPTextEncode": 2435,
   "SaveImage": 1762,
+  "SaveImageAdvanced": 1762,
   "VAEDecode": 1754,
   "KSampler": 1511,
   "CheckpointLoaderSimple": 1293,


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Adds an entry for the new `SaveImageAdvanced` node to `public/assets/sorted-custom-node-map.json` with the same frequency stat (1762) as the existing `SaveImage` node, so the new Save Image node ranks at the top of search results when typing "save" — matching the original node's behavior.

Context: the new Save Image node ([Notion spec](https://www.notion.so/comfy-org/Save-Image-94a77c506ce145fc9b8c477c52091a04)) replaces/deprecates the original `SaveImage`. Search ranking uses the static node frequency map; the new node had no entry and was therefore ranked at frequency 0. Mirroring the original's stat is the manual-boost approach discussed in the thread.

## Changes
- `public/assets/sorted-custom-node-map.json`: add `"SaveImageAdvanced": 1762` directly after `"SaveImage": 1762` to preserve descending sort order.

## Verification
- `pnpm typecheck`, `pnpm lint`, and `pnpm format` all pass via lint-staged on commit.
- JSON validated and entry placement confirmed (position 4, between `SaveImage` and `VAEDecode`).
- Review (oracle) ran clean: 0 critical / 0 warning / 0 suggestion.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11853-feat-boost-SaveImageAdvanced-node-frequency-for-search-ranking-3546d73d36508168b058d9d750fc3c56) by [Unito](https://www.unito.io)
