### PR TITLE
feat: unify workspace model and update billing UI

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2391,7 +2391,7 @@
     "viewMoreDetails": "View more details",
     "learnMore": "Learn more",
     "billedMonthly": "Billed monthly",
-    "billedYearly": "{total} Billed yearly",
+    "billedYearly": "{total} billed yearly",
     "monthly": "Monthly",
     "yearly": "Yearly",
     "tierNameYearly": "{name} Yearly",
@@ -2434,6 +2434,7 @@
     "subscribeToRunFull": "Subscribe to Run",
     "subscribeForMore": "Upgrade",
     "upgradeToAddCredits": "Upgrade to add credits",
+    "subscribe": "Subscribe",
     "subscribeNow": "Subscribe Now",
     "subscribeToComfyCloud": "Subscribe to Comfy Cloud",
     "workspaceNotSubscribed": "This workspace is not on a subscription",
@@ -2492,6 +2493,52 @@
       "pro": "1 hr",
       "founder": "30 min"
     },
+    "forPersonal": "For Personal",
+    "forTeams": "For Teams",
+    "choosePlan": "Choose a Plan",
+    "choosePersonalPlan": "Choose a Personal Plan",
+    "personalDisclaimer": "Personal plans are for individual use only. {teamBold}.",
+    "personalDisclaimerTeam": "To add teammates, upgrade to the Team plan",
+    "lookingForSimpler": "Looking for simpler fixed plans? See personal plans.",
+    "everythingInPlus": "Everything in {tier}, plus:",
+    "freeVideoEstimate": "Generates ~{count} 5s videos*",
+    "freeTierMaxRuntime": "10-minute max runtime",
+    "standardMaxRuntime": "30 minute max workflow runtime",
+    "proMaxRuntimeLong": "Longer workflow runtime (up to 1 hr)",
+    "addMoreCreditsAnytime": "Add more credits anytime",
+    "importOwnLoRAs": "Import your own LoRAs",
+    "teamPlanSubtitle": "For growing teams running Comfy in production. Need more? {learnMore} about enterprise.",
+    "teamPlanLearnMore": "Learn more",
+    "teamPlan": {
+      "title": "Team Plan",
+      "customizeYourPlan": "Customize your plan",
+      "planDetails": "Plan details",
+      "saveUpTo": "Save up to {percent}%",
+      "save": "Save {percent}%",
+      "monthlyCredits": "monthly credits",
+      "billedYearlyAmount": "${amount} billed yearly",
+      "largerDiscount": "Get a larger discount when you select more credits.",
+      "generatesVideos": "Generates ~{count} 5s videos*",
+      "subscribeToYearly": "Subscribe to Yearly",
+      "subscribeToMonthly": "Subscribe to Monthly",
+      "subscribeAndCreate": "Subscribe to Team",
+      "maxRuntime": "1 hr max workflow runtime",
+      "addCredits": "Add more credits anytime",
+      "importLoRAs": "Import your own LoRAs",
+      "centralizedBilling": "Centralized billing for the whole team",
+      "roleBasedPermissions": "Role-based permissions",
+      "comingSoon": "Coming soon:",
+      "projectManagement": "Project & asset management",
+      "memberDescription": "Add, remove, and manage up to 30 members in your workspace. All members automatically get Pro tier benefits and their own concurrency.",
+      "memberNeedMore": "Need more than 30?",
+      "videoDisclaimer": "*Based on this template. {details}.",
+      "clickForDetails": "Click for details",
+      "wanTemplate": "Wan 2.2 Image-to-Video template",
+      "contactFooter": "Contact us for {questions} or {enterprise}. For more pricing details, {pricing}.",
+      "questions": "questions",
+      "enterpriseDiscussions": "enterprise discussions",
+      "clickHere": "click here"
+    },
     "billingComingSoon": {
       "title": "Coming Soon",
       "message": "Team billing is coming soon. You'll be able to subscribe to a plan for your workspace with per-seat pricing. Stay tuned for updates."
@@ -2516,7 +2563,38 @@
       "addCreditCard": "Add credit card",
       "confirm": "Confirm",
       "backToAllPlans": "Back to all plans"
-    }
+    },
+    "teamWorkspacePlan": "Team Workspace Plan",
+    "customizeYourPlan": "Customize your plan",
+    "planDetails": "Plan details",
+    "saveUpTo": "Save up to {percent}%",
+    "save": "Save {percent}%",
+    "monthlyCredits": "monthly credits",
+    "billedYearlyAmount": "${amount} billed yearly",
+    "billedMonthlyAmount": "Billed monthly",
+    "largerDiscount": "Get a larger discount when you select more credits.",
+    "generatesVideos": "Generates ~{count} 5s videos*",
+    "subscribeToYearly": "Subscribe to Yearly",
+    "subscribeToMonthly": "Subscribe to Monthly",
+    "subscribeAndCreate": "Subscribe to Team",
+    "features": {
+      "maxRuntime": "1 hr max workflow runtime",
+      "addCredits": "Add more credits anytime",
+      "importLoRAs": "Import your own LoRAs",
+      "centralizedBilling": "Centralized billing for the whole team",
+      "roleBasedPermissions": "Role-based permissions"
+    },
+    "comingSoon": "Coming soon:",
+    "comingSoonFeatures": {
+      "projectManagement": "Project & asset management"
+    },
+    "memberDescription": "Add, remove, and manage up to 30 members in your workspace. All members automatically get Pro tier benefits and their own concurrency. Need more than 30?",
+    "videoDisclaimer": "*Based on 5s videos created with the {template} using default settings (81 frames, 18fps, 640×640, 4-step sampler).",
+    "wanTemplate": "Wan 2.2 Image-to-Video template",
+    "contactForQuestions": "Contact us for {questions} or {enterprise}. For more pricing details, {pricing}.",
+    "questions": "questions",
+    "enterpriseDiscussions": "enterprise discussions",
+    "clickHere": "click here"
   },
   "userSettings": {
     "title": "My Account Settings",
@@ -2535,13 +2613,14 @@
     "tabs": {
       "dashboard": "Dashboard",
       "planCredits": "Plan & Credits",
+      "members": "Members",
       "membersCount": "Members ({count})"
     },
     "dashboard": {
       "placeholder": "Dashboard workspace settings"
     },
     "members": {
-      "membersCount": "{count}/{maxSeats} Members",
+      "membersCount": "{count} of {maxSeats} members",
       "pendingInvitesCount": "{count} pending invite | {count} pending invites",
       "tabs": {
         "active": "Active",
@@ -2563,7 +2642,12 @@
       "noInvites": "No pending invites",
       "noMembers": "No members",
       "personalWorkspaceMessage": "You can't invite other members to your personal workspace right now. To add members to a workspace,",
-      "createNewWorkspace": "create a new one."
+      "createNewWorkspace": "create a new one.",
+      "personalWorkspaceDisclaimer": "Personal workspaces are for individual use only. {teamBold}",
+      "personalWorkspaceDisclaimerTeam": "To add teammates, create a team workspace.",
+      "seeTeamPlan": "See Team plan",
+      "upgradeToAddTeammates": "To add teammates, upgrade your plan.",
+      "upgradeToTeam": "Upgrade to Team"
     },
     "menu": {
       "editWorkspace": "Edit workspace details",
@@ -2622,10 +2706,12 @@
     },
     "createWorkspaceDialog": {
       "title": "Create a new workspace",
-      "message": "Workspaces create a new credit pool that can be shared among members. You'll become the owner after creating this.",
-      "nameLabel": "Workspace name*",
+      "message": "Workspaces keep your projects and files organized. Subscribe to a Team plan to invite members.",
+      "nameLabel": "Workspace name",
       "namePlaceholder": "Enter workspace name",
-      "create": "Create"
+      "personalStaysInfo": "Your personal workspace stays. Swap between this new workspace and your personal at any time.",
+      "create": "Create",
+      "next": "Next"
     },
     "toast": {
       "workspaceCreated": {
@@ -2670,7 +2756,9 @@
     "personal": "Personal",
     "roleOwner": "Owner",
     "roleMember": "Member",
+    "teamWorkspacesSection": "TEAM WORKSPACES",
     "createWorkspace": "Create new workspace",
+    "createTeamWorkspace": "Create a workspace",
     "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one.",
     "failedToSwitch": "Failed to switch workspace"
   },

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -1,219 +1,328 @@
 <template>
-  <div class="flex flex-col gap-6">
-    <div class="flex justify-center">
-      <SelectButton
-        v-model="currentBillingCycle"
-        :options="billingCycleOptions"
-        option-label="label"
-        option-value="value"
-        :allow-empty="false"
-        unstyled
-        :pt="{
-          root: {
-            class: 'flex gap-1 bg-secondary-background rounded-lg p-1.5'
-          },
-          pcToggleButton: {
-            root: ({ context }: ToggleButtonPassThroughMethodOptions) => ({
-              class: [
-                'w-36  h-8 rounded-md transition-colors cursor-pointer border-none outline-none ring-0 text-sm font-medium flex items-center justify-center',
-                context.active
-                  ? 'bg-base-foreground text-base-background'
-                  : 'bg-transparent text-muted-foreground hover:bg-secondary-background-hover'
-              ]
-            }),
-            label: { class: 'flex items-center gap-2 ' }
-          }
-        }"
-      >
-        <template #option="{ option }">
-          <div class="flex items-center gap-2">
-            <span>{{ option.label }}</span>
-            <div
-              v-if="option.value === 'yearly'"
-              class="flex items-center rounded-full bg-primary-background px-1 py-0.5 text-2xs font-bold text-white"
-            >
-              -20%
-            </div>
-          </div>
-        </template>
-      </SelectButton>
-    </div>
-    <div class="flex flex-col items-stretch gap-4 xl:flex-row">
-      <div
-        v-for="tier in tiers"
-        :key="tier.id"
+  <div class="relative flex flex-col">
+    <!-- Close button -->
+    <button
+      class="absolute top-0 right-0 z-10 flex size-8 cursor-pointer items-center justify-center rounded-lg border-none bg-transparent text-muted-foreground hover:text-base-foreground"
+      :aria-label="t('g.close')"
+      @click="emit('close')"
+    >
+      <i class="icon-[lucide--x] size-4" />
+    </button>
+
+    <!-- Title -->
+    <h2
+      class="m-0 py-6 text-center font-inter text-2xl font-semibold text-base-foreground"
+    >
+      {{ t('subscription.choosePlan') }}
+    </h2>
+
+    <!-- Tab bar -->
+    <div class="flex items-center justify-center">
+      <button
         :class="
           cn(
-            'flex flex-1 flex-col rounded-2xl border border-border-default bg-base-background shadow-[0_0_12px_rgba(0,0,0,0.1)]',
-            tier.isPopular ? 'border-muted-foreground' : ''
+            'flex h-10 cursor-pointer items-center justify-center rounded-t-lg border-none bg-base-background px-4 py-2 text-sm font-bold',
+            activeTab === 'personal'
+              ? 'text-base-foreground'
+              : 'text-muted-foreground opacity-50'
+          )
+        "
+        @click="activeTab = 'personal'"
+      >
+        {{ t('subscription.forPersonal') }}
+      </button>
+      <button
+        :class="
+          cn(
+            'flex h-10 cursor-pointer items-center justify-center rounded-t-lg border-none bg-base-background px-4 py-2 text-sm font-bold',
+            activeTab === 'teams'
+              ? 'text-base-foreground'
+              : 'text-muted-foreground opacity-50'
+          )
+        "
+        @click="activeTab = 'teams'"
+      >
+        {{ t('subscription.forTeams') }}
+      </button>
+    </div>
+
+    <!-- Tab content: grid overlay keeps height stable across tab switches -->
+    <div class="grid">
+      <!-- Personal tab content -->
+      <div
+        :class="
+          cn(
+            'col-start-1 row-start-1 flex flex-col',
+            activeTab !== 'personal' && 'invisible'
           )
         "
       >
-        <div class="flex flex-col gap-4 p-6 pb-0">
-          <div class="flex flex-row items-center justify-between gap-2">
-            <span
-              class="font-inter text-base/normal font-bold text-base-foreground"
-            >
-              {{ tier.name }}
-            </span>
-            <div
-              v-if="tier.isPopular"
-              class="flex h-5 items-center rounded-full bg-base-foreground px-1.5 text-2xs font-bold tracking-tight text-base-background uppercase"
-            >
-              {{ t('subscription.mostPopular') }}
-            </div>
-          </div>
-          <div class="flex flex-col">
-            <div class="flex flex-col gap-2">
-              <div class="flex flex-row items-baseline gap-2">
+        <div
+          class="flex flex-1 flex-col items-center gap-6 rounded-2xl bg-base-background p-8"
+        >
+          <!-- Disclaimer -->
+          <p class="m-0 text-center text-base text-muted-foreground">
+            <i18n-t keypath="subscription.personalDisclaimer">
+              <template #teamBold>
                 <span
-                  class="font-inter text-[28px] leading-normal font-semibold text-base-foreground"
+                  class="cursor-pointer text-base-foreground hover:text-muted-foreground"
+                  role="button"
+                  tabindex="0"
+                  @click="activeTab = 'teams'"
+                  @keydown.enter="activeTab = 'teams'"
                 >
-                  <span
-                    v-show="currentBillingCycle === 'yearly'"
-                    class="text-2xl text-muted-foreground line-through"
-                  >
-                    ${{ tier.pricing.monthly }}
-                  </span>
-                  ${{ getPrice(tier) }}
+                  {{ t('subscription.personalDisclaimerTeam') }}
                 </span>
-                <span class="font-inter text-xl/normal text-base-foreground">
-                  {{ t('subscription.usdPerMonth') }}
-                </span>
-              </div>
-              <div class="flex items-center gap-2">
-                <span class="text-sm text-muted-foreground">
-                  {{
-                    currentBillingCycle === 'yearly'
-                      ? t('subscription.billedYearly', {
-                          total: `$${getAnnualTotal(tier)}`
-                        })
-                      : t('subscription.billedMonthly')
-                  }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <p
-            role="note"
-            :aria-label="t('subscription.soloUseOnly')"
-            class="m-0 flex h-10 items-center rounded-lg bg-muted-foreground/30 px-3 text-sm text-muted-foreground"
-          >
-            {{ t('subscription.soloUseOnly') }}
-            <span class="mx-1 text-muted-foreground">–</span>
-            <button
-              class="text-primary-foreground cursor-pointer border-none bg-transparent p-0 text-sm font-medium underline hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
-              @click="emit('chooseTeamWorkspace')"
-            >
-              {{ t('subscription.needTeamWorkspace') }}
-            </button>
+              </template>
+            </i18n-t>
           </p>
 
-          <div class="flex flex-1 flex-col gap-3 pb-0">
-            <div class="flex flex-row items-center justify-between">
-              <span
-                class="text-foreground font-inter text-sm/normal font-normal"
-              >
-                {{
-                  currentBillingCycle === 'yearly'
-                    ? t('subscription.yearlyCreditsLabel')
-                    : t('subscription.monthlyCreditsLabel')
-                }}
-              </span>
-              <div class="flex flex-row items-center gap-1">
-                <i class="icon-[lucide--component] text-sm text-amber-400" />
-                <span
-                  class="font-inter text-sm/normal font-bold text-base-foreground"
+          <!-- Billing toggle -->
+          <SelectButton
+            v-model="currentBillingCycle"
+            :options="billingCycleOptions"
+            option-label="label"
+            option-value="value"
+            :allow-empty="false"
+            unstyled
+            :pt="{
+              root: {
+                class: 'flex gap-1 bg-secondary-background rounded-lg p-1.5'
+              },
+              pcToggleButton: {
+                root: ({ context }: ToggleButtonPassThroughMethodOptions) => ({
+                  class: [
+                    'w-36 h-8 rounded-md transition-colors cursor-pointer border-none outline-none ring-0 text-sm font-medium flex items-center justify-center',
+                    context.active
+                      ? 'bg-base-foreground text-base-background'
+                      : 'bg-transparent text-muted-foreground hover:bg-secondary-background-hover'
+                  ]
+                }),
+                label: { class: 'flex items-center gap-2' }
+              }
+            }"
+          >
+            <template #option="{ option }">
+              <div class="flex items-center gap-2">
+                <span>{{ option.label }}</span>
+                <div
+                  v-if="option.value === 'yearly'"
+                  class="flex items-center rounded-full bg-primary-background px-1 py-0.5 text-2xs font-bold text-white"
                 >
-                  {{ n(getCreditsDisplay(tier)) }}
-                </span>
+                  {{ t('subscription.teamPlan.save', { percent: 20 }) }}
+                </div>
               </div>
-            </div>
+            </template>
+          </SelectButton>
 
-            <div class="flex flex-row items-center justify-between">
-              <span class="text-foreground text-sm font-normal">
-                {{ t('subscription.maxDurationLabel') }}
-              </span>
-              <span
-                class="font-inter text-sm/normal font-bold text-base-foreground"
-              >
-                {{ tier.maxDuration }}
-              </span>
-            </div>
-
-            <div class="flex flex-row items-center justify-between">
-              <span class="text-foreground text-sm font-normal">
-                {{ t('subscription.gpuLabel') }}
-              </span>
-              <i class="pi pi-check text-success-foreground text-xs" />
-            </div>
-
-            <div class="flex flex-row items-center justify-between">
-              <span class="text-foreground text-sm font-normal">
-                {{ t('subscription.addCreditsLabel') }}
-              </span>
-              <i class="pi pi-check text-success-foreground text-xs" />
-            </div>
-
-            <div class="flex flex-row items-center justify-between">
-              <span class="text-foreground text-sm font-normal">
-                {{ t('subscription.customLoRAsLabel') }}
-              </span>
-              <i
-                v-if="tier.customLoRAs"
-                class="pi pi-check text-success-foreground text-xs"
-              />
-              <i v-else class="pi pi-times text-foreground text-xs" />
-            </div>
-
-            <div class="flex flex-col gap-2">
-              <div class="flex flex-row items-start justify-between">
-                <div class="flex flex-col gap-2">
-                  <span class="text-foreground text-sm/relaxed font-normal">
-                    {{ t('subscription.videoEstimateLabel') }}
+          <!-- 4 Tier Cards -->
+          <div class="flex flex-col items-stretch gap-6 lg:flex-row">
+            <div
+              v-for="tier in tiers"
+              :key="tier.id"
+              :class="
+                cn(
+                  'flex flex-1 flex-col overflow-clip rounded-2xl border bg-base-background shadow-md',
+                  tier.isPopular
+                    ? 'border-muted-foreground'
+                    : 'border-border-default'
+                )
+              "
+            >
+              <!-- Body -->
+              <div class="flex flex-1 flex-col gap-6 p-8">
+                <!-- Plan name + badge -->
+                <div class="flex items-center justify-between">
+                  <span
+                    class="font-inter text-base/normal font-bold text-base-foreground"
+                  >
+                    {{ tier.name }}
                   </span>
-                  <div class="group flex flex-row items-center gap-2 pt-2">
+                  <div
+                    v-if="tier.isPopular"
+                    class="flex h-4 items-center rounded-full bg-base-foreground px-1 text-2xs font-bold tracking-tight text-base-background uppercase"
+                  >
+                    {{ t('subscription.mostPopular') }}
+                  </div>
+                </div>
+
+                <!-- Price -->
+                <div class="flex flex-col gap-2">
+                  <p class="m-0 mb-1 flex items-baseline text-base-foreground">
+                    <span class="text-[32px] leading-none font-semibold">
+                      ${{ getPrice(tier) }}
+                    </span>
+                    <span class="text-base font-normal">
+                      &nbsp;{{ t('subscription.usdPerMonth') }}
+                    </span>
+                  </p>
+
+                  <!-- Credits -->
+                  <div class="flex items-center gap-1">
                     <i
-                      class="pi pi-question-circle text-xs text-muted-foreground group-hover:text-base-foreground"
+                      class="icon-[lucide--component] size-4 text-amber-400"
+                      aria-hidden="true"
                     />
                     <span
-                      class="cursor-pointer text-sm font-normal text-muted-foreground group-hover:text-base-foreground"
-                      @click="togglePopover"
+                      class="font-inter text-base/normal font-bold text-base-foreground"
                     >
-                      {{ t('subscription.videoEstimateHelp') }}
+                      {{ n(tier.pricing.credits) }}
+                    </span>
+                    <span class="text-sm text-base-foreground">
+                      {{ t('subscription.teamPlan.monthlyCredits') }}
+                    </span>
+                  </div>
+
+                  <!-- Billed text (invisible for free tier to keep dividers aligned) -->
+                  <div class="flex items-center pt-1">
+                    <span
+                      :class="
+                        cn(
+                          'text-sm text-muted-foreground',
+                          tier.key === 'free' && 'invisible'
+                        )
+                      "
+                    >
+                      {{
+                        tier.key === 'free'
+                          ? '\u00A0'
+                          : currentBillingCycle === 'yearly'
+                            ? t('subscription.billedYearly', {
+                                total: `$${getAnnualTotal(tier)}`
+                              })
+                            : t('subscription.billedMonthly')
+                      }}
                     </span>
                   </div>
                 </div>
-                <span
-                  class="font-inter text-sm/normal font-bold text-base-foreground"
+
+                <!-- Video estimate -->
+                <div class="flex items-center gap-2">
+                  <span class="text-sm text-muted-foreground">
+                    {{
+                      t('subscription.freeVideoEstimate', {
+                        count: n(tier.pricing.videoEstimate)
+                      })
+                    }}
+                  </span>
+                </div>
+
+                <!-- Divider -->
+                <div class="border-t border-border-default" />
+
+                <!-- Features -->
+                <div class="flex flex-col gap-4">
+                  <span
+                    :class="
+                      cn(
+                        'text-sm text-muted-foreground',
+                        !tier.inheritsFrom && 'invisible'
+                      )
+                    "
+                  >
+                    {{
+                      t('subscription.everythingInPlus', {
+                        tier: tier.inheritsFrom ?? tier.name
+                      })
+                    }}
+                  </span>
+                  <div
+                    v-for="feature in tier.features"
+                    :key="feature"
+                    class="flex items-center gap-2"
+                  >
+                    <i
+                      class="icon-[lucide--check] size-4 shrink-0 text-base-foreground"
+                      aria-hidden="true"
+                    />
+                    <span class="text-sm text-base-foreground">
+                      {{ feature }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Subscribe button -->
+              <div class="p-8">
+                <Button
+                  size="lg"
+                  :variant="tier.isPopular ? 'inverted' : 'secondary'"
+                  :disabled="isLoading || isCurrentPlan(tier.key)"
+                  :loading="loadingTier === tier.key"
+                  class="w-full font-bold"
+                  @click="handleSubscribe(tier.key)"
                 >
-                  ~{{ n(tier.pricing.videoEstimate) }}
-                </span>
+                  {{ getButtonLabel(tier) }}
+                </Button>
               </div>
             </div>
           </div>
         </div>
-        <div class="flex flex-col p-6">
-          <Button
-            :variant="getButtonSeverity(tier)"
-            :disabled="isLoading || isCurrentPlan(tier.key)"
-            :loading="loadingTier === tier.key"
-            :class="
-              cn(
-                'h-10 w-full',
-                getButtonTextClass(tier),
-                tier.key === 'creator'
-                  ? 'border-transparent bg-base-foreground hover:bg-inverted-background-hover'
-                  : 'border-transparent bg-secondary-background hover:bg-secondary-background-hover focus:bg-secondary-background-selected'
-              )
-            "
-            @click="() => handleSubscribe(tier.key)"
-          >
-            {{ getButtonLabel(tier) }}
-          </Button>
+
+        <!-- Footer disclaimer (personal tab) -->
+        <div
+          class="flex items-start gap-4 pt-4 pb-2 text-sm text-muted-foreground"
+        >
+          <p class="m-0">
+            <i18n-t keypath="subscription.teamPlan.videoDisclaimer">
+              <template #details>
+                <button
+                  class="cursor-pointer border-none bg-transparent p-0 font-inter text-sm text-base-foreground no-underline hover:text-muted-foreground"
+                  @click="togglePopover"
+                >
+                  {{ t('subscription.teamPlan.clickForDetails') }}
+                </button>
+              </template>
+            </i18n-t>
+          </p>
+          <p class="m-0">
+            <i18n-t keypath="subscription.teamPlan.contactFooter">
+              <template #questions>
+                <a
+                  href="https://www.comfy.org/discord"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-base-foreground no-underline hover:text-muted-foreground"
+                >
+                  {{ t('subscription.teamPlan.questions') }}
+                </a>
+              </template>
+              <template #enterprise>
+                <a
+                  href="https://www.comfy.org/enterprise"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-base-foreground no-underline hover:text-muted-foreground"
+                >
+                  {{ t('subscription.teamPlan.enterpriseDiscussions') }}
+                </a>
+              </template>
+              <template #pricing>
+                <a
+                  href="https://www.comfy.org/pricing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-base-foreground no-underline hover:text-muted-foreground"
+                >
+                  {{ t('subscription.teamPlan.clickHere') }}
+                </a>
+              </template>
+            </i18n-t>
+          </p>
         </div>
       </div>
+
+      <!-- Teams tab content -->
+      <TeamPlanLayout
+        :class="
+          cn('col-start-1 row-start-1', activeTab !== 'teams' && 'invisible')
+        "
+        :is-loading="isLoading"
+        :loading-tier="loadingTier"
+        :subscribe-button-label="t('subscription.teamPlan.subscribeAndCreate')"
+        @subscribe="handleTeamSubscribe"
+        @contact-us="handleContactUs"
+      />
     </div>
 
     <!-- Video Estimate Help Popover -->
@@ -228,12 +337,12 @@
       :pt="{
         root: {
           class:
-            'rounded-lg border border-interface-stroke bg-interface-panel-surface shadow-lg p-4 max-w-xs'
+            'rounded-lg border border-border-default bg-base-background shadow-lg p-4 max-w-xs'
         }
       }"
     >
       <div class="flex flex-col gap-2">
-        <p class="text-sm/normal text-base-foreground">
+        <p class="m-0 text-sm/normal text-base-foreground">
           {{ t('subscription.videoEstimateExplanation') }}
         </p>
         <a
@@ -242,10 +351,8 @@
           rel="noopener noreferrer"
           class="flex gap-1 text-sm text-azure-600 no-underline hover:text-azure-400"
         >
-          <span class="underline">
-            {{ t('subscription.videoEstimateTryTemplate') }}
-          </span>
-          <span class="no-underline" v-html="'&rarr;'"></span>
+          <span>{{ t('subscription.videoEstimateTryTemplate') }}</span>
+          <span v-html="'&rarr;'"></span>
         </a>
       </div>
     </Popover>
@@ -253,7 +360,6 @@
 </template>
 
 <script setup lang="ts">
-import { cn } from '@comfyorg/tailwind-utils'
 import { storeToRefs } from 'pinia'
 import Popover from 'primevue/popover'
 import SelectButton from 'primevue/selectbutton'
@@ -261,6 +367,7 @@ import type { ToggleButtonPassThroughMethodOptions } from 'primevue/togglebutton
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { cn } from '@comfyorg/tailwind-utils'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
@@ -282,9 +389,13 @@ import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { CheckoutAttributionMetadata } from '@/platform/telemetry/types'
 import { useAuthStore } from '@/stores/authStore'
+import TeamPlanLayout from '@/platform/cloud/subscription/components/TeamPlanLayout.vue'
 
 type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
 type CheckoutTier = CheckoutTierKey | `${CheckoutTierKey}-yearly`
+
+const FREE_TIER_CREDITS = 400
+const FREE_TIER_VIDEO_ESTIMATE = 35
 
 const getCheckoutTier = (
   tierKey: CheckoutTierKey,
@@ -309,20 +420,27 @@ interface BillingCycleOption {
 }
 
 interface PricingTierConfig {
-  id: SubscriptionTier
-  key: CheckoutTierKey
+  id: SubscriptionTier | 'FREE'
+  key: TierKey
   name: string
   pricing: TierPricing
-  maxDuration: string
-  customLoRAs: boolean
+  features: string[]
+  inheritsFrom?: string
   isPopular?: boolean
 }
 
+const { defaultTab = 'personal' } = defineProps<{
+  defaultTab?: 'personal' | 'teams'
+}>()
+
 const emit = defineEmits<{
   chooseTeamWorkspace: []
+  close: []
 }>()
 
 const { t, n } = useI18n()
+
+const activeTab = ref<'personal' | 'teams'>(defaultTab)
 
 const billingCycleOptions: BillingCycleOption[] = [
   { label: t('subscription.yearly'), value: 'yearly' },
@@ -331,12 +449,28 @@ const billingCycleOptions: BillingCycleOption[] = [
 
 const tiers: PricingTierConfig[] = [
   {
+    id: 'FREE',
+    key: 'free',
+    name: t('subscription.tiers.free.name'),
+    pricing: {
+      monthly: 0,
+      yearly: 0,
+      credits: FREE_TIER_CREDITS,
+      videoEstimate: FREE_TIER_VIDEO_ESTIMATE
+    },
+    features: [t('subscription.freeTierMaxRuntime')],
+    isPopular: false
+  },
+  {
     id: 'STANDARD',
     key: 'standard',
     name: t('subscription.tiers.standard.name'),
     pricing: TIER_PRICING.standard,
-    maxDuration: t('subscription.maxDuration.standard'),
-    customLoRAs: false,
+    features: [
+      t('subscription.standardMaxRuntime'),
+      t('subscription.addMoreCreditsAnytime')
+    ],
+    inheritsFrom: t('subscription.tiers.free.name'),
     isPopular: false
   },
   {
@@ -344,8 +478,11 @@ const tiers: PricingTierConfig[] = [
     key: 'creator',
     name: t('subscription.tiers.creator.name'),
     pricing: TIER_PRICING.creator,
-    maxDuration: t('subscription.maxDuration.creator'),
-    customLoRAs: true,
+    features: [
+      t('subscription.importOwnLoRAs'),
+      t('subscription.addMoreCreditsAnytime')
+    ],
+    inheritsFrom: t('subscription.tiers.standard.name'),
     isPopular: true
   },
   {
@@ -353,8 +490,8 @@ const tiers: PricingTierConfig[] = [
     key: 'pro',
     name: t('subscription.tiers.pro.name'),
     pricing: TIER_PRICING.pro,
-    maxDuration: t('subscription.maxDuration.pro'),
-    customLoRAs: true,
+    features: [t('subscription.proMaxRuntimeLong')],
+    inheritsFrom: t('subscription.tiers.creator.name'),
     isPopular: false
   }
 ]
@@ -391,8 +528,10 @@ const currentPlanDescriptor = computed(() => {
   } as const
 })
 
-const isCurrentPlan = (tierKey: CheckoutTierKey): boolean => {
+function isCurrentPlan(tierKey: TierKey): boolean {
   if (!currentTierKey.value) return false
+
+  if (tierKey === 'free') return isFreeTier.value
 
   const selectedIsYearly = currentBillingCycle.value === 'yearly'
 
@@ -402,15 +541,11 @@ const isCurrentPlan = (tierKey: CheckoutTierKey): boolean => {
   )
 }
 
-const togglePopover = (event: Event) => {
-  popover.value.toggle(event)
-}
-
-const getButtonLabel = (tier: PricingTierConfig): string => {
+function getButtonLabel(tier: PricingTierConfig): string {
   if (isCurrentPlan(tier.key)) return t('subscription.currentPlan')
 
   const planName =
-    currentBillingCycle.value === 'yearly'
+    currentBillingCycle.value === 'yearly' && tier.key !== 'free'
       ? t('subscription.tierNameYearly', { name: tier.name })
       : tier.name
 
@@ -419,96 +554,91 @@ const getButtonLabel = (tier: PricingTierConfig): string => {
     : t('subscription.subscribeTo', { plan: planName })
 }
 
-const getButtonSeverity = (
-  tier: PricingTierConfig
-): 'primary' | 'secondary' => {
-  if (isCurrentPlan(tier.key)) return 'secondary'
-  if (tier.key === 'creator') return 'primary'
-  return 'secondary'
+function getPrice(tier: PricingTierConfig): number {
+  if (tier.key === 'free') return 0
+  return tier.pricing[currentBillingCycle.value]
 }
 
-const getButtonTextClass = (tier: PricingTierConfig): string =>
-  tier.key === 'creator'
-    ? 'font-inter text-sm font-bold leading-normal text-base-background'
-    : 'font-inter text-sm font-bold leading-normal text-primary-foreground'
+function getAnnualTotal(tier: PricingTierConfig): number {
+  return tier.pricing.yearly * 12
+}
 
-const getPrice = (tier: PricingTierConfig): number =>
-  tier.pricing[currentBillingCycle.value]
+function togglePopover(event: Event) {
+  popover.value.toggle(event)
+}
 
-const getAnnualTotal = (tier: PricingTierConfig): number =>
-  tier.pricing.yearly * 12
+function handleContactUs() {
+  window.open('https://www.comfy.org/discord', '_blank')
+}
 
-const getCreditsDisplay = (tier: PricingTierConfig): number =>
-  tier.pricing.credits * (currentBillingCycle.value === 'yearly' ? 12 : 1)
+function handleTeamSubscribe() {
+  emit('chooseTeamWorkspace')
+}
 
-const handleSubscribe = wrapWithErrorHandlingAsync(
-  async (tierKey: CheckoutTierKey) => {
-    if (!isCloud || isLoading.value || isCurrentPlan(tierKey)) return
+const handleSubscribe = wrapWithErrorHandlingAsync(async (tierKey: TierKey) => {
+  if (!isCloud || isLoading.value || isCurrentPlan(tierKey)) return
+  if (tierKey === 'free') return
 
-    isLoading.value = true
-    loadingTier.value = tierKey
+  const checkoutTierKey = tierKey as CheckoutTierKey
 
-    try {
-      if (hasPaidSubscription.value) {
-        const targetPlan = {
-          tierKey,
-          billingCycle: currentBillingCycle.value
-        } as const
-        const previousPlan = currentPlanDescriptor.value
-        const checkoutAttribution = await getCheckoutAttributionForCloud()
-        if (userId.value) {
-          telemetry?.trackBeginCheckout({
-            user_id: userId.value,
-            tier: targetPlan.tierKey,
-            cycle: targetPlan.billingCycle,
-            checkout_type: 'change',
-            ...checkoutAttribution,
-            ...(previousPlan ? { previous_tier: previousPlan.tierKey } : {})
-          })
-        }
-        // Pass the target tier to create a deep link to subscription update confirmation
-        const checkoutTier = getCheckoutTier(
-          targetPlan.tierKey,
-          targetPlan.billingCycle
-        )
-        const downgrade =
-          previousPlan &&
-          isPlanDowngrade({
-            current: previousPlan,
-            target: targetPlan
-          })
+  isLoading.value = true
+  loadingTier.value = checkoutTierKey
 
-        if (downgrade) {
-          // TODO(COMFY-StripeProration): Remove once backend checkout creation mirrors portal proration ("change at billing end")
-          await accessBillingPortal()
-        } else {
-          const didOpenPortal = await accessBillingPortal(checkoutTier)
-          if (!didOpenPortal) {
-            return
-          }
-
-          recordPendingSubscriptionCheckoutAttempt({
-            tier: targetPlan.tierKey,
-            cycle: targetPlan.billingCycle,
-            checkout_type: 'change',
-            ...(previousPlan ? { previous_tier: previousPlan.tierKey } : {}),
-            ...(previousPlan
-              ? { previous_cycle: previousPlan.billingCycle }
-              : {})
-          })
-        }
-      } else {
-        await performSubscriptionCheckout(
-          tierKey,
-          currentBillingCycle.value,
-          true
-        )
+  try {
+    if (hasPaidSubscription.value) {
+      const targetPlan = {
+        tierKey: checkoutTierKey,
+        billingCycle: currentBillingCycle.value
+      } as const
+      const previousPlan = currentPlanDescriptor.value
+      const checkoutAttribution = await getCheckoutAttributionForCloud()
+      if (userId.value) {
+        telemetry?.trackBeginCheckout({
+          user_id: userId.value,
+          tier: targetPlan.tierKey,
+          cycle: targetPlan.billingCycle,
+          checkout_type: 'change',
+          ...checkoutAttribution,
+          ...(previousPlan ? { previous_tier: previousPlan.tierKey } : {})
+        })
       }
-    } finally {
-      isLoading.value = false
-      loadingTier.value = null
+      const checkoutTier = getCheckoutTier(
+        targetPlan.tierKey,
+        targetPlan.billingCycle
+      )
+      const downgrade =
+        previousPlan &&
+        isPlanDowngrade({
+          current: previousPlan,
+          target: targetPlan
+        })
+
+      if (downgrade) {
+        await accessBillingPortal()
+      } else {
+        const didOpenPortal = await accessBillingPortal(checkoutTier)
+        if (!didOpenPortal) {
+          return
+        }
+
+        recordPendingSubscriptionCheckoutAttempt({
+          tier: targetPlan.tierKey,
+          cycle: targetPlan.billingCycle,
+          checkout_type: 'change',
+          ...(previousPlan ? { previous_tier: previousPlan.tierKey } : {}),
+          ...(previousPlan ? { previous_cycle: previousPlan.billingCycle } : {})
+        })
+      }
+    } else {
+      await performSubscriptionCheckout(
+        checkoutTierKey,
+        currentBillingCycle.value,
+        true
+      )
     }
-  },
-  reportError
-)
+  } finally {
+    isLoading.value = false
+    loadingTier.value = null
+  }
+}, reportError)
 </script>

--- a/src/platform/cloud/subscription/components/SubscribeButton.vue
+++ b/src/platform/cloud/subscription/components/SubscribeButton.vue
@@ -6,6 +6,7 @@
     :class="cn('font-bold', fluid && 'w-full')"
     @click="handleSubscribe"
   >
+    <i v-if="showLockIcon" class="icon-[lucide--lock] size-4" />
     {{ label || $t('subscription.required.subscribe') }}
   </Button>
 </template>
@@ -25,13 +26,15 @@ const {
   fluid = true,
   buttonVariant = 'default',
   label,
-  disabled = false
+  disabled = false,
+  showLockIcon = false
 } = defineProps<{
   label?: string
   size?: 'sm' | 'lg'
   buttonVariant?: 'default' | 'gradient'
   fluid?: boolean
   disabled?: boolean
+  showLockIcon?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -4,13 +4,13 @@
       value: $t('subscription.subscribeToRunFull'),
       showDelay: 600
     }"
-    class="subscribe-to-run-button whitespace-nowrap"
+    class="subscribe-to-run-button text-sm whitespace-nowrap"
     variant="gradient"
-    size="sm"
+    size="md"
     data-testid="subscribe-to-run-button"
     @click="handleSubscribeToRun"
   >
-    <i class="pi pi-lock" />
+    <i class="icon-[lucide--lock] size-4" />
     {{ buttonLabel }}
   </Button>
 </template>

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -1,65 +1,13 @@
 <template>
   <div
     v-if="showCustomPricingTable"
-    class="relative flex h-full flex-col gap-6 overflow-y-auto p-4 pt-8 md:px-16 md:py-8"
+    class="relative flex flex-col gap-6 overflow-y-auto bg-secondary-background p-4"
   >
-    <Button
-      size="icon"
-      variant="muted-textonly"
-      class="absolute top-2.5 right-2.5 shrink-0 rounded-full text-text-secondary hover:bg-white/10"
-      :aria-label="$t('g.close')"
-      @click="handleClose"
-    >
-      <i class="pi pi-times text-xl" aria-hidden="true" />
-    </Button>
-    <div class="flex flex-col items-center gap-3">
-      <div
-        class="flex size-10 items-center justify-center rounded-xl bg-muted-foreground/30 text-lg font-semibold text-white"
-        aria-hidden="true"
-      >
-        <!-- Decorative initial for "Personal" workspace icon; not user-facing text -->
-        P
-      </div>
-      <i18n-t
-        keypath="subscription.plansForWorkspace"
-        tag="h2"
-        class="m-0 font-inter text-2xl font-semibold text-base-foreground"
-      >
-        <template #workspace>
-          <span class="text-muted-foreground">
-            {{ $t('subscription.personalWorkspace') }}
-          </span>
-        </template>
-      </i18n-t>
-    </div>
-
-    <PricingTable class="flex-1" @choose-team-workspace="handleChooseTeam" />
-
-    <!-- Contact and Enterprise Links -->
-    <div class="flex flex-col items-center gap-2">
-      <p class="m-0 text-sm text-text-secondary">
-        {{ $t('subscription.haveQuestions') }}
-      </p>
-      <div class="flex items-center gap-1.5">
-        <Button
-          variant="muted-textonly"
-          class="h-6 p-1 text-sm text-text-secondary hover:text-base-foreground"
-          @click="handleContactUs"
-        >
-          {{ $t('subscription.contactUs') }}
-          <i class="pi pi-comments" />
-        </Button>
-        <span class="text-sm text-text-secondary">{{ $t('g.or') }}</span>
-        <Button
-          variant="muted-textonly"
-          class="h-6 p-1 text-sm text-text-secondary hover:text-base-foreground"
-          @click="handleViewEnterprise"
-        >
-          {{ $t('subscription.viewEnterprise') }}
-          <i class="pi pi-external-link" />
-        </Button>
-      </div>
-    </div>
+    <PricingTable
+      :default-tab="defaultTab"
+      @choose-team-workspace="handleChooseTeam"
+      @close="handleClose"
+    />
   </div>
   <div v-else class="legacy-dialog relative grid h-full grid-cols-5">
     <!-- Custom close button -->
@@ -155,14 +103,13 @@ import SubscribeButton from '@/platform/cloud/subscription/components/SubscribeB
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { isCloud } from '@/platform/distribution/types'
-import { useTelemetry } from '@/platform/telemetry'
-import { useCommandStore } from '@/stores/commandStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
-const { onClose, reason, onChooseTeam } = defineProps<{
+const { onClose, reason, onChooseTeam, defaultTab } = defineProps<{
   onClose: () => void
   reason?: SubscriptionDialogReason
   onChooseTeam?: () => void
+  defaultTab?: 'personal' | 'teams'
 }>()
 
 const emit = defineEmits<{
@@ -184,8 +131,6 @@ const formattedMonthlyPrice = new Intl.NumberFormat(
     maximumFractionDigits: 0
   }
 ).format(MONTHLY_SUBSCRIPTION_PRICE)
-const commandStore = useCommandStore()
-const telemetry = useTelemetry()
 
 // Always show custom pricing table for cloud subscriptions
 const showCustomPricingTable = computed(() => isSubscriptionEnabled())
@@ -213,24 +158,6 @@ const handleChooseTeam = () => {
 
 const handleClose = () => {
   onClose()
-}
-
-const handleContactUs = async () => {
-  telemetry?.trackHelpResourceClicked({
-    resource_type: 'help_feedback',
-    is_external: true,
-    source: 'subscription'
-  })
-  await commandStore.execute('Comfy.ContactSupport')
-}
-
-const handleViewEnterprise = () => {
-  telemetry?.trackHelpResourceClicked({
-    resource_type: 'docs',
-    is_external: true,
-    source: 'subscription'
-  })
-  window.open('https://www.comfy.org/cloud/enterprise', '_blank')
 }
 </script>
 

--- a/src/platform/cloud/subscription/components/TeamPlanLayout.vue
+++ b/src/platform/cloud/subscription/components/TeamPlanLayout.vue
@@ -1,0 +1,464 @@
+<template>
+  <div class="flex flex-col">
+    <!-- Inner content -->
+    <div
+      class="flex flex-1 flex-col items-center gap-6 rounded-2xl bg-base-background p-8"
+    >
+      <!-- Subtitle -->
+      <p class="m-0 text-center text-base text-muted-foreground">
+        <i18n-t keypath="subscription.teamPlanSubtitle">
+          <template #learnMore>
+            <a
+              href="https://www.comfy.org/cloud/enterprise"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-base-foreground no-underline hover:text-muted-foreground"
+            >
+              {{ t('subscription.teamPlanLearnMore') }}
+            </a>
+          </template>
+        </i18n-t>
+      </p>
+
+      <!-- Billing cycle toggle -->
+      <SelectButton
+        v-model="currentBillingCycle"
+        :options="billingCycleOptions"
+        option-label="label"
+        option-value="value"
+        :allow-empty="false"
+        unstyled
+        :pt="{
+          root: {
+            class: 'flex gap-1 bg-secondary-background rounded-lg p-1.5'
+          },
+          pcToggleButton: {
+            root: ({ context }: ToggleButtonPassThroughMethodOptions) => ({
+              class: [
+                'w-36 h-8 rounded-md transition-colors cursor-pointer border-none outline-none ring-0 text-sm font-medium flex items-center justify-center',
+                context.active
+                  ? 'bg-base-foreground text-base-background'
+                  : 'bg-transparent text-muted-foreground hover:bg-secondary-background-hover'
+              ]
+            }),
+            label: { class: 'flex items-center gap-2' }
+          }
+        }"
+      >
+        <template #option="{ option }">
+          <div class="flex items-center gap-2">
+            <span>{{ option.label }}</span>
+            <div
+              v-if="option.value === 'yearly'"
+              class="flex items-center rounded-full bg-primary-background px-1 py-0.5 text-2xs font-bold text-white"
+            >
+              {{ t('subscription.teamPlan.save', { percent: 20 }) }}
+            </div>
+          </div>
+        </template>
+      </SelectButton>
+
+      <!-- Two-panel layout -->
+      <div class="flex flex-1 flex-col gap-8 lg:flex-row">
+        <!-- Left panel: Customize your plan -->
+        <div
+          class="flex w-full flex-col overflow-clip rounded-2xl border border-border-default bg-base-background shadow-md lg:max-w-[416px]"
+        >
+          <!-- Body -->
+          <div class="flex flex-1 flex-col gap-6 p-8">
+            <h3 class="m-0 text-base font-bold text-base-foreground">
+              {{ t('subscription.teamPlan.customizeYourPlan') }}
+            </h3>
+
+            <!-- Amount section: price + credits + billed + slider -->
+            <div class="flex flex-col gap-2">
+              <p class="m-0 mb-1 flex items-baseline text-base-foreground">
+                <span class="text-[32px] leading-none font-semibold">
+                  ${{ currentPrice }}
+                </span>
+                <span class="text-base font-normal">
+                  &nbsp;{{ t('subscription.usdPerMonth') }}
+                </span>
+              </p>
+
+              <div class="flex items-center gap-1">
+                <i
+                  class="icon-[lucide--component] size-4 text-amber-400"
+                  aria-hidden="true"
+                />
+                <span
+                  class="font-inter text-base/normal font-bold text-base-foreground"
+                >
+                  {{ n(currentCredits) }}
+                </span>
+                <span class="text-sm text-base-foreground">
+                  {{ t('subscription.teamPlan.monthlyCredits') }}
+                </span>
+              </div>
+
+              <p class="m-0 pt-1 text-sm text-muted-foreground">
+                {{
+                  currentBillingCycle === 'yearly'
+                    ? t('subscription.teamPlan.billedYearlyAmount', {
+                        amount: n(currentPrice * 12)
+                      })
+                    : t('subscription.billedMonthly')
+                }}
+              </p>
+
+              <!-- Slider -->
+              <div class="flex flex-col pt-2">
+                <div class="py-3">
+                  <Slider
+                    :model-value="[sliderValue]"
+                    :min="SLIDER_MIN"
+                    :max="SLIDER_MAX"
+                    :step="SLIDER_STEP"
+                    class="w-full"
+                    @update:model-value="onSliderChange"
+                  />
+                </div>
+                <div class="flex items-start justify-between">
+                  <span class="text-sm text-muted-foreground">
+                    ${{ SLIDER_MIN }}
+                  </span>
+                  <span class="text-center text-sm text-muted-foreground">
+                    $1,000
+                  </span>
+                  <span class="text-sm text-muted-foreground">
+                    ${{ n(SLIDER_MAX) }}
+                  </span>
+                </div>
+                <div class="flex items-start justify-between pt-1">
+                  <div class="w-[48px]" />
+                  <span
+                    class="rounded-full bg-secondary-background px-1.5 py-0.5 text-2xs font-bold text-base-foreground"
+                  >
+                    {{ t('subscription.teamPlan.save', { percent: 10 }) }}
+                  </span>
+                  <span
+                    class="rounded-full bg-secondary-background px-1.5 py-0.5 text-2xs font-bold text-base-foreground"
+                  >
+                    {{ t('subscription.teamPlan.save', { percent: 20 }) }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Description -->
+            <div class="flex flex-col gap-2">
+              <p class="m-0 text-sm text-muted-foreground">
+                {{
+                  t('subscription.teamPlan.generatesVideos', {
+                    count: n(videoEstimate)
+                  })
+                }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="p-8">
+            <Button
+              size="lg"
+              variant="inverted"
+              :disabled="isLoading || isCurrentPlanSelected"
+              :loading="loadingTier !== null"
+              class="w-full font-bold"
+              @click="handleSubscribe"
+            >
+              {{
+                isCurrentPlanSelected
+                  ? t('subscription.currentPlan')
+                  : resolvedButtonLabel
+              }}
+            </Button>
+          </div>
+        </div>
+
+        <!-- Right panel: Plan details -->
+        <div
+          class="flex flex-1 flex-col overflow-clip rounded-2xl border border-border-default bg-base-background shadow-md"
+        >
+          <div class="flex flex-col gap-6 p-8">
+            <h3 class="m-0 text-base font-bold text-base-foreground">
+              {{ t('subscription.teamPlan.planDetails') }}
+            </h3>
+
+            <!-- Feature list -->
+            <div class="flex flex-col gap-4">
+              <div
+                v-for="feature in features"
+                :key="feature"
+                class="flex items-center gap-2"
+              >
+                <i
+                  class="icon-[lucide--check] size-4 shrink-0 text-base-foreground"
+                  aria-hidden="true"
+                />
+                <span class="text-sm text-base-foreground">{{ feature }}</span>
+              </div>
+            </div>
+
+            <!-- Coming soon -->
+            <div class="flex flex-col gap-4">
+              <span class="text-sm text-muted-foreground">
+                {{ t('subscription.teamPlan.comingSoon') }}
+              </span>
+              <div class="flex items-center gap-2">
+                <i
+                  class="icon-[lucide--clock] size-4 shrink-0 text-muted-foreground"
+                  aria-hidden="true"
+                />
+                <span class="text-sm text-muted-foreground">
+                  {{ t('subscription.teamPlan.projectManagement') }}
+                </span>
+              </div>
+            </div>
+
+            <!-- Divider -->
+            <div class="border-t border-border-default" />
+
+            <!-- Member description -->
+            <div
+              class="flex flex-col gap-2 text-sm leading-[20px] text-muted-foreground"
+            >
+              <p class="m-0">
+                {{ t('subscription.teamPlan.memberDescription') }}
+              </p>
+              <p class="m-0">
+                {{ t('subscription.teamPlan.memberNeedMore') }}
+                <button
+                  class="cursor-pointer border-none bg-transparent p-0 font-inter text-sm font-medium text-base-foreground no-underline hover:text-muted-foreground"
+                  @click="handleContactUs"
+                >
+                  {{ t('subscription.contactUs') }}.
+                </button>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer disclaimer -->
+    <div class="flex items-start gap-4 pt-4 pb-2 text-sm text-muted-foreground">
+      <p class="m-0">
+        <i18n-t keypath="subscription.teamPlan.videoDisclaimer">
+          <template #details>
+            <button
+              class="cursor-pointer border-none bg-transparent p-0 font-inter text-sm text-base-foreground no-underline hover:text-muted-foreground"
+              @click="togglePopover"
+            >
+              {{ t('subscription.teamPlan.clickForDetails') }}
+            </button>
+          </template>
+        </i18n-t>
+      </p>
+      <p class="m-0">
+        <i18n-t keypath="subscription.teamPlan.contactFooter">
+          <template #questions>
+            <a
+              href="https://www.comfy.org/discord"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-base-foreground no-underline hover:text-muted-foreground"
+            >
+              {{ t('subscription.teamPlan.questions') }}
+            </a>
+          </template>
+          <template #enterprise>
+            <a
+              href="https://www.comfy.org/enterprise"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-base-foreground no-underline hover:text-muted-foreground"
+            >
+              {{ t('subscription.teamPlan.enterpriseDiscussions') }}
+            </a>
+          </template>
+          <template #pricing>
+            <a
+              href="https://www.comfy.org/pricing"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-base-foreground no-underline hover:text-muted-foreground"
+            >
+              {{ t('subscription.teamPlan.clickHere') }}
+            </a>
+          </template>
+        </i18n-t>
+      </p>
+    </div>
+
+    <Popover
+      ref="popover"
+      append-to="body"
+      :auto-z-index="true"
+      :base-z-index="1000"
+      :dismissable="true"
+      :close-on-escape="true"
+      unstyled
+      :pt="{
+        root: {
+          class:
+            'rounded-lg border border-border-default bg-base-background shadow-lg p-4 max-w-xs'
+        }
+      }"
+    >
+      <div class="flex flex-col gap-2">
+        <p class="m-0 text-sm/normal text-base-foreground">
+          {{ t('subscription.videoEstimateExplanation') }}
+        </p>
+        <a
+          href="https://cloud.comfy.org/?template=video_wan2_2_14B_i2v"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex gap-1 text-sm text-azure-600 no-underline hover:text-azure-400"
+        >
+          <span>{{ t('subscription.videoEstimateTryTemplate') }}</span>
+          <span v-html="'&rarr;'"></span>
+        </a>
+      </div>
+    </Popover>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Popover from 'primevue/popover'
+import SelectButton from 'primevue/selectbutton'
+import type { ToggleButtonPassThroughMethodOptions } from 'primevue/togglebutton'
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import Slider from '@/components/ui/slider/Slider.vue'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import {
+  TIER_PRICING,
+  TIER_TO_KEY
+} from '@/platform/cloud/subscription/constants/tierPricing'
+import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
+import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
+
+type CheckoutTierKey = Exclude<TierKey, 'free' | 'founder'>
+
+const {
+  isLoading = false,
+  loadingTier = null,
+  subscribeButtonLabel
+} = defineProps<{
+  isLoading?: boolean
+  loadingTier?: CheckoutTierKey | null
+  subscribeButtonLabel?: string
+}>()
+
+const emit = defineEmits<{
+  subscribe: [payload: { tierKey: CheckoutTierKey; billingCycle: BillingCycle }]
+  contactUs: []
+}>()
+
+const { t, n } = useI18n()
+const { subscription, fetchPlans } = useBillingContext()
+
+const popover = ref()
+
+function togglePopover(event: Event) {
+  popover.value.toggle(event)
+}
+
+// Slider constants
+const SLIDER_MIN = 100
+const SLIDER_MAX = 2000
+const SLIDER_STEP = 100
+
+// Credits per dollar at base rate (derived from Pro tier: 21,100 credits / $100)
+const BASE_CREDITS_PER_DOLLAR =
+  TIER_PRICING.pro.credits / TIER_PRICING.pro.monthly
+// Video estimate ratio (derived from Pro tier)
+const CREDITS_PER_VIDEO =
+  TIER_PRICING.pro.credits / TIER_PRICING.pro.videoEstimate
+
+const sliderValue = ref(290)
+const currentBillingCycle = ref<BillingCycle>('yearly')
+
+interface BillingCycleOption {
+  label: string
+  value: BillingCycle
+}
+
+const billingCycleOptions: BillingCycleOption[] = [
+  { label: t('subscription.yearly'), value: 'yearly' },
+  { label: t('subscription.monthly'), value: 'monthly' }
+]
+
+onMounted(() => {
+  void fetchPlans()
+})
+
+/** Discount multiplier based on slider position */
+function getDiscountMultiplier(price: number): number {
+  if (price >= 2000) return 1.2
+  if (price >= 1000) return 1.0 + 0.1 * ((price - 1000) / 1000) + 0.1
+  return 1.0
+}
+
+const currentPrice = computed(() => {
+  if (currentBillingCycle.value === 'yearly') {
+    return Math.round(sliderValue.value * 0.8)
+  }
+  return sliderValue.value
+})
+
+const currentCredits = computed(() => {
+  const baseCredits = sliderValue.value * BASE_CREDITS_PER_DOLLAR
+  const multiplier = getDiscountMultiplier(sliderValue.value)
+  return Math.round(baseCredits * multiplier)
+})
+
+const videoEstimate = computed(() =>
+  Math.round(currentCredits.value / CREDITS_PER_VIDEO)
+)
+
+const currentTierKey = computed<TierKey | null>(() =>
+  subscription.value?.tier ? TIER_TO_KEY[subscription.value.tier] : null
+)
+
+const isCurrentPlanSelected = computed(() => {
+  return currentTierKey.value === 'pro' && !subscription.value?.isCancelled
+})
+
+const features = computed(() => [
+  t('subscription.teamPlan.maxRuntime'),
+  t('subscription.teamPlan.addCredits'),
+  t('subscription.teamPlan.importLoRAs'),
+  t('subscription.teamPlan.centralizedBilling'),
+  t('subscription.teamPlan.roleBasedPermissions')
+])
+
+const resolvedButtonLabel = computed(() => {
+  if (subscribeButtonLabel) return subscribeButtonLabel
+  return currentBillingCycle.value === 'yearly'
+    ? t('subscription.teamPlan.subscribeToYearly')
+    : t('subscription.teamPlan.subscribeToMonthly')
+})
+
+function onSliderChange(values?: number[]) {
+  if (values?.length) {
+    sliderValue.value = values[0]
+  }
+}
+
+function handleSubscribe() {
+  if (isLoading) return
+
+  emit('subscribe', {
+    tierKey: 'pro',
+    billingCycle: currentBillingCycle.value
+  })
+}
+
+function handleContactUs() {
+  emit('contactUs')
+}
+</script>

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -27,7 +27,10 @@ export const useSubscriptionDialog = () => {
     dialogStore.closeDialog({ key: FREE_TIER_DIALOG_KEY })
   }
 
-  function showPricingTable(options?: { reason?: SubscriptionDialogReason }) {
+  function showPricingTable(options?: {
+    reason?: SubscriptionDialogReason
+    defaultTab?: 'personal' | 'teams'
+  }) {
     if (!isCloud) return
 
     const useWorkspaceVariant =
@@ -46,6 +49,7 @@ export const useSubscriptionDialog = () => {
     const personalProps = {
       onClose: hide,
       reason: options?.reason,
+      defaultTab: options?.defaultTab,
       onChooseTeam: () => startTeamWorkspaceUpgradeFlow()
     }
     const workspaceProps = {
@@ -53,26 +57,33 @@ export const useSubscriptionDialog = () => {
       reason: options?.reason
     }
 
+    const dialogStyle = useWorkspaceVariant
+      ? 'width: min(960px, 95vw); max-height: 95vh;'
+      : 'width: min(1328px, 95vw); max-height: 95vh;'
+
+    const dialogPt = {
+      root: { class: 'rounded-2xl bg-transparent' },
+      content: {
+        class:
+          '!p-0 rounded-2xl border border-border-default bg-base-background/60 backdrop-blur-md shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
+      }
+    }
+
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
       component,
       props: useWorkspaceVariant ? workspaceProps : personalProps,
       dialogComponentProps: {
-        style: 'width: min(1328px, 95vw); max-height: 958px;',
-        pt: {
-          root: {
-            class: 'rounded-2xl bg-transparent h-full'
-          },
-          content: {
-            class:
-              '!p-0 rounded-2xl border border-border-default bg-base-background/60 backdrop-blur-md shadow-[0_25px_80px_rgba(5,6,12,0.45)] h-full'
-          }
-        }
+        style: dialogStyle,
+        pt: dialogPt
       }
     })
   }
 
-  function show(options?: { reason?: SubscriptionDialogReason }) {
+  function show(options?: {
+    reason?: SubscriptionDialogReason
+    defaultTab?: 'personal' | 'teams'
+  }) {
     if (isFreeTier.value && workspaceStore.isInPersonalWorkspace) {
       const component = defineAsyncComponent(
         () =>

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -24,36 +24,40 @@
     </div>
 
     <!-- Workspace Selector -->
-    <div
-      class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
-      @click="toggleWorkspaceSwitcher"
-    >
-      <div class="flex min-w-0 flex-1 items-center gap-2">
-        <WorkspaceProfilePic
-          class="size-6 shrink-0 text-xs"
-          :workspace-name="workspaceName"
-        />
-        <span class="truncate text-sm text-base-foreground">{{
-          workspaceName
-        }}</span>
-      </div>
-      <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
-    </div>
-
-    <Popover
-      ref="workspaceSwitcherPopover"
-      append-to="body"
-      :pt="{
-        content: {
-          class: 'p-0'
-        }
-      }"
-    >
-      <WorkspaceSwitcherPopover
-        @select="workspaceSwitcherPopover?.hide()"
-        @create="handleCreateWorkspace"
-      />
-    </Popover>
+    <PopoverRoot v-model:open="isWorkspaceSwitcherOpen">
+      <PopoverTrigger as-child>
+        <div
+          class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        >
+          <div class="flex min-w-0 flex-1 items-center gap-2">
+            <WorkspaceProfilePic
+              class="size-6 shrink-0 text-xs"
+              :workspace-name="workspaceName"
+            />
+            <span class="truncate text-sm text-base-foreground">{{
+              workspaceName
+            }}</span>
+          </div>
+          <i
+            class="icon-[lucide--chevron-down] size-3 shrink-0 text-muted-foreground"
+          />
+        </div>
+      </PopoverTrigger>
+      <PopoverPortal>
+        <PopoverContent
+          side="left"
+          align="start"
+          :side-offset="16"
+          :collision-padding="10"
+          class="data-[state=open]:data-[side=left]:animate-slideRightAndFade z-1700 rounded-lg border border-border-subtle bg-base-background shadow-sm will-change-[transform,opacity]"
+        >
+          <WorkspaceSwitcherPopover
+            @select="isWorkspaceSwitcherOpen = false"
+            @create="handleCreateWorkspace"
+          />
+        </PopoverContent>
+      </PopoverPortal>
+    </PopoverRoot>
 
     <!-- Credits Section -->
 
@@ -104,6 +108,7 @@
         "
         size="sm"
         button-variant="gradient"
+        show-lock-icon
       />
       <Button
         v-if="showSubscribeAction && !isPersonalWorkspace"
@@ -210,8 +215,13 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import Divider from 'primevue/divider'
-import Popover from 'primevue/popover'
 import Skeleton from 'primevue/skeleton'
+import {
+  PopoverContent,
+  PopoverPortal,
+  PopoverRoot,
+  PopoverTrigger
+} from 'reka-ui'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -240,7 +250,7 @@ const {
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
 const { permissions } = useWorkspaceUI()
-const workspaceSwitcherPopover = ref<InstanceType<typeof Popover> | null>(null)
+const isWorkspaceSwitcherOpen = ref(false)
 
 const emit = defineEmits<{
   close: []
@@ -352,13 +362,9 @@ const handleLogout = async () => {
 }
 
 const handleCreateWorkspace = () => {
-  workspaceSwitcherPopover.value?.hide()
+  isWorkspaceSwitcherOpen.value = false
   dialogService.showCreateWorkspaceDialog()
   emit('close')
-}
-
-const toggleWorkspaceSwitcher = (event: MouseEvent) => {
-  workspaceSwitcherPopover.value?.toggle(event)
 }
 
 const refreshBalance = () => {

--- a/src/platform/workspace/components/WorkspaceSelectorButton.vue
+++ b/src/platform/workspace/components/WorkspaceSelectorButton.vue
@@ -1,0 +1,68 @@
+<template>
+  <PopoverRoot v-model:open="isOpen">
+    <PopoverTrigger as-child>
+      <button
+        class="flex cursor-pointer items-center gap-2 rounded-lg border-none bg-transparent p-1 hover:bg-secondary-background-hover"
+        :aria-label="$t('workspaceSwitcher.switchWorkspace')"
+      >
+        <WorkspaceProfilePic
+          class="size-6 text-xs"
+          :workspace-name="workspaceName"
+        />
+        <span class="text-sm text-base-foreground">
+          {{ workspaceDisplayName }}
+        </span>
+        <i class="icon-[lucide--chevron-down] size-3 text-muted-foreground" />
+      </button>
+    </PopoverTrigger>
+    <PopoverPortal>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        :side-offset="5"
+        :collision-padding="10"
+        class="data-[state=open]:data-[side=bottom]:animate-slideUpAndFade z-1700 rounded-lg border border-border-subtle bg-base-background shadow-sm will-change-[transform,opacity]"
+      >
+        <WorkspaceSwitcherPopover
+          @select="isOpen = false"
+          @create="handleCreateWorkspace"
+        />
+      </PopoverContent>
+    </PopoverPortal>
+  </PopoverRoot>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import {
+  PopoverContent,
+  PopoverPortal,
+  PopoverRoot,
+  PopoverTrigger
+} from 'reka-ui'
+import { computed, ref } from 'vue'
+
+import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
+import WorkspaceSwitcherPopover from '@/platform/workspace/components/WorkspaceSwitcherPopover.vue'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogService } from '@/services/dialogService'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const workspaceStore = useTeamWorkspaceStore()
+const { workspaceName, isInPersonalWorkspace } = storeToRefs(workspaceStore)
+const dialogService = useDialogService()
+
+const isOpen = ref(false)
+
+const workspaceDisplayName = computed(() =>
+  isInPersonalWorkspace.value
+    ? t('workspaceSwitcher.personal')
+    : workspaceName.value
+)
+
+function handleCreateWorkspace() {
+  isOpen.value = false
+  dialogService.showCreateWorkspaceDialog()
+}
+</script>

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -1,108 +1,91 @@
 <template>
-  <div class="flex w-80 flex-col overflow-hidden rounded-lg">
-    <div class="flex flex-col overflow-y-auto">
+  <div
+    class="flex w-[316px] flex-col overflow-hidden rounded-lg py-2 font-[Inter,Arial,sans-serif]"
+  >
+    <div class="flex flex-col gap-2 overflow-y-auto">
       <!-- Loading state -->
-      <div v-if="isFetchingWorkspaces" class="flex flex-col gap-2 p-2">
+      <template v-if="isFetchingWorkspaces">
         <div
           v-for="i in 2"
           :key="i"
-          class="flex h-[54px] animate-pulse items-center gap-2 rounded-sm px-2 py-4"
+          class="flex h-[54px] animate-pulse items-center gap-2 rounded-lg px-4 py-2"
         >
-          <div class="size-8 rounded-full bg-secondary-background" />
+          <div class="size-8 rounded-sm bg-secondary-background" />
           <div class="flex flex-1 flex-col gap-1">
             <div class="h-4 w-24 rounded-sm bg-secondary-background" />
             <div class="h-3 w-16 rounded-sm bg-secondary-background" />
           </div>
         </div>
-      </div>
-
-      <!-- Workspace list -->
-      <template v-else>
-        <template v-for="workspace in availableWorkspaces" :key="workspace.id">
-          <div class="border-b border-border-default p-2">
-            <div
-              :class="
-                cn(
-                  'group flex h-[54px] w-full items-center gap-2 rounded-sm px-2 py-4',
-                  'hover:bg-secondary-background-hover',
-                  isCurrentWorkspace(workspace) && 'bg-secondary-background'
-                )
-              "
-            >
-              <button
-                class="flex flex-1 cursor-pointer items-center gap-2 border-none bg-transparent p-0"
-                @click="handleSelectWorkspace(workspace)"
-              >
-                <WorkspaceProfilePic
-                  class="size-8 text-sm"
-                  :workspace-name="workspace.name"
-                />
-                <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
-                  <div class="flex items-center gap-1.5">
-                    <span class="text-sm text-base-foreground">
-                      {{
-                        workspace.type === 'personal'
-                          ? $t('workspaceSwitcher.personal')
-                          : workspace.name
-                      }}
-                    </span>
-                    <span
-                      v-if="resolveTierLabel(workspace)"
-                      class="rounded-full bg-base-foreground px-1 py-0.5 text-2xs font-bold text-base-background uppercase"
-                    >
-                      {{ resolveTierLabel(workspace) }}
-                    </span>
-                  </div>
-                  <span class="text-xs text-muted-foreground">
-                    {{ getRoleLabel(workspace.role) }}
-                  </span>
-                </div>
-                <i
-                  v-if="isCurrentWorkspace(workspace)"
-                  class="pi pi-check text-sm text-base-foreground"
-                />
-              </button>
-            </div>
-          </div>
-        </template>
       </template>
 
-      <!-- Create workspace button -->
-      <div class="p-2">
+      <template v-else>
+        <!-- All workspaces -->
         <div
-          :class="
-            cn(
-              'flex h-12 w-full items-center gap-2 rounded-sm p-2',
-              canCreateWorkspace
-                ? 'cursor-pointer hover:bg-secondary-background-hover'
-                : 'cursor-default'
-            )
-          "
-          @click="canCreateWorkspace && handleCreateWorkspace()"
+          v-for="workspace in availableWorkspaces"
+          :key="workspace.id"
+          class="px-2"
         >
-          <div
+          <button
             :class="
               cn(
-                'flex size-8 items-center justify-center rounded-full bg-secondary-background',
-                !canCreateWorkspace && 'opacity-50'
+                'flex h-[54px] w-full cursor-pointer items-center gap-2 rounded-lg border-none bg-transparent p-2',
+                'hover:bg-secondary-background-hover',
+                isCurrentWorkspace(workspace) && 'bg-secondary-background'
               )
             "
+            @click="handleSelectWorkspace(workspace)"
           >
-            <i class="pi pi-plus text-sm text-muted-foreground" />
-          </div>
-          <div class="flex min-w-0 flex-1 flex-col">
-            <span
-              v-if="canCreateWorkspace"
-              class="text-sm text-muted-foreground"
-            >
-              {{ $t('workspaceSwitcher.createWorkspace') }}
-            </span>
-            <span v-else class="text-sm text-muted-foreground">
-              {{ $t('workspaceSwitcher.maxWorkspacesReached') }}
-            </span>
-          </div>
+            <WorkspaceProfilePic
+              class="size-8 text-sm"
+              :workspace-name="workspace.name"
+            />
+            <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
+              <span class="text-left text-sm text-base-foreground">
+                {{ workspace.name }}
+              </span>
+              <span class="text-left text-sm text-muted-foreground">
+                {{ getRoleLabel(workspace) }}
+              </span>
+            </div>
+            <i
+              v-if="isCurrentWorkspace(workspace)"
+              class="icon-[lucide--check] size-4 shrink-0 text-base-foreground"
+            />
+          </button>
         </div>
-      </div>
+
+        <!-- Divider -->
+        <div class="border-t border-border-default" />
+
+        <!-- Create workspace button -->
+        <div class="px-2">
+          <button
+            :class="
+              cn(
+                'flex w-full items-center gap-2 rounded-lg border-none bg-transparent p-2',
+                canCreateWorkspace
+                  ? 'cursor-pointer hover:bg-secondary-background-hover'
+                  : 'cursor-default opacity-50'
+              )
+            "
+            :disabled="!canCreateWorkspace"
+            @click="canCreateWorkspace && handleCreateWorkspace()"
+          >
+            <div
+              class="flex size-8 items-center justify-center rounded-full bg-secondary-background"
+            >
+              <i class="icon-[lucide--plus] size-4 text-muted-foreground" />
+            </div>
+            <span class="text-left text-sm text-base-foreground">
+              {{
+                canCreateWorkspace
+                  ? $t('workspaceSwitcher.createWorkspace')
+                  : $t('workspaceSwitcher.maxWorkspacesReached')
+              }}
+            </span>
+          </button>
+        </div>
+      </template>
     </div>
   </div>
 </template>
@@ -113,25 +96,15 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useWorkspaceSwitch } from '@/platform/workspace/composables/useWorkspaceSwitch'
-import { useWorkspaceTierLabel } from '@/platform/workspace/composables/useWorkspaceTierLabel'
-import type {
-  SubscriptionTier,
-  WorkspaceRole,
-  WorkspaceType
-} from '@/platform/workspace/api/workspaceApi'
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
 interface AvailableWorkspace {
   id: string
   name: string
-  type: WorkspaceType
   role: WorkspaceRole
-  isSubscribed: boolean
-  subscriptionPlan: string | null
-  subscriptionTier: SubscriptionTier | null
 }
 
 const emit = defineEmits<{
@@ -141,15 +114,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { switchWorkspace } = useWorkspaceSwitch()
-const { subscription } = useBillingContext()
-const { formatTierName, getTierLabel } = useWorkspaceTierLabel()
-
-const currentSubscriptionTierName = computed(() => {
-  const tier = subscription.value?.tier
-  if (!tier) return ''
-  const isYearly = subscription.value?.duration === 'ANNUAL'
-  return formatTierName(tier, isYearly)
-})
 
 const workspaceStore = useTeamWorkspaceStore()
 const { workspaceId, workspaces, canCreateWorkspace, isFetchingWorkspaces } =
@@ -159,11 +123,7 @@ const availableWorkspaces = computed<AvailableWorkspace[]>(() =>
   workspaces.value.map((w) => ({
     id: w.id,
     name: w.name,
-    type: w.type,
-    role: w.role,
-    isSubscribed: w.isSubscribed,
-    subscriptionPlan: w.subscriptionPlan,
-    subscriptionTier: w.subscriptionTier
+    role: w.role
   }))
 )
 
@@ -171,18 +131,10 @@ function isCurrentWorkspace(workspace: AvailableWorkspace): boolean {
   return workspace.id === workspaceId.value
 }
 
-function getRoleLabel(role: AvailableWorkspace['role']): string {
-  if (role === 'owner') return t('workspaceSwitcher.roleOwner')
-  if (role === 'member') return t('workspaceSwitcher.roleMember')
+function getRoleLabel(workspace: AvailableWorkspace): string {
+  if (workspace.role === 'owner') return t('workspaceSwitcher.roleOwner')
+  if (workspace.role === 'member') return t('workspaceSwitcher.roleMember')
   return ''
-}
-
-function resolveTierLabel(workspace: AvailableWorkspace): string | null {
-  if (isCurrentWorkspace(workspace)) {
-    return currentSubscriptionTierName.value || null
-  }
-
-  return getTierLabel(workspace)
 }
 
 async function handleSelectWorkspace(workspace: AvailableWorkspace) {

--- a/src/platform/workspace/components/dialogs/CreateTeamWorkspaceDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/CreateTeamWorkspaceDialogContent.vue
@@ -3,55 +3,51 @@
     class="flex w-full max-w-[400px] flex-col rounded-2xl border border-border-default bg-base-background"
   >
     <!-- Header -->
-    <div
-      class="flex h-12 items-center justify-between border-b border-border-default px-4"
-    >
+    <div class="flex h-12 items-center border-b border-border-default px-4">
       <h2 class="m-0 text-sm font-normal text-base-foreground">
         {{ $t('workspacePanel.createWorkspaceDialog.title') }}
       </h2>
-      <button
-        class="focus-visible:ring-secondary-foreground cursor-pointer rounded-sm border-none bg-transparent p-0 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
-        :aria-label="$t('g.close')"
-        @click="onCancel"
-      >
-        <i class="pi pi-times size-4" />
-      </button>
     </div>
 
     <!-- Body -->
-    <div class="flex flex-col gap-4 p-4">
-      <p class="m-0 text-sm text-muted-foreground">
+    <div class="flex flex-col gap-6 p-4">
+      <p class="m-0 text-sm/5 text-muted-foreground">
         {{ $t('workspacePanel.createWorkspaceDialog.message') }}
       </p>
       <div class="flex flex-col gap-2">
-        <label class="text-sm text-base-foreground">
+        <label class="text-sm text-muted-foreground">
           {{ $t('workspacePanel.createWorkspaceDialog.nameLabel') }}
         </label>
         <input
           v-model="workspaceName"
           type="text"
-          class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
+          class="focus:ring-secondary-foreground h-10 w-full rounded-lg border-none bg-secondary-background px-4 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
           :placeholder="
             $t('workspacePanel.createWorkspaceDialog.namePlaceholder')
           "
-          @keydown.enter="isValidName && onCreate()"
+          @keydown.enter="isValidName && onNext()"
         />
+      </div>
+      <div
+        class="flex items-center gap-2 rounded-lg border border-border-subtle bg-secondary-background p-4"
+      >
+        <i class="icon-[lucide--info] size-4 shrink-0 text-base-foreground" />
+        <p class="m-0 text-sm/5 text-base-foreground">
+          {{ $t('workspacePanel.createWorkspaceDialog.personalStaysInfo') }}
+        </p>
       </div>
     </div>
 
     <!-- Footer -->
     <div class="flex items-center justify-end gap-2 p-4">
-      <Button variant="muted-textonly" size="lg" @click="onCancel">
-        {{ $t('g.cancel') }}
-      </Button>
       <Button
-        variant="primary"
+        variant="secondary"
         size="lg"
         :loading
         :disabled="!isValidName"
-        @click="onCreate"
+        @click="onNext"
       >
-        {{ $t('workspacePanel.createWorkspaceDialog.create') }}
+        {{ $t('workspacePanel.createWorkspaceDialog.next') }}
       </Button>
     </div>
   </div>
@@ -83,22 +79,19 @@ const isValidName = computed(() => {
   return name.length >= 1 && name.length <= 50 && safeNameRegex.test(name)
 })
 
-function onCancel() {
-  dialogStore.closeDialog({ key: 'create-workspace' })
-}
-
-async function onCreate() {
+async function onNext() {
   if (!isValidName.value) return
   loading.value = true
   try {
     const name = workspaceName.value.trim()
-    // Call optional callback if provided
     await onConfirm?.(name)
-    dialogStore.closeDialog({ key: 'create-workspace' })
-    // Create workspace and switch to it (triggers reload internally)
+    dialogStore.closeDialog({ key: 'create-team-workspace' })
     await workspaceStore.createWorkspace(name)
   } catch (error) {
-    console.error('[CreateWorkspaceDialog] Failed to create workspace:', error)
+    console.error(
+      '[CreateTeamWorkspaceDialog] Failed to create workspace:',
+      error
+    )
     toast.add({
       severity: 'error',
       summary: t('workspacePanel.toast.failedToCreateWorkspace'),

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grow overflow-auto pt-6">
+  <div class="flex grow flex-col gap-6 overflow-auto pt-6">
     <div
       class="border-inter flex size-full flex-col gap-2 rounded-2xl border border-interface-stroke p-6"
     >
@@ -8,15 +8,7 @@
         <div class="flex min-w-0 flex-1 items-baseline gap-2">
           <span class="text-base font-semibold text-base-foreground">
             <template v-if="activeView === 'active'">
-              {{
-                $t('workspacePanel.members.membersCount', {
-                  count:
-                    isSingleSeatPlan || isPersonalWorkspace
-                      ? 1
-                      : members.length,
-                  maxSeats: maxSeats
-                })
-              }}
+              {{ $t('workspacePanel.tabs.members') }}
             </template>
             <template v-else-if="permissions.canViewPendingInvites">
               {{
@@ -127,49 +119,26 @@
         <div class="min-h-0 flex-1 overflow-y-auto">
           <!-- Active Members -->
           <template v-if="activeView === 'active'">
-            <!-- Personal Workspace: show only current user -->
-            <template v-if="isPersonalWorkspace">
-              <MemberListItem
-                :member="personalWorkspaceMember"
-                :is-current-user="true"
-                :photo-url="userPhotoUrl ?? undefined"
-                :grid-cols="uiConfig.membersGridCols"
-                :show-role-badge="uiConfig.showRoleBadge"
-              />
-            </template>
+            <MemberListItem
+              v-for="(member, index) in filteredMembers"
+              :key="member.id"
+              :member="member"
+              :is-current-user="isCurrentUser(member)"
+              :photo-url="
+                isCurrentUser(member) ? (userPhotoUrl ?? undefined) : undefined
+              "
+              :grid-cols="uiConfig.membersGridCols"
+              :show-role-badge="uiConfig.showRoleBadge"
+              :show-date-column="uiConfig.showDateColumn"
+              :can-remove-members="permissions.canRemoveMembers"
+              :is-single-seat-plan="isSingleSeatPlan"
+              :striped="index % 2 === 1"
+              @show-menu="showMemberMenu($event, member)"
+            />
 
-            <!-- Team Workspace: sorted list -->
-            <template v-else>
-              <MemberListItem
-                v-for="(member, index) in filteredMembers"
-                :key="member.id"
-                :member="member"
-                :is-current-user="isCurrentUser(member)"
-                :photo-url="
-                  isCurrentUser(member)
-                    ? (userPhotoUrl ?? undefined)
-                    : undefined
-                "
-                :grid-cols="uiConfig.membersGridCols"
-                :show-role-badge="uiConfig.showRoleBadge"
-                :show-date-column="uiConfig.showDateColumn"
-                :can-remove-members="permissions.canRemoveMembers"
-                :is-single-seat-plan="isSingleSeatPlan"
-                :striped="index % 2 === 1"
-                @show-menu="showMemberMenu($event, member)"
-              />
-
-              <!-- Member actions menu (shared for all members) -->
-              <Menu ref="memberMenu" :model="memberMenuItems" :popup="true" />
-            </template>
+            <!-- Member actions menu (shared for all members) -->
+            <Menu ref="memberMenu" :model="memberMenuItems" :popup="true" />
           </template>
-
-          <!-- Upsell Banner -->
-          <MemberUpsellBanner
-            v-if="isSingleSeatPlan"
-            :is-active-subscription="isActiveSubscription"
-            @show-plans="showSubscriptionDialog()"
-          />
 
           <!-- Pending Invites -->
           <PendingInvitesList
@@ -182,17 +151,28 @@
         </div>
       </div>
     </div>
-    <!-- Personal Workspace Message -->
-    <div v-if="isPersonalWorkspace" class="flex items-center">
-      <p class="text-sm text-muted-foreground">
-        {{ $t('workspacePanel.members.personalWorkspaceMessage') }}
-      </p>
-      <button
-        class="cursor-pointer border-none bg-transparent underline"
-        @click="handleCreateWorkspace"
+    <!-- Upgrade upsell (shown when not on a team plan) -->
+    <div
+      v-if="showUpgradeUpsell"
+      class="flex items-center justify-between rounded-2xl border border-interface-stroke bg-secondary-background p-6"
+    >
+      <div class="flex items-center gap-2">
+        <i
+          class="icon-[lucide--info] size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <p class="m-0 text-sm text-muted-foreground">
+          {{ $t('workspacePanel.members.upgradeToAddTeammates') }}
+        </p>
+      </div>
+      <Button
+        variant="inverted"
+        size="lg"
+        class="shrink-0"
+        @click="showPricingDialog({ defaultTab: 'teams' })"
       >
-        {{ $t('workspacePanel.members.createNewWorkspace') }}
-      </button>
+        {{ $t('workspacePanel.members.upgradeToTeam') }}
+      </Button>
     </div>
   </div>
 </template>
@@ -210,8 +190,8 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
 import MemberListItem from '@/platform/workspace/components/dialogs/settings/MemberListItem.vue'
-import MemberUpsellBanner from '@/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue'
 import PendingInvitesList from '@/platform/workspace/components/dialogs/settings/PendingInvitesList.vue'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import type {
   PendingInvite,
@@ -224,28 +204,15 @@ import { cn } from '@comfyorg/tailwind-utils'
 const { t } = useI18n()
 const toast = useToast()
 const { userPhotoUrl, userEmail, userDisplayName } = useCurrentUser()
-const {
-  showRemoveMemberDialog,
-  showRevokeInviteDialog,
-  showCreateWorkspaceDialog
-} = useDialogService()
+const { showRemoveMemberDialog, showRevokeInviteDialog } = useDialogService()
 const workspaceStore = useTeamWorkspaceStore()
-const {
-  members,
-  pendingInvites,
-  isInPersonalWorkspace: isPersonalWorkspace
-} = storeToRefs(workspaceStore)
+const { members, pendingInvites } = storeToRefs(workspaceStore)
 const { copyInviteLink } = workspaceStore
 const { permissions, uiConfig } = useWorkspaceUI()
-const {
-  isActiveSubscription,
-  subscription,
-  showSubscriptionDialog,
-  getMaxSeats
-} = useBillingContext()
+const { show: showPricingDialog } = useSubscriptionDialog()
+const { isActiveSubscription, subscription, getMaxSeats } = useBillingContext()
 
 const maxSeats = computed(() => {
-  if (isPersonalWorkspace.value) return 1
   const tier = subscription.value?.tier
   if (!tier) return 1
   const tierKey = TIER_TO_KEY[tier]
@@ -254,18 +221,13 @@ const maxSeats = computed(() => {
 })
 
 const isSingleSeatPlan = computed(() => {
-  if (isPersonalWorkspace.value) return false
   if (!isActiveSubscription.value) return true
   return maxSeats.value <= 1
 })
 
-const personalWorkspaceMember = computed<WorkspaceMember>(() => ({
-  id: 'self',
-  name: userDisplayName.value ?? '',
-  email: userEmail.value ?? '',
-  role: 'owner' as const,
-  joinDate: new Date(0)
-}))
+const showUpgradeUpsell = computed(
+  () => isSingleSeatPlan.value && permissions.value.canManageSubscription
+)
 
 const searchQuery = ref('')
 const activeView = ref<'active' | 'pending'>('active')
@@ -296,8 +258,21 @@ function isCurrentUser(member: WorkspaceMember): boolean {
   return member.email.toLowerCase() === userEmail.value?.toLowerCase()
 }
 
+const effectiveMembers = computed<WorkspaceMember[]>(() => {
+  if (members.value.length > 0) return members.value
+  return [
+    {
+      id: 'self',
+      name: userDisplayName.value ?? '',
+      email: userEmail.value ?? '',
+      role: 'owner' as const,
+      joinDate: new Date(0)
+    }
+  ]
+})
+
 const filteredMembers = computed(() => {
-  let result = [...members.value]
+  let result = [...effectiveMembers.value]
 
   if (searchQuery.value) {
     const query = searchQuery.value.toLowerCase()
@@ -375,10 +350,6 @@ async function handleCopyInviteLink(invite: PendingInvite) {
 
 function handleRevokeInvite(invite: PendingInvite) {
   showRevokeInviteDialog(invite.id)
-}
-
-function handleCreateWorkspace() {
-  showCreateWorkspaceDialog()
 }
 
 function handleRemoveMember(member: WorkspaceMember) {

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -5,66 +5,112 @@
         class="size-12 text-3xl!"
         :workspace-name="workspaceName"
       />
-      <h1 class="text-3xl text-base-foreground">
+      <h1 class="text-2xl font-semibold text-base-foreground">
         {{ workspaceName }}
       </h1>
     </header>
     <TabsRoot v-model="activeTab">
       <div class="flex w-full items-center justify-between">
         <TabsList class="flex items-center gap-2 pb-1">
-          <TabsTrigger
-            value="plan"
-            :class="
-              cn(
-                tabTriggerBase,
-                activeTab === 'plan' ? tabTriggerActive : tabTriggerInactive
-              )
-            "
-          >
-            {{ $t('workspacePanel.tabs.planCredits') }}
+          <TabsTrigger value="plan" as-child>
+            <Button
+              :variant="activeTab === 'plan' ? 'secondary' : 'muted-textonly'"
+              size="lg"
+            >
+              {{ $t('workspacePanel.tabs.planCredits') }}
+            </Button>
           </TabsTrigger>
-          <TabsTrigger
-            value="members"
-            :class="
-              cn(
-                tabTriggerBase,
-                activeTab === 'members' ? tabTriggerActive : tabTriggerInactive
-              )
-            "
-          >
-            {{
-              $t('workspacePanel.tabs.membersCount', {
-                count: members.length
-              })
-            }}
+          <TabsTrigger value="members" as-child>
+            <Button
+              :variant="
+                activeTab === 'members' ? 'secondary' : 'muted-textonly'
+              "
+              size="lg"
+            >
+              {{
+                members.length <= 1
+                  ? $t('workspacePanel.tabs.members')
+                  : $t('workspacePanel.tabs.membersCount', {
+                      count: members.length
+                    })
+              }}
+            </Button>
           </TabsTrigger>
         </TabsList>
-        <div class="flex items-center gap-1">
+        <!-- Plan tab actions -->
+        <div v-if="activeTab === 'plan'" class="flex items-center gap-2">
+          <Button
+            v-if="showSubscribePrompt"
+            size="lg"
+            variant="inverted"
+            @click="handleSubscribeWorkspace"
+          >
+            {{ $t('subscription.subscribe') }}
+          </Button>
+          <template
+            v-else-if="
+              isActiveSubscription && permissions.canManageSubscription
+            "
+          >
+            <template v-if="isCancelled">
+              <Button
+                size="lg"
+                variant="inverted"
+                :loading="isResubscribing"
+                @click="handleResubscribe"
+              >
+                {{ $t('subscription.resubscribe') }}
+              </Button>
+            </template>
+            <template v-else>
+              <Button
+                v-if="!isFreeTierPlan"
+                size="lg"
+                variant="secondary"
+                @click="manageSubscription"
+              >
+                {{ $t('subscription.managePayment') }}
+              </Button>
+              <Button size="lg" variant="inverted" @click="handleUpgrade">
+                {{ $t('subscription.upgradePlan') }}
+              </Button>
+              <Button
+                v-if="!isFreeTierPlan"
+                v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
+                variant="secondary"
+                size="icon-lg"
+                :aria-label="$t('g.moreOptions')"
+                @click="planMenu?.toggle($event)"
+              >
+                <i class="pi pi-ellipsis-h" />
+              </Button>
+              <Menu ref="planMenu" :model="planMenuItems" :popup="true" />
+            </template>
+          </template>
+        </div>
+
+        <!-- Members tab actions -->
+        <div v-if="activeTab === 'members'" class="flex items-center gap-2">
           <Button
             v-if="permissions.canInviteMembers"
             v-tooltip="
-              inviteTooltip
-                ? { value: inviteTooltip, showDelay: 0 }
-                : { value: $t('workspacePanel.inviteMember'), showDelay: 300 }
+              inviteTooltip ? { value: inviteTooltip, showDelay: 0 } : undefined
             "
             variant="secondary"
             size="lg"
-            :disabled="!isSingleSeatPlan && isInviteLimitReached"
-            :class="
-              !isSingleSeatPlan &&
-              isInviteLimitReached &&
-              'cursor-not-allowed opacity-50'
-            "
+            :disabled="isInviteDisabled"
+            :class="isInviteDisabled && 'cursor-not-allowed opacity-30'"
             :aria-label="$t('workspacePanel.inviteMember')"
             @click="handleInviteMember"
           >
+            {{ $t('workspacePanel.invite') }}
             <i class="pi pi-plus text-sm" />
           </Button>
           <template v-if="permissions.canAccessWorkspaceMenu">
             <Button
               v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
-              variant="muted-textonly"
-              size="icon"
+              variant="secondary"
+              size="icon-lg"
               :aria-label="$t('g.moreOptions')"
               @click="menu?.toggle($event)"
             >
@@ -124,34 +170,41 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import MembersPanelContent from '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { useToast } from 'primevue/usetoast'
+
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
 import { cn } from '@comfyorg/tailwind-utils'
-
-const tabTriggerBase =
-  'flex items-center justify-center shrink-0 px-2.5 py-2 text-sm rounded-lg cursor-pointer transition-all duration-200 outline-hidden border-none'
-const tabTriggerActive =
-  'bg-interface-menu-component-surface-hovered text-text-primary font-bold'
-const tabTriggerInactive =
-  'bg-transparent text-text-secondary hover:bg-button-hover-surface focus:bg-button-hover-surface'
 
 const { defaultTab = 'plan' } = defineProps<{
   defaultTab?: string
 }>()
 
 const { t } = useI18n()
+const toast = useToast()
 const {
   showLeaveWorkspaceDialog,
   showDeleteWorkspaceDialog,
   showInviteMemberDialog,
   showInviteMemberUpsellDialog,
-  showEditWorkspaceDialog
+  showEditWorkspaceDialog,
+  showCancelSubscriptionDialog
 } = useDialogService()
-const { isActiveSubscription, subscription, getMaxSeats } = useBillingContext()
+const {
+  isActiveSubscription,
+  isFreeTier: isFreeTierPlan,
+  subscription,
+  getMaxSeats,
+  manageSubscription,
+  showSubscriptionDialog
+} = useBillingContext()
+const { showPricingTable } = useSubscriptionDialog()
 
 const isSingleSeatPlan = computed(() => {
   if (!isActiveSubscription.value) return true
@@ -162,8 +215,13 @@ const isSingleSeatPlan = computed(() => {
   return getMaxSeats(tierKey) <= 1
 })
 const workspaceStore = useTeamWorkspaceStore()
-const { workspaceName, members, isInviteLimitReached, isWorkspaceSubscribed } =
-  storeToRefs(workspaceStore)
+const {
+  workspaceName,
+  members,
+  isInviteLimitReached,
+  isWorkspaceSubscribed,
+  isInPersonalWorkspace
+} = storeToRefs(workspaceStore)
 const { fetchMembers, fetchPendingInvites } = workspaceStore
 
 const { workspaceRole, permissions, uiConfig } = useWorkspaceUI()
@@ -197,8 +255,13 @@ const deleteTooltip = computed(() => {
   return tooltipKey ? t(tooltipKey) : null
 })
 
+const isInviteDisabled = computed(
+  () => isSingleSeatPlan.value || isInviteLimitReached.value
+)
+
 const inviteTooltip = computed(() => {
-  if (isSingleSeatPlan.value) return null
+  if (isSingleSeatPlan.value)
+    return t('workspacePanel.members.upgradeToAddTeammates')
   if (!isInviteLimitReached.value) return null
   return t('workspacePanel.inviteLimitReached')
 })
@@ -245,6 +308,64 @@ const menuItems = computed(() => {
 
   return items
 })
+
+// Plan tab actions
+const isCancelled = computed(
+  () =>
+    !isInPersonalWorkspace.value && (subscription.value?.isCancelled ?? false)
+)
+
+const showSubscribePrompt = computed(() => {
+  if (!permissions.value.canManageSubscription) return false
+  if (isCancelled.value) return false
+  if (isInPersonalWorkspace.value) return !isActiveSubscription.value
+  return !isWorkspaceSubscribed.value
+})
+
+function handleSubscribeWorkspace() {
+  showSubscriptionDialog()
+}
+
+const isResubscribing = ref(false)
+
+async function handleResubscribe() {
+  isResubscribing.value = true
+  try {
+    await workspaceApi.resubscribe()
+    toast.add({
+      severity: 'success',
+      summary: t('subscription.resubscribeSuccess'),
+      life: 5000
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to resubscribe'
+    toast.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail: message
+    })
+  } finally {
+    isResubscribing.value = false
+  }
+}
+
+function handleUpgrade() {
+  if (isFreeTierPlan.value) showPricingTable()
+  else showSubscriptionDialog()
+}
+
+const planMenu = ref<InstanceType<typeof Menu> | null>(null)
+
+const planMenuItems = computed(() => [
+  {
+    label: t('subscription.cancelSubscription'),
+    icon: 'pi pi-times',
+    command: () => {
+      showCancelSubscriptionDialog(subscription.value?.endDate ?? undefined)
+    }
+  }
+])
 
 onMounted(() => {
   fetchMembers()

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -33,23 +33,9 @@ interface WorkspaceUIConfig {
 }
 
 function getPermissions(
-  type: WorkspaceType,
+  _type: WorkspaceType,
   role: WorkspaceRole
 ): WorkspacePermissions {
-  if (type === 'personal') {
-    return {
-      canViewOtherMembers: false,
-      canViewPendingInvites: false,
-      canInviteMembers: false,
-      canManageInvites: false,
-      canRemoveMembers: false,
-      canLeaveWorkspace: false,
-      canAccessWorkspaceMenu: false,
-      canManageSubscription: true,
-      canTopUp: true
-    }
-  }
-
   if (role === 'owner') {
     return {
       canViewOtherMembers: true,
@@ -79,25 +65,9 @@ function getPermissions(
 }
 
 function getUIConfig(
-  type: WorkspaceType,
+  _type: WorkspaceType,
   role: WorkspaceRole
 ): WorkspaceUIConfig {
-  if (type === 'personal') {
-    return {
-      showMembersList: false,
-      showPendingTab: false,
-      showSearch: false,
-      showDateColumn: false,
-      showRoleBadge: false,
-      membersGridCols: 'grid-cols-1',
-      pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
-      headerGridCols: 'grid-cols-1',
-      showEditWorkspaceMenuItem: false,
-      workspaceMenuAction: null,
-      workspaceMenuDisabledTooltip: null
-    }
-  }
-
   if (role === 'owner') {
     return {
       showMembersList: true,

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -457,6 +457,21 @@ export const useDialogService = () => {
     })
   }
 
+  async function showCreateTeamWorkspaceDialog(
+    onConfirm?: (name: string) => void | Promise<void>
+  ) {
+    const { default: component } =
+      await import('@/platform/workspace/components/dialogs/CreateTeamWorkspaceDialogContent.vue')
+    return dialogStore.showDialog({
+      key: 'create-team-workspace',
+      component,
+      props: { onConfirm },
+      dialogComponentProps: {
+        ...workspaceDialogPt
+      }
+    })
+  }
+
   /**
    * Show the team workspaces dialog for creating or switching workspaces.
    * Optionally calls `onConfirm` after a workspace is successfully created.
@@ -628,6 +643,7 @@ export const useDialogService = () => {
     showSmallLayoutDialog,
     showDeleteWorkspaceDialog,
     showCreateWorkspaceDialog,
+    showCreateTeamWorkspaceDialog,
     showTeamWorkspacesDialog,
     showLeaveWorkspaceDialog,
     showEditWorkspaceDialog,


### PR DESCRIPTION
## ⚠️ This PR is for reference only — not intended to be merged as-is.

## Summary

Removes the personal/team workspace distinction. All workspaces are now the same — capabilities are gated by plan (personal vs team plan) instead of workspace type.

## Changes

### Workspace Switcher
- Flat workspace list without "TEAM WORKSPACES" section header or dividers
- New `WorkspaceSelectorButton` component with Reka UI popover
- Workspace switcher popover opens to the left of the profile menu (Reka UI, replaces PrimeVue)

### Members Tab (Settings Dialog)
- All workspaces show the full members list (no special personal workspace view)
- Invite button disabled when not on a team plan, with tooltip
- "Upgrade to Team" upsell banner replaces "Create a team workspace" messaging
- Permissions no longer branch on workspace type — only on role

### Pricing Table
- Shared "Choose a Plan" title moved above tabs, center-aligned
- Tab bar, disclaimer text, and billing toggle center-aligned
- Description text bumped from 14px to 16px
- Removed `flatTopLeft` prop from TeamPlanLayout
- Updated copy: "Subscribe to Team" (was "Subscribe and create a team workspace")

### Create Workspace Dialog
- Title: "Create a new workspace" (dropped "team")
- Updated description copy
- Consistent button sizing
- Post-payment variant (`CreateTeamWorkspaceDialogContent`) with info box and "Next" button

### Subscribe Buttons
- Lock icon added to SubscribeButton (via `showLockIcon` prop)
- Lock icon added to SubscribeToRun button

### i18n
- Updated copy throughout to reflect unified workspace model
- Added new keys for upgrade upsell, plan descriptions

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11933-feat-unify-workspace-model-and-update-billing-UI-3566d73d365081318784cffad9938f31) by [Unito](https://www.unito.io)
