### PR TITLE
fix: RAF-batch canvas ResizeObserver to stop link overlay redraw lag

### DIFF
--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -8,6 +8,7 @@ import { useCanvasPositionConversion } from '@/composables/element/useCanvasPosi
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { syncLayoutStoreNodeBoundsFromGraph } from '@/renderer/core/layout/sync/syncLayoutStoreFromGraph'
 import { flushScheduledSlotLayoutSync } from '@/renderer/extensions/vueNodes/composables/useSlotElementTracking'
+import { createRafBatch } from '@/utils/rafBatch'
 
 import { st, t } from '@/i18n'
 import { ChangeTracker } from '@/scripts/changeTracker'
@@ -949,10 +950,16 @@ export class ComfyApp {
 
     this.rootGraph.start()
 
-    // Ensure the canvas fills the window
+    // Coalesce ResizeObserver bursts during splitter / window drags into one
+    // resize per frame to stop redundant draw(true, true) calls and the link
+    // overlay redraw lag they cause.
+    const scheduleCanvasResize = createRafBatch(() => {
+      const canvasEl = this.canvasElRef.value
+      if (canvasEl) this.resizeCanvas(canvasEl)
+    })
     useResizeObserver(this.canvasElRef, ([canvasEl]) => {
       if (canvasEl.target instanceof HTMLCanvasElement) {
-        this.resizeCanvas(canvasEl.target)
+        scheduleCanvasResize.schedule()
       }
     })
 

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -6,6 +6,7 @@ import { shallowRef } from 'vue'
 
 import { partnerRunGateBlocksAutoQueue } from '@/composables/billing/usePartnerNodesRunGate'
 import { useCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
+import { createRafBatch } from '@/utils/rafBatch'
 
 import { promotedInputSource } from '@/core/graph/subgraph/promotedInputWidget'
 import { resolveConcretePromotedWidget } from '@/core/graph/subgraph/resolveConcretePromotedWidget'
@@ -1056,10 +1057,16 @@ export class ComfyApp {
 
     this.rootGraph.start()
 
-    // Ensure the canvas fills the window
+    // Coalesce ResizeObserver bursts during splitter / window drags into one
+    // resize per frame to stop redundant draw(true, true) calls and the link
+    // overlay redraw lag they cause.
+    const scheduleCanvasResize = createRafBatch(() => {
+      const canvasEl = this.canvasElRef.value
+      if (canvasEl) this.resizeCanvas(canvasEl)
+    })
     useResizeObserver(this.canvasElRef, ([canvasEl]) => {
       if (canvasEl.target instanceof HTMLCanvasElement) {
-        this.resizeCanvas(canvasEl.target)
+        scheduleCanvasResize.schedule()
       }
     })
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The canvas-element `useResizeObserver` in `app.ts` calls `resizeCanvas()` (which does `canvas.width = NaN`, `getBoundingClientRect`, and a full `draw(true, true)`) on every fire with no batching. During an animated bottom-panel splitter open or window drag, the RO fires many times per second, producing visible link-overlay redraw lag — the link overlay canvas re-syncs its dimensions on the next RAF after each main canvas resize (via `useRafFn` in `LinkOverlayCanvas.vue`), so each extra resize buys an extra frame of misalignment.

## Change

Wrap the callback in `createRafBatch(...)` from `@/utils/rafBatch`. Multiple RO fires within the same animation frame coalesce into a single `resizeCanvas()` call using the canvas's current container dimensions at flush time.

## Verification

- `pnpm typecheck` clean (pre-commit)
- `oxfmt` clean
- ESLint ignores `app.ts` (existing convention)

No unit test added — `app.ts` is a monolithic singleton without test infrastructure, and the change is a mechanical one-line wrap around an existing pattern already used heavily elsewhere in the codebase (`useSlotElementTracking`, the sibling node tracking, etc.).

## Note

This is one of three planned PRs that work together to fix the bottom-panel/node-displacement bug. The other two: (1) RAF-batch the per-node Vue ResizeObserver writes (#12299), and (3) an explicit `bottomPanelVisible` watcher as belt-and-braces for the splitter transition (separate PR).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12300-fix-RAF-batch-canvas-ResizeObserver-to-stop-link-overlay-redraw-lag-3616d73d3650818c9922c37f9955845e) by [Unito](https://www.unito.io)
