### PR TITLE
feat: experimental flag to replace canvas Add Node menu with search box

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -146,6 +146,7 @@ import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
+import { useCanvasSearchBoxMenu } from '@/composables/useCanvasSearchBoxMenu'
 import { useContextMenuTranslation } from '@/composables/useContextMenuTranslation'
 import { useCopy } from '@/composables/useCopy'
 import { useGlobalLitegraph } from '@/composables/useGlobalLitegraph'
@@ -459,6 +460,7 @@ useLitegraphSettings()
 useNodeBadge()
 
 useGlobalLitegraph()
+useCanvasSearchBoxMenu()
 useContextMenuTranslation()
 useCopy()
 usePaste()

--- a/src/composables/useCanvasSearchBoxMenu.test.ts
+++ b/src/composables/useCanvasSearchBoxMenu.test.ts
@@ -2,8 +2,12 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useCanvasSearchBoxMenu } from '@/composables/useCanvasSearchBoxMenu'
-import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
+import type {
+  ContextMenu,
+  IContextMenuValue
+} from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { createMockCanvas } from '@/utils/__tests__/litegraphTestUtils'
@@ -39,6 +43,19 @@ describe('useCanvasSearchBoxMenu', () => {
     vi.restoreAllMocks()
   })
 
+  function invokeAddNodeCallback(
+    addNode: IContextMenuValue,
+    previousMenu?: Partial<ContextMenu<unknown>>
+  ) {
+    void addNode.callback?.call(
+      addNode as never,
+      undefined,
+      undefined,
+      undefined as never,
+      previousMenu as ContextMenu<unknown> | undefined
+    )
+  }
+
   it('leaves the default Add Node entry untouched when the setting is off', () => {
     vi.spyOn(useSettingStore(), 'get').mockImplementation((id) =>
       id === 'Comfy.NodeSearchBox.ReplaceCanvasMenu' ? false : undefined
@@ -52,11 +69,20 @@ describe('useCanvasSearchBoxMenu', () => {
     expect(addNode?.has_submenu).toBe(true)
   })
 
-  it('replaces the Add Node callback with the search box trigger when the setting is on', () => {
+  it('forwards the original right-click event to the search box so the node lands at the click position', () => {
     vi.spyOn(useSettingStore(), 'get').mockImplementation((id) =>
       id === 'Comfy.NodeSearchBox.ReplaceCanvasMenu' ? true : undefined
     )
+    const openAtEvent = vi.spyOn(useSearchBoxStore(), 'openAtEvent')
     const toggleVisible = vi.spyOn(useSearchBoxStore(), 'toggleVisible')
+
+    const triggerEvent = {
+      canvasX: 123,
+      canvasY: 456
+    } as unknown as CanvasPointerEvent
+    const previousMenu = {
+      getFirstEvent: () => triggerEvent
+    } as unknown as Partial<ContextMenu<unknown>>
 
     useCanvasSearchBoxMenu()
     const items = LGraphCanvas.prototype.getCanvasMenuOptions.call(mockCanvas)
@@ -64,15 +90,25 @@ describe('useCanvasSearchBoxMenu', () => {
 
     expect(addNode).toBeTruthy()
     expect(addNode?.has_submenu).toBe(false)
-    expect(addNode?.callback).not.toBe(LGraphCanvas.onMenuAdd)
+    invokeAddNodeCallback(addNode!, previousMenu)
 
-    void addNode?.callback?.call(
-      addNode as never,
-      undefined,
-      undefined,
-      undefined as never,
-      undefined
-    )
+    expect(openAtEvent).toHaveBeenCalledTimes(1)
+    expect(openAtEvent).toHaveBeenCalledWith(triggerEvent)
+    expect(toggleVisible).not.toHaveBeenCalled()
+  })
+
+  it('falls back to toggleVisible when no originating event is available', () => {
+    vi.spyOn(useSettingStore(), 'get').mockReturnValue(true)
+    const openAtEvent = vi.spyOn(useSearchBoxStore(), 'openAtEvent')
+    const toggleVisible = vi.spyOn(useSearchBoxStore(), 'toggleVisible')
+
+    useCanvasSearchBoxMenu()
+    const items = LGraphCanvas.prototype.getCanvasMenuOptions.call(mockCanvas)
+    const addNode = items.find((i) => i?.content === 'Add Node')
+
+    invokeAddNodeCallback(addNode!, undefined)
+
+    expect(openAtEvent).not.toHaveBeenCalled()
     expect(toggleVisible).toHaveBeenCalledTimes(1)
   })
 
@@ -84,5 +120,15 @@ describe('useCanvasSearchBoxMenu', () => {
 
     const contents = items.map((i) => i?.content)
     expect(contents).toEqual(['Add Node', 'Add Group'])
+  })
+
+  it('is idempotent across repeated invocations (HMR, remount)', () => {
+    useCanvasSearchBoxMenu()
+    const firstPatch = LGraphCanvas.prototype.getCanvasMenuOptions
+
+    useCanvasSearchBoxMenu()
+    useCanvasSearchBoxMenu()
+
+    expect(LGraphCanvas.prototype.getCanvasMenuOptions).toBe(firstPatch)
   })
 })

--- a/src/composables/useCanvasSearchBoxMenu.test.ts
+++ b/src/composables/useCanvasSearchBoxMenu.test.ts
@@ -1,0 +1,88 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCanvasSearchBoxMenu } from '@/composables/useCanvasSearchBoxMenu'
+import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
+import { createMockCanvas } from '@/utils/__tests__/litegraphTestUtils'
+
+describe('useCanvasSearchBoxMenu', () => {
+  let originalGetCanvasMenuOptions: typeof LGraphCanvas.prototype.getCanvasMenuOptions
+  let mockCanvas: LGraphCanvas
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    originalGetCanvasMenuOptions = LGraphCanvas.prototype.getCanvasMenuOptions
+
+    LGraphCanvas.prototype.getCanvasMenuOptions =
+      function (): (IContextMenuValue | null)[] {
+        const items: (IContextMenuValue<string> | null)[] = [
+          {
+            content: 'Add Node',
+            has_submenu: true,
+            callback: LGraphCanvas.onMenuAdd
+          },
+          { content: 'Add Group', callback: vi.fn() }
+        ]
+        return items as (IContextMenuValue | null)[]
+      }
+
+    mockCanvas = createMockCanvas({
+      constructor: { prototype: LGraphCanvas.prototype } as typeof LGraphCanvas
+    } as Partial<LGraphCanvas>)
+  })
+
+  afterEach(() => {
+    LGraphCanvas.prototype.getCanvasMenuOptions = originalGetCanvasMenuOptions
+    vi.restoreAllMocks()
+  })
+
+  it('leaves the default Add Node entry untouched when the setting is off', () => {
+    vi.spyOn(useSettingStore(), 'get').mockImplementation((id) =>
+      id === 'Comfy.NodeSearchBox.ReplaceCanvasMenu' ? false : undefined
+    )
+
+    useCanvasSearchBoxMenu()
+    const items = LGraphCanvas.prototype.getCanvasMenuOptions.call(mockCanvas)
+
+    const addNode = items.find((i) => i?.content === 'Add Node')
+    expect(addNode?.callback).toBe(LGraphCanvas.onMenuAdd)
+    expect(addNode?.has_submenu).toBe(true)
+  })
+
+  it('replaces the Add Node callback with the search box trigger when the setting is on', () => {
+    vi.spyOn(useSettingStore(), 'get').mockImplementation((id) =>
+      id === 'Comfy.NodeSearchBox.ReplaceCanvasMenu' ? true : undefined
+    )
+    const toggleVisible = vi.spyOn(useSearchBoxStore(), 'toggleVisible')
+
+    useCanvasSearchBoxMenu()
+    const items = LGraphCanvas.prototype.getCanvasMenuOptions.call(mockCanvas)
+    const addNode = items.find((i) => i?.content === 'Add Node')
+
+    expect(addNode).toBeTruthy()
+    expect(addNode?.has_submenu).toBe(false)
+    expect(addNode?.callback).not.toBe(LGraphCanvas.onMenuAdd)
+
+    void addNode?.callback?.call(
+      addNode as never,
+      undefined,
+      undefined,
+      undefined as never,
+      undefined
+    )
+    expect(toggleVisible).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves other canvas menu entries', () => {
+    vi.spyOn(useSettingStore(), 'get').mockReturnValue(true)
+
+    useCanvasSearchBoxMenu()
+    const items = LGraphCanvas.prototype.getCanvasMenuOptions.call(mockCanvas)
+
+    const contents = items.map((i) => i?.content)
+    expect(contents).toEqual(['Add Node', 'Add Group'])
+  })
+})

--- a/src/composables/useCanvasSearchBoxMenu.ts
+++ b/src/composables/useCanvasSearchBoxMenu.ts
@@ -1,10 +1,15 @@
 import { legacyMenuCompat } from '@/lib/litegraph/src/contextMenuCompat'
-import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
+import type {
+  ContextMenu,
+  IContextMenuValue
+} from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 
 const REPLACE_SETTING_ID = 'Comfy.NodeSearchBox.ReplaceCanvasMenu'
+const WRAPPER_MARK = Symbol('useCanvasSearchBoxMenu.wrapper')
 
 /**
  * When the experimental "replace canvas menu" setting is enabled, the
@@ -14,19 +19,25 @@ const REPLACE_SETTING_ID = 'Comfy.NodeSearchBox.ReplaceCanvasMenu'
  *
  * The replacement is identified by callback identity against
  * {@link LGraphCanvas.onMenuAdd} so it remains stable across the translation
- * wrapper installed by {@link useContextMenuTranslation}.
+ * wrapper installed by {@link useContextMenuTranslation}. The original
+ * right-click event is forwarded via {@link ContextMenu.getFirstEvent} so the
+ * resulting node lands at the click position instead of canvas center.
+ *
+ * Installation is idempotent: repeated calls (e.g. HMR remounts) do not stack
+ * wrappers because the wrapper is tagged and detected on re-entry.
  */
 export const useCanvasSearchBoxMenu = () => {
   legacyMenuCompat.install(LGraphCanvas.prototype, 'getCanvasMenuOptions')
 
-  const originalGetCanvasMenuOptions =
+  const previousGetCanvasMenuOptions =
     LGraphCanvas.prototype.getCanvasMenuOptions
+  if (isOurWrapper(previousGetCanvasMenuOptions)) return
 
-  const wrapped = function (
+  const wrapped: typeof previousGetCanvasMenuOptions = function (
     this: LGraphCanvas,
-    ...args: Parameters<typeof originalGetCanvasMenuOptions>
+    ...args
   ) {
-    const items = originalGetCanvasMenuOptions.apply(this, args)
+    const items = previousGetCanvasMenuOptions.apply(this, args)
 
     const settingStore = useSettingStore()
     if (!settingStore.get(REPLACE_SETTING_ID)) return items
@@ -35,14 +46,28 @@ export const useCanvasSearchBoxMenu = () => {
       isLegacyAddNode(item) ? buildSearchBoxAddNode(item) : item
     )
   }
+  markAsOurWrapper(wrapped)
 
   LGraphCanvas.prototype.getCanvasMenuOptions = wrapped
   legacyMenuCompat.registerWrapper(
     'getCanvasMenuOptions',
     wrapped,
-    originalGetCanvasMenuOptions,
+    previousGetCanvasMenuOptions,
     LGraphCanvas.prototype
   )
+}
+
+function isOurWrapper(fn: unknown): boolean {
+  return !!fn && (fn as { [WRAPPER_MARK]?: true })[WRAPPER_MARK] === true
+}
+
+function markAsOurWrapper(fn: object) {
+  Object.defineProperty(fn, WRAPPER_MARK, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false
+  })
 }
 
 function isLegacyAddNode(
@@ -60,8 +85,21 @@ function buildSearchBoxAddNode(original: IContextMenuValue): IContextMenuValue {
     ...original,
     has_submenu: false,
     submenu: undefined,
-    callback: () => {
-      useSearchBoxStore().toggleVisible()
+    callback: (
+      _value?: unknown,
+      _options?: unknown,
+      _event?: MouseEvent,
+      previousMenu?: ContextMenu<unknown>
+    ) => {
+      const triggerEvent = previousMenu?.getFirstEvent() as
+        | CanvasPointerEvent
+        | undefined
+      const store = useSearchBoxStore()
+      if (triggerEvent) {
+        store.openAtEvent(triggerEvent)
+      } else {
+        store.toggleVisible()
+      }
     }
   }
 }

--- a/src/composables/useCanvasSearchBoxMenu.ts
+++ b/src/composables/useCanvasSearchBoxMenu.ts
@@ -1,0 +1,67 @@
+import { legacyMenuCompat } from '@/lib/litegraph/src/contextMenuCompat'
+import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
+
+const REPLACE_SETTING_ID = 'Comfy.NodeSearchBox.ReplaceCanvasMenu'
+
+/**
+ * When the experimental "replace canvas menu" setting is enabled, the
+ * right-click canvas menu's "Add Node" entry opens the Vue node search box
+ * (which already includes blueprints, partner nodes, core nodes, and
+ * extensions) instead of the legacy LiteGraph category submenu.
+ *
+ * The replacement is identified by callback identity against
+ * {@link LGraphCanvas.onMenuAdd} so it remains stable across the translation
+ * wrapper installed by {@link useContextMenuTranslation}.
+ */
+export const useCanvasSearchBoxMenu = () => {
+  legacyMenuCompat.install(LGraphCanvas.prototype, 'getCanvasMenuOptions')
+
+  const originalGetCanvasMenuOptions =
+    LGraphCanvas.prototype.getCanvasMenuOptions
+
+  const wrapped = function (
+    this: LGraphCanvas,
+    ...args: Parameters<typeof originalGetCanvasMenuOptions>
+  ) {
+    const items = originalGetCanvasMenuOptions.apply(this, args)
+
+    const settingStore = useSettingStore()
+    if (!settingStore.get(REPLACE_SETTING_ID)) return items
+
+    return items.map((item) =>
+      isLegacyAddNode(item) ? buildSearchBoxAddNode(item) : item
+    )
+  }
+
+  LGraphCanvas.prototype.getCanvasMenuOptions = wrapped
+  legacyMenuCompat.registerWrapper(
+    'getCanvasMenuOptions',
+    wrapped,
+    originalGetCanvasMenuOptions,
+    LGraphCanvas.prototype
+  )
+}
+
+function isLegacyAddNode(
+  item: IContextMenuValue | null
+): item is IContextMenuValue {
+  return (
+    !!item &&
+    typeof item === 'object' &&
+    item.callback === LGraphCanvas.onMenuAdd
+  )
+}
+
+function buildSearchBoxAddNode(original: IContextMenuValue): IContextMenuValue {
+  return {
+    ...original,
+    has_submenu: false,
+    submenu: undefined,
+    callback: () => {
+      useSearchBoxStore().toggleVisible()
+    }
+  }
+}

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -328,6 +328,10 @@
     "name": "Show node frequency in search results",
     "tooltip": "Only applies to v1 (legacy)"
   },
+  "Comfy_NodeSearchBox_ReplaceCanvasMenu": {
+    "name": "Replace canvas right-click \"Add Node\" with search box",
+    "tooltip": "When enabled, the right-click canvas menu opens the node search box instead of the LiteGraph category submenu. The search box includes blueprints, partner nodes, core nodes, and extensions."
+  },
   "Comfy_NodeSuggestions_number": {
     "name": "Number of nodes suggestions",
     "tooltip": "Only for litegraph searchbox/context menu"

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -39,6 +39,17 @@ export const CORE_SETTINGS: SettingParams[] = [
     defaultValue: 'default'
   },
   {
+    id: 'Comfy.NodeSearchBox.ReplaceCanvasMenu',
+    category: ['Comfy', 'Node Search Box', 'ReplaceCanvasMenu'],
+    experimental: true,
+    name: 'Replace canvas right-click "Add Node" with search box',
+    tooltip:
+      'When enabled, the right-click canvas menu opens the node search box instead of the LiteGraph category submenu. The search box includes blueprints, partner nodes, core nodes, and extensions.',
+    type: 'boolean',
+    defaultValue: false,
+    versionAdded: '1.46.0'
+  },
+  {
     id: 'Comfy.LinkRelease.Action',
     category: ['LiteGraph', 'LinkRelease', 'Action'],
     name: 'Action on link release (No modifier)',

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -344,6 +344,7 @@ const zSettings = z.object({
   'Comfy.NodeSearchBoxImpl.ShowCategory': z.boolean(),
   'Comfy.NodeSearchBoxImpl.ShowIdName': z.boolean(),
   'Comfy.NodeSearchBoxImpl.ShowNodeFrequency': z.boolean(),
+  'Comfy.NodeSearchBox.ReplaceCanvasMenu': z.boolean(),
   'Comfy.NodeSuggestions.number': z.number(),
   'Comfy.Node.BypassAllLinksOnDelete': z.boolean(),
   'Comfy.Node.Opacity': z.number(),

--- a/src/stores/workspace/searchBoxStore.test.ts
+++ b/src/stores/workspace/searchBoxStore.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type NodeSearchBoxPopover from '@/components/searchbox/NodeSearchBoxPopover.vue'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/litegraph'
 import type { useSettingStore } from '@/platform/settings/settingStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 
@@ -132,6 +133,45 @@ describe('useSearchBoxStore', () => {
   describe('when user first loads the application', () => {
     it('should have search box hidden by default', () => {
       const store = useSearchBoxStore()
+      expect(store.visible).toBe(false)
+    })
+  })
+
+  describe('openAtEvent', () => {
+    const event = {
+      canvasX: 123,
+      canvasY: 456
+    } as unknown as CanvasPointerEvent
+
+    it('forwards the event to the popover when one is registered', () => {
+      vi.mocked(mockSettingStore.get).mockReturnValue('default')
+      const store = useSearchBoxStore()
+      const mockPopover = createMockPopover()
+      store.setPopoverRef(mockPopover)
+
+      store.openAtEvent(event)
+
+      expect(vi.mocked(mockPopover.showSearchBox)).toHaveBeenCalledWith(event)
+      expect(store.visible).toBe(false)
+    })
+
+    it('falls back to showing the new search box when no popover is registered', () => {
+      vi.mocked(mockSettingStore.get).mockReturnValue('default')
+      const store = useSearchBoxStore()
+      store.setPopoverRef(null)
+
+      store.openAtEvent(event)
+
+      expect(store.visible).toBe(true)
+    })
+
+    it('does nothing when the legacy litegraph search box is selected and no popover is registered', () => {
+      vi.mocked(mockSettingStore.get).mockReturnValue('litegraph (legacy)')
+      const store = useSearchBoxStore()
+      store.setPopoverRef(null)
+
+      store.openAtEvent(event)
+
       expect(store.visible).toBe(false)
     })
   })

--- a/src/stores/workspace/searchBoxStore.ts
+++ b/src/stores/workspace/searchBoxStore.ts
@@ -46,7 +46,13 @@ export const useSearchBoxStore = defineStore('searchBox', () => {
   }
 
   function openAtEvent(event: CanvasPointerEvent) {
-    popoverRef.value?.showSearchBox(event)
+    if (popoverRef.value) {
+      popoverRef.value.showSearchBox(event)
+      return
+    }
+    if (newSearchBoxEnabled.value) {
+      visible.value = true
+    }
   }
 
   return {

--- a/src/stores/workspace/searchBoxStore.ts
+++ b/src/stores/workspace/searchBoxStore.ts
@@ -45,11 +45,16 @@ export const useSearchBoxStore = defineStore('searchBox', () => {
     )
   }
 
+  function openAtEvent(event: CanvasPointerEvent) {
+    popoverRef.value?.showSearchBox(event)
+  }
+
   return {
     useSearchBoxV2,
     newSearchBoxEnabled,
     setPopoverRef,
     toggleVisible,
+    openAtEvent,
     visible
   }
 })


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Proof of concept for replacing the LiteGraph right-click "Add Node" submenu with the V2 node search box. Driven by a discussion in `#qol-wishlist` about subgraph blueprints being absent from the right-click context menu while present in the left-panel node library.

The root cause of the existing gap: the right-click menu reads from `LiteGraph.registered_node_types` (a native LiteGraph registry), while the left panel and search box read from `nodeDefStore.visibleNodeDefs` (a Vue store). Blueprints, partner nodes, and other Vue-only sources live only in the latter. Mirroring blueprints into the LiteGraph registry would split the source of truth and require keeping two menus in sync forever; routing the menu action to the V2 search box consolidates discovery on a single, blueprint-aware surface.

## Behavior

- Gated by new experimental setting `Comfy.NodeSearchBox.ReplaceCanvasMenu` (default `false`).
- When enabled, right-click → "Add Node" opens the V2 search box (which already includes blueprints, partner, comfy, extensions tabs).
- When disabled, the legacy LiteGraph category submenu is unchanged.
- All other canvas menu entries (Add Group, Paste, Templates, etc.) are untouched.

## Implementation

- `src/composables/useCanvasSearchBoxMenu.ts` — wraps `LGraphCanvas.prototype.getCanvasMenuOptions` using the existing `legacyMenuCompat` pattern (same approach as `useContextMenuTranslation`). Identifies the "Add Node" entry by callback identity against `LGraphCanvas.onMenuAdd`, then swaps its callback to call `useSearchBoxStore().toggleVisible()`. Installed before `useContextMenuTranslation()` so translation runs on top.
- No changes inside `src/lib/litegraph/` (vendored library left untouched).

## Known follow-up

Self-review flagged that the current implementation routes through `toggleVisible()`, which doesn't forward the original right-click event. The search box still opens, but the resulting node lands at the canvas center instead of the right-click position. Fix incoming as a follow-up commit — needs the menu callback's `previous_menu?.getFirstEvent()` to be plumbed through a dedicated "open at event" path on the popover.

## Manual verification

Screenshots attached: default submenu (flag off), submenu arrow removed (flag on), V2 search box opens with Blueprints/Comfy/Essentials/Partner/Extensions tabs, and searching `blueprint` returns blueprint nodes with `Blueprint` tags — feature parity with the left panel.

Plus typecheck, lint (0 new errors), and unit tests pass.

## Tests

- `src/composables/useCanvasSearchBoxMenu.test.ts` — 3 cases covering flag off / flag on / preservation of other entries.

## Screenshots

![Default right-click context menu with Add Node > submenu (flag off)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3abf08ad4063e8afd21504b5c9daed1fdd1a1af8dfa00019150243b02002ee31/pr-images/1778562408255-673c554a-9892-4e3f-9984-6c87f9d40357.png)

![Right-click menu with flag on — Add Node entry no longer has submenu arrow](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3abf08ad4063e8afd21504b5c9daed1fdd1a1af8dfa00019150243b02002ee31/pr-images/1778562408586-4cc93c6d-9eb5-4246-862a-23a6066a1e20.png)

![V2 search box opens after clicking Add Node, showing Blueprints/Comfy/Essentials/Partner/Extensions tabs](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3abf08ad4063e8afd21504b5c9daed1fdd1a1af8dfa00019150243b02002ee31/pr-images/1778562408889-6fb16d1f-5d6a-40b7-b456-b2b84b07e642.png)

![Searching 'blueprint' returns blueprint nodes with Blueprint tags — feature parity achieved](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/3abf08ad4063e8afd21504b5c9daed1fdd1a1af8dfa00019150243b02002ee31/pr-images/1778562409235-9be8cc8b-5749-4549-859d-813a7578250d.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12168-feat-experimental-flag-to-replace-canvas-Add-Node-menu-with-search-box-35e6d73d365081b08feaed8838349609) by [Unito](https://www.unito.io)
