### PR TITLE
FE-566: fix Painter mask submission edge cases on cloud

### DIFF
--- a/browser_tests/tests/painter.spec.ts
+++ b/browser_tests/tests/painter.spec.ts
@@ -549,7 +549,7 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
       expect(uploadCount, 'should upload exactly once').toBe(1)
     })
 
-    test('Empty canvas does not upload on serialization', async ({
+    test('Empty canvas uploads a transparent placeholder on serialization', async ({
       comfyPage
     }) => {
       let uploadCount = 0
@@ -566,7 +566,10 @@ test.describe('Painter', { tag: ['@widget', '@vue-nodes'] }, () => {
 
       await triggerSerialization(comfyPage.page)
 
-      expect(uploadCount, 'empty canvas should not upload').toBe(0)
+      expect(
+        uploadCount,
+        'empty canvas should upload a transparent PNG so the backend receives a valid asset reference (Painter.execute treats painter_alpha=0 as no-mask)'
+      ).toBe(1)
     })
 
     test('Upload failure shows error toast', async ({ comfyPage }) => {

--- a/src/composables/painter/usePainter.test.ts
+++ b/src/composables/painter/usePainter.test.ts
@@ -349,25 +349,75 @@ describe('usePainter', () => {
   })
 
   describe('serializeValue', () => {
-    it('returns empty string when canvas has no strokes', async () => {
+    it('returns existing modelValue when not dirty (preserves workflow-restored mask reference across WidgetPainter remount)', async () => {
       const maskWidget = makeWidget('mask', '')
       mockWidgets.push(maskWidget)
 
-      mountPainter()
+      mountPainter('test-node', 'painter/existing.png [temp]')
 
       const result = await maskWidget.serializeValue!({} as LGraphNode, 0)
-      expect(result).toBe('')
+      expect(result).toBe('painter/existing.png [temp]')
     })
 
-    it('returns empty string when canvas has no strokes even if modelValue is set', async () => {
+    it('uploads the current canvas when no cached modelValue is present, even if nothing has been painted yet', async () => {
       const maskWidget = makeWidget('mask', '')
       mockWidgets.push(maskWidget)
 
-      const { modelValue } = mountPainter()
-      modelValue.value = 'painter/existing.png [temp]'
+      const fetchApiMock = vi.mocked(api.fetchApi)
+      fetchApiMock.mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({ name: 'uploaded.png' })
+      } as Response)
+
+      const fakeCanvas = {
+        width: 4,
+        height: 4,
+        toBlob: (cb: BlobCallback) => cb(new Blob(['x']))
+      } as unknown as HTMLCanvasElement
+
+      const { canvasEl } = mountPainter('test-node', '')
+      canvasEl.value = fakeCanvas
+      await nextTick()
 
       const result = await maskWidget.serializeValue!({} as LGraphNode, 0)
-      expect(result).toBe('')
+      expect(fetchApiMock).toHaveBeenCalledWith(
+        '/upload/image',
+        expect.objectContaining({ method: 'POST' })
+      )
+      expect(result).toBe('painter/uploaded.png [temp]')
+    })
+
+    it('returns existing modelValue when canvas element is unmounted at serialize time', async () => {
+      const maskWidget = makeWidget('mask', '')
+      mockWidgets.push(maskWidget)
+
+      mountPainter('test-node', 'painter/cached.png [temp]')
+
+      const result = await maskWidget.serializeValue!({} as LGraphNode, 0)
+      expect(result).toBe('painter/cached.png [temp]')
+    })
+
+    it('clears the cached upload reference when the user clears the canvas', () => {
+      const maskWidget = makeWidget('mask', '')
+      mockWidgets.push(maskWidget)
+
+      const fakeCanvas = {
+        width: 4,
+        height: 4,
+        getContext: vi.fn(() => ({
+          clearRect: vi.fn()
+        }))
+      } as unknown as HTMLCanvasElement
+
+      const { painter, canvasEl, modelValue } = mountPainter(
+        'test-node',
+        'painter/old-upload.png [temp]'
+      )
+      canvasEl.value = fakeCanvas
+
+      painter.handleClear()
+
+      expect(modelValue.value).toBe('')
     })
   })
 

--- a/src/composables/painter/usePainter.ts
+++ b/src/composables/painter/usePainter.ts
@@ -61,7 +61,6 @@ export function usePainter(nodeId: string, options: UsePainterOptions) {
   let baseCanvas: HTMLCanvasElement | null = null
   let baseCtx: CanvasRenderingContext2D | null = null
   let hasBaseSnapshot = false
-  let hasStrokes = false
 
   let dirtyX0 = 0
   let dirtyY0 = 0
@@ -413,7 +412,6 @@ export function usePainter(nodeId: string, options: UsePainterOptions) {
 
     isDrawing = true
     isDirty.value = true
-    hasStrokes = true
     snapshotBrush()
     strokeProcessor = new StrokeProcessor(Math.max(1, strokeBrush!.radius / 2))
     strokeProcessor.addPoint(point)
@@ -513,7 +511,7 @@ export function usePainter(nodeId: string, options: UsePainterOptions) {
     if (!el || !ctx) return
     ctx.clearRect(0, 0, el.width, el.height)
     isDirty.value = true
-    hasStrokes = false
+    modelValue.value = ''
   }
 
   function updateCursorPos(e: PointerEvent) {
@@ -619,17 +617,11 @@ export function usePainter(nodeId: string, options: UsePainterOptions) {
     return { filename, subfolder, type }
   }
 
-  function isCanvasEmpty(): boolean {
-    return !hasStrokes
-  }
-
   async function serializeValue(): Promise<string> {
     const el = canvasEl.value
-    if (!el) return ''
+    if (!el) return modelValue.value
 
-    if (isCanvasEmpty()) return ''
-
-    if (!isDirty.value) return modelValue.value
+    if (!isDirty.value && modelValue.value) return modelValue.value
 
     const blob = await new Promise<Blob | null>((resolve) =>
       el.toBlob(resolve, 'image/png')
@@ -717,7 +709,6 @@ export function usePainter(nodeId: string, options: UsePainterOptions) {
       mainCtx = null
       getCtx()?.drawImage(img, 0, 0)
       isDirty.value = false
-      hasStrokes = true
     }
     img.onerror = () => {
       modelValue.value = ''


### PR DESCRIPTION
## Summary
Rework the painter always hands the backend a valid asset reference:
- Drop the `hasStrokes` flag and the `isCanvasEmpty` check.
- `serializeValue` falls back to the existing `modelValue` when the canvas element is transiently unmounted, reuses the cached upload when not dirty and a value is present, and otherwise uploads the current canvas (a fully transparent PNG is a valid no-op mask, Painter's Python `execute()` treats painter_alpha=0 the same as "no mask painted").
- `handleClear` now also clears `modelValue` so a user-initiated clear doesn't resurrect a stale upload on the next serialize.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12196-FE-566-fix-Painter-mask-submission-edge-cases-on-cloud-35e6d73d365081dd8856ddb785952526) by [Unito](https://www.unito.io)
