### PR TITLE
[backport core/1.43] fix cloud frontend runtime guard regressions (#11180)

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -1,6 +1,6 @@
 import { setActivePinia } from 'pinia'
 import { createTestingPinia } from '@pinia/testing'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
@@ -9,6 +9,9 @@ import type { HasInitialMinSize } from '@/services/litegraphService'
 
 setActivePinia(createTestingPinia())
 type DynamicInputs = ('INT' | 'STRING' | 'IMAGE' | DynamicInputs)[][]
+type TestAutogrowNode = LGraphNode & {
+  comfyDynamic: { autogrow: Record<string, unknown> }
+}
 
 const { addNodeInput } = useLitegraphService()
 
@@ -181,6 +184,45 @@ describe('Autogrow', () => {
     node.disconnectInput(0)
     await nextTick()
     expect(node.inputs.length).toBe(5)
+  })
+  test('Removing a connection ignores stale autogrow callbacks after group removal', () => {
+    const graph = new LGraph()
+    const node = testNode() as TestAutogrowNode
+    const onConnectionsChange = vi.fn()
+    node.onConnectionsChange = onConnectionsChange
+    graph.add(node)
+    addAutogrow(node, { min: 1, input: inputsSpec, prefix: 'test' })
+
+    const rafCallbacks: FrameRequestCallback[] = []
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+
+    try {
+      connectInput(node, 0, graph)
+      expect(node.inputs.length).toBe(2)
+
+      rafCallbacks.shift()?.(0)
+
+      node.disconnectInput(0)
+
+      const staleDisconnectCallback = rafCallbacks.shift()
+      expect(staleDisconnectCallback).toBeDefined()
+
+      delete node.comfyDynamic.autogrow['0']
+
+      const callbackCountBeforeFlush = onConnectionsChange.mock.calls.length
+      staleDisconnectCallback?.(0)
+
+      expect(onConnectionsChange).toHaveBeenCalledTimes(
+        callbackCountBeforeFlush
+      )
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+    }
   })
   test('Multi-group autogrow shifts second group indices on first group growth', () => {
     const graph = new LGraph()

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -460,7 +460,10 @@ function autogrowInputDisconnected(index: number, node: AutogrowNode) {
   const input = node.inputs[index]
   if (!input) return
   const groupName = input.name.slice(0, input.name.lastIndexOf('.'))
-  const { min = 1, inputSpecs } = node.comfyDynamic.autogrow[groupName]
+  const autogrowGroup = node.comfyDynamic.autogrow[groupName]
+  if (!autogrowGroup) return
+
+  const { min = 1, inputSpecs } = autogrowGroup
   const ordinal = resolveAutogrowOrdinal(input.name, groupName, node)
   if (ordinal == undefined || ordinal + 1 < min) return
 

--- a/src/extensions/core/customWidgets.ts
+++ b/src/extensions/core/customWidgets.ts
@@ -1,51 +1,16 @@
 import { shallowReactive } from 'vue'
 
 import { useChainCallback } from '@/composables/functional/useChainCallback'
-import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
-import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LLink } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { LLink } from '@/lib/litegraph/src/litegraph'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
+import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
+
 function applyToGraph(this: LGraphNode, extraLinks: LLink[] = []) {
-  if (!this.outputs[0].links?.length || !this.graph) return
-
-  const links = [
-    ...this.outputs[0].links.map((l) => this.graph!.links[l]),
-    ...extraLinks
-  ]
-  let v = this.widgets?.[0].value
-  // For each output link copy our value over the original widget value
-  for (const linkInfo of links) {
-    const node = this.graph?.getNodeById(linkInfo.target_id)
-    const input = node?.inputs[linkInfo.target_slot]
-    if (!input) {
-      console.warn('Unable to resolve node or input for link', linkInfo)
-      continue
-    }
-
-    const widgetName = input.widget?.name
-    if (!widgetName) {
-      console.warn('Invalid widget or widget name', input.widget)
-      continue
-    }
-
-    const widget = node.widgets?.find((w) => w.name === widgetName)
-    if (!widget) {
-      console.warn(`Unable to find widget "${widgetName}" on node [${node.id}]`)
-      continue
-    }
-
-    widget.value = v
-    widget.callback?.(
-      widget.value,
-      app.canvas,
-      node,
-      app.canvas.graph_mouse,
-      {} as CanvasPointerEvent
-    )
-  }
+  applyFirstWidgetValueToGraph(this, extraLinks)
 }
 
 function onCustomComboCreated(this: LGraphNode) {

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -26,6 +26,8 @@ import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
 import { mergeInputSpec } from '@/utils/nodeDefUtil'
 import { applyTextReplacements } from '@/utils/searchAndReplace'
 
+import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
+
 const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
   controlValues?: TWidgetValue[]
@@ -43,49 +45,15 @@ export class PrimitiveNode extends LGraphNode {
   }
 
   override applyToGraph(extraLinks: LLink[] = []) {
-    if (!this.outputs[0].links?.length || !this.graph) return
+    const sourceWidget = this.widgets?.[0]
+    const graph = this.graph
+    if (!sourceWidget || !graph) return
 
-    const links = [
-      ...this.outputs[0].links.map((l) => this.graph!.links[l]),
-      ...extraLinks
-    ]
-    let v = this.widgets?.[0].value
+    let v = sourceWidget.value
     if (v && this.properties[replacePropertyName]) {
-      v = applyTextReplacements(this.graph, v as string)
+      v = applyTextReplacements(graph, v as string)
     }
-
-    // For each output link copy our value over the original widget value
-    for (const linkInfo of links) {
-      const node = this.graph?.getNodeById(linkInfo.target_id)
-      const input = node?.inputs[linkInfo.target_slot]
-      if (!input) {
-        console.warn('Unable to resolve node or input for link', linkInfo)
-        continue
-      }
-
-      const widgetName = input.widget?.name
-      if (!widgetName) {
-        console.warn('Invalid widget or widget name', input.widget)
-        continue
-      }
-
-      const widget = node.widgets?.find((w) => w.name === widgetName)
-      if (!widget) {
-        console.warn(
-          `Unable to find widget "${widgetName}" on node [${node.id}]`
-        )
-        continue
-      }
-
-      widget.value = v
-      widget.callback?.(
-        widget.value,
-        app.canvas,
-        node,
-        app.canvas.graph_mouse,
-        {} as CanvasPointerEvent
-      )
-    }
+    applyFirstWidgetValueToGraph(this, extraLinks, () => v)
   }
 
   override refreshComboInNode() {
@@ -98,7 +66,7 @@ export class PrimitiveNode extends LGraphNode {
       if (!widget.options.values.includes(widget.value as string)) {
         // @ts-expect-error fixme ts strict error
         widget.value = widget.options.values[0]
-        ;(widget.callback as Function)(widget.value)
+        widget.callback?.(widget.value)
       }
     }
   }
@@ -273,7 +241,7 @@ export class PrimitiveNode extends LGraphNode {
       )
       if (this.widgets?.[1]) widget.linkedWidgets = [this.widgets[1]]
 
-      let filter = this.widgets_values?.[2]
+      const filter = this.widgets_values?.[2]
       if (filter && this.widgets && this.widgets.length === 3) {
         this.widgets[2].value = filter
       }

--- a/src/extensions/core/widgetValuePropagation.test.ts
+++ b/src/extensions/core/widgetValuePropagation.test.ts
@@ -1,0 +1,127 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  INodeInputSlot,
+  INodeOutputSlot,
+  LLink
+} from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { createMockLLink } from '@/utils/__tests__/litegraphTestUtils'
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: {
+      graph_mouse: [0, 0]
+    }
+  }
+}))
+
+import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
+
+type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
+
+function createWidget(
+  name: string,
+  value: IBaseWidget['value'],
+  callback = vi.fn()
+): IBaseWidget {
+  return fromPartial<IBaseWidget>({
+    name,
+    value,
+    callback
+  })
+}
+
+function createTargetNode(
+  widget: IBaseWidget,
+  id = 7
+): Pick<LGraphNode, 'id' | 'inputs' | 'widgets'> {
+  return fromPartial<Pick<LGraphNode, 'id' | 'inputs' | 'widgets'>>({
+    id,
+    inputs: [
+      fromPartial<INodeInputSlot>({
+        widget: { name: widget.name }
+      })
+    ],
+    widgets: [widget]
+  })
+}
+
+function createLink(targetId: LLink['target_id'], targetSlot = 0): LLink {
+  return createMockLLink({
+    target_id: targetId,
+    target_slot: targetSlot
+  })
+}
+
+function createSourceNode(options: {
+  link: LLink
+  targetNode: Pick<LGraphNode, 'id' | 'inputs' | 'widgets'>
+  widgets?: IBaseWidget[]
+}): SourceNode {
+  return {
+    graph: {
+      links: { 1: options.link },
+      getNodeById: vi.fn((id: LLink['target_id']) =>
+        id === options.targetNode.id ? options.targetNode : null
+      )
+    } as unknown as NonNullable<LGraphNode['graph']>,
+    outputs: [{ links: [1] } as INodeOutputSlot],
+    widgets: options.widgets ?? []
+  }
+}
+
+describe('applyFirstWidgetValueToGraph', () => {
+  it('returns early when the source widget is missing', () => {
+    const targetCallback = vi.fn()
+    const targetWidget = createWidget('value', 'unchanged', targetCallback)
+    const targetNode = createTargetNode(targetWidget)
+    const sourceNode = createSourceNode({
+      link: createLink(targetNode.id),
+      targetNode
+    })
+
+    expect(() => applyFirstWidgetValueToGraph(sourceNode)).not.toThrow()
+    expect(targetWidget.value).toBe('unchanged')
+    expect(targetCallback).not.toHaveBeenCalled()
+  })
+
+  it('propagates the first widget value to the linked widget', () => {
+    const targetCallback = vi.fn()
+    const targetWidget = createWidget('value', 'old', targetCallback)
+    const targetNode = createTargetNode(targetWidget)
+    const sourceNode = createSourceNode({
+      link: createLink(targetNode.id),
+      targetNode,
+      widgets: [createWidget('source', 'new value')]
+    })
+
+    applyFirstWidgetValueToGraph(sourceNode)
+
+    expect(targetWidget.value).toBe('new value')
+    expect(targetCallback).toHaveBeenCalledOnce()
+    expect(targetCallback).toHaveBeenCalledWith(
+      'new value',
+      expect.anything(),
+      targetNode,
+      [0, 0],
+      expect.anything()
+    )
+  })
+
+  it('applies a transform before propagating the widget value', () => {
+    const targetWidget = createWidget('value', 'old')
+    const targetNode = createTargetNode(targetWidget)
+    const sourceNode = createSourceNode({
+      link: createLink(targetNode.id),
+      targetNode,
+      widgets: [createWidget('source', 'draft')]
+    })
+
+    applyFirstWidgetValueToGraph(sourceNode, [], (value) => `${value}-saved`)
+
+    expect(targetWidget.value).toBe('draft-saved')
+  })
+})

--- a/src/extensions/core/widgetValuePropagation.ts
+++ b/src/extensions/core/widgetValuePropagation.ts
@@ -1,0 +1,68 @@
+import type { Point } from '@/lib/litegraph/src/interfaces'
+import type { LLink } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
+import { app } from '@/scripts/app'
+
+type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
+
+export function applyFirstWidgetValueToGraph(
+  node: SourceNode,
+  extraLinks: LLink[] = [],
+  transformValue?: (value: TWidgetValue) => TWidgetValue
+) {
+  const output = node.outputs[0]
+  if (!output?.links?.length || !node.graph) return
+
+  const sourceWidget = node.widgets?.[0]
+  if (!sourceWidget) return
+
+  let value = sourceWidget.value
+  if (transformValue) {
+    value = transformValue(value)
+  }
+
+  const graphMouse: Point = app.canvas?.graph_mouse ?? [0, 0]
+
+  const links = [
+    ...output.links.map((linkId) => node.graph!.links[linkId]),
+    ...extraLinks
+  ]
+
+  for (const linkInfo of links) {
+    if (!linkInfo) continue
+
+    const targetNode = node.graph.getNodeById(linkInfo.target_id)
+    const input = targetNode?.inputs[linkInfo.target_slot]
+    if (!targetNode || !input) {
+      console.warn('Unable to resolve node or input for link', linkInfo)
+      continue
+    }
+
+    const widgetName = input.widget?.name
+    if (!widgetName) {
+      console.warn('Invalid widget or widget name', input.widget)
+      continue
+    }
+
+    const targetWidget = targetNode.widgets?.find(
+      (widget) => widget.name === widgetName
+    )
+    if (!targetWidget) {
+      console.warn(
+        `Unable to find widget "${widgetName}" on node [${targetNode.id}]`
+      )
+      continue
+    }
+
+    targetWidget.value = value
+    targetWidget.callback?.(
+      targetWidget.value,
+      app.canvas,
+      targetNode,
+      graphMouse,
+      {} as CanvasPointerEvent
+    )
+  }
+}

--- a/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
+++ b/src/renderer/extensions/linearMode/flattenNodeOutput.test.ts
@@ -11,6 +11,11 @@ function makeOutput(
 }
 
 describe(flattenNodeOutput, () => {
+  it('returns empty array for nullish node output', () => {
+    expect(flattenNodeOutput(['1', null])).toEqual([])
+    expect(flattenNodeOutput(['1', undefined])).toEqual([])
+  })
+
   it('returns empty array for output with no known media types', () => {
     const result = flattenNodeOutput(['1', makeOutput({ unknown: 'hello' })])
     expect(result).toEqual([])

--- a/src/renderer/extensions/linearMode/flattenNodeOutput.ts
+++ b/src/renderer/extensions/linearMode/flattenNodeOutput.ts
@@ -4,7 +4,7 @@ import type { ResultItemImpl } from '@/stores/queueStore'
 
 export function flattenNodeOutput([nodeId, nodeOutput]: [
   string | number,
-  NodeExecutionOutput
+  NodeExecutionOutput | null | undefined
 ]): ResultItemImpl[] {
   return parseNodeOutput(nodeId, nodeOutput)
 }

--- a/src/stores/resultItemParsing.test.ts
+++ b/src/stores/resultItemParsing.test.ts
@@ -11,6 +11,11 @@ function makeOutput(
 }
 
 describe(parseNodeOutput, () => {
+  it('returns empty array for nullish node output', () => {
+    expect(parseNodeOutput('1', null)).toEqual([])
+    expect(parseNodeOutput('1', undefined)).toEqual([])
+  })
+
   it('returns empty array for output with no known media types', () => {
     const result = parseNodeOutput('1', makeOutput({ text: 'hello' }))
     expect(result).toEqual([])
@@ -152,6 +157,22 @@ describe(parseNodeOutput, () => {
 })
 
 describe(parseTaskOutput, () => {
+  it('ignores nullish node outputs', () => {
+    const taskOutput: Record<string, NodeExecutionOutput | null | undefined> = {
+      '1': null,
+      '2': undefined,
+      '3': makeOutput({
+        images: [{ filename: 'a.png', subfolder: '', type: 'output' }]
+      })
+    }
+
+    const result = parseTaskOutput(taskOutput)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].nodeId).toBe('3')
+    expect(result[0].filename).toBe('a.png')
+  })
+
   it('flattens across multiple nodes', () => {
     const taskOutput: Record<string, NodeExecutionOutput> = {
       '1': makeOutput({

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -29,8 +29,10 @@ function isResultItem(item: unknown): item is ResultItem {
 
 export function parseNodeOutput(
   nodeId: string | number,
-  nodeOutput: NodeExecutionOutput
+  nodeOutput: NodeExecutionOutput | null | undefined
 ): ResultItemImpl[] {
+  if (!nodeOutput) return []
+
   return Object.entries(nodeOutput)
     .filter(([key, value]) => !METADATA_KEYS.has(key) && Array.isArray(value))
     .flatMap(([mediaType, items]) =>
@@ -41,7 +43,7 @@ export function parseNodeOutput(
 }
 
 export function parseTaskOutput(
-  taskOutput: Record<string, NodeExecutionOutput>
+  taskOutput: Record<string, NodeExecutionOutput | null | undefined>
 ): ResultItemImpl[] {
   return Object.entries(taskOutput).flatMap(([nodeId, nodeOutput]) =>
     parseNodeOutput(nodeId, nodeOutput)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Manual backport of #11180 to `core/1.43` for inclusion in `v1.43.16`. Cherry-picked from upstream merge commit `9599a4e00`.

Hardens 3 runtime crash paths reproducing on `cloud.comfy.org`:
- widget propagation crash when `this.widgets[0]` is missing (CLOUD-FRONTEND-STAGING-429)
- ignored stale autogrow disconnect callbacks after group removal
- treats nullish executed outputs as empty during flatten/parsing

## Conflict resolution
- Dropped `src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenuActions.test.ts`. PR #11180 modified this test file but it was added on `main` by unrelated PR #11443 which is **not** backported. Runtime fixes are in source files; coverage exists in the targeted unit tests this PR adds.

## Validation
- `pnpm typecheck` ✅
- `pnpm test:unit` on changed test files ✅ (42/42 passing)
- `pnpm exec eslint <changed files>` ✅ (0 errors)
- `pnpm exec oxfmt --check` ✅ (clean)

Manual end-to-end verification not performed — these are crash-guard fixes that require specific cloud-staging conditions to reproduce. Source changes are byte-identical to upstream `9599a4e00` (baking on `main` for ~3 weeks through `v1.44.x`).

Original PR: #11180 / Original commit: `9599a4e00`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11857-backport-core-1-43-fix-cloud-frontend-runtime-guard-regressions-11180-3556d73d365081b2a21dcb32c60d9927) by [Unito](https://www.unito.io)
