### PR TITLE
[chore] Update Comfy Registry API types from comfy-api@69cbc3b

### DIFF
--- a/packages/registry-types/src/comfyRegistryTypes.ts
+++ b/packages/registry-types/src/comfyRegistryTypes.ts
@@ -12575,12 +12575,16 @@ export interface components {
         Rodin3DGenerateRequest: {
             /** @description The reference images to generate 3D Assets. */
             images: string;
+            /** @description Text prompt used by the upstream Rodin API. Required by upstream for text-to-3D requests (no images uploaded); optional for image-to-3D requests where it acts as additional guidance. */
+            prompt?: string;
             /** @description Seed. */
             seed?: number;
             tier?: components["schemas"]["RodinTierType"];
             material?: components["schemas"]["RodinMaterialType"];
             quality?: components["schemas"]["RodinQualityType"];
             mesh_mode?: components["schemas"]["RodinMeshModeType"];
+            /** @description Optional list of upstream addon flags (e.g. "HighPack"). */
+            addons?: string[];
         };
         /**
          * @description Rodin Tier para options


### PR DESCRIPTION
## Automated API Type Update

This PR updates the Comfy Registry API types from the latest comfy-api OpenAPI specification.

- API commit: 69cbc3b
- Generated on: 2026-05-05T15:48:16Z

These types are automatically generated using openapi-typescript.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11994-chore-Update-Comfy-Registry-API-types-from-comfy-api-69cbc3b-3576d73d3650818f85e4c98c783a6490) by [Unito](https://www.unito.io)
