### PR TITLE
feat: add new_user_default_template_tab feature flag for onboarding A/B test

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -596,8 +596,7 @@ const coordinateNavAndSort = (source: 'nav' | 'sort') => {
   }
 }
 
-// Watch for changes from the two sources ('nav' and 'sort') and trigger the coordinator.
-watch(selectedNavItem, () => coordinateNavAndSort('nav'))
+watch(selectedNavItem, () => coordinateNavAndSort('nav'), { immediate: true })
 watch(sortBy, () => coordinateNavAndSort('sort'))
 
 // Convert between string array and object array for MultiSelect component

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -219,5 +219,47 @@ describe('useFeatureFlags', () => {
       const { flags } = useFeatureFlags()
       expect(flags.teamWorkspacesEnabled).toBe(true)
     })
+
+    it('newUserDefaultTemplateTab returns dev override value', () => {
+      localStorage.setItem(
+        'ff:new_user_default_template_tab',
+        JSON.stringify('popular')
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.newUserDefaultTemplateTab).toBe('popular')
+    })
+
+    it('newUserDefaultTemplateTab trims whitespace', () => {
+      localStorage.setItem(
+        'ff:new_user_default_template_tab',
+        JSON.stringify('  popular  ')
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.newUserDefaultTemplateTab).toBe('popular')
+    })
+
+    it.each(['', '   ', '\t\n'])(
+      'newUserDefaultTemplateTab normalizes %j to undefined',
+      (raw) => {
+        localStorage.setItem(
+          'ff:new_user_default_template_tab',
+          JSON.stringify(raw)
+        )
+
+        const { flags } = useFeatureFlags()
+        expect(flags.newUserDefaultTemplateTab).toBeUndefined()
+      }
+    )
+
+    it('newUserDefaultTemplateTab returns undefined when unset', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.newUserDefaultTemplateTab).toBeUndefined()
+    })
   })
 })

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -261,5 +261,24 @@ describe('useFeatureFlags', () => {
       const { flags } = useFeatureFlags()
       expect(flags.newUserDefaultTemplateTab).toBeUndefined()
     })
+
+    it('newUserDefaultTemplateTab falls through to server feature when remoteConfig is blank', async () => {
+      const { remoteConfig } =
+        await import('@/platform/remoteConfig/remoteConfig')
+      const previous = remoteConfig.value
+      remoteConfig.value = { new_user_default_template_tab: '   ' }
+      vi.mocked(api.getServerFeature).mockImplementation((path) => {
+        if (path === ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB)
+          return 'popular'
+        return undefined
+      })
+
+      try {
+        const { flags } = useFeatureFlags()
+        expect(flags.newUserDefaultTemplateTab).toBe('popular')
+      } finally {
+        remoteConfig.value = previous
+      }
+    })
   })
 })

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -768,5 +768,24 @@ describe('useFeatureFlags', () => {
       const { flags } = useFeatureFlags()
       expect(flags.newUserDefaultTemplateTab).toBeUndefined()
     })
+
+    it('newUserDefaultTemplateTab falls through to server feature when remoteConfig is blank', async () => {
+      const { remoteConfig } =
+        await import('@/platform/remoteConfig/remoteConfig')
+      const previous = remoteConfig.value
+      remoteConfig.value = { new_user_default_template_tab: '   ' }
+      vi.mocked(api.getServerFeature).mockImplementation((path) => {
+        if (path === ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB)
+          return 'popular'
+        return undefined
+      })
+
+      try {
+        const { flags } = useFeatureFlags()
+        expect(flags.newUserDefaultTemplateTab).toBe('popular')
+      } finally {
+        remoteConfig.value = previous
+      }
+    })
   })
 })

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -726,5 +726,47 @@ describe('useFeatureFlags', () => {
       const { flags } = useFeatureFlags()
       expect(flags.billingControlEnabled).toBe(true)
     })
+
+    it('newUserDefaultTemplateTab returns dev override value', () => {
+      localStorage.setItem(
+        'ff:new_user_default_template_tab',
+        JSON.stringify('popular')
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.newUserDefaultTemplateTab).toBe('popular')
+    })
+
+    it('newUserDefaultTemplateTab trims whitespace', () => {
+      localStorage.setItem(
+        'ff:new_user_default_template_tab',
+        JSON.stringify('  popular  ')
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.newUserDefaultTemplateTab).toBe('popular')
+    })
+
+    it.each(['', '   ', '\t\n'])(
+      'newUserDefaultTemplateTab normalizes %j to undefined',
+      (raw) => {
+        localStorage.setItem(
+          'ff:new_user_default_template_tab',
+          JSON.stringify(raw)
+        )
+
+        const { flags } = useFeatureFlags()
+        expect(flags.newUserDefaultTemplateTab).toBeUndefined()
+      }
+    )
+
+    it('newUserDefaultTemplateTab returns undefined when unset', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.newUserDefaultTemplateTab).toBeUndefined()
+    })
   })
 })

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -27,7 +27,8 @@ export enum ServerFeatureFlag {
   WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
   COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
-  SHOW_SIGNIN_BUTTON = 'show_signin_button'
+  SHOW_SIGNIN_BUTTON = 'show_signin_button',
+  NEW_USER_DEFAULT_TEMPLATE_TAB = 'new_user_default_template_tab'
 }
 
 /**
@@ -161,6 +162,19 @@ export function useFeatureFlags() {
     get showSignInButton(): boolean | undefined {
       return api.getServerFeature<boolean | undefined>(
         ServerFeatureFlag.SHOW_SIGNIN_BUTTON,
+        undefined
+      )
+    },
+    /**
+     * Template category id shown by default when the template selector
+     * opens for a new user during onboarding. Used for A/B testing the
+     * onboarding tab via PostHog feature flags. Returns `undefined` when
+     * unset so callers fall back to the built-in default.
+     */
+    get newUserDefaultTemplateTab(): string | undefined {
+      return resolveFlag<string | undefined>(
+        ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB,
+        remoteConfig.value.new_user_default_template_tab,
         undefined
       )
     }

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -172,11 +172,13 @@ export function useFeatureFlags() {
      * unset so callers fall back to the built-in default.
      */
     get newUserDefaultTemplateTab(): string | undefined {
-      return resolveFlag<string | undefined>(
+      const value = resolveFlag<string | undefined>(
         ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB,
         remoteConfig.value.new_user_default_template_tab,
         undefined
       )
+      const normalized = value?.trim()
+      return normalized ? normalized : undefined
     }
   })
 

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -172,9 +172,10 @@ export function useFeatureFlags() {
      * unset so callers fall back to the built-in default.
      */
     get newUserDefaultTemplateTab(): string | undefined {
+      const remote = remoteConfig.value.new_user_default_template_tab?.trim()
       const value = resolveFlag<string | undefined>(
         ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB,
-        remoteConfig.value.new_user_default_template_tab,
+        remote ? remote : undefined,
         undefined
       )
       const normalized = value?.trim()

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -296,9 +296,10 @@ export function useFeatureFlags() {
      * unset so callers fall back to the built-in default.
      */
     get newUserDefaultTemplateTab(): string | undefined {
+      const remote = remoteConfig.value.new_user_default_template_tab?.trim()
       const value = resolveFlag<string | undefined>(
         ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB,
-        remoteConfig.value.new_user_default_template_tab,
+        remote ? remote : undefined,
         undefined
       )
       const normalized = value?.trim()

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -44,7 +44,8 @@ export enum ServerFeatureFlag {
   CHURNKEY_APP_ID = 'churnkey_app_id',
   SIGNUP_TURNSTILE = 'signup_turnstile',
   SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags',
-  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled'
+  ONBOARDING_TOUR_ENABLED = 'onboarding_tour_enabled',
+  NEW_USER_DEFAULT_TEMPLATE_TAB = 'new_user_default_template_tab'
 }
 
 /**
@@ -287,6 +288,19 @@ export function useFeatureFlags() {
     },
     get assetsEnabled() {
       return isCloud || resolveFlag('assets', undefined, false)
+    },
+    /**
+     * Template category id shown by default when the template selector
+     * opens for a new user during onboarding. Used for A/B testing the
+     * onboarding tab via PostHog feature flags. Returns `undefined` when
+     * unset so callers fall back to the built-in default.
+     */
+    get newUserDefaultTemplateTab(): string | undefined {
+      return resolveFlag<string | undefined>(
+        ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB,
+        remoteConfig.value.new_user_default_template_tab,
+        undefined
+      )
     }
   })
 

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -296,11 +296,13 @@ export function useFeatureFlags() {
      * unset so callers fall back to the built-in default.
      */
     get newUserDefaultTemplateTab(): string | undefined {
-      return resolveFlag<string | undefined>(
+      const value = resolveFlag<string | undefined>(
         ServerFeatureFlag.NEW_USER_DEFAULT_TEMPLATE_TAB,
         remoteConfig.value.new_user_default_template_tab,
         undefined
       )
+      const normalized = value?.trim()
+      return normalized ? normalized : undefined
     }
   })
 

--- a/src/composables/useWorkflowTemplateSelectorDialog.test.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.test.ts
@@ -16,6 +16,10 @@ const mockTelemetry = vi.hoisted(() => ({
   trackTemplateLibraryOpened: vi.fn()
 }))
 
+const mockFlags = vi.hoisted(() => ({
+  newUserDefaultTemplateTab: undefined as string | undefined
+}))
+
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => mockDialogService
 }))
@@ -32,6 +36,10 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => mockTelemetry
 }))
 
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFlags })
+}))
+
 vi.mock(
   '@/components/custom/widget/WorkflowTemplateSelectorDialog.vue',
   () => ({
@@ -44,6 +52,7 @@ import { useWorkflowTemplateSelectorDialog } from './useWorkflowTemplateSelector
 describe('useWorkflowTemplateSelectorDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockFlags.newUserDefaultTemplateTab = undefined
   })
 
   describe('show', () => {
@@ -79,6 +88,38 @@ describe('useWorkflowTemplateSelectorDialog', () => {
 
     it('defaults to "all" when new user status is undetermined', () => {
       mockNewUserService.isNewUser.mockReturnValue(null)
+
+      const dialog = useWorkflowTemplateSelectorDialog()
+      dialog.show()
+
+      expect(mockDialogService.showLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            initialCategory: 'all'
+          })
+        })
+      )
+    })
+
+    it('uses feature flag override for new users when set', () => {
+      mockNewUserService.isNewUser.mockReturnValue(true)
+      mockFlags.newUserDefaultTemplateTab = 'popular'
+
+      const dialog = useWorkflowTemplateSelectorDialog()
+      dialog.show()
+
+      expect(mockDialogService.showLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            initialCategory: 'popular'
+          })
+        })
+      )
+    })
+
+    it('ignores feature flag override for non-new users', () => {
+      mockNewUserService.isNewUser.mockReturnValue(false)
+      mockFlags.newUserDefaultTemplateTab = 'popular'
 
       const dialog = useWorkflowTemplateSelectorDialog()
       dialog.show()

--- a/src/composables/useWorkflowTemplateSelectorDialog.test.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockDialogService = vi.hoisted(() => ({
   showLayoutDialog: vi.fn()
@@ -14,6 +14,10 @@ const mockNewUserService = vi.hoisted(() => ({
 
 const mockTelemetry = vi.hoisted(() => ({
   trackTemplateLibraryOpened: vi.fn()
+}))
+
+const mockFlags = vi.hoisted(() => ({
+  newUserDefaultTemplateTab: undefined as string | undefined
 }))
 
 vi.mock('@/services/dialogService', () => ({
@@ -32,6 +36,10 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => mockTelemetry
 }))
 
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFlags })
+}))
+
 vi.mock(
   '@/components/custom/widget/WorkflowTemplateSelectorDialog.vue',
   () => ({
@@ -42,6 +50,11 @@ vi.mock(
 import { useWorkflowTemplateSelectorDialog } from './useWorkflowTemplateSelectorDialog'
 
 describe('useWorkflowTemplateSelectorDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFlags.newUserDefaultTemplateTab = undefined
+  })
+
   describe('show', () => {
     it('defaults to "all" category for non-new users', () => {
       mockNewUserService.isNewUser.mockReturnValue(false)
@@ -73,6 +86,38 @@ describe('useWorkflowTemplateSelectorDialog', () => {
 
     it('defaults to "all" when new user status is undetermined', () => {
       mockNewUserService.isNewUser.mockReturnValue(null)
+
+      const dialog = useWorkflowTemplateSelectorDialog()
+      dialog.show()
+
+      expect(mockDialogService.showLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            initialCategory: 'all'
+          })
+        })
+      )
+    })
+
+    it('uses feature flag override for new users when set', () => {
+      mockNewUserService.isNewUser.mockReturnValue(true)
+      mockFlags.newUserDefaultTemplateTab = 'popular'
+
+      const dialog = useWorkflowTemplateSelectorDialog()
+      dialog.show()
+
+      expect(mockDialogService.showLayoutDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            initialCategory: 'popular'
+          })
+        })
+      )
+    })
+
+    it('ignores feature flag override for non-new users', () => {
+      mockNewUserService.isNewUser.mockReturnValue(false)
+      mockFlags.newUserDefaultTemplateTab = 'popular'
 
       const dialog = useWorkflowTemplateSelectorDialog()
       dialog.show()

--- a/src/composables/useWorkflowTemplateSelectorDialog.test.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.test.ts
@@ -71,7 +71,7 @@ describe('useWorkflowTemplateSelectorDialog', () => {
       )
     })
 
-    it('defaults to "popular" category for new users', () => {
+    it('defaults to "basics-getting-started" category for new users', () => {
       mockNewUserService.isNewUser.mockReturnValue(true)
 
       const dialog = useWorkflowTemplateSelectorDialog()
@@ -79,7 +79,9 @@ describe('useWorkflowTemplateSelectorDialog', () => {
 
       expect(mockDialogService.showLayoutDialog).toHaveBeenCalledWith(
         expect.objectContaining({
-          props: expect.objectContaining({ initialCategory: 'popular' })
+          props: expect.objectContaining({
+            initialCategory: 'basics-getting-started'
+          })
         })
       )
     })

--- a/src/composables/useWorkflowTemplateSelectorDialog.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.ts
@@ -1,4 +1,5 @@
 import WorkflowTemplateSelectorDialog from '@/components/custom/widget/WorkflowTemplateSelectorDialog.vue'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useTelemetry } from '@/platform/telemetry'
 import type { TemplateLibraryMetadata } from '@/platform/telemetry/types'
 import { useDialogService } from '@/services/dialogService'
@@ -12,9 +13,14 @@ export const useWorkflowTemplateSelectorDialog = () => {
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
   const newUserService = useNewUserService()
+  const { flags } = useFeatureFlags()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
+  }
+
+  function newUserDefaultCategory() {
+    return flags.newUserDefaultTemplateTab ?? GETTING_STARTED_CATEGORY_ID
   }
 
   function show(
@@ -25,7 +31,7 @@ export const useWorkflowTemplateSelectorDialog = () => {
 
     const initialCategory =
       options?.initialCategory ??
-      (newUserService.isNewUser() ? GETTING_STARTED_CATEGORY_ID : 'all')
+      (newUserService.isNewUser() ? newUserDefaultCategory() : 'all')
 
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,

--- a/src/composables/useWorkflowTemplateSelectorDialog.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.ts
@@ -1,4 +1,5 @@
 import WorkflowTemplateSelectorDialog from '@/components/custom/widget/WorkflowTemplateSelectorDialog.vue'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useTelemetry } from '@/platform/telemetry'
 import type { TemplateLibraryMetadata } from '@/platform/telemetry/types'
 import { useDialogService } from '@/services/dialogService'
@@ -6,15 +7,20 @@ import { useNewUserService } from '@/services/useNewUserService'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const DIALOG_KEY = 'global-workflow-template-selector'
-const POPULAR_CATEGORY_ID = 'popular'
+const GETTING_STARTED_CATEGORY_ID = 'basics-getting-started'
 
 export const useWorkflowTemplateSelectorDialog = () => {
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
   const newUserService = useNewUserService()
+  const { flags } = useFeatureFlags()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
+  }
+
+  function newUserDefaultCategory() {
+    return flags.newUserDefaultTemplateTab ?? GETTING_STARTED_CATEGORY_ID
   }
 
   function show(
@@ -25,7 +31,7 @@ export const useWorkflowTemplateSelectorDialog = () => {
 
     const initialCategory =
       options?.initialCategory ??
-      (newUserService.isNewUser() ? POPULAR_CATEGORY_ID : 'all')
+      (newUserService.isNewUser() ? newUserDefaultCategory() : 'all')
 
     dialogService.showLayoutDialog({
       key: DIALOG_KEY,

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -104,4 +104,5 @@ export type RemoteConfig = {
   comfyhub_upload_enabled?: boolean
   comfyhub_profile_gate_enabled?: boolean
   sentry_dsn?: string
+  new_user_default_template_tab?: string
 }

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -135,6 +135,7 @@ export type RemoteConfig = {
   // Always funnel it through normalizeTurnstileMode before trusting it as a
   // TurnstileMode — that resolver is the single narrowing boundary.
   signup_turnstile?: string
+  new_user_default_template_tab?: string
 }
 
 /**


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Adds a runtime config / server feature flag (`new_user_default_template_tab`) that lets us A/B test which template category is shown by default when the template selector opens for a new user. Enables PostHog multivariate flags to drive the experiment without a frontend release.

Context: https://comfy-organization.slack.com/archives/C09HV6S5KUH/p1778469351463809

## Changes

- `platform/remoteConfig/types.ts`: Add optional `new_user_default_template_tab?: string` to `RemoteConfig`.
- `composables/useFeatureFlags.ts`: Add `NEW_USER_DEFAULT_TEMPLATE_TAB` to `ServerFeatureFlag` and expose `flags.newUserDefaultTemplateTab` (string | undefined; uses dev override > remoteConfig > server feature priority).
- `composables/useWorkflowTemplateSelectorDialog.ts`: When the dialog opens for a new user and no `initialCategory` is passed, use the flag value if set, otherwise fall back to the existing `'basics-getting-started'` default. Non-new-user behavior is unchanged.
- `components/custom/widget/WorkflowTemplateSelectorDialog.vue`: Make the nav/sort coordinator run on mount so opening with `initialCategory: 'popular'` correctly initializes `sortBy = 'popular'` on first render (oracle review finding).
- Tests: add two cases in `useWorkflowTemplateSelectorDialog.test.ts` covering the flag override for new users and the no-effect-for-existing-users case.

## Behavior

| New user? | Flag value | initialCategory |
|---|---|---|
| yes | unset | `basics-getting-started` (current default) |
| yes | `'popular'` | `'popular'` |
| yes | `'all'` | `'all'` |
| no | any | `'all'` (unchanged) |
| any caller | explicit `options.initialCategory` | that value (unchanged) |

## PostHog wiring

Once the backend `/features` endpoint serves `new_user_default_template_tab`, a PostHog multivariate flag can drive the value per variant. Locally:

```js
localStorage.setItem('ff:new_user_default_template_tab', '"popular"')
```

## Verification

- `pnpm typecheck` clean
- Targeted unit tests: 25/25 pass (`useWorkflowTemplateSelectorDialog.test.ts`, `useFeatureFlags.test.ts`)
- `pnpm format:check` / eslint on changed files clean
- Manual E2E with Playwright against `pnpm dev` + comfyui backend:
  - Default (no flag): new user → dialog opens to **Getting Started**, sort = **Default**
  - Flag set to `"popular"`: new user → dialog opens to **Popular**, sort = **Popular** (verifying the coordinator fix)


## Screenshots

![Default behavior: new user sees Getting Started tab (flag unset)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1b02e403e4c62002099dd293d0458ad6ab8515c9208d4d57b1df2792725c4f19/pr-images/1778555495528-636da6b4-5c53-4276-ad45-bcbe2ce123e9.png)

![With ff:new_user_default_template_tab=popular: new user sees Popular tab with sortBy=Popular](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1b02e403e4c62002099dd293d0458ad6ab8515c9208d4d57b1df2792725c4f19/pr-images/1778555495884-c576e780-13ee-4d97-911a-f5a54ffc51f2.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12160-feat-add-new_user_default_template_tab-feature-flag-for-onboarding-A-B-test-35e6d73d3650812fb608e0171e5e9b2a) by [Unito](https://www.unito.io)
