### PR TITLE
ci: add Windows Chromium browser tests

### DIFF
--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -7,22 +7,30 @@ runs:
       id: detect-version
       shell: bash
       run: |
-        PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --json | jq --raw-output '.[0].devDependencies["@playwright/test"].version')
+        PLAYWRIGHT_VERSION=$(node -p "require('./node_modules/@playwright/test/package.json').version")
         echo "playwright-version=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
 
     - name: Cache Playwright Browsers
       uses: actions/cache@v5 # v5.0.2
       id: cache-playwright-browsers
       with:
-        path: '~/.cache/ms-playwright'
+        path: |
+          ~/.cache/ms-playwright
+          ~/AppData/Local/ms-playwright
+          ~/Library/Caches/ms-playwright
         key: ${{ runner.os }}-playwright-browsers-${{ steps.detect-version.outputs.playwright-version }}
 
     - name: Install Playwright Browsers
-      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' && runner.os == 'Linux'
       shell: bash
       run: pnpm exec playwright install chromium --with-deps
 
+    - name: Install Playwright Browsers
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' && runner.os != 'Linux'
+      shell: bash
+      run: pnpm exec playwright install chromium
+
     - name: Install Playwright Browsers (operating system dependencies)
-      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true' && runner.os == 'Linux'
       shell: bash
       run: pnpm exec playwright install-deps

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -173,6 +173,57 @@ jobs:
           path: ./playwright-report/
           retention-days: 30
 
+  playwright-tests-windows:
+    # Covers Windows-specific browser/runtime behavior that Linux container
+    # jobs cannot catch.
+    timeout-minutes: 90
+    needs: setup
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download built frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-dist
+          path: dist/
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Install Playwright browser
+        uses: ./.github/actions/setup-playwright
+
+      - name: Setup and start ComfyUI server
+        uses: ./.github/actions/setup-comfyui-server
+        with:
+          launch_server: 'true'
+
+      - name: Run Playwright tests (Windows Chromium)
+        id: playwright
+        shell: bash
+        run: pnpm exec playwright test --project=chromium --reporter=blob
+        env:
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
+
+      - name: Generate HTML and JSON reports
+        if: always()
+        shell: bash
+        run: |
+          pnpm exec playwright merge-reports --reporter=html ./blob-report
+          PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json pnpm exec playwright merge-reports --reporter=json ./blob-report
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: playwright-report-windows-chromium
+          path: ./playwright-report/
+          retention-days: 30
+
   # Merge sharded test reports (no container needed - only runs CLI)
   merge-reports:
     needs: [changes, playwright-tests-chromium-sharded]
@@ -211,7 +262,11 @@ jobs:
   # expanded check names so PRs with no e2e-relevant changes aren't stuck.
   e2e-status:
     if: ${{ always() }}
-    needs: [changes, playwright-tests-chromium-sharded, playwright-tests]
+    needs:
+      - changes
+      - playwright-tests-chromium-sharded
+      - playwright-tests
+      - playwright-tests-windows
     runs-on: ubuntu-latest
     steps:
       - name: Check E2E results
@@ -219,9 +274,10 @@ jobs:
           SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
           SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
           BROWSERS: ${{ needs.playwright-tests.result }}
+          WINDOWS: ${{ needs.playwright-tests-windows.result }}
         run: |
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
-          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" ]] && echo "E2E failed" && exit 1
+          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || "$WINDOWS" != "success" ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
 
   #### BEGIN Deployment and commenting (non-forked PRs only)
@@ -247,16 +303,17 @@ jobs:
       - name: Post starting comment
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          PR_HEAD_REF: ${{ github.head_ref }}
         run: |
           chmod +x scripts/cicd/pr-playwright-deploy-and-comment.sh
           ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
             "${{ github.event.pull_request.number }}" \
-            "${{ github.head_ref }}" \
+            "$PR_HEAD_REF" \
             "starting"
 
   # Deploy and comment for non-forked PRs only
   deploy-and-comment:
-    needs: [changes, playwright-tests, merge-reports]
+    needs: [changes, playwright-tests, playwright-tests-windows, merge-reports]
     runs-on: ubuntu-latest
     if: >-
       ${{
@@ -284,9 +341,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.head_ref }}
         run: |
           bash ./scripts/cicd/pr-playwright-deploy-and-comment.sh \
             "${{ github.event.pull_request.number }}" \
-            "${{ github.head_ref }}" \
+            "$PR_HEAD_REF" \
             "completed"
   #### END Deployment and commenting (non-forked PRs only)


### PR DESCRIPTION
## Summary

Adds a Windows Chromium Playwright E2E lane so CI covers browser behavior outside the Linux container runner.

## Changes

- **What**: Added a `windows-latest` Playwright job that downloads the built frontend, starts a real ComfyUI backend, runs the `chromium` project, and uploads a Windows report artifact.
- **What**: Included the Windows job in the aggregate `e2e-status` gate and PR report deployment dependencies.
- **What**: Made the shared Playwright setup action OS-aware by caching platform-specific browser directories and avoiding Linux-only dependency installation on non-Linux runners.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- The Windows lane reuses the existing `setup-comfyui-server` action instead of the Linux-only prebuilt CI container.
- The shared Playwright action still installs Linux browser dependencies on Linux cache hits, while Windows/macOS only install the browser package.

Fixes #3197

## Screenshots (if applicable)

N/A - CI workflow change.

## Validation

- `uvx yamllint --config-file .yamllint .github/actions/setup-playwright/action.yaml .github/workflows/ci-tests-e2e.yaml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci-tests-e2e.yaml`
- `git diff --check`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12128-ci-add-Windows-Chromium-browser-tests-35d6d73d365081fc9bf9c4165b6fb230) by [Unito](https://www.unito.io)
