### PR TITLE
[backport cloud/1.43] fix: skip nested subgraph containers in replay scan

### DIFF
--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -831,6 +831,58 @@ describe('scan skips interior of bypassed subgraph containers', () => {
 
     expect(useMissingModelStore().missingModelCandidates).toBeNull()
   })
+
+  it('skips nested subgraph containers during parent subgraph replay scan', async () => {
+    const rootGraph = new LGraph()
+    const outerSubgraph = createTestSubgraph({ rootGraph })
+    const innerSubgraph = createTestSubgraph({ rootGraph })
+    const leafNode = new LGraphNode('UNETLoader')
+    innerSubgraph.add(leafNode)
+
+    const innerSubgraphNode = createTestSubgraphNode(innerSubgraph, {
+      parentGraph: outerSubgraph,
+      id: 76
+    })
+    outerSubgraph.add(innerSubgraphNode)
+
+    const outerSubgraphNode = createTestSubgraphNode(outerSubgraph, {
+      parentGraph: rootGraph,
+      id: 205
+    })
+    rootGraph.add(outerSubgraphNode)
+
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
+    const modelScanSpy = vi
+      .spyOn(missingModelScan, 'scanNodeModelCandidates')
+      .mockReturnValue([])
+    const mediaScanSpy = vi
+      .spyOn(missingMediaScan, 'scanNodeMediaCandidates')
+      .mockReturnValue([])
+
+    installErrorClearingHooks(rootGraph)
+
+    rootGraph.onNodeAdded?.(outerSubgraphNode)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(modelScanSpy).toHaveBeenCalledWith(
+      rootGraph,
+      leafNode,
+      expect.any(Function),
+      expect.any(Function)
+    )
+    expect(modelScanSpy).not.toHaveBeenCalledWith(
+      rootGraph,
+      innerSubgraphNode,
+      expect.any(Function),
+      expect.any(Function)
+    )
+    expect(mediaScanSpy).toHaveBeenCalledWith(rootGraph, leafNode, false)
+    expect(mediaScanSpy).not.toHaveBeenCalledWith(
+      rootGraph,
+      innerSubgraphNode,
+      false
+    )
+  })
 })
 
 describe('clearWidgetRelatedErrors parameter routing', () => {

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -162,6 +162,7 @@ function scanAndAddNodeErrors(node: LGraphNode): void {
 
   if (node.isSubgraphNode?.() && node.subgraph) {
     for (const innerNode of collectAllNodes(node.subgraph)) {
+      if (innerNode.isSubgraphNode?.()) continue
       if (isNodeInactive(innerNode.mode)) continue
       scanSingleNodeErrors(innerNode)
     }


### PR DESCRIPTION
## Summary
- Backports #11908 to `cloud/1.43`.
- Keeps the shared runtime fix in `src/composables/graph/useErrorClearingHooks.ts`.
- Keeps the focused unit coverage in `src/composables/graph/useErrorClearingHooks.test.ts`.
- Drops the E2E-only change to `browser_tests/tests/propertiesPanel/errorsTabCloudMissingModels.spec.ts` from this stable backport.

## Backport notes
- Auto-backport is not practical here because #11908 was stacked on the #11907 regression-test PR. Cherry-picking #11908 into `cloud/1.43` pulls a modify/delete conflict for the E2E file that does not exist on this branch.
- Backporting #11907 first would require newer browser-test fixture/test-infra changes and would add stable-branch test churn that is unrelated to the runtime fix.
- This is still safe because main keeps the Cloud E2E regression coverage from #11907/#11908, while this backport carries the production fix plus unit coverage for the shared replay-scan behavior.

## Verification
- `pnpm typecheck` (pre-commit hook)
- `pnpm exec vitest run src/composables/graph/useErrorClearingHooks.test.ts`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11963-backport-cloud-1-43-fix-skip-nested-subgraph-containers-in-replay-scan-3576d73d3650812a82fbe1e54a4d8f99) by [Unito](https://www.unito.io)
