### PR TITLE
fix(website): prevent video glitch when c-projection.webp loads on /customers

### DIFF
--- a/apps/website/e2e/customers.spec.ts
+++ b/apps/website/e2e/customers.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/blockExternalMedia'
+
+test.describe('Customers @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/customers')
+  })
+
+  test('hero image declares intrinsic dimensions so layout reserves space before load', async ({
+    page
+  }) => {
+    const heroImage = page.locator('img[alt="Comfy 3D logo"]')
+    await expect(heroImage).toBeVisible()
+    await expect(heroImage).toHaveAttribute('width', /^\d+$/)
+    await expect(heroImage).toHaveAttribute('height', /^\d+$/)
+
+    // Regression guard: an unloaded <img> without intrinsic dimensions
+    // collapses to ~0px, then jumps to its natural size on load and pushes
+    // the video below it. Reserved space must persist before bytes arrive.
+    const heightWhileUnloaded = await page.evaluate(() => {
+      const img = document.querySelector<HTMLImageElement>(
+        'img[alt="Comfy 3D logo"]'
+      )
+      if (!img) return null
+      img.removeAttribute('src')
+      return img.getBoundingClientRect().height
+    })
+
+    expect(heightWhileUnloaded).not.toBeNull()
+    expect(heightWhileUnloaded!).toBeGreaterThan(100)
+  })
+})

--- a/apps/website/src/components/customers/HeroSection.vue
+++ b/apps/website/src/components/customers/HeroSection.vue
@@ -25,7 +25,7 @@ useHeroAnimation({
 })
 
 function handleLogoLoad() {
-  ScrollTrigger.refresh()
+  ScrollTrigger.refresh(true)
 }
 </script>
 

--- a/apps/website/src/components/customers/HeroSection.vue
+++ b/apps/website/src/components/customers/HeroSection.vue
@@ -5,6 +5,7 @@ import { useHeroAnimation } from '../../composables/useHeroAnimation'
 import SectionLabel from '../common/SectionLabel.vue'
 import type { Locale } from '../../i18n/translations'
 import { t } from '../../i18n/translations'
+import { ScrollTrigger } from '../../scripts/gsapSetup'
 import VideoPlayer from '../common/VideoPlayer.vue'
 
 const { locale = 'en' } = defineProps<{ locale?: Locale }>()
@@ -22,6 +23,10 @@ useHeroAnimation({
   logo: logoRef,
   video: videoRef
 })
+
+function handleLogoLoad() {
+  ScrollTrigger.refresh()
+}
 </script>
 
 <template>
@@ -37,7 +42,10 @@ useHeroAnimation({
         <img
           src="https://media.comfy.org/website/customers/c-projection.webp"
           alt="Comfy 3D logo"
-          class="mx-auto w-full max-w-md lg:max-w-none"
+          width="1568"
+          height="1763"
+          class="mx-auto h-auto w-full max-w-md lg:max-w-none"
+          @load="handleLogoLoad"
         />
       </div>
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fix the video position glitch on `/customers` caused by `c-projection.webp` loading.

## Root cause

In `HeroSection.vue` the hero `<img>` for `c-projection.webp` had no `width`/`height` attributes, so the browser reserved no space for it. When the image finished loading, the layout shifted ~192px, pushing the `VideoPlayer` below it. `useHeroAnimation` registers a GSAP `ScrollTrigger` parallax against the video in `onMounted` (before the image is loaded), so the cached scroll geometry then went stale and the video visibly glitched.

## Fix

- Add explicit `width="1568"` / `height="1763"` to the `<img>` (the image's native size) so the browser reserves the correct aspect-ratio'd space upfront.
- Add `h-auto` so the height attribute doesn't override the responsive layout.
- Refresh `ScrollTrigger` on the image's `@load` (with `refresh(true)` so measurements happen after layout has settled) as a defensive measure for any sub-pixel adjustments.

## Test coverage

Added `apps/website/e2e/customers.spec.ts` with a regression guard that:
1. Asserts the hero `<img>` declares numeric `width`/`height` attributes.
2. Asserts the unloaded image still reserves vertical space (>100px), which is the exact property that prevents the video from jumping when the image finishes loading.

Verified the test fails when the `width`/`height` attributes are removed and passes with the fix applied.

## Verification

- `pnpm typecheck` clean.
- `pnpm test:unit` (website app) — 30/30 pass.
- `pnpm test:e2e customers.spec.ts --project=desktop` — passes.
- ESLint + oxfmt clean on changed files.
- Manual Playwright verification confirmed the video bounding rect stays at `top=785, height=628` through the full image load lifecycle. Reverting the fix in DevTools and re-loading the image reproduces the original ~192px shift.

## Out of scope

`apps/website/src/components/contact/FormSection.vue` uses the same `c-projection.webp` pattern (also without `width`/`height`). It runs `useHeroAnimation` with `parallax: false`, so the symptom is much smaller — leaving as a follow-up to keep this PR minimal.

- Fixes [FE-607](https://linear.app/comfyorg/issue/FE-607/bug-video-on-customers-shifts-position-when-c-projectionwebp-finishes)

## Screenshots

![/customers page rendered with the fix applied — video stays in correct position below the hero](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/0ecf73b69b644739e2bdcce0e77bbe7eb44562f7643b82addc8903d68d25fef3/pr-images/1778167649187-841bf1fa-f3a7-4104-9dab-a024e62dcf4d.jpg)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12060-fix-website-prevent-video-glitch-when-c-projection-webp-loads-on-customers-3596d73d365081ebbcb8db25aaa5c451) by [Unito](https://www.unito.io)
