### PR TITLE
[Phase A · Child] ext-api/i-ext — three new core extension conversions (I-EXT)

### DIFF
--- a/src/extension-api-v2/harness.ts
+++ b/src/extension-api-v2/harness.ts
@@ -1,19 +1,16 @@
 /**
- * Test harness for v1/v2 extension compatibility tests.
- * Provides minimal World + MiniGraph + MiniComfyApp stubs for proof-of-concept tests.
+ * Test harness stubs for v1 contract tests.
  *
- * Phase A limitation: These are minimal stubs. Phase B will provide a full
- * eval sandbox + LiteGraph prototype wiring for real behavioral tests.
+ * Phase A limitation: These are minimal stubs to make tests compile.
+ * Real implementations land with Phase B (ECS substrate + eval sandbox).
  */
 
-type NodeEntityId = string
+import type { NodeEntityId } from '@/world/entityIds'
 
 interface HarnessWorld {
   findNode(id: NodeEntityId): { type: string } | undefined
-  allNodes(): NodeEntityId[]
+  allNodes(): { type: string }[]
   clear(): void
-  _addNode(id: NodeEntityId, data: { type: string }): void
-  _removeNode(id: NodeEntityId): void
 }
 
 interface MiniGraph {
@@ -25,69 +22,51 @@ interface MiniComfyApp {
   graph: MiniGraph
 }
 
-/**
- * Creates a minimal harness World for testing.
- */
-export function createHarnessWorld(): HarnessWorld {
-  const nodes = new Map<NodeEntityId, { type: string }>()
+const nodes = new Map<NodeEntityId, { type: string }>()
+let nodeCounter = 0
 
+export function createHarnessWorld(): HarnessWorld {
+  nodes.clear()
+  nodeCounter = 0
   return {
     findNode(id: NodeEntityId) {
       return nodes.get(id)
     },
     allNodes() {
-      return [...nodes.keys()]
+      return [...nodes.values()]
     },
     clear() {
       nodes.clear()
-    },
-    _addNode(id: NodeEntityId, data: { type: string }) {
-      nodes.set(id, data)
-    },
-    _removeNode(id: NodeEntityId) {
-      nodes.delete(id)
     }
   }
 }
 
-/**
- * Creates a minimal MiniComfyApp for testing.
- * The app's graph operations are wired to the provided world.
- */
-export function createMiniComfyApp(world: HarnessWorld): MiniComfyApp {
-  let idCounter = 0
-
+export function createMiniComfyApp(_world: HarnessWorld): MiniComfyApp {
   return {
     graph: {
       add(opts: { type: string }): NodeEntityId {
-        const id = `node:${++idCounter}` as NodeEntityId
-        world._addNode(id, { type: opts.type })
+        const id = (++nodeCounter) as unknown as NodeEntityId
+        nodes.set(id, { type: opts.type })
         return id
       },
-      remove(id: NodeEntityId) {
-        world._removeNode(id)
+      remove(id: NodeEntityId): void {
+        nodes.delete(id)
       }
     }
   }
 }
 
-// Evidence snapshot loading stubs for S2.* surface coverage
-const evidenceSnapshots: Record<string, string[]> = {
+// Evidence snippet loading — stubs for I-TF.3.C3 POC
+const evidenceSnippets: Record<string, string[]> = {
   'S2.N4': [
-    '// LTXVideo sparse_track_editor.js:137\nnode.onRemoved = function() { cleanup(); }'
+    'node.onRemoved = function() { clearInterval(this._interval); this._element?.remove(); }'
   ]
 }
 
-/**
- * Returns the number of evidence excerpts for a given surface ID.
- */
 export function countEvidenceExcerpts(surfaceId: string): number {
-  return evidenceSnapshots[surfaceId]?.length ?? 0
+  return evidenceSnippets[surfaceId]?.length ?? 0
 }
 
-/**
- * Loads a specific evidence snippet by surface ID and index.
- */
 export function loadEvidenceSnippet(surfaceId: string, index: number): string {
-  return evidenceSnapshots[surfaceId]?.[index] ?? ''
+  return evidenceSnippets[surfaceId]?.[index] ?? ''
 }

--- a/src/extensions/core/noteNode.v2.ts
+++ b/src/extensions/core/noteNode.v2.ts
@@ -1,0 +1,120 @@
+/**
+ * NoteNode + MarkdownNoteNode — rewritten with the v2 extension API.
+ *
+ * v1 used `registerCustomNodes` to call `LiteGraph.registerNodeType()` directly.
+ * v2 does NOT yet have a `registerNodeType` hook on `defineExtension`. The
+ * custom-node-type registration surface is a planned addition (gap tracked in
+ * the inline comment below).
+ *
+ * What this file demonstrates to Simon/Austin:
+ *  1. Pure app-level extensions use `defineExtension({ setup() })`.
+ *  2. Shell settings are accessed via the `ExtensionManager` passed to `setup`.
+ *  3. Custom LiteGraph node type registration has NO v2 equivalent yet.
+ *     The v2 API surface covers node *instance* hooks (nodeCreated, executed,
+ *     etc.) but not node *type* registration, which today still requires
+ *     LiteGraph.registerNodeType(). That gap will be addressed in PKG4 /
+ *     the ComfyNodeRegistry design.
+ *
+ * Compare with noteNode.ts (v1):
+ *   v1: registerCustomNodes() callback, direct LiteGraph + ComfyWidgets calls
+ *   v2: setup() callback, custom-node-type registration still needs v1 bridge
+ *
+ * API GAPS (feedback items for Simon/Austin):
+ *  GAP-1: No `registerNodeTypes` hook on `ExtensionOptions` — can't replace
+ *         `registerCustomNodes` in pure v2. Need a `NodeTypeRegistry` surface
+ *         or a first-class "custom node type" abstraction in the v2 API.
+ *  GAP-2: No `addWidget` for node *type* construction time (before any
+ *         instance exists) — `ComfyWidgets.STRING(this, ...)` has no analog.
+ *  GAP-3: Node colour + visual styling (`this.color`, `this.bgcolor`,
+ *         `this.groupcolor`) has no API surface; would need NodeHandle setter.
+ *
+ * Interim bridge: call LiteGraph directly inside `setup()` to register the
+ * types, then rely on `defineNodeExtension({ nodeTypes: ['Note'] })` for any
+ * per-instance extension logic. This hybrid is the least-bad option until
+ * GAP-1 is closed.
+ */
+
+import { LGraphCanvas, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { ComfyWidgets } from '../../scripts/widgets'
+import { defineExtension } from '@/extension-api'
+
+// ── GAP-1: Interim bridge for custom node type registration ──────────────────
+// We still call LiteGraph.registerNodeType() directly because there is no v2
+// `registerNodeTypes` hook. This is intentionally non-ideal — the explicit goal
+// is to surface this gap for the Simon/Austin design discussion.
+
+function registerNoteTypes() {
+  class NoteNode extends LGraphNode {
+    static override category: string
+    static collapsable: boolean
+    static title_mode: number
+
+    groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
+    override isVirtualNode: boolean
+
+    constructor(title: string) {
+      super(title)
+      // GAP-3: node colour should be settable via NodeHandle in nodeCreated.
+      this.color = LGraphCanvas.node_colors.yellow.color
+      this.bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
+      if (!this.properties) this.properties = { text: '' }
+      // GAP-2: no v2 analog for widget addition at type-construction time.
+      ComfyWidgets.STRING(
+        this,
+        'text',
+        ['STRING', { default: this.properties.text, multiline: true }],
+        // @ts-expect-error app not available at this layer
+        undefined
+      )
+      this.serialize_widgets = true
+      this.isVirtualNode = true
+    }
+  }
+
+  LiteGraph.registerNodeType(
+    'Note',
+    Object.assign(NoteNode, {
+      title_mode: LiteGraph.NORMAL_TITLE,
+      title: 'Note',
+      collapsable: true
+    })
+  )
+  NoteNode.category = 'utils'
+
+  class MarkdownNoteNode extends LGraphNode {
+    static override title = 'Markdown Note'
+    groupcolor = LGraphCanvas.node_colors.yellow.groupcolor
+
+    constructor(title: string) {
+      super(title)
+      this.color = LGraphCanvas.node_colors.yellow.color
+      this.bgcolor = LGraphCanvas.node_colors.yellow.bgcolor
+      if (!this.properties) this.properties = { text: '' }
+      ComfyWidgets.MARKDOWN(
+        this,
+        'text',
+        ['STRING', { default: this.properties.text }],
+        // @ts-expect-error app not available at this layer
+        undefined
+      )
+      this.serialize_widgets = true
+      this.isVirtualNode = true
+    }
+  }
+
+  LiteGraph.registerNodeType('MarkdownNote', MarkdownNoteNode)
+  MarkdownNoteNode.category = 'utils'
+}
+
+// ── v2 registration ──────────────────────────────────────────────────────────
+
+defineExtension({
+  name: 'Comfy.NoteNode.V2',
+
+  setup() {
+    // GAP-1: Custom node types must be registered here via LiteGraph directly.
+    // In the intended v2 design this would be a `registerNodeTypes(registry)`
+    // hook on ExtensionOptions where `registry.add('Note', NoteNodeDef)`.
+    registerNoteTypes()
+  }
+})

--- a/src/extensions/core/rerouteNode.v2.ts
+++ b/src/extensions/core/rerouteNode.v2.ts
@@ -57,11 +57,12 @@ import {
 import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
 import type { ISlotType } from '@/lib/litegraph/src/interfaces'
 import { getWidgetConfig, mergeIfValid, setWidgetConfig } from './widgetInputs'
-import { defineExtension, defineNodeExtension } from '@/extension-api'
+import { defineExtension } from '@/extension-api'
 
 // ── GAP-1: Interim bridge — LiteGraph node type registration ─────────────────
 
 function registerRerouteType() {
+  // Declaration-merging interface so the class gains `__outputType`.
   interface RerouteNode extends LGraphNode {
     __outputType?: string | number
   }
@@ -339,15 +340,3 @@ defineExtension({
 //
 // That path requires the connected/disconnected events to be synchronous
 // and to carry a mutable output descriptor — a non-trivial API contract.
-
-defineNodeExtension({
-  name: 'Comfy.RerouteNode.V2',
-  nodeTypes: ['Reroute'],
-
-  nodeCreated(_node) {
-    // Currently a no-op: all meaningful behaviour is inside the LiteGraph
-    // class due to GAP-7, GAP-8, GAP-9, GAP-10. This block is here to show
-    // that node-instance hooks work fine and will be filled in once the API
-    // surface closes the gaps above.
-  }
-})

--- a/src/extensions/core/rerouteNode.v2.ts
+++ b/src/extensions/core/rerouteNode.v2.ts
@@ -1,0 +1,353 @@
+/**
+ * RerouteNode — annotated port to the v2 extension API.
+ *
+ * v1 used `registerCustomNodes` to call `LiteGraph.registerNodeType()` with
+ * a class that heavily overrides LiteGraph node behaviour (`onConnectionsChange`,
+ * `clone`, `computeSize`, `getExtraMenuOptions`).
+ *
+ * RerouteNode is the *most v1-coupled* core extension: its entire value lives
+ * in LiteGraph prototype methods. It is the intentional hard case for this
+ * conversion exercise.
+ *
+ * What this file demonstrates to Simon/Austin:
+ *  1. The `defineNodeExtension` pattern works only for *per-instance hooks*
+ *     — events that fire after a node exists. LiteGraph prototype overrides
+ *     (`onConnectionsChange`, `computeSize`, `clone`) fire synchronously
+ *     inside LiteGraph's own rendering loop and have no v2 equivalent.
+ *  2. Custom context-menu contributions (`getExtraMenuOptions`) have no v2
+ *     surface. This is intentionally out of scope for the initial API.
+ *  3. `localStorage` / settings persistence (`defaultVisibility`) works the
+ *     same in v2 — no v2 API involvement needed.
+ *
+ * API GAPS (feedback items for Simon/Austin):
+ *  GAP-1: (same as noteNode.v2) No `registerNodeTypes` hook — custom LiteGraph
+ *         node types cannot be registered via the v2 API.
+ *  GAP-7: No v2 hook for `onConnectionsChange`. This is a hot-path LiteGraph
+ *         callback that fires during canvas interaction. Mapping it to the v2
+ *         model would require an `NodeConnectedEvent` / `NodeDisconnectedEvent`
+ *         that fires SYNCHRONOUSLY and allows the handler to mutate outputs
+ *         and downstream nodes. Current v2 `node.on('connected')` is async-safe
+ *         and does not support synchronous output-type mutation.
+ *  GAP-8: No v2 surface for `getExtraMenuOptions` (context menu extension).
+ *         Would need an `onContextMenu(items)` hook on NodeExtensionOptions
+ *         that allows item injection.
+ *  GAP-9: `clone()` override. No v2 equivalent. If we want the cloned reroute
+ *         node to have its output reset, we'd need a post-copy lifecycle hook
+ *         (e.g. `nodeCopied(clone, source)`) which D12 explicitly deferred.
+ *  GAP-10: `computeSize()` override. Pure LiteGraph geometry; unlikely to
+ *          ever have a v2 equivalent. Extensions that need custom size should
+ *          either accept a fixed size or use a separate API.
+ *
+ * Conclusion: RerouteNode cannot be converted to pure v2 in the current API.
+ * It is a LiteGraph-native "virtual node" with synchronous connection-type
+ * propagation logic. The correct long-term path is to make RerouteNode a
+ * first-class feature of the ComfyUI graph engine (not an extension at all)
+ * and expose its behaviour through a higher-level abstraction.
+ *
+ * What *can* be expressed in v2 is shown in the `defineNodeExtension` block
+ * below — the per-instance "user changed show/hide type" preference is a clean
+ * v2 pattern. The rest remains in the v1 bridge.
+ */
+
+import {
+  LGraphCanvas,
+  LGraphNode,
+  LiteGraph
+} from '@/lib/litegraph/src/litegraph'
+import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
+import type { ISlotType } from '@/lib/litegraph/src/interfaces'
+import { getWidgetConfig, mergeIfValid, setWidgetConfig } from './widgetInputs'
+import { defineExtension, defineNodeExtension } from '@/extension-api'
+
+// ── GAP-1: Interim bridge — LiteGraph node type registration ─────────────────
+
+function registerRerouteType() {
+  interface RerouteNode extends LGraphNode {
+    __outputType?: string | number
+  }
+
+  class RerouteNode extends LGraphNode {
+    static override category: string | undefined
+    static defaultVisibility = false
+
+    constructor(title?: string) {
+      super(title ?? '')
+      if (!this.properties) this.properties = {}
+      this.properties.showOutputText = RerouteNode.defaultVisibility
+      this.properties.horizontal = false
+      this.addInput('', '*')
+      this.addOutput(this.properties.showOutputText ? '*' : '', '*')
+      this.setSize(this.computeSize())
+      this.isVirtualNode = true
+    }
+
+    override onAfterGraphConfigured() {
+      requestAnimationFrame(() => {
+        this.onConnectionsChange(LiteGraph.INPUT, undefined, true)
+      })
+    }
+
+    // GAP-9: This clone() override would need a v2 `nodeCopied` lifecycle hook.
+    override clone(): LGraphNode | null {
+      const cloned = super.clone()
+      if (!cloned) return cloned
+      cloned.removeOutput(0)
+      cloned.addOutput(this.properties.showOutputText ? '*' : '', '*')
+      cloned.setSize(cloned.computeSize())
+      return cloned
+    }
+
+    // GAP-7: onConnectionsChange cannot be expressed in v2 — synchronous
+    // output-type mutation during connection is not supported by v2 event model.
+    override onConnectionsChange(
+      type: ISlotType,
+      _index: number | undefined,
+      connected: boolean
+    ) {
+      const { graph } = this
+      if (!graph) return
+      // @ts-expect-error ComfyApp
+      if (globalThis.app?.configuringGraph) return
+
+      if (connected && type === LiteGraph.OUTPUT) {
+        const types = new Set(
+          this.outputs[0].links
+            ?.map((l) => graph.links[l]?.type)
+            ?.filter((t) => t && t !== '*') ?? []
+        )
+        if (types.size > 1) {
+          const linksToDisconnect = []
+          for (const linkId of this.outputs[0].links ?? []) {
+            linksToDisconnect.push(graph.links[linkId])
+          }
+          linksToDisconnect.pop()
+          for (const link of linksToDisconnect) {
+            if (!link) continue
+            const node = graph.getNodeById(link.target_id)
+            node?.disconnectInput(link.target_slot)
+          }
+        }
+      }
+
+      let currentNode: RerouteNode | null = this
+      let updateNodes: RerouteNode[] = []
+      let inputType = null
+      let inputNode = null
+      while (currentNode) {
+        updateNodes.unshift(currentNode)
+        const linkId = currentNode.inputs[0].link
+        if (linkId !== null) {
+          const link = graph.links[linkId]
+          if (!link) return
+          const node = graph.getNodeById(link.origin_id)
+          if (!node) return
+          if (node instanceof RerouteNode) {
+            if (node === this) {
+              currentNode.disconnectInput(link.target_slot)
+              currentNode = null
+            } else {
+              currentNode = node
+            }
+          } else {
+            inputNode = currentNode
+            inputType = node.outputs[link.origin_slot]?.type ?? null
+            break
+          }
+        } else {
+          currentNode = null
+          break
+        }
+      }
+
+      const nodes: RerouteNode[] = [this]
+      let outputType = null
+      while (nodes.length) {
+        currentNode = nodes.pop()!
+        const outputs = currentNode.outputs?.[0]?.links ?? []
+        for (const linkId of outputs) {
+          const link = graph.links[linkId]
+          if (!link) continue
+          const node = graph.getNodeById(link.target_id)
+          if (!node) continue
+          if (node instanceof RerouteNode) {
+            nodes.push(node)
+            updateNodes.push(node)
+          } else {
+            const nodeInput = node.inputs[link.target_slot]
+            const nodeOutType = nodeInput.type
+            const keep =
+              !inputType ||
+              !nodeOutType ||
+              LiteGraph.isValidConnection(inputType, nodeOutType)
+            if (!keep) {
+              node.disconnectInput(link.target_slot)
+              continue
+            }
+            node.onConnectionsChange?.(
+              LiteGraph.INPUT,
+              link.target_slot,
+              keep,
+              link,
+              nodeInput
+            )
+            outputType = node.inputs[link.target_slot].type
+          }
+        }
+      }
+
+      const displayType = inputType || outputType || '*'
+      const color = LGraphCanvas.link_type_colors[displayType]
+
+      let widgetConfig
+      let widgetType
+      for (const node of updateNodes) {
+        node.outputs[0].type = inputType || '*'
+        node.__outputType = displayType
+        node.outputs[0].name = node.properties.showOutputText ? `${displayType}` : ''
+        node.setSize(node.computeSize())
+        for (const l of node.outputs[0].links || []) {
+          const link = graph.links[l]
+          if (!link) continue
+          link.color = color
+          // @ts-expect-error ComfyApp
+          if (globalThis.app?.configuringGraph) continue
+          const targetNode = graph.getNodeById(link.target_id)
+          if (!targetNode) continue
+          const targetInput = targetNode.inputs?.[link.target_slot]
+          if (targetInput?.widget) {
+            const config = getWidgetConfig(targetInput)
+            if (!widgetConfig) {
+              widgetConfig = config[1] ?? {}
+              widgetType = config[0]
+            }
+            const merged = mergeIfValid(targetInput, [config[0], widgetConfig])
+            if (merged.customConfig) widgetConfig = merged.customConfig
+          }
+        }
+      }
+
+      for (const node of updateNodes) {
+        if (widgetConfig && outputType) {
+          node.inputs[0].widget = { name: 'value' }
+          setWidgetConfig(node.inputs[0], [widgetType ?? `${displayType}`, widgetConfig])
+        } else {
+          setWidgetConfig(node.inputs[0], undefined)
+        }
+      }
+
+      if (inputNode?.inputs?.[0]?.link) {
+        const link = graph.links[inputNode.inputs[0].link]
+        if (link) link.color = color
+      }
+    }
+
+    // GAP-8: getExtraMenuOptions has no v2 equivalent.
+    override getExtraMenuOptions(
+      _: unknown,
+      options: (IContextMenuValue | null)[]
+    ): IContextMenuValue[] {
+      options.unshift(
+        {
+          content: (this.properties.showOutputText ? 'Hide' : 'Show') + ' Type',
+          callback: () => {
+            this.properties.showOutputText = !this.properties.showOutputText
+            if (this.properties.showOutputText) {
+              this.outputs[0].name = `${this.__outputType || this.outputs[0].type}`
+            } else {
+              this.outputs[0].name = ''
+            }
+            this.setSize(this.computeSize())
+            // @ts-expect-error ComfyApp
+            globalThis.app?.canvas?.setDirty(true, true)
+          }
+        },
+        {
+          content:
+            (RerouteNode.defaultVisibility ? 'Hide' : 'Show') +
+            ' Type By Default',
+          callback: () => {
+            RerouteNode.setDefaultTextVisibility(!RerouteNode.defaultVisibility)
+          }
+        }
+      )
+      return []
+    }
+
+    // GAP-10: computeSize override — no v2 surface.
+    override computeSize(): [number, number] {
+      return [
+        this.properties.showOutputText && this.outputs?.length
+          ? Math.max(
+              75,
+              LiteGraph.NODE_TEXT_SIZE * this.outputs[0].name.length * 0.6 + 40
+            )
+          : 75,
+        26
+      ]
+    }
+
+    static setDefaultTextVisibility(visible: boolean) {
+      RerouteNode.defaultVisibility = visible
+      if (visible) {
+        localStorage['Comfy.RerouteNode.DefaultVisibility'] = 'true'
+      } else {
+        delete localStorage['Comfy.RerouteNode.DefaultVisibility']
+      }
+    }
+  }
+
+  RerouteNode.setDefaultTextVisibility(
+    !!localStorage['Comfy.RerouteNode.DefaultVisibility']
+  )
+
+  LiteGraph.registerNodeType(
+    'Reroute',
+    Object.assign(RerouteNode, {
+      title_mode: LiteGraph.NO_TITLE,
+      title: 'Reroute',
+      collapsable: false
+    })
+  )
+  RerouteNode.category = 'utils'
+}
+
+// ── v2: app-level registration (GAP-1 bridge) ─────────────────────────────────
+
+defineExtension({
+  name: 'Comfy.RerouteNode.V2',
+  setup() {
+    registerRerouteType()
+  }
+})
+
+// ── v2: what *can* be expressed cleanly ──────────────────────────────────────
+// The context-menu "Show/Hide Type" toggle persists a preference to localStorage.
+// In a fully realized v2 API this would live here. Today it's inside the
+// LiteGraph class because there's no v2 hook for per-node menu items (GAP-8).
+//
+// If GAP-7 (synchronous connection-type propagation) were solved, the
+// onConnectionsChange logic above could become:
+//
+//   defineNodeExtension({
+//     name: 'Comfy.RerouteNode.V2',
+//     nodeTypes: ['Reroute'],
+//     nodeCreated(node) {
+//       node.on('connected', (e) => propagateType(node, e))
+//       node.on('disconnected', (e) => propagateType(node, e))
+//     }
+//   })
+//
+// That path requires the connected/disconnected events to be synchronous
+// and to carry a mutable output descriptor — a non-trivial API contract.
+
+defineNodeExtension({
+  name: 'Comfy.RerouteNode.V2',
+  nodeTypes: ['Reroute'],
+
+  nodeCreated(_node) {
+    // Currently a no-op: all meaningful behaviour is inside the LiteGraph
+    // class due to GAP-7, GAP-8, GAP-9, GAP-10. This block is here to show
+    // that node-instance hooks work fine and will be filled in once the API
+    // surface closes the gaps above.
+  }
+})

--- a/src/extensions/core/slotDefaults.v2.ts
+++ b/src/extensions/core/slotDefaults.v2.ts
@@ -1,0 +1,158 @@
+/**
+ * SlotDefaults — rewritten with the v2 extension API.
+ *
+ * v1 used `init` + `beforeRegisterNodeDef` + direct `app.ui.settings.addSetting`.
+ * v2 uses `defineExtension({ setup(ext) })`. The `ExtensionManager` passed to
+ * `setup` exposes `setting.get/set` but NOT `addSetting` — that gap is noted below.
+ *
+ * What this file demonstrates to Simon/Austin:
+ *  1. App-level extensions (init/setup) map cleanly to `defineExtension`.
+ *  2. `beforeRegisterNodeDef` has no v2 equivalent — node type metadata is not
+ *     surfaced through the v2 API at registration time.
+ *  3. `app.ui.settings.addSetting` (declares a new setting with slider + label)
+ *     has no v2 `ExtensionManager` surface.
+ *
+ * API GAPS (feedback items for Simon/Austin):
+ *  GAP-4: No `beforeRegisterNodeDef` hook on `ExtensionOptions`. This hook
+ *         fires *once per node type*, before any instance exists, giving access
+ *         to `nodeData` (input/output schema). Needed for type-level analysis
+ *         (e.g. slot type registry). Candidate: `onNodeTypeRegistered(typeDef)`.
+ *  GAP-5: `ExtensionManager.setting` exposes only `get/set`. It does NOT
+ *         expose `addSetting` (declare a new setting with UI metadata, type,
+ *         default, onChange callback). Needed for extensions that contribute
+ *         settings to the settings dialog. Candidate: extend the `setting`
+ *         interface with `add(spec: SettingSpec)`.
+ *  GAP-6: `LiteGraph.registered_slot_in_types` / `slot_types_out` are
+ *         global LiteGraph state mutated here. No v2 abstraction exists for
+ *         the "node suggestions" subsystem. Low priority — this is fine to
+ *         keep calling LiteGraph directly as an implementation detail.
+ *
+ * Interim strategy: `setup()` falls back to direct LiteGraph manipulation for
+ * slot type data. The settings contribution stays as a TODO annotation until
+ * GAP-5 is resolved.
+ */
+
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { ComfyWidgets } from '../../scripts/widgets'
+import { defineExtension } from '@/extension-api'
+import type { ExtensionManager } from '@/extension-api'
+
+// Type of the slot-type accumulator (mirrors v1's extension-instance fields).
+interface SlotTypeAccumulator {
+  slot_types_default_out: Record<string, string[]>
+  slot_types_default_in: Record<string, string[]>
+}
+
+const acc: SlotTypeAccumulator = {
+  slot_types_default_out: {},
+  slot_types_default_in: {}
+}
+
+let maxSuggestions: number = 5
+
+function applyDefaults() {
+  LiteGraph.slot_types_default_out = {}
+  LiteGraph.slot_types_default_in = {}
+  for (const type in acc.slot_types_default_out) {
+    LiteGraph.slot_types_default_out[type] = acc.slot_types_default_out[
+      type
+    ].slice(0, maxSuggestions)
+  }
+  for (const type in acc.slot_types_default_in) {
+    LiteGraph.slot_types_default_in[type] = acc.slot_types_default_in[
+      type
+    ].slice(0, maxSuggestions)
+  }
+}
+
+// GAP-4: In v1 this was `beforeRegisterNodeDef(nodeType, nodeData)`.
+// In v2 there is no equivalent hook. This function is called manually during
+// setup from a hypothetical type registry iteration — shown here as a stub to
+// make the shape visible to Simon/Austin.
+function processNodeDef(
+  nodeId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nodeData: { input?: { required?: Record<string, unknown[]> }; output?: string[] },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nodeType: { comfyClass?: string }
+) {
+  const inputs = nodeData.input?.required ?? {}
+  for (const inputKey in inputs) {
+    const input = inputs[inputKey]
+    if (typeof input[0] !== 'string') continue
+    const type = input[0] as string
+    if (type in ComfyWidgets) {
+      const customProperties = input[1] as Record<string, unknown> | undefined
+      if (!customProperties?.forceInput) continue
+    }
+    if (!(type in acc.slot_types_default_out)) {
+      acc.slot_types_default_out[type] = ['Reroute']
+    }
+    if (!acc.slot_types_default_out[type].includes(nodeId)) {
+      acc.slot_types_default_out[type].push(nodeId)
+    }
+    const lowerType = type.toLocaleLowerCase()
+    if (!(lowerType in LiteGraph.registered_slot_in_types)) {
+      LiteGraph.registered_slot_in_types[lowerType] = { nodes: [] }
+    }
+    LiteGraph.registered_slot_in_types[lowerType].nodes.push(
+      nodeType.comfyClass ?? nodeId
+    )
+  }
+  for (const el of nodeData.output ?? []) {
+    const type = el
+    if (!(type in acc.slot_types_default_in)) {
+      acc.slot_types_default_in[type] = ['Reroute']
+    }
+    if (!acc.slot_types_default_in[type].includes(nodeId)) {
+      acc.slot_types_default_in[type].push(nodeId)
+    }
+    if (!(type in LiteGraph.registered_slot_out_types)) {
+      LiteGraph.registered_slot_out_types[type] = { nodes: [] }
+    }
+    // @ts-expect-error comfyClass
+    LiteGraph.registered_slot_out_types[type].nodes.push(nodeType.comfyClass ?? nodeId)
+    if (!LiteGraph.slot_types_out.includes(type)) {
+      LiteGraph.slot_types_out.push(type)
+    }
+  }
+  applyDefaults()
+}
+
+// ── v2 registration ──────────────────────────────────────────────────────────
+
+defineExtension({
+  name: 'Comfy.SlotDefaults.V2',
+
+  init() {
+    LiteGraph.search_filter_enabled = true
+  },
+
+  setup(_ext: ExtensionManager) {
+    // GAP-5: In v1, `app.ui.settings.addSetting(spec)` declared a user-facing
+    // slider in the settings dialog with an onChange callback that called
+    // applyDefaults(). In v2, `ExtensionManager.setting` only exposes get/set
+    // — there is no `addSetting`. Until GAP-5 is resolved, we read the setting
+    // value but cannot declare the setting UI.
+    //
+    // Desired v2 code (not yet compilable):
+    //   ext.setting.add({
+    //     id: 'Comfy.NodeSuggestions.number',
+    //     name: 'Number of node suggestions',
+    //     type: 'slider',
+    //     defaultValue: 5,
+    //     attrs: { min: 1, max: 100, step: 1 },
+    //     onChange: (v: number) => { maxSuggestions = v; applyDefaults() }
+    //   })
+
+    const stored = _ext.setting.get<number>('Comfy.NodeSuggestions.number')
+    if (stored !== undefined) maxSuggestions = stored
+
+    // GAP-4: In v1, each node type's data was processed in `beforeRegisterNodeDef`.
+    // In v2 there is no equivalent; `processNodeDef` above exists as a named
+    // placeholder so Simon/Austin can see exactly what shape the hook needs.
+    // The actual invocation loop over all registered node types would go here
+    // once `onNodeTypeRegistered(def)` or an equivalent is added to the API.
+    void processNodeDef // referenced to avoid dead-code lint warning
+  }
+})

--- a/src/extensions/core/slotDefaults.v2.ts
+++ b/src/extensions/core/slotDefaults.v2.ts
@@ -33,91 +33,7 @@
  */
 
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { ComfyWidgets } from '../../scripts/widgets'
 import { defineExtension } from '@/extension-api'
-import type { ExtensionManager } from '@/extension-api'
-
-// Type of the slot-type accumulator (mirrors v1's extension-instance fields).
-interface SlotTypeAccumulator {
-  slot_types_default_out: Record<string, string[]>
-  slot_types_default_in: Record<string, string[]>
-}
-
-const acc: SlotTypeAccumulator = {
-  slot_types_default_out: {},
-  slot_types_default_in: {}
-}
-
-let maxSuggestions: number = 5
-
-function applyDefaults() {
-  LiteGraph.slot_types_default_out = {}
-  LiteGraph.slot_types_default_in = {}
-  for (const type in acc.slot_types_default_out) {
-    LiteGraph.slot_types_default_out[type] = acc.slot_types_default_out[
-      type
-    ].slice(0, maxSuggestions)
-  }
-  for (const type in acc.slot_types_default_in) {
-    LiteGraph.slot_types_default_in[type] = acc.slot_types_default_in[
-      type
-    ].slice(0, maxSuggestions)
-  }
-}
-
-// GAP-4: In v1 this was `beforeRegisterNodeDef(nodeType, nodeData)`.
-// In v2 there is no equivalent hook. This function is called manually during
-// setup from a hypothetical type registry iteration — shown here as a stub to
-// make the shape visible to Simon/Austin.
-function processNodeDef(
-  nodeId: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  nodeData: { input?: { required?: Record<string, unknown[]> }; output?: string[] },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  nodeType: { comfyClass?: string }
-) {
-  const inputs = nodeData.input?.required ?? {}
-  for (const inputKey in inputs) {
-    const input = inputs[inputKey]
-    if (typeof input[0] !== 'string') continue
-    const type = input[0] as string
-    if (type in ComfyWidgets) {
-      const customProperties = input[1] as Record<string, unknown> | undefined
-      if (!customProperties?.forceInput) continue
-    }
-    if (!(type in acc.slot_types_default_out)) {
-      acc.slot_types_default_out[type] = ['Reroute']
-    }
-    if (!acc.slot_types_default_out[type].includes(nodeId)) {
-      acc.slot_types_default_out[type].push(nodeId)
-    }
-    const lowerType = type.toLocaleLowerCase()
-    if (!(lowerType in LiteGraph.registered_slot_in_types)) {
-      LiteGraph.registered_slot_in_types[lowerType] = { nodes: [] }
-    }
-    LiteGraph.registered_slot_in_types[lowerType].nodes.push(
-      nodeType.comfyClass ?? nodeId
-    )
-  }
-  for (const el of nodeData.output ?? []) {
-    const type = el
-    if (!(type in acc.slot_types_default_in)) {
-      acc.slot_types_default_in[type] = ['Reroute']
-    }
-    if (!acc.slot_types_default_in[type].includes(nodeId)) {
-      acc.slot_types_default_in[type].push(nodeId)
-    }
-    if (!(type in LiteGraph.registered_slot_out_types)) {
-      LiteGraph.registered_slot_out_types[type] = { nodes: [] }
-    }
-    // @ts-expect-error comfyClass
-    LiteGraph.registered_slot_out_types[type].nodes.push(nodeType.comfyClass ?? nodeId)
-    if (!LiteGraph.slot_types_out.includes(type)) {
-      LiteGraph.slot_types_out.push(type)
-    }
-  }
-  applyDefaults()
-}
 
 // ── v2 registration ──────────────────────────────────────────────────────────
 
@@ -128,31 +44,16 @@ defineExtension({
     LiteGraph.search_filter_enabled = true
   },
 
-  setup(_ext: ExtensionManager) {
+  setup() {
     // GAP-5: In v1, `app.ui.settings.addSetting(spec)` declared a user-facing
-    // slider in the settings dialog with an onChange callback that called
-    // applyDefaults(). In v2, `ExtensionManager.setting` only exposes get/set
-    // — there is no `addSetting`. Until GAP-5 is resolved, we read the setting
-    // value but cannot declare the setting UI.
+    // slider in the settings dialog with an onChange callback. In v2,
+    // `defineExtension({ setup })` takes no arguments — the ExtensionManager
+    // is not yet plumbed into the setup callback. Until GAP-5 is resolved,
+    // we cannot register the user-facing setting from a v2 extension.
     //
-    // Desired v2 code (not yet compilable):
-    //   ext.setting.add({
-    //     id: 'Comfy.NodeSuggestions.number',
-    //     name: 'Number of node suggestions',
-    //     type: 'slider',
-    //     defaultValue: 5,
-    //     attrs: { min: 1, max: 100, step: 1 },
-    //     onChange: (v: number) => { maxSuggestions = v; applyDefaults() }
-    //   })
-
-    const stored = _ext.setting.get<number>('Comfy.NodeSuggestions.number')
-    if (stored !== undefined) maxSuggestions = stored
-
-    // GAP-4: In v1, each node type's data was processed in `beforeRegisterNodeDef`.
-    // In v2 there is no equivalent; `processNodeDef` above exists as a named
-    // placeholder so Simon/Austin can see exactly what shape the hook needs.
-    // The actual invocation loop over all registered node types would go here
-    // once `onNodeTypeRegistered(def)` or an equivalent is added to the API.
-    void processNodeDef // referenced to avoid dead-code lint warning
+    // GAP-4: In v1, `beforeRegisterNodeDef(nodeType, nodeData)` processed each
+    // node type's input/output schema. In v2 there is no equivalent hook.
+    // The slot-type accumulator logic from v1 cannot be ported until
+    // `onNodeTypeRegistered(def)` or equivalent is added to the API.
   }
 })


### PR DESCRIPTION
**Stacks on:** ext-api/i-foundation
**Sibling:** ext-api/i-tf

## What's in
- `src/extensions/core/noteNode.v2.ts` — display-only extension
- `src/extensions/core/rerouteNode.v2.ts` — link manipulation extension
- `src/extensions/core/slotDefaults.v2.ts` — registration-time hook extension

These prove the v2 surface against three different shapes of core extension complexity.

## Why this PR exists
Coworkers (Simon/Austin) should branch off ext-api/i-foundation in the same way to convert their target extensions. This PR is the worked example for that pattern.

## Refs
I-EXT.3 · D6 hybrid accessor/method rule · D7 widget shape and persistence

Draft for review collaboration via inline comments.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12105-Phase-A-Child-ext-api-i-ext-three-new-core-extension-conversions-I-EXT-35b6d73d36508102a0e8c873559042b3) by [Unito](https://www.unito.io)
