### PR TITLE
test(maskeditor): expand useBrushDrawing behavioral coverage

### DIFF
--- a/src/composables/maskeditor/useBrushDrawing.test.ts
+++ b/src/composables/maskeditor/useBrushDrawing.test.ts
@@ -233,6 +233,35 @@ describe('handleDrawing', () => {
     expect(rafSpy).toHaveBeenCalled()
     rafSpy.mockRestore()
   })
+
+  it('sets DestinationOut composition when tool is eraser during move', async () => {
+    mockStoreDef.currentTool = 'eraser'
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+    const { startDrawing, handleDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await handleDrawing(makePointerEvent(55, 55))
+    expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
+      'destination-out'
+    )
+    vi.restoreAllMocks()
+  })
+
+  it('sets DestinationOut composition when right mouse button held during move', async () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+    const { startDrawing, handleDrawing } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await handleDrawing(makePointerEvent(55, 55, { buttons: 2 }))
+    expect(mockStoreDef.maskCtx!.globalCompositeOperation).toBe(
+      'destination-out'
+    )
+    vi.restoreAllMocks()
+  })
 })
 
 describe('drawEnd canvas visibility', () => {
@@ -270,6 +299,36 @@ describe('drawEnd', () => {
     await drawEnd(makePointerEvent(60, 60))
     expect(useGPUResources().compositeStroke).toHaveBeenCalledOnce()
     expect(useGPUResources().compositeStroke).toHaveBeenCalledWith(false, false)
+  })
+
+  it('passes isRgb=true to compositeStroke when active layer is rgb', async () => {
+    mockStoreDef.activeLayer = 'rgb'
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(useGPUResources().compositeStroke).toHaveBeenCalledWith(true, false)
+  })
+
+  it('passes isErasing=true to compositeStroke when tool is eraser', async () => {
+    mockStoreDef.currentTool = 'eraser'
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(useGPUResources().compositeStroke).toHaveBeenCalledWith(false, true)
+  })
+
+  it('restores mask canvas opacity after drawing on mask layer', async () => {
+    mockStoreDef.activeLayer = 'mask'
+    const mockMaskCanvas = {
+      width: 200,
+      height: 200,
+      style: { opacity: '' }
+    } as unknown as HTMLCanvasElement
+    mockStoreDef.maskCanvas = mockMaskCanvas
+    const { startDrawing, drawEnd } = setup()
+    await startDrawing(makePointerEvent(50, 50))
+    await drawEnd(makePointerEvent(60, 60))
+    expect(mockMaskCanvas.style.opacity).toBe(String(mockStoreDef.maskOpacity))
   })
 
   it('calls clearPreview to clean up the GPU overlay', async () => {


### PR DESCRIPTION
Adds targeted behavioral tests for the slimmed `useBrushDrawing` orchestration composable (Phase E of the brush-drawing refactor).

## Changes

- 5 new tests covering previously untested branches:
  - `compositeStroke` receives `isRgb=true` when active layer is `rgb`
  - `compositeStroke` receives `isErasing=true` when tool is `eraser`
  - Mask canvas opacity is restored after drawing on the mask layer
  - `globalCompositeOperation` is set to `destination-out` during `handleDrawing` when tool is eraser
  - `globalCompositeOperation` is set to `destination-out` during `handleDrawing` when right mouse button is held

## Coverage (useBrushDrawing.ts)

| Metric | Before | After |
|--------|--------|-------|
| Statements | 86.33% | 87.05% |
| Branches | 68.75% | 70.00% |
| Functions | 90.00% | 90.00% |
| Lines | 89.23% | 90.00% |

All 18 tests pass. GPU paths remain `/* c8 ignore */` excluded (untestable without WebGL).

- Fixes #0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to unit tests, adding coverage for eraser/right-click composition and `drawEnd` GPU compositing/opacity restoration paths without altering production logic.
> 
> **Overview**
> Adds new `useBrushDrawing` test cases to cover previously untested branches: setting `globalCompositeOperation` to `destination-out` during `handleDrawing` when erasing (tool or right-click), and verifying `drawEnd` passes correct `isRgb`/`isErasing` flags to `gpu.compositeStroke`.
> 
> Also asserts mask-layer opacity is restored after `drawEnd`, increasing behavioral coverage around stroke completion and canvas visibility cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c411e6ce289620da879588242f1d6fdcffbb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12001-test-maskeditor-expand-useBrushDrawing-behavioral-coverage-3586d73d365081388ebcef91c2172c0a) by [Unito](https://www.unito.io)
