### PR TITLE
fix: route footer Support link to Zendesk help center

### DIFF
--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -88,7 +88,7 @@ const contactColumn = {
     { label: t('footer.sales', locale), href: routes.contact },
     {
       label: t('footer.support', locale),
-      href: externalLinks.discord,
+      href: externalLinks.support,
       external: true
     },
     { label: t('footer.press', locale), href: 'mailto:press@comfy.org' }

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -35,6 +35,7 @@ export const externalLinks = {
   docsApi: 'https://docs.comfy.org/api-reference/cloud',
   github: 'https://github.com/Comfy-Org/ComfyUI',
   platform: 'https://platform.comfy.org',
+  support: 'https://support.comfy.org/hc/en-us',
   workflows: 'https://comfy.org/workflows',
   youtube: 'https://www.youtube.com/@ComfyOrg'
 } as const


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The "Support" link in the marketing site footer (Contact column) was reusing
the Discord external link. Update it to point at the Zendesk help center at
`https://support.comfy.org/hc/en-us`, as requested in the
`#website-and-docs` Slack thread.

## Changes

- `apps/website/src/config/routes.ts` — add `support` entry to `externalLinks`
  pointing at `https://support.comfy.org/hc/en-us`.
- `apps/website/src/components/common/SiteFooter.vue` — use
  `externalLinks.support` for the Contact > Support entry instead of
  `externalLinks.discord`.

## Verification

- `pnpm format` and `pnpm exec eslint` clean on both files.
- `pnpm typecheck` passes.
- Verified locally with `pnpm dev` (Astro on `localhost:4321`); the rendered
  footer Support link now resolves to `https://support.comfy.org/hc/en-us`
  (screenshot below).

## Notes

Reviewer flagged that `/hc/en-us` forces English and bypasses Zendesk locale
negotiation. The exact URL was explicitly requested by the user in the Slack
thread, so it is preserved here. Switching to a locale-neutral
`https://support.comfy.org/` can be done as a follow-up if desired.


## Screenshots

![Marketing site footer with Support link pointing to support.comfy.org/hc/en-us](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/7cb1cde676098ecfc7a07ab2b8d341ba402b097e134b5eaaf42572e925bd6d40/pr-images/1777906238675-00158842-4368-478a-ae6e-c91d536a7986.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11904-fix-route-footer-Support-link-to-Zendesk-help-center-3566d73d36508189abcff34ae766d3c4) by [Unito](https://www.unito.io)
