### PR TITLE
FE-557: fix(painter): responsive label layout + correct resize min-height

### DIFF
--- a/browser_tests/tests/painter.spec.ts
+++ b/browser_tests/tests/painter.spec.ts
@@ -692,18 +692,26 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
     })
   })
 
-  test('Controls collapse to single column in compact mode', async ({
+  test('Controls stack label above widget in compact mode', async ({
     comfyPage
   }) => {
     const painterWidget = comfyPage.vueNodes
       .getNodeLocator('1')
       .locator('.widget-expands')
     const toolLabel = painterWidget.getByText('Tool', { exact: true })
+    const brushButton = painterWidget.getByText('Brush', { exact: true })
 
     await expect(
       toolLabel,
-      'tool label should be visible in two-column layout'
+      'tool label should be visible in wide layout'
     ).toBeVisible()
+
+    const wideLabelBox = await toolLabel.boundingBox()
+    const wideBrushBox = await brushButton.boundingBox()
+    expect(
+      wideLabelBox && wideBrushBox && wideLabelBox.x < wideBrushBox.x,
+      'label should sit to the left of the brush button in wide layout'
+    ).toBe(true)
 
     await comfyPage.page.evaluate(() => {
       const graph = window.graph as TestGraphAccess | undefined
@@ -716,8 +724,22 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
 
     await expect(
       toolLabel,
-      'tool label should hide in compact single-column layout'
-    ).toBeHidden()
+      'tool label should remain visible in compact layout'
+    ).toBeVisible()
+
+    await expect
+      .poll(
+        async () => {
+          const labelBox = await toolLabel.boundingBox()
+          const brushBox = await brushButton.boundingBox()
+          if (!labelBox || !brushBox) return false
+          return labelBox.y + labelBox.height <= brushBox.y
+        },
+        {
+          message: 'label should stack above the brush button in compact layout'
+        }
+      )
+      .toBe(true)
   })
 
   test('Multiple sequential strokes at different positions all accumulate', async ({

--- a/src/components/painter/WidgetPainter.test.ts
+++ b/src/components/painter/WidgetPainter.test.ts
@@ -1,0 +1,334 @@
+import { fireEvent, render, screen, within } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+const sizeHolder = vi.hoisted(() => ({ width: 0, height: 0 }))
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    useElementSize: () => ({
+      width: ref(sizeHolder.width),
+      height: ref(sizeHolder.height)
+    })
+  }
+})
+
+const painterHolder = vi.hoisted(() => ({
+  state: null as Record<string, unknown> | null
+}))
+
+function createDefaultPainterState() {
+  return {
+    tool: ref('brush'),
+    brushSize: ref(20),
+    brushColor: ref('#000000'),
+    brushOpacity: ref(1),
+    brushHardness: ref(1),
+    backgroundColor: ref('#ffffff'),
+    canvasWidth: ref(512),
+    canvasHeight: ref(512),
+    cursorVisible: ref(true),
+    displayBrushSize: ref(20),
+    inputImageUrl: ref<string | null>(null),
+    isImageInputConnected: ref(false),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handlePointerUp: vi.fn(),
+    handlePointerEnter: vi.fn(),
+    handlePointerLeave: vi.fn(),
+    handleInputImageLoad: vi.fn(),
+    handleClear: vi.fn()
+  }
+}
+
+vi.mock('@/composables/painter/usePainter', () => ({
+  PAINTER_TOOLS: { BRUSH: 'brush', ERASER: 'eraser' } as const,
+  usePainter: () => {
+    if (!painterHolder.state) painterHolder.state = createDefaultPainterState()
+    return painterHolder.state
+  }
+}))
+
+import WidgetPainter from './WidgetPainter.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      painter: {
+        tool: 'Tool',
+        brush: 'Brush',
+        eraser: 'Eraser',
+        size: 'Size',
+        color: 'Color',
+        hardness: 'Hardness',
+        width: 'Width',
+        height: 'Height',
+        background: 'Background',
+        clear: 'Clear'
+      }
+    }
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'Button',
+  inheritAttrs: false,
+  template: '<button v-bind="$attrs" type="button"><slot /></button>'
+})
+
+const SliderStub = defineComponent({
+  name: 'Slider',
+  props: {
+    modelValue: { type: Array, default: () => [] },
+    min: Number,
+    max: Number,
+    step: Number
+  },
+  emits: ['update:modelValue'],
+  template:
+    '<div data-testid="slider-stub" :data-min="min" @click="$emit(\'update:modelValue\', [Number(min) + Number(step ?? 1)])" />'
+})
+
+function primePainterState(overrides: Record<string, unknown> = {}) {
+  painterHolder.state = { ...createDefaultPainterState(), ...overrides }
+}
+
+function renderWidget(initialModel = '') {
+  const value = ref(initialModel)
+  const Harness = defineComponent({
+    components: { WidgetPainter },
+    setup: () => ({ value }),
+    template: '<WidgetPainter v-model="value" node-id="42" />'
+  })
+  return render(Harness, {
+    global: {
+      plugins: [i18n],
+      stubs: { Button: ButtonStub, Slider: SliderStub }
+    }
+  })
+}
+
+describe('WidgetPainter', () => {
+  beforeEach(() => {
+    sizeHolder.width = 0
+    sizeHolder.height = 0
+    painterHolder.state = null
+  })
+
+  describe('Label visibility', () => {
+    const allLabels = [
+      'Tool',
+      'Size',
+      'Color',
+      'Hardness',
+      'Width',
+      'Height',
+      'Background'
+    ]
+
+    it('renders every label in wide layout (width >= 350)', () => {
+      sizeHolder.width = 600
+      primePainterState()
+      renderWidget()
+      for (const label of allLabels) {
+        expect(screen.getByText(label)).toBeInTheDocument()
+      }
+    })
+
+    it('still renders every label in compact layout (width < 350)', () => {
+      sizeHolder.width = 200
+      primePainterState()
+      renderWidget()
+      for (const label of allLabels) {
+        expect(screen.getByText(label)).toBeInTheDocument()
+      }
+    })
+
+    it('keeps labels at the responsive boundary (width = 350)', () => {
+      sizeHolder.width = 350
+      primePainterState()
+      renderWidget()
+      for (const label of allLabels) {
+        expect(screen.getByText(label)).toBeInTheDocument()
+      }
+    })
+  })
+
+  describe('Image-input branch', () => {
+    it('hides canvas-size and background controls when an image is connected', () => {
+      primePainterState({
+        isImageInputConnected: ref(true),
+        inputImageUrl: ref('/img.png')
+      })
+      renderWidget()
+
+      expect(screen.queryByText('Width')).toBeNull()
+      expect(screen.queryByText('Height')).toBeNull()
+      expect(screen.queryByText('Background')).toBeNull()
+      expect(screen.getByTestId('painter-dimension-text')).toBeInTheDocument()
+    })
+
+    it('renders the input image inside the canvas container', () => {
+      primePainterState({
+        isImageInputConnected: ref(true),
+        inputImageUrl: ref('/img.png')
+      })
+      renderWidget()
+
+      const container = screen.getByTestId('painter-canvas-container')
+      expect(within(container).getByRole('img')).toBeInTheDocument()
+    })
+  })
+
+  describe('Tool selection', () => {
+    it('hides brush-only controls when the eraser tool is active', () => {
+      primePainterState({ tool: ref('eraser') })
+      renderWidget()
+
+      expect(screen.queryByText('Color')).toBeNull()
+      expect(screen.queryByText('Hardness')).toBeNull()
+    })
+
+    it('updates the active tool when clicking brush/eraser buttons', async () => {
+      const tool = ref<'brush' | 'eraser'>('brush')
+      primePainterState({ tool })
+      renderWidget()
+      const user = userEvent.setup()
+
+      await user.click(screen.getByText('Eraser'))
+      expect(tool.value).toBe('eraser')
+
+      await user.click(screen.getByText('Brush'))
+      expect(tool.value).toBe('brush')
+    })
+  })
+
+  describe('Canvas events', () => {
+    it('forwards pointerdown/up to the composable on click', async () => {
+      primePainterState()
+      renderWidget()
+      const user = userEvent.setup()
+
+      await user.click(screen.getByTestId('painter-canvas'))
+
+      const s = painterHolder.state!
+      expect(s.handlePointerDown).toHaveBeenCalled()
+      expect(s.handlePointerUp).toHaveBeenCalled()
+    })
+
+    it('forwards pointerenter/leave to the composable on hover', async () => {
+      primePainterState()
+      renderWidget()
+      const user = userEvent.setup()
+      const canvas = screen.getByTestId('painter-canvas')
+
+      await user.hover(canvas)
+      await user.unhover(canvas)
+
+      const s = painterHolder.state!
+      expect(s.handlePointerEnter).toHaveBeenCalled()
+      expect(s.handlePointerLeave).toHaveBeenCalled()
+    })
+
+    it('invokes handleInputImageLoad when the input image fires load', async () => {
+      primePainterState({
+        isImageInputConnected: ref(true),
+        inputImageUrl: ref('/img.png')
+      })
+      renderWidget()
+
+      const img = within(
+        screen.getByTestId('painter-canvas-container')
+      ).getByRole('img')
+      await fireEvent.load(img)
+      expect(painterHolder.state!.handleInputImageLoad).toHaveBeenCalled()
+    })
+  })
+
+  describe('Control bindings', () => {
+    it('invokes handleClear when the clear button is clicked', async () => {
+      primePainterState()
+      renderWidget()
+      const user = userEvent.setup()
+
+      await user.click(screen.getByTestId('painter-clear-button'))
+      expect(painterHolder.state!.handleClear).toHaveBeenCalled()
+    })
+
+    it('updates brushSize via the size slider', async () => {
+      const brushSize = ref(20)
+      primePainterState({ brushSize })
+      renderWidget()
+      const user = userEvent.setup()
+
+      const slider = within(screen.getByTestId('painter-size-row')).getByTestId(
+        'slider-stub'
+      )
+      await user.click(slider)
+      expect(brushSize.value).toBe(2) // min=1, step=1 -> emits 2
+    })
+
+    it('updates brushColor via the color picker', async () => {
+      const brushColor = ref('#000000')
+      primePainterState({ brushColor })
+      renderWidget()
+
+      const colorInput = within(
+        screen.getByTestId('painter-color-row')
+      ).getByDisplayValue('#000000')
+      // <input type="color"> has no userEvent equivalent — fire input directly
+      // eslint-disable-next-line testing-library/prefer-user-event
+      await fireEvent.input(colorInput, { target: { value: '#ff0000' } })
+      expect(brushColor.value.toLowerCase()).toBe('#ff0000')
+    })
+
+    it('updates brushOpacity via the percent input', async () => {
+      const brushOpacity = ref(1)
+      primePainterState({ brushOpacity })
+      renderWidget()
+      const user = userEvent.setup()
+
+      const percentInput = within(
+        screen.getByTestId('painter-color-row')
+      ).getByDisplayValue('100')
+      await user.clear(percentInput)
+      await user.type(percentInput, '50')
+      await user.tab() // blur to trigger @change
+      expect(brushOpacity.value).toBeCloseTo(0.5)
+    })
+
+    it('clamps opacity input to the 0-100 range', async () => {
+      const brushOpacity = ref(1)
+      primePainterState({ brushOpacity })
+      renderWidget()
+      const user = userEvent.setup()
+
+      const percentInput = within(
+        screen.getByTestId('painter-color-row')
+      ).getByDisplayValue('100')
+      await user.clear(percentInput)
+      await user.type(percentInput, '999')
+      await user.tab()
+      expect(brushOpacity.value).toBe(1) // clamped to 100% -> 1.0
+    })
+
+    it('updates background color via the bg color input', async () => {
+      const backgroundColor = ref('#ffffff')
+      primePainterState({ backgroundColor })
+      renderWidget()
+
+      const bgInput = within(
+        screen.getByTestId('painter-bg-color-row')
+      ).getByDisplayValue('#ffffff')
+      // eslint-disable-next-line testing-library/prefer-user-event
+      await fireEvent.input(bgInput, { target: { value: '#00ff00' } })
+      expect(backgroundColor.value.toLowerCase()).toBe('#00ff00')
+    })
+  })
+})

--- a/src/components/painter/WidgetPainter.vue
+++ b/src/components/painter/WidgetPainter.vue
@@ -23,6 +23,7 @@
         />
         <canvas
           ref="canvasEl"
+          data-testid="painter-canvas"
           class="absolute inset-0 size-full cursor-none touch-none"
           @pointerdown="handlePointerDown"
           @pointermove="handlePointerMove"
@@ -58,7 +59,6 @@
       "
     >
       <div
-        v-if="!compact"
         class="flex w-28 items-center truncate text-sm text-muted-foreground"
       >
         {{ $t('painter.tool') }}
@@ -99,7 +99,6 @@
       </div>
 
       <div
-        v-if="!compact"
         class="flex w-28 items-center truncate text-sm text-muted-foreground"
       >
         {{ $t('painter.size') }}
@@ -126,7 +125,6 @@
 
       <template v-if="tool === PAINTER_TOOLS.BRUSH">
         <div
-          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.color') }}
@@ -170,7 +168,6 @@
         </div>
 
         <div
-          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.hardness') }}
@@ -199,7 +196,6 @@
 
       <template v-if="!isImageInputConnected">
         <div
-          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.width') }}
@@ -222,7 +218,6 @@
         </div>
 
         <div
-          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.height') }}
@@ -245,7 +240,6 @@
         </div>
 
         <div
-          v-if="!compact"
           class="flex w-28 items-center truncate text-sm text-muted-foreground"
         >
           {{ $t('painter.background') }}

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -465,5 +465,51 @@ describe('useNodeResize', () => {
       // Probe value should be reverted, not left at '0px'
       expect(el.style.getPropertyValue('--node-height')).toBe('400px')
     })
+
+    it('measures with the candidate width applied (responsive breakpoint frame)', async () => {
+      // Simulate a responsive widget: when width < 350, content reflows to
+      // 280; when width >= 350, content fits in 150.
+      const breakpointAwareElement = (() => {
+        const element = document.createElement('div')
+        element.setAttribute('data-node-id', 'test-node')
+        element.style.setProperty('min-width', `${MIN_NODE_WIDTH}px`)
+        element.getBoundingClientRect = () => {
+          const nodeHeight = element.style.getPropertyValue('--node-height')
+          if (nodeHeight === '0px') {
+            const widthVar = element.style.getPropertyValue('--node-width')
+            const probedWidth = parseFloat(widthVar) || 300
+            const minH = probedWidth < 350 ? 280 : 150
+            return { width: probedWidth, height: minH } as DOMRect
+          }
+          return { width: 300, height: 400 } as DOMRect
+        }
+        return element
+      })()
+      const cb = vi.fn<ResizeCallback>()
+      const h = createMockHandle(breakpointAwareElement)
+      const { useNodeResize } = await import('./useNodeResize')
+      const { startResize } = useNodeResize(cb)
+
+      // Start at width=300 (still narrow side, but the breakpoint logic
+      // matters when the user attempts to shrink toward narrow on this frame).
+      breakpointAwareElement.style.setProperty('--node-width', '400px')
+      startResizeAt(startResize, h, 'SE')
+
+      // First move drives newWidth to 340 (below breakpoint). Probe must use
+      // 340, not the DOM's currently-applied 400, to return 280.
+      simulateMove(-60, -300)
+      const payload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(payload.size.height).toBe(280)
+    })
+
+    it('restores --node-width after probing (does not clobber state)', async () => {
+      const { el, handle: h, startResize } = await setupDynamic(() => 150)
+      el.style.setProperty('--node-width', '350px')
+
+      startResizeAt(startResize, h, 'SE')
+      simulateMove(10, 10)
+
+      expect(el.style.getPropertyValue('--node-width')).toBe('350px')
+    })
   })
 })

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.test.ts
@@ -34,11 +34,21 @@ vi.mock('@/renderer/core/layout/transform/useTransformState', () => ({
   })
 }))
 
+const snapState = vi.hoisted(() => ({
+  shouldSnap: false,
+  applySnapToPosition: (pos: { x: number; y: number }) => pos,
+  applySnapToSize: (size: { width: number; height: number }) => size
+}))
+
 vi.mock('@/renderer/extensions/vueNodes/composables/useNodeSnap', () => ({
   useNodeSnap: () => ({
-    shouldSnap: vi.fn(() => false),
-    applySnapToPosition: vi.fn((pos: { x: number; y: number }) => pos),
-    applySnapToSize: vi.fn((size: { width: number; height: number }) => size)
+    shouldSnap: vi.fn(() => snapState.shouldSnap),
+    applySnapToPosition: vi.fn((pos: { x: number; y: number }) =>
+      snapState.applySnapToPosition(pos)
+    ),
+    applySnapToSize: vi.fn((size: { width: number; height: number }) =>
+      snapState.applySnapToSize(size)
+    )
   })
 }))
 
@@ -149,6 +159,9 @@ describe('useNodeResize', () => {
     vi.clearAllMocks()
     eventHandlers.pointermove = null
     eventHandlers.pointerup = null
+    snapState.shouldSnap = false
+    snapState.applySnapToPosition = (pos) => pos
+    snapState.applySnapToSize = (size) => size
 
     callback = vi.fn<ResizeCallback>()
     nodeElement = createMockNodeElement()
@@ -271,6 +284,186 @@ describe('useNodeResize', () => {
       expect(payload.size.height).toBe(150)
       // y = startY + startHeight - minContentHeight = 200 + 400 - 150 = 450
       expect(payload.position!.y).toBe(450)
+    })
+  })
+
+  describe('dynamic content height (re-measured per move)', () => {
+    function makeReflowingElement(
+      width: number,
+      height: number,
+      getMinContentHeight: () => number
+    ): HTMLElement {
+      const element = document.createElement('div')
+      element.setAttribute('data-node-id', 'test-node')
+      element.style.setProperty('min-width', `${MIN_NODE_WIDTH}px`)
+      element.getBoundingClientRect = () => {
+        const nodeHeight = element.style.getPropertyValue('--node-height')
+        const h = nodeHeight === '0px' ? getMinContentHeight() : height
+        return {
+          width,
+          height: h,
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: width,
+          bottom: h,
+          toJSON: () => {}
+        } as DOMRect
+      }
+      return element
+    }
+
+    async function setupDynamic(getMinContentHeight: () => number) {
+      vi.clearAllMocks()
+      eventHandlers.pointermove = null
+      eventHandlers.pointerup = null
+      const cb = vi.fn<ResizeCallback>()
+      const el = makeReflowingElement(300, 400, getMinContentHeight)
+      const h = createMockHandle(el)
+      const { useNodeResize } = await import('./useNodeResize')
+      const { startResize } = useNodeResize(cb)
+      return { cb, el, handle: h, startResize }
+    }
+
+    it('uses the latest measured content height when content reflows taller', async () => {
+      let currentMinHeight = 150
+      const {
+        cb,
+        handle: h,
+        startResize
+      } = await setupDynamic(() => currentMinHeight)
+
+      startResizeAt(startResize, h, 'SE')
+
+      // First move: clamp uses initial minContentHeight = 150
+      simulateMove(0, -300)
+      const firstPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(firstPayload.size.height).toBe(150)
+
+      // Content reflows taller (e.g. painter switches to compact layout)
+      currentMinHeight = 280
+
+      // Second move at the same position must reflect the new minimum,
+      // not the value captured at drag start.
+      simulateMove(0, -300)
+      const secondPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(secondPayload.size.height).toBe(280)
+    })
+
+    it('also re-measures for N corners and updates the y-position clamp', async () => {
+      let currentMinHeight = 150
+      const {
+        cb,
+        handle: h,
+        startResize
+      } = await setupDynamic(() => currentMinHeight)
+
+      startResizeAt(startResize, h, 'NW')
+
+      simulateMove(0, 500)
+      const firstPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(firstPayload.size.height).toBe(150)
+      expect(firstPayload.position!.y).toBe(450) // 200 + 400 - 150
+
+      currentMinHeight = 220
+
+      simulateMove(0, 500)
+      const secondPayload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(secondPayload.size.height).toBe(220)
+      expect(secondPayload.position!.y).toBe(380) // 200 + 400 - 220
+    })
+
+    it('stops responding to pointermove after pointerup', async () => {
+      const currentMinHeight = 150
+      const {
+        cb,
+        handle: h,
+        startResize
+      } = await setupDynamic(() => currentMinHeight)
+
+      startResizeAt(startResize, h, 'SE')
+      simulateMove(20, 20)
+      const callsBeforeUp = cb.mock.calls.length
+
+      const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
+      eventHandlers.pointerup?.(upEvent)
+
+      // Subsequent moves should be ignored after cleanup
+      simulateMove(40, 40)
+      expect(cb.mock.calls.length).toBe(callsBeforeUp)
+    })
+
+    it('handles releasePointerCapture throwing without breaking cleanup', async () => {
+      const { cb, el, handle: h, startResize } = await setupDynamic(() => 150)
+      h.releasePointerCapture = vi.fn(() => {
+        throw new Error('already released')
+      })
+
+      startResizeAt(startResize, h, 'SE')
+      simulateMove(10, 10)
+
+      const upEvent = createPointerEvent('pointerup', { pointerId: 1 })
+      expect(() => eventHandlers.pointerup?.(upEvent)).not.toThrow()
+
+      // Further moves are ignored — cleanup still ran.
+      const callsAfterUp = cb.mock.calls.length
+      simulateMove(50, 50)
+      expect(cb.mock.calls.length).toBe(callsAfterUp)
+      expect(el).toBeDefined()
+    })
+
+    it('applies snap-to-grid on SE (size only)', async () => {
+      snapState.shouldSnap = true
+      snapState.applySnapToSize = ({ width, height }) => ({
+        width: Math.round(width / 10) * 10,
+        height: Math.round(height / 10) * 10
+      })
+
+      const { cb, handle: h, startResize } = await setupDynamic(() => 50)
+      startResizeAt(startResize, h, 'SE')
+      simulateMove(53, 27)
+
+      const payload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(payload.size.width).toBe(350) // 353 -> 350
+      expect(payload.size.height).toBe(430) // 427 -> 430
+      expect(payload.position).toBeUndefined()
+    })
+
+    it('applies snap-to-grid on NW (position + size compensation)', async () => {
+      snapState.shouldSnap = true
+      // Snap position down to nearest 10
+      snapState.applySnapToPosition = ({ x, y }) => ({
+        x: Math.floor(x / 10) * 10,
+        y: Math.floor(y / 10) * 10
+      })
+      snapState.applySnapToSize = ({ width, height }) => ({
+        width: Math.round(width / 10) * 10,
+        height: Math.round(height / 10) * 10
+      })
+
+      const { cb, handle: h, startResize } = await setupDynamic(() => 50)
+      startResizeAt(startResize, h, 'NW')
+      // delta: x=-53, y=-27 -> raw newX=47, newY=173
+      // applySnapToPosition floors -> {40, 170}
+      // size compensated: width += 47-40=7 (-> 360), height += 173-170=3 (-> 430)
+      // applySnapToSize rounds -> 360, 430
+      simulateMove(-53, -27)
+
+      const payload = cb.mock.calls.at(-1)![0] as ResizeCallbackPayload
+      expect(payload.position).toEqual({ x: 40, y: 170 })
+      expect(payload.size).toEqual({ width: 360, height: 430 })
+    })
+
+    it('restores --node-height after measuring (does not clobber state)', async () => {
+      const { el, handle: h, startResize } = await setupDynamic(() => 150)
+      el.style.setProperty('--node-height', '400px')
+
+      startResizeAt(startResize, h, 'SE')
+      simulateMove(10, 10)
+
+      // Probe value should be reverted, not left at '0px'
+      expect(el.style.getPropertyValue('--node-height')).toBe('400px')
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
@@ -59,12 +59,14 @@ export function useNodeResize(
       height: rect.height / scale
     }
 
-    const measureMinContentHeight = () => {
-      const savedNodeHeight =
-        nodeElement.style.getPropertyValue('--node-height')
+    const measureMinContentHeight = (candidateWidth: number) => {
+      const savedWidth = nodeElement.style.getPropertyValue('--node-width')
+      const savedHeight = nodeElement.style.getPropertyValue('--node-height')
+      nodeElement.style.setProperty('--node-width', `${candidateWidth}px`)
       nodeElement.style.setProperty('--node-height', '0px')
       const measured = nodeElement.getBoundingClientRect().height
-      nodeElement.style.setProperty('--node-height', savedNodeHeight || '')
+      nodeElement.style.setProperty('--node-height', savedHeight || '')
+      nodeElement.style.setProperty('--node-width', savedWidth || '')
       const currentScale = transformState.camera.z || 1
       return measured / currentScale
     }
@@ -170,9 +172,12 @@ export function useNodeResize(
         }
         newWidth = minWidth
       }
-      // Re-measure on each move: widget content (e.g. painter controls)
-      // can re-flow taller as width shrinks, raising the true minimum.
-      const minContentHeight = measureMinContentHeight()
+      // Re-measure on each move with the candidate width applied: widget
+      // content (e.g. painter controls) can re-flow taller as width shrinks,
+      // raising the true minimum. Probing with newWidth — not the DOM's
+      // current width — keeps the clamp accurate on the frame that crosses
+      // a responsive breakpoint.
+      const minContentHeight = measureMinContentHeight(newWidth)
       if (newHeight < minContentHeight) {
         if (activeCorner.includes('N')) {
           newY =

--- a/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
+++ b/src/renderer/extensions/vueNodes/interactions/resize/useNodeResize.ts
@@ -59,10 +59,15 @@ export function useNodeResize(
       height: rect.height / scale
     }
 
-    const savedNodeHeight = nodeElement.style.getPropertyValue('--node-height')
-    nodeElement.style.setProperty('--node-height', '0px')
-    const minContentHeight = nodeElement.getBoundingClientRect().height / scale
-    nodeElement.style.setProperty('--node-height', savedNodeHeight || '')
+    const measureMinContentHeight = () => {
+      const savedNodeHeight =
+        nodeElement.style.getPropertyValue('--node-height')
+      nodeElement.style.setProperty('--node-height', '0px')
+      const measured = nodeElement.getBoundingClientRect().height
+      nodeElement.style.setProperty('--node-height', savedNodeHeight || '')
+      const currentScale = transformState.camera.z || 1
+      return measured / currentScale
+    }
 
     const nodeLayout = layoutStore.getNodeLayoutRef(nodeId).value
     const startPosition: Point = nodeLayout
@@ -165,6 +170,9 @@ export function useNodeResize(
         }
         newWidth = minWidth
       }
+      // Re-measure on each move: widget content (e.g. painter controls)
+      // can re-flow taller as width shrinks, raising the true minimum.
+      const minContentHeight = measureMinContentHeight()
       if (newHeight < minContentHeight) {
         if (activeCorner.includes('N')) {
           newY =


### PR DESCRIPTION
## Summary

- WidgetPainter: stack label above widget when controls width < 350px, side-by-side otherwise; labels are always rendered (no longer hidden when narrow).
- useNodeResize: re-measure the node's intrinsic min content height on every pointermove instead of capturing it once at drag start, so the height clamp tracks widgets whose controls reflow taller as width shrinks (e.g. painter switching to compact layout). Without this, the node visually sticks at its current height and the user has to release and grab the corner again to free it.
- Add unit tests for both changes.

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/74889ad5-63a7-439f-b8e4-0185ed95327f


after

https://github.com/user-attachments/assets/bca77c36-2f90-4685-8603-f8f9c02abe77

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12025-FE-557-fix-painter-responsive-label-layout-correct-resize-min-height-3586d73d365081cf9036f7d52bfabe6c) by [Unito](https://www.unito.io)
