### PR TITLE
refactor(litegraph): prune dead surfaces (AUDIT-LG implementation, draft)

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -329,12 +329,6 @@ export class LGraph
     this.state.lastLinkId = value
   }
 
-  onAfterStep?(): void
-  onBeforeStep?(): void
-  onPlayEvent?(): void
-  onStopEvent?(): void
-  onAfterExecute?(): void
-  onExecuteStep?(): void
   onNodeAdded?(node: LGraphNode): void
   onNodeRemoved?(node: LGraphNode): void
   onTrigger?: LGraphTriggerHandler
@@ -506,8 +500,6 @@ export class LGraph
   start(interval?: number): void {
     if (this.status == LGraph.STATUS_RUNNING) return
     this.status = LGraph.STATUS_RUNNING
-
-    this.onPlayEvent?.()
     this.sendEventToAllNodes('onStart')
 
     // launch
@@ -525,9 +517,7 @@ export class LGraph
         if (this.execution_timer_id != -1) return
 
         window.requestAnimationFrame(on_frame)
-        this.onBeforeStep?.()
         this.runStep(1, !this.catch_errors)
-        this.onAfterStep?.()
       }
       this.execution_timer_id = -1
       on_frame()
@@ -536,9 +526,7 @@ export class LGraph
       // @ts-expect-error - Timer ID type mismatch needs fixing
       this.execution_timer_id = setInterval(() => {
         // execute
-        this.onBeforeStep?.()
         this.runStep(1, !this.catch_errors)
-        this.onAfterStep?.()
       }, interval)
     }
   }
@@ -551,9 +539,6 @@ export class LGraph
     if (this.status == LGraph.STATUS_STOPPED) return
 
     this.status = LGraph.STATUS_STOPPED
-
-    this.onStopEvent?.()
-
     if (this.execution_timer_id != null) {
       if (this.execution_timer_id != -1) {
         clearInterval(this.execution_timer_id)
@@ -594,10 +579,7 @@ export class LGraph
         }
 
         this.fixedtime += this.fixedtime_lapse
-        this.onExecuteStep?.()
       }
-
-      this.onAfterExecute?.()
     } else {
       try {
         // iterations
@@ -610,10 +592,7 @@ export class LGraph
           }
 
           this.fixedtime += this.fixedtime_lapse
-          this.onExecuteStep?.()
         }
-
-        this.onAfterExecute?.()
         this.errors_in_execution = false
       } catch (error) {
         this.errors_in_execution = true


### PR DESCRIPTION
Implements the AUDIT-LG verdicts (#12223, #12224, #12225) as a single deletion PR off main.

> **DRAFT — sequencing.** Per the AUDIT-LG framing doc, deletions land **after Phase B ECS migration** (Alex's #11939 + #11811). Open early to capture the diff and let CI cascade-flag any unused-export fallout. Flip to ready-for-review post-Alex-rebase.

## Status

| commit | scope | status |
|---|---|---|
| 1 | Delete 6 LGraph stepping hooks (`onAfterStep`, `onBeforeStep`, `onPlayEvent`, `onStopEvent`, `onAfterExecute`, `onExecuteStep`) + their dispatch sites in `start()`/`stop()`/`runStep()` | ✅ landed (this commit) |
| 2 | Delete the rest of the dead executor cluster (`start()`/`stop()`/`runStep()`/`sendEventToAllNodes()` + state fields + `STATUS_*` constants) | follow-up |
| 3 | Delete `LGraphNode` dead event hooks (~22 fields per #12224) | follow-up |
| 4 | Delete trigger/action subsystem (~22 symbols, #12223) | follow-up |
| 5 | `ON_EVENT` deprecation cycle, release N (#12225) | follow-up |

## Verification (commit 1)

```
$ pnpm lint && pnpm format:check && pnpm knip
✓ format: All matched files use the correct format
✓ lint: pre-existing icon-name warnings only
✓ knip: no new unused exports flagged
```

## Verdicts the deletion is grounded in

- AUDIT-LG.7 master verdict table (146 surfaces classified DELETE-NOW / DEPRECATE / KEEP)
- AUDIT-LG.9 per-symbol attribution sweep (confirmed zero functional callers for the trigger cluster + the dead hooks)

For each surface in this PR:

- **`internal_count` from rg over `src/`, `browser_tests/`, `packages/` excluding `lib/litegraph/`:** 0
- **External use from touch-points DB:** 0 (per AUDIT-LG.3 + AUDIT-LG.9 per-symbol attribution)
- **Host methods (`start()`/`stop()`/`runStep()`):** `@deprecated 'Will be removed in 0.9'` already

The dispatch sites (`this.onAfterStep?.()` etc.) are inside the deprecated host methods — removing the dispatchers does not change observable behaviour because no listener is attached to begin with.

## Why batched, why draft

Per AUDIT-LG framing, the deletion sequences behind Alex's PR #11939 (ECS world-combo). Opening as draft lets CI run early and flags any unused-export cascades the audit script missed. Each follow-up commit will be its own atomic deletion (one feature per commit) so any single one can be reverted in isolation if needed.

cc @drjkl @christian-byrne

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12228-refactor-litegraph-prune-dead-surfaces-AUDIT-LG-implementation-draft-35f6d73d365081e0b72cd292228e2ca6) by [Unito](https://www.unito.io)
