### PR TITLE
fix: route default topbar feedback button to Typeform

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -129,7 +129,7 @@ describe('HelpCenterMenuContent feedback item', () => {
     distribution.isCloud = true
     const { user } = renderComponent()
 
-    await user.click(screen.getByTestId('help-menu-item-feedback'))
+    await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).toHaveBeenCalledWith(
       'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=help-center',
@@ -143,7 +143,7 @@ describe('HelpCenterMenuContent feedback item', () => {
     distribution.isNightly = true
     const { user } = renderComponent()
 
-    await user.click(screen.getByTestId('help-menu-item-feedback'))
+    await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).toHaveBeenCalledWith(
       'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=help-center',
@@ -156,7 +156,7 @@ describe('HelpCenterMenuContent feedback item', () => {
   it('falls back to Comfy.ContactSupport on OSS builds', async () => {
     const { user } = renderComponent()
 
-    await user.click(screen.getByTestId('help-menu-item-feedback'))
+    await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).not.toHaveBeenCalled()
     expect(commandStoreExecute).toHaveBeenCalledWith('Comfy.ContactSupport')

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -1,0 +1,164 @@
+import { cleanup, render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+
+import HelpCenterMenuContent from './HelpCenterMenuContent.vue'
+
+const distribution = vi.hoisted(() => ({
+  isCloud: false,
+  isDesktop: false,
+  isNightly: false
+}))
+
+const commandStoreExecute = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return distribution.isCloud
+  },
+  get isDesktop() {
+    return distribution.isDesktop
+  },
+  get isNightly() {
+    return distribution.isNightly
+  }
+}))
+
+vi.mock('@/composables/useExternalLink', () => ({
+  useExternalLink: () => ({
+    staticUrls: { discord: '', github: '' },
+    buildDocsUrl: () => 'https://docs.comfy.org'
+  })
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: () => false
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackHelpResourceClicked: vi.fn(),
+    trackHelpCenterOpened: vi.fn(),
+    trackHelpCenterClosed: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/updates/common/releaseStore', () => ({
+  useReleaseStore: () => ({
+    releases: [],
+    recentReleases: [],
+    isLoading: false,
+    fetchReleases: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({ execute: commandStoreExecute })
+}))
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: () => null
+}))
+
+vi.mock(
+  '@/workbench/extensions/manager/composables/useConflictAcknowledgment',
+  () => ({
+    useConflictAcknowledgment: () => ({ shouldShowRedDot: { value: false } })
+  })
+)
+
+vi.mock('@/workbench/extensions/manager/composables/useManagerState', () => ({
+  useManagerState: () => ({ isNewManagerUI: { value: false } })
+}))
+
+vi.mock('@/workbench/extensions/manager/services/comfyManagerService', () => ({
+  useComfyManagerService: () => ({})
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: vi.fn() })
+}))
+
+vi.mock('@/components/icons/PuzzleIcon.vue', () => ({
+  default: defineComponent({
+    name: 'PuzzleIconStub',
+    render: () => h('div')
+  })
+}))
+
+function renderComponent() {
+  const user = userEvent.setup()
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
+
+  const result = render(HelpCenterMenuContent, {
+    global: {
+      plugins: [i18n]
+    }
+  })
+
+  return { user, ...result }
+}
+
+describe('HelpCenterMenuContent feedback item', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    distribution.isCloud = false
+    distribution.isDesktop = false
+    distribution.isNightly = false
+    commandStoreExecute.mockReset()
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
+    cleanup()
+  })
+
+  it('opens the Typeform survey tagged with help-center source on Cloud', async () => {
+    distribution.isCloud = true
+    const { user } = renderComponent()
+
+    await user.click(screen.getByTestId('help-menu-item-feedback'))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=help-center',
+      '_blank',
+      'noopener,noreferrer'
+    )
+    expect(commandStoreExecute).not.toHaveBeenCalled()
+  })
+
+  it('opens the Typeform survey tagged with help-center source on Nightly', async () => {
+    distribution.isNightly = true
+    const { user } = renderComponent()
+
+    await user.click(screen.getByTestId('help-menu-item-feedback'))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=help-center',
+      '_blank',
+      'noopener,noreferrer'
+    )
+    expect(commandStoreExecute).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Comfy.ContactSupport on OSS builds', async () => {
+    const { user } = renderComponent()
+
+    await user.click(screen.getByTestId('help-menu-item-feedback'))
+
+    expect(openSpy).not.toHaveBeenCalled()
+    expect(commandStoreExecute).toHaveBeenCalledWith('Comfy.ContactSupport')
+  })
+})

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -163,7 +163,7 @@ import PuzzleIcon from '@/components/icons/PuzzleIcon.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
+import { buildFeedbackTypeformUrl } from '@/platform/support/config'
 import { useTelemetry } from '@/platform/telemetry'
 import type { ReleaseNote } from '@/platform/updates/common/releaseService'
 import { useReleaseStore } from '@/platform/updates/common/releaseStore'
@@ -306,7 +306,11 @@ const menuItems = computed<MenuItem[]>(() => {
       action: () => {
         trackResourceClick('help_feedback', isCloud || isNightly)
         if (isCloud || isNightly) {
-          window.open(FEEDBACK_TYPEFORM_URL, '_blank', 'noopener,noreferrer')
+          window.open(
+            buildFeedbackTypeformUrl('help-center'),
+            '_blank',
+            'noopener,noreferrer'
+          )
         } else {
           void commandStore.execute('Comfy.ContactSupport')
         }

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -163,6 +163,7 @@ import PuzzleIcon from '@/components/icons/PuzzleIcon.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
 import { useTelemetry } from '@/platform/telemetry'
 import type { ReleaseNote } from '@/platform/updates/common/releaseService'
 import { useReleaseStore } from '@/platform/updates/common/releaseStore'
@@ -305,11 +306,7 @@ const menuItems = computed<MenuItem[]>(() => {
       action: () => {
         trackResourceClick('help_feedback', isCloud || isNightly)
         if (isCloud || isNightly) {
-          window.open(
-            'https://form.typeform.com/to/q7azbWPi',
-            '_blank',
-            'noopener,noreferrer'
-          )
+          window.open(FEEDBACK_TYPEFORM_URL, '_blank', 'noopener,noreferrer')
         } else {
           void commandStore.execute('Comfy.ContactSupport')
         }

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -1,0 +1,187 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, reactive } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
+
+import WorkflowTabs from './WorkflowTabs.vue'
+
+const distribution = vi.hoisted(() => ({
+  isCloud: false,
+  isDesktop: false,
+  isNightly: false
+}))
+
+const tabBarLayout = vi.hoisted(() => ({ value: 'Default' }))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return distribution.isCloud
+  },
+  get isDesktop() {
+    return distribution.isDesktop
+  },
+  get isNightly() {
+    return distribution.isNightly
+  }
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: (key: string) =>
+      key === 'Comfy.UI.TabBarLayout' ? tabBarLayout.value : undefined
+  })
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({ isLoggedIn: { value: false } })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: { showSignInButton: false } })
+}))
+
+vi.mock('@/composables/element/useOverflowObserver', () => ({
+  useOverflowObserver: () => ({
+    isOverflowing: { value: false },
+    disposed: { value: false },
+    checkOverflow: vi.fn(),
+    dispose: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/workflow/core/services/workflowService', () => ({
+  useWorkflowService: () => ({
+    openWorkflow: vi.fn(),
+    closeWorkflow: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () =>
+    reactive({
+      openWorkflows: [],
+      activeWorkflow: null
+    })
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({ execute: vi.fn() })
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => ({ shiftDown: false })
+}))
+
+vi.mock('@/utils/mouseDownUtil', () => ({
+  whileMouseDown: vi.fn()
+}))
+
+vi.mock('./WorkflowOverflowMenu.vue', () => ({
+  default: defineComponent({
+    name: 'WorkflowOverflowMenuStub',
+    render: () => h('div')
+  })
+}))
+
+vi.mock('./WorkflowTab.vue', () => ({
+  default: defineComponent({
+    name: 'WorkflowTabStub',
+    render: () => h('div')
+  })
+}))
+
+vi.mock('./CurrentUserButton.vue', () => ({
+  default: defineComponent({
+    name: 'CurrentUserButtonStub',
+    render: () => h('div')
+  })
+}))
+
+vi.mock('./LoginButton.vue', () => ({
+  default: defineComponent({
+    name: 'LoginButtonStub',
+    render: () => h('div')
+  })
+}))
+
+function renderComponent() {
+  const user = userEvent.setup()
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
+
+  const result = render(WorkflowTabs, {
+    global: {
+      plugins: [i18n],
+      directives: {
+        tooltip: {}
+      }
+    }
+  })
+
+  return { user, ...result }
+}
+
+describe('WorkflowTabs feedback button', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    distribution.isCloud = false
+    distribution.isDesktop = false
+    distribution.isNightly = false
+    tabBarLayout.value = 'Default'
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
+  })
+
+  it('opens the Typeform survey when clicked on a Cloud build', async () => {
+    distribution.isCloud = true
+    const { user } = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Feedback' }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      FEEDBACK_TYPEFORM_URL,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('opens the Typeform survey when clicked on a Nightly build', async () => {
+    distribution.isNightly = true
+    const { user } = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Feedback' }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      FEEDBACK_TYPEFORM_URL,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('does not render the feedback button on non-Cloud/non-Nightly builds', () => {
+    renderComponent()
+    expect(
+      screen.queryByRole('button', { name: 'Feedback' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not render the feedback button when the legacy tab bar is active', () => {
+    distribution.isCloud = true
+    tabBarLayout.value = 'Legacy'
+    renderComponent()
+    expect(
+      screen.queryByRole('button', { name: 'Feedback' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -5,7 +5,6 @@ import { defineComponent, h, reactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
-import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
 
 import WorkflowTabs from './WorkflowTabs.vue'
 
@@ -143,27 +142,27 @@ describe('WorkflowTabs feedback button', () => {
     openSpy.mockRestore()
   })
 
-  it('opens the Typeform survey when clicked on a Cloud build', async () => {
+  it('opens the Typeform survey tagged with topbar source on Cloud', async () => {
     distribution.isCloud = true
     const { user } = renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Feedback' }))
 
     expect(openSpy).toHaveBeenCalledWith(
-      FEEDBACK_TYPEFORM_URL,
+      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=topbar',
       '_blank',
       'noopener,noreferrer'
     )
   })
 
-  it('opens the Typeform survey when clicked on a Nightly build', async () => {
+  it('opens the Typeform survey tagged with topbar source on Nightly', async () => {
     distribution.isNightly = true
     const { user } = renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Feedback' }))
 
     expect(openSpy).toHaveBeenCalledWith(
-      FEEDBACK_TYPEFORM_URL,
+      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=topbar',
       '_blank',
       'noopener,noreferrer'
     )

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -118,7 +118,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useOverflowObserver } from '@/composables/element/useOverflowObserver'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { buildFeedbackUrl } from '@/platform/support/config'
+import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -151,9 +151,8 @@ const isIntegratedTabBar = computed(
 )
 const showCurrentUser = computed(() => isCloud || isLoggedIn.value)
 
-const feedbackUrl = buildFeedbackUrl()
 function openFeedback() {
-  window.open(feedbackUrl, '_blank', 'noopener,noreferrer')
+  window.open(FEEDBACK_TYPEFORM_URL, '_blank', 'noopener,noreferrer')
 }
 
 const containerRef = ref<HTMLElement | null>(null)

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -118,7 +118,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useOverflowObserver } from '@/composables/element/useOverflowObserver'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
+import { buildFeedbackTypeformUrl } from '@/platform/support/config'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -152,7 +152,11 @@ const isIntegratedTabBar = computed(
 const showCurrentUser = computed(() => isCloud || isLoggedIn.value)
 
 function openFeedback() {
-  window.open(FEEDBACK_TYPEFORM_URL, '_blank', 'noopener,noreferrer')
+  window.open(
+    buildFeedbackTypeformUrl('topbar'),
+    '_blank',
+    'noopener,noreferrer'
+  )
 }
 
 const containerRef = ref<HTMLElement | null>(null)

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
 import type { ActionBarButton } from '@/types/comfy'
+
+const distribution = vi.hoisted(() => ({ isCloud: false, isNightly: false }))
 
 const tabBarLayout = vi.hoisted(() => ({ value: 'Default' }))
 const registerExtension = vi.hoisted(() => vi.fn())
@@ -23,12 +24,23 @@ vi.mock('@/services/extensionService', () => ({
   })
 }))
 
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return distribution.isCloud
+  },
+  get isNightly() {
+    return distribution.isNightly
+  }
+}))
+
 describe('cloudFeedbackTopbarButton', () => {
   let openSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     vi.resetModules()
     registerExtension.mockReset()
+    distribution.isCloud = false
+    distribution.isNightly = false
     openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
   })
 
@@ -44,19 +56,22 @@ describe('cloudFeedbackTopbarButton', () => {
     return extension.actionBarButtons
   }
 
-  it('opens the Typeform survey when the Legacy action bar button is clicked', async () => {
+  it('opens the Typeform survey tagged with action-bar source on Cloud', async () => {
     tabBarLayout.value = 'Legacy'
+    distribution.isCloud = true
     await import('./cloudFeedbackTopbarButton')
 
     const buttons = getRegisteredButtons()
     expect(buttons).toHaveLength(1)
     buttons[0].onClick?.()
 
-    expect(openSpy).toHaveBeenCalledWith(
-      FEEDBACK_TYPEFORM_URL,
-      '_blank',
-      'noopener,noreferrer'
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    const [url, target, features] = openSpy.mock.calls[0]
+    expect(url).toBe(
+      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=action-bar'
     )
+    expect(target).toBe('_blank')
+    expect(features).toBe('noopener,noreferrer')
   })
 
   it('only registers the action bar button when the tab bar is Legacy', async () => {

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
+import type { ActionBarButton } from '@/types/comfy'
+
+const tabBarLayout = vi.hoisted(() => ({ value: 'Default' }))
+const registerExtension = vi.hoisted(() => vi.fn())
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: (key: string) =>
+      key === 'Comfy.UI.TabBarLayout' ? tabBarLayout.value : undefined
+  })
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension
+  })
+}))
+
+describe('cloudFeedbackTopbarButton', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    registerExtension.mockReset()
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
+  })
+
+  function getRegisteredButtons(): ActionBarButton[] {
+    expect(registerExtension).toHaveBeenCalledTimes(1)
+    const extension = registerExtension.mock.calls[0]?.[0] as {
+      actionBarButtons: ActionBarButton[]
+    }
+    return extension.actionBarButtons
+  }
+
+  it('opens the Typeform survey when the Legacy action bar button is clicked', async () => {
+    tabBarLayout.value = 'Legacy'
+    await import('./cloudFeedbackTopbarButton')
+
+    const buttons = getRegisteredButtons()
+    expect(buttons).toHaveLength(1)
+    buttons[0].onClick?.()
+
+    expect(openSpy).toHaveBeenCalledWith(
+      FEEDBACK_TYPEFORM_URL,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('only registers the action bar button when the tab bar is Legacy', async () => {
+    tabBarLayout.value = 'Default'
+    await import('./cloudFeedbackTopbarButton')
+
+    expect(getRegisteredButtons()).toEqual([])
+  })
+})

--- a/src/extensions/core/cloudFeedbackTopbarButton.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.ts
@@ -1,6 +1,6 @@
 import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
+import { buildFeedbackTypeformUrl } from '@/platform/support/config'
 import { useExtensionService } from '@/services/extensionService'
 import type { ActionBarButton } from '@/types/comfy'
 
@@ -10,7 +10,11 @@ const buttons: ActionBarButton[] = [
     label: t('actionbar.feedback'),
     tooltip: t('actionbar.feedbackTooltip'),
     onClick: () => {
-      window.open(FEEDBACK_TYPEFORM_URL, '_blank', 'noopener,noreferrer')
+      window.open(
+        buildFeedbackTypeformUrl('action-bar'),
+        '_blank',
+        'noopener,noreferrer'
+      )
     }
   }
 ]

--- a/src/extensions/core/cloudFeedbackTopbarButton.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.ts
@@ -1,9 +1,8 @@
 import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { FEEDBACK_TYPEFORM_URL } from '@/platform/support/config'
 import { useExtensionService } from '@/services/extensionService'
 import type { ActionBarButton } from '@/types/comfy'
-
-const TYPEFORM_SURVEY_URL = 'https://form.typeform.com/to/q7azbWPi'
 
 const buttons: ActionBarButton[] = [
   {
@@ -11,7 +10,7 @@ const buttons: ActionBarButton[] = [
     label: t('actionbar.feedback'),
     tooltip: t('actionbar.feedbackTooltip'),
     onClick: () => {
-      window.open(TYPEFORM_SURVEY_URL, '_blank', 'noopener,noreferrer')
+      window.open(FEEDBACK_TYPEFORM_URL, '_blank', 'noopener,noreferrer')
     }
   }
 ]

--- a/src/platform/support/config.test.ts
+++ b/src/platform/support/config.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const distribution = vi.hoisted(() => ({ isCloud: false, isNightly: false }))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return distribution.isCloud
+  },
+  get isNightly() {
+    return distribution.isNightly
+  }
+}))
+
+describe('buildFeedbackTypeformUrl', () => {
+  beforeEach(() => {
+    distribution.isCloud = false
+    distribution.isNightly = false
+  })
+
+  async function build(source: 'topbar' | 'action-bar' | 'help-center') {
+    vi.resetModules()
+    const { buildFeedbackTypeformUrl } = await import('./config')
+    return buildFeedbackTypeformUrl(source)
+  }
+
+  it('tags Cloud builds with distribution=ccloud', async () => {
+    distribution.isCloud = true
+    expect(await build('topbar')).toBe(
+      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=topbar'
+    )
+  })
+
+  it('tags Nightly builds with distribution=oss-nightly', async () => {
+    distribution.isNightly = true
+    expect(await build('action-bar')).toBe(
+      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=action-bar'
+    )
+  })
+
+  it('tags OSS builds with distribution=oss', async () => {
+    expect(await build('help-center')).toBe(
+      'https://form.typeform.com/to/q7azbWPi#distribution=oss&source=help-center'
+    )
+  })
+
+  it('uses a URL fragment so distribution and source are not sent to the server', async () => {
+    distribution.isCloud = true
+    const url = new URL(await build('topbar'))
+    expect(url.search).toBe('')
+    expect(url.hash).toBe('#distribution=ccloud&source=topbar')
+  })
+})

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -25,18 +25,9 @@ function getDistribution(): 'ccloud' | 'oss-nightly' | 'oss' {
 }
 
 const SUPPORT_BASE_URL = 'https://support.comfy.org/hc/en-us/requests/new'
-const ZENDESK_FEEDBACK_FORM_ID = '43066738713236'
 
-/**
- * Builds the feedback form URL with the appropriate distribution tag.
- */
-export function buildFeedbackUrl(): string {
-  const params = new URLSearchParams({
-    ticket_form_id: ZENDESK_FEEDBACK_FORM_ID,
-    [ZENDESK_FIELDS.DISTRIBUTION]: getDistribution()
-  })
-  return `${SUPPORT_BASE_URL}?${params.toString()}`
-}
+/** Shared Typeform feedback survey URL for all Cloud/Nightly feedback buttons. */
+export const FEEDBACK_TYPEFORM_URL = 'https://form.typeform.com/to/q7azbWPi'
 
 /**
  * Builds the support URL with optional user information for pre-filling.

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -15,7 +15,7 @@ const ZENDESK_FIELDS = {
 } as const
 
 /**
- * Gets the distribution identifier for Zendesk tracking.
+ * Gets the distribution identifier for tracking.
  * Helps distinguish feedback from different build types.
  */
 function getDistribution(): 'ccloud' | 'oss-nightly' | 'oss' {
@@ -25,9 +25,23 @@ function getDistribution(): 'ccloud' | 'oss-nightly' | 'oss' {
 }
 
 const SUPPORT_BASE_URL = 'https://support.comfy.org/hc/en-us/requests/new'
+const FEEDBACK_TYPEFORM_BASE_URL = 'https://form.typeform.com/to/q7azbWPi'
 
-/** Shared Typeform feedback survey URL for all Cloud/Nightly feedback buttons. */
-export const FEEDBACK_TYPEFORM_URL = 'https://form.typeform.com/to/q7azbWPi'
+/**
+ * Builds the feedback Typeform URL tagged with the current build distribution
+ * and the UI source that opened it. Tags are passed via the URL fragment
+ * (Typeform's hidden-field convention) so survey responses can be segmented
+ * by distribution (cloud / oss-nightly / oss) and entry point.
+ */
+export function buildFeedbackTypeformUrl(
+  source: 'topbar' | 'action-bar' | 'help-center'
+): string {
+  const params = new URLSearchParams({
+    distribution: getDistribution(),
+    source
+  })
+  return `${FEEDBACK_TYPEFORM_BASE_URL}#${params.toString()}`
+}
 
 /**
  * Builds the support URL with optional user information for pre-filling.


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

PR #10890 routed the legacy action bar feedback button and the Help Center feedback item to the nightly Typeform survey, but the **default topbar feedback button** in `WorkflowTabs.vue` still called `buildFeedbackUrl()` and opened Zendesk. Since `Comfy.UI.TabBarLayout` defaults to `Default` (not `Legacy`), most Cloud/Nightly users were clicking the WorkflowTabs button and never reaching the Typeform survey — explaining the lack of survey responses.

## Changes

- Added a shared `buildFeedbackTypeformUrl(source)` helper in `platform/support/config.ts` that tags the survey URL with:
  - `distribution`: `ccloud` / `oss-nightly` / `oss` (preserves the build-tagging the old `buildFeedbackUrl()` sent to Zendesk so responses stay segmented)
  - `source`: `topbar` / `action-bar` / `help-center` (identifies which UI entry point launched the survey)

  Tags are passed via the URL fragment (Typeform's hidden-field convention), so they reach the survey but are never sent to the server in the request line.
- `WorkflowTabs.vue`: replaced `buildFeedbackUrl()` with `buildFeedbackTypeformUrl('topbar')`.
- `cloudFeedbackTopbarButton.ts` and `HelpCenterMenuContent.vue`: use the shared builder with their respective source labels instead of inline URL literals.
- Removed the now-unused `buildFeedbackUrl()` and `ZENDESK_FEEDBACK_FORM_ID` (knip-clean). `buildSupportUrl()` is preserved — `Comfy.ContactSupport` (the Help Center "Help" item) still routes to Zendesk as before.
- Added unit tests for the builder, the WorkflowTabs feedback button, the legacy action bar button, and the Help Center feedback item (covering both the Cloud/Nightly Typeform path and the OSS `Comfy.ContactSupport` fallback).

## Verification

- `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm knip`: clean (one pre-existing unrelated lint warning in `useWorkspaceBilling.test.ts`)
- `pnpm test:unit` (impacted scope): 506/506 passing, including 13 new tests

## Review Focus

- Cloud/Nightly gating in `WorkflowTabs.vue` (`v-if="isCloud || isNightly"`) is unchanged and matches PR #10890's gating philosophy.
- The Help Center "Help" item and `Comfy.ContactSupport` command intentionally still route to Zendesk — feedback ≠ support.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11863-fix-route-default-topbar-feedback-button-to-Typeform-3556d73d3650815fb446dac33095d4be) by [Unito](https://www.unito.io)
