### PR TITLE
fix: resolve scroll event leak in text widget (#3990)

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -134,8 +134,16 @@ function addMultilineWidget(
       }
 
       // Vertical scrolling when gestures disabled: let textarea scroll if scrollable
+      // but prevent event from leaking to canvas when scroll reaches bounds
       if (canScrollY) {
-        event.stopPropagation()
+        const atTop = inputEl.scrollTop === 0
+        const atBottom = inputEl.scrollTop + inputEl.clientHeight >= inputEl.scrollHeight
+        if (atTop || atBottom) {
+          // At scroll bounds: prevent default AND stop propagation so canvas doesn't scroll
+          event.preventDefault()
+          event.stopPropagation()
+        }
+        // In middle of scrollable content: let textarea scroll naturally
         return
       }
 


### PR DESCRIPTION
## Summary
Fix for [Bug Bounty] Scroll event leak after scrolling to the top of a text widget — Issue #3990

## Root cause
In `useStringWidget.ts`, when the textarea was scrollable (`canScrollY = true`), only `event.stopPropagation()` was called without `event.preventDefault()`. Since LiteGraph canvas listens at the `document` level via `addEventListener` with capture or bubbling, `stopPropagation()` alone doesn't prevent the wheel event from reaching the canvas. The canvas would still process the event after the textarea reached its scroll bounds (top/bottom).

## Fix
When the textarea is scrollable AND the scroll position is at the top or bottom boundary, call both `preventDefault()` and `stopPropagation()` to block the event from leaking to the canvas layer. In the middle of scrollable content, let the textarea scroll naturally without intervention.

## Changes
- `src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts`: Added scroll boundary detection (`atTop`/`atBottom`) and `preventDefault()` at scroll bounds to fully block event propagation to canvas.

Closes #3990

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12305-fix-resolve-scroll-event-leak-in-text-widget-3990-3626d73d365081028372efd74399f76d) by [Unito](https://www.unito.io)
