### PR TITLE
fix: clear nodeOutputStore on node removal

### DIFF
--- a/browser_tests/tests/nodeOutputClearingOnRemove.spec.ts
+++ b/browser_tests/tests/nodeOutputClearingOnRemove.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from '@playwright/test'
+
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+async function getNodeOutputImageCount(
+  comfyPage: ComfyPage,
+  nodeId: string
+): Promise<number> {
+  return await comfyPage.page.evaluate(
+    (id) => window.app!.nodeOutputs?.[id]?.images?.length ?? 0,
+    nodeId
+  )
+}
+
+async function seedNodeOutput(
+  comfyPage: ComfyPage,
+  nodeId: string
+): Promise<void> {
+  await comfyPage.page.evaluate((id) => {
+    window.app!.nodeOutputs[id] = {
+      images: [
+        { filename: 'seeded-preview.png', subfolder: '', type: 'output' }
+      ]
+    }
+  }, nodeId)
+}
+
+test.describe('Node output cleanup on removal', { tag: '@workflow' }, () => {
+  test('Deleting a node clears its outputs from the store', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'Pressing delete left previews behind because nodeOutputStore did not listen to onNodeRemoved'
+    })
+
+    const node = (await comfyPage.nodeOps.getFirstNodeRef())!
+    expect(node).toBeTruthy()
+    const nodeId = String(node.id)
+
+    await seedNodeOutput(comfyPage, nodeId)
+    await expect.poll(() => getNodeOutputImageCount(comfyPage, nodeId)).toBe(1)
+
+    await node.click('title')
+    await comfyPage.page.keyboard.press('Delete')
+
+    await expect.poll(() => getNodeOutputImageCount(comfyPage, nodeId)).toBe(0)
+  })
+
+  test('Undoing a node addition clears outputs produced for the removed node', async ({
+    comfyPage
+  }) => {
+    test.info().annotations.push({
+      type: 'regression',
+      description:
+        'Undo removed the node but left its preview rendered because the removal lifecycle did not invalidate nodeOutputStore'
+    })
+
+    const initialNodeCount = await comfyPage.nodeOps.getGraphNodesCount()
+
+    await comfyPage.canvasOps.clickEmptySpace()
+    await comfyPage.page.keyboard.press('Control+a')
+
+    const addedNodeId = await comfyPage.page.evaluate(() => {
+      const litegraph = window.LiteGraph
+      if (!litegraph) throw new Error('LiteGraph is not available on window')
+      const graph = window.app!.graph
+      const registered = litegraph.registered_node_types
+      const typeName = registered['LoadImage']
+        ? 'LoadImage'
+        : registered['PreviewImage']
+          ? 'PreviewImage'
+          : undefined
+      if (!typeName) {
+        throw new Error('No suitable node type registered for the test')
+      }
+      const node = litegraph.createNode(typeName)
+      if (!node) throw new Error('Failed to create test node')
+      graph.add(node)
+      return String(node.id)
+    })
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+      .toBe(initialNodeCount + 1)
+
+    await seedNodeOutput(comfyPage, addedNodeId)
+    await expect
+      .poll(() => getNodeOutputImageCount(comfyPage, addedNodeId))
+      .toBe(1)
+
+    await comfyPage.canvasOps.clickEmptySpace()
+    await comfyPage.keyboard.undo()
+
+    await expect
+      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+      .toBe(initialNodeCount)
+    await expect
+      .poll(() => getNodeOutputImageCount(comfyPage, addedNodeId))
+      .toBe(0)
+  })
+})

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -143,6 +143,7 @@ import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { installNodeOutputClearingHooks } from '@/composables/graph/useNodeOutputClearingHooks'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
@@ -249,11 +250,16 @@ const vueNodeLifecycle = useVueNodeLifecycle()
 
 // Error-clearing hooks run regardless of rendering mode (Vue or legacy canvas).
 let cleanupErrorHooks: (() => void) | null = null
+let cleanupNodeOutputHooks: (() => void) | null = null
 watch(
   () => canvasStore.currentGraph,
   (graph) => {
     cleanupErrorHooks?.()
     cleanupErrorHooks = graph ? installErrorClearingHooks(graph) : null
+    cleanupNodeOutputHooks?.()
+    cleanupNodeOutputHooks = graph
+      ? installNodeOutputClearingHooks(graph)
+      : null
   }
 )
 
@@ -538,6 +544,9 @@ onMounted(async () => {
     // Install error-clearing hooks on the initial graph
     if (comfyApp.canvas?.graph) {
       cleanupErrorHooks = installErrorClearingHooks(comfyApp.canvas.graph)
+      cleanupNodeOutputHooks = installNodeOutputClearingHooks(
+        comfyApp.canvas.graph
+      )
     }
 
     vueNodeLifecycle.setupEmptyGraphListener()
@@ -597,6 +606,8 @@ onMounted(async () => {
 onUnmounted(() => {
   cleanupErrorHooks?.()
   cleanupErrorHooks = null
+  cleanupNodeOutputHooks?.()
+  cleanupNodeOutputHooks = null
   vueNodeLifecycle.cleanup()
 })
 function forwardPanEvent(e: PointerEvent) {

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -165,6 +165,7 @@ import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
 import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
+import { installNodeOutputClearingHooks } from '@/composables/graph/useNodeOutputClearingHooks'
 import type { NodeState } from '@/types/nodeState'
 import { useNodeBadge } from '@/composables/node/useNodeBadge'
 import { useCanvasDrop } from '@/composables/useCanvasDrop'
@@ -276,11 +277,16 @@ const { shouldRenderVueNodes } = useVueFeatureFlags()
 
 // Error-clearing hooks run regardless of rendering mode (Vue or legacy canvas).
 let cleanupErrorHooks: (() => void) | null = null
+let cleanupNodeOutputHooks: (() => void) | null = null
 watch(
   () => canvasStore.currentGraph,
   (graph) => {
     cleanupErrorHooks?.()
     cleanupErrorHooks = graph ? installErrorClearingHooks(graph) : null
+    cleanupNodeOutputHooks?.()
+    cleanupNodeOutputHooks = graph
+      ? installNodeOutputClearingHooks(graph)
+      : null
   }
 )
 
@@ -564,6 +570,9 @@ onMounted(async () => {
     // Install error-clearing hooks on the initial graph
     if (comfyApp.canvas?.graph) {
       cleanupErrorHooks = installErrorClearingHooks(comfyApp.canvas.graph)
+      cleanupNodeOutputHooks = installNodeOutputClearingHooks(
+        comfyApp.canvas.graph
+      )
     }
 
     // Load color palette
@@ -614,6 +623,8 @@ onMounted(async () => {
 onUnmounted(() => {
   cleanupErrorHooks?.()
   cleanupErrorHooks = null
+  cleanupNodeOutputHooks?.()
+  cleanupNodeOutputHooks = null
 })
 function forwardPointerDownPanEvent(e: PointerEvent) {
   forwardPanEvent(e, isMiddlePointerInput)

--- a/src/composables/graph/useNodeOutputClearingHooks.test.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.test.ts
@@ -1,0 +1,134 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { installNodeOutputClearingHooks } from '@/composables/graph/useNodeOutputClearingHooks'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import {
+  createTestSubgraph,
+  createTestSubgraphNode
+} from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
+import { app } from '@/scripts/app'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+
+function seedOutputForLocator(locatorId: string) {
+  app.nodeOutputs[locatorId] = {
+    images: [{ filename: 'preview.png', type: 'output', subfolder: '' }]
+  }
+}
+
+describe('installNodeOutputClearingHooks', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    app.nodeOutputs = {}
+    app.nodePreviewImages = {}
+  })
+
+  it('removes outputs for a root-level node when it is removed from the graph', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const node = new LGraphNode('LoadImage')
+    graph.add(node)
+
+    const locatorId = String(node.id)
+    seedOutputForLocator(locatorId)
+    expect(app.nodeOutputs[locatorId]).toBeDefined()
+
+    installNodeOutputClearingHooks(graph)
+    graph.remove(node)
+
+    expect(app.nodeOutputs[locatorId]).toBeUndefined()
+    expect(useNodeOutputStore().nodeOutputs[locatorId]).toBeUndefined()
+  })
+
+  it('removes outputs for a subgraph interior node using subgraphUuid:nodeId locator', () => {
+    const subgraph = createTestSubgraph()
+    const interiorNode = new LGraphNode('LoadImage')
+    subgraph.add(interiorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 65 })
+    const rootGraph = subgraphNode.graph as LGraph
+    rootGraph.add(subgraphNode)
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
+
+    const interiorLocator = `${subgraph.id}:${interiorNode.id}`
+    seedOutputForLocator(interiorLocator)
+    expect(app.nodeOutputs[interiorLocator]).toBeDefined()
+
+    installNodeOutputClearingHooks(subgraph)
+    subgraph.remove(interiorNode)
+
+    expect(app.nodeOutputs[interiorLocator]).toBeUndefined()
+  })
+
+  it('does not affect outputs for other nodes that remain in the graph', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const removed = new LGraphNode('LoadImage')
+    const kept = new LGraphNode('LoadImage')
+    graph.add(removed)
+    graph.add(kept)
+
+    const removedLocator = String(removed.id)
+    const keptLocator = String(kept.id)
+    seedOutputForLocator(removedLocator)
+    seedOutputForLocator(keptLocator)
+
+    installNodeOutputClearingHooks(graph)
+    graph.remove(removed)
+
+    expect(app.nodeOutputs[removedLocator]).toBeUndefined()
+    expect(app.nodeOutputs[keptLocator]).toBeDefined()
+  })
+
+  it('chains with existing onNodeRemoved callbacks', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    let calledWith: LGraphNode | undefined
+    graph.onNodeRemoved = (node) => {
+      calledWith = node
+    }
+
+    const node = new LGraphNode('LoadImage')
+    graph.add(node)
+    seedOutputForLocator(String(node.id))
+
+    installNodeOutputClearingHooks(graph)
+    graph.remove(node)
+
+    expect(calledWith).toBe(node)
+    expect(app.nodeOutputs[String(node.id)]).toBeUndefined()
+  })
+
+  it('restores original onNodeRemoved when cleanup is called', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const original = () => undefined
+    graph.onNodeRemoved = original
+
+    const cleanup = installNodeOutputClearingHooks(graph)
+    expect(graph.onNodeRemoved).not.toBe(original)
+
+    cleanup()
+    expect(graph.onNodeRemoved).toBe(original)
+  })
+
+  it('does not throw when the removal hook fires for an already-cleared node', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const node = new LGraphNode('LoadImage')
+    graph.add(node)
+    const locator = String(node.id)
+    seedOutputForLocator(locator)
+
+    installNodeOutputClearingHooks(graph)
+    graph.remove(node)
+    expect(() => graph.onNodeRemoved?.(node)).not.toThrow()
+    expect(app.nodeOutputs[locator]).toBeUndefined()
+  })
+})

--- a/src/composables/graph/useNodeOutputClearingHooks.test.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 
 function seedOutputForLocator(locatorId: string) {
   app.nodeOutputs[locatorId] = {
@@ -137,6 +138,29 @@ describe('installNodeOutputClearingHooks', () => {
 
     expect(app.nodeOutputs[subgraphNodeLocator]).toBeUndefined()
     expect(app.nodeOutputs[interiorLocator]).toBeUndefined()
+  })
+
+  it('also prunes the active workflow change tracker output cache so undo cannot resurrect the entry', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const node = new LGraphNode('LoadImage')
+    graph.add(node)
+    const locator = String(node.id)
+    seedOutputForLocator(locator)
+
+    const trackerCache: Record<string, unknown> = {
+      [locator]: { images: [{ filename: 'preview.png' }] }
+    }
+    vi.spyOn(useWorkflowStore(), 'activeWorkflow', 'get').mockReturnValue({
+      changeTracker: { nodeOutputs: trackerCache }
+    } as never)
+
+    installNodeOutputClearingHooks(graph)
+    graph.remove(node)
+
+    expect(app.nodeOutputs[locator]).toBeUndefined()
+    expect(trackerCache[locator]).toBeUndefined()
   })
 
   it('does not throw when the removal hook fires for an already-cleared node', () => {

--- a/src/composables/graph/useNodeOutputClearingHooks.test.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.test.ts
@@ -9,6 +9,7 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { app } from '@/scripts/app'
+import { ChangeTracker } from '@/scripts/changeTracker'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 
@@ -161,6 +162,33 @@ describe('installNodeOutputClearingHooks', () => {
 
     expect(app.nodeOutputs[locator]).toBeUndefined()
     expect(trackerCache[locator]).toBeUndefined()
+  })
+
+  it('preserves the tracker cache during workflow tab switch teardown', () => {
+    const graph = new LGraph()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    const node = new LGraphNode('LoadImage')
+    graph.add(node)
+    const locator = String(node.id)
+    seedOutputForLocator(locator)
+
+    const trackerCache: Record<string, unknown> = {
+      [locator]: { images: [{ filename: 'preview.png' }] }
+    }
+    vi.spyOn(useWorkflowStore(), 'activeWorkflow', 'get').mockReturnValue({
+      changeTracker: { nodeOutputs: trackerCache, _restoringState: false }
+    } as never)
+
+    installNodeOutputClearingHooks(graph)
+    ChangeTracker.isLoadingGraph = true
+    try {
+      graph.remove(node)
+    } finally {
+      ChangeTracker.isLoadingGraph = false
+    }
+
+    expect(trackerCache[locator]).toBeDefined()
   })
 
   it('does not throw when the removal hook fires for an already-cleared node', () => {

--- a/src/composables/graph/useNodeOutputClearingHooks.test.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.test.ts
@@ -117,6 +117,28 @@ describe('installNodeOutputClearingHooks', () => {
     expect(graph.onNodeRemoved).toBe(original)
   })
 
+  it('clears interior node outputs when a subgraph container is removed from the root graph', () => {
+    const subgraph = createTestSubgraph()
+    const interiorNode = new LGraphNode('LoadImage')
+    subgraph.add(interiorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 65 })
+    const rootGraph = subgraphNode.graph as LGraph
+    rootGraph.add(subgraphNode)
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
+
+    const subgraphNodeLocator = String(subgraphNode.id)
+    const interiorLocator = `${subgraph.id}:${interiorNode.id}`
+    seedOutputForLocator(subgraphNodeLocator)
+    seedOutputForLocator(interiorLocator)
+
+    installNodeOutputClearingHooks(rootGraph)
+    rootGraph.remove(subgraphNode)
+
+    expect(app.nodeOutputs[subgraphNodeLocator]).toBeUndefined()
+    expect(app.nodeOutputs[interiorLocator]).toBeUndefined()
+  })
+
   it('does not throw when the removal hook fires for an already-cleared node', () => {
     const graph = new LGraph()
     vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)

--- a/src/composables/graph/useNodeOutputClearingHooks.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.ts
@@ -2,18 +2,30 @@ import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { getExecutionIdForNodeInGraph } from '@/utils/graphTraversalUtil'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 
-function clearInteriorOutputs(subgraphNode: SubgraphNode) {
+function dropTrackerCacheEntry(execId: string) {
+  const tracked = useWorkflowStore().activeWorkflow?.changeTracker?.nodeOutputs
+  if (tracked) delete tracked[execId]
+}
+
+function clearInteriorOutputs(
+  subgraphNode: SubgraphNode,
+  execIdPrefix: string
+) {
   const subgraph: Subgraph | undefined = subgraphNode.subgraph
   if (!subgraph) return
 
   const store = useNodeOutputStore()
   for (const interior of subgraph.nodes) {
     store.removeOutputsByLocatorId(`${subgraph.id}:${interior.id}`)
+    const interiorExecId = `${execIdPrefix}:${interior.id}`
+    dropTrackerCacheEntry(interiorExecId)
     if (interior.isSubgraphNode()) {
-      clearInteriorOutputs(interior)
+      clearInteriorOutputs(interior, interiorExecId)
     }
   }
 }
@@ -29,8 +41,13 @@ export function installNodeOutputClearingHooks(graph: LGraph): () => void {
       : String(node.id)
     store.removeOutputsByLocatorId(locatorId)
 
+    const execId = app.rootGraph
+      ? getExecutionIdForNodeInGraph(app.rootGraph, graph, node.id)
+      : String(node.id)
+    dropTrackerCacheEntry(execId)
+
     if (node.isSubgraphNode()) {
-      clearInteriorOutputs(node)
+      clearInteriorOutputs(node, execId)
     }
 
     originalOnNodeRemoved?.call(this, node)

--- a/src/composables/graph/useNodeOutputClearingHooks.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.ts
@@ -3,11 +3,18 @@ import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { app } from '@/scripts/app'
+import { ChangeTracker } from '@/scripts/changeTracker'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { getExecutionIdForNodeInGraph } from '@/utils/graphTraversalUtil'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 
+function isTabSwitchTeardown(): boolean {
+  const tracker = useWorkflowStore().activeWorkflow?.changeTracker
+  return ChangeTracker.isLoadingGraph && !tracker?._restoringState
+}
+
 function dropTrackerCacheEntry(execId: string) {
+  if (isTabSwitchTeardown()) return
   const tracked = useWorkflowStore().activeWorkflow?.changeTracker?.nodeOutputs
   if (tracked) delete tracked[execId]
 }

--- a/src/composables/graph/useNodeOutputClearingHooks.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.ts
@@ -41,23 +41,25 @@ export function installNodeOutputClearingHooks(graph: LGraph): () => void {
   const originalOnNodeRemoved = graph.onNodeRemoved
 
   graph.onNodeRemoved = function (node: LGraphNode) {
-    const store = useNodeOutputStore()
-    const { nodeIdToNodeLocatorId } = useWorkflowStore()
-    const locatorId = isSubgraph(graph)
-      ? nodeIdToNodeLocatorId(node.id, graph)
-      : String(node.id)
-    store.removeOutputsByLocatorId(locatorId)
+    try {
+      const store = useNodeOutputStore()
+      const { nodeIdToNodeLocatorId } = useWorkflowStore()
+      const locatorId = isSubgraph(graph)
+        ? nodeIdToNodeLocatorId(node.id, graph)
+        : String(node.id)
+      store.removeOutputsByLocatorId(locatorId)
 
-    const execId = app.rootGraph
-      ? getExecutionIdForNodeInGraph(app.rootGraph, graph, node.id)
-      : String(node.id)
-    dropTrackerCacheEntry(execId)
+      const execId = app.rootGraph
+        ? getExecutionIdForNodeInGraph(app.rootGraph, graph, node.id)
+        : String(node.id)
+      dropTrackerCacheEntry(execId)
 
-    if (node.isSubgraphNode()) {
-      clearInteriorOutputs(node, execId)
+      if (node.isSubgraphNode()) {
+        clearInteriorOutputs(node, execId)
+      }
+    } finally {
+      originalOnNodeRemoved?.call(this, node)
     }
-
-    originalOnNodeRemoved?.call(this, node)
   }
 
   return () => {

--- a/src/composables/graph/useNodeOutputClearingHooks.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.ts
@@ -1,0 +1,21 @@
+import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { isSubgraph } from '@/utils/typeGuardUtil'
+
+export function installNodeOutputClearingHooks(graph: LGraph): () => void {
+  const originalOnNodeRemoved = graph.onNodeRemoved
+
+  graph.onNodeRemoved = function (node: LGraphNode) {
+    const { nodeIdToNodeLocatorId } = useWorkflowStore()
+    const locatorId = isSubgraph(graph)
+      ? nodeIdToNodeLocatorId(node.id, graph)
+      : String(node.id)
+    useNodeOutputStore().removeOutputsByLocatorId(locatorId)
+    originalOnNodeRemoved?.call(this, node)
+  }
+
+  return () => {
+    graph.onNodeRemoved = originalOnNodeRemoved || undefined
+  }
+}

--- a/src/composables/graph/useNodeOutputClearingHooks.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.ts
@@ -1,17 +1,38 @@
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { Subgraph } from '@/lib/litegraph/src/subgraph/Subgraph'
+import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { isSubgraph } from '@/utils/typeGuardUtil'
+
+function clearInteriorOutputs(subgraphNode: SubgraphNode) {
+  const subgraph: Subgraph | undefined = subgraphNode.subgraph
+  if (!subgraph) return
+
+  const store = useNodeOutputStore()
+  for (const interior of subgraph.nodes) {
+    store.removeOutputsByLocatorId(`${subgraph.id}:${interior.id}`)
+    if (interior.isSubgraphNode()) {
+      clearInteriorOutputs(interior)
+    }
+  }
+}
 
 export function installNodeOutputClearingHooks(graph: LGraph): () => void {
   const originalOnNodeRemoved = graph.onNodeRemoved
 
   graph.onNodeRemoved = function (node: LGraphNode) {
+    const store = useNodeOutputStore()
     const { nodeIdToNodeLocatorId } = useWorkflowStore()
     const locatorId = isSubgraph(graph)
       ? nodeIdToNodeLocatorId(node.id, graph)
       : String(node.id)
-    useNodeOutputStore().removeOutputsByLocatorId(locatorId)
+    store.removeOutputsByLocatorId(locatorId)
+
+    if (node.isSubgraphNode()) {
+      clearInteriorOutputs(node)
+    }
+
     originalOnNodeRemoved?.call(this, node)
   }
 

--- a/src/composables/graph/useNodeOutputClearingHooks.ts
+++ b/src/composables/graph/useNodeOutputClearingHooks.ts
@@ -5,6 +5,7 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { app } from '@/scripts/app'
 import { ChangeTracker } from '@/scripts/changeTracker'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 import { getExecutionIdForNodeInGraph } from '@/utils/graphTraversalUtil'
 import { isSubgraph } from '@/utils/typeGuardUtil'
 
@@ -27,8 +28,9 @@ function clearInteriorOutputs(
   if (!subgraph) return
 
   const store = useNodeOutputStore()
+  const { nodeIdToNodeLocatorId } = useWorkflowStore()
   for (const interior of subgraph.nodes) {
-    store.removeOutputsByLocatorId(`${subgraph.id}:${interior.id}`)
+    store.removeOutputsByLocatorId(nodeIdToNodeLocatorId(interior.id, subgraph))
     const interiorExecId = `${execIdPrefix}:${interior.id}`
     dropTrackerCacheEntry(interiorExecId)
     if (interior.isSubgraphNode()) {
@@ -46,11 +48,12 @@ export function installNodeOutputClearingHooks(graph: LGraph): () => void {
       const { nodeIdToNodeLocatorId } = useWorkflowStore()
       const locatorId = isSubgraph(graph)
         ? nodeIdToNodeLocatorId(node.id, graph)
-        : String(node.id)
+        : createNodeLocatorId(null, node.id)
       store.removeOutputsByLocatorId(locatorId)
 
       const execId = app.rootGraph
-        ? getExecutionIdForNodeInGraph(app.rootGraph, graph, node.id)
+        ? (getExecutionIdForNodeInGraph(app.rootGraph, graph, node.id) ??
+          String(node.id))
         : String(node.id)
       dropTrackerCacheEntry(execId)
 

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -499,6 +499,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     revokeSubgraphPreviews,
     removeNodeOutputs,
     removeNodeOutputsForNode,
+    removeOutputsByLocatorId,
     snapshotOutputs,
     restoreOutputs,
     resetAllOutputsAndPreviews,

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -545,6 +545,7 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
     discardPreviewsForWorkflow,
     removeNodeOutputs,
     removeNodeOutputsForNode,
+    removeOutputsByLocatorId,
     snapshotOutputs,
     replaceOutputsFromLegacy,
     setOutputFromLegacy,


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Pressing undo to remove a node left preview images on screen because nothing invalidated the node's outputs when the node was removed. The locator-keyed entry in `nodeOutputStore` survived the removal, and the per-workflow `ChangeTracker` output cache happily wrote it back on the next restore, so any future node that reused the id (or any path that re-applied the snapshot) inherited the stale preview.

This adds `installNodeOutputClearingHooks`, modeled on `useErrorClearingHooks`, that wraps `graph.onNodeRemoved` and prunes both the live `nodeOutputStore` and the active workflow's `ChangeTracker.nodeOutputs` cache. The hook derives the locator id from the graph it's installed on (because `node.graph` is nulled before the callback fires) and recurses into subgraph containers so removing a `SubgraphNode` from the root also clears interior nodes, including nested subgraphs.

Wired up in `GraphCanvas.vue` alongside the existing error-clearing hooks for both legacy and Vue node rendering modes.

## Tests

- `src/composables/graph/useNodeOutputClearingHooks.test.ts` — 8 unit tests covering root removal, subgraph interior removal, subgraph container removal (root + interior cleanup), tracker cache pruning, callback chaining, cleanup restoration, and the double-fire edge case. Tests were written first against a stub composable to confirm they fail before the fix.
- `browser_tests/tests/nodeOutputClearingOnRemove.spec.ts` — Playwright e2e for the direct delete path and the undo path.

## Verification

- `pnpm vitest run src/composables/graph/` → 139 passed
- `pnpm typecheck` → clean
- `pnpm typecheck:browser` → clean
- `pnpm exec eslint` on changed files → clean
- Manual repro via Playwright against a live dev server: added a node, seeded `app.nodeOutputs` and `changeTracker.nodeOutputs`, pressed undo — node removed, both caches cleared, no resurrection.

## Screenshots

![ComfyUI canvas after performing the undo manual verification — node removed and no orphan preview rendered.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/89548db914d1d2221caff7801dad61200edcac591b28c9527f0ff04a5b32f7d2/pr-images/1778562734473-643205c3-d89c-4e54-95f3-0345ea8b5dac.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12171-fix-clear-nodeOutputStore-on-node-removal-35e6d73d365081bc9c4dd5106ef24507) by [Unito](https://www.unito.io)
