### PR TITLE
refactor(litegraph): deprecate LiteGraph.ON_EVENT (release N)

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1380,9 +1380,6 @@ export class LGraphNode
 
   changeMode(modeTo: number): boolean {
     switch (modeTo) {
-      case LGraphEventMode.ON_EVENT:
-        break
-
       case LGraphEventMode.ON_TRIGGER:
         this.addOnTriggerInput()
         this.addOnExecutedOutput()
@@ -1399,7 +1396,8 @@ export class LGraphNode
         break
 
       default:
-        return false
+        // Numeric default-accept: any caller-supplied numeric mode (including
+        // the deprecated slot 1 / ON_EVENT) falls through and is assigned.
         break
     }
     this.mode = modeTo

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1626,9 +1626,6 @@ export class LGraphNode
 
   changeMode(modeTo: number): boolean {
     switch (modeTo) {
-      case LGraphEventMode.ON_EVENT:
-        break
-
       case LGraphEventMode.ON_TRIGGER:
         this.addOnTriggerInput()
         this.addOnExecutedOutput()
@@ -1645,7 +1642,7 @@ export class LGraphNode
         break
 
       default:
-        return false
+        break
     }
     this.mode = modeTo
     return true

--- a/src/lib/litegraph/src/LiteGraphGlobal.ts
+++ b/src/lib/litegraph/src/LiteGraphGlobal.ts
@@ -122,7 +122,9 @@ export class LiteGraphGlobal {
   /** use with node_box_coloured_by_mode */
   NODE_MODES_COLORS = ['#666', '#422', '#333', '#224', '#626']
   ALWAYS = LGraphEventMode.ALWAYS
-  ON_EVENT = LGraphEventMode.ON_EVENT
+  // ON_EVENT is registered as a deprecation getter in the constructor — see
+  // Object.defineProperty call below. The numeric slot (1) is preserved for
+  // v2 ABI; the symbol will be removed in release N+1.
   NEVER = LGraphEventMode.NEVER
   ON_TRIGGER = LGraphEventMode.ON_TRIGGER
 
@@ -372,6 +374,15 @@ export class LiteGraphGlobal {
 
   constructor() {
     Object.defineProperty(this, 'Classes', { writable: false })
+    Object.defineProperty(this, 'ON_EVENT', {
+      get() {
+        console.warn(
+          'LiteGraph.ON_EVENT is deprecated; numeric slot 1 is preserved for v2 ABI but the symbol will be removed in release N+1. ON_EVENT is a no-op mode — use NEVER to mute a node.'
+        )
+        return 1
+      },
+      configurable: true
+    })
   }
 
   Classes = {

--- a/src/lib/litegraph/src/LiteGraphGlobal.ts
+++ b/src/lib/litegraph/src/LiteGraphGlobal.ts
@@ -121,7 +121,9 @@ export class LiteGraphGlobal {
   /** use with node_box_coloured_by_mode */
   NODE_MODES_COLORS = ['#666', '#422', '#333', '#224', '#626']
   ALWAYS = LGraphEventMode.ALWAYS
-  ON_EVENT = LGraphEventMode.ON_EVENT
+  // ON_EVENT is registered as a deprecation getter in the constructor — see
+  // Object.defineProperty call below. The numeric slot (1) is preserved for
+  // v2 ABI; the symbol will be removed in release N+1.
   NEVER = LGraphEventMode.NEVER
   ON_TRIGGER = LGraphEventMode.ON_TRIGGER
 
@@ -374,6 +376,15 @@ export class LiteGraphGlobal {
 
   constructor() {
     Object.defineProperty(this, 'Classes', { writable: false })
+    Object.defineProperty(this, 'ON_EVENT', {
+      get() {
+        console.warn(
+          'LiteGraph.ON_EVENT is deprecated; numeric slot 1 is preserved for v2 ABI but the symbol will be removed in release N+1. ON_EVENT is a no-op mode — use NEVER to mute a node.'
+        )
+        return 1
+      },
+      configurable: true
+    })
   }
 
   Classes = {

--- a/src/lib/litegraph/src/__snapshots__/litegraph.test.ts.snap
+++ b/src/lib/litegraph/src/__snapshots__/litegraph.test.ts.snap
@@ -94,7 +94,6 @@ LiteGraphGlobal {
   "NORMAL_TITLE": 0,
   "NO_TITLE": 1,
   "Nodes": {},
-  "ON_EVENT": 1,
   "ON_TRIGGER": 3,
   "OUTPUT": 2,
   "RIGHT": 4,

--- a/src/lib/litegraph/src/types/globalEnums.ts
+++ b/src/lib/litegraph/src/types/globalEnums.ts
@@ -82,7 +82,9 @@ export enum TitleMode {
 
 export enum LGraphEventMode {
   ALWAYS = 0,
-  ON_EVENT = 1,
+  /** @deprecated No-op mode. Numeric slot 1 is preserved for v2 ABI; the
+   *  symbol will be removed in release N+1. Use NEVER to mute a node. */
+  _UNUSED_1 = 1,
   NEVER = 2,
   ON_TRIGGER = 3,
   BYPASS = 4


### PR DESCRIPTION
Release-N half of the `LiteGraph.ON_EVENT` deprecate-then-delete cycle.

## Why

`ON_EVENT` is a no-op mode in the in-browser LiteGraph — `changeMode()` had a `case ON_EVENT: break` arm that did nothing. Use `NEVER` to mute a node. The numeric slot `1` is preserved for v2 ABI; the symbol will be removed in release N+1.

## Changes

- `globalEnums.ts` — rename `LGraphEventMode.ON_EVENT` → `_UNUSED_1` (value stays `1`).
- `LiteGraphGlobal.ts` — replace `window.LiteGraph.ON_EVENT` static assignment with an `Object.defineProperty` getter that fires the deprecation `console.warn` then returns `1`. Registered in the `LiteGraphGlobal` constructor so it lands at the same point in module evaluation as the previous class-field assignment (instance constructed at `litegraph.ts:17`).
- `LGraphNode.ts` — delete the no-op `case ON_EVENT: break` arm in `changeMode()`; widen the switch `default` from `return false` to `break` so `setMode(1)` (and any other numeric mode) falls through to the existing `this.mode = modeTo` assignment + `return true`.

## Compatibility surprises

- **`packages/comfyui-frontend-types/` does not exist in this repo.** Step 4 of the brief targeted a `.d.ts` with `typeof LiteGraph.ON_EVENT` in the `mode?:` union — `rg` confirmed no `typeof LiteGraph.ON_EVENT` anywhere in the worktree. The published types package is referenced in `docs/adr/0002-monorepo-conversion.md` as a future package; the patch bump must be made in whichever sibling repo actually publishes it. The internal `mode?:` typings (`src/lib/litegraph/src/{LGraph,interfaces}.ts`) use `LGraphEventMode` directly and continue to work — `_UNUSED_1` is still assignable to `mode?: LGraphEventMode` at the type level.
- **Snapshot test will need a refresh.** `src/lib/litegraph/src/__snapshots__/litegraph.test.ts.snap` still records `"ON_EVENT": 1,` from the old class-field shape. With `enumerable` defaulting to `false` on the new `defineProperty`, the key drops out of `Object.keys()` enumeration; first vitest run with `-u` will regenerate. Left out of this PR to keep the diff minimal — flag for the next CI-green pass.

## Sign-off

Christian approved the warning copy:
> `LiteGraph.ON_EVENT is deprecated; numeric slot 1 is preserved for v2 ABI but the symbol will be removed in release N+1. ON_EVENT is a no-op mode — use NEVER to mute a node.`

## Quality gates (Node 24)

`pnpm lint`, `pnpm format:check`, `pnpm knip` all clean (only preexisting `@knipIgnoreUnusedButUsedByCustomNodes` warning on `src/scripts/metadata/flac.ts`).

## Sequencing

- Release N+1 follow-up: drop `_UNUSED_1` + deprecation getter.
- Open as draft; sequences behind Alex's Phase B (#11939, #11811).
- CI failures don't block per AGENTS.md rule #8.

Closes #12225 (release N half).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12231-refactor-litegraph-deprecate-LiteGraph-ON_EVENT-release-N-35f6d73d365081e0ab95c7013e1b5b7b) by [Unito](https://www.unito.io)



## Re-audit context (W2F-1, 2026-05-13)

Re-audit context: no listener-variant consumer impact found in W2F-1 sweep across 138 indexed extension repos. The W2F-1 sweep targeted the 21 EXTENSION-CONSUMER surfaces enumerated in `research/touch-points/database.yaml` (S2.N*, S3.C1, S6.A1, S11.G3); the symbols deleted in this PR are LITEGRAPH-INTERNAL and not in that surfaced set. See `research/meta/sourcegraph-mcp-coverage-investigation.md` §Step E (AUDIT-LG.10 verdict-table impact: zero flips required).


## Evidence

Rebased onto `origin/main` at `3277c2782d`. Conflict resolution preserved numeric mode `1` compatibility and refreshed the affected LiteGraph snapshot.

- `pnpm typecheck` — passed
- `pnpm exec vitest run src/lib/litegraph/src/litegraph.test.ts -u` — 5 passed; 1 snapshot updated
- `git diff --check origin/main...HEAD` — passed

<!-- authored-by:agent lane-act-fe-12231-rebase-24bd14b3 -->