### PR TITLE
fix(terminal): resync logs console on backend reconnect

### DIFF
--- a/browser_tests/fixtures/helpers/LogsTerminalHelper.ts
+++ b/browser_tests/fixtures/helpers/LogsTerminalHelper.ts
@@ -1,19 +1,26 @@
-import { test as base } from '@playwright/test'
-import type { Page, Route } from '@playwright/test'
+import { test as base, expect } from '@playwright/test'
+import type { Page, Route, WebSocketRoute } from '@playwright/test'
 
 import type { LogsRawResponse } from '@/schemas/apiSchema'
+
+const RAW_LOGS_URL = '**/internal/logs/raw**'
+const SUBSCRIBE_LOGS_URL = '**/internal/logs/subscribe**'
 
 export class LogsTerminalHelper {
   constructor(private readonly page: Page) {}
 
-  async mockRawLogs(messages: string[]) {
-    await this.page.route('**/internal/logs/raw**', (route: Route) =>
-      route.fulfill({
+  async mockRawLogs(messages: string[]): Promise<() => number> {
+    let count = 0
+    await this.page.unroute(RAW_LOGS_URL)
+    await this.page.route(RAW_LOGS_URL, async (route: Route) => {
+      count += 1
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(LogsTerminalHelper.buildRawLogsResponse(messages))
       })
-    )
+    })
+    return () => count
   }
 
   async mockRawLogsPending(messages: string[] = []): Promise<() => void> {
@@ -21,7 +28,8 @@ export class LogsTerminalHelper {
     const pending = new Promise<void>((r) => {
       resolve = r
     })
-    await this.page.route('**/internal/logs/raw**', async (route: Route) => {
+    await this.page.unroute(RAW_LOGS_URL)
+    await this.page.route(RAW_LOGS_URL, async (route: Route) => {
       await pending
       await route.fulfill({
         status: 200,
@@ -33,15 +41,39 @@ export class LogsTerminalHelper {
   }
 
   async mockRawLogsError() {
-    await this.page.route('**/internal/logs/raw**', (route: Route) =>
+    await this.page.unroute(RAW_LOGS_URL)
+    await this.page.route(RAW_LOGS_URL, (route: Route) =>
       route.fulfill({ status: 500, body: 'Internal Server Error' })
     )
   }
 
-  async mockSubscribeLogs() {
-    await this.page.route('**/internal/logs/subscribe**', (route: Route) =>
-      route.fulfill({ status: 200, body: '' })
-    )
+  async mockSubscribeLogs(): Promise<() => number> {
+    let count = 0
+    await this.page.unroute(SUBSCRIBE_LOGS_URL)
+    await this.page.route(SUBSCRIBE_LOGS_URL, async (route: Route) => {
+      count += 1
+      await route.fulfill({ status: 200, body: '' })
+    })
+    return () => count
+  }
+
+  /**
+   * Force the frontend to reconnect by closing the proxied WebSocket. The
+   * api layer reschedules a fresh `WebSocket(...)`, the routeWebSocket
+   * handler fires again, and on `open` with `isReconnect=true` it dispatches
+   * `'reconnected'`, which triggers the logs-terminal resync.
+   *
+   * Use the resync's `subscribeLogs(true)` HTTP call as the sync point — by
+   * the time the count goes up, the new socket is open and resync has
+   * completed enough to assert against the terminal.
+   */
+  async triggerReconnect(
+    ws: WebSocketRoute,
+    subscribeFetches: () => number
+  ): Promise<void> {
+    const before = subscribeFetches()
+    await ws.close()
+    await expect.poll(subscribeFetches).toBeGreaterThan(before)
   }
 
   static buildWsLogFrame(messages: string[]): string {

--- a/browser_tests/tests/bottomPanelLogs.spec.ts
+++ b/browser_tests/tests/bottomPanelLogs.spec.ts
@@ -147,5 +147,68 @@ test.describe('Bottom Panel Logs', { tag: '@ui' }, () => {
       )
       await expect(comfyPage.bottomPanel.logs.terminalRoot).toBeHidden()
     })
+
+    test('resyncs the terminal when the WebSocket reconnects', async ({
+      comfyPage,
+      logsTerminal,
+      getWebSocket
+    }) => {
+      const subscribeFetches = await logsTerminal.mockSubscribeLogs()
+      const initialLine = 'pre-reboot log line'
+      const postRebootLineA = 'post-reboot line A'
+      const postRebootLineB = 'post-reboot line B'
+
+      await logsTerminal.mockRawLogs([initialLine])
+      await comfyPage.bottomPanel.toggleLogs()
+      await expect(comfyPage.bottomPanel.logs.terminalRoot).toContainText(
+        initialLine
+      )
+
+      // Swap the raw-logs mock so the next fetch returns the post-reboot view.
+      await logsTerminal.mockRawLogs([postRebootLineA, postRebootLineB])
+
+      const ws = await getWebSocket()
+      await logsTerminal.triggerReconnect(ws, subscribeFetches)
+
+      await expect(comfyPage.bottomPanel.logs.terminalRoot).toContainText(
+        postRebootLineA
+      )
+      await expect(comfyPage.bottomPanel.logs.terminalRoot).toContainText(
+        postRebootLineB
+      )
+      // reset() before write means the pre-reboot line must be gone.
+      await expect(comfyPage.bottomPanel.logs.terminalRoot).not.toContainText(
+        initialLine
+      )
+    })
+
+    test('resumes WebSocket log streaming after the reconnect', async ({
+      comfyPage,
+      logsTerminal,
+      getWebSocket
+    }) => {
+      const subscribeFetches = await logsTerminal.mockSubscribeLogs()
+      await logsTerminal.mockRawLogs(['initial'])
+      await comfyPage.bottomPanel.toggleLogs()
+      await expect(comfyPage.bottomPanel.logs.terminalRoot).toContainText(
+        'initial'
+      )
+
+      await logsTerminal.mockRawLogs(['after-reboot snapshot'])
+
+      const ws = await getWebSocket()
+      await logsTerminal.triggerReconnect(ws, subscribeFetches)
+
+      // The route handler fires again on the new connection; pull the latest
+      // WebSocketRoute and push a live frame to prove the 'logs' listener
+      // survived the reconnect.
+      const liveLine = 'live log emitted after the reconnect'
+      const newWs = await getWebSocket()
+      newWs.send(LogsTerminalHelper.buildWsLogFrame([liveLine]))
+
+      await expect(comfyPage.bottomPanel.logs.terminalRoot).toContainText(
+        liveLine
+      )
+    })
   })
 })

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -212,6 +212,29 @@ describe('LogsTerminal', () => {
     })
   })
 
+  it('recovers from an initial load failure when a reconnect arrives', async () => {
+    apiMock.getRawLogs
+      .mockRejectedValueOnce(new Error('initial fail'))
+      .mockResolvedValueOnce({ entries: [{ m: 'recovered\n' }] })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    renderLogsTerminal()
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByTestId('terminal-error-message').textContent
+      ).toContain('Unable to load logs')
+    })
+
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('terminal-error-message')).toBeNull()
+      expect(screen.queryByTestId('terminal-loading-spinner')).toBeNull()
+      expect(terminalMock.write).toHaveBeenCalledWith('recovered\n')
+    })
+  })
+
   it('cleans up listeners and unsubscribes on unmount', async () => {
     const { unmount } = renderLogsTerminal()
     await vi.waitFor(() => {

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -1,0 +1,112 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import LogsTerminal from '@/components/bottomPanel/tabs/terminal/LogsTerminal.vue'
+
+const apiMock = vi.hoisted(() => {
+  const target = new EventTarget() as EventTarget & {
+    clientId: string | null
+    getRawLogs: ReturnType<typeof vi.fn>
+    subscribeLogs: ReturnType<typeof vi.fn>
+  }
+  target.clientId = 'test-client'
+  target.getRawLogs = vi.fn(async () => ({ entries: [{ m: 'log line\n' }] }))
+  target.subscribeLogs = vi.fn(async () => {})
+  return target
+})
+
+vi.mock('@/scripts/api', () => ({ api: apiMock }))
+
+const terminalMock = vi.hoisted(() => ({
+  open: vi.fn(),
+  dispose: vi.fn(),
+  write: vi.fn(),
+  reset: vi.fn(),
+  onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+  hasSelection: vi.fn(() => false),
+  getSelection: vi.fn(() => ''),
+  selectAll: vi.fn(),
+  clearSelection: vi.fn()
+}))
+
+vi.mock('@/composables/bottomPanelTabs/useTerminal', () => ({
+  useTerminal: vi.fn(() => ({
+    terminal: terminalMock,
+    useAutoSize: vi.fn(() => ({ resize: vi.fn() }))
+  }))
+}))
+
+vi.mock('@/components/bottomPanel/tabs/terminal/BaseTerminal.vue', async () => {
+  const { defineComponent, ref } = await import('vue')
+  const { useTerminal } =
+    await import('@/composables/bottomPanelTabs/useTerminal')
+  return {
+    default: defineComponent({
+      emits: ['created'],
+      setup(_, { emit }) {
+        const root = ref<HTMLElement | undefined>(undefined)
+        emit('created', useTerminal(root), root)
+        return () => null
+      }
+    })
+  }
+})
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+const renderLogsTerminal = () =>
+  render(LogsTerminal, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          stubActions: false,
+          initialState: { execution: { clientId: 'test-client' } }
+        }),
+        i18n
+      ]
+    }
+  })
+
+describe('LogsTerminal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('resyncs logs when the api dispatches "reconnected"', async () => {
+    renderLogsTerminal()
+
+    await vi.waitFor(() => {
+      expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+    })
+
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+
+    await vi.waitFor(() => {
+      expect(terminalMock.reset).toHaveBeenCalledTimes(1)
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('stops handling "reconnected" after unmount', async () => {
+    const { unmount } = renderLogsTerminal()
+
+    await vi.waitFor(() => {
+      expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+    await vi.waitFor(() => {
+      expect(apiMock.subscribeLogs).toHaveBeenCalledWith(false)
+    })
+
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+
+    expect(terminalMock.reset).not.toHaveBeenCalled()
+    expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -104,6 +104,10 @@ describe('LogsTerminal', () => {
     apiMock.subscribeLogs.mockImplementation(async () => {})
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('loads logs and subscribes to streaming on mount', async () => {
     renderLogsTerminal()
 
@@ -131,12 +135,14 @@ describe('LogsTerminal', () => {
       expect(apiMock.subscribeLogs).toHaveBeenLastCalledWith(true)
     })
 
-    // The full sequence must be: refetch -> reset -> write -> scroll -> subscribe
+    // The full sequence must be: reset -> write -> scroll -> subscribe
     const resetOrder = terminalMock.reset.mock.invocationCallOrder[0]
+    const writeOrder = terminalMock.write.mock.invocationCallOrder.at(-1)!
     const scrollOrder = terminalMock.scrollToBottom.mock.invocationCallOrder[0]
     const subscribeOrder =
       apiMock.subscribeLogs.mock.invocationCallOrder.at(-1)!
-    expect(resetOrder).toBeLessThan(scrollOrder)
+    expect(resetOrder).toBeLessThan(writeOrder)
+    expect(writeOrder).toBeLessThan(scrollOrder)
     expect(scrollOrder).toBeLessThan(subscribeOrder)
   })
 

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -1,21 +1,19 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import LogsTerminal from '@/components/bottomPanel/tabs/terminal/LogsTerminal.vue'
 
-const apiMock = vi.hoisted(() => {
-  const target = new EventTarget() as EventTarget & {
-    clientId: string | null
-    getRawLogs: ReturnType<typeof vi.fn>
-    subscribeLogs: ReturnType<typeof vi.fn>
-  }
-  target.clientId = 'test-client'
-  target.getRawLogs = vi.fn(async () => ({ entries: [{ m: 'log line\n' }] }))
-  target.subscribeLogs = vi.fn(async () => {})
-  return target
-})
+const apiMock = vi.hoisted(
+  () =>
+    new (class extends EventTarget {
+      clientId: string | null = 'test-client'
+      getRawLogs = vi.fn(async () => ({ entries: [{ m: 'log line\n' }] }))
+      subscribeLogs = vi.fn(async () => {})
+    })()
+)
 
 vi.mock('@/scripts/api', () => ({ api: apiMock }))
 
@@ -55,7 +53,20 @@ vi.mock('@/components/bottomPanel/tabs/terminal/BaseTerminal.vue', async () => {
   }
 })
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      logsTerminal: {
+        loadError:
+          'Unable to load logs, please ensure you have updated your ComfyUI backend.',
+        resyncError:
+          'Unable to resync logs after the backend reconnected. Reopen the console to retry.'
+      }
+    }
+  }
+})
 
 const renderLogsTerminal = () =>
   render(LogsTerminal, {
@@ -71,38 +82,140 @@ const renderLogsTerminal = () =>
     }
   })
 
+// Resolve a getRawLogs call manually to drive deterministic timing in tests
+// that need to observe behavior mid-fetch.
+const deferredRawLogs = () => {
+  let resolve!: (value: { entries: { m: string }[] }) => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<{ entries: { m: string }[] }>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 describe('LogsTerminal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    apiMock.clientId = 'test-client'
+    apiMock.getRawLogs.mockImplementation(async () => ({
+      entries: [{ m: 'log line\n' }]
+    }))
+    apiMock.subscribeLogs.mockImplementation(async () => {})
   })
 
-  it('resyncs logs, re-subscribes, and scrolls to bottom on "reconnected"', async () => {
+  it('loads logs and subscribes to streaming on mount', async () => {
+    renderLogsTerminal()
+
+    await vi.waitFor(() => {
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+      expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
+      expect(terminalMock.write).toHaveBeenCalledWith('log line\n')
+    })
+  })
+
+  it('resyncs, snaps to tail, and re-subscribes on "reconnected"', async () => {
     renderLogsTerminal()
 
     await vi.waitFor(() => {
       expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
-      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
     })
 
     apiMock.dispatchEvent(new CustomEvent('reconnected'))
 
-    // Backend loses its per-client log subscription on restart, so the
-    // terminal must reset + refetch + re-subscribe + snap to the new tail.
     await vi.waitFor(() => {
-      expect(terminalMock.reset).toHaveBeenCalledTimes(1)
       expect(apiMock.getRawLogs).toHaveBeenCalledTimes(2)
+      expect(terminalMock.reset).toHaveBeenCalledTimes(1)
       expect(terminalMock.scrollToBottom).toHaveBeenCalledTimes(1)
       expect(apiMock.subscribeLogs).toHaveBeenCalledTimes(2)
       expect(apiMock.subscribeLogs).toHaveBeenLastCalledWith(true)
     })
+
+    // The full sequence must be: refetch -> reset -> write -> scroll -> subscribe
+    const resetOrder = terminalMock.reset.mock.invocationCallOrder[0]
+    const scrollOrder = terminalMock.scrollToBottom.mock.invocationCallOrder[0]
+    const subscribeOrder =
+      apiMock.subscribeLogs.mock.invocationCallOrder.at(-1)!
+    expect(resetOrder).toBeLessThan(scrollOrder)
+    expect(scrollOrder).toBeLessThan(subscribeOrder)
   })
 
-  it('stops handling "reconnected" after unmount', async () => {
-    const { unmount } = renderLogsTerminal()
-
+  it('aborts an in-flight resync when a second "reconnected" arrives', async () => {
+    renderLogsTerminal()
     await vi.waitFor(() => {
       expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
-      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+    })
+
+    // First resync hangs on getRawLogs
+    const first = deferredRawLogs()
+    apiMock.getRawLogs.mockImplementationOnce(() => first.promise)
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+    await vi.waitFor(() => {
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(2)
+    })
+
+    // Second resync resolves immediately
+    apiMock.getRawLogs.mockImplementationOnce(async () => ({
+      entries: [{ m: 'fresh\n' }]
+    }))
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+    await vi.waitFor(() => {
+      expect(terminalMock.reset).toHaveBeenCalledTimes(1)
+    })
+
+    // Now resolve the first (aborted) resync — none of its side effects must apply
+    first.resolve({ entries: [{ m: 'stale\n' }] })
+    await nextTick()
+    await nextTick()
+
+    expect(terminalMock.reset).toHaveBeenCalledTimes(1)
+    expect(terminalMock.write).not.toHaveBeenCalledWith('stale\n')
+    expect(terminalMock.write).toHaveBeenCalledWith('fresh\n')
+  })
+
+  it('surfaces an inline error when the resync fetch fails', async () => {
+    renderLogsTerminal()
+    await vi.waitFor(() => {
+      expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
+    })
+
+    apiMock.getRawLogs.mockRejectedValueOnce(new Error('boom'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error resyncing logs after reconnect',
+        expect.any(Error)
+      )
+      expect(
+        screen.getByTestId('terminal-error-message').textContent
+      ).toContain('Unable to resync logs')
+    })
+  })
+
+  it('shows a load error when the initial fetch fails', async () => {
+    apiMock.getRawLogs.mockRejectedValueOnce(new Error('boom'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    renderLogsTerminal()
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'Error loading logs',
+        expect.any(Error)
+      )
+      expect(
+        screen.getByTestId('terminal-error-message').textContent
+      ).toContain('Unable to load logs')
+    })
+  })
+
+  it('cleans up listeners and unsubscribes on unmount', async () => {
+    const { unmount } = renderLogsTerminal()
+    await vi.waitFor(() => {
+      expect(apiMock.subscribeLogs).toHaveBeenCalledWith(true)
     })
 
     unmount()
@@ -111,8 +224,27 @@ describe('LogsTerminal', () => {
     })
 
     apiMock.dispatchEvent(new CustomEvent('reconnected'))
+    await nextTick()
 
     expect(terminalMock.reset).not.toHaveBeenCalled()
+    // No additional getRawLogs beyond the mount-time call
     expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not write to the terminal when unmount happens mid-fetch', async () => {
+    const pending = deferredRawLogs()
+    apiMock.getRawLogs.mockImplementationOnce(() => pending.promise)
+
+    const { unmount } = renderLogsTerminal()
+    await vi.waitFor(() => {
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+    pending.resolve({ entries: [{ m: 'late\n' }] })
+    await nextTick()
+    await nextTick()
+
+    expect(terminalMock.write).not.toHaveBeenCalled()
   })
 })

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -175,6 +175,33 @@ describe('LogsTerminal', () => {
     expect(terminalMock.write).toHaveBeenCalledWith('fresh\n')
   })
 
+  it('aborts an in-flight mount fetch when "reconnected" arrives first', async () => {
+    // Mount's getRawLogs hangs so we can drive the race deterministically.
+    const mount = deferredRawLogs()
+    apiMock.getRawLogs.mockImplementationOnce(() => mount.promise)
+    renderLogsTerminal()
+    await vi.waitFor(() => {
+      expect(apiMock.getRawLogs).toHaveBeenCalledTimes(1)
+    })
+
+    // Resync wins the race and writes the post-reboot snapshot.
+    apiMock.getRawLogs.mockImplementationOnce(async () => ({
+      entries: [{ m: 'fresh\n' }]
+    }))
+    apiMock.dispatchEvent(new CustomEvent('reconnected'))
+    await vi.waitFor(() => {
+      expect(terminalMock.reset).toHaveBeenCalledTimes(1)
+      expect(terminalMock.write).toHaveBeenCalledWith('fresh\n')
+    })
+
+    // Mount's late response must not stomp on the freshly-reset terminal.
+    mount.resolve({ entries: [{ m: 'stale-mount\n' }] })
+    await nextTick()
+    await nextTick()
+
+    expect(terminalMock.write).not.toHaveBeenCalledWith('stale-mount\n')
+  })
+
   it('surfaces an inline error when the resync fetch fails', async () => {
     renderLogsTerminal()
     await vi.waitFor(() => {

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -24,6 +24,7 @@ const terminalMock = vi.hoisted(() => ({
   dispose: vi.fn(),
   write: vi.fn(),
   reset: vi.fn(),
+  scrollToBottom: vi.fn(),
   onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
   hasSelection: vi.fn(() => false),
   getSelection: vi.fn(() => ''),
@@ -75,7 +76,7 @@ describe('LogsTerminal', () => {
     vi.clearAllMocks()
   })
 
-  it('resyncs logs when the api dispatches "reconnected"', async () => {
+  it('resyncs logs, re-subscribes, and scrolls to bottom on "reconnected"', async () => {
     renderLogsTerminal()
 
     await vi.waitFor(() => {
@@ -85,9 +86,14 @@ describe('LogsTerminal', () => {
 
     apiMock.dispatchEvent(new CustomEvent('reconnected'))
 
+    // Backend loses its per-client log subscription on restart, so the
+    // terminal must reset + refetch + re-subscribe + snap to the new tail.
     await vi.waitFor(() => {
       expect(terminalMock.reset).toHaveBeenCalledTimes(1)
       expect(apiMock.getRawLogs).toHaveBeenCalledTimes(2)
+      expect(terminalMock.scrollToBottom).toHaveBeenCalledTimes(1)
+      expect(apiMock.subscribeLogs).toHaveBeenCalledTimes(2)
+      expect(apiMock.subscribeLogs).toHaveBeenLastCalledWith(true)
     })
   })
 

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -82,6 +82,10 @@ const renderLogsTerminal = () =>
     }
   })
 
+// Silence the production console.error calls in error-path tests. Vitest
+// isolates this file's module graph so the spy does not affect other files.
+vi.spyOn(console, 'error').mockImplementation(() => {})
+
 // Resolve a getRawLogs call manually to drive deterministic timing in tests
 // that need to observe behavior mid-fetch.
 const deferredRawLogs = () => {
@@ -98,14 +102,6 @@ describe('LogsTerminal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     apiMock.clientId = 'test-client'
-    apiMock.getRawLogs.mockImplementation(async () => ({
-      entries: [{ m: 'log line\n' }]
-    }))
-    apiMock.subscribeLogs.mockImplementation(async () => {})
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
   })
 
   it('loads logs and subscribes to streaming on mount', async () => {
@@ -186,15 +182,10 @@ describe('LogsTerminal', () => {
     })
 
     apiMock.getRawLogs.mockRejectedValueOnce(new Error('boom'))
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     apiMock.dispatchEvent(new CustomEvent('reconnected'))
 
     await vi.waitFor(() => {
-      expect(consoleError).toHaveBeenCalledWith(
-        'Error resyncing logs after reconnect',
-        expect.any(Error)
-      )
       expect(
         screen.getByTestId('terminal-error-message').textContent
       ).toContain('Unable to resync logs')
@@ -203,15 +194,10 @@ describe('LogsTerminal', () => {
 
   it('shows a load error when the initial fetch fails', async () => {
     apiMock.getRawLogs.mockRejectedValueOnce(new Error('boom'))
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     renderLogsTerminal()
 
     await vi.waitFor(() => {
-      expect(consoleError).toHaveBeenCalledWith(
-        'Error loading logs',
-        expect.any(Error)
-      )
       expect(
         screen.getByTestId('terminal-error-message').textContent
       ).toContain('Unable to load logs')
@@ -222,7 +208,6 @@ describe('LogsTerminal', () => {
     apiMock.getRawLogs
       .mockRejectedValueOnce(new Error('initial fail'))
       .mockResolvedValueOnce({ entries: [{ m: 'recovered\n' }] })
-    vi.spyOn(console, 'error').mockImplementation(() => {})
 
     renderLogsTerminal()
 

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
@@ -87,12 +87,15 @@ const terminalCreated = (
     loading.value = false
   })
 
-  onUnmounted(async () => {
-    if (api.clientId) {
-      await api.subscribeLogs(false)
-    }
+  onUnmounted(() => {
     api.removeEventListener('logs', logReceived)
     api.removeEventListener('reconnected', resyncLogs)
+
+    if (!api.clientId) return
+
+    api.subscribeLogs(false).catch((err) => {
+      console.error('Error unsubscribing from logs', err)
+    })
   })
 }
 </script>

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
@@ -55,6 +55,13 @@ const terminalCreated = (
     update(logs.entries)
   }
 
+  const resyncLogs = () => {
+    terminal.reset()
+    loadLogEntries().catch((err) => {
+      console.error('Error resyncing logs after reconnect', err)
+    })
+  }
+
   const watchLogs = async () => {
     const { clientId } = storeToRefs(useExecutionStore())
     if (!clientId.value) {
@@ -62,6 +69,7 @@ const terminalCreated = (
     }
     await api.subscribeLogs(true)
     api.addEventListener('logs', logReceived)
+    api.addEventListener('reconnected', resyncLogs)
   }
 
   onMounted(async () => {
@@ -84,6 +92,7 @@ const terminalCreated = (
       await api.subscribeLogs(false)
     }
     api.removeEventListener('logs', logReceived)
+    api.removeEventListener('reconnected', resyncLogs)
   })
 }
 </script>

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
@@ -55,11 +55,21 @@ const terminalCreated = (
     update(logs.entries)
   }
 
-  const resyncLogs = () => {
+  const resyncLogs = async () => {
     terminal.reset()
-    loadLogEntries().catch((err) => {
+    try {
+      await loadLogEntries()
+      terminal.scrollToBottom()
+      // Backend lost the per-client log subscription across the restart;
+      // re-subscribe so new runtime logs stream over the fresh WebSocket.
+      await api.subscribeLogs(true)
+    } catch (err) {
       console.error('Error resyncing logs after reconnect', err)
-    })
+    }
+  }
+
+  const handleReconnected = () => {
+    void resyncLogs()
   }
 
   const watchLogs = async () => {
@@ -69,7 +79,7 @@ const terminalCreated = (
     }
     await api.subscribeLogs(true)
     api.addEventListener('logs', logReceived)
-    api.addEventListener('reconnected', resyncLogs)
+    api.addEventListener('reconnected', handleReconnected)
   }
 
   onMounted(async () => {
@@ -89,7 +99,7 @@ const terminalCreated = (
 
   onUnmounted(() => {
     api.removeEventListener('logs', logReceived)
-    api.removeEventListener('reconnected', resyncLogs)
+    api.removeEventListener('reconnected', handleReconnected)
 
     if (!api.clientId) return
 

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
@@ -17,96 +17,28 @@
 </template>
 
 <script setup lang="ts">
-import { until } from '@vueuse/core'
-import { storeToRefs } from 'pinia'
+import type { Terminal } from '@xterm/xterm'
 import ProgressSpinner from 'primevue/progressspinner'
 import type { Ref } from 'vue'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { shallowRef } from 'vue'
 
 import type { useTerminal } from '@/composables/bottomPanelTabs/useTerminal'
-import type { LogEntry, LogsWsMessage } from '@/schemas/apiSchema'
-import { api } from '@/scripts/api'
-import { useExecutionStore } from '@/stores/executionStore'
+import { useLogsTerminal } from '@/composables/bottomPanelTabs/useLogsTerminal'
 
 import BaseTerminal from './BaseTerminal.vue'
 
-const errorMessage = ref('')
-const loading = ref(true)
+const terminal = shallowRef<Terminal>()
+const { errorMessage, loading } = useLogsTerminal(terminal)
 
 const terminalCreated = (
-  { terminal, useAutoSize }: ReturnType<typeof useTerminal>,
+  { terminal: instance, useAutoSize }: ReturnType<typeof useTerminal>,
   root: Ref<HTMLElement | undefined>
 ) => {
   // Auto-size terminal to fill container width.
   // minCols: 80 ensures minimum width for colab environments.
   // See https://github.com/comfyanonymous/ComfyUI/issues/6396
   useAutoSize({ root, autoRows: true, autoCols: true, minCols: 80 })
-
-  const update = (entries: Array<LogEntry>) => {
-    terminal.write(entries.map((e) => e.m).join(''))
-  }
-
-  const logReceived = (e: CustomEvent<LogsWsMessage>) => {
-    update(e.detail.entries)
-  }
-
-  const loadLogEntries = async () => {
-    const logs = await api.getRawLogs()
-    update(logs.entries)
-  }
-
-  const resyncLogs = async () => {
-    terminal.reset()
-    try {
-      await loadLogEntries()
-      terminal.scrollToBottom()
-      // Backend lost the per-client log subscription across the restart;
-      // re-subscribe so new runtime logs stream over the fresh WebSocket.
-      await api.subscribeLogs(true)
-    } catch (err) {
-      console.error('Error resyncing logs after reconnect', err)
-    }
-  }
-
-  const handleReconnected = () => {
-    void resyncLogs()
-  }
-
-  const watchLogs = async () => {
-    const { clientId } = storeToRefs(useExecutionStore())
-    if (!clientId.value) {
-      await until(clientId).not.toBeNull()
-    }
-    await api.subscribeLogs(true)
-    api.addEventListener('logs', logReceived)
-    api.addEventListener('reconnected', handleReconnected)
-  }
-
-  onMounted(async () => {
-    try {
-      await loadLogEntries()
-    } catch (err) {
-      console.error('Error loading logs', err)
-      // On older backends the endpoints won't exist
-      errorMessage.value =
-        'Unable to load logs, please ensure you have updated your ComfyUI backend.'
-      return
-    }
-
-    await watchLogs()
-    loading.value = false
-  })
-
-  onUnmounted(() => {
-    api.removeEventListener('logs', logReceived)
-    api.removeEventListener('reconnected', handleReconnected)
-
-    if (!api.clientId) return
-
-    api.subscribeLogs(false).catch((err) => {
-      console.error('Error unsubscribing from logs', err)
-    })
-  })
+  terminal.value = instance
 }
 </script>
 

--- a/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
+++ b/src/components/bottomPanel/tabs/terminal/LogsTerminal.vue
@@ -12,7 +12,10 @@
       data-testid="terminal-loading-spinner"
       class="relative inset-0 z-10 flex h-full items-center justify-center"
     />
-    <BaseTerminal v-show="!loading" @created="terminalCreated" />
+    <BaseTerminal
+      v-show="!loading && !errorMessage"
+      @created="terminalCreated"
+    />
   </div>
 </template>
 

--- a/src/composables/bottomPanelTabs/useLogsTerminal.ts
+++ b/src/composables/bottomPanelTabs/useLogsTerminal.ts
@@ -55,6 +55,7 @@ export function useLogsTerminal(
       await api.subscribeLogs(true)
       if (signal.aborted) return
       errorMessage.value = ''
+      loading.value = false
     } catch (err) {
       if (signal.aborted) return
       console.error('Error resyncing logs after reconnect', err)
@@ -87,6 +88,7 @@ export function useLogsTerminal(
       if (signal.aborted) return
       console.error('Error loading logs', err)
       errorMessage.value = t('logsTerminal.loadError')
+      loading.value = false
       return
     }
 

--- a/src/composables/bottomPanelTabs/useLogsTerminal.ts
+++ b/src/composables/bottomPanelTabs/useLogsTerminal.ts
@@ -39,6 +39,10 @@ export function useLogsTerminal(
   }
 
   const resyncLogs = async () => {
+    // Cancel both the in-flight mount fetch and any prior resync so a late
+    // mount response can't write a stale snapshot on top of a freshly-reset
+    // terminal after we've already written the post-reconnect view.
+    mountController?.abort()
     resyncController?.abort()
     const controller = new AbortController()
     resyncController = controller

--- a/src/composables/bottomPanelTabs/useLogsTerminal.ts
+++ b/src/composables/bottomPanelTabs/useLogsTerminal.ts
@@ -1,0 +1,117 @@
+import { until, useEventListener } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
+import type { Ref } from 'vue'
+import { onMounted, onScopeDispose, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { LogEntry, LogsWsMessage } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import { useExecutionStore } from '@/stores/executionStore'
+
+type TerminalLike = {
+  write: (data: string) => void
+  reset: () => void
+  scrollToBottom: () => void
+}
+
+/**
+ * Drives the built-in logs terminal: initial load, live `logs` stream, and
+ * full resync when the backend WebSocket reconnects (e.g., after a reboot).
+ *
+ * Listeners are registered synchronously so we cannot miss a `reconnected`
+ * event during the mount-time fetch/subscribe awaits. In-flight fetches are
+ * tied to AbortControllers so that:
+ *   - rapid double-reconnects don't interleave writes / double-subscribe
+ *   - unmount mid-fetch never writes to a disposed terminal
+ */
+export function useLogsTerminal(
+  terminal: Readonly<Ref<TerminalLike | undefined>>
+) {
+  const { t } = useI18n()
+  const errorMessage = ref('')
+  const loading = ref(true)
+
+  let mountController: AbortController | undefined
+  let resyncController: AbortController | undefined
+
+  const writeEntries = (entries: LogEntry[]) => {
+    terminal.value?.write(entries.map((e) => e.m).join(''))
+  }
+
+  const resyncLogs = async () => {
+    resyncController?.abort()
+    const controller = new AbortController()
+    resyncController = controller
+    const { signal } = controller
+
+    try {
+      const logs = await api.getRawLogs()
+      if (signal.aborted || !terminal.value) return
+      terminal.value.reset()
+      writeEntries(logs.entries)
+      terminal.value.scrollToBottom()
+      // Backend lost the per-client log subscription across the restart;
+      // re-subscribe so new runtime logs stream over the fresh WebSocket.
+      await api.subscribeLogs(true)
+      if (signal.aborted) return
+      errorMessage.value = ''
+    } catch (err) {
+      if (signal.aborted) return
+      console.error('Error resyncing logs after reconnect', err)
+      errorMessage.value = t('logsTerminal.resyncError')
+    }
+  }
+
+  // Register listeners synchronously, before any awaits, so a reconnect
+  // fired during mount cannot be missed. useEventListener handles cleanup
+  // on scope dispose.
+  useEventListener(api, 'logs', (e: CustomEvent<LogsWsMessage>) => {
+    writeEntries(e.detail.entries)
+  })
+  useEventListener(api, 'reconnected', () => {
+    void resyncLogs()
+  })
+
+  onMounted(async () => {
+    if (!terminal.value) await until(terminal).toBeTruthy()
+
+    const controller = new AbortController()
+    mountController = controller
+    const { signal } = controller
+
+    try {
+      const logs = await api.getRawLogs()
+      if (signal.aborted || !terminal.value) return
+      writeEntries(logs.entries)
+    } catch (err) {
+      if (signal.aborted) return
+      console.error('Error loading logs', err)
+      errorMessage.value = t('logsTerminal.loadError')
+      return
+    }
+
+    const { clientId } = storeToRefs(useExecutionStore())
+    if (!clientId.value) await until(clientId).not.toBeNull()
+    if (signal.aborted) return
+
+    try {
+      await api.subscribeLogs(true)
+    } catch (err) {
+      if (signal.aborted) return
+      console.error('Error subscribing to logs', err)
+    }
+
+    if (!signal.aborted) loading.value = false
+  })
+
+  onScopeDispose(() => {
+    mountController?.abort()
+    resyncController?.abort()
+    if (!api.clientId) return
+    api.subscribeLogs(false).catch((err) => {
+      console.error('Error unsubscribing from logs', err)
+    })
+  })
+
+  return { errorMessage, loading }
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1160,6 +1160,10 @@
     "saveAsTemplate": "Save as template",
     "enterName": "Enter name"
   },
+  "logsTerminal": {
+    "loadError": "Unable to load logs, please ensure you have updated your ComfyUI backend.",
+    "resyncError": "Unable to resync logs after the backend reconnected. Reopen the console to retry."
+  },
   "workflowService": {
     "exportWorkflow": "Export Workflow",
     "enterFilename": "Enter the filename",


### PR DESCRIPTION
## Summary

When the built-in logs terminal stayed open during a backend restart, the buffer froze on pre-restart entries and live log streaming silently stopped — only closing and reopening the panel resynced. Listen for the api `reconnected` event and rebuild the terminal contents the same way a fresh open would.

## Changes

- **What**:
  - Extract `useLogsTerminal` composable. The SFC is now a thin shell holding `terminal: shallowRef<Terminal>` and forwarding to the composable, so `onMounted`/`onScopeDispose` no longer rely on the child's emit callback timing.
  - Subscribe to `api`'s `reconnected` event via `useEventListener`, registered synchronously before any awaits. On reconnect: `terminal.reset()` → refetch raw logs → `scrollToBottom()` → `subscribeLogs(true)` (the backend loses the per-client subscription on restart, so re-subscribe is required for live streaming to resume).
  - Wrap in-flight resync/mount fetches in AbortControllers. Overlapping reconnects abort the prior resync, and unmount mid-fetch suppresses writes to the disposed xterm.
  - Hide BaseTerminal whenever `errorMessage` is set so the error layout doesn't expose an empty xterm container behind the message; `loading=false` after both load failure and resync success so a later successful reconnect can clear a stuck spinner.
  - Migrate the load/resync error strings to vue-i18n (`logsTerminal.loadError`, `logsTerminal.resyncError`).

## Review Focus

- **Re-subscribe is the non-obvious half of the fix** — without it, even after the WebSocket reconnects the backend never resumes streaming logs to this client because its subscription state was wiped on restart. The visible "stale buffer" is only one symptom; the silent "no new logs" symptom needed the explicit `subscribeLogs(true)` re-call in resync.
- `terminal.reset()` lives after a successful raw-logs fetch (not before) so a failed resync leaves the prior buffer visible instead of blanking it; resync errors surface via the same inline error message the mount path uses.
- 8 unit tests around the composable: mount + subscribe, resync ordering (reset → write → scroll → subscribe via `invocationCallOrder`), in-flight resync abort on double reconnect, resync error surfacing, mount-failure-then-recovery, unmount-mid-fetch terminal-write suppression, listener cleanup on unmount.
- 2 E2E tests using `ws.close()` on the proxied WebSocket as the reconnect trigger and `subscribeLogs` HTTP fetch count as the sync point (same pattern as `wsReconnectStaleJob.spec.ts`). Red-checked: disabling the `reconnected` listener fails exactly the two new tests, all 8 pre-existing tests stay green.

Fixes FE-712

## Screenshots

Before - (After rebooting, the console window does not update from its state before the reboot must remount the console window for it to resync.)

https://github.com/user-attachments/assets/b1e49c2c-89a4-4a4a-82b4-064412acee12

After - (The console window syncs automatically after a reboot.)

https://github.com/user-attachments/assets/54b582c5-ad42-41c0-9886-18f4495859da




┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12270-fix-terminal-resync-logs-console-on-backend-reconnect-3606d73d3650812fb13fd1934c632344) by [Unito](https://www.unito.io)