### PR TITLE
fix: node stuck to cursor after drag interrupted by Space key

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -12,11 +12,15 @@ import { useNodeDrag } from '@/renderer/extensions/vueNodes/layout/useNodeDrag'
 const forwardEventToCanvasMock = vi.fn()
 const selectedItemsState: { items: Array<{ id?: string }> } = { items: [] }
 
+const { shouldHandleNodePointerEventsMock } = vi.hoisted(() => ({
+  shouldHandleNodePointerEventsMock: { value: true } as { value: boolean }
+}))
+
 // Mock the dependencies
 vi.mock('@/renderer/core/canvas/useCanvasInteractions', () => ({
   useCanvasInteractions: () => ({
     forwardEventToCanvas: forwardEventToCanvasMock,
-    shouldHandleNodePointerEvents: ref(true)
+    shouldHandleNodePointerEvents: shouldHandleNodePointerEventsMock
   })
 }))
 
@@ -136,6 +140,7 @@ describe('useNodePointerInteractions', () => {
     vi.resetAllMocks()
     selectedItemsState.items = []
     setActivePinia(createTestingPinia())
+    shouldHandleNodePointerEventsMock.value = true
   })
 
   it('should only start drag on left-click', async () => {
@@ -268,6 +273,32 @@ describe('useNodePointerInteractions', () => {
 
     // Selection should still only have been called once
     expect(handleNodeSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears drag state when pointerup fires while canvas is read-only (e.g. Space held)', async () => {
+    const { pointerHandlers } = useNodePointerInteractions('test-node-123')
+
+    // Start a drag normally
+    pointerHandlers.onPointerdown(
+      createPointerEvent('pointerdown', { clientX: 100, clientY: 100 })
+    )
+    pointerHandlers.onPointermove(
+      createPointerEvent('pointermove', {
+        clientX: 115,
+        clientY: 115,
+        buttons: 1
+      })
+    )
+    expect(layoutStore.isDraggingVueNodes.value).toBe(true)
+
+    // Canvas goes read-only (Space pressed) before mouse is released
+    shouldHandleNodePointerEventsMock.value = false
+
+    pointerHandlers.onPointerup(
+      createPointerEvent('pointerup', { clientX: 115, clientY: 115 })
+    )
+
+    expect(layoutStore.isDraggingVueNodes.value).toBe(false)
   })
 
   it('on ctrl+click: calls toggleNodeSelectionAfterPointerUp on pointer up (not pointer down)', async () => {

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -124,6 +124,11 @@ export function useNodePointerInteractions(
     // Don't handle pointer events when canvas is in panning mode - forward to canvas instead
     const canHandlePointer = shouldHandleNodePointerEvents.value
     if (!canHandlePointer) {
+      // Space (or other read_only triggers) can go active between pointerdown and
+      // pointerup; call safeDragEnd so isDraggingVueNodes doesn't get stuck true.
+      if (hasDraggingStarted || layoutStore.isDraggingVueNodes.value) {
+        safeDragEnd(event)
+      }
       forwardEventToCanvas(event)
       return
     }


### PR DESCRIPTION
## Summary

Fixes a bug where a VueNode gets stuck following the cursor after the user presses Space mid-drag and releases the mouse while Space is held.

## Changes

- **What**: In `onPointerup`, call `safeDragEnd` before forwarding to canvas when `shouldHandleNodePointerEvents` is false and a drag was in progress — previously the early-return path skipped cleanup, leaving `isDraggingVueNodes` stuck `true`
- **Test**: Added regression test that simulates the exact sequence (drag → Space → pointerup) and asserts `isDraggingVueNodes` resets to `false`; refactored `useCanvasInteractions` mock to use `vi.hoisted()` singleton so per-test state mutation is type-safe

## Review Focus

The fix is a single guard added to the `!canHandlePointer` branch in `onPointerup`. The key invariant: `isDraggingVueNodes` must always be reset to `false` on pointerup regardless of whether canvas is in read-only mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches node pointer/drag termination logic; a small change but it affects common interaction paths and could regress drag/selection behavior if the new cleanup triggers unexpectedly.
> 
> **Overview**
> Fixes an edge case where a node drag could remain active if the canvas switches to read-only/panning mode (e.g. Space held) before `pointerup`, by ensuring `safeDragEnd` runs before forwarding the event to the canvas.
> 
> Adds a regression test that simulates drag → canvas becomes read-only → `pointerup` and asserts `layoutStore.isDraggingVueNodes` is cleared; the canvas interactions mock is refactored to use a hoisted, mutable `shouldHandleNodePointerEvents` ref for per-test toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f38585c6e130ea54e9e170f44eb2b92aed2645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11867-fix-node-stuck-to-cursor-after-drag-interrupted-by-Space-key-3556d73d365081abaeb7d38b9abf9faf) by [Unito](https://www.unito.io)
