### PR TITLE
ci: run Playwright Chromium tests on Windows

### DIFF
--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -18,11 +18,16 @@ runs:
         key: ${{ runner.os }}-playwright-browsers-${{ steps.detect-version.outputs.playwright-version }}
 
     - name: Install Playwright Browsers
-      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' && runner.os != 'Windows'
       shell: bash
       run: pnpm exec playwright install chromium --with-deps
 
+    - name: Install Playwright Browsers (Windows)
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      shell: bash
+      run: pnpm exec playwright install chromium
+
     - name: Install Playwright Browsers (operating system dependencies)
-      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true' && runner.os != 'Windows'
       shell: bash
       run: pnpm exec playwright install-deps

--- a/.github/workflows/ci-tests-e2e.yaml
+++ b/.github/workflows/ci-tests-e2e.yaml
@@ -173,6 +173,54 @@ jobs:
           path: ./playwright-report/
           retention-days: 30
 
+  playwright-tests-windows:
+    timeout-minutes: 60
+    needs: setup
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download built frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-dist
+          path: dist/
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Setup and start ComfyUI server
+        uses: ./.github/actions/setup-comfyui-server
+        with:
+          launch_server: 'true'
+
+      - name: Run Playwright tests (Windows Chromium)
+        id: playwright
+        run: pnpm exec playwright test --project=chromium --reporter=blob
+        env:
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
+
+      - name: Generate HTML and JSON reports
+        if: always()
+        run: |
+          pnpm exec playwright merge-reports --reporter=html ./blob-report
+          $env:PLAYWRIGHT_JSON_OUTPUT_NAME = 'playwright-report/report.json'
+          pnpm exec playwright merge-reports --reporter=json ./blob-report
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: playwright-report-windows-chromium
+          path: ./playwright-report/
+          retention-days: 30
+
   # Merge sharded test reports (no container needed - only runs CLI)
   merge-reports:
     needs: [changes, playwright-tests-chromium-sharded]
@@ -211,7 +259,13 @@ jobs:
   # expanded check names so PRs with no e2e-relevant changes aren't stuck.
   e2e-status:
     if: ${{ always() }}
-    needs: [changes, playwright-tests-chromium-sharded, playwright-tests]
+    needs:
+      [
+        changes,
+        playwright-tests-chromium-sharded,
+        playwright-tests,
+        playwright-tests-windows
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Check E2E results
@@ -219,9 +273,10 @@ jobs:
           SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
           SHARDED: ${{ needs.playwright-tests-chromium-sharded.result }}
           BROWSERS: ${{ needs.playwright-tests.result }}
+          WINDOWS: ${{ needs.playwright-tests-windows.result }}
         run: |
           [[ "$SHOULD_RUN" != "true" ]] && echo "E2E skipped" && exit 0
-          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" ]] && echo "E2E failed" && exit 1
+          [[ "$SHARDED" != "success" || "$BROWSERS" != "success" || "$WINDOWS" != "success" ]] && echo "E2E failed" && exit 1
           echo "E2E passed"
 
   #### BEGIN Deployment and commenting (non-forked PRs only)


### PR DESCRIPTION
Fixes Comfy-Org/ComfyUI_frontend#3197

Adds Windows coverage for browser tests by running the Chromium Playwright project on a windows-latest runner.

Changes:
- Add a Windows Playwright Chromium E2E job
- Reuse the existing setup-comfyui-server action to launch ComfyUI on Windows
- Include the Windows job in the E2E gate
- Skip Linux Playwright dependency installation on Windows

Verified:
- YAML parses cleanly
- yamllint .github/workflows/ci-tests-e2e.yaml .github/actions/setup-playwright/action.yaml

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12150-ci-run-Playwright-Chromium-tests-on-Windows-35d6d73d3650812a9857cdec06a7ef18) by [Unito](https://www.unito.io)
