### PR TITLE
ci: add windows playwright runner

### DIFF
--- a/.github/actions/setup-comfyui-server/action.yaml
+++ b/.github/actions/setup-comfyui-server/action.yaml
@@ -52,4 +52,11 @@ runs:
       working-directory: ComfyUI
       run: |
         python main.py --cpu --multi-user --front-end-root ../dist ${{ inputs.extra_server_params }} &
-        wait-for-it --service 127.0.0.1:8188 -t 600
+        if command -v wait-for-it &> /dev/null; then
+          wait-for-it --service 127.0.0.1:8188 -t 600
+        else
+          for i in $(seq 1 60); do
+            curl -s http://127.0.0.1:8188 > /dev/null && break
+            sleep 10
+          done
+        fi

--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -14,7 +14,7 @@ runs:
       uses: actions/cache@v5 # v5.0.2
       id: cache-playwright-browsers
       with:
-        path: '~/.cache/ms-playwright'
+        path: ${{ runner.os == 'Windows' && '~/AppData/Local/ms-playwright' || '~/.cache/ms-playwright' }}
         key: ${{ runner.os }}-playwright-browsers-${{ steps.detect-version.outputs.playwright-version }}
 
     - name: Install Playwright Browsers
@@ -23,6 +23,6 @@ runs:
       run: pnpm exec playwright install chromium --with-deps
 
     - name: Install Playwright Browsers (operating system dependencies)
-      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true' && runner.os != 'Windows'
       shell: bash
       run: pnpm exec playwright install-deps

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -173,6 +173,45 @@ jobs:
           path: ./playwright-report/
           retention-days: 30
 
+  # Windows runner — smoke test chromium only, no container
+  playwright-tests-windows:
+    needs: setup
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Download built frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-dist
+          path: dist/
+
+      - name: Setup ComfyUI server (Windows)
+        uses: ./.github/actions/setup-comfyui-server
+        with:
+          launch_server: 'true'
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Run Playwright tests (chromium)
+        id: playwright
+        run: pnpm exec playwright test --project=chromium --reporter=html
+        env:
+          PLAYWRIGHT_HTML_REPORT: playwright-report
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: playwright-report-windows
+          path: ./playwright-report/
+          retention-days: 30
+
   # Merge sharded test reports (no container needed - only runs CLI)
   merge-reports:
     needs: [changes, playwright-tests-chromium-sharded]
@@ -211,7 +250,7 @@ jobs:
   # expanded check names so PRs with no e2e-relevant changes aren't stuck.
   e2e-status:
     if: ${{ always() }}
-    needs: [changes, playwright-tests-chromium-sharded, playwright-tests]
+    needs: [changes, playwright-tests-chromium-sharded, playwright-tests, playwright-tests-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Check E2E results
@@ -219,9 +258,13 @@ jobs:
           SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
           SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
           BROWSERS: ${{ needs.playwright-tests.result }}
+          WINDOWS: ${{ needs.playwright-tests-windows.result }}
         run: |
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
           [[ "$SHARDED" != "success" || "$BROWSERS" != "success" ]] && echo "E2E failed" && exit 1
+          if [[ "$WINDOWS" == "failure" ]]; then
+            echo "::warning::Windows E2E failed (non-blocking — see playwright-report-windows artifact)"
+          fi
           echo "E2E passed"
 
   #### BEGIN Deployment and commenting (non-forked PRs only)


### PR DESCRIPTION
adds a windows-latest job so browser tests get coverage on windows too. right now everything runs on ubuntu only.