### PR TITLE
feat(website): add 4 team photos and remove infinite scroll loop

### DIFF
--- a/apps/website/src/components/careers/TeamPhotosSection.vue
+++ b/apps/website/src/components/careers/TeamPhotosSection.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
-
 const photos = [
   {
     src: 'https://media.comfy.org/website/careers/team0.webp',
@@ -17,45 +15,34 @@ const photos = [
   {
     src: 'https://media.comfy.org/website/careers/team3.webp',
     alt: 'Team on a boat'
+  },
+  {
+    src: 'https://media.comfy.org/website/careers/team4.webp',
+    alt: 'Teammates posing at a restaurant'
+  },
+  {
+    src: 'https://media.comfy.org/website/careers/team5.webp',
+    alt: 'Teammates at a social gathering'
+  },
+  {
+    src: 'https://media.comfy.org/website/careers/team6.webp',
+    alt: 'Team sailing at golden hour'
+  },
+  {
+    src: 'https://media.comfy.org/website/careers/team7.webp',
+    alt: 'Team on a sailboat at sunset'
   }
 ]
-
-const loopedPhotos = [...photos, ...photos, ...photos]
-
-const scrollRef = ref<HTMLElement>()
-
-function onScroll() {
-  const el = scrollRef.value
-  if (!el) return
-
-  const third = el.scrollWidth / 3
-  const maxScroll = el.scrollWidth - el.clientWidth
-
-  if (el.scrollLeft >= maxScroll - 1) {
-    el.scrollLeft -= third
-  } else if (el.scrollLeft <= 1) {
-    el.scrollLeft += third
-  }
-}
-
-onMounted(() => {
-  const el = scrollRef.value
-  if (el) {
-    el.scrollLeft = el.scrollWidth / 3
-  }
-})
 </script>
 
 <template>
   <section class="py-12 md:py-24">
     <div
-      ref="scrollRef"
       class="flex gap-4 overflow-x-auto px-6 md:gap-6 md:px-20"
       style="scrollbar-width: none"
-      @scroll="onScroll"
     >
       <div
-        v-for="(photo, i) in loopedPhotos"
+        v-for="(photo, i) in photos"
         :key="i"
         class="aspect-3/4 h-64 shrink-0 md:h-96"
       >


### PR DESCRIPTION
## Summary

Add 4 new team photos and remove the infinite scroll behavior from the careers page team photos carousel.

## Changes

- **What**:
  - Add 4 new photos (team4–team7) to `TeamPhotosSection.vue`
  - Remove the infinite scroll loop (`loopedPhotos`, `onScroll` handler, `onMounted` scroll initializer)

<img width="1000" height="308" alt="Kapture 2026-05-05 at 11 02 16" src="https://github.com/user-attachments/assets/f5f6737f-c6bf-4abf-8780-d72c895f4015" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11945-feat-website-add-4-team-photos-and-remove-infinite-scroll-loop-3576d73d365081cabebecbc06666b9d9) by [Unito](https://www.unito.io)
