### PR TITLE
refactor: replace public input cache with vue query

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@primevue/themes": "catalog:",
     "@sentry/vue": "catalog:",
     "@sparkjsdev/spark": "catalog:",
+    "@tanstack/vue-query": "catalog:",
     "@tanstack/vue-virtual": "catalog:",
     "@tiptap/core": "catalog:",
     "@tiptap/extension-link": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ catalogs:
     '@tailwindcss/vite':
       specifier: ^4.2.0
       version: 4.2.0
+    '@tanstack/vue-query':
+      specifier: ^5.100.9
+      version: 5.100.9
     '@tanstack/vue-virtual':
       specifier: ^3.13.12
       version: 3.13.12
@@ -476,6 +479,9 @@ importers:
       '@sparkjsdev/spark':
         specifier: 'catalog:'
         version: 0.1.10
+      '@tanstack/vue-query':
+        specifier: 'catalog:'
+        version: 5.100.9(vue@3.5.13(typescript@5.9.3))
       '@tanstack/vue-virtual':
         specifier: 'catalog:'
         version: 3.13.12(vue@3.5.13(typescript@5.9.3))
@@ -4197,8 +4203,24 @@ packages:
     peerDependencies:
       vite: ^8.0.0
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
+    engines: {node: '>=12'}
+
+  '@tanstack/query-core@5.100.9':
+    resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
+
   '@tanstack/virtual-core@3.13.12':
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
+
+  '@tanstack/vue-query@5.100.9':
+    resolution: {integrity: sha512-wGiv/AirRuITlTDl87zdBRaZIZTejMItUswKgMzzcX/1gfn95iKw2EaCuz7qlX9ceB0DwBj9FqaroLnDoJCecg==}
+    peerDependencies:
+      '@vue/composition-api': ^1.1.2
+      vue: ^2.6.0 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@tanstack/vue-virtual@3.13.12':
     resolution: {integrity: sha512-vhF7kEU9EXWXh+HdAwKJ2m3xaOnTTmgcdXcF2pim8g4GvI7eRrk2YRuV5nUlZnd/NbCIX4/Ja2OZu5EjJL06Ww==}
@@ -8679,6 +8701,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+
   request-light@0.5.8:
     resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
 
@@ -9883,8 +9908,8 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
-  vue-component-type-helpers@3.2.7:
-    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
+  vue-component-type-helpers@3.2.8:
+    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -13405,7 +13430,7 @@ snapshots:
       storybook: 10.2.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.7
+      vue-component-type-helpers: 3.2.8
 
   '@swc/helpers@0.5.17':
     dependencies:
@@ -13486,7 +13511,21 @@ snapshots:
       tailwindcss: 4.2.0
       vite: 8.0.0(@types/node@25.0.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.2)
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    dependencies:
+      remove-accents: 0.5.0
+
+  '@tanstack/query-core@5.100.9': {}
+
   '@tanstack/virtual-core@3.13.12': {}
+
+  '@tanstack/vue-query@5.100.9(vue@3.5.13(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.19.4
+      '@tanstack/query-core': 5.100.9
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.9.3)
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.9.3))
 
   '@tanstack/vue-virtual@3.13.12(vue@3.5.13(typescript@5.9.3))':
     dependencies:
@@ -14189,7 +14228,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/ui@4.0.16)(esbuild@0.27.3)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.2)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.0.16)(esbuild@0.27.3)(happy-dom@20.0.11)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -19016,6 +19055,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  remove-accents@0.5.0: {}
+
   request-light@0.5.8: {}
 
   request-light@0.7.0: {}
@@ -20530,7 +20571,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.6: {}
 
-  vue-component-type-helpers@3.2.7: {}
+  vue-component-type-helpers@3.2.8: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.9.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalog:
   '@storybook/vue3': ^10.2.10
   '@storybook/vue3-vite': ^10.2.10
   '@tailwindcss/vite': ^4.2.0
+  '@tanstack/vue-query': ^5.100.9
   '@tanstack/vue-virtual': ^3.13.12
   '@testing-library/jest-dom': ^6.9.1
   '@testing-library/user-event': ^14.6.1

--- a/src/platform/assets/queries/inputAssetsIncludingPublicQuery.ts
+++ b/src/platform/assets/queries/inputAssetsIncludingPublicQuery.ts
@@ -1,0 +1,29 @@
+import { QueryClient } from '@tanstack/vue-query'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+const queryClient = new QueryClient()
+const inputAssetsIncludingPublicQueryPrefix = ['assets', 'input'] as const
+let inputAssetsIncludingPublicGeneration = 0
+
+export function invalidateInputAssetsIncludingPublicQuery(): void {
+  inputAssetsIncludingPublicGeneration++
+  void queryClient.invalidateQueries({
+    queryKey: inputAssetsIncludingPublicQueryPrefix,
+    refetchType: 'none'
+  })
+}
+
+export async function fetchInputAssetsIncludingPublicQuery(
+  fetchAssets: () => Promise<AssetItem[]>
+): Promise<AssetItem[]> {
+  return await queryClient.fetchQuery({
+    queryKey: [
+      ...inputAssetsIncludingPublicQueryPrefix,
+      { includePublic: true, generation: inputAssetsIncludingPublicGeneration }
+    ],
+    queryFn: fetchAssets,
+    retry: false,
+    staleTime: Infinity
+  })
+}

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -713,66 +713,22 @@ describe(assetService.getInputAssetsIncludingPublic, () => {
     expect(fetchApiMock).toHaveBeenCalledTimes(2)
   })
 
-  it('does not let one caller abort the shared input asset load for other callers', async () => {
-    const firstController = new AbortController()
-    const secondController = new AbortController()
+  it('deduplicates concurrent input asset loads while the request is pending', async () => {
     const assets = [validAsset({ id: 'public-input', tags: ['input'] })]
     let resolveResponse!: (response: Response) => void
-    let serviceSignal: AbortSignal | undefined
-    fetchApiMock.mockImplementationOnce(async (_url, options) => {
-      serviceSignal = options?.signal ?? undefined
+    fetchApiMock.mockImplementationOnce(async () => {
       return await new Promise<Response>((resolve) => {
         resolveResponse = resolve
       })
     })
 
-    const first = assetService.getInputAssetsIncludingPublic(
-      firstController.signal
-    )
-    const second = assetService.getInputAssetsIncludingPublic(
-      secondController.signal
-    )
-    firstController.abort()
-
-    await expect(first).rejects.toMatchObject({ name: 'AbortError' })
-    expect(serviceSignal).toBeUndefined()
+    const first = assetService.getInputAssetsIncludingPublic()
+    const second = assetService.getInputAssetsIncludingPublic()
 
     resolveResponse(buildAssetListResponse(assets))
 
+    await expect(first).resolves.toEqual(assets)
     await expect(second).resolves.toEqual(assets)
-    expect(fetchApiMock).toHaveBeenCalledOnce()
-  })
-
-  it('keeps the shared input asset load alive after all callers abort', async () => {
-    const firstController = new AbortController()
-    const secondController = new AbortController()
-    const assets = [validAsset({ id: 'public-input', tags: ['input'] })]
-    let resolveResponse!: (response: Response) => void
-    fetchApiMock.mockImplementationOnce(
-      async () =>
-        await new Promise<Response>((resolve) => {
-          resolveResponse = resolve
-        })
-    )
-
-    const first = assetService.getInputAssetsIncludingPublic(
-      firstController.signal
-    )
-    const second = assetService.getInputAssetsIncludingPublic(
-      secondController.signal
-    )
-    firstController.abort()
-    secondController.abort()
-
-    await expect(first).rejects.toMatchObject({ name: 'AbortError' })
-    await expect(second).rejects.toMatchObject({ name: 'AbortError' })
-
-    resolveResponse(buildAssetListResponse(assets))
-    await Promise.resolve()
-
-    await expect(assetService.getInputAssetsIncludingPublic()).resolves.toEqual(
-      assets
-    )
     expect(fetchApiMock).toHaveBeenCalledOnce()
   })
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -4,6 +4,10 @@ import { z } from 'zod'
 import { st } from '@/i18n'
 
 import {
+  fetchInputAssetsIncludingPublicQuery,
+  invalidateInputAssetsIncludingPublicQuery
+} from '@/platform/assets/queries/inputAssetsIncludingPublicQuery'
+import {
   assetItemSchema,
   assetResponseSchema,
   asyncUploadResponseSchema,
@@ -202,35 +206,6 @@ export function toBlake3AssetHash(hash: string | undefined): string | null {
   return `blake3:${hash}`
 }
 
-function createAbortError(): DOMException {
-  return new DOMException('Aborted', 'AbortError')
-}
-
-function throwIfAborted(signal?: AbortSignal): void {
-  if (signal?.aborted) throw createAbortError()
-}
-
-async function withCallerAbort<T>(
-  promise: Promise<T>,
-  signal?: AbortSignal
-): Promise<T> {
-  throwIfAborted(signal)
-  if (!signal) return await promise
-
-  let removeAbortListener = () => {}
-  const abortPromise = new Promise<never>((_, reject) => {
-    const onAbort = () => reject(createAbortError())
-    signal.addEventListener('abort', onAbort, { once: true })
-    removeAbortListener = () => signal.removeEventListener('abort', onAbort)
-  })
-
-  try {
-    return await Promise.race([promise, abortPromise])
-  } finally {
-    removeAbortListener()
-  }
-}
-
 /**
  * Validates asset response data using Zod schema
  */
@@ -266,15 +241,9 @@ function validateUploadedAssetResponse(
  * Not exposed globally - used internally by ComfyApi
  */
 function createAssetService() {
-  let inputAssetsIncludingPublic: AssetItem[] | null = null
-  let inputAssetsIncludingPublicRequestId = 0
-  let pendingInputAssetsIncludingPublic: Promise<AssetItem[]> | null = null
-
   /** Invalidates the cached public-inclusive input assets without aborting in-flight readers. */
   function invalidateInputAssetsIncludingPublic(): void {
-    inputAssetsIncludingPublicRequestId++
-    pendingInputAssetsIncludingPublic = null
-    inputAssetsIncludingPublic = null
+    invalidateInputAssetsIncludingPublicQuery()
   }
 
   function invalidateInputAssetsCacheIfNeeded(tags?: string[]): void {
@@ -530,7 +499,7 @@ function createAssetService() {
     let offset = 0
 
     while (true) {
-      if (signal?.aborted) throw createAbortError()
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
 
       const data = await handleAssetRequest(
         {
@@ -553,43 +522,19 @@ function createAssetService() {
     }
   }
 
-  function startInputAssetsIncludingPublicRequest(): Promise<AssetItem[]> {
-    const requestId = ++inputAssetsIncludingPublicRequestId
-
-    pendingInputAssetsIncludingPublic = getAllAssetsByTag('input', true, {
-      limit: INPUT_ASSETS_WITH_PUBLIC_LIMIT
-    })
-      .then((assets) => {
-        if (requestId === inputAssetsIncludingPublicRequestId) {
-          inputAssetsIncludingPublic = assets
-        }
-        return assets
-      })
-      .finally(() => {
-        if (requestId === inputAssetsIncludingPublicRequestId) {
-          pendingInputAssetsIncludingPublic = null
-        }
-      })
-
-    void pendingInputAssetsIncludingPublic.catch(() => {})
-    return pendingInputAssetsIncludingPublic
-  }
-
   /**
    * Gets cached input assets including public assets for missing media checks.
-   * Caller aborts cancel only that caller; shared fetches are invalidated
-   * through invalidateInputAssetsIncludingPublic().
+   * The signal parameter is accepted for existing callers; callers guard aborted
+   * scan results outside this shared query cache.
    */
   async function getInputAssetsIncludingPublic(
-    signal?: AbortSignal
+    _signal?: AbortSignal
   ): Promise<AssetItem[]> {
-    throwIfAborted(signal)
-    if (inputAssetsIncludingPublic) return inputAssetsIncludingPublic
-
-    const request =
-      pendingInputAssetsIncludingPublic ??
-      startInputAssetsIncludingPublicRequest()
-    return await withCallerAbort(request, signal)
+    return await fetchInputAssetsIncludingPublicQuery(() =>
+      getAllAssetsByTag('input', true, {
+        limit: INPUT_ASSETS_WITH_PUBLIC_LIMIT
+      })
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary

Replace the hand-rolled public-inclusive input asset cache with a small TanStack Query-backed cache.

## Changes

- **What**: Adds `@tanstack/vue-query`, moves the public-inclusive input cache into `inputAssetsIncludingPublicQuery.ts`, and removes the manual pending promise/request id/cache state from `assetService.ts`.
- **Breaking**: None
- **Dependencies**: Adds `@tanstack/vue-query`.

## Review Focus

This is PR4 in the missing asset follow-up stack. The first pass intentionally applies TanStack Query only to the public-inclusive input asset cache; should the remaining hash lookup path also be included in a follow-up?

Stack map:
- PR1: #11899 - Asset schema / pagination cleanup
- PR2: #11900 - Missing asset hash verification utility cleanup
- PR3: #11901 - Browser regression coverage for public input assets
- PR4: this PR - TanStack Query public-input cache replacement

Closes #11898
Closes #11883
Partially addresses #11881

## Screenshots (if applicable)

N/A - cache refactor only.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11902-refactor-replace-public-input-cache-with-vue-query-3566d73d365081d29259e78a7cf71d79) by [Unito](https://www.unito.io)
