### PR TITLE
fix: prevent escape from exiting subgraph while a context menu is open

### DIFF
--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -152,6 +152,7 @@ import { useGlobalLitegraph } from '@/composables/useGlobalLitegraph'
 import { usePaste } from '@/composables/usePaste'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useLiteGraphContextMenuTracking } from '@/platform/keybindings/raisedSurfaceLiteGraphBridge'
 import { useLitegraphSettings } from '@/platform/settings/composables/useLitegraphSettings'
 import { CORE_SETTINGS } from '@/platform/settings/constants/coreSettings'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -460,6 +461,7 @@ useNodeBadge()
 
 useGlobalLitegraph()
 useContextMenuTranslation()
+useLiteGraphContextMenuTracking()
 useCopy()
 usePaste()
 useWorkflowAutoSave()

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -175,6 +175,7 @@ import { usePaste } from '@/composables/usePaste'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useLiteGraphContextMenuTracking } from '@/platform/keybindings/raisedSurfaceLiteGraphBridge'
 import { useLitegraphSettings } from '@/platform/settings/composables/useLitegraphSettings'
 import { CORE_SETTINGS } from '@/platform/settings/constants/coreSettings'
 import { useSettingStore } from '@/platform/settings/settingStore'
@@ -484,6 +485,7 @@ useNodeBadge()
 useGlobalLitegraph()
 useContextMenuTranslation()
 useGroupContextMenu()
+useLiteGraphContextMenuTracking()
 useCopy()
 usePaste()
 useWorkflowAutoSave()

--- a/src/components/graph/NodeContextMenu.vue
+++ b/src/components/graph/NodeContextMenu.vue
@@ -59,6 +59,7 @@ import type {
   MenuOption,
   SubMenuOption
 } from '@/composables/graph/useMoreOptionsMenu'
+import { useRaisedSurface } from '@/platform/keybindings/raisedSurfaceStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import SubmenuPopover from './selectionToolbox/SubmenuPopover.vue'
@@ -77,6 +78,8 @@ const isOpen = ref(false)
 
 const { menuOptions, bump } = useMoreOptionsMenu()
 const canvasStore = useCanvasStore()
+
+useRaisedSurface('context-menu', isOpen)
 
 // World position (canvas coordinates) where menu was opened
 const worldPosition = ref({ x: 0, y: 0 })

--- a/src/components/graph/NodeContextMenu.vue
+++ b/src/components/graph/NodeContextMenu.vue
@@ -52,6 +52,7 @@ import type {
   MenuOption,
   SubMenuOption
 } from '@/composables/graph/useMoreOptionsMenu'
+import { useRaisedSurface } from '@/platform/keybindings/raisedSurfaceStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 import ColorPickerMenu from './selectionToolbox/ColorPickerMenu.vue'
@@ -68,6 +69,8 @@ const isOpen = ref(false)
 
 const { menuOptions, bump } = useMoreOptionsMenu()
 const canvasStore = useCanvasStore()
+
+useRaisedSurface('context-menu', isOpen)
 
 // World position (canvas coordinates) where menu was opened
 const worldPosition = ref({ x: 0, y: 0 })

--- a/src/lib/litegraph/src/ContextMenu.test.ts
+++ b/src/lib/litegraph/src/ContextMenu.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ContextMenu } from '@/lib/litegraph/src/ContextMenu'
+
+describe('ContextMenu lifecycle events', () => {
+  let listener: (event: Event) => void
+  let calls: Event[]
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    calls = []
+    listener = (event) => calls.push(event)
+    document.addEventListener('litegraph:contextmenu', listener)
+  })
+
+  afterEach(() => {
+    document.removeEventListener('litegraph:contextmenu', listener)
+  })
+
+  it('dispatches an "open" event when a top-level menu is constructed', () => {
+    new ContextMenu(['Item A', 'Item B'], {})
+
+    expect(calls).toHaveLength(1)
+    const detail = (calls[0] as CustomEvent).detail
+    expect(detail.type).toBe('open')
+  })
+
+  it('dispatches a "close" event when a top-level menu closes', () => {
+    const menu = new ContextMenu(['Item A'], {})
+    calls.length = 0
+
+    menu.close()
+
+    expect(calls).toHaveLength(1)
+    const detail = (calls[0] as CustomEvent).detail
+    expect(detail.type).toBe('close')
+    expect(detail.menu).toBe(menu)
+  })
+
+  it('does not dispatch lifecycle events for submenus', () => {
+    const parent = new ContextMenu(['Item A'], {})
+    calls.length = 0
+
+    new ContextMenu(['Sub Item'], { parentMenu: parent })
+
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/src/lib/litegraph/src/ContextMenu.test.ts
+++ b/src/lib/litegraph/src/ContextMenu.test.ts
@@ -5,20 +5,23 @@ import { ContextMenu } from '@/lib/litegraph/src/ContextMenu'
 describe('ContextMenu lifecycle events', () => {
   let listener: (event: Event) => void
   let calls: Event[]
+  let menus: ContextMenu[]
 
   beforeEach(() => {
     document.body.innerHTML = ''
     calls = []
+    menus = []
     listener = (event) => calls.push(event)
     document.addEventListener('litegraph:contextmenu', listener)
   })
 
   afterEach(() => {
+    for (const menu of menus) menu.close()
     document.removeEventListener('litegraph:contextmenu', listener)
   })
 
   it('dispatches an "open" event when a top-level menu is constructed', () => {
-    new ContextMenu(['Item A', 'Item B'], {})
+    menus.push(new ContextMenu(['Item A', 'Item B'], {}))
 
     expect(calls).toHaveLength(1)
     const detail = (calls[0] as CustomEvent).detail
@@ -39,6 +42,7 @@ describe('ContextMenu lifecycle events', () => {
 
   it('does not dispatch lifecycle events for submenus', () => {
     const parent = new ContextMenu(['Item A'], {})
+    menus.push(parent)
     calls.length = 0
 
     new ContextMenu(['Sub Item'], { parentMenu: parent })

--- a/src/lib/litegraph/src/ContextMenu.ts
+++ b/src/lib/litegraph/src/ContextMenu.ts
@@ -213,7 +213,7 @@ export class ContextMenu<TValue = unknown> {
         left = rect.left + rect.width
       }
 
-      const body_rect = document.body.getBoundingClientRect()
+      const body_rect = ownerDocument.body.getBoundingClientRect()
       const root_rect = root.getBoundingClientRect()
       if (body_rect.height == 0)
         console.error(

--- a/src/lib/litegraph/src/ContextMenu.ts
+++ b/src/lib/litegraph/src/ContextMenu.ts
@@ -126,6 +126,16 @@ export class ContextMenu<TValue = unknown> {
         },
         eventOptions
       )
+      document.addEventListener(
+        'keydown',
+        (e) => {
+          if (e.key !== 'Escape' || e.ctrlKey || e.altKey || e.metaKey) return
+          this.close()
+          e.preventDefault()
+          e.stopPropagation()
+        },
+        eventOptions
+      )
     }
 
     // this prevents the default context browser menu to open in case this menu was created when pressing right button
@@ -218,6 +228,14 @@ export class ContextMenu<TValue = unknown> {
 
     if (LiteGraph.context_menu_scaling && options.scale) {
       root.style.transform = `scale(${Math.round(options.scale * 4) * 0.25})`
+    }
+
+    if (!parent) {
+      document.dispatchEvent(
+        new CustomEvent('litegraph:contextmenu', {
+          detail: { type: 'open', menu: this }
+        })
+      )
     }
   }
 
@@ -402,6 +420,13 @@ export class ContextMenu<TValue = unknown> {
       }
     }
     this.current_submenu?.close(e, true)
+    if (!this.parentMenu) {
+      document.dispatchEvent(
+        new CustomEvent('litegraph:contextmenu', {
+          detail: { type: 'close', menu: this }
+        })
+      )
+    }
   }
 
   /** @deprecated Likely unused, however code search was inconclusive (too many results to check by hand). */

--- a/src/lib/litegraph/src/ContextMenu.ts
+++ b/src/lib/litegraph/src/ContextMenu.ts
@@ -56,6 +56,7 @@ export class ContextMenu<TValue = unknown> {
   root: ContextMenuDivElement<TValue>
   current_submenu?: ContextMenu<TValue>
   lock?: boolean
+  ownerDocument: Document
 
   controller: AbortController = new AbortController()
 
@@ -105,7 +106,13 @@ export class ContextMenu<TValue = unknown> {
       options.event = undefined
     }
 
-    const root: ContextMenuDivElement<TValue> = document.createElement('div')
+    const ownerDocument =
+      (options.event?.target as Node | null | undefined)?.ownerDocument ??
+      document
+    this.ownerDocument = ownerDocument
+
+    const root: ContextMenuDivElement<TValue> =
+      ownerDocument.createElement('div')
     let classes = 'litegraph litecontextmenu litemenubar-panel'
     if (options.className) classes += ` ${options.className}`
     root.className = classes
@@ -117,7 +124,7 @@ export class ContextMenu<TValue = unknown> {
     const eventOptions = { capture: true, signal }
 
     if (!this.parentMenu) {
-      document.addEventListener(
+      ownerDocument.addEventListener(
         'pointerdown',
         (e) => {
           if (e.target instanceof Node && !this.containsNode(e.target)) {
@@ -126,7 +133,7 @@ export class ContextMenu<TValue = unknown> {
         },
         eventOptions
       )
-      document.addEventListener(
+      ownerDocument.addEventListener(
         'keydown',
         (e) => {
           if (e.key !== 'Escape' || e.ctrlKey || e.altKey || e.metaKey) return
@@ -189,13 +196,9 @@ export class ContextMenu<TValue = unknown> {
     }
 
     // insert before checking position
-    const ownerDocument = (options.event?.target as Node | null | undefined)
-      ?.ownerDocument
-    const root_document = ownerDocument || document
-
-    if (root_document.fullscreenElement)
-      root_document.fullscreenElement.append(root)
-    else root_document.body.append(root)
+    if (ownerDocument.fullscreenElement)
+      ownerDocument.fullscreenElement.append(root)
+    else ownerDocument.body.append(root)
 
     // compute best position
     let left = options.left || 0
@@ -231,7 +234,7 @@ export class ContextMenu<TValue = unknown> {
     }
 
     if (!parent) {
-      document.dispatchEvent(
+      ownerDocument.dispatchEvent(
         new CustomEvent('litegraph:contextmenu', {
           detail: { type: 'open', menu: this }
         })
@@ -421,7 +424,7 @@ export class ContextMenu<TValue = unknown> {
     }
     this.current_submenu?.close(e, true)
     if (!this.parentMenu) {
-      document.dispatchEvent(
+      this.ownerDocument.dispatchEvent(
         new CustomEvent('litegraph:contextmenu', {
           detail: { type: 'close', menu: this }
         })

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -7,6 +7,7 @@ import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useRaisedSurfaceStore } from '@/platform/keybindings/raisedSurfaceStore'
 import { useCommandStore } from '@/stores/commandStore'
 import type { DialogInstance } from '@/stores/dialogStore'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -106,6 +107,31 @@ describe('keybindingService - Escape key handling', () => {
     await keybindingService.keybindHandler(event)
 
     expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('should NOT execute Escape keybinding when a raised surface is open', async () => {
+    const raisedSurfaceStore = useRaisedSurfaceStore()
+    raisedSurfaceStore.open('context-menu')
+
+    keybindingService = useKeybindingService()
+
+    const event = createKeyboardEvent('Escape')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('should resume executing Escape keybinding after a raised surface closes', async () => {
+    const raisedSurfaceStore = useRaisedSurfaceStore()
+    const id = raisedSurfaceStore.open('context-menu')
+    raisedSurfaceStore.close(id)
+
+    keybindingService = useKeybindingService()
+
+    const event = createKeyboardEvent('Escape')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.Graph.ExitSubgraph')
   })
 
   it('should execute Escape keybinding with modifiers regardless of dialog state', async () => {

--- a/src/platform/keybindings/keybindingService.escape.test.ts
+++ b/src/platform/keybindings/keybindingService.escape.test.ts
@@ -7,6 +7,7 @@ import { KeyComboImpl } from '@/platform/keybindings/keyCombo'
 import { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingService } from '@/platform/keybindings/keybindingService'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
+import { useRaisedSurfaceStore } from '@/platform/keybindings/raisedSurfaceStore'
 import { useCommandStore } from '@/stores/commandStore'
 import type { DialogInstance } from '@/stores/dialogStore'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -106,7 +107,32 @@ describe('keybindingService - Escape key handling', () => {
     expect(mockCommandExecute).not.toHaveBeenCalled()
   })
 
-  it('should NOT execute Escape keybinding with modifiers when a dialog is open', async () => {
+  it('should NOT execute Escape keybinding when a raised surface is open', async () => {
+    const raisedSurfaceStore = useRaisedSurfaceStore()
+    raisedSurfaceStore.open('context-menu')
+
+    keybindingService = useKeybindingService()
+
+    const event = createKeyboardEvent('Escape')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).not.toHaveBeenCalled()
+  })
+
+  it('should resume executing Escape keybinding after a raised surface closes', async () => {
+    const raisedSurfaceStore = useRaisedSurfaceStore()
+    const id = raisedSurfaceStore.open('context-menu')
+    raisedSurfaceStore.close(id)
+
+    keybindingService = useKeybindingService()
+
+    const event = createKeyboardEvent('Escape')
+    await keybindingService.keybindHandler(event)
+
+    expect(mockCommandExecute).toHaveBeenCalledWith('Comfy.Graph.ExitSubgraph')
+  })
+
+  it('should execute Escape keybinding with modifiers regardless of dialog state', async () => {
     const dialogStore = useDialogStore()
     dialogStore.dialogStack.push(createTestDialogInstance('test-dialog'))
 

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -7,12 +7,14 @@ import { CORE_KEYBINDINGS } from './defaults'
 import { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import { useKeybindingStore } from './keybindingStore'
+import { useRaisedSurfaceStore } from './raisedSurfaceStore'
 
 export function useKeybindingService() {
   const keybindingStore = useKeybindingStore()
   const commandStore = useCommandStore()
   const settingStore = useSettingStore()
   const dialogStore = useDialogStore()
+  const raisedSurfaceStore = useRaisedSurfaceStore()
 
   async function keybindHandler(event: KeyboardEvent) {
     const keyCombo = KeyComboImpl.fromEvent(event)
@@ -50,7 +52,10 @@ export function useKeybindingService() {
         !event.altKey &&
         !event.metaKey
       ) {
-        if (dialogStore.dialogStack.length > 0) {
+        if (
+          raisedSurfaceStore.isAnyOpen ||
+          dialogStore.dialogStack.length > 0
+        ) {
           return
         }
       }

--- a/src/platform/keybindings/keybindingService.ts
+++ b/src/platform/keybindings/keybindingService.ts
@@ -8,12 +8,14 @@ import { CORE_KEYBINDINGS } from './defaults'
 import { KeyComboImpl } from './keyCombo'
 import { KeybindingImpl } from './keybinding'
 import { useKeybindingStore } from './keybindingStore'
+import { useRaisedSurfaceStore } from './raisedSurfaceStore'
 
 export function useKeybindingService() {
   const keybindingStore = useKeybindingStore()
   const commandStore = useCommandStore()
   const settingStore = useSettingStore()
   const dialogStore = useDialogStore()
+  const raisedSurfaceStore = useRaisedSurfaceStore()
 
   async function keybindHandler(event: KeyboardEvent) {
     const keyCombo = KeyComboImpl.fromEvent(event)
@@ -50,6 +52,16 @@ export function useKeybindingService() {
           return
         }
       }
+      if (
+        event.key === 'Escape' &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        raisedSurfaceStore.isAnyOpen
+      ) {
+        return
+      }
+
       if (isModalOpen(dialogStore.dialogStack.length)) {
         // Bare keys still have to reach inputs inside the dialog.
         if (keyCombo.ctrl) {

--- a/src/platform/keybindings/raisedSurfaceLiteGraphBridge.ts
+++ b/src/platform/keybindings/raisedSurfaceLiteGraphBridge.ts
@@ -9,7 +9,7 @@ interface LiteGraphContextMenuEventDetail {
 
 export function useLiteGraphContextMenuTracking(): void {
   const store = useRaisedSurfaceStore()
-  const idsByMenu = new WeakMap<object, symbol>()
+  const idsByMenu = new Map<object, symbol>()
 
   const handler = (event: Event) => {
     const detail = (event as CustomEvent<LiteGraphContextMenuEventDetail>)
@@ -28,5 +28,7 @@ export function useLiteGraphContextMenuTracking(): void {
   document.addEventListener('litegraph:contextmenu', handler)
   onScopeDispose(() => {
     document.removeEventListener('litegraph:contextmenu', handler)
+    for (const id of idsByMenu.values()) store.close(id)
+    idsByMenu.clear()
   })
 }

--- a/src/platform/keybindings/raisedSurfaceLiteGraphBridge.ts
+++ b/src/platform/keybindings/raisedSurfaceLiteGraphBridge.ts
@@ -1,0 +1,32 @@
+import { onScopeDispose } from 'vue'
+
+import { useRaisedSurfaceStore } from './raisedSurfaceStore'
+
+interface LiteGraphContextMenuEventDetail {
+  type: 'open' | 'close'
+  menu: object
+}
+
+export function useLiteGraphContextMenuTracking(): void {
+  const store = useRaisedSurfaceStore()
+  const idsByMenu = new WeakMap<object, symbol>()
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<LiteGraphContextMenuEventDetail>)
+      .detail
+    if (detail.type === 'open') {
+      idsByMenu.set(detail.menu, store.open('context-menu'))
+      return
+    }
+    const id = idsByMenu.get(detail.menu)
+    if (id !== undefined) {
+      store.close(id)
+      idsByMenu.delete(detail.menu)
+    }
+  }
+
+  document.addEventListener('litegraph:contextmenu', handler)
+  onScopeDispose(() => {
+    document.removeEventListener('litegraph:contextmenu', handler)
+  })
+}

--- a/src/platform/keybindings/raisedSurfaceStore.test.ts
+++ b/src/platform/keybindings/raisedSurfaceStore.test.ts
@@ -1,0 +1,89 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { effectScope, ref } from 'vue'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useRaisedSurface, useRaisedSurfaceStore } from './raisedSurfaceStore'
+
+describe('raisedSurfaceStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('is empty by default', () => {
+    const store = useRaisedSurfaceStore()
+    expect(store.isAnyOpen).toBe(false)
+    expect(store.stack).toHaveLength(0)
+  })
+
+  it('tracks open/close and reports isAnyOpen', () => {
+    const store = useRaisedSurfaceStore()
+    const id = store.open('context-menu')
+    expect(store.isAnyOpen).toBe(true)
+    expect(store.stack).toHaveLength(1)
+    store.close(id)
+    expect(store.isAnyOpen).toBe(false)
+    expect(store.stack).toHaveLength(0)
+  })
+
+  it('supports concurrent surfaces and closes by id (LIFO not required)', () => {
+    const store = useRaisedSurfaceStore()
+    const a = store.open('context-menu')
+    const b = store.open('popover')
+    expect(store.stack).toHaveLength(2)
+    store.close(a)
+    expect(store.stack).toHaveLength(1)
+    expect(store.stack[0].kind).toBe('popover')
+    store.close(b)
+    expect(store.isAnyOpen).toBe(false)
+  })
+
+  it('close is a no-op for unknown ids', () => {
+    const store = useRaisedSurfaceStore()
+    store.open('modal')
+    store.close(Symbol('stale'))
+    expect(store.stack).toHaveLength(1)
+  })
+})
+
+describe('useRaisedSurface', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('opens when reactive flag turns true and closes when it turns false', () => {
+    const store = useRaisedSurfaceStore()
+    const isOpen = ref(false)
+    const scope = effectScope()
+    scope.run(() => useRaisedSurface('context-menu', isOpen))
+
+    expect(store.isAnyOpen).toBe(false)
+    isOpen.value = true
+    expect(store.isAnyOpen).toBe(true)
+    isOpen.value = false
+    expect(store.isAnyOpen).toBe(false)
+    scope.stop()
+  })
+
+  it('does not double-register when flag is toggled true twice', () => {
+    const store = useRaisedSurfaceStore()
+    const isOpen = ref(false)
+    const scope = effectScope()
+    scope.run(() => useRaisedSurface('context-menu', isOpen))
+
+    isOpen.value = true
+    isOpen.value = true
+    expect(store.stack).toHaveLength(1)
+    scope.stop()
+  })
+
+  it('releases the surface when the owning scope is disposed', () => {
+    const store = useRaisedSurfaceStore()
+    const isOpen = ref(true)
+    const scope = effectScope()
+    scope.run(() => useRaisedSurface('context-menu', isOpen))
+
+    expect(store.isAnyOpen).toBe(true)
+    scope.stop()
+    expect(store.isAnyOpen).toBe(false)
+  })
+})

--- a/src/platform/keybindings/raisedSurfaceStore.ts
+++ b/src/platform/keybindings/raisedSurfaceStore.ts
@@ -1,0 +1,72 @@
+import { defineStore } from 'pinia'
+import { computed, onScopeDispose, ref, toValue, watch } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+
+/**
+ * Tracks open "raised surfaces" — popovers, context menus, and top-level
+ * modals — that should suppress global keybindings while they are open.
+ *
+ * UX axiom: standard keybindings work in every context EXCEPT when a raised
+ * surface is open. Consumers register/unregister surfaces here; the keybinding
+ * service consults {@link isAnyOpen} as its single source of truth.
+ */
+type RaisedSurfaceKind = 'context-menu' | 'popover' | 'modal'
+
+interface RaisedSurfaceEntry {
+  id: symbol
+  kind: RaisedSurfaceKind
+}
+
+export const useRaisedSurfaceStore = defineStore('raisedSurface', () => {
+  const stack = ref<RaisedSurfaceEntry[]>([])
+  const isAnyOpen = computed(() => stack.value.length > 0)
+
+  function open(kind: RaisedSurfaceKind): symbol {
+    const id = Symbol(kind)
+    stack.value.push({ id, kind })
+    return id
+  }
+
+  function close(id: symbol): void {
+    const index = stack.value.findIndex((entry) => entry.id === id)
+    if (index !== -1) stack.value.splice(index, 1)
+  }
+
+  return { stack, isAnyOpen, open, close }
+})
+
+/**
+ * Bind a surface's reactive open-state to the raised-surface registry.
+ *
+ * @example
+ * const isOpen = ref(false)
+ * useRaisedSurface('context-menu', isOpen)
+ */
+export function useRaisedSurface(
+  kind: RaisedSurfaceKind,
+  isOpen: MaybeRefOrGetter<boolean>
+): void {
+  const store = useRaisedSurfaceStore()
+  let id: symbol | null = null
+
+  function release() {
+    if (id !== null) {
+      store.close(id)
+      id = null
+    }
+  }
+
+  watch(
+    () => toValue(isOpen),
+    (open) => {
+      if (open && id === null) {
+        id = store.open(kind)
+      } else if (!open) {
+        release()
+      }
+    },
+    { immediate: true, flush: 'sync' }
+  )
+
+  onScopeDispose(release)
+}


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Pressing Escape on a right-click context menu while inside a subgraph used to fire the global `Comfy.Graph.ExitSubgraph` keybinding, exiting the subgraph while leaving the menu open. The keybinding service only suppressed Escape when a Pinia dialog was on the stack, so other raised surfaces (LiteGraph context menus, PrimeVue popovers) leaked the event to the window-level handler.

This PR encodes the UX axiom — *standard keybindings are suppressed whenever any raised surface (context menu, popover, or top-level modal) is open* — as a centralized reactive registry that the keybinding service consults as its single source of truth.

## Changes

- **New `useRaisedSurfaceStore`** (`src/platform/keybindings/raisedSurfaceStore.ts`) — a Pinia store that tracks open raised surfaces by id. Sibling to the existing `dialogStore`.
- **New `useRaisedSurface(kind, isOpen)` composable** — one-line opt-in for any surface. Releases the entry both when `isOpen` flips to false and when the owning Vue scope is disposed.
- **`keybindingService.ts`** consults `raisedSurfaceStore.isAnyOpen` alongside the existing `dialogStore.dialogStack` check.
- **`ContextMenu.ts` (LiteGraph)** now closes itself on Escape (mirroring its existing outside-pointerdown handler) and dispatches `litegraph:contextmenu` document events on open/close. No monkey patching — the registration lives directly in litegraph.
- **`raisedSurfaceLiteGraphBridge.ts`** subscribes to those events and updates the store. Installed once from `GraphCanvas.vue` next to the existing `useContextMenuTranslation()` install.
- **`NodeContextMenu.vue`** registers via `useRaisedSurface('context-menu', isOpen)` — one line.

The legacy LiteGraph menu's Escape handler also calls `e.stopPropagation()`, consistent with the existing `stopEscapeToDocument` pattern used by `SingleSelect` and `MultiSelect`. This keeps the bubble-phase `keybindingService` consultation race-free without preempting other surfaces' Escape handlers via capture-phase listening.

## Verification

- New unit tests: `raisedSurfaceStore.test.ts` (7), `ContextMenu.test.ts` (3), plus 2 new regression cases in `keybindingService.escape.test.ts`.
- All 113 keybinding + litegraph context-menu tests pass.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm knip` clean (3 pre-existing lint warnings, 1 pre-existing knip tag, all unrelated).
- Manual: opened a LiteGraph context menu via dev build, pressed Escape — menu closes, active graph unchanged, `event.defaultPrevented` is true.

## Follow-ups (out of scope for this PR)

1. Migrate `useDialogStore.dialogStack` to register itself in `raisedSurfaceStore` as `kind: 'modal'` so there's a single source of truth.
2. Adopt `useRaisedSurface('popover', isOpen)` in `SingleSelect`/`MultiSelect` (and other Reka popovers) so their existing `stopEscapeToDocument` calls can eventually be removed.
3. Replace ad-hoc precedents like the ghost-placement `e.stopPropagation()` at `LGraphCanvas.ts:3727`.

## Screenshots

![Context menu open at canvas right-click position](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/80c300908a31b36c370509882ab1bb5a81406d030e9ab4a2968a5a5ec0a0d56a/pr-images/1778900263477-47e7f274-57c5-4012-887b-42d967d97f47.png)

![After pressing Escape: menu closed, no subgraph exit](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/80c300908a31b36c370509882ab1bb5a81406d030e9ab4a2968a5a5ec0a0d56a/pr-images/1778900263989-dd05c1d7-5b4e-4186-a637-6b8ae82681ac.png)

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12308-fix-prevent-escape-from-exiting-subgraph-while-a-context-menu-is-open-3626d73d36508174b2eee5ea838a9953) by [Unito](https://www.unito.io)
