### PR TITLE
fix(website): center GitHubStarBadge text in Safari

### DIFF
--- a/apps/website/src/components/common/GitHubStarBadge.vue
+++ b/apps/website/src/components/common/GitHubStarBadge.vue
@@ -18,7 +18,7 @@ const { stars } = defineProps<{
     <NodeBadge
       :segments="[{ text: stars }]"
       segment-class="px-1.5 py-0 sm:py-0 lg:py-0"
-      text-class="ppformula-text-center text-[10px] leading-none translate-y-0"
+      text-class="text-[10px] translate-y-0"
       size-class="h-5 sm:h-5"
     />
     <span

--- a/apps/website/src/components/common/GitHubStarBadge.vue
+++ b/apps/website/src/components/common/GitHubStarBadge.vue
@@ -18,7 +18,7 @@ const { stars } = defineProps<{
     <NodeBadge
       :segments="[{ text: stars }]"
       segment-class="px-1.5 py-0 sm:py-0 lg:py-0"
-      text-class="text-[10px] leading-none translate-y-0"
+      text-class="ppformula-text-center text-[10px] leading-none translate-y-0"
       size-class="h-5 sm:h-5"
     />
     <span

--- a/apps/website/src/components/common/GitHubStarBadge.vue
+++ b/apps/website/src/components/common/GitHubStarBadge.vue
@@ -18,7 +18,7 @@ const { stars } = defineProps<{
     <NodeBadge
       :segments="[{ text: stars }]"
       segment-class="px-1.5 py-0 sm:py-0 lg:py-0"
-      text-class="text-[10px] translate-y-0"
+      text-class="text-[10px] leading-none translate-y-0"
       size-class="h-5 sm:h-5"
     />
     <span

--- a/apps/website/src/components/common/NodeBadge.vue
+++ b/apps/website/src/components/common/NodeBadge.vue
@@ -26,7 +26,7 @@ const {
     <img
       src="/icons/node-left.svg"
       alt=""
-      class="-mx-px self-stretch"
+      class="-mx-px h-full w-auto self-stretch"
       aria-hidden="true"
     />
 
@@ -38,7 +38,7 @@ const {
         v-if="i > 0"
         src="/icons/node-union.svg"
         alt=""
-        class="-mx-px self-stretch"
+        class="-mx-px h-full w-auto self-stretch"
         aria-hidden="true"
       />
       <span
@@ -72,7 +72,7 @@ const {
     <img
       src="/icons/node-right.svg"
       alt=""
-      class="-mx-px self-stretch"
+      class="-mx-px h-full w-auto self-stretch"
       aria-hidden="true"
     />
   </div>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The 10px star count text inside the desktop nav GitHub star badge rendered vertically off-center in Safari/WebKit. The text was visibly shifted upward inside the yellow badge body, while Chromium rendered it centered correctly.

## Root cause

`NodeBadge.vue` centers its inner text span by setting `flex items-center justify-center` on the segment, then nudging the text with `translate-y-1` (or `translate-y-0` for the small variant). The text span itself is an `inline-block` with no explicit `line-height`, so it inherits the default `line-height: 1.5` (15px for a 10px font).

Safari and Chromium distribute that extra leading differently for the `PP Formula Narrow` custom font: Safari pushes the glyph higher inside its 15px line box, while Chromium positions it near the middle. With only a 5px gap above/below the glyph to play with, that browser-specific divergence is enough to make the badge look misaligned in Safari.

## Fix

Add `leading-none` to the star count text class so the inline-block's line box equals the font size (10px) and the parent flex container's `items-center` produces deterministic vertical centering across browsers.

Verified at lg breakpoint (1440×900) in both WebKit and Chromium via Playwright; the badge now renders identically and is properly centered.

## Verification

- `pnpm typecheck` (website) — clean
- `pnpm build` (website) — 51 pages built successfully
- Pre-commit hooks (stylelint, oxfmt, oxlint, eslint, typecheck, typecheck:website) — all passed
- Visual inspection in WebKit and Chromium via Playwright

Fixes FE-648

## Screenshots

![BEFORE (Safari/WebKit): star count text displaced upward in yellow badge](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/364b285ccc004b7d3778b6129dab4410e0bffe9db5ef124e37443414f9790d70/pr-images/1778513564903-c047c9ac-4719-479e-8442-f15ad389be02.png)

![AFTER (Safari/WebKit): star count text properly centered in yellow badge](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/364b285ccc004b7d3778b6129dab4410e0bffe9db5ef124e37443414f9790d70/pr-images/1778513565238-a4f00af8-54d7-4131-a5fd-849105e427d6.png)

![Zoomed Safari/WebKit view showing the fixed badge with centered 85K text](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/364b285ccc004b7d3778b6129dab4410e0bffe9db5ef124e37443414f9790d70/pr-images/1778513565587-f6aca193-5ced-45aa-b692-3340629f64be.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12138-fix-website-center-GitHubStarBadge-text-in-Safari-35d6d73d3650818aa0e8e0f341b60378) by [Unito](https://www.unito.io)
