### PR TITLE
fix(website): link careers page to Ashby job description, not application form

### DIFF
--- a/apps/website/e2e/careers.spec.ts
+++ b/apps/website/e2e/careers.spec.ts
@@ -23,18 +23,6 @@ test.describe('Careers page @smoke', () => {
     expect(await roles.count()).toBeGreaterThan(0)
   })
 
-  test('each role links to the Ashby job description page, not the application form', async ({
-    page
-  }) => {
-    const roles = page.getByTestId('careers-role-link')
-    const count = await roles.count()
-    for (let i = 0; i < count; i++) {
-      const href = await roles.nth(i).getAttribute('href')
-      expect(href).toMatch(/^https:\/\/jobs\.ashbyhq\.com\//)
-      expect(href).not.toMatch(/\/application\/?$/)
-    }
-  })
-
   test('clicking a department button scrolls to and activates that section', async ({
     page
   }) => {
@@ -63,6 +51,21 @@ test.describe('Careers page @smoke', () => {
     await expect(engineeringSection).toBeInViewport()
 
     expect(await page.getByTestId('careers-role-link').count()).toBe(allCount)
+  })
+})
+
+test.describe('Careers page role links', () => {
+  test('each role links to the Ashby job description page, not the application form', async ({
+    page
+  }) => {
+    await page.goto('/careers')
+    const roles = page.getByTestId('careers-role-link')
+    const count = await roles.count()
+    for (let i = 0; i < count; i++) {
+      const href = await roles.nth(i).getAttribute('href')
+      expect(href).toMatch(/^https:\/\/jobs\.ashbyhq\.com\//)
+      expect(href).not.toMatch(/\/application\/?$/)
+    }
   })
 })
 

--- a/apps/website/e2e/careers.spec.ts
+++ b/apps/website/e2e/careers.spec.ts
@@ -23,12 +23,15 @@ test.describe('Careers page @smoke', () => {
     expect(await roles.count()).toBeGreaterThan(0)
   })
 
-  test('each role links to jobs.ashbyhq.com', async ({ page }) => {
+  test('each role links to the Ashby job description page, not the application form', async ({
+    page
+  }) => {
     const roles = page.getByTestId('careers-role-link')
     const count = await roles.count()
     for (let i = 0; i < count; i++) {
       const href = await roles.nth(i).getAttribute('href')
       expect(href).toMatch(/^https:\/\/jobs\.ashbyhq\.com\//)
+      expect(href).not.toMatch(/\/application\/?$/)
     }
   })
 

--- a/apps/website/src/components/careers/RolesSection.vue
+++ b/apps/website/src/components/careers/RolesSection.vue
@@ -130,7 +130,7 @@ function scrollToDepartment(deptKey: string) {
             <a
               v-for="role in dept.roles"
               :key="role.id"
-              :href="role.applyUrl"
+              :href="role.jobUrl"
               target="_blank"
               rel="noopener noreferrer"
               class="border-primary-warm-gray/20 group flex items-center justify-between border-b py-5"

--- a/apps/website/src/data/ashby-roles.snapshot.json
+++ b/apps/website/src/data/ashby-roles.snapshot.json
@@ -6,25 +6,25 @@
       "key": "design",
       "roles": [
         {
-          "id": "e915f2c78b17f93b",
+          "id": "18743530eb448c99",
           "title": "Senior Product Designer",
           "department": "Design",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/b2e864c6-4754-4e04-8f46-1022baa103c3/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/b2e864c6-4754-4e04-8f46-1022baa103c3"
         },
         {
-          "id": "547b6ba622c800a5",
+          "id": "8718d17012f26fa2",
           "title": "Senior Product Designer - Craft",
           "department": "Design",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/a32c6769-b791-41f4-9225-50bbd8a1cf0f/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/a32c6769-b791-41f4-9225-50bbd8a1cf0f"
         },
         {
-          "id": "7bb02634a24763bc",
+          "id": "1e181b9ed8fb2e86",
           "title": "Staff Product Designer - Systems",
           "department": "Design",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/0bc8356b-615e-4f40-b632-fd3b2691be34/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/0bc8356b-615e-4f40-b632-fd3b2691be34"
         }
       ]
     },
@@ -33,67 +33,67 @@
       "key": "engineering",
       "roles": [
         {
-          "id": "102d58e35a8a9817",
+          "id": "6a6d865eeb3c10a8",
           "title": "Senior Software Engineer, Frontend",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/c3e0584d-5490-491f-aae4-b5922ef63fd2/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/c3e0584d-5490-491f-aae4-b5922ef63fd2"
         },
         {
-          "id": "d01d69fba7743905",
+          "id": "1b4f7f1da9616e14",
           "title": "Senior Software Engineer, Backend Generalist",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/732f8b39-076d-4847-afe3-f54d4451607e/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/732f8b39-076d-4847-afe3-f54d4451607e"
         },
         {
-          "id": "f36f60cfd5bb5910",
+          "id": "a6d8269c66e37c5c",
           "title": "Senior/Staff Applied Machine Learning Engineer",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/5cc4d0bc-97b0-463b-8466-3ec1d07f6ac0/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/5cc4d0bc-97b0-463b-8466-3ec1d07f6ac0"
         },
         {
-          "id": "9d8ec4c65e20b19e",
+          "id": "841da783e6e41928",
           "title": "Software Engineer, Frontend",
           "department": "Engineering",
           "location": "Remote",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/99dc26c7-51ca-43cd-a1ba-7d475a0f4a40/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/99dc26c7-51ca-43cd-a1ba-7d475a0f4a40"
         },
         {
-          "id": "be94b193d1f4d482",
+          "id": "5d01d58b03870d7a",
           "title": "Tech Lead Manager, Frontend",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/a0665088-3314-457a-aa7b-12ca5c3eb261/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/a0665088-3314-457a-aa7b-12ca5c3eb261"
         },
         {
-          "id": "ab48f5db6bd1783c",
+          "id": "91604c4182a1bc3c",
           "title": "Software Engineer, Core ComfyUI Contributor",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/7d4062d6-d500-445a-9a5f-014971af259f/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/7d4062d6-d500-445a-9a5f-014971af259f"
         },
         {
-          "id": "c5dff4ee628bdcd1",
+          "id": "a1dbc0576ab14034",
           "title": "Software Engineer, ComfyUI Desktop",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/ad2f76cb-a787-47d8-81c5-7e7f917747c0/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/ad2f76cb-a787-47d8-81c5-7e7f917747c0"
         },
         {
-          "id": "4302a7aaa87e16e3",
+          "id": "0b8f4fecd89c3b11",
           "title": "Product Manager, ComfyUI",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/9e4b9029-c3e9-436b-82c4-a1a9f1b8c16e/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/9e4b9029-c3e9-436b-82c4-a1a9f1b8c16e"
         },
         {
-          "id": "2eb53e8943cc9396",
+          "id": "2f6bac39d723dfef",
           "title": "Growth Engineer",
           "department": "Engineering",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/f1fdde76-84ae-48c1-b0f9-9654dd8e7de5/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/f1fdde76-84ae-48c1-b0f9-9654dd8e7de5"
         }
       ]
     },
@@ -102,39 +102,39 @@
       "key": "marketing",
       "roles": [
         {
-          "id": "4c5d6afb78652df7",
+          "id": "23dd98cab77ff459",
           "title": "Freelance Motion Designer",
           "department": "Marketing",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/a7ccc2b4-4d9d-4e04-b39c-28a711995b5b/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/a7ccc2b4-4d9d-4e04-b39c-28a711995b5b"
         },
         {
-          "id": "0f5256cf302e552b",
+          "id": "a998b9fc973ff3c0",
           "title": "Creative Artist",
           "department": "Marketing",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/19ba10aa-4961-45e8-8473-66a8a7a8079d/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/19ba10aa-4961-45e8-8473-66a8a7a8079d"
         },
         {
-          "id": "5746486d87874937",
+          "id": "3e730938026d6e70",
           "title": "Graphic Designer",
           "department": "Marketing",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/49fa0b07-3fa1-4a3a-b2c6-d2cc684ad63f/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/49fa0b07-3fa1-4a3a-b2c6-d2cc684ad63f"
         },
         {
-          "id": "b5803a0d4785d406",
+          "id": "6f771af6858283aa",
           "title": "Lifecycle Growth Marketer",
           "department": "Marketing",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/be74d210-3b50-408c-9f61-8fee8833ce64/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/be74d210-3b50-408c-9f61-8fee8833ce64"
         },
         {
-          "id": "130d7218d7895bdb",
+          "id": "527a47e82970afc1",
           "title": "Partnership & Events Marketing Manager",
           "department": "Marketing",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/89d3ff75-2055-4e92-9c69-81feff55627c/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/89d3ff75-2055-4e92-9c69-81feff55627c"
         }
       ]
     },
@@ -143,18 +143,18 @@
       "key": "operations",
       "roles": [
         {
-          "id": "ec68ae44dd5943c9",
+          "id": "0c6cc3685194ab7a",
           "title": "Head of Talent",
           "department": "Operations",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/d5008532-c45d-46e6-ba2c-20489d364362/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/d5008532-c45d-46e6-ba2c-20489d364362"
         },
         {
-          "id": "8e773a72c1b8e099",
+          "id": "82bd6ed26adab1c3",
           "title": "Founding Customer Success Manager",
           "department": "Operations",
           "location": "San Francisco",
-          "applyUrl": "https://jobs.ashbyhq.com/comfy-org/a1c5c5ed-62ac-4767-af57-a3ba4e0bf5e4/application"
+          "jobUrl": "https://jobs.ashbyhq.com/comfy-org/a1c5c5ed-62ac-4767-af57-a3ba4e0bf5e4"
         }
       ]
     }

--- a/apps/website/src/data/roles.ts
+++ b/apps/website/src/data/roles.ts
@@ -3,7 +3,7 @@ export interface Role {
   title: string
   department: string
   location: string
-  applyUrl: string
+  jobUrl: string
 }
 
 export interface Department {

--- a/apps/website/src/utils/ashby.ci.test.ts
+++ b/apps/website/src/utils/ashby.ci.test.ts
@@ -22,7 +22,7 @@ function baseSnapshot(): RolesSnapshot {
             title: 'Design Engineer',
             department: 'Engineering',
             location: 'San Francisco',
-            applyUrl: 'https://jobs.ashbyhq.com/comfy-org/x'
+            jobUrl: 'https://jobs.ashbyhq.com/comfy-org/x'
           }
         ]
       }
@@ -50,7 +50,7 @@ function freshOutcome(droppedCount = 0): FetchOutcome {
               title: 'Design Engineer',
               department: 'Engineering',
               location: 'San Francisco',
-              applyUrl: 'https://jobs.ashbyhq.com/comfy-org/x'
+              jobUrl: 'https://jobs.ashbyhq.com/comfy-org/x'
             }
           ]
         }

--- a/apps/website/src/utils/ashby.test.ts
+++ b/apps/website/src/utils/ashby.test.ts
@@ -40,7 +40,7 @@ function makeSnapshot(roleCount = 2): RolesSnapshot {
     title: `Snapshot Role ${i}`,
     department: 'Engineering',
     location: 'San Francisco',
-    applyUrl: `https://jobs.ashbyhq.com/comfy-org/snapshot-${i}`
+    jobUrl: `https://jobs.ashbyhq.com/comfy-org/snapshot-${i}`
   }))
   return {
     fetchedAt: '2026-04-01T00:00:00.000Z',
@@ -85,16 +85,14 @@ describe('fetchRolesForBuild', () => {
     if (outcome.status !== 'fresh') return
     expect(outcome.droppedCount).toBe(0)
     expect(outcome.snapshot.departments).toHaveLength(1)
-    expect(outcome.snapshot.departments[0]!.roles[0]!.applyUrl).toMatch(
-      /design-engineer\/apply$/
+    expect(outcome.snapshot.departments[0]!.roles[0]!.jobUrl).toBe(
+      'https://jobs.ashbyhq.com/comfy-org/design-engineer'
     )
   })
 
-  it('falls back to jobUrl when applyUrl is missing and keeps the role', async () => {
-    const job = validJob()
-    delete (job as Record<string, unknown>).applyUrl
+  it('uses jobUrl even when applyUrl is also present', async () => {
     const fetchImpl = vi.fn(async () =>
-      response({ apiVersion: '1', jobs: [job] })
+      response({ apiVersion: '1', jobs: [validJob()] })
     )
     const outcome = await fetchRolesForBuild({
       apiKey: KEY,
@@ -104,7 +102,7 @@ describe('fetchRolesForBuild', () => {
     })
     expect(outcome.status).toBe('fresh')
     if (outcome.status !== 'fresh') return
-    expect(outcome.snapshot.departments[0]!.roles[0]!.applyUrl).toBe(
+    expect(outcome.snapshot.departments[0]!.roles[0]!.jobUrl).toBe(
       'https://jobs.ashbyhq.com/comfy-org/design-engineer'
     )
   })

--- a/apps/website/src/utils/ashby.test.ts
+++ b/apps/website/src/utils/ashby.test.ts
@@ -90,23 +90,6 @@ describe('fetchRolesForBuild', () => {
     )
   })
 
-  it('uses jobUrl even when applyUrl is also present', async () => {
-    const fetchImpl = vi.fn(async () =>
-      response({ apiVersion: '1', jobs: [validJob()] })
-    )
-    const outcome = await fetchRolesForBuild({
-      apiKey: KEY,
-      boardName: BOARD,
-      baseUrl: BASE_URL,
-      fetchImpl: fetchImpl as unknown as typeof fetch
-    })
-    expect(outcome.status).toBe('fresh')
-    if (outcome.status !== 'fresh') return
-    expect(outcome.snapshot.departments[0]!.roles[0]!.jobUrl).toBe(
-      'https://jobs.ashbyhq.com/comfy-org/design-engineer'
-    )
-  })
-
   it('drops invalid roles individually and keeps the valid ones', async () => {
     const snapshotUrl = withSnapshotDir(makeSnapshot())
     const fetchImpl = vi.fn(async () =>

--- a/apps/website/src/utils/ashby.ts
+++ b/apps/website/src/utils/ashby.ts
@@ -243,13 +243,13 @@ function groupByDepartment(jobs: readonly AshbyJobPosting[]): Department[] {
 }
 
 function toDomainRole(job: AshbyJobPosting, department: string): Role {
-  const applyUrl = job.applyUrl ?? job.jobUrl
+  const jobUrl = job.jobUrl
   return {
-    id: createHash('sha1').update(applyUrl).digest('hex').slice(0, 16),
+    id: createHash('sha1').update(jobUrl).digest('hex').slice(0, 16),
     title: job.title,
     department: capitalize(department),
     location: (job.location ?? '').trim() || DEFAULT_LOCATION,
-    applyUrl
+    jobUrl
   }
 }
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The careers page at comfy.org/careers was linking every role to its Ashby application form (`.../{id}/application`) instead of the job description page (`.../{id}/`). Users expect to first read the role description, not land on the submit-resume page.

Ashby's job board API returns both `jobUrl` (description) and `applyUrl` (application form). `toDomainRole` was preferring `applyUrl`; this PR switches to `jobUrl` and renames the `Role` field accordingly so the field name matches its meaning.

## Changes

- `apps/website/src/utils/ashby.ts`: use `job.jobUrl` directly instead of `job.applyUrl ?? job.jobUrl`.
- `apps/website/src/data/roles.ts`: rename `Role.applyUrl` → `Role.jobUrl`.
- `apps/website/src/components/careers/RolesSection.vue`: update the `<a :href>` binding.
- `apps/website/src/data/ashby-roles.snapshot.json`: regenerated fallback snapshot — URLs stripped of `/application`, `id`s recomputed from the new URLs.
- Unit + E2E tests updated; new E2E assertion that links do not end in `/application` prevents regressions.

The Ashby schema (`ashby.schema.ts`) still accepts `applyUrl` since the API returns it — we just no longer consume it.

## Verification

- `pnpm test:unit` — 70/70 pass
- `pnpm typecheck` — 0 errors
- `pnpm build` — succeeds; inspected `dist/careers/index.html`, all 19 Ashby links now point to description URLs and zero contain `/application`
- Oracle code review — 0 issues

Fixes user report in #hiring-ideas (Slack).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12200-fix-website-link-careers-page-to-Ashby-job-description-not-application-form-35e6d73d3650815cbedadf974f7d3364) by [Unito](https://www.unito.io)
