### PR TITLE
feat: move PrimitiveNode to utils/primitive subcategory

### DIFF
--- a/src/constants/primitiveNodes.ts
+++ b/src/constants/primitiveNodes.ts
@@ -1,0 +1,1 @@
+export const PRIMITIVE_NODE_CATEGORY = 'utils/primitive'

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -23,6 +23,7 @@ import {
 } from '@/scripts/widgets'
 import { isPrimitiveNode } from '@/renderer/utils/nodeTypeGuards'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
+import { PRIMITIVE_NODE_CATEGORY } from '@/stores/nodeDefStore'
 import { mergeInputSpec } from '@/utils/nodeDefUtil'
 import { applyTextReplacements } from '@/utils/searchAndReplace'
 
@@ -624,6 +625,6 @@ app.registerExtension({
         title: 'Primitive'
       })
     )
-    PrimitiveNode.category = 'utils/primitive'
+    PrimitiveNode.category = PRIMITIVE_NODE_CATEGORY
   }
 })

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -23,7 +23,7 @@ import {
 } from '@/scripts/widgets'
 import { isPrimitiveNode } from '@/renderer/utils/nodeTypeGuards'
 import { CONFIG, GET_CONFIG } from '@/services/litegraphService'
-import { PRIMITIVE_NODE_CATEGORY } from '@/stores/nodeDefStore'
+import { PRIMITIVE_NODE_CATEGORY } from '@/constants/primitiveNodes'
 import { mergeInputSpec } from '@/utils/nodeDefUtil'
 import { applyTextReplacements } from '@/utils/searchAndReplace'
 

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -624,6 +624,6 @@ app.registerExtension({
         title: 'Primitive'
       })
     )
-    PrimitiveNode.category = 'utils'
+    PrimitiveNode.category = 'utils/primitive'
   }
 })

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import {
   ComfyNodeDefImpl,
+  PRIMITIVE_NODE_CATEGORY,
   SYSTEM_NODE_DEFS,
   buildNodeDefTree,
   useNodeDefStore
@@ -366,8 +367,14 @@ describe('useNodeDefStore', () => {
   })
 
   describe('SYSTEM_NODE_DEFS', () => {
+    it('exposes the shared utils/primitive constant', () => {
+      expect(PRIMITIVE_NODE_CATEGORY).toBe('utils/primitive')
+    })
+
     it('places PrimitiveNode under the utils/primitive subcategory', () => {
-      expect(SYSTEM_NODE_DEFS.PrimitiveNode.category).toBe('utils/primitive')
+      expect(SYSTEM_NODE_DEFS.PrimitiveNode.category).toBe(
+        PRIMITIVE_NODE_CATEGORY
+      )
     })
 
     it('keeps remaining frontend-only virtual nodes under the flat utils category', () => {

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import {
   ComfyNodeDefImpl,
-  PRIMITIVE_NODE_CATEGORY,
   SYSTEM_NODE_DEFS,
   buildNodeDefTree,
   useNodeDefStore
@@ -367,14 +366,8 @@ describe('useNodeDefStore', () => {
   })
 
   describe('SYSTEM_NODE_DEFS', () => {
-    it('exposes the shared utils/primitive constant', () => {
-      expect(PRIMITIVE_NODE_CATEGORY).toBe('utils/primitive')
-    })
-
     it('places PrimitiveNode under the utils/primitive subcategory', () => {
-      expect(SYSTEM_NODE_DEFS.PrimitiveNode.category).toBe(
-        PRIMITIVE_NODE_CATEGORY
-      )
+      expect(SYSTEM_NODE_DEFS.PrimitiveNode.category).toBe('utils/primitive')
     })
 
     it('keeps remaining frontend-only virtual nodes under the flat utils category', () => {

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -3,7 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { SYSTEM_NODE_DEFS, useNodeDefStore } from '@/stores/nodeDefStore'
 import type { NodeDefFilter } from '@/stores/nodeDefStore'
 
 describe('useNodeDefStore', () => {
@@ -357,6 +357,18 @@ describe('useNodeDefStore', () => {
 
       // Each node (10) should be checked by each filter (5 test + 2 core = 7 total)
       expect(filterCallCount).toBe(10 * 5)
+    })
+  })
+
+  describe('SYSTEM_NODE_DEFS', () => {
+    it('places PrimitiveNode under the utils/primitive subcategory', () => {
+      expect(SYSTEM_NODE_DEFS.PrimitiveNode.category).toBe('utils/primitive')
+    })
+
+    it('keeps remaining frontend-only virtual nodes under the flat utils category', () => {
+      expect(SYSTEM_NODE_DEFS.Reroute.category).toBe('utils')
+      expect(SYSTEM_NODE_DEFS.Note.category).toBe('utils')
+      expect(SYSTEM_NODE_DEFS.MarkdownNote.category).toBe('utils')
     })
   })
 })

--- a/src/stores/nodeDefStore.test.ts
+++ b/src/stores/nodeDefStore.test.ts
@@ -3,7 +3,12 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
-import { SYSTEM_NODE_DEFS, useNodeDefStore } from '@/stores/nodeDefStore'
+import {
+  ComfyNodeDefImpl,
+  SYSTEM_NODE_DEFS,
+  buildNodeDefTree,
+  useNodeDefStore
+} from '@/stores/nodeDefStore'
 import type { NodeDefFilter } from '@/stores/nodeDefStore'
 
 describe('useNodeDefStore', () => {
@@ -369,6 +374,36 @@ describe('useNodeDefStore', () => {
       expect(SYSTEM_NODE_DEFS.Reroute.category).toBe('utils')
       expect(SYSTEM_NODE_DEFS.Note.category).toBe('utils')
       expect(SYSTEM_NODE_DEFS.MarkdownNote.category).toBe('utils')
+    })
+
+    it('routes PrimitiveNode into the utils/primitive branch of the node tree', () => {
+      const systemDefs = Object.values(SYSTEM_NODE_DEFS).map(
+        (def) => new ComfyNodeDefImpl(def)
+      )
+      const tree = buildNodeDefTree(systemDefs)
+
+      const utilsBranch = tree.children?.find(
+        (child) => child.label === 'utils'
+      )
+      expect(utilsBranch).toBeDefined()
+
+      const primitiveBranch = utilsBranch?.children?.find(
+        (child) => child.label === 'primitive'
+      )
+      expect(primitiveBranch).toBeDefined()
+
+      const primitiveLeaf = primitiveBranch?.children?.find(
+        (child) => child.data?.name === 'PrimitiveNode'
+      )
+      expect(primitiveLeaf).toBeDefined()
+
+      const flatUtilsLeaves =
+        utilsBranch?.children
+          ?.filter((child) => child.label !== 'primitive')
+          .map((child) => child.data?.name) ?? []
+      expect(flatUtilsLeaves).toEqual(
+        expect.arrayContaining(['Reroute', 'Note', 'MarkdownNote'])
+      )
     })
   })
 })

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -212,7 +212,7 @@ export const SYSTEM_NODE_DEFS: Record<string, ComfyNodeDefV1> = {
   PrimitiveNode: {
     name: 'PrimitiveNode',
     display_name: 'Primitive',
-    category: 'utils',
+    category: 'utils/primitive',
     input: { required: {}, optional: {} },
     output: ['*'],
     output_name: ['connect to widget input'],

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -208,11 +208,13 @@ export class ComfyNodeDefImpl
   }
 }
 
+export const PRIMITIVE_NODE_CATEGORY = 'utils/primitive'
+
 export const SYSTEM_NODE_DEFS: Record<string, ComfyNodeDefV1> = {
   PrimitiveNode: {
     name: 'PrimitiveNode',
     display_name: 'Primitive',
-    category: 'utils/primitive',
+    category: PRIMITIVE_NODE_CATEGORY,
     input: { required: {}, optional: {} },
     output: ['*'],
     output_name: ['connect to widget input'],

--- a/src/stores/nodeDefStore.ts
+++ b/src/stores/nodeDefStore.ts
@@ -25,6 +25,7 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { NodeSearchService } from '@/services/nodeSearchService'
 import { useSubgraphStore } from '@/stores/subgraphStore'
 import { ESSENTIALS_CATEGORY_CANONICAL } from '@/constants/essentialsNodes'
+import { PRIMITIVE_NODE_CATEGORY } from '@/constants/primitiveNodes'
 import { CORE_NODE_MODULES, getNodeSource } from '@/types/nodeSource'
 import type { NodeSource } from '@/types/nodeSource'
 import type { TreeNode } from '@/types/treeExplorerTypes'
@@ -207,8 +208,6 @@ export class ComfyNodeDefImpl
     return ''
   }
 }
-
-export const PRIMITIVE_NODE_CATEGORY = 'utils/primitive'
 
 export const SYSTEM_NODE_DEFS: Record<string, ComfyNodeDefV1> = {
   PrimitiveNode: {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Move the legacy frontend-registered `PrimitiveNode` from the flat `utils` category into the `utils/primitive` subcategory so it sits alongside its modern backend-derived siblings (`PrimitiveInt`, `PrimitiveFloat`, `PrimitiveString`, `PrimitiveStringMultiline`, `PrimitiveBoolean`, `PrimitiveBoundingBox`).

## Changes

- **What**: Update `PrimitiveNode.category` in two synced sites — the runtime LiteGraph registration (`src/extensions/core/widgetInputs.ts`) and the `SYSTEM_NODE_DEFS` descriptor (`src/stores/nodeDefStore.ts`) — and add unit + tree-routing tests.

## Review Focus

- **Sync of two sites**: `widgetInputs.ts` (LiteGraph runtime) and `nodeDefStore.ts` (`SYSTEM_NODE_DEFS`) must agree, otherwise the search/sidebar disagrees with the canvas add-node menu.
- **i18n**: No locale changes needed. The `primitive` translation key already exists in all 12 locales (`en`, `zh`, `zh-TW`, `es`, `fr`, `ru`, `tr`, `ja`, `fa`, `pt-BR`, `ko`, `ar`), and `src/scripts/app.ts:1034-1037` splits category strings on `/` and translates each segment via `nodeCategories.<segment>` for backend defs.
- **Sanity check on scope**: I audited all `LiteGraph.registerNodeType` calls and `isVirtualNode` usages — there are exactly four frontend-only virtual nodes (`PrimitiveNode`, `NoteNode`, `MarkdownNoteNode`, `RerouteNode`), all currently flat under `utils`. This PR moves only `PrimitiveNode`; the other three intentionally stay flat (verified by a regression test).
- **Known follow-up (out of scope)**: `SYSTEM_NODE_DEFS` are merged into the Vue store in `app.ts:updateVueAppNodeDefs` without going through the `translateNodeDef` pipeline that `getNodeDefs` applies to backend defs. This is a pre-existing gap that affects all four system node defs equally, both before and after this PR. The English-locale UX matches the design intent; addressing the i18n architectural gap belongs in a separate, focused PR so this change can stay scoped.

## Verification

- `pnpm test:unit src/stores/nodeDefStore.test.ts` — 20/20 pass (added 3 new assertions including a behavior test that builds the node tree from `SYSTEM_NODE_DEFS` and asserts the routing).
- `pnpm typecheck` — clean.
- `pnpm format:check` on touched files — clean.
- `pnpm knip` — clean (only the pre-existing `flac.ts` warning).
- Manual verification with backend + dev server running:
  - `LiteGraph.registered_node_types.PrimitiveNode.category === 'utils/primitive'`
  - `nodeDefStore.nodeTree` resolves `utils → primitive → [PrimitiveBoundingBox, PrimitiveString, PrimitiveStringMultiline, PrimitiveInt, PrimitiveFloat, PrimitiveBoolean, PrimitiveNode]`, with `Reroute`, `Note`, `MarkdownNote` remaining as direct leaves under `utils`.
  - Node Library sidebar shows `Primitive` grouped with `Int`, `Float`, `Text String`, `Text String (Multiline)`, `Boolean`, `Bounding Box` under `utils/primitive` (see screenshot).

## Screenshots

The Node Library sidebar with `primitive` typed in the search field, showing `PrimitiveNode` (labelled "Primitive") sitting next to its backend-derived siblings under `utils/primitive`.

## Screenshots

![Node Library sidebar after change: utils/primitive contains Primitive (legacy frontend node) alongside backend-derived Int, Text String, Text String (Multiline), Float, Boolean, Bounding Box](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/cf6fe2b2ee5fd41d41dd19a2bc0d59619ca30910ab0af1a494ecd057939db892/pr-images/1778089830600-9b1a2234-1f6b-49ad-a5de-1806e564ef64.png)

![Node Library sidebar overview](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/cf6fe2b2ee5fd41d41dd19a2bc0d59619ca30910ab0af1a494ecd057939db892/pr-images/1778089830966-d82492f0-3b2c-4eeb-aa57-a592aad5104b.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12027-feat-move-PrimitiveNode-to-utils-primitive-subcategory-3586d73d365081568ec6ce2242a8cdc6) by [Unito](https://www.unito.io)
