### PR TITLE
[backport core/1.43] fix: stop duplicate node creation when dropping image on Vue nodes (#11541)

### DIFF
--- a/src/composables/node/useNodeDragAndDrop.ts
+++ b/src/composables/node/useNodeDragAndDrop.ts
@@ -1,3 +1,4 @@
+import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 
 type DragHandler = (e: DragEvent) => boolean
@@ -43,19 +44,29 @@ export const useNodeDragAndDrop = <T>(
     return !!e?.dataTransfer?.getData('text/uri-list')
   }
 
-  node.onDragOver = isDraggingFiles
+  const installedDragOver = isDraggingFiles
+  node.onDragOver = installedDragOver
 
-  node.onDragDrop = async function (e: DragEvent) {
+  const installedDragDrop = async function (e: DragEvent, claimEvent = false) {
     if (!isDraggingValidFiles(e)) return false
 
     const files = filterFiles(e.dataTransfer!.files)
     if (files.length) {
+      if (claimEvent) {
+        e.preventDefault()
+        e.stopPropagation()
+      }
       await onDrop(files)
       return true
     }
 
     const uri = URL.parse(e?.dataTransfer?.getData('text/uri-list') ?? '')
     if (!uri || uri.origin !== location.origin) return false
+
+    if (claimEvent) {
+      e.preventDefault()
+      e.stopPropagation()
+    }
 
     try {
       const resp = await fetch(uri)
@@ -73,4 +84,10 @@ export const useNodeDragAndDrop = <T>(
     }
     return true
   }
+  node.onDragDrop = installedDragDrop
+
+  node.onRemoved = useChainCallback(node.onRemoved, () => {
+    if (node.onDragOver === installedDragOver) node.onDragOver = undefined
+    if (node.onDragDrop === installedDragDrop) node.onDragDrop = undefined
+  })
 }

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -362,8 +362,8 @@ describe('LGraphNode', () => {
   })
 
   describe('handleDrop', () => {
-    it('should stop propagation when onDragDrop returns true', async () => {
-      const onDragDrop = vi.fn().mockReturnValue(true)
+    it('should call onDragDrop with claimEvent=true so the handler can claim the event sync', async () => {
+      const onDragDrop = vi.fn().mockResolvedValue(true)
       mockData.mockLgraphNode = {
         onDragDrop,
         onDragOver: vi.fn(),
@@ -372,25 +372,15 @@ describe('LGraphNode', () => {
 
       const { container } = renderLGraphNode({ nodeData: mockNodeData })
       const nodeEl = getNodeRoot(container)
-      // eslint-disable-next-line testing-library/no-node-access
-      const parent = nodeEl.parentElement!
 
-      const parentListener = vi.fn()
-      expect(parent).not.toBeNull()
-      parent.addEventListener('drop', parentListener)
+      const dropEvent = new Event('drop', { bubbles: true, cancelable: true })
+      nodeEl.dispatchEvent(dropEvent)
 
-      nodeEl.dispatchEvent(
-        new Event('drop', { bubbles: true, cancelable: true })
-      )
-
-      expect(onDragDrop).toHaveBeenCalled()
-      expect(parentListener).not.toHaveBeenCalled()
+      expect(onDragDrop).toHaveBeenCalledWith(dropEvent, true)
     })
 
-    it('should not stop propagation when onDragDrop returns false', async () => {
-      const onDragDrop = vi.fn().mockReturnValue(false)
+    it('should not stop propagation when node has no onDragDrop handler', async () => {
       mockData.mockLgraphNode = {
-        onDragDrop,
         onDragOver: vi.fn(),
         isSubgraphNode: () => false
       }
@@ -408,7 +398,6 @@ describe('LGraphNode', () => {
         new Event('drop', { bubbles: true, cancelable: true })
       )
 
-      expect(onDragDrop).toHaveBeenCalled()
       expect(parentListener).toHaveBeenCalled()
     })
   })

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -814,16 +814,23 @@ function handleDragLeave() {
   isDraggingOver.value = false
 }
 
-function handleDrop(event: DragEvent) {
+async function handleDrop(event: DragEvent) {
   isDraggingOver.value = false
 
   const node = lgraphNode.value
   if (!node?.onDragDrop) return
 
-  const handled = node.onDragDrop(event)
-  if (handled === true) {
+  // Backport-only compat: preserve the legacy `handled === true` sync-return
+  // path for custom-node `onDragDrop` implementations that don't participate
+  // in the new `claimEvent` flag. Async handlers from `useNodeDragAndDrop`
+  // claim the event themselves via the second arg; sync handlers that
+  // return `true` still get their event claimed here so the drop does not
+  // bubble to the document fallback in `app.ts`.
+  const result = node.onDragDrop(event, true)
+  if (result === true && !event.defaultPrevented) {
     event.preventDefault()
     event.stopPropagation()
   }
+  await result
 }
 </script>

--- a/src/types/litegraph-augmentation.d.ts
+++ b/src/types/litegraph-augmentation.d.ts
@@ -144,9 +144,13 @@ declare module '@/lib/litegraph/src/litegraph' {
      * Callback invoked when the node is dropped from an external source, i.e.
      * a file or another HTML element.
      * @param e The drag event
+     * @param claimEvent If true, the handler should call preventDefault and
+     *   stopPropagation synchronously before any await once it has decided to
+     *   accept the drop, so bubbling fallback handlers know not to also process
+     *   the event.
      * @returns {boolean} True if the drag event should be handled by this node, false otherwise
      */
-    onDragDrop?(e: DragEvent): Promise<boolean> | boolean
+    onDragDrop?(e: DragEvent, claimEvent?: boolean): Promise<boolean> | boolean
 
     index?: number
     runningInternalNodeId?: NodeId


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Manual backport of #11541 to `core/1.43` for inclusion in `v1.43.16`.

Cherry-picked from upstream merge commit `b23283144`.

## Why

`handleDrop` checked `handled === true` to gate `stopPropagation`, but `onDragDrop` from `useNodeDragAndDrop` is async and always returns a Promise — so the check never matched. The drop then bubbled to the document handler in `app.ts` and spawned a new LoadImage node in addition to the one that accepted the drop.

The fix moves the `preventDefault()`/`stopPropagation()` claim *into* `onDragDrop` itself, gated by a new optional `claimEvent` flag.

## Conflict resolution

- **`src/composables/node/useNodeDragAndDrop.ts`** — `core/1.43` had the older inline `node.onDragDrop = async function (e: DragEvent) { ... }` form. Took #11541's full refactored version (named `installedDragDrop` const + `onRemoved` cleanup via `useChainCallback`). `useChainCallback` already exists on `core/1.43`. The new `(e, claimEvent = false)` signature is backward-compatible with all existing callers.
- **`src/composables/node/useNodeDragAndDrop.test.ts`** — PR modified this test file but the file was added on `main` by unrelated PR #11417 (`fix: reset file input value...`) which is **not** backported. Dropped the test file from this backport. Runtime fix is intact; coverage exists in `LGraphNode.test.ts` for the `claimEvent=true` call site.
- **`LGraphNode.{vue,test.ts}`, `litegraph-augmentation.d.ts`** — auto-merged cleanly.

## Backport-only compatibility fix (added after code review)

The upstream PR removed `handleDrop`'s legacy `handled === true` sync-return check in `LGraphNode.vue`. On `main` that's safe — all in-repo `onDragDrop` handlers participate in the new `claimEvent` flag. On `core/1.43` this is a public LiteGraph extension callback, and custom-node packages may have synchronous `onDragDrop` implementations that return `true` without honoring the new optional second argument. Without the fallback, those drops would still bubble to the document handler in `app.ts` and create duplicate nodes — the very bug this PR is fixing.

Restored the legacy `handled === true` synchronous-claim path in `handleDrop()` while keeping the new `claimEvent=true` call:
- async handlers from `useNodeDragAndDrop` claim the event themselves
- sync handlers returning `true` still get their event claimed
- handlers that return `false`/`undefined` still bubble (correct)

## Validation

- `pnpm typecheck` ✅
- `pnpm test:unit -- run src/renderer/extensions/vueNodes/components/LGraphNode.test.ts` ✅ (15/15 passing)
- `pnpm exec eslint <changed files>` ✅ (0 errors)
- `pnpm exec oxfmt --check <changed files>` ✅ (clean)

Manual end-to-end verification (Playwright) was not performed because the duplicate-node-creation bug requires a live ComfyUI backend with model loading and real drag-drop interaction on an actual canvas — not reproducible in the sandbox. The fix is byte-identical to upstream `b23283144` (which has been baking on `main` for ~1 week through `v1.44.x`) plus the backport-only sync-handler compatibility shim documented above.

Original PR: #11541
Original commit: `b23283144`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11856-backport-core-1-43-fix-stop-duplicate-node-creation-when-dropping-image-on-Vue-nodes--3556d73d36508165b811f2f4ab3ae749) by [Unito](https://www.unito.io)
