### PR TITLE
test: migrate MaxHistoryItems browser coverage

### DIFF
--- a/browser_tests/fixtures/jobsRouteFixture.ts
+++ b/browser_tests/fixtures/jobsRouteFixture.ts
@@ -29,6 +29,7 @@ interface JobsListRoute {
   jobs: readonly RawJobListItem[]
   limit?: number
   offset?: number
+  responseLimit?: number
 }
 
 interface JobsScenario {
@@ -75,15 +76,16 @@ function isJobsListRequest(url: URL, route: JobsListRoute): boolean {
 function createJobsListResponse({
   jobs,
   limit = defaultJobsListLimit,
-  offset = defaultJobsListOffset
+  offset = defaultJobsListOffset,
+  responseLimit = limit
 }: Omit<JobsListRoute, 'statuses'>): JobsListResponse {
-  const pageJobs = jobs.slice(offset, offset + limit)
+  const pageJobs = jobs.slice(offset, offset + responseLimit)
 
   return {
     jobs: pageJobs,
     pagination: {
       offset,
-      limit,
+      limit: responseLimit,
       total: jobs.length,
       has_more: offset + pageJobs.length < jobs.length
     }
@@ -117,12 +119,14 @@ export class JobsRouteMocker {
 
   async mockJobsHistory(
     jobs: readonly RawJobListItem[],
-    limit = defaultJobsListLimit
+    limit = defaultJobsListLimit,
+    options: Pick<JobsListRoute, 'responseLimit'> = {}
   ): Promise<void> {
     await this.mockJobsList({
       statuses: terminalJobStatuses,
       jobs,
-      limit
+      limit,
+      ...options
     })
   }
 

--- a/browser_tests/tests/queue/queueSettings.spec.ts
+++ b/browser_tests/tests/queue/queueSettings.spec.ts
@@ -1,22 +1,36 @@
 import { mergeTests } from '@playwright/test'
 import type { Locator, Page, Request } from '@playwright/test'
-import type { JobsListResponse } from '@comfyorg/ingest-types'
 
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
   comfyPageFixture
 } from '@e2e/fixtures/ComfyPage'
-import { createMockJobs } from '@e2e/fixtures/helpers/AssetsHelper'
 import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
+import {
+  createRouteMockJob,
+  jobsRouteFixture
+} from '@e2e/fixtures/jobsRouteFixture'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { webSocketFixture } from '@e2e/fixtures/ws'
+import type { RawJobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 
-const test = mergeTests(comfyPageFixture, webSocketFixture)
+const test = mergeTests(comfyPageFixture, webSocketFixture, jobsRouteFixture)
 
 const TOTAL_MOCK_JOBS = 20
 const MAX_HISTORY_ITEMS_SETTING = 'Comfy.Queue.MaxHistoryItems'
-const overflowJobsListRoutePattern = '**/api/jobs?*'
+
+function createMockJobs(count: number): RawJobListItem[] {
+  const now = Date.now()
+  return Array.from({ length: count }, (_, i) =>
+    createRouteMockJob({
+      id: `job-${String(i + 1).padStart(3, '0')}`,
+      create_time: now - i * 60_000,
+      execution_start_time: now - i * 60_000,
+      execution_end_time: now - i * 60_000 + 5000
+    })
+  )
+}
 
 function isHistoryJobsRequest(url: string): boolean {
   if (!url.includes('/api/jobs')) return false
@@ -44,21 +58,16 @@ function getJobListResults(page: Page): Locator {
 test.describe('Queue settings', { tag: '@canvas' }, () => {
   test.describe('Comfy.Queue.MaxHistoryItems', () => {
     test.describe('limit query parameter', () => {
-      test.beforeEach(async ({ comfyPage }) => {
-        await comfyPage.assets.mockOutputHistory(
-          createMockJobs(TOTAL_MOCK_JOBS)
-        )
-      })
-
-      test.afterEach(async ({ comfyPage }) => {
-        await comfyPage.assets.clearMocks()
-      })
-
       test('limit query parameter on /api/jobs reflects the setting', async ({
         comfyPage,
-        getWebSocket
+        getWebSocket,
+        jobsRoutes
       }) => {
         const TARGET_LIMIT = 6
+        await jobsRoutes.mockJobsHistory(
+          createMockJobs(TOTAL_MOCK_JOBS),
+          TARGET_LIMIT
+        )
         await comfyPage.settings.setSetting(
           MAX_HISTORY_ITEMS_SETTING,
           TARGET_LIMIT
@@ -73,39 +82,14 @@ test.describe('Queue settings', { tag: '@canvas' }, () => {
 
     test('queue panel caps history items to the configured number', async ({
       comfyPage,
-      getWebSocket
+      getWebSocket,
+      jobsRoutes
     }) => {
-      // Add a mock route that returns all jobs regardless of the request's `limit` param
-      const overflowJobs = createMockJobs(TOTAL_MOCK_JOBS)
-      await comfyPage.page.route(
-        overflowJobsListRoutePattern,
-        async (route) => {
-          const url = new URL(route.request().url())
-          if (!url.searchParams.get('status')?.includes('completed')) {
-            await route.continue()
-            return
-          }
-          const response = {
-            jobs: overflowJobs,
-            pagination: {
-              offset: 0,
-              limit: overflowJobs.length,
-              total: overflowJobs.length,
-              has_more: false
-            }
-          } satisfies {
-            jobs: unknown[]
-            pagination: JobsListResponse['pagination']
-          }
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(response)
-          })
-        }
-      )
-
       const VISIBLE_LIMIT = 6
+      const overflowJobs = createMockJobs(TOTAL_MOCK_JOBS)
+      await jobsRoutes.mockJobsHistory(overflowJobs, VISIBLE_LIMIT, {
+        responseLimit: overflowJobs.length
+      })
       await comfyPage.settings.setSetting(
         MAX_HISTORY_ITEMS_SETTING,
         VISIBLE_LIMIT


### PR DESCRIPTION
## Summary

Migrates the MaxHistoryItems browser coverage to the accepted jobs route fixture pattern.

## Changes

- **What**: Composes `jobsRouteFixture` into the queue settings spec and removes the old `AssetsHelper` route setup.
- **What**: Adds a `responseLimit` option to `jobsRouteFixture` so tests can match a requested history limit while intentionally returning more jobs.
- **Dependencies**: None.

## Review Focus

The key behavior is preserving both FE-501 acceptance cases: `/api/jobs` still receives the configured `limit`, and the queue panel still caps rendered history even if the mocked backend returns more rows than requested.

Fixes FE-501

## Screenshots (if applicable)

Not applicable.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12298-test-migrate-MaxHistoryItems-browser-coverage-3616d73d365081d6bf77fb205fcd51d4) by [Unito](https://www.unito.io)
