### PR TITLE
fix(website): unstretch See all case studies button

### DIFF
--- a/apps/website/e2e/homepage.spec.ts
+++ b/apps/website/e2e/homepage.spec.ts
@@ -69,6 +69,32 @@ test.describe('Homepage @smoke', () => {
     ).toBeVisible()
   })
 
+  test('CaseStudySpotlight CTA sizes to its content, not the column', async ({
+    page
+  }) => {
+    const section = page.locator('section', {
+      has: page.getByText('Customer Stories')
+    })
+    const cta = section.getByRole('link', { name: /see all case studies/i })
+
+    await cta.scrollIntoViewIfNeeded()
+    await expect(cta).toBeVisible()
+
+    const contentColumn = section
+      .getByRole('heading', { name: /See Comfy/i })
+      .locator('..')
+      .locator('..')
+
+    const [columnBox, ctaBox] = await Promise.all([
+      contentColumn.boundingBox(),
+      cta.boundingBox()
+    ])
+
+    expect(columnBox).not.toBeNull()
+    expect(ctaBox).not.toBeNull()
+    expect(ctaBox!.width).toBeLessThan(columnBox!.width * 0.7)
+  })
+
   test('BuildWhatSection is visible', async ({ page }) => {
     // "DOESN'T EXIST" is the actual badge text rendered in the Build What section
     await expect(page.getByText("DOESN'T EXIST")).toBeVisible()

--- a/apps/website/e2e/homepage.spec.ts
+++ b/apps/website/e2e/homepage.spec.ts
@@ -72,18 +72,13 @@ test.describe('Homepage @smoke', () => {
   test('CaseStudySpotlight CTA sizes to its content, not the column', async ({
     page
   }) => {
-    const section = page.locator('section', {
-      has: page.getByText('Customer Stories')
+    const contentColumn = page.getByTestId('case-study-content')
+    const cta = contentColumn.getByRole('link', {
+      name: /see all case studies/i
     })
-    const cta = section.getByRole('link', { name: /see all case studies/i })
 
     await cta.scrollIntoViewIfNeeded()
     await expect(cta).toBeVisible()
-
-    const contentColumn = section
-      .getByRole('heading', { name: /See Comfy/i })
-      .locator('..')
-      .locator('..')
 
     const [columnBox, ctaBox] = await Promise.all([
       contentColumn.boundingBox(),
@@ -93,6 +88,29 @@ test.describe('Homepage @smoke', () => {
     expect(columnBox).not.toBeNull()
     expect(ctaBox).not.toBeNull()
     expect(ctaBox!.width).toBeLessThan(columnBox!.width * 0.7)
+  })
+
+  test('CaseStudySpotlight CTA has breathing room above it on mobile @mobile', async ({
+    page
+  }) => {
+    const contentColumn = page.getByTestId('case-study-content')
+    const subheading = contentColumn.getByText(
+      /Videos & case studies from teams/i
+    )
+    const cta = contentColumn.getByRole('link', {
+      name: /see all case studies/i
+    })
+
+    await cta.scrollIntoViewIfNeeded()
+
+    const [subBox, ctaBox] = await Promise.all([
+      subheading.boundingBox(),
+      cta.boundingBox()
+    ])
+
+    expect(subBox).not.toBeNull()
+    expect(ctaBox).not.toBeNull()
+    expect(ctaBox!.y - (subBox!.y + subBox!.height)).toBeGreaterThanOrEqual(24)
   })
 
   test('BuildWhatSection is visible', async ({ page }) => {

--- a/apps/website/src/components/home/CaseStudySpotlightSection.vue
+++ b/apps/website/src/components/home/CaseStudySpotlightSection.vue
@@ -35,7 +35,10 @@ const routes = getRoutes(locale)
       </div>
 
       <!-- Right: content -->
-      <div class="flex flex-col justify-between p-6 lg:flex-1">
+      <div
+        data-testid="case-study-content"
+        class="flex flex-col justify-between p-6 lg:flex-1"
+      >
         <div class="flex flex-col gap-8">
           <p
             class="text-primary-comfy-yellow text-sm font-bold tracking-widest uppercase"
@@ -52,7 +55,7 @@ const routes = getRoutes(locale)
           </p>
         </div>
 
-        <div class="mt-8 flex flex-col items-start gap-3 sm:flex-row">
+        <div class="mt-8 flex flex-col items-start gap-3 sm:flex-row lg:mt-0">
           <BrandButton :href="routes.customers" variant="outline">
             {{ t('caseStudy.seeAll', locale) }}
           </BrandButton>

--- a/apps/website/src/components/home/CaseStudySpotlightSection.vue
+++ b/apps/website/src/components/home/CaseStudySpotlightSection.vue
@@ -52,7 +52,7 @@ const routes = getRoutes(locale)
           </p>
         </div>
 
-        <div class="flex flex-col items-start gap-3 sm:flex-row">
+        <div class="mt-8 flex flex-col items-start gap-3 sm:flex-row">
           <BrandButton :href="routes.customers" variant="outline">
             {{ t('caseStudy.seeAll', locale) }}
           </BrandButton>

--- a/apps/website/src/components/home/CaseStudySpotlightSection.vue
+++ b/apps/website/src/components/home/CaseStudySpotlightSection.vue
@@ -52,12 +52,8 @@ const routes = getRoutes(locale)
           </p>
         </div>
 
-        <div class="flex flex-col gap-3 sm:flex-row">
-          <BrandButton
-            :href="routes.customers"
-            variant="outline"
-            class="flex-1 text-center"
-          >
+        <div class="flex flex-col items-start gap-3 sm:flex-row">
+          <BrandButton :href="routes.customers" variant="outline">
             {{ t('caseStudy.seeAll', locale) }}
           </BrandButton>
         </div>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The "See all case studies" button on the homepage `CaseStudySpotlightSection` was rendering oddly stretched because it had `class="flex-1 text-center"` while being the sole child of a `flex-row` container — it expanded to fill the entire content column (~592px) instead of sizing to its label.

This drops `flex-1`/`text-center` and adds `items-start` to the wrapper so the button sizes to its content and is left-aligned, matching the proportions of every other outline `BrandButton` on the site (Hero, UseCase, customer detail, etc.).

## Changes

- `apps/website/src/components/home/CaseStudySpotlightSection.vue`: remove `flex-1 text-center` from the `BrandButton` and align the row's items to the start.

`BrandButton` already centers its label internally via `inline-flex … justify-center`, so dropping `text-center` is a no-op visually.

## Before / After

- Desktop before: button width = 592px (stretched across the column)
- Desktop after: button width = 223px (natural)
- Mobile: 1-column layout, now consistently left-aligned

## Review Focus

Whether the fix should also live on the `BrandButton` component itself (e.g. a global `max-width`) instead of at the call site. I went with the instance-level fix because every other CTA in the website intentionally uses bare `BrandButton` and lets the content size it; only this one had `flex-1`. A blanket `max-width` would risk changing Hero/MobileMenu buttons that explicitly opt into `w-full lg:w-auto lg:min-w-60`.

## Screenshots

![Before: button stretched across the full content column](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/19522cd256addec524dfcc25228a9ad732d07646330472c58513d6b4714808ca/pr-images/1777774244354-4dd9af45-2458-4d8a-a1a7-1f6b88b6fc4b.png)

![After: button sized to content, left-aligned](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/19522cd256addec524dfcc25228a9ad732d07646330472c58513d6b4714808ca/pr-images/1777774244808-5bab2801-0140-4b4a-9d9e-61a467090de3.png)

![After: mobile view, left-aligned natural width](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/19522cd256addec524dfcc25228a9ad732d07646330472c58513d6b4714808ca/pr-images/1777774245316-1ca9609d-3de0-4c85-973e-a87e296fa65f.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11854-fix-website-unstretch-See-all-case-studies-button-3556d73d365081abb3bbe9dbc51cbc07) by [Unito](https://www.unito.io)
