### PR TITLE
[backport cloud/1.43] Load3D fixes follow-up: #11825 + #11838

### DIFF
--- a/src/composables/useLoad3dViewer.test.ts
+++ b/src/composables/useLoad3dViewer.test.ts
@@ -478,6 +478,23 @@ describe('useLoad3dViewer', () => {
           .intensity
       ).toBe(1)
     })
+
+    it('should preserve unknown fields on Model Config when restoring', async () => {
+      const viewer = useLoad3dViewer(mockNode)
+      const containerRef = document.createElement('div')
+
+      await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
+      ;(
+        mockNode.properties!['Model Config'] as Record<string, unknown>
+      ).futureField = 'preserve-me'
+
+      viewer.restoreInitialState()
+
+      expect(
+        (mockNode.properties!['Model Config'] as Record<string, unknown>)
+          .futureField
+      ).toBe('preserve-me')
+    })
   })
 
   describe('applyChanges', () => {
@@ -530,6 +547,23 @@ describe('useLoad3dViewer', () => {
       const result = await viewer.applyChanges()
 
       expect(result).toBe(false)
+    })
+
+    it('should preserve unknown fields on Model Config when applying', async () => {
+      const viewer = useLoad3dViewer(mockNode)
+      const containerRef = document.createElement('div')
+
+      await viewer.initializeViewer(containerRef, mockSourceLoad3d as Load3d)
+      ;(
+        mockNode.properties!['Model Config'] as Record<string, unknown>
+      ).futureField = 'preserve-me'
+
+      await viewer.applyChanges()
+
+      expect(
+        (mockNode.properties!['Model Config'] as Record<string, unknown>)
+          .futureField
+      ).toBe('preserve-me')
     })
   })
 

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -570,7 +570,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
         intensity: initialState.value.lightIntensity
       }
 
+      const existingModelConfig = nodeValue.properties['Model Config'] as
+        | ModelConfig
+        | undefined
       nodeValue.properties['Model Config'] = {
+        ...existingModelConfig,
         upDirection: initialState.value.upDirection,
         materialMode: initialState.value.materialMode
       }
@@ -614,7 +618,11 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
         intensity: lightIntensity.value
       }
 
+      const existingModelConfig = nodeValue.properties['Model Config'] as
+        | ModelConfig
+        | undefined
       nodeValue.properties['Model Config'] = {
+        ...existingModelConfig,
         upDirection: upDirection.value,
         materialMode: materialMode.value
       }

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -517,15 +517,16 @@ export class SceneModelManager implements ModelManagerInterface {
     model.position.set(-center.x, -box.min.y, -center.z)
 
     this.scene.add(model)
+    const pendingMaterialMode = this.materialMode
+    this.setupModelMaterials(model)
 
-    if (this.materialMode !== 'original') {
-      this.setMaterialMode(this.materialMode)
+    if (pendingMaterialMode !== 'original') {
+      this.setMaterialMode(pendingMaterialMode)
     }
 
     if (this.currentUpDirection !== 'original') {
       this.setUpDirection(this.currentUpDirection)
     }
-    this.setupModelMaterials(model)
 
     this.setupCamera(size)
   }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Small follow-up to #11926 picking up two Load3D bug fixes the strict pass identified as still missing on `cloud/1.43`. Skips one originally-shortlisted candidate (#11810) after verification — the bug doesn't exist on `cloud/1.43`.

## Picked

| PR | Subject | User-visible bug |
|---|---|---|
| `#11825` | fix(load3d): snapshot original materials before reapplying materialMode | Wireframe / normal / depth modes don't restore the model's true original materials on reload |
| `#11838` | fix(load3d): preserve unknown Model Config fields with spread | Future Model Config fields silently dropped on viewer dialog cancel/apply (Fixes #11346) |

## Skipped

- **`#11810`** ("use capitalize for keybinding badges") — verified not applicable. The bug is `uppercase` Tailwind class on the Tag in `KeyComboDisplay.vue`. `cloud/1.43`'s file already uses neither `uppercase` nor `capitalize` — it just renders whatever `KeyComboImpl.getKeySequences()` returns directly, which is already canonical (`Ctrl`, `Alt`, `Shift`). No action needed.

## Conflict resolution notes

- **`#11825`** — modify/delete on `SceneModelManager.test.ts` (deleted on cloud/1.43). Dropped the test additions; runtime fix in `SceneModelManager.ts` applied cleanly.
- **`#11838`** — text conflict in `useLoad3dViewer.ts` because cloud/1.43 lacks gizmo support. Kept the spread fix (`...existingModelConfig` + `ModelConfig` typing) — that *is* the bug fix — and omitted the gizmo-related Model Config additions.

## Verification

- ✅ `pnpm typecheck` clean
- ✅ `pnpm typecheck:browser` clean
- ✅ `pnpm knip` clean
- ✅ `pnpm vitest run src/composables/useLoad3dViewer.test.ts` — 39/39 passed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11975-backport-cloud-1-43-Load3D-fixes-follow-up-11825-11838-3576d73d365081428051cb75e1bb2318) by [Unito](https://www.unito.io)
