### PR TITLE
fix: dedupe Bypass context-menu items by making legacy entry state-aware

### DIFF
--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -245,6 +245,22 @@ describe('useSelectedLiteGraphItems', () => {
       expect(node2.mode).toBe(LGraphEventMode.NEVER)
     })
 
+    it('areAllSelectedNodesInMode returns true only when every selected node matches', () => {
+      const { areAllSelectedNodesInMode } = useSelectedLiteGraphItems()
+      const bypassed1 = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
+      const bypassed2 = { id: 2, mode: LGraphEventMode.BYPASS } as LGraphNode
+      const active = { id: 3, mode: LGraphEventMode.ALWAYS } as LGraphNode
+
+      app.canvas.selected_nodes = { '0': bypassed1, '1': bypassed2 }
+      expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(true)
+
+      app.canvas.selected_nodes = { '0': bypassed1, '1': active }
+      expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(false)
+
+      app.canvas.selected_nodes = {}
+      expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(false)
+    })
+
     it('toggleSelectedNodesMode should set mode to ALWAYS when already in target mode', () => {
       const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
       const node = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode

--- a/src/composables/canvas/useSelectedLiteGraphItems.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.ts
@@ -94,6 +94,19 @@ export function useSelectedLiteGraphItems() {
   }
 
   /**
+   * True iff every selected (top-level) node is already in the given mode.
+   * Mirrors the predicate inside {@link toggleSelectedNodesMode} so callers
+   * (e.g. context-menu labels) can preview what the toggle will do.
+   */
+  const areAllSelectedNodesInMode = (mode: LGraphEventMode): boolean => {
+    const selectedNodes = app.canvas.selected_nodes
+    if (!selectedNodes) return false
+    const selectedNodeArray = Object.values(selectedNodes)
+    if (selectedNodeArray.length === 0) return false
+    return selectedNodeArray.every((node) => node.mode === mode)
+  }
+
+  /**
    * Toggle the execution mode of all selected nodes
    *
    * - If any nodes are not already the specified node mode → all are set to specified mode
@@ -105,15 +118,10 @@ export function useSelectedLiteGraphItems() {
     const selectedNodes = app.canvas.selected_nodes
     if (!selectedNodes) return
 
-    // Convert selected_nodes object to array
-    const selectedNodeArray: LGraphNode[] = []
-    for (const i in selectedNodes) {
-      selectedNodeArray.push(selectedNodes[i])
-    }
-    const allNodesMatch = !selectedNodeArray.some(
-      (selectedNode) => selectedNode.mode !== mode
-    )
-    const newModeForSelectedNode = allNodesMatch ? LGraphEventMode.ALWAYS : mode
+    const selectedNodeArray = Object.values(selectedNodes)
+    const newModeForSelectedNode = areAllSelectedNodesInMode(mode)
+      ? LGraphEventMode.ALWAYS
+      : mode
 
     for (const selectedNode of selectedNodeArray)
       selectedNode.mode = newModeForSelectedNode
@@ -126,6 +134,7 @@ export function useSelectedLiteGraphItems() {
     hasSelectableItems,
     hasMultipleSelectableItems,
     getSelectedNodes,
-    toggleSelectedNodesMode
+    toggleSelectedNodesMode,
+    areAllSelectedNodesInMode
   }
 }

--- a/src/composables/graph/contextMenuConverter.test.ts
+++ b/src/composables/graph/contextMenuConverter.test.ts
@@ -135,6 +135,33 @@ describe('contextMenuConverter', () => {
       expect(getIndex('Node Info')).toBeLessThanOrEqual(getIndex('Color'))
     })
 
+    it('should collapse legacy and Vue Remove Bypass to the Vue item when a node is bypassed', () => {
+      const options: MenuOption[] = [
+        { label: 'Remove Bypass', action: () => {}, source: 'litegraph' },
+        { label: 'Remove Bypass', action: () => {}, source: 'vue' }
+      ]
+
+      const result = buildStructuredMenu(options)
+
+      const removeBypassItems = result.filter(
+        (opt) => opt.label === 'Remove Bypass'
+      )
+      expect(removeBypassItems).toHaveLength(1)
+      expect(removeBypassItems[0].source).toBe('vue')
+    })
+
+    it('should not treat Bypass and Remove Bypass as equivalent labels', () => {
+      const options: MenuOption[] = [
+        { label: 'Bypass', action: () => {}, source: 'litegraph' },
+        { label: 'Remove Bypass', action: () => {}, source: 'vue' }
+      ]
+
+      const result = buildStructuredMenu(options)
+
+      expect(result.find((opt) => opt.label === 'Bypass')).toBeDefined()
+      expect(result.find((opt) => opt.label === 'Remove Bypass')).toBeDefined()
+    })
+
     it('should recognize Frame Nodes as a core menu item', () => {
       const options: MenuOption[] = [
         { label: 'Rename', source: 'vue' },

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -719,7 +719,8 @@ export const useLitegraphService = () => {
       }
 
       options.push({
-        content: 'Bypass',
+        content:
+          this.mode === LGraphEventMode.BYPASS ? 'Remove Bypass' : 'Bypass',
         callback: () => {
           toggleSelectedNodesMode(LGraphEventMode.BYPASS)
           canvas.setDirty(true, true)

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -176,7 +176,8 @@ export const useLitegraphService = () => {
   const toastStore = useToastStore()
   const widgetStore = useWidgetStore()
   const canvasStore = useCanvasStore()
-  const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
+  const { toggleSelectedNodesMode, areAllSelectedNodesInMode } =
+    useSelectedLiteGraphItems()
   const subgraphPseudoWidgetCache = new WeakMap<
     SubgraphNode,
     SubgraphPseudoWidgetCache<LGraphNode, IBaseWidget>
@@ -719,8 +720,9 @@ export const useLitegraphService = () => {
       }
 
       options.push({
-        content:
-          this.mode === LGraphEventMode.BYPASS ? 'Remove Bypass' : 'Bypass',
+        content: areAllSelectedNodesInMode(LGraphEventMode.BYPASS)
+          ? 'Remove Bypass'
+          : 'Bypass',
         callback: () => {
           toggleSelectedNodesMode(LGraphEventMode.BYPASS)
           canvas.setDirty(true, true)

--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -721,8 +721,8 @@ export const useLitegraphService = () => {
 
       options.push({
         content: areAllSelectedNodesInMode(LGraphEventMode.BYPASS)
-          ? 'Remove Bypass'
-          : 'Bypass',
+          ? t('contextMenu.Remove Bypass')
+          : t('contextMenu.Bypass'),
         callback: () => {
           toggleSelectedNodesMode(LGraphEventMode.BYPASS)
           canvas.setDirty(true, true)


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Right-clicking a bypassed node showed two bypass-related items in the Vue node context menu (see [FE-720](https://linear.app/comfyorg/issue/FE-720/bug-duplicate-bypass-items-in-node-context-menu-when-node-is-already)):

- A plain `Bypass` from the legacy LiteGraph `getExtraMenuOptions` hook in [`litegraphService.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/services/litegraphService.ts#L721-L727).
- `Remove Bypass` (with `Ctrl+B` and an icon) from the Vue `getBypassOption` composable in [`useNodeMenuOptions.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/composables/graph/useNodeMenuOptions.ts#L93-L106).

The Vue menu's exact-label deduplicator in [`contextMenuConverter.ts`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/composables/graph/contextMenuConverter.ts#L146-L212) already collapses the unbypassed case (both registrations emit `Bypass` → exact match → Vue source wins), but not the bypassed case (`Bypass` vs `Remove Bypass`).

## Fix

Make the legacy hook emit a stateful label that matches the Vue label, so the existing exact-label dedupe handles both states uniformly — no new label-equivalence rules, no callback-identity coupling, no blacklist that could hide third-party extension items.

The label must reflect what the click action will actually do. The action (`toggleSelectedNodesMode`) operates on the whole selection and only un-bypasses when every selected node is already in `BYPASS`. To keep the label and the action in sync (and avoid a misleading `Remove Bypass` on mixed selections), the predicate is extracted as `areAllSelectedNodesInMode` on the `useSelectedLiteGraphItems` composable and reused by both the toggle and the menu label.

```ts
options.push({
  content: areAllSelectedNodesInMode(LGraphEventMode.BYPASS)
    ? 'Remove Bypass'
    : 'Bypass',
  callback: () => {
    toggleSelectedNodesMode(LGraphEventMode.BYPASS)
    canvas.setDirty(true, true)
  }
})
```

Side benefit: the legacy LiteGraph menu (`Comfy.UseNewMenu: 'Disabled'`) also gets the correct conditional label, which previously was stuck on `Bypass` regardless of node state.

Considered and rejected:

- Adding `bypass: ['bypass', 'remove bypass']` to the `equivalents` map — would silently drop third-party extension menu items labeled `Bypass`.
- Adding `'Bypass'` to `HARD_BLACKLIST` — same third-party problem.
- Exporting a stable callback identity for filtering — adds cross-file coupling between `litegraphService` and `contextMenuConverter` for a 3-line behavioral change.

## Tests

- `contextMenuConverter.test.ts`: two new tests — legacy + Vue `Remove Bypass` collapse to the Vue item; `Bypass` and `Remove Bypass` are NOT treated as equivalents (locks in that we did not regress by adding a label-equivalence rule that would hide extension items).
- `useSelectedLiteGraphItems.test.ts`: one new test for `areAllSelectedNodesInMode` covering all-bypassed, mixed, and empty-selection cases — directly addresses the review concern that the label could drift from the toggle's predicate.

Local verification:

```
pnpm test:unit -- --run \
  src/composables/canvas/useSelectedLiteGraphItems.test.ts \
  src/composables/graph/contextMenuConverter.test.ts \
  src/services/litegraphService.test.ts
# 41 tests passed

pnpm typecheck                                # clean
pnpm exec oxlint <touched files>              # 0 warnings, 0 errors
```

Manual browser verification was attempted via Playwright but the test harness could not reliably reproduce the Vue context-menu open state in headless mode within the available time budget. The behavior is exercised end-to-end by the existing Playwright suite (`browser_tests/tests/vueNodes/interactions/node/contextMenu.spec.ts`) and gated by the targeted unit tests above.

- Fixes FE-720

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12296-fix-dedupe-Bypass-context-menu-items-by-making-legacy-entry-state-aware-3616d73d36508138a911fd4f0853ac4a) by [Unito](https://www.unito.io)
