### PR TITLE
FE-416: route 3D node outputs to owner workflow on tab switch

### DIFF
--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -10,14 +10,16 @@ const {
   onLoad3dReadyMock,
   configureMock,
   getLoad3dMock,
-  toastAddAlertMock
+  toastAddAlertMock,
+  getNodeByLocatorIdMock
 } = vi.hoisted(() => ({
   registerExtensionMock: vi.fn(),
   waitForLoad3dMock: vi.fn(),
   onLoad3dReadyMock: vi.fn(),
   configureMock: vi.fn(),
   getLoad3dMock: vi.fn(),
-  toastAddAlertMock: vi.fn()
+  toastAddAlertMock: vi.fn(),
+  getNodeByLocatorIdMock: vi.fn()
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -76,8 +78,12 @@ vi.mock('@/scripts/api', () => ({
 }))
 
 vi.mock('@/scripts/app', () => ({
-  app: { canvas: { selected_nodes: {} } },
+  app: { canvas: { selected_nodes: {} }, rootGraph: {} },
   ComfyApp: { copyToClipspace: vi.fn(), clipspace_return_node: null }
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  getNodeByLocatorId: getNodeByLocatorIdMock
 }))
 
 vi.mock('@/i18n', () => ({
@@ -107,6 +113,9 @@ type ExtCreated = ComfyExtension & {
     nodeData: ComfyNodeDef
   ) => Promise<void>
   getNodeMenuItems: (node: LGraphNode) => unknown[]
+  onNodeOutputsUpdated: (
+    nodeOutputs: Record<string, Record<string, unknown>>
+  ) => void
 }
 
 async function loadExtensionsFresh(): Promise<{
@@ -515,5 +524,88 @@ describe('getNodeMenuItems', () => {
     } as unknown as LGraphNode
 
     expect(preview3DExt.getNodeMenuItems(node)).toEqual([{ content: 'Export' }])
+  })
+})
+
+describe('Comfy.Preview3D.onNodeOutputsUpdated', () => {
+  beforeEach(setupBaseMocks)
+
+  it('rehydrates a Preview3D node from restored outputs', async () => {
+    const { preview3DExt } = await loadExtensionsFresh()
+    const node = makePreview3DNode()
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    preview3DExt.onNodeOutputsUpdated!({
+      '7': { result: ['sub\\nested\\mesh.glb', { position: [1, 2, 3] }] }
+    } as never)
+
+    const modelWidget = node.widgets!.find((w) => w.name === 'model_file')!
+    expect(modelWidget.value).toBe('sub/nested/mesh.glb')
+    expect(node.properties['Last Time Model File']).toBe('sub/nested/mesh.glb')
+    expect(configureMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loadFolder: 'output',
+        cameraState: { position: [1, 2, 3] },
+        silentOnNotFound: true
+      })
+    )
+  })
+
+  it('skips entries with no result file path', async () => {
+    const { preview3DExt } = await loadExtensionsFresh()
+    const node = makePreview3DNode()
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    preview3DExt.onNodeOutputsUpdated!({
+      '7': { result: [undefined] }
+    } as never)
+
+    expect(getNodeByLocatorIdMock).not.toHaveBeenCalled()
+    expect(configureMock).not.toHaveBeenCalled()
+  })
+
+  it('skips entries whose node is not in the active rootGraph', async () => {
+    const { preview3DExt } = await loadExtensionsFresh()
+    getNodeByLocatorIdMock.mockReturnValue(null)
+
+    preview3DExt.onNodeOutputsUpdated!({
+      '7': { result: ['mesh.glb'] }
+    } as never)
+
+    expect(configureMock).not.toHaveBeenCalled()
+  })
+
+  it('skips nodes whose comfyClass is not Preview3D', async () => {
+    const { preview3DExt } = await loadExtensionsFresh()
+    const node = makePreview3DNode({ comfyClass: 'Load3D' })
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    preview3DExt.onNodeOutputsUpdated!({
+      '7': { result: ['mesh.glb'] }
+    } as never)
+
+    expect(configureMock).not.toHaveBeenCalled()
+  })
+
+  it('re-applies even when the file path is unchanged so camera/bg updates do not get dropped', async () => {
+    const { preview3DExt } = await loadExtensionsFresh()
+    const node = makePreview3DNode({
+      properties: { 'Last Time Model File': 'mesh.glb' },
+      widgets: [{ name: 'model_file', value: 'mesh.glb' }]
+    })
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    preview3DExt.onNodeOutputsUpdated!({
+      '7': {
+        result: ['mesh.glb', { position: [9, 9, 9] }, 'new-bg.png']
+      }
+    } as never)
+
+    expect(configureMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cameraState: { position: [9, 9, 9] },
+        bgImagePath: 'new-bg.png'
+      })
+    )
   })
 })

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -19,8 +19,10 @@ import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
 import type { IStringWidget } from '@/lib/litegraph/src/types/widgets'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import type { NodeOutputWith } from '@/schemas/apiSchema'
+import type { NodeExecutionOutput, NodeOutputWith } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 
 type Matrix = number[][]
 type Load3dPreviewOutput = NodeOutputWith<{
@@ -426,6 +428,59 @@ useExtensionService().registerExtension({
   }
 })
 
+function applyPreview3DOutput(
+  node: LGraphNode,
+  result: NonNullable<Load3dPreviewOutput['result']>
+): void {
+  const filePath = result[0]
+  const cameraState = result[1]
+  const bgImagePath = result[2]
+  const extrinsics = result[3]
+  const intrinsics = result[4]
+  if (!filePath) return
+
+  const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
+  if (!modelWidget) return
+
+  const normalizedPath = filePath.replaceAll('\\', '/')
+
+  // Always re-apply, even when the file path matches: the same model file
+  // can arrive with a new camera state, background image, or matrices, and
+  // a path-only guard would silently drop those updates and diverge from
+  // the active `node.onExecuted` path which always reapplies.
+  modelWidget.value = normalizedPath
+  node.properties['Last Time Model File'] = normalizedPath
+
+  useLoad3d(node).waitForLoad3d((load3d) => {
+    const config = new Load3DConfiguration(load3d, node.properties)
+    config.configure({
+      loadFolder: 'output',
+      modelWidget,
+      cameraState,
+      bgImagePath,
+      silentOnNotFound: true
+    })
+
+    if (bgImagePath) load3d.setBackgroundImage(bgImagePath)
+
+    if (extrinsics && intrinsics) {
+      const targetGeneration = load3d.currentLoadGeneration
+      void load3d
+        .whenLoadIdle()
+        .then(() => {
+          if (load3d.currentLoadGeneration !== targetGeneration) return
+          load3d.setCameraFromMatrices(extrinsics, intrinsics)
+        })
+        .catch((error) => {
+          console.error(
+            'Failed to apply camera matrices from Preview3D output:',
+            error
+          )
+        })
+    }
+  })
+}
+
 useExtensionService().registerExtension({
   name: 'Comfy.Preview3D',
 
@@ -436,6 +491,20 @@ useExtensionService().registerExtension({
     if ('Preview3D' === nodeData.name) {
       // @ts-expect-error InputSpec is not typed correctly
       nodeData.input.required.image = ['PREVIEW_3D']
+    }
+  },
+
+  onNodeOutputsUpdated(
+    nodeOutputs: Record<NodeLocatorId, NodeExecutionOutput>
+  ) {
+    for (const [locatorId, output] of Object.entries(nodeOutputs)) {
+      const result = (output as Load3dPreviewOutput).result
+      if (!result?.[0]) continue
+
+      const node = getNodeByLocatorId(app.rootGraph, locatorId)
+      if (!node || node.constructor.comfyClass !== 'Preview3D') continue
+
+      applyPreview3DOutput(node, result)
     }
   },
 

--- a/src/extensions/core/saveMesh.test.ts
+++ b/src/extensions/core/saveMesh.test.ts
@@ -7,12 +7,14 @@ const {
   registerExtensionMock,
   waitForLoad3dMock,
   onLoad3dReadyMock,
-  configureForSaveMeshMock
+  configureForSaveMeshMock,
+  getNodeByLocatorIdMock
 } = vi.hoisted(() => ({
   registerExtensionMock: vi.fn(),
   waitForLoad3dMock: vi.fn(),
   onLoad3dReadyMock: vi.fn(),
-  configureForSaveMeshMock: vi.fn()
+  configureForSaveMeshMock: vi.fn(),
+  getNodeByLocatorIdMock: vi.fn()
 }))
 
 vi.mock('@/services/extensionService', () => ({
@@ -52,8 +54,19 @@ vi.mock('@/platform/assets/utils/assetPreviewUtil', () => ({
   persistThumbnail: vi.fn()
 }))
 
+vi.mock('@/scripts/app', () => ({
+  app: { rootGraph: {} }
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  getNodeByLocatorId: getNodeByLocatorIdMock
+}))
+
 type SaveMeshExtension = ComfyExtension & {
   nodeCreated: (node: LGraphNode) => Promise<void>
+  onNodeOutputsUpdated: (
+    nodeOutputs: Record<string, Record<string, unknown>>
+  ) => void
 }
 
 async function loadSaveMeshExtensionFresh(): Promise<SaveMeshExtension> {
@@ -232,5 +245,99 @@ describe('saveMesh', () => {
       'sub/mesh.glb',
       { silentOnNotFound: true }
     )
+  })
+})
+
+describe('Comfy.SaveGLB.onNodeOutputsUpdated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    waitForLoad3dMock.mockImplementation((cb: (load3d: unknown) => void) => {
+      cb({
+        whenLoadIdle: () => Promise.resolve(),
+        captureThumbnail: vi.fn()
+      })
+    })
+  })
+
+  it('rehydrates a SaveGLB node from restored outputs', async () => {
+    const ext = await loadSaveMeshExtensionFresh()
+    const node = makeNode()
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    ext.onNodeOutputsUpdated!({
+      '7': {
+        '3d': [{ filename: 'mesh.glb', subfolder: 'sub', type: 'output' }]
+      }
+    } as never)
+
+    const modelWidget = node.widgets!.find((w) => w.name === 'image')!
+    expect(modelWidget.value).toBe('sub/mesh.glb')
+    expect(node.properties['Last Time Model File']).toBe('sub/mesh.glb')
+    expect(node.properties['Last Time Model Folder']).toBe('output')
+    expect(configureForSaveMeshMock).toHaveBeenCalledWith(
+      'output',
+      'sub/mesh.glb',
+      { silentOnNotFound: true }
+    )
+  })
+
+  it('skips entries with no 3d output', async () => {
+    const ext = await loadSaveMeshExtensionFresh()
+    const node = makeNode()
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    ext.onNodeOutputsUpdated!({ '7': {} } as never)
+
+    expect(getNodeByLocatorIdMock).not.toHaveBeenCalled()
+    expect(configureForSaveMeshMock).not.toHaveBeenCalled()
+  })
+
+  it('skips entries whose node is not in the active rootGraph', async () => {
+    const ext = await loadSaveMeshExtensionFresh()
+    getNodeByLocatorIdMock.mockReturnValue(null)
+
+    ext.onNodeOutputsUpdated!({
+      '7': {
+        '3d': [{ filename: 'mesh.glb', subfolder: 'sub', type: 'output' }]
+      }
+    } as never)
+
+    expect(configureForSaveMeshMock).not.toHaveBeenCalled()
+  })
+
+  it('skips nodes whose comfyClass is not SaveGLB', async () => {
+    const ext = await loadSaveMeshExtensionFresh()
+    const node = makeNode({ comfyClass: 'Preview3D' })
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    ext.onNodeOutputsUpdated!({
+      '7': {
+        '3d': [{ filename: 'mesh.glb', subfolder: 'sub', type: 'output' }]
+      }
+    } as never)
+
+    expect(configureForSaveMeshMock).not.toHaveBeenCalled()
+  })
+
+  it('does not re-apply when the same result is already loaded', async () => {
+    const ext = await loadSaveMeshExtensionFresh()
+    const node = makeNode({
+      properties: {
+        'Last Time Model File': 'sub/mesh.glb',
+        'Last Time Model Folder': 'output'
+      }
+    })
+    ;(
+      node.widgets!.find((w) => w.name === 'image') as { value: string }
+    ).value = 'sub/mesh.glb'
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    ext.onNodeOutputsUpdated!({
+      '7': {
+        '3d': [{ filename: 'mesh.glb', subfolder: 'sub', type: 'output' }]
+      }
+    } as never)
+
+    expect(configureForSaveMeshMock).not.toHaveBeenCalled()
   })
 })

--- a/src/extensions/core/saveMesh.ts
+++ b/src/extensions/core/saveMesh.ts
@@ -6,7 +6,11 @@ import { createExportMenuItems } from '@/extensions/core/load3d/exportMenuHelper
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
-import type { NodeOutputWith, ResultItem } from '@/schemas/apiSchema'
+import type {
+  NodeExecutionOutput,
+  NodeOutputWith,
+  ResultItem
+} from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 
 type SaveMeshOutput = NodeOutputWith<{
@@ -17,14 +21,55 @@ import {
   isAssetPreviewSupported,
   persistThumbnail
 } from '@/platform/assets/utils/assetPreviewUtil'
+import { app } from '@/scripts/app'
 import { ComponentWidgetImpl, addWidget } from '@/scripts/domWidget'
 import { useExtensionService } from '@/services/extensionService'
 import { useLoad3dService } from '@/services/load3dService'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
 
 const inputSpec: CustomInputSpec = {
   name: 'image',
   type: 'Preview3D',
   isPreview: true
+}
+
+function applySaveGLBOutput(node: LGraphNode, fileInfo: ResultItem): void {
+  const filePath = (fileInfo.subfolder ?? '') + '/' + (fileInfo.filename ?? '')
+  const loadFolder = fileInfo.type as 'input' | 'output'
+
+  const modelWidget = node.widgets?.find((w) => w.name === 'image')
+  if (!modelWidget) return
+
+  if (
+    modelWidget.value === filePath &&
+    node.properties['Last Time Model File'] === filePath &&
+    node.properties['Last Time Model Folder'] === loadFolder
+  ) {
+    return
+  }
+
+  modelWidget.value = filePath
+  node.properties['Last Time Model File'] = filePath
+  node.properties['Last Time Model Folder'] = loadFolder
+
+  useLoad3d(node).waitForLoad3d((load3d) => {
+    if (!load3d) return
+    const config = new Load3DConfiguration(load3d, node.properties)
+    config.configureForSaveMesh(loadFolder, filePath, {
+      silentOnNotFound: true
+    })
+
+    if (isAssetPreviewSupported()) {
+      const filename = fileInfo.filename ?? ''
+      void load3d
+        .whenLoadIdle()
+        .then(() => load3d.captureThumbnail(256, 256))
+        .then((dataUrl) => fetch(dataUrl).then((r) => r.blob()))
+        .then((blob) => persistThumbnail(filename, blob))
+        .catch(() => {})
+    }
+  })
 }
 
 useExtensionService().registerExtension({
@@ -37,6 +82,20 @@ useExtensionService().registerExtension({
     if ('SaveGLB' === nodeData.name) {
       // @ts-expect-error InputSpec is not typed correctly
       nodeData.input.required.image = ['PREVIEW_3D']
+    }
+  },
+
+  onNodeOutputsUpdated(
+    nodeOutputs: Record<NodeLocatorId, NodeExecutionOutput>
+  ) {
+    for (const [locatorId, output] of Object.entries(nodeOutputs)) {
+      const fileInfo = (output as SaveMeshOutput)['3d']?.[0]
+      if (!fileInfo) continue
+
+      const node = getNodeByLocatorId(app.rootGraph, locatorId)
+      if (!node || node.constructor.comfyClass !== 'SaveGLB') continue
+
+      applySaveGLBOutput(node, fileInfo)
     }
   },
 


### PR DESCRIPTION
## Summary
When a workflow queues a 3D job (Preview3D / Load3D / SaveGLB) and the user switches to another tab before the job completes, the WS `executed` payload was silently dropped: `getNodeByExecutionId(app.rootGraph, …)` resolves against the currently-visible workflow's graph, so the node isn't found, `onExecuted` never fires, and the workflow JSON never learns the path of the asset the backend just saved.

Worse, `setNodeOutputsByExecutionId` for top-level execution ids returns the id verbatim without consulting rootGraph, so the old handler also wrote the payload into the *active* (wrong) workflow's `app.nodeOutputs`, polluting it and getting mis-attributed by `ChangeTracker` snapshot/restore on subsequent tab switches.

This change introduces a single routing point — no new public API, no new in-memory cache layer — that re-uses three pieces of infrastructure that already exist independently:

  1. `executionStore.jobIdToSessionWorkflowPath` already records which workflow queued each prompt_id.
  2. Each `ComfyWorkflow.ChangeTracker` already snapshots `nodeOutputs` on `deactivate()` and replays it through the `app.nodeOutputs = …` setter on `restore()`, which fires `onNodeOutputsUpdated` for every extension.
  3. Audio nodes already implement `onNodeOutputsUpdated` to rehydrate their widget from `nodeOutputs`. They have always been silently broken in this same scenario (no one noticed because missing audio is less visible than a missing 3D model); the fix here repairs audio for free as a side effect.

The new behaviour:

  - `app.ts` looks up the node against the active rootGraph *first*. Only when found do we touch `nodeOutputStore` and call `node.onExecuted` (existing path, unchanged). Moving the `nodeOutputStore` write inside `if (node)` is the part that eliminates the cross-workflow pollution above.
  - When the node is not in the active rootGraph, the new `routeExecutedToInactiveOwner` helper finds the owner workflow via `jobIdToSessionWorkflowPath`, then writes the payload directly into `owner.changeTracker.nodeOutputs` — the same field that `restore()` already drains on tab switch back.
  - Preview3D / SaveGLB add `onNodeOutputsUpdated` (mirroring the pattern audio uses), normalise the path, write `node.properties['Last Time Model File']` (already workflow-JSON-serialised), and apply it to the viewer. The legacy `node.onExecuted` chain stays intact for live active-workflow executions — both paths are idempotent.

## Screenshots (if applicable)
Before

https://github.com/user-attachments/assets/3803af1f-2eb6-41af-87ed-ac885a2eaad6


After

https://github.com/user-attachments/assets/72e1bed9-5f94-414d-ac31-fc925651d11b

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12295-FE-416-route-3D-node-outputs-to-owner-workflow-on-tab-switch-3616d73d3650817b908de48a32b1d6bd) by [Unito](https://www.unito.io)
