### PR TITLE
fix: clear missing media errors on upload callbacks (Closed)

### DIFF
--- a/browser_tests/fixtures/helpers/ClipboardHelper.ts
+++ b/browser_tests/fixtures/helpers/ClipboardHelper.ts
@@ -6,6 +6,15 @@ import type { Locator, Page } from '@playwright/test'
 import type { KeyboardHelper } from '@e2e/fixtures/helpers/KeyboardHelper'
 import { getMimeType } from '@e2e/fixtures/utils/mimeTypeUtil'
 
+function readFilePayload(filePath: string) {
+  const buffer = readFileSync(filePath)
+  const bufferArray = [...new Uint8Array(buffer)]
+  const fileName = basename(filePath)
+  const fileType = getMimeType(fileName)
+
+  return { bufferArray, fileName, fileType }
+}
+
 export class ClipboardHelper {
   constructor(
     private readonly keyboard: KeyboardHelper,
@@ -21,42 +30,56 @@ export class ClipboardHelper {
   }
 
   async pasteFile(filePath: string): Promise<void> {
-    const buffer = readFileSync(filePath)
-    const bufferArray = [...new Uint8Array(buffer)]
-    const fileName = basename(filePath)
-    const fileType = getMimeType(fileName)
+    const payload = readFilePayload(filePath)
 
     // Register a one-time capturing-phase listener that intercepts the next
     // paste event and injects file data onto clipboardData.
-    await this.page.evaluate(
-      ({ bufferArray, fileName, fileType }) => {
-        document.addEventListener(
-          'paste',
-          (e: ClipboardEvent) => {
-            e.preventDefault()
-            e.stopImmediatePropagation()
+    await this.page.evaluate(({ bufferArray, fileName, fileType }) => {
+      document.addEventListener(
+        'paste',
+        (e: ClipboardEvent) => {
+          e.preventDefault()
+          e.stopImmediatePropagation()
 
-            const file = new File([new Uint8Array(bufferArray)], fileName, {
-              type: fileType
-            })
-            const dataTransfer = new DataTransfer()
-            dataTransfer.items.add(file)
+          const file = new File([new Uint8Array(bufferArray)], fileName, {
+            type: fileType
+          })
+          const dataTransfer = new DataTransfer()
+          dataTransfer.items.add(file)
 
-            const syntheticEvent = new ClipboardEvent('paste', {
-              clipboardData: dataTransfer,
-              bubbles: true,
-              cancelable: true
-            })
-            document.dispatchEvent(syntheticEvent)
-          },
-          { capture: true, once: true }
-        )
-      },
-      { bufferArray, fileName, fileType }
-    )
+          const syntheticEvent = new ClipboardEvent('paste', {
+            clipboardData: dataTransfer,
+            bubbles: true,
+            cancelable: true
+          })
+          document.dispatchEvent(syntheticEvent)
+        },
+        { capture: true, once: true }
+      )
+    }, payload)
 
     // Trigger a real Ctrl+V keystroke — the capturing listener above will
     // intercept it and re-dispatch with file data attached.
     await this.paste()
+  }
+
+  async dispatchPasteFile(filePath: string): Promise<void> {
+    const payload = readFilePayload(filePath)
+
+    await this.page.evaluate(({ bufferArray, fileName, fileType }) => {
+      const file = new File([new Uint8Array(bufferArray)], fileName, {
+        type: fileType
+      })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(file)
+
+      document.dispatchEvent(
+        new ClipboardEvent('paste', {
+          clipboardData: dataTransfer,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    }, payload)
   }
 }

--- a/browser_tests/fixtures/helpers/ClipboardHelper.ts
+++ b/browser_tests/fixtures/helpers/ClipboardHelper.ts
@@ -37,6 +37,40 @@ async function dispatchFilePaste(
   }, payload)
 }
 
+async function interceptNextFilePaste(
+  page: Page,
+  payload: ReturnType<typeof readFilePayload>
+): Promise<void> {
+  await page.evaluate(({ bufferArray, fileName, fileType }) => {
+    document.addEventListener(
+      'paste',
+      (e: ClipboardEvent) => {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+
+        const file = new File([new Uint8Array(bufferArray)], fileName, {
+          type: fileType
+        })
+        const dataTransfer = new DataTransfer()
+        dataTransfer.items.add(file)
+
+        document.dispatchEvent(
+          new ClipboardEvent('paste', {
+            clipboardData: dataTransfer,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      },
+      { capture: true, once: true }
+    )
+  }, payload)
+}
+
+type PasteFileOptions = {
+  mode?: 'keyboard' | 'direct'
+}
+
 export class ClipboardHelper {
   constructor(
     private readonly keyboard: KeyboardHelper,
@@ -51,8 +85,17 @@ export class ClipboardHelper {
     await this.keyboard.ctrlSend('KeyV', locator ?? null)
   }
 
-  async pasteFile(filePath: string): Promise<void> {
+  async pasteFile(
+    filePath: string,
+    { mode = 'keyboard' }: PasteFileOptions = {}
+  ): Promise<void> {
     const payload = readFilePayload(filePath)
+
+    if (mode === 'keyboard') {
+      await interceptNextFilePaste(this.page, payload)
+      await this.paste()
+      return
+    }
 
     // Browser clipboard APIs cannot reliably seed arbitrary files in tests.
     // Dispatch the app-level paste event with file clipboardData directly.

--- a/browser_tests/fixtures/helpers/ClipboardHelper.ts
+++ b/browser_tests/fixtures/helpers/ClipboardHelper.ts
@@ -15,6 +15,28 @@ function readFilePayload(filePath: string) {
   return { bufferArray, fileName, fileType }
 }
 
+async function dispatchFilePaste(
+  page: Page,
+  payload: ReturnType<typeof readFilePayload>
+): Promise<void> {
+  await page.evaluate(({ bufferArray, fileName, fileType }) => {
+    const file = new File([new Uint8Array(bufferArray)], fileName, {
+      type: fileType
+    })
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(file)
+
+    const target = document.activeElement ?? document
+    target.dispatchEvent(
+      new ClipboardEvent('paste', {
+        clipboardData: dataTransfer,
+        bubbles: true,
+        cancelable: true
+      })
+    )
+  }, payload)
+}
+
 export class ClipboardHelper {
   constructor(
     private readonly keyboard: KeyboardHelper,
@@ -32,54 +54,8 @@ export class ClipboardHelper {
   async pasteFile(filePath: string): Promise<void> {
     const payload = readFilePayload(filePath)
 
-    // Register a one-time capturing-phase listener that intercepts the next
-    // paste event and injects file data onto clipboardData.
-    await this.page.evaluate(({ bufferArray, fileName, fileType }) => {
-      document.addEventListener(
-        'paste',
-        (e: ClipboardEvent) => {
-          e.preventDefault()
-          e.stopImmediatePropagation()
-
-          const file = new File([new Uint8Array(bufferArray)], fileName, {
-            type: fileType
-          })
-          const dataTransfer = new DataTransfer()
-          dataTransfer.items.add(file)
-
-          const syntheticEvent = new ClipboardEvent('paste', {
-            clipboardData: dataTransfer,
-            bubbles: true,
-            cancelable: true
-          })
-          document.dispatchEvent(syntheticEvent)
-        },
-        { capture: true, once: true }
-      )
-    }, payload)
-
-    // Trigger a real Ctrl+V keystroke — the capturing listener above will
-    // intercept it and re-dispatch with file data attached.
-    await this.paste()
-  }
-
-  async dispatchPasteFile(filePath: string): Promise<void> {
-    const payload = readFilePayload(filePath)
-
-    await this.page.evaluate(({ bufferArray, fileName, fileType }) => {
-      const file = new File([new Uint8Array(bufferArray)], fileName, {
-        type: fileType
-      })
-      const dataTransfer = new DataTransfer()
-      dataTransfer.items.add(file)
-
-      document.dispatchEvent(
-        new ClipboardEvent('paste', {
-          clipboardData: dataTransfer,
-          bubbles: true,
-          cancelable: true
-        })
-      )
-    }, payload)
+    // Browser clipboard APIs cannot reliably seed arbitrary files in tests.
+    // Dispatch the app-level paste event with file clipboardData directly.
+    await dispatchFilePaste(this.page, payload)
   }
 }

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'fs'
-
 import { mergeTests } from '@playwright/test'
 
 import {
@@ -18,6 +16,7 @@ import {
 } from '@e2e/fixtures/helpers/ExecutionHelper'
 import type { NodeError } from '@/schemas/apiSchema'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
+import { assetPath } from '@e2e/fixtures/utils/paths'
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
 const test = mergeTests(comfyPageFixture, webSocketFixture)
@@ -66,34 +65,6 @@ async function selectLoadImageNodeForPaste(
     window.app!.canvas.selectNode(node)
     window.app!.canvas.current_node = node
   }, loadImageId)
-}
-
-async function dispatchImagePaste(
-  comfyPage: ComfyPage,
-  fileName: string
-): Promise<void> {
-  const bufferArray = [
-    ...new Uint8Array(readFileSync(comfyPage.assetPath(fileName)))
-  ]
-
-  await comfyPage.page.evaluate(
-    ({ bufferArray, fileName }) => {
-      const file = new File([new Uint8Array(bufferArray)], fileName, {
-        type: 'image/png'
-      })
-      const dataTransfer = new DataTransfer()
-      dataTransfer.items.add(file)
-
-      document.dispatchEvent(
-        new ClipboardEvent('paste', {
-          clipboardData: dataTransfer,
-          bubbles: true,
-          cancelable: true
-        })
-      )
-    },
-    { bufferArray, fileName }
-  )
 }
 
 test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
@@ -333,7 +304,9 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
           (resp) => resp.url().includes('/upload/') && resp.status() === 200,
           { timeout: 10_000 }
         )
-        await dispatchImagePaste(comfyPage, LOAD_IMAGE_UPLOAD_FILE)
+        await comfyPage.clipboard.dispatchPasteFile(
+          assetPath(LOAD_IMAGE_UPLOAD_FILE)
+        )
         await uploadResponse
         await expect
           .poll(() => imageWidget.getValue())

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -67,6 +67,20 @@ async function selectLoadImageNodeForPaste(
   }, loadImageId)
 }
 
+async function loadImageErrorTestRefs(comfyPage: ComfyPage) {
+  await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
+  const loadImageNode = (
+    await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+  )[0]
+  const loadImageId = String(loadImageNode.id)
+
+  return {
+    loadImageId,
+    innerWrapper: comfyPage.vueNodes.getNodeInnerWrapper(loadImageId),
+    imageWidget: await loadImageNode.getWidgetByName(LOAD_IMAGE_INPUT_NAME)
+  }
+}
+
 test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
   test('should display error state when node is missing (node from workflow is not installed)', async ({
     comfyPage
@@ -239,15 +253,8 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
     test('clears error ring when user drops an image file onto Load Image', async ({
       comfyPage
     }) => {
-      await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
-      const loadImageNode = (
-        await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
-      )[0]
-      const loadImageId = String(loadImageNode.id)
-      const innerWrapper = comfyPage.vueNodes.getNodeInnerWrapper(loadImageId)
-      const imageWidget = await loadImageNode.getWidgetByName(
-        LOAD_IMAGE_INPUT_NAME
-      )
+      const { loadImageId, innerWrapper, imageWidget } =
+        await loadImageErrorTestRefs(comfyPage)
 
       await test.step('queue with missing image input to surface the error', async () => {
         await surfaceLoadImageMissingInputError(comfyPage, loadImageId)
@@ -276,15 +283,8 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
     test('clears error ring when user pastes an image file onto Load Image', async ({
       comfyPage
     }) => {
-      await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
-      const loadImageNode = (
-        await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
-      )[0]
-      const loadImageId = String(loadImageNode.id)
-      const innerWrapper = comfyPage.vueNodes.getNodeInnerWrapper(loadImageId)
-      const imageWidget = await loadImageNode.getWidgetByName(
-        LOAD_IMAGE_INPUT_NAME
-      )
+      const { loadImageId, innerWrapper, imageWidget } =
+        await loadImageErrorTestRefs(comfyPage)
 
       await test.step('queue with missing image input to surface the error', async () => {
         await surfaceLoadImageMissingInputError(comfyPage, loadImageId)
@@ -304,9 +304,7 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
           (resp) => resp.url().includes('/upload/') && resp.status() === 200,
           { timeout: 10_000 }
         )
-        await comfyPage.clipboard.dispatchPasteFile(
-          assetPath(LOAD_IMAGE_UPLOAD_FILE)
-        )
+        await comfyPage.clipboard.pasteFile(assetPath(LOAD_IMAGE_UPLOAD_FILE))
         await uploadResponse
         await expect
           .poll(() => imageWidget.getValue())

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -67,7 +67,7 @@ async function selectLoadImageNodeForPaste(
   }, loadImageId)
 }
 
-async function loadImageErrorTestRefs(comfyPage: ComfyPage) {
+async function setupLoadImageErrorScenario(comfyPage: ComfyPage) {
   await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
   const loadImageNode = (
     await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
@@ -254,7 +254,7 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
       comfyPage
     }) => {
       const { loadImageId, innerWrapper, imageWidget } =
-        await loadImageErrorTestRefs(comfyPage)
+        await setupLoadImageErrorScenario(comfyPage)
 
       await test.step('queue with missing image input to surface the error', async () => {
         await surfaceLoadImageMissingInputError(comfyPage, loadImageId)
@@ -284,7 +284,7 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
       comfyPage
     }) => {
       const { loadImageId, innerWrapper, imageWidget } =
-        await loadImageErrorTestRefs(comfyPage)
+        await setupLoadImageErrorScenario(comfyPage)
 
       await test.step('queue with missing image input to surface the error', async () => {
         await surfaceLoadImageMissingInputError(comfyPage, loadImageId)
@@ -304,7 +304,11 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
           (resp) => resp.url().includes('/upload/') && resp.status() === 200,
           { timeout: 10_000 }
         )
-        await comfyPage.clipboard.pasteFile(assetPath(LOAD_IMAGE_UPLOAD_FILE))
+        // File clipboard contents cannot be seeded reliably in Playwright;
+        // use the direct document paste mode to exercise usePaste.
+        await comfyPage.clipboard.pasteFile(assetPath(LOAD_IMAGE_UPLOAD_FILE), {
+          mode: 'direct'
+        })
         await uploadResponse
         await expect
           .poll(() => imageWidget.getValue())

--- a/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
+++ b/browser_tests/tests/vueNodes/nodeStates/error.spec.ts
@@ -1,9 +1,12 @@
+import { readFileSync } from 'fs'
+
 import { mergeTests } from '@playwright/test'
 
 import {
   comfyExpect as expect,
   comfyPageFixture
 } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   cleanupFakeModel,
   dismissErrorOverlay,
@@ -13,6 +16,7 @@ import {
   ExecutionHelper,
   buildKSamplerError
 } from '@e2e/fixtures/helpers/ExecutionHelper'
+import type { NodeError } from '@/schemas/apiSchema'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
 import { webSocketFixture } from '@e2e/fixtures/ws'
 
@@ -22,6 +26,75 @@ const ERROR_CLASS = /ring-destructive-background/
 const UNKNOWN_NODE_ID = '1'
 const INNER_EXECUTION_ID = '2:1'
 const KSAMPLER_MODEL_INPUT_NAME = 'model'
+const LOAD_IMAGE_INPUT_NAME = 'image'
+const LOAD_IMAGE_UPLOAD_FILE = 'test_upload_image.png'
+
+function buildLoadImageRequiredInputError(): NodeError {
+  return {
+    class_type: 'LoadImage',
+    dependent_outputs: [],
+    errors: [
+      {
+        type: 'required_input_missing',
+        message: `Required input is missing: ${LOAD_IMAGE_INPUT_NAME}`,
+        details: '',
+        extra_info: { input_name: LOAD_IMAGE_INPUT_NAME }
+      }
+    ]
+  }
+}
+
+async function surfaceLoadImageMissingInputError(
+  comfyPage: ComfyPage,
+  loadImageId: string
+): Promise<void> {
+  const exec = new ExecutionHelper(comfyPage)
+  await exec.mockValidationFailure({
+    [loadImageId]: buildLoadImageRequiredInputError()
+  })
+  await comfyPage.runButton.click()
+  await dismissErrorOverlay(comfyPage)
+}
+
+async function selectLoadImageNodeForPaste(
+  comfyPage: ComfyPage,
+  loadImageId: string
+): Promise<void> {
+  await comfyPage.page.evaluate((nodeId) => {
+    const node = window.app!.graph.getNodeById(Number(nodeId))
+    if (!node) throw new Error(`Load Image node ${nodeId} not found`)
+    window.app!.canvas.selectNode(node)
+    window.app!.canvas.current_node = node
+  }, loadImageId)
+}
+
+async function dispatchImagePaste(
+  comfyPage: ComfyPage,
+  fileName: string
+): Promise<void> {
+  const bufferArray = [
+    ...new Uint8Array(readFileSync(comfyPage.assetPath(fileName)))
+  ]
+
+  await comfyPage.page.evaluate(
+    ({ bufferArray, fileName }) => {
+      const file = new File([new Uint8Array(bufferArray)], fileName, {
+        type: 'image/png'
+      })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(file)
+
+      document.dispatchEvent(
+        new ClipboardEvent('paste', {
+          clipboardData: dataTransfer,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    },
+    { bufferArray, fileName }
+  )
+}
 
 test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
   test('should display error state when node is missing (node from workflow is not installed)', async ({
@@ -187,6 +260,84 @@ test.describe('Vue Node Error', { tag: '@vue-nodes' }, () => {
           'sampler_name',
           'dpmpp_2m'
         )
+      })
+
+      await expect(innerWrapper).not.toHaveClass(ERROR_CLASS)
+    })
+
+    test('clears error ring when user drops an image file onto Load Image', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
+      const loadImageNode = (
+        await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+      )[0]
+      const loadImageId = String(loadImageNode.id)
+      const innerWrapper = comfyPage.vueNodes.getNodeInnerWrapper(loadImageId)
+      const imageWidget = await loadImageNode.getWidgetByName(
+        LOAD_IMAGE_INPUT_NAME
+      )
+
+      await test.step('queue with missing image input to surface the error', async () => {
+        await surfaceLoadImageMissingInputError(comfyPage, loadImageId)
+        await expect(innerWrapper).toHaveClass(ERROR_CLASS)
+      })
+
+      await test.step('drop an image onto the Load Image node', async () => {
+        const dropPosition =
+          await comfyPage.canvasOps.getNodeCenterByTitle('Load Image')
+        if (!dropPosition) {
+          throw new Error('Load Image node center must be available for drop')
+        }
+
+        await comfyPage.dragDrop.dragAndDropFile(LOAD_IMAGE_UPLOAD_FILE, {
+          dropPosition,
+          waitForUpload: true
+        })
+        await expect
+          .poll(() => imageWidget.getValue())
+          .toContain(LOAD_IMAGE_UPLOAD_FILE)
+      })
+
+      await expect(innerWrapper).not.toHaveClass(ERROR_CLASS)
+    })
+
+    test('clears error ring when user pastes an image file onto Load Image', async ({
+      comfyPage
+    }) => {
+      await comfyPage.workflow.loadWorkflow('widgets/load_image_widget')
+      const loadImageNode = (
+        await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+      )[0]
+      const loadImageId = String(loadImageNode.id)
+      const innerWrapper = comfyPage.vueNodes.getNodeInnerWrapper(loadImageId)
+      const imageWidget = await loadImageNode.getWidgetByName(
+        LOAD_IMAGE_INPUT_NAME
+      )
+
+      await test.step('queue with missing image input to surface the error', async () => {
+        await surfaceLoadImageMissingInputError(comfyPage, loadImageId)
+        await expect(innerWrapper).toHaveClass(ERROR_CLASS)
+      })
+
+      await test.step('paste an image while Load Image is selected', async () => {
+        await comfyPage.canvas.focus()
+        await selectLoadImageNodeForPaste(comfyPage, loadImageId)
+        await expect
+          .poll(() =>
+            comfyPage.page.evaluate(() => window.app!.canvas.current_node?.type)
+          )
+          .toBe('LoadImage')
+
+        const uploadResponse = comfyPage.page.waitForResponse(
+          (resp) => resp.url().includes('/upload/') && resp.status() === 200,
+          { timeout: 10_000 }
+        )
+        await dispatchImagePaste(comfyPage, LOAD_IMAGE_UPLOAD_FILE)
+        await uploadResponse
+        await expect
+          .poll(() => imageWidget.getValue())
+          .toContain(LOAD_IMAGE_UPLOAD_FILE)
       })
 
       await expect(innerWrapper).not.toHaveClass(ERROR_CLASS)

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -21,6 +21,7 @@ import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNod
 import { app } from '@/scripts/app'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { seedRequiredInputMissingNodeError } from '@/utils/__tests__/executionErrorTestUtils'
+import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 
 beforeEach(() => {
@@ -206,6 +207,65 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     }
 
     node.onWidgetChanged!.call(node, 'steps', 50, 20, node.widgets![0])
+
+    expect(store.lastNodeErrors).not.toBeNull()
+  })
+
+  it('clears missing media when media widget callback fires', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('LoadImage')
+    node.type = 'LoadImage'
+    const widget = node.addWidget(
+      'combo',
+      'image',
+      'missing.png',
+      function noopWidgetCallback() {},
+      { values: [] }
+    )
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const store = useExecutionErrorStore()
+    const mediaStore = useMissingMediaStore()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
+    mediaStore.setMissingMedia([
+      {
+        nodeId: String(node.id),
+        nodeType: 'LoadImage',
+        widgetName: 'image',
+        mediaType: 'image',
+        name: 'missing.png',
+        isMissing: true
+      } satisfies MissingMediaCandidate
+    ])
+
+    widget.value = 'uploaded.png'
+    widget.callback?.('uploaded.png')
+
+    expect(store.lastNodeErrors).toBeNull()
+    expect(mediaStore.missingMediaCandidates).toBeNull()
+  })
+
+  it('does not clear widget errors for valueless callbacks', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    const widget = node.addWidget(
+      'button',
+      'image',
+      '',
+      function noopWidgetCallback() {},
+      {}
+    )
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const store = useExecutionErrorStore()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
+
+    const callback = widget.callback as (() => void) | undefined
+    callback?.()
 
     expect(store.lastNodeErrors).not.toBeNull()
   })

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -13,6 +13,7 @@ import {
   LGraphEventMode,
   NodeSlotType
 } from '@/lib/litegraph/src/types/globalEnums'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import * as missingMediaScan from '@/platform/missingMedia/missingMediaScan'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import * as missingModelScan from '@/platform/missingModel/missingModelScan'
@@ -27,6 +28,43 @@ import type { MissingModelCandidate } from '@/platform/missingModel/types'
 beforeEach(() => {
   vi.restoreAllMocks()
 })
+
+function addLoadImageWidget(
+  node: LGraphNode,
+  callback: IBaseWidget['callback'] | null = function noopWidgetCallback() {}
+) {
+  return node.addWidget('combo', 'image', 'missing.png', callback, {
+    values: []
+  })
+}
+
+function createLoadImageGraph(callback?: IBaseWidget['callback'] | null) {
+  const graph = new LGraph()
+  const node = new LGraphNode('LoadImage')
+  node.type = 'LoadImage'
+  const widget = addLoadImageWidget(node, callback)
+
+  return { graph, node, widget }
+}
+
+function seedMissingImageError(graph: LGraph, nodeId: string) {
+  const store = useExecutionErrorStore()
+  const mediaStore = useMissingMediaStore()
+  vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+  seedRequiredInputMissingNodeError(store, nodeId, 'image')
+  mediaStore.setMissingMedia([
+    {
+      nodeId,
+      nodeType: 'LoadImage',
+      widgetName: 'image',
+      mediaType: 'image',
+      name: 'missing.png',
+      isMissing: true
+    } satisfies MissingMediaCandidate
+  ])
+
+  return { store, mediaStore }
+}
 
 describe('Connection error clearing via onConnectionsChange', () => {
   beforeEach(() => {
@@ -212,33 +250,11 @@ describe('Widget change error clearing via onWidgetChanged', () => {
   })
 
   it('clears missing media when media widget callback fires', () => {
-    const graph = new LGraph()
-    const node = new LGraphNode('LoadImage')
-    node.type = 'LoadImage'
-    const widget = node.addWidget(
-      'combo',
-      'image',
-      'missing.png',
-      function noopWidgetCallback() {},
-      { values: [] }
-    )
+    const { graph, node, widget } = createLoadImageGraph()
     graph.add(node)
     installErrorClearingHooks(graph)
 
-    const store = useExecutionErrorStore()
-    const mediaStore = useMissingMediaStore()
-    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
-    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
-    mediaStore.setMissingMedia([
-      {
-        nodeId: String(node.id),
-        nodeType: 'LoadImage',
-        widgetName: 'image',
-        mediaType: 'image',
-        name: 'missing.png',
-        isMissing: true
-      } satisfies MissingMediaCandidate
-    ])
+    const { store, mediaStore } = seedMissingImageError(graph, String(node.id))
 
     expect(store.lastNodeErrors).not.toBeNull()
     expect(mediaStore.missingMediaCandidates).toHaveLength(1)
@@ -315,32 +331,14 @@ describe('Widget change error clearing via onWidgetChanged', () => {
   })
 
   it('clears missing media when widget callback is assigned after hook installation', () => {
-    const graph = new LGraph()
-    const node = new LGraphNode('LoadImage')
-    node.type = 'LoadImage'
-    const widget = node.addWidget('combo', 'image', 'missing.png', null, {
-      values: []
-    })
+    const { graph, node, widget } = createLoadImageGraph(null)
     graph.add(node)
     installErrorClearingHooks(graph)
 
     const assignedCallback = vi.fn()
     widget.callback = assignedCallback
 
-    const store = useExecutionErrorStore()
-    const mediaStore = useMissingMediaStore()
-    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
-    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
-    mediaStore.setMissingMedia([
-      {
-        nodeId: String(node.id),
-        nodeType: 'LoadImage',
-        widgetName: 'image',
-        mediaType: 'image',
-        name: 'missing.png',
-        isMissing: true
-      } satisfies MissingMediaCandidate
-    ])
+    const { store, mediaStore } = seedMissingImageError(graph, String(node.id))
 
     widget.callback?.('uploaded.png')
 
@@ -360,28 +358,9 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     graph.add(node)
     installErrorClearingHooks(graph)
 
-    const widget = node.addWidget(
-      'combo',
-      'image',
-      'missing.png',
-      function noopWidgetCallback() {},
-      { values: [] }
-    )
+    const widget = addLoadImageWidget(node)
 
-    const store = useExecutionErrorStore()
-    const mediaStore = useMissingMediaStore()
-    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
-    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
-    mediaStore.setMissingMedia([
-      {
-        nodeId: String(node.id),
-        nodeType: 'LoadImage',
-        widgetName: 'image',
-        mediaType: 'image',
-        name: 'missing.png',
-        isMissing: true
-      } satisfies MissingMediaCandidate
-    ])
+    const { store, mediaStore } = seedMissingImageError(graph, String(node.id))
 
     widget.callback?.('uploaded.png')
 
@@ -469,13 +448,7 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     const subgraph = createTestSubgraph()
     const interiorNode = new LGraphNode('LoadImage')
     interiorNode.type = 'LoadImage'
-    const widget = interiorNode.addWidget(
-      'combo',
-      'image',
-      'missing.png',
-      function noopWidgetCallback() {},
-      { values: [] }
-    )
+    const widget = addLoadImageWidget(interiorNode)
     subgraph.add(interiorNode)
 
     const subgraphNode = createTestSubgraphNode(subgraph, { id: 65 })
@@ -485,20 +458,11 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
     installErrorClearingHooks(rootGraph)
 
-    const store = useExecutionErrorStore()
-    const mediaStore = useMissingMediaStore()
     const interiorExecId = `${subgraphNode.id}:${interiorNode.id}`
-    seedRequiredInputMissingNodeError(store, interiorExecId, 'image')
-    mediaStore.setMissingMedia([
-      {
-        nodeId: interiorExecId,
-        nodeType: 'LoadImage',
-        widgetName: 'image',
-        mediaType: 'image',
-        name: 'missing.png',
-        isMissing: true
-      } satisfies MissingMediaCandidate
-    ])
+    const { store, mediaStore } = seedMissingImageError(
+      rootGraph,
+      interiorExecId
+    )
 
     widget.callback?.('uploaded.png')
 

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -3,6 +3,7 @@ import { fromAny } from '@total-typescript/shoehorn'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import {
@@ -351,6 +352,56 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     expect(widget.callback).toBe(assignedCallback)
   })
 
+  it('deactivates stale widget callback wrappers after restore', () => {
+    const { graph, node, widget } = createLoadImageGraph()
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const staleCallback = widget.callback
+    graph.onNodeRemoved!(node)
+
+    const { store } = seedMissingImageError(graph, String(node.id))
+
+    staleCallback?.('uploaded.png')
+
+    expect(store.lastNodeErrors).not.toBeNull()
+  })
+
+  it('deactivates stale widget callback wrappers when node restore aborts', () => {
+    const { graph, node, widget } = createLoadImageGraph()
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const staleCallback = widget.callback
+    node.onWidgetChanged = vi.fn()
+    graph.onNodeRemoved!(node)
+
+    const { store } = seedMissingImageError(graph, String(node.id))
+
+    staleCallback?.('uploaded.png')
+
+    expect(store.lastNodeErrors).not.toBeNull()
+  })
+
+  it('does not recurse when another system chains the hooked widget callback', () => {
+    const originalCallback = vi.fn()
+    const { graph, node, widget } = createLoadImageGraph(originalCallback)
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const chainedCallback = vi.fn()
+    widget.callback = useChainCallback(widget.callback, chainedCallback)
+
+    const { store, mediaStore } = seedMissingImageError(graph, String(node.id))
+
+    expect(() => widget.callback?.('uploaded.png')).not.toThrow()
+
+    expect(originalCallback).toHaveBeenCalledOnce()
+    expect(chainedCallback).toHaveBeenCalledOnce()
+    expect(store.lastNodeErrors).toBeNull()
+    expect(mediaStore.missingMediaCandidates).toBeNull()
+  })
+
   it('clears missing media for widgets added after hook installation', () => {
     const graph = new LGraph()
     const node = new LGraphNode('LoadImage')
@@ -371,11 +422,12 @@ describe('Widget change error clearing via onWidgetChanged', () => {
   it('does not double-wrap widget callbacks when hooks are installed twice', () => {
     const graph = new LGraph()
     const node = new LGraphNode('test')
+    const originalCallback = vi.fn()
     const widget = node.addWidget(
       'combo',
       'image',
       'missing.png',
-      function noopWidgetCallback() {},
+      originalCallback,
       { values: [] }
     )
     graph.add(node)
@@ -389,6 +441,37 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     widget.callback?.('uploaded.png')
 
     expect(clearSpy).toHaveBeenCalledOnce()
+    expect(originalCallback).toHaveBeenCalledOnce()
+  })
+
+  it('uses the addCustomWidget call receiver for late widget hooks', () => {
+    const graph = new LGraph()
+    const sourceNode = new LGraphNode('LoadImage')
+    sourceNode.type = 'LoadImage'
+    const targetNode = new LGraphNode('LoadImage')
+    targetNode.type = 'LoadImage'
+    graph.add(sourceNode)
+    graph.add(targetNode)
+    installErrorClearingHooks(graph)
+
+    const widget = sourceNode.addCustomWidget.call(targetNode, {
+      type: 'combo',
+      name: 'image',
+      value: 'missing.png',
+      callback: function noopWidgetCallback() {},
+      options: { values: [] },
+      y: 0
+    })
+
+    const { store, mediaStore } = seedMissingImageError(
+      graph,
+      String(targetNode.id)
+    )
+
+    widget.callback?.('uploaded.png')
+
+    expect(store.lastNodeErrors).toBeNull()
+    expect(mediaStore.missingMediaCandidates).toBeNull()
   })
 
   it('uses interior node execution ID for promoted widget error clearing', () => {
@@ -550,7 +633,14 @@ describe('installErrorClearingHooks lifecycle', () => {
     const graph = new LGraph()
     const node = new LGraphNode('test')
     node.addInput('clip', 'CLIP')
-    node.addWidget('number', 'steps', 20, () => undefined, {})
+    const originalWidgetCallback = vi.fn()
+    const widget = node.addWidget(
+      'number',
+      'steps',
+      20,
+      originalWidgetCallback,
+      {}
+    )
     graph.add(node)
 
     installErrorClearingHooks(graph)
@@ -564,6 +654,26 @@ describe('installErrorClearingHooks lifecycle', () => {
 
     expect(node.onConnectionsChange).toBe(laterOnConnectionsChange)
     expect(node.onWidgetChanged).toBe(laterOnWidgetChanged)
+    expect(Object.getOwnPropertyDescriptor(widget, 'callback')?.get).toBe(
+      undefined
+    )
+    expect(widget.callback).toBe(originalWidgetCallback)
+  })
+
+  it('does not reinstall hooks over later node callback wrappers', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    node.addInput('clip', 'CLIP')
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const laterOnConnectionsChange = vi.fn()
+    node.onConnectionsChange = laterOnConnectionsChange
+
+    graph.onNodeRemoved!(node)
+    installErrorClearingHooks(graph)
+
+    expect(node.onConnectionsChange).toBe(laterOnConnectionsChange)
   })
 
   it('does not double-wrap callbacks when installErrorClearingHooks is called twice', () => {

--- a/src/composables/graph/useErrorClearingHooks.test.ts
+++ b/src/composables/graph/useErrorClearingHooks.test.ts
@@ -240,7 +240,9 @@ describe('Widget change error clearing via onWidgetChanged', () => {
       } satisfies MissingMediaCandidate
     ])
 
-    widget.value = 'uploaded.png'
+    expect(store.lastNodeErrors).not.toBeNull()
+    expect(mediaStore.missingMediaCandidates).toHaveLength(1)
+
     widget.callback?.('uploaded.png')
 
     expect(store.lastNodeErrors).toBeNull()
@@ -268,6 +270,146 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     callback?.()
 
     expect(store.lastNodeErrors).not.toBeNull()
+  })
+
+  it('does not clear widget errors when callback value is explicitly undefined', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    const widget = node.addWidget(
+      'button',
+      'image',
+      '',
+      function noopWidgetCallback() {},
+      {}
+    )
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const store = useExecutionErrorStore()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
+
+    widget.callback?.(undefined)
+
+    expect(store.lastNodeErrors).not.toBeNull()
+  })
+
+  it('preserves widget callback return values', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    const originalCallback = vi.fn(() => false)
+    const widget = node.addWidget(
+      'combo',
+      'image',
+      'missing.png',
+      originalCallback,
+      { values: [] }
+    )
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    expect(widget.callback?.('uploaded.png')).toBe(false)
+    expect(originalCallback).toHaveBeenCalledOnce()
+  })
+
+  it('clears missing media when widget callback is assigned after hook installation', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('LoadImage')
+    node.type = 'LoadImage'
+    const widget = node.addWidget('combo', 'image', 'missing.png', null, {
+      values: []
+    })
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const assignedCallback = vi.fn()
+    widget.callback = assignedCallback
+
+    const store = useExecutionErrorStore()
+    const mediaStore = useMissingMediaStore()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
+    mediaStore.setMissingMedia([
+      {
+        nodeId: String(node.id),
+        nodeType: 'LoadImage',
+        widgetName: 'image',
+        mediaType: 'image',
+        name: 'missing.png',
+        isMissing: true
+      } satisfies MissingMediaCandidate
+    ])
+
+    widget.callback?.('uploaded.png')
+
+    expect(assignedCallback).toHaveBeenCalledWith('uploaded.png')
+    expect(store.lastNodeErrors).toBeNull()
+    expect(mediaStore.missingMediaCandidates).toBeNull()
+
+    graph.onNodeRemoved!(node)
+
+    expect(widget.callback).toBe(assignedCallback)
+  })
+
+  it('clears missing media for widgets added after hook installation', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('LoadImage')
+    node.type = 'LoadImage'
+    graph.add(node)
+    installErrorClearingHooks(graph)
+
+    const widget = node.addWidget(
+      'combo',
+      'image',
+      'missing.png',
+      function noopWidgetCallback() {},
+      { values: [] }
+    )
+
+    const store = useExecutionErrorStore()
+    const mediaStore = useMissingMediaStore()
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+    seedRequiredInputMissingNodeError(store, String(node.id), 'image')
+    mediaStore.setMissingMedia([
+      {
+        nodeId: String(node.id),
+        nodeType: 'LoadImage',
+        widgetName: 'image',
+        mediaType: 'image',
+        name: 'missing.png',
+        isMissing: true
+      } satisfies MissingMediaCandidate
+    ])
+
+    widget.callback?.('uploaded.png')
+
+    expect(store.lastNodeErrors).toBeNull()
+    expect(mediaStore.missingMediaCandidates).toBeNull()
+  })
+
+  it('does not double-wrap widget callbacks when hooks are installed twice', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    const widget = node.addWidget(
+      'combo',
+      'image',
+      'missing.png',
+      function noopWidgetCallback() {},
+      { values: [] }
+    )
+    graph.add(node)
+    installErrorClearingHooks(graph)
+    installErrorClearingHooks(graph)
+
+    const store = useExecutionErrorStore()
+    const clearSpy = vi.spyOn(store, 'clearWidgetRelatedErrors')
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(graph)
+
+    widget.callback?.('uploaded.png')
+
+    expect(clearSpy).toHaveBeenCalledOnce()
   })
 
   it('uses interior node execution ID for promoted widget error clearing', () => {
@@ -321,6 +463,47 @@ describe('Widget change error clearing via onWidgetChanged', () => {
     )
 
     expect(store.lastNodeErrors).toBeNull()
+  })
+
+  it('clears missing media from a subgraph interior widget callback', () => {
+    const subgraph = createTestSubgraph()
+    const interiorNode = new LGraphNode('LoadImage')
+    interiorNode.type = 'LoadImage'
+    const widget = interiorNode.addWidget(
+      'combo',
+      'image',
+      'missing.png',
+      function noopWidgetCallback() {},
+      { values: [] }
+    )
+    subgraph.add(interiorNode)
+
+    const subgraphNode = createTestSubgraphNode(subgraph, { id: 65 })
+    const rootGraph = subgraphNode.graph as LGraph
+    rootGraph.add(subgraphNode)
+
+    vi.spyOn(app, 'rootGraph', 'get').mockReturnValue(rootGraph)
+    installErrorClearingHooks(rootGraph)
+
+    const store = useExecutionErrorStore()
+    const mediaStore = useMissingMediaStore()
+    const interiorExecId = `${subgraphNode.id}:${interiorNode.id}`
+    seedRequiredInputMissingNodeError(store, interiorExecId, 'image')
+    mediaStore.setMissingMedia([
+      {
+        nodeId: interiorExecId,
+        nodeType: 'LoadImage',
+        widgetName: 'image',
+        mediaType: 'image',
+        name: 'missing.png',
+        isMissing: true
+      } satisfies MissingMediaCandidate
+    ])
+
+    widget.callback?.('uploaded.png')
+
+    expect(store.lastNodeErrors).toBeNull()
+    expect(mediaStore.missingMediaCandidates).toBeNull()
   })
 })
 
@@ -397,6 +580,26 @@ describe('installErrorClearingHooks lifecycle', () => {
     // Original callbacks should be restored
     expect(node.onConnectionsChange).toBe(originalOnConnectionsChange)
     expect(node.onWidgetChanged).toBe(originalOnWidgetChanged)
+  })
+
+  it('keeps later node callback wrappers when a node is removed', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    node.addInput('clip', 'CLIP')
+    node.addWidget('number', 'steps', 20, () => undefined, {})
+    graph.add(node)
+
+    installErrorClearingHooks(graph)
+
+    const laterOnConnectionsChange = vi.fn()
+    const laterOnWidgetChanged = vi.fn()
+    node.onConnectionsChange = laterOnConnectionsChange
+    node.onWidgetChanged = laterOnWidgetChanged
+
+    graph.onNodeRemoved!(node)
+
+    expect(node.onConnectionsChange).toBe(laterOnConnectionsChange)
+    expect(node.onWidgetChanged).toBe(laterOnWidgetChanged)
   })
 
   it('does not double-wrap callbacks when installErrorClearingHooks is called twice', () => {

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -66,15 +66,26 @@ function resolvePromotedExecId(
 const hookedNodes = new WeakSet<LGraphNode>()
 
 type OriginalCallbacks = {
-  onConnectionsChange: LGraphNode['onConnectionsChange']
-  onWidgetChanged: LGraphNode['onWidgetChanged']
-  widgetCallbacks: Map<
-    IBaseWidget,
-    {
-      original: IBaseWidget['callback']
-      hooked: IBaseWidget['callback']
-    }
-  >
+  onConnectionsChange: {
+    original: LGraphNode['onConnectionsChange']
+    hooked: LGraphNode['onConnectionsChange']
+  }
+  onWidgetChanged: {
+    original: LGraphNode['onWidgetChanged']
+    hooked: LGraphNode['onWidgetChanged']
+  }
+  addCustomWidget: {
+    original: LGraphNode['addCustomWidget']
+    hooked: LGraphNode['addCustomWidget']
+  }
+  widgetCallbacks: Map<IBaseWidget, WidgetCallbackHook>
+}
+
+type WidgetCallbackHook = {
+  originalDescriptor: PropertyDescriptor | undefined
+  get: () => IBaseWidget['callback']
+  set: (callback: IBaseWidget['callback']) => void
+  getCurrentCallback: () => IBaseWidget['callback']
 }
 
 const originalCallbacks = new WeakMap<LGraphNode, OriginalCallbacks>()
@@ -102,27 +113,90 @@ function clearWidgetRelatedErrors(
   )
 }
 
+function installWidgetCallbackHook(
+  node: LGraphNode,
+  widget: IBaseWidget,
+  widgetCallbacks: OriginalCallbacks['widgetCallbacks']
+): void {
+  if (widgetCallbacks.has(widget)) return
+
+  const originalDescriptor = Object.getOwnPropertyDescriptor(widget, 'callback')
+  const originalCallback = widget.callback
+  let currentCallback = originalCallback
+
+  const hookedCallback: IBaseWidget['callback'] = function (
+    this: IBaseWidget,
+    newValue,
+    ...args
+  ) {
+    const result = currentCallback?.call(this, newValue, ...args)
+    if (newValue !== undefined) {
+      clearWidgetRelatedErrors(node, widget, newValue)
+    }
+    return result
+  }
+
+  const get = () => (currentCallback ? hookedCallback : undefined)
+  const set = (callback: IBaseWidget['callback']) => {
+    currentCallback = callback
+  }
+
+  Object.defineProperty(widget, 'callback', {
+    configurable: true,
+    enumerable: originalDescriptor?.enumerable ?? true,
+    get,
+    set
+  })
+
+  widgetCallbacks.set(widget, {
+    originalDescriptor,
+    get,
+    set,
+    getCurrentCallback: () => currentCallback
+  })
+}
+
 function installWidgetCallbackHooks(
   node: LGraphNode,
   widgetCallbacks: OriginalCallbacks['widgetCallbacks']
 ): void {
   for (const widget of node.widgets ?? []) {
-    const originalCallback = widget.callback
-    if (!originalCallback) continue
+    installWidgetCallbackHook(node, widget, widgetCallbacks)
+  }
+}
 
-    const hookedCallback = useChainCallback<
-      IBaseWidget,
-      IBaseWidget['callback']
-    >(originalCallback, function (newValue) {
-      if (arguments.length === 0) return
-      clearWidgetRelatedErrors(node, widget, newValue)
-    })
+function restoreWidgetCallbackHooks(
+  widgetCallbacks: OriginalCallbacks['widgetCallbacks']
+): void {
+  for (const [widget, callbackHook] of widgetCallbacks) {
+    const currentDescriptor = Object.getOwnPropertyDescriptor(
+      widget,
+      'callback'
+    )
+    if (
+      currentDescriptor?.get !== callbackHook.get ||
+      currentDescriptor?.set !== callbackHook.set
+    ) {
+      continue
+    }
 
-    widget.callback = hookedCallback
-    widgetCallbacks.set(widget, {
-      original: originalCallback,
-      hooked: hookedCallback
-    })
+    const currentCallback = callbackHook.getCurrentCallback()
+    if (
+      callbackHook.originalDescriptor &&
+      'value' in callbackHook.originalDescriptor
+    ) {
+      Object.defineProperty(widget, 'callback', {
+        ...callbackHook.originalDescriptor,
+        value: currentCallback
+      })
+    } else {
+      Object.defineProperty(widget, 'callback', {
+        configurable: callbackHook.originalDescriptor?.configurable ?? true,
+        enumerable: callbackHook.originalDescriptor?.enumerable ?? true,
+        writable: true,
+        value: currentCallback
+      })
+    }
   }
 }
 
@@ -131,27 +205,31 @@ function installNodeHooks(node: LGraphNode): void {
   hookedNodes.add(node)
 
   const widgetCallbacks: OriginalCallbacks['widgetCallbacks'] = new Map()
-  originalCallbacks.set(node, {
-    onConnectionsChange: node.onConnectionsChange,
-    onWidgetChanged: node.onWidgetChanged,
-    widgetCallbacks
+  const originalAddCustomWidget = node.addCustomWidget
+  const hookedAddCustomWidget: LGraphNode['addCustomWidget'] = function (
+    this: LGraphNode,
+    customWidget
+  ) {
+    const widget = originalAddCustomWidget.call(this, customWidget)
+    installWidgetCallbackHook(node, widget, widgetCallbacks)
+    return widget
+  } as LGraphNode['addCustomWidget']
+  const hookedOnConnectionsChange = useChainCallback<
+    LGraphNode,
+    LGraphNode['onConnectionsChange']
+  >(node.onConnectionsChange, function (type, slotIndex, isConnected) {
+    if (type !== NodeSlotType.INPUT || !isConnected) return
+    if (!app.rootGraph) return
+    const slotName = node.inputs?.[slotIndex]?.name
+    if (!slotName) return
+    const execId = getExecutionIdByNode(app.rootGraph, node)
+    if (!execId) return
+    useExecutionErrorStore().clearSimpleNodeErrors(execId, slotName)
   })
-  installWidgetCallbackHooks(node, widgetCallbacks)
-
-  node.onConnectionsChange = useChainCallback(
-    node.onConnectionsChange,
-    function (type, slotIndex, isConnected) {
-      if (type !== NodeSlotType.INPUT || !isConnected) return
-      if (!app.rootGraph) return
-      const slotName = node.inputs?.[slotIndex]?.name
-      if (!slotName) return
-      const execId = getExecutionIdByNode(app.rootGraph, node)
-      if (!execId) return
-      useExecutionErrorStore().clearSimpleNodeErrors(execId, slotName)
-    }
-  )
-
-  node.onWidgetChanged = useChainCallback(
+  const hookedOnWidgetChanged = useChainCallback<
+    LGraphNode,
+    LGraphNode['onWidgetChanged']
+  >(
     node.onWidgetChanged,
     // _name is the LiteGraph callback arg; re-derive from the widget
     // object to handle promoted widgets where sourceWidgetName differs.
@@ -159,18 +237,42 @@ function installNodeHooks(node: LGraphNode): void {
       clearWidgetRelatedErrors(node, widget, newValue)
     }
   )
+
+  originalCallbacks.set(node, {
+    onConnectionsChange: {
+      original: node.onConnectionsChange,
+      hooked: hookedOnConnectionsChange
+    },
+    onWidgetChanged: {
+      original: node.onWidgetChanged,
+      hooked: hookedOnWidgetChanged
+    },
+    addCustomWidget: {
+      original: originalAddCustomWidget,
+      hooked: hookedAddCustomWidget
+    },
+    widgetCallbacks
+  })
+  installWidgetCallbackHooks(node, widgetCallbacks)
+
+  node.addCustomWidget = hookedAddCustomWidget
+  node.onConnectionsChange = hookedOnConnectionsChange
+  node.onWidgetChanged = hookedOnWidgetChanged
 }
 
 function restoreNodeHooks(node: LGraphNode): void {
   const originals = originalCallbacks.get(node)
   if (!originals) return
-  for (const [widget, callbacks] of originals.widgetCallbacks) {
-    if (widget.callback === callbacks.hooked) {
-      widget.callback = callbacks.original
-    }
+  restoreWidgetCallbackHooks(originals.widgetCallbacks)
+  if (node.addCustomWidget === originals.addCustomWidget.hooked) {
+    node.addCustomWidget = originals.addCustomWidget.original
   }
-  node.onConnectionsChange = originals.onConnectionsChange
-  node.onWidgetChanged = originals.onWidgetChanged
+  if (node.onConnectionsChange === originals.onConnectionsChange.hooked) {
+    node.onConnectionsChange = originals.onConnectionsChange.original
+  }
+  if (node.onWidgetChanged === originals.onWidgetChanged.hooked) {
+    node.onWidgetChanged = originals.onWidgetChanged.original
+  }
   originalCallbacks.delete(node)
   hookedNodes.delete(node)
 }

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -86,6 +86,13 @@ type WidgetCallbackHook = {
   get: () => IBaseWidget['callback']
   set: (callback: IBaseWidget['callback']) => void
   getCurrentCallback: () => IBaseWidget['callback']
+  deactivate: () => void
+}
+
+type WidgetHookState = {
+  active: boolean
+  node: LGraphNode | undefined
+  widget: IBaseWidget | undefined
 }
 
 const originalCallbacks = new WeakMap<LGraphNode, OriginalCallbacks>()
@@ -121,24 +128,51 @@ function installWidgetCallbackHook(
   if (widgetCallbacks.has(widget)) return
 
   const originalDescriptor = Object.getOwnPropertyDescriptor(widget, 'callback')
-  const originalCallback = widget.callback
-  let currentCallback = originalCallback
+  let currentCallback = widget.callback
+  let currentHookedCallback: IBaseWidget['callback']
+  let currentHookState: WidgetHookState | undefined
 
-  const hookedCallback: IBaseWidget['callback'] = function (
-    this: IBaseWidget,
-    newValue,
-    ...args
-  ) {
-    const result = currentCallback?.call(this, newValue, ...args)
-    if (newValue !== undefined) {
-      clearWidgetRelatedErrors(node, widget, newValue)
-    }
-    return result
+  function deactivateCurrentHook(): void {
+    if (!currentHookState) return
+    currentHookState.active = false
+    currentHookState.node = undefined
+    currentHookState.widget = undefined
+    currentHookState = undefined
   }
 
-  const get = () => (currentCallback ? hookedCallback : undefined)
+  const createHookedCallback = (
+    callback: IBaseWidget['callback']
+  ): IBaseWidget['callback'] => {
+    deactivateCurrentHook()
+    if (!callback) {
+      currentHookState = undefined
+      return undefined
+    }
+
+    const hookState: WidgetHookState = { active: true, node, widget }
+    currentHookState = hookState
+
+    return function (this: IBaseWidget, newValue, ...args) {
+      const result = callback.call(this, newValue, ...args)
+      // Read node/widget from hookState so deactivation can release them from
+      // externally-held stale wrappers.
+      if (
+        hookState.active &&
+        hookState.node &&
+        hookState.widget &&
+        newValue !== undefined
+      ) {
+        clearWidgetRelatedErrors(hookState.node, hookState.widget, newValue)
+      }
+      return result
+    }
+  }
+
+  currentHookedCallback = createHookedCallback(currentCallback)
+  const get = () => currentHookedCallback
   const set = (callback: IBaseWidget['callback']) => {
     currentCallback = callback
+    currentHookedCallback = createHookedCallback(callback)
   }
 
   Object.defineProperty(widget, 'callback', {
@@ -152,7 +186,8 @@ function installWidgetCallbackHook(
     originalDescriptor,
     get,
     set,
-    getCurrentCallback: () => currentCallback
+    getCurrentCallback: () => currentCallback,
+    deactivate: deactivateCurrentHook
   })
 }
 
@@ -165,10 +200,12 @@ function installWidgetCallbackHooks(
   }
 }
 
-function restoreWidgetCallbackHooks(
+function deactivateAndRestoreWidgetCallbackHooks(
   widgetCallbacks: OriginalCallbacks['widgetCallbacks']
-): void {
+): boolean {
+  let restoredAll = true
   for (const [widget, callbackHook] of widgetCallbacks) {
+    callbackHook.deactivate()
     const currentDescriptor = Object.getOwnPropertyDescriptor(
       widget,
       'callback'
@@ -177,6 +214,7 @@ function restoreWidgetCallbackHooks(
       currentDescriptor?.get !== callbackHook.get ||
       currentDescriptor?.set !== callbackHook.set
     ) {
+      restoredAll = false
       continue
     }
 
@@ -198,6 +236,15 @@ function restoreWidgetCallbackHooks(
       })
     }
   }
+  return restoredAll
+}
+
+function canRestoreNodeCallback<T>(
+  current: T,
+  original: T,
+  hooked: T
+): boolean {
+  return current === hooked || current === original
 }
 
 function installNodeHooks(node: LGraphNode): void {
@@ -211,7 +258,10 @@ function installNodeHooks(node: LGraphNode): void {
     customWidget
   ) {
     const widget = originalAddCustomWidget.call(this, customWidget)
-    installWidgetCallbackHook(node, widget, widgetCallbacks)
+    const ownerWidgetCallbacks = originalCallbacks.get(this)?.widgetCallbacks
+    if (ownerWidgetCallbacks) {
+      installWidgetCallbackHook(this, widget, ownerWidgetCallbacks)
+    }
     return widget
   } as LGraphNode['addCustomWidget']
   const hookedOnConnectionsChange = useChainCallback<
@@ -263,7 +313,32 @@ function installNodeHooks(node: LGraphNode): void {
 function restoreNodeHooks(node: LGraphNode): void {
   const originals = originalCallbacks.get(node)
   if (!originals) return
-  restoreWidgetCallbackHooks(originals.widgetCallbacks)
+
+  // Deactivate widget wrappers before node-level identity checks. Stale
+  // externally-captured wrappers must be neutered even when restore aborts.
+  const allWidgetCallbacksRestored = deactivateAndRestoreWidgetCallbackHooks(
+    originals.widgetCallbacks
+  )
+  const canRestore =
+    allWidgetCallbacksRestored &&
+    canRestoreNodeCallback(
+      node.addCustomWidget,
+      originals.addCustomWidget.original,
+      originals.addCustomWidget.hooked
+    ) &&
+    canRestoreNodeCallback(
+      node.onConnectionsChange,
+      originals.onConnectionsChange.original,
+      originals.onConnectionsChange.hooked
+    ) &&
+    canRestoreNodeCallback(
+      node.onWidgetChanged,
+      originals.onWidgetChanged.original,
+      originals.onWidgetChanged.hooked
+    )
+
+  if (!canRestore) return
+
   if (node.addCustomWidget === originals.addCustomWidget.hooked) {
     node.addCustomWidget = originals.addCustomWidget.original
   }

--- a/src/composables/graph/useErrorClearingHooks.ts
+++ b/src/composables/graph/useErrorClearingHooks.ts
@@ -68,18 +68,75 @@ const hookedNodes = new WeakSet<LGraphNode>()
 type OriginalCallbacks = {
   onConnectionsChange: LGraphNode['onConnectionsChange']
   onWidgetChanged: LGraphNode['onWidgetChanged']
+  widgetCallbacks: Map<
+    IBaseWidget,
+    {
+      original: IBaseWidget['callback']
+      hooked: IBaseWidget['callback']
+    }
+  >
 }
 
 const originalCallbacks = new WeakMap<LGraphNode, OriginalCallbacks>()
+
+function clearWidgetRelatedErrors(
+  node: LGraphNode,
+  widget: IBaseWidget,
+  newValue: unknown
+): void {
+  if (!app.rootGraph) return
+  const hostExecId = getExecutionIdByNode(app.rootGraph, node)
+  if (!hostExecId) return
+
+  const execId = resolvePromotedExecId(app.rootGraph, node, widget, hostExecId)
+  const widgetName = isPromotedWidgetView(widget)
+    ? widget.sourceWidgetName
+    : widget.name
+
+  useExecutionErrorStore().clearWidgetRelatedErrors(
+    execId,
+    widget.name,
+    widgetName,
+    newValue,
+    { min: widget.options?.min, max: widget.options?.max }
+  )
+}
+
+function installWidgetCallbackHooks(
+  node: LGraphNode,
+  widgetCallbacks: OriginalCallbacks['widgetCallbacks']
+): void {
+  for (const widget of node.widgets ?? []) {
+    const originalCallback = widget.callback
+    if (!originalCallback) continue
+
+    const hookedCallback = useChainCallback<
+      IBaseWidget,
+      IBaseWidget['callback']
+    >(originalCallback, function (newValue) {
+      if (arguments.length === 0) return
+      clearWidgetRelatedErrors(node, widget, newValue)
+    })
+
+    widget.callback = hookedCallback
+    widgetCallbacks.set(widget, {
+      original: originalCallback,
+      hooked: hookedCallback
+    })
+  }
+}
 
 function installNodeHooks(node: LGraphNode): void {
   if (hookedNodes.has(node)) return
   hookedNodes.add(node)
 
+  const widgetCallbacks: OriginalCallbacks['widgetCallbacks'] = new Map()
   originalCallbacks.set(node, {
     onConnectionsChange: node.onConnectionsChange,
-    onWidgetChanged: node.onWidgetChanged
+    onWidgetChanged: node.onWidgetChanged,
+    widgetCallbacks
   })
+  installWidgetCallbackHooks(node, widgetCallbacks)
 
   node.onConnectionsChange = useChainCallback(
     node.onConnectionsChange,
@@ -99,27 +156,7 @@ function installNodeHooks(node: LGraphNode): void {
     // _name is the LiteGraph callback arg; re-derive from the widget
     // object to handle promoted widgets where sourceWidgetName differs.
     function (_name, newValue, _oldValue, widget) {
-      if (!app.rootGraph) return
-      const hostExecId = getExecutionIdByNode(app.rootGraph, node)
-      if (!hostExecId) return
-
-      const execId = resolvePromotedExecId(
-        app.rootGraph,
-        node,
-        widget,
-        hostExecId
-      )
-      const widgetName = isPromotedWidgetView(widget)
-        ? widget.sourceWidgetName
-        : widget.name
-
-      useExecutionErrorStore().clearWidgetRelatedErrors(
-        execId,
-        widget.name,
-        widgetName,
-        newValue,
-        { min: widget.options?.min, max: widget.options?.max }
-      )
+      clearWidgetRelatedErrors(node, widget, newValue)
     }
   )
 }
@@ -127,6 +164,11 @@ function installNodeHooks(node: LGraphNode): void {
 function restoreNodeHooks(node: LGraphNode): void {
   const originals = originalCallbacks.get(node)
   if (!originals) return
+  for (const [widget, callbacks] of originals.widgetCallbacks) {
+    if (widget.callback === callbacks.hooked) {
+      widget.callback = callbacks.original
+    }
+  }
   node.onConnectionsChange = originals.onConnectionsChange
   node.onWidgetChanged = originals.onWidgetChanged
   originalCallbacks.delete(node)


### PR DESCRIPTION
## Summary

Clear missing input and missing media errors when media loader widgets are updated through drag/drop or paste uploads.

## Changes

- **What**: Emit the existing `node.onWidgetChanged` path after image/video upload completion changes the file combo widget value.
- **What**: Apply the same widget-change emit to Load Audio upload completion.
- **What**: Add unit coverage for upload completion emitting `onWidgetChanged` and for missing media clearing through that existing hook path.
- **What**: Add E2E coverage for Load Image drag/drop and paste clearing validation rings, with red/green verified from a fresh `main` base.
- **Dependencies**: None.

## Review Focus

Please check that paste/drop upload paths now reuse the existing widget-change error-clearing path instead of expanding `widget.callback` patching.

Also check the Load Image E2E helper path for synthetic paste/drop behavior.

Ref: FE-687

## Screenshots (if applicable)

N/A

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12207-fix-clear-missing-media-errors-on-upload-callbacks-35f6d73d365081a69a1ae88e6c3d9897) by [Unito](https://www.unito.io)
