### PR TITLE
fix(website): prevent cloud hero text from overflowing at lg viewports

### DIFF
--- a/apps/website/src/components/product/cloud/HeroSection.vue
+++ b/apps/website/src/components/product/cloud/HeroSection.vue
@@ -379,7 +379,7 @@ const { locale = 'en' } = defineProps<{ locale?: Locale }>()
 
     <!-- Text -->
     <div
-      class="relative z-10 mt-17 w-full px-4 pb-16 lg:mt-0 lg:min-w-160 lg:flex-1 lg:translate-x-[25%] lg:px-20 lg:py-14"
+      class="relative z-10 mt-17 w-full px-4 pb-16 lg:mt-0 lg:min-w-160 lg:flex-1 lg:translate-x-[10%] lg:px-20 lg:py-14"
     >
       <ProductHeroBadge text="CLOUD" />
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The cloud hero text wrapper used `lg:translate-x-[25%]`, which translates by 25% of its own `lg:min-w-160` (640px) container — pushing the text **160px past the viewport** at the lg-but-not-xl width range (1024–1279px). On portrait monitors like 1080×1920, this clipped the `CLOUD` badge, the `<h1>` heading, and the subtitle.

The three sibling product heroes — [`local`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/apps/website/src/components/product/local/HeroSection.vue#L284), [`enterprise`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/apps/website/src/components/product/enterprise/HeroSection.vue#L365), [`api`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/apps/website/src/components/product/api/HeroSection.vue#L208) — all use `lg:translate-x-[10%]` on the equivalent text wrapper. The `25%` in `cloud/HeroSection.vue` is the lone outlier. This PR aligns it.

```diff
- class="... lg:min-w-160 lg:flex-1 lg:translate-x-[25%] lg:px-20 lg:py-14"
+ class="... lg:min-w-160 lg:flex-1 lg:translate-x-[10%] lg:px-20 lg:py-14"
```

- Fixes FE-610

## Verification

**Automated** (all on apps/website):
- `oxlint`, `eslint`, `stylelint`, `oxfmt --check` — pass
- `pnpm typecheck` (`astro check`) — 0 errors, 0 warnings
- `pnpm build` — 280 pages built successfully
- `playwright test e2e/cloud.spec.ts --project=desktop` — **13/13 pass**
- `playwright test e2e/visual-responsive.spec.ts --grep "/cloud .* no overflow"` — **4/4 pass** (393, 768, 1280, 1536)

**Manual** Playwright width-sweep on `/cloud` hero: all of 393, 768, 1024, 1080, 1200, 1280, 1366, 1440, 1536, 1600 render with the `CLOUD` badge, h1, subtitle, and CTA fully visible.

The text container still extends slightly past its parent at lg (same pattern as the canonical enterprise hero, which relies on `html { overflow-x-clip }` in `BaseLayout.astro`), but the **visible content** — capped by `max-w-md` on the subtitle and `lg:max-w-2xl` on the h1 — now fits within every viewport tested.

## Screenshots

![Before: at 1080x1920 the CLOUD badge, h1, and subtitle are clipped on the right edge](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/7d27fa7468f7aa98940a138ed941fc11297ed490be24999607e8d0993def20d9/pr-images/1778858285964-15c87579-9640-4b78-8d67-aeadb9115ac8.png)

![After: at 1080x1920 all hero content is fully visible within the viewport](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/7d27fa7468f7aa98940a138ed941fc11297ed490be24999607e8d0993def20d9/pr-images/1778858286364-3714244d-278b-46c0-8a75-2f5e2c7cb822.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12293-fix-website-prevent-cloud-hero-text-from-overflowing-at-lg-viewports-3616d73d365081bc8006e78af0770b0e) by [Unito](https://www.unito.io)
