### PR TITLE
test: enable vitest/consistent-each-for and migrate .each → .for

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -85,6 +85,15 @@
     "typescript/no-unused-vars": "off",
     "unicorn/no-empty-file": "off",
     "vitest/require-mock-type-parameters": "off",
+    "vitest/consistent-each-for": [
+      "error",
+      {
+        "test": "for",
+        "it": "for",
+        "describe": "for",
+        "suite": "for"
+      }
+    ],
     "unicorn/no-new-array": "off",
     "unicorn/no-single-promise-in-promise-methods": "off",
     "unicorn/no-useless-fallback-in-spread": "off",

--- a/src/components/common/Badge.test.ts
+++ b/src/components/common/Badge.test.ts
@@ -42,7 +42,7 @@ describe('Badge', () => {
   })
 
   describe('twMerge preserves color alongside text-3xs font size', () => {
-    it.each([
+    it.for([
       ['default', 'text-white'],
       ['secondary', 'text-white'],
       ['warn', 'text-white'],
@@ -50,7 +50,7 @@ describe('Badge', () => {
       ['contrast', 'text-base-background']
     ] as const)(
       '%s severity retains its text color class',
-      (severity, expectedColor) => {
+      ([severity, expectedColor]) => {
         const classes = badgeVariants({ severity, variant: 'label' })
         expect(classes).toContain(expectedColor)
         expect(classes).toContain('text-3xs')

--- a/src/components/load3d/Load3DControls.test.ts
+++ b/src/components/load3d/Load3DControls.test.ts
@@ -251,10 +251,10 @@ describe('Load3DControls', () => {
       await user.click(screen.getByRole('button', { name: label }))
     }
 
-    it.each([
+    it.for([
       ['Model', 'model-controls'],
       ['Camera', 'camera-controls']
-    ])('%s category renders only %s', async (label, testId) => {
+    ])('%s category renders only %s', async ([label, testId]) => {
       const { user } = renderControls()
       await selectCategory(user, label)
 
@@ -315,12 +315,12 @@ describe('Load3DControls', () => {
       ).not.toBeInTheDocument()
     })
 
-    it.each([
+    it.for([
       ['Gizmo', 'gizmo-controls', 'canUseGizmo' as const],
       ['Export', 'export-controls', 'canExport' as const]
     ])(
       'hides the %s panel when its capability flips off at runtime',
-      async (label, testId, capabilityProp) => {
+      async ([label, testId, capabilityProp]) => {
         const { user, rerender } = renderControls()
 
         await openMenu(user)

--- a/src/components/load3d/controls/GizmoControls.test.ts
+++ b/src/components/load3d/controls/GizmoControls.test.ts
@@ -97,13 +97,13 @@ describe('GizmoControls', () => {
     expect(emitted().toggleGizmo).toEqual([[false]])
   })
 
-  it.each([
+  it.for([
     ['Translate', 'translate'],
     ['Rotate', 'rotate'],
     ['Scale', 'scale']
   ] as const)(
     'sets mode to %s and emits setGizmoMode when clicked',
-    async (label, mode) => {
+    async ([label, mode]) => {
       const { user, gizmoConfig, emitted } = renderComponent({ enabled: true })
 
       await user.click(screen.getByRole('button', { name: label }))

--- a/src/components/load3d/controls/LightControls.test.ts
+++ b/src/components/load3d/controls/LightControls.test.ts
@@ -107,7 +107,7 @@ describe('LightControls', () => {
       ).toBeInTheDocument()
     })
 
-    it.each(['normal', 'wireframe'] as const)(
+    it.for(['normal', 'wireframe'] as const)(
       'hides the intensity control when materialMode is %s',
       (mode) => {
         renderComponent({ materialMode: mode })

--- a/src/components/load3d/controls/viewer/ViewerGizmoControls.test.ts
+++ b/src/components/load3d/controls/viewer/ViewerGizmoControls.test.ts
@@ -94,13 +94,13 @@ describe('ViewerGizmoControls', () => {
     expect(enabled.value).toBe(false)
   })
 
-  it.each([
+  it.for([
     ['Translate', 'translate'],
     ['Rotate', 'rotate'],
     ['Scale', 'scale']
   ] as const)(
     'updates mode to %s when its toggle item is clicked',
-    async (label, expected) => {
+    async ([label, expected]) => {
       const { user, mode } = renderComponent({
         enabled: true,
         mode: 'translate'

--- a/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
+++ b/src/components/maskeditor/ImageLayerSettingsPanel.test.ts
@@ -111,26 +111,29 @@ describe('ImageLayerSettingsPanel', () => {
   })
 
   describe('blend mode select', () => {
-    it.each([
+    it.for([
       ['black', MaskBlendMode.Black],
       ['white', MaskBlendMode.White],
       ['negative', MaskBlendMode.Negative],
       ['unknown-fallback', MaskBlendMode.Black]
-    ] as const)('should map %s to MaskBlendMode.%s', async (raw, expected) => {
-      const { container } = renderPanel()
-      const select = container.querySelector('select') as HTMLSelectElement
+    ] as const)(
+      'should map %s to MaskBlendMode.%s',
+      async ([raw, expected]) => {
+        const { container } = renderPanel()
+        const select = container.querySelector('select') as HTMLSelectElement
 
-      Object.defineProperty(select, 'value', {
-        value: raw,
-        configurable: true
-      })
-      select.dispatchEvent(new Event('change', { bubbles: true }))
+        Object.defineProperty(select, 'value', {
+          value: raw,
+          configurable: true
+        })
+        select.dispatchEvent(new Event('change', { bubbles: true }))
 
-      await new Promise((r) => setTimeout(r, 0))
+        await new Promise((r) => setTimeout(r, 0))
 
-      expect(mockStore.maskBlendMode).toBe(expected)
-      expect(mockUpdateMaskColor).toHaveBeenCalled()
-    })
+        expect(mockStore.maskBlendMode).toBe(expected)
+        expect(mockUpdateMaskColor).toHaveBeenCalled()
+      }
+    )
   })
 
   describe('layer visibility checkboxes', () => {

--- a/src/components/maskeditor/PointerZone.test.ts
+++ b/src/components/maskeditor/PointerZone.test.ts
@@ -63,13 +63,13 @@ describe('PointerZone', () => {
   })
 
   describe('pointer event forwarding', () => {
-    it.each([
+    it.for([
       ['pointerdown', 'handlePointerDown'],
       ['pointermove', 'handlePointerMove'],
       ['pointerup', 'handlePointerUp']
     ] as const)(
       'should forward %s to toolManager.%s',
-      async (eventName, handlerName) => {
+      async ([eventName, handlerName]) => {
         renderZone()
         const zone = getZone()
 
@@ -103,13 +103,13 @@ describe('PointerZone', () => {
   })
 
   describe('touch event forwarding', () => {
-    it.each([
+    it.for([
       ['touchstart', 'handleTouchStart'],
       ['touchmove', 'handleTouchMove'],
       ['touchend', 'handleTouchEnd']
     ] as const)(
       'should forward %s to panZoom.%s',
-      async (eventName, handlerName) => {
+      async ([eventName, handlerName]) => {
         renderZone()
         const zone = getZone()
 

--- a/src/components/maskeditor/ToolPanel.test.ts
+++ b/src/components/maskeditor/ToolPanel.test.ts
@@ -85,7 +85,7 @@ describe('ToolPanel', () => {
   })
 
   describe('current tool highlight', () => {
-    it.each([Tools.MaskPen, Tools.Eraser, Tools.PaintPen] as const)(
+    it.for([Tools.MaskPen, Tools.Eraser, Tools.PaintPen] as const)(
       'should mark the %s button as selected when it is the current tool',
       (tool) => {
         mockStore.currentTool = tool

--- a/src/components/maskeditor/dialog/TopBarHeader.test.ts
+++ b/src/components/maskeditor/dialog/TopBarHeader.test.ts
@@ -130,14 +130,14 @@ describe('TopBarHeader', () => {
   })
 
   describe('canvas transform buttons', () => {
-    it.each([
+    it.for([
       ['Rotate Left', 'rotateCounterclockwise'],
       ['Rotate Right', 'rotateClockwise'],
       ['Mirror Horizontal', 'mirrorHorizontal'],
       ['Mirror Vertical', 'mirrorVertical']
     ] as const)(
       'should call canvasTransform.%s when %s button is clicked',
-      async (label, method) => {
+      async ([label, method]) => {
         const user = userEvent.setup()
         renderHeader()
 
@@ -147,14 +147,14 @@ describe('TopBarHeader', () => {
       }
     )
 
-    it.each([
+    it.for([
       ['Rotate Left', 'rotateCounterclockwise', 'Rotate left failed:'],
       ['Rotate Right', 'rotateClockwise', 'Rotate right failed:'],
       ['Mirror Horizontal', 'mirrorHorizontal', 'Mirror horizontal failed:'],
       ['Mirror Vertical', 'mirrorVertical', 'Mirror vertical failed:']
     ] as const)(
       'should swallow and log errors from %s',
-      async (label, method, expectedMsg) => {
+      async ([label, method, expectedMsg]) => {
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         mockCanvasTransform[method].mockRejectedValueOnce(new Error('boom'))
         const user = userEvent.setup()

--- a/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
+++ b/src/components/searchbox/v2/NodeSearchFilterBar.test.ts
@@ -55,7 +55,7 @@ describe(NodeSearchFilterBar, () => {
   const buttonTexts = () =>
     screen.getAllByRole('button').map((b) => b.textContent?.trim())
 
-  it.each([
+  it.for([
     { prop: 'hasFavorites', label: 'Bookmarked' },
     { prop: 'hasBlueprintNodes', label: 'Blueprints' },
     { prop: 'hasEssentialNodes', label: 'Essentials' },

--- a/src/composables/queue/useJobMenu.test.ts
+++ b/src/composables/queue/useJobMenu.test.ts
@@ -263,10 +263,10 @@ describe('useJobMenu', () => {
     expect(copyToClipboardMock).not.toHaveBeenCalled()
   })
 
-  it.each([
+  it.for([
     ['running', interruptMock, deleteItemMock],
     ['initialization', interruptMock, deleteItemMock]
-  ])('cancels %s job via interrupt', async (state) => {
+  ])('cancels %s job via interrupt', async ([state]) => {
     const { cancelJob } = mountJobMenu()
     setCurrentItem(createJobItem({ state: state as JobListItem['state'] }))
 
@@ -417,7 +417,7 @@ describe('useJobMenu', () => {
     }
   ] as const
 
-  it.each(previewCases)(
+  it.for(previewCases)(
     'adds loader node for %s preview output',
     async ({ flags, expectedNode, widget }) => {
       const widgetCallback = vi.fn()

--- a/src/composables/queue/useQueueProgress.test.ts
+++ b/src/composables/queue/useQueueProgress.test.ts
@@ -58,7 +58,7 @@ describe('useQueueProgress', () => {
     setExecutingNodeProgress(null)
   })
 
-  it.each([
+  it.for([
     {
       description: 'defaults to 0% when execution store values are missing',
       execution: undefined,

--- a/src/composables/useErrorHandling.test.ts
+++ b/src/composables/useErrorHandling.test.ts
@@ -324,11 +324,11 @@ describe('useErrorHandling', () => {
     })
 
     describe('network error detection', () => {
-      it.each([
+      it.for([
         ['Failed to fetch', 'Chrome/Edge'],
         ['NetworkError when attempting to fetch resource.', 'Firefox'],
         ['Load failed', 'Safari']
-      ])('should show disconnected toast for "%s" (%s)', async (message) => {
+      ])('should show disconnected toast for "%s" (%s)', async ([message]) => {
         const action = vi.fn(async () => {
           throw new TypeError(message)
         })

--- a/src/constants/essentialsDisplayNames.test.ts
+++ b/src/constants/essentialsDisplayNames.test.ts
@@ -8,7 +8,7 @@ import { resolveEssentialsDisplayName } from '@/constants/essentialsDisplayNames
 
 describe('resolveEssentialsDisplayName', () => {
   describe('exact name matches', () => {
-    it.each([
+    it.for([
       ['LoadImage', 'essentials.loadImage'],
       ['SaveImage', 'essentials.saveImage'],
       ['PrimitiveStringMultiline', 'essentials.text'],
@@ -22,26 +22,26 @@ describe('resolveEssentialsDisplayName', () => {
       ['Video Slice', 'essentials.extractFrame'],
       ['KlingLipSyncAudioToVideoNode', 'essentials.lipsync'],
       ['KlingLipSyncTextToVideoNode', 'essentials.lipsync']
-    ])('%s -> %s', (name, expected) => {
+    ])('%s -> %s', ([name, expected]) => {
       expect(resolveEssentialsDisplayName({ name })).toBe(expected)
     })
   })
 
   describe('3D API node alternatives', () => {
-    it.each([
+    it.for([
       ['TencentTextToModelNode', 'essentials.textTo3DModel'],
       ['MeshyTextToModelNode', 'essentials.textTo3DModel'],
       ['TripoTextToModelNode', 'essentials.textTo3DModel'],
       ['TencentImageToModelNode', 'essentials.imageTo3DModel'],
       ['MeshyImageToModelNode', 'essentials.imageTo3DModel'],
       ['TripoImageToModelNode', 'essentials.imageTo3DModel']
-    ])('%s -> %s', (name, expected) => {
+    ])('%s -> %s', ([name, expected]) => {
       expect(resolveEssentialsDisplayName({ name })).toBe(expected)
     })
   })
 
   describe('blueprint prefix matches', () => {
-    it.each([
+    it.for([
       [
         'SubgraphBlueprint.text_to_image_flux_schnell.json',
         'essentials.textToImage'
@@ -82,7 +82,7 @@ describe('resolveEssentialsDisplayName', () => {
         'SubgraphBlueprint.image_outpainting_qwen_image_instantx.json',
         'essentials.outpaintImage'
       ]
-    ])('%s -> %s', (name, expected) => {
+    ])('%s -> %s', ([name, expected]) => {
       expect(resolveEssentialsDisplayName({ name })).toBe(expected)
     })
   })

--- a/src/extensions/core/editAttention.test.ts
+++ b/src/extensions/core/editAttention.test.ts
@@ -39,8 +39,16 @@ describe('incrementWeight', () => {
   })
 })
 
+type Enclosure = { start: number; end: number } | null
+type EnclosureCase = [
+  name: string,
+  text: string,
+  cursor: number,
+  expected: Enclosure
+]
+
 describe('findNearestEnclosure', () => {
-  it.each([
+  it.for<EnclosureCase>([
     [
       'returns start and end of a simple parenthesized expression',
       '(cat)',
@@ -74,13 +82,15 @@ describe('findNearestEnclosure', () => {
       2,
       null
     ]
-  ])('%s', (_, text, cursor, expected) => {
+  ])('%s', ([, text, cursor, expected]) => {
     expect(findNearestEnclosure(text, cursor)).toEqual(expected)
   })
 })
 
+type WeightCase = [name: string, input: string, expected: string]
+
 describe('addWeightToParentheses', () => {
-  it.each([
+  it.for<WeightCase>([
     ['adds weight 1.0 to a bare parenthesized token', '(cat)', '(cat:1.0)'],
     [
       'leaves a token that already has a weight unchanged',
@@ -118,7 +128,7 @@ describe('addWeightToParentheses', () => {
       '(sdxl1:0.8)',
       '(sdxl1:0.8)'
     ]
-  ])('%s', (_, input, expected) => {
+  ])('%s', ([, input, expected]) => {
     expect(addWeightToParentheses(input)).toBe(expected)
   })
 })

--- a/src/extensions/core/load3d/Load3d.test.ts
+++ b/src/extensions/core/load3d/Load3d.test.ts
@@ -136,7 +136,7 @@ describe('Load3d', () => {
       expect(ctx.forceRender).toHaveBeenCalledOnce()
     })
 
-    it.each(['translate', 'rotate', 'scale'] as const)(
+    it.for(['translate', 'rotate', 'scale'] as const)(
       'setGizmoMode delegates "%s" and forces a render',
       (mode: GizmoMode) => {
         ctx.load3d.setGizmoMode(mode)

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -241,7 +241,7 @@ describe('LoaderManager', () => {
   })
 
   describe('pickAdapter', () => {
-    it.each(['stl', 'fbx', 'obj', 'gltf', 'glb'])(
+    it.for(['stl', 'fbx', 'obj', 'gltf', 'glb'])(
       'routes %s to the mesh adapter',
       (ext) => {
         const { pick } = makeLoaderManager()
@@ -249,7 +249,7 @@ describe('LoaderManager', () => {
       }
     )
 
-    it.each(['spz', 'splat', 'ksplat'])(
+    it.for(['spz', 'splat', 'ksplat'])(
       'routes %s to the splat adapter',
       (ext) => {
         const { pick } = makeLoaderManager()

--- a/src/extensions/core/load3d/cameraFromMatrices.test.ts
+++ b/src/extensions/core/load3d/cameraFromMatrices.test.ts
@@ -132,13 +132,13 @@ describe('computeCameraFromMatrices', () => {
     ).toThrow(/intrinsics/)
   })
 
-  it.each([
+  it.for<[label: string, fy: number]>([
     ['zero', 0],
     ['NaN', Number.NaN],
     ['Infinity', Number.POSITIVE_INFINITY]
   ])(
     'throws when fy is %s rather than producing a NaN/Infinite FOV',
-    (_label, fy) => {
+    ([, fy]) => {
       expect(() =>
         computeCameraFromMatrices(
           extrinsics(IDENTITY_R, [0, 0, 0]),

--- a/src/extensions/core/load3d/exportMenuHelper.test.ts
+++ b/src/extensions/core/load3d/exportMenuHelper.test.ts
@@ -98,13 +98,13 @@ describe('createExportMenuItems', () => {
     )
   })
 
-  it.each([
+  it.for<[label: string, value: string]>([
     ['GLB', 'glb'],
     ['OBJ', 'obj'],
     ['STL', 'stl']
   ])(
     'invokes load3d.exportModel(%s) and shows a success toast when the %s submenu item is clicked',
-    async (label, value) => {
+    async ([label, value]) => {
       const exportModel = vi.fn().mockResolvedValue(undefined)
       const items = createExportMenuItems(makeLoad3d(exportModel))
       ;(items[1]!.callback as (...args: unknown[]) => void)(

--- a/src/extensions/core/load3d/load3dViewport.test.ts
+++ b/src/extensions/core/load3d/load3dViewport.test.ts
@@ -96,13 +96,13 @@ describe('isLoad3dActive', () => {
     expect(isLoad3dActive({ ...idle, initialRenderDone: false })).toBe(true)
   })
 
-  it.each([
+  it.for([
     ['mouseOnNode'],
     ['mouseOnScene'],
     ['mouseOnViewer'],
     ['recording'],
     ['animationPlaying']
-  ] as const)('is active when %s is true', (flag) => {
+  ] as const)('is active when %s is true', ([flag]) => {
     expect(isLoad3dActive({ ...idle, [flag]: true })).toBe(true)
   })
 })

--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -83,7 +83,7 @@ describe('load3dLazy', () => {
     expect(enabledExtensionsGetter).not.toHaveBeenCalled()
   })
 
-  it.each(['Load3D', 'Preview3D', 'SaveGLB'])(
+  it.for(['Load3D', 'Preview3D', 'SaveGLB'])(
     'recognizes %s as a 3D node type and triggers the lazy-load path',
     async (nodeType) => {
       const { hook } = await loadLazyExtensionFresh()

--- a/src/lib/litegraph/src/infrastructure/Rectangle.test.ts
+++ b/src/lib/litegraph/src/infrastructure/Rectangle.test.ts
@@ -301,7 +301,7 @@ describe('Rectangle', () => {
   describe('containment and overlap', () => {
     const rect = new Rectangle(10, 10, 20, 20) // x: 10, y: 10, right: 30, bottom: 30
 
-    test.each([
+    test.for([
       [10, 10, true], // top-left corner
       [29, 29, true], // bottom-right corner
       [15, 15, true], // inside
@@ -311,14 +311,14 @@ describe('Rectangle', () => {
       [15, 30, false], // outside bottom
       [10, 29, true], // on bottom edge
       [29, 10, true] // on right edge
-    ])(
+    ] as const)(
       'when checking if (%s, %s) is inside, should return %s',
-      (x, y, expected) => {
+      ([x, y, expected]) => {
         expect(rect.containsXy(x, y)).toBe(expected)
       }
     )
 
-    test.each([
+    test.for([
       [[0, 0] as Point, true],
       [[9, 9] as Point, true],
       [[5, 5] as Point, true],
@@ -326,12 +326,15 @@ describe('Rectangle', () => {
       [[11, 5] as Point, false],
       [[5, -1] as Point, false],
       [[5, 11] as Point, false]
-    ])('should return %s for point %j', (point: Point, expected: boolean) => {
-      rect.updateTo([0, 0, 10, 10])
-      expect(rect.containsPoint(point)).toBe(expected)
-    })
+    ] as const)(
+      'should return %s for point %j',
+      ([point, expected]: readonly [Point, boolean]) => {
+        rect.updateTo([0, 0, 10, 10])
+        expect(rect.containsPoint(point)).toBe(expected)
+      }
+    )
 
-    test.each([
+    test.for([
       // Completely inside
       [new Rectangle(10, 10, 10, 10), true],
       // Touching edges
@@ -348,13 +351,13 @@ describe('Rectangle', () => {
       [new Rectangle(0, 0, 5, 5), new Rectangle(0, 0, 10, 10), true],
       // Same size
       [new Rectangle(0, 0, 99, 99), true]
-    ])(
+    ] as const)(
       'should return %s when checking if %s is inside outer rect',
-      (
-        inner: Rectangle,
-        expectedOrOuter: boolean | Rectangle,
-        expectedIfThreeArgs?: boolean
-      ) => {
+      ([inner, expectedOrOuter, expectedIfThreeArgs]: readonly [
+        Rectangle,
+        boolean | Rectangle,
+        boolean?
+      ]) => {
         let testOuter = rect
         rect.updateTo([0, 0, 100, 100])
 
@@ -367,7 +370,7 @@ describe('Rectangle', () => {
       }
     )
 
-    test.each([
+    test.for([
       // Completely overlapping
       [new Rectangle(15, 15, 10, 10), true], // r2 inside r1
       // Partially overlapping
@@ -387,7 +390,7 @@ describe('Rectangle', () => {
       [new Rectangle(0, 0, 5, 5), false], // r2 outside top-left
       // rect1 inside rect2
       [new Rectangle(0, 0, 100, 100), true]
-    ])('should return %s for overlap with %s', (rect2, expected) => {
+    ] as const)('should return %s for overlap with %s', ([rect2, expected]) => {
       const rect = new Rectangle(10, 10, 20, 20) // 10,10 to 30,30
 
       expect(rect.overlaps(rect2)).toBe(expected)

--- a/src/lib/litegraph/src/utils/mathParser.test.ts
+++ b/src/lib/litegraph/src/utils/mathParser.test.ts
@@ -3,52 +3,52 @@ import { describe, expect, test } from 'vitest'
 import { evaluateMathExpression } from '@/lib/litegraph/src/utils/mathParser'
 
 describe('evaluateMathExpression', () => {
-  test.each([
+  test.for<[string, number]>([
     ['2+3', 5],
     ['10-4', 6],
     ['3*7', 21],
     ['15/3', 5]
-  ])('basic arithmetic: %s = %d', (input, expected) => {
+  ])('basic arithmetic: %s = %d', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['2+3*4', 14],
     ['(2+3)*4', 20],
     ['10-2*3', 4],
     ['10/2+3', 8]
-  ])('operator precedence: %s = %d', (input, expected) => {
+  ])('operator precedence: %s = %d', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['3.14*2', 6.28],
     ['.5+.5', 1],
     ['1.5+2.5', 4],
     ['0.1+0.2', 0.1 + 0.2],
     ['123.', 123],
     ['123.+3', 126]
-  ])('decimals: %s', (input, expected) => {
+  ])('decimals: %s', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     [' 2 + 3 ', 5],
     ['  10  -  4  ', 6],
     [' ( 2 + 3 ) * 4 ', 20]
-  ])('whitespace handling: "%s" = %d', (input, expected) => {
+  ])('whitespace handling: "%s" = %d', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['((2+3))', 5],
     ['(1+(2*(3+4)))', 15],
     ['((1+2)*(3+4))', 21]
-  ])('nested parentheses: %s = %d', (input, expected) => {
+  ])('nested parentheses: %s = %d', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['-5', -5],
     ['-(3+2)', -5],
     ['--5', 5],
@@ -59,11 +59,11 @@ describe('evaluateMathExpression', () => {
     ['2--3', 5],
     ['-2*-3', 6],
     ['-(2+3)*-(4+5)', 45]
-  ])('unary operators: %s = %d', (input, expected) => {
+  ])('unary operators: %s = %d', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['2 /2+3 * 4.75- -6', 21.25],
     ['2 / (2 + 3) * 4.33 - -6', 7.732],
     ['12* 123/-(-5 + 2)', 492],
@@ -78,11 +78,11 @@ describe('evaluateMathExpression', () => {
       '(123.45*(678.90 / (-2.5+ 11.5)-(((80 -(19))) *33.25)) / 20) - (123.45*(678.90 / (-2.5+ 11.5)-(((80 -(19))) *33.25)) / 20) + (13 - 2)/ -(-11) ',
       1
     ]
-  ])('complex expression: %s', (input, expected) => {
+  ])('complex expression: %s', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBeCloseTo(expected as number)
   })
 
-  test.each(['', 'abc', '2+', '(2+3', '2+3)', '()', '*3', '2 3', '.', '123..'])(
+  test.for(['', 'abc', '2+', '(2+3', '2+3)', '()', '*3', '2 3', '.', '123..'])(
     'invalid input returns undefined: "%s"',
     (input) => {
       expect(evaluateMathExpression(input)).toBeUndefined()
@@ -97,11 +97,11 @@ describe('evaluateMathExpression', () => {
     expect(evaluateMathExpression('0/0')).toBeNaN()
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['10%3', 1],
     ['10%3+1', 2],
     ['7%2', 1]
-  ])('modulo: %s = %d', (input, expected) => {
+  ])('modulo: %s = %d', ([input, expected]) => {
     expect(evaluateMathExpression(input)).toBe(expected)
   })
 

--- a/src/lib/litegraph/src/utils/widget.test.ts
+++ b/src/lib/litegraph/src/utils/widget.test.ts
@@ -73,21 +73,21 @@ describe('resolveNodeRootGraphId', () => {
 })
 
 describe('evaluateInput', () => {
-  test.each([
+  test.for<[string, number]>([
     ['42', 42],
     ['3.14', 3.14],
     ['-7', -7],
     ['0', 0]
-  ])('plain number: "%s" = %d', (input, expected) => {
+  ])('plain number: "%s" = %d', ([input, expected]) => {
     expect(evaluateInput(input)).toBe(expected)
   })
 
-  test.each([
+  test.for<[string, number]>([
     ['2+3', 5],
     ['(4+2)*3', 18],
     ['3.14*2', 6.28],
     ['10/2+3', 8]
-  ])('expression: "%s" = %d', (input, expected) => {
+  ])('expression: "%s" = %d', ([input, expected]) => {
     expect(evaluateInput(input)).toBe(expected)
   })
 
@@ -95,7 +95,7 @@ describe('evaluateInput', () => {
     expect(evaluateInput('')).toBe(0)
   })
 
-  test.each(['abc', 'hello world'])(
+  test.for(['abc', 'hello world'])(
     'invalid input returns undefined: "%s"',
     (input) => {
       expect(evaluateInput(input)).toBeUndefined()
@@ -118,7 +118,7 @@ describe('evaluateInput', () => {
     expect(evaluateInput('0xff')).toBe(255)
   })
 
-  test.each(['Infinity', '-Infinity'])(
+  test.for(['Infinity', '-Infinity'])(
     '"%s" returns undefined (non-finite rejected)',
     (input) => {
       expect(evaluateInput(input)).toBeUndefined()

--- a/src/platform/assets/composables/media/assetMappers.test.ts
+++ b/src/platform/assets/composables/media/assetMappers.test.ts
@@ -21,21 +21,24 @@ describe('mapInputFileToAssetItem', () => {
     expect(asset.preview_url).toBe('/api/view?filename=photo.png&type=input')
   })
 
-  it.each([
+  it.for([
     ['photo.png [input]', 'photo.png'],
     ['photo.png [output]', 'photo.png'],
     ['photo.png [temp]', 'photo.png'],
     ['clip.mp4[input]', 'clip.mp4'],
     ['MyFile.WEBP [Input]', 'MyFile.WEBP']
-  ])('strips ComfyUI directory annotation: %s -> %s', (input, expectedName) => {
-    const asset = mapInputFileToAssetItem(input, 1, 'input')
+  ])(
+    'strips ComfyUI directory annotation: %s -> %s',
+    ([input, expectedName]) => {
+      const asset = mapInputFileToAssetItem(input, 1, 'input')
 
-    expect(asset.name).toBe(expectedName)
-    expect(asset.id).toBe(`input-1-${expectedName}`)
-    expect(asset.preview_url).toBe(
-      `/api/view?filename=${encodeURIComponent(expectedName)}&type=input`
-    )
-  })
+      expect(asset.name).toBe(expectedName)
+      expect(asset.id).toBe(`input-1-${expectedName}`)
+      expect(asset.preview_url).toBe(
+        `/api/view?filename=${encodeURIComponent(expectedName)}&type=input`
+      )
+    }
+  )
 
   it('leaves non-annotation brackets in the filename intact', () => {
     const asset = mapInputFileToAssetItem('my [draft] image.png', 0, 'input')

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -580,7 +580,7 @@ describe(assetService.getAllAssetsByTag, () => {
     expect(secondParams.get('offset')).toBe('2')
   })
 
-  it.each([
+  it.for([
     {
       name: 'missing has_more',
       body: {

--- a/src/platform/assets/utils/createModelNodeFromAsset.test.ts
+++ b/src/platform/assets/utils/createModelNodeFromAsset.test.ts
@@ -299,7 +299,7 @@ describe('createModelNodeFromAsset', () => {
     beforeEach(() => {
       vi.spyOn(console, 'error').mockImplementation(() => {})
     })
-    it.each([
+    it.for([
       {
         case: 'missing user_metadata with no fallback',
         overrides: { user_metadata: undefined, metadata: undefined, name: '' },
@@ -329,7 +329,7 @@ describe('createModelNodeFromAsset', () => {
         }
       }
     )
-    it.each([
+    it.for([
       {
         case: 'no tags',
         overrides: { tags: undefined },

--- a/src/platform/cloud/subscription/utils/tierBenefits.test.ts
+++ b/src/platform/cloud/subscription/utils/tierBenefits.test.ts
@@ -45,7 +45,7 @@ describe('getCommonTierBenefits', () => {
     expect(benefits.some((b) => b.key === 'monthlyCredits')).toBe(false)
   })
 
-  it.each(['free', 'standard', 'creator', 'pro', 'founder'] as const)(
+  it.for(['free', 'standard', 'creator', 'pro', 'founder'] as const)(
     'includes a tier-scoped maxDuration metric for %s',
     (tier) => {
       const benefits = getCommonTierBenefits(tier, translate, formatNumber)
@@ -70,7 +70,7 @@ describe('getCommonTierBenefits', () => {
     })
   })
 
-  it.each(['standard', 'creator', 'pro', 'founder'] as const)(
+  it.for(['standard', 'creator', 'pro', 'founder'] as const)(
     'adds the addCredits benefit for %s tier',
     (tier) => {
       const benefits = getCommonTierBenefits(tier, translate, formatNumber)
@@ -83,7 +83,7 @@ describe('getCommonTierBenefits', () => {
     expect(freeBenefits.some((b) => b.key === 'addCredits')).toBe(false)
   })
 
-  it.each(['creator', 'pro'] as const)(
+  it.for(['creator', 'pro'] as const)(
     'includes customLoRAs for %s tier',
     (tier) => {
       const benefits = getCommonTierBenefits(tier, translate, formatNumber)
@@ -91,7 +91,7 @@ describe('getCommonTierBenefits', () => {
     }
   )
 
-  it.each(['free', 'standard', 'founder'] as const)(
+  it.for(['free', 'standard', 'founder'] as const)(
     'omits customLoRAs for %s tier',
     (tier) => {
       const benefits = getCommonTierBenefits(tier, translate, formatNumber)

--- a/src/platform/keybindings/keyCombo.test.ts
+++ b/src/platform/keybindings/keyCombo.test.ts
@@ -15,7 +15,7 @@ describe('KeyComboImpl', () => {
   }
 
   describe('getKeySequences', () => {
-    it.each([
+    it.for([
       {
         event: { key: 'Shift', shiftKey: true },
         expected: ['Shift'],
@@ -66,7 +66,7 @@ describe('KeyComboImpl', () => {
   })
 
   describe('isBrowserReserved', () => {
-    it.each([
+    it.for([
       { key: 't', ctrl: true, label: 'Ctrl + t' },
       { key: 'w', ctrl: true, label: 'Ctrl + w' },
       { key: 'F12', label: 'F12' },
@@ -83,7 +83,7 @@ describe('KeyComboImpl', () => {
       expect(combo.isBrowserReserved).toBe(true)
     })
 
-    it.each([
+    it.for([
       { key: 'k', ctrl: true, label: 'Ctrl + k' },
       { key: 's', alt: true, label: 'Alt + s' },
       { key: 'z', ctrl: true, label: 'Ctrl + z' },

--- a/src/platform/missingMedia/mediaPathDetectionUtil.test.ts
+++ b/src/platform/missingMedia/mediaPathDetectionUtil.test.ts
@@ -7,21 +7,21 @@ import {
 } from './mediaPathDetectionUtil'
 
 describe('normalizeAnnotatedMediaPathForDetection', () => {
-  it.each([
+  it.for([
     ['photo.png [input]', 'photo.png'],
     ['result.png [output]', 'result.png'],
     ['photo.png   [input]', 'photo.png'],
     ['with spaces.png [output]', 'with spaces.png'],
     ['nested/folder/video.mp4 [output]', 'nested/folder/video.mp4']
-  ])('strips Core-style annotation from %s', (value, expected) => {
+  ])('strips Core-style annotation from %s', ([value, expected]) => {
     expect(normalizeAnnotatedMediaPathForDetection(value)).toBe(expected)
   })
 
-  it.each([
+  it.for([
     ['photo.png[input]', 'photo.png'],
     ['result.png[output]', 'result.png'],
     ['with spaces.png   [output]', 'with spaces.png']
-  ])('strips Cloud compact annotation from %s', (value, expected) => {
+  ])('strips Cloud compact annotation from %s', ([value, expected]) => {
     expect(
       normalizeAnnotatedMediaPathForDetection(value, {
         allowCompactSuffix: true
@@ -35,7 +35,7 @@ describe('normalizeAnnotatedMediaPathForDetection', () => {
     )
   })
 
-  it.each(['photo.png [draft]', 'photo [output] copy.png', 'photo.png', ''])(
+  it.for(['photo.png [draft]', 'photo [output] copy.png', 'photo.png', ''])(
     'leaves non-matching values unchanged: %s',
     (value) => {
       expect(normalizeAnnotatedMediaPathForDetection(value)).toBe(value)
@@ -57,10 +57,10 @@ describe('getMediaPathDetectionNames', () => {
 })
 
 describe('getAnnotatedMediaPathTypeForDetection', () => {
-  it.each([
+  it.for([
     ['photo.png [input]', 'input'],
     ['photo.png [output]', 'output']
-  ])('returns the Core-style annotation type from %s', (value, expected) => {
+  ])('returns the Core-style annotation type from %s', ([value, expected]) => {
     expect(getAnnotatedMediaPathTypeForDetection(value)).toBe(expected)
   })
 

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -204,7 +204,7 @@ describe('scanNodeMediaCandidates', () => {
     expect(result).toEqual([])
   })
 
-  it.each([
+  it.for([
     {
       nodeType: 'LoadImage',
       widgetName: 'image',
@@ -257,7 +257,7 @@ describe('scanNodeMediaCandidates', () => {
     }
   )
 
-  it.each([
+  it.for([
     {
       nodeType: 'LoadImage',
       widgetName: 'image',

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
@@ -167,13 +167,18 @@ describe('MixpanelTelemetryProvider — with configured token', () => {
     expect(mockMixpanel.track).not.toHaveBeenCalled()
   })
 
-  it.each([
+  it.for<
+    [
+      'opened' | 'requested' | 'completed',
+      (typeof TelemetryEvents)[keyof typeof TelemetryEvents]
+    ]
+  >([
     ['opened' as const, TelemetryEvents.USER_EMAIL_VERIFY_OPENED],
     ['requested' as const, TelemetryEvents.USER_EMAIL_VERIFY_REQUESTED],
     ['completed' as const, TelemetryEvents.USER_EMAIL_VERIFY_COMPLETED]
   ])(
     'trackEmailVerification(%s) dispatches %s',
-    async (stage, expectedEvent) => {
+    async ([stage, expectedEvent]) => {
       const provider = new MixpanelTelemetryProvider()
       await waitForMixpanelInit()
       mockMixpanel.track.mockClear()
@@ -184,13 +189,18 @@ describe('MixpanelTelemetryProvider — with configured token', () => {
     }
   )
 
-  it.each([
+  it.for<
+    [
+      'modal_opened' | 'subscribe_clicked',
+      (typeof TelemetryEvents)[keyof typeof TelemetryEvents]
+    ]
+  >([
     [
       'modal_opened' as const,
       TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED
     ],
     ['subscribe_clicked' as const, TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED]
-  ])('trackSubscription(%s) dispatches %s', async (event, expectedEvent) => {
+  ])('trackSubscription(%s) dispatches %s', async ([event, expectedEvent]) => {
     const provider = new MixpanelTelemetryProvider()
     await waitForMixpanelInit()
     mockMixpanel.track.mockClear()
@@ -282,7 +292,7 @@ describe('MixpanelTelemetryProvider — direct event tracking methods', () => {
   const executionSuccessMetadata: ExecutionSuccessMetadata = { jobId: 'job-1' }
   const authMetadata: AuthMetadata = {}
 
-  it.each<
+  it.for<
     [string, Trackable, (typeof TelemetryEvents)[keyof typeof TelemetryEvents]]
   >([
     [
@@ -365,7 +375,7 @@ describe('MixpanelTelemetryProvider — direct event tracking methods', () => {
       (p) => p.trackSignupOpened(),
       TelemetryEvents.USER_SIGN_UP_OPENED
     ]
-  ])('%s dispatches %s', async (_name, invoke, expectedEvent) => {
+  ])('%s dispatches %s', async ([_name, invoke, expectedEvent]) => {
     const provider = new MixpanelTelemetryProvider()
     await waitForMixpanelInit()
     mockMixpanel.track.mockClear()

--- a/src/platform/workflow/validation/schemas/workflowSchema.test.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.test.ts
@@ -199,7 +199,7 @@ describe('parseComfyWorkflow', () => {
       'valid/valid',
       'valid-username-with-dash/valid_github-repo-name-with-underscore'
     ]
-    it.each(validAuxIds)('valid aux_id: %s', async (aux_id) => {
+    it.for(validAuxIds)('valid aux_id: %s', async (aux_id) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))
       workflow.nodes[0].properties.aux_id = aux_id
       await expect(validateComfyWorkflow(workflow)).resolves.not.toBeNull()
@@ -210,7 +210,7 @@ describe('parseComfyWorkflow', () => {
       'github-name/invalid spaces in repo',
       'not-both-names-with-slash'
     ]
-    it.each(invalidAuxIds)('invalid aux_id: %s', async (aux_id) => {
+    it.for(invalidAuxIds)('invalid aux_id: %s', async (aux_id) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))
       workflow.nodes[0].properties.aux_id = aux_id
       await expect(validateComfyWorkflow(workflow)).resolves.toBeNull()
@@ -219,14 +219,14 @@ describe('parseComfyWorkflow', () => {
 
   describe('workflow.nodes.properties.cnr_id', () => {
     const validCnrIds = ['valid', 'valid-with-dash', 'valid_with_underscores']
-    it.each(validCnrIds)('valid cnr_id: %s', async (cnr_id) => {
+    it.for(validCnrIds)('valid cnr_id: %s', async (cnr_id) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))
       workflow.nodes[0].properties.cnr_id = cnr_id
       await expect(validateComfyWorkflow(workflow)).resolves.not.toBeNull()
     })
 
     const invalidCnrIds = ['invalid cnr-id', 'invalid^cnr-id', 'invalid cnr id']
-    it.each(invalidCnrIds)('invalid cnr_id: %s', async (cnr_id) => {
+    it.for(invalidCnrIds)('invalid cnr_id: %s', async (cnr_id) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))
       workflow.nodes[0].properties.cnr_id = cnr_id
       await expect(validateComfyWorkflow(workflow)).resolves.toBeNull()
@@ -248,7 +248,7 @@ describe('parseComfyWorkflow', () => {
       'v0.3.9-7-g1419dee',
       'v0.3.9-7-g1419dee-dirty'
     ]
-    it.each(validVersionStrings)('valid version: %s', async (ver) => {
+    it.for(validVersionStrings)('valid version: %s', async (ver) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))
       workflow.nodes[0].properties.ver = ver
       await expect(validateComfyWorkflow(workflow)).resolves.not.toBeNull()
@@ -262,7 +262,7 @@ describe('parseComfyWorkflow', () => {
       // Git hash
       '080e6d4af809a46852d1c4b7ed85f06e8a3a72be-invalid'
     ]
-    it.each(invalidVersionStrings)('invalid version: %s', async (ver) => {
+    it.for(invalidVersionStrings)('invalid version: %s', async (ver) => {
       const workflow = JSON.parse(JSON.stringify(defaultGraph))
       workflow.nodes[0].properties.ver = ver
       await expect(validateComfyWorkflow(workflow)).resolves.toBeNull()

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -372,22 +372,19 @@ describe('useWorkspaceBilling', () => {
     it.for([
       ['empty string', ''],
       ['null', null]
-    ])(
-      'does not open a window when API returns %s url',
-      async ([_label, url]) => {
-        const openSpy = vi.fn()
-        vi.stubGlobal('open', openSpy)
+    ])('does not open a window when API returns %s url', async ([, url]) => {
+      const openSpy = vi.fn()
+      vi.stubGlobal('open', openSpy)
 
-        mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
-          url: url as string
-        })
+      mockWorkspaceApi.getPaymentPortalUrl.mockResolvedValue({
+        url: url as string
+      })
 
-        const billing = setupBilling()
-        await billing.manageSubscription()
+      const billing = setupBilling()
+      await billing.manageSubscription()
 
-        expect(openSpy).not.toHaveBeenCalled()
-      }
-    )
+      expect(openSpy).not.toHaveBeenCalled()
+    })
 
     it('records error when API call fails', async () => {
       mockWorkspaceApi.getPaymentPortalUrl.mockRejectedValue(

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -369,12 +369,12 @@ describe('useWorkspaceBilling', () => {
       )
     })
 
-    it.each([
+    it.for([
       ['empty string', ''],
       ['null', null]
     ])(
       'does not open a window when API returns %s url',
-      async (_label, url) => {
+      async ([_label, url]) => {
         const openSpy = vi.fn()
         vi.stubGlobal('open', openSpy)
 

--- a/src/renderer/core/canvas/pathRenderer.test.ts
+++ b/src/renderer/core/canvas/pathRenderer.test.ts
@@ -940,7 +940,7 @@ describe('CanvasPathRenderer', () => {
   })
 
   describe('direction offsets', () => {
-    it.each([
+    it.for([
       { dir: 'left', expectedInnerA: [-15, 0] },
       { dir: 'right', expectedInnerA: [15, 0] },
       { dir: 'up', expectedInnerA: [0, -15] },

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.test.ts
@@ -134,7 +134,7 @@ describe('useSlotElementTracking', () => {
     mockClientPosToCanvasPos.mockClear()
   })
 
-  it.each([
+  it.for([
     { type: 'input' as const, isInput: true },
     { type: 'output' as const, isInput: false }
   ])('cleans up $type slot layout on unmount', async ({ type, isInput }) => {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -349,7 +349,7 @@ describe('useComboWidget', () => {
     const HASH_FILENAME_2 =
       'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456.jpg'
 
-    it.each([
+    it.for([
       { nodeClass: 'LoadImage', inputName: 'image' },
       { nodeClass: 'LoadVideo', inputName: 'video' },
       { nodeClass: 'LoadAudio', inputName: 'audio' }

--- a/src/schemas/nodeDef/migration.test.ts
+++ b/src/schemas/nodeDef/migration.test.ts
@@ -519,7 +519,7 @@ describe('ComfyNodeDefImpl', () => {
     expect(result.inputs['floatInput']).toBeDefined()
   })
 
-  it.each([
+  it.for([
     { api_node: true, expected: true },
     { api_node: false, expected: false },
     { api_node: undefined, expected: false }

--- a/src/schemas/nodeDefSchema.validation.test.ts
+++ b/src/schemas/nodeDefSchema.validation.test.ts
@@ -27,7 +27,7 @@ describe('validateNodeDef', () => {
     expect(validateComfyNodeDef(EXAMPLE_NODE_DEF)).not.toBeNull()
   })
 
-  describe.each([
+  describe.for([
     [{ ckpt_name: ['foo', { default: 1 }] }, ['foo', { default: 1 }]],
     // Extra input spec should be preserved
     [{ ckpt_name: ['foo', { bar: 1 }] }, ['foo', { bar: 1 }]],
@@ -35,7 +35,7 @@ describe('validateNodeDef', () => {
     [{ ckpt_name: [[1, 2, 3], { bar: 1 }] }, [[1, 2, 3], { bar: 1 }]]
   ])(
     'validateComfyNodeDef with various input spec formats',
-    (inputSpec, expected) => {
+    ([inputSpec, expected]) => {
       it(`should accept input spec format: ${JSON.stringify(inputSpec)}`, async () => {
         expect(
           // @ts-expect-error fixme ts strict error
@@ -50,7 +50,7 @@ describe('validateNodeDef', () => {
     }
   )
 
-  describe.each([
+  describe.for([
     [{ ckpt_name: { 'model1.safetensors': 'foo' } }],
     [{ ckpt_name: ['*', ''] }],
     [{ ckpt_name: ['foo', { default: 1 }, { default: 2 }] }],

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -593,7 +593,7 @@ describe('useAuthStore', () => {
         )
       })
 
-      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+      it.for(['loginWithGoogle', 'loginWithGithub'] as const)(
         '%s should track is_new_user=true when Firebase says new user',
         async (method) => {
           vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
@@ -610,7 +610,7 @@ describe('useAuthStore', () => {
         }
       )
 
-      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+      it.for(['loginWithGoogle', 'loginWithGithub'] as const)(
         '%s should track is_new_user=true when UI options say new user',
         async (method) => {
           vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
@@ -627,7 +627,7 @@ describe('useAuthStore', () => {
         }
       )
 
-      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+      it.for(['loginWithGoogle', 'loginWithGithub'] as const)(
         '%s should track is_new_user=false when neither source says new user',
         async (method) => {
           vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
@@ -644,7 +644,7 @@ describe('useAuthStore', () => {
         }
       )
 
-      it.each(['loginWithGoogle', 'loginWithGithub'] as const)(
+      it.for(['loginWithGoogle', 'loginWithGithub'] as const)(
         '%s should track is_new_user=false when getAdditionalUserInfo returns null',
         async (method) => {
           vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue(null)

--- a/src/stores/maskEditorStore.test.ts
+++ b/src/stores/maskEditorStore.test.ts
@@ -256,13 +256,13 @@ describe('maskEditorStore', () => {
   })
 
   describe('canvas → ctx watchers', () => {
-    it.each([
+    it.for([
       ['maskCanvas', 'maskCtx'],
       ['rgbCanvas', 'rgbCtx'],
       ['imgCanvas', 'imgCtx']
     ] as const)(
       'should derive %s using getContext with willReadFrequently',
-      async (canvasKey, ctxKey) => {
+      async ([canvasKey, ctxKey]) => {
         const store = useMaskEditorStore()
         const canvas = makeCanvas()
 
@@ -276,13 +276,13 @@ describe('maskEditorStore', () => {
       }
     )
 
-    it.each([
+    it.for([
       ['maskCanvas', 'maskCtx'],
       ['rgbCanvas', 'rgbCtx'],
       ['imgCanvas', 'imgCtx']
     ] as const)(
       'should leave existing %s ctx untouched when canvas is cleared',
-      async (canvasKey, ctxKey) => {
+      async ([canvasKey, ctxKey]) => {
         const store = useMaskEditorStore()
         const canvas = makeCanvas()
         store[canvasKey] = canvas

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -274,9 +274,9 @@ describe('useModelToNodeStore', () => {
       }
     )
 
-    it.for([['ultralytics'], ['ultralytics/bbox'], ['ultralytics/segm']])(
+    it.for(['ultralytics', 'ultralytics/bbox', 'ultralytics/segm'])(
       'should not register %s as a default provider, so the node falls back to its static combo (regression for #8468)',
-      ([modelType]) => {
+      (modelType) => {
         const modelToNodeStore = useModelToNodeStore()
         modelToNodeStore.registerDefaults()
 

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -253,7 +253,7 @@ describe('useModelToNodeStore', () => {
       expect(provider?.key).toBe('')
     })
 
-    it.each([
+    it.for([
       ['sam2', 'DownloadAndLoadSAM2Model', 'model'],
       ['sams', 'SAMLoader', 'model_name'],
       ['ipadapter', 'IPAdapterModelLoader', 'ipadapter_file'],
@@ -264,7 +264,7 @@ describe('useModelToNodeStore', () => {
       ['segformer_b3_fashion', 'LS_LoadSegformerModel', 'model_name']
     ])(
       'should return correct provider for %s',
-      (modelType, expectedNodeName, expectedKey) => {
+      ([modelType, expectedNodeName, expectedKey]) => {
         const modelToNodeStore = useModelToNodeStore()
         modelToNodeStore.registerDefaults()
 
@@ -274,9 +274,9 @@ describe('useModelToNodeStore', () => {
       }
     )
 
-    it.each([['ultralytics'], ['ultralytics/bbox'], ['ultralytics/segm']])(
+    it.for([['ultralytics'], ['ultralytics/bbox'], ['ultralytics/segm']])(
       'should not register %s as a default provider, so the node falls back to its static combo (regression for #8468)',
-      (modelType) => {
+      ([modelType]) => {
         const modelToNodeStore = useModelToNodeStore()
         modelToNodeStore.registerDefaults()
 

--- a/src/utils/colorUtil.test.ts
+++ b/src/utils/colorUtil.test.ts
@@ -218,7 +218,7 @@ describe('colorUtil conversions', () => {
   })
 
   describe('parseToRgb edge cases', () => {
-    it.each(['', 'not-a-color', '#GGGGGG', 'cmky(1,2,3,4)'])(
+    it.for(['', 'not-a-color', '#GGGGGG', 'cmky(1,2,3,4)'])(
       'returns black for unrecognized input %s',
       (input) => {
         expect(parseToRgb(input)).toEqual({ r: 0, g: 0, b: 0 })
@@ -309,8 +309,8 @@ describe('colorUtil - adjustColor', () => {
     })
   }
 
-  describe.each(Object.entries(colors))('%s color', (_colorName, color) => {
-    describe.each(formats)('%s format', (format) => {
+  describe.for(Object.entries(colors))('%s color', ([_colorName, color]) => {
+    describe.for(formats)('%s format', (format) => {
       runAdjustColorTests(color, format as ColorFormat)
     })
   })

--- a/src/utils/hostWhitelist.test.ts
+++ b/src/utils/hostWhitelist.test.ts
@@ -4,7 +4,7 @@ import { isHostWhitelisted, normalizeHost } from '@/utils/hostWhitelist'
 
 describe('hostWhitelist utils', () => {
   describe('normalizeHost', () => {
-    it.each([
+    it.for([
       ['LOCALHOST', 'localhost'],
       ['localhost.', 'localhost'], // trims trailing dot
       ['localhost:5173', 'localhost'], // strips :port
@@ -17,7 +17,7 @@ describe('hostWhitelist utils', () => {
       ['example.com.', 'example.com'], // trims trailing dot
       ['[2001:db8::1]:8443', '2001:db8::1'], // IPv6 with brackets+port
       ['2001:db8::1', '2001:db8::1'] // plain IPv6 stays
-    ])('normalizeHost(%o) -> %o', (input, expected) => {
+    ])('normalizeHost(%o) -> %o', ([input, expected]) => {
       expect(normalizeHost(input)).toBe(expected)
     })
 
@@ -29,7 +29,7 @@ describe('hostWhitelist utils', () => {
 
   describe('isHostWhitelisted', () => {
     describe('localhost label', () => {
-      it.each([
+      it.for([
         'localhost',
         'LOCALHOST',
         'localhost.',
@@ -42,7 +42,7 @@ describe('hostWhitelist utils', () => {
         expect(isHostWhitelisted(input)).toBe(true)
       })
 
-      it.each([
+      it.for([
         'localhost.com',
         'evil-localhost',
         'notlocalhost',
@@ -53,7 +53,7 @@ describe('hostWhitelist utils', () => {
     })
 
     describe('IPv4 127/8 loopback', () => {
-      it.each([
+      it.for([
         '127.0.0.1',
         '127.1.2.3',
         '127.255.255.255',
@@ -64,7 +64,7 @@ describe('hostWhitelist utils', () => {
         expect(isHostWhitelisted(input)).toBe(true)
       })
 
-      it.each([
+      it.for([
         '126.0.0.1',
         '127.256.0.1',
         '127.-1.0.1',
@@ -82,7 +82,7 @@ describe('hostWhitelist utils', () => {
     })
 
     describe('IPv6 loopback ::1 (all textual forms)', () => {
-      it.each([
+      it.for([
         '::1',
         '[::1]',
         '[::1]:5173',
@@ -97,7 +97,7 @@ describe('hostWhitelist utils', () => {
         expect(isHostWhitelisted(input)).toBe(true)
       })
 
-      it.each([
+      it.for([
         '::2',
         '::',
         '::0',
@@ -121,7 +121,7 @@ describe('hostWhitelist utils', () => {
     })
 
     describe('comfy.org hosts', () => {
-      it.each([
+      it.for([
         'staging.comfy.org',
         'stagingcloud.comfy.org',
         'pr-123.testingcloud.comfy.org',
@@ -130,7 +130,7 @@ describe('hostWhitelist utils', () => {
         expect(isHostWhitelisted(input)).toBe(true)
       })
 
-      it.each([
+      it.for([
         'comfy.org.evil.com',
         'evil-comfy.org',
         'comfy.organization',

--- a/src/utils/migration/migrateReroute.test.ts
+++ b/src/utils/migration/migrateReroute.test.ts
@@ -14,7 +14,7 @@ describe('migrateReroute', () => {
       return JSON.parse(fileContent) as WorkflowJSON04
     }
 
-    it.each([
+    it.for([
       'branching.json',
       'single_connected.json',
       'floating.json',

--- a/src/workbench/extensions/manager/stores/comfyManagerStore.test.ts
+++ b/src/workbench/extensions/manager/stores/comfyManagerStore.test.ts
@@ -340,7 +340,7 @@ describe('useComfyManagerStore', () => {
   ]
 
   describe('isPackEnabled', () => {
-    it.each(testCases)(
+    it.for(testCases)(
       '$expectState when $desc',
       async ({ installed, expectState, packName }) => {
         packName ??= 'name'


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Enables the oxlint rule `vitest/consistent-each-for` (configured to prefer `.for` for `test`, `it`, `describe`, and `suite`) and migrates every `.each` parameterized test in the repo to `.for`. Using `.for` avoids accidentally splatting tuple elements into separate callback arguments and exposes `TestContext` as the second callback argument.

The first commit covers the 38 lint-detected files (88 callsites): renames `.each` → `.for` and updates callback signatures to destructure when the data is an array of tuples (objects/primitives already work unchanged with `.for`).

The follow-up commit addresses code review feedback: oxlint's rule does not recognize `test.each` on extended test bases (`baseTest.extend(...)`) and skips files in `ignorePatterns` (`src/extensions/core/*`). These were converted manually so the policy is uniform across the codebase.

## Verification

- `node_modules/.bin/oxlint src` — 0 errors, 0 `consistent-each-for` violations
- `pnpm typecheck` — passes
- `pnpm test:unit` — all modified test files pass; pre-existing environmental flakes (`GraphView.test.ts`, `ColorWidget.test.ts`, etc., unchanged here and flaky on `main` in this sandbox) are unrelated
- `pnpm lint` / `pnpm knip` — clean
- Manual verification: 362 tests across 6 representative converted suites re-run in an interactive shell — all passing

Manual UI verification (Playwright/screenshots) is not applicable: changes are test-file-only refactors with no production runtime or UI behavior change.

## Notes on `.for` semantics

- Array-of-tuples (`[[a, b], ...]`) passes the tuple as a single arg, so callbacks were changed from `(a, b) => …` to `([a, b]) => …`.
- Array-of-objects (`[{a}, …]`) already used destructuring — unchanged.
- Array-of-primitives (`['a', …]`) — callback signature unchanged.
- A handful of complex cases use a small `type Case = [...]` alias plus `it.for<Case>([...])` to preserve tuple inference where TS narrowed unions otherwise broke parameter types.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12161-test-enable-vitest-consistent-each-for-and-migrate-each-for-35e6d73d3650810c9417e07bdd9f27a2) by [Unito](https://www.unito.io)
