### PR TITLE
test: add assets sidebar action locators

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -275,86 +275,76 @@ function getMediaFilterLabel(
 }
 
 export class AssetsSidebarTab extends SidebarTab {
-  // --- Tab navigation ---
+  public readonly root: Locator
   public readonly generatedTab: Locator
   public readonly importedTab: Locator
-
-  // --- Empty state ---
   public readonly emptyStateMessage: Locator
-
-  // --- Search & filter ---
   public readonly searchInput: Locator
   public readonly settingsButton: Locator
   public readonly filterButton: Locator
-
-  // --- Filter menu checkboxes (cloud-only, shown inside filter popover) ---
   public readonly filterImageCheckbox: Locator
   public readonly filterVideoCheckbox: Locator
   public readonly filterAudioCheckbox: Locator
   public readonly filter3DCheckbox: Locator
-
-  // --- View mode ---
   public readonly listViewOption: Locator
   public readonly gridViewOption: Locator
-
-  // --- Sort options (cloud-only, shown inside settings popover) ---
+  public readonly backToAssetsButton: Locator
+  public readonly copyJobIdButton: Locator
+  public readonly previewDialog: Locator
   public readonly sortNewestFirst: Locator
   public readonly sortOldestFirst: Locator
   public readonly sortLongestFirst: Locator
   public readonly sortFastestFirst: Locator
-
-  // --- Asset cards ---
   public readonly assetCards: Locator
   public readonly selectedCards: Locator
-
-  // --- List view items ---
   public readonly listViewItems: Locator
-
-  // --- Selection footer ---
   public readonly selectionFooter: Locator
   public readonly selectionCountButton: Locator
   public readonly deselectAllButton: Locator
   public readonly deleteSelectedButton: Locator
   public readonly downloadSelectedButton: Locator
-
-  // --- Folder view ---
-  public readonly backToAssetsButton: Locator
-
-  // --- Loading ---
   public readonly skeletonLoaders: Locator
 
   constructor(public override readonly page: Page) {
     super(page, 'assets')
+    this.root = page.locator('.sidebar-content-container')
     this.generatedTab = page.getByRole('tab', { name: 'Generated' })
     this.importedTab = page.getByRole('tab', { name: 'Imported' })
     this.emptyStateMessage = page.getByText(
       'Upload files or generate content to see them here'
     )
-    this.searchInput = page.getByPlaceholder('Search Assets...')
-    this.settingsButton = page.getByRole('button', { name: 'View settings' })
-    this.filterButton = page.getByRole('button', { name: 'Filter by' })
+    this.searchInput = this.root.getByPlaceholder(/Search Assets/i)
+    this.settingsButton = this.root.getByLabel('View settings')
+    this.filterButton = this.root.getByRole('button', { name: 'Filter by' })
     this.filterImageCheckbox = page.getByRole('checkbox', { name: 'Image' })
     this.filterVideoCheckbox = page.getByRole('checkbox', { name: 'Video' })
     this.filterAudioCheckbox = page.getByRole('checkbox', { name: 'Audio' })
     this.filter3DCheckbox = page.getByRole('checkbox', { name: '3D' })
     this.listViewOption = page.getByText('List view')
     this.gridViewOption = page.getByText('Grid view')
+    this.backToAssetsButton = page.getByRole('button', {
+      name: 'Back to all assets'
+    })
+    this.copyJobIdButton = page.getByRole('button', {
+      name: 'Copy job ID'
+    })
+    this.previewDialog = page.getByRole('dialog', { name: 'Gallery' })
     this.sortNewestFirst = page.getByText('Newest first')
     this.sortOldestFirst = page.getByText('Oldest first')
     this.sortLongestFirst = page.getByText('Generation time (longest first)')
     this.sortFastestFirst = page.getByText('Generation time (fastest first)')
-    this.assetCards = page
+    this.assetCards = this.root
       .getByRole('button')
-      .and(page.locator('[data-selected]'))
-    this.selectedCards = page.locator('[data-selected="true"]')
-    this.listViewItems = page.locator(
-      '.sidebar-content-container [role="button"][tabindex="0"]'
-    )
-    this.selectionFooter = page
-      .locator('.sidebar-content-container')
-      .locator('..')
-      .locator('[class*="h-18"]')
-    this.selectionCountButton = page.getByText(/Assets Selected: \d+/)
+      .and(this.root.locator('[data-selected]'))
+    this.selectedCards = this.root.locator('[data-selected="true"]')
+    this.listViewItems = this.root.getByRole('button', { name: /asset$/i })
+    this.selectionFooter = this.root.locator('..').getByRole('toolbar', {
+      name: 'Selected asset actions'
+    })
+    this.selectionCountButton = this.root
+      .getByRole('button', { name: /Assets Selected:/ })
+      .or(page.getByText(/Assets Selected: \d+/))
+      .first()
     this.deselectAllButton = page.getByText('Deselect all')
     this.deleteSelectedButton = page
       .getByTestId('assets-delete-selected')
@@ -364,10 +354,7 @@ export class AssetsSidebarTab extends SidebarTab {
       .getByTestId('assets-download-selected')
       .or(page.locator('button:has(.icon-\\[lucide--download\\])').last())
       .first()
-    this.backToAssetsButton = page.getByText('Back to all assets')
-    this.skeletonLoaders = page.locator(
-      '.sidebar-content-container .animate-pulse'
-    )
+    this.skeletonLoaders = this.root.locator('.animate-pulse')
   }
 
   emptyStateTitle(title: string) {
@@ -378,6 +365,14 @@ export class AssetsSidebarTab extends SidebarTab {
     return this.page.getByRole('checkbox', {
       name: getMediaFilterLabel(filter)
     })
+  }
+
+  previewImage(filename: string) {
+    return this.previewDialog.getByRole('img', { name: filename })
+  }
+
+  asset(name: string) {
+    return this.getAssetCardByName(name)
   }
 
   getAssetCardByName(name: string) {
@@ -392,10 +387,94 @@ export class AssetsSidebarTab extends SidebarTab {
     return this.page.locator('.p-contextmenu').getByText(label)
   }
 
+  contextMenuAction(label: string) {
+    return this.contextMenuItem(label)
+  }
+
+  async showGenerated() {
+    await this.switchToGenerated()
+  }
+
+  async showImported() {
+    await this.switchToImported()
+  }
+
+  async search(query: string) {
+    await this.searchInput.fill(query)
+  }
+
+  async switchToListView() {
+    await this.openSettingsMenu()
+    await this.listViewOption.click()
+  }
+
+  async switchToGridView() {
+    await this.openSettingsMenu()
+    await this.gridViewOption.click()
+  }
+
+  async openContextMenuForAsset(name: string) {
+    await this.asset(name).dispatchEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      button: 2
+    })
+    await this.page
+      .locator('.p-contextmenu')
+      .waitFor({ state: 'visible', timeout: 3000 })
+  }
+
+  async runContextMenuAction(assetName: string, actionName: string) {
+    await this.openContextMenuForAsset(assetName)
+    await this.contextMenuAction(actionName).click()
+  }
+
+  async openAssetPreview(name: string) {
+    const asset = this.asset(name)
+    await asset.hover()
+
+    const zoomButton = asset.getByLabel('Zoom in')
+    if (await zoomButton.isVisible().catch(() => false)) {
+      await zoomButton.click()
+      return
+    }
+
+    await asset.dblclick()
+  }
+
+  async openOutputFolder(name: string) {
+    await this.asset(name)
+      .getByRole('button', { name: 'See more outputs' })
+      .click()
+
+    await this.backToAssetsButton.waitFor({ state: 'visible' })
+  }
+
+  async toggleStack(name: string) {
+    await this.asset(name)
+      .getByRole('button', { name: 'See more outputs' })
+      .click()
+  }
+
+  async selectAssets(names: string[]) {
+    if (names.length === 0) {
+      return
+    }
+
+    await this.asset(names[0]).click()
+
+    for (const name of names.slice(1)) {
+      await this.asset(name).click({
+        modifiers: ['ControlOrMeta']
+      })
+    }
+  }
+
   override async open() {
     // Remove any toast notifications that may overlay the sidebar button
     await this.dismissToasts()
     await super.open()
+    await this.root.waitFor({ state: 'visible' })
     await this.generatedTab.waitFor({ state: 'visible' })
   }
 

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -297,7 +297,6 @@ export class AssetsSidebarTab extends SidebarTab {
   public readonly sortFastestFirst: Locator
   public readonly assetCards: Locator
   public readonly selectedCards: Locator
-  public readonly listViewItems: Locator
   public readonly selectionFooter: Locator
   public readonly selectionCountButton: Locator
   public readonly deselectAllButton: Locator
@@ -337,7 +336,6 @@ export class AssetsSidebarTab extends SidebarTab {
       .getByRole('button')
       .and(this.root.locator('[data-selected]'))
     this.selectedCards = this.root.locator('[data-selected="true"]')
-    this.listViewItems = this.root.getByRole('button', { name: /asset$/i })
     this.selectionFooter = this.root.locator('..').getByRole('toolbar', {
       name: 'Selected asset actions'
     })
@@ -383,20 +381,16 @@ export class AssetsSidebarTab extends SidebarTab {
     )
   }
 
+  listViewItem(name: string) {
+    return this.root.getByRole('button').filter({ hasText: name }).first()
+  }
+
   contextMenuItem(label: string) {
     return this.page.locator('.p-contextmenu').getByText(label)
   }
 
   contextMenuAction(label: string) {
     return this.contextMenuItem(label)
-  }
-
-  async showGenerated() {
-    await this.switchToGenerated()
-  }
-
-  async showImported() {
-    await this.switchToImported()
   }
 
   async search(query: string) {
@@ -427,33 +421,6 @@ export class AssetsSidebarTab extends SidebarTab {
   async runContextMenuAction(assetName: string, actionName: string) {
     await this.openContextMenuForAsset(assetName)
     await this.contextMenuAction(actionName).click()
-  }
-
-  async openAssetPreview(name: string) {
-    const asset = this.asset(name)
-    await asset.hover()
-
-    const zoomButton = asset.getByLabel('Zoom in')
-    if (await zoomButton.isVisible().catch(() => false)) {
-      await zoomButton.click()
-      return
-    }
-
-    await asset.dblclick()
-  }
-
-  async openOutputFolder(name: string) {
-    await this.asset(name)
-      .getByRole('button', { name: 'See more outputs' })
-      .click()
-
-    await this.backToAssetsButton.waitFor({ state: 'visible' })
-  }
-
-  async toggleStack(name: string) {
-    await this.asset(name)
-      .getByRole('button', { name: 'See more outputs' })
-      .click()
   }
 
   async selectAssets(names: string[]) {

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -276,8 +276,8 @@ test.describe('Assets sidebar - view mode toggle', () => {
     await tab.openSettingsMenu()
     await tab.listViewOption.click()
 
-    // List view items should now be visible
-    await expect(tab.listViewItems.first()).toBeVisible()
+    // List view should render the existing asset row.
+    await expect(tab.listViewItem('landscape.png')).toBeVisible()
   })
 
   test('Can switch back to grid view', async ({ comfyPage }) => {
@@ -288,7 +288,7 @@ test.describe('Assets sidebar - view mode toggle', () => {
     // Switch to list view
     await tab.openSettingsMenu()
     await tab.listViewOption.click()
-    await expect(tab.listViewItems.first()).toBeVisible()
+    await expect(tab.listViewItem('landscape.png')).toBeVisible()
 
     // Switch back to grid view (settings popover is still open)
     await tab.gridViewOption.click()


### PR DESCRIPTION
## Summary

Add stable assets sidebar page-object locators for action coverage.

## Changes

- **What**: Scopes asset locators to the sidebar, adds preview/context-menu/selection helpers, and keeps filename matching on accessible names.

## Review Focus

This is test infrastructure only; the filename locator avoids the CI timeout from matching visible text without extensions.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11993-test-add-assets-sidebar-action-locators-3576d73d3650810ea368e5a5ec9938ed) by [Unito](https://www.unito.io)
