### PR TITLE
test: add failing test for deleting inner nodes with promoted widgets

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -190,6 +190,9 @@ export class ComfyPage {
   /** Worker index to test user ID */
   public readonly userIds: string[] = []
 
+  /** Whether the current test runs in Vue Nodes mode (initialized from `@vue-nodes` tag). */
+  public isVueNodes = false
+
   /** Test user ID for the current context */
   get id() {
     return this.userIds[comfyPageFixture.info().parallelIndex]
@@ -500,6 +503,7 @@ export const comfyPageFixture = base.extend<{
     comfyPage.userIds[parallelIndex] = userId
 
     const isVueNodes = testInfo.tags.includes('@vue-nodes')
+    comfyPage.isVueNodes = isVueNodes
 
     try {
       await comfyPage.setupSettings({

--- a/browser_tests/fixtures/components/ContextMenu.ts
+++ b/browser_tests/fixtures/components/ContextMenu.ts
@@ -20,6 +20,7 @@ export class ContextMenu {
 
   async clickMenuItemExact(name: string): Promise<void> {
     await this.page.getByRole('menuitem', { name, exact: true }).click()
+    await this.waitForHidden()
   }
 
   /**

--- a/browser_tests/fixtures/helpers/SubgraphHelper.ts
+++ b/browser_tests/fixtures/helpers/SubgraphHelper.ts
@@ -362,6 +362,9 @@ export class SubgraphHelper {
 
     await this.comfyPage.nextFrame()
     await expect.poll(async () => this.isInSubgraph()).toBe(false)
+    if (this.comfyPage.isVueNodes) {
+      await this.comfyPage.vueNodes.waitForNodes()
+    }
   }
 
   async countGraphPseudoPreviewEntries(): Promise<number> {

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -39,6 +39,16 @@ export class VueNodeFixture {
     await this.collapseButton.click()
   }
 
+  /**
+   * Select this node and delete it via the Delete key, waiting for the node
+   * element to leave the DOM before resolving.
+   */
+  async delete(): Promise<void> {
+    await this.header.click()
+    await this.header.press('Delete')
+    await this.locator.waitFor({ state: 'hidden' })
+  }
+
   async getCollapseIconClass(): Promise<string> {
     return (await this.collapseIcon.getAttribute('class')) ?? ''
   }

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -558,5 +558,59 @@ test.describe(
           .toBe(0)
       })
     })
+
+    test.fail(
+      'Promoted text widget is removed when source node is deleted inside the subgraph',
+      { tag: '@vue-nodes' },
+      async ({ comfyPage }) => {
+        await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
+        await comfyPage.workflow.loadWorkflow('default')
+        await comfyPage.vueNodes.waitForNodes()
+
+        const clipFixture = await comfyPage.vueNodes.getFixtureByTitle(
+          'CLIP Text Encode (Prompt)'
+        )
+        await comfyPage.contextMenu.openForVueNode(clipFixture.header)
+        await comfyPage.contextMenu.clickMenuItemExact('Convert to Subgraph')
+        await comfyPage.contextMenu.waitForHidden()
+
+        const subgraphNode = comfyPage.vueNodes
+          .getNodeByTitle('New Subgraph')
+          .first()
+        await expect(subgraphNode).toBeVisible()
+
+        const subgraphNodeId =
+          await comfyPage.vueNodes.getNodeIdByTitle('New Subgraph')
+
+        await expect
+          .poll(() => getPromotedWidgetNames(comfyPage, subgraphNodeId))
+          .toContain('text')
+        await expect(
+          subgraphNode.getByTestId(TestIds.widgets.domWidgetTextarea)
+        ).toBeVisible()
+
+        await comfyPage.vueNodes.enterSubgraph(subgraphNodeId)
+        await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
+        await comfyPage.vueNodes.waitForNodes()
+
+        const interiorClipId = await comfyPage.vueNodes.getNodeIdByTitle(
+          'CLIP Text Encode (Prompt)'
+        )
+        await comfyPage.vueNodes.deleteNode(interiorClipId)
+        await expect(
+          comfyPage.vueNodes.getNodeLocator(interiorClipId)
+        ).toBeHidden()
+
+        await comfyPage.subgraph.exitViaBreadcrumb()
+        await comfyPage.vueNodes.waitForNodes()
+
+        const subgraphNodeAfter =
+          comfyPage.vueNodes.getNodeLocator(subgraphNodeId)
+        await expect(subgraphNodeAfter).toBeVisible()
+        await expect(
+          subgraphNodeAfter.getByTestId(TestIds.widgets.domWidgetTextarea)
+        ).toBeHidden()
+      }
+    )
   }
 )

--- a/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphPromotion.spec.ts
@@ -564,15 +564,12 @@ test.describe(
       { tag: '@vue-nodes' },
       async ({ comfyPage }) => {
         await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Top')
-        await comfyPage.workflow.loadWorkflow('default')
-        await comfyPage.vueNodes.waitForNodes()
 
         const clipFixture = await comfyPage.vueNodes.getFixtureByTitle(
           'CLIP Text Encode (Prompt)'
         )
         await comfyPage.contextMenu.openForVueNode(clipFixture.header)
         await comfyPage.contextMenu.clickMenuItemExact('Convert to Subgraph')
-        await comfyPage.contextMenu.waitForHidden()
 
         const subgraphNode = comfyPage.vueNodes
           .getNodeByTitle('New Subgraph')
@@ -593,16 +590,12 @@ test.describe(
         await expect.poll(() => comfyPage.subgraph.isInSubgraph()).toBe(true)
         await comfyPage.vueNodes.waitForNodes()
 
-        const interiorClipId = await comfyPage.vueNodes.getNodeIdByTitle(
+        const interiorClip = await comfyPage.vueNodes.getFixtureByTitle(
           'CLIP Text Encode (Prompt)'
         )
-        await comfyPage.vueNodes.deleteNode(interiorClipId)
-        await expect(
-          comfyPage.vueNodes.getNodeLocator(interiorClipId)
-        ).toBeHidden()
+        await interiorClip.delete()
 
         await comfyPage.subgraph.exitViaBreadcrumb()
-        await comfyPage.vueNodes.waitForNodes()
 
         const subgraphNodeAfter =
           comfyPage.vueNodes.getNodeLocator(subgraphNodeId)


### PR DESCRIPTION
## Summary

Adds a failing test for a current bug with subgraphs where deleting an inner node where the widget is promoted does not remove the outer widget

## Changes

- **What**: 
- add failing test

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12058-test-add-failing-test-for-deleting-inner-nodes-with-promoted-widgets-3596d73d3650811f9629c0ed3f4bc3c8) by [Unito](https://www.unito.io)
