### PR TITLE
fix: stop PreviewAny widgets from triggering re-execution

### DIFF
--- a/browser_tests/tests/previewAsText.spec.ts
+++ b/browser_tests/tests/previewAsText.spec.ts
@@ -1,0 +1,42 @@
+import {
+  comfyPageFixture as test,
+  comfyExpect as expect
+} from '../fixtures/ComfyPage'
+
+test.describe('Preview as Text node', () => {
+  test('does not include preview widget values in the API prompt', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode('PreviewAny')!
+      node.pos = [500, 200]
+      window.app!.graph.add(node)
+    })
+
+    // Simulate a previous execution: backend returned text and the frontend
+    // populated the preview widget values. The next prompt submission must
+    // NOT echo those values back as inputs (which would change the cache
+    // signature and trigger a redundant re-execution).
+    await comfyPage.page.evaluate(() => {
+      const node = window.app!.graph.nodes.find((n) => n.type === 'PreviewAny')!
+      for (const widget of node.widgets ?? []) {
+        if (widget.name?.startsWith('preview_')) {
+          widget.value = 'rendered preview content from previous execution'
+        }
+      }
+    })
+
+    const apiWorkflow = await comfyPage.workflow.getExportedWorkflow({
+      api: true
+    })
+
+    const previewEntry = Object.values(apiWorkflow).find(
+      (n) => n.class_type === 'PreviewAny'
+    )
+    expect(previewEntry).toBeDefined()
+
+    expect(previewEntry!.inputs).not.toHaveProperty('preview_markdown')
+    expect(previewEntry!.inputs).not.toHaveProperty('preview_text')
+    expect(previewEntry!.inputs).not.toHaveProperty('previewMode')
+  })
+})

--- a/src/extensions/core/previewAny.test.ts
+++ b/src/extensions/core/previewAny.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyExtension } from '@/types/comfy'
+
+const capturedExtensions: ComfyExtension[] = []
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension: (ext: ComfyExtension) => {
+      capturedExtensions.push(ext)
+    }
+  })
+}))
+
+vi.mock('@/scripts/app', () => ({ app: {} }))
+
+interface MockWidget {
+  name: string
+  options: Record<string, unknown>
+  element: { readOnly: boolean }
+  callback?: (value: unknown) => void
+  value: unknown
+  hidden: boolean
+  label: string
+  serialize?: boolean
+}
+
+const createdWidgets: MockWidget[] = []
+
+vi.mock('@/scripts/widgets', () => {
+  const create =
+    (kind: string) =>
+    (
+      node: { widgets?: MockWidget[] },
+      name: string,
+      _info: unknown,
+      _app: unknown
+    ) => {
+      const widget: MockWidget = {
+        name,
+        options: {},
+        element: { readOnly: false },
+        value: kind === 'BOOLEAN' ? false : '',
+        hidden: false,
+        label: ''
+      }
+      node.widgets = node.widgets ?? []
+      node.widgets.push(widget)
+      createdWidgets.push(widget)
+      return { widget }
+    }
+  return {
+    ComfyWidgets: {
+      MARKDOWN: create('MARKDOWN'),
+      STRING: create('STRING'),
+      BOOLEAN: create('BOOLEAN')
+    }
+  }
+})
+
+describe('PreviewAny extension', () => {
+  beforeEach(async () => {
+    capturedExtensions.length = 0
+    createdWidgets.length = 0
+    vi.resetModules()
+    await import('./previewAny')
+  })
+
+  async function setupNode() {
+    const ext = capturedExtensions.find((e) => e.name === 'Comfy.PreviewAny')
+    expect(ext).toBeDefined()
+
+    const nodeType = { prototype: {} } as unknown as Parameters<
+      NonNullable<ComfyExtension['beforeRegisterNodeDef']>
+    >[0]
+    const nodeData = { name: 'PreviewAny' } as Parameters<
+      NonNullable<ComfyExtension['beforeRegisterNodeDef']>
+    >[1]
+
+    await ext!.beforeRegisterNodeDef!(
+      nodeType,
+      nodeData,
+      {} as Parameters<NonNullable<ComfyExtension['beforeRegisterNodeDef']>>[2]
+    )
+
+    const node: { widgets?: MockWidget[] } = {}
+    const proto = nodeType.prototype as { onNodeCreated?: () => void }
+    proto.onNodeCreated!.call(node)
+    return node
+  }
+
+  it('excludes preview widgets from the API prompt to prevent re-execution', async () => {
+    await setupNode()
+
+    const previewMarkdown = createdWidgets.find(
+      (w) => w.name === 'preview_markdown'
+    )
+    const previewText = createdWidgets.find((w) => w.name === 'preview_text')
+    const previewMode = createdWidgets.find((w) => w.name === 'previewMode')
+
+    expect(previewMarkdown).toBeDefined()
+    expect(previewText).toBeDefined()
+    expect(previewMode).toBeDefined()
+
+    // widget.options.serialize === false is what executionUtil.graphToPrompt
+    // checks to exclude a widget from the API prompt sent to the backend.
+    // Without this, post-execution widget value updates (the rendered preview
+    // text) get serialized as inputs, change the cache signature, and cause
+    // the node to re-execute on the next prompt.
+    expect(previewMarkdown!.options.serialize).toBe(false)
+    expect(previewText!.options.serialize).toBe(false)
+    expect(previewMode!.options.serialize).toBe(false)
+  })
+})

--- a/src/extensions/core/previewAny.ts
+++ b/src/extensions/core/previewAny.ts
@@ -57,6 +57,7 @@ useExtensionService().registerExtension({
         showValueWidget.hidden = true
         showValueWidget.options.hidden = true
         showValueWidget.options.read_only = true
+        showValueWidget.options.serialize = false
         showValueWidget.element.readOnly = true
         showValueWidget.serialize = false
 
@@ -64,8 +65,14 @@ useExtensionService().registerExtension({
         showValueWidgetPlain.hidden = false
         showValueWidgetPlain.options.hidden = false
         showValueWidgetPlain.options.read_only = true
+        showValueWidgetPlain.options.serialize = false
         showValueWidgetPlain.element.readOnly = true
         showValueWidgetPlain.serialize = false
+
+        // The previewMode toggle is a frontend-only display preference and
+        // is not declared in the backend INPUT_TYPES, so it must not be
+        // serialized into the API prompt (would alter the cache signature).
+        showAsPlaintextWidget.widget.options.serialize = false
       }
 
       const onExecuted = nodeType.prototype.onExecuted


### PR DESCRIPTION
## Summary

Preview as Text (`PreviewAny`) nodes were re-executing on every prompt submission because the rendered preview text was being echoed back to the backend as input values, mutating the cache signature.

## Changes

- **What**: Set `widget.options.serialize = false` on the three widgets the `Comfy.PreviewAny` extension adds (`preview_markdown`, `preview_text`, `previewMode`) so they are excluded from the API prompt sent to the backend.

## Root cause

The extension was setting `widget.serialize = false`, which only controls **workflow JSON** persistence (checked in `LGraphNode.serialize`). The **API prompt** serializer in `executionUtil.graphToPrompt` checks `widget.options.serialize` instead — a distinct property documented in litegraph's `WIDGET_SERIALIZATION` convention.

After `onExecuted` writes the rendered text into the widget value, the next `graphToPrompt` call serialized that text into `inputs.preview_text` / `inputs.preview_markdown`. The backend cache signature in `comfy_execution/caching.py` hashes all keys in `node["inputs"]`, so the changing text invalidated the cache and forced a redundant execution every time.

## Review Focus

Two commits, red-green TDD:
1. `test:` failing unit + e2e tests asserting the desired behavior.
2. `fix:` adds `options.serialize = false` to make them pass.

Tests verify the widgets are excluded from the API prompt; e2e additionally simulates a prior execution populating widget values to mirror the real bug condition.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12010-fix-stop-PreviewAny-widgets-from-triggering-re-execution-3586d73d3650810585cdd077f3ac64f5) by [Unito](https://www.unito.io)
