### PR TITLE
FE-657: prevent browser zoom on ctrl+wheel in mask editor

### DIFF
--- a/src/components/maskeditor/PointerZone.test.ts
+++ b/src/components/maskeditor/PointerZone.test.ts
@@ -141,6 +141,21 @@ describe('PointerZone', () => {
         y: 45
       })
     })
+
+    it('should preventDefault on wheel to block browser zoom on ctrl+wheel', () => {
+      renderZone()
+      const zone = getZone()
+
+      const event = new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaY: -1,
+        ctrlKey: true
+      })
+      zone.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+    })
   })
 
   describe('isPanning watcher', () => {

--- a/src/components/maskeditor/PointerZone.vue
+++ b/src/components/maskeditor/PointerZone.vue
@@ -11,7 +11,7 @@
     @touchstart="handleTouchStart"
     @touchmove="handleTouchMove"
     @touchend="handleTouchEnd"
-    @wheel="handleWheel"
+    @wheel.prevent="handleWheel"
     @contextmenu.prevent
   />
 </template>


### PR DESCRIPTION
## Summary

Wheel events on the mask editor pointer zone now call preventDefault, matching the main canvas behavior so ctrl+wheel only zooms the mask canvas instead of also triggering page zoom.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12215-FE-657-prevent-browser-zoom-on-ctrl-wheel-in-mask-editor-35f6d73d36508131a9b8dbf2f6640d72) by [Unito](https://www.unito.io)
