### PR TITLE
perf: debounce template search input to keep typing responsive

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -14,10 +14,12 @@
     </template>
 
     <template #header>
-      <SearchInput
-        v-model="searchQuery"
-        size="lg"
-        class="max-w-96 flex-1"
+      <FormSearchInput
+        v-model="searchInput"
+        :searcher="applySearchQuery"
+        :debounce-ms="400"
+        :debounce-max-wait-ms="4000"
+        class="h-10 max-w-96 flex-1"
         autofocus
       />
     </template>
@@ -410,7 +412,7 @@ import CardBottom from '@/components/card/CardBottom.vue'
 import CardContainer from '@/components/card/CardContainer.vue'
 import CardTop from '@/components/card/CardTop.vue'
 import Tag from '@/components/chip/Tag.vue'
-import SearchInput from '@/components/ui/search-input/SearchInput.vue'
+import FormSearchInput from '@/renderer/extensions/vueNodes/widgets/components/form/FormSearchInput.vue'
 import MultiSelect from '@/components/ui/multi-select/MultiSelect.vue'
 import SingleSelect from '@/components/ui/single-select/SingleSelect.vue'
 import AudioThumbnail from '@/components/templates/thumbnails/AudioThumbnail.vue'
@@ -569,6 +571,25 @@ const {
   resetFilters,
   loadFuseOptions
 } = useTemplateFiltering(navigationFilteredTemplates)
+
+/**
+ * Raw search input bound to the search box. The actual `searchQuery` consumed
+ * by the filtering composable is only updated via `applySearchQuery` after the
+ * debounce settles, keeping Fuse/grid re-renders off the keystroke critical path.
+ */
+const searchInput = ref(searchQuery.value)
+
+const applySearchQuery = async (query: string) => {
+  searchQuery.value = query
+}
+
+/**
+ * Sync the visible search input when `searchQuery` is reset externally
+ * (e.g. via the "Clear Filters" button).
+ */
+watch(searchQuery, (value) => {
+  if (value !== searchInput.value) searchInput.value = value
+})
 
 /**
  * Coordinates state between the selected navigation item and the sort order to

--- a/src/renderer/extensions/vueNodes/widgets/components/form/FormSearchInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/FormSearchInput.vue
@@ -9,6 +9,8 @@ const {
   searcher = async () => {},
   updateKey,
   autofocus = false,
+  debounceMs = 250,
+  debounceMaxWaitMs = 1000,
   class: customClass
 } = defineProps<{
   searcher?: (
@@ -17,14 +19,16 @@ const {
   ) => Promise<void>
   updateKey?: MaybeRefOrGetter<unknown>
   autofocus?: boolean
+  debounceMs?: number
+  debounceMaxWaitMs?: number
   class?: HTMLAttributes['class']
 }>()
 
 const searchQuery = defineModel<string>({ default: '' })
 
 const isQuerying = ref(false)
-const debouncedSearchQuery = refDebounced(searchQuery, 250, {
-  maxWait: 1000
+const debouncedSearchQuery = refDebounced(searchQuery, debounceMs, {
+  maxWait: debounceMaxWaitMs
 })
 watch(searchQuery, (value) => {
   isQuerying.value = value !== debouncedSearchQuery.value


### PR DESCRIPTION
## Summary

Route the templates dialog search through `FormSearchInput`'s debounced searcher so per-keystroke work no longer trips the heavy filter/render path.

## Changes

- **What**: `WorkflowTemplateSelectorDialog` now uses `FormSearchInput` instead of `SearchInput`. The raw input is bound to a local ref; the actual `searchQuery` consumed by `useTemplateFiltering` is only written after the input debounce settles, so dependent computeds (notably `shouldUsePagination`, which used to flip on every keystroke and force a full grid rebuild) stay stable while typing.
- **What**: `FormSearchInput` gains optional `debounceMs` (default `250`) and `debounceMaxWaitMs` (default `1000`) props. Existing callers are unchanged; the templates dialog passes `400` / `4000` to match the feel tuned in this PR.

## Review Focus

- Reset path: `searchQuery` is still owned by `useTemplateFiltering` and cleared by `resetFilters`; a watch syncs the visible input back to empty when that happens.
- `FormSearchInput` is currently under `src/renderer/...` but already imported by workbench-level components (rightSidePanel tabs). This PR follows that existing precedent rather than relocating the component.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12183-perf-debounce-template-search-input-to-keep-typing-responsive-35e6d73d365081b7a11ec4a84323095f) by [Unito](https://www.unito.io)
