### PR TITLE
fix(website): remove placeholder author info for groove-jones customer story

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3498,18 +3498,6 @@ const translations = {
     en: 'Dale Carman | Co-founder @ Groove Jones',
     'zh-CN': 'Dale Carman | Groove Jones 联合创始人'
   },
-  'customers.detail.groove-jones.topic-10.block.2.label': {
-    en: 'GROOVE JONES CONTRIBUTORS',
-    'zh-CN': 'GROOVE JONES 贡献者'
-  },
-  'customers.detail.groove-jones.topic-10.block.2.name': {
-    en: 'TBD',
-    'zh-CN': '待补充'
-  },
-  'customers.detail.groove-jones.topic-10.block.2.role': {
-    en: 'TBD',
-    'zh-CN': '待补充'
-  },
 
   // Contact – FormSection
   'contact.form.badge': {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Removes the placeholder "GROOVE JONES CONTRIBUTORS" author card from the Groove Jones customer story (`/customers/groove-jones`). The card was rendering with `TBD` / `待补充` values for the contributor name and role.

## Change

Deletes 3 i18n keys from `apps/website/src/i18n/translations.ts`:

- `customers.detail.groove-jones.topic-10.block.2.label`
- `customers.detail.groove-jones.topic-10.block.2.name`
- `customers.detail.groove-jones.topic-10.block.2.role`

Block types in `ContentSection.vue` are inferred from the presence of suffix keys (`.role` → `author` block) via `deriveSections` in `apps/website/src/config/contentSections.ts`. Removing the keys causes the author card to drop out of the rendered output entirely. The other two blocks in topic-10 (intro paragraph + Dale Carman blockquote) remain unchanged.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — 0 errors (1 pre-existing warning, unrelated)
- `pnpm format` — applied
- `pnpm knip` — clean (1 pre-existing warning, unrelated)
- Manual: ran `pnpm dev` for the website app, navigated to `/customers/groove-jones`, confirmed the conclusion section ends naturally — no `TBD` text, no orphan `CONTRIBUTORS` label, no broken card.

Code review (Oracle): 0 critical / 0 warning / 0 suggestion.

## Screenshots

![Conclusion section of the Groove Jones customer story — ends with the Dale Carman blockquote, no contributor card, no TBD placeholders](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/97021278678b2d01e3b2a67eed39f0499d7de31ad48cc414e95caca876eb37d9/pr-images/1777939400797-d8b627c0-a52c-42ab-990f-f7d36ab8ef66.jpg)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11937-fix-website-remove-placeholder-author-info-for-groove-jones-customer-story-3576d73d36508193b1a0c0c3cd887686) by [Unito](https://www.unito.io)
