### PR TITLE
fix: remove team workspace teaser from personal pricing table

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2341,8 +2341,6 @@
     "plansForWorkspace": "Plans for {workspace}",
     "personalWorkspace": "Personal Workspace",
     "teamWorkspace": "Team Workspace",
-    "soloUseOnly": "Solo use only",
-    "needTeamWorkspace": "Need team workspace?",
     "inviteUpTo": "Invite up to",
     "title": "Subscription",
     "titleUnsubscribed": "Subscribe to Comfy Cloud",

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -151,8 +151,6 @@ const i18n = createI18n({
         videoEstimateHelp: 'How is this calculated?',
         videoEstimateExplanation: 'Based on average usage.',
         videoEstimateTryTemplate: 'Try template',
-        soloUseOnly: 'Solo use only',
-        needTeamWorkspace: 'Need team workspace?',
         maxDuration: {
           standard: '30 min',
           creator: '30 min',
@@ -177,9 +175,6 @@ const i18n = createI18n({
 
 function renderComponent() {
   return render(PricingTable, {
-    props: {
-      onChooseTeamWorkspace: onChooseTeamWorkspace
-    },
     global: {
       plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
       components: {
@@ -209,8 +204,6 @@ function renderComponent() {
     }
   })
 }
-
-const onChooseTeamWorkspace = vi.fn()
 
 describe('PricingTable', () => {
   beforeEach(() => {
@@ -421,22 +414,6 @@ describe('PricingTable', () => {
       await flushPromises()
 
       expect(mockAccessBillingPortal).toHaveBeenCalledWith('standard-yearly')
-    })
-  })
-
-  describe('team workspace link', () => {
-    it('should emit chooseTeamWorkspace when clicking "Need team workspace?" link', async () => {
-      renderComponent()
-      await flushPromises()
-
-      const teamLink = screen
-        .getAllByRole('button')
-        .find((b) => b.textContent?.includes('Need team workspace?'))
-
-      expect(teamLink).toBeDefined()
-      await userEvent.click(teamLink!)
-
-      expect(onChooseTeamWorkspace).toHaveBeenCalledOnce()
     })
   })
 })

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -95,21 +95,6 @@
             </div>
           </div>
 
-          <p
-            role="note"
-            :aria-label="t('subscription.soloUseOnly')"
-            class="m-0 flex h-10 items-center rounded-lg bg-muted-foreground/30 px-3 text-sm text-muted-foreground"
-          >
-            {{ t('subscription.soloUseOnly') }}
-            <span class="mx-1 text-muted-foreground">–</span>
-            <button
-              class="text-primary-foreground cursor-pointer border-none bg-transparent p-0 text-sm font-medium underline hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
-              @click="emit('chooseTeamWorkspace')"
-            >
-              {{ t('subscription.needTeamWorkspace') }}
-            </button>
-          </p>
-
           <div class="flex flex-1 flex-col gap-3 pb-0">
             <div class="flex flex-row items-center justify-between">
               <span
@@ -317,10 +302,6 @@ interface PricingTierConfig {
   customLoRAs: boolean
   isPopular?: boolean
 }
-
-const emit = defineEmits<{
-  chooseTeamWorkspace: []
-}>()
 
 const { t, n } = useI18n()
 

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -33,7 +33,7 @@
       </i18n-t>
     </div>
 
-    <PricingTable class="flex-1" @choose-team-workspace="handleChooseTeam" />
+    <PricingTable class="flex-1" />
 
     <!-- Contact and Enterprise Links -->
     <div class="flex flex-col items-center gap-2">
@@ -159,10 +159,9 @@ import { useTelemetry } from '@/platform/telemetry'
 import { useCommandStore } from '@/stores/commandStore'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 
-const { onClose, reason, onChooseTeam } = defineProps<{
+const { onClose, reason } = defineProps<{
   onClose: () => void
   reason?: SubscriptionDialogReason
-  onChooseTeam?: () => void
 }>()
 
 const emit = defineEmits<{
@@ -201,14 +200,6 @@ watch(
 
 const handleSubscribed = () => {
   emit('close', true)
-}
-
-const handleChooseTeam = () => {
-  if (onChooseTeam) {
-    onChooseTeam()
-  } else {
-    onClose()
-  }
 }
 
 const handleClose = () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -43,12 +43,7 @@ export const useSubscriptionDialog = () => {
             import('@/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue')
         )
 
-    const personalProps = {
-      onClose: hide,
-      reason: options?.reason,
-      onChooseTeam: () => startTeamWorkspaceUpgradeFlow()
-    }
-    const workspaceProps = {
+    const dialogProps = {
       onClose: hide,
       reason: options?.reason
     }
@@ -56,7 +51,7 @@ export const useSubscriptionDialog = () => {
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,
       component,
-      props: useWorkspaceVariant ? workspaceProps : personalProps,
+      props: dialogProps,
       dialogComponentProps: {
         style: 'width: min(1328px, 95vw); max-height: 958px;',
         pt: {


### PR DESCRIPTION
## Summary

The personal pricing table previously showed a "Solo use only — Need team workspace?" CTA that teased team workspaces. Since team workspaces shipped via a different release path, the teaser is no longer relevant in the personal workspace flow.

## Changes

- **What**: Removed the team workspace hint section (and its associated emit/prop chain) from PricingTable, SubscriptionRequiredDialogContent, and useSubscriptionDialog. Cleaned up the unused i18n strings (`subscription.soloUseOnly`, `subscription.needTeamWorkspace`) and the corresponding test.

## Review Focus

- `useSubscriptionDialog.startTeamWorkspaceUpgradeFlow` and `resumePendingPricingFlow` are intentionally retained — `resumePendingPricingFlow` is still wired in `WorkspaceAuthGate.vue`.

Closes BE-837