### PR TITLE
feat(website): remove left-edge fade-out from local hero illustration

### DIFF
--- a/apps/website/src/components/product/local/HeroSection.vue
+++ b/apps/website/src/components/product/local/HeroSection.vue
@@ -276,29 +276,6 @@ onUnmounted(() => {
             fill="#211927"
           />
         </g>
-
-        <!-- Left-edge fade -->
-        <rect
-          x="300"
-          y="150"
-          width="250"
-          height="900"
-          fill="url(#localHeroFadeLeft)"
-        />
-
-        <defs>
-          <linearGradient
-            id="localHeroFadeLeft"
-            x1="550"
-            y1="600"
-            x2="300"
-            y2="600"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stop-color="#211927" stop-opacity="0" />
-            <stop offset="1" stop-color="#211927" />
-          </linearGradient>
-        </defs>
       </svg>
     </div>
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Removes the left-edge fade-out gradient overlay on the hexagonal hero illustration on the `/download` (local) page. The hex cluster now reads fully edge-to-edge instead of being blended into the page background on the left side.

Tracked in [FE-650: Remove fade-out effect on local page hero illustration](https://linear.app/comfyorg/issue/FE-650/remove-fade-out-effect-on-local-page-hero-illustration).

## Change

Drops the `<!-- Left-edge fade -->` `<rect>` and its `<defs><linearGradient id="localHeroFadeLeft">…</linearGradient></defs>` from `apps/website/src/components/product/local/HeroSection.vue`. Animation logic (panel expansion + hex ring rotation) is untouched.

## Verification

- `pnpm nx typecheck website` — pass (0 errors)
- `pnpm nx build website` — pass (51 pages built)
- `pnpm exec eslint apps/website/src/components/product/local/HeroSection.vue` — clean
- `pnpm format:check apps/website/src/components/product/local/HeroSection.vue` — clean
- Manual: `pnpm dev` + visited `/download` at 390×844 (mobile), 1280×800, and 1440×900. Mobile screenshots clearly show the fade is gone; the leftmost hexagons are now fully visible.

## Screenshots

Mobile (390×844), before — note the dark fade obscuring the left side of the hex cluster:

## Screenshots

![Mobile /download hero before — fade visible on left edge of hex illustration](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/105d446470b90b36fa6b9a79fa686c98d107b8a1a7bc8cd5ace92e73fe590e94/pr-images/1778512980323-c51be60d-d64c-4f62-8b07-916206e7704d.png)

![Mobile /download hero after — fade removed, leftmost hexagons fully visible](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/105d446470b90b36fa6b9a79fa686c98d107b8a1a7bc8cd5ace92e73fe590e94/pr-images/1778512980688-6848a1ca-f24b-4821-be57-1704bf5ceae7.png)

![Desktop /download hero after at 1280×800](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/105d446470b90b36fa6b9a79fa686c98d107b8a1a7bc8cd5ace92e73fe590e94/pr-images/1778512981012-02a221c7-0c9c-4b2c-a6e0-97d32f3fa306.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12137-feat-website-remove-left-edge-fade-out-from-local-hero-illustration-35d6d73d365081cba690ed7d46a19882) by [Unito](https://www.unito.io)
