### PR TITLE
fix(website): change 'Blogs' to 'Blog' in Resources nav dropdown

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1599,7 +1599,7 @@ const translations = {
   },
   'nav.comfyHub': { en: 'Comfy Hub', 'zh-CN': 'Comfy Hub' },
   'nav.gallery': { en: 'Gallery', 'zh-CN': '画廊' },
-  'nav.blogs': { en: 'Blogs', 'zh-CN': '博客' },
+  'nav.blogs': { en: 'Blog', 'zh-CN': '博客' },
   'nav.github': { en: 'GitHub', 'zh-CN': 'GitHub' },
   'nav.discord': { en: 'Discord', 'zh-CN': 'Discord' },
   'nav.docs': { en: 'Docs', 'zh-CN': '文档' },


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Corrects the "Blogs" label to "Blog" (singular) in the website header's Resources dropdown menu, as requested in #website-and-docs Slack channel.

## Changes

- `apps/website/src/i18n/translations.ts`: `nav.blogs` English value `Blogs` → `Blog` (zh-CN translation `博客` left unchanged since it was already correct)

This also makes the header consistent with the footer, which already labeled the same link as "Blog".

## Verification

- `pnpm typecheck` (astro check): 0 errors, 0 warnings, 0 hints (87 files)
- `pnpm test:unit`: 30 tests passed across 4 files
- `pnpm exec eslint apps/website/src/i18n/translations.ts`: clean
- Manual verification via Playwright on `pnpm dev` — Resources dropdown now displays "Blog"
- Code review (oracle): 0 issues found

## Screenshot

Resources dropdown after the change:

## Screenshots

![Resources dropdown in site header showing 'Blog' (singular)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/65e8a452a2ef553db097f1a5b55a024084f75cfc77f4f18359fcf73f31e264f8/pr-images/1777991675069-e9e180b3-54e5-48d3-8365-3abafa09df27.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11970-fix-website-change-Blogs-to-Blog-in-Resources-nav-dropdown-3576d73d365081638245d235bec04230) by [Unito](https://www.unito.io)
