### PR TITLE
fix(website): restore registry metadata for cloud nodes catalog

### DIFF
--- a/apps/website/src/utils/cloudNodes.registry.test.ts
+++ b/apps/website/src/utils/cloudNodes.registry.test.ts
@@ -17,7 +17,7 @@ function jsonResponse(
 }
 
 describe('fetchRegistryPacks', () => {
-  it('requests node ids in batches of 50', async () => {
+  it('requests node ids in batches of 50 with matching limit param', async () => {
     const ids = Array.from({ length: 120 }, (_, i) => `pack-${i}`)
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const url = new URL(String(input))
@@ -40,6 +40,73 @@ describe('fetchRegistryPacks', () => {
     expect(firstCallUrl.origin).toBe(DEFAULT_REGISTRY_BASE_URL)
     expect(firstCallUrl.pathname).toBe('/nodes')
     expect(firstCallUrl.searchParams.getAll('node_id')).toHaveLength(50)
+    expect(firstCallUrl.searchParams.get('limit')).toBe('50')
+    const lastCallUrl = new URL(String(fetchImpl.mock.calls[2]?.[0]))
+    expect(lastCallUrl.searchParams.getAll('node_id')).toHaveLength(20)
+    expect(lastCallUrl.searchParams.get('limit')).toBe('20')
+  })
+
+  it('survives the server defaulting to a small page size (regression for missing limit)', async () => {
+    // Mock applies the server's pre-fix behavior: default limit=10 silently
+    // truncates batches with more node_id filters than the page size.
+    const ids = Array.from({ length: 30 }, (_, i) => `pack-${i}`)
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      const requestedLimit = Number(url.searchParams.get('limit') ?? '10')
+      const batchIds = url.searchParams
+        .getAll('node_id')
+        .slice(0, requestedLimit)
+      return jsonResponse({
+        nodes: batchIds.map((id) => ({ id, name: id })),
+        total: batchIds.length,
+        page: 1,
+        limit: requestedLimit
+      })
+    })
+
+    const result = await fetchRegistryPacks(ids, {
+      fetchImpl: fetchImpl as typeof fetch
+    })
+
+    const enriched = [...result.values()].filter((pack) => pack !== null)
+    expect(enriched).toHaveLength(30)
+  })
+
+  it('accepts null values for optional registry fields and normalizes them to undefined', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        nodes: [
+          {
+            id: 'pack-with-nulls',
+            name: 'Pack With Nulls',
+            description: null,
+            icon: null,
+            banner_url: null,
+            supported_os: null,
+            supported_accelerators: null,
+            publisher: null,
+            latest_version: null,
+            downloads: 42
+          }
+        ],
+        total: 1,
+        page: 1,
+        limit: 50
+      })
+    )
+
+    const result = await fetchRegistryPacks(['pack-with-nulls'], {
+      fetchImpl: fetchImpl as typeof fetch
+    })
+
+    const pack = result.get('pack-with-nulls')
+    expect(pack).not.toBeNull()
+    expect(pack?.downloads).toBe(42)
+    expect(pack?.description).toBeUndefined()
+    expect(pack?.supported_os).toBeUndefined()
+    expect(pack?.supported_accelerators).toBeUndefined()
+    expect(pack?.publisher).toBeUndefined()
+    expect(pack?.latest_version).toBeUndefined()
   })
 
   it('retries a failed batch once and then succeeds', async () => {

--- a/apps/website/src/utils/cloudNodes.registry.ts
+++ b/apps/website/src/utils/cloudNodes.registry.ts
@@ -8,34 +8,47 @@ const BATCH_SIZE = 50
 
 export type RegistryPack = components['schemas']['Node']
 
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
+  return value ?? undefined
+}
+
+const optionalString = z.string().nullish().transform(nullToUndefined)
+const optionalNumber = z.number().nullish().transform(nullToUndefined)
+const optionalStringArray = z
+  .array(z.string())
+  .nullish()
+  .transform(nullToUndefined)
+
 const RegistryPackSchema = z
   .object({
-    id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    icon: z.string().optional(),
-    banner_url: z.string().optional(),
-    repository: z.string().optional(),
-    license: z.string().optional(),
-    downloads: z.number().optional(),
-    github_stars: z.number().optional(),
-    created_at: z.string().optional(),
-    supported_os: z.array(z.string()).optional(),
-    supported_accelerators: z.array(z.string()).optional(),
+    id: optionalString,
+    name: optionalString,
+    description: optionalString,
+    icon: optionalString,
+    banner_url: optionalString,
+    repository: optionalString,
+    license: optionalString,
+    downloads: optionalNumber,
+    github_stars: optionalNumber,
+    created_at: optionalString,
+    supported_os: optionalStringArray,
+    supported_accelerators: optionalStringArray,
     publisher: z
       .object({
-        id: z.string().optional(),
-        name: z.string().optional()
+        id: optionalString,
+        name: optionalString
       })
       .passthrough()
-      .optional(),
+      .nullish()
+      .transform(nullToUndefined),
     latest_version: z
       .object({
-        version: z.string().optional(),
-        createdAt: z.string().optional()
+        version: optionalString,
+        createdAt: optionalString
       })
       .passthrough()
-      .optional()
+      .nullish()
+      .transform(nullToUndefined)
   })
   .passthrough()
 
@@ -141,6 +154,7 @@ async function fetchBatch(
   timeoutMs: number
 ): Promise<BatchResponse> {
   const params = new URLSearchParams()
+  params.set('limit', String(packIds.length))
   for (const packId of packIds) {
     params.append('node_id', packId)
   }


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The [`/cloud/supported-nodes`](https://comfy-website-preview-pr-12271.vercel.app/cloud/supported-nodes) page was rendering packs without descriptions, icons, or download counts (PR #12271 preview, [`Release: Website` run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/25866708684/job/76010642686)). The registry enrichment in `apps/website/src/utils/cloudNodes.registry.ts` was silently failing for **two** reasons:

1. **Missing `limit` query parameter.** `api.comfy.org /nodes` applies a default page size of `10` when no `limit` is sent. Each batch of up to 50 `node_id` filters was therefore truncated to 10 results, dropping metadata for every pack past the first ten.
2. **Schema rejected `null` for optional arrays.** The registry serializes empty server-side slices as JSON `null`, so any pack with `supported_os: null` or `supported_accelerators: null` failed Zod validation — and because parse failure is not retryable, the **entire batch** got `null` enrichment.

Both bugs produce the same user-visible symptom ("packs fetched, but no metadata"), so they were entangled.

## Changes (2 files)

- `cloudNodes.registry.ts`: send `?limit=<batch length>` on every batch and accept `null` for all optional registry fields. The schema normalizes `null → undefined` at the parse boundary via `.transform()`, so the parsed shape continues to match the generated OpenAPI `Node` type contract; downstream code (`toDomainPack`, the rendered `Pack`) is unchanged.
- `cloudNodes.registry.test.ts`: two new regression tests:
  - Server-side default page size: simulates the pre-fix behavior (default `limit=10` truncates) and asserts all 30 batched IDs are enriched.
  - `null` registry fields: asserts `null` values are normalized to `undefined` on the parsed pack.

## Verification

End-to-end fetch against the live registry on this branch (14 packs from the current snapshot):

```
Requested: 14, enriched: 14
  comfyui-kjnodes                downloads=3,404,416
  rgthree-comfy                  downloads=3,105,034
  comfyui-easy-use               downloads=2,829,702
  comfyui-impact-pack            downloads=2,680,589
  comfyui_essentials             downloads=2,418,367  (supported_os null → undefined)
  ComfyUI-Crystools              downloads=1,729,087
  comfyui_layerstyle             downloads=1,696,809
  comfyui_ultimatesdupscale      downloads=1,478,763
  comfyui_ipadapter_plus         downloads=1,236,442  (supported_os null → undefined)
  was-node-suite-comfyui         downloads=993,960    (supported_os null → undefined)
  comfyui-advanced-controlnet    downloads=600,849
  comfyui-animatediff-evolved    downloads=503,831
  comfyui-cogvideoxwrapper       downloads=121,716    (supported_os null → undefined)
  comfyui_steudio                downloads=58,470     (supported_os null → undefined)
```

5 of 14 packs returned `null` arrays — all parse cleanly now. Sort-by-downloads (already implemented in `useFilteredPacks.ts`) becomes meaningful again once `downloads` is populated.

Quality gates:

- `pnpm --filter @comfyorg/website test:unit` → 77/77 pass (includes 2 new regression tests)
- `pnpm --filter @comfyorg/website typecheck` → 0 errors, 0 warnings on changed files
- `pnpm exec eslint` on changed files → clean
- `pnpm exec oxfmt --check` on changed files → clean

## Follow-ups (separate tickets)

- "New" badge + `dateAdded` field for newly added packs.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12307-fix-website-restore-registry-metadata-for-cloud-nodes-catalog-3626d73d365081288a2cfc30003160cf) by [Unito](https://www.unito.io)
