### PR TITLE
feat: add Anthropic partner icon

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -16,7 +16,7 @@
 @plugin "./lucideStrokePlugin.js";
 
 /* Safelist dynamic comfy icons for node library folders */
-@source inline("icon-[comfy--{ai-model,bfl,bria,bytedance,credits,elevenlabs,extensions-blocks,file-output,gemini,grok,hitpaw,ideogram,image-ai-edit,kling,ltxv,luma,magnific,mask,meshy,minimax,moonvalley-marey,node,openai,pin,pixverse,play,recraft,reve,rodin,runway,sora,stability-ai,template,tencent,topaz,tripo,veo,vidu,wan,wavespeed,workflow,quiver}]");
+@source inline("icon-[comfy--{ai-model,anthropic,bfl,bria,bytedance,credits,elevenlabs,extensions-blocks,file-output,gemini,grok,hitpaw,ideogram,image-ai-edit,kling,ltxv,luma,magnific,mask,meshy,minimax,moonvalley-marey,node,openai,pin,pixverse,play,recraft,reve,rodin,runway,sora,stability-ai,template,tencent,topaz,tripo,veo,vidu,wan,wavespeed,workflow,quiver}]");
 
 /* Safelist dynamic comfy icons for essential nodes (kebab-case of node names) */
 @source inline("icon-[comfy--{save-image,load-video,save-video,load-3-d,save-glb,image-batch,batch-images-node,image-crop,image-scale,image-rotate,image-blur,image-invert,canny,recraft-remove-background-node,kling-lip-sync-audio-to-video-node,load-audio,save-audio,stability-text-to-audio,lora-loader,lora-loader-model-only,primitive-string-multiline,get-video-components,video-slice,tencent-text-to-model-node,tencent-image-to-model-node,open-ai-chat-node,preview-image,image-and-mask-preview,layer-mask-mask-preview,mask-preview,image-preview-from-latent,i-tools-preview-image,i-tools-compare-image,canny-to-image,image-edit,text-to-image,pose-to-image,depth-to-video,image-to-image,canny-to-video,depth-to-image,image-to-video,pose-to-video,text-to-video,image-inpainting,image-outpainting}]");

--- a/packages/design-system/src/icons/anthropic.svg
+++ b/packages/design-system/src/icons/anthropic.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd"><title>Anthropic</title><path d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-7.258 0h3.767L16.906 20h-3.674l-1.343-3.461H5.017l-1.344 3.46H0L6.57 3.522zm4.132 9.959L8.453 7.687 6.205 13.48H10.7z"/></svg>

--- a/src/utils/categoryUtil.test.ts
+++ b/src/utils/categoryUtil.test.ts
@@ -28,6 +28,7 @@ describe('getProviderIcon', () => {
   it('returns icon class for simple provider name', () => {
     expect(getProviderIcon('BFL')).toBe('icon-[comfy--bfl]')
     expect(getProviderIcon('OpenAI')).toBe('icon-[comfy--openai]')
+    expect(getProviderIcon('Anthropic')).toBe('icon-[comfy--anthropic]')
   })
 
   it('converts spaces to hyphens', () => {
@@ -47,6 +48,7 @@ describe('getProviderBorderStyle', () => {
     expect(getProviderBorderStyle('BFL')).toBe('#ffffff')
     expect(getProviderBorderStyle('OpenAI')).toBe('#B6B6B6')
     expect(getProviderBorderStyle('Bria')).toBe('#B6B6B6')
+    expect(getProviderBorderStyle('Anthropic')).toBe('#D97757')
   })
 
   it('returns gradient for dual-color providers', () => {

--- a/src/utils/categoryUtil.ts
+++ b/src/utils/categoryUtil.ts
@@ -56,6 +56,7 @@ export const getCategoryIcon = (categoryId: string): string => {
  * Each entry can be a single color or [color1, color2] for gradient.
  */
 const PROVIDER_COLORS: Record<string, string | [string, string]> = {
+  anthropic: '#D97757',
   bfl: '#ffffff',
   bria: '#B6B6B6',
   elevenlabs: '#B6B6B6',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Adds the Anthropic logo to the partner-node icon set so nodes whose category ends in `Anthropic` (e.g. the Claude node added in Comfy-Org/ComfyUI#13867 with `category="api node/text/Anthropic"`) render the correct provider badge in the node library.

## Changes

- `packages/design-system/src/icons/anthropic.svg` — new auto-discovered partner icon (Anthropic A glyph, sourced from [lobehub/lobe-icons](https://github.com/lobehub/lobe-icons), uses `fill="currentColor"` for theme adaptation)
- `src/utils/categoryUtil.ts` — register Anthropic's brand coral `#D97757` as the badge border color
- `packages/design-system/src/css/style.css` — add `anthropic` to the dynamic comfy-icon safelist so Tailwind/Iconify emits CSS for `icon-[comfy--anthropic]` in production builds
- `src/utils/categoryUtil.test.ts` — regression tests for `getProviderIcon('Anthropic')` and `getProviderBorderStyle('Anthropic')`

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓ (0 errors; 3 pre-existing warnings in unrelated files)
- `pnpm format:check` ✓
- `pnpm test:unit -- src/utils/categoryUtil.test.ts` ✓ (13/13)
- `pnpm build` ✓ — confirmed `comfy--anthropic` class is emitted into `dist/assets/index-*.css`
- Manual visual check via Playwright against `pnpm dev`: injected `<i class="icon-[comfy--anthropic]">` elements at badge size (10px) and 48px alongside the existing OpenAI and BFL icons and confirmed the Anthropic "A" glyph renders correctly in coral. See screenshot.

End-to-end visual verification of the live badge in the node library requires Comfy-Org/ComfyUI#13867 to land first (the Claude node is what produces the `Anthropic` category that triggers the icon lookup).

Related: Comfy-Org/ComfyUI#13867

## Screenshots

![Anthropic icon rendered in coral alongside OpenAI and BFL partner icons at badge and large sizes](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/c0076decedd8863eec6253b44e583da6b3eaacc20081d126aaf5267c72c8cc84/pr-images/1778683078329-49e37a7b-86ed-4ef2-988f-5702433f8412.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12216-feat-add-Anthropic-partner-icon-35f6d73d36508133a134fcafaf72f4f8) by [Unito](https://www.unito.io)
