### PR TITLE
fix: surface error dialog when Open Workflow from Job Queue fails (FE-215)

### DIFF
--- a/src/composables/queue/useJobMenu.test.ts
+++ b/src/composables/queue/useJobMenu.test.ts
@@ -246,6 +246,24 @@ describe('useJobMenu', () => {
     expect(workflowServiceMock.openWorkflow).not.toHaveBeenCalled()
   })
 
+  it('surfaces an error dialog when workflow open fails', async () => {
+    const { openJobWorkflow } = mountJobMenu()
+    const workflow = { nodes: [{ type: 'rgthree.DisplayAny' }] }
+    getJobWorkflowMock.mockResolvedValue(workflow)
+    const loadError = new Error('configure() failed: malformed widget')
+    workflowServiceMock.openWorkflow.mockRejectedValueOnce(loadError)
+    setCurrentItem(createJobItem({ id: '77' }))
+
+    await expect(openJobWorkflow()).resolves.toBeUndefined()
+
+    expect(dialogServiceMock.showErrorDialog).toHaveBeenCalledWith(
+      loadError,
+      expect.objectContaining({
+        reportType: 'queueOpenWorkflowError'
+      })
+    )
+  })
+
   it('copies job id to clipboard', async () => {
     const { copyJobId } = mountJobMenu()
     setCurrentItem(createJobItem({ id: 'job-99' }))

--- a/src/composables/queue/useJobMenu.ts
+++ b/src/composables/queue/useJobMenu.ts
@@ -63,7 +63,14 @@ export function useJobMenu(
     if (!data) return
     const filename = `Job ${target.id}.json`
     const temp = workflowStore.createTemporary(filename, data)
-    await workflowService.openWorkflow(temp)
+    try {
+      await workflowService.openWorkflow(temp)
+    } catch (error) {
+      useDialogService().showErrorDialog(error, {
+        title: t('errorDialog.queueOpenWorkflowFailedTitle'),
+        reportType: 'queueOpenWorkflowError'
+      })
+    }
   }
 
   const copyJobId = async (item?: JobListItem | null) => {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1903,6 +1903,7 @@
   "errorDialog": {
     "defaultTitle": "An error occurred",
     "loadWorkflowTitle": "Loading aborted due to error reloading workflow data",
+    "queueOpenWorkflowFailedTitle": "Failed to Open Workflow",
     "noStackTrace": "No stacktrace available",
     "extensionFileHint": "This may be due to the following script",
     "promptExecutionError": "Prompt execution failed",


### PR DESCRIPTION
## Summary

`openJobWorkflow` (Job Queue → "Open Workflow in New Tab") had no error handling around `workflowService.openWorkflow`. When workflow JSON contained nodes that fail `LiteGraph.configure()` (e.g. rgthree `DisplayAny`, stale `GetNode/SetNode aux_id`), the menu action appeared to do nothing — either an early return after a generic "Load Workflow Error" dialog (`app.ts:1340-1347`) or a context-less toast from the surrounding `wrapWithErrorHandlingAsync`.

This PR catches the error inside `openJobWorkflow` and routes it to `dialogService.showErrorDialog` with a Job-Queue-specific `reportType` so users get a clear, actionable message tied to the action they invoked.

- Fixes #8841
- Linear: [FE-215](https://linear.app/comfyorg/issue/FE-215/open-workflow-from-frontend-not-working)

## Red-Green Verification

| Commit | CI Status | Run |
|--------|-----------|-----|
| `test: add failing test for openJobWorkflow swallowing load errors` (a422b392d) | :red_circle: failure | https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/25531063427 |
| `fix: surface error dialog when Open Workflow from Job Queue fails` (86b2a3a9) | :green_circle: success | https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/25531374096 |

## Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [ ] Manual: load a workflow containing rgthree `DisplayAny` from Job Queue → "Open Workflow in New Tab" → confirm error dialog appears with Job-Queue context instead of nothing
<img width="972" height="662" alt="Screenshot 2026-05-13 at 5 58 31 PM" src="https://github.com/user-attachments/assets/bf1d8d96-85b7-47a8-89d8-b3bb69a526cb" />
