### PR TITLE
fix(website): update payment-failed heading to "Unable to complete payment"

### DIFF
--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -102,7 +102,7 @@ test.describe('Payment pages zh-CN @smoke', () => {
     await expect(page).toHaveTitle('支付失败 — Comfy')
     await expectNoIndex(page)
     await expect(
-      page.getByRole('heading', { name: '支付未完成', level: 1 })
+      page.getByRole('heading', { name: '无法完成支付', level: 1 })
     ).toBeVisible()
     await expect(page.getByRole('link', { name: '联系支持' })).toHaveAttribute(
       'href',

--- a/apps/website/e2e/payment.spec.ts
+++ b/apps/website/e2e/payment.spec.ts
@@ -61,7 +61,7 @@ test.describe('Payment failed page @smoke', () => {
   test('shows failure heading and subtitle', async ({ page }) => {
     await expect(
       page.getByRole('heading', {
-        name: /Payment was not completed/i,
+        name: /Unable to complete payment/i,
         level: 1
       })
     ).toBeVisible()

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -3694,8 +3694,8 @@ const translations = {
     'zh-CN': '支付'
   },
   'payment.failed.title': {
-    en: 'Payment was not completed',
-    'zh-CN': '支付未完成'
+    en: 'Unable to complete payment',
+    'zh-CN': '无法完成支付'
   },
   'payment.failed.subtitle': {
     en: "Your payment didn't go through and you have not been charged. Reach out to support or read the subscription docs if you need help.",


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Reword the `payment.failed.title` copy on `comfy.org/payment/failed` from "Payment was not completed" to "Unable to complete payment" — a more active, distinguishing phrasing per design feedback.

## Changes

- `apps/website/src/i18n/translations.ts` — update English (`Unable to complete payment`) and Chinese (`无法完成支付`) translations
- `apps/website/e2e/payment.spec.ts` — update both English and zh-CN heading assertions to match

## Verification

- `pnpm --filter website typecheck` — passes
- `pnpm --filter website test:unit` — 30 tests passing
- Pre-commit hooks (oxfmt, oxlint, eslint, typecheck, typecheck:website) — all pass
- Manual visual verification with Playwright on `/payment/failed` and `/zh-CN/payment/failed` — both render the new heading correctly (screenshots attached)

## Screenshots

![English /payment/failed page showing 'Unable to complete payment' heading](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/704ef878d4d0c345146cd20fece87d6edf7e1cd0bbe5094daad0f00b414035fe/pr-images/1777946058984-deb77e19-c7ce-4c25-a004-c8425856145e.png)

![Chinese /zh-CN/payment/failed page showing the new heading](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/704ef878d4d0c345146cd20fece87d6edf7e1cd0bbe5094daad0f00b414035fe/pr-images/1777946059339-c50ac07c-d4ed-46af-992b-0c56ac469c23.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11943-fix-website-update-payment-failed-heading-to-Unable-to-complete-payment-3576d73d3650817e85e2e7a3891cc307) by [Unito](https://www.unito.io)
