### PR TITLE
[backport core/1.43] fix: trigger Vue reactivity on output slot type changes in matchType (#9935)

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -323,6 +323,10 @@ function withComfyMatchType(node: LGraphNode): asserts node is MatchTypeNode {
         if (!(outputGroups?.[idx] == matchKey)) return
         changeOutputType(this, output, outputType)
       })
+      // Force Vue reactivity update for output slot types.
+      // Outputs are wrapped in shallowReactive by useGraphNodeManager,
+      // so mutating output.type alone doesn't trigger re-render.
+      this.outputs = [...this.outputs]
       app.canvas?.setDirty(true, true)
     }
   )


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Manual backport of #9935 to `core/1.43` for inclusion in `v1.43.16`. Cherry-picked from upstream merge commit `2fea0aa53` cleanly.

## Why
VHS unbatch output slot color did not update when slot types changed via `matchType` resolution in the Vue renderer. After `changeOutputType` mutates `output.type` on objects inside a `shallowReactive` array, spread-copies `this.outputs` to trigger the shallowReactive setter so `SlotConnectionDot` re-evaluates the slot color.

## Conflict resolution
None — clean cherry-pick. 1 file, +4 lines.

## Validation
- `pnpm typecheck` ✅
- `pnpm exec eslint src/core/graph/widgets/dynamicWidgets.ts` ✅ (0 errors)
- `pnpm exec oxfmt --check` ✅ (clean)

Source identical to upstream `2fea0aa53`, baking on `main` for ~2 weeks through `v1.44.x`.

Original PR: #9935 / Original commit: `2fea0aa53`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11862-backport-core-1-43-fix-trigger-Vue-reactivity-on-output-slot-type-changes-in-matchTyp-3556d73d365081678f67c9949ccd4bb7) by [Unito](https://www.unito.io)
