### PR TITLE
test: expose assets selection action labels

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -119,6 +119,8 @@
       <div
         v-if="hasSelection"
         ref="footerRef"
+        role="toolbar"
+        :aria-label="$t('mediaAsset.selection.actions')"
         class="flex h-18 w-full items-center justify-between gap-1"
       >
         <div class="flex-1 pl-4">
@@ -144,6 +146,7 @@
             <Button
               v-if="shouldShowDeleteButton"
               size="icon"
+              :aria-label="$t('mediaAsset.selection.deleteSelected')"
               data-testid="assets-delete-selected"
               @click="handleDeleteSelected"
             >
@@ -151,6 +154,7 @@
             </Button>
             <Button
               size="icon"
+              :aria-label="$t('mediaAsset.selection.downloadSelected')"
               data-testid="assets-download-selected"
               @click="handleDownloadSelected"
             >

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3122,6 +3122,7 @@
     "selection": {
       "selectedCount": "Assets Selected: {count}",
       "multipleSelectedAssets": "Multiple assets selected",
+      "actions": "Selected asset actions",
       "deselectAll": "Deselect all",
       "downloadSelected": "Download",
       "downloadSelectedAll": "Download all",


### PR DESCRIPTION
## Summary

Expose stable accessible labels for the assets selection action bar.

## Changes

- **What**: Adds toolbar/button labels used by browser tests and assistive tech.

## Review Focus

Small production hook split out ahead of the action coverage stack.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11992-test-expose-assets-selection-action-labels-3576d73d365081579e94fa1119f11a67) by [Unito](https://www.unito.io)
