### PR TITLE
ci: exclude release branches from website previews

### DIFF
--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -4,6 +4,9 @@ name: 'CI: Vercel Website Preview'
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches-ignore:
+      - 'core/*'
+      - 'cloud/*'
     paths:
       - 'apps/website/**'
       - 'packages/design-system/**'

--- a/.github/workflows/ci-vercel-website-preview.yaml
+++ b/.github/workflows/ci-vercel-website-preview.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches-ignore:
-      - 'core/*'
-      - 'cloud/*'
+      - 'core/**'
+      - 'cloud/**'
     paths:
       - 'apps/website/**'
       - 'packages/design-system/**'


### PR DESCRIPTION
## Summary

Exclude core and cloud minor release branches from Vercel website preview deployments.

## Changes

- **What**: Added `pull_request.branches-ignore` entries for `core/*` and `cloud/*` to the Vercel Website Preview workflow.

## Review Focus

Confirm the branch exclusion patterns match the minor release branch naming convention.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11952-ci-exclude-release-branches-from-website-previews-3576d73d36508194b835eda9bc12f174) by [Unito](https://www.unito.io)
