### PR TITLE
test: add public input missing media regression coverage

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMedia.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMedia.spec.ts
@@ -1,9 +1,62 @@
 import { expect } from '@playwright/test'
+import type { Route } from '@playwright/test'
 
+import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
-import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { STABLE_INPUT_IMAGE } from '@e2e/fixtures/data/assetFixtures'
 import { TestIds } from '@e2e/fixtures/selectors'
-import { loadWorkflowAndOpenErrorsTab } from '@e2e/fixtures/helpers/ErrorsTabHelper'
+import {
+  loadWorkflowAndOpenErrorsTab,
+  openErrorsTab
+} from '@e2e/fixtures/helpers/ErrorsTabHelper'
+
+const test = comfyPageFixture
+const PUBLIC_INPUT_ASSET_HASH = 'nonexistent_test_image_12345.png'
+const PUBLIC_INPUT_ASSET: Asset = {
+  ...STABLE_INPUT_IMAGE,
+  id: 'test-public-input-001',
+  name: 'public_reference_photo.png',
+  asset_hash: PUBLIC_INPUT_ASSET_HASH
+}
+
+function makeAssetsResponse(assets: Asset[]): ListAssetsResponse {
+  return { assets, total: assets.length, has_more: false }
+}
+
+const cloudTest = comfyPageFixture.extend<{
+  cloudAssetRequests: string[]
+  stubCloudAssets: void
+}>({
+  cloudAssetRequests: async ({ page: _page }, use) => {
+    await use([])
+  },
+  stubCloudAssets: [
+    async ({ cloudAssetRequests, page }, use) => {
+      const assetsRoutePattern = /\/api\/assets(?:\?.*)?$/
+      const assetsRouteHandler = (route: Route) => {
+        const url = new URL(route.request().url())
+        const includeTags = url.searchParams.get('include_tags') ?? ''
+        const tags = includeTags.split(',').filter(Boolean)
+        const includePublic = url.searchParams.get('include_public') === 'true'
+        const assets =
+          tags.includes('input') && includePublic ? [PUBLIC_INPUT_ASSET] : []
+
+        cloudAssetRequests.push(route.request().url())
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(makeAssetsResponse(assets))
+        })
+      }
+
+      await page.route(assetsRoutePattern, assetsRouteHandler)
+      await use()
+      await page.unroute(assetsRoutePattern, assetsRouteHandler)
+    },
+    { auto: true }
+  ]
+})
 
 async function uploadFileViaDropzone(comfyPage: ComfyPage) {
   const dropzone = comfyPage.page.getByTestId(
@@ -203,3 +256,44 @@ test.describe('Errors tab - Missing media', { tag: '@ui' }, () => {
     })
   })
 })
+
+cloudTest.describe(
+  'Errors tab - Missing media cloud assets',
+  {
+    tag: '@cloud'
+  },
+  () => {
+    cloudTest.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.RightSidePanel.ShowErrorsTab',
+        true
+      )
+    })
+
+    cloudTest(
+      'does not report public input assets as missing',
+      async ({ cloudAssetRequests, comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('missing/missing_media_single')
+
+        await expect
+          .poll(() =>
+            cloudAssetRequests.some((requestUrl) => {
+              const url = new URL(requestUrl)
+              const includeTags = url.searchParams.get('include_tags') ?? ''
+              return (
+                includeTags.split(',').includes('input') &&
+                url.searchParams.get('include_public') === 'true'
+              )
+            })
+          )
+          .toBe(true)
+
+        await openErrorsTab(comfyPage)
+
+        await expect(
+          comfyPage.page.getByTestId(TestIds.dialogs.missingMediaGroup)
+        ).toBeHidden()
+      }
+    )
+  }
+)

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMedia.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMedia.spec.ts
@@ -6,10 +6,8 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import { STABLE_INPUT_IMAGE } from '@e2e/fixtures/data/assetFixtures'
 import { TestIds } from '@e2e/fixtures/selectors'
-import {
-  loadWorkflowAndOpenErrorsTab,
-  openErrorsTab
-} from '@e2e/fixtures/helpers/ErrorsTabHelper'
+import { loadWorkflowAndOpenErrorsTab } from '@e2e/fixtures/helpers/ErrorsTabHelper'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
 
 const test = comfyPageFixture
 const PUBLIC_INPUT_ASSET_HASH = 'nonexistent_test_image_12345.png'
@@ -288,7 +286,12 @@ cloudTest.describe(
           )
           .toBe(true)
 
-        await openErrorsTab(comfyPage)
+        const panel = new PropertiesPanelHelper(comfyPage.page)
+        await panel.open(comfyPage.actionbar.propertiesButton)
+
+        await expect(
+          comfyPage.page.getByTestId(TestIds.propertiesPanel.errorsTab)
+        ).toBeHidden()
 
         await expect(
           comfyPage.page.getByTestId(TestIds.dialogs.missingMediaGroup)

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -1,3 +1,4 @@
+import { zListAssetsResponse } from '@comfyorg/ingest-types/zod'
 import { z } from 'zod'
 
 // Zod schemas for asset API validation matching ComfyUI Assets REST API spec
@@ -21,9 +22,9 @@ const zAsset = z.object({
 })
 
 const zAssetResponse = z.object({
-  assets: z.array(zAsset).optional(),
-  total: z.number().optional(),
-  has_more: z.boolean().optional()
+  assets: z.array(zAsset),
+  total: zListAssetsResponse.shape.total,
+  has_more: zListAssetsResponse.shape.has_more
 })
 
 const zModelFolder = z.object({

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -64,6 +64,16 @@ function buildResponse(
   } as unknown as Response
 }
 
+function buildAssetListResponse(
+  assets: AssetItem[],
+  {
+    hasMore = false,
+    total = assets.length
+  }: { hasMore?: boolean; total?: number } = {}
+): Response {
+  return buildResponse({ assets, total, has_more: hasMore })
+}
+
 function validAsset(overrides: Partial<AssetItem> = {}): AssetItem {
   return {
     id: 'asset-1',
@@ -218,7 +228,7 @@ describe(assetService.uploadAssetFromUrl, () => {
     const staleAssets = [validAsset({ id: 'stale-input', tags: ['input'] })]
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(buildResponse({ id: 'missing-name' }))
 
     await assetService.getInputAssetsIncludingPublic()
@@ -240,7 +250,7 @@ describe(assetService.uploadAssetFromUrl, () => {
     const staleAssets = [validAsset({ id: 'stale-input', tags: ['input'] })]
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(
         buildResponse(validAsset({ id: 'uploaded-input', tags: ['input'] }))
       )
@@ -301,7 +311,7 @@ describe(assetService.uploadAssetFromBase64, () => {
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response('hello'))
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(buildResponse({ id: 'missing-name' }))
 
     await assetService.getInputAssetsIncludingPublic()
@@ -327,7 +337,7 @@ describe(assetService.uploadAssetFromBase64, () => {
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response('hello'))
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(
         buildResponse({
           ...validAsset({ id: 'uploaded-input', tags: ['input'] }),
@@ -423,15 +433,13 @@ describe(assetService.getAssetModelFolders, () => {
 
   it('filters out missing-tagged assets and blacklisted directories, returning alphabetical unique folders without include_public', async () => {
     fetchApiMock.mockResolvedValueOnce(
-      buildResponse({
-        assets: [
-          validAsset({ id: 'a', tags: ['models', 'loras'] }),
-          validAsset({ id: 'b', tags: ['models', 'checkpoints'] }),
-          validAsset({ id: 'c', tags: ['models', 'configs'] }),
-          validAsset({ id: 'd', tags: ['models', 'missing', 'controlnet'] }),
-          validAsset({ id: 'e', tags: ['models', 'loras'] })
-        ]
-      })
+      buildAssetListResponse([
+        validAsset({ id: 'a', tags: ['models', 'loras'] }),
+        validAsset({ id: 'b', tags: ['models', 'checkpoints'] }),
+        validAsset({ id: 'c', tags: ['models', 'configs'] }),
+        validAsset({ id: 'd', tags: ['models', 'missing', 'controlnet'] }),
+        validAsset({ id: 'e', tags: ['models', 'loras'] })
+      ])
     )
 
     const folders = await assetService.getAssetModelFolders()
@@ -492,12 +500,10 @@ describe(assetService.getAssetsByTag, () => {
 
   it('forwards include_public=true by default and excludes missing-tagged assets', async () => {
     fetchApiMock.mockResolvedValueOnce(
-      buildResponse({
-        assets: [
-          validAsset({ id: 'visible', tags: ['input'] }),
-          validAsset({ id: 'hidden', tags: ['input', 'missing'] })
-        ]
-      })
+      buildAssetListResponse([
+        validAsset({ id: 'visible', tags: ['input'] }),
+        validAsset({ id: 'hidden', tags: ['input', 'missing'] })
+      ])
     )
 
     const assets = await assetService.getAssetsByTag('input')
@@ -518,17 +524,16 @@ describe(assetService.getAllAssetsByTag, () => {
   it('paginates tagged asset requests with include_public=true', async () => {
     fetchApiMock
       .mockResolvedValueOnce(
-        buildResponse({
-          assets: [
+        buildAssetListResponse(
+          [
             validAsset({ id: 'a', tags: ['input'] }),
             validAsset({ id: 'b', tags: ['input'] })
-          ]
-        })
+          ],
+          { hasMore: true }
+        )
       )
       .mockResolvedValueOnce(
-        buildResponse({
-          assets: [validAsset({ id: 'c', tags: ['input'] })]
-        })
+        buildAssetListResponse([validAsset({ id: 'c', tags: ['input'] })])
       )
 
     const assets = await assetService.getAllAssetsByTag('input', true, {
@@ -553,17 +558,18 @@ describe(assetService.getAllAssetsByTag, () => {
   it('paginates from raw response size before filtering missing-tagged assets', async () => {
     fetchApiMock
       .mockResolvedValueOnce(
-        buildResponse({
-          assets: [
+        buildAssetListResponse(
+          [
             validAsset({ id: 'visible', tags: ['input'] }),
             validAsset({ id: 'hidden', tags: ['input', MISSING_TAG] })
-          ]
-        })
+          ],
+          { hasMore: true }
+        )
       )
       .mockResolvedValueOnce(
-        buildResponse({
-          assets: [validAsset({ id: 'later-public', tags: ['input'] })]
-        })
+        buildAssetListResponse([
+          validAsset({ id: 'later-public', tags: ['input'] })
+        ])
       )
 
     const assets = await assetService.getAllAssetsByTag('input', true, {
@@ -584,23 +590,22 @@ describe(assetService.getAllAssetsByTag, () => {
   it('honors has_more when walking tagged asset pages', async () => {
     fetchApiMock
       .mockResolvedValueOnce(
-        buildResponse({
-          assets: [
+        buildAssetListResponse(
+          [
             validAsset({ id: 'first', tags: ['input'] }),
             validAsset({ id: 'second', tags: ['input'] })
           ],
-          has_more: true
-        })
+          { hasMore: true }
+        )
       )
       .mockResolvedValueOnce(
-        buildResponse({
-          assets: [validAsset({ id: 'later-public', tags: ['input'] })],
-          has_more: false
-        })
+        buildAssetListResponse([
+          validAsset({ id: 'later-public', tags: ['input'] })
+        ])
       )
 
     const assets = await assetService.getAllAssetsByTag('input', true, {
-      limit: 3
+      limit: 2
     })
 
     expect(assets.map((a) => a.id)).toEqual(['first', 'second', 'later-public'])
@@ -614,12 +619,23 @@ describe(assetService.getAllAssetsByTag, () => {
     expect(secondParams.get('offset')).toBe('2')
   })
 
+  it('rejects tagged asset pages without has_more', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildResponse({
+        assets: [validAsset({ id: 'a', tags: ['input'] })],
+        total: 1
+      })
+    )
+
+    await expect(
+      assetService.getAllAssetsByTag('input', true, { limit: 2 })
+    ).rejects.toThrow(/Invalid asset response/)
+  })
+
   it('passes abort signals through paginated requests', async () => {
     const controller = new AbortController()
     fetchApiMock.mockResolvedValueOnce(
-      buildResponse({
-        assets: [validAsset({ id: 'a', tags: ['input'] })]
-      })
+      buildAssetListResponse([validAsset({ id: 'a', tags: ['input'] })])
     )
 
     await assetService.getAllAssetsByTag('input', true, {
@@ -636,12 +652,13 @@ describe(assetService.getAllAssetsByTag, () => {
     const controller = new AbortController()
     fetchApiMock.mockImplementationOnce(async () => {
       controller.abort()
-      return buildResponse({
-        assets: [
+      return buildAssetListResponse(
+        [
           validAsset({ id: 'a', tags: ['input'] }),
           validAsset({ id: 'b', tags: ['input'] })
-        ]
-      })
+        ],
+        { hasMore: true }
+      )
     })
 
     await expect(
@@ -666,7 +683,7 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
       validAsset({ id: 'user-input', tags: ['input'] }),
       validAsset({ id: 'public-input', tags: ['input'], is_immutable: true })
     ]
-    fetchApiMock.mockResolvedValueOnce(buildResponse({ assets }))
+    fetchApiMock.mockResolvedValueOnce(buildAssetListResponse(assets))
 
     const first = await assetService.getInputAssetsIncludingPublic()
     const second = await assetService.getInputAssetsIncludingPublic()
@@ -685,8 +702,8 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
     const staleAssets = [validAsset({ id: 'stale-input', tags: ['input'] })]
     const freshAssets = [validAsset({ id: 'fresh-input', tags: ['input'] })]
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
-      .mockResolvedValueOnce(buildResponse({ assets: freshAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
+      .mockResolvedValueOnce(buildAssetListResponse(freshAssets))
 
     await assetService.getInputAssetsIncludingPublic()
     assetService.invalidateInputAssetsIncludingPublic()
@@ -720,7 +737,7 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
     await expect(first).rejects.toMatchObject({ name: 'AbortError' })
     expect(serviceSignal).toBeUndefined()
 
-    resolveResponse(buildResponse({ assets }))
+    resolveResponse(buildAssetListResponse(assets))
 
     await expect(second).resolves.toEqual(assets)
     expect(fetchApiMock).toHaveBeenCalledOnce()
@@ -750,7 +767,7 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
     await expect(first).rejects.toMatchObject({ name: 'AbortError' })
     await expect(second).rejects.toMatchObject({ name: 'AbortError' })
 
-    resolveResponse(buildResponse({ assets }))
+    resolveResponse(buildAssetListResponse(assets))
     await Promise.resolve()
 
     await expect(assetService.getInputAssetsIncludingPublic()).resolves.toEqual(
@@ -770,12 +787,12 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
             resolveResponse = resolve
           })
       )
-      .mockResolvedValueOnce(buildResponse({ assets: freshAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(freshAssets))
 
     const inFlight = assetService.getInputAssetsIncludingPublic()
     assetService.invalidateInputAssetsIncludingPublic()
 
-    resolveResponse(buildResponse({ assets }))
+    resolveResponse(buildAssetListResponse(assets))
 
     await expect(inFlight).resolves.toEqual(assets)
     await expect(assetService.getInputAssetsIncludingPublic()).resolves.toEqual(
@@ -788,9 +805,9 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
     const staleAssets = [validAsset({ id: 'stale-input', tags: ['input'] })]
     const freshAssets = [validAsset({ id: 'fresh-input', tags: ['input'] })]
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(buildResponse(null))
-      .mockResolvedValueOnce(buildResponse({ assets: freshAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(freshAssets))
 
     await assetService.getInputAssetsIncludingPublic()
     await assetService.deleteAsset('stale-input')
@@ -809,9 +826,9 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
     const uploadedAsset = validAsset({ id: 'uploaded-input', tags: ['input'] })
     const freshAssets = [uploadedAsset]
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(buildResponse(uploadedAsset))
-      .mockResolvedValueOnce(buildResponse({ assets: freshAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(freshAssets))
 
     await assetService.getInputAssetsIncludingPublic()
     await assetService.uploadAssetAsync({
@@ -827,7 +844,7 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
   it('does not invalidate cached input assets for pending async input uploads', async () => {
     const staleAssets = [validAsset({ id: 'stale-input', tags: ['input'] })]
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(
         buildResponse(
           { task_id: 'task-1', status: 'running' },
@@ -849,7 +866,7 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
   it('does not invalidate cached input assets for non-input uploads', async () => {
     const staleAssets = [validAsset({ id: 'stale-input', tags: ['input'] })]
     fetchApiMock
-      .mockResolvedValueOnce(buildResponse({ assets: staleAssets }))
+      .mockResolvedValueOnce(buildAssetListResponse(staleAssets))
       .mockResolvedValueOnce(buildResponse(validAsset({ tags: ['models'] })))
 
     await assetService.getInputAssetsIncludingPublic()

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -473,11 +473,8 @@ function createAssetService() {
     }
     const data = await res.json()
 
-    // Validate the single asset response against our schema
-    const result = assetResponseSchema.safeParse({ assets: [data] })
-    if (result.success && result.data.assets?.[0]) {
-      return result.data.assets[0]
-    }
+    const result = assetItemSchema.safeParse(data)
+    if (result.success) return result.data
 
     const error = result.error
       ? fromZodError(result.error)
@@ -548,10 +545,7 @@ function createAssetService() {
       const batch = data.assets ?? []
       assets.push(...batch.filter((asset) => !asset.tags.includes(MISSING_TAG)))
 
-      const noMoreFromServer = data.has_more === false
-      const inferredLastPage =
-        data.has_more === undefined && batch.length < pageSize
-      if (batch.length === 0 || noMoreFromServer || inferredLastPage) {
+      if (batch.length === 0 || !data.has_more) {
         return assets
       }
 

--- a/src/platform/assets/utils/assetHashVerification.test.ts
+++ b/src/platform/assets/utils/assetHashVerification.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { verifyCandidatesByAssetHash } from './assetHashVerification'
+
+interface Candidate {
+  id: string
+  hash: string | null
+}
+
+function candidate(id: string, hash: string | null): Candidate {
+  return { id, hash }
+}
+
+describe(verifyCandidatesByAssetHash, () => {
+  it('deduplicates hash checks and groups existing and missing candidates', async () => {
+    const existingHash = 'blake3:existing'
+    const missingHash = 'blake3:missing'
+    const candidates = [
+      candidate('a', existingHash),
+      candidate('b', existingHash),
+      candidate('c', missingHash)
+    ]
+    const checkAssetHash = vi.fn(async (hash: string) =>
+      hash === existingHash ? ('exists' as const) : ('missing' as const)
+    )
+
+    const result = await verifyCandidatesByAssetHash({
+      candidates,
+      getAssetHash: (candidate) => candidate.hash,
+      checkAssetHash
+    })
+
+    expect(result.aborted).toBe(false)
+    expect(result.existing.map((candidate) => candidate.id)).toEqual(['a', 'b'])
+    expect(result.missing.map((candidate) => candidate.id)).toEqual(['c'])
+    expect(result.fallback).toEqual([])
+    expect(checkAssetHash).toHaveBeenCalledTimes(2)
+  })
+
+  it('routes candidates without hashes and invalid hashes to fallback', async () => {
+    const invalidHash = 'blake3:invalid'
+    const candidates = [candidate('a', null), candidate('b', invalidHash)]
+    const checkAssetHash = vi.fn(async () => 'invalid' as const)
+
+    const result = await verifyCandidatesByAssetHash({
+      candidates,
+      getAssetHash: (candidate) => candidate.hash,
+      checkAssetHash
+    })
+
+    expect(result.existing).toEqual([])
+    expect(result.missing).toEqual([])
+    expect(result.fallback.map((candidate) => candidate.id)).toEqual(['a', 'b'])
+    expect(checkAssetHash).toHaveBeenCalledOnce()
+  })
+
+  it('routes non-abort verification failures to fallback', async () => {
+    const candidates = [candidate('a', 'blake3:network-failure')]
+    const error = new Error('network failed')
+    const onError = vi.fn()
+
+    const result = await verifyCandidatesByAssetHash({
+      candidates,
+      getAssetHash: (candidate) => candidate.hash,
+      checkAssetHash: async () => {
+        throw error
+      },
+      onError
+    })
+
+    expect(result.fallback).toEqual(candidates)
+    expect(result.aborted).toBe(false)
+    expect(onError).toHaveBeenCalledWith(error)
+  })
+
+  it('returns aborted without resolving candidates when the signal is aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const candidates = [candidate('a', 'blake3:aborted')]
+    const checkAssetHash = vi.fn(async () => 'exists' as const)
+
+    const result = await verifyCandidatesByAssetHash({
+      candidates,
+      getAssetHash: (candidate) => candidate.hash,
+      checkAssetHash,
+      signal: controller.signal
+    })
+
+    expect(result).toEqual({
+      existing: [],
+      missing: [],
+      fallback: [],
+      aborted: true
+    })
+    expect(checkAssetHash).not.toHaveBeenCalled()
+  })
+
+  it('silences abort errors from hash verification', async () => {
+    const candidates = [candidate('a', 'blake3:aborted')]
+    const onError = vi.fn()
+
+    const result = await verifyCandidatesByAssetHash({
+      candidates,
+      getAssetHash: (candidate) => candidate.hash,
+      checkAssetHash: async () => {
+        throw new DOMException('aborted', 'AbortError')
+      },
+      onError
+    })
+
+    expect(result.aborted).toBe(true)
+    expect(result.existing).toEqual([])
+    expect(result.missing).toEqual([])
+    expect(result.fallback).toEqual([])
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('caps concurrent hash checks', async () => {
+    let activeChecks = 0
+    let maxActiveChecks = 0
+    const candidates = Array.from({ length: 6 }, (_, index) =>
+      candidate(String(index), `blake3:${index}`)
+    )
+
+    await verifyCandidatesByAssetHash({
+      candidates,
+      getAssetHash: (candidate) => candidate.hash,
+      maxConcurrent: 2,
+      checkAssetHash: async () => {
+        activeChecks++
+        maxActiveChecks = Math.max(maxActiveChecks, activeChecks)
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        activeChecks--
+        return 'missing'
+      }
+    })
+
+    expect(maxActiveChecks).toBeLessThanOrEqual(2)
+  })
+})

--- a/src/platform/assets/utils/assetHashVerification.ts
+++ b/src/platform/assets/utils/assetHashVerification.ts
@@ -1,0 +1,111 @@
+import type { AssetHashStatus } from '@/platform/assets/services/assetService'
+import { isAbortError } from '@/utils/typeGuardUtil'
+
+export type AssetHashVerifier = (
+  assetHash: string,
+  signal?: AbortSignal
+) => Promise<AssetHashStatus>
+
+interface AssetHashVerificationResult<T> {
+  existing: T[]
+  missing: T[]
+  fallback: T[]
+  aborted: boolean
+}
+
+interface VerifyCandidatesByAssetHashOptions<T> {
+  candidates: readonly T[]
+  getAssetHash: (candidate: T) => string | null
+  checkAssetHash: AssetHashVerifier
+  signal?: AbortSignal
+  maxConcurrent?: number
+  onError?: (error: unknown) => void
+}
+
+const DEFAULT_MAX_CONCURRENT_HASH_CHECKS = 12
+
+export async function verifyCandidatesByAssetHash<T>({
+  candidates,
+  getAssetHash,
+  checkAssetHash,
+  signal,
+  maxConcurrent = DEFAULT_MAX_CONCURRENT_HASH_CHECKS,
+  onError
+}: VerifyCandidatesByAssetHashOptions<T>): Promise<
+  AssetHashVerificationResult<T>
+> {
+  const result: AssetHashVerificationResult<T> = {
+    existing: [],
+    missing: [],
+    fallback: [],
+    aborted: false
+  }
+
+  if (signal?.aborted) return { ...result, aborted: true }
+
+  const candidatesByHash = new Map<string, T[]>()
+  for (const candidate of candidates) {
+    const assetHash = getAssetHash(candidate)
+    if (!assetHash) {
+      result.fallback.push(candidate)
+      continue
+    }
+
+    const hashCandidates = candidatesByHash.get(assetHash)
+    if (hashCandidates) hashCandidates.push(candidate)
+    else candidatesByHash.set(assetHash, [candidate])
+  }
+
+  const entries = [...candidatesByHash.entries()]
+  let nextIndex = 0
+  const workerCount = Math.min(
+    entries.length,
+    Math.max(1, Math.floor(maxConcurrent))
+  )
+
+  async function verifyNextHash(): Promise<void> {
+    while (!result.aborted && nextIndex < entries.length) {
+      const entry = entries[nextIndex++]
+      if (!entry) return
+
+      const [assetHash, hashCandidates] = entry
+      if (signal?.aborted) {
+        result.aborted = true
+        return
+      }
+
+      let status: AssetHashStatus
+      try {
+        status = await checkAssetHash(assetHash, signal)
+      } catch (error) {
+        if (signal?.aborted || isAbortError(error)) {
+          result.aborted = true
+          return
+        }
+
+        onError?.(error)
+        result.fallback.push(...hashCandidates)
+        continue
+      }
+
+      if (signal?.aborted) {
+        result.aborted = true
+        return
+      }
+
+      if (status === 'exists') {
+        result.existing.push(...hashCandidates)
+      } else if (status === 'missing') {
+        result.missing.push(...hashCandidates)
+      } else {
+        result.fallback.push(...hashCandidates)
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => await verifyNextHash())
+  )
+
+  return result
+}

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -403,8 +403,7 @@ describe('verifyCloudMediaCandidates', () => {
   })
 
   it('silences aborts while loading legacy fallback input assets', async () => {
-    const abortError = new Error('aborted')
-    abortError.name = 'AbortError'
+    const abortError = new DOMException('aborted', 'AbortError')
     const controller = new AbortController()
     const candidates = [
       makeCandidate('1', 'photo.png', { isMissing: undefined })
@@ -427,8 +426,7 @@ describe('verifyCloudMediaCandidates', () => {
   })
 
   it('silences aborts from the default legacy fallback input asset store path', async () => {
-    const abortError = new Error('aborted')
-    abortError.name = 'AbortError'
+    const abortError = new DOMException('aborted', 'AbortError')
     const controller = new AbortController()
     const candidates = [
       makeCandidate('1', 'photo.png', { isMissing: undefined })

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -19,11 +19,13 @@ import {
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { resolveComboValues } from '@/utils/litegraphUtil'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import type { AssetHashStatus } from '@/platform/assets/services/assetService'
 import {
   assetService,
   isBlake3AssetHash
 } from '@/platform/assets/services/assetService'
+import { verifyCandidatesByAssetHash } from '@/platform/assets/utils/assetHashVerification'
+import type { AssetHashVerifier } from '@/platform/assets/utils/assetHashVerification'
+import { isAbortError } from '@/utils/typeGuardUtil'
 
 /** Map of node types to their media widget name and media type. */
 const MEDIA_NODE_WIDGETS: Record<
@@ -112,69 +114,7 @@ export function scanNodeMediaCandidates(
   return candidates
 }
 
-type AssetHashVerifier = (
-  assetHash: string,
-  signal?: AbortSignal
-) => Promise<AssetHashStatus>
-
 type InputAssetFetcher = (signal?: AbortSignal) => Promise<AssetItem[]>
-
-function groupCandidatesForHashLookup(candidates: MissingMediaCandidate[]): {
-  candidatesByHash: Map<string, MissingMediaCandidate[]>
-  legacyCandidates: MissingMediaCandidate[]
-} {
-  const candidatesByHash = new Map<string, MissingMediaCandidate[]>()
-  const legacyCandidates: MissingMediaCandidate[] = []
-
-  for (const candidate of candidates) {
-    if (!isBlake3AssetHash(candidate.name)) {
-      legacyCandidates.push(candidate)
-      continue
-    }
-
-    const hashCandidates = candidatesByHash.get(candidate.name)
-    if (hashCandidates) hashCandidates.push(candidate)
-    else candidatesByHash.set(candidate.name, [candidate])
-  }
-
-  return { candidatesByHash, legacyCandidates }
-}
-
-async function verifyCandidatesByHash(
-  candidatesByHash: Map<string, MissingMediaCandidate[]>,
-  legacyCandidates: MissingMediaCandidate[],
-  signal: AbortSignal | undefined,
-  checkAssetHash: AssetHashVerifier
-): Promise<void> {
-  await Promise.all(
-    Array.from(candidatesByHash, async ([assetHash, hashCandidates]) => {
-      if (signal?.aborted) return
-
-      let status: AssetHashStatus
-      try {
-        status = await checkAssetHash(assetHash, signal)
-        if (signal?.aborted) return
-      } catch (err) {
-        if (signal?.aborted || isAbortError(err)) return
-        console.warn(
-          '[Missing Media Pipeline] Failed to verify asset hash:',
-          err
-        )
-        legacyCandidates.push(...hashCandidates)
-        return
-      }
-
-      if (status === 'invalid') {
-        legacyCandidates.push(...hashCandidates)
-        return
-      }
-
-      for (const candidate of hashCandidates) {
-        candidate.isMissing = status === 'missing'
-      }
-    })
-  )
-}
 
 /**
  * Verify cloud media candidates by probing the asset hash endpoint first.
@@ -191,16 +131,26 @@ export async function verifyCloudMediaCandidates(
   const pending = candidates.filter((c) => c.isMissing === undefined)
   if (pending.length === 0) return
 
-  const { candidatesByHash, legacyCandidates } =
-    groupCandidatesForHashLookup(pending)
-  await verifyCandidatesByHash(
-    candidatesByHash,
-    legacyCandidates,
+  const verification = await verifyCandidatesByAssetHash({
+    candidates: pending,
+    getAssetHash: (candidate) =>
+      isBlake3AssetHash(candidate.name) ? candidate.name : null,
     signal,
-    checkAssetHash
-  )
+    checkAssetHash,
+    onError: (err) => {
+      console.warn('[Missing Media Pipeline] Failed to verify asset hash:', err)
+    }
+  })
+  if (verification.aborted) return
 
-  if (signal?.aborted || legacyCandidates.length === 0) return
+  for (const candidate of verification.existing) {
+    candidate.isMissing = false
+  }
+  for (const candidate of verification.missing) {
+    candidate.isMissing = true
+  }
+
+  if (signal?.aborted || verification.fallback.length === 0) return
 
   let inputAssets: AssetItem[]
   try {
@@ -216,7 +166,7 @@ export async function verifyCloudMediaCandidates(
     inputAssets.map((a) => a.asset_hash).filter((h): h is string => !!h)
   )
 
-  for (const candidate of legacyCandidates) {
+  for (const candidate of verification.fallback) {
     candidate.isMissing = !assetHashes.has(candidate.name)
   }
 }
@@ -225,15 +175,6 @@ async function fetchMissingInputAssets(
   signal?: AbortSignal
 ): Promise<AssetItem[]> {
   return await assetService.getInputAssetsIncludingPublic(signal)
-}
-
-function isAbortError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'name' in err &&
-    err.name === 'AbortError'
-  )
 }
 
 /** Group confirmed-missing candidates by file name into view models. */

--- a/src/platform/missingModel/missingModelScan.test.ts
+++ b/src/platform/missingModel/missingModelScan.test.ts
@@ -1557,8 +1557,7 @@ describe('verifyAssetSupportedCandidates', () => {
 
   it('should not warn or fall back when hash verification is aborted', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const abortError = new Error('aborted')
-    abortError.name = 'AbortError'
+    const abortError = new DOMException('aborted', 'AbortError')
     const hash =
       '4444444444444444444444444444444444444444444444444444444444444444'
     const candidates = [

--- a/src/platform/missingModel/missingModelScan.ts
+++ b/src/platform/missingModel/missingModelScan.ts
@@ -24,11 +24,12 @@ import {
 } from '@/utils/graphTraversalUtil'
 import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { resolveComboValues } from '@/utils/litegraphUtil'
-import type { AssetHashStatus } from '@/platform/assets/services/assetService'
 import {
   assetService,
   toBlake3AssetHash
 } from '@/platform/assets/services/assetService'
+import { verifyCandidatesByAssetHash } from '@/platform/assets/utils/assetHashVerification'
+import type { AssetHashVerifier } from '@/platform/assets/utils/assetHashVerification'
 
 export type MissingModelWorkflowData = FlattenableWorkflowGraph & {
   models?: ModelFile[]
@@ -450,11 +451,6 @@ interface AssetVerifier {
   getAssets: (nodeType: string) => AssetItem[] | undefined
 }
 
-type AssetHashVerifier = (
-  assetHash: string,
-  signal?: AbortSignal
-) => Promise<AssetHashStatus>
-
 export async function verifyAssetSupportedCandidates(
   candidates: MissingModelCandidate[],
   signal?: AbortSignal,
@@ -468,47 +464,25 @@ export async function verifyAssetSupportedCandidates(
   )
   if (pendingCandidates.length === 0) return
 
-  const pendingNodeTypes = new Set<string>()
-  const candidatesByHash = new Map<string, MissingModelCandidate[]>()
-
-  for (const candidate of pendingCandidates) {
-    const assetHash = getBlake3AssetHash(candidate)
-    if (!assetHash) {
-      pendingNodeTypes.add(candidate.nodeType)
-      continue
+  const verification = await verifyCandidatesByAssetHash({
+    candidates: pendingCandidates,
+    getAssetHash: getBlake3AssetHash,
+    signal,
+    checkAssetHash,
+    onError: (err) => {
+      console.warn('[Missing Model Pipeline] Failed to verify asset hash:', err)
     }
+  })
+  if (verification.aborted) return
 
-    const hashCandidates = candidatesByHash.get(assetHash)
-    if (hashCandidates) hashCandidates.push(candidate)
-    else candidatesByHash.set(assetHash, [candidate])
+  for (const candidate of verification.existing) {
+    candidate.isMissing = false
   }
 
-  await Promise.all(
-    Array.from(candidatesByHash, async ([assetHash, hashCandidates]) => {
-      if (signal?.aborted) return
-
-      try {
-        const status = await checkAssetHash(assetHash, signal)
-        if (signal?.aborted) return
-
-        if (status === 'exists') {
-          for (const candidate of hashCandidates) {
-            candidate.isMissing = false
-          }
-          return
-        }
-      } catch (err) {
-        if (signal?.aborted || isAbortError(err)) return
-        console.warn(
-          '[Missing Model Pipeline] Failed to verify asset hash:',
-          err
-        )
-      }
-
-      for (const candidate of hashCandidates) {
-        pendingNodeTypes.add(candidate.nodeType)
-      }
-    })
+  const pendingNodeTypes = new Set(
+    [...verification.missing, ...verification.fallback].map(
+      (candidate) => candidate.nodeType
+    )
   )
 
   if (signal?.aborted) return
@@ -547,15 +521,6 @@ export async function verifyAssetSupportedCandidates(
 function getBlake3AssetHash(candidate: MissingModelCandidate): string | null {
   if (candidate.hashType?.toLowerCase() !== 'blake3') return null
   return toBlake3AssetHash(candidate.hash)
-}
-
-function isAbortError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'name' in err &&
-    err.name === 'AbortError'
-  )
 }
 
 function normalizePath(path: string): string {

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -6,6 +6,7 @@ import { t } from '@/i18n'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { isAbortError } from '@/utils/typeGuardUtil'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import type { AssetMetadata } from '@/platform/assets/schemas/assetSchema'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -271,10 +272,6 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     urlImporting.value = {}
     folderPaths.value = {}
     fileSizes.value = {}
-  }
-
-  function isAbortError(error: unknown) {
-    return error instanceof Error && error.name === 'AbortError'
   }
 
   async function refreshMissingModels() {


### PR DESCRIPTION
## Summary

Adds browser regression coverage for cloud public input assets so template media inputs that resolve through `include_public=true` are not reported as missing.

## Changes

- **What**: Adds a cloud-tagged Playwright regression test for the missing media errors tab. The test stubs `/api/assets` so `include_tags=input&include_public=true` returns the referenced public input asset, then asserts the missing media group stays hidden.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

This is PR3 in the missing asset follow-up stack and is test-only. The route stub is scoped to `/api/assets` so static `/assets/*` bundles are not intercepted.

Stack map:
- PR1: #11899 - Asset schema / pagination cleanup
- PR2: #11900 - Missing asset hash verification utility cleanup
- PR3: this PR - Browser regression coverage for public input assets
- PR4: #11902 - TanStack Query public-input cache replacement

Fixes #11896

## Screenshots (if applicable)

N/A - browser regression test only.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11901-test-add-public-input-missing-media-regression-coverage-3566d73d365081fb84c2d9e500a76146) by [Unito](https://www.unito.io)