### PR TITLE
Use server downloads for missing models

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3589,6 +3589,10 @@
       "missingModelsTitle": "Missing Models",
       "assetLoadTimeout": "Model detection timed out. Try reloading the workflow.",
       "downloadAll": "Download all",
+      "downloadAllToServer": "Download all to server",
+      "downloadToServer": "Download to server",
+      "downloadingToServer": "Downloading to server...",
+      "serverDownloadFailed": "Failed to download model to server.",
       "refresh": "Refresh",
       "refreshing": "Refreshing missing models.",
       "refreshFailed": "Failed to refresh missing models. Please try again."

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -344,7 +344,12 @@ describe('MissingModelCard (OSS)', () => {
       missingModelGroups: [makeGroup({ withDownloadUrls: true })]
     })
 
-    expect(screen.getByRole('button', { name: /Download all/ })).toBeVisible()
+    // Use an exact name match so this assertion does not accidentally
+    // succeed against the OSS "Download all to server" label.
+    expect(screen.getByRole('button', { name: 'Download all' })).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: /Download all to server/i })
+    ).not.toBeInTheDocument()
   })
 
   it('hides bulk actions when no model is downloadable', () => {

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -23,12 +23,30 @@ vi.mock('./MissingModelRow.vue', () => ({
   }
 }))
 
-const mockIsCloud = vi.hoisted(() => ({ value: true }))
+const mockDistribution = vi.hoisted(() => ({
+  isCloud: true,
+  isDesktop: false
+}))
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
-    return mockIsCloud.value
+    return mockDistribution.isCloud
+  },
+  get isDesktop() {
+    return mockDistribution.isDesktop
   }
 }))
+
+const mockDownloadModel = vi.hoisted(() => vi.fn())
+vi.mock(
+  '@/platform/missingModel/missingModelDownload',
+  async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>
+    return {
+      ...actual,
+      downloadModel: mockDownloadModel
+    }
+  }
+)
 
 import MissingModelCard from './MissingModelCard.vue'
 
@@ -44,6 +62,8 @@ const i18n = createI18n({
             'Cloud environment does not support model imports for custom nodes.',
           unknownCategory: 'Unknown Category',
           downloadAll: 'Download all',
+          downloadAllToServer: 'Download all to server',
+          downloadingToServer: 'Downloading to server...',
           refresh: 'Refresh',
           refreshing: 'Refreshing missing models.'
         }
@@ -126,7 +146,10 @@ function mountCard(
 
 describe('MissingModelCard', () => {
   beforeEach(() => {
-    mockIsCloud.value = true
+    mockDistribution.isCloud = true
+    mockDistribution.isDesktop = false
+    mockDownloadModel.mockReset()
+    mockDownloadModel.mockResolvedValue(undefined)
   })
 
   describe('Rendering & Props', () => {
@@ -243,11 +266,15 @@ describe('MissingModelCard', () => {
 
 describe('MissingModelCard (OSS)', () => {
   beforeEach(() => {
-    mockIsCloud.value = false
+    mockDistribution.isCloud = false
+    mockDistribution.isDesktop = false
+    mockDownloadModel.mockReset()
+    mockDownloadModel.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
-    mockIsCloud.value = true
+    mockDistribution.isCloud = true
+    mockDistribution.isDesktop = false
   })
 
   it('shows directory name instead of "Import Not Supported" for unsupported groups', () => {
@@ -284,8 +311,40 @@ describe('MissingModelCard (OSS)', () => {
       missingModelGroups: [makeGroup({ withDownloadUrls: true })]
     })
 
-    expect(screen.getByRole('button', { name: /Download all/ })).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Download all to server/ })
+    ).toBeVisible()
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeVisible()
+  })
+
+  it('downloads all models and refreshes missing models', async () => {
+    mountCard({
+      missingModelGroups: [
+        makeGroup({
+          modelNames: ['a.safetensors', 'b.safetensors'],
+          withDownloadUrls: true
+        })
+      ]
+    })
+    const store = useMissingModelStore()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /Download all to server/ })
+    )
+
+    await waitFor(() => {
+      expect(mockDownloadModel).toHaveBeenCalledTimes(2)
+      expect(store.refreshMissingModels).toHaveBeenCalled()
+    })
+  })
+
+  it('keeps the original bulk label in desktop builds', () => {
+    mockDistribution.isDesktop = true
+    mountCard({
+      missingModelGroups: [makeGroup({ withDownloadUrls: true })]
+    })
+
+    expect(screen.getByRole('button', { name: /Download all/ })).toBeVisible()
   })
 
   it('hides bulk actions when no model is downloadable', () => {

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -10,9 +10,21 @@
         variant="secondary"
         size="sm"
         class="h-8 min-w-0 flex-1 rounded-lg text-sm"
+        :aria-busy="isDownloadingAll"
+        :disabled="isDownloadingAll"
         @click="downloadAllModels"
       >
-        <i aria-hidden="true" class="icon-[lucide--download] size-4 shrink-0" />
+        <DotSpinner
+          v-if="isDownloadingAll"
+          aria-hidden="true"
+          duration="1s"
+          :size="12"
+        />
+        <i
+          v-else
+          aria-hidden="true"
+          class="icon-[lucide--download] size-4 shrink-0"
+        />
         <span class="truncate">{{ downloadAllLabel }}</span>
       </Button>
       <!-- Keep this focusable while refreshing so the live status remains discoverable. -->
@@ -42,7 +54,9 @@
         {{
           missingModelStore.isRefreshingMissingModels
             ? t('rightSidePanel.missingModels.refreshing')
-            : ''
+            : isDownloadingAll
+              ? t('rightSidePanel.missingModels.downloadingToServer')
+              : ''
         }}
       </span>
     </div>
@@ -114,16 +128,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isDesktop } from '@/platform/distribution/types'
 import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.vue'
 import Button from '@/components/ui/button/Button.vue'
 import DotSpinner from '@/components/common/DotSpinner.vue'
 import { downloadModel } from '@/platform/missingModel/missingModelDownload'
 import { getDownloadableModels } from '@/platform/missingModel/missingModelViewUtils'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { formatSize } from '@/utils/formatUtil'
 
 const { missingModelGroups, showNodeIdBadge } = defineProps<{
@@ -137,6 +152,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const missingModelStore = useMissingModelStore()
+const toastStore = useToastStore()
+const isDownloadingAll = ref(false)
 
 const downloadableModels = computed(() => {
   if (isCloud) return []
@@ -145,7 +162,9 @@ const downloadableModels = computed(() => {
 })
 
 const downloadAllLabel = computed(() => {
-  const base = t('rightSidePanel.missingModels.downloadAll')
+  const base = !isDesktop
+    ? t('rightSidePanel.missingModels.downloadAllToServer')
+    : t('rightSidePanel.missingModels.downloadAll')
   const total = downloadableModels.value.reduce(
     (sum, model) => sum + (missingModelStore.fileSizes[model.url] ?? 0),
     0
@@ -153,9 +172,28 @@ const downloadAllLabel = computed(() => {
   return total > 0 ? `${base} (${formatSize(total)})` : base
 })
 
-function downloadAllModels() {
-  for (const model of downloadableModels.value) {
-    downloadModel(model, missingModelStore.folderPaths)
+async function downloadAllModels() {
+  if (isDownloadingAll.value) return
+
+  isDownloadingAll.value = true
+  try {
+    for (const model of downloadableModels.value) {
+      await downloadModel(model, missingModelStore.folderPaths)
+    }
+    if (!isDesktop) {
+      await missingModelStore.refreshMissingModels()
+    }
+  } catch (error) {
+    toastStore.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail:
+        error instanceof Error
+          ? error.message
+          : t('rightSidePanel.missingModels.serverDownloadFailed')
+    })
+  } finally {
+    isDownloadingAll.value = false
   }
 }
 

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -156,10 +156,20 @@
             variant="secondary"
             size="md"
             class="flex w-full flex-1"
-            :aria-label="`${t('g.download')} ${model.name}`"
+            :aria-busy="isServerDownloadActive"
+            :disabled="isServerDownloadActive"
+            :aria-label="`${downloadActionLabel} ${model.name}`"
             @click="handleDownload"
           >
+            <DotSpinner
+              v-if="isServerDownloadActive"
+              aria-hidden="true"
+              class="mr-1"
+              duration="1s"
+              :size="12"
+            />
             <i
+              v-else
               aria-hidden="true"
               class="text-foreground mr-1 icon-[lucide--download] size-4 shrink-0"
             />
@@ -184,11 +194,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { cn } from '@comfyorg/tailwind-utils'
 import Button from '@/components/ui/button/Button.vue'
+import DotSpinner from '@/components/common/DotSpinner.vue'
 import TransitionCollapse from '@/components/rightSidePanel/layout/TransitionCollapse.vue'
 import MissingModelStatusCard from '@/platform/missingModel/components/MissingModelStatusCard.vue'
 import MissingModelUrlInput from '@/platform/missingModel/components/MissingModelUrlInput.vue'
@@ -203,7 +214,8 @@ import {
 } from '@/platform/missingModel/composables/useMissingModelInteractions'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isDesktop } from '@/platform/distribution/types'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import {
   downloadModel,
   fetchModelMetadata,
@@ -225,6 +237,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { copyToClipboard } = useCopyToClipboard()
+const toastStore = useToastStore()
+const isServerDownloadActive = ref(false)
 
 const modelKey = computed(() =>
   getModelStateKey(model.name, directory, isAssetSupported)
@@ -277,22 +291,56 @@ const downloadable = computed(() => {
   )
 })
 
+const downloadActionLabel = computed(() =>
+  !isDesktop
+    ? t('rightSidePanel.missingModels.downloadToServer')
+    : t('g.download')
+)
+
 const downloadLabel = computed(() => {
-  const base = t('g.download')
+  const base = isServerDownloadActive.value
+    ? t('rightSidePanel.missingModels.downloadingToServer')
+    : downloadActionLabel.value
   const url = model.representative.url
   const size = url ? store.fileSizes[url] : undefined
-  return size ? `${base} (${formatSize(size)})` : base
+  return size && !isServerDownloadActive.value
+    ? `${base} (${formatSize(size)})`
+    : base
 })
 
-function handleDownload() {
+async function handleDownload() {
   const rep = model.representative
-  if (rep.url && rep.directory) {
-    downloadModel(
+  if (!rep.url || !rep.directory) {
+    console.warn('[MissingModelRow] Cannot download: missing url or directory')
+    return
+  }
+
+  if (isDesktop) {
+    await downloadModel(
       { name: rep.name, url: rep.url, directory: rep.directory },
       store.folderPaths
     )
-  } else {
-    console.warn('[MissingModelRow] Cannot download: missing url or directory')
+    return
+  }
+
+  isServerDownloadActive.value = true
+  try {
+    await downloadModel(
+      { name: rep.name, url: rep.url, directory: rep.directory },
+      store.folderPaths
+    )
+    await store.refreshMissingModels()
+  } catch (error) {
+    toastStore.add({
+      severity: 'error',
+      summary: t('g.error'),
+      detail:
+        error instanceof Error
+          ? error.message
+          : t('rightSidePanel.missingModels.serverDownloadFailed')
+    })
+  } finally {
+    isServerDownloadActive.value = false
   }
 }
 

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -274,4 +274,20 @@ describe('downloadModel', () => {
     })
     expect(mockApi.downloadModelToServer).not.toHaveBeenCalled()
   })
+
+  it('propagates server download failures so callers can surface a toast', async () => {
+    const model = {
+      name: 'model.safetensors',
+      url: 'https://huggingface.co/org/repo/resolve/main/model.safetensors',
+      directory: 'checkpoints'
+    }
+    mockApi.downloadModelToServer.mockRejectedValueOnce(
+      new Error('Model download URL is not allowed.')
+    )
+
+    await expect(downloadModel(model, {})).rejects.toThrow(
+      'Model download URL is not allowed.'
+    )
+    expect(mockElectronDownloadStore.start).not.toHaveBeenCalled()
+  })
 })

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import {
+  downloadModel,
   fetchModelMetadata,
   isModelDownloadable,
   toBrowsableUrl
@@ -9,14 +10,31 @@ import {
 const fetchMock = vi.fn()
 vi.stubGlobal('fetch', fetchMock)
 
-vi.mock('@/platform/distribution/types', () => ({ isDesktop: false }))
-vi.mock('@/stores/electronDownloadStore', () => ({}))
+const mockDistribution = vi.hoisted(() => ({ isDesktop: false }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isDesktop() {
+    return mockDistribution.isDesktop
+  }
+}))
+
+const mockElectronDownloadStore = vi.hoisted(() => ({ start: vi.fn() }))
+vi.mock('@/stores/electronDownloadStore', () => ({
+  useElectronDownloadStore: () => mockElectronDownloadStore
+}))
+
+const mockApi = vi.hoisted(() => ({
+  downloadModelToServer: vi.fn()
+}))
+vi.mock('@/scripts/api', () => ({ api: mockApi }))
 
 let testId = 0
 
 describe('fetchModelMetadata', () => {
   beforeEach(() => {
     fetchMock.mockReset()
+    mockApi.downloadModelToServer.mockReset()
+    mockElectronDownloadStore.start.mockReset()
+    mockDistribution.isDesktop = false
     testId++
   })
 
@@ -211,5 +229,49 @@ describe('isModelDownloadable', () => {
         directory: 'checkpoints'
       })
     ).toBe(false)
+  })
+})
+
+describe('downloadModel', () => {
+  beforeEach(() => {
+    mockApi.downloadModelToServer.mockReset()
+    mockElectronDownloadStore.start.mockReset()
+    mockDistribution.isDesktop = false
+  })
+
+  it('downloads models to the server for non-desktop builds', async () => {
+    const model = {
+      name: 'model.safetensors',
+      url: 'https://huggingface.co/org/repo/resolve/main/model.safetensors',
+      directory: 'checkpoints'
+    }
+    mockApi.downloadModelToServer.mockResolvedValueOnce({
+      status: 'downloaded',
+      ...model,
+      path: '/models/checkpoints/model.safetensors'
+    })
+
+    await downloadModel(model, {})
+
+    expect(mockApi.downloadModelToServer).toHaveBeenCalledWith(model)
+    expect(mockElectronDownloadStore.start).not.toHaveBeenCalled()
+  })
+
+  it('keeps using the Electron download store for desktop builds', async () => {
+    mockDistribution.isDesktop = true
+    const model = {
+      name: 'model.safetensors',
+      url: 'https://huggingface.co/org/repo/resolve/main/model.safetensors',
+      directory: 'checkpoints'
+    }
+
+    await downloadModel(model, { checkpoints: ['/models/checkpoints'] })
+
+    expect(mockElectronDownloadStore.start).toHaveBeenCalledWith({
+      url: model.url,
+      savePath: '/models/checkpoints',
+      filename: model.name
+    })
+    expect(mockApi.downloadModelToServer).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -1,6 +1,7 @@
 import { downloadUrlToHfRepoUrl, isCivitaiModelUrl } from '@/utils/formatUtil'
 import { isDesktop } from '@/platform/distribution/types'
 import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
+import { api } from '@/scripts/api'
 
 const ALLOWED_SOURCES = [
   'https://civitai.com/',
@@ -59,15 +60,9 @@ export function isModelDownloadable(model: ModelWithUrl): boolean {
 export function downloadModel(
   model: ModelWithUrl,
   paths: Record<string, string[]>
-): void {
+): Promise<void> {
   if (!isDesktop) {
-    const link = document.createElement('a')
-    link.href = model.url
-    link.download = model.name
-    link.target = '_blank'
-    link.rel = 'noopener noreferrer'
-    link.click()
-    return
+    return api.downloadModelToServer(model).then(() => undefined)
   }
 
   const modelPaths = paths[model.directory]
@@ -78,6 +73,7 @@ export function downloadModel(
       filename: model.name
     })
   }
+  return Promise.resolve()
 }
 
 interface ModelMetadata {

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1333,15 +1333,43 @@ export class ComfyApi extends EventTarget {
       },
       body: JSON.stringify(model)
     })
-    const data = await response.json().catch(() => null)
+    const rawBody = await response.text()
+    let data: unknown = null
+    if (rawBody) {
+      try {
+        data = JSON.parse(rawBody)
+      } catch {
+        // Leave `data` as null so the error branch falls back to raw body
+        // or status. Non-JSON bodies typically come from reverse proxies
+        // (502 HTML, plain-text 503, etc.) and the operator needs to see
+        // them to diagnose the failure.
+      }
+    }
     if (!response.ok) {
+      const errorFromJson =
+        data &&
+        typeof data === 'object' &&
+        'error' in data &&
+        typeof (data as { error: unknown }).error === 'string'
+          ? (data as { error: string }).error
+          : null
+      const rawFallback = rawBody.trim()
+      const statusFallback =
+        `${response.status} ${response.statusText}`.trim() ||
+        String(response.status)
       const message =
-        data && typeof data.error === 'string'
-          ? data.error
-          : 'Failed to download model to server.'
+        errorFromJson ||
+        (rawFallback.length > 0 ? rawFallback : statusFallback) ||
+        'Failed to download model to server.'
       throw new Error(message)
     }
-    return data
+    return data as {
+      status: 'downloaded' | 'already_exists'
+      name: string
+      directory: string
+      path: string
+      size?: number
+    }
   }
 
   /* Frees memory by unloading models and optionally freeing execution cache

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -1313,6 +1313,37 @@ export class ComfyApi extends EventTarget {
     return response.data
   }
 
+  async downloadModelToServer(model: {
+    name: string
+    url: string
+    directory: string
+  }): Promise<{
+    status: 'downloaded' | 'already_exists'
+    name: string
+    directory: string
+    path: string
+    size?: number
+  }> {
+    const response = await fetch(this.internalURL('/models/download'), {
+      method: 'POST',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+        'Comfy-User': this.user
+      },
+      body: JSON.stringify(model)
+    })
+    const data = await response.json().catch(() => null)
+    if (!response.ok) {
+      const message =
+        data && typeof data.error === 'string'
+          ? data.error
+          : 'Failed to download model to server.'
+      throw new Error(message)
+    }
+    return data
+  }
+
   /* Frees memory by unloading models and optionally freeing execution cache
    * @param {Object} options - The options object
    * @param {boolean} options.freeExecutionCache - If true, also frees execution cache


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## Summary
- route OSS web missing-model downloads through the ComfyUI server instead of creating browser-local `<a>` downloads
- keep the existing Electron desktop download flow unchanged
- add busy states and refresh missing-model detection after server downloads complete
- update tests for server and desktop download behavior

## Context
Refs Comfy-Org/ComfyUI#12961. Depends on backend PR Comfy-Org/ComfyUI#13961, which adds `/internal/models/download`.

This is the frontend half of the server-side download fix. It supersedes the browser-local behavior clarified in the smaller UX PR Comfy-Org/ComfyUI_frontend#12316.

## Validation
- `pnpm exec vitest run src/platform/missingModel/missingModelDownload.test.ts src/platform/missingModel/components/MissingModelCard.test.ts`
- `pnpm typecheck`
- `pnpm lint:unstaged` (passes with the existing ignored-file warning for `src/scripts/api.ts`)
- `pnpm exec oxfmt --check src/scripts/api.ts src/platform/missingModel/missingModelDownload.ts src/platform/missingModel/missingModelDownload.test.ts src/platform/missingModel/components/MissingModelCard.vue src/platform/missingModel/components/MissingModelCard.test.ts src/platform/missingModel/components/MissingModelRow.vue src/locales/en/main.json`
- `git diff --check`

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12317-Use-server-downloads-for-missing-models-3646d73d36508100b4e9c8a2dc9446a9) by [Unito](https://www.unito.io)
