### PR TITLE
fix(model-library): auto-refresh after upload, plus 'r' key fallback (FE-695)

### DIFF
--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.test.ts
@@ -16,7 +16,9 @@ const {
   resetRoot,
   mockAddNodeOnGraph,
   mockGetNodeProvider,
-  mockToggleNodeOnEvent
+  mockToggleNodeOnEvent,
+  mockRefreshModelFolder,
+  downloadStoreState
 } = vi.hoisted(() => {
   let capturedRoot: TreeExplorerNode<unknown> | null = null
   return {
@@ -29,7 +31,9 @@ const {
     },
     mockAddNodeOnGraph: vi.fn(),
     mockGetNodeProvider: vi.fn(),
-    mockToggleNodeOnEvent: vi.fn()
+    mockToggleNodeOnEvent: vi.fn(),
+    mockRefreshModelFolder: vi.fn().mockResolvedValue(undefined),
+    downloadStoreState: { setLastCompleted: (_: unknown) => {} }
   }
 })
 
@@ -59,9 +63,30 @@ vi.mock('@/stores/modelStore', () => ({
     modelFolders: [],
     models: [mockModel],
     loadModels: vi.fn().mockResolvedValue([]),
-    loadModelFolders: vi.fn().mockResolvedValue([])
+    loadModelFolders: vi.fn().mockResolvedValue([]),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    refreshModelFolder: mockRefreshModelFolder
   })
 }))
+
+vi.mock('@/stores/assetDownloadStore', async () => {
+  const { ref } = await import('vue')
+  const lastCompletedDownload = ref<{
+    taskId: string
+    modelType: string
+    timestamp: number
+  } | null>(null)
+  downloadStoreState.setLastCompleted = (value) => {
+    lastCompletedDownload.value = value as typeof lastCompletedDownload.value
+  }
+  return {
+    useAssetDownloadStore: () => ({
+      get lastCompletedDownload() {
+        return lastCompletedDownload.value
+      }
+    })
+  }
+})
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
@@ -131,6 +156,7 @@ describe('ModelLibrarySidebarTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetRoot()
+    downloadStoreState.setLastCompleted(null)
   })
 
   function renderComponent() {
@@ -187,5 +213,28 @@ describe('ModelLibrarySidebarTab', () => {
     await checkpointsFolder?.handleClick?.(mockEvent)
 
     expect(mockToggleNodeOnEvent).toHaveBeenCalled()
+  })
+
+  it('refreshes the affected folder when an asset download completes', async () => {
+    renderComponent()
+    await nextTick()
+
+    expect(mockRefreshModelFolder).not.toHaveBeenCalled()
+
+    downloadStoreState.setLastCompleted({
+      taskId: 'task-1',
+      modelType: 'checkpoints',
+      timestamp: Date.now()
+    })
+    await nextTick()
+
+    expect(mockRefreshModelFolder).toHaveBeenCalledWith('checkpoints')
+  })
+
+  it('does not refresh when no download has completed', async () => {
+    renderComponent()
+    await nextTick()
+
+    expect(mockRefreshModelFolder).not.toHaveBeenCalled()
   })
 })

--- a/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
+++ b/src/components/sidebar/tabs/ModelLibrarySidebarTab.vue
@@ -6,7 +6,7 @@
         variant="muted-textonly"
         size="icon"
         :aria-label="$t('g.refresh')"
-        @click="modelStore.loadModelFolders"
+        @click="modelStore.refresh"
       >
         <i class="icon-[lucide--refresh-cw] size-4" />
       </Button>
@@ -66,6 +66,7 @@ import Button from '@/components/ui/button/Button.vue'
 import { useTreeExpansion } from '@/composables/useTreeExpansion'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useLitegraphService } from '@/services/litegraphService'
+import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import type { ComfyModelDef, ModelFolder } from '@/stores/modelStore'
 import { ResourceState, useModelStore } from '@/stores/modelStore'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
@@ -76,6 +77,7 @@ import { buildTree } from '@/utils/treeUtil'
 const modelStore = useModelStore()
 const modelToNodeStore = useModelToNodeStore()
 const settingStore = useSettingStore()
+const assetDownloadStore = useAssetDownloadStore()
 const searchBoxRef = ref()
 const searchQuery = ref<string>('')
 const expandedKeys = ref<Record<string, boolean>>({})
@@ -187,6 +189,14 @@ watch(
     })
   },
   { deep: true }
+)
+
+watch(
+  () => assetDownloadStore.lastCompletedDownload,
+  (completed) => {
+    if (!completed) return
+    void modelStore.refreshModelFolder(completed.modelType)
+  }
 )
 
 onMounted(async () => {

--- a/src/composables/useCoreCommands.test.ts
+++ b/src/composables/useCoreCommands.test.ts
@@ -8,6 +8,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
+import type * as ModelStoreModule from '@/stores/modelStore'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 // Mock vue-i18n for useExternalLink
@@ -66,6 +67,15 @@ vi.mock('@/scripts/api', () => ({
     apiURL: vi.fn(() => 'http://localhost:8188')
   }
 }))
+
+const mockModelStoreRefresh = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/stores/modelStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof ModelStoreModule>()
+  return {
+    ...actual,
+    useModelStore: () => ({ refresh: mockModelStoreRefresh })
+  }
+})
 
 vi.mock('@/platform/settings/settingStore')
 
@@ -558,10 +568,11 @@ describe('useCoreCommands', () => {
       expect(app.openClipspace).toHaveBeenCalled()
     })
 
-    it('Comfy.RefreshNodeDefinitions awaits app.refreshComboInNodes', async () => {
+    it('Comfy.RefreshNodeDefinitions refreshes combos and the model library', async () => {
       await findCmd('Comfy.RefreshNodeDefinitions').function()
 
       expect(app.refreshComboInNodes).toHaveBeenCalled()
+      expect(mockModelStoreRefresh).toHaveBeenCalled()
     })
   })
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -40,6 +40,7 @@ import { useDialogService } from '@/services/dialogService'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { ComfyCommand } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
+import { useModelStore } from '@/stores/modelStore'
 import { useHelpCenterStore } from '@/stores/helpCenterStore'
 import {
   useQueueSettingsStore,
@@ -82,6 +83,7 @@ export function useCoreCommands(): ComfyCommand[] {
   const toastStore = useToastStore()
   const canvasStore = useCanvasStore()
   const executionStore = useExecutionStore()
+  const modelStore = useModelStore()
   const telemetry = useTelemetry()
   const { staticUrls, buildDocsUrl } = useExternalLink()
   const settingStore = useSettingStore()
@@ -306,7 +308,7 @@ export function useCoreCommands(): ComfyCommand[] {
       label: 'Refresh Node Definitions',
       category: 'essentials' as const,
       function: async () => {
-        await app.refreshComboInNodes()
+        await Promise.all([app.refreshComboInNodes(), modelStore.refresh()])
       }
     },
     {

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -148,6 +148,69 @@ describe('useModelStore', () => {
     expect(api.getModels).toHaveBeenCalledTimes(1)
   })
 
+  describe('refreshModelFolder', () => {
+    it('re-fetches the contents of a previously loaded folder', async () => {
+      enableMocks()
+      store = useModelStore()
+      await store.loadModelFolders()
+      await store.getLoadedModelFolder('checkpoints')
+      expect(api.getModels).toHaveBeenCalledTimes(1)
+
+      vi.mocked(api.getModels).mockResolvedValueOnce([
+        { name: 'sdxl.safetensors', pathIndex: 0 },
+        { name: 'sdv15.safetensors', pathIndex: 0 },
+        { name: 'noinfo.safetensors', pathIndex: 0 },
+        { name: 'new-upload.safetensors', pathIndex: 0 }
+      ])
+
+      await store.refreshModelFolder('checkpoints')
+
+      expect(api.getModels).toHaveBeenCalledTimes(2)
+      const folder = await store.getLoadedModelFolder('checkpoints')
+      expect(Object.keys(folder!.models)).toHaveLength(4)
+      expect(folder!.models['0/new-upload.safetensors']).toBeDefined()
+    })
+
+    it('falls back to refreshing folder structure when folder is unknown', async () => {
+      enableMocks()
+      store = useModelStore()
+      await store.loadModelFolders()
+      expect(api.getModelFolders).toHaveBeenCalledTimes(1)
+
+      await store.refreshModelFolder('loras')
+
+      expect(api.getModelFolders).toHaveBeenCalledTimes(2)
+      expect(api.getModels).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('refresh', () => {
+    it('re-loads only folders that were previously loaded', async () => {
+      enableMocks()
+      store = useModelStore()
+      await store.loadModelFolders()
+      await store.getLoadedModelFolder('checkpoints')
+      expect(api.getModels).toHaveBeenCalledTimes(1)
+
+      await store.refresh()
+
+      expect(api.getModelFolders).toHaveBeenCalledTimes(2)
+      expect(api.getModels).toHaveBeenCalledTimes(2)
+      expect(api.getModels).toHaveBeenLastCalledWith('checkpoints')
+    })
+
+    it('does not load folders that were never opened', async () => {
+      enableMocks()
+      store = useModelStore()
+      await store.loadModelFolders()
+
+      await store.refresh()
+
+      expect(api.getModelFolders).toHaveBeenCalledTimes(2)
+      expect(api.getModels).not.toHaveBeenCalled()
+    })
+  })
+
   describe('API switching functionality', () => {
     it('should use experimental API for complete workflow when UseAssetAPI setting is false', async () => {
       enableMocks(false) // useAssetAPI = false

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -205,6 +205,13 @@ export const useModelStore = defineStore('models', () => {
     modelFolders.value.flatMap((folder) => Object.values(folder.models))
   )
 
+  function createGetModelsFunc(): (folder: string) => Promise<ModelFile[]> {
+    const useAssetAPI: boolean = settingStore.get('Comfy.Assets.UseAssetAPI')
+    return useAssetAPI
+      ? (folder) => assetService.getAssetModels(folder)
+      : (folder) => api.getModels(folder)
+  }
+
   /**
    * Loads the model folders from the server
    */
@@ -216,11 +223,8 @@ export const useModelStore = defineStore('models', () => {
       : await api.getModelFolders()
     modelFolderNames.value = resData.map((folder) => folder.name)
     modelFolderByName.value = {}
+    const getModelsFunc = createGetModelsFunc()
     for (const folderName of modelFolderNames.value) {
-      const getModelsFunc = useAssetAPI
-        ? (folder: string) => assetService.getAssetModels(folder)
-        : (folder: string) => api.getModels(folder)
-
       modelFolderByName.value[folderName] = new ModelFolder(
         folderName,
         getModelsFunc
@@ -242,11 +246,46 @@ export const useModelStore = defineStore('models', () => {
     return Promise.all(modelFolders.value.map((folder) => folder.load()))
   }
 
+  /**
+   * Discards the cache for a single folder and re-loads its contents.
+   * Use when on-disk contents of that folder have changed (e.g. after upload).
+   * Falls back to refreshing the folder structure when the folder is unknown.
+   */
+  async function refreshModelFolder(folderName: string) {
+    if (!(folderName in modelFolderByName.value)) {
+      await loadModelFolders()
+      return
+    }
+    const folder = new ModelFolder(folderName, createGetModelsFunc())
+    await folder.load()
+    modelFolderByName.value[folderName] = folder
+  }
+
+  /**
+   * Refreshes the folder structure and re-loads any folder whose contents
+   * had previously been loaded. Used by manual refresh actions ("r" key,
+   * sidebar refresh button) to pick up on-disk changes without losing the
+   * currently-visible contents.
+   */
+  async function refresh() {
+    const previouslyLoaded = modelFolders.value
+      .filter((folder) => folder.state === ResourceState.Loaded)
+      .map((folder) => folder.directory)
+    await loadModelFolders()
+    await Promise.all(
+      previouslyLoaded
+        .filter((name) => name in modelFolderByName.value)
+        .map((name) => modelFolderByName.value[name].load())
+    )
+  }
+
   return {
     models,
     modelFolders,
     loadModelFolders,
     loadModels,
-    getLoadedModelFolder
+    getLoadedModelFolder,
+    refreshModelFolder,
+    refresh
   }
 })

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -249,11 +249,13 @@ export const useModelStore = defineStore('models', () => {
   /**
    * Discards the cache for a single folder and re-loads its contents.
    * Use when on-disk contents of that folder have changed (e.g. after upload).
-   * Falls back to refreshing the folder structure when the folder is unknown.
+   * Falls back to refreshing the whole library when the folder is unknown so
+   * a newly-introduced folder type is picked up without dropping other
+   * folders' loaded contents.
    */
   async function refreshModelFolder(folderName: string) {
     if (!(folderName in modelFolderByName.value)) {
-      await loadModelFolders()
+      await refresh()
       return
     }
     const folder = new ModelFolder(folderName, createGetModelsFunc())


### PR DESCRIPTION
## Summary

Model Library sidebar now refreshes automatically when an upload completes, and the `r` keybinding refreshes the library in addition to refreshing combo widgets inside graph nodes.

## Changes

- **What**:
  - `modelStore`: new `refreshModelFolder(name)` for surgical reset+reload of one folder, and `refresh()` that re-loads any folders that had been loaded
  - `ModelLibrarySidebarTab.vue`: watches `assetDownloadStore.lastCompletedDownload` and refreshes the affected folder; the in-panel refresh button now routes through `refresh()`
  - `Comfy.RefreshNodeDefinitions` (`r` key): also calls `modelStore.refresh()` so the keyboard fallback actually refreshes the Model Library list

## Review Focus

- Both `modelStore` and `assetsStore` exist; the upload wizard was only refreshing the latter, which is what caused the bug. Confirm the new watcher path is the right hook (rather than wiring it inside the wizard) — chose this so it also covers completions that happen after the wizard has been closed.
- `refreshModelFolder` falls back to `refresh()` (not raw `loadModelFolders()`) for unknown folder types, to avoid dropping other folders' loaded contents.
- Generated tab half of the ticket is intentionally **deferred** until BE-885 (cursor pagination on `GET /api/jobs`) lands — AC items around "no duplicates" and "cursor state maintained" depend on it.

Fixes FE-695 (Model Library half).

## Screenshots (if applicable)

N/A — behavior change verified by unit tests.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12257-fix-model-library-auto-refresh-after-upload-plus-r-key-fallback-3606d73d3650811a8895ef6e3ef2b4b8) by [Unito](https://www.unito.io)
