### PR TITLE
feat: add model-to-node mappings for new model directories

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -197,5 +197,18 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   ['mediapipe', 'LivePortraitLoadMediaPipeCropper', ''],
 
   // ---- Superprompt text enhancement ----
-  ['superprompt-v1', 'Superprompt', '']
+  ['superprompt-v1', 'Superprompt', ''],
+
+  // ---- ComfyUI core background removal (v0.21+) ----
+  ['background_removal', 'LoadBackgroundRemovalModel', 'bg_removal_name'],
+
+  // ---- ComfyUI core frame interpolation (v0.21+) ----
+  ['frame_interpolation', 'FrameInterpolationModelLoader', 'model_name'],
+
+  // ---- FILM frame interpolation (ComfyUI-Frame-Interpolation) ----
+  ['film', 'FILM VFI', 'ckpt_name'],
+
+  // ---- Ultralytics YOLO detectors (ComfyUI-Impact-Pack) ----
+  ['ultralytics/bbox', 'UltralyticsDetectorProvider', 'model_name'],
+  ['ultralytics/segm', 'UltralyticsDetectorProvider', 'model_name']
 ] as const satisfies ReadonlyArray<readonly [string, string, string]>


### PR DESCRIPTION
## Summary

Add entries to `MODEL_NODE_MAPPINGS` so the model browser's "Use" button correctly creates a loader node for five model directories that currently have no mapping.

## Changes

- **What**: 5 new entries in `src/platform/assets/mappings/modelNodeMappings.ts`:
  - `background_removal` → `LoadBackgroundRemovalModel` / `bg_removal_name` (ComfyUI v0.21+ core)
  - `frame_interpolation` → `FrameInterpolationModelLoader` / `model_name` (ComfyUI v0.21+ core)
  - `film` → `FILM VFI` / `ckpt_name` (ComfyUI-Frame-Interpolation)
  - `ultralytics/bbox` → `UltralyticsDetectorProvider` / `model_name` (ComfyUI-Impact-Pack)
  - `ultralytics/segm` → `UltralyticsDetectorProvider` / `model_name` (ComfyUI-Impact-Pack)
- **Breaking**: none

## Review Focus

- Node class names and input keys were cross-checked against the ComfyUI v0.21.0 source and the published Impact-Pack / Frame-Interpolation node definitions
- Both `ultralytics/bbox` and `ultralytics/segm` map to the same node (`UltralyticsDetectorProvider`); its `model_name` combo accepts values from both subdirectories (`bbox/...` and `segm/...`)
- `film` and `frame_interpolation` are separate directories serving different node packs — keeping them as distinct entries rather than collapsing under a parent

## Test plan

- [ ] In the model browser, clicking "Use" on `birefnet.safetensors` creates a `LoadBackgroundRemovalModel` node with the model preselected
- [ ] Same for one model in each of: `frame_interpolation`, `film`, `ultralytics/bbox`, `ultralytics/segm`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12151-feat-add-model-to-node-mappings-for-new-model-directories-35d6d73d365081ff834bf6eb610da160) by [Unito](https://www.unito.io)
