### PR TITLE
FE-407: fix(assets): show 3D thumbnail without reopening the panel

### DIFF
--- a/src/platform/assets/components/Media3DTop.test.ts
+++ b/src/platform/assets/components/Media3DTop.test.ts
@@ -1,0 +1,220 @@
+import { render, screen } from '@testing-library/vue'
+import type * as VueUseCore from '@vueuse/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AssetMeta } from '../schemas/mediaAssetSchema'
+import Media3DTop from './Media3DTop.vue'
+
+const {
+  mockUseIntersectionObserver,
+  mockFindServerPreviewUrl,
+  mockIsAssetPreviewSupported
+} = vi.hoisted(() => ({
+  mockUseIntersectionObserver: vi.fn(),
+  mockFindServerPreviewUrl: vi.fn(),
+  mockIsAssetPreviewSupported: vi.fn(() => true)
+}))
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueUseCore>()
+  return {
+    ...actual,
+    useIntersectionObserver: mockUseIntersectionObserver
+  }
+})
+
+vi.mock('../utils/assetPreviewUtil', () => ({
+  findServerPreviewUrl: mockFindServerPreviewUrl,
+  isAssetPreviewSupported: mockIsAssetPreviewSupported
+}))
+
+function makeAsset(overrides: Partial<AssetMeta> = {}): AssetMeta {
+  return {
+    id: 'asset-1',
+    name: 'mesh.glb',
+    asset_hash: null,
+    mime_type: 'model/gltf-binary',
+    tags: [],
+    kind: '3D',
+    src: 'http://example.com/mesh.glb',
+    ...overrides
+  } as AssetMeta
+}
+
+function fireObserverIntersecting() {
+  mockUseIntersectionObserver.mockImplementation(
+    (
+      _target: unknown,
+      callback: (entries: { isIntersecting: boolean }[]) => void
+    ) => {
+      callback([{ isIntersecting: true }])
+      return { stop: vi.fn() }
+    }
+  )
+}
+
+function noopObserver() {
+  mockUseIntersectionObserver.mockImplementation(() => ({ stop: vi.fn() }))
+}
+
+async function flush() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
+
+const globalConfig = { mocks: { $t: (key: string) => key } }
+
+describe('Media3DTop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAssetPreviewSupported.mockReturnValue(true)
+  })
+
+  it('renders the placeholder when no thumbnail has loaded', () => {
+    noopObserver()
+    const { container } = render(Media3DTop, {
+      props: { asset: makeAsset() },
+      global: globalConfig
+    })
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- <img> has no role until src is set
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('assetBrowser.media.threeDModelPlaceholder')
+    ).toBeInTheDocument()
+  })
+
+  it('uses asset.preview_url directly when preview_id is already on the prop', async () => {
+    fireObserverIntersecting()
+    const { container } = render(Media3DTop, {
+      props: {
+        asset: makeAsset({
+          preview_id: 'p1',
+          preview_url: 'http://server/preview.png'
+        })
+      },
+      global: globalConfig
+    })
+    await flush()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('src', 'http://server/preview.png')
+    expect(mockFindServerPreviewUrl).not.toHaveBeenCalled()
+  })
+
+  it('queries the server for a preview when preview_id is missing on the prop', async () => {
+    fireObserverIntersecting()
+    mockFindServerPreviewUrl.mockResolvedValue('http://server/from-name.png')
+    const { container } = render(Media3DTop, {
+      props: { asset: makeAsset() },
+      global: globalConfig
+    })
+    await flush()
+
+    expect(mockFindServerPreviewUrl).toHaveBeenCalledWith('mesh.glb')
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('src', 'http://server/from-name.png')
+  })
+
+  it('skips the server query when isAssetPreviewSupported is false', async () => {
+    fireObserverIntersecting()
+    mockIsAssetPreviewSupported.mockReturnValue(false)
+    render(Media3DTop, {
+      props: { asset: makeAsset() },
+      global: globalConfig
+    })
+    await flush()
+
+    expect(mockFindServerPreviewUrl).not.toHaveBeenCalled()
+  })
+
+  it('picks up a patched preview_url after the IntersectionObserver gate has closed', async () => {
+    // Initial render: observer fires, server has no preview yet — hasAttempted=true
+    fireObserverIntersecting()
+    mockFindServerPreviewUrl.mockResolvedValue(null)
+
+    const { container, rerender } = render(Media3DTop, {
+      props: {
+        asset: makeAsset({
+          preview_id: null,
+          preview_url: undefined
+        })
+      },
+      global: globalConfig
+    })
+    await flush()
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+
+    // Simulate persistThumbnail patching the store: the prop arrives with the
+    // new preview. The watch on [preview_id, preview_url] should apply it
+    // directly even though the observer won't refire.
+    await rerender({
+      asset: makeAsset({
+        preview_id: 'p-new',
+        preview_url: 'http://server/patched.png'
+      })
+    })
+    await flush()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('src', 'http://server/patched.png')
+  })
+
+  it('does not overwrite a thumbnail that is already showing', async () => {
+    fireObserverIntersecting()
+    const { container, rerender } = render(Media3DTop, {
+      props: {
+        asset: makeAsset({
+          preview_id: 'p1',
+          preview_url: 'http://server/first.png'
+        })
+      },
+      global: globalConfig
+    })
+    await flush()
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      'http://server/first.png'
+    )
+
+    await rerender({
+      asset: makeAsset({
+        preview_id: 'p2',
+        preview_url: 'http://server/second.png'
+      })
+    })
+    await flush()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      'http://server/first.png'
+    )
+  })
+
+  it('does not apply a patch with no preview_id', async () => {
+    fireObserverIntersecting()
+    mockFindServerPreviewUrl.mockResolvedValue(null)
+
+    const { container, rerender } = render(Media3DTop, {
+      props: { asset: makeAsset({ preview_id: null, preview_url: undefined }) },
+      global: globalConfig
+    })
+    await flush()
+
+    await rerender({
+      asset: makeAsset({
+        preview_id: null,
+        preview_url: 'http://server/no-id.png'
+      })
+    })
+    await flush()
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+  })
+})

--- a/src/platform/assets/components/Media3DTop.vue
+++ b/src/platform/assets/components/Media3DTop.vue
@@ -74,5 +74,20 @@ watch(
   }
 )
 
+watch(
+  () => [asset?.preview_id, asset?.preview_url] as const,
+  ([newPreviewId, newPreviewUrl], [, oldPreviewUrl]) => {
+    if (
+      newPreviewId &&
+      newPreviewUrl &&
+      newPreviewUrl !== oldPreviewUrl &&
+      !thumbnailSrc.value
+    ) {
+      thumbnailSrc.value = newPreviewUrl
+      hasAttempted.value = true
+    }
+  }
+)
+
 onBeforeUnmount(revokeThumbnail)
 </script>

--- a/src/platform/assets/utils/assetPreviewUtil.test.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.test.ts
@@ -15,6 +15,7 @@ const mockGetServerFeature = vi.hoisted(() => vi.fn(() => false))
 const mockIsAssetAPIEnabled = vi.hoisted(() => vi.fn(() => false))
 const mockUploadAssetFromBase64 = vi.hoisted(() => vi.fn())
 const mockUpdateAsset = vi.hoisted(() => vi.fn())
+const mockSetAssetPreview = vi.hoisted(() => vi.fn())
 
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -31,6 +32,10 @@ vi.mock('@/platform/assets/services/assetService', () => ({
     uploadAssetFromBase64: mockUploadAssetFromBase64,
     updateAsset: mockUpdateAsset
   }
+}))
+
+vi.mock('@/stores/assetsStore', () => ({
+  useAssetsStore: () => ({ setAssetPreview: mockSetAssetPreview })
 }))
 
 function mockFetchResponse(assets: Record<string, unknown>[]) {
@@ -263,5 +268,67 @@ describe('persistThumbnail', () => {
     expect(mockUpdateAsset).toHaveBeenCalledWith(cloudAsset.id, {
       preview_id: 'new-preview-id'
     })
+  })
+
+  it('patches the assets store by name with the new preview after upload', async () => {
+    mockFetchEmpty()
+    mockFetchResponse([localAsset])
+    mockUploadAssetFromBase64.mockResolvedValue({ id: 'new-preview-id' })
+    mockUpdateAsset.mockResolvedValue({})
+
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    await persistThumbnail('ComfyUI_00081_.glb', blob)
+
+    expect(mockSetAssetPreview).toHaveBeenCalledWith(
+      localAsset.name,
+      'new-preview-id',
+      'http://localhost:8188/assets/new-preview-id/content'
+    )
+  })
+
+  it('uses the cloud asset name (not the hash) when patching the store', async () => {
+    mockFetchResponse([cloudAsset])
+    mockUploadAssetFromBase64.mockResolvedValue({ id: 'new-preview-id' })
+    mockUpdateAsset.mockResolvedValue({})
+
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    await persistThumbnail('c6cadcee57dd.glb', blob)
+
+    expect(mockSetAssetPreview).toHaveBeenCalledWith(
+      cloudAsset.name,
+      'new-preview-id',
+      'http://localhost:8188/assets/new-preview-id/content'
+    )
+  })
+
+  it('does not patch the store when the asset already has a preview', async () => {
+    mockFetchEmpty()
+    mockFetchResponse([localAssetWithPreview])
+
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    await persistThumbnail('ComfyUI_00081_.glb', blob)
+
+    expect(mockSetAssetPreview).not.toHaveBeenCalled()
+  })
+
+  it('does not patch the store when no asset is found', async () => {
+    mockFetchEmpty()
+    mockFetchEmpty()
+
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    await persistThumbnail('nonexistent.glb', blob)
+
+    expect(mockSetAssetPreview).not.toHaveBeenCalled()
+  })
+
+  it('does not patch the store when upload fails', async () => {
+    mockFetchEmpty()
+    mockFetchResponse([localAsset])
+    mockUploadAssetFromBase64.mockRejectedValue(new Error('upload failed'))
+
+    const blob = new Blob(['fake-png'], { type: 'image/png' })
+    await persistThumbnail('ComfyUI_00081_.glb', blob)
+
+    expect(mockSetAssetPreview).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/assets/utils/assetPreviewUtil.ts
+++ b/src/platform/assets/utils/assetPreviewUtil.ts
@@ -1,5 +1,6 @@
 import { assetService } from '@/platform/assets/services/assetService'
 import { api } from '@/scripts/api'
+import { useAssetsStore } from '@/stores/assetsStore'
 
 interface AssetRecord {
   id: string
@@ -80,6 +81,9 @@ export async function persistThumbnail(
     await assetService.updateAsset(asset.id, {
       preview_id: uploaded.id
     })
+
+    const previewUrl = api.apiURL(`/assets/${uploaded.id}/content`)
+    useAssetsStore().setAssetPreview(asset.name, uploaded.id, previewUrl)
   } catch {
     // Non-critical — client still shows the rendered thumbnail
   }

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -542,6 +542,88 @@ describe('assetsStore - Refactored (Option A)', () => {
     })
   })
 
+  describe('setAssetPreview', () => {
+    it('patches preview_id and preview_url on the matching history asset by name', async () => {
+      const mockHistory = Array.from({ length: 3 }, (_, i) =>
+        createMockJobItem(i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+      await store.updateHistory()
+
+      const target = store.historyAssets[1]
+      const targetName = target.name
+
+      store.setAssetPreview(
+        targetName,
+        'preview-xyz',
+        '/assets/preview-xyz/content'
+      )
+
+      const updated = store.historyAssets.find((a) => a.name === targetName)
+      expect(updated?.preview_id).toBe('preview-xyz')
+      expect(updated?.preview_url).toBe('/assets/preview-xyz/content')
+    })
+
+    it('matches by name even when ids differ between APIs', async () => {
+      const mockHistory = [createMockJobItem(0)]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+      await store.updateHistory()
+
+      const historyAssetId = store.historyAssets[0].id
+      const targetName = store.historyAssets[0].name
+
+      // Simulate the cloud-api side using a different id space
+      store.setAssetPreview(targetName, 'p1', '/assets/p1/content')
+
+      expect(store.historyAssets[0].id).toBe(historyAssetId)
+      expect(store.historyAssets[0].preview_id).toBe('p1')
+      expect(store.historyAssets[0].preview_url).toBe('/assets/p1/content')
+    })
+
+    it('does nothing when no asset with that name is loaded', async () => {
+      const mockHistory = Array.from({ length: 2 }, (_, i) =>
+        createMockJobItem(i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+      await store.updateHistory()
+
+      const before = store.historyAssets.map((a) => ({ ...a }))
+      store.setAssetPreview('does-not-exist.glb', 'p', '/p')
+
+      expect(store.historyAssets).toEqual(before)
+    })
+
+    it('only patches the asset whose name matches exactly', async () => {
+      const mockHistory = Array.from({ length: 3 }, (_, i) =>
+        createMockJobItem(i)
+      )
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+      await store.updateHistory()
+
+      // Patch using a non-matching prefix; the other assets must stay untouched
+      store.setAssetPreview('output_1', 'p', '/p')
+
+      for (const asset of store.historyAssets) {
+        expect(asset.preview_id).toBeUndefined()
+      }
+    })
+
+    it('replaces the asset object so reactivity fires for v-for keyed by id', async () => {
+      const mockHistory = [createMockJobItem(0)]
+      vi.mocked(api.getHistory).mockResolvedValue(mockHistory)
+      await store.updateHistory()
+
+      const before = store.historyAssets[0]
+      const targetName = before.name
+
+      store.setAssetPreview(targetName, 'p', '/p')
+
+      // setAssetPreview replaces the item with a new object via list[idx] = {...}
+      // (rather than mutating in place) so Vue triggers dependent watchers.
+      expect(store.historyAssets[0]).not.toBe(before)
+    })
+  })
+
   describe('jobDetailView Support', () => {
     it('should include outputCount and allOutputs in user_metadata', async () => {
       const mockHistory = Array.from({ length: 5 }, (_, i) =>

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -253,6 +253,32 @@ export const useAssetsStore = defineStore('assets', () => {
   }
 
   /**
+   * Patch preview_id/preview_url for a single asset already in memory,
+   * matched by name. Used after persistThumbnail succeeds so an open Asset
+   * panel reflects the new thumbnail without refetching the whole history.
+   * Match by name because the cloud assets API and the history API use
+   * different id spaces; name is the stable cross-API identifier.
+   */
+  const setAssetPreview = (
+    name: string,
+    previewId: string,
+    previewUrl: string
+  ) => {
+    const patch = (list: AssetItem[]) => {
+      const idx = list.findIndex((a) => a.name === name)
+      if (idx < 0) return
+      list[idx] = {
+        ...list[idx],
+        preview_id: previewId,
+        preview_url: previewUrl
+      }
+    }
+    patch(historyAssets.value)
+    patch(allHistoryItems.value)
+    patch(inputAssets.value)
+  }
+
+  /**
    * Map of asset hash filename to asset item for O(1) lookup
    * Cloud assets use asset_hash for the hash-based filename
    */
@@ -747,6 +773,7 @@ export const useAssetsStore = defineStore('assets', () => {
     updateInputs,
     updateHistory,
     loadMoreHistory,
+    setAssetPreview,
 
     // Input mapping helpers
     inputAssetsByFilename,


### PR DESCRIPTION
## Summary
After persistThumbnail uploads the preview, patch the in-memory asset by name (the cross-API stable id) so an open Asset panel reflects the new preview_url. Media3DTop also picks up the patched preview_url directly, bypassing the IntersectionObserver gate.

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/ba0b753f-fede-43c0-b790-5c19a82455f9


after

https://github.com/user-attachments/assets/6273ec0b-0d2e-4355-9889-68c3550f1a72

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11972-FE-407-fix-assets-show-3D-thumbnail-without-reopening-the-panel-3576d73d365081febcbfe6ae84a4a68b) by [Unito](https://www.unito.io)
