### PR TITLE
fix: fix drop location and zindex of dragged in images

### DIFF
--- a/browser_tests/tests/loadWorkflowInMedia.spec.ts
+++ b/browser_tests/tests/loadWorkflowInMedia.spec.ts
@@ -74,6 +74,90 @@ test.describe(
       })
     })
 
+    test.describe('Image without workflow', () => {
+      test('places LoadImage at the drop cursor when graph_mouse is stale', async ({
+        comfyPage
+      }) => {
+        await comfyPage.nodeOps.clearGraph()
+        await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(0)
+
+        await comfyPage.page.evaluate(() => {
+          window.app!.canvas.graph_mouse[0] = -9999
+          window.app!.canvas.graph_mouse[1] = -9999
+        })
+
+        const dropPosition = { x: 480, y: 320 }
+        await comfyPage.dragDrop.dragAndDropFile('image32x32.webp', {
+          dropPosition,
+          waitForUpload: true
+        })
+
+        await expect.poll(() => comfyPage.nodeOps.getGraphNodesCount()).toBe(1)
+
+        const { nodePos, expectedPos } = await comfyPage.page.evaluate(
+          (drop) => {
+            const canvas = window.app!.canvas
+            const expected = canvas.convertEventToCanvasOffset(
+              new MouseEvent('drop', {
+                clientX: drop.x,
+                clientY: drop.y
+              })
+            ) as [number, number]
+            const node = window.app!.graph.nodes[0]
+            return {
+              nodePos: [node.pos[0], node.pos[1]] as [number, number],
+              expectedPos: expected
+            }
+          },
+          dropPosition
+        )
+
+        expect(nodePos[0]).toBeCloseTo(expectedPos[0], 0)
+        expect(nodePos[1]).toBeCloseTo(expectedPos[1], 0)
+        expect(nodePos[0]).not.toBe(-9999)
+        expect(nodePos[1]).not.toBe(-9999)
+      })
+
+      test('places LoadImage above existing nodes (zIndex)', async ({
+        comfyPage
+      }) => {
+        await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+        await comfyPage.vueNodes.waitForNodes()
+
+        const initialNodeIds = await comfyPage.vueNodes.getNodeIds()
+        expect(initialNodeIds.length).toBeGreaterThan(0)
+
+        await comfyPage.dragDrop.dragAndDropFile('image32x32.webp', {
+          dropPosition: { x: 540, y: 380 },
+          waitForUpload: true
+        })
+
+        await expect
+          .poll(() => comfyPage.vueNodes.getNodeCount())
+          .toBe(initialNodeIds.length + 1)
+
+        const newNodeIds = await comfyPage.vueNodes.getNodeIds()
+        const addedNodeId = newNodeIds.find(
+          (id) => !initialNodeIds.includes(id)
+        )
+        expect(addedNodeId).toBeDefined()
+
+        const newNodeZ = await comfyPage.vueNodes
+          .getNodeLocator(addedNodeId!)
+          .evaluate((el) => Number((el as HTMLElement).style.zIndex))
+
+        const existingZIndexes = await comfyPage.vueNodes.nodes.evaluateAll(
+          (els, id) =>
+            els
+              .filter((el) => el.getAttribute('data-node-id') !== id)
+              .map((el) => Number((el as HTMLElement).style.zIndex)),
+          addedNodeId!
+        )
+
+        expect(newNodeZ).toBeGreaterThan(Math.max(0, ...existingZIndexes))
+      })
+    })
+
     test('Load workflow from URL dropped onto Vue node', async ({
       comfyPage
     }) => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -436,4 +436,30 @@ describe('ComfyApp', () => {
       )
     })
   })
+
+  describe('drop handler', () => {
+    it('syncs graph_mouse from the drop event before downstream handlers run', async () => {
+      // graph_mouse is only updated on mousemove, so when files are dragged in
+      // from another window the canvas-space cursor is stale. The drop handler
+      // must derive the position from the drop event itself.
+      const graphMouse: [number, number] = [-999, -999]
+      const adjustMouseEvent = vi.fn((e: DragEvent) => {
+        ;(e as DragEvent & { canvasX: number; canvasY: number }).canvasX = 123
+        ;(e as DragEvent & { canvasX: number; canvasY: number }).canvasY = 456
+      })
+      app.canvas = {
+        ...mockCanvas,
+        graph_mouse: graphMouse,
+        adjustMouseEvent
+      } as unknown as LGraphCanvas
+
+      ;(app as unknown as { addDropHandler(): void }).addDropHandler()
+
+      document.dispatchEvent(new DragEvent('drop'))
+      await Promise.resolve()
+
+      expect(adjustMouseEvent).toHaveBeenCalledTimes(1)
+      expect(graphMouse).toEqual([123, 456])
+    })
+  })
 })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -591,6 +591,13 @@ export class ComfyApp {
         event.preventDefault()
         event.stopPropagation()
 
+        // graph_mouse is only updated on mousemove, so when files are dragged
+        // in from another window the canvas-space cursor is stale. Sync it
+        // from the drop event so nodes created below land at the cursor.
+        this.canvas.adjustMouseEvent(event)
+        this.canvas.graph_mouse[0] = event.canvasX
+        this.canvas.graph_mouse[1] = event.canvasY
+
         const n = this.dragOverNode
         this.dragOverNode = null
         // Node handles file drop, we dont use the built in onDropFile handler as its buggy

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { createTestSubgraph } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 
-import { resolveNode } from './litegraphUtil'
+import { createNode, resolveNode } from './litegraphUtil'
+
+const mockBringNodeToFront = vi.fn()
+
+vi.mock('@/renderer/extensions/vueNodes/composables/useNodeZIndex', () => ({
+  useNodeZIndex: () => ({ bringNodeToFront: mockBringNodeToFront })
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert: vi.fn() })
+}))
 
 describe('resolveNode', () => {
   it('returns undefined when graph is null', () => {
@@ -66,5 +77,68 @@ describe('resolveNode', () => {
 
     const targetNode = sg2._nodes[0]
     expect(resolveNode(targetNode.id, rootGraph)).toBe(targetNode)
+  })
+})
+
+describe('createNode', () => {
+  function makeCanvas(graph: LGraph): LGraphCanvas {
+    return {
+      graph,
+      graph_mouse: [100, 200] as [number, number]
+    } as Partial<LGraphCanvas> as LGraphCanvas
+  }
+
+  beforeEach(() => {
+    mockBringNodeToFront.mockClear()
+  })
+
+  it('returns null when name is empty', async () => {
+    const result = await createNode(makeCanvas(new LGraph()), '')
+    expect(result).toBeNull()
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+  })
+
+  it('places the new node at the canvas graph_mouse position', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const spy = vi.spyOn(LiteGraph, 'createNode').mockReturnValue(newNode)
+    const graph = new LGraph()
+
+    const result = await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(result).toBe(newNode)
+    expect(Array.from(newNode.pos)).toEqual([100, 200])
+    spy.mockRestore()
+  })
+
+  it('brings the new node to front so it renders above existing nodes', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const spy = vi.spyOn(LiteGraph, 'createNode').mockReturnValue(newNode)
+    const graph = new LGraph()
+
+    const result = await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(result).toBe(newNode)
+    expect(mockBringNodeToFront).toHaveBeenCalledTimes(1)
+    expect(mockBringNodeToFront).toHaveBeenCalledWith(newNode.id)
+    spy.mockRestore()
+  })
+
+  it('does not bring node to front when LiteGraph.createNode returns null', async () => {
+    const spy = vi.spyOn(LiteGraph, 'createNode').mockReturnValue(null)
+    await createNode(makeCanvas(new LGraph()), 'NonexistentNode')
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('does not bring node to front when graph.add returns null', async () => {
+    const newNode = new LGraphNode('LoadImage')
+    const spy = vi.spyOn(LiteGraph, 'createNode').mockReturnValue(newNode)
+    const graph = new LGraph()
+    vi.spyOn(graph, 'add').mockReturnValue(null as unknown as LGraphNode)
+
+    await createNode(makeCanvas(graph), 'LoadImage')
+
+    expect(mockBringNodeToFront).not.toHaveBeenCalled()
+    spy.mockRestore()
   })
 })

--- a/src/utils/litegraphUtil.ts
+++ b/src/utils/litegraphUtil.ts
@@ -24,6 +24,7 @@ import type {
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
 import { app } from '@/scripts/app'
 import { t } from '@/i18n'
 
@@ -57,7 +58,10 @@ export async function createNode(
     newNode.pos = [posX, posY]
     const addedNode = graph.add(newNode) ?? null
 
-    if (addedNode) graph.change()
+    if (addedNode) {
+      useNodeZIndex().bringNodeToFront(addedNode.id)
+      graph.change()
+    }
     return addedNode
   } else {
     useToastStore().addAlert(t('assetBrowser.failedToCreateNode'))


### PR DESCRIPTION
## Summary

Images dragged into the canvas were placed at the last graph mouse position, which is not updated during the drag event - meaning nodes were created in "random" locations. Additionally, the z-index was not set so newly created nodes can appear under other nodes.

## Changes

- **What**: 
- ensure added nodes are at top level
- update graph mouse pos with position from drop event
- tests

## Screenshots (if applicable)


Before / After
https://github.com/user-attachments/assets/34b4652e-a834-4c22-b191-2875a2404ac5

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12194-fix-fix-drop-location-and-zindex-of-dragged-in-images-35e6d73d3650814781edc9f4b4b5b223) by [Unito](https://www.unito.io)
