### PR TITLE
test: add Playwright regression test for nested subgraph Cloud missing model

### DIFF
--- a/browser_tests/assets/missing/nested_subgraph_installed_model.json
+++ b/browser_tests/assets/missing/nested_subgraph_installed_model.json
@@ -1,0 +1,232 @@
+{
+  "id": "14af6003-d4ee-4dee-8e3d-cbff2e5519b3",
+  "revision": 0,
+  "last_node_id": 205,
+  "last_link_id": 383,
+  "nodes": [
+    {
+      "id": 205,
+      "type": "821645cc-a5d2-468f-990c-17d9de2e0d1b",
+      "pos": [4720, 5820],
+      "size": [400, 470],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "lotus_model",
+          "name": "unet_name_1",
+          "type": "COMBO",
+          "widget": {
+            "name": "unet_name_1"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [["76", "unet_name"]]
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "821645cc-a5d2-468f-990c-17d9de2e0d1b",
+        "version": 1,
+        "state": {
+          "lastGroupId": 8,
+          "lastNodeId": 205,
+          "lastLinkId": 383,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Depth to Image (Z-Image-Turbo)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [28, 4936, 128, 68]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1599, 4936, 128, 68]
+        },
+        "inputs": [
+          {
+            "id": "80e6915f-5d59-4d6b-a197-d8c565ad2922",
+            "name": "unet_name_1",
+            "type": "COMBO",
+            "linkIds": [258],
+            "pos": [132, 4960]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "47f9a22d-6619-4917-9447-a7d5d08dceb5",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [],
+            "pos": [1623, 4960]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 76,
+            "type": "a1134394-29e4-48dc-9b1e-e601a14d6fb8",
+            "pos": [250, 4910],
+            "size": [400, 210],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 258
+              }
+            ],
+            "outputs": [
+              {
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": []
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [["203", "unet_name"]]
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 258,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 76,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ds": {
+            "scale": 1,
+            "offset": [-30, -4760]
+          }
+        }
+      },
+      {
+        "id": "a1134394-29e4-48dc-9b1e-e601a14d6fb8",
+        "version": 1,
+        "state": {
+          "lastGroupId": 8,
+          "lastNodeId": 205,
+          "lastLinkId": 383,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image to Depth Map (Lotus)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [-60, -173, 128, 68]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [1650, -173, 128, 68]
+        },
+        "inputs": [
+          {
+            "id": "d721b249-fd2a-441b-9a78-2805f04e2644",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [256],
+            "pos": [44, -149]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "2ec278bd-0b66-4b30-9c5b-994d5f638214",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [],
+            "pos": [1674, -149]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 203,
+            "type": "UNETLoader",
+            "pos": [180, -200],
+            "size": [400, 200],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 256
+              }
+            ],
+            "outputs": [
+              {
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": []
+              }
+            ],
+            "properties": {},
+            "widgets_values": ["lotus-depth-d-v1-1.safetensors", "default"]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 256,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 203,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ds": {
+            "scale": 1,
+            "offset": [40, 350]
+          }
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "workflowRendererVersion": "LG",
+    "ds": {
+      "scale": 1,
+      "offset": [-4500, -5670]
+    }
+  },
+  "version": 0.4
+}

--- a/browser_tests/fixtures/assetApiFixture.ts
+++ b/browser_tests/fixtures/assetApiFixture.ts
@@ -1,7 +1,33 @@
 import { test as base } from '@playwright/test'
+import type { Page, Route } from '@playwright/test'
 
+import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 import type { AssetHelper } from '@e2e/fixtures/helpers/AssetHelper'
 import { createAssetHelper } from '@e2e/fixtures/helpers/AssetHelper'
+
+const ASSETS_ROUTE_PATTERN = /\/api\/assets(?:\?.*)?$/
+const cloudAssetRequestsByPage = new WeakMap<Page, string[]>()
+
+function makeAssetsResponse(assets: ReadonlyArray<Asset>): ListAssetsResponse {
+  return { assets: [...assets], total: assets.length, has_more: false }
+}
+
+export function assetRequestIncludesTag(url: string, tag: string): boolean {
+  const includeTags = new URL(url).searchParams.get('include_tags') ?? ''
+  return includeTags
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .includes(tag)
+}
+
+export function countAssetRequestsByTag(
+  requests: string[],
+  tag: string
+): number {
+  return requests.filter((url) => assetRequestIncludesTag(url, tag)).length
+}
 
 export const assetApiFixture = base.extend<{
   assetApi: AssetHelper
@@ -14,3 +40,31 @@ export const assetApiFixture = base.extend<{
     await assetApi.clearMocks()
   }
 })
+
+export function createCloudAssetsFixture(assets: ReadonlyArray<Asset>) {
+  return comfyPageFixture.extend<{
+    cloudAssetRequests: string[]
+  }>({
+    page: async ({ page }, use) => {
+      const cloudAssetRequests: string[] = []
+      cloudAssetRequestsByPage.set(page, cloudAssetRequests)
+
+      async function assetsRouteHandler(route: Route) {
+        cloudAssetRequests.push(route.request().url())
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(makeAssetsResponse(assets))
+        })
+      }
+
+      await page.route(ASSETS_ROUTE_PATTERN, assetsRouteHandler)
+      await use(page)
+      await page.unroute(ASSETS_ROUTE_PATTERN, assetsRouteHandler)
+      cloudAssetRequestsByPage.delete(page)
+    },
+    cloudAssetRequests: async ({ page }, use) => {
+      await use(cloudAssetRequestsByPage.get(page) ?? [])
+    }
+  })
+}

--- a/browser_tests/tests/cloud-asset-default.spec.ts
+++ b/browser_tests/tests/cloud-asset-default.spec.ts
@@ -1,51 +1,20 @@
 import { expect } from '@playwright/test'
-import type { Route } from '@playwright/test'
 
-import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
-import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { Asset } from '@comfyorg/ingest-types'
+import {
+  assetRequestIncludesTag,
+  createCloudAssetsFixture
+} from '@e2e/fixtures/assetApiFixture'
 import {
   STABLE_CHECKPOINT,
   STABLE_CHECKPOINT_2
 } from '@e2e/fixtures/data/assetFixtures'
 
-function makeAssetsResponse(assets: Asset[]): ListAssetsResponse {
-  return { assets, total: assets.length, has_more: false }
-}
-
 const CLOUD_ASSETS: Asset[] = [STABLE_CHECKPOINT, STABLE_CHECKPOINT_2]
 const WAITING_FOR_WIDGET_TYPE = 'waiting:type'
 const WAITING_FOR_WIDGET_VALUE = 'waiting:value'
 
-// Stub /api/assets before the app loads. The local ComfyUI backend has no
-// /api/assets endpoint (returns 503), which poisons the assets store on
-// first load. Narrow pattern avoids intercepting static /assets/*.js bundles.
-//
-// TODO: Consider moving this stub into ComfyPage fixture for all @cloud tests.
-const test = comfyPageFixture.extend<{
-  cloudAssetRequests: string[]
-  stubCloudAssets: void
-}>({
-  cloudAssetRequests: async ({ page: _page }, use) => {
-    await use([])
-  },
-  stubCloudAssets: [
-    async ({ cloudAssetRequests, page }, use) => {
-      const pattern = /\/api\/assets(?:\?.*)?$/
-      const assetsRouteHandler = (route: Route) => {
-        cloudAssetRequests.push(route.request().url())
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(makeAssetsResponse(CLOUD_ASSETS))
-        })
-      }
-      await page.route(pattern, assetsRouteHandler)
-      await use()
-      await page.unroute(pattern, assetsRouteHandler)
-    },
-    { auto: true }
-  ]
-})
+const test = createCloudAssetsFixture(CLOUD_ASSETS)
 
 test.describe('Asset-supported node default value', { tag: '@cloud' }, () => {
   test.afterEach(async ({ comfyPage }) => {
@@ -62,11 +31,9 @@ test.describe('Asset-supported node default value', { tag: '@cloud' }, () => {
     // new nodes resolve against the cloud asset list after the fetch.
     await expect
       .poll(() =>
-        cloudAssetRequests.some((url) => {
-          const includeTags =
-            new URL(url).searchParams.get('include_tags') ?? ''
-          return includeTags.split(',').includes('checkpoints')
-        })
+        cloudAssetRequests.some((url) =>
+          assetRequestIncludesTag(url, 'checkpoints')
+        )
       )
       .toBe(true)
 

--- a/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
@@ -116,22 +116,21 @@ test.describe(
       await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
       await panel.open(comfyPage.actionbar.propertiesButton)
 
+      await expect
+        .poll(
+          () =>
+            countDiffusionModelAssetRequests(cloudAssetRequests) >
+            requestCountBeforeRootReturn,
+          { timeout: 10_000 }
+        )
+        .toBe(true)
+
       test.fail(
         true,
         'Root return currently replays nested subgraph container model widgets as missing in Cloud. Remove this annotation when the replay scan skips nested subgraph containers.'
       )
 
-      await expect
-        .poll(
-          async () => ({
-            didReplayScan:
-              countDiffusionModelAssetRequests(cloudAssetRequests) >
-              requestCountBeforeRootReturn,
-            errorsTabVisible: await errorsTab.isVisible()
-          }),
-          { timeout: 10_000 }
-        )
-        .toEqual({ didReplayScan: true, errorsTabVisible: false })
+      await expect(errorsTab).toBeHidden()
     })
   }
 )

--- a/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
@@ -1,0 +1,137 @@
+import { expect } from '@playwright/test'
+import type { Route } from '@playwright/test'
+
+import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+
+const WORKFLOW = 'missing/nested_subgraph_installed_model'
+const OUTER_SUBGRAPH_NODE_ID = '205'
+const LOTUS_MODEL_NAME = 'lotus-depth-d-v1-1.safetensors'
+
+const LOTUS_DIFFUSION_MODEL: Asset = {
+  id: 'test-lotus-depth-d-v1-1',
+  name: LOTUS_MODEL_NAME,
+  asset_hash:
+    'blake3:0000000000000000000000000000000000000000000000000000000000000203',
+  size: 1_024,
+  mime_type: 'application/octet-stream',
+  tags: ['models', 'diffusion_models'],
+  created_at: '2026-05-05T00:00:00Z',
+  updated_at: '2026-05-05T00:00:00Z',
+  last_access_time: '2026-05-05T00:00:00Z',
+  user_metadata: {
+    filename: LOTUS_MODEL_NAME
+  }
+}
+
+function makeAssetsResponse(assets: Asset[]): ListAssetsResponse {
+  return { assets, total: assets.length, has_more: false }
+}
+
+function isDiffusionModelAssetRequest(url: string): boolean {
+  const includeTags = new URL(url).searchParams.get('include_tags') ?? ''
+  return includeTags.split(',').includes('diffusion_models')
+}
+
+function countDiffusionModelAssetRequests(requests: string[]): number {
+  return requests.filter(isDiffusionModelAssetRequest).length
+}
+
+const test = comfyPageFixture.extend<{
+  cloudAssetRequests: string[]
+  stubCloudAssets: void
+}>({
+  cloudAssetRequests: async ({ page: _page }, use) => {
+    await use([])
+  },
+  stubCloudAssets: [
+    async ({ cloudAssetRequests, page }, use) => {
+      const pattern = /\/api\/assets(?:\?.*)?$/
+      const assetsRouteHandler = (route: Route) => {
+        cloudAssetRequests.push(route.request().url())
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(makeAssetsResponse([LOTUS_DIFFUSION_MODEL]))
+        })
+      }
+
+      await page.route(pattern, assetsRouteHandler)
+      await use()
+      await page.unroute(pattern, assetsRouteHandler)
+    },
+    { auto: true }
+  ]
+})
+
+test.describe(
+  'Errors tab - Cloud missing models',
+  { tag: ['@cloud', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.RightSidePanel.ShowErrorsTab',
+        true
+      )
+      await comfyPage.settings.setSetting('Comfy.Assets.UseAssetAPI', true)
+    })
+
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.nodeOps.clearGraph()
+    })
+
+    test('keeps installed models resolved after returning from a nested subgraph', async ({
+      cloudAssetRequests,
+      comfyPage
+    }) => {
+      test.fail(
+        true,
+        'Root return currently replays nested subgraph container model widgets as missing in Cloud. Remove this annotation when the replay scan skips nested subgraph containers.'
+      )
+
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+      const errorOverlay = comfyPage.page.getByTestId(
+        TestIds.dialogs.errorOverlay
+      )
+      const errorsTab = comfyPage.page.getByTestId(
+        TestIds.propertiesPanel.errorsTab
+      )
+      const panel = new PropertiesPanelHelper(comfyPage.page)
+
+      await expect
+        .poll(() => countDiffusionModelAssetRequests(cloudAssetRequests))
+        .toBeGreaterThan(0)
+      await expect(errorOverlay).toBeHidden()
+      await panel.open(comfyPage.actionbar.propertiesButton)
+      await expect(errorsTab).toBeHidden()
+      await panel.close()
+
+      await comfyPage.vueNodes.waitForNodes()
+      await comfyPage.vueNodes.enterSubgraph(OUTER_SUBGRAPH_NODE_ID)
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+      await expect(errorOverlay).toBeHidden()
+
+      const requestCountBeforeRootReturn =
+        countDiffusionModelAssetRequests(cloudAssetRequests)
+
+      await comfyPage.page.getByTestId(TestIds.breadcrumb.item('root')).click()
+      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
+      await panel.open(comfyPage.actionbar.propertiesButton)
+
+      await expect
+        .poll(
+          async () => ({
+            didReplayScan:
+              countDiffusionModelAssetRequests(cloudAssetRequests) >
+              requestCountBeforeRootReturn,
+            errorsTabVisible: await errorsTab.isVisible()
+          }),
+          { timeout: 10_000 }
+        )
+        .toEqual({ didReplayScan: true, errorsTabVisible: false })
+    })
+  }
+)

--- a/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
@@ -1,8 +1,10 @@
 import { expect } from '@playwright/test'
-import type { Route } from '@playwright/test'
 
-import type { Asset, ListAssetsResponse } from '@comfyorg/ingest-types'
-import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { Asset } from '@comfyorg/ingest-types'
+import {
+  countAssetRequestsByTag,
+  createCloudAssetsFixture
+} from '@e2e/fixtures/assetApiFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
 
@@ -26,45 +28,7 @@ const LOTUS_DIFFUSION_MODEL: Asset = {
   }
 }
 
-function makeAssetsResponse(assets: Asset[]): ListAssetsResponse {
-  return { assets, total: assets.length, has_more: false }
-}
-
-function isDiffusionModelAssetRequest(url: string): boolean {
-  const includeTags = new URL(url).searchParams.get('include_tags') ?? ''
-  return includeTags.split(',').includes('diffusion_models')
-}
-
-function countDiffusionModelAssetRequests(requests: string[]): number {
-  return requests.filter(isDiffusionModelAssetRequest).length
-}
-
-const test = comfyPageFixture.extend<{
-  cloudAssetRequests: string[]
-  stubCloudAssets: void
-}>({
-  cloudAssetRequests: async ({ page: _page }, use) => {
-    await use([])
-  },
-  stubCloudAssets: [
-    async ({ cloudAssetRequests, page }, use) => {
-      const pattern = /\/api\/assets(?:\?.*)?$/
-      const assetsRouteHandler = (route: Route) => {
-        cloudAssetRequests.push(route.request().url())
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(makeAssetsResponse([LOTUS_DIFFUSION_MODEL]))
-        })
-      }
-
-      await page.route(pattern, assetsRouteHandler)
-      await use()
-      await page.unroute(pattern, assetsRouteHandler)
-    },
-    { auto: true }
-  ]
-})
+const test = createCloudAssetsFixture([LOTUS_DIFFUSION_MODEL])
 
 test.describe(
   'Errors tab - Cloud missing models',
@@ -75,11 +39,6 @@ test.describe(
         'Comfy.RightSidePanel.ShowErrorsTab',
         true
       )
-      await comfyPage.settings.setSetting('Comfy.Assets.UseAssetAPI', true)
-    })
-
-    test.afterEach(async ({ comfyPage }) => {
-      await comfyPage.nodeOps.clearGraph()
     })
 
     test('keeps installed models resolved after returning from a nested subgraph', async ({
@@ -88,38 +47,40 @@ test.describe(
     }) => {
       await comfyPage.workflow.loadWorkflow(WORKFLOW)
 
+      const panel = new PropertiesPanelHelper(comfyPage.page)
       const errorOverlay = comfyPage.page.getByTestId(
         TestIds.dialogs.errorOverlay
       )
-      const errorsTab = comfyPage.page.getByTestId(
+      const errorsTab = panel.root.getByTestId(
         TestIds.propertiesPanel.errorsTab
       )
-      const panel = new PropertiesPanelHelper(comfyPage.page)
 
       await expect
-        .poll(() => countDiffusionModelAssetRequests(cloudAssetRequests))
+        .poll(() =>
+          countAssetRequestsByTag(cloudAssetRequests, 'diffusion_models')
+        )
         .toBeGreaterThan(0)
       await expect(errorOverlay).toBeHidden()
       await panel.open(comfyPage.actionbar.propertiesButton)
       await expect(errorsTab).toBeHidden()
       await panel.close()
 
-      await comfyPage.vueNodes.waitForNodes()
       await comfyPage.vueNodes.enterSubgraph(OUTER_SUBGRAPH_NODE_ID)
       await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
       await expect(errorOverlay).toBeHidden()
 
-      const requestCountBeforeRootReturn =
-        countDiffusionModelAssetRequests(cloudAssetRequests)
+      const requestCountBeforeRootReturn = countAssetRequestsByTag(
+        cloudAssetRequests,
+        'diffusion_models'
+      )
 
-      await comfyPage.page.getByTestId(TestIds.breadcrumb.item('root')).click()
-      await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
+      await comfyPage.subgraph.exitViaBreadcrumb()
       await panel.open(comfyPage.actionbar.propertiesButton)
 
       await expect
         .poll(
           () =>
-            countDiffusionModelAssetRequests(cloudAssetRequests) >
+            countAssetRequestsByTag(cloudAssetRequests, 'diffusion_models') >
             requestCountBeforeRootReturn,
           { timeout: 10_000 }
         )

--- a/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
@@ -56,8 +56,9 @@ test.describe(
       )
 
       await expect
-        .poll(() =>
-          countAssetRequestsByTag(cloudAssetRequests, 'diffusion_models')
+        .poll(
+          () => countAssetRequestsByTag(cloudAssetRequests, 'diffusion_models'),
+          { timeout: 10_000 }
         )
         .toBeGreaterThan(0)
       await expect(errorOverlay).toBeHidden()

--- a/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts
@@ -86,11 +86,6 @@ test.describe(
       cloudAssetRequests,
       comfyPage
     }) => {
-      test.fail(
-        true,
-        'Root return currently replays nested subgraph container model widgets as missing in Cloud. Remove this annotation when the replay scan skips nested subgraph containers.'
-      )
-
       await comfyPage.workflow.loadWorkflow(WORKFLOW)
 
       const errorOverlay = comfyPage.page.getByTestId(
@@ -120,6 +115,11 @@ test.describe(
       await comfyPage.page.getByTestId(TestIds.breadcrumb.item('root')).click()
       await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(false)
       await panel.open(comfyPage.actionbar.propertiesButton)
+
+      test.fail(
+        true,
+        'Root return currently replays nested subgraph container model widgets as missing in Cloud. Remove this annotation when the replay scan skips nested subgraph containers.'
+      )
 
       await expect
         .poll(


### PR DESCRIPTION
## Summary

Adds a Cloud Playwright regression test for the nested subgraph case where an installed Lotus diffusion model is incorrectly surfaced as missing after returning to the root graph.

The fixture keeps the reproduction small: root graph -> subgraph node -> nested subgraph node -> `UNETLoader` using `lotus-depth-d-v1-1.safetensors`. The test stubs `/api/assets` through the shared asset API fixture so that model is explicitly present as a `diffusion_models` asset.

This test is intentionally written as an XFAIL regression guard. Its setup and precondition checks are outside the XFAIL section: initial workflow load must not show the error overlay, the Errors tab must initially stay hidden, subgraph entry must succeed, root return must succeed, and the replay scan must run. Only the final `Errors` tab visibility assertion is expected to fail on current Cloud behavior.

## What a green run means

A green CI run for this PR means the Cloud-only bug was reproduced at the intended point. The test reaches the root-return replay scan, verifies that the replay scan ran, and then current Cloud behavior makes the Errors tab visible even though the Lotus model exists in `/api/assets`.

If any earlier setup or navigation step fails, or if the root-return replay scan does not run, the test fails normally because those checks happen before `test.fail()` is applied.

Locally, removing `test.fail()` produces the expected red result after the replay-scan precondition passes, with `panel-tab-errors` visible.

The intended post-fix contract is that the replay scan still runs, but the Errors tab remains hidden.

## Why this is XFAIL

This PR intentionally ships only the regression test, not the production fix. The final behavioral assertion is annotated with `test.fail()` because the current Cloud replay path still treats the nested subgraph promoted model widget as missing.

When the follow-up fix lands, Playwright will report this test as an unexpected pass until the `test.fail()` annotation is removed. That is the handoff point for converting this regression guard into a normal passing E2E test.

## Follow-up

The stacked fix PR is #11908. It updates the replay scan so nested subgraph container nodes are skipped, then removes the `test.fail()` annotation from this test.

## Verification

- `pnpm exec oxfmt --check browser_tests/fixtures/assetApiFixture.ts browser_tests/tests/cloud-asset-default.spec.ts browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts`
- `pnpm exec oxlint browser_tests/fixtures/assetApiFixture.ts browser_tests/tests/cloud-asset-default.spec.ts browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts --type-aware`
- `pnpm exec eslint browser_tests/fixtures/assetApiFixture.ts browser_tests/tests/cloud-asset-default.spec.ts browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts`
- `pnpm typecheck:browser`
- `pnpm typecheck`
- `pnpm lint`
- `PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:8188 pnpm exec playwright test browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts browser_tests/tests/cloud-asset-default.spec.ts --project=cloud`
- Temporarily removed `test.fail()` locally and verified the test fails only after the replay-scan precondition passes, with `panel-tab-errors` visible

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11907-test-add-Playwright-regression-test-for-nested-subgraph-Cloud-missing-model-3566d73d3650810b86d4de916c2852f9) by [Unito](https://www.unito.io)
