### PR TITLE
fix(litegraph): use renderingSize for collapsed nodes in arrange functions

### DIFF
--- a/src/lib/litegraph/src/utils/arrange.ts
+++ b/src/lib/litegraph/src/utils/arrange.ts
@@ -19,11 +19,13 @@ export function getBoundaryNodes(nodes: LGraphNode[]): IBoundaryNodes | null {
   for (const node of nodes) {
     if (!node) continue
     const [x, y] = node.pos
-    const [width, height] = node.size
+    const [width, height] = node.flags.collapsed ? node.renderingSize : node.size
+    const [rightWidth, rightHeight] = right.flags.collapsed ? right.renderingSize : right.size
+    const [bottomWidth, bottomHeight] = bottom.flags.collapsed ? bottom.renderingSize : bottom.size
 
     if (y < top.pos[1]) top = node
-    if (x + width > right.pos[0] + right.size[0]) right = node
-    if (y + height > bottom.pos[1] + bottom.size[1]) bottom = node
+    if (x + width > right.pos[0] + rightWidth) right = node
+    if (y + height > bottom.pos[1] + bottomHeight) bottom = node
     if (x < left.pos[0]) left = node
   }
 
@@ -53,9 +55,10 @@ export function distributeNodes(
   let highest = -Infinity
 
   for (const node of nodes) {
-    total += node.size[index]
+    const [width, height] = node.flags.collapsed ? node.renderingSize : node.size
+    total += width
 
-    const high = node.pos[index] + node.size[index]
+    const high = node.pos[index] + (index === 0 ? width : height)
     if (high > highest) highest = high
   }
   const sorted = [...nodes].sort((a, b) => a.pos[index] - b.pos[index])
@@ -65,8 +68,9 @@ export function distributeNodes(
   let startAt = lowest
   for (let i = 0; i < nodeCount; i++) {
     const node = sorted[i]
+    const [nodeWidth, nodeHeight] = node.flags.collapsed ? node.renderingSize : node.size
     node.pos[index] = startAt + gap * i
-    startAt += node.size[index]
+    startAt += index === 0 ? nodeWidth : nodeHeight
   }
   const newPositions = sorted.map(
     (node): NewNodePosition => ({
@@ -101,12 +105,14 @@ export function alignNodes(
   if (boundary === null) return []
 
   const nodePositions = nodes.map((node): NewNodePosition => {
+    const nodeWidth = node.flags.collapsed ? node.renderingSize[0] : node.size[0]
+    const nodeHeight = node.flags.collapsed ? node.renderingSize[1] : node.size[1]
     switch (direction) {
       case 'right':
         return {
           node,
           newPos: {
-            x: boundary.right.pos[0] + boundary.right.size[0] - node.size[0],
+            x: boundary.right.pos[0] + boundary.right.renderingSize[0] - nodeWidth,
             y: node.pos[1]
           }
         }
@@ -131,7 +137,7 @@ export function alignNodes(
           node,
           newPos: {
             x: node.pos[0],
-            y: boundary.bottom.pos[1] + boundary.bottom.size[1] - node.size[1]
+            y: boundary.bottom.pos[1] + boundary.bottom.renderingSize[1] - nodeHeight
           }
         }
     }


### PR DESCRIPTION
## Summary

When a node is collapsed, its full size is preserved in `node.size` for re-expansion but the actual visible area is much smaller. The arrange functions were reading `node.size` directly, causing collapsed nodes to use invisible edges during align/distribute operations.

## Changes

### src/lib/litegraph/src/utils/arrange.ts

- `getBoundaryNodes`: use `node.renderingSize` for current node dimensions, and for boundary node reference dimensions
- `distributeNodes`: use `node.renderingSize` for node width/height and for gap/highest calculations
- `alignNodes`: use `node.renderingSize[0]` and `node.renderingSize[1]` for node dimensions, and `boundary.*.renderingSize` for boundary node dimensions

Fixes #12022