### PR TITLE
fix: redraw canvas and resync slot layouts on bottom-panel toggle

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -299,7 +299,14 @@ watch(
 )
 
 const { bottomPanelVisible } = storeToRefs(useBottomPanelStore())
-watch(bottomPanelVisible, () => {
+// Mirror the splitter's rendered condition: the bottom panel is hidden when
+// focusMode is on, regardless of bottomPanelVisible (see
+// LiteGraphCanvasSplitterOverlay.vue). Watching the composite means entering
+// or leaving focus mode while the panel is open also triggers the redraw.
+const bottomPanelRendered = computed(
+  () => bottomPanelVisible.value && !workspaceStore.focusMode
+)
+watch(bottomPanelRendered, () => {
   // The splitter resizes the canvas container, which triggers the canvas
   // ResizeObserver and (eventually) the per-node Vue ResizeObservers. Force a
   // slot/link redraw once the splitter has settled so links stay aligned with

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -181,6 +181,7 @@ import { useCommandStore } from '@/stores/commandStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useSearchBoxStore } from '@/stores/workspace/searchBoxStore'
 import { useAppMode } from '@/composables/useAppMode'
@@ -296,6 +297,18 @@ watch(
     layoutStore.setPendingSlotSync(true)
   }
 )
+
+const { bottomPanelVisible } = storeToRefs(useBottomPanelStore())
+watch(bottomPanelVisible, () => {
+  // The splitter resizes the canvas container, which triggers the canvas
+  // ResizeObserver and (eventually) the per-node Vue ResizeObservers. Force a
+  // slot/link redraw once the splitter has settled so links stay aligned with
+  // slot connectors even if any RO callback was missed or measured stale
+  // viewport state during the transition.
+  if (!canvasStore.canvas) return
+  requestSlotLayoutSyncForAllNodes()
+  canvasStore.canvas.setDirty(true, true)
+})
 
 function onLinkOverlayReady(el: HTMLCanvasElement) {
   if (!canvasStore.canvas) return


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Belt-and-braces for the bottom-panel/node-displacement bug. When the bottom panel opens or closes, the PrimeVue Splitter changes the canvas container size which triggers the canvas `ResizeObserver` and the per-node Vue `ResizeObserver`s. Both have failure modes during animated transitions (RAF batching, suspended-tab handling, stale viewport state on the first measurement). Add an explicit watcher so the canvas is always redrawn and slot layouts re-measured after the panel toggles, regardless of what the RO chain did.

## Change

In `GraphCanvas.vue`, watch the same composite condition the splitter uses to render the panel (`bottomPanelVisible && !focusMode`). When it flips:

- `requestSlotLayoutSyncForAllNodes()` — force a DOM re-measurement of every node's slot connectors so links re-aim correctly.
- `canvasStore.canvas.setDirty(true, true)` — force a full foreground + background canvas redraw.

This mirrors the existing `linearMode` watcher pattern in the same file (lines 285–298).

## Notes

- Watches the composite condition (`bottomPanelVisible && !focusMode`) rather than `bottomPanelVisible` alone, because `LiteGraphCanvasSplitterOverlay.vue` hides the panel whenever `focusMode` is on regardless of the store flag — so entering/leaving focus mode while the panel is "open" also resizes the canvas.
- No unit test: meaningful coverage requires either mounting the full `GraphCanvas` SFC (brittle integration test mostly exercising Pinia + Vue reactivity) or extracting a one-line watcher into its own composable (over-engineering for one consumer). This is a UI timing fix; an E2E regression toggling the bottom panel with Vue nodes enabled is the right shape for coverage.

## Verification

- `pnpm typecheck` (`vue-tsc --noEmit`) clean
- `oxfmt`, `eslint` clean (pre-commit hooks)

## Note

This is the third of three PRs that work together to fix the bottom-panel/node-displacement bug. The other two: (1) RAF-batch the per-node Vue ResizeObserver writes ([#12299](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12299)), (2) RAF-batch the canvas ResizeObserver ([#12300](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12300)).

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12302-fix-redraw-canvas-and-resync-slot-layouts-on-bottom-panel-toggle-3616d73d3650815eaeacf58dc0095506) by [Unito](https://www.unito.io)
