### PR TITLE
fix: sanitize null/NaN widget values when loading workflows

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.configure.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.configure.test.ts
@@ -1,0 +1,68 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
+
+function serialisedNode(
+  overrides: Partial<ISerialisedNode> = {}
+): ISerialisedNode {
+  return {
+    id: 1,
+    type: 'TestNode',
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    ...overrides
+  }
+}
+
+describe('LGraphNode.configure numeric widget sanitization', () => {
+  let node: LGraphNode
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    node = new LGraphNode('TestNode')
+  })
+
+  it('preserves default when widgets_values contains null for a number widget', () => {
+    node.addWidget('number', 'seed', 42, null, {})
+
+    // null can appear in widgets_values after JSON round-trip of NaN
+    node.configure(
+      serialisedNode({ widgets_values: [null] as unknown[] as number[] })
+    )
+
+    expect(node.widgets![0].value).toBe(42)
+  })
+
+  it('preserves default when widgets_values contains NaN for a number widget', () => {
+    node.addWidget('number', 'seed', 42, null, {})
+
+    node.configure(serialisedNode({ widgets_values: [NaN] }))
+
+    expect(Number.isNaN(node.widgets![0].value)).toBe(false)
+    expect(node.widgets![0].value).toBe(42)
+  })
+
+  it('still applies valid numeric values normally', () => {
+    node.addWidget('number', 'seed', 42, null, {})
+
+    node.configure(serialisedNode({ widgets_values: [99999] }))
+
+    expect(node.widgets![0].value).toBe(99999)
+  })
+
+  it('does not sanitize null for non-numeric widget types', () => {
+    node.addWidget('text', 'prompt', 'default text', null, {})
+
+    node.configure(
+      serialisedNode({ widgets_values: [null] as unknown[] as string[] })
+    )
+
+    expect(node.widgets![0].value).toBeNull()
+  })
+})

--- a/src/lib/litegraph/src/LGraphNode.configure.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.configure.test.ts
@@ -1,12 +1,15 @@
-import { createTestingPinia } from '@pinia/testing'
-import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedNode } from '@/lib/litegraph/src/types/serialisation'
 
+// Mirrors JSON.stringify(NaN) === "null" — the real source of null in workflows.
+const roundTrip = <T>(v: T): T => JSON.parse(JSON.stringify(v))
+
 function serialisedNode(
-  overrides: Partial<ISerialisedNode> = {}
+  overrides: Partial<Omit<ISerialisedNode, 'widgets_values'>> & {
+    widgets_values?: unknown[]
+  } = {}
 ): ISerialisedNode {
   return {
     id: 1,
@@ -17,24 +20,20 @@ function serialisedNode(
     order: 0,
     mode: 0,
     ...overrides
-  }
+  } as ISerialisedNode
 }
 
 describe('LGraphNode.configure numeric widget sanitization', () => {
   let node: LGraphNode
 
   beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
     node = new LGraphNode('TestNode')
   })
 
   it('preserves default when widgets_values contains null for a number widget', () => {
     node.addWidget('number', 'seed', 42, null, {})
 
-    // null can appear in widgets_values after JSON round-trip of NaN
-    node.configure(
-      serialisedNode({ widgets_values: [null] as unknown[] as number[] })
-    )
+    node.configure(serialisedNode({ widgets_values: roundTrip([NaN]) }))
 
     expect(node.widgets![0].value).toBe(42)
   })
@@ -59,20 +58,31 @@ describe('LGraphNode.configure numeric widget sanitization', () => {
   it('preserves default when widgets_values contains null for a gradientslider widget', () => {
     node.addWidget('gradientslider', 'denoise', 0.75, null, {})
 
-    node.configure(
-      serialisedNode({ widgets_values: [null] as unknown[] as number[] })
-    )
+    node.configure(serialisedNode({ widgets_values: roundTrip([NaN]) }))
 
     expect(node.widgets![0].value).toBe(0.75)
   })
 
   it('does not sanitize null for non-numeric widget types', () => {
+    // TODO: null from a serialized workflow probably should not clobber text
+    // widgets either; this test documents the current intentional scope limit.
     node.addWidget('text', 'prompt', 'default text', null, {})
 
-    node.configure(
-      serialisedNode({ widgets_values: [null] as unknown[] as string[] })
-    )
+    node.configure(serialisedNode({ widgets_values: [null] }))
 
     expect(node.widgets![0].value).toBeNull()
+  })
+
+  it('preserves correct slot ordering when a non-serialized widget precedes a sanitized numeric widget', () => {
+    // widget A has serialize:false and must not consume a slot in widgets_values
+    const widgetA = node.addWidget('text', 'label', 'hello', null, {})
+    widgetA.serialize = false
+    node.addWidget('number', 'seed', 42, null, {})
+
+    // widgets_values has one entry — for the number widget only
+    node.configure(serialisedNode({ widgets_values: roundTrip([NaN]) }))
+
+    expect(node.widgets![0].value).toBe('hello') // non-serialized, untouched
+    expect(node.widgets![1].value).toBe(42) // sanitized, default preserved
   })
 })

--- a/src/lib/litegraph/src/LGraphNode.configure.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.configure.test.ts
@@ -56,6 +56,16 @@ describe('LGraphNode.configure numeric widget sanitization', () => {
     expect(node.widgets![0].value).toBe(99999)
   })
 
+  it('preserves default when widgets_values contains null for a gradientslider widget', () => {
+    node.addWidget('gradientslider', 'denoise', 0.75, null, {})
+
+    node.configure(
+      serialisedNode({ widgets_values: [null] as unknown[] as number[] })
+    )
+
+    expect(node.widgets![0].value).toBe(0.75)
+  })
+
   it('does not sanitize null for non-numeric widget types', () => {
     node.addWidget('text', 'prompt', 'default text', null, {})
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -93,7 +93,7 @@ import { warnDeprecated } from './utils/feedback'
 import { distributeSpace } from './utils/spaceDistribution'
 import { truncateText } from './utils/textUtils'
 import { BaseWidget } from './widgets/BaseWidget'
-import { toConcreteWidget } from './widgets/widgetMap'
+import { isNumericWidget, toConcreteWidget } from './widgets/widgetMap'
 import type { WidgetTypeMap } from './widgets/widgetMap'
 
 // #region Types
@@ -920,19 +920,11 @@ export class LGraphNode
           if (widget.serialize === false) continue
           if (i >= info.widgets_values.length) break
           const incoming = info.widgets_values[i++]
-          const isNumeric = [
-            'number',
-            'slider',
-            'gradientslider',
-            'knob'
-          ].includes(widget.type)
           const isInvalid =
-            incoming === null ||
-            incoming === undefined ||
+            incoming == null ||
             (typeof incoming === 'number' && !Number.isFinite(incoming))
-          if (!(isNumeric && isInvalid)) {
-            widget.value = incoming
-          }
+          if (isNumericWidget(widget) && isInvalid) continue
+          widget.value = incoming
         }
       }
     }

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -919,7 +919,15 @@ export class LGraphNode
         for (const widget of this.widgets ?? []) {
           if (widget.serialize === false) continue
           if (i >= info.widgets_values.length) break
-          widget.value = info.widgets_values[i++]
+          const incoming = info.widgets_values[i++]
+          const isNumeric = ['number', 'slider', 'knob'].includes(widget.type)
+          const isInvalid =
+            incoming === null ||
+            incoming === undefined ||
+            (typeof incoming === 'number' && !Number.isFinite(incoming))
+          if (!(isNumeric && isInvalid)) {
+            widget.value = incoming
+          }
         }
       }
     }

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -920,7 +920,12 @@ export class LGraphNode
           if (widget.serialize === false) continue
           if (i >= info.widgets_values.length) break
           const incoming = info.widgets_values[i++]
-          const isNumeric = ['number', 'slider', 'knob'].includes(widget.type)
+          const isNumeric = [
+            'number',
+            'slider',
+            'gradientslider',
+            'knob'
+          ].includes(widget.type)
           const isInvalid =
             incoming === null ||
             incoming === undefined ||

--- a/src/lib/litegraph/src/widgets/widgetMap.ts
+++ b/src/lib/litegraph/src/widgets/widgetMap.ts
@@ -165,4 +165,16 @@ export function isAssetWidget(widget: IBaseWidget): widget is IAssetWidget {
   return widget.type === 'asset'
 }
 
+const NUMERIC_WIDGET_TYPES = new Set<string>([
+  'number',
+  'slider',
+  'gradientslider',
+  'knob'
+])
+
+/** Returns true when the widget's value must be a finite number (rejects null/NaN). */
+export function isNumericWidget(widget: IBaseWidget): boolean {
+  return NUMERIC_WIDGET_TYPES.has(widget.type)
+}
+
 // #endregion Type Guards


### PR DESCRIPTION
## Summary

When a workflow JSON contains `null` in `widgets_values` for a numeric widget (which happens when a widget's value is `NaN` and gets JSON-serialized — `JSON.stringify(NaN) === "null"`), the value was directly assigned to the widget without any sanitization.

With `control_after_generate` set to `fixed`, the `null` value is preserved through `graphToPrompt` and sent to the backend as `null`, causing:

```
int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

**Root cause:** `LGraphNode.configure` (`LGraphNode.ts:922`) had no guard against `null`/`NaN` in `widgets_values` for numeric widget types.

**Fix:** In the configure loop, skip the assignment when the incoming value is `null`/`undefined`/`NaN` and the widget is a numeric type (`number`, `slider`, `knob`). The widget retains its initial default value instead.

## Red-Green Verification

| Commit | Purpose |
|--------|---------|
| `test: add failing tests for null/NaN numeric widget value sanitization on configure` | Proves the test catches the bug (CI red) |
| `fix: sanitize null/NaN widget values when loading workflows` | Proves the fix resolves the bug (CI green) |

## Test Plan
before
<img width="1892" height="764" alt="Screenshot 2026-05-03 at 8 56 31 PM" src="https://github.com/user-attachments/assets/6e32a255-d522-4d22-825a-249fca4e3422" />
after
<img width="1103" height="862" alt="Screenshot 2026-05-03 at 9 05 57 PM" src="https://github.com/user-attachments/assets/30b52c25-3154-4250-9e63-c78dbd043f5d" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes workflow deserialization to skip invalid values only for numeric widget types, with focused unit tests; main risk is edge cases where some nodes previously relied on null/NaN being applied.
> 
> **Overview**
> Fixes workflow loading so `LGraphNode.configure` no longer overwrites *numeric* widget defaults when `widgets_values` contains `null`/`undefined` or non-finite numbers (e.g. `NaN` serialized as `null`).
> 
> Adds `isNumericWidget` (covering `number`, `slider`, `gradientslider`, `knob`) and introduces tests verifying defaults are preserved for invalid numeric values, valid numbers still apply, non-numeric widgets are unaffected, and `serialize:false` widgets don’t break `widgets_values` slot ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d610c4fec5f350ab033f9c806a64a674300bf04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->