### PR TITLE
feat: add model-to-node mappings for new node packs

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -197,5 +197,18 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   ['mediapipe', 'LivePortraitLoadMediaPipeCropper', ''],
 
   // ---- Superprompt text enhancement ----
-  ['superprompt-v1', 'Superprompt', '']
+  ['superprompt-v1', 'Superprompt', ''],
+
+  // ---- Background removal (ComfyUI core) ----
+  ['background_removal', 'LoadBackgroundRemovalModel', 'bg_removal_name'],
+
+  // ---- Frame interpolation (ComfyUI core) ----
+  ['frame_interpolation', 'FrameInterpolationModelLoader', 'model_name'],
+
+  // ---- FILM VFI (ComfyUI-Frame-Interpolation) ----
+  ['film', 'FILM VFI', 'ckpt_name']
+
+  // NOTE: ultralytics/bbox + ultralytics/segm intentionally NOT registered
+  // here. Tracked in BE-689 — re-enable only after cloud-side fixes land
+  // (tag lookup + submitted value mismatch). See PR #12075.
 ] as const satisfies ReadonlyArray<readonly [string, string, string]>

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -38,7 +38,10 @@ const EXPECTED_DEFAULT_TYPES = [
   'segformer_b3_fashion',
   'nlf',
   'FlashVSR',
-  'FlashVSR-v1.1'
+  'FlashVSR-v1.1',
+  'background_removal',
+  'frame_interpolation',
+  'film'
 ] as const
 
 type NodeDefStoreType = ReturnType<typeof useNodeDefStore>
@@ -87,7 +90,10 @@ const MOCK_NODE_NAMES = [
   'IPAdapterModelLoader',
   'LS_LoadSegformerModel',
   'LoadNLFModel',
-  'FlashVSRNode'
+  'FlashVSRNode',
+  'LoadBackgroundRemovalModel',
+  'FrameInterpolationModelLoader',
+  'FILM VFI'
 ] as const
 
 const mockNodeDefsByName = Object.fromEntries(
@@ -261,7 +267,10 @@ describe('useModelToNodeStore', () => {
       ['FlashVSR', 'FlashVSRNode', ''],
       ['FlashVSR-v1.1', 'FlashVSRNode', ''],
       ['segformer_b2_clothes', 'LS_LoadSegformerModel', 'model_name'],
-      ['segformer_b3_fashion', 'LS_LoadSegformerModel', 'model_name']
+      ['segformer_b3_fashion', 'LS_LoadSegformerModel', 'model_name'],
+      ['background_removal', 'LoadBackgroundRemovalModel', 'bg_removal_name'],
+      ['frame_interpolation', 'FrameInterpolationModelLoader', 'model_name'],
+      ['film', 'FILM VFI', 'ckpt_name']
     ])(
       'should return correct provider for %s',
       (modelType, expectedNodeName, expectedKey) => {

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -34,7 +34,10 @@ const EXPECTED_DEFAULT_TYPES = [
   'ipadapter',
   'nlf',
   'FlashVSR',
-  'FlashVSR-v1.1'
+  'FlashVSR-v1.1',
+  'background_removal',
+  'frame_interpolation',
+  'film'
 ] as const
 
 type NodeDefStoreType = ReturnType<typeof useNodeDefStore>
@@ -82,7 +85,10 @@ const MOCK_NODE_NAMES = [
   'IPAdapterModelLoader',
   'LoadNLFModel',
   'FlashVSRNode',
-  'LTXICLoRALoaderModelOnly'
+  'LTXICLoRALoaderModelOnly',
+  'LoadBackgroundRemovalModel',
+  'FrameInterpolationModelLoader',
+  'FILM VFI'
 ] as const
 
 const mockNodeDefsByName = Object.fromEntries(
@@ -248,7 +254,10 @@ describe('useModelToNodeStore', () => {
       ['sams', 'SAMLoader', 'model_name'],
       ['ipadapter', 'IPAdapterModelLoader', 'ipadapter_file'],
       ['FlashVSR', 'FlashVSRNode', ''],
-      ['FlashVSR-v1.1', 'FlashVSRNode', '']
+      ['FlashVSR-v1.1', 'FlashVSRNode', ''],
+      ['background_removal', 'LoadBackgroundRemovalModel', 'bg_removal_name'],
+      ['frame_interpolation', 'FrameInterpolationModelLoader', 'model_name'],
+      ['film', 'FILM VFI', 'ckpt_name']
     ])(
       'should return correct provider for %s',
       ([modelType, expectedNodeName, expectedKey]) => {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Add entries to `MODEL_NODE_MAPPINGS` for three model directories that previously had no UI backlink, so the "Use" button in the model browser correctly creates the appropriate loader node.

### New mappings

| Directory | Node Class | Input Key | Pack |
|---|---|---|---|
| `background_removal` | `LoadBackgroundRemovalModel` | `bg_removal_name` | ComfyUI core |
| `frame_interpolation` | `FrameInterpolationModelLoader` | `model_name` | ComfyUI core |
| `film` | `FILM VFI` | `ckpt_name` | `Fannovel16/ComfyUI-Frame-Interpolation` |

Each mapping was verified against the loader node's `INPUT_TYPES` in the upstream source:
- `LoadBackgroundRemovalModel`: `comfy_extras/nodes_bg_removal.py` — `folder_paths.get_filename_list("background_removal")`, input `bg_removal_name`.
- `FrameInterpolationModelLoader`: `comfy_extras/nodes_frame_interpolation.py` — `folder_paths.get_filename_list("frame_interpolation")`, input `model_name`.
- `FILM VFI`: `Fannovel16/ComfyUI-Frame-Interpolation` (`vfi_models/film/__init__.py`) — `MODEL_TYPE = "film"`, input `ckpt_name`.

### Intentionally excluded: ultralytics

`ultralytics/bbox` and `ultralytics/segm` are **not** registered here, even though they also lack backlinks. PR #12075 (`a4faaa015`) disabled the `UltralyticsDetectorProvider` mapping because of a known asset-metadata mismatch (tag lookup + submitted-value format). Adding `ultralytics/*` rows here would reintroduce that regression. The exclusion is documented inline next to the array's closing bracket and enforced by the existing regression test (`should not register %s as a default provider` covering `ultralytics`, `ultralytics/bbox`, `ultralytics/segm`).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format` applied (oxfmt)
- [x] `pnpm test:unit src/stores/modelToNodeStore.test.ts` — 57/57 passing (was 54; added 3 new `it.each` cases)
- [x] Runtime smoke test against the built module confirms each new entry resolves with the expected `nodeClass` + `inputKey`, and the ultralytics regression remains in place (0 `UltralyticsDetectorProvider` entries, 87 total mappings — 84 from `main` + 3 new)
- [ ] Verify "Use" button works for each new model directory in the model browser (requires staging environment with the backing models present)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12146-feat-add-model-to-node-mappings-for-new-node-packs-35d6d73d3650810a9b82d62b45b883f5) by [Unito](https://www.unito.io)
