### PR TITLE
[codex] Keep scrollable text wheel events out of canvas

### DIFF
--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -46,14 +46,32 @@ function createMockPointerEvent(
   return mockEvent as PointerEvent
 }
 
-function createMockWheelEvent(ctrlKey = false, metaKey = false): WheelEvent {
+function createMockWheelEvent(
+  ctrlKey = false,
+  metaKey = false,
+  deltaX = 0,
+  deltaY = 100
+): WheelEvent {
   const mockEvent: Partial<WheelEvent> = {
     ctrlKey,
     metaKey,
+    deltaX,
+    deltaY,
     preventDefault: vi.fn(),
     stopPropagation: vi.fn()
   }
   return mockEvent as WheelEvent
+}
+
+function makeScrollable(element: HTMLElement) {
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    value: 100
+  })
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    value: 200
+  })
 }
 
 describe('useCanvasInteractions', () => {
@@ -177,20 +195,20 @@ describe('useCanvasInteractions', () => {
       document.body.removeChild(captureElement)
     })
 
-    it('should NOT forward wheel events when capture element IS focused', () => {
+    it('should NOT forward wheel events when non-text capture element IS focused', () => {
       const { get } = useSettingStore()
       vi.mocked(get).mockReturnValue('legacy')
 
       const captureElement = document.createElement('div')
       captureElement.setAttribute('data-capture-wheel', 'true')
-      const textarea = document.createElement('textarea')
-      captureElement.appendChild(textarea)
+      const input = document.createElement('input')
+      captureElement.appendChild(input)
       document.body.appendChild(captureElement)
-      textarea.focus()
+      input.focus()
 
       const { handleWheel } = useCanvasInteractions()
       const mockEvent = createMockWheelEvent()
-      Object.defineProperty(mockEvent, 'target', { value: textarea })
+      Object.defineProperty(mockEvent, 'target', { value: input })
 
       handleWheel(mockEvent)
 
@@ -198,6 +216,48 @@ describe('useCanvasInteractions', () => {
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
 
       document.body.removeChild(captureElement)
+    })
+
+    it('should NOT forward vertical wheel events when text capture element is scrollable', () => {
+      const { get } = useSettingStore()
+      vi.mocked(get).mockReturnValue('legacy')
+
+      const textarea = document.createElement('textarea')
+      textarea.setAttribute('data-capture-wheel', 'true')
+      makeScrollable(textarea)
+      document.body.appendChild(textarea)
+
+      const { handleWheel } = useCanvasInteractions()
+      const mockEvent = createMockWheelEvent(false, false, 0, 100)
+      Object.defineProperty(mockEvent, 'target', { value: textarea })
+
+      handleWheel(mockEvent)
+
+      expect(mockEvent.preventDefault).not.toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
+
+      document.body.removeChild(textarea)
+    })
+
+    it('should forward vertical wheel events when text capture element is not scrollable', () => {
+      const { get } = useSettingStore()
+      vi.mocked(get).mockReturnValue('legacy')
+
+      const textarea = document.createElement('textarea')
+      textarea.setAttribute('data-capture-wheel', 'true')
+      document.body.appendChild(textarea)
+      textarea.focus()
+
+      const { handleWheel } = useCanvasInteractions()
+      const mockEvent = createMockWheelEvent(false, false, 0, 100)
+      Object.defineProperty(mockEvent, 'target', { value: textarea })
+
+      handleWheel(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).toHaveBeenCalled()
+
+      document.body.removeChild(textarea)
     })
 
     it('should forward ctrl+wheel to canvas when capture element IS focused in standard mode', () => {

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -7,6 +7,47 @@ import { app } from '@/scripts/app'
 
 const TEXT_WHEEL_CAPTURE_SELECTOR = 'textarea, [role="textarea"]'
 
+function getWheelCaptureElement(event: WheelEvent): HTMLElement | null {
+  const target = event.target as HTMLElement | null
+  const captureElement = target?.closest('[data-capture-wheel="true"]')
+
+  return captureElement instanceof HTMLElement ? captureElement : null
+}
+
+function getTextWheelCaptureElement(event: WheelEvent): HTMLElement | null {
+  const target = event.target as HTMLElement | null
+  const captureElement = getWheelCaptureElement(event)
+  const textCaptureElement = target?.closest(TEXT_WHEEL_CAPTURE_SELECTOR)
+
+  if (
+    textCaptureElement instanceof HTMLElement &&
+    captureElement?.contains(textCaptureElement)
+  ) {
+    return textCaptureElement
+  }
+
+  return captureElement?.matches(TEXT_WHEEL_CAPTURE_SELECTOR)
+    ? captureElement
+    : null
+}
+
+function isVerticalWheel(event: WheelEvent): boolean {
+  return (
+    Math.abs(event.deltaY) > 0 &&
+    Math.abs(event.deltaY) >= Math.abs(event.deltaX)
+  )
+}
+
+function textCapturesVerticalScroll(event: WheelEvent): boolean {
+  const textCaptureElement = getTextWheelCaptureElement(event)
+
+  return !!(
+    textCaptureElement &&
+    isVerticalWheel(event) &&
+    textCaptureElement.scrollHeight > textCaptureElement.clientHeight
+  )
+}
+
 /**
  * Composable for handling canvas interactions from Vue components.
  * This provides a unified way to forward events to the LiteGraph canvas.
@@ -27,46 +68,6 @@ export function useCanvasInteractions() {
   const shouldHandleNodePointerEvents = computed(
     () => !(canvasStore.canvas?.read_only ?? false)
   )
-
-  const getWheelCaptureElement = (event: WheelEvent): HTMLElement | null => {
-    const target = event.target as HTMLElement | null
-    const captureElement = target?.closest('[data-capture-wheel="true"]')
-
-    return captureElement instanceof HTMLElement ? captureElement : null
-  }
-
-  const getTextWheelCaptureElement = (
-    event: WheelEvent
-  ): HTMLElement | null => {
-    const target = event.target as HTMLElement | null
-    const captureElement = getWheelCaptureElement(event)
-    const textCaptureElement = target?.closest(TEXT_WHEEL_CAPTURE_SELECTOR)
-
-    if (
-      textCaptureElement instanceof HTMLElement &&
-      captureElement?.contains(textCaptureElement)
-    ) {
-      return textCaptureElement
-    }
-
-    return captureElement?.matches(TEXT_WHEEL_CAPTURE_SELECTOR)
-      ? captureElement
-      : null
-  }
-
-  const isVerticalWheel = (event: WheelEvent): boolean =>
-    Math.abs(event.deltaY) > 0 &&
-    Math.abs(event.deltaY) >= Math.abs(event.deltaX)
-
-  const textCapturesVerticalScroll = (event: WheelEvent): boolean => {
-    const textCaptureElement = getTextWheelCaptureElement(event)
-
-    return !!(
-      textCaptureElement &&
-      isVerticalWheel(event) &&
-      textCaptureElement.scrollHeight > textCaptureElement.clientHeight
-    )
-  }
 
   /**
    * Returns true if the wheel event target is inside an element that should

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -5,6 +5,8 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { app } from '@/scripts/app'
 
+const TEXT_WHEEL_CAPTURE_SELECTOR = 'textarea, [role="textarea"]'
+
 /**
  * Composable for handling canvas interactions from Vue components.
  * This provides a unified way to forward events to the LiteGraph canvas.
@@ -26,23 +28,69 @@ export function useCanvasInteractions() {
     () => !(canvasStore.canvas?.read_only ?? false)
   )
 
+  const getWheelCaptureElement = (event: WheelEvent): HTMLElement | null => {
+    const target = event.target as HTMLElement | null
+    const captureElement = target?.closest('[data-capture-wheel="true"]')
+
+    return captureElement instanceof HTMLElement ? captureElement : null
+  }
+
+  const getTextWheelCaptureElement = (
+    event: WheelEvent
+  ): HTMLElement | null => {
+    const target = event.target as HTMLElement | null
+    const captureElement = getWheelCaptureElement(event)
+    const textCaptureElement = target?.closest(TEXT_WHEEL_CAPTURE_SELECTOR)
+
+    if (
+      textCaptureElement instanceof HTMLElement &&
+      captureElement?.contains(textCaptureElement)
+    ) {
+      return textCaptureElement
+    }
+
+    return captureElement?.matches(TEXT_WHEEL_CAPTURE_SELECTOR)
+      ? captureElement
+      : null
+  }
+
+  const isVerticalWheel = (event: WheelEvent): boolean =>
+    Math.abs(event.deltaY) > 0 &&
+    Math.abs(event.deltaY) >= Math.abs(event.deltaX)
+
+  const textCapturesVerticalScroll = (event: WheelEvent): boolean => {
+    const textCaptureElement = getTextWheelCaptureElement(event)
+
+    return !!(
+      textCaptureElement &&
+      isVerticalWheel(event) &&
+      textCaptureElement.scrollHeight > textCaptureElement.clientHeight
+    )
+  }
+
   /**
    * Returns true if the wheel event target is inside an element that should
    * capture wheel events AND that element (or a descendant) currently has focus.
    *
    * This allows two-finger panning to continue over inputs until the user has
    * actively focused the widget, at which point the widget can consume scroll.
+   * Text inputs are handled by scrollability so short text still pans the canvas.
    */
   const wheelCapturedByFocusedElement = (event: WheelEvent): boolean => {
-    const target = event.target as HTMLElement | null
-    const captureElement = target?.closest('[data-capture-wheel="true"]')
+    const captureElement = getWheelCaptureElement(event)
     const active = document.activeElement as Element | null
 
-    return !!(captureElement && active && captureElement.contains(active))
+    return !!(
+      captureElement &&
+      !getTextWheelCaptureElement(event) &&
+      active &&
+      captureElement.contains(active)
+    )
   }
 
   const shouldForwardWheelEvent = (event: WheelEvent): boolean =>
-    !wheelCapturedByFocusedElement(event) ||
+    (!textCapturesVerticalScroll(event) &&
+      !wheelCapturedByFocusedElement(event)) ||
     (isStandardNavMode.value && (event.ctrlKey || event.metaKey))
 
   /**

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -117,6 +117,13 @@ function addMultilineWidget(
       const isLikelyTrackpad =
         Math.abs(deltaX) > 0 || Math.abs(deltaY) < TRACKPAD_DETECTION_THRESHOLD
 
+      // Vertical scrolling in scrollable text should stay inside the textarea,
+      // even at its top/bottom boundary where the canvas also listens for wheel.
+      if (!isHorizontal && canScrollY) {
+        event.stopPropagation()
+        return
+      }
+
       // Trackpad gestures: when enabled, trackpad panning goes to canvas
       if (gesturesEnabled && isLikelyTrackpad) {
         event.preventDefault()
@@ -130,12 +137,6 @@ function addMultilineWidget(
         event.preventDefault()
         event.stopPropagation()
         app.canvas.processMouseWheel(event)
-        return
-      }
-
-      // Vertical scrolling when gestures disabled: let textarea scroll if scrollable
-      if (canScrollY) {
-        event.stopPropagation()
         return
       }
 


### PR DESCRIPTION
﻿## Summary

Fixes wheel event leakage from scrollable text widgets into the canvas when the text area reaches its top or bottom boundary.

## Changes

- Treat scrollable text capture targets as local handlers for vertical wheel events, independent of focus state.
- Keep non-scrollable text widgets forwarding vertical wheel events to the canvas so canvas scrolling still works for short text.
- Let scrollable legacy multiline widgets stop vertical wheel propagation before trackpad gesture routing.
- Add regression coverage for scrollable and non-scrollable text capture behavior.

## Validation

- `.\node_modules\.bin\vitest.cmd run src/renderer/core/canvas/useCanvasInteractions.test.ts` (`12 passed`)
- `.\node_modules\.bin\oxfmt.cmd --check src/renderer/core/canvas/useCanvasInteractions.ts src/renderer/core/canvas/useCanvasInteractions.test.ts src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts`
- `.\node_modules\.bin\eslint.cmd src/renderer/core/canvas/useCanvasInteractions.ts src/renderer/core/canvas/useCanvasInteractions.test.ts src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts`
- `.\node_modules\.bin\oxlint.cmd src/renderer/core/canvas/useCanvasInteractions.ts src/renderer/core/canvas/useCanvasInteractions.test.ts src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts --type-aware`
- Pre-commit hook completed: `pnpm exec oxfmt`, `pnpm exec oxlint`, `pnpm exec eslint`, `pnpm typecheck`

## E2E Coverage

I did not add a Playwright E2E test under `browser_tests/` because this regression is isolated to DOM wheel-event routing between textarea widgets and the canvas interaction layer. The focused Vitest coverage constructs scrollable and non-scrollable textarea targets and asserts `shouldForwardWheelEvent` behavior directly, which is the decision point that caused #3990. A browser-level regression would need a full ComfyUI backend workflow/canvas fixture with a rendered text widget and synthetic wheel input, which is outside this narrow frontend fix and would be less deterministic than the unit coverage for the event-routing boundary.

Notes: I did not run a live ComfyUI browser reproduction in this frontend-only checkout. Local shell is on Node `25.6.1`; the repo asks for Node `24.x`, but the targeted checks and hook passed.

Fixes #3990.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12116-codex-Keep-scrollable-text-wheel-events-out-of-canvas-35c6d73d3650818facc9d9b3ed101cf1) by [Unito](https://www.unito.io)