### PR TITLE
[backport core/1.43] fix: route progress_text feature flag check through getDevOverride (#11384)

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -638,7 +638,7 @@ export class ComfyApi extends EventTarget {
                 let promptId: string | undefined
 
                 if (
-                  this.serverFeatureFlags.value?.supports_progress_text_metadata
+                  this.serverSupportsFeature('supports_progress_text_metadata')
                 ) {
                   const promptIdLength = rawView.getUint32(offset)
                   offset += 4


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Cherry-pick of `4b7a02794` (PR #11384) from `main` onto `core/1.43`.

This is **PR 2 of 2** in a sequential stack. **Stacked on top of #11957** (`fix: guard progress_text before canvas init`). **Merge #11957 first**, then this PR's base will retarget to `core/1.43`.

## Why

Cloud reports of "Preview as Text" not displaying output when fed by API nodes traced back to two missing `progress_text` WebSocket fixes on `core/1.43`. The bundle PR #11926 picked these onto `cloud/1.43` but `core/1.43` was not in scope.

This is the **primary fix** for the API-node Preview-as-Text symptom: `api.ts` was checking the **client** feature flags instead of **server** feature flags before parsing the new `progress_text` binary wire format (`[event_type][prompt_id_len][prompt_id][node_id_len][node_id][text]`). When the server advertised `supports_progress_text_metadata` (which v0.20.2 does) but the client check failed silently, the new wire format was parsed as the legacy format, mangling the bytes — which is exactly why API-node text outputs (which stream via `progress_text`) failed while Concatenate (which doesn't use `progress_text`) worked.

Status confirmed via:
- `git merge-base --is-ancestor 4b7a02794 origin/main` → YES
- `git merge-base --is-ancestor 4b7a02794 origin/core/1.43` → NO (needs pick)

## Original PR Summary (#11384)

> Route the `progress_text` binary parser's feature-flag check through `serverSupportsFeature()` so dev overrides via `localStorage` take effect. Replace `this.getClientFeatureFlags()?.supports_progress_text_metadata` with `this.serverSupportsFeature('supports_progress_text_metadata')` in the `case 3` binary message handler, consistent with all other feature-flag checks in the class.

## Files Changed

- `src/scripts/api.ts` — 1 line: route the `progress_text` flag check through `serverSupportsFeature()`

## Verification

**Local automated checks:**
- `pnpm typecheck` → clean
- `pnpm exec eslint src/scripts/api.ts` → 0 errors (file is in lint ignore list, expected)
- `pnpm exec vitest run src/scripts/api.featureFlags.test.ts` → **15/15 passed**
- Cherry-pick applied cleanly with no conflicts

**Code review (Oracle):** 0 critical, 0 warning, 1 suggestion. Suggestion was about extending test coverage in `executionStore.test.ts` for an adjacent nullable branch — that file belongs to PR 1 (#11957) and the suggestion is out of scope for this 1-line API fix. Backports should not drift from main's test scope.

**Manual / browser verification:** N/A for this change. The fix is a 1-line feature-flag routing correction with deterministic unit-test coverage. The behavior (binary-decoding `progress_text` event-type-3 frames) is the same code path already shipping in production via `main` (v1.44.16+) and `cloud/1.43` (via bundle PR #11926). End-to-end repro requires the cloud frontend pin to be bumped to a `core/1.43` build that includes this commit, which is the follow-up step outside this PR.

## Stack

- Previous PR (#11957) → `core/1.43`
- **This PR** → `glary/backport-core-1.43-11174-guard-progress-text` (merge that first, then retarget)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11958-backport-core-1-43-fix-route-progress_text-feature-flag-check-through-getDevOverride--3576d73d365081d486b2d71ee8beb522) by [Unito](https://www.unito.io)
