### PR TITLE
fix(assets): show stripped model name on asset card thumbnail fallback

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -417,7 +417,7 @@
   --modal-card-background-hovered: var(--secondary-background-hover);
   --modal-card-border-highlighted: var(--color-ash-400);
   --modal-card-button-surface: var(--color-charcoal-300);
-  --modal-card-placeholder-background: var(--secondary-background);
+  --modal-card-placeholder-background: var(--color-charcoal-700);
   --modal-card-tag-background: var(--color-ash-800);
   --modal-card-tag-foreground: var(--base-foreground);
   --modal-panel-background: var(--color-charcoal-600);

--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -295,6 +295,7 @@
   --modal-card-border-highlighted: var(--secondary-background-selected);
   --modal-card-button-surface: var(--color-smoke-300);
   --modal-card-placeholder-background: var(--color-smoke-600);
+  --asset-card-fallback-background: var(--color-smoke-500);
   --modal-card-tag-background: var(--color-smoke-200);
   --modal-card-tag-foreground: var(--base-foreground);
   --modal-panel-background: var(--color-white);
@@ -417,7 +418,8 @@
   --modal-card-background-hovered: var(--secondary-background-hover);
   --modal-card-border-highlighted: var(--color-ash-400);
   --modal-card-button-surface: var(--color-charcoal-300);
-  --modal-card-placeholder-background: var(--color-charcoal-700);
+  --modal-card-placeholder-background: var(--secondary-background);
+  --asset-card-fallback-background: var(--color-charcoal-700);
   --modal-card-tag-background: var(--color-ash-800);
   --modal-card-tag-foreground: var(--base-foreground);
   --modal-panel-background: var(--color-charcoal-600);
@@ -438,6 +440,7 @@
   --color-modal-card-placeholder-background: var(
     --modal-card-placeholder-background
   );
+  --color-asset-card-fallback-background: var(--asset-card-fallback-background);
   --color-modal-card-tag-background: var(--modal-card-tag-background);
   --color-modal-card-tag-foreground: var(--modal-card-tag-foreground);
   --color-modal-panel-background: var(--modal-panel-background);

--- a/src/platform/assets/components/AssetCard.stories.ts
+++ b/src/platform/assets/components/AssetCard.stories.ts
@@ -100,7 +100,7 @@ export const WithPreviewImage: Story = {
   }
 }
 
-export const FallbackGradient: Story = {
+export const FallbackPlaceholder: Story = {
   args: {
     asset: createAssetData({
       preview_url: undefined
@@ -116,7 +116,31 @@ export const FallbackGradient: Story = {
     docs: {
       description: {
         story:
-          'AssetCard showing fallback gradient when no preview image is available.'
+          'AssetCard showing the neutral placeholder when no preview image is available — filename is stripped of extension and separators.'
+      }
+    }
+  }
+}
+
+export const FallbackPlaceholderLongName: Story = {
+  args: {
+    asset: createAssetData({
+      name: 'Qwen-Image-Edit-2511-Lightning-8steps-V1.0-fp32.safetensors',
+      preview_url: undefined,
+      tags: ['models', 'loras']
+    }),
+    interactive: true
+  },
+  decorators: [
+    () => ({
+      template: '<div class="p-8 bg-base-background max-w-96"><story /></div>'
+    })
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Fallback placeholder for an asset with a very long filename — text wraps and clamps to 3 lines.'
       }
     }
   }

--- a/src/platform/assets/components/AssetCard.stories.ts
+++ b/src/platform/assets/components/AssetCard.stories.ts
@@ -116,7 +116,7 @@ export const FallbackPlaceholder: Story = {
     docs: {
       description: {
         story:
-          'AssetCard showing the neutral placeholder when no preview image is available — filename is stripped of extension and separators.'
+          'AssetCard showing the neutral placeholder when no preview image is available — filename is reduced to the last path segment with any known model extension stripped; hyphens and underscores are preserved.'
       }
     }
   }

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -146,18 +146,14 @@ import Button from '@/components/ui/button/Button.vue'
 import AssetBadgeGroup from '@/platform/assets/components/AssetBadgeGroup.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import { assetService } from '@/platform/assets/services/assetService'
-import { getAssetCardTitle } from '@/platform/assets/utils/assetMetadataUtils'
+import {
+  getAssetCardTitle,
+  stripModelFilename
+} from '@/platform/assets/utils/assetMetadataUtils'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { cn } from '@comfyorg/tailwind-utils'
-
-function stripModelFilename(name: string): string {
-  const filename = name.split('/').pop() ?? name
-  return filename
-    .replace(/\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx)$/i, '')
-    .trim()
-}
 
 const { asset, interactive, focused } = defineProps<{
   asset: AssetDisplayItem

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -20,8 +20,14 @@
     <div class="relative aspect-square w-full overflow-hidden rounded-xl">
       <div
         v-if="isLoading || error"
-        class="flex size-full cursor-pointer items-center justify-center bg-linear-to-br from-smoke-400 via-smoke-800 to-charcoal-400"
-      />
+        class="flex size-full cursor-pointer items-center justify-center bg-modal-card-placeholder-background p-4"
+      >
+        <span
+          class="line-clamp-3 px-2 text-center text-sm font-medium tracking-wide wrap-break-word text-muted-foreground"
+        >
+          {{ fallbackName }}
+        </span>
+      </div>
       <img
         v-else
         :src="asset.preview_url"
@@ -146,6 +152,13 @@ import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
+function stripModelFilename(name: string): string {
+  const filename = name.split('/').pop() ?? name
+  return filename
+    .replace(/\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx)$/i, '')
+    .trim()
+}
+
 const { asset, interactive, focused } = defineProps<{
   asset: AssetDisplayItem
   interactive?: boolean
@@ -172,6 +185,8 @@ const titleId = useId()
 const descId = useId()
 
 const displayName = computed(() => getAssetCardTitle(asset))
+
+const fallbackName = computed(() => stripModelFilename(displayName.value))
 
 // Format at render so locale switches re-flow; the upstream WeakMap caches
 // AssetItem -> AssetDisplayItem by reference, which would otherwise pin the

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -20,9 +20,10 @@
     <div class="relative aspect-square w-full overflow-hidden rounded-xl">
       <div
         v-if="isLoading || error"
-        class="flex size-full cursor-pointer items-center justify-center bg-modal-card-placeholder-background p-4"
+        class="flex size-full cursor-pointer items-center justify-center bg-asset-card-fallback-background p-4"
       >
         <span
+          aria-hidden="true"
           class="line-clamp-3 px-2 text-center text-sm font-medium tracking-wide wrap-break-word text-muted-foreground"
         >
           {{ fallbackName }}
@@ -147,8 +148,8 @@ import AssetBadgeGroup from '@/platform/assets/components/AssetBadgeGroup.vue'
 import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
 import { assetService } from '@/platform/assets/services/assetService'
 import {
-  getAssetCardTitle,
-  stripModelFilename
+  formatAssetCardPlaceholderLabel,
+  getAssetCardTitle
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
@@ -182,7 +183,9 @@ const descId = useId()
 
 const displayName = computed(() => getAssetCardTitle(asset))
 
-const fallbackName = computed(() => stripModelFilename(displayName.value))
+const fallbackName = computed(() =>
+  formatAssetCardPlaceholderLabel(displayName.value)
+)
 
 // Format at render so locale switches re-flow; the upstream WeakMap caches
 // AssetItem -> AssetDisplayItem by reference, which would otherwise pin the

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -14,7 +14,8 @@ import {
   getAssetSourceUrl,
   getAssetTriggerPhrases,
   getAssetUserDescription,
-  getSourceName
+  getSourceName,
+  stripModelFilename
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 describe('assetMetadataUtils', () => {
@@ -381,6 +382,44 @@ describe('assetMetadataUtils', () => {
         display_name: 'pretty.png'
       }
       expect(getAssetCardTitle(asset)).toBe('pretty.png')
+    })
+  })
+
+  describe('stripModelFilename', () => {
+    it('strips a single safetensors extension', () => {
+      expect(stripModelFilename('v1-5-pruned-emaonly.safetensors')).toBe(
+        'v1-5-pruned-emaonly'
+      )
+    })
+
+    it('strips path prefix and keeps only the last segment', () => {
+      expect(stripModelFilename('owner/repo/model.safetensors')).toBe('model')
+    })
+
+    it('preserves hyphens and underscores as part of the name', () => {
+      expect(stripModelFilename('detail-tweaker_v2.ckpt')).toBe(
+        'detail-tweaker_v2'
+      )
+    })
+
+    it('only strips the trailing extension on double-extension names', () => {
+      expect(stripModelFilename('model.fp16.safetensors')).toBe('model.fp16')
+    })
+
+    it('matches extensions case-insensitively', () => {
+      expect(stripModelFilename('Lora_v1.CKPT')).toBe('Lora_v1')
+    })
+
+    it('handles a trailing slash by falling back to the preceding segment', () => {
+      expect(stripModelFilename('Author/')).toBe('Author')
+    })
+
+    it('does not return an empty string when the input is just an extension', () => {
+      expect(stripModelFilename('.safetensors')).toBe('.safetensors')
+    })
+
+    it('returns plain names unchanged', () => {
+      expect(stripModelFilename('plain-name')).toBe('plain-name')
     })
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -427,5 +427,17 @@ describe('assetMetadataUtils', () => {
     it('returns plain names unchanged', () => {
       expect(formatAssetCardPlaceholderLabel('plain-name')).toBe('plain-name')
     })
+
+    it('handles Windows-style backslash separators', () => {
+      expect(
+        formatAssetCardPlaceholderLabel('C:\\Models\\loras\\foo.safetensors')
+      ).toBe('foo')
+    })
+
+    it('trims whitespace before extension matching', () => {
+      expect(formatAssetCardPlaceholderLabel('  model.safetensors  ')).toBe(
+        'model'
+      )
+    })
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -15,7 +15,7 @@ import {
   getAssetTriggerPhrases,
   getAssetUserDescription,
   getSourceName,
-  stripModelFilename
+  formatAssetCardPlaceholderLabel
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 describe('assetMetadataUtils', () => {
@@ -385,41 +385,47 @@ describe('assetMetadataUtils', () => {
     })
   })
 
-  describe('stripModelFilename', () => {
+  describe('formatAssetCardPlaceholderLabel', () => {
     it('strips a single safetensors extension', () => {
-      expect(stripModelFilename('v1-5-pruned-emaonly.safetensors')).toBe(
-        'v1-5-pruned-emaonly'
-      )
+      expect(
+        formatAssetCardPlaceholderLabel('v1-5-pruned-emaonly.safetensors')
+      ).toBe('v1-5-pruned-emaonly')
     })
 
     it('strips path prefix and keeps only the last segment', () => {
-      expect(stripModelFilename('owner/repo/model.safetensors')).toBe('model')
+      expect(
+        formatAssetCardPlaceholderLabel('owner/repo/model.safetensors')
+      ).toBe('model')
     })
 
     it('preserves hyphens and underscores as part of the name', () => {
-      expect(stripModelFilename('detail-tweaker_v2.ckpt')).toBe(
+      expect(formatAssetCardPlaceholderLabel('detail-tweaker_v2.ckpt')).toBe(
         'detail-tweaker_v2'
       )
     })
 
     it('only strips the trailing extension on double-extension names', () => {
-      expect(stripModelFilename('model.fp16.safetensors')).toBe('model.fp16')
+      expect(formatAssetCardPlaceholderLabel('model.fp16.safetensors')).toBe(
+        'model.fp16'
+      )
     })
 
     it('matches extensions case-insensitively', () => {
-      expect(stripModelFilename('Lora_v1.CKPT')).toBe('Lora_v1')
+      expect(formatAssetCardPlaceholderLabel('Lora_v1.CKPT')).toBe('Lora_v1')
     })
 
     it('handles a trailing slash by falling back to the preceding segment', () => {
-      expect(stripModelFilename('Author/')).toBe('Author')
+      expect(formatAssetCardPlaceholderLabel('Author/')).toBe('Author')
     })
 
     it('does not return an empty string when the input is just an extension', () => {
-      expect(stripModelFilename('.safetensors')).toBe('.safetensors')
+      expect(formatAssetCardPlaceholderLabel('.safetensors')).toBe(
+        '.safetensors'
+      )
     })
 
     it('returns plain names unchanged', () => {
-      expect(stripModelFilename('plain-name')).toBe('plain-name')
+      expect(formatAssetCardPlaceholderLabel('plain-name')).toBe('plain-name')
     })
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -204,3 +204,19 @@ export function getAssetCardTitle(asset: AssetItem): string {
   if (curatedName && curatedName !== asset.name) return curatedName
   return getAssetDisplayFilename(asset)
 }
+
+const MODEL_FILE_EXTENSION_PATTERN =
+  /\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx)$/i
+
+/**
+ * Builds a short caption for an asset card's placeholder when no preview
+ * image is available. Strips path segments and common model file extensions
+ * while preserving hyphens and underscores (these are part of the model name,
+ * not delimiters). Never returns an empty string for a non-empty input.
+ */
+export function stripModelFilename(name: string): string {
+  const segments = name.split('/').filter(Boolean)
+  const filename = segments.at(-1) ?? name
+  const stripped = filename.replace(MODEL_FILE_EXTENSION_PATTERN, '').trim()
+  return stripped || filename.trim() || name
+}

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -223,14 +223,14 @@ export const MODEL_FILE_EXTENSIONS = new Set([
  * not delimiters). Never returns an empty string for a non-empty input.
  */
 export function formatAssetCardPlaceholderLabel(name: string): string {
-  const segments = name.split('/').filter(Boolean)
-  const filename = segments.at(-1) ?? name
+  const segments = name.split(/[\\/]/).filter(Boolean)
+  const filename = (segments.at(-1) ?? name).trim()
   const lower = filename.toLowerCase()
   for (const ext of MODEL_FILE_EXTENSIONS) {
     if (lower.endsWith(ext)) {
       const stripped = filename.slice(0, -ext.length).trim()
-      return stripped || filename.trim()
+      return stripped || filename || name
     }
   }
-  return filename.trim() || name
+  return filename || name
 }

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -205,8 +205,16 @@ export function getAssetCardTitle(asset: AssetItem): string {
   return getAssetDisplayFilename(asset)
 }
 
-const MODEL_FILE_EXTENSION_PATTERN =
-  /\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx)$/i
+export const MODEL_FILE_EXTENSIONS = new Set([
+  '.safetensors',
+  '.ckpt',
+  '.pt',
+  '.pth',
+  '.bin',
+  '.sft',
+  '.onnx',
+  '.gguf'
+])
 
 /**
  * Builds a short caption for an asset card's placeholder when no preview
@@ -214,9 +222,15 @@ const MODEL_FILE_EXTENSION_PATTERN =
  * while preserving hyphens and underscores (these are part of the model name,
  * not delimiters). Never returns an empty string for a non-empty input.
  */
-export function stripModelFilename(name: string): string {
+export function formatAssetCardPlaceholderLabel(name: string): string {
   const segments = name.split('/').filter(Boolean)
   const filename = segments.at(-1) ?? name
-  const stripped = filename.replace(MODEL_FILE_EXTENSION_PATTERN, '').trim()
-  return stripped || filename.trim() || name
+  const lower = filename.toLowerCase()
+  for (const ext of MODEL_FILE_EXTENSIONS) {
+    if (lower.endsWith(ext)) {
+      const stripped = filename.slice(0, -ext.length).trim()
+      return stripped || filename.trim()
+    }
+  }
+  return filename.trim() || name
 }

--- a/src/platform/missingModel/missingModelScan.ts
+++ b/src/platform/missingModel/missingModelScan.ts
@@ -6,7 +6,10 @@ import type {
   MissingModelViewModel,
   EmbeddedModelWithSource
 } from './types'
-import { getAssetFilename } from '@/platform/assets/utils/assetMetadataUtils'
+import {
+  MODEL_FILE_EXTENSIONS,
+  getAssetFilename
+} from '@/platform/assets/utils/assetMetadataUtils'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 // eslint-disable-next-line import-x/no-restricted-paths
 import { getSelectedModelsMetadata } from '@/workbench/utils/modelMetadataUtil'
@@ -70,19 +73,10 @@ function isAssetWidget(widget: IBaseWidget): widget is IAssetWidget {
   return widget.type === 'asset'
 }
 
-// Full set of model file extensions used for scanning candidate widgets.
-// Intentionally broader than ALLOWED_SUFFIXES in missingModelDownload.ts,
-// which restricts which files are eligible for download.
-export const MODEL_FILE_EXTENSIONS = new Set([
-  '.safetensors',
-  '.ckpt',
-  '.pt',
-  '.pth',
-  '.bin',
-  '.sft',
-  '.onnx',
-  '.gguf'
-])
+// Re-export the canonical model extension set from assets/utils so existing
+// callers continue to work; ALLOWED_SUFFIXES in missingModelDownload.ts is
+// intentionally narrower and lives there.
+export { MODEL_FILE_EXTENSIONS }
 
 export function isModelFileName(name: string): boolean {
   const lower = name.toLowerCase()


### PR DESCRIPTION
## Summary

Replace the empty silver gradient placeholder on `AssetCard` (Model Library / model picker modal) with a neutral dark surface and the stripped model name centered on it — so cards without thumbnails are informative and on-brand instead of looking like a broken state.

## Changes

- **What**:
  - `AssetCard.vue` — when `preview_url` is missing or fails to load, render the stripped filename centered on the placeholder surface instead of the previous `from-smoke-400 via-smoke-800 to-charcoal-400` gradient.
  - `assetMetadataUtils.ts` — new `stripModelFilename` helper alongside the other display-name helpers. Takes the last path segment of the display name, strips common model file extensions (`.safetensors`, `.ckpt`, `.pt`, `.pth`, `.bin`, `.gguf`, `.sft`, `.onnx`), and preserves hyphens / underscores. Guards trailing-slash and bare-extension inputs so the placeholder caption is never empty.
  - `assetMetadataUtils.test.ts` — 8 new test cases for `stripModelFilename` covering path-strip, double-extension, case-insensitivity, trailing slash, bare extension, and a plain name.
  - `style.css` — dark-mode `--modal-card-placeholder-background` token bumped from `var(--secondary-background)` (#262729) to `var(--color-charcoal-700)` (#202121). Before this, the token resolved to the same value as `--modal-card-background`, so the placeholder was invisible against the card surface in every consumer (see below).
  - `AssetCard.stories.ts` — renamed `FallbackGradient` → `FallbackPlaceholder` and added a `FallbackPlaceholderLongName` variant to exercise multi-line wrapping.
- **Breaking**: none — pure visual replacement of an existing fallback. Cards with valid `preview_url` render the same `<img>` as before.
- **Dependencies**: none.

## Review Focus

- **CSS token ripple — wider than the initial framing.** `--modal-card-placeholder-background` is consumed by these other surfaces, all of which previously had the placeholder bg equal to the card bg in dark mode (effectively invisible):
  - `MediaImageTop.vue`, `MediaAudioTop.vue`, `MediaTextTop.vue`, `Media3DTop.vue`, `MediaOtherTop.vue`
  - `MediaAssetCard.vue` (skeleton/loading state)
  - `ActiveMediaAssetCard.vue`
  - `FormDropdownMenuItem.vue` (node-widget thumbnail surface)
  - `AssetsListItem.stories.ts`

  None had test pins on the old color value. The darker bg slightly improves the icon contrast in dark mode wherever a `pi-image`/equivalent icon is rendered. Worth eyeballing the workflow-tab asset grid loading skeleton, the output gallery loading state, and the node-widget dropdown thumbnail in dark mode.
- `stripModelFilename` operates on the result of `getAssetCardTitle()`. For most assets this is `display_name`, which can include a `repo/owner` prefix; we strip everything before the last `/` so users see just the model identifier in the placeholder. The filename is still shown verbatim in the card's secondary text below — no information is lost.

## Screenshots (if applicable)
### Before
<img width="1608" height="826" alt="image" src="https://github.com/user-attachments/assets/58d5f859-90b7-4004-a4e2-96d2dee5157a" />
### After
<img width="1621" height="827" alt="image" src="https://github.com/user-attachments/assets/8a994e51-701c-42ff-ad79-591fac1888a2" />


Compare locally in Storybook → `Platform / Assets / AssetCard / Fallback Placeholder` and `Fallback Placeholder Long Name`.