### PR TITLE
chore(i18n): correct zh and zh-TW translations

### DIFF
--- a/src/locales/zh-TW/commands.json
+++ b/src/locales/zh-TW/commands.json
@@ -294,7 +294,7 @@
     "label": "說明中心"
   },
   "Comfy_ToggleLinear": {
-    "label": "切換線性模式"
+    "label": "切換應用模式"
   },
   "Comfy_ToggleQPOV2": {
     "label": "切換佇列面板 V2"
@@ -312,7 +312,7 @@
     "label": "登出"
   },
   "Experimental_ToggleVueNodes": {
-    "label": "實驗性：啟用 Vue 節點"
+    "label": "啟用 Nodes 2.0"
   },
   "Workspace_CloseWorkflow": {
     "label": "關閉當前工作流程"

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -903,8 +903,8 @@
     "resume": "繼續下載"
   },
   "errorDialog": {
-    "accessRestrictedMessage": "Your account is not authorized for this feature.",
-    "accessRestrictedTitle": "Access Restricted",
+    "accessRestrictedMessage": "您的帳戶無權使用此功能。",
+    "accessRestrictedTitle": "存取受限",
     "defaultTitle": "發生錯誤",
     "extensionFileHint": "這可能是由於以下指令碼所致",
     "loadWorkflowTitle": "由於重新載入工作流程資料時發生錯誤，已中止載入",

--- a/src/locales/zh-TW/nodeDefs.json
+++ b/src/locales/zh-TW/nodeDefs.json
@@ -371,7 +371,7 @@
   },
   "BriaImageEditNode": {
     "description": "使用 Bria 最新模型編輯圖像",
-    "display_name": "Bria 圖像編輯",
+    "display_name": "Bria FIBO 圖像編輯",
     "inputs": {
       "control_after_generate": {
         "name": "生成後控制"
@@ -864,7 +864,7 @@
   },
   "ByteDanceSeedreamNode": {
     "description": "統一文字生成圖片和精確單句編輯，最高支援 4K 解析度。",
-    "display_name": "字節跳動 Seedream 4",
+    "display_name": "ByteDance Seedream 4.5 & 5.0",
     "inputs": {
       "control_after_generate": {
         "name": "生成後控制"
@@ -1047,7 +1047,7 @@
     }
   },
   "CLIPLoader": {
-    "description": "[配方]\n\nstable_diffusion: clip-l\nstable_cascade: clip-g\nsd3: t5 xxl/ clip-g / clip-l\nstable_audio: t5 base\nmochi: t5 xxl\ncosmos: 舊 t5 xxl\nlumina2: gemma 2 2B\nwan: umt5 xxl\nhidream: llama-3.1（推薦）或 t5",
+    "description": "[配方]\n\nstable_diffusion: clip-l\nstable_cascade: clip-g\nsd3: t5 xxl/ clip-g / clip-l\nstable_audio: t5 base\nmochi: t5 xxl\ncosmos: 舊 t5 xxl\nlumina2: gemma 2 2B\nwan: umt5 xxl\nhidream: llama-3.1（推薦）或 t5\nomnigen2: qwen vl 2.5 3B",
     "display_name": "載入 CLIP",
     "inputs": {
       "clip_name": {

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -428,11 +428,11 @@
     "name": "驗證工作流程"
   },
   "Comfy_VueNodes_AutoScaleLayout": {
-    "name": "自動縮放佈局 (Vue 節點)",
+    "name": "自動縮放佈局 (Nodes 2.0)",
     "tooltip": "切換至 Vue 渲染時自動縮放節點位置以防止重疊"
   },
   "Comfy_VueNodes_Enabled": {
-    "name": "現代節點設計 (Vue 節點)",
+    "name": "現代節點設計 (Nodes 2.0)",
     "tooltip": "現代：基於 DOM 的渲染，具備增強的互動性、原生瀏覽器功能和更新的視覺設計。經典：傳統畫布渲染。"
   },
   "Comfy_WidgetControlMode": {

--- a/src/locales/zh/commands.json
+++ b/src/locales/zh/commands.json
@@ -294,7 +294,7 @@
     "label": "说明中心"
   },
   "Comfy_ToggleLinear": {
-    "label": "切换线性模式"
+    "label": "切换应用模式"
   },
   "Comfy_ToggleQPOV2": {
     "label": "切换队列面板V2"
@@ -312,7 +312,7 @@
     "label": "退出登录"
   },
   "Experimental_ToggleVueNodes": {
-    "label": "实验性：启用 Vue 节点"
+    "label": "启用 Nodes 2.0"
   },
   "Workspace_CloseWorkflow": {
     "label": "关闭当前工作流"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -903,8 +903,8 @@
     "resume": "恢复下载"
   },
   "errorDialog": {
-    "accessRestrictedMessage": "Your account is not authorized for this feature.",
-    "accessRestrictedTitle": "Access Restricted",
+    "accessRestrictedMessage": "您的账户无权使用此功能。",
+    "accessRestrictedTitle": "访问受限",
     "defaultTitle": "发生错误",
     "extensionFileHint": "这可能是由于以下脚本",
     "loadWorkflowTitle": "由于重新加载工作流数据出错，加载被中止",

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -1047,7 +1047,7 @@
     }
   },
   "CLIPLoader": {
-    "description": "[配方]\n\nstable_diffusion: clip-l\nstable_cascade: clip-g\nsd3: t5 xxl/ clip-g / clip-l\nstable_audio: t5 base\nmochi: t5 xxl\ncosmos: old t5 xxl\nlumina2: gemma 2 2B\nwan: umt5 xxl\nhidream: llama-3.1（推荐）或 t5\nomnigen2: qwen vl 2.5 3B",
+    "description": "[配方]\n\nstable_diffusion: clip-l\nstable_cascade: clip-g\nsd3: t5 xxl/ clip-g / clip-l\nstable_audio: t5 base\nmochi: t5 xxl\ncosmos: 旧 t5 xxl\nlumina2: gemma 2 2B\nwan: umt5 xxl\nhidream: llama-3.1（推荐）或 t5\nomnigen2: qwen vl 2.5 3B",
     "display_name": "加载CLIP",
     "inputs": {
       "clip_name": {

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -3,7 +3,7 @@
     "display_name": "自适应投影引导",
     "inputs": {
       "eta": {
-        "name": "预计到达时间",
+        "name": "eta",
         "tooltip": "控制平行引导向量的缩放比例。默认 CFG 行为设置为 1。"
       },
       "model": {
@@ -371,7 +371,7 @@
   },
   "BriaImageEditNode": {
     "description": "使用 Bria 最新模型编辑图像",
-    "display_name": "Bria 图像编辑",
+    "display_name": "Bria FIBO 图像编辑",
     "inputs": {
       "control_after_generate": {
         "name": "control after generate"
@@ -864,7 +864,7 @@
   },
   "ByteDanceSeedreamNode": {
     "description": "统一文本到图像生成，支持高达4K分辨率的精确单句编辑。",
-    "display_name": "字节跳动Seedream 4",
+    "display_name": "ByteDance Seedream 4.5 & 5.0",
     "inputs": {
       "control_after_generate": {
         "name": "生成后控制"
@@ -1047,7 +1047,7 @@
     }
   },
   "CLIPLoader": {
-    "description": "[配方]\n\nStable Diffusion：clip-l\nStable Cascade：clip-g\nSD3：t5 / clip-g / clip-l\nStable Audio：t5\nMochi：t5\ncosmos：old t5 xxl",
+    "description": "[配方]\n\nstable_diffusion: clip-l\nstable_cascade: clip-g\nsd3: t5 xxl/ clip-g / clip-l\nstable_audio: t5 base\nmochi: t5 xxl\ncosmos: old t5 xxl\nlumina2: gemma 2 2B\nwan: umt5 xxl\nhidream: llama-3.1（推荐）或 t5\nomnigen2: qwen vl 2.5 3B",
     "display_name": "加载CLIP",
     "inputs": {
       "clip_name": {

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -428,11 +428,11 @@
     "name": "校验工作流"
   },
   "Comfy_VueNodes_AutoScaleLayout": {
-    "name": "自动缩放布局（Vue节点）",
+    "name": "自动缩放布局（Nodes 2.0）",
     "tooltip": "切换到Vue渲染时自动缩放节点位置以防止重叠"
   },
   "Comfy_VueNodes_Enabled": {
-    "name": "现代节点设计（Vue节点）",
+    "name": "现代节点设计（Nodes 2.0）",
     "tooltip": "现代：基于DOM的渲染，具有增强的交互性、原生浏览器功能和更新的视觉设计。经典：传统的画布渲染。"
   },
   "Comfy_WidgetControlMode": {


### PR DESCRIPTION
## Summary

Fixes several issues in both Simplified Chinese (zh) and Traditional Chinese (zh-TW) locale files that were identified through systematic comparison against the English source.

### Changes

**nodeDefs.json (zh + zh-TW):**
- **CLIPLoader.description**: Added missing model recipes (lumina2, wan, hidream, omnigen2) to match English source
- **ByteDanceSeedreamNode.display_name**: Updated version from "Seedream 4" to "Seedream 4.5 and 5.0" to match English
- **BriaImageEditNode.display_name**: Added missing "FIBO" model name

**nodeDefs.json (zh only):**
- **APG.inputs.eta.name**: Fixed incorrect translation "预计到达时间" (ETA) -> kept as "eta" (technical parameter name)

**commands.json (zh + zh-TW):**
- **Comfy_ToggleLinear**: Updated label to match English "Toggle App Mode"
- **Experimental_ToggleVueNodes**: Rebranded "Vue 节点"/"Vue 節點" to "Nodes 2.0" to match English

**settings.json (zh + zh-TW):**
- **Comfy_VueNodes_Enabled / Comfy_VueNodes_AutoScaleLayout**: Rebranded "Vue 节点"/"Vue 節點" to "Nodes 2.0"

**main.json (zh + zh-TW):**
- **errorDialog.accessRestrictedMessage / accessRestrictedTitle**: Added missing Chinese translations

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11930-fix-i18n-correct-zh-and-zh-TW-translations-3566d73d365081ff9b0beb1c1fc7ef1a) by [Unito](https://www.unito.io)
