### PR TITLE
fix: restore nightly publish_types build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:cloud": "cross-env DISTRIBUTION=cloud NODE_OPTIONS='--max-old-space-size=8192' nx build",
     "build:desktop": "nx build @comfyorg/desktop-ui",
     "build-storybook": "storybook build",
-    "build:types": "nx build --config vite.types.config.mts && node scripts/prepare-types.js",
+    "build:types": "cross-env NODE_OPTIONS='--max-old-space-size=8192' nx build --config vite.types.config.mts && node scripts/prepare-types.js",
     "build:analyze": "cross-env ANALYZE_BUNDLE=true pnpm build",
     "build": "cross-env NODE_OPTIONS='--max-old-space-size=8192' pnpm typecheck && nx build",
     "size:collect": "node scripts/size-collect.js",


### PR DESCRIPTION
## Summary

The nightly `Release Draft Create` -> `publish_types / Build types` job has been failing on every run since 1.45.1 ([failed run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/25531376650)). Reproduced locally on `main` (`c8c0e5386`).

## Root cause

`pnpm build:types` ends with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`. The `vite-plugin-dts` rolled-up type generation now exceeds Node's default ~4GB heap on the GH runner. The `TS2742`/`TS4082` warnings printed earlier are non-fatal diagnostics from the plugin pre-pass — the api-extractor rollup itself completes once the heap is large enough.

## Fix

Set `NODE_OPTIONS='--max-old-space-size=8192'` in `build:types`, matching the existing pattern already used by `build` and `build:cloud` (only one-line change).

## Verification

- `pnpm build:types` exits 0 locally with the change (built in ~40s).
- `dist/index.d.ts` (1.9MB) emitted with the public types intact: `ComfyExtension`, `ComfyApi`, `ComfyApp`, `ComfyNodeDef`, `InputSpec`, `DOMWidget`, etc.
- `dist/package.json` correctly produced by `scripts/prepare-types.js`.
- Reverting the change reproduces the OOM crash.

## Test plan

- [ ] Trigger `Release NPM Types` workflow manually (or wait for next nightly) and confirm `Build types` step succeeds.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12073-fix-restore-nightly-publish_types-build-35a6d73d3650819e95aecfbd8a66847c) by [Unito](https://www.unito.io)
