### PR TITLE
fix: hide magic-prefixed widgets from right side panel (FE-563)

### DIFF
--- a/browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts
+++ b/browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+
+/**
+ * FE-563: the `$$canvas-image-preview` pseudo-widget is not user-facing and
+ * must not appear in the right side panel. Filtered by `$$` prefix until
+ * image-preview rendering in the panel is properly designed.
+ *
+ * Intentionally brittle: when the preview is given a real, user-facing name
+ * in a future refactor, this test is expected to FAIL so the temporary
+ * filter (and this test) get cleaned up at the right time.
+ */
+test.describe('Properties panel - canvas image preview widget', () => {
+  let panel: PropertiesPanelHelper
+
+  test.beforeEach(async ({ comfyPage }) => {
+    panel = new PropertiesPanelHelper(comfyPage.page)
+  })
+
+  test('does not render the $$canvas-image-preview widget for LoadImage', async ({
+    comfyPage
+  }) => {
+    await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
+
+    const loadImageNode = (
+      await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+    )[0]
+    const { x, y } = await loadImageNode.getPosition()
+
+    await comfyPage.dragDrop.dragAndDropFile('image64x64.webp', {
+      dropPosition: { x, y }
+    })
+
+    await expect
+      .poll(async () =>
+        comfyPage.page.evaluate((id) => {
+          const node = window.app!.graph.getNodeById(id)
+          return (
+            node?.widgets?.some((w) => w.name === '$$canvas-image-preview') ??
+            false
+          )
+        }, loadImageNode.id)
+      )
+      .toBe(true)
+
+    await comfyPage.nodeOps.selectNodes(['Load Image'])
+    await comfyPage.actionbar.propertiesButton.click()
+
+    await expect(panel.panelTitle).toContainText('Load Image')
+
+    const widgetItems = panel.contentArea.locator('.widget-item')
+    await expect(widgetItems).toHaveCount(2)
+    for (const name of ['image', 'upload']) {
+      await expect(widgetItems.filter({ hasText: name })).toHaveCount(1)
+    }
+  })
+})

--- a/browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts
+++ b/browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts
@@ -19,44 +19,25 @@ test.describe('Properties panel - canvas image preview widget', () => {
     panel = new PropertiesPanelHelper(comfyPage.page)
   })
 
-  test('does not render the $$canvas-image-preview widget for LoadImage', async ({
+  test('does not render the $$canvas-image-preview promoted widget on a subgraph node', async ({
     comfyPage
   }) => {
-    await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
+    await comfyPage.workflow.loadWorkflow(
+      'subgraphs/subgraph-with-preview-node'
+    )
 
-    const loadImageNode = (
-      await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
-    )[0]
-    const { x, y } = await loadImageNode.getPosition()
-
-    await comfyPage.dragDrop.dragAndDropFile('image64x64.webp', {
-      dropPosition: { x, y }
-    })
-
-    await expect
-      .poll(async () =>
-        comfyPage.page.evaluate((id) => {
-          const node = window.app!.graph.getNodeById(id)
-          return (
-            node?.widgets?.some((w) => w.name === '$$canvas-image-preview') ??
-            false
-          )
-        }, loadImageNode.id)
-      )
-      .toBe(true)
-
-    await comfyPage.nodeOps.selectNodes(['Load Image'])
+    await comfyPage.nodeOps.selectNodes(['New Subgraph'])
     await comfyPage.actionbar.propertiesButton.click()
 
-    await expect(panel.panelTitle).toContainText('Load Image')
+    await expect(panel.panelTitle).toContainText('New Subgraph')
 
     const widgetItems = panel.contentArea.locator('.widget-item')
-    for (const name of ['image', 'upload']) {
-      await expect(widgetItems.filter({ hasText: name })).toHaveCount(1)
-    }
+    await expect(
+      widgetItems.filter({ hasText: 'filename_prefix' })
+    ).toHaveCount(1)
     await expect(
       panel.contentArea.getByText('$$canvas-image-preview')
     ).toHaveCount(0)
-    await expect(widgetItems).toHaveCount(2)
+    await expect(widgetItems).toHaveCount(1)
   })
 })

--- a/browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts
+++ b/browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts
@@ -51,9 +51,12 @@ test.describe('Properties panel - canvas image preview widget', () => {
     await expect(panel.panelTitle).toContainText('Load Image')
 
     const widgetItems = panel.contentArea.locator('.widget-item')
-    await expect(widgetItems).toHaveCount(2)
     for (const name of ['image', 'upload']) {
       await expect(widgetItems.filter({ hasText: name })).toHaveCount(1)
     }
+    await expect(
+      panel.contentArea.getByText('$$canvas-image-preview')
+    ).toHaveCount(0)
+    await expect(widgetItems).toHaveCount(2)
   })
 })

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -9,7 +9,11 @@ import FormSearchInput from '@/renderer/extensions/vueNodes/widgets/components/f
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 
-import { computedSectionDataList, searchWidgetsAndNodes } from '../shared'
+import {
+  computedSectionDataList,
+  isPanelHiddenWidget,
+  searchWidgetsAndNodes
+} from '../shared'
 import type { NodeWidgetsListList } from '../shared'
 import SectionWidgets from './SectionWidgets.vue'
 
@@ -36,10 +40,7 @@ const advancedWidgetsSectionDataList = computed((): NodeWidgetsListList => {
     .map((node) => {
       const { widgets = [] } = node
       const advancedWidgets = widgets
-        .filter(
-          (w) =>
-            !(w.options?.canvasOnly || w.options?.hidden) && w.options?.advanced
-        )
+        .filter((w) => !isPanelHiddenWidget(w) && w.options?.advanced)
         .map((widget) => ({ node, widget }))
       return { widgets: advancedWidgets, node }
     })

--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -9,7 +9,11 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import type { NodeId } from '@/types/nodeId'
 
-import { computedSectionDataList, searchWidgetsAndNodes } from '../shared'
+import {
+  computedSectionDataList,
+  isPanelHiddenWidget,
+  searchWidgetsAndNodes
+} from '../shared'
 import type { NodeWidgetsListList } from '../shared'
 import PanelSearchHeader from './PanelSearchHeader.vue'
 import SectionWidgets from './SectionWidgets.vue'
@@ -37,14 +41,7 @@ const advancedWidgetsSectionDataList = computed((): NodeWidgetsListList => {
     .map((node) => {
       const { widgets = [] } = node
       const advancedWidgets = widgets
-        .filter(
-          (w) =>
-            !(
-              w.options?.canvasOnly ||
-              w.options?.hidden ||
-              w.options?.hideInPanel
-            ) && w.options?.advanced
-        )
+        .filter((w) => !isPanelHiddenWidget(w) && w.options?.advanced)
         .map((widget) => ({ node, widget }))
       return { widgets: advancedWidgets, node }
     })

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -23,7 +23,7 @@ import { DraggableList } from '@/scripts/ui/draggableList'
 import { usePromotionStore } from '@/stores/promotionStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 
-import { searchWidgets } from '../shared'
+import { isPanelHiddenWidget, searchWidgets } from '../shared'
 import type { NodeWidgetsList } from '../shared'
 import SectionWidgets from './SectionWidgets.vue'
 
@@ -107,7 +107,7 @@ const widgetsList = computed((): NodeWidgetsList => {
       }
       return w.name === sourceWidgetName
     })
-    if (widget) {
+    if (widget && !isPanelHiddenWidget(widget)) {
       result.push({ node, widget })
     }
   }
@@ -120,7 +120,7 @@ const advancedInputsWidgets = computed((): NodeWidgetsList => {
   const allInteriorWidgets = interiorNodes.flatMap((interiorNode) => {
     const { widgets = [] } = interiorNode
     return widgets
-      .filter((w) => !w.computedDisabled)
+      .filter((w) => !w.computedDisabled && !isPanelHiddenWidget(w))
       .map((widget) => ({ node: interiorNode, widget }))
   })
 

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -13,7 +13,7 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import CollapseToggleButton from '@/components/rightSidePanel/layout/CollapseToggleButton.vue'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 
-import { searchWidgets } from '../shared'
+import { isPanelHiddenWidget, searchWidgets } from '../shared'
 import type { NodeWidgetsList } from '../shared'
 import PanelSearchHeader from './PanelSearchHeader.vue'
 import SectionWidgets from './SectionWidgets.vue'
@@ -65,7 +65,9 @@ watch(
 )
 
 const widgetsList = computed((): NodeWidgetsList => {
-  return promotedInputWidgets(node).map((widget) => ({ node, widget }))
+  return promotedInputWidgets(node)
+    .filter((widget) => !isPanelHiddenWidget(widget))
+    .map((widget) => ({ node, widget }))
 })
 
 const advancedInputsWidgets = computed((): NodeWidgetsList => {
@@ -74,7 +76,7 @@ const advancedInputsWidgets = computed((): NodeWidgetsList => {
   const allInteriorWidgets = interiorNodes.flatMap((interiorNode) => {
     const { widgets = [] } = interiorNode
     return widgets
-      .filter((w) => !w.computedDisabled && !w.options.canvasOnly)
+      .filter((w) => !w.computedDisabled && !isPanelHiddenWidget(w))
       .map((widget) => ({ node: interiorNode, widget }))
   })
 

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -266,6 +266,7 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
             !(
               w.options?.canvasOnly ||
               w.options?.hidden ||
+              w.name.startsWith('$$') ||
               (w.options?.advanced && !includesAdvanced.value)
             )
         )

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -250,6 +250,14 @@ function repeatItems<T>(items: T[]): T[] {
   return result
 }
 
+export function isPanelHiddenWidget(widget: IBaseWidget): boolean {
+  return Boolean(
+    widget.options?.canvasOnly ||
+    widget.options?.hidden ||
+    widget.name.startsWith('$$')
+  )
+}
+
 export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
   const settingStore = useSettingStore()
 
@@ -263,12 +271,8 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
       const shownWidgets = widgets
         .filter(
           (w) =>
-            !(
-              w.options?.canvasOnly ||
-              w.options?.hidden ||
-              w.name.startsWith('$$') ||
-              (w.options?.advanced && !includesAdvanced.value)
-            )
+            !isPanelHiddenWidget(w) &&
+            !(w.options?.advanced && !includesAdvanced.value)
         )
         .map((widget) => ({ node, widget }))
       return { widgets: shownWidgets, node }

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -264,6 +264,7 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
               w.options?.canvasOnly ||
               w.options?.hidden ||
               w.options?.hideInPanel ||
+              w.name.startsWith('$$') ||
               (w.options?.advanced && !includesAdvanced.value)
             )
         )

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -247,6 +247,15 @@ function repeatItems<T>(items: T[]): T[] {
   return result
 }
 
+export function isPanelHiddenWidget(widget: IBaseWidget): boolean {
+  return Boolean(
+    widget.options?.canvasOnly ||
+    widget.options?.hidden ||
+    widget.options?.hideInPanel ||
+    widget.name.startsWith('$$')
+  )
+}
+
 export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
   const settingStore = useSettingStore()
 
@@ -260,13 +269,8 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
       const shownWidgets = widgets
         .filter(
           (w) =>
-            !(
-              w.options?.canvasOnly ||
-              w.options?.hidden ||
-              w.options?.hideInPanel ||
-              w.name.startsWith('$$') ||
-              (w.options?.advanced && !includesAdvanced.value)
-            )
+            !isPanelHiddenWidget(w) &&
+            !(w.options?.advanced && !includesAdvanced.value)
         )
         .map((widget) => ({ node, widget }))
       return { widgets: shownWidgets, node }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The internal `$$canvas-image-preview` pseudo-widget was leaking into the right side panel as a literal `$$canvas-image-preview` item. The bug surfaces on subgraph nodes that promote a canvas image preview from an interior `SaveImage`/`PreviewImage`/`GLSLShader` node — the promoted virtual widget on the parent subgraph node lacks the `canvasOnly: true` option that filters it out on regular nodes, so it leaked through to `TabSubgraphInputs`.

Extract a shared `isPanelHiddenWidget` predicate (covers `canvasOnly`, `hidden`, and the `$$` magic-prefix convention used by `isPreviewPseudoWidget` and `isPseudoPromotion`) and apply it consistently in all three right-side-panel widget pipelines:

- `computedSectionDataList` in `shared.ts` (normal `TabNormalInputs` / `TabNodes`)
- `advancedWidgetsSectionDataList` in `TabNormalInputs.vue`
- `widgetsList` and `advancedInputsWidgets` in `TabSubgraphInputs.vue` (the actual bug surface)

This is an intentionally temporary fix until image-preview rendering in the right side panel is properly designed.

- Fixes [FE-563](https://linear.app/comfyorg/issue/FE-563/bug-dollardollarcanvas-image-preview-displayed-as-item-in-right-side)

## Test

Adds `browser_tests/tests/propertiesPanel/canvasImagePreviewWidget.spec.ts`:

- Loads the `subgraphs/subgraph-with-preview-node` workflow (a subgraph that promotes both `filename_prefix` and `$$canvas-image-preview` from an interior `SaveImage`)
- Selects the subgraph node
- Opens the right side panel via the actionbar button
- Asserts the panel contains exactly 1 widget item (`filename_prefix`) and that `$$canvas-image-preview` text is not present

The test is intentionally brittle: it asserts an exact widget count rather than just the literal `$$canvas-image-preview` string. When the preview is given a real, user-facing name in a future refactor, the new widget will appear in the panel, the count will become 2, and the test will fail — forcing this temporary filter (and the test) to be cleaned up at the right time.

## Verification

- `pnpm typecheck` ✓
- `pnpm typecheck:browser` ✓
- `pnpm lint` ✓ (no new warnings/errors)
- `pnpm test:unit src/components/rightSidePanel/shared.test.ts` ✓ (13 passed)
- Manual verification with the local dev server reproduced the bug on `main` with `subgraph-with-preview-node.json` (panel shows `$$canvas-image-preview` widget item with that literal text) and confirmed the filter removes it on this branch.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12172-fix-hide-magic-prefixed-widgets-from-right-side-panel-FE-563-35e6d73d3650813dbac8c44dbaa5bc4a) by [Unito](https://www.unito.io)
