### PR TITLE
test: add tests for dragging workflow tabs

### DIFF
--- a/browser_tests/tests/topbar/workflowTabs.spec.ts
+++ b/browser_tests/tests/topbar/workflowTabs.spec.ts
@@ -125,6 +125,48 @@ test.describe('Workflow tabs', () => {
     await expect(activeTab.locator('text=•')).toBeVisible()
   })
 
+  test('Can drag tab to end', async ({ comfyPage }) => {
+    const topbar = comfyPage.menu.topbar
+
+    await topbar.newWorkflowButton.click()
+    await topbar.newWorkflowButton.click()
+    await expect.poll(() => topbar.getTabNames()).toHaveLength(3)
+    const [a, b, c] = await topbar.getTabNames()
+
+    await topbar.getTab(0).dragTo(topbar.getTab(2))
+
+    await expect.poll(() => topbar.getTabNames()).toEqual([b, c, a])
+  })
+
+  test('Can drag tab to start', async ({ comfyPage }) => {
+    const topbar = comfyPage.menu.topbar
+
+    await topbar.newWorkflowButton.click()
+    await topbar.newWorkflowButton.click()
+    await expect.poll(() => topbar.getTabNames()).toHaveLength(3)
+    const [a, b, c] = await topbar.getTabNames()
+
+    await topbar.getTab(2).dragTo(topbar.getTab(0))
+
+    await expect.poll(() => topbar.getTabNames()).toEqual([c, a, b])
+  })
+
+  test('Drag preserves active tab', async ({ comfyPage }) => {
+    const topbar = comfyPage.menu.topbar
+
+    await topbar.newWorkflowButton.click()
+    await topbar.newWorkflowButton.click()
+    await expect.poll(() => topbar.getTabNames()).toHaveLength(3)
+
+    const [, b] = await topbar.getTabNames()
+    await topbar.getTab(1).click()
+    await expect.poll(() => topbar.getActiveTabName()).toContain(b)
+
+    await topbar.getTab(0).dragTo(topbar.getTab(2))
+
+    await expect.poll(() => topbar.getActiveTabName()).toContain(b)
+  })
+
   test('Multiple tabs can be created, switched, and closed', async ({
     comfyPage
   }) => {


### PR DESCRIPTION
## Summary

Adds tests for drag to reorder workflow tabs

## Changes

- **What**: 
- test drag start/end, ensure active tab is maintained

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11971-test-add-tests-for-dragging-workflow-tabs-3576d73d365081d090fccfc8804fa6aa) by [Unito](https://www.unito.io)
