### PR TITLE
fix: bring newly created nodes to front in createNode helper

### DIFF
--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { createTestSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 
-import { resolveNode } from './litegraphUtil'
+import { createNode, resolveNode } from './litegraphUtil'
+
+const mockBringNodeToFront = vi.fn()
+
+vi.mock('@/renderer/extensions/vueNodes/composables/useNodeZIndex', () => ({
+  useNodeZIndex: () => ({ bringNodeToFront: mockBringNodeToFront })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert: vi.fn() })
+}))
 
 describe('resolveNode', () => {
   it('returns undefined when graph is null', () => {
@@ -66,5 +77,120 @@ describe('resolveNode', () => {
 
     const targetNode = sg2._nodes[0]
     expect(resolveNode(targetNode.id, rootGraph)).toBe(targetNode)
+  })
+})
+
+describe('createNode', () => {
+  function makeCanvas(graph: LGraph): LGraphCanvas {
+    return {
+      graph,
+      graph_mouse: [100, 200] as [number, number]
+    } as Partial<LGraphCanvas> as LGraphCanvas
+  }
+
+  beforeEach(() => {
+    mockBringNodeToFront.mockClear()
+  })
+
+  it('returns null when name is empty', async () => {
+    const result = await createNode(makeCanvas(new LGraph()), '')
+    expect(result).toBeNull()
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+  })
+
+  it('places the new node at the canvas graph_mouse position', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(newNode)
+    const graph = new LGraph()
+
+    const result = await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(result).toBe(newNode)
+    expect(Array.from(newNode.pos)).toEqual([100, 200])
+    createNodeSpy.mockRestore()
+  })
+
+  it('brings the newly created node to the front via useNodeZIndex', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(newNode)
+    const graph = new LGraph()
+
+    const result = await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(result).toBe(newNode)
+    expect(mockBringNodeToFront).toHaveBeenCalledTimes(1)
+    expect(mockBringNodeToFront).toHaveBeenCalledWith(newNode.id)
+    createNodeSpy.mockRestore()
+  })
+
+  it('brings the new node to the front AFTER it has been added to the graph', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(newNode)
+    const graph = new LGraph()
+
+    const callOrder: string[] = []
+    const originalAdd = graph.add.bind(graph)
+    graph.add = vi.fn((...args: Parameters<typeof originalAdd>) => {
+      callOrder.push('graph.add')
+      return originalAdd(...args)
+    }) as typeof graph.add
+    mockBringNodeToFront.mockImplementation(() => {
+      callOrder.push('bringNodeToFront')
+    })
+
+    await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(callOrder).toEqual(['graph.add', 'bringNodeToFront'])
+    createNodeSpy.mockRestore()
+  })
+
+  it('does not call bringNodeToFront when LiteGraph fails to create the node', async () => {
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(null)
+    const graph = new LGraph()
+
+    const result = await createNode(makeCanvas(graph), 'NonExistentNode')
+
+    expect(result).toBeNull()
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+    createNodeSpy.mockRestore()
+  })
+
+  it('does not call bringNodeToFront when the canvas has no graph', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(newNode)
+    const canvas = {
+      graph: null,
+      graph_mouse: [0, 0] as [number, number]
+    } as Partial<LGraphCanvas> as LGraphCanvas
+
+    const result = await createNode(canvas, 'LoadImage')
+
+    expect(result).toBeNull()
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+    createNodeSpy.mockRestore()
+  })
+
+  it('does not call bringNodeToFront when graph.add fails to attach the node', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const createNodeSpy = vi
+      .spyOn(LiteGraph, 'createNode')
+      .mockReturnValue(newNode)
+    const graph = new LGraph()
+    graph.add = vi.fn(() => null) as unknown as typeof graph.add
+
+    await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+    createNodeSpy.mockRestore()
   })
 })

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -59,9 +59,6 @@ export async function createNode(
     const addedNode = graph.add(newNode) ?? null
 
     if (addedNode) {
-      // Ensure newly created nodes appear above existing ones in the
-      // Vue node renderer (Nodes 2.0). Without this, nodes default to
-      // zIndex 0 and render underneath existing nodes (FE-555).
       useNodeZIndex().bringNodeToFront(addedNode.id)
       graph.change()
     }

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -24,6 +24,7 @@ import type {
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
 import { app } from '@/scripts/app'
 import { t } from '@/i18n'
 
@@ -57,7 +58,13 @@ export async function createNode(
     newNode.pos = [posX, posY]
     const addedNode = graph.add(newNode) ?? null
 
-    if (addedNode) graph.change()
+    if (addedNode) {
+      // Ensure newly created nodes appear above existing ones in the
+      // Vue node renderer (Nodes 2.0). Without this, nodes default to
+      // zIndex 0 and render underneath existing nodes (FE-555).
+      useNodeZIndex().bringNodeToFront(addedNode.id)
+      graph.change()
+    }
     return addedNode
   } else {
     useToastStore().addAlert(t('assetBrowser.failedToCreateNode'))


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

When an image / audio / video is **dropped or pasted onto the canvas without an embedded workflow**, the `createNode` helper in `src/utils/litegraphUtil.ts` is used to spawn the corresponding `LoadImage` / `LoadAudio` / `LoadVideo` node. The Vue node layout store (Nodes 2.0) defaults newly created nodes to `zIndex: 0`, while existing nodes are initialized with `zIndex: index` (1, 2, 3, …). As a result the new node renders **underneath** every existing node.

This PR makes `createNode` call `useNodeZIndex().bringNodeToFront(addedNode.id)` immediately after the node is added to the graph. `bringNodeToFront` already implements `max(zIndex) + 1` across all nodes in the graph, so the helper does not duplicate that math.

Built TDD-style: failing unit tests added first in `src/utils/litegraphUtil.test.ts`, then the minimal implementation change.

## Scope

This PR addresses **only** the z-order aspect of FE-555 (`appears beneath existing nodes in Nodes 2.0`). The drop-position aspect is being investigated separately.

## Changes

- `src/utils/litegraphUtil.ts`: `createNode` now invokes `useNodeZIndex().bringNodeToFront(addedNode.id)` after `graph.add` succeeds.
- `src/utils/litegraphUtil.test.ts`: New `describe('createNode')` block with 7 tests covering:
  - position assignment from `graph_mouse`
  - `bringNodeToFront` called with the new node id
  - `bringNodeToFront` called **after** `graph.add` (ordering)
  - no `bringNodeToFront` when name is empty / `LiteGraph.createNode` returns null / canvas has no graph / `graph.add` fails

## Verification

### Automated
- `pnpm exec vitest run src/utils/litegraphUtil.test.ts` — 14/14 pass
- `pnpm exec vitest run src/composables/usePaste.test.ts src/renderer/extensions/vueNodes/composables/useNodeZIndex.test.ts src/renderer/core/layout/operations/layoutMutations.test.ts` — 58/58 pass
- `pnpm typecheck` — clean
- `pnpm lint` — clean (only a pre-existing warning in unrelated `useWorkspaceBilling.test.ts`)
- `pnpm format` — applied
- Code review (oracle): 0 critical / 0 warning / 0 suggestion

### Manual (Playwright)
1. Enabled `Comfy.VueNodes.Enabled` setting.
2. Seeded the graph with a `SaveImage` node at `[600, 400]` (zIndex 0).
3. Set `canvas.graph_mouse = [600, 400]` and called `createNode(canvas, 'LoadImage')` — same code path used by `pasteImageNode`.
4. Confirmed:
   - LoadImage placed at `[600, 400]` (overlapping SaveImage).
   - LoadImage has `zIndex: 2`; SaveImage has `zIndex: 0`.
   - Visually, LoadImage renders **on top** of the SaveImage in the Vue node renderer.

Before fix the LoadImage would have defaulted to `zIndex: 0` and rendered underneath.

- Fixes FE-555 (z-order aspect)

## Screenshots

![After fix: newly-created LoadImage renders ON TOP of an overlapping existing SaveImage](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c90203e2a7b2c4ddcd6ac199d1154568136903199426c645068cb2a185bd4f40/pr-images/1778562082984-4d3f1f79-8172-46fb-8fb5-902b05e36baf.png)

![Newly-created LoadImage rendered above three existing SaveImage nodes](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c90203e2a7b2c4ddcd6ac199d1154568136903199426c645068cb2a185bd4f40/pr-images/1778562083433-30ca5016-b137-4a81-8b57-d20bcb5dc23f.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12166-fix-bring-newly-created-nodes-to-front-in-createNode-helper-35e6d73d36508171a3b0f0cdc6e1bbe5) by [Unito](https://www.unito.io)
