### PR TITLE
fix: update color widget colors

### DIFF
--- a/src/components/ui/color-picker/ColorPicker.vue
+++ b/src/components/ui/color-picker/ColorPicker.vue
@@ -91,7 +91,7 @@ const isOpen = ref(false)
           </div>
         </div>
         <div
-          class="flex flex-1 items-center justify-between pl-1 text-xs text-node-component-slot-text"
+          class="flex flex-1 items-center justify-between pl-1 text-xs text-component-node-foreground"
         >
           <template v-if="displayMode === 'hex'">
             <span>{{ displayHex }}</span>

--- a/src/components/ui/color-picker/ColorPicker.vue
+++ b/src/components/ui/color-picker/ColorPicker.vue
@@ -68,7 +68,7 @@ const isOpen = ref(false)
         type="button"
         :class="
           cn(
-            'flex h-8 w-full items-center overflow-clip rounded-lg border border-transparent bg-node-component-surface pr-2 outline-none hover:bg-component-node-widget-background-hovered',
+            'flex h-8 w-full items-center overflow-clip rounded-lg border border-transparent bg-component-node-widget-background pr-2 outline-none hover:bg-component-node-widget-background-hovered',
             isOpen && 'border-node-stroke',
             $props.class
           )


### PR DESCRIPTION
## Summary

The widget was using a different fg/background compared to all other widgets, this updates to use the standard classes.

## Changes

- **What**: 
- update styles

## Screenshots (if applicable)

Before
<img width="570" height="597" alt="Screen Shot 2026-05-11 at 07 19 12" src="https://github.com/user-attachments/assets/18a5330f-5e9a-4d16-b3f0-0acfab5d6f99" />

After
<img width="570" height="597" alt="Screen Shot 2026-05-11 at 07 15 46" src="https://github.com/user-attachments/assets/81c9da58-fdda-4539-ae1e-98727f12b9ac" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12133-fix-update-color-widget-colors-35d6d73d365081da8515cd48a8e8ecc2) by [Unito](https://www.unito.io)

No e2e tests for this as they would be simple screenshot asserts on the color of nodes, which is not worthwhile.