### PR TITLE
[backport core/1.43] fix: disable pointer events on non-visible DOM widget overlays (#11063)

### DIFF
--- a/src/components/graph/widgets/DomWidget.test.ts
+++ b/src/components/graph/widgets/DomWidget.test.ts
@@ -114,4 +114,21 @@ describe('DomWidget disabled style', () => {
     expect(root.style.pointerEvents).toBe('none')
     expect(root.style.opacity).toBe('0.5')
   })
+
+  it('disables pointer events when widget is not visible', async () => {
+    const widgetState = createWidgetState(false)
+    widgetState.visible = false
+    const { container } = render(DomWidget, {
+      props: {
+        widgetState
+      }
+    })
+
+    widgetState.zIndex = 3
+    await nextTick()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const root = container.querySelector('.dom-widget') as HTMLElement
+    expect(root.style.pointerEvents).toBe('none')
+  })
 })

--- a/src/components/graph/widgets/DomWidget.vue
+++ b/src/components/graph/widgets/DomWidget.vue
@@ -113,7 +113,10 @@ function composeStyle() {
     ...positionStyle.value,
     ...(enableDomClipping.value ? clippingStyle.value : {}),
     zIndex: widgetState.zIndex,
-    pointerEvents: widgetState.readonly || isDisabled ? 'none' : 'auto',
+    pointerEvents:
+      !widgetState.visible || widgetState.readonly || isDisabled
+        ? 'none'
+        : 'auto',
     opacity: isDisabled ? 0.5 : 1
   }
 }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Manual backport of #11063 to `core/1.43` for inclusion in `v1.43.16`. Cherry-picked from upstream merge commit `4cf160d66`.

## Why
When a node with DOM widget overlays (e.g. CLIPTextEncode) is collapsed, the overlay elements can intercept pointer events intended for the canvas collapse toggler, making click-to-expand unreliable. Adds `!widgetState.visible` to the `pointerEvents` condition in `composeStyle()`, immediately setting `pointer-events: none` when the widget becomes invisible — closing the timing gap before `v-show` applies `display: none`. Fixes upstream issue #11006.

## Conflict resolution
- Skipped the change to `browser_tests/tests/interaction.spec.ts`. PR #11063 removed a programmatic-collapse workaround introduced by unrelated PR #10967 (which is **not** on `core/1.43`). On 1.43 the test uses an older `delay(1000) + click` form that doesn't need adjustment — the source fix in `DomWidget.vue` makes the second click reliable on its own. Kept the source + unit-test changes.

## Validation
- `pnpm typecheck` ✅
- `pnpm test:unit -- run src/components/graph/widgets/DomWidget.test.ts` ✅ (2/2 passing)
- `pnpm exec eslint <changed files>` ✅ (0 errors)
- `pnpm exec oxfmt --check` ✅ (clean)

Manual end-to-end verification not performed — DOM widget pointer-event timing requires live canvas+widget interaction, not feasible to reproduce reliably in headless. Source identical to upstream `4cf160d66`, baking on `main` for ~3 weeks through `v1.44.x`.

Original PR: #11063 / Original commit: `4cf160d66`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11859-backport-core-1-43-fix-disable-pointer-events-on-non-visible-DOM-widget-overlays-11-3556d73d365081cab95ef32c17c0401e) by [Unito](https://www.unito.io)
