### PR TITLE
docs(litegraph): mark subgraph building blocks as @internal

### DIFF
--- a/src/lib/litegraph/src/subgraph/EmptySubgraphInput.ts
+++ b/src/lib/litegraph/src/subgraph/EmptySubgraphInput.ts
@@ -10,6 +10,8 @@ import type { SubgraphInputNode } from './SubgraphInputNode'
 
 /**
  * A virtual slot that simply creates a new input slot when connected to.
+ *
+ * @internal
  */
 export class EmptySubgraphInput extends SubgraphInput {
   declare parent: SubgraphInputNode

--- a/src/lib/litegraph/src/subgraph/EmptySubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/EmptySubgraphOutput.ts
@@ -10,6 +10,8 @@ import type { SubgraphOutputNode } from './SubgraphOutputNode'
 
 /**
  * A virtual slot that simply creates a new output slot when connected to.
+ *
+ * @internal
  */
 export class EmptySubgraphOutput extends SubgraphOutput {
   declare parent: SubgraphOutputNode

--- a/src/lib/litegraph/src/subgraph/PromotedWidgetViewManager.ts
+++ b/src/lib/litegraph/src/subgraph/PromotedWidgetViewManager.ts
@@ -9,6 +9,8 @@ type ViewManagerEntry = PromotedWidgetSource & {
  *
  * Keeps object identity stable by key while preserving the current
  * promotion order and deduplicating duplicate entries by first occurrence.
+ *
+ * @internal
  */
 export class PromotedWidgetViewManager<TView> {
   private viewCache = new Map<string, TView>()

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -29,6 +29,7 @@ import type { Subgraph } from './Subgraph'
 import type { SubgraphInput } from './SubgraphInput'
 import type { SubgraphOutput } from './SubgraphOutput'
 
+/** @internal */
 export abstract class SubgraphIONodeBase<
   TSlot extends SubgraphInput | SubgraphOutput
 >

--- a/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphIONodeBase.ts
@@ -30,6 +30,7 @@ import type { Subgraph } from './Subgraph'
 import type { SubgraphInput } from './SubgraphInput'
 import type { SubgraphOutput } from './SubgraphOutput'
 
+/** @internal */
 export abstract class SubgraphIONodeBase<
   TSlot extends SubgraphInput | SubgraphOutput
 >

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -27,6 +27,8 @@ import { isNodeSlot, isSubgraphInput } from './subgraphUtils'
  * You have "Subgraph Outputs", because they go from inside the subgraph and out, but links to them come from "node outputs".
  *
  * Functionally, however, when editing a subgraph, that "subgraph output" is the "target" or "input side" of a link.
+ *
+ * @internal
  */
 export class SubgraphOutput extends SubgraphSlot {
   declare parent: SubgraphOutputNode

--- a/src/lib/litegraph/src/subgraph/SubgraphSlotBase.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphSlotBase.ts
@@ -37,7 +37,11 @@ interface SubgraphSlotDrawOptions {
   editorAlpha?: number
 }
 
-/** Shared base class for the slots used on Subgraph . */
+/**
+ * Shared base class for the slots used on Subgraph .
+ *
+ * @internal
+ */
 export abstract class SubgraphSlot
   extends SlotBase
   implements SubgraphIO, Hoverable, Serialisable<SubgraphIO>

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
@@ -28,6 +28,8 @@ interface DeduplicationResult {
  * @param reservedNodeIds - Node IDs already in use by root-level nodes
  * @param state - Graph state containing the `lastNodeId` counter (mutated)
  * @param rootNodes - Optional root-level nodes with proxyWidgets to patch
+ *
+ * @internal
  */
 export function deduplicateSubgraphNodeIds(
   subgraphs: ExportedSubgraph[],
@@ -148,6 +150,8 @@ function patchPromotedWidgets(
  *
  * Falls back to the original order if no reordering is needed or if the
  * dependency graph contains cycles.
+ *
+ * @internal
  */
 export function topologicalSortSubgraphs(
   subgraphs: ExportedSubgraph[]

--- a/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphDeduplication.ts
@@ -171,6 +171,13 @@ function firstById<T, Id>(
  * `GraphCanvas.vue` also keys Vue node instances by bare `NodeId`, so
  * collisions could reuse a component across graph changes instead of
  * remounting it.
+ *
+ * @param subgraphs - Serialized subgraph definitions to deduplicate
+ * @param reservedNodeIds - Node IDs already in use by root-level nodes
+ * @param state - Graph state containing the `lastNodeId` counter (mutated)
+ * @param rootNodes - Optional root-level nodes with proxyWidgets to patch
+ *
+ * @internal
  */
 export function deduplicateSubgraphNodeIds(
   subgraphs: ExportedSubgraph[],
@@ -503,6 +510,8 @@ function patchRerouteReferences(
  *
  * Falls back to the original order if no reordering is needed or if the
  * dependency graph contains cycles.
+ *
+ * @internal
  */
 export function topologicalSortSubgraphs(
   subgraphs: ExportedSubgraph[]

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -37,6 +37,7 @@ interface FilteredItems {
   unknown: Set<Positionable>
 }
 
+/** @internal */
 export function splitPositionables(
   items: Iterable<Positionable>
 ): FilteredItems {
@@ -89,6 +90,7 @@ interface BoundaryLinks {
   boundaryOutputLinks: LLink[]
 }
 
+/** @internal */
 export function getBoundaryLinks(
   graph: LGraph,
   items: Set<Positionable>
@@ -213,6 +215,7 @@ export function getBoundaryLinks(
   }
 }
 
+/** @internal */
 export function multiClone(nodes: Iterable<LGraphNode>): ISerialisedNode[] {
   const clonedNodes: ISerialisedNode[] = []
 
@@ -240,6 +243,8 @@ export function multiClone(nodes: Iterable<LGraphNode>): ISerialisedNode[] {
  * Groups resolved connections by output object. If the output is nullish, the connection will be in its own group.
  * @param resolvedConnections The resolved connections to group
  * @returns A map of grouped connections.
+ *
+ * @internal
  */
 export function groupResolvedByOutput(
   resolvedConnections: ResolvedConnection[]
@@ -278,6 +283,7 @@ function mapReroutes(
   return lastId
 }
 
+/** @internal */
 export function mapSubgraphInputsAndLinks(
   resolvedInputLinks: ResolvedConnection[],
   links: SerialisableLLink[],
@@ -358,6 +364,8 @@ export function mapSubgraphInputsAndLinks(
  * @param resolvedOutputLinks The resolved output links.
  * @param links The links to add to the subgraph.
  * @returns The subgraph output slots.
+ *
+ * @internal
  */
 export function mapSubgraphOutputsAndLinks(
   resolvedOutputLinks: ResolvedConnection[],
@@ -436,6 +444,8 @@ export function mapSubgraphOutputsAndLinks(
  * Collects all subgraph IDs used directly in a single graph (non-recursive).
  * @param graph The graph to check for subgraph nodes
  * @returns Set of subgraph IDs used in this graph
+ *
+ * @internal
  */
 export function getDirectSubgraphIds(graph: GraphOrSubgraph): Set<SubgraphId> {
   const subgraphIds = new Set<SubgraphId>()
@@ -454,6 +464,8 @@ export function getDirectSubgraphIds(graph: GraphOrSubgraph): Set<SubgraphId> {
  * @param rootGraph The graph to start from
  * @param subgraphRegistry Map of all available subgraphs
  * @returns Set of all subgraph IDs found
+ *
+ * @internal
  */
 export function findUsedSubgraphIds(
   rootGraph: GraphOrSubgraph,
@@ -484,6 +496,8 @@ export function findUsedSubgraphIds(
  * Type guard to check if a slot is a SubgraphInput.
  * @param slot The slot to check
  * @returns true if the slot is a SubgraphInput
+ *
+ * @internal
  */
 export function isSubgraphInput(slot: unknown): slot is SubgraphInput {
   return (
@@ -498,6 +512,8 @@ export function isSubgraphInput(slot: unknown): slot is SubgraphInput {
  * Type guard to check if a slot is a SubgraphOutput.
  * @param slot The slot to check
  * @returns true if the slot is a SubgraphOutput
+ *
+ * @internal
  */
 export function isSubgraphOutput(slot: unknown): slot is SubgraphOutput {
   return (
@@ -512,6 +528,8 @@ export function isSubgraphOutput(slot: unknown): slot is SubgraphOutput {
  * Type guard to check if a slot is a regular node slot (INodeInputSlot or INodeOutputSlot).
  * @param slot The slot to check
  * @returns true if the slot is a regular node slot
+ *
+ * @internal
  */
 export function isNodeSlot(
   slot: unknown

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -46,6 +46,7 @@ interface FilteredItems {
   unknown: Set<Positionable>
 }
 
+/** @internal */
 export function splitPositionables(
   items: Iterable<Positionable>
 ): FilteredItems {
@@ -98,6 +99,7 @@ interface BoundaryLinks {
   boundaryOutputLinks: LLink[]
 }
 
+/** @internal */
 export function getBoundaryLinks(
   graph: LGraph,
   items: Set<Positionable>
@@ -226,6 +228,7 @@ export function getBoundaryLinks(
   }
 }
 
+/** @internal */
 export function multiClone(nodes: Iterable<LGraphNode>): ISerialisedNode[] {
   const clonedNodes: ISerialisedNode[] = []
 
@@ -253,6 +256,8 @@ export function multiClone(nodes: Iterable<LGraphNode>): ISerialisedNode[] {
  * Groups resolved connections by output object. If the output is nullish, the connection will be in its own group.
  * @param resolvedConnections The resolved connections to group
  * @returns A map of grouped connections.
+ *
+ * @internal
  */
 export function groupResolvedByOutput(
   resolvedConnections: ResolvedConnection[]
@@ -295,6 +300,7 @@ function mapReroutes(
   return lastId
 }
 
+/** @internal */
 export function mapSubgraphInputsAndLinks(
   resolvedInputLinks: ResolvedConnection[],
   links: SerialisableLLink[],
@@ -376,6 +382,8 @@ export function mapSubgraphInputsAndLinks(
  * @param resolvedOutputLinks The resolved output links.
  * @param links The links to add to the subgraph.
  * @returns The subgraph output slots.
+ *
+ * @internal
  */
 export function mapSubgraphOutputsAndLinks(
   resolvedOutputLinks: ResolvedConnection[],
@@ -454,6 +462,8 @@ export function mapSubgraphOutputsAndLinks(
  * Collects all subgraph IDs used directly in a single graph (non-recursive).
  * @param graph The graph to check for subgraph nodes
  * @returns Set of subgraph IDs used in this graph
+ *
+ * @internal
  */
 export function getDirectSubgraphIds(graph: GraphOrSubgraph): Set<SubgraphId> {
   const subgraphIds = new Set<SubgraphId>()
@@ -472,6 +482,8 @@ export function getDirectSubgraphIds(graph: GraphOrSubgraph): Set<SubgraphId> {
  * @param rootGraph The graph to start from
  * @param subgraphRegistry Map of all available subgraphs
  * @returns Set of all subgraph IDs found
+ *
+ * @internal
  */
 export function findUsedSubgraphIds(
   rootGraph: GraphOrSubgraph,
@@ -625,6 +637,8 @@ export function reorderSubgraphInputs(
  * Type guard to check if a slot is a SubgraphInput.
  * @param slot The slot to check
  * @returns true if the slot is a SubgraphInput
+ *
+ * @internal
  */
 export function isSubgraphInput(slot: unknown): slot is SubgraphInput {
   return (
@@ -639,6 +653,8 @@ export function isSubgraphInput(slot: unknown): slot is SubgraphInput {
  * Type guard to check if a slot is a SubgraphOutput.
  * @param slot The slot to check
  * @returns true if the slot is a SubgraphOutput
+ *
+ * @internal
  */
 export function isSubgraphOutput(slot: unknown): slot is SubgraphOutput {
   return (
@@ -653,6 +669,8 @@ export function isSubgraphOutput(slot: unknown): slot is SubgraphOutput {
  * Type guard to check if a slot is a regular node slot (INodeInputSlot or INodeOutputSlot).
  * @param slot The slot to check
  * @returns true if the slot is a regular node slot
+ *
+ * @internal
  */
 export function isNodeSlot(
   slot: unknown


### PR DESCRIPTION
Tightens the published `@comfyorg/extension-api` ABI by marking subgraph cluster building blocks `@internal` per AUDIT-LG.9 §subgraph correction.

## Marked @internal

- `EmptySubgraphInput`, `EmptySubgraphOutput`
- `SubgraphSlot` (in `SubgraphSlotBase.ts`), `SubgraphIONodeBase`
- `PromotedWidgetViewManager`
- `subgraphDeduplication` exports (`deduplicateSubgraphNodeIds`, `topologicalSortSubgraphs`)
- `subgraphUtils` exports (`splitPositionables`, `getBoundaryLinks`, `multiClone`, `groupResolvedByOutput`, `mapSubgraphInputsAndLinks`, `mapSubgraphOutputsAndLinks`, `getDirectSubgraphIds`, `findUsedSubgraphIds`, `isSubgraphInput`, `isSubgraphOutput`, `isNodeSlot`)
- `SubgraphOutput`

## Preserves (external-facing)

- `SubgraphNode`, `Subgraph`, `SubgraphInput`
- `ExecutableNodeDTO`
- `subgraphTest` / `createTestSubgraph*` / `subgraphHelpers` (test fixtures)

## Effect

TypeDoc (with `excludeInternal: true`) will strip the marked exports from the published `@comfyorg/extension-api` ABI snapshot once that pipeline lands (PKG2). The tags are inert today but encode the public/internal boundary at the source so the cluster surface is correct when TypeDoc starts running.

## TypeDoc config

`packages/extension-api/` does not exist on `main` yet (PKG2 work), so there is no TypeDoc config to update in this PR. The `@internal` tags are forward-compatible with the standard TypeDoc `excludeInternal: true` default.

## Quality gates (Node 24)

- `pnpm lint`: clean
- `pnpm format:check`: clean
- `pnpm knip`: clean (no new unused exports — all marked symbols still have internal callers)

## Sequencing

- Documentation-only; safe to land independently.
- Open as draft; sequences behind Alex's Phase B (#11939, #11811).
- CI failures don't block per AGENTS.md rule #8.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12232-docs-litegraph-mark-subgraph-building-blocks-as-internal-35f6d73d365081a5a24bd57c8acd2ffa) by [Unito](https://www.unito.io)
