### PR TITLE
fix: select node after click placement to match drag behavior (FE-564)

### DIFF
--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.test.ts
@@ -16,6 +16,7 @@ const {
   getRoot,
   resetRoot,
   mockAddNodeOnGraph,
+  mockSelectItems,
   mockSearchNode,
   mockOrganizeNodes,
   mockToggleNodeOnEvent
@@ -30,6 +31,7 @@ const {
       capturedRoot = null
     },
     mockAddNodeOnGraph: vi.fn(),
+    mockSelectItems: vi.fn(),
     mockSearchNode: vi.fn(() => []),
     mockOrganizeNodes: vi.fn(
       (): TreeNode => ({
@@ -44,6 +46,12 @@ const {
 
 vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: { selectItems: mockSelectItems }
+  })
 }))
 
 vi.mock('@/services/nodeOrganizationService', () => ({
@@ -201,6 +209,41 @@ describe('NodeLibrarySidebarTab', () => {
 
     await leaf?.handleClick?.(new MouseEvent('click'))
     expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockNode)
+  })
+
+  it('selects the placed node so click placement matches drag (FE-564)', async () => {
+    const placedNode = { id: 42 }
+    mockAddNodeOnGraph.mockReturnValue(placedNode)
+    mockOrganizeNodes.mockReturnValue({
+      key: 'root',
+      label: 'Root',
+      children: [{ key: 'leaf', label: 'Leaf', leaf: true, data: mockNode }]
+    })
+
+    renderComponent()
+    await nextTick()
+
+    const leaf = getRoot().children?.[0]
+    await leaf?.handleClick?.(new MouseEvent('click'))
+
+    expect(mockSelectItems).toHaveBeenCalledWith([placedNode])
+  })
+
+  it('does not call selectItems when node creation fails', async () => {
+    mockAddNodeOnGraph.mockReturnValue(null)
+    mockOrganizeNodes.mockReturnValue({
+      key: 'root',
+      label: 'Root',
+      children: [{ key: 'leaf', label: 'Leaf', leaf: true, data: mockNode }]
+    })
+
+    renderComponent()
+    await nextTick()
+
+    const leaf = getRoot().children?.[0]
+    await leaf?.handleClick?.(new MouseEvent('click'))
+
+    expect(mockSelectItems).not.toHaveBeenCalled()
   })
 
   it('adds and removes filters', async () => {

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.test.ts
@@ -16,6 +16,7 @@ const {
   getRoot,
   resetRoot,
   mockAddNodeOnGraph,
+  mockSelectItems,
   mockSearchNode,
   mockOrganizeNodes,
   mockToggleNodeOnEvent
@@ -30,6 +31,7 @@ const {
       capturedRoot = null
     },
     mockAddNodeOnGraph: vi.fn(),
+    mockSelectItems: vi.fn(),
     mockSearchNode: vi.fn(() => []),
     mockOrganizeNodes: vi.fn(
       (): TreeNode => ({
@@ -44,6 +46,12 @@ const {
 
 vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: { selectItems: mockSelectItems }
+  })
 }))
 
 vi.mock('@/services/nodeOrganizationService', () => ({
@@ -200,6 +208,41 @@ describe('NodeLibrarySidebarTab', () => {
 
     await leaf?.handleClick?.(new MouseEvent('click'))
     expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockNode)
+  })
+
+  it('selects the placed node so click placement matches drag (FE-564)', async () => {
+    const placedNode = { id: 42 }
+    mockAddNodeOnGraph.mockReturnValue(placedNode)
+    mockOrganizeNodes.mockReturnValue({
+      key: 'root',
+      label: 'Root',
+      children: [{ key: 'leaf', label: 'Leaf', leaf: true, data: mockNode }]
+    })
+
+    renderComponent()
+    await nextTick()
+
+    const leaf = getRoot().children?.[0]
+    await leaf?.handleClick?.(new MouseEvent('click'))
+
+    expect(mockSelectItems).toHaveBeenCalledWith([placedNode])
+  })
+
+  it('does not call selectItems when node creation fails', async () => {
+    mockAddNodeOnGraph.mockReturnValue(null)
+    mockOrganizeNodes.mockReturnValue({
+      key: 'root',
+      label: 'Root',
+      children: [{ key: 'leaf', label: 'Leaf', leaf: true, data: mockNode }]
+    })
+
+    renderComponent()
+    await nextTick()
+
+    const leaf = getRoot().children?.[0]
+    await leaf?.handleClick?.(new MouseEvent('click'))
+
+    expect(mockSelectItems).not.toHaveBeenCalled()
   })
 
   it('adds and removes filters', async () => {

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -189,6 +189,7 @@ import NodeTreeFolder from '@/components/sidebar/tabs/nodeLibrary/NodeTreeFolder
 import NodeTreeLeaf from '@/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useTreeExpansion } from '@/composables/useTreeExpansion'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLitegraphService } from '@/services/litegraphService'
 import {
   DEFAULT_GROUPING_ID,
@@ -322,7 +323,8 @@ const renderedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(() => {
       },
       handleClick(e: MouseEvent) {
         if (this.leaf && this.data) {
-          useLitegraphService().addNodeOnGraph(this.data)
+          const node = useLitegraphService().addNodeOnGraph(this.data)
+          if (node) useCanvasStore().canvas?.selectItems([node])
         } else {
           toggleNodeOnEvent(e, this)
         }

--- a/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/NodeLibrarySidebarTab.vue
@@ -190,6 +190,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { useTreeExpansion } from '@/composables/useTreeExpansion'
 import { withNodeAddSource } from '@/platform/telemetry/nodeAdded/nodeAddSource'
 import { useSearchQueryTracking } from '@/platform/telemetry/searchQuery/useSearchQueryTracking'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLitegraphService } from '@/services/litegraphService'
 import {
   DEFAULT_GROUPING_ID,
@@ -322,9 +323,10 @@ const renderedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(() => {
       handleClick(e: MouseEvent) {
         const nodeDef = this.data
         if (this.leaf && nodeDef) {
-          withNodeAddSource('sidebar_drag', () =>
+          const node = withNodeAddSource('sidebar_drag', () =>
             useLitegraphService().addNodeOnGraph(nodeDef)
           )
+          if (node) useCanvasStore().canvas?.selectItems([node])
         } else {
           toggleNodeOnEvent(e, this)
         }

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
@@ -19,6 +19,7 @@ const {
   mockIsBookmarked,
   mockToggleBookmark,
   mockAddNodeOnGraph,
+  mockSelectItems,
   mockToggleNodeOnEvent,
   captureRoot,
   getRoot,
@@ -31,6 +32,7 @@ const {
     mockIsBookmarked: vi.fn().mockReturnValue(false),
     mockToggleBookmark: vi.fn(),
     mockAddNodeOnGraph: vi.fn(),
+    mockSelectItems: vi.fn(),
     mockToggleNodeOnEvent: vi.fn(),
     captureRoot: (root: TreeExplorerNode<unknown>) => {
       capturedRoot = root
@@ -99,6 +101,12 @@ vi.mock('@/stores/nodeBookmarkStore', () => ({
 
 vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: { selectItems: mockSelectItems }
+  })
 }))
 
 vi.mock('@/composables/useTreeExpansion', () => ({
@@ -220,6 +228,29 @@ describe('NodeBookmarkTreeExplorer', () => {
       await leafNode?.handleClick?.call(leafNode, mockEvent)
 
       expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockLeafNodeDef)
+    })
+
+    it('selects the placed node so click placement matches drag (FE-564)', async () => {
+      const placedNode = { id: 7 }
+      mockAddNodeOnGraph.mockReturnValue(placedNode)
+
+      const root = await renderAndGetRoot()
+      const leafNode = root.children?.[0].children?.[0]
+
+      await leafNode?.handleClick?.call(leafNode, new MouseEvent('click'))
+
+      expect(mockSelectItems).toHaveBeenCalledWith([placedNode])
+    })
+
+    it('does not call selectItems when node creation fails', async () => {
+      mockAddNodeOnGraph.mockReturnValue(null)
+
+      const root = await renderAndGetRoot()
+      const leafNode = root.children?.[0].children?.[0]
+
+      await leafNode?.handleClick?.call(leafNode, new MouseEvent('click'))
+
+      expect(mockSelectItems).not.toHaveBeenCalled()
     })
 
     it('toggles node expansion when a folder node is clicked', async () => {

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.test.ts
@@ -19,6 +19,7 @@ const {
   mockIsBookmarked,
   mockToggleBookmark,
   mockAddNodeOnGraph,
+  mockSelectItems,
   mockToggleNodeOnEvent,
   captureRoot,
   getRoot,
@@ -31,6 +32,7 @@ const {
     mockIsBookmarked: vi.fn().mockReturnValue(false),
     mockToggleBookmark: vi.fn(),
     mockAddNodeOnGraph: vi.fn(),
+    mockSelectItems: vi.fn(),
     mockToggleNodeOnEvent: vi.fn(),
     captureRoot: (root: TreeExplorerNode<unknown>) => {
       capturedRoot = root
@@ -99,6 +101,12 @@ vi.mock('@/stores/nodeBookmarkStore', () => ({
 
 vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({ addNodeOnGraph: mockAddNodeOnGraph })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    canvas: { selectItems: mockSelectItems }
+  })
 }))
 
 vi.mock('@/composables/useTreeExpansion', () => ({
@@ -219,6 +227,29 @@ describe('NodeBookmarkTreeExplorer', () => {
       await leafNode?.handleClick?.call(leafNode, mockEvent)
 
       expect(mockAddNodeOnGraph).toHaveBeenCalledWith(mockLeafNodeDef)
+    })
+
+    it('selects the placed node so click placement matches drag (FE-564)', async () => {
+      const placedNode = { id: 7 }
+      mockAddNodeOnGraph.mockReturnValue(placedNode)
+
+      const root = await renderAndGetRoot()
+      const leafNode = root.children?.[0].children?.[0]
+
+      await leafNode?.handleClick?.call(leafNode, new MouseEvent('click'))
+
+      expect(mockSelectItems).toHaveBeenCalledWith([placedNode])
+    })
+
+    it('does not call selectItems when node creation fails', async () => {
+      mockAddNodeOnGraph.mockReturnValue(null)
+
+      const root = await renderAndGetRoot()
+      const leafNode = root.children?.[0].children?.[0]
+
+      await leafNode?.handleClick?.call(leafNode, new MouseEvent('click'))
+
+      expect(mockSelectItems).not.toHaveBeenCalled()
     })
 
     it('toggles node expansion when a folder node is clicked', async () => {

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
@@ -39,6 +39,7 @@ import NodePreview from '@/components/node/NodePreview.vue'
 import NodeTreeFolder from '@/components/sidebar/tabs/nodeLibrary/NodeTreeFolder.vue'
 import NodeTreeLeaf from '@/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue'
 import { useTreeExpansion } from '@/composables/useTreeExpansion'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -184,7 +185,8 @@ const renderedBookmarkedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(
         },
         handleClick(e: MouseEvent) {
           if (this.leaf && this.data) {
-            useLitegraphService().addNodeOnGraph(this.data)
+            const placed = useLitegraphService().addNodeOnGraph(this.data)
+            if (placed) useCanvasStore().canvas?.selectItems([placed])
           } else {
             toggleNodeOnEvent(e, node)
           }

--- a/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
+++ b/src/components/sidebar/tabs/nodeLibrary/NodeBookmarkTreeExplorer.vue
@@ -40,6 +40,7 @@ import NodeTreeFolder from '@/components/sidebar/tabs/nodeLibrary/NodeTreeFolder
 import NodeTreeLeaf from '@/components/sidebar/tabs/nodeLibrary/NodeTreeLeaf.vue'
 import { useTreeExpansion } from '@/composables/useTreeExpansion'
 import { withNodeAddSource } from '@/platform/telemetry/nodeAdded/nodeAddSource'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeBookmarkStore } from '@/stores/nodeBookmarkStore'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
@@ -186,9 +187,10 @@ const renderedBookmarkedRoot = computed<TreeExplorerNode<ComfyNodeDefImpl>>(
         handleClick(e: MouseEvent) {
           const nodeDef = this.data
           if (this.leaf && nodeDef) {
-            withNodeAddSource('sidebar_drag', () =>
+            const placed = withNodeAddSource('sidebar_drag', () =>
               useLitegraphService().addNodeOnGraph(nodeDef)
             )
+            if (placed) useCanvasStore().canvas?.selectItems([placed])
           } else {
             toggleNodeOnEvent(e, node)
           }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Fixes inconsistent node-selection behavior between drag and click placement from the Node Library and Bookmark panels. Previously, dragging a node onto the canvas left it selected while clicking the same node in the panel left it unselected. Now both placement methods consistently select the newly placed node.

- Fixes [FE-564](https://linear.app/comfyorg/issue/FE-564/bug-inconsistent-node-selection-behavior-between-drag-vs-click)

## Root cause

In `NodeLibrarySidebarTab.vue` and `NodeBookmarkTreeExplorer.vue`, the leaf-node `handleClick` handler calls `useLitegraphService().addNodeOnGraph(this.data)` and discards the return value. `addNodeOnGraph` doesn't select the node on its own (selection is only triggered by `LGraphCanvas.startGhostPlacement`, which the click path doesn't enter). The drag path ends up selected via the canvas's pointer interaction.

## Fix

Call `useCanvasStore().canvas?.selectItems([node])` on the returned node from the two click handlers. The fix is intentionally local to these two call sites — an earlier draft modifying the shared `addNodeOnGraph` service was reverted because it would have changed selection semantics for batch insert flows (e.g. `useMediaAssetActions.addMultipleToWorkflow`).

## Tests (TDD)

Added new tests that failed before the fix and pass after:

- `NodeLibrarySidebarTab.test.ts`: "selects the placed node so click placement matches drag (FE-564)" + "does not call selectItems when node creation fails"
- `NodeBookmarkTreeExplorer.test.ts`: same two cases for the bookmark panel

Confirmed by running the test suite with the fix temporarily reverted — both new selection tests failed, matching the original bug behavior.

## Verification

- `pnpm test:unit` on touched files + related tests (`NodeLibrarySidebarTab`, `NodeBookmarkTreeExplorer`, `litegraphService`, `NodeSearchBoxPopover`, `useMediaAssetActions`, `ModelLibrarySidebarTab`): all pass
- `pnpm lint`: clean (1 pre-existing warning unrelated)
- `pnpm typecheck`: clean
- `pnpm format`: applied
- **Manual browser verification (Playwright against local dev server)** — reproduced the bug and confirmed the fix:
  - Adding a `KSampler` via `addNodeOnGraph` alone (buggy state): `selectedItems.size = 0` ❌
  - Same call followed by `canvas.selectItems([node])` (fixed state): `selectedItems.size = 1`, node is in the selection ✅

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12174-fix-select-node-after-click-placement-to-match-drag-behavior-FE-564-35e6d73d365081999edafde520a61f4f) by [Unito](https://www.unito.io)
