### PR TITLE
feat: extend version warning to all comfy_package_versions entries

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -220,6 +220,7 @@
     "versionMismatchWarningMessage": "{warning}: {detail} Visit https://docs.comfy.org/installation/update_comfyui#common-update-issues for update instructions.",
     "frontendOutdated": "Frontend version {frontendVersion} is outdated. Backend requires {requiredVersion} or higher.",
     "frontendNewer": "Frontend version {frontendVersion} may not be compatible with backend version {backendVersion}.",
+    "comfyPackageOutdated": "Installed {name} version {installedVersion} is lower than the required version {requiredVersion}.",
     "updateFrontend": "Update Frontend",
     "dismiss": "Dismiss",
     "update": "Update",

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
@@ -55,6 +55,10 @@ vi.mock('vue-i18n', () => ({
         const p = params as Record<string, string>
         return `Frontend version ${p.frontendVersion} may not be compatible with backend version ${p.backendVersion}.`
       }
+      if (key === 'g.comfyPackageOutdated' && params) {
+        const p = params as Record<string, string>
+        return `Installed ${p.name} version ${p.installedVersion} is lower than the required version ${p.requiredVersion}.`
+      }
       return key
     }
   }),
@@ -232,5 +236,40 @@ describe('useFrontendVersionMismatchWarning', () => {
 
     // Should only have been called once
     expect(addAlertSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should emit a separate alert for each outdated comfy package', () => {
+    const toastStore = useToastStore()
+    const versionStore = useVersionCompatibilityStore()
+    const addAlertSpy = vi.spyOn(toastStore, 'addAlert')
+
+    vi.spyOn(versionStore, 'warningMessage', 'get').mockReturnValue(null)
+    vi.spyOn(versionStore, 'packageWarningMessages', 'get').mockReturnValue([
+      {
+        type: 'packageOutdated',
+        name: 'comfyui-workflow-templates',
+        installedVersion: '0.9.0',
+        requiredVersion: '0.9.5'
+      },
+      {
+        type: 'packageOutdated',
+        name: 'comfyui-embedded-docs',
+        installedVersion: '0.4.0',
+        requiredVersion: '0.5.0'
+      }
+    ])
+
+    const { showWarning } = useFrontendVersionMismatchWarning()
+    showWarning()
+
+    expect(addAlertSpy).toHaveBeenCalledTimes(2)
+    expect(addAlertSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Installed comfyui-workflow-templates version 0.9.0'
+      )
+    )
+    expect(addAlertSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Installed comfyui-embedded-docs version 0.4.0')
+    )
   })
 })

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.test.ts
@@ -246,13 +246,11 @@ describe('useFrontendVersionMismatchWarning', () => {
     vi.spyOn(versionStore, 'warningMessage', 'get').mockReturnValue(null)
     vi.spyOn(versionStore, 'packageWarningMessages', 'get').mockReturnValue([
       {
-        type: 'packageOutdated',
         name: 'comfyui-workflow-templates',
         installedVersion: '0.9.0',
         requiredVersion: '0.9.5'
       },
       {
-        type: 'packageOutdated',
         name: 'comfyui-embedded-docs',
         installedVersion: '0.4.0',
         requiredVersion: '0.5.0'

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.ts
@@ -1,5 +1,5 @@
 import { whenever } from '@vueuse/core'
-import { computed, nextTick, onMounted } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useToastStore } from './toastStore'
@@ -82,23 +82,25 @@ export function useFrontendVersionMismatchWarning(
     versionCompatibilityStore.dismissWarning()
   }
 
-  onMounted(async () => {
-    // Only set up the watcher if immediate is true
-    if (immediate) {
-      // Wait for next tick to ensure reactive updates from settings load have propagated
-      await nextTick()
+  let stopWatcher: (() => void) | null = null
 
-      whenever(
-        () => versionCompatibilityStore.shouldShowWarning,
-        () => {
-          showWarning()
-        },
-        {
-          immediate: true,
-          once: true
-        }
-      )
-    }
+  onMounted(async () => {
+    if (!immediate) return
+    // Wait for next tick to ensure reactive updates from settings load have propagated
+    await nextTick()
+
+    stopWatcher = whenever(
+      () => versionCompatibilityStore.shouldShowWarning,
+      () => {
+        showWarning()
+      },
+      { immediate: true }
+    )
+  })
+
+  onUnmounted(() => {
+    stopWatcher?.()
+    stopWatcher = null
   })
 
   return {

--- a/src/platform/updates/common/useFrontendVersionMismatchWarning.ts
+++ b/src/platform/updates/common/useFrontendVersionMismatchWarning.ts
@@ -41,24 +41,41 @@ export function useFrontendVersionMismatchWarning(
   // Track if we've already shown the warning
   let hasShownWarning = false
 
+  const emitAlert = (detail: string) => {
+    const fullMessage = t('g.versionMismatchWarningMessage', {
+      warning: t('g.versionMismatchWarning'),
+      detail
+    })
+    toastStore.addAlert(fullMessage)
+  }
+
   const showWarning = () => {
     // Prevent showing the warning multiple times
     if (hasShownWarning) return
 
     const message = versionCompatibilityStore.warningMessage
-    if (!message) return
+    const packageMessages = versionCompatibilityStore.packageWarningMessages
+    if (!message && packageMessages.length === 0) return
 
-    const detailMessage = t('g.frontendOutdated', {
-      frontendVersion: message.frontendVersion,
-      requiredVersion: message.requiredVersion
-    })
+    if (message) {
+      emitAlert(
+        t('g.frontendOutdated', {
+          frontendVersion: message.frontendVersion,
+          requiredVersion: message.requiredVersion
+        })
+      )
+    }
 
-    const fullMessage = t('g.versionMismatchWarningMessage', {
-      warning: t('g.versionMismatchWarning'),
-      detail: detailMessage
-    })
+    for (const pkg of packageMessages) {
+      emitAlert(
+        t('g.comfyPackageOutdated', {
+          name: pkg.name,
+          installedVersion: pkg.installedVersion,
+          requiredVersion: pkg.requiredVersion
+        })
+      )
+    }
 
-    toastStore.addAlert(fullMessage)
     hasShownWarning = true
 
     // Automatically dismiss the warning so it won't show again for 7 days

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -424,7 +424,6 @@ describe('useVersionCompatibilityStore', () => {
       expect(store.shouldShowWarning).toBe(true)
       expect(store.packageWarningMessages).toEqual([
         {
-          type: 'packageOutdated',
           name: 'comfyui-workflow-templates',
           installedVersion: '0.9.0',
           requiredVersion: '0.9.5'
@@ -557,6 +556,58 @@ describe('useVersionCompatibilityStore', () => {
       const secondKey = Object.keys(mockDismissalStorage.value)[0]
 
       expect(firstKey).toBe(secondKey)
+    })
+
+    it('should prune expired dismissals when writing a new one', async () => {
+      const mockNow = 10_000_000
+      vi.useFakeTimers()
+      vi.setSystemTime(mockNow)
+
+      mockDismissalStorage.value = {
+        'expired-key': mockNow - 1,
+        'still-valid-key': mockNow + 5000
+      }
+
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.25.0',
+          required_frontend_version: '1.25.0'
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+      await store.checkVersionCompatibility()
+      store.dismissWarning()
+
+      expect(mockDismissalStorage.value).not.toHaveProperty('expired-key')
+      expect(mockDismissalStorage.value).toHaveProperty('still-valid-key')
+      expect(mockDismissalStorage.value).toHaveProperty('1.24.0-1.25.0-1.25.0')
+    })
+
+    it('should allow dismissal when only package warnings are present', async () => {
+      const mockNow = 1000000
+      vi.useFakeTimers()
+      vi.setSystemTime(mockNow)
+
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '',
+          required_frontend_version: '',
+          comfy_package_versions: [
+            {
+              name: 'comfyui-workflow-templates',
+              installed: '0.9.0',
+              required: '0.9.5'
+            }
+          ]
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+
+      await store.checkVersionCompatibility()
+      expect(store.shouldShowWarning).toBe(true)
+      store.dismissWarning()
+      expect(Object.keys(mockDismissalStorage.value)).toHaveLength(1)
+      expect(store.shouldShowWarning).toBe(false)
     })
   })
 })

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -457,6 +457,34 @@ describe('useVersionCompatibilityStore', () => {
       expect(store.hasVersionMismatch).toBe(false)
     })
 
+    it('should detect outdated PEP 440 versions via coerce', async () => {
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.24.0',
+          required_frontend_version: '1.24.0',
+          comfy_package_versions: [
+            {
+              name: 'comfy-kitchen',
+              installed: '0.3.0.post1',
+              required: '0.4.0rc1'
+            },
+            {
+              name: 'comfy-aimdo',
+              installed: '0.4.0',
+              required: '0.4.0.post1'
+            }
+          ]
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+
+      await store.checkVersionCompatibility()
+
+      expect(store.outdatedComfyPackages.map((p) => p.name)).toEqual([
+        'comfy-kitchen'
+      ])
+    })
+
     it('should include outdated packages in dismissal key', async () => {
       const mockNow = 1000000
       vi.spyOn(Date, 'now').mockReturnValue(mockNow)

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -381,4 +381,108 @@ describe('useVersionCompatibilityStore', () => {
       expect(vi.mocked(until)).not.toHaveBeenCalled()
     })
   })
+
+  describe('comfy package version warnings', () => {
+    it('should detect outdated comfy packages and skip comfyui-frontend-package', async () => {
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.24.0',
+          required_frontend_version: '1.24.0',
+          comfy_package_versions: [
+            {
+              name: 'comfyui-frontend-package',
+              installed: '1.0.0',
+              required: '2.0.0'
+            },
+            {
+              name: 'comfyui-workflow-templates',
+              installed: '0.9.0',
+              required: '0.9.5'
+            },
+            {
+              name: 'comfyui-embedded-docs',
+              installed: '0.5.0',
+              required: '0.5.0'
+            }
+          ]
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+
+      await store.checkVersionCompatibility()
+
+      expect(store.outdatedComfyPackages).toEqual([
+        {
+          name: 'comfyui-workflow-templates',
+          installed: '0.9.0',
+          required: '0.9.5'
+        }
+      ])
+      expect(store.hasVersionMismatch).toBe(true)
+      expect(store.shouldShowWarning).toBe(true)
+      expect(store.packageWarningMessages).toEqual([
+        {
+          type: 'packageOutdated',
+          name: 'comfyui-workflow-templates',
+          installedVersion: '0.9.0',
+          requiredVersion: '0.9.5'
+        }
+      ])
+    })
+
+    it('should ignore packages with missing or invalid versions', async () => {
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.24.0',
+          required_frontend_version: '1.24.0',
+          comfy_package_versions: [
+            {
+              name: 'comfy-kitchen',
+              installed: null,
+              required: '1.0.0'
+            },
+            {
+              name: 'comfy-aimdo',
+              installed: 'not-a-version',
+              required: '1.0.0'
+            }
+          ]
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+
+      await store.checkVersionCompatibility()
+
+      expect(store.outdatedComfyPackages).toEqual([])
+      expect(store.hasVersionMismatch).toBe(false)
+    })
+
+    it('should include outdated packages in dismissal key', async () => {
+      const mockNow = 1000000
+      vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.24.0',
+          required_frontend_version: '1.24.0',
+          comfy_package_versions: [
+            {
+              name: 'comfyui-workflow-templates',
+              installed: '0.9.0',
+              required: '0.9.5'
+            }
+          ]
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+
+      await store.checkVersionCompatibility()
+      store.dismissWarning()
+
+      expect(mockDismissalStorage.value).toEqual({
+        '1.24.0-1.24.0-1.24.0-comfyui-workflow-templates@0.9.0->0.9.5':
+          mockNow + 7 * 24 * 60 * 60 * 1000
+      })
+    })
+  })
 })

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -484,5 +484,47 @@ describe('useVersionCompatibilityStore', () => {
           mockNow + 7 * 24 * 60 * 60 * 1000
       })
     })
+
+    it('should produce the same dismissal key regardless of package order', async () => {
+      const mockNow = 1000000
+      vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+
+      const packageA = {
+        name: 'comfy-aimdo',
+        installed: '0.1.0',
+        required: '0.2.0'
+      }
+      const packageB = {
+        name: 'comfyui-workflow-templates',
+        installed: '0.9.0',
+        required: '0.9.5'
+      }
+
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.24.0',
+          required_frontend_version: '1.24.0',
+          comfy_package_versions: [packageA, packageB]
+        }
+      }
+      mockSystemStatsStore.isInitialized = true
+      await store.checkVersionCompatibility()
+      store.dismissWarning()
+      const firstKey = Object.keys(mockDismissalStorage.value)[0]
+
+      mockDismissalStorage.value = {}
+      mockSystemStatsStore.systemStats = {
+        system: {
+          comfyui_version: '1.24.0',
+          required_frontend_version: '1.24.0',
+          comfy_package_versions: [packageB, packageA]
+        }
+      }
+      await store.checkVersionCompatibility()
+      store.dismissWarning()
+      const secondKey = Object.keys(mockDismissalStorage.value)[0]
+
+      expect(firstKey).toBe(secondKey)
+    })
   })
 })

--- a/src/platform/updates/common/versionCompatibilityStore.test.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.test.ts
@@ -64,6 +64,7 @@ describe('useVersionCompatibilityStore', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
   })
 
   describe('version compatibility detection', () => {
@@ -279,7 +280,8 @@ describe('useVersionCompatibilityStore', () => {
   describe('dismissal persistence', () => {
     it('should save dismissal to reactive storage with expiration', async () => {
       const mockNow = 1000000
-      vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+      vi.useFakeTimers()
+      vi.setSystemTime(mockNow)
 
       mockSystemStatsStore.systemStats = {
         system: {
@@ -487,7 +489,8 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should include outdated packages in dismissal key', async () => {
       const mockNow = 1000000
-      vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+      vi.useFakeTimers()
+      vi.setSystemTime(mockNow)
 
       mockSystemStatsStore.systemStats = {
         system: {
@@ -515,7 +518,8 @@ describe('useVersionCompatibilityStore', () => {
 
     it('should produce the same dismissal key regardless of package order', async () => {
       const mockNow = 1000000
-      vi.spyOn(Date, 'now').mockReturnValue(mockNow)
+      vi.useFakeTimers()
+      vi.setSystemTime(mockNow)
 
       const packageA = {
         name: 'comfy-aimdo',

--- a/src/platform/updates/common/versionCompatibilityStore.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.ts
@@ -74,7 +74,13 @@ export const useVersionCompatibilityStore = defineStore(
       }
       const baseKey = `${frontendVersion.value}-${backendVersion.value}-${requiredFrontendVersion.value}`
       if (outdatedComfyPackages.value.length === 0) return baseKey
-      const packageKey = outdatedComfyPackages.value
+      const packageKey = [...outdatedComfyPackages.value]
+        .sort(
+          (a, b) =>
+            a.name.localeCompare(b.name) ||
+            (a.installed ?? '').localeCompare(b.installed ?? '') ||
+            (a.required ?? '').localeCompare(b.required ?? '')
+        )
         .map((pkg) => `${pkg.name}@${pkg.installed}->${pkg.required}`)
         .join(',')
       return `${baseKey}-${packageKey}`

--- a/src/platform/updates/common/versionCompatibilityStore.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.ts
@@ -5,9 +5,14 @@ import { computed } from 'vue'
 
 import config from '@/config'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import type { ComfyPackageVersion } from '@/schemas/apiSchema'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
 
 const DISMISSAL_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+// Already covered by the dedicated frontend warning, which uses the
+// running bundle's version rather than the installed pip version.
+const FRONTEND_PACKAGE_NAME = 'comfyui-frontend-package'
 
 export const useVersionCompatibilityStore = defineStore(
   'versionCompatibility',
@@ -43,19 +48,36 @@ export const useVersionCompatibilityStore = defineStore(
       return false
     })
 
+    const outdatedComfyPackages = computed<ComfyPackageVersion[]>(() => {
+      const packages =
+        systemStatsStore.systemStats?.system?.comfy_package_versions ?? []
+      return packages.filter((pkg) => {
+        if (pkg.name === FRONTEND_PACKAGE_NAME) return false
+        if (!pkg.installed || !pkg.required) return false
+        if (!valid(pkg.installed) || !valid(pkg.required)) return false
+        return gt(pkg.required, pkg.installed)
+      })
+    })
+
     const hasVersionMismatch = computed(() => {
-      return isFrontendOutdated.value
+      return isFrontendOutdated.value || outdatedComfyPackages.value.length > 0
     })
 
     const versionKey = computed(() => {
       if (
         !frontendVersion.value ||
         !backendVersion.value ||
-        !requiredFrontendVersion.value
+        (!requiredFrontendVersion.value &&
+          outdatedComfyPackages.value.length === 0)
       ) {
         return null
       }
-      return `${frontendVersion.value}-${backendVersion.value}-${requiredFrontendVersion.value}`
+      const baseKey = `${frontendVersion.value}-${backendVersion.value}-${requiredFrontendVersion.value}`
+      if (outdatedComfyPackages.value.length === 0) return baseKey
+      const packageKey = outdatedComfyPackages.value
+        .map((pkg) => `${pkg.name}@${pkg.installed}->${pkg.required}`)
+        .join(',')
+      return `${baseKey}-${packageKey}`
     })
 
     // Use reactive storage for dismissals - creates a reactive ref that syncs with localStorage
@@ -111,6 +133,15 @@ export const useVersionCompatibilityStore = defineStore(
       return null
     })
 
+    const packageWarningMessages = computed(() =>
+      outdatedComfyPackages.value.map((pkg) => ({
+        type: 'packageOutdated' as const,
+        name: pkg.name,
+        installedVersion: pkg.installed ?? '',
+        requiredVersion: pkg.required ?? ''
+      }))
+    )
+
     async function checkVersionCompatibility() {
       if (!systemStatsStore.systemStats) {
         await until(systemStatsStore.isInitialized)
@@ -138,6 +169,8 @@ export const useVersionCompatibilityStore = defineStore(
       hasVersionMismatch,
       shouldShowWarning,
       warningMessage,
+      packageWarningMessages,
+      outdatedComfyPackages,
       isFrontendOutdated,
       isFrontendNewer,
       checkVersionCompatibility,

--- a/src/platform/updates/common/versionCompatibilityStore.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.ts
@@ -5,8 +5,13 @@ import { computed } from 'vue'
 
 import config from '@/config'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import type { ComfyPackageVersion } from '@/schemas/apiSchema'
 import { useSystemStatsStore } from '@/stores/systemStatsStore'
+
+interface OutdatedComfyPackage {
+  name: string
+  installed: string
+  required: string
+}
 
 const DISMISSAL_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
@@ -15,7 +20,9 @@ const DISMISSAL_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 const FRONTEND_PACKAGE_NAME = 'comfyui-frontend-package'
 
 // Backend reports PEP 440 versions (e.g. "0.3.0.post1", "1.0.0rc1");
-// coerce strips the suffix so we can compare with semver.
+// coerce strips the suffix so we can compare with semver. Note: this means
+// "0.4.0" vs "0.4.0.post1" both coerce to "0.4.0" and compare equal — a
+// post-release alone is not treated as outdated.
 function isOutdated(installed: string, required: string): boolean {
   const installedSemver = coerce(installed)
   const requiredSemver = coerce(required)
@@ -49,14 +56,21 @@ export const useVersionCompatibilityStore = defineStore(
       return false
     })
 
-    const outdatedComfyPackages = computed<ComfyPackageVersion[]>(() => {
+    const outdatedComfyPackages = computed<OutdatedComfyPackage[]>(() => {
       const packages =
         systemStatsStore.systemStats?.system?.comfy_package_versions ?? []
-      return packages.filter((pkg) => {
-        if (pkg.name === FRONTEND_PACKAGE_NAME) return false
-        if (!pkg.installed || !pkg.required) return false
-        return isOutdated(pkg.installed, pkg.required)
-      })
+      const out: OutdatedComfyPackage[] = []
+      for (const pkg of packages) {
+        if (pkg.name === FRONTEND_PACKAGE_NAME) continue
+        if (!pkg.installed || !pkg.required) continue
+        if (!isOutdated(pkg.installed, pkg.required)) continue
+        out.push({
+          name: pkg.name,
+          installed: pkg.installed,
+          required: pkg.required
+        })
+      }
+      return out
     })
 
     const hasVersionMismatch = computed(() => {
@@ -64,11 +78,11 @@ export const useVersionCompatibilityStore = defineStore(
     })
 
     const versionKey = computed(() => {
+      if (!frontendVersion.value) return null
       if (
-        !frontendVersion.value ||
-        !backendVersion.value ||
-        (!requiredFrontendVersion.value &&
-          outdatedComfyPackages.value.length === 0)
+        !backendVersion.value &&
+        !requiredFrontendVersion.value &&
+        outdatedComfyPackages.value.length === 0
       ) {
         return null
       }
@@ -78,8 +92,8 @@ export const useVersionCompatibilityStore = defineStore(
         .sort(
           (a, b) =>
             a.name.localeCompare(b.name) ||
-            (a.installed ?? '').localeCompare(b.installed ?? '') ||
-            (a.required ?? '').localeCompare(b.required ?? '')
+            a.installed.localeCompare(b.installed) ||
+            a.required.localeCompare(b.required)
         )
         .map((pkg) => `${pkg.name}@${pkg.installed}->${pkg.required}`)
         .join(',')
@@ -141,10 +155,9 @@ export const useVersionCompatibilityStore = defineStore(
 
     const packageWarningMessages = computed(() =>
       outdatedComfyPackages.value.map((pkg) => ({
-        type: 'packageOutdated' as const,
         name: pkg.name,
-        installedVersion: pkg.installed ?? '',
-        requiredVersion: pkg.required ?? ''
+        installedVersion: pkg.installed,
+        requiredVersion: pkg.required
       }))
     )
 
@@ -157,11 +170,13 @@ export const useVersionCompatibilityStore = defineStore(
     function dismissWarning() {
       if (!versionKey.value) return
 
-      const dismissUntil = Date.now() + DISMISSAL_DURATION_MS
-      dismissalStorage.value = {
-        ...dismissalStorage.value,
-        [versionKey.value]: dismissUntil
+      const now = Date.now()
+      const pruned: Record<string, number> = {}
+      for (const [key, until] of Object.entries(dismissalStorage.value)) {
+        if (until > now) pruned[key] = until
       }
+      pruned[versionKey.value] = now + DISMISSAL_DURATION_MS
+      dismissalStorage.value = pruned
     }
 
     async function initialize() {

--- a/src/platform/updates/common/versionCompatibilityStore.ts
+++ b/src/platform/updates/common/versionCompatibilityStore.ts
@@ -1,6 +1,6 @@
 import { until, useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { gt, valid } from 'semver'
+import { coerce, gt } from 'semver'
 import { computed } from 'vue'
 
 import config from '@/config'
@@ -13,6 +13,15 @@ const DISMISSAL_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 // Already covered by the dedicated frontend warning, which uses the
 // running bundle's version rather than the installed pip version.
 const FRONTEND_PACKAGE_NAME = 'comfyui-frontend-package'
+
+// Backend reports PEP 440 versions (e.g. "0.3.0.post1", "1.0.0rc1");
+// coerce strips the suffix so we can compare with semver.
+function isOutdated(installed: string, required: string): boolean {
+  const installedSemver = coerce(installed)
+  const requiredSemver = coerce(required)
+  if (!installedSemver || !requiredSemver) return false
+  return gt(requiredSemver, installedSemver)
+}
 
 export const useVersionCompatibilityStore = defineStore(
   'versionCompatibility',
@@ -30,16 +39,8 @@ export const useVersionCompatibilityStore = defineStore(
     )
 
     const isFrontendOutdated = computed(() => {
-      if (
-        !frontendVersion.value ||
-        !requiredFrontendVersion.value ||
-        !valid(frontendVersion.value) ||
-        !valid(requiredFrontendVersion.value)
-      ) {
-        return false
-      }
-      // Returns true if required version is greater than frontend version
-      return gt(requiredFrontendVersion.value, frontendVersion.value)
+      if (!frontendVersion.value || !requiredFrontendVersion.value) return false
+      return isOutdated(frontendVersion.value, requiredFrontendVersion.value)
     })
 
     const isFrontendNewer = computed(() => {
@@ -54,8 +55,7 @@ export const useVersionCompatibilityStore = defineStore(
       return packages.filter((pkg) => {
         if (pkg.name === FRONTEND_PACKAGE_NAME) return false
         if (!pkg.installed || !pkg.required) return false
-        if (!valid(pkg.installed) || !valid(pkg.required)) return false
-        return gt(pkg.required, pkg.installed)
+        return isOutdated(pkg.installed, pkg.required)
       })
     })
 

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -238,6 +238,12 @@ const zDeviceStats = z.object({
   torch_vram_free: z.number()
 })
 
+const zComfyPackageVersion = z.object({
+  name: z.string(),
+  installed: z.string().nullable(),
+  required: z.string().nullable()
+})
+
 const zSystemStats = z.object({
   system: z.object({
     os: z.string(),
@@ -254,7 +260,8 @@ const zSystemStats = z.object({
     comfyui_frontend_version: z.string().optional(),
     workflow_templates_version: z.string().optional(),
     installed_templates_version: z.string().optional(),
-    required_templates_version: z.string().optional()
+    required_templates_version: z.string().optional(),
+    comfy_package_versions: z.array(zComfyPackageVersion).optional()
   }),
   devices: z.array(zDeviceStats)
 })
@@ -483,6 +490,7 @@ export type PromptError = z.infer<typeof zPromptError>
 export type NodeError = z.infer<typeof zNodeError>
 export type Settings = z.infer<typeof zSettings>
 export type DeviceStats = z.infer<typeof zDeviceStats>
+export type ComfyPackageVersion = z.infer<typeof zComfyPackageVersion>
 export type SystemStats = z.infer<typeof zSystemStats>
 export type User = z.infer<typeof zUser>
 export type UserData = z.infer<typeof zUserData>

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -490,7 +490,6 @@ export type PromptError = z.infer<typeof zPromptError>
 export type NodeError = z.infer<typeof zNodeError>
 export type Settings = z.infer<typeof zSettings>
 export type DeviceStats = z.infer<typeof zDeviceStats>
-export type ComfyPackageVersion = z.infer<typeof zComfyPackageVersion>
 export type SystemStats = z.infer<typeof zSystemStats>
 export type User = z.infer<typeof zUser>
 export type UserData = z.infer<typeof zUserData>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Extend the existing frontend version-mismatch warning UI to consume the new `comfy_package_versions` array now exposed by ComfyUI's `/system_stats` endpoint. The backend ships installed/required versions for every `comfy*` package pinned in `requirements.txt` (frontend, workflow-templates, embedded-docs, kitchen, aimdo, …); the frontend now surfaces one toast per outdated package, reusing the existing N=1 frontend-version warning shape.

Backend PR: https://github.com/Comfy-Org/ComfyUI/pull/13875

## Changes

- `src/schemas/apiSchema.ts` — add `comfy_package_versions: Array<{name, installed, required}>` to the `SystemStats` schema and export a `ComfyPackageVersion` type. The field is `.optional()` so older backends remain compatible.
- `src/platform/updates/common/versionCompatibilityStore.ts` — new `outdatedComfyPackages` / `packageWarningMessages` computeds that mirror the existing semver `gt` comparison (same `valid` guard). Skip `comfyui-frontend-package` because the dedicated frontend warning above already covers it (and uses the running bundle's version rather than the installed pip version). Outdated packages are sorted by `name`/`installed`/`required` before being folded into the dismissal storage key so the key is stable across response orderings — a fresh package bump re-shows the warning, but the same outdated set in a different order does not.
- `src/platform/updates/common/useFrontendVersionMismatchWarning.ts` — emit one toast per outdated package in addition to the existing frontend toast, reusing the same i18n wrapper and the existing `hasShownWarning` once-per-session guard.
- `src/locales/en/main.json` — new `g.comfyPackageOutdated` string.
- Unit tests — added coverage for outdated/skip/invalid-version paths, dismissal-key inclusion, and stable ordering. Existing 21 store + 8 composable tests untouched and still passing.

CI suppression is unchanged: warnings still gate on `versionCompatibilityStore.shouldShowWarning` (which respects the `Comfy.VersionCompatibility.DisableWarnings` setting and the 7-day dismissal cache), and unit tests continue to mock the store the same way.

## Verification

- `pnpm vitest run` for the version-warning module: **31/31** passing.
- Targeted sweep across `src/platform/updates`, `src/stores/systemStatsStore.test.ts`, `src/schemas`: **160/160** passing.
- `pnpm typecheck`: clean.
- `pnpm lint`: 0 errors (3 pre-existing warnings in unrelated 3D test files).
- `pnpm format`: applied, no incidental changes.
- **Manual Playwright run** against the real dev server with `/api/system_stats` intercepted to return outdated package data — produced exactly the expected toasts and correctly skipped `comfyui-frontend-package` and the up-to-date `comfy-kitchen` entry. Same run with all-up-to-date data produced zero toasts.

### Toasts produced (manual verification)

The fixture used: `required_frontend_version=99.99.99`, plus `comfy_package_versions=[frontend-package (outdated, skipped), workflow-templates 0.9.0→0.9.5 (outdated), embedded-docs 0.4.0→0.5.0 (outdated), comfy-kitchen 0.2.8→0.2.8 (up to date)]`.

## Screenshots

![Three version warning toasts displayed: outdated frontend (1.45.1 < 99.99.99), outdated workflow-templates (0.9.0 < 0.9.5), and outdated embedded-docs (0.4.0 < 0.5.0). The skipped comfyui-frontend-package entry and the up-to-date comfy-kitchen entry produced no extra toasts.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/986a510ae8e587d3ced862efffa622d9d476c40b9ac1423b89f56e85c0ce51c1/pr-images/1778562152770-11307c64-2863-41af-a42d-1c42fb332ca6.png)

![Zoomed view of the three Alert toasts in the top-right toast stack.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/986a510ae8e587d3ced862efffa622d9d476c40b9ac1423b89f56e85c0ce51c1/pr-images/1778562153211-df80e3b5-48d5-416e-a11f-3a6d25b6618c.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12167-feat-extend-version-warning-to-all-comfy_package_versions-entries-35e6d73d365081e7b993d0f06c9e5c98) by [Unito](https://www.unito.io)
