### PR TITLE
fix(i18n): rename OpenAI GPT Image 1 to GPT Image 2 across locales

### DIFF
--- a/src/locales/ar/nodeDefs.json
+++ b/src/locales/ar/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "ينشئ صورًا بشكل متزامن عبر نقطة نهاية GPT Image 1 من OpenAI.",
-    "display_name": "OpenAI GPT صورة 1",
+    "description": "ينشئ صورًا بشكل متزامن عبر نقطة نهاية GPT Image 2 من OpenAI.",
+    "display_name": "OpenAI GPT صورة 2",
     "inputs": {
       "background": {
         "name": "الخلفية",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "النص الوصفي",
-        "tooltip": "النص الوصفي لـ GPT Image 1"
+        "tooltip": "النص الوصفي لـ GPT Image 2"
       },
       "quality": {
         "name": "الجودة",

--- a/src/locales/es/nodeDefs.json
+++ b/src/locales/es/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "Genera imágenes de forma síncrona a través del endpoint GPT Image 1 de OpenAI.",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "Genera imágenes de forma síncrona a través del endpoint GPT Image 2 de OpenAI.",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "background",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "prompt",
-        "tooltip": "Texto de entrada para GPT Image 1"
+        "tooltip": "Texto de entrada para GPT Image 2"
       },
       "quality": {
         "name": "quality",

--- a/src/locales/fa/nodeDefs.json
+++ b/src/locales/fa/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "تولید تصویر به صورت همزمان از طریق نقطه پایانی GPT Image 1 شرکت OpenAI.",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "تولید تصویر به صورت همزمان از طریق نقطه پایانی GPT Image 2 شرکت OpenAI.",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "background",

--- a/src/locales/fr/nodeDefs.json
+++ b/src/locales/fr/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "Génère des images de manière synchrone via l'endpoint GPT Image 1 d'OpenAI.",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "Génère des images de manière synchrone via l'endpoint GPT Image 2 d'OpenAI.",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "arrière-plan",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "prompt",
-        "tooltip": "Invite textuelle pour GPT Image 1"
+        "tooltip": "Invite textuelle pour GPT Image 2"
       },
       "quality": {
         "name": "qualité",

--- a/src/locales/ja/nodeDefs.json
+++ b/src/locales/ja/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "OpenAIのGPT Image 1エンドポイントを通じて同期的に画像を生成します。",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "OpenAIのGPT Image 2エンドポイントを通じて同期的に画像を生成します。",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "背景",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "プロンプト",
-        "tooltip": "GPT Image 1用のテキストプロンプト"
+        "tooltip": "GPT Image 2用のテキストプロンプト"
       },
       "quality": {
         "name": "品質",

--- a/src/locales/ko/nodeDefs.json
+++ b/src/locales/ko/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "OpenAI의 GPT Image 1 엔드포인트를 통해 동기적으로 이미지를 생성합니다.",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "OpenAI의 GPT Image 2 엔드포인트를 통해 동기적으로 이미지를 생성합니다.",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "배경",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "프롬프트",
-        "tooltip": "GPT Image 1을 위한 텍스트 프롬프트"
+        "tooltip": "GPT Image 2를 위한 텍스트 프롬프트"
       },
       "quality": {
         "name": "품질",

--- a/src/locales/pt-BR/nodeDefs.json
+++ b/src/locales/pt-BR/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "Gera imagens de forma síncrona via endpoint GPT Image 1 da OpenAI.",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "Gera imagens de forma síncrona via endpoint GPT Image 2 da OpenAI.",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "fundo",

--- a/src/locales/ru/nodeDefs.json
+++ b/src/locales/ru/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "Генерирует изображения синхронно через конечную точку OpenAI GPT Image 1.",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "Генерирует изображения синхронно через конечную точку OpenAI GPT Image 2.",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "background",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "prompt",
-        "tooltip": "Текстовый запрос для GPT Image 1"
+        "tooltip": "Текстовый запрос для GPT Image 2"
       },
       "quality": {
         "name": "quality",

--- a/src/locales/tr/nodeDefs.json
+++ b/src/locales/tr/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "OpenAI'nin GPT Görüntü 1 uç noktası aracılığıyla eşzamanlı olarak görüntüler oluşturur.",
-    "display_name": "OpenAI GPT Görüntü 1",
+    "description": "OpenAI'nin GPT Görüntü 2 uç noktası aracılığıyla eşzamanlı olarak görüntüler oluşturur.",
+    "display_name": "OpenAI GPT Görüntü 2",
     "inputs": {
       "background": {
         "name": "arka_plan",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "istem",
-        "tooltip": "GPT Görüntü 1 için metin istemi"
+        "tooltip": "GPT Görüntü 2 için metin istemi"
       },
       "quality": {
         "name": "kalite",

--- a/src/locales/zh-TW/nodeDefs.json
+++ b/src/locales/zh-TW/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "透過 OpenAI 的 GPT Image 1 端點同步產生影像。",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "透過 OpenAI 的 GPT Image 2 端點同步產生影像。",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "背景",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "提示詞",
-        "tooltip": "用於 GPT Image 1 的文字提示"
+        "tooltip": "用於 GPT Image 2 的文字提示"
       },
       "quality": {
         "name": "品質",

--- a/src/locales/zh/nodeDefs.json
+++ b/src/locales/zh/nodeDefs.json
@@ -11711,8 +11711,8 @@
     }
   },
   "OpenAIGPTImage1": {
-    "description": "通过 OpenAI 的 GPT Image 1 端点同步生成图像。",
-    "display_name": "OpenAI GPT Image 1",
+    "description": "通过 OpenAI 的 GPT Image 2 端点同步生成图像。",
+    "display_name": "OpenAI GPT Image 2",
     "inputs": {
       "background": {
         "name": "背景",
@@ -11746,7 +11746,7 @@
       },
       "prompt": {
         "name": "提示词",
-        "tooltip": "用于 GPT Image 1 的文本提示"
+        "tooltip": "用于 GPT Image 2 的文本提示"
       },
       "quality": {
         "name": "质量",


### PR DESCRIPTION
## Summary

Aligns the `OpenAIGPTImage1` node display name in all 11 non-English `nodeDefs.json` locale files with the English source-of-truth, which was already updated to `OpenAI GPT Image 2`.

## Changes

- **What**: Updates `display_name`, the description string, and the prompt tooltip in `ja`, `ru`, `zh`, `zh-TW`, `ar`, `pt-BR`, `ko`, `fr`, `es`, `fa`, and `tr` locales from `GPT Image 1` to `GPT Image 2` (and `GPT Görüntü 1` → `GPT Görüntü 2` in Turkish, `GPT صورة 1` → `GPT صورة 2` in Arabic). Other tooltips already referenced `GPT Image 2` and are unchanged.
- **Breaking**: None — the registry node id `OpenAIGPTImage1` is preserved (it is an internal identifier, not user-facing).

## Review Focus

- Translations were updated mechanically — please confirm the version-number change is acceptable as-is for non-Latin scripts (Arabic, Persian, Korean, Japanese, Chinese) where the version number was kept as `2` per the existing pattern.
- The English locale already used `OpenAI GPT Image 2`, so this PR brings the other locales into sync; no English copy was changed.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11968-fix-i18n-rename-OpenAI-GPT-Image-1-to-GPT-Image-2-across-locales-3576d73d365081bfa204cbf528d84bf3) by [Unito](https://www.unito.io)
