### PR TITLE
feat: align cloud batch count limit with server-side queue cap

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -659,7 +659,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     tooltip:
       'The maximum number of tasks added to the queue at one button click',
     type: 'number',
-    defaultValue: isCloud ? 32 : 100,
+    defaultValue: 100,
     versionAdded: '1.3.5'
   },
   {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Raises `Comfy.QueueButton.BatchCountLimit` on cloud from `32` to `100` to match the server-side `MaxQueuedJobsPerUser` cap (`cloud/infrastructure/dynamicconfig/prod/config.json:3`). The desktop default was already `100` and is unchanged — collapsing both branches to the same constant.

Addresses Discord feature request: [Increase queue batch limit from 200](https://discord.com/channels/1218270712402415686/1243609826299220039/1499104231381012641).

## Change

```diff
-    defaultValue: isCloud ? 32 : 100,
+    defaultValue: 100,
```

The setting is read dynamically by all batch count UIs (`BatchCountEdit.vue`, `LinearControls.vue`).

## Why 100 (not 512)

Original ask was 200→512. Investigation showed:

- The actual previous default was `100` (desktop) / `32` (cloud), not 200.
- Cloud enforces `MaxQueuedJobsPerUser = 100` per workspace server-side. A higher frontend cap can't unlock more queued work — extra prompts just get rejected with `QUEUE_LIMIT`.
- Frontend submits prompts as N sequential `POST /prompt` calls (no batched-prompt endpoint), so the UI cap is purely about how many clicks it takes — not throughput.
- Going from 32 → 100 lets cloud users match the server cap in one click instead of 4. No new behavior is unlocked.

## Known limitation (pre-existing, not introduced here)

The new max equals the absolute server cap, not the user's remaining capacity. A user with already-queued work can hit `QUEUE_LIMIT` mid-batch. The pre-existing 32 limit had the same shape (just at a smaller scale); deriving the UI max from `cap - outstanding` would require polling and reactive state and is out of scope for a one-line setting bump.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — 0 errors (1 pre-existing warning in unrelated test file)
- `pnpm test:unit` — `BatchCountEdit.test.ts` (3 tests) + `src/platform/settings/**` (70 tests) all pass
- **Manual (Playwright)**:
  - `settingStore.get('Comfy.QueueButton.BatchCountLimit')` returns `100` at runtime
  - Typing `999` into the batch count widget clamps to `100`
  - Increment button is disabled at `100` (max reached)

## Screenshots

![Queue batch count widget set to 100 (the new max). Increment button is disabled because the limit was reached.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/6a01e1ea573fa88f163fb64768a619d250a0b5da26b04249929b8734e04dac57/pr-images/1777863864881-dcc0e33d-e5e7-4a12-9cf3-89af60fd12f6.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11876-feat-align-cloud-batch-count-limit-with-server-side-queue-cap-3566d73d3650819b8d01dbf83d1a8e49) by [Unito](https://www.unito.io)
