### PR TITLE
test: add test for custom node i18n

### DIFF
--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -470,6 +470,7 @@ const COLLECT_COVERAGE = process.env.COLLECT_COVERAGE === 'true'
 
 export const comfyPageFixture = base.extend<{
   initialFeatureFlags: Record<string, unknown>
+  initialSettings: Record<string, unknown>
   comfyPage: ComfyPage
   comfyMouse: ComfyMouse
   comfyFiles: ComfyFiles
@@ -477,6 +478,10 @@ export const comfyPageFixture = base.extend<{
   // Allows configuring feature flags for tests with before initial setup:
   // `test.use({ initialFeatureFlags: { my_flag: true } })`.
   initialFeatureFlags: [{}, { option: true }],
+  // Allows seeding user settings before initial page load:
+  // `test.use({ initialSettings: { 'Comfy.Locale': 'zh' } })`. Merged on top of
+  // the fixture's defaults so per-test values win.
+  initialSettings: [{}, { option: true }],
 
   page: async ({ page, browserName }, use) => {
     if (browserName !== 'chromium' || !COLLECT_COVERAGE) {
@@ -494,7 +499,11 @@ export const comfyPageFixture = base.extend<{
     await mcr.add(coverage)
   },
 
-  comfyPage: async ({ page, request, initialFeatureFlags }, use, testInfo) => {
+  comfyPage: async (
+    { page, request, initialFeatureFlags, initialSettings },
+    use,
+    testInfo
+  ) => {
     const comfyPage = new ComfyPage(page, request)
 
     const { parallelIndex } = testInfo
@@ -529,7 +538,8 @@ export const comfyPageFixture = base.extend<{
         // Disable errors tab to prevent missing model detection from
         // rendering error indicators on nodes during unrelated tests.
         'Comfy.RightSidePanel.ShowErrorsTab': false,
-        ...(isVueNodes && { 'Comfy.VueNodes.Enabled': true })
+        ...(isVueNodes && { 'Comfy.VueNodes.Enabled': true }),
+        ...initialSettings
       })
     } catch (e) {
       console.error(e)

--- a/browser_tests/tests/customNodeLocales.spec.ts
+++ b/browser_tests/tests/customNodeLocales.spec.ts
@@ -1,8 +1,8 @@
+import type { CustomNodesI18n } from '@/schemas/apiSchema'
 import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
-import type { CustomNodesI18n } from '@/schemas/apiSchema'
 
 const NODE_TYPE = 'DevToolsNodeWithStringInput'
 const LOCALIZED_ZH = '本地化字符串输入 (ZH)'
@@ -19,6 +19,8 @@ test.describe(
   'Custom node locales loading',
   { tag: ['@ui', '@vue-nodes'] },
   () => {
+    test.use({ initialSettings: { 'Comfy.Locale': 'zh' } })
+
     test.beforeEach(async ({ page }) => {
       await page.route('**/api/i18n', async (route) => {
         await route.fulfill({
@@ -35,8 +37,6 @@ test.describe(
     test('preserves custom-node /api/i18n translation through lazy locale load', async ({
       comfyPage
     }) => {
-      await comfyPage.settings.setSetting('Comfy.Locale', 'zh')
-
       await comfyPage.nodeOps.addNode(NODE_TYPE)
 
       await expect(comfyPage.vueNodes.getNodeByTitle(LOCALIZED_ZH)).toHaveCount(

--- a/browser_tests/tests/customNodeLocales.spec.ts
+++ b/browser_tests/tests/customNodeLocales.spec.ts
@@ -2,9 +2,18 @@ import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import type { CustomNodesI18n } from '@/schemas/apiSchema'
 
 const NODE_TYPE = 'DevToolsNodeWithStringInput'
 const LOCALIZED_ZH = '本地化字符串输入 (ZH)'
+
+const i18nResponse: CustomNodesI18n = {
+  zh: {
+    nodeDefs: {
+      [NODE_TYPE]: { display_name: LOCALIZED_ZH }
+    }
+  }
+}
 
 test.describe(
   'Custom node locales loading',
@@ -15,13 +24,7 @@ test.describe(
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({
-            zh: {
-              nodeDefs: {
-                [NODE_TYPE]: { display_name: LOCALIZED_ZH }
-              }
-            }
-          })
+          body: JSON.stringify(i18nResponse)
         })
       })
     })

--- a/browser_tests/tests/customNodeLocales.spec.ts
+++ b/browser_tests/tests/customNodeLocales.spec.ts
@@ -1,0 +1,44 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+const NODE_TYPE = 'DevToolsNodeWithStringInput'
+const LOCALIZED_ZH = '本地化字符串输入 (ZH)'
+
+test.describe(
+  'Custom node locales loading',
+  { tag: ['@ui', '@vue-nodes'] },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.route('**/api/i18n', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            zh: {
+              nodeDefs: {
+                [NODE_TYPE]: { display_name: LOCALIZED_ZH }
+              }
+            }
+          })
+        })
+      })
+    })
+
+    // Regression test for PR #7214 (issue #7025): custom-node i18n data was
+    // clobbered when a non-English locale was lazily loaded, so nodes from
+    // custom packs lost their translated display_name on locale switch.
+    test('preserves custom-node /api/i18n translation through lazy locale load', async ({
+      comfyPage
+    }) => {
+      await comfyPage.settings.setSetting('Comfy.Locale', 'zh')
+
+      await comfyPage.nodeOps.addNode(NODE_TYPE)
+
+      await expect(comfyPage.vueNodes.getNodeByTitle(LOCALIZED_ZH)).toHaveCount(
+        1
+      )
+    })
+  }
+)


### PR DESCRIPTION
## Summary

Adds e2e test for custom node i18n

## Changes

- **What**: 
- add e2e regression for previous fix with no e2e

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12132-test-add-test-for-custom-node-i18n-35d6d73d365081f7bed2db39af38f855) by [Unito](https://www.unito.io)
