### PR TITLE
Fix restoring values to dynamic combos

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
@@ -57,37 +57,19 @@ test.describe('Vue Widget Reactivity', { tag: '@vue-nodes' }, () => {
   })
 
   test('Can load dynamic combos', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting(
-      'Comfy.NodeSearchBoxImpl',
-      'v1 (legacy)'
-    )
-    await comfyPage.menu.topbar.newWorkflowButton.click()
-    await comfyPage.nextFrame()
-
-    await test.step('Add node with dynamic combo', async () => {
-      await comfyPage.page.mouse.dblclick(500, 500, { delay: 5 })
-      await comfyPage.searchBox.fillAndSelectFirstNode('Resize Image/Mask')
-      await expect(comfyPage.searchBox.input).toBeHidden()
-    })
-
-    const widget = comfyPage.vueNodes.getWidgetByName(
-      'Resize Image/Mask',
-      'resize_type'
-    )
+    await comfyPage.searchBoxV2.addNode('Resize Image/Mask')
+    const widgetTuple = ['Resize Image/Mask', 'resize_type'] as const
+    const widget = comfyPage.vueNodes.getWidgetByName(...widgetTuple)
 
     await test.step('Update value of the dynamic combo widget', async () => {
-      await widget.click()
-      await comfyPage.page.getByRole('searchbox').fill('scale width')
-      await comfyPage.page.keyboard.press('ArrowDown')
-      await comfyPage.page.keyboard.press('Enter')
-      await expect(widget.locator('input')).toBeHidden()
+      await comfyPage.vueNodes.selectComboOption(...widgetTuple, 'scale width')
       await expect(widget).toHaveText('scale width')
     })
 
     await test.step('Swap to a different workflow and back', async () => {
-      await comfyPage.menu.topbar.getTab(0).click()
+      await comfyPage.menu.topbar.newWorkflowButton.click()
       await expect(widget).toBeHidden()
-      await comfyPage.menu.topbar.getTab(1).click()
+      await comfyPage.menu.topbar.getTab(0).click()
       await expect(widget).toBeVisible()
     })
 

--- a/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/widgetReactivity.spec.ts
@@ -55,4 +55,42 @@ test.describe('Vue Widget Reactivity', { tag: '@vue-nodes' }, () => {
     })
     await expect(loadCheckpointNode).toHaveCount(3)
   })
+
+  test('Can load dynamic combos', async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting(
+      'Comfy.NodeSearchBoxImpl',
+      'v1 (legacy)'
+    )
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+    await comfyPage.nextFrame()
+
+    await test.step('Add node with dynamic combo', async () => {
+      await comfyPage.page.mouse.dblclick(500, 500, { delay: 5 })
+      await comfyPage.searchBox.fillAndSelectFirstNode('Resize Image/Mask')
+      await expect(comfyPage.searchBox.input).toBeHidden()
+    })
+
+    const widget = comfyPage.vueNodes.getWidgetByName(
+      'Resize Image/Mask',
+      'resize_type'
+    )
+
+    await test.step('Update value of the dynamic combo widget', async () => {
+      await widget.click()
+      await comfyPage.page.getByRole('searchbox').fill('scale width')
+      await comfyPage.page.keyboard.press('ArrowDown')
+      await comfyPage.page.keyboard.press('Enter')
+      await expect(widget.locator('input')).toBeHidden()
+      await expect(widget).toHaveText('scale width')
+    })
+
+    await test.step('Swap to a different workflow and back', async () => {
+      await comfyPage.menu.topbar.getTab(0).click()
+      await expect(widget).toBeHidden()
+      await comfyPage.menu.topbar.getTab(1).click()
+      await expect(widget).toBeVisible()
+    })
+
+    await expect(widget, 'Widget has restored value').toHaveText('scale width')
+  })
 })

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -187,11 +187,11 @@ function dynamicComboWidget(
   //A little hacky, but onConfigure won't work.
   //It fires too late and is overly disruptive
   let widgetValue = widget.value
-  const graphId = resolveNodeRootGraphId(node)
-  const getState = () =>
-    graphId
-      ? useWidgetValueStore().getWidget(graphId, node.id, widget.name)
-      : undefined
+  const getState = () => {
+    const graphId = resolveNodeRootGraphId(node)
+    if (!graphId) return undefined
+    return useWidgetValueStore().getWidget(graphId, node.id, widget.name)
+  }
   Object.defineProperty(widget, 'value', {
     get() {
       return getState()?.value ?? widgetValue

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -22,6 +22,7 @@ import {
 import { useLitegraphService } from '@/services/litegraphService'
 import { app } from '@/scripts/app'
 import type { ComfyApp } from '@/scripts/app'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 const INLINE_INPUTS = false
 
@@ -185,11 +186,15 @@ function dynamicComboWidget(
   //A little hacky, but onConfigure won't work.
   //It fires too late and is overly disruptive
   let widgetValue = widget.value
+  const getState = () =>
+    useWidgetValueStore().getWidget(app.rootGraph.id, node.id, widget.name)
   Object.defineProperty(widget, 'value', {
     get() {
-      return widgetValue
+      return getState()?.value ?? widgetValue
     },
     set(value) {
+      const state = getState()
+      if (state) state.value = value
       widgetValue = value
       updateWidgets(value)
     }

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -11,6 +11,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import { commonType } from '@/lib/litegraph/src/utils/type'
+import { resolveNodeRootGraphId } from '@/lib/litegraph/src/utils/widget'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { ComboInputSpec, InputSpec } from '@/schemas/nodeDefSchema'
 import type { InputSpec as InputSpecV2 } from '@/schemas/nodeDef/nodeDefSchemaV2'
@@ -186,8 +187,11 @@ function dynamicComboWidget(
   //A little hacky, but onConfigure won't work.
   //It fires too late and is overly disruptive
   let widgetValue = widget.value
+  const graphId = resolveNodeRootGraphId(node)
   const getState = () =>
-    useWidgetValueStore().getWidget(app.rootGraph.id, node.id, widget.name)
+    graphId
+      ? useWidgetValueStore().getWidget(graphId, node.id, widget.name)
+      : undefined
   Object.defineProperty(widget, 'value', {
     get() {
       return getState()?.value ?? widgetValue


### PR DESCRIPTION
`DynamicCombo`s redefined `widget.value` without going through the store. This would result in desync of state. Most noticeably, swapping to and from a workflow would break vue reactivity and cause the default option to display visually

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12211-Fix-restoring-values-to-dynamic-combos-35f6d73d3650814ba12ccda42615239a) by [Unito](https://www.unito.io)
