### PR TITLE
fix: use resized QPO thumbnails

### DIFF
--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -72,6 +72,7 @@ vi.mock('vue-i18n', () => {
 
 type TestPreviewOutput = {
   url: string
+  previewUrl: string
   isImage: boolean
   isVideo: boolean
 }
@@ -96,6 +97,7 @@ const createPreviewOutput = (
   const url = `/api/view/${filename}`
   return {
     url,
+    previewUrl: mediaType === 'images' ? `${url}?res=512` : url,
     isImage: mediaType === 'images',
     isVideo: mediaType === 'video'
   }
@@ -238,6 +240,18 @@ describe('JobAssetsList', () => {
     await user.click(screen.getByTestId('preview-trigger'))
 
     expect(onViewItem).toHaveBeenCalledWith(job)
+  })
+
+  it('uses thumbnail preview URLs for completed image rows', () => {
+    const preview = createPreviewOutput('job-1.png')
+    const job = buildJob({
+      taskRef: createTaskRef(preview)
+    })
+    const { container } = renderJobAssetsList({ jobs: [job] })
+
+    const stubRoot = container.querySelector('.assets-list-item-stub')!
+    expect(stubRoot.getAttribute('data-preview-url')).toBe(preview.previewUrl)
+    expect(stubRoot.getAttribute('data-preview-url')).not.toBe(preview.url)
   })
 
   it('emits viewItem on double-click for completed jobs with preview', async () => {

--- a/src/components/queue/job/JobAssetsList.vue
+++ b/src/components/queue/job/JobAssetsList.vue
@@ -287,7 +287,7 @@ function getPreviewOutput(job: JobListItem) {
 function getJobPreviewUrl(job: JobListItem) {
   const preview = getPreviewOutput(job)
   if (preview?.isImage || preview?.isVideo) {
-    return preview.url
+    return preview.previewUrl
   }
   return job.iconImageUrl
 }


### PR DESCRIPTION
## Summary

Use resized preview URLs for floating QPO row thumbnails so the expanded overlay does not load full-size image assets while the canvas is being navigated.

Linear: FE-538

## Changes

- **What**: Pass `ResultItemImpl.previewUrl` into `AssetsListItem` for completed image/video job rows.
- **Dependencies**: None.

## Review Focus

Confirm this only changes the row thumbnail source; full asset viewing still flows through the existing job/task preview output.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11946-fix-use-resized-QPO-thumbnails-3576d73d365081b68682d1b7b109af30) by [Unito](https://www.unito.io)
