### PR TITLE
test: cover job history sidebar with typed route mocks

### DIFF
--- a/browser_tests/fixtures/components/QueuePanel.ts
+++ b/browser_tests/fixtures/components/QueuePanel.ts
@@ -5,11 +5,13 @@ import { TestIds } from '@e2e/fixtures/selectors'
 
 export class QueuePanel {
   readonly overlayToggle: Locator
+  readonly overlay: Locator
   readonly moreOptionsButton: Locator
 
   constructor(readonly page: Page) {
     this.overlayToggle = page.getByTestId(TestIds.queue.overlayToggle)
-    this.moreOptionsButton = page.getByLabel(/More options/i).first()
+    this.overlay = page.getByTestId(TestIds.queue.progressOverlay)
+    this.moreOptionsButton = this.overlay.getByLabel(/More options/i)
   }
 
   async openClearHistoryDialog() {

--- a/browser_tests/fixtures/jobsRouteFixture.ts
+++ b/browser_tests/fixtures/jobsRouteFixture.ts
@@ -1,6 +1,11 @@
 import { test as base } from '@playwright/test'
 import type { Page } from '@playwright/test'
 import type { z } from 'zod'
+import {
+  zHistoryManageRequest,
+  zQueueManageRequest,
+  zQueueManageResponse
+} from '@comfyorg/ingest-types/zod'
 
 import type {
   JobStatus,
@@ -9,6 +14,8 @@ import type {
 } from '@/platform/remote/comfyui/jobs/jobTypes'
 
 type JobsListResponse = z.infer<typeof zJobsListResponse>
+type HistoryManageRequest = z.infer<typeof zHistoryManageRequest>
+type QueueManageRequest = z.infer<typeof zQueueManageRequest>
 
 const terminalJobStatuses = [
   'completed',
@@ -22,7 +29,8 @@ const activeJobStatuses = [
 const defaultJobsListLimit = 200
 const defaultScenarioHistoryLimit = 64
 const defaultJobsListOffset = 0
-const defaultRouteMockJobTimestamp = Date.UTC(2026, 0, 1, 12)
+
+export const routeMockJobTimestamp = Date.UTC(2026, 0, 1, 12)
 
 interface JobsListRoute {
   statuses: readonly JobStatus[]
@@ -64,11 +72,9 @@ function hasJobsListPageParams(
   )
 }
 
-function isJobsListRequest(url: URL, route: JobsListRoute): boolean {
+function matchesJobsListRoute(url: URL, route: JobsListRoute): boolean {
   return (
-    url.pathname.endsWith('/api/jobs') &&
-    hasExactStatuses(url, route.statuses) &&
-    hasJobsListPageParams(url, route)
+    hasExactStatuses(url, route.statuses) && hasJobsListPageParams(url, route)
   )
 }
 
@@ -97,9 +103,9 @@ export function createRouteMockJob({
   return {
     id,
     status: 'completed',
-    create_time: defaultRouteMockJobTimestamp,
-    execution_start_time: defaultRouteMockJobTimestamp,
-    execution_end_time: defaultRouteMockJobTimestamp + 5_000,
+    create_time: routeMockJobTimestamp,
+    execution_start_time: routeMockJobTimestamp,
+    execution_end_time: routeMockJobTimestamp + 5_000,
     preview_output: {
       filename: `output_${id}.png`,
       subfolder: '',
@@ -146,7 +152,8 @@ export class JobsRouteMocker {
     const response = createJobsListResponse(route)
 
     await this.page.route(
-      (url) => isJobsListRequest(url, route),
+      (url) =>
+        url.pathname.endsWith('/api/jobs') && matchesJobsListRoute(url, route),
       async (requestRoute) => {
         if (requestRoute.request().method().toUpperCase() !== 'GET') {
           await requestRoute.fallback()
@@ -157,6 +164,44 @@ export class JobsRouteMocker {
       }
     )
   }
+
+  async mockClearQueue(): Promise<QueueManageRequest[]> {
+    const response = zQueueManageResponse.parse({ cleared: true })
+    return await this.mockPostManageRoute(
+      'queue',
+      zQueueManageRequest,
+      response
+    )
+  }
+
+  async mockClearHistory(): Promise<HistoryManageRequest[]> {
+    return await this.mockPostManageRoute('history', zHistoryManageRequest, {})
+  }
+
+  private async mockPostManageRoute<TRequest>(
+    type: 'queue' | 'history',
+    requestSchema: z.ZodType<TRequest>,
+    response: unknown
+  ): Promise<TRequest[]> {
+    const requests: TRequest[] = []
+
+    await this.page.route(
+      (url) => url.pathname.endsWith(`/api/${type}`),
+      async (requestRoute) => {
+        if (requestRoute.request().method().toUpperCase() !== 'POST') {
+          await requestRoute.fallback()
+          return
+        }
+
+        requests.push(
+          requestSchema.parse(requestRoute.request().postDataJSON())
+        )
+        await requestRoute.fulfill({ json: response })
+      }
+    )
+
+    return requests
+  }
 }
 
 export const jobsRouteFixture = base.extend<{
@@ -164,6 +209,5 @@ export const jobsRouteFixture = base.extend<{
 }>({
   jobsRoutes: async ({ page }, use) => {
     await use(new JobsRouteMocker(page))
-    await page.unrouteAll({ behavior: 'wait' })
   }
 })

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -224,7 +224,10 @@ export const TestIds = {
     currentUserIndicator: 'current-user-indicator'
   },
   queue: {
+    jobHistorySidebar: 'job-history-sidebar',
+    progressOverlay: 'queue-progress-overlay',
     overlayToggle: 'queue-overlay-toggle',
+    dockedJobHistoryAction: 'docked-job-history-action',
     jobDetailsPopover: 'queue-job-details-popover',
     clearHistoryAction: 'clear-history-action',
     jobAssetsList: 'job-assets-list',

--- a/browser_tests/tests/sidebar/jobHistory.spec.ts
+++ b/browser_tests/tests/sidebar/jobHistory.spec.ts
@@ -1,0 +1,280 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  createRouteMockJob,
+  jobsRouteFixture,
+  routeMockJobTimestamp
+} from '@e2e/fixtures/jobsRouteFixture'
+import type { JobsRouteMocker } from '@e2e/fixtures/jobsRouteFixture'
+import { TestIds } from '@e2e/fixtures/selectors'
+import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
+
+const test = mergeTests(comfyPageFixture, jobsRouteFixture)
+
+const historyJobs: RawJobListItem[] = [
+  createRouteMockJob({
+    id: 'history-completed',
+    status: 'completed',
+    create_time: routeMockJobTimestamp - 60_000,
+    execution_start_time: routeMockJobTimestamp - 60_000,
+    execution_end_time: routeMockJobTimestamp - 55_000,
+    preview_output: {
+      filename: 'completed-output.png',
+      subfolder: '',
+      type: 'output',
+      nodeId: '1',
+      mediaType: 'images'
+    }
+  }),
+  createRouteMockJob({
+    id: 'history-failed',
+    status: 'failed',
+    create_time: routeMockJobTimestamp - 120_000,
+    execution_start_time: routeMockJobTimestamp - 120_000,
+    execution_end_time: routeMockJobTimestamp - 118_000,
+    outputs_count: 0,
+    execution_error: {
+      node_id: '1',
+      node_type: 'SaveImage',
+      exception_message: 'Intentional fixture failure',
+      exception_type: 'Error',
+      traceback: [],
+      current_inputs: {},
+      current_outputs: {}
+    }
+  }),
+  createRouteMockJob({
+    id: 'history-cancelled',
+    status: 'cancelled',
+    create_time: routeMockJobTimestamp - 180_000,
+    execution_start_time: routeMockJobTimestamp - 180_000,
+    execution_end_time: routeMockJobTimestamp - 179_000,
+    outputs_count: 0
+  })
+]
+
+const activeJobs: RawJobListItem[] = [
+  createRouteMockJob({
+    id: 'queue-running',
+    status: 'in_progress',
+    create_time: routeMockJobTimestamp - 10_000,
+    execution_start_time: routeMockJobTimestamp - 9_000,
+    execution_end_time: null,
+    outputs_count: 0
+  }),
+  createRouteMockJob({
+    id: 'queue-pending',
+    status: 'pending',
+    create_time: routeMockJobTimestamp - 5_000,
+    execution_start_time: null,
+    execution_end_time: null,
+    outputs_count: 0
+  })
+]
+const runningOnlyJobs = activeJobs.filter((job) => job.status !== 'pending')
+
+async function setupJobHistorySidebar(
+  comfyPage: ComfyPage,
+  jobsRoutes: JobsRouteMocker,
+  {
+    history = historyJobs,
+    queue = activeJobs
+  }: {
+    history?: readonly RawJobListItem[]
+    queue?: readonly RawJobListItem[]
+  } = {}
+) {
+  await jobsRoutes.mockJobsScenario({ history, queue })
+  await comfyPage.settings.setSetting('Comfy.Queue.QPOV2', true)
+  await comfyPage.setup()
+
+  await comfyPage.page
+    .getByTestId(TestIds.sidebar.toolbar)
+    .getByRole('button', { name: 'Job History', exact: true })
+    .click()
+  await expect(jobHistorySidebar(comfyPage)).toBeVisible()
+}
+
+function jobRow(comfyPage: ComfyPage) {
+  const list = comfyPage.page.getByTestId(TestIds.queue.jobAssetsList)
+
+  return (jobId: string) => list.locator(`[data-job-id="${jobId}"]`)
+}
+
+function jobHistorySidebar(comfyPage: ComfyPage) {
+  return comfyPage.page.getByTestId(TestIds.queue.jobHistorySidebar)
+}
+
+function clearQueueButton(comfyPage: ComfyPage) {
+  return jobHistorySidebar(comfyPage).getByRole('button', {
+    name: 'Clear queue',
+    exact: true
+  })
+}
+
+async function openSidebarClearHistoryDialog(comfyPage: ComfyPage) {
+  await jobHistorySidebar(comfyPage)
+    .getByLabel(/More options/i)
+    .click()
+  await comfyPage.page.getByTestId(TestIds.queue.clearHistoryAction).click()
+}
+
+test.describe('Job history sidebar', { tag: '@ui' }, () => {
+  test('opens from the queue overlay docked history action', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await jobsRoutes.mockJobsScenario({
+      history: historyJobs,
+      queue: activeJobs
+    })
+    await comfyPage.settings.setSetting('Comfy.Queue.QPOV2', false)
+    await comfyPage.setup()
+
+    await comfyPage.page.getByTestId(TestIds.queue.overlayToggle).click()
+    await comfyPage.queuePanel.moreOptionsButton.click()
+    await comfyPage.page
+      .getByTestId(TestIds.queue.dockedJobHistoryAction)
+      .click()
+
+    await expect(jobHistorySidebar(comfyPage)).toBeVisible()
+    await expect(jobRow(comfyPage)('history-completed')).toBeVisible()
+    await expect(jobRow(comfyPage)('queue-pending')).toBeVisible()
+  })
+
+  test('shows terminal and active job states', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await setupJobHistorySidebar(comfyPage, jobsRoutes)
+
+    const row = jobRow(comfyPage)
+    await expect(row('queue-pending')).toBeVisible()
+    await expect(row('queue-running')).toBeVisible()
+    await expect(row('history-completed')).toBeVisible()
+    await expect(row('history-failed')).toBeVisible()
+    await expect(row('history-cancelled')).toBeVisible()
+
+    await expect(clearQueueButton(comfyPage)).toBeEnabled()
+  })
+
+  test('filters completed and failed history jobs', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await setupJobHistorySidebar(comfyPage, jobsRoutes)
+
+    await comfyPage.page
+      .getByRole('button', { name: 'Completed', exact: true })
+      .click()
+
+    const row = jobRow(comfyPage)
+    await expect(row('history-completed')).toBeVisible()
+    await expect(row('history-failed')).toBeHidden()
+    await expect(row('queue-running')).toBeHidden()
+
+    await comfyPage.page
+      .getByRole('button', { name: 'Failed', exact: true })
+      .click()
+
+    await expect(row('history-failed')).toBeVisible()
+    await expect(row('history-cancelled')).toBeVisible()
+    await expect(row('history-completed')).toBeHidden()
+  })
+
+  test('searches by job id and output filename', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await setupJobHistorySidebar(comfyPage, jobsRoutes)
+
+    const row = jobRow(comfyPage)
+    const searchInput = comfyPage.page.getByPlaceholder('Search...')
+
+    await searchInput.fill('history-failed')
+    await expect(row('history-failed')).toBeVisible()
+    await expect(row('history-completed')).toBeHidden()
+    await expect(row('queue-running')).toBeHidden()
+
+    await searchInput.fill('completed-output')
+    await expect(row('history-completed')).toBeVisible()
+    await expect(row('history-failed')).toBeHidden()
+
+    await searchInput.clear()
+    await expect(row('history-completed')).toBeVisible()
+    await expect(row('queue-running')).toBeVisible()
+  })
+
+  test('disables clear queue when there are no pending jobs', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await setupJobHistorySidebar(comfyPage, jobsRoutes, {
+      queue: runningOnlyJobs
+    })
+
+    await expect(clearQueueButton(comfyPage)).toBeDisabled()
+  })
+
+  test('clears pending queue jobs and leaves running/history jobs', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await setupJobHistorySidebar(comfyPage, jobsRoutes)
+
+    const row = jobRow(comfyPage)
+    await expect(row('queue-pending')).toBeVisible()
+
+    const clearQueueRequests = await jobsRoutes.mockClearQueue()
+    const clearHistoryRequests = await jobsRoutes.mockClearHistory()
+    await jobsRoutes.mockJobsScenario({
+      history: historyJobs,
+      queue: runningOnlyJobs
+    })
+
+    await clearQueueButton(comfyPage).click()
+
+    await expect.poll(() => clearQueueRequests.length).toBe(1)
+    expect(clearQueueRequests).toContainEqual({ clear: true })
+    await expect(row('queue-pending')).toBeHidden()
+    await expect(row('queue-running')).toBeVisible()
+    await expect(row('history-completed')).toBeVisible()
+    await expect(clearQueueButton(comfyPage)).toBeDisabled()
+    expect(clearHistoryRequests).toHaveLength(0)
+  })
+
+  test('clears history from the sidebar menu and keeps active jobs', async ({
+    comfyPage,
+    jobsRoutes
+  }) => {
+    await setupJobHistorySidebar(comfyPage, jobsRoutes)
+
+    const row = jobRow(comfyPage)
+    await expect(row('history-completed')).toBeVisible()
+
+    const clearHistoryRequests = await jobsRoutes.mockClearHistory()
+    const clearQueueRequests = await jobsRoutes.mockClearQueue()
+    await jobsRoutes.mockJobsScenario({
+      history: [],
+      queue: activeJobs
+    })
+
+    await openSidebarClearHistoryDialog(comfyPage)
+    await expect(
+      comfyPage.page.getByText('Clear your job queue history?')
+    ).toBeVisible()
+    await comfyPage.page
+      .getByRole('button', { name: 'Clear', exact: true })
+      .click()
+
+    await expect.poll(() => clearHistoryRequests.length).toBe(1)
+    expect(clearHistoryRequests).toContainEqual({ clear: true })
+    await expect(row('history-completed')).toBeHidden()
+    await expect(row('history-failed')).toBeHidden()
+    await expect(row('queue-running')).toBeVisible()
+    await expect(row('queue-pending')).toBeVisible()
+    expect(clearQueueRequests).toHaveLength(0)
+  })
+})

--- a/src/components/queue/QueueProgressOverlay.vue
+++ b/src/components/queue/QueueProgressOverlay.vue
@@ -4,6 +4,7 @@
     :class="['flex', 'justify-end', 'w-full', 'pointer-events-none']"
   >
     <div
+      data-testid="queue-progress-overlay"
       class="pointer-events-auto flex max-h-[60vh] w-[350px] min-w-[310px] flex-col overflow-hidden rounded-lg border font-inter transition-colors duration-200 ease-in-out"
       :class="containerClass"
       @mouseenter="isHovered = true"

--- a/src/components/sidebar/tabs/JobHistorySidebarTab.vue
+++ b/src/components/sidebar/tabs/JobHistorySidebarTab.vue
@@ -1,5 +1,8 @@
 <template>
-  <SidebarTabTemplate :title="$t('queue.jobHistory')">
+  <SidebarTabTemplate
+    data-testid="job-history-sidebar"
+    :title="$t('queue.jobHistory')"
+  >
     <template #alt-title>
       <div class="ml-auto flex shrink-0 items-center">
         <JobHistoryActionsMenu @clear-history="onClearHistory" />


### PR DESCRIPTION
## Summary

Add the first product-area browser coverage on top of the merged typed route mock foundation: the docked job history sidebar.

## Changes

- **What**: Adds `browser_tests/tests/sidebar/jobHistory.spec.ts` using `jobsRouteFixture`.
- **What**: Covers direct sidebar entry, docked QPO history entry, terminal history jobs, active queue jobs, tab filtering, search, clear queue, and clear history.
- **What**: Adds typed `POST /api/queue` and `POST /api/history` route helpers that validate request bodies with generated zod schemas.
- **What**: Adds stable test ids for the job history sidebar and queue progress overlay so tests avoid structural CSS selectors.
- **Dependencies**: Builds on the typed route mock foundation merged in #12267.

## Review Focus

Review the product assertions and whether this is the right first coverage slice on top of the typed route mock foundation. This PR intentionally avoids asset sidebar and floating QPO lifecycle coverage; those should remain follow-up PRs.

## Screenshots (if applicable)

Not applicable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12272-test-cover-job-history-sidebar-with-typed-route-mocks-3606d73d3650817481d5f9fac4bfc93c) by [Unito](https://www.unito.io)