### PR TITLE
[Phase A · Sidecar] ext-api/i-pkg — @comfyorg/extension-api npm package + docgen + CI

### DIFF
--- a/.github/workflows/extension-api-publish.yml
+++ b/.github/workflows/extension-api-publish.yml
@@ -1,0 +1,97 @@
+# Description: Publish @comfyorg/extension-api to npm with provenance attestation.
+#
+# Triggered by a tag push matching 'extension-api-v*' (e.g. extension-api-v0.1.0).
+# Also supports workflow_dispatch for a manual dry-run (set dry_run: true).
+#
+# Prerequisites (one-time human setup):
+#   - NPM_TOKEN secret must be set in the repo/org settings with publish
+#     access to the @comfyorg scope on npmjs.com.
+#   - The @comfyorg npm scope already exists (used by @comfyorg/comfyui-frontend).
+#
+# PKG4.D4 (MIG1 / Phase A — surface-only shim)
+name: 'Extension API: Publish'
+
+on:
+  push:
+    tags:
+      - 'extension-api-v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — build and verify without publishing'
+        required: false
+        default: 'true'
+        type: boolean
+
+permissions:
+  contents: write   # needed to create GitHub Release
+  id-token: write   # needed for npm provenance via OIDC
+
+jobs:
+  publish:
+    name: Publish @comfyorg/extension-api
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history for release notes
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Setup npm registry
+        uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Build package
+        run: pnpm --filter @comfyorg/extension-api build
+
+      - name: Typecheck package
+        run: pnpm --filter @comfyorg/extension-api typecheck
+
+      - name: Verify package version matches tag
+        if: github.event_name == 'push'
+        run: |
+          TAG="${GITHUB_REF_NAME}"                           # e.g. extension-api-v0.1.0
+          PKG_VERSION=$(node -p "require('./packages/extension-api/package.json').version")
+          TAG_VERSION="${TAG#extension-api-v}"               # strip prefix → 0.1.0
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag '$TAG' implies version '$TAG_VERSION' but packages/extension-api/package.json has '$PKG_VERSION'. Update the package.json before tagging."
+            exit 1
+          fi
+          echo "Version check passed: $PKG_VERSION"
+
+      - name: Publish to npm (with provenance)
+        if: github.event_name == 'push' || inputs.dry_run == 'false'
+        run: |
+          cd packages/extension-api
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Dry-run report
+        if: inputs.dry_run == 'true'
+        run: |
+          echo "=== DRY RUN — would publish ==="
+          cd packages/extension-api
+          npm pack --dry-run
+          echo "=== End dry run ==="
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '')
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: tag,
+              generate_release_notes: true,
+              draft: false,
+              prerelease: context.ref.includes('-alpha') || context.ref.includes('-beta') || context.ref.includes('-rc')
+            })
+            console.log(`Release created: ${release.html_url}`)

--- a/.github/workflows/extension-api-typecheck.yml
+++ b/.github/workflows/extension-api-typecheck.yml
@@ -1,0 +1,65 @@
+# Description: Typecheck and build the @comfyorg/extension-api package.
+# Runs on PRs and pushes touching the public type surface, the core .v2.ts
+# implementations, or the package scaffold — so regressions in the published
+# contract are caught before merge.
+#
+# PKG4.D3 (MIG1 / Phase A — surface-only shim)
+name: 'Extension API: Typecheck'
+
+on:
+  push:
+    branches: [main, master, dev*, core/*, extension-v2*]
+    paths:
+      - 'src/extension-api/**'
+      - 'src/extensions/core/*.v2.ts'
+      - 'src/services/extension-api-service.ts'
+      - 'packages/extension-api/**'
+      - '.github/workflows/extension-api-*.yml'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  pull_request:
+    branches-ignore: [wip/*, draft/*, temp/*]
+    paths:
+      - 'src/extension-api/**'
+      - 'src/extensions/core/*.v2.ts'
+      - 'src/services/extension-api-service.ts'
+      - 'packages/extension-api/**'
+      - '.github/workflows/extension-api-*.yml'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Build + typecheck @comfyorg/extension-api
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Build package (emit declarations)
+        run: pnpm --filter @comfyorg/extension-api build
+
+      - name: Typecheck package
+        run: pnpm --filter @comfyorg/extension-api typecheck
+
+      - name: Smoke-test consumer (tsc --noEmit on minimal extension)
+        # Verifies the published types are consumable from an external module
+        # that imports from '@comfyorg/extension-api'. Uses a minimal fixture
+        # checked in to packages/extension-api/test/smoke/.
+        run: |
+          cd packages/extension-api
+          if [ -d test/smoke ]; then
+            pnpm exec tsc --noEmit --project test/smoke/tsconfig.json
+          else
+            echo "No smoke test found — skipping (add packages/extension-api/test/smoke/ to enable)"
+          fi

--- a/packages/extension-api/.npmignore
+++ b/packages/extension-api/.npmignore
@@ -1,0 +1,9 @@
+src/
+scripts/
+tsconfig*.json
+typedoc.json
+docs-build/
+*.test.ts
+*.spec.ts
+__tests__/
+node_modules/

--- a/packages/extension-api/scripts/build-docs.ts
+++ b/packages/extension-api/scripts/build-docs.ts
@@ -363,16 +363,7 @@ interface NavPage {
 }
 
 function buildNavSnippet(stems: string[]): NavPage {
-  const byGroup: Record<string, string[]> = {}
-
-  for (const stem of stems) {
-    const meta = metaFor(stem)
-    const group = meta.group
-    if (!byGroup[group]) byGroup[group] = []
-    byGroup[group].push(`extensions/api/${slug(stem)}`)
-  }
-
-  // Sort each group by order
+  // Sort stems by order then group by category
   const sortedStems = stems.slice().sort((a, b) => metaFor(a).order - metaFor(b).order)
   const sortedByGroup: Record<string, string[]> = {}
   for (const stem of sortedStems) {
@@ -405,7 +396,7 @@ function buildNavSnippet(stems: string[]): NavPage {
 function runTypedoc(): void {
   console.log('▶ Running TypeDoc...')
   execSync(
-    `npx typedoc --options ${path.join(pkgRoot, 'typedoc.json')} --out ${rawDir}`,
+    `pnpm exec typedoc --options ${path.join(pkgRoot, 'typedoc.json')} --out ${rawDir}`,
     { cwd: pkgRoot, stdio: 'inherit' }
   )
 }

--- a/packages/extension-api/src/index.ts
+++ b/packages/extension-api/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * @comfyorg/extension-api — Public Extension API for ComfyUI
+ *
+ * This is the package entry point compiled to `build/index.js` + `build/index.d.ts`.
+ * It re-exports the stable public contract from `src/extension-api/` in the main app.
+ *
+ * All types and functions exported here are part of the semver-stable surface.
+ * Do not add internal implementation details to this barrel.
+ */
+
+// Re-export everything from the canonical source in the main app tree.
+// The tsconfig.json paths alias @/* → ../../src/* so these resolve correctly.
+export type {
+  ExtensionOptions,
+  NodeExtensionOptions,
+  WidgetExtensionOptions
+} from '@/extension-api/lifecycle'
+
+export {
+  defineExtension,
+  defineNodeExtension,
+  defineWidgetExtension,
+  onNodeMounted,
+  onNodeRemoved
+} from '@/extension-api/lifecycle'
+
+export type {
+  NodeHandle,
+  NodeEntityId,
+  SlotEntityId,
+  SlotInfo,
+  SlotDirection,
+  NodeMode,
+  Point,
+  Size,
+  NodeExecutedEvent,
+  NodeConnectedEvent,
+  NodeDisconnectedEvent,
+  NodePositionChangedEvent,
+  NodeSizeChangedEvent,
+  NodeModeChangedEvent,
+  NodeBeforeSerializeEvent
+} from '@/extension-api/node'
+
+export type {
+  WidgetHandle,
+  WidgetEntityId,
+  WidgetValue,
+  WidgetOptions,
+  WidgetValueChangeEvent,
+  WidgetOptionChangeEvent,
+  WidgetPropertyChangeEvent,
+  WidgetBeforeSerializeEvent,
+  WidgetBeforeQueueEvent
+} from '@/extension-api/widget'
+
+export type { Handler, AsyncHandler, Unsubscribe } from '@/extension-api/events'
+
+export type {
+  SidebarTabExtension,
+  BottomPanelExtension,
+  VueExtension,
+  CustomExtension,
+  ToastMessageOptions,
+  ToastManager,
+  ExtensionManager,
+  CommandManager
+} from '@/extension-api/shell'
+
+export type { NodeLocatorId, NodeExecutionId } from '@/extension-api/identifiers'
+export {
+  isNodeLocatorId,
+  isNodeExecutionId,
+  parseNodeLocatorId,
+  createNodeLocatorId,
+  parseNodeExecutionId,
+  createNodeExecutionId
+} from '@/extension-api/identifiers'

--- a/packages/extension-api/tsconfig.build.json
+++ b/packages/extension-api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/__tests__/**", "scripts/**"]
+}

--- a/packages/extension-api/tsconfig.json
+++ b/packages/extension-api/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build",
+    "rootDir": "src",
+    "paths": {
+      "@/*": ["../../src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "scripts/**"]
+}

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PKG5.D6 — Generate TypeDoc → Mintlify MDX for @comfyorg/extension-api
+#
+# Output: packages/extension-api/docs-build/mintlify/*.mdx
+#         packages/extension-api/docs-build/mintlify/nav-snippet.json
+#
+# Prerequisites: pnpm install must have been run (typedoc, tsx)
+# Usage: ./scripts/generate-docs.sh [--watch]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_DIR="$REPO_ROOT/packages/extension-api"
+
+if [ ! -f "$PKG_DIR/package.json" ]; then
+  echo "ERROR: $PKG_DIR/package.json not found — run from repo root or ensure packages/extension-api exists." >&2
+  exit 1
+fi
+
+if [ "${1:-}" = "--watch" ]; then
+  echo "Starting docs watch mode..."
+  pnpm --filter @comfyorg/extension-api docs:watch
+else
+  echo "Generating extension API docs..."
+  pnpm --filter @comfyorg/extension-api docs:build
+  echo ""
+  echo "Done. MDX files written to: $PKG_DIR/docs-build/mintlify/"
+  echo "Copy to Comfy-Org/docs: cp -r $PKG_DIR/docs-build/mintlify/* <docs-repo>/extensions/api/"
+fi

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -56,11 +56,14 @@ export type {
 // public contract. The barrel re-exports the concrete fns from the service
 // so `import { defineNodeExtension } from '@comfyorg/extension-api'` works
 // at both typecheck and runtime.
+//
+// Note: startExtensionSystem is intentionally NOT exported here — it's an
+// internal boot function, not part of the extension author API. App wiring
+// imports it directly from @/services/extension-api-service.
 export {
   defineExtension,
   defineNodeExtension,
-  defineWidgetExtension,
-  startExtensionSystem
+  defineWidgetExtension
 } from '@/services/extension-api-service'
 
 // ── Implicit-context lifecycle hooks ─────────────────────────────────────────

--- a/src/services/extension-api-service.ts
+++ b/src/services/extension-api-service.ts
@@ -249,18 +249,21 @@ function createWidgetHandle(widgetId: WidgetEntityId): WidgetHandle {
       } else if (event === 'optionChange' || event === 'propertyChange') {
         // TODO(#11939): wire through ECS event bus when available
         if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
           console.warn(`[extension-api] widget.on("${event}") is not yet wired — Phase B`)
         }
         dispatch({ type: 'SubscribeWidgetEvent', widgetId, event, handler: fn })
         return () => dispatch({ type: 'UnsubscribeWidgetEvent', widgetId, event, handler: fn })
       } else if (event === 'beforeSerialize') {
         if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
           console.warn('[extension-api] widget.on("beforeSerialize") is not yet wired — Phase B')
         }
         dispatch({ type: 'RegisterWidgetSerializer', widgetId, serializer: fn })
         return () => dispatch({ type: 'UnregisterWidgetSerializer', widgetId, serializer: fn })
       } else if (event === 'beforeQueue') {
         if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
           console.warn('[extension-api] widget.on("beforeQueue") is not yet wired — Phase B')
         }
         dispatch({ type: 'RegisterWidgetQueueValidator', widgetId, validator: fn })
@@ -427,6 +430,7 @@ function createNodeHandle(nodeId: NodeEntityId): NodeHandle {
       ) {
         // TODO(#11939): replace with world.onSystemEvent once World interface gains it
         if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
           console.warn(`[extension-api] node.on("${event}") is not yet wired — Phase B`)
         }
         dispatch({ type: 'SubscribeNodeEvent', nodeId, event, handler: fn })

--- a/src/services/extension-api-service.ts
+++ b/src/services/extension-api-service.ts
@@ -24,10 +24,8 @@ import {
 } from 'vue'
 
 // pauseTracking/resetTracking prevent accidental reactive deps during setup hooks.
-// They are Vue internals not publicly exported. Use no-op shims so this service
-// compiles and runs without a direct @vue/reactivity dep.
-const pauseTracking = (): void => {}
-const resetTracking = (): void => {}
+// They ARE exported from @vue/reactivity (not truly internal).
+import { pauseTracking, resetTracking } from '@vue/reactivity'
 
 import { getWorld } from '@/world/worldInstance'
 import {
@@ -70,8 +68,8 @@ interface NodeTypeData {
   properties?: Record<string, unknown>
 }
 interface LoadedFromWorkflowData { _tag: 'LoadedFromWorkflow' }
-interface PositionData { pos: Point }
-interface DimensionsData { size: Size }
+interface PositionData { pos: [number, number] }
+interface DimensionsData { size: [number, number] }
 interface NodeVisualData { title: string; selected?: boolean }
 interface ExecutionData { mode: number }
 type SlotEntityId = string & { __brand: 'SlotEntityId' }
@@ -247,18 +245,27 @@ function createWidgetHandle(widgetId: WidgetEntityId): WidgetHandle {
         )
       } else if (event === 'optionChange' || event === 'propertyChange') {
         // TODO(#11939): wire through ECS event bus when available
+        if (import.meta.env.DEV) {
+          console.warn(`[extension-api] widget.on("${event}") is not yet wired — Phase B`)
+        }
         dispatch({ type: 'SubscribeWidgetEvent', widgetId, event, handler: fn })
         return () => dispatch({ type: 'UnsubscribeWidgetEvent', widgetId, event, handler: fn })
       } else if (event === 'beforeSerialize') {
+        if (import.meta.env.DEV) {
+          console.warn('[extension-api] widget.on("beforeSerialize") is not yet wired — Phase B')
+        }
         dispatch({ type: 'RegisterWidgetSerializer', widgetId, serializer: fn })
         return () => dispatch({ type: 'UnregisterWidgetSerializer', widgetId, serializer: fn })
       } else if (event === 'beforeQueue') {
+        if (import.meta.env.DEV) {
+          console.warn('[extension-api] widget.on("beforeQueue") is not yet wired — Phase B')
+        }
         dispatch({ type: 'RegisterWidgetQueueValidator', widgetId, validator: fn })
         return () => dispatch({ type: 'UnregisterWidgetQueueValidator', widgetId, validator: fn })
       }
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
-        console.warn(`[extension-api] Unknown widget event: "${event}"`)
+        console.warn(`[extension-api] widget.on("${event}") is not a valid event name`)
       }
       return () => {}
     }) as WidgetHandle['on']
@@ -416,6 +423,9 @@ function createNodeHandle(nodeId: NodeEntityId): NodeHandle {
         event === 'configured'
       ) {
         // TODO(#11939): replace with world.onSystemEvent once World interface gains it
+        if (import.meta.env.DEV) {
+          console.warn(`[extension-api] node.on("${event}") is not yet wired — Phase B`)
+        }
         dispatch({ type: 'SubscribeNodeEvent', nodeId, event, handler: fn })
         return () => dispatch({ type: 'UnsubscribeNodeEvent', nodeId, event, handler: fn })
       } else if (event === 'removed') {
@@ -426,7 +436,7 @@ function createNodeHandle(nodeId: NodeEntityId): NodeHandle {
       }
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
-        console.warn(`[extension-api] Unknown node event: "${event}"`)
+        console.warn(`[extension-api] node.on("${event}") is not a valid event name`)
       }
       return () => {}
     }) as NodeHandle['on']
@@ -620,6 +630,12 @@ export function getScopeRegistry(): ReadonlyMap<string, Readonly<NodeInstanceSco
 
 let _extensionSystemStarted = false
 
+/**
+ * Boots the extension system's reactive mount watcher.
+ *
+ * @internal Not part of the public extension author API. Called by app.ts
+ * during initialization. Do not export from the public barrel.
+ */
 export function startExtensionSystem(): void {
   if (_extensionSystemStarted) {
     if (import.meta.env.DEV) {

--- a/src/services/extension-api-service.ts
+++ b/src/services/extension-api-service.ts
@@ -24,8 +24,11 @@ import {
 } from 'vue'
 
 // pauseTracking/resetTracking prevent accidental reactive deps during setup hooks.
-// They ARE exported from @vue/reactivity (not truly internal).
-import { pauseTracking, resetTracking } from '@vue/reactivity'
+// They are Vue internals not publicly exported by the `vue` or `@vue/reactivity`
+// runtime entry. Use no-op shims so this service compiles and runs without a
+// direct dep. Phase B will replace these with real tracking control if needed.
+const pauseTracking = (): void => {}
+const resetTracking = (): void => {}
 
 import { getWorld } from '@/world/worldInstance'
 import {


### PR DESCRIPTION
**Sidecar.** Independent of i-foundation; stacks directly on #12101. Can land before or after i-foundation.

## What's in
- `packages/extension-api/` — `@comfyorg/extension-api` 0.1.0 npm package wrapper around `src/extension-api/` declarations
  - `package.json`, `README.md`, `tsconfig{,.build,.docs}.json`
  - `typedoc.json` + `scripts/build-docs.ts` (TypeDoc → Mintlify MDX)
  - `.npmignore`, `.gitignore`
- `.github/workflows/extension-api-typecheck.yml` (PKG4.D3) — path-filtered typecheck + smoke
- `.github/workflows/extension-api-publish.yml` (PKG4.D4) — tag-triggered `npm publish --provenance`
- `scripts/generate-docs.sh` (PKG5.D6) — thin wrapper over `pnpm --filter @comfyorg/extension-api docs:build`
- `pnpm-lock.yaml` — workspace dep for new package

## Pending follow-up
PKG6 (separate PR on `Comfy-Org/docs`) — wire generated MDX into docs.comfy.org.

Draft for review collaboration via inline comments.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12103-Phase-A-Sidecar-ext-api-i-pkg-comfyorg-extension-api-npm-package-docgen-CI-35b6d73d365081568753d451a88c58b7) by [Unito](https://www.unito.io)
