### PR TITLE
perf: drop useMouseInElement to fix templates search lag

### DIFF
--- a/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import CompareSliderThumbnail from '@/components/templates/thumbnails/CompareSliderThumbnail.vue'
 
@@ -21,13 +21,19 @@ vi.mock('@/components/common/LazyImage.vue', () => ({
   }
 }))
 
-vi.mock('@vueuse/core', () => ({
-  useMouseInElement: () => ({
-    elementX: ref(50),
-    elementWidth: ref(100),
-    isOutside: ref(false)
-  })
-}))
+const mockRect = (el: HTMLElement, width: number) => {
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    right: width,
+    bottom: 100,
+    width,
+    height: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  } as DOMRect)
+}
 
 describe('CompareSliderThumbnail', () => {
   const renderThumbnail = (props = {}) => {
@@ -71,6 +77,30 @@ describe('CompareSliderThumbnail', () => {
 
   it('positions slider based on default value', () => {
     renderThumbnail()
+    const divider = screen.getByTestId('compare-slider-divider')
+    expect(divider.style.left).toBe('50%')
+  })
+
+  it('updates slider position on mousemove', async () => {
+    renderThumbnail()
+    const container = screen.getByTestId('compare-slider-container')
+    mockRect(container, 200)
+
+    const user = userEvent.setup()
+    await user.pointer({ target: container, coords: { clientX: 50 } })
+
+    const divider = screen.getByTestId('compare-slider-divider')
+    expect(divider.style.left).toBe('25%')
+  })
+
+  it('ignores mousemove when container has zero width', async () => {
+    renderThumbnail()
+    const container = screen.getByTestId('compare-slider-container')
+    mockRect(container, 0)
+
+    const user = userEvent.setup()
+    await user.pointer({ target: container, coords: { clientX: 50 } })
+
     const divider = screen.getByTestId('compare-slider-divider')
     expect(divider.style.left).toBe('50%')
   })

--- a/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.test.ts
@@ -93,6 +93,22 @@ describe('CompareSliderThumbnail', () => {
     expect(divider.style.left).toBe('25%')
   })
 
+  it('clamps slider position to [0, 100] when pointer overshoots', async () => {
+    renderThumbnail()
+    const container = screen.getByTestId('compare-slider-container')
+    mockRect(container, 200)
+
+    const user = userEvent.setup()
+
+    await user.pointer({ target: container, coords: { clientX: -10 } })
+    let divider = screen.getByTestId('compare-slider-divider')
+    expect(divider.style.left).toBe('0%')
+
+    await user.pointer({ target: container, coords: { clientX: 250 } })
+    divider = screen.getByTestId('compare-slider-divider')
+    expect(divider.style.left).toBe('100%')
+  })
+
   it('ignores mousemove when container has zero width', async () => {
     renderThumbnail()
     const container = screen.getByTestId('compare-slider-container')

--- a/src/components/templates/thumbnails/CompareSliderThumbnail.vue
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.vue
@@ -9,7 +9,11 @@
           : 'max-w-full max-h-64 object-contain'
       "
     />
-    <div ref="containerRef" class="absolute inset-0">
+    <div
+      data-testid="compare-slider-container"
+      class="absolute inset-0"
+      @mousemove="updateSliderPosition"
+    >
       <LazyImage
         :src="overlayImageSrc"
         :alt="alt"
@@ -34,8 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { useMouseInElement } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 
 import LazyImage from '@/components/common/LazyImage.vue'
 import BaseThumbnail from '@/components/templates/thumbnails/BaseThumbnail.vue'
@@ -57,18 +60,16 @@ const isVideoType =
   false
 
 const sliderPosition = ref(SLIDER_START_POSITION)
-const containerRef = ref<HTMLElement | null>(null)
 
-const { elementX, elementWidth, isOutside } = useMouseInElement(containerRef)
-
-// Update slider position based on mouse position when hovered
-watch(
-  [() => isHovered, elementX, elementWidth, isOutside],
-  ([isHovered, x, width, outside]) => {
-    if (!isHovered) return
-    if (!outside) {
-      sliderPosition.value = (x / width) * 100
-    }
-  }
-)
+/**
+ * Update slider position from a local mousemove. Scoped to currentTarget so
+ * only the hovered card reads its rect — unlike useMouseInElement which
+ * attaches a global mousemove listener and fires for every mounted instance.
+ */
+function updateSliderPosition(event: MouseEvent) {
+  const el = event.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  if (rect.width === 0) return
+  sliderPosition.value = ((event.clientX - rect.left) / rect.width) * 100
+}
 </script>

--- a/src/components/templates/thumbnails/CompareSliderThumbnail.vue
+++ b/src/components/templates/thumbnails/CompareSliderThumbnail.vue
@@ -70,6 +70,10 @@ function updateSliderPosition(event: MouseEvent) {
   const el = event.currentTarget as HTMLElement
   const rect = el.getBoundingClientRect()
   if (rect.width === 0) return
-  sliderPosition.value = ((event.clientX - rect.left) / rect.width) * 100
+  // Clamp to [0, 100] — subpixel rounding or stale rects on hover-in can
+  // push the raw percentage slightly out of range, which would offset the
+  // divider past the container or invert the overlay's clipPath.
+  const raw = ((event.clientX - rect.left) / rect.width) * 100
+  sliderPosition.value = Math.max(0, Math.min(100, raw))
 }
 </script>


### PR DESCRIPTION
## Summary

Replace `useMouseInElement` in `CompareSliderThumbnail` with a local `@mousemove` handler to eliminate ~1s of forced layout per keystroke in the templates dialog search.

## Changes

- **What**: Profiling the templates dialog search (4× CPU throttle, cloud distribution) showed a single `getClientRects` block at 977ms inside Vue's `flushPostFlushCbs → update` path on every keystroke. The call traces back to VueUse's `useMouseInElement`, which (a) shares a global `mousemove` listener via `useMouse`, and (b) runs `el.getBoundingClientRect()` inside a `watch([targetRef, x, y], …, { immediate: true })`. Every template card with `thumbnailVariant === 'compareSlider'` mounts one instance — when search filters change and the page's compareSlider cards re-mount, each instance's `immediate` watch fires a rect read against freshly-inserted DOM, forcing synchronous layout of the entire new subtree. With many cards on screen the costs stack into the ~977ms block. Replaced with a native `@mousemove` listener bound directly to the slider container; the rect is read from `event.currentTarget` only when the mouse is actually over that one card, so the work no longer scales with mounted instance count and is gated by real pointer activity.
- **Breaking**: None
- **Dependencies**: None

## Review Focus

- UX is unchanged: `sliderPosition` still follows the mouse during hover and keeps its last value on mouseleave (matches previous behaviour where `if (!isHovered) return` simply stopped updates without resetting).
- The same `useMouseInElement` pattern still exists in `src/platform/workflow/sharing/composables/useSliderFromMouse.ts` (used by `ComfyHubThumbnailStep` in the publish dialog). That path is single-instance and off the templates hot path, so it's left untouched to keep this PR scoped — happy to fix it in a follow-up.
- New tests use `userEvent.pointer({ coords })` with a stubbed `getBoundingClientRect` to lock in the native mousemove path and the zero-width guard.

## E2E coverage

No `browser_tests/` changes. The `fix:` commit is a defensive clamp inside `updateSliderPosition`; the overshoot it guards against comes from subpixel rounding and stale rects observed during hover-in, neither of which can be deterministically reproduced under Playwright. The perf change itself is verified via the DevTools profiler (forced-layout block disappears) — also not assertable as a stable e2e signal across CI hardware. Both the mousemove-driven slider behavior and the clamp guard are covered by unit tests in `src/components/templates/thumbnails/CompareSliderThumbnail.test.ts` (8 cases, including out-of-range pointer coordinates and zero-width containers).
