### PR TITLE
[backport core/1.44] fix(i18n): clamp unsupported browser locales to a shipped tag (#11712)

### DIFF
--- a/apps/desktop-ui/src/i18n.ts
+++ b/apps/desktop-ui/src/i18n.ts
@@ -9,6 +9,7 @@ import en from '@frontend-locales/en/main.json' with { type: 'json' }
 import enNodes from '@frontend-locales/en/nodeDefs.json' with { type: 'json' }
 
 import enSettings from '@frontend-locales/en/settings.json' with { type: 'json' }
+import { getDefaultLocale } from '@frontend-locales/localeConfig'
 import { createI18n } from 'vue-i18n'
 
 function buildLocale<
@@ -167,7 +168,7 @@ const messages: Record<string, LocaleMessages> = {
 export const i18n = createI18n({
   // Must set `false`, as Vue I18n Legacy API is for Vue 2
   legacy: false,
-  locale: navigator.language.split('-')[0] || 'en',
+  locale: getDefaultLocale(),
   fallbackLocale: 'en',
   messages,
   // Ignore warnings for locale options as each option is in its own language.

--- a/browser_tests/tests/i18nLocaleFallback.spec.ts
+++ b/browser_tests/tests/i18nLocaleFallback.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+
+// Regression test for https://github.com/Comfy-Org/ComfyUI_frontend/issues/10563
+//
+// Pins the end-to-end cascade through createI18n + coreSettings defaultValue +
+// GraphView watchEffect: when navigator.language base tag is unsupported (e.g.
+// 'de-DE') and Comfy.Locale is unset (fresh-install state), sidebar labels
+// must render translated strings, not literal i18n keys like
+// 'sideToolbar.labels.assets'.
+test.describe('i18n locale fallback', () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.page.addInitScript(() => {
+      Object.defineProperty(navigator, 'language', {
+        value: 'de-DE',
+        configurable: true
+      })
+      Object.defineProperty(navigator, 'languages', {
+        value: ['de-DE', 'de'],
+        configurable: true
+      })
+    })
+    // Default sidebar size on small viewports hides labels; force normal so
+    // .side-bar-button-label is rendered for the assertion.
+    await comfyPage.settings.setSetting('Comfy.Sidebar.Size', 'normal')
+    await comfyPage.page.reload()
+    await comfyPage.waitForAppReady()
+  })
+
+  test('sidebar labels render translated strings, not raw i18n keys', async ({
+    comfyPage
+  }) => {
+    const { page } = comfyPage
+    await page.setViewportSize({ width: 1920, height: 1080 })
+
+    const labelTexts = await page
+      .getByTestId('side-toolbar')
+      .locator('.side-bar-button-label')
+      .allTextContents()
+
+    expect(labelTexts.length).toBeGreaterThan(0)
+    for (const text of labelTexts) {
+      expect(text).not.toContain('sideToolbar.labels')
+    }
+  })
+})

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -131,48 +131,51 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
   test('Falls back to English templates when locale file not found', async ({
     comfyPage
   }) => {
-    // Set locale to a language that doesn't have a template file
-    await comfyPage.settings.setSetting('Comfy.Locale', 'de') // German - no index.de.json exists
+    // Pick a shipped LTR locale and simulate its template index returning 404.
+    // (Previously this test used 'de', but unsupported locales are now
+    // clamped to 'en' at boot so they never hit the template fallback path.
+    // 'fa' would also work but flips document.dir to rtl, which can leak
+    // into adjacent specs in the same worker.)
+    const locale = 'tr'
 
-    // Wait for the German request (expected to 404)
-    const germanRequestPromise = comfyPage.page.waitForRequest(
-      '**/templates/index.de.json'
+    await comfyPage.page.route(
+      `**/templates/index.${locale}.json`,
+      async (route) => {
+        await route.fulfill({
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+          body: 'Not Found'
+        })
+      }
     )
 
-    // Wait for the fallback English request
-    const englishRequestPromise = comfyPage.page.waitForRequest(
-      '**/templates/index.json'
-    )
-
-    // Intercept the German file to simulate a 404
-    await comfyPage.page.route('**/templates/index.de.json', async (route) => {
-      await route.fulfill({
-        status: 404,
-        headers: { 'Content-Type': 'text/plain' },
-        body: 'Not Found'
-      })
-    })
-
-    // Allow the English index to load normally
     await comfyPage.page.route('**/templates/index.json', (route) =>
       route.continue()
     )
 
-    // Load the templates dialog
+    await comfyPage.settings.setSetting('Comfy.Locale', locale)
+
+    const localeRequestPromise = comfyPage.page.waitForRequest(
+      `**/templates/index.${locale}.json`
+    )
+    const englishRequestPromise = comfyPage.page.waitForRequest(
+      '**/templates/index.json'
+    )
+
     await comfyPage.command.executeCommand('Comfy.BrowseTemplates')
     await expect(comfyPage.templates.content).toBeVisible()
 
-    // Verify German was requested first, then English as fallback
-    const germanRequest = await germanRequestPromise
+    const localeRequest = await localeRequestPromise
     const englishRequest = await englishRequestPromise
 
-    expect(germanRequest.url()).toContain('templates/index.de.json')
+    expect(localeRequest.url()).toContain(`templates/index.${locale}.json`)
     expect(englishRequest.url()).toContain('templates/index.json')
 
-    // Verify English titles are shown as fallback
-    await expect(
-      comfyPage.page.getByRole('main').getByText('All Templates')
-    ).toBeVisible()
+    // Assert on rendered content, not just the container — the container
+    // testid is present even when the dialog body is empty, which would let
+    // a regression where the fallback fetch succeeds but no cards render
+    // pass silently.
+    await expect(comfyPage.templates.allTemplateCards.first()).toBeVisible()
   })
 
   test('template cards are dynamically sized and responsive', async ({

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,5 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-const { i18n, loadLocale, mergeCustomNodesI18n } = await import('./i18n')
+
+import type * as I18nModule from './i18n'
+
+let i18n: typeof I18nModule.i18n
+let loadLocale: typeof I18nModule.loadLocale
+let mergeCustomNodesI18n: typeof I18nModule.mergeCustomNodesI18n
+let resolveSupportedLocale: typeof I18nModule.resolveSupportedLocale
+let setActiveLocale: typeof I18nModule.setActiveLocale
+
+async function importI18nModule() {
+  const i18nModule = await import('./i18n')
+  i18n = i18nModule.i18n
+  loadLocale = i18nModule.loadLocale
+  mergeCustomNodesI18n = i18nModule.mergeCustomNodesI18n
+  resolveSupportedLocale = i18nModule.resolveSupportedLocale
+  setActiveLocale = i18nModule.setActiveLocale
+}
 
 // Mock the JSON imports before importing i18n module
 vi.mock('./locales/en/main.json', () => ({ default: { welcome: 'Welcome' } }))
@@ -24,6 +40,7 @@ vi.mock('./locales/zh/settings.json', () => ({ default: { theme: '主题' } }))
 describe('i18n', () => {
   beforeEach(async () => {
     vi.resetModules()
+    await importI18nModule()
   })
 
   describe('mergeCustomNodesI18n', () => {
@@ -46,8 +63,6 @@ describe('i18n', () => {
     })
 
     it('should store data for not-yet-loaded locales', async () => {
-      const { i18n, mergeCustomNodesI18n } = await import('./i18n')
-
       // Chinese is not pre-loaded, data should be stored but not merged yet
       mergeCustomNodesI18n({
         zh: {
@@ -148,7 +163,7 @@ describe('i18n', () => {
     it('should handle calling mergeCustomNodesI18n multiple times', async () => {
       // Use fresh module instance to ensure clean state
       vi.resetModules()
-      const { i18n, loadLocale, mergeCustomNodesI18n } = await import('./i18n')
+      await importI18nModule()
 
       mergeCustomNodesI18n({
         zh: { plugin1: { name: '插件1' } }
@@ -175,26 +190,88 @@ describe('i18n', () => {
     it('should not reload already loaded locale', async () => {
       await loadLocale('zh')
       await loadLocale('zh')
-
-      // Should complete without error (second call returns early)
     })
 
-    it('should warn for unsupported locale', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-      await loadLocale('unsupported-locale')
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Locale "unsupported-locale" is not supported'
+    it('should load shipped BCP-47 variants', async () => {
+      await loadLocale('zh-TW')
+      expect(i18n.global.getLocaleMessage('zh-TW')).toEqual(
+        expect.objectContaining({
+          commands: expect.any(Object),
+          nodeDefs: expect.any(Object),
+          settings: expect.any(Object)
+        })
       )
-      consoleSpy.mockRestore()
     })
 
     it('should handle concurrent load requests for same locale', async () => {
-      // Start multiple loads concurrently
       const promises = [loadLocale('zh'), loadLocale('zh'), loadLocale('zh')]
-
       await Promise.all(promises)
+    })
+  })
+
+  describe('setActiveLocale', () => {
+    it('clamps unsupported input to en', async () => {
+      expect(await setActiveLocale('de')).toBe('en')
+      expect(i18n.global.locale.value).toBe('en')
+    })
+
+    it('resolves shipped variants and sets the active locale', async () => {
+      expect(await setActiveLocale('pt-BR')).toBe('pt-BR')
+      expect(i18n.global.locale.value).toBe('pt-BR')
+      // pt is not shipped — pt-BR must not be promoted as a base match
+      expect(await setActiveLocale('pt')).toBe('en')
+    })
+
+    it('honors prioritized navigator.languages', async () => {
+      // First preference unsupported, second shipped — should land on French.
+      expect(await setActiveLocale(['de-DE', 'fr-CA', 'en'])).toBe('fr')
+    })
+  })
+
+  describe('resolveSupportedLocale', () => {
+    it('returns the canonical tag when the input is shipped', () => {
+      expect(resolveSupportedLocale('en')).toBe('en')
+      expect(resolveSupportedLocale('ja')).toBe('ja')
+      expect(resolveSupportedLocale('zh-TW')).toBe('zh-TW')
+      expect(resolveSupportedLocale('pt-BR')).toBe('pt-BR')
+    })
+
+    it('matches case-insensitively per BCP-47 and returns canonical casing', () => {
+      // Older browsers / OS configs may emit lowercase region tags.
+      expect(resolveSupportedLocale('pt-br')).toBe('pt-BR')
+      expect(resolveSupportedLocale('PT-BR')).toBe('pt-BR')
+      expect(resolveSupportedLocale('zh-tw')).toBe('zh-TW')
+      expect(resolveSupportedLocale('ZH-TW')).toBe('zh-TW')
+      expect(resolveSupportedLocale('EN')).toBe('en')
+    })
+
+    it('falls back to the base tag when the full tag is unshipped', () => {
+      // de-DE → de (unshipped) → en
+      expect(resolveSupportedLocale('de-DE')).toBe('en')
+      // fr-CA → fr (shipped) → fr
+      expect(resolveSupportedLocale('fr-CA')).toBe('fr')
+      // ko-KR → ko (shipped) → ko
+      expect(resolveSupportedLocale('ko-KR')).toBe('ko')
+      // zh-CN → zh (shipped) → zh (Simplified is the base)
+      expect(resolveSupportedLocale('zh-CN')).toBe('zh')
+    })
+
+    it('falls back to en for unsupported and missing inputs', () => {
+      expect(resolveSupportedLocale('de')).toBe('en')
+      expect(resolveSupportedLocale('it')).toBe('en')
+      expect(resolveSupportedLocale('nl')).toBe('en')
+      expect(resolveSupportedLocale('xx-YY')).toBe('en')
+      expect(resolveSupportedLocale('')).toBe('en')
+      expect(resolveSupportedLocale(undefined)).toBe('en')
+      expect(resolveSupportedLocale(null)).toBe('en')
+    })
+
+    it('walks a prioritized array per RFC 4647 lookup order', () => {
+      // First shipped match wins (de unshipped → fr shipped → fr).
+      expect(resolveSupportedLocale(['de-DE', 'fr-CA', 'en'])).toBe('fr')
+      // Empty / all-unshipped arrays fall back to en.
+      expect(resolveSupportedLocale([])).toBe('en')
+      expect(resolveSupportedLocale(['de', 'it'])).toBe('en')
     })
   })
 })

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,13 +1,19 @@
 import { createI18n } from 'vue-i18n'
 
-// ESLint cannot statically resolve dynamic imports with relative paths in template strings,
-// but these are valid ES module imports that Vite processes correctly at build time.
+import {
+  getDefaultLocale,
+  localeDefinitions,
+  resolveSupportedLocale
+} from '@/locales/localeConfig'
+import type { SupportedLocale } from '@/locales/localeConfig'
 
 // Import only English locale eagerly as the default/fallback
 import enCommands from './locales/en/commands.json' with { type: 'json' }
 import en from './locales/en/main.json' with { type: 'json' }
 import enNodes from './locales/en/nodeDefs.json' with { type: 'json' }
 import enSettings from './locales/en/settings.json' with { type: 'json' }
+
+export { resolveSupportedLocale }
 
 function buildLocale<
   M extends Record<string, unknown>,
@@ -23,75 +29,6 @@ function buildLocale<
   } as M & { nodeDefs: N; commands: C; settings: S }
 }
 
-// Locale loader map - dynamically import locales only when needed
-const localeLoaders: Record<
-  string,
-  () => Promise<{ default: Record<string, unknown> }>
-> = {
-  ar: () => import('./locales/ar/main.json'),
-  es: () => import('./locales/es/main.json'),
-  fa: () => import('./locales/fa/main.json'),
-  fr: () => import('./locales/fr/main.json'),
-  ja: () => import('./locales/ja/main.json'),
-  ko: () => import('./locales/ko/main.json'),
-  ru: () => import('./locales/ru/main.json'),
-  tr: () => import('./locales/tr/main.json'),
-  zh: () => import('./locales/zh/main.json'),
-  'zh-TW': () => import('./locales/zh-TW/main.json'),
-  'pt-BR': () => import('./locales/pt-BR/main.json')
-}
-
-const nodeDefsLoaders: Record<
-  string,
-  () => Promise<{ default: Record<string, unknown> }>
-> = {
-  ar: () => import('./locales/ar/nodeDefs.json'),
-  es: () => import('./locales/es/nodeDefs.json'),
-  fa: () => import('./locales/fa/nodeDefs.json'),
-  fr: () => import('./locales/fr/nodeDefs.json'),
-  ja: () => import('./locales/ja/nodeDefs.json'),
-  ko: () => import('./locales/ko/nodeDefs.json'),
-  ru: () => import('./locales/ru/nodeDefs.json'),
-  tr: () => import('./locales/tr/nodeDefs.json'),
-  zh: () => import('./locales/zh/nodeDefs.json'),
-  'zh-TW': () => import('./locales/zh-TW/nodeDefs.json'),
-  'pt-BR': () => import('./locales/pt-BR/nodeDefs.json')
-}
-
-const commandsLoaders: Record<
-  string,
-  () => Promise<{ default: Record<string, unknown> }>
-> = {
-  ar: () => import('./locales/ar/commands.json'),
-  es: () => import('./locales/es/commands.json'),
-  fa: () => import('./locales/fa/commands.json'),
-  fr: () => import('./locales/fr/commands.json'),
-  ja: () => import('./locales/ja/commands.json'),
-  ko: () => import('./locales/ko/commands.json'),
-  ru: () => import('./locales/ru/commands.json'),
-  tr: () => import('./locales/tr/commands.json'),
-  zh: () => import('./locales/zh/commands.json'),
-  'zh-TW': () => import('./locales/zh-TW/commands.json'),
-  'pt-BR': () => import('./locales/pt-BR/commands.json')
-}
-
-const settingsLoaders: Record<
-  string,
-  () => Promise<{ default: Record<string, unknown> }>
-> = {
-  ar: () => import('./locales/ar/settings.json'),
-  es: () => import('./locales/es/settings.json'),
-  fa: () => import('./locales/fa/settings.json'),
-  fr: () => import('./locales/fr/settings.json'),
-  ja: () => import('./locales/ja/settings.json'),
-  ko: () => import('./locales/ko/settings.json'),
-  ru: () => import('./locales/ru/settings.json'),
-  tr: () => import('./locales/tr/settings.json'),
-  zh: () => import('./locales/zh/settings.json'),
-  'zh-TW': () => import('./locales/zh-TW/settings.json'),
-  'pt-BR': () => import('./locales/pt-BR/settings.json')
-}
-
 // Track which locales have been loaded
 const loadedLocales = new Set<string>(['en'])
 
@@ -102,37 +39,33 @@ const loadingLocales = new Map<string, Promise<void>>()
 const customNodesI18nData: Record<string, unknown> = {}
 
 /**
- * Dynamically load a locale and its associated files (nodeDefs, commands, settings)
+ * Dynamically load a shipped locale's bundles (nodeDefs, commands, settings).
+ * Callers must pre-resolve untrusted input via `resolveSupportedLocale` or
+ * `setActiveLocale`, which is the boundary helper for arbitrary input.
  */
-export async function loadLocale(locale: string): Promise<void> {
+export async function loadLocale(locale: SupportedLocale): Promise<void> {
   if (loadedLocales.has(locale)) {
     return
   }
 
-  // If already loading, return the existing promise to prevent duplicate loads
   const existingLoad = loadingLocales.get(locale)
   if (existingLoad) {
-    return existingLoad
-  }
-
-  const loader = localeLoaders[locale]
-  const nodeDefsLoader = nodeDefsLoaders[locale]
-  const commandsLoader = commandsLoaders[locale]
-  const settingsLoader = settingsLoaders[locale]
-
-  if (!loader || !nodeDefsLoader || !commandsLoader || !settingsLoader) {
-    console.warn(`Locale "${locale}" is not supported`)
+    await existingLoad
     return
   }
 
-  // Create and track the loading promise
+  const loaders = localeDefinitions[locale].loaders
+  if (!loaders) {
+    return
+  }
+
   const loadPromise = (async () => {
     try {
       const [main, nodes, commands, settings] = await Promise.all([
-        loader(),
-        nodeDefsLoader(),
-        commandsLoader(),
-        settingsLoader()
+        loaders.main(),
+        loaders.nodeDefs(),
+        loaders.commands(),
+        loaders.settings()
       ])
 
       const messages = buildLocale(
@@ -152,13 +85,33 @@ export async function loadLocale(locale: string): Promise<void> {
       console.error(`Failed to load locale "${locale}":`, error)
       throw error
     } finally {
-      // Clean up the loading promise once complete
       loadingLocales.delete(locale)
     }
   })()
 
   loadingLocales.set(locale, loadPromise)
-  return loadPromise
+  await loadPromise
+}
+
+/**
+ * Boundary helper for arbitrary locale input (settings, browser preferences):
+ * resolves to a shipped tag, loads it, and updates the active locale.
+ *
+ * Returns the resolved tag so callers can detect a clamp (e.g. a stale stored
+ * `Comfy.Locale` from an older build) and self-heal persisted state.
+ */
+export async function setActiveLocale(
+  input: string | readonly string[] | null | undefined
+): Promise<SupportedLocale> {
+  const resolved = resolveSupportedLocale(input)
+  if (typeof input === 'string' && input && input !== resolved) {
+    // Single warn — gated on a real clamp event, never per missing key — so
+    // stale stored locales surface in logs without re-introducing #1867's spam.
+    console.warn(`Locale "${input}" not shipped; using "${resolved}"`)
+  }
+  await loadLocale(resolved)
+  i18n.global.locale.value = resolved
+  return resolved
 }
 
 /**
@@ -179,18 +132,18 @@ export function mergeCustomNodesI18n(i18nData: Record<string, unknown>): void {
   }
 }
 
-// Only include English in the initial bundle
-const messages = {
-  en: buildLocale(en, enNodes, enCommands, enSettings)
-}
+// Only include English in the initial bundle; other locales lazy-load.
+const enMessages = buildLocale(en, enNodes, enCommands, enSettings)
+type LocaleMessages = typeof enMessages
 
-// Type for locale messages - inferred from the English locale structure
-type LocaleMessages = typeof messages.en
+const messages: Partial<Record<SupportedLocale, LocaleMessages>> = {
+  en: enMessages
+}
 
 export const i18n = createI18n({
   // Must set `false`, as Vue I18n Legacy API is for Vue 2
   legacy: false,
-  locale: navigator.language.split('-')[0] || 'en',
+  locale: getDefaultLocale(),
   fallbackLocale: 'en',
   escapeParameter: true,
   messages,

--- a/src/locales/CONTRIBUTING.md
+++ b/src/locales/CONTRIBUTING.md
@@ -35,47 +35,13 @@ module.exports = defineConfig({
 })
 ```
 
-#### 1.2 Update `src/platform/settings/constants/coreSettings.ts`
+#### 1.2 Update `src/locales/localeConfig.ts`
 
-Add your language to the dropdown options:
-
-```typescript
-{
-  id: 'Comfy.Locale',
-  name: 'Language',
-  type: 'combo',
-  options: [
-    { value: 'en', text: 'English' },
-    { value: 'zh', text: '中文' },
-    { value: 'zh-TW', text: '繁體中文 (台灣)' }, // Add your language here
-    { value: 'ru', text: 'Русский' },
-    { value: 'ja', text: '日本語' },
-    { value: 'ko', text: '한국어' },
-    { value: 'fr', text: 'Français' },
-    { value: 'es', text: 'Español' }
-  ],
-  defaultValue: () => navigator.language.split('-')[0] || 'en'
-},
-```
-
-#### 1.3 Update `src/i18n.ts`
-
-Add imports for your new language files:
+Add your language to the shared runtime locale definition. This feeds the
+settings dropdown, supported-locale resolution, and lazy locale loading:
 
 ```typescript
-// Add these imports (replace zh-TW with your language code)
-import zhTWCommands from './locales/zh-TW/commands.json'
-import zhTW from './locales/zh-TW/main.json'
-import zhTWNodes from './locales/zh-TW/nodeDefs.json'
-import zhTWSettings from './locales/zh-TW/settings.json'
-
-// Add to the messages object
-const messages = {
-  en: buildLocale(en, enNodes, enCommands, enSettings),
-  zh: buildLocale(zh, zhNodes, zhCommands, zhSettings),
-  'zh-TW': buildLocale(zhTW, zhTWNodes, zhTWCommands, zhTWSettings) // Add this line
-  // ... other languages
-}
+'zh-TW': { text: '繁體中文', loaders: loadersFor('zh-TW') }
 ```
 
 ### Step 2: Generate Translation Files
@@ -168,7 +134,7 @@ Each language has 4 translation files:
 
 ### Issue: Language not appearing in dropdown
 
-**Solution**: Check that the language code in `coreSettings.ts` matches your other files exactly
+**Solution**: Check that the language code in `src/locales/localeConfig.ts` matches your other files exactly
 
 ### Issue: Rate limits during local translation
 

--- a/src/locales/localeConfig.ts
+++ b/src/locales/localeConfig.ts
@@ -1,0 +1,82 @@
+type LocaleJsonLoader = () => Promise<{
+  default: Record<string, unknown>
+}>
+
+type LocaleLoaderBundle = {
+  main: LocaleJsonLoader
+  nodeDefs: LocaleJsonLoader
+  commands: LocaleJsonLoader
+  settings: LocaleJsonLoader
+}
+
+type LocaleDefinition = {
+  text: string
+  loaders: LocaleLoaderBundle | null
+}
+
+// Vite code-splits each matched module into its own async chunk; only the
+// resolved locale's bundle is fetched at runtime.
+const localeFiles = import.meta.glob<{ default: Record<string, unknown> }>(
+  './*/{main,nodeDefs,commands,settings}.json'
+)
+
+function loadersFor(locale: string): LocaleLoaderBundle {
+  return {
+    main: localeFiles[`./${locale}/main.json`],
+    nodeDefs: localeFiles[`./${locale}/nodeDefs.json`],
+    commands: localeFiles[`./${locale}/commands.json`],
+    settings: localeFiles[`./${locale}/settings.json`]
+  }
+}
+
+export const localeDefinitions = {
+  en: { text: 'English', loaders: null },
+  zh: { text: '中文', loaders: loadersFor('zh') },
+  'zh-TW': { text: '繁體中文', loaders: loadersFor('zh-TW') },
+  ru: { text: 'Русский', loaders: loadersFor('ru') },
+  ja: { text: '日本語', loaders: loadersFor('ja') },
+  ko: { text: '한국어', loaders: loadersFor('ko') },
+  fr: { text: 'Français', loaders: loadersFor('fr') },
+  es: { text: 'Español', loaders: loadersFor('es') },
+  ar: { text: 'عربي', loaders: loadersFor('ar') },
+  tr: { text: 'Türkçe', loaders: loadersFor('tr') },
+  'pt-BR': { text: 'Português (BR)', loaders: loadersFor('pt-BR') },
+  fa: { text: 'فارسی', loaders: loadersFor('fa') }
+} as const satisfies Record<string, LocaleDefinition>
+
+export type SupportedLocale = keyof typeof localeDefinitions
+
+const SUPPORTED_LOCALES = Object.keys(localeDefinitions) as SupportedLocale[]
+
+export const SUPPORTED_LOCALE_OPTIONS = SUPPORTED_LOCALES.map((value) => ({
+  value,
+  text: localeDefinitions[value].text
+}))
+
+const supportedLocaleByLower = new Map<string, SupportedLocale>(
+  SUPPORTED_LOCALES.map((locale) => [locale.toLowerCase(), locale])
+)
+
+function matchSingle(candidate: string): SupportedLocale | undefined {
+  const normalized = candidate.toLowerCase()
+  return (
+    supportedLocaleByLower.get(normalized) ??
+    supportedLocaleByLower.get(normalized.split('-')[0])
+  )
+}
+
+export function resolveSupportedLocale(
+  input?: string | readonly string[] | null
+): SupportedLocale {
+  const candidates = Array.isArray(input) ? input : input ? [input] : []
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const matched = matchSingle(candidate)
+    if (matched) return matched
+  }
+  return 'en'
+}
+
+export function getDefaultLocale(): SupportedLocale {
+  return resolveSupportedLocale(navigator.languages)
+}

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1,4 +1,8 @@
 import { LinkMarkerShape, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import {
+  getDefaultLocale,
+  SUPPORTED_LOCALE_OPTIONS
+} from '@/locales/localeConfig'
 import { isCloud, isDesktop, isNightly } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingParams } from '@/platform/settings/types'
@@ -439,21 +443,8 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Locale',
     name: 'Language',
     type: 'combo',
-    options: [
-      { value: 'en', text: 'English' },
-      { value: 'zh', text: '中文' },
-      { value: 'zh-TW', text: '繁體中文' },
-      { value: 'ru', text: 'Русский' },
-      { value: 'ja', text: '日本語' },
-      { value: 'ko', text: '한국어' },
-      { value: 'fr', text: 'Français' },
-      { value: 'es', text: 'Español' },
-      { value: 'ar', text: 'عربي' },
-      { value: 'tr', text: 'Türkçe' },
-      { value: 'pt-BR', text: 'Português (BR)' },
-      { value: 'fa', text: 'فارسی' }
-    ],
-    defaultValue: () => navigator.language.split('-')[0] || 'en'
+    options: SUPPORTED_LOCALE_OPTIONS,
+    defaultValue: getDefaultLocale
   },
   {
     id: 'Comfy.NodeBadge.NodeSourceBadgeMode',

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -60,7 +60,7 @@ import { useReconnectingNotification } from '@/composables/useReconnectingNotifi
 import { useProgressFavicon } from '@/composables/useProgressFavicon'
 import { SERVER_CONFIG_ITEMS } from '@/constants/serverConfig'
 import type { ServerConfig, ServerConfigValue } from '@/constants/serverConfig'
-import { i18n, loadLocale } from '@/i18n'
+import { setActiveLocale } from '@/i18n'
 import AssetExportProgressDialog from '@/platform/assets/components/AssetExportProgressDialog.vue'
 import ModelImportProgressDialog from '@/platform/assets/components/ModelImportProgressDialog.vue'
 import DesktopCloudNotificationController from '@/platform/cloud/notification/components/DesktopCloudNotificationController.vue'
@@ -189,15 +189,17 @@ watchEffect(() => {
 
 watchEffect(async () => {
   const locale = settingStore.get('Comfy.Locale')
-  if (locale) {
-    // Load the locale dynamically if not already loaded
-    try {
-      await loadLocale(locale)
-      // Type assertion is safe here as loadLocale validates the locale exists
-      i18n.global.locale.value = locale as typeof i18n.global.locale.value
-    } catch (error) {
-      console.error(`Failed to switch to locale "${locale}":`, error)
+  if (!locale) return
+  try {
+    const resolved = await setActiveLocale(locale)
+    // Self-heal: a stored value from an older build (e.g. 'de') would otherwise
+    // leave the language dropdown — derived from SUPPORTED_LOCALE_OPTIONS —
+    // showing nothing selected until the user picks one manually.
+    if (resolved !== locale) {
+      await settingStore.set('Comfy.Locale', resolved)
     }
+  } catch (error) {
+    console.error(`Failed to switch to locale "${locale}":`, error)
   }
 })
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Backport of #11712 to `core/1.44`.

## Summary

Cherry-picks `ceb993605` ("fix(i18n): clamp unsupported browser locales to a shipped tag") onto `core/1.44`.

Sidebar buttons rendered literal i18n keys (e.g. `sideToolbar.labels.assets`) on a fresh install when the user's `navigator.language` base tag wasn't one of the 12 shipped locales — German/Italian/Polish/Dutch/Brazilian-Portuguese users among others.

## Cherry-pick conflict resolution

One file required manual resolution:

- **`browser_tests/tests/customNodeLocales.spec.ts`** — `modify/delete` conflict. This file does not exist on `core/1.44` (it was introduced on `main` after the 1.44 branch cut, in #12132). Dropped the modification from the backport; the underlying test file is not on the release branch, so its updates are irrelevant here.

All other files merged cleanly (`src/views/GraphView.vue` had an auto-merge that resolved without intervention).

## Verification

- `pnpm typecheck` — clean
- `pnpm test:unit src/i18n.test.ts` — **17/17 passing** (covers the new `resolveSupportedLocale` block and the updated unsupported-locale clamp behaviour)
- `eslint` on all changed files — clean
- **Manual verification via Playwright on the backport branch**, simulating a fresh install with `navigator.language='de-DE'`:
  - Sidebar `aria-label`s render real strings ("Assets (a)", "Node Library (n)", "Workflows (w)", "Settings", …) — **no** literal i18n keys like `sideToolbar.labels.assets`.
  - Confirmed `hasLiteralKeys: false` on the rendered DOM, matching the fixed behaviour from the original PR.
  - Screenshot attached.

## Files

```
 apps/desktop-ui/src/i18n.ts                     |   3 +-
 browser_tests/tests/i18nLocaleFallback.spec.ts  |  47 ++++++++
 browser_tests/tests/templates.spec.ts           |  59 +++++-----
 src/i18n.test.ts                                | 109 +++++++++++++++---
 src/i18n.ts                                     | 145 ++++++++----------------
 src/locales/CONTRIBUTING.md                     |  44 +------
 src/locales/localeConfig.ts                     |  82 ++++++++++++++
 src/platform/settings/constants/coreSettings.ts |  21 +---
 src/views/GraphView.vue                         |  20 ++--
```

Backport-of: #11712
Fixes #10563 on the 1.44 release line


## Screenshots

![Core 1.44 backport — sidebar with navigator.language=de-DE shows real labels (Assets, Node Library, Workflows...) instead of literal i18n keys](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/08da2130835cfe011512360b413c21eae085ac145ae94852e9dc841da09d0411/pr-images/1778566788268-adcce911-6973-40c7-8c29-7fb8941587f4.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12178-backport-core-1-44-fix-i18n-clamp-unsupported-browser-locales-to-a-shipped-tag-117-35e6d73d3650817dae90d9ae68c7f0c6) by [Unito](https://www.unito.io)
