### PR TITLE
[backport cloud/1.43] QPO thumbnails (#11946) + Vue node slot validation (#11950)

### DIFF
--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -5,6 +5,7 @@ import type { Locator, Page } from '@playwright/test'
 
 import { TestIds } from '@e2e/fixtures/selectors'
 import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
+import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 
 export class VueNodeHelpers {
   constructor(private page: Page) {}
@@ -28,6 +29,22 @@ export class VueNodeHelpers {
    */
   get selectedNodes(): Locator {
     return this.page.locator('[data-node-id].outline-node-component-outline')
+  }
+
+  getInputSlotRow(nodeId: string, slotIndex: number): Locator {
+    return this.getNodeLocator(nodeId)
+      .locator('.lg-slot--input')
+      .filter({
+        has: this.page.locator(
+          `[data-slot-key="${getSlotKey(nodeId, slotIndex, true)}"]`
+        )
+      })
+  }
+
+  getInputSlotConnectionDot(nodeId: string, slotIndex: number): Locator {
+    return this.getInputSlotRow(nodeId, slotIndex).getByTestId(
+      TestIds.node.slotConnectionDot
+    )
   }
 
   /**

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -99,7 +99,8 @@ export const TestIds = {
     titleInput: 'node-title-input',
     pinIndicator: 'node-pin-indicator',
     innerWrapper: 'node-inner-wrapper',
-    mainImage: 'main-image'
+    mainImage: 'main-image',
+    slotConnectionDot: 'slot-connection-dot'
   },
   selectionToolbox: {
     colorPickerButton: 'color-picker-button',

--- a/src/components/queue/job/JobAssetsList.test.ts
+++ b/src/components/queue/job/JobAssetsList.test.ts
@@ -72,6 +72,7 @@ vi.mock('vue-i18n', () => {
 
 type TestPreviewOutput = {
   url: string
+  previewUrl: string
   isImage: boolean
   isVideo: boolean
 }
@@ -96,6 +97,7 @@ const createPreviewOutput = (
   const url = `/api/view/${filename}`
   return {
     url,
+    previewUrl: mediaType === 'images' ? `${url}?res=512` : url,
     isImage: mediaType === 'images',
     isVideo: mediaType === 'video'
   }
@@ -238,6 +240,18 @@ describe('JobAssetsList', () => {
     await user.click(screen.getByTestId('preview-trigger'))
 
     expect(onViewItem).toHaveBeenCalledWith(job)
+  })
+
+  it('uses thumbnail preview URLs for completed image rows', () => {
+    const preview = createPreviewOutput('job-1.png')
+    const job = buildJob({
+      taskRef: createTaskRef(preview)
+    })
+    const { container } = renderJobAssetsList({ jobs: [job] })
+
+    const stubRoot = container.querySelector('.assets-list-item-stub')!
+    expect(stubRoot.getAttribute('data-preview-url')).toBe(preview.previewUrl)
+    expect(stubRoot.getAttribute('data-preview-url')).not.toBe(preview.url)
   })
 
   it('emits viewItem on double-click for completed jobs with preview', async () => {

--- a/src/components/queue/job/JobAssetsList.vue
+++ b/src/components/queue/job/JobAssetsList.vue
@@ -287,7 +287,7 @@ function getPreviewOutput(job: JobListItem) {
 function getJobPreviewUrl(job: JobListItem) {
   const preview = getPreviewOutput(job)
   if (preview?.isImage || preview?.isVideo) {
-    return preview.url
+    return preview.previewUrl
   }
   return job.iconImageUrl
 }

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -20,27 +20,7 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { app } from '@/scripts/app'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
-
-function seedSimpleError(
-  store: ReturnType<typeof useExecutionErrorStore>,
-  executionId: string,
-  inputName: string
-) {
-  store.lastNodeErrors = {
-    [executionId]: {
-      errors: [
-        {
-          type: 'required_input_missing',
-          message: 'Missing',
-          details: '',
-          extra_info: { input_name: inputName }
-        }
-      ],
-      dependent_outputs: [],
-      class_type: 'TestNode'
-    }
-  }
-}
+import { seedRequiredInputMissingNodeError } from '@/utils/__tests__/executionErrorTestUtils'
 
 describe('Connection error clearing via onConnectionsChange', () => {
   beforeEach(() => {
@@ -63,7 +43,7 @@ describe('Connection error clearing via onConnectionsChange', () => {
 
     const store = useExecutionErrorStore()
     vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
-    seedSimpleError(store, String(node.id), 'clip')
+    seedRequiredInputMissingNodeError(store, String(node.id), 'clip')
 
     node.onConnectionsChange!(NodeSlotType.INPUT, 0, true, null, node.inputs[0])
 
@@ -75,7 +55,7 @@ describe('Connection error clearing via onConnectionsChange', () => {
     installErrorClearingHooks(graph)
 
     const store = useExecutionErrorStore()
-    seedSimpleError(store, String(node.id), 'clip')
+    seedRequiredInputMissingNodeError(store, String(node.id), 'clip')
 
     node.onConnectionsChange!(
       NodeSlotType.INPUT,
@@ -94,7 +74,7 @@ describe('Connection error clearing via onConnectionsChange', () => {
     installErrorClearingHooks(graph)
 
     const store = useExecutionErrorStore()
-    seedSimpleError(store, String(node.id), 'clip')
+    seedRequiredInputMissingNodeError(store, String(node.id), 'clip')
 
     node.onConnectionsChange!(
       NodeSlotType.OUTPUT,
@@ -116,7 +96,7 @@ describe('Connection error clearing via onConnectionsChange', () => {
 
     const store = useExecutionErrorStore()
     vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
-    seedSimpleError(store, String(node.id), 'model')
+    seedRequiredInputMissingNodeError(store, String(node.id), 'model')
 
     node.onConnectionsChange!(NodeSlotType.INPUT, 0, true, null, node.inputs[0])
 
@@ -261,7 +241,11 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     // PromotedWidgetView.name returns displayName ("ckpt_input"), which is
     // passed as errorInputName to clearSimpleNodeErrors. Seed the error
     // with that name so the slot-name filter matches.
-    seedSimpleError(store, interiorExecId, promotedWidget!.name)
+    seedRequiredInputMissingNodeError(
+      store,
+      interiorExecId,
+      promotedWidget!.name
+    )
 
     subgraphNode.onWidgetChanged!.call(
       subgraphNode,
@@ -300,7 +284,7 @@ describe('installErrorClearingHooks lifecycle', () => {
     // Verify the hooks actually work
     const store = useExecutionErrorStore()
     vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
-    seedSimpleError(store, String(lateNode.id), 'value')
+    seedRequiredInputMissingNodeError(store, String(lateNode.id), 'value')
 
     lateNode.onConnectionsChange!(
       NodeSlotType.INPUT,

--- a/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.test.ts
@@ -1,19 +1,31 @@
 /* eslint-disable vue/one-component-per-file */
 import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
-import { describe, expect, it } from 'vitest'
-import { defineComponent } from 'vue'
+import type { RenderOptions } from '@testing-library/vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
 import type { PropType } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
-import type {
-  INodeInputSlot,
-  INodeOutputSlot
-} from '@/lib/litegraph/src/interfaces'
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import type { NodeId as VueNodeId } from '@/renderer/core/layout/types'
+import { app } from '@/scripts/app'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { seedRequiredInputMissingNodeError } from '@/utils/__tests__/executionErrorTestUtils'
+import {
+  createMockNodeInputSlot,
+  createMockNodeOutputSlot
+} from '@/utils/__tests__/litegraphTestUtils'
 
 import NodeSlots from './NodeSlots.vue'
+
+const toVueNodeId = (id: string | number): VueNodeId => String(id)
 
 const makeNodeData = (overrides: Partial<VueNodeData> = {}): VueNodeData => ({
   id: '123',
@@ -29,22 +41,6 @@ const makeNodeData = (overrides: Partial<VueNodeData> = {}): VueNodeData => ({
   ...overrides
 })
 
-function makeInputSlot(
-  name: string,
-  type: string,
-  extra?: Partial<INodeInputSlot>
-): INodeInputSlot {
-  return { name, type, boundingRect: [0, 0, 0, 0], link: null, ...extra }
-}
-
-function makeOutputSlot(
-  name: string,
-  type: string,
-  extra?: Partial<INodeOutputSlot>
-): INodeOutputSlot {
-  return { name, type, boundingRect: [0, 0, 0, 0], links: [], ...extra }
-}
-
 // Explicit stubs to capture props for assertions
 interface StubSlotData {
   name?: string
@@ -55,6 +51,7 @@ interface StubSlotData {
 const STUB_SLOT_PROPS = {
   slotData: { type: Object as PropType<StubSlotData>, required: true },
   nodeId: { type: String, required: false, default: '' },
+  hasError: { type: Boolean, required: false, default: false },
   index: { type: Number, required: true },
   readonly: { type: Boolean, required: false, default: false }
 } as const
@@ -69,6 +66,7 @@ const InputSlotStub = defineComponent({
       :data-name="slotData && slotData.name ? slotData.name : ''"
       :data-type="slotData && slotData.type ? slotData.type : ''"
       :data-node-id="nodeId"
+      :data-has-error="hasError ? 'true' : 'false'"
       :data-readonly="readonly ? 'true' : 'false'"
     />
   `
@@ -88,6 +86,21 @@ const OutputSlotStub = defineComponent({
     />
   `
 })
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+type SlotComponentStubs = NonNullable<
+  NonNullable<RenderOptions<typeof NodeSlots>['global']>['stubs']
+>
+
+const defaultSlotStubs: SlotComponentStubs = {
+  InputSlot: InputSlotStub,
+  OutputSlot: OutputSlotStub
+}
 
 function createTrackingStub(
   componentName: 'InputSlot' | 'OutputSlot',
@@ -112,40 +125,10 @@ function createTrackingStub(
   })
 }
 
-const mountSlots = (nodeData: VueNodeData) => {
-  const i18n = createI18n({
-    legacy: false,
-    locale: 'en',
-    messages: { en: enMessages }
-  })
-  return render(NodeSlots, {
-    global: {
-      plugins: [i18n, createTestingPinia({ stubActions: false })],
-      stubs: {
-        InputSlot: InputSlotStub,
-        OutputSlot: OutputSlotStub
-      }
-    },
-    props: { nodeData }
-  })
-}
-
-function mountSlotsWithTracking(
+function renderSlots(
   nodeData: VueNodeData,
-  mountCounts: Map<string, number>,
-  trackingTarget: 'InputSlot' | 'OutputSlot'
+  stubs: SlotComponentStubs = defaultSlotStubs
 ) {
-  const i18n = createI18n({
-    legacy: false,
-    locale: 'en',
-    messages: { en: enMessages }
-  })
-  const trackingStub = createTrackingStub(trackingTarget, mountCounts)
-  const stubs =
-    trackingTarget === 'InputSlot'
-      ? { InputSlot: trackingStub, OutputSlot: OutputSlotStub }
-      : { InputSlot: InputSlotStub, OutputSlot: trackingStub }
-
   return render(NodeSlots, {
     global: {
       plugins: [i18n, createTestingPinia({ stubActions: false })],
@@ -155,8 +138,26 @@ function mountSlotsWithTracking(
   })
 }
 
+function renderSlotsWithTracking(
+  nodeData: VueNodeData,
+  mountCounts: Map<string, number>,
+  trackingTarget: 'InputSlot' | 'OutputSlot'
+) {
+  const trackingStub = createTrackingStub(trackingTarget, mountCounts)
+  const stubs =
+    trackingTarget === 'InputSlot'
+      ? { InputSlot: trackingStub, OutputSlot: OutputSlotStub }
+      : { InputSlot: InputSlotStub, OutputSlot: trackingStub }
+
+  return renderSlots(nodeData, stubs)
+}
+
 const INPUT_SLOT_SELECTOR = '.stub-input-slot'
 const OUTPUT_SLOT_SELECTOR = '.stub-output-slot'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function querySlotElements(
   container: Element,
@@ -170,25 +171,42 @@ function querySlotElements(
 }
 
 function getRenderedSlotIndex(container: Element, slotName: string) {
+  return Number(getRenderedSlotElement(container, slotName).dataset.index)
+}
+
+function getRenderedSlotElement(container: Element, slotName: string) {
   // eslint-disable-next-line testing-library/no-node-access
   const el = container.querySelector(`[data-name="${slotName}"]`)
   if (!(el instanceof HTMLElement)) {
     throw new Error(`Slot element "${slotName}" not found`)
   }
-  return Number(el.dataset.index)
+  return el
+}
+
+function expectSlotError(
+  container: Element,
+  slotName: string,
+  hasError: boolean
+) {
+  expect(getRenderedSlotElement(container, slotName)).toHaveAttribute(
+    'data-has-error',
+    hasError ? 'true' : 'false'
+  )
 }
 
 describe('NodeSlots.vue', () => {
   it('filters out inputs with widget property and maps indexes correctly', () => {
-    const inputs: INodeInputSlot[] = [
-      makeInputSlot('objNoWidget', 'number'),
-      makeInputSlot('objWithWidget', 'number', {
+    const inputs = [
+      createMockNodeInputSlot({ name: 'objNoWidget', type: 'number' }),
+      createMockNodeInputSlot({
+        name: 'objWithWidget',
+        type: 'number',
         widget: { name: 'objWithWidget' }
       }),
-      makeInputSlot('stringInput', 'string')
+      createMockNodeInputSlot({ name: 'stringInput', type: 'string' })
     ]
 
-    const { container } = mountSlots(makeNodeData({ inputs }))
+    const { container } = renderSlots(makeNodeData({ inputs }))
 
     const inputEls = querySlotElements(container, INPUT_SLOT_SELECTOR)
     expect(inputEls).toHaveLength(2)
@@ -222,12 +240,12 @@ describe('NodeSlots.vue', () => {
   })
 
   it('maps outputs and passes correct indexes', () => {
-    const outputs: INodeOutputSlot[] = [
-      makeOutputSlot('outA', 'any'),
-      makeOutputSlot('outB', 'any')
+    const outputs = [
+      createMockNodeOutputSlot({ name: 'outA', type: 'any' }),
+      createMockNodeOutputSlot({ name: 'outB', type: 'any' })
     ]
 
-    const { container } = mountSlots(makeNodeData({ outputs }))
+    const { container } = renderSlots(makeNodeData({ outputs }))
     const outputEls = querySlotElements(container, OUTPUT_SLOT_SELECTOR)
 
     expect(outputEls).toHaveLength(2)
@@ -244,15 +262,100 @@ describe('NodeSlots.vue', () => {
     ])
   })
 
+  it('passes validation error state to matching input slots', async () => {
+    const inputs = [
+      createMockNodeInputSlot({ name: 'model', type: 'MODEL' }),
+      createMockNodeInputSlot({ name: 'steps', type: 'INT' })
+    ]
+    const nodeData = makeNodeData({ inputs })
+    const { container } = renderSlots(nodeData)
+    seedRequiredInputMissingNodeError(
+      useExecutionErrorStore(),
+      nodeData.id,
+      'model'
+    )
+    await nextTick()
+
+    expectSlotError(container, 'model', true)
+    expectSlotError(container, 'steps', false)
+  })
+
+  it('maps one-level subgraph execution ids to input slot errors', async () => {
+    const subgraph = createTestSubgraph()
+    const interiorNode = new LGraphNode('InteriorNode')
+    interiorNode.id = 70
+    interiorNode.addInput('model', 'MODEL')
+    interiorNode.addInput('steps', 'INT')
+    subgraph.add(interiorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 65 })
+    const graph = subgraphNode.rootGraph
+    graph.add(subgraphNode)
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const nodeData = makeNodeData({
+      id: toVueNodeId(interiorNode.id),
+      subgraphId: subgraph.id,
+      inputs: interiorNode.inputs
+    })
+    const { container } = renderSlots(nodeData)
+    seedRequiredInputMissingNodeError(
+      useExecutionErrorStore(),
+      '65:70',
+      'model'
+    )
+    await nextTick()
+
+    expectSlotError(container, 'model', true)
+    expectSlotError(container, 'steps', false)
+  })
+
+  it('maps nested subgraph execution ids to input slot errors', async () => {
+    const innerSubgraph = createTestSubgraph()
+    const innerNode = new LGraphNode('InnerNode')
+    innerNode.id = 63
+    innerNode.addInput('image', 'IMAGE')
+    innerNode.addInput('mask', 'MASK')
+    innerSubgraph.add(innerNode)
+
+    const outerSubgraph = createTestSubgraph()
+    const innerSubgraphNode = createTestSubgraphNode(innerSubgraph, {
+      id: 70,
+      parentGraph: outerSubgraph
+    })
+    outerSubgraph.add(innerSubgraphNode)
+
+    const outerSubgraphNode = createTestSubgraphNode(outerSubgraph, { id: 65 })
+    const graph = outerSubgraphNode.rootGraph
+    graph.add(outerSubgraphNode)
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const nodeData = makeNodeData({
+      id: toVueNodeId(innerNode.id),
+      subgraphId: innerSubgraph.id,
+      inputs: innerNode.inputs
+    })
+    const { container } = renderSlots(nodeData)
+    seedRequiredInputMissingNodeError(
+      useExecutionErrorStore(),
+      '65:70:63',
+      'mask'
+    )
+    await nextTick()
+
+    expectSlotError(container, 'image', false)
+    expectSlotError(container, 'mask', true)
+  })
+
   it('remounts OutputSlot when index shifts due to output removal', async () => {
     const mountCounts = new Map<string, number>()
     const outputs = [
-      makeOutputSlot('outA', 'IMAGE'),
-      makeOutputSlot('outB', 'VIDEO'),
-      makeOutputSlot('outC', 'AUDIO')
+      createMockNodeOutputSlot({ name: 'outA', type: 'IMAGE' }),
+      createMockNodeOutputSlot({ name: 'outB', type: 'VIDEO' }),
+      createMockNodeOutputSlot({ name: 'outC', type: 'AUDIO' })
     ]
 
-    const { container, rerender } = mountSlotsWithTracking(
+    const { container, rerender } = renderSlotsWithTracking(
       makeNodeData({ outputs }),
       mountCounts,
       'OutputSlot'
@@ -264,8 +367,8 @@ describe('NodeSlots.vue', () => {
     await rerender({
       nodeData: makeNodeData({
         outputs: [
-          makeOutputSlot('outA', 'IMAGE'),
-          makeOutputSlot('outC', 'AUDIO')
+          createMockNodeOutputSlot({ name: 'outA', type: 'IMAGE' }),
+          createMockNodeOutputSlot({ name: 'outC', type: 'AUDIO' })
         ]
       })
     })
@@ -275,21 +378,21 @@ describe('NodeSlots.vue', () => {
   })
 
   it('renders nothing when there are no inputs/outputs', () => {
-    const { container } = mountSlots(makeNodeData({ inputs: [], outputs: [] }))
+    const { container } = renderSlots(makeNodeData({ inputs: [], outputs: [] }))
     expect(querySlotElements(container, INPUT_SLOT_SELECTOR)).toHaveLength(0)
     expect(querySlotElements(container, OUTPUT_SLOT_SELECTOR)).toHaveLength(0)
   })
 
   it('passes correct actual indices for multi-group input layout', () => {
-    const inputs: INodeInputSlot[] = [
-      makeInputSlot('ref_images.img0', 'IMAGE'),
-      makeInputSlot('ref_images.img1', 'IMAGE'),
-      makeInputSlot('ref_images.img2', 'IMAGE'),
-      makeInputSlot('ref_videos.vid0', 'VIDEO'),
-      makeInputSlot('ref_videos.vid1', 'VIDEO')
+    const inputs = [
+      createMockNodeInputSlot({ name: 'ref_images.img0', type: 'IMAGE' }),
+      createMockNodeInputSlot({ name: 'ref_images.img1', type: 'IMAGE' }),
+      createMockNodeInputSlot({ name: 'ref_images.img2', type: 'IMAGE' }),
+      createMockNodeInputSlot({ name: 'ref_videos.vid0', type: 'VIDEO' }),
+      createMockNodeInputSlot({ name: 'ref_videos.vid1', type: 'VIDEO' })
     ]
 
-    const { container } = mountSlots(makeNodeData({ inputs }))
+    const { container } = renderSlots(makeNodeData({ inputs }))
 
     const inputEls = querySlotElements(container, INPUT_SLOT_SELECTOR)
 
@@ -311,11 +414,11 @@ describe('NodeSlots.vue', () => {
   it('remounts InputSlot when index shifts due to autogrow insertion', async () => {
     const mountCounts = new Map<string, number>()
     const initialInputs = [
-      makeInputSlot('ref_images.img0', 'IMAGE'),
-      makeInputSlot('ref_videos.vid0', 'VIDEO')
+      createMockNodeInputSlot({ name: 'ref_images.img0', type: 'IMAGE' }),
+      createMockNodeInputSlot({ name: 'ref_videos.vid0', type: 'VIDEO' })
     ]
 
-    const { container, rerender } = mountSlotsWithTracking(
+    const { container, rerender } = renderSlotsWithTracking(
       makeNodeData({ inputs: initialInputs }),
       mountCounts,
       'InputSlot'
@@ -327,9 +430,9 @@ describe('NodeSlots.vue', () => {
     await rerender({
       nodeData: makeNodeData({
         inputs: [
-          makeInputSlot('ref_images.img0', 'IMAGE'),
-          makeInputSlot('ref_images.img1', 'IMAGE'),
-          makeInputSlot('ref_videos.vid0', 'VIDEO')
+          createMockNodeInputSlot({ name: 'ref_images.img0', type: 'IMAGE' }),
+          createMockNodeInputSlot({ name: 'ref_images.img1', type: 'IMAGE' }),
+          createMockNodeInputSlot({ name: 'ref_videos.vid0', type: 'VIDEO' })
         ]
       })
     })

--- a/src/renderer/extensions/vueNodes/components/NodeSlots.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeSlots.vue
@@ -13,6 +13,7 @@
         :slot-data="input"
         :node-type="nodeData?.type || ''"
         :node-id="nodeData?.id != null ? String(nodeData.id) : ''"
+        :has-error="inputHasError(input)"
         :index="getActualInputIndex(input, index)"
       />
     </div>
@@ -44,6 +45,8 @@ import {
   linkedWidgetedInputs,
   nonWidgetedInputs
 } from '@/renderer/extensions/vueNodes/utils/nodeDataUtils'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { getLocatorIdFromNodeData } from '@/utils/graphTraversalUtil'
 import { cn } from '@/utils/tailwindUtil'
 
 import InputSlot from './InputSlot.vue'
@@ -55,6 +58,8 @@ interface NodeSlotsProps {
 }
 
 const { nodeData, unified = false } = defineProps<NodeSlotsProps>()
+const executionErrorStore = useExecutionErrorStore()
+const nodeLocatorId = computed(() => getLocatorIdFromNodeData(nodeData))
 
 const linkedWidgetInputs = computed(() =>
   unified ? linkedWidgetedInputs(nodeData) : []
@@ -64,6 +69,10 @@ const filteredInputs = computed(() => [
   ...nonWidgetedInputs(nodeData),
   ...linkedWidgetInputs.value
 ])
+
+function inputHasError(input: INodeSlot): boolean {
+  return executionErrorStore.slotHasError(nodeLocatorId.value, input.name)
+}
 
 const unifiedWrapperClass = computed((): string =>
   cn(

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -59,6 +59,7 @@ const slotClass = computed(() =>
 
 <template>
   <div
+    data-testid="slot-connection-dot"
     :class="
       cn(
         'group/slot relative flex size-6 items-center justify-center after:absolute after:inset-y-0 after:w-5/2',

--- a/src/utils/__tests__/executionErrorTestUtils.ts
+++ b/src/utils/__tests__/executionErrorTestUtils.ts
@@ -1,0 +1,30 @@
+import type { NodeError } from '@/schemas/apiSchema'
+import type { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import type { NodeExecutionId } from '@/types/nodeIdentification'
+
+type ExecutionErrorStore = ReturnType<typeof useExecutionErrorStore>
+
+function createRequiredInputMissingNodeError(inputName: string): NodeError {
+  return {
+    errors: [
+      {
+        type: 'required_input_missing',
+        message: 'Missing',
+        details: '',
+        extra_info: { input_name: inputName }
+      }
+    ],
+    dependent_outputs: [],
+    class_type: 'TestNode'
+  }
+}
+
+export function seedRequiredInputMissingNodeError(
+  store: ExecutionErrorStore,
+  executionId: NodeExecutionId,
+  inputName: string
+): void {
+  store.lastNodeErrors = {
+    [executionId]: createRequiredInputMissingNodeError(inputName)
+  }
+}

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -179,8 +179,12 @@ export function createMockNodeInputSlot(
   overrides: Partial<INodeInputSlot> = {}
 ): INodeInputSlot {
   return {
+    name: 'input',
+    type: '*',
+    boundingRect: [0, 0, 0, 0],
+    link: null,
     ...overrides
-  } as INodeInputSlot
+  }
 }
 
 /**
@@ -190,8 +194,12 @@ export function createMockNodeOutputSlot(
   overrides: Partial<INodeOutputSlot> = {}
 ): INodeOutputSlot {
   return {
+    name: 'output',
+    type: '*',
+    boundingRect: [0, 0, 0, 0],
+    links: null,
     ...overrides
-  } as INodeOutputSlot
+  }
 }
 
 /**


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Two follow-up bug fixes that landed on `main` after the previous backport batches (#11926, #11975).

## Picked

| PR | Subject | User-visible bug |
|---|---|---|
| `#11946` | fix: use resized QPO thumbnails (FE-538) | Floating QPO row thumbnails currently load full-size image/video assets while the canvas is being navigated; this swaps to `previewUrl` to use resized thumbnails. |
| `#11950` | fix: highlight missing input slots on Vue nodes | Required-input validation highlighting was lost on Vue-rendered node input slots. Restores the error ring on the missing slot itself by wiring `useExecutionErrorStore` through `NodeSlots.vue` → `InputSlot`. |

## Conflict resolution notes

- **#11946** — applied cleanly, no conflicts.
- **#11950** —
  - `src/renderer/extensions/vueNodes/components/NodeSlots.vue`: cloud/1.43 imports `cn` from `@/utils/tailwindUtil`, main from `@comfyorg/tailwind-utils`. Kept cloud/1.43's import path; pulled in the new `useExecutionErrorStore` and `getLocatorIdFromNodeData` imports (both modules already exist on cloud/1.43).
  - `browser_tests/tests/vueNodes/nodeStates/error.spec.ts`: incoming version references helpers (`ErrorsTabHelper`, `cleanupFakeModel`) that don't exist on cloud/1.43. Restored cloud/1.43's version of the test file and removed the new `vue-node-required-input-missing-slot-error-chromium-linux.png` snapshot. The runtime fix in `NodeSlots.vue` lands; the new e2e regression test would need its helper deps backported separately.

## Verification

- ✅ `pnpm typecheck` clean
- ✅ `pnpm typecheck:browser` clean
- ✅ `pnpm knip` clean
- ✅ Targeted unit tests passing: `NodeSlots.test.ts` (9), `useErrorClearingHooks.test.ts` (24), `JobAssetsList.test.ts` (16) — 49/49 passed

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-11996-backport-cloud-1-43-QPO-thumbnails-11946-Vue-node-slot-validation-11950-3576d73d365081e5b48bd3552cd34294) by [Unito](https://www.unito.io)
