### PR TITLE
FE-604: fix(website): activate last section badge when scrolled to bottom

### DIFF
--- a/apps/website/e2e/content-section.spec.ts
+++ b/apps/website/e2e/content-section.spec.ts
@@ -2,41 +2,60 @@ import { expect } from '@playwright/test'
 
 import { test } from './fixtures/blockExternalMedia'
 
-// Regression for FE-604. Viewport matches the 14" M4 Pro logical resolution
-// from the original bug report; /privacy-policy reliably reproduces it
-// because of its many short trailing sections.
-test.describe('ContentSection scroll-spy @smoke', () => {
-  test.use({ viewport: { width: 2016, height: 1310 } })
+const M4_PRO_14_INCH_VIEWPORT = { width: 2016, height: 1310 }
+const LAST_SECTION_HASH = '#contact'
 
-  test('activates the last badge when scrolled to the bottom', async ({
-    page
-  }) => {
-    await page.goto('/privacy-policy')
+test.describe(
+  'ContentSection scroll-spy @smoke',
+  {
+    annotation: [
+      {
+        type: 'issue',
+        description:
+          'https://linear.app/comfyorg/issue/FE-604/bug-bottom-badge-not-activating-on-scroll-at-high-resolution-3024x1964'
+      },
+      {
+        type: 'environment',
+        description:
+          '14" MacBook M4 Pro logical viewport reported in FE-604; /privacy-policy reproduces because of its short trailing sections'
+      }
+    ]
+  },
+  () => {
+    test.use({ viewport: M4_PRO_14_INCH_VIEWPORT })
 
-    const sidebarNav = page.getByRole('navigation', { name: 'Category filter' })
-    const badges = sidebarNav.getByRole('button')
-    const lastBadge = badges.last()
+    test('activates the last badge when user scrolls to the bottom', async ({
+      page
+    }) => {
+      await page.goto('/privacy-policy')
 
-    await expect(badges.first()).toHaveAttribute('aria-pressed', 'true')
-    await expect(lastBadge).toHaveAttribute('aria-pressed', 'false')
+      const sidebarNav = page.getByRole('navigation', {
+        name: 'Category filter'
+      })
+      const badges = sidebarNav.getByRole('button')
+      const lastBadge = badges.last()
 
-    await page.evaluate(() => {
-      window.scrollTo(0, document.documentElement.scrollHeight)
+      await expect(badges.first()).toHaveAttribute('aria-pressed', 'true')
+      await expect(lastBadge).toHaveAttribute('aria-pressed', 'false')
+
+      await page.evaluate(() =>
+        window.scrollTo(0, document.documentElement.scrollHeight)
+      )
+
+      await expect(lastBadge).toHaveAttribute('aria-pressed', 'true')
     })
 
-    await expect(lastBadge).toHaveAttribute('aria-pressed', 'true')
-  })
+    test('activates the last badge when page mounts already at the bottom via trailing hash', async ({
+      page
+    }) => {
+      await page.goto(`/privacy-policy${LAST_SECTION_HASH}`)
 
-  // Hash makes the page mount already at the bottom; covers the onMounted()
-  // path that runs before any scroll event fires.
-  test('activates the last badge on initial render at the bottom', async ({
-    page
-  }) => {
-    await page.goto('/privacy-policy#contact')
+      const sidebarNav = page.getByRole('navigation', {
+        name: 'Category filter'
+      })
+      const lastBadge = sidebarNav.getByRole('button').last()
 
-    const sidebarNav = page.getByRole('navigation', { name: 'Category filter' })
-    const lastBadge = sidebarNav.getByRole('button').last()
-
-    await expect(lastBadge).toHaveAttribute('aria-pressed', 'true')
-  })
-})
+      await expect(lastBadge).toHaveAttribute('aria-pressed', 'true')
+    })
+  }
+)

--- a/apps/website/e2e/content-section.spec.ts
+++ b/apps/website/e2e/content-section.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/blockExternalMedia'
+
+// Regression for FE-604. Viewport matches the 14" M4 Pro logical resolution
+// from the original bug report; /privacy-policy reliably reproduces it
+// because of its many short trailing sections.
+test.describe('ContentSection scroll-spy @smoke', () => {
+  test.use({ viewport: { width: 2016, height: 1310 } })
+
+  test('activates the last badge when scrolled to the bottom', async ({
+    page
+  }) => {
+    await page.goto('/privacy-policy')
+
+    const sidebarNav = page.getByRole('navigation', { name: 'Category filter' })
+    const badges = sidebarNav.getByRole('button')
+    const lastBadge = badges.last()
+
+    await expect(badges.first()).toHaveAttribute('aria-pressed', 'true')
+    await expect(lastBadge).toHaveAttribute('aria-pressed', 'false')
+
+    await page.evaluate(() => {
+      window.scrollTo(0, document.documentElement.scrollHeight)
+    })
+
+    await expect(lastBadge).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  // Hash makes the page mount already at the bottom; covers the onMounted()
+  // path that runs before any scroll event fires.
+  test('activates the last badge on initial render at the bottom', async ({
+    page
+  }) => {
+    await page.goto('/privacy-policy#contact')
+
+    const sidebarNav = page.getByRole('navigation', { name: 'Category filter' })
+    const lastBadge = sidebarNav.getByRole('button').last()
+
+    await expect(lastBadge).toHaveAttribute('aria-pressed', 'true')
+  })
+})

--- a/apps/website/src/components/common/ContentSection.vue
+++ b/apps/website/src/components/common/ContentSection.vue
@@ -5,7 +5,7 @@ import {
   useIntersectionObserver,
   useTemplateRefsList
 } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 import type { Locale, TranslationKey } from '../../i18n/translations'
 
@@ -71,16 +71,15 @@ function isAtBottom(): boolean {
   )
 }
 
-useEventListener(
-  'scroll',
-  () => {
-    if (isScrolling) return
-    if (!isAtBottom()) return
-    const lastId = sections[sections.length - 1]?.id
-    if (lastId) activeSection.value = lastId
-  },
-  { passive: true }
-)
+function activateLastIfAtBottom() {
+  if (isScrolling) return
+  if (!isAtBottom()) return
+  const lastId = sections[sections.length - 1]?.id
+  if (lastId) activeSection.value = lastId
+}
+
+onMounted(activateLastIfAtBottom)
+useEventListener('scroll', activateLastIfAtBottom, { passive: true })
 
 function scrollToSection(id: string) {
   activeSection.value = id

--- a/apps/website/src/components/common/ContentSection.vue
+++ b/apps/website/src/components/common/ContentSection.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { useIntersectionObserver, useTemplateRefsList } from '@vueuse/core'
+import {
+  useEventListener,
+  useIntersectionObserver,
+  useTemplateRefsList
+} from '@vueuse/core'
 import { computed, ref } from 'vue'
 
 import type { Locale, TranslationKey } from '../../i18n/translations'
@@ -42,11 +46,13 @@ const sectionRefs = useTemplateRefsList<HTMLElement>()
 let isScrolling = false
 
 const HEADER_OFFSET = -144
+const BOTTOM_THRESHOLD_PX = 4
 
 useIntersectionObserver(
   sectionRefs,
   (entries) => {
     if (isScrolling) return
+    if (isAtBottom()) return
     let best: IntersectionObserverEntry | null = null
     for (const entry of entries) {
       if (!entry.isIntersecting) continue
@@ -56,6 +62,24 @@ useIntersectionObserver(
     if (best) activeSection.value = best.target.id
   },
   { rootMargin: '-20% 0px -60% 0px' }
+)
+
+function isAtBottom(): boolean {
+  const scrollBottom = window.scrollY + window.innerHeight
+  return (
+    scrollBottom >= document.documentElement.scrollHeight - BOTTOM_THRESHOLD_PX
+  )
+}
+
+useEventListener(
+  'scroll',
+  () => {
+    if (isScrolling) return
+    if (!isAtBottom()) return
+    const lastId = sections[sections.length - 1]?.id
+    if (lastId) activeSection.value = lastId
+  },
+  { passive: true }
 )
 
 function scrollToSection(id: string) {

--- a/apps/website/src/components/common/ContentSection.vue
+++ b/apps/website/src/components/common/ContentSection.vue
@@ -44,9 +44,19 @@ const activeSection = ref(sections[0]?.id ?? '')
 
 const sectionRefs = useTemplateRefsList<HTMLElement>()
 let isScrolling = false
+let scrollSafetyTimer: ReturnType<typeof setTimeout> | undefined
 
 const HEADER_OFFSET = -144
 const BOTTOM_THRESHOLD_PX = 4
+const SCROLL_SAFETY_MS = 1500
+
+function clearScrollLock() {
+  isScrolling = false
+  if (scrollSafetyTimer !== undefined) {
+    clearTimeout(scrollSafetyTimer)
+    scrollSafetyTimer = undefined
+  }
+}
 
 useIntersectionObserver(
   sectionRefs,
@@ -83,20 +93,20 @@ useEventListener('scroll', activateLastIfAtBottom, { passive: true })
 
 function scrollToSection(id: string) {
   activeSection.value = id
+  clearScrollLock()
   isScrolling = true
+  scrollSafetyTimer = setTimeout(clearScrollLock, SCROLL_SAFETY_MS)
   const el = document.getElementById(id)
   if (el) {
     scrollTo(el, {
       offset: HEADER_OFFSET,
       duration: 0.8,
       immediate: prefersReducedMotion(),
-      onComplete: () => {
-        isScrolling = false
-      }
+      onComplete: clearScrollLock
     })
     return
   }
-  isScrolling = false
+  clearScrollLock()
 }
 </script>
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fixes the bug where the last badge in `ContentSection`'s sticky sidebar nav stays unhighlighted when the user scrolls to the very bottom of the page on tall viewports (reported on a 14" MacBook M4 Pro at 3024×1964 / 2016×1310 logical, both Chrome and Safari).

## Root cause

The scroll-spy uses an IntersectionObserver with `rootMargin: '-20% 0px -60% 0px'`, which makes only a 20%–40% horizontal band from the viewport top "active". When multiple intersecting entries are reported, the callback picks the one whose `boundingClientRect.top` is smallest (highest up on screen).

On tall viewports, when the page is scrolled to the absolute bottom, the last *and* the second-to-last sections frequently both sit inside that 20%–40% band at the same time. The "smallest top" tiebreak then selects the second-to-last section, leaving the last badge inactive even though the user has reached the end of the page.

## Fix

`apps/website/src/components/common/ContentSection.vue`:

1. Add `isAtBottom()` — true when the viewport bottom has reached the document bottom (within 4px to absorb sub-pixel rounding).
2. The IntersectionObserver callback bails out when `isAtBottom()` so it cannot overwrite the choice below.
3. A passive `scroll` listener (and a one-shot `onMounted` call) sets `activeSection` to the last section whenever the page is at the bottom — including when the component mounts already at the bottom (e.g. hash navigation to a trailing anchor, restored scroll position, or a page shorter than the viewport).
4. Both the scroll handler and the IO callback honor the existing `isScrolling` flag, so click-driven smooth scroll-to-section behavior is unchanged.

## Verification

Reproduced the bug at viewport 2016×1310 (14" M4 Pro "More Space" mode) on `/privacy-policy`:

- Before fix: at absolute bottom, IntersectionObserver picks `australian-privacy` (second-to-last) — bug confirmed via DOM inspection that showed multiple sections intersecting the active band, with the second-to-last winning the "smallest top" tiebreak.
- After fix:
  - Scrolled to bottom → last badge `CONTACT` is active.
  - Scrolled to top → first badge `INTRO` is active.
  - Scrolled mid-page → correct mid-section is active.
  - Click on a badge → smooth scrolls and that badge becomes active.
  - Initial render at bottom (loaded `/privacy-policy#contact`, browser scrolls to the bottom on mount) → `CONTACT` active immediately.

`pnpm typecheck` and `pnpm typecheck:website` pass; `pnpm lint` reports 0 errors; existing website unit tests pass.

Note: The website app currently has no Vue component test setup (`vitest.config.ts` is configured for `node` env, no DOM). Adding component tests for this scroll-spy interaction would require setting up `happy-dom` and `@testing-library/vue` for the website app, which is out of scope for this bug fix.

Fixes FE-604

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12057-FE-604-fix-website-activate-last-section-badge-when-scrolled-to-bottom-3596d73d365081faa243f4dd8e6ee54a) by [Unito](https://www.unito.io)
