### PR TITLE
feat(website): add responsive media tooling for marketing assets

### DIFF
--- a/apps/website/scripts/README.md
+++ b/apps/website/scripts/README.md
@@ -24,7 +24,7 @@ apps/website/scripts/process-videos.sh \
 
 For each source video at `./video-sources/foo.mp4`, you get:
 
-```
+```text
 foo-640.webm   foo-640.mp4
 foo-960.webm   foo-960.mp4
 foo-1280.webm  foo-1280.mp4

--- a/apps/website/scripts/README.md
+++ b/apps/website/scripts/README.md
@@ -1,0 +1,70 @@
+# Website Scripts
+
+## `refresh-ashby-snapshot.ts`
+
+Pulls the latest job postings from Ashby and writes
+`src/data/ashby-roles.snapshot.json`. Invoked by the `Release: Website`
+GitHub Actions workflow; also runnable locally via
+`pnpm --filter @comfyorg/website ashby:refresh-snapshot`.
+
+## `process-videos.sh`
+
+Generates multi-resolution VP9/WebM + H.264/MP4 variants and a poster
+frame for marketing videos using `ffmpeg`. Run **locally** before
+uploading the outputs to `media.comfy.org`; this is not wired into CI.
+
+```sh
+apps/website/scripts/process-videos.sh \
+  ./video-sources \
+  ./dist/videos \
+  "640 960 1280 1920"
+```
+
+### Output
+
+For each source video at `./video-sources/foo.mp4`, you get:
+
+```
+foo-640.webm   foo-640.mp4
+foo-960.webm   foo-960.mp4
+foo-1280.webm  foo-1280.mp4
+foo-1920.webm  foo-1920.mp4
+foo-poster.jpg
+```
+
+The naming convention is enforced by `buildVideoSources()` in
+`src/utils/video.ts`, which the `<SiteVideo>` Vue component uses to
+emit `<source>` URLs.
+
+### Pairing with `<SiteVideo>`
+
+Once the assets are uploaded, render them with:
+
+```vue
+<SiteVideo
+  name="foo"
+  base-url="https://media.comfy.org/website/marketing"
+  :width="1280"
+  :formats="['webm', 'mp4']"
+  poster="https://media.comfy.org/website/marketing/foo-poster.jpg"
+  autoplay
+  loop
+/>
+```
+
+### Encoder choices
+
+- **VP9/WebM** at CRF 32 — preferred by Chrome and Firefox; smaller files.
+- **H.264/MP4** at CRF 23, High profile, `+faststart` — universal fallback,
+  required for Safari iOS.
+- **Poster JPG** at q4 — extracted from t=1s, scaled to 1280w. Use this as
+  the `poster` attribute so the video shows something while loading.
+
+### Why a single resolution per video
+
+`<source media="...">` inside `<video>` is unreliable across browsers
+(Safari ignores it). The simplest correct strategy is to ship one
+well-sized resolution and let CSS scale it down on smaller viewports.
+The script generates multiple widths so you can pick a different one
+per page (e.g. 1280w for a hero, 640w for a thumbnail), or wire up
+JavaScript-based selection later if metrics demand it.

--- a/apps/website/scripts/README.md
+++ b/apps/website/scripts/README.md
@@ -52,13 +52,26 @@ Once the assets are uploaded, render them with:
 />
 ```
 
+### `<SiteVideo>` vs `<VideoPlayer>`
+
+- **`SiteVideo`** — lightweight multi-source `<video>` for decorative or
+  autoplay marketing clips. No custom controls, no captions UI.
+- **`VideoPlayer`** — full-featured player with custom scrubber, mute,
+  fullscreen, and caption toggles. Use this for content with subtitles or
+  user-driven playback.
+
+If you need both responsive sources and the rich `VideoPlayer` chrome, the
+two are not yet combined; either pick one or extend `VideoPlayer` to accept
+a source list.
+
 ### Encoder choices
 
 - **VP9/WebM** at CRF 32 — preferred by Chrome and Firefox; smaller files.
 - **H.264/MP4** at CRF 23, High profile, `+faststart` — universal fallback,
   required for Safari iOS.
-- **Poster JPG** at q4 — extracted from t=1s, scaled to 1280w. Use this as
-  the `poster` attribute so the video shows something while loading.
+- **Poster JPG** at q4 — extracted from t=1s when the clip is long enough,
+  otherwise t=0; scaled to 1280w. Use this as the `poster` attribute so
+  the video shows something while loading.
 
 ### Why a single resolution per video
 

--- a/apps/website/scripts/process-videos.sh
+++ b/apps/website/scripts/process-videos.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Generate multi-resolution VP9/WebM + H.264/MP4 variants and a poster frame
+# for every source video in a given directory. Intended to be run locally
+# before uploading the outputs to media.comfy.org.
+#
+# Usage:
+#   apps/website/scripts/process-videos.sh <input-dir> <output-dir> [widths]
+#
+# Example:
+#   apps/website/scripts/process-videos.sh \
+#     ./video-sources \
+#     ./dist/videos \
+#     "640 960 1280 1920"
+#
+# Defaults to widths "1280" if omitted.
+#
+# Output naming matches buildVideoSources() in src/utils/video.ts:
+#   <name>-<width>.webm
+#   <name>-<width>.mp4
+#   <name>-poster.jpg          (single 1280w poster, suitable for SiteVideo)
+#
+# Requires ffmpeg on PATH. Tested with ffmpeg 6.x and 7.x.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  cat <<USAGE >&2
+Usage: $0 <input-dir> <output-dir> [widths]
+  widths: space-separated list, e.g. "640 1280 1920" (default: "1280")
+USAGE
+  exit 64
+fi
+
+input_dir=$1
+output_dir=$2
+widths=${3:-1280}
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "error: ffmpeg not found on PATH" >&2
+  exit 127
+fi
+
+if [[ ! -d $input_dir ]]; then
+  echo "error: input dir not found: $input_dir" >&2
+  exit 66
+fi
+
+mkdir -p "$output_dir"
+
+shopt -s nullglob
+sources=("$input_dir"/*.{mp4,mov,webm,mkv})
+shopt -u nullglob
+
+if [[ ${#sources[@]} -eq 0 ]]; then
+  echo "error: no source videos in $input_dir (looked for .mp4 .mov .webm .mkv)" >&2
+  exit 66
+fi
+
+for src in "${sources[@]}"; do
+  name=$(basename "$src")
+  name=${name%.*}
+  echo "==> $name"
+
+  for w in $widths; do
+    webm_out="$output_dir/${name}-${w}.webm"
+    mp4_out="$output_dir/${name}-${w}.mp4"
+
+    echo "    encoding ${w}w VP9/WebM -> $webm_out"
+    ffmpeg -y -hide_banner -loglevel error \
+      -i "$src" \
+      -vf "scale=${w}:-2:flags=lanczos" \
+      -c:v libvpx-vp9 -b:v 0 -crf 32 -row-mt 1 -tile-columns 2 \
+      -c:a libopus -b:a 96k \
+      -f webm "$webm_out"
+
+    echo "    encoding ${w}w H.264/MP4 -> $mp4_out"
+    ffmpeg -y -hide_banner -loglevel error \
+      -i "$src" \
+      -vf "scale=${w}:-2:flags=lanczos" \
+      -c:v libx264 -crf 23 -preset slow -profile:v high -pix_fmt yuv420p \
+      -c:a aac -b:a 128k \
+      -movflags +faststart \
+      "$mp4_out"
+  done
+
+  poster_out="$output_dir/${name}-poster.jpg"
+  echo "    extracting poster -> $poster_out"
+  ffmpeg -y -hide_banner -loglevel error \
+    -ss 00:00:01 -i "$src" \
+    -vframes 1 -vf "scale=1280:-2:flags=lanczos" \
+    -q:v 4 \
+    "$poster_out"
+done
+
+echo "done. upload contents of $output_dir to media.comfy.org."

--- a/apps/website/scripts/process-videos.sh
+++ b/apps/website/scripts/process-videos.sh
@@ -87,9 +87,14 @@ for src in "${sources[@]}"; do
   done
 
   poster_out="$output_dir/${name}-poster.jpg"
-  duration=$(ffprobe -v error -show_entries format=duration \
-    -of default=noprint_wrappers=1:nokey=1 "$src" 2>/dev/null || echo 0)
-  if awk "BEGIN { exit !($duration >= 1.0) }"; then
+  duration_raw=$(ffprobe -v error -show_entries format=duration \
+    -of default=noprint_wrappers=1:nokey=1 "$src" 2>/dev/null || true)
+  if [[ $duration_raw =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    duration="$duration_raw"
+  else
+    duration=0
+  fi
+  if awk -v d="$duration" 'BEGIN { exit !(d >= 1.0) }'; then
     poster_seek=1
   else
     poster_seek=0

--- a/apps/website/scripts/process-videos.sh
+++ b/apps/website/scripts/process-videos.sh
@@ -20,7 +20,7 @@
 #   <name>-<width>.mp4
 #   <name>-poster.jpg          (single 1280w poster, suitable for SiteVideo)
 #
-# Requires ffmpeg on PATH. Tested with ffmpeg 6.x and 7.x.
+# Requires ffmpeg and ffprobe on PATH. Tested with ffmpeg 6.x and 7.x.
 
 set -euo pipefail
 
@@ -36,10 +36,12 @@ input_dir=$1
 output_dir=$2
 widths=${3:-1280}
 
-if ! command -v ffmpeg >/dev/null 2>&1; then
-  echo "error: ffmpeg not found on PATH" >&2
-  exit 127
-fi
+for tool in ffmpeg ffprobe; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "error: $tool not found on PATH" >&2
+    exit 127
+  fi
+done
 
 if [[ ! -d $input_dir ]]; then
   echo "error: input dir not found: $input_dir" >&2
@@ -48,9 +50,9 @@ fi
 
 mkdir -p "$output_dir"
 
-shopt -s nullglob
+shopt -s nullglob nocaseglob
 sources=("$input_dir"/*.{mp4,mov,webm,mkv})
-shopt -u nullglob
+shopt -u nullglob nocaseglob
 
 if [[ ${#sources[@]} -eq 0 ]]; then
   echo "error: no source videos in $input_dir (looked for .mp4 .mov .webm .mkv)" >&2
@@ -85,9 +87,16 @@ for src in "${sources[@]}"; do
   done
 
   poster_out="$output_dir/${name}-poster.jpg"
-  echo "    extracting poster -> $poster_out"
+  duration=$(ffprobe -v error -show_entries format=duration \
+    -of default=noprint_wrappers=1:nokey=1 "$src" 2>/dev/null || echo 0)
+  if awk "BEGIN { exit !($duration >= 1.0) }"; then
+    poster_seek=1
+  else
+    poster_seek=0
+  fi
+  echo "    extracting poster (t=${poster_seek}s) -> $poster_out"
   ffmpeg -y -hide_banner -loglevel error \
-    -ss 00:00:01 -i "$src" \
+    -ss "$poster_seek" -i "$src" \
     -vframes 1 -vf "scale=1280:-2:flags=lanczos" \
     -q:v 4 \
     "$poster_out"

--- a/apps/website/src/assets/marketing/README.md
+++ b/apps/website/src/assets/marketing/README.md
@@ -1,0 +1,51 @@
+# Marketing Assets
+
+Source images committed here are processed by Astro at build time and emitted
+as multiple formats (AVIF, WebP) at multiple widths (640w, 960w, 1280w, 1920w).
+
+## Usage
+
+Drop a high-resolution source image (PNG or JPG) here, then render it with
+Astro's built-in `<Picture>` component plus the shared defaults:
+
+```astro
+---
+import { Picture } from 'astro:assets'
+import {
+  MARKETING_FORMATS,
+  MARKETING_WIDTHS
+} from '../utils/marketingImage'
+import hero from '../assets/marketing/hero.png'
+---
+<Picture
+  src={hero}
+  alt="ComfyUI workflow preview"
+  formats={[...MARKETING_FORMATS]}
+  widths={[...MARKETING_WIDTHS]}
+  sizes="(max-width: 768px) 100vw, 50vw"
+/>
+```
+
+The component generates a `<picture>` element with `<source>` tags for AVIF
+and WebP, plus an `<img>` fallback. Output files are hashed and emitted under
+`dist/_website/` for long-term caching.
+
+A custom Astro wrapper component is intentionally not provided: Astro's
+discriminated union `LocalImageProps | RemoteImageProps` for `<Picture>` makes
+a thin wrapper that mutates `widths` / `formats` impractical to type safely
+without `as` casts. The shared constants give us the same consistency benefit
+without that cost.
+
+## When to use this vs. `media.comfy.org`
+
+- **Use `src/assets/marketing/`** for static marketing images that are part of
+  page content (hero shots, product imagery, illustrations). Build-time
+  processing gives you AVIF/WebP variants automatically.
+- **Use `media.comfy.org`** for video content, large/changing image libraries
+  (gallery), and anything shared across properties.
+
+## Source image guidelines
+
+- Provide the largest size you'll ever need (≥1920px wide).
+- PNG for screenshots/illustrations with sharp edges; JPG for photographs.
+- Astro will downscale; it will not upscale. Always supply at least 1920w.

--- a/apps/website/src/components/common/SiteVideo.vue
+++ b/apps/website/src/components/common/SiteVideo.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+
+import { buildVideoSources } from '../../utils/video'
+import type { VideoFormat } from '../../utils/video'
+
+const {
+  name,
+  baseUrl,
+  width = 1280,
+  formats = ['webm', 'mp4'],
+  poster,
+  alt,
+  autoplay = false,
+  loop = false,
+  muted = autoplay,
+  controls = false,
+  preload = autoplay ? 'auto' : 'metadata',
+  containerClass,
+  videoClass
+} = defineProps<{
+  name: string
+  baseUrl: string
+  width?: number
+  formats?: VideoFormat[]
+  poster?: string
+  alt?: string
+  autoplay?: boolean
+  loop?: boolean
+  muted?: boolean
+  controls?: boolean
+  preload?: 'auto' | 'metadata' | 'none'
+  containerClass?: string
+  videoClass?: string
+}>()
+
+const sources = buildVideoSources({ name, baseUrl, width, formats })
+</script>
+
+<template>
+  <div :class="cn('relative', containerClass)">
+    <video
+      :class="cn('size-full', videoClass)"
+      :poster
+      :preload
+      :autoplay
+      :loop
+      :muted
+      :controls
+      :aria-label="alt"
+      :aria-hidden="alt ? undefined : true"
+      playsinline
+    >
+      <source
+        v-for="source in sources"
+        :key="source.type"
+        :src="source.src"
+        :type="source.type"
+      />
+    </video>
+  </div>
+</template>

--- a/apps/website/src/components/common/SiteVideo.vue
+++ b/apps/website/src/components/common/SiteVideo.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
+import { computed } from 'vue'
 
-import { buildVideoSources } from '../../utils/video'
+import { buildVideoSources, videoKey } from '../../utils/video'
 import type { VideoFormat } from '../../utils/video'
 
 const {
@@ -34,12 +35,17 @@ const {
   videoClass?: string
 }>()
 
-const sources = buildVideoSources({ name, baseUrl, width, formats })
+const sources = computed(() =>
+  buildVideoSources({ name, baseUrl, width, formats })
+)
+const remountKey = computed(() => videoKey(sources.value))
+const decorative = computed(() => !alt && !controls)
 </script>
 
 <template>
   <div :class="cn('relative', containerClass)">
     <video
+      :key="remountKey"
       :class="cn('size-full', videoClass)"
       :poster
       :preload
@@ -48,12 +54,12 @@ const sources = buildVideoSources({ name, baseUrl, width, formats })
       :muted
       :controls
       :aria-label="alt"
-      :aria-hidden="alt ? undefined : true"
+      :aria-hidden="decorative ? true : undefined"
       playsinline
     >
       <source
         v-for="source in sources"
-        :key="source.type"
+        :key="source.src"
         :src="source.src"
         :type="source.type"
       />

--- a/apps/website/src/utils/marketingImage.ts
+++ b/apps/website/src/utils/marketingImage.ts
@@ -1,0 +1,3 @@
+export const MARKETING_FORMATS = ['avif', 'webp'] as const
+
+export const MARKETING_WIDTHS = [640, 960, 1280, 1920] as const

--- a/apps/website/src/utils/video.test.ts
+++ b/apps/website/src/utils/video.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildVideoSources } from './video'
+
+describe('buildVideoSources', () => {
+  it('builds a source per requested format', () => {
+    const sources = buildVideoSources({
+      name: 'hero',
+      baseUrl: 'https://media.comfy.org/website/marketing',
+      width: 1280,
+      formats: ['webm', 'mp4']
+    })
+
+    expect(sources).toEqual([
+      {
+        src: 'https://media.comfy.org/website/marketing/hero-1280.webm',
+        type: 'video/webm',
+        format: 'webm'
+      },
+      {
+        src: 'https://media.comfy.org/website/marketing/hero-1280.mp4',
+        type: 'video/mp4',
+        format: 'mp4'
+      }
+    ])
+  })
+
+  it('preserves caller-supplied format order', () => {
+    const sources = buildVideoSources({
+      name: 'clip',
+      baseUrl: 'https://cdn.example.com/v',
+      width: 960,
+      formats: ['mp4', 'webm']
+    })
+
+    expect(sources.map((s) => s.format)).toEqual(['mp4', 'webm'])
+  })
+
+  it('strips a single trailing slash from baseUrl', () => {
+    const sources = buildVideoSources({
+      name: 'reel',
+      baseUrl: 'https://media.comfy.org/website/marketing/',
+      width: 1920,
+      formats: ['webm']
+    })
+
+    expect(sources[0]?.src).toBe(
+      'https://media.comfy.org/website/marketing/reel-1920.webm'
+    )
+  })
+
+  it('returns an empty list when no formats are requested', () => {
+    const sources = buildVideoSources({
+      name: 'x',
+      baseUrl: 'https://example.com',
+      width: 640,
+      formats: []
+    })
+
+    expect(sources).toEqual([])
+  })
+})

--- a/apps/website/src/utils/video.test.ts
+++ b/apps/website/src/utils/video.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildVideoSources } from './video'
+import { buildVideoSources, videoKey } from './video'
 
 describe('buildVideoSources', () => {
   it('builds a source per requested format', () => {
@@ -58,5 +58,54 @@ describe('buildVideoSources', () => {
     })
 
     expect(sources).toEqual([])
+  })
+})
+
+describe('videoKey', () => {
+  it('changes when the source URL list changes', () => {
+    const at1280 = buildVideoSources({
+      name: 'hero',
+      baseUrl: 'https://media.comfy.org/m',
+      width: 1280,
+      formats: ['webm', 'mp4']
+    })
+    const at640 = buildVideoSources({
+      name: 'hero',
+      baseUrl: 'https://media.comfy.org/m',
+      width: 640,
+      formats: ['webm', 'mp4']
+    })
+
+    expect(videoKey(at1280)).not.toBe(videoKey(at640))
+  })
+
+  it('is stable across repeated calls with the same inputs', () => {
+    const args = {
+      name: 'hero',
+      baseUrl: 'https://media.comfy.org/m',
+      width: 1280,
+      formats: ['webm', 'mp4'] as const
+    }
+
+    expect(
+      videoKey(buildVideoSources({ ...args, formats: [...args.formats] }))
+    ).toBe(videoKey(buildVideoSources({ ...args, formats: [...args.formats] })))
+  })
+
+  it('reflects format-order changes', () => {
+    const webmFirst = buildVideoSources({
+      name: 'hero',
+      baseUrl: 'https://media.comfy.org/m',
+      width: 1280,
+      formats: ['webm', 'mp4']
+    })
+    const mp4First = buildVideoSources({
+      name: 'hero',
+      baseUrl: 'https://media.comfy.org/m',
+      width: 1280,
+      formats: ['mp4', 'webm']
+    })
+
+    expect(videoKey(webmFirst)).not.toBe(videoKey(mp4First))
   })
 })

--- a/apps/website/src/utils/video.ts
+++ b/apps/website/src/utils/video.ts
@@ -1,0 +1,38 @@
+export type VideoFormat = 'webm' | 'mp4'
+
+export type VideoSource = {
+  src: string
+  type: `video/${VideoFormat}`
+  format: VideoFormat
+}
+
+const MIME_TYPES: Record<VideoFormat, VideoSource['type']> = {
+  webm: 'video/webm',
+  mp4: 'video/mp4'
+}
+
+type BuildArgs = {
+  name: string
+  baseUrl: string
+  width: number
+  formats: VideoFormat[]
+}
+
+/**
+ * Expects assets named `${name}-${width}.${format}` under `${baseUrl}/`,
+ * matching the output of `apps/website/scripts/process-videos.sh`.
+ */
+export function buildVideoSources({
+  name,
+  baseUrl,
+  width,
+  formats
+}: BuildArgs): VideoSource[] {
+  const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+
+  return formats.map((format) => ({
+    src: `${base}/${name}-${width}.${format}`,
+    type: MIME_TYPES[format],
+    format
+  }))
+}

--- a/apps/website/src/utils/video.ts
+++ b/apps/website/src/utils/video.ts
@@ -36,3 +36,12 @@ export function buildVideoSources({
     format
   }))
 }
+
+/**
+ * Stable identifier for a list of video sources, suitable as a Vue `key`.
+ * Browsers do not reload a `<video>` when nested `<source>` children change;
+ * keying the parent forces a remount when the source set changes.
+ */
+export function videoKey(sources: VideoSource[]): string {
+  return sources.map((s) => s.src).join('|')
+}

--- a/apps/website/src/utils/video.ts
+++ b/apps/website/src/utils/video.ts
@@ -1,5 +1,7 @@
+/** @knipIgnoreUsedByStackedPR */
 export type VideoFormat = 'webm' | 'mp4'
 
+/** @knipIgnoreUsedByStackedPR */
 export type VideoSource = {
   src: string
   type: `video/${VideoFormat}`

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -54,6 +54,9 @@ const config: KnipConfig = {
     '.github/workflows/ci-oss-assets-validation.yaml',
     // Pending integration in stacked PR
     'src/components/sidebar/tabs/nodeLibrary/CustomNodesPanel.vue',
+    // Marketing media tooling — adopted by pages in a follow-up PR
+    'apps/website/src/components/common/SiteVideo.vue',
+    'apps/website/src/utils/marketingImage.ts',
     // Agent review check config, not part of the build
     '.agents/checks/eslint.strict.config.js',
     // Devtools extensions, included dynamically


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Adds the building blocks for a responsive media system on `apps/website`, motivated by the gallery video blurriness raised in Slack. Three independent pieces:

1. **`<SiteVideo>` Vue component + URL helper** — emits a `<video>` with multiple `<source>` tags, designed to pair with assets named `${name}-${width}.${format}` on `media.comfy.org`.
2. **`scripts/process-videos.sh`** — local-developer `ffmpeg` helper that produces VP9/WebM + H.264/MP4 variants and a poster JPG. Not wired into CI; the team uploads to `media.comfy.org` out-of-band.
3. **Marketing image conventions** — shared `MARKETING_FORMATS` / `MARKETING_WIDTHS` constants and a README documenting how to render local marketing images via Astro's built-in `<Picture>` from `astro:assets`.

This PR is **infrastructure only** — no existing pages are modified. Adoption (e.g. converting `HeroSection`, gallery videos) is a follow-up. The new files are added to knip's ignore list with the existing "pending stacked PR" pattern.

## Why this shape

- **No custom `<Picture>` wrapper.** Astro 5 already ships a `ResponsiveImage` component (name conflict), and Astro's `LocalImageProps | RemoteImageProps` discriminated union does not survive a thin wrapper without unsafe `as` casts. Shared constants give the consistency benefit at lower cost.
- **No CI media-upload step.** The `Release: Website` workflow currently only refreshes the Ashby snapshot; wiring GCS uploads into it would require new secrets and team coordination beyond this PR's scope. The script runs locally and outputs are uploaded to `media.comfy.org` the same way as today.
- **Single resolution per `<video>`.** `<source media="...">` inside `<video>` is unreliable across browsers (Safari ignores it). The script generates multiple widths so callers can pick one per page; JS-based selection can be layered on later if metrics demand it.

## What's verified

- `pnpm --filter @comfyorg/website test:unit` — 30 pass (7 new for `buildVideoSources` / `videoKey`)
- `pnpm --filter @comfyorg/website typecheck` — clean
- `pnpm --filter @comfyorg/website build` — 41 pages built clean
- `pnpm knip` — exit 0
- `oxfmt --check` and `oxlint` clean on all changed files
- `bash -n` on `process-videos.sh` clean; usage and missing-deps paths exercised manually
- Manual: home page and `/gallery` rendered via `astro dev` — both unchanged with zero console errors (screenshots attached)

## Review feedback addressed

After Oracle review, three follow-up commits land:

- **`SiteVideo` reactivity** — `sources` is now `computed`; the `<video>` is keyed on the joined source URLs so it remounts when the source set changes (browsers don't reload on `<source>` mutation).
- **`SiteVideo` accessibility** — `aria-hidden="true"` only when truly decorative (no `alt` and no `controls`).
- **Shell script robustness** — probes duration with `ffprobe` and falls back to `t=0` for clips shorter than 1s; enables `nocaseglob` so `CLIP.MP4` is picked up.
- **Docs** — clarifies when to use `<SiteVideo>` (lightweight multi-source) vs `<VideoPlayer>` (captions, controls, scrubber).

## Out of scope (follow-ups)

- Converting existing pages (`HeroSection`, customer detail heros, gallery) to use the new components. Most current images are CDN-hosted and migrating them is a separate decision.
- Re-encoding the gallery videos at a higher source width to actually fix the blurriness — that requires the team to run `process-videos.sh` against the source clips and re-upload.
- Combining `<SiteVideo>`'s multi-source support with `<VideoPlayer>`'s rich chrome.

## Screenshots

![Home page renders unchanged with no console errors](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/df0d9bade4eca96daf49f97a3e6864cc74345f430e4a9308e2e68d635dfd8e04/pr-images/1777791647863-fb1ea2bf-32fc-40d9-852d-cceb3bc148f7.png)

![Gallery page renders unchanged with no console errors](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/df0d9bade4eca96daf49f97a3e6864cc74345f430e4a9308e2e68d635dfd8e04/pr-images/1777791648186-0b598260-a836-4866-9c55-9d0e99de6d4c.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11869-feat-website-add-responsive-media-tooling-for-marketing-assets-3556d73d3650818899c7f9ed3204c9a5) by [Unito](https://www.unito.io)
