### PR TITLE
fix: resolve widget input link position drift on reload

### DIFF
--- a/browser_tests/assets/vueNodes/ksampler-denoise-widget-link.json
+++ b/browser_tests/assets/vueNodes/ksampler-denoise-widget-link.json
@@ -1,0 +1,90 @@
+{
+  "id": "06e5b524-5a40-40b9-b561-199dfab18cf0",
+  "revision": 0,
+  "last_node_id": 12,
+  "last_link_id": 10,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "KSampler",
+      "pos": [230, 110],
+      "size": [270, 317.5666809082031],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": null
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": null
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": null
+        },
+        {
+          "name": "denoise",
+          "type": "FLOAT",
+          "widget": {
+            "name": "denoise"
+          },
+          "link": 10
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [0, "randomize", 20, 8, "euler", "simple", 1]
+    },
+    {
+      "id": 11,
+      "type": "PrimitiveFloat",
+      "pos": [-80.55032348632812, 375.2260443115233],
+      "size": [270, 80.23332977294922],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [10]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PrimitiveFloat"
+      },
+      "widgets_values": [0]
+    }
+  ],
+  "links": [[10, 11, 0, 10, 4, "FLOAT"]],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.8264462809917354,
+      "offset": [1335.8909766107738, 692.7345403667316]
+    },
+    "frontendVersion": "1.45.4"
+  },
+  "version": 0.4
+}

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1133,3 +1133,108 @@ test.describe(
     })
   }
 )
+
+test.describe('Vue Node Widget Link Position', { tag: '@vue-nodes' }, () => {
+  test('should keep widget-input link aligned after persisted-workflow reload', async ({
+    comfyPage
+  }) => {
+    test.setTimeout(30000)
+
+    await comfyPage.workflow.loadWorkflow(
+      'vueNodes/ksampler-denoise-widget-link'
+    )
+    await comfyPage.vueNodes.waitForNodes(2)
+    await comfyPage.workflow.waitForDraftPersisted()
+    await comfyPage.workflow.reloadAndWaitForApp()
+    await comfyPage.vueNodes.waitForNodes(2)
+
+    const ksampler = await comfyPage.page.evaluate(() => {
+      const node = window.app!.graph.nodes.find((n) => n.type === 'KSampler')
+      if (!node) return null
+      const findIndex = (name: string) =>
+        node.inputs.findIndex(
+          (input) => input.name === name || input.widget?.name === name
+        )
+      return {
+        id: node.id,
+        denoiseIndex: findIndex('denoise'),
+        schedulerIndex: findIndex('scheduler')
+      }
+    })
+    if (!ksampler) {
+      throw new Error('KSampler should be present in fixture')
+    }
+    expect(
+      ksampler.denoiseIndex,
+      'denoise input slot not found'
+    ).toBeGreaterThanOrEqual(0)
+    expect(
+      ksampler.schedulerIndex,
+      'scheduler input slot not found'
+    ).toBeGreaterThanOrEqual(0)
+
+    const denoiseSlot = slotLocator(
+      comfyPage.page,
+      ksampler.id,
+      ksampler.denoiseIndex,
+      true
+    )
+    const schedulerSlot = slotLocator(
+      comfyPage.page,
+      ksampler.id,
+      ksampler.schedulerIndex,
+      true
+    )
+    await expectVisibleAll(denoiseSlot, schedulerSlot)
+
+    await expect
+      .poll(() =>
+        getInputLinkDetails(comfyPage.page, ksampler.id, ksampler.denoiseIndex)
+      )
+      .toMatchObject({
+        targetId: ksampler.id,
+        targetSlot: ksampler.denoiseIndex
+      })
+
+    // If the regression returns, getInputPos stays stale relative to the
+    // grown slot DOM and the endpoint drifts toward scheduler. Re-read
+    // positions each retry so layout settle doesn't cause flakes.
+    await expect(async () => {
+      const linkEnd = await comfyPage.page.evaluate(
+        ([nodeId, targetSlotIndex]) => {
+          const node = window.app!.graph.getNodeById(nodeId)
+          if (!node) return null
+          const slotPos = node.getInputPos(targetSlotIndex)
+          const [cx, cy] = window.app!.canvas.ds.convertOffsetToCanvas([
+            slotPos[0],
+            slotPos[1]
+          ])
+          const rect = window.app!.canvas.canvas.getBoundingClientRect()
+          return { x: cx + rect.left, y: cy + rect.top }
+        },
+        [ksampler.id, ksampler.denoiseIndex] as const
+      )
+      expect(linkEnd, 'link endpoint should resolve').not.toBeNull()
+
+      const denoiseCenter = await getCenter(denoiseSlot)
+      const schedulerCenter = await getCenter(schedulerSlot)
+      const distToDenoise = Math.hypot(
+        linkEnd!.x - denoiseCenter.x,
+        linkEnd!.y - denoiseCenter.y
+      )
+      const rowGap = Math.hypot(
+        denoiseCenter.x - schedulerCenter.x,
+        denoiseCenter.y - schedulerCenter.y
+      )
+
+      // Bound at rowGap / 4 - half the inter-slot midpoint, so any drift
+      // toward scheduler fails well before reaching it.
+      expect(
+        distToDenoise,
+        `Link endpoint (${linkEnd!.x.toFixed(1)}, ${linkEnd!.y.toFixed(1)}) is ` +
+          `${distToDenoise.toFixed(1)}px from denoise — should be within ` +
+          `${(rowGap / 4).toFixed(1)}px (quarter of inter-slot gap ${rowGap.toFixed(1)}px)`
+      ).toBeLessThan(rowGap / 4)
+    }).toPass({ timeout: 5000 })
+  })
+})

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -90,6 +90,7 @@ import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteracti
 import AppInput from '@/renderer/extensions/linearMode/AppInput.vue'
 import { useNodeZIndex } from '@/renderer/extensions/vueNodes/composables/useNodeZIndex'
 import { useProcessedWidgets } from '@/renderer/extensions/vueNodes/composables/useProcessedWidgets'
+import { useVueElementTracking } from '@/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import InputSlot from './InputSlot.vue'
@@ -134,4 +135,9 @@ const {
   processedWidgets,
   showAdvanced
 } = useProcessedWidgets(() => nodeData)
+
+// Tracks widget-row growth that the node-level RO can't see
+if (nodeData?.id != null) {
+  useVueElementTracking(String(nodeData.id), 'widgets-grid')
+}
 </script>

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -29,7 +29,10 @@ const raf = createRafBatch(() => {
   flushScheduledSlotLayoutSync()
 })
 
-function scheduleSlotLayoutSync(nodeId: string) {
+export function scheduleSlotLayoutSync(nodeId: string) {
+  // Drop signals for unregistered nodes (e.g. preview nodes with synthetic
+  // ids from LGraphNodePreview) - they'd otherwise pump setDirty per RAF.
+  if (!useNodeSlotRegistryStore().getNode(nodeId)) return
   pendingNodes.add(nodeId)
   raf.schedule()
 }

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.test.ts
@@ -43,7 +43,8 @@ const testState = vi.hoisted(() => ({
   nodeLayouts: new Map<NodeId, NodeLayout>(),
   batchUpdateNodeBounds: vi.fn(),
   setSource: vi.fn(),
-  syncNodeSlotLayoutsFromDOM: vi.fn()
+  syncNodeSlotLayoutsFromDOM: vi.fn(),
+  scheduleSlotLayoutSync: vi.fn()
 }))
 
 vi.mock('@vueuse/core', () => ({
@@ -73,6 +74,7 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
 }))
 
 vi.mock('./useSlotElementTracking', () => ({
+  scheduleSlotLayoutSync: testState.scheduleSlotLayoutSync,
   syncNodeSlotLayoutsFromDOM: testState.syncNodeSlotLayoutsFromDOM
 }))
 
@@ -159,6 +161,7 @@ describe('useVueNodeResizeTracking', () => {
     testState.batchUpdateNodeBounds.mockReset()
     testState.setSource.mockReset()
     testState.syncNodeSlotLayoutsFromDOM.mockReset()
+    testState.scheduleSlotLayoutSync.mockReset()
     resizeObserverState.observe.mockReset()
     resizeObserverState.unobserve.mockReset()
     resizeObserverState.disconnect.mockReset()
@@ -316,5 +319,26 @@ describe('useVueNodeResizeTracking', () => {
 
     expect(testState.setSource).toHaveBeenCalledWith(LayoutSource.DOM)
     expect(testState.batchUpdateNodeBounds).toHaveBeenCalled()
+  })
+
+  it('widgets-grid resize schedules a slot resync without writing node bounds', () => {
+    const parentNodeId: NodeId = 'parent-node'
+    const element = document.createElement('div')
+    element.dataset.widgetsGridNodeId = parentNodeId
+    const boxSizes = [{ inlineSize: 200, blockSize: 80 }]
+    const entry = {
+      target: element,
+      borderBoxSize: boxSizes,
+      contentBoxSize: boxSizes,
+      devicePixelContentBoxSize: boxSizes,
+      contentRect: new DOMRect(0, 0, 200, 80)
+    } satisfies ResizeEntryLike
+
+    resizeObserverState.callback?.([entry], createObserverMock())
+
+    expect(testState.scheduleSlotLayoutSync).toHaveBeenCalledWith(parentNodeId)
+    expect(testState.batchUpdateNodeBounds).not.toHaveBeenCalled()
+    expect(testState.setSource).not.toHaveBeenCalled()
+    expect(testState.syncNodeSlotLayoutsFromDOM).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useVueNodeResizeTracking.ts
@@ -24,7 +24,10 @@ import {
 } from '@/renderer/core/layout/utils/geometry'
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
 
-import { syncNodeSlotLayoutsFromDOM } from './useSlotElementTracking'
+import {
+  scheduleSlotLayoutSync,
+  syncNodeSlotLayoutsFromDOM
+} from './useSlotElementTracking'
 
 /**
  * Generic update item for element bounds tracking
@@ -47,14 +50,14 @@ interface CachedNodeMeasurement {
 interface ElementTrackingConfig {
   /** Data attribute name (e.g., 'nodeId') */
   dataAttribute: string
-  /** Handler for processing bounds updates */
-  updateHandler: (updates: ElementBoundsUpdate[]) => void
+  /** Handler for processing bounds updates. Omit for signal-only entries. */
+  updateHandler?: (updates: ElementBoundsUpdate[]) => void
 }
 
 /**
  * Registry of tracking configurations by element type
  */
-const trackingConfigs: Map<string, ElementTrackingConfig> = new Map([
+const trackingConfigs = new Map<string, ElementTrackingConfig>([
   [
     'node',
     {
@@ -67,7 +70,10 @@ const trackingConfigs: Map<string, ElementTrackingConfig> = new Map([
         layoutStore.batchUpdateNodeBounds(nodeUpdates)
       }
     }
-  ]
+  ],
+  // Signal-only: outer node stays at its persisted min-h floor during
+  // widget hydration, so the inner grid's RO is the only slot-drift signal.
+  ['widgets-grid', { dataAttribute: 'widgetsGridNodeId' }]
 ])
 
 // Elements whose ResizeObserver fired while the tab was hidden
@@ -120,6 +126,14 @@ const resizeObserver = new ResizeObserver((entries) => {
   for (const entry of entries) {
     if (!(entry.target instanceof HTMLElement)) continue
     const element = entry.target
+
+    // Signal-only widgets-grid resize - route the parent node through the
+    // slot-layout pipeline and skip bounds processing entirely.
+    const widgetsGridParentNodeId = element.dataset.widgetsGridNodeId
+    if (widgetsGridParentNodeId) {
+      scheduleSlotLayoutSync(widgetsGridParentNodeId as NodeId)
+      continue
+    }
 
     // Find which type this element belongs to
     let elementType: string | undefined
@@ -238,7 +252,7 @@ const resizeObserver = new ResizeObserver((entries) => {
     // Flush per-type
     for (const [type, updates] of updatesByType) {
       const config = trackingConfigs.get(type)
-      if (config && updates.length) config.updateHandler(updates)
+      if (config?.updateHandler && updates.length) config.updateHandler(updates)
     }
   }
 

--- a/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
+++ b/src/workbench/extensions/manager/components/manager/packCard/PackCard.test.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import ProgressSpinner from 'primevue/progressspinner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
 import { render, screen } from '@testing-library/vue'
 
@@ -56,7 +57,8 @@ vi.mock('@vueuse/core', () => ({
   createSharedComposable: vi.fn((fn) => {
     let cached: ReturnType<typeof fn>
     return (...args: Parameters<typeof fn>) => (cached ??= fn(...args))
-  })
+  }),
+  useDocumentVisibility: vi.fn(() => ref<'visible' | 'hidden'>('visible'))
 }))
 
 vi.mock('@/config', () => ({


### PR DESCRIPTION
## Summary
The position of a link relative to its slot was able to drift on load, due to widgets inside a node being able to resize without triggering an node-level resize event (min-height node with space at the bottom could have widgets expand into free space, causing misalignment).

Recreation:
1. Add KSampler
2. Add Float
3. Connect Float to KSamper.denoise
4. Reload workflow (F5)
5. Observe misalignment

## Changes

- **What**: 
- track widget grid element as signal only that triggers resync
- node bound calculations skipped for widget signals
- prevent setDirty on non-graph nodes (e.g. LGraphNodePreview)
- tests

## Review Focus
This is a small focused approach to fix the reported issue - it does not address the underlying issue of the layout not being a SSOT. This fix is a small bandaid and investigation into resolving the layout SOT issue is not impacted by this.

## Screenshots (if applicable)

Before:
<img width="673" height="374" alt="image" src="https://github.com/user-attachments/assets/2d34b8e3-0731-4fd2-8553-4dd429010ced" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12214-fix-resolve-widget-input-link-position-drift-on-reload-35f6d73d3650814eb31bebb3042ff58b) by [Unito](https://www.unito.io)
