### PR TITLE
feat(website): add payment success and failed pages

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -3,6 +3,18 @@ import sitemap from '@astrojs/sitemap'
 import vue from '@astrojs/vue'
 import tailwindcss from '@tailwindcss/vite'
 
+const SITEMAP_EXCLUDED_PATHNAMES = new Set([
+  '/payment/success',
+  '/payment/failed',
+  '/zh-CN/payment/success',
+  '/zh-CN/payment/failed'
+])
+
+function isExcludedFromSitemap(page: string): boolean {
+  const pathname = new URL(page).pathname.replace(/\/$/, '')
+  return SITEMAP_EXCLUDED_PATHNAMES.has(pathname)
+}
+
 export default defineConfig({
   site: 'https://comfy.org',
   output: 'static',
@@ -20,7 +32,7 @@ export default defineConfig({
   integrations: [
     vue(),
     sitemap({
-      filter: (page) => !/\/payment\/(success|failed)\/?$/.test(page)
+      filter: (page) => !isExcludedFromSitemap(page)
     })
   ],
   vite: {

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -17,7 +17,12 @@ export default defineConfig({
     assets: '_website'
   },
   devToolbar: { enabled: !process.env.NO_TOOLBAR },
-  integrations: [vue(), sitemap()],
+  integrations: [
+    vue(),
+    sitemap({
+      filter: (page) => !/\/payment\/(success|failed)\/?$/.test(page)
+    })
+  ],
   vite: {
     plugins: [tailwindcss()],
     server: {

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -3,12 +3,13 @@ import sitemap from '@astrojs/sitemap'
 import vue from '@astrojs/vue'
 import tailwindcss from '@tailwindcss/vite'
 
-const SITEMAP_EXCLUDED_PATHNAMES = new Set([
-  '/payment/success',
-  '/payment/failed',
-  '/zh-CN/payment/success',
-  '/zh-CN/payment/failed'
-])
+const PAYMENT_STATUSES = ['success', 'failed'] as const
+const LOCALE_PREFIXES = ['', '/zh-CN'] as const
+const SITEMAP_EXCLUDED_PATHNAMES = new Set(
+  LOCALE_PREFIXES.flatMap((prefix) =>
+    PAYMENT_STATUSES.map((status) => `${prefix}/payment/${status}`)
+  )
+)
 
 function isExcludedFromSitemap(page: string): boolean {
   const pathname = new URL(page).pathname.replace(/\/$/, '')

--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -3,8 +3,12 @@ import sitemap from '@astrojs/sitemap'
 import vue from '@astrojs/vue'
 import tailwindcss from '@tailwindcss/vite'
 
+const LOCALES = ['en', 'zh-CN'] as const
+const DEFAULT_LOCALE = 'en'
 const PAYMENT_STATUSES = ['success', 'failed'] as const
-const LOCALE_PREFIXES = ['', '/zh-CN'] as const
+const LOCALE_PREFIXES = LOCALES.map((locale) =>
+  locale === DEFAULT_LOCALE ? '' : `/${locale}`
+)
 const SITEMAP_EXCLUDED_PATHNAMES = new Set(
   LOCALE_PREFIXES.flatMap((prefix) =>
     PAYMENT_STATUSES.map((status) => `${prefix}/payment/${status}`)
@@ -45,8 +49,8 @@ export default defineConfig({
     }
   },
   i18n: {
-    locales: ['en', 'zh-CN'],
-    defaultLocale: 'en',
+    locales: [...LOCALES],
+    defaultLocale: DEFAULT_LOCALE,
     routing: {
       prefixDefaultLocale: false
     }

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -3,7 +3,9 @@ import { expect } from '@playwright/test'
 
 import { test } from './fixtures/blockExternalMedia'
 
-const PLATFORM_DASHBOARD_URL = 'https://platform.comfy.org/profile/api-keys'
+const APP_URL = 'https://app.comfy.org'
+const PLATFORM_URL = 'https://platform.comfy.org'
+const BILLING_DOCS_URL = 'https://docs.comfy.org/api-reference/cloud'
 
 async function expectNoIndex(page: Page) {
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
@@ -29,16 +31,18 @@ test.describe('Payment success page @smoke', () => {
     await expect(page.getByText(/Thanks for your purchase/i)).toBeVisible()
   })
 
-  test('primary CTA links to platform dashboard', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /GO TO DASHBOARD/i })
+  test('primary CTA links to ComfyUI app (default fallback)', async ({
+    page
+  }) => {
+    const cta = page.getByRole('link', { name: /CONTINUE IN COMFYUI/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', PLATFORM_DASHBOARD_URL)
+    await expect(cta).toHaveAttribute('href', APP_URL)
   })
 
-  test('secondary CTA links back to home', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /BACK TO HOME/i })
+  test('secondary CTA links to platform balance & usage', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /VIEW BALANCE & USAGE/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', '/')
+    await expect(cta).toHaveAttribute('href', PLATFORM_URL)
   })
 })
 
@@ -62,16 +66,21 @@ test.describe('Payment failed page @smoke', () => {
     await expect(page.getByText(/payment didn't go through/i)).toBeVisible()
   })
 
-  test('primary CTA links to platform dashboard', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /TRY AGAIN/i })
-    await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', PLATFORM_DASHBOARD_URL)
-  })
-
-  test('secondary CTA links to contact page', async ({ page }) => {
+  test('primary CTA links to contact page', async ({ page }) => {
     const cta = page.getByRole('link', { name: /CONTACT SUPPORT/i })
     await expect(cta).toBeVisible()
     await expect(cta).toHaveAttribute('href', '/contact')
+  })
+
+  test('secondary CTA links to billing docs', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /READ BILLING DOCS/i })
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', BILLING_DOCS_URL)
+  })
+
+  test('tertiary CTA is a close-tab button', async ({ page }) => {
+    const button = page.getByRole('button', { name: /CLOSE TAB/i })
+    await expect(button).toBeVisible()
   })
 })
 
@@ -84,12 +93,11 @@ test.describe('Payment pages zh-CN @smoke', () => {
       page.getByRole('heading', { name: '支付成功', level: 1 })
     ).toBeVisible()
     await expect(
-      page.getByRole('link', { name: '前往控制台' })
-    ).toHaveAttribute('href', PLATFORM_DASHBOARD_URL)
-    await expect(page.getByRole('link', { name: '返回首页' })).toHaveAttribute(
-      'href',
-      '/zh-CN/'
-    )
+      page.getByRole('link', { name: '返回 COMFYUI' })
+    ).toHaveAttribute('href', APP_URL)
+    await expect(
+      page.getByRole('link', { name: '查看余额与用量' })
+    ).toHaveAttribute('href', PLATFORM_URL)
   })
 
   test('zh-CN failed page renders and links correctly', async ({ page }) => {
@@ -99,13 +107,25 @@ test.describe('Payment pages zh-CN @smoke', () => {
     await expect(
       page.getByRole('heading', { name: '支付未完成', level: 1 })
     ).toBeVisible()
-    await expect(page.getByRole('link', { name: '重新尝试' })).toHaveAttribute(
-      'href',
-      PLATFORM_DASHBOARD_URL
-    )
     await expect(page.getByRole('link', { name: '联系支持' })).toHaveAttribute(
       'href',
       '/zh-CN/contact'
     )
+    await expect(
+      page.getByRole('link', { name: '查看计费文档' })
+    ).toHaveAttribute('href', BILLING_DOCS_URL)
+    await expect(page.getByRole('button', { name: '关闭页面' })).toBeVisible()
+  })
+})
+
+test.describe('Payment success origin-aware referrer @interaction', () => {
+  test('falls back to default app URL for non-allowlisted referrer', async ({
+    page
+  }) => {
+    await page.goto('/payment/success', {
+      referer: 'https://evil.example.com/'
+    })
+    const cta = page.getByRole('link', { name: /CONTINUE IN COMFYUI/i })
+    await expect(cta).toHaveAttribute('href', APP_URL)
   })
 })

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/blockExternalMedia'
+
+test.describe('Payment success page @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/payment/success')
+  })
+
+  test('has correct title', async ({ page }) => {
+    await expect(page).toHaveTitle('Payment Successful — Comfy')
+  })
+
+  test('is marked noindex', async ({ page }) => {
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex, nofollow'
+    )
+  })
+
+  test('shows success heading and subtitle', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: /Payment successful/i, level: 1 })
+    ).toBeVisible()
+    await expect(page.getByText(/Thanks for your purchase/i)).toBeVisible()
+  })
+
+  test('primary CTA links to platform dashboard', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /GO TO DASHBOARD/i })
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', 'https://platform.comfy.org/')
+  })
+
+  test('secondary CTA links back to home', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /BACK TO HOME/i })
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', '/')
+  })
+})
+
+test.describe('Payment failed page @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/payment/failed')
+  })
+
+  test('has correct title', async ({ page }) => {
+    await expect(page).toHaveTitle('Payment Failed — Comfy')
+  })
+
+  test('shows failure heading and subtitle', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', {
+        name: /Payment was not completed/i,
+        level: 1
+      })
+    ).toBeVisible()
+    await expect(page.getByText(/payment didn't go through/i)).toBeVisible()
+  })
+
+  test('primary CTA links to platform dashboard', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /TRY AGAIN/i })
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', 'https://platform.comfy.org/')
+  })
+
+  test('secondary CTA links to contact page', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /CONTACT SUPPORT/i })
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveAttribute('href', '/contact')
+  })
+})
+
+test.describe('Payment pages zh-CN @smoke', () => {
+  test('zh-CN success page has Chinese title and dashboard CTA', async ({
+    page
+  }) => {
+    await page.goto('/zh-CN/payment/success')
+    await expect(page).toHaveTitle('支付成功 — Comfy')
+    await expect(
+      page.getByRole('heading', { name: '支付成功', level: 1 })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: '前往控制台' })
+    ).toHaveAttribute('href', 'https://platform.comfy.org/')
+    await expect(page.getByRole('link', { name: '返回首页' })).toHaveAttribute(
+      'href',
+      '/zh-CN/'
+    )
+  })
+
+  test('zh-CN failed page has Chinese title and contact CTA', async ({
+    page
+  }) => {
+    await page.goto('/zh-CN/payment/failed')
+    await expect(page).toHaveTitle('支付失败 — Comfy')
+    await expect(
+      page.getByRole('heading', { name: '支付未完成', level: 1 })
+    ).toBeVisible()
+    await expect(page.getByRole('link', { name: '联系支持' })).toHaveAttribute(
+      'href',
+      '/zh-CN/contact'
+    )
+  })
+})

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -1,14 +1,13 @@
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
-import { externalLinks, getRoutes } from '../src/config/routes'
+import { externalLinks } from '../src/config/routes'
 import { test } from './fixtures/blockExternalMedia'
 
-const APP_URL = externalLinks.app
-const PLATFORM_URL = externalLinks.platform
-const BILLING_DOCS_URL = externalLinks.docsApi
-const EN_ROUTES = getRoutes('en')
-const ZH_CN_ROUTES = getRoutes('zh-CN')
+const CLOUD_URL = externalLinks.cloud
+const PLATFORM_USAGE_URL = externalLinks.platformUsage
+const SUPPORT_URL = externalLinks.support
+const DOCS_SUBSCRIPTION_URL = externalLinks.docsSubscription
 
 async function expectNoIndex(page: Page) {
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
@@ -34,18 +33,16 @@ test.describe('Payment success page @smoke', () => {
     await expect(page.getByText(/Thanks for your purchase/i)).toBeVisible()
   })
 
-  test('primary CTA links to ComfyUI app (default fallback)', async ({
-    page
-  }) => {
-    const cta = page.getByRole('link', { name: /CONTINUE IN COMFYUI/i })
+  test('primary CTA links to Comfy Cloud', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /CONTINUE TO COMFY CLOUD/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', APP_URL)
+    await expect(cta).toHaveAttribute('href', CLOUD_URL)
   })
 
-  test('secondary CTA links to platform balance & usage', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /VIEW BALANCE & USAGE/i })
+  test('secondary CTA links to platform usage page', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /VIEW USAGE/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', PLATFORM_URL)
+    await expect(cta).toHaveAttribute('href', PLATFORM_USAGE_URL)
   })
 })
 
@@ -69,21 +66,16 @@ test.describe('Payment failed page @smoke', () => {
     await expect(page.getByText(/payment didn't go through/i)).toBeVisible()
   })
 
-  test('primary CTA links to contact page', async ({ page }) => {
+  test('primary CTA links to support help center', async ({ page }) => {
     const cta = page.getByRole('link', { name: /CONTACT SUPPORT/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', EN_ROUTES.contact)
+    await expect(cta).toHaveAttribute('href', SUPPORT_URL)
   })
 
-  test('secondary CTA links to billing docs', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /READ BILLING DOCS/i })
+  test('secondary CTA links to subscription docs', async ({ page }) => {
+    const cta = page.getByRole('link', { name: /READ SUBSCRIPTION DOCS/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', BILLING_DOCS_URL)
-  })
-
-  test('tertiary CTA is a close-tab button', async ({ page }) => {
-    const button = page.getByRole('button', { name: /CLOSE TAB/i })
-    await expect(button).toBeVisible()
+    await expect(cta).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
   })
 })
 
@@ -96,11 +88,12 @@ test.describe('Payment pages zh-CN @smoke', () => {
       page.getByRole('heading', { name: '支付成功', level: 1 })
     ).toBeVisible()
     await expect(
-      page.getByRole('link', { name: '返回 COMFYUI' })
-    ).toHaveAttribute('href', APP_URL)
-    await expect(
-      page.getByRole('link', { name: '查看余额与用量' })
-    ).toHaveAttribute('href', PLATFORM_URL)
+      page.getByRole('link', { name: '前往 COMFY CLOUD' })
+    ).toHaveAttribute('href', CLOUD_URL)
+    await expect(page.getByRole('link', { name: '查看用量' })).toHaveAttribute(
+      'href',
+      PLATFORM_USAGE_URL
+    )
   })
 
   test('zh-CN failed page renders and links correctly', async ({ page }) => {
@@ -112,11 +105,10 @@ test.describe('Payment pages zh-CN @smoke', () => {
     ).toBeVisible()
     await expect(page.getByRole('link', { name: '联系支持' })).toHaveAttribute(
       'href',
-      ZH_CN_ROUTES.contact
+      SUPPORT_URL
     )
     await expect(
-      page.getByRole('link', { name: '查看计费文档' })
-    ).toHaveAttribute('href', BILLING_DOCS_URL)
-    await expect(page.getByRole('button', { name: '关闭页面' })).toBeVisible()
+      page.getByRole('link', { name: '查看订阅文档' })
+    ).toHaveAttribute('href', DOCS_SUBSCRIPTION_URL)
   })
 })

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -1,21 +1,25 @@
+import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { test } from './fixtures/blockExternalMedia'
+
+const PLATFORM_DASHBOARD_URL = 'https://platform.comfy.org/profile/api-keys'
+
+async function expectNoIndex(page: Page) {
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    'content',
+    'noindex, nofollow'
+  )
+}
 
 test.describe('Payment success page @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/payment/success')
   })
 
-  test('has correct title', async ({ page }) => {
+  test('has correct title and is noindex', async ({ page }) => {
     await expect(page).toHaveTitle('Payment Successful — Comfy')
-  })
-
-  test('is marked noindex', async ({ page }) => {
-    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
-      'content',
-      'noindex, nofollow'
-    )
+    await expectNoIndex(page)
   })
 
   test('shows success heading and subtitle', async ({ page }) => {
@@ -28,7 +32,7 @@ test.describe('Payment success page @smoke', () => {
   test('primary CTA links to platform dashboard', async ({ page }) => {
     const cta = page.getByRole('link', { name: /GO TO DASHBOARD/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', 'https://platform.comfy.org/')
+    await expect(cta).toHaveAttribute('href', PLATFORM_DASHBOARD_URL)
   })
 
   test('secondary CTA links back to home', async ({ page }) => {
@@ -43,8 +47,9 @@ test.describe('Payment failed page @smoke', () => {
     await page.goto('/payment/failed')
   })
 
-  test('has correct title', async ({ page }) => {
+  test('has correct title and is noindex', async ({ page }) => {
     await expect(page).toHaveTitle('Payment Failed — Comfy')
+    await expectNoIndex(page)
   })
 
   test('shows failure heading and subtitle', async ({ page }) => {
@@ -60,7 +65,7 @@ test.describe('Payment failed page @smoke', () => {
   test('primary CTA links to platform dashboard', async ({ page }) => {
     const cta = page.getByRole('link', { name: /TRY AGAIN/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', 'https://platform.comfy.org/')
+    await expect(cta).toHaveAttribute('href', PLATFORM_DASHBOARD_URL)
   })
 
   test('secondary CTA links to contact page', async ({ page }) => {
@@ -71,31 +76,33 @@ test.describe('Payment failed page @smoke', () => {
 })
 
 test.describe('Payment pages zh-CN @smoke', () => {
-  test('zh-CN success page has Chinese title and dashboard CTA', async ({
-    page
-  }) => {
+  test('zh-CN success page renders and links correctly', async ({ page }) => {
     await page.goto('/zh-CN/payment/success')
     await expect(page).toHaveTitle('支付成功 — Comfy')
+    await expectNoIndex(page)
     await expect(
       page.getByRole('heading', { name: '支付成功', level: 1 })
     ).toBeVisible()
     await expect(
       page.getByRole('link', { name: '前往控制台' })
-    ).toHaveAttribute('href', 'https://platform.comfy.org/')
+    ).toHaveAttribute('href', PLATFORM_DASHBOARD_URL)
     await expect(page.getByRole('link', { name: '返回首页' })).toHaveAttribute(
       'href',
       '/zh-CN/'
     )
   })
 
-  test('zh-CN failed page has Chinese title and contact CTA', async ({
-    page
-  }) => {
+  test('zh-CN failed page renders and links correctly', async ({ page }) => {
     await page.goto('/zh-CN/payment/failed')
     await expect(page).toHaveTitle('支付失败 — Comfy')
+    await expectNoIndex(page)
     await expect(
       page.getByRole('heading', { name: '支付未完成', level: 1 })
     ).toBeVisible()
+    await expect(page.getByRole('link', { name: '重新尝试' })).toHaveAttribute(
+      'href',
+      PLATFORM_DASHBOARD_URL
+    )
     await expect(page.getByRole('link', { name: '联系支持' })).toHaveAttribute(
       'href',
       '/zh-CN/contact'

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -1,11 +1,12 @@
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
+import { externalLinks } from '../src/config/routes'
 import { test } from './fixtures/blockExternalMedia'
 
-const APP_URL = 'https://app.comfy.org'
-const PLATFORM_URL = 'https://platform.comfy.org'
-const BILLING_DOCS_URL = 'https://docs.comfy.org/api-reference/cloud'
+const APP_URL = externalLinks.app
+const PLATFORM_URL = externalLinks.platform
+const BILLING_DOCS_URL = externalLinks.docsApi
 
 async function expectNoIndex(page: Page) {
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
@@ -115,17 +116,5 @@ test.describe('Payment pages zh-CN @smoke', () => {
       page.getByRole('link', { name: '查看计费文档' })
     ).toHaveAttribute('href', BILLING_DOCS_URL)
     await expect(page.getByRole('button', { name: '关闭页面' })).toBeVisible()
-  })
-})
-
-test.describe('Payment success origin-aware referrer @interaction', () => {
-  test('falls back to default app URL for non-allowlisted referrer', async ({
-    page
-  }) => {
-    await page.goto('/payment/success', {
-      referer: 'https://evil.example.com/'
-    })
-    const cta = page.getByRole('link', { name: /CONTINUE IN COMFYUI/i })
-    await expect(cta).toHaveAttribute('href', APP_URL)
   })
 })

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -1,12 +1,14 @@
 import type { Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
-import { externalLinks } from '../src/config/routes'
+import { externalLinks, getRoutes } from '../src/config/routes'
 import { test } from './fixtures/blockExternalMedia'
 
 const APP_URL = externalLinks.app
 const PLATFORM_URL = externalLinks.platform
 const BILLING_DOCS_URL = externalLinks.docsApi
+const EN_ROUTES = getRoutes('en')
+const ZH_CN_ROUTES = getRoutes('zh-CN')
 
 async function expectNoIndex(page: Page) {
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
@@ -70,7 +72,7 @@ test.describe('Payment failed page @smoke', () => {
   test('primary CTA links to contact page', async ({ page }) => {
     const cta = page.getByRole('link', { name: /CONTACT SUPPORT/i })
     await expect(cta).toBeVisible()
-    await expect(cta).toHaveAttribute('href', '/contact')
+    await expect(cta).toHaveAttribute('href', EN_ROUTES.contact)
   })
 
   test('secondary CTA links to billing docs', async ({ page }) => {
@@ -110,7 +112,7 @@ test.describe('Payment pages zh-CN @smoke', () => {
     ).toBeVisible()
     await expect(page.getByRole('link', { name: '联系支持' })).toHaveAttribute(
       'href',
-      '/zh-CN/contact'
+      ZH_CN_ROUTES.contact
     )
     await expect(
       page.getByRole('link', { name: '查看计费文档' })

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -39,8 +39,10 @@ test.describe('Payment success page @smoke', () => {
     await expect(cta).toHaveAttribute('href', CLOUD_URL)
   })
 
-  test('secondary CTA links to platform usage page', async ({ page }) => {
-    const cta = page.getByRole('link', { name: /VIEW USAGE/i })
+  test('secondary CTA links to platform usage & payments page', async ({
+    page
+  }) => {
+    const cta = page.getByRole('link', { name: /VIEW USAGE & PAYMENTS/i })
     await expect(cta).toBeVisible()
     await expect(cta).toHaveAttribute('href', PLATFORM_USAGE_URL)
   })
@@ -90,10 +92,9 @@ test.describe('Payment pages zh-CN @smoke', () => {
     await expect(
       page.getByRole('link', { name: '前往 COMFY CLOUD' })
     ).toHaveAttribute('href', CLOUD_URL)
-    await expect(page.getByRole('link', { name: '查看用量' })).toHaveAttribute(
-      'href',
-      PLATFORM_USAGE_URL
-    )
+    await expect(
+      page.getByRole('link', { name: '查看用量与支付' })
+    ).toHaveAttribute('href', PLATFORM_USAGE_URL)
   })
 
   test('zh-CN failed page renders and links correctly', async ({ page }) => {

--- a/apps/website/public/robots.txt
+++ b/apps/website/public/robots.txt
@@ -29,5 +29,6 @@ Allow: /
 Disallow: /_astro/
 Disallow: /_website/
 Disallow: /_vercel/
+Disallow: /payment/
 
 Sitemap: https://comfy.org/sitemap-index.xml

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 
-import { externalLinks, getRoutes } from '../../config/routes'
+import { externalLinks } from '../../config/routes'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
@@ -18,18 +18,12 @@ const { status, locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
-const routes = getRoutes(locale)
-
-function handleCloseTab() {
-  if (typeof window === 'undefined') return
-  window.close()
-  // window.close() only succeeds on tabs that were script-opened. After a
-  // Stripe Checkout redirect the opener relationship is unreliable, so fall
-  // back to navigating home if the tab is still open shortly after.
-  setTimeout(() => {
-    if (!window.closed) window.location.href = routes.home
-  }, 100)
-}
+const primaryHref =
+  status === 'success' ? externalLinks.cloud : externalLinks.support
+const secondaryHref =
+  status === 'success'
+    ? externalLinks.platformUsage
+    : externalLinks.docsSubscription
 
 const iconRingClass =
   status === 'success'
@@ -95,33 +89,12 @@ const iconRingClass =
       <div
         class="mt-2 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center"
       >
-        <template v-if="status === 'success'">
-          <BrandButton :href="externalLinks.app" variant="solid" size="nav">
-            {{ t('payment.success.primaryCta', locale) }}
-          </BrandButton>
-          <BrandButton
-            :href="externalLinks.platform"
-            variant="outline"
-            size="nav"
-          >
-            {{ t('payment.success.secondaryCta', locale) }}
-          </BrandButton>
-        </template>
-        <template v-else>
-          <BrandButton :href="routes.contact" variant="solid" size="nav">
-            {{ t('payment.failed.primaryCta', locale) }}
-          </BrandButton>
-          <BrandButton
-            :href="externalLinks.docsApi"
-            variant="outline"
-            size="nav"
-          >
-            {{ t('payment.failed.secondaryCta', locale) }}
-          </BrandButton>
-          <BrandButton variant="outline" size="nav" @click="handleCloseTab">
-            {{ t('payment.failed.tertiaryCta', locale) }}
-          </BrandButton>
-        </template>
+        <BrandButton :href="primaryHref" variant="solid" size="nav">
+          {{ t(`payment.${status}.primaryCta`, locale) }}
+        </BrandButton>
+        <BrandButton :href="secondaryHref" variant="outline" size="nav">
+          {{ t(`payment.${status}.secondaryCta`, locale) }}
+        </BrandButton>
       </div>
     </div>
   </section>

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
+import type { Locale, TranslationKey } from '../../i18n/translations'
+import { t } from '../../i18n/translations'
+import BrandButton from '../common/BrandButton.vue'
+import SectionLabel from '../common/SectionLabel.vue'
+
+type Status = 'success' | 'failed'
+
+const { status, locale = 'en' } = defineProps<{
+  status: Status
+  locale?: Locale
+}>()
+
+const labelKey = `payment.${status}.label` as const satisfies TranslationKey
+const titleKey = `payment.${status}.title` as const satisfies TranslationKey
+const subtitleKey =
+  `payment.${status}.subtitle` as const satisfies TranslationKey
+const primaryCtaKey =
+  `payment.${status}.primaryCta` as const satisfies TranslationKey
+const secondaryCtaKey =
+  `payment.${status}.secondaryCta` as const satisfies TranslationKey
+
+const primaryHref = 'https://platform.comfy.org/'
+
+const localePrefix = locale === 'zh-CN' ? '/zh-CN' : ''
+const secondaryHref =
+  status === 'success' ? `${localePrefix}/` : `${localePrefix}/contact`
+
+const iconRingClass =
+  status === 'success'
+    ? 'border-primary-comfy-yellow text-primary-comfy-yellow'
+    : 'border-secondary-mauve text-secondary-mauve'
+</script>
+
+<template>
+  <section
+    class="flex min-h-[calc(100dvh-12rem)] items-center justify-center px-6 py-16 lg:py-24"
+  >
+    <div class="flex max-w-2xl flex-col items-center gap-6 text-center">
+      <div
+        :class="
+          cn(
+            'flex size-20 items-center justify-center rounded-full border-2',
+            iconRingClass
+          )
+        "
+        aria-hidden="true"
+      >
+        <svg
+          v-if="status === 'success'"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="size-10"
+        >
+          <path d="M5 12.5l4.5 4.5L19 7.5" />
+        </svg>
+        <svg
+          v-else
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="size-10"
+        >
+          <path d="M6 6l12 12" />
+          <path d="M18 6L6 18" />
+        </svg>
+      </div>
+
+      <SectionLabel>{{ t(labelKey, locale) }}</SectionLabel>
+
+      <h1
+        class="text-primary-comfy-canvas text-4xl/tight font-light md:text-5xl/tight lg:text-6xl/tight"
+      >
+        {{ t(titleKey, locale) }}
+      </h1>
+
+      <p
+        class="text-primary-comfy-canvas/80 max-w-xl text-base font-light lg:text-lg"
+      >
+        {{ t(subtitleKey, locale) }}
+      </p>
+
+      <div
+        class="mt-2 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center"
+      >
+        <BrandButton
+          :href="primaryHref"
+          variant="solid"
+          size="nav"
+          target="_self"
+        >
+          {{ t(primaryCtaKey, locale) }}
+        </BrandButton>
+        <BrandButton :href="secondaryHref" variant="outline" size="nav">
+          {{ t(secondaryCtaKey, locale) }}
+        </BrandButton>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 
+import { externalLinks } from '../../config/routes'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
@@ -22,7 +23,7 @@ const primaryCtaKey =
 const secondaryCtaKey =
   `payment.${status}.secondaryCta` as const satisfies TranslationKey
 
-const primaryHref = 'https://platform.comfy.org/'
+const primaryHref = externalLinks.apiKeys
 
 const localePrefix = locale === 'zh-CN' ? '/zh-CN' : ''
 const secondaryHref =

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
+import { onMounted, ref } from 'vue'
 
-import { externalLinks, getRoutes } from '../../config/routes'
-import type { Locale, TranslationKey } from '../../i18n/translations'
+import { externalLinks, getRoutes, resolveAppOrigin } from '../../config/routes'
+import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
 import SectionLabel from '../common/SectionLabel.vue'
@@ -14,19 +15,18 @@ const { status, locale = 'en' } = defineProps<{
   locale?: Locale
 }>()
 
-const labelKey = `payment.${status}.label` as const satisfies TranslationKey
-const titleKey = `payment.${status}.title` as const satisfies TranslationKey
-const subtitleKey =
-  `payment.${status}.subtitle` as const satisfies TranslationKey
-const primaryCtaKey =
-  `payment.${status}.primaryCta` as const satisfies TranslationKey
-const secondaryCtaKey =
-  `payment.${status}.secondaryCta` as const satisfies TranslationKey
-
-const primaryHref = externalLinks.apiKeys
-
 const routes = getRoutes(locale)
-const secondaryHref = status === 'success' ? routes.home : routes.contact
+
+const appOrigin = ref(externalLinks.app)
+onMounted(() => {
+  if (status === 'success' && typeof document !== 'undefined') {
+    appOrigin.value = resolveAppOrigin(document.referrer)
+  }
+})
+
+function handleCloseTab() {
+  if (typeof window !== 'undefined') window.close()
+}
 
 const iconRingClass =
   status === 'success'
@@ -75,34 +75,50 @@ const iconRingClass =
         </svg>
       </div>
 
-      <SectionLabel>{{ t(labelKey, locale) }}</SectionLabel>
+      <SectionLabel>{{ t(`payment.${status}.label`, locale) }}</SectionLabel>
 
       <h1
         class="text-primary-comfy-canvas text-4xl/tight font-light md:text-5xl/tight lg:text-6xl/tight"
       >
-        {{ t(titleKey, locale) }}
+        {{ t(`payment.${status}.title`, locale) }}
       </h1>
 
       <p
         class="text-primary-comfy-canvas/80 max-w-xl text-base font-light lg:text-lg"
       >
-        {{ t(subtitleKey, locale) }}
+        {{ t(`payment.${status}.subtitle`, locale) }}
       </p>
 
       <div
         class="mt-2 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center"
       >
-        <BrandButton
-          :href="primaryHref"
-          variant="solid"
-          size="nav"
-          target="_self"
-        >
-          {{ t(primaryCtaKey, locale) }}
-        </BrandButton>
-        <BrandButton :href="secondaryHref" variant="outline" size="nav">
-          {{ t(secondaryCtaKey, locale) }}
-        </BrandButton>
+        <template v-if="status === 'success'">
+          <BrandButton :href="appOrigin" variant="solid" size="nav">
+            {{ t('payment.success.primaryCta', locale) }}
+          </BrandButton>
+          <BrandButton
+            :href="externalLinks.platform"
+            variant="outline"
+            size="nav"
+          >
+            {{ t('payment.success.secondaryCta', locale) }}
+          </BrandButton>
+        </template>
+        <template v-else>
+          <BrandButton :href="routes.contact" variant="solid" size="nav">
+            {{ t('payment.failed.primaryCta', locale) }}
+          </BrandButton>
+          <BrandButton
+            :href="externalLinks.docsApi"
+            variant="outline"
+            size="nav"
+          >
+            {{ t('payment.failed.secondaryCta', locale) }}
+          </BrandButton>
+          <BrandButton variant="outline" size="nav" @click="handleCloseTab">
+            {{ t('payment.failed.tertiaryCta', locale) }}
+          </BrandButton>
+        </template>
       </div>
     </div>
   </section>

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 
-import { externalLinks } from '../../config/routes'
+import { externalLinks, getRoutes } from '../../config/routes'
 import type { Locale, TranslationKey } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
@@ -25,9 +25,8 @@ const secondaryCtaKey =
 
 const primaryHref = externalLinks.apiKeys
 
-const localePrefix = locale === 'zh-CN' ? '/zh-CN' : ''
-const secondaryHref =
-  status === 'success' ? `${localePrefix}/` : `${localePrefix}/contact`
+const routes = getRoutes(locale)
+const secondaryHref = status === 'success' ? routes.home : routes.contact
 
 const iconRingClass =
   status === 'success'

--- a/apps/website/src/components/payment/PaymentStatusSection.vue
+++ b/apps/website/src/components/payment/PaymentStatusSection.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { onMounted, ref } from 'vue'
 
-import { externalLinks, getRoutes, resolveAppOrigin } from '../../config/routes'
+import { externalLinks, getRoutes } from '../../config/routes'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
 import BrandButton from '../common/BrandButton.vue'
 import SectionLabel from '../common/SectionLabel.vue'
+
+// Display-only thank-you / failure pages: payment state is verified
+// server-side via Stripe webhooks (see comfy-api). These pages exist
+// solely as the redirect target for Stripe Checkout.
 
 type Status = 'success' | 'failed'
 
@@ -17,15 +20,15 @@ const { status, locale = 'en' } = defineProps<{
 
 const routes = getRoutes(locale)
 
-const appOrigin = ref(externalLinks.app)
-onMounted(() => {
-  if (status === 'success' && typeof document !== 'undefined') {
-    appOrigin.value = resolveAppOrigin(document.referrer)
-  }
-})
-
 function handleCloseTab() {
-  if (typeof window !== 'undefined') window.close()
+  if (typeof window === 'undefined') return
+  window.close()
+  // window.close() only succeeds on tabs that were script-opened. After a
+  // Stripe Checkout redirect the opener relationship is unreliable, so fall
+  // back to navigating home if the tab is still open shortly after.
+  setTimeout(() => {
+    if (!window.closed) window.location.href = routes.home
+  }, 100)
 }
 
 const iconRingClass =
@@ -93,7 +96,7 @@ const iconRingClass =
         class="mt-2 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center"
       >
         <template v-if="status === 'success'">
-          <BrandButton :href="appOrigin" variant="solid" size="nav">
+          <BrandButton :href="externalLinks.app" variant="solid" size="nav">
             {{ t('payment.success.primaryCta', locale) }}
           </BrandButton>
           <BrandButton

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -28,14 +28,15 @@ export function getRoutes(locale: Locale = 'en'): Routes {
 
 export const externalLinks = {
   apiKeys: 'https://platform.comfy.org/profile/api-keys',
-  app: 'https://app.comfy.org',
   blog: 'https://blog.comfy.org/',
   cloud: 'https://cloud.comfy.org',
   discord: 'https://discord.com/invite/comfyorg',
   docs: 'https://docs.comfy.org/',
   docsApi: 'https://docs.comfy.org/api-reference/cloud',
+  docsSubscription: 'https://docs.comfy.org/support/subscription/subscribing',
   github: 'https://github.com/Comfy-Org/ComfyUI',
   platform: 'https://platform.comfy.org',
+  platformUsage: 'https://platform.comfy.org/profile/usage',
   support: 'https://support.comfy.org/hc/en-us',
   workflows: 'https://comfy.org/workflows',
   youtube: 'https://www.youtube.com/@ComfyOrg'

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -28,6 +28,7 @@ export function getRoutes(locale: Locale = 'en'): Routes {
 
 export const externalLinks = {
   apiKeys: 'https://platform.comfy.org/profile/api-keys',
+  app: 'https://app.comfy.org',
   blog: 'https://blog.comfy.org/',
   cloud: 'https://cloud.comfy.org',
   discord: 'https://discord.com/invite/comfyorg',
@@ -39,3 +40,18 @@ export const externalLinks = {
   workflows: 'https://comfy.org/workflows',
   youtube: 'https://www.youtube.com/@ComfyOrg'
 } as const
+
+const APP_REFERRER_ALLOWLIST: ReadonlySet<string> = new Set([
+  'https://app.comfy.org',
+  'https://stagingapp.comfy.org'
+])
+
+export function resolveAppOrigin(referrer: string | undefined): string {
+  if (!referrer) return externalLinks.app
+  try {
+    const origin = new URL(referrer).origin
+    return APP_REFERRER_ALLOWLIST.has(origin) ? origin : externalLinks.app
+  } catch {
+    return externalLinks.app
+  }
+}

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -40,18 +40,3 @@ export const externalLinks = {
   workflows: 'https://comfy.org/workflows',
   youtube: 'https://www.youtube.com/@ComfyOrg'
 } as const
-
-const APP_REFERRER_ALLOWLIST: ReadonlySet<string> = new Set([
-  'https://app.comfy.org',
-  'https://stagingapp.comfy.org'
-])
-
-export function resolveAppOrigin(referrer: string | undefined): string {
-  if (!referrer) return externalLinks.app
-  try {
-    const origin = new URL(referrer).origin
-    return APP_REFERRER_ALLOWLIST.has(origin) ? origin : externalLinks.app
-  } catch {
-    return externalLinks.app
-  }
-}

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3624,9 +3624,9 @@ const translations = {
     'zh-CN': '支付未完成'
   },
   'payment.failed.subtitle': {
-    en: "Your payment didn't go through and you have not been charged. You can retry from where you started, or check the billing docs if the issue continues.",
+    en: "Your payment didn't go through and you have not been charged. Reach out to support or check the billing docs if you need help.",
     'zh-CN':
-      '您的支付未能完成，未发生扣款。您可以从原页面重试，或查阅计费文档了解更多信息。'
+      '您的支付未能完成，未发生扣款。如需帮助，请联系支持或查阅计费文档。'
   },
   'payment.failed.primaryCta': {
     en: 'CONTACT SUPPORT',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3592,6 +3592,49 @@ const translations = {
   'customers.feedback.role3': {
     en: 'Head of AI at Creative Studios',
     'zh-CN': 'Creative Studios AI 负责人'
+  },
+
+  // Payment status pages
+  'payment.success.label': {
+    en: 'PAYMENT',
+    'zh-CN': '支付'
+  },
+  'payment.success.title': {
+    en: 'Payment successful',
+    'zh-CN': '支付成功'
+  },
+  'payment.success.subtitle': {
+    en: "Thanks for your purchase. Your account has been credited and you're ready to keep building.",
+    'zh-CN': '感谢您的购买。您的账户已充值完成，可以继续创作了。'
+  },
+  'payment.success.primaryCta': {
+    en: 'GO TO DASHBOARD',
+    'zh-CN': '前往控制台'
+  },
+  'payment.success.secondaryCta': {
+    en: 'BACK TO HOME',
+    'zh-CN': '返回首页'
+  },
+  'payment.failed.label': {
+    en: 'PAYMENT',
+    'zh-CN': '支付'
+  },
+  'payment.failed.title': {
+    en: 'Payment was not completed',
+    'zh-CN': '支付未完成'
+  },
+  'payment.failed.subtitle': {
+    en: "Your payment didn't go through and you have not been charged. You can try again from your dashboard or contact us if the issue continues.",
+    'zh-CN':
+      '您的支付未能完成，未发生扣款。您可以前往控制台重试，如问题仍未解决，请联系我们。'
+  },
+  'payment.failed.primaryCta': {
+    en: 'TRY AGAIN',
+    'zh-CN': '重新尝试'
+  },
+  'payment.failed.secondaryCta': {
+    en: 'CONTACT SUPPORT',
+    'zh-CN': '联系支持'
   }
 } as const satisfies Record<string, Record<Locale, string>>
 

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3608,12 +3608,12 @@ const translations = {
     'zh-CN': '感谢您的购买。您的账户已充值完成，可以继续创作了。'
   },
   'payment.success.primaryCta': {
-    en: 'GO TO DASHBOARD',
-    'zh-CN': '前往控制台'
+    en: 'CONTINUE IN COMFYUI',
+    'zh-CN': '返回 COMFYUI'
   },
   'payment.success.secondaryCta': {
-    en: 'BACK TO HOME',
-    'zh-CN': '返回首页'
+    en: 'VIEW BALANCE & USAGE',
+    'zh-CN': '查看余额与用量'
   },
   'payment.failed.label': {
     en: 'PAYMENT',
@@ -3624,17 +3624,21 @@ const translations = {
     'zh-CN': '支付未完成'
   },
   'payment.failed.subtitle': {
-    en: "Your payment didn't go through and you have not been charged. You can try again from your dashboard or contact us if the issue continues.",
+    en: "Your payment didn't go through and you have not been charged. You can retry from where you started, or check the billing docs if the issue continues.",
     'zh-CN':
-      '您的支付未能完成，未发生扣款。您可以前往控制台重试，如问题仍未解决，请联系我们。'
+      '您的支付未能完成，未发生扣款。您可以从原页面重试，或查阅计费文档了解更多信息。'
   },
   'payment.failed.primaryCta': {
-    en: 'TRY AGAIN',
-    'zh-CN': '重新尝试'
-  },
-  'payment.failed.secondaryCta': {
     en: 'CONTACT SUPPORT',
     'zh-CN': '联系支持'
+  },
+  'payment.failed.secondaryCta': {
+    en: 'READ BILLING DOCS',
+    'zh-CN': '查看计费文档'
+  },
+  'payment.failed.tertiaryCta': {
+    en: 'CLOSE TAB',
+    'zh-CN': '关闭页面'
   }
 } as const satisfies Record<string, Record<Locale, string>>
 

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3608,12 +3608,12 @@ const translations = {
     'zh-CN': '感谢您的购买。您的账户已充值完成，可以继续创作了。'
   },
   'payment.success.primaryCta': {
-    en: 'CONTINUE IN COMFYUI',
-    'zh-CN': '返回 COMFYUI'
+    en: 'CONTINUE TO COMFY CLOUD',
+    'zh-CN': '前往 COMFY CLOUD'
   },
   'payment.success.secondaryCta': {
-    en: 'VIEW BALANCE & USAGE',
-    'zh-CN': '查看余额与用量'
+    en: 'VIEW USAGE',
+    'zh-CN': '查看用量'
   },
   'payment.failed.label': {
     en: 'PAYMENT',
@@ -3624,21 +3624,17 @@ const translations = {
     'zh-CN': '支付未完成'
   },
   'payment.failed.subtitle': {
-    en: "Your payment didn't go through and you have not been charged. Reach out to support or check the billing docs if you need help.",
+    en: "Your payment didn't go through and you have not been charged. Reach out to support or read the subscription docs if you need help.",
     'zh-CN':
-      '您的支付未能完成，未发生扣款。如需帮助，请联系支持或查阅计费文档。'
+      '您的支付未能完成，未发生扣款。如需帮助，请联系支持或查阅订阅文档。'
   },
   'payment.failed.primaryCta': {
     en: 'CONTACT SUPPORT',
     'zh-CN': '联系支持'
   },
   'payment.failed.secondaryCta': {
-    en: 'READ BILLING DOCS',
-    'zh-CN': '查看计费文档'
-  },
-  'payment.failed.tertiaryCta': {
-    en: 'CLOSE TAB',
-    'zh-CN': '关闭页面'
+    en: 'READ SUBSCRIPTION DOCS',
+    'zh-CN': '查看订阅文档'
   }
 } as const satisfies Record<string, Record<Locale, string>>
 

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3612,8 +3612,8 @@ const translations = {
     'zh-CN': '前往 COMFY CLOUD'
   },
   'payment.success.secondaryCta': {
-    en: 'VIEW USAGE',
-    'zh-CN': '查看用量'
+    en: 'VIEW USAGE & PAYMENTS',
+    'zh-CN': '查看用量与支付'
   },
   'payment.failed.label': {
     en: 'PAYMENT',

--- a/apps/website/src/pages/payment/failed.astro
+++ b/apps/website/src/pages/payment/failed.astro
@@ -8,5 +8,5 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
   description="Your payment was not completed."
   noindex
 >
-  <PaymentStatusSection status="failed" />
+  <PaymentStatusSection status="failed" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/payment/failed.astro
+++ b/apps/website/src/pages/payment/failed.astro
@@ -8,5 +8,5 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
   description="Your payment was not completed."
   noindex
 >
-  <PaymentStatusSection status="failed" client:load />
+  <PaymentStatusSection status="failed" />
 </BaseLayout>

--- a/apps/website/src/pages/payment/failed.astro
+++ b/apps/website/src/pages/payment/failed.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import PaymentStatusSection from '../../components/payment/PaymentStatusSection.vue'
+---
+
+<BaseLayout
+  title="Payment Failed — Comfy"
+  description="Your payment was not completed."
+  noindex
+>
+  <PaymentStatusSection status="failed" client:load />
+</BaseLayout>

--- a/apps/website/src/pages/payment/success.astro
+++ b/apps/website/src/pages/payment/success.astro
@@ -8,5 +8,5 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
   description="Your payment was processed successfully."
   noindex
 >
-  <PaymentStatusSection status="success" />
+  <PaymentStatusSection status="success" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/payment/success.astro
+++ b/apps/website/src/pages/payment/success.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import PaymentStatusSection from '../../components/payment/PaymentStatusSection.vue'
+---
+
+<BaseLayout
+  title="Payment Successful — Comfy"
+  description="Your payment was processed successfully."
+  noindex
+>
+  <PaymentStatusSection status="success" client:load />
+</BaseLayout>

--- a/apps/website/src/pages/payment/success.astro
+++ b/apps/website/src/pages/payment/success.astro
@@ -8,5 +8,5 @@ import PaymentStatusSection from '../../components/payment/PaymentStatusSection.
   description="Your payment was processed successfully."
   noindex
 >
-  <PaymentStatusSection status="success" client:load />
+  <PaymentStatusSection status="success" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/failed.astro
+++ b/apps/website/src/pages/zh-CN/payment/failed.astro
@@ -4,5 +4,5 @@ import PaymentStatusSection from '../../../components/payment/PaymentStatusSecti
 ---
 
 <BaseLayout title="支付失败 — Comfy" description="您的支付未能完成。" noindex>
-  <PaymentStatusSection status="failed" locale="zh-CN" client:load />
+  <PaymentStatusSection status="failed" locale="zh-CN" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/failed.astro
+++ b/apps/website/src/pages/zh-CN/payment/failed.astro
@@ -1,0 +1,8 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro'
+import PaymentStatusSection from '../../../components/payment/PaymentStatusSection.vue'
+---
+
+<BaseLayout title="支付失败 — Comfy" description="您的支付未能完成。" noindex>
+  <PaymentStatusSection status="failed" locale="zh-CN" client:load />
+</BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/failed.astro
+++ b/apps/website/src/pages/zh-CN/payment/failed.astro
@@ -4,5 +4,5 @@ import PaymentStatusSection from '../../../components/payment/PaymentStatusSecti
 ---
 
 <BaseLayout title="支付失败 — Comfy" description="您的支付未能完成。" noindex>
-  <PaymentStatusSection status="failed" locale="zh-CN" />
+  <PaymentStatusSection status="failed" locale="zh-CN" client:load />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/success.astro
+++ b/apps/website/src/pages/zh-CN/payment/success.astro
@@ -4,5 +4,5 @@ import PaymentStatusSection from '../../../components/payment/PaymentStatusSecti
 ---
 
 <BaseLayout title="支付成功 — Comfy" description="您的支付已成功完成。" noindex>
-  <PaymentStatusSection status="success" locale="zh-CN" client:load />
+  <PaymentStatusSection status="success" locale="zh-CN" />
 </BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/success.astro
+++ b/apps/website/src/pages/zh-CN/payment/success.astro
@@ -1,0 +1,8 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro'
+import PaymentStatusSection from '../../../components/payment/PaymentStatusSection.vue'
+---
+
+<BaseLayout title="支付成功 — Comfy" description="您的支付已成功完成。" noindex>
+  <PaymentStatusSection status="success" locale="zh-CN" client:load />
+</BaseLayout>

--- a/apps/website/src/pages/zh-CN/payment/success.astro
+++ b/apps/website/src/pages/zh-CN/payment/success.astro
@@ -4,5 +4,5 @@ import PaymentStatusSection from '../../../components/payment/PaymentStatusSecti
 ---
 
 <BaseLayout title="支付成功 — Comfy" description="您的支付已成功完成。" noindex>
-  <PaymentStatusSection status="success" locale="zh-CN" />
+  <PaymentStatusSection status="success" locale="zh-CN" client:load />
 </BaseLayout>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Recreate the two payment status pages that were never migrated from Framer (they weren't in the sitemap, so were missed). The Stripe checkout flow in `comfy-api` redirects to `https://www.comfy.org/payment/{success,failed}` after a checkout session, so users currently hit a 404 on completion or cancel.

## Changes

- **What**: New static Astro pages at `/payment/success`, `/payment/failed` and their `/zh-CN/` variants, sharing a `PaymentStatusSection.vue` component built from the existing `BrandButton` / `SectionLabel` primitives. Translation keys live in `src/i18n/translations.ts` for both locales. Pages are `noindex` and explicitly excluded from the generated sitemap. Adds a Playwright e2e spec covering both pages in both locales.
- **Dependencies**: none

## Review Focus

- **URL slug**: matches production Stripe config (`STRIPE_CANCEL_URL=…/payment/failed` in `comfy-api/run-service-{prod,staging}.yaml`), not `/payment/failure`.
- **Primary CTA target**: links to `externalLinks.apiKeys` (`platform.comfy.org/profile/api-keys`) — the platform root is just a redirect, so this avoids a hop.
- **Locale-aware secondary CTA**: derived from `getRoutes(locale)` so future i18n/route changes flow through the existing helper.
- **Stale fallback** (out of scope): `comfy-api/gateways/stripe/stripe.go:159` has an unrelated stale fallback pointing at `/payments/` (plural) that's overridden by the env config in production. Worth fixing in a follow-up.

## Screenshots

EN success / failed and zh-CN success / failed at desktop widths. Mobile viewport stacks the CTA buttons vertically (verified locally).

## Screenshots

![Payment success page (EN, desktop)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c44f59e47f22968047255c353237b19fb0543c1e166ec4c315cd9c1085308814/pr-images/1777774408278-fd3b63f2-357d-401a-8861-5e45050bc930.png)

![Payment failed page (EN, desktop)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c44f59e47f22968047255c353237b19fb0543c1e166ec4c315cd9c1085308814/pr-images/1777774408672-a8ada80c-030c-4f7e-805d-c9e3edd2ec1e.png)

![Payment success page (zh-CN, desktop)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c44f59e47f22968047255c353237b19fb0543c1e166ec4c315cd9c1085308814/pr-images/1777774408994-2ac1dc5a-8556-4ca1-929b-71d8812337e1.png)

![Payment failed page (zh-CN, desktop)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c44f59e47f22968047255c353237b19fb0543c1e166ec4c315cd9c1085308814/pr-images/1777774409357-a79be0ae-36b3-4c1a-84ce-cb65415fee0a.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11855-feat-website-add-payment-success-and-failed-pages-3556d73d3650819f8f45d8ecf27cb264) by [Unito](https://www.unito.io)
