### PR TITLE
fix: avoid false missing media errors after importing shared workflow assets

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -76,7 +76,15 @@ export const TestIds = {
     publishTabPanel: 'publish-tab-panel',
     apiSignin: 'api-signin-dialog',
     updatePassword: 'update-password-dialog',
-    cloudNotification: 'cloud-notification-dialog'
+    cloudNotification: 'cloud-notification-dialog',
+    openSharedWorkflow: 'open-shared-workflow-dialog',
+    openSharedWorkflowTitle: 'open-shared-workflow-title',
+    openSharedWorkflowClose: 'open-shared-workflow-close',
+    openSharedWorkflowErrorClose: 'open-shared-workflow-error-close',
+    openSharedWorkflowCancel: 'open-shared-workflow-cancel',
+    openSharedWorkflowOpenWithoutImporting:
+      'open-shared-workflow-open-without-importing',
+    openSharedWorkflowConfirm: 'open-shared-workflow-confirm'
   },
   keybindings: {
     presetMenu: 'keybinding-preset-menu'

--- a/browser_tests/fixtures/sharedWorkflowImportFixture.ts
+++ b/browser_tests/fixtures/sharedWorkflowImportFixture.ts
@@ -1,0 +1,224 @@
+import { test as base } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import type {
+  Asset,
+  ImportPublishedAssetsRequest,
+  ListAssetsResponse
+} from '@comfyorg/ingest-types'
+import type { z } from 'zod'
+
+import type { zSharedWorkflowResponse } from '@/platform/workflow/sharing/schemas/shareSchemas'
+import type { AssetInfo } from '@/schemas/apiSchema'
+
+type SharedWorkflowResponse = z.input<typeof zSharedWorkflowResponse>
+
+export const sharedWorkflowImportScenario = {
+  shareId: 'shared-missing-media-e2e',
+  workflowId: 'shared-missing-media-workflow',
+  publishedAssetId: 'published-input-asset-1',
+  inputFileName: 'shared_imported_image.png'
+} as const
+
+export type SharedWorkflowRequestEvent =
+  | 'import'
+  | 'input-assets-including-public-before-import'
+  | 'input-assets-including-public-after-import'
+
+export interface SharedWorkflowImportMocks {
+  resetAndStartRecording: () => void
+  getImportBody: () => ImportPublishedAssetsRequest | undefined
+  getRequestEvents: () => SharedWorkflowRequestEvent[]
+}
+
+const defaultInputFileName = '00000000000000000000000Aexample.png'
+
+const sharedWorkflowAsset: AssetInfo = {
+  id: sharedWorkflowImportScenario.publishedAssetId,
+  name: sharedWorkflowImportScenario.inputFileName,
+  preview_url: '',
+  storage_url: '',
+  model: false,
+  public: false,
+  in_library: false
+}
+
+const defaultInputAsset: Asset = {
+  id: 'default-input-asset',
+  name: defaultInputFileName,
+  asset_hash: defaultInputFileName,
+  size: 1_024,
+  mime_type: 'image/png',
+  tags: ['input'],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  last_access_time: '2026-05-01T00:00:00Z'
+}
+
+const importedInputAsset: Asset = {
+  id: 'imported-input-asset',
+  name: sharedWorkflowImportScenario.inputFileName,
+  asset_hash: sharedWorkflowImportScenario.inputFileName,
+  size: 1_024,
+  mime_type: 'image/png',
+  tags: ['input'],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  last_access_time: '2026-05-01T00:00:00Z'
+}
+
+const sharedWorkflowResponse: SharedWorkflowResponse = {
+  share_id: sharedWorkflowImportScenario.shareId,
+  workflow_id: sharedWorkflowImportScenario.workflowId,
+  name: 'Shared Missing Media Workflow',
+  listed: true,
+  publish_time: '2026-05-01T00:00:00Z',
+  workflow_json: {
+    version: 0.4,
+    last_node_id: 10,
+    last_link_id: 0,
+    nodes: [
+      {
+        id: 10,
+        type: 'LoadImage',
+        pos: [50, 200],
+        size: [315, 314],
+        flags: {},
+        order: 0,
+        mode: 0,
+        inputs: [],
+        outputs: [
+          {
+            name: 'IMAGE',
+            type: 'IMAGE',
+            links: null
+          },
+          {
+            name: 'MASK',
+            type: 'MASK',
+            links: null
+          }
+        ],
+        properties: {
+          'Node name for S&R': 'LoadImage'
+        },
+        widgets_values: [sharedWorkflowImportScenario.inputFileName, 'image']
+      }
+    ],
+    links: [],
+    groups: [],
+    config: {},
+    extra: {
+      ds: {
+        offset: [0, 0],
+        scale: 1
+      }
+    }
+  },
+  assets: [sharedWorkflowAsset]
+}
+
+export const sharedWorkflowImportFixture = base.extend<{
+  sharedWorkflowImportMocks: SharedWorkflowImportMocks
+}>({
+  sharedWorkflowImportMocks: async ({ page }, use) => {
+    const mocks = await mockSharedWorkflowImportFlow(page)
+    await use(mocks)
+  }
+})
+
+async function mockSharedWorkflowImportFlow(
+  page: Page
+): Promise<SharedWorkflowImportMocks> {
+  let isRecording = false
+  let importEndpointCalled = false
+  let importBody: ImportPublishedAssetsRequest | undefined
+  const requestEvents: SharedWorkflowRequestEvent[] = []
+
+  function recordRequestEvent(event: SharedWorkflowRequestEvent) {
+    if (isRecording) requestEvents.push(event)
+  }
+
+  await page.route(
+    `**/workflows/published/${sharedWorkflowImportScenario.shareId}`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(sharedWorkflowResponse)
+      })
+    }
+  )
+
+  await page.route('**/api/assets/import', async (route) => {
+    recordRequestEvent('import')
+    importBody = route.request().postDataJSON() as ImportPublishedAssetsRequest
+    importEndpointCalled = true
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({})
+    })
+  })
+
+  // Excludes `/api/assets/import` so the specific route above
+  // remains isolated from the general asset listing mock.
+  await page.route(/\/api\/assets(?=\?|$)/, async (route) => {
+    const url = new URL(route.request().url())
+    const includeTags = getTagParam(url, 'include_tags')
+    const isInputAssetRequest = includeTags.includes('input')
+    const includesPublicAssets =
+      url.searchParams.get('include_public') === 'true'
+
+    if (isInputAssetRequest && includesPublicAssets) {
+      recordRequestEvent(
+        importEndpointCalled
+          ? 'input-assets-including-public-after-import'
+          : 'input-assets-including-public-before-import'
+      )
+    }
+
+    const allAssets = [
+      defaultInputAsset,
+      ...(importEndpointCalled ? [importedInputAsset] : [])
+    ]
+    const assets = includeTags.length
+      ? allAssets.filter((asset) =>
+          includeTags.every((tag) => asset.tags?.includes(tag))
+        )
+      : allAssets
+
+    const response: ListAssetsResponse = {
+      assets,
+      total: assets.length,
+      has_more: false
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response)
+    })
+  })
+
+  return {
+    resetAndStartRecording: () => {
+      isRecording = true
+      importEndpointCalled = false
+      importBody = undefined
+      requestEvents.length = 0
+    },
+    getImportBody: () => importBody,
+    getRequestEvents: () => [...requestEvents]
+  }
+}
+
+function getTagParam(url: URL, key: string): string[] {
+  return (
+    url.searchParams
+      .get(key)
+      ?.split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean) ?? []
+  )
+}

--- a/browser_tests/fixtures/sharedWorkflowImportFixture.ts
+++ b/browser_tests/fixtures/sharedWorkflowImportFixture.ts
@@ -28,6 +28,7 @@ export interface SharedWorkflowImportMocks {
   resetAndStartRecording: () => void
   getImportBody: () => ImportPublishedAssetsRequest | undefined
   getRequestEvents: () => SharedWorkflowRequestEvent[]
+  waitForPublicInclusiveInputAssetResponseAfterImport: () => Promise<void>
 }
 
 const defaultInputFileName = '00000000000000000000000Aexample.png'
@@ -132,7 +133,21 @@ async function mockSharedWorkflowImportFlow(
   let isRecording = false
   let importEndpointCalled = false
   let importBody: ImportPublishedAssetsRequest | undefined
+  let resolvePublicInclusiveInputAssetResponseAfterImport: () => void = () => {}
+  let publicInclusiveInputAssetResponseAfterImport = new Promise<void>(
+    (resolve) => {
+      resolvePublicInclusiveInputAssetResponseAfterImport = resolve
+    }
+  )
   const requestEvents: SharedWorkflowRequestEvent[] = []
+
+  function resetPublicInclusiveInputAssetResponseWaiter() {
+    publicInclusiveInputAssetResponseAfterImport = new Promise<void>(
+      (resolve) => {
+        resolvePublicInclusiveInputAssetResponseAfterImport = resolve
+      }
+    )
+  }
 
   function recordRequestEvent(event: SharedWorkflowRequestEvent) {
     if (isRecording) requestEvents.push(event)
@@ -169,8 +184,12 @@ async function mockSharedWorkflowImportFlow(
     const isInputAssetRequest = includeTags.includes('input')
     const includesPublicAssets =
       url.searchParams.get('include_public') === 'true'
+    const isPublicInclusiveInputAssetRequest =
+      isInputAssetRequest && includesPublicAssets
+    const isAfterImportPublicInclusiveInputAssetRequest =
+      isPublicInclusiveInputAssetRequest && importEndpointCalled
 
-    if (isInputAssetRequest && includesPublicAssets) {
+    if (isPublicInclusiveInputAssetRequest) {
       recordRequestEvent(
         importEndpointCalled
           ? 'input-assets-including-public-after-import'
@@ -199,6 +218,10 @@ async function mockSharedWorkflowImportFlow(
       contentType: 'application/json',
       body: JSON.stringify(response)
     })
+
+    if (isAfterImportPublicInclusiveInputAssetRequest) {
+      resolvePublicInclusiveInputAssetResponseAfterImport()
+    }
   })
 
   return {
@@ -207,9 +230,12 @@ async function mockSharedWorkflowImportFlow(
       importEndpointCalled = false
       importBody = undefined
       requestEvents.length = 0
+      resetPublicInclusiveInputAssetResponseWaiter()
     },
     getImportBody: () => importBody,
-    getRequestEvents: () => [...requestEvents]
+    getRequestEvents: () => [...requestEvents],
+    waitForPublicInclusiveInputAssetResponseAfterImport: () =>
+      publicInclusiveInputAssetResponseAfterImport
   }
 }
 

--- a/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
+++ b/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
@@ -9,9 +9,9 @@ import {
 } from '@e2e/fixtures/sharedWorkflowImportFixture'
 import type { SharedWorkflowImportMocks } from '@e2e/fixtures/sharedWorkflowImportFixture'
 import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+import type { WorkspaceStore } from '@e2e/types/globals'
 
 const IMPORT_ORDER_TIMEOUT_MS = 5_000
-const MISSING_MEDIA_SETTLING_WINDOW_MS = 1_000
 
 async function expectImportPrecedesPublicInclusiveInputAssetScan(
   mocks: SharedWorkflowImportMocks
@@ -34,53 +34,31 @@ async function expectImportPrecedesPublicInclusiveInputAssetScan(
   }).toPass({ timeout: IMPORT_ORDER_TIMEOUT_MS })
 }
 
-async function expectNoMissingMediaOverlayDuringSettling(
+async function getCachedMissingMediaWarningNames(
   comfyPage: ComfyPage
-): Promise<void> {
-  await expect(
-    comfyPage.page.evaluate(
-      async ({ errorOverlay, settlingWindowMs }) => {
-        const isVisible = (element: Element | null) => {
-          if (!element) return false
-          const style = window.getComputedStyle(element)
-          const rect = element.getBoundingClientRect()
-          return (
-            style.display !== 'none' &&
-            style.visibility !== 'hidden' &&
-            rect.width > 0 &&
-            rect.height > 0
-          )
-        }
-
-        const startedAt = performance.now()
-        return await new Promise<boolean>((resolve) => {
-          const check = () => {
-            if (
-              isVisible(
-                document.querySelector(`[data-testid="${errorOverlay}"]`)
-              )
-            ) {
-              resolve(false)
-              return
-            }
-
-            if (performance.now() - startedAt >= settlingWindowMs) {
-              resolve(true)
-              return
-            }
-
-            requestAnimationFrame(check)
-          }
-
-          check()
-        })
-      },
-      {
-        errorOverlay: TestIds.dialogs.errorOverlay,
-        settlingWindowMs: MISSING_MEDIA_SETTLING_WINDOW_MS
-      }
+): Promise<string[]> {
+  return await comfyPage.page.evaluate(() => {
+    const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
+      .activeWorkflow
+    return (
+      workflow?.pendingWarnings?.missingMediaCandidates?.map(
+        (candidate) => candidate.name
+      ) ?? []
     )
-  ).resolves.toBe(true)
+  })
+}
+
+async function expectNoMissingMediaAfterPublicInclusiveAssetScan(
+  comfyPage: ComfyPage,
+  mocks: SharedWorkflowImportMocks
+): Promise<void> {
+  await mocks.waitForPublicInclusiveInputAssetResponseAfterImport()
+  await comfyPage.nextFrame()
+
+  await expect(
+    comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
+  ).toBeHidden()
+  expect(await getCachedMissingMediaWarningNames(comfyPage)).toEqual([])
 }
 
 async function openPanelAndExpectNoMissingMedia(
@@ -149,7 +127,10 @@ test.describe('Shared workflow missing media', { tag: '@cloud' }, () => {
     await expectImportPrecedesPublicInclusiveInputAssetScan(
       sharedWorkflowImportMocks
     )
-    await expectNoMissingMediaOverlayDuringSettling(comfyPage)
+    await expectNoMissingMediaAfterPublicInclusiveAssetScan(
+      comfyPage,
+      sharedWorkflowImportMocks
+    )
 
     expect(sharedWorkflowImportMocks.getImportBody()).toEqual({
       published_asset_ids: [sharedWorkflowImportScenario.publishedAssetId],

--- a/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
+++ b/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
@@ -1,0 +1,161 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import {
+  sharedWorkflowImportFixture,
+  sharedWorkflowImportScenario
+} from '@e2e/fixtures/sharedWorkflowImportFixture'
+import type { SharedWorkflowImportMocks } from '@e2e/fixtures/sharedWorkflowImportFixture'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+
+const IMPORT_ORDER_TIMEOUT_MS = 5_000
+const MISSING_MEDIA_SETTLING_WINDOW_MS = 1_000
+
+async function expectImportPrecedesPublicInclusiveInputAssetScan(
+  mocks: SharedWorkflowImportMocks
+): Promise<void> {
+  await expect(async () => {
+    const events = mocks.getRequestEvents()
+    const importIndex = events.indexOf('import')
+    const afterImportIndex = events.indexOf(
+      'input-assets-including-public-after-import'
+    )
+
+    expect(
+      events,
+      'public-inclusive input assets must not be scanned before import'
+    ).not.toContain('input-assets-including-public-before-import')
+    expect(importIndex, `events: ${events.join(',')}`).toBeGreaterThanOrEqual(0)
+    expect(afterImportIndex, `events: ${events.join(',')}`).toBeGreaterThan(
+      importIndex
+    )
+  }).toPass({ timeout: IMPORT_ORDER_TIMEOUT_MS })
+}
+
+async function expectNoMissingMediaOverlayDuringSettling(
+  comfyPage: ComfyPage
+): Promise<void> {
+  await expect(
+    comfyPage.page.evaluate(
+      async ({ errorOverlay, settlingWindowMs }) => {
+        const isVisible = (element: Element | null) => {
+          if (!element) return false
+          const style = window.getComputedStyle(element)
+          const rect = element.getBoundingClientRect()
+          return (
+            style.display !== 'none' &&
+            style.visibility !== 'hidden' &&
+            rect.width > 0 &&
+            rect.height > 0
+          )
+        }
+
+        const startedAt = performance.now()
+        return await new Promise<boolean>((resolve) => {
+          const check = () => {
+            if (
+              isVisible(
+                document.querySelector(`[data-testid="${errorOverlay}"]`)
+              )
+            ) {
+              resolve(false)
+              return
+            }
+
+            if (performance.now() - startedAt >= settlingWindowMs) {
+              resolve(true)
+              return
+            }
+
+            requestAnimationFrame(check)
+          }
+
+          check()
+        })
+      },
+      {
+        errorOverlay: TestIds.dialogs.errorOverlay,
+        settlingWindowMs: MISSING_MEDIA_SETTLING_WINDOW_MS
+      }
+    )
+  ).resolves.toBe(true)
+}
+
+async function openPanelAndExpectNoMissingMedia(
+  comfyPage: ComfyPage
+): Promise<void> {
+  const page = comfyPage.page
+  const errorOverlay = page.getByTestId(TestIds.dialogs.errorOverlay)
+  await expect(errorOverlay).toBeHidden()
+
+  const panel = new PropertiesPanelHelper(page)
+  await panel.open(comfyPage.actionbar.propertiesButton)
+  await expect(
+    panel.root.getByTestId(TestIds.propertiesPanel.errorsTab)
+  ).toBeHidden()
+  await expect(page.getByTestId(TestIds.dialogs.missingMediaGroup)).toHaveCount(
+    0
+  )
+}
+
+const test = mergeTests(comfyPageFixture, sharedWorkflowImportFixture)
+
+test.describe('Shared workflow missing media', { tag: '@cloud' }, () => {
+  // Missing media only surfaces the overlay when the Errors tab is enabled.
+  test.use({
+    initialSettings: {
+      'Comfy.RightSidePanel.ShowErrorsTab': true
+    }
+  })
+
+  test.beforeEach(async ({ comfyPage, sharedWorkflowImportMocks }) => {
+    sharedWorkflowImportMocks.resetAndStartRecording()
+    await comfyPage.setup({
+      clearStorage: false,
+      url: `/?share=${sharedWorkflowImportScenario.shareId}`
+    })
+  })
+
+  test('imports shared media before loading workflow so missing media is not surfaced', async ({
+    comfyPage,
+    sharedWorkflowImportMocks
+  }) => {
+    const { page } = comfyPage
+
+    const dialog = page.getByTestId(TestIds.dialogs.openSharedWorkflow)
+    await expect(
+      dialog.getByTestId(TestIds.dialogs.openSharedWorkflowTitle)
+    ).toBeVisible()
+
+    await dialog.getByTestId(TestIds.dialogs.openSharedWorkflowConfirm).click()
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.app!.graph.nodes.map((node) => ({
+            type: node.type,
+            value: node.widgets?.[0]?.value
+          }))
+        )
+      )
+      .toEqual([
+        {
+          type: 'LoadImage',
+          value: sharedWorkflowImportScenario.inputFileName
+        }
+      ])
+    await expectImportPrecedesPublicInclusiveInputAssetScan(
+      sharedWorkflowImportMocks
+    )
+    await expectNoMissingMediaOverlayDuringSettling(comfyPage)
+
+    expect(sharedWorkflowImportMocks.getImportBody()).toEqual({
+      published_asset_ids: [sharedWorkflowImportScenario.publishedAssetId],
+      share_id: sharedWorkflowImportScenario.shareId
+    })
+    expect(new URL(page.url()).searchParams.has('share')).toBe(false)
+    await openPanelAndExpectNoMissingMedia(comfyPage)
+  })
+})

--- a/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
+++ b/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
@@ -36,12 +36,14 @@ async function expectImportPrecedesPublicInclusiveInputAssetScan(
 
 async function getCachedMissingMediaWarningNames(
   comfyPage: ComfyPage
-): Promise<string[]> {
+): Promise<string[] | null> {
   return await comfyPage.page.evaluate(() => {
     const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
       .activeWorkflow
+    if (!workflow) return null
+
     return (
-      workflow?.pendingWarnings?.missingMediaCandidates?.map(
+      workflow.pendingWarnings?.missingMediaCandidates?.map(
         (candidate) => candidate.name
       ) ?? []
     )
@@ -58,7 +60,9 @@ async function expectNoMissingMediaAfterPublicInclusiveAssetScan(
   await expect(
     comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
   ).toBeHidden()
-  expect(await getCachedMissingMediaWarningNames(comfyPage)).toEqual([])
+  await expect
+    .poll(() => getCachedMissingMediaWarningNames(comfyPage))
+    .toEqual([])
 }
 
 async function openPanelAndExpectNoMissingMedia(
@@ -81,7 +85,8 @@ async function openPanelAndExpectNoMissingMedia(
 const test = mergeTests(comfyPageFixture, sharedWorkflowImportFixture)
 
 test.describe('Shared workflow missing media', { tag: '@cloud' }, () => {
-  // Missing media only surfaces the overlay when the Errors tab is enabled.
+  // Missing media only surfaces the overlay when the Errors tab is enabled
+  // (src/stores/executionErrorStore.ts).
   test.use({
     initialSettings: {
       'Comfy.RightSidePanel.ShowErrorsTab': true

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -143,7 +143,7 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
     })
 
     await expect(
-      comfyPage.page.getByRole('heading', { name: 'Open shared workflow' })
+      comfyPage.page.getByTestId(TestIds.dialogs.openSharedWorkflowTitle)
     ).toBeVisible()
 
     await expect(comfyPage.templates.content).toBeHidden()

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,17 @@
 <template>
   <router-view />
   <GlobalDialog />
-  <BlockUI full-screen :blocked="isLoading" />
+  <BlockUI full-screen :blocked="isLoading">
+    <div
+      v-if="isLoading"
+      class="pointer-events-none fixed inset-0 z-1200 flex items-center justify-center"
+    >
+      <div
+        class="size-12 animate-spin rounded-full border-4 border-muted-foreground border-t-base-foreground"
+        aria-hidden="true"
+      />
+    </div>
+  </BlockUI>
 </template>
 
 <script setup lang="ts">

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,23 +1,28 @@
 <template>
   <router-view />
   <GlobalDialog />
-  <BlockUI full-screen :blocked="isLoading">
+  <BlockUI full-screen :blocked="isLoading" />
+  <Teleport to="body">
     <div
       v-if="isLoading"
       class="pointer-events-none fixed inset-0 z-1200 flex items-center justify-center"
+      role="status"
+      aria-live="polite"
     >
       <div
-        class="size-12 animate-spin rounded-full border-4 border-muted-foreground border-t-base-foreground"
+        class="size-12 rounded-full border-4 border-muted-foreground border-t-base-foreground motion-safe:animate-spin"
         aria-hidden="true"
       />
+      <span class="sr-only">{{ t('g.loading') }}</span>
     </div>
-  </BlockUI>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
 import { captureException } from '@sentry/vue'
 import BlockUI from 'primevue/blockui'
 import { computed, onMounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
@@ -31,6 +36,7 @@ import { useConflictDetection } from '@/workbench/extensions/manager/composables
 const workspaceStore = useWorkspaceStore()
 app.extensionManager = useWorkspaceStore()
 
+const { t } = useI18n()
 const conflictDetection = useConflictDetection()
 const isLoading = computed<boolean>(() => workspaceStore.spinner)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,27 +2,12 @@
   <router-view />
   <GlobalDialog />
   <BlockUI full-screen :blocked="isLoading" />
-  <Teleport to="body">
-    <div
-      v-if="isLoading"
-      class="pointer-events-none fixed inset-0 z-1200 flex items-center justify-center"
-      role="status"
-      aria-live="polite"
-    >
-      <div
-        class="size-12 rounded-full border-4 border-muted-foreground border-t-base-foreground motion-safe:animate-spin"
-        aria-hidden="true"
-      />
-      <span class="sr-only">{{ t('g.loading') }}</span>
-    </div>
-  </Teleport>
 </template>
 
 <script setup lang="ts">
 import { captureException } from '@sentry/vue'
 import BlockUI from 'primevue/blockui'
 import { computed, onMounted, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import GlobalDialog from '@/components/dialog/GlobalDialog.vue'
 import config from '@/config'
@@ -36,7 +21,6 @@ import { useConflictDetection } from '@/workbench/extensions/manager/composables
 const workspaceStore = useWorkspaceStore()
 app.extensionManager = useWorkspaceStore()
 
-const { t } = useI18n()
 const conflictDetection = useConflictDetection()
 const isLoading = computed<boolean>(() => workspaceStore.spinner)
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3221,6 +3221,7 @@
     "copyAssetsAndOpen": "Import assets & open workflow",
     "openWorkflow": "Open workflow",
     "openWithoutImporting": "Open without importing",
+    "opening": "Opening shared workflow...",
     "importFailed": "Failed to import workflow assets",
     "loadError": "Could not load this shared workflow. Please try again later."
   },

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
@@ -34,6 +34,7 @@ const i18n = createI18n({
         copyAssetsAndOpen: 'Copy assets & open workflow',
         openWorkflow: 'Open workflow',
         openWithoutImporting: 'Open without importing',
+        opening: 'Opening shared workflow...',
         loadError:
           'Could not load this shared workflow. Please try again later.'
       },
@@ -290,6 +291,36 @@ describe('OpenSharedWorkflowDialogContent', () => {
       const buttons = container.querySelectorAll('footer button')
       await userEvent.click(buttons[buttons.length - 1] as HTMLElement)
       expect(onConfirm).toHaveBeenCalledWith(assetsPayload)
+    })
+
+    it('shows opening status and disables actions while opening', async () => {
+      mockGetSharedWorkflow.mockResolvedValue(assetsPayload)
+      const { container } = renderComponent({ openingAction: 'copy-and-open' })
+      await flushPromises()
+
+      expect(screen.getByRole('status').textContent).toContain(
+        'Opening shared workflow...'
+      )
+      expect(
+        container.querySelector(
+          '[data-testid="open-shared-workflow-close"]'
+        ) as HTMLButtonElement
+      ).toBeDisabled()
+      expect(
+        container.querySelector(
+          '[data-testid="open-shared-workflow-cancel"]'
+        ) as HTMLButtonElement
+      ).toBeDisabled()
+      expect(
+        container.querySelector(
+          '[data-testid="open-shared-workflow-open-without-importing"]'
+        ) as HTMLButtonElement
+      ).toBeDisabled()
+      expect(
+        container.querySelector(
+          '[data-testid="open-shared-workflow-confirm"]'
+        ) as HTMLButtonElement
+      ).toBeDisabled()
     })
 
     it('filters out assets already in library', async () => {

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
@@ -304,26 +304,12 @@ describe('OpenSharedWorkflowDialogContent', () => {
       expect(container.textContent).not.toContain(
         'Opening the workflow will create a new copy in your workspace'
       )
+      expect(screen.getByTestId('open-shared-workflow-close')).toBeEnabled()
+      expect(screen.getByTestId('open-shared-workflow-cancel')).toBeDisabled()
       expect(
-        container.querySelector(
-          '[data-testid="open-shared-workflow-close"]'
-        ) as HTMLButtonElement
+        screen.getByTestId('open-shared-workflow-open-without-importing')
       ).toBeDisabled()
-      expect(
-        container.querySelector(
-          '[data-testid="open-shared-workflow-cancel"]'
-        ) as HTMLButtonElement
-      ).toBeDisabled()
-      expect(
-        container.querySelector(
-          '[data-testid="open-shared-workflow-open-without-importing"]'
-        ) as HTMLButtonElement
-      ).toBeDisabled()
-      expect(
-        container.querySelector(
-          '[data-testid="open-shared-workflow-confirm"]'
-        ) as HTMLButtonElement
-      ).toBeDisabled()
+      expect(screen.getByTestId('open-shared-workflow-confirm')).toBeDisabled()
     })
 
     it('filters out assets already in library', async () => {

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
@@ -301,6 +301,9 @@ describe('OpenSharedWorkflowDialogContent', () => {
       expect(screen.getByRole('status').textContent).toContain(
         'Opening shared workflow...'
       )
+      expect(container.textContent).not.toContain(
+        'Opening the workflow will create a new copy in your workspace'
+      )
       expect(
         container.querySelector(
           '[data-testid="open-shared-workflow-close"]'

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
@@ -1,12 +1,20 @@
 <template>
-  <div class="flex w-full flex-col">
+  <div data-testid="open-shared-workflow-dialog" class="flex w-full flex-col">
     <header
       class="flex h-12 items-center justify-between gap-2 border-b border-border-default px-4"
     >
-      <h2 class="text-sm text-base-foreground">
+      <h2
+        data-testid="open-shared-workflow-title"
+        class="text-sm text-base-foreground"
+      >
         {{ $t('openSharedWorkflow.dialogTitle') }}
       </h2>
-      <Button size="icon" :aria-label="$t('g.close')" @click="onCancel">
+      <Button
+        data-testid="open-shared-workflow-close"
+        size="icon"
+        :aria-label="$t('g.close')"
+        @click="onCancel"
+      >
         <i class="icon-[lucide--x] size-4" />
       </Button>
     </header>
@@ -43,7 +51,12 @@
       <footer
         class="flex items-center justify-end gap-2.5 border-t border-border-default px-8 py-4"
       >
-        <Button variant="secondary" size="lg" @click="onCancel">
+        <Button
+          data-testid="open-shared-workflow-error-close"
+          variant="secondary"
+          size="lg"
+          @click="onCancel"
+        >
           {{ $t('g.close') }}
         </Button>
       </footer>
@@ -102,18 +115,29 @@
       <footer
         class="flex items-center justify-end gap-2.5 border-t border-border-default px-8 py-4"
       >
-        <Button variant="secondary" size="lg" @click="onCancel">
+        <Button
+          data-testid="open-shared-workflow-cancel"
+          variant="secondary"
+          size="lg"
+          @click="onCancel"
+        >
           {{ $t('g.cancel') }}
         </Button>
         <Button
           v-if="hasAssets"
+          data-testid="open-shared-workflow-open-without-importing"
           variant="secondary"
           size="lg"
           @click="onOpenWithoutImporting(sharedWorkflow)"
         >
           {{ $t('openSharedWorkflow.openWithoutImporting') }}
         </Button>
-        <Button variant="primary" size="lg" @click="onConfirm(sharedWorkflow)">
+        <Button
+          data-testid="open-shared-workflow-confirm"
+          variant="primary"
+          size="lg"
+          @click="onConfirm(sharedWorkflow)"
+        >
           {{
             hasAssets
               ? $t('openSharedWorkflow.copyAssetsAndOpen')

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
@@ -1,5 +1,9 @@
 <template>
-  <div data-testid="open-shared-workflow-dialog" class="flex w-full flex-col">
+  <div
+    data-testid="open-shared-workflow-dialog"
+    class="flex w-full flex-col"
+    :aria-busy="isOpening"
+  >
     <header
       class="flex h-12 items-center justify-between gap-2 border-b border-border-default px-4"
     >
@@ -12,6 +16,7 @@
       <Button
         data-testid="open-shared-workflow-close"
         size="icon"
+        :disabled="isOpening"
         :aria-label="$t('g.close')"
         @click="onCancel"
       >
@@ -71,6 +76,15 @@
           <p class="m-0 text-sm text-muted-foreground">
             {{ $t('openSharedWorkflow.copyDescription') }}
           </p>
+          <p
+            v-if="isOpening"
+            role="status"
+            aria-live="polite"
+            class="m-0 flex items-center gap-2 text-sm text-muted-foreground"
+          >
+            <i class="pi pi-spin pi-spinner" aria-hidden="true" />
+            <span>{{ $t('openSharedWorkflow.opening') }}</span>
+          </p>
         </div>
 
         <div v-if="hasAssets" class="flex w-96 shrink-0 flex-col gap-2 py-4">
@@ -119,6 +133,7 @@
           data-testid="open-shared-workflow-cancel"
           variant="secondary"
           size="lg"
+          :disabled="isOpening"
           @click="onCancel"
         >
           {{ $t('g.cancel') }}
@@ -128,6 +143,8 @@
           data-testid="open-shared-workflow-open-without-importing"
           variant="secondary"
           size="lg"
+          :loading="openingAction === 'open-only'"
+          :disabled="isOpening"
           @click="onOpenWithoutImporting(sharedWorkflow)"
         >
           {{ $t('openSharedWorkflow.openWithoutImporting') }}
@@ -136,6 +153,8 @@
           data-testid="open-shared-workflow-confirm"
           variant="primary"
           size="lg"
+          :loading="openingAction === 'copy-and-open'"
+          :disabled="isOpening"
           @click="onConfirm(sharedWorkflow)"
         >
           {{
@@ -165,8 +184,17 @@ import Button from '@/components/ui/button/Button.vue'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import { cn } from '@comfyorg/tailwind-utils'
 
-const { shareId, onConfirm, onOpenWithoutImporting, onCancel } = defineProps<{
+type OpeningAction = 'copy-and-open' | 'open-only'
+
+const {
+  shareId,
+  openingAction = null,
+  onConfirm,
+  onOpenWithoutImporting,
+  onCancel
+} = defineProps<{
   shareId: string
+  openingAction?: OpeningAction | null
   onConfirm: (payload: SharedWorkflowPayload) => void
   onOpenWithoutImporting: (payload: SharedWorkflowPayload) => void
   onCancel: () => void
@@ -186,6 +214,7 @@ const nonOwnedAssets = computed(
 )
 
 const hasAssets = computed(() => nonOwnedAssets.value.length > 0)
+const isOpening = computed(() => openingAction !== null)
 
 const workflowName = computed(() => {
   if (!sharedWorkflow.value) return ''

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
@@ -16,7 +16,6 @@
       <Button
         data-testid="open-shared-workflow-close"
         size="icon"
-        :disabled="isOpening"
         :aria-label="$t('g.close')"
         @click="onCancel"
       >
@@ -74,13 +73,13 @@
             {{ workflowName }}
           </h2>
           <p
-            :role="isOpening ? 'status' : undefined"
-            :aria-live="isOpening ? 'polite' : undefined"
+            role="status"
+            aria-live="polite"
             class="m-0 flex items-center gap-2 text-sm text-muted-foreground"
           >
             <i
               v-if="isOpening"
-              class="pi pi-spin pi-spinner"
+              class="icon-[lucide--loader-circle] size-4 motion-safe:animate-spin"
               aria-hidden="true"
             />
             <span>

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
@@ -73,17 +73,23 @@
           <h2 class="m-0 text-2xl font-semibold text-base-foreground">
             {{ workflowName }}
           </h2>
-          <p class="m-0 text-sm text-muted-foreground">
-            {{ $t('openSharedWorkflow.copyDescription') }}
-          </p>
           <p
-            v-if="isOpening"
-            role="status"
-            aria-live="polite"
+            :role="isOpening ? 'status' : undefined"
+            :aria-live="isOpening ? 'polite' : undefined"
             class="m-0 flex items-center gap-2 text-sm text-muted-foreground"
           >
-            <i class="pi pi-spin pi-spinner" aria-hidden="true" />
-            <span>{{ $t('openSharedWorkflow.opening') }}</span>
+            <i
+              v-if="isOpening"
+              class="pi pi-spin pi-spinner"
+              aria-hidden="true"
+            />
+            <span>
+              {{
+                isOpening
+                  ? $t('openSharedWorkflow.opening')
+                  : $t('openSharedWorkflow.copyDescription')
+              }}
+            </span>
           </p>
         </div>
 

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -80,6 +80,7 @@ vi.mock('vue-i18n', () => ({
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockCloseDialog = vi.hoisted(() => vi.fn())
 const mockHideTemplateSelector = vi.hoisted(() => vi.fn())
+const mockWorkspaceStore = vi.hoisted(() => ({ spinner: false }))
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
@@ -91,6 +92,10 @@ vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({
     closeDialog: mockCloseDialog
   })
+}))
+
+vi.mock('@/stores/workspaceStore', () => ({
+  useWorkspaceStore: () => mockWorkspaceStore
 }))
 
 vi.mock('@/composables/useWorkflowTemplateSelectorDialog', () => ({
@@ -139,8 +144,9 @@ function resolveDialogWithCancel() {
 
 describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     mockQueryParams = {}
+    mockWorkspaceStore.spinner = false
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -161,11 +167,15 @@ describe('useSharedWorkflowUrlLoader', () => {
       expect(mockLoadGraphData).not.toHaveBeenCalled()
       resolveDialogWithConfirm(payload)
     })
+    mockLoadGraphData.mockImplementation(() => {
+      expect(mockWorkspaceStore.spinner).toBe(true)
+    })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded')
+    expect(mockWorkspaceStore.spinner).toBe(false)
     const dialogCall = mockShowLayoutDialog.mock.calls[0][0]
     expect(dialogCall.props.shareId).toBe('share-id-1')
     expect(mockLoadGraphData).toHaveBeenCalledWith(
@@ -222,7 +232,7 @@ describe('useSharedWorkflowUrlLoader', () => {
     expect(mockHideTemplateSelector).not.toHaveBeenCalled()
   })
 
-  it('calls import when non-owned assets exist and user confirms', async () => {
+  it('imports non-owned assets before loading graph when user confirms', async () => {
     mockQueryParams = { share: 'share-id-1' }
     const payload = makePayload({
       assets: [
@@ -240,11 +250,17 @@ describe('useSharedWorkflowUrlLoader', () => {
     mockShowLayoutDialog.mockImplementation(() => {
       resolveDialogWithConfirm(payload)
     })
+    mockImportPublishedAssets.mockImplementation(() => {
+      expect(mockWorkspaceStore.spinner).toBe(true)
+    })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
     await loadSharedWorkflowFromUrl()
 
     expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'], 'share-id-1')
+    expect(mockImportPublishedAssets.mock.invocationCallOrder[0]).toBeLessThan(
+      mockLoadGraphData.mock.invocationCallOrder[0]
+    )
   })
 
   it('does not call import when user chooses open-only', async () => {
@@ -309,6 +325,13 @@ describe('useSharedWorkflowUrlLoader', () => {
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded-without-assets')
+    expect(mockLoadGraphData).toHaveBeenCalledWith(
+      { nodes: [] },
+      true,
+      true,
+      'Test Workflow',
+      { openSource: 'shared_url' }
+    )
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -80,7 +80,6 @@ vi.mock('vue-i18n', () => ({
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockCloseDialog = vi.hoisted(() => vi.fn())
 const mockHideTemplateSelector = vi.hoisted(() => vi.fn())
-const mockWorkspaceStore = vi.hoisted(() => ({ spinner: false }))
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
@@ -92,10 +91,6 @@ vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({
     closeDialog: mockCloseDialog
   })
-}))
-
-vi.mock('@/stores/workspaceStore', () => ({
-  useWorkspaceStore: () => mockWorkspaceStore
 }))
 
 vi.mock('@/composables/useWorkflowTemplateSelectorDialog', () => ({
@@ -122,17 +117,11 @@ function makePayload(
 }
 
 function resolveDialogWithConfirm(payload: SharedWorkflowPayload) {
-  const call = mockShowLayoutDialog.mock.calls.at(-1)
-  if (!call) throw new Error('showLayoutDialog was not called')
-  const options = call[0]
-  options.props.onConfirm(payload)
+  getLastDialogOptions().props.onConfirm(payload)
 }
 
 function resolveDialogWithOpenOnly(payload: SharedWorkflowPayload) {
-  const call = mockShowLayoutDialog.mock.calls.at(-1)
-  if (!call) throw new Error('showLayoutDialog was not called')
-  const options = call[0]
-  options.props.onOpenWithoutImporting(payload)
+  getLastDialogOptions().props.onOpenWithoutImporting(payload)
 }
 
 function resolveDialogWithCancel() {
@@ -142,11 +131,35 @@ function resolveDialogWithCancel() {
   options.props.onCancel()
 }
 
+function getLastDialogOptions() {
+  const call = mockShowLayoutDialog.mock.calls.at(-1)
+  if (!call) throw new Error('showLayoutDialog was not called')
+  return call[0]
+}
+
+function createDialogInstance(options: {
+  props: Record<string, unknown>
+  dialogComponentProps?: Record<string, unknown>
+}) {
+  return {
+    contentProps: { ...options.props },
+    dialogComponentProps: { ...options.dialogComponentProps }
+  }
+}
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockQueryParams = {}
-    mockWorkspaceStore.spinner = false
+    mockShowLayoutDialog.mockImplementation(createDialogInstance)
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -163,21 +176,15 @@ describe('useSharedWorkflowUrlLoader', () => {
   it('opens dialog immediately with shareId and loads graph on confirm', async () => {
     mockQueryParams = { share: 'share-id-1' }
     const payload = makePayload()
-    let spinnerDuringGraphLoad: boolean | undefined
     mockShowLayoutDialog.mockImplementation(() => {
       expect(mockLoadGraphData).not.toHaveBeenCalled()
       resolveDialogWithConfirm(payload)
-    })
-    mockLoadGraphData.mockImplementation(() => {
-      spinnerDuringGraphLoad = mockWorkspaceStore.spinner
     })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded')
-    expect(spinnerDuringGraphLoad).toBe(true)
-    expect(mockWorkspaceStore.spinner).toBe(false)
     const dialogCall = mockShowLayoutDialog.mock.calls[0][0]
     expect(dialogCall.props.shareId).toBe('share-id-1')
     expect(mockLoadGraphData).toHaveBeenCalledWith(
@@ -203,6 +210,34 @@ describe('useSharedWorkflowUrlLoader', () => {
     await loadSharedWorkflowFromUrl()
 
     expect(mockHideTemplateSelector).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps dialog open with opening state while shared workflow loads', async () => {
+    mockQueryParams = { share: 'share-id-1' }
+    const graphLoad = createDeferred()
+    mockLoadGraphData.mockReturnValue(graphLoad.promise)
+
+    const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
+    const loadPromise = loadSharedWorkflowFromUrl()
+    await Promise.resolve()
+    const dialogOptions = getLastDialogOptions()
+    const dialogInstance = mockShowLayoutDialog.mock.results[0].value
+
+    dialogOptions.props.onConfirm(makePayload())
+    await Promise.resolve()
+
+    expect(dialogInstance.contentProps.openingAction).toBe('copy-and-open')
+    expect(dialogInstance.dialogComponentProps.closable).toBe(false)
+    expect(dialogInstance.dialogComponentProps.closeOnEscape).toBe(false)
+    expect(dialogInstance.dialogComponentProps.dismissableMask).toBe(false)
+    expect(mockCloseDialog).not.toHaveBeenCalled()
+
+    graphLoad.resolve()
+    await loadPromise
+
+    expect(mockCloseDialog).toHaveBeenLastCalledWith({
+      key: 'open-shared-workflow'
+    })
   })
 
   it('does not load graph when user cancels dialog', async () => {
@@ -249,19 +284,14 @@ describe('useSharedWorkflowUrlLoader', () => {
         }
       ]
     })
-    let spinnerDuringImport: boolean | undefined
     mockShowLayoutDialog.mockImplementation(() => {
       resolveDialogWithConfirm(payload)
-    })
-    mockImportPublishedAssets.mockImplementation(() => {
-      spinnerDuringImport = mockWorkspaceStore.spinner
     })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded')
-    expect(spinnerDuringImport).toBe(true)
     expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'], 'share-id-1')
     expect(mockImportPublishedAssets.mock.invocationCallOrder[0]).toBeLessThan(
       mockLoadGraphData.mock.invocationCallOrder[0]

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -163,18 +163,20 @@ describe('useSharedWorkflowUrlLoader', () => {
   it('opens dialog immediately with shareId and loads graph on confirm', async () => {
     mockQueryParams = { share: 'share-id-1' }
     const payload = makePayload()
+    let spinnerDuringGraphLoad: boolean | undefined
     mockShowLayoutDialog.mockImplementation(() => {
       expect(mockLoadGraphData).not.toHaveBeenCalled()
       resolveDialogWithConfirm(payload)
     })
     mockLoadGraphData.mockImplementation(() => {
-      expect(mockWorkspaceStore.spinner).toBe(true)
+      spinnerDuringGraphLoad = mockWorkspaceStore.spinner
     })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded')
+    expect(spinnerDuringGraphLoad).toBe(true)
     expect(mockWorkspaceStore.spinner).toBe(false)
     const dialogCall = mockShowLayoutDialog.mock.calls[0][0]
     expect(dialogCall.props.shareId).toBe('share-id-1')
@@ -247,16 +249,19 @@ describe('useSharedWorkflowUrlLoader', () => {
         }
       ]
     })
+    let spinnerDuringImport: boolean | undefined
     mockShowLayoutDialog.mockImplementation(() => {
       resolveDialogWithConfirm(payload)
     })
     mockImportPublishedAssets.mockImplementation(() => {
-      expect(mockWorkspaceStore.spinner).toBe(true)
+      spinnerDuringImport = mockWorkspaceStore.spinner
     })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
-    await loadSharedWorkflowFromUrl()
+    const loaded = await loadSharedWorkflowFromUrl()
 
+    expect(loaded).toBe('loaded')
+    expect(spinnerDuringImport).toBe(true)
     expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'], 'share-id-1')
     expect(mockImportPublishedAssets.mock.invocationCallOrder[0]).toBeLessThan(
       mockLoadGraphData.mock.invocationCallOrder[0]
@@ -337,6 +342,37 @@ describe('useSharedWorkflowUrlLoader', () => {
         severity: 'error',
         detail: 'Failed to import workflow assets'
       })
+    )
+  })
+
+  it('clears share intent when graph load fails after importing assets', async () => {
+    mockQueryParams = { share: 'share-id-1', tab: 'assets' }
+    const payload = makePayload({
+      assets: [
+        {
+          id: 'a1',
+          name: 'img.png',
+          preview_url: '',
+          storage_url: '',
+          model: false,
+          public: false,
+          in_library: false
+        }
+      ]
+    })
+    mockShowLayoutDialog.mockImplementation(() => {
+      resolveDialogWithConfirm(payload)
+    })
+    mockLoadGraphData.mockRejectedValue(new Error('Graph load failed'))
+
+    const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
+    const loaded = await loadSharedWorkflowFromUrl()
+
+    expect(loaded).toBe('failed')
+    expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'], 'share-id-1')
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: { tab: 'assets' } })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'share'
     )
   })
 

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -80,6 +80,14 @@ vi.mock('vue-i18n', () => ({
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockCloseDialog = vi.hoisted(() => vi.fn())
 const mockHideTemplateSelector = vi.hoisted(() => vi.fn())
+const mockDialogStack = vi.hoisted(
+  () =>
+    [] as Array<{
+      key: string
+      contentProps: Record<string, unknown>
+      dialogComponentProps: Record<string, unknown>
+    }>
+)
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
@@ -89,6 +97,7 @@ vi.mock('@/services/dialogService', () => ({
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({
+    dialogStack: mockDialogStack,
     closeDialog: mockCloseDialog
   })
 }))
@@ -138,13 +147,17 @@ function getLastDialogOptions() {
 }
 
 function createDialogInstance(options: {
+  key: string
   props: Record<string, unknown>
   dialogComponentProps?: Record<string, unknown>
 }) {
-  return {
+  const dialog = {
+    key: options.key,
     contentProps: { ...options.props },
     dialogComponentProps: { ...options.dialogComponentProps }
   }
+  mockDialogStack.push(dialog)
+  return dialog
 }
 
 function createDeferred() {
@@ -159,6 +172,7 @@ describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockQueryParams = {}
+    mockDialogStack.length = 0
     mockShowLayoutDialog.mockImplementation(createDialogInstance)
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -88,6 +88,7 @@ const mockDialogStack = vi.hoisted(
       dialogComponentProps: Record<string, unknown>
     }>
 )
+const mockUpdateDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
@@ -98,7 +99,8 @@ vi.mock('@/services/dialogService', () => ({
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({
     dialogStack: mockDialogStack,
-    closeDialog: mockCloseDialog
+    closeDialog: mockCloseDialog,
+    updateDialog: mockUpdateDialog
   })
 }))
 
@@ -174,6 +176,32 @@ describe('useSharedWorkflowUrlLoader', () => {
     mockQueryParams = {}
     mockDialogStack.length = 0
     mockShowLayoutDialog.mockImplementation(createDialogInstance)
+    mockUpdateDialog.mockImplementation(
+      (options: {
+        key: string
+        contentProps?: Record<string, unknown>
+        dialogComponentProps?: Record<string, unknown>
+      }) => {
+        const dialog = mockDialogStack.find((item) => item.key === options.key)
+        if (!dialog) return false
+
+        if (options.contentProps) {
+          dialog.contentProps = {
+            ...dialog.contentProps,
+            ...options.contentProps
+          }
+        }
+
+        if (options.dialogComponentProps) {
+          dialog.dialogComponentProps = {
+            ...dialog.dialogComponentProps,
+            ...options.dialogComponentProps
+          }
+        }
+
+        return true
+      }
+    )
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -241,9 +269,13 @@ describe('useSharedWorkflowUrlLoader', () => {
     await Promise.resolve()
 
     expect(dialogInstance.contentProps.openingAction).toBe('copy-and-open')
-    expect(dialogInstance.dialogComponentProps.closable).toBe(false)
-    expect(dialogInstance.dialogComponentProps.closeOnEscape).toBe(false)
-    expect(dialogInstance.dialogComponentProps.dismissableMask).toBe(false)
+    expect(mockUpdateDialog).toHaveBeenCalledWith({
+      key: 'open-shared-workflow',
+      contentProps: { openingAction: 'copy-and-open' }
+    })
+    expect(dialogInstance.dialogComponentProps.closable).toBeUndefined()
+    expect(dialogInstance.dialogComponentProps.closeOnEscape).toBeUndefined()
+    expect(dialogInstance.dialogComponentProps.dismissableMask).toBeUndefined()
     expect(mockCloseDialog).not.toHaveBeenCalled()
 
     graphLoad.resolve()

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -15,7 +15,6 @@ import { useWorkflowShareService } from '@/platform/workflow/sharing/services/wo
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
-import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 type SharedWorkflowUrlLoadStatus =
   | 'not-present'
@@ -29,6 +28,21 @@ type DialogResult =
   | { action: 'open-only'; payload: SharedWorkflowPayload }
   | { action: 'cancel' }
 
+type OpeningAction = Exclude<DialogResult['action'], 'cancel'>
+
+type OpenSharedWorkflowDialogInstance = {
+  contentProps: {
+    openingAction?: OpeningAction | null
+  }
+  dialogComponentProps: {
+    closable?: boolean
+    closeOnEscape?: boolean
+    dismissableMask?: boolean
+  }
+}
+
+const OPEN_SHARED_WORKFLOW_DIALOG_KEY = 'open-shared-workflow'
+
 export function useSharedWorkflowUrlLoader() {
   const route = useRoute()
   const router = useRouter()
@@ -37,7 +51,6 @@ export function useSharedWorkflowUrlLoader() {
   const workflowShareService = useWorkflowShareService()
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
-  const workspaceStore = useWorkspaceStore()
   const templateSelectorDialog = useWorkflowTemplateSelectorDialog()
   const SHARE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.SHARE
 
@@ -73,25 +86,38 @@ export function useSharedWorkflowUrlLoader() {
   function showOpenSharedWorkflowDialog(
     shareId: string
   ): Promise<DialogResult> {
-    const dialogKey = 'open-shared-workflow'
+    let dialog: OpenSharedWorkflowDialogInstance | undefined
+
+    function setOpeningAction(openingAction: OpeningAction) {
+      if (!dialog) return
+
+      dialog.contentProps.openingAction = openingAction
+      dialog.dialogComponentProps = {
+        ...dialog.dialogComponentProps,
+        closable: false,
+        closeOnEscape: false,
+        dismissableMask: false
+      }
+    }
 
     return new Promise<DialogResult>((resolve) => {
-      dialogService.showLayoutDialog({
-        key: dialogKey,
+      dialog = dialogService.showLayoutDialog({
+        key: OPEN_SHARED_WORKFLOW_DIALOG_KEY,
         component: OpenSharedWorkflowDialogContent,
         props: {
           shareId,
+          openingAction: null,
           onConfirm: (payload: SharedWorkflowPayload) => {
+            setOpeningAction('copy-and-open')
             resolve({ action: 'copy-and-open', payload })
-            dialogStore.closeDialog({ key: dialogKey })
           },
           onOpenWithoutImporting: (payload: SharedWorkflowPayload) => {
+            setOpeningAction('open-only')
             resolve({ action: 'open-only', payload })
-            dialogStore.closeDialog({ key: dialogKey })
           },
           onCancel: () => {
             resolve({ action: 'cancel' })
-            dialogStore.closeDialog({ key: dialogKey })
+            dialogStore.closeDialog({ key: OPEN_SHARED_WORKFLOW_DIALOG_KEY })
           }
         },
         dialogComponentProps: {
@@ -140,9 +166,6 @@ export function useSharedWorkflowUrlLoader() {
     }
 
     templateSelectorDialog.hide()
-
-    const previousSpinner = workspaceStore.spinner
-    workspaceStore.spinner = true
 
     try {
       const { payload } = result
@@ -197,7 +220,7 @@ export function useSharedWorkflowUrlLoader() {
       clearShareIntent()
       return importFailed ? 'loaded-without-assets' : 'loaded'
     } finally {
-      workspaceStore.spinner = previousSpinner
+      dialogStore.closeDialog({ key: OPEN_SHARED_WORKFLOW_DIALOG_KEY })
     }
   }
 

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -15,6 +15,7 @@ import { useWorkflowShareService } from '@/platform/workflow/sharing/services/wo
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 type SharedWorkflowUrlLoadStatus =
   | 'not-present'
@@ -36,6 +37,7 @@ export function useSharedWorkflowUrlLoader() {
   const workflowShareService = useWorkflowShareService()
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
+  const workspaceStore = useWorkspaceStore()
   const templateSelectorDialog = useWorkflowTemplateSelectorDialog()
   const SHARE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.SHARE
 
@@ -137,52 +139,64 @@ export function useSharedWorkflowUrlLoader() {
 
     templateSelectorDialog.hide()
 
-    const { payload } = result
-    const workflowName = payload.name || t('openSharedWorkflow.dialogTitle')
-    const nonOwnedAssets = payload.assets.filter((a) => !a.in_library)
+    const previousSpinner = workspaceStore.spinner
+    workspaceStore.spinner = true
 
     try {
-      await app.loadGraphData(payload.workflowJson, true, true, workflowName, {
-        openSource: 'shared_url'
-      })
-    } catch (error) {
-      console.error(
-        '[useSharedWorkflowUrlLoader] Failed to load workflow graph:',
-        error
-      )
-      toast.add({
-        severity: 'error',
-        summary: t('g.error'),
-        detail: t('shareWorkflow.loadFailed')
-      })
-      return 'failed'
-    }
+      const { payload } = result
+      const workflowName = payload.name || t('openSharedWorkflow.dialogTitle')
+      const nonOwnedAssets = payload.assets.filter((a) => !a.in_library)
+      let importFailed = false
 
-    if (result.action === 'copy-and-open' && nonOwnedAssets.length > 0) {
+      if (result.action === 'copy-and-open' && nonOwnedAssets.length > 0) {
+        try {
+          await workflowShareService.importPublishedAssets(
+            nonOwnedAssets.map((a) => a.id),
+            payload.shareId
+          )
+        } catch (importError) {
+          importFailed = true
+          console.error(
+            '[useSharedWorkflowUrlLoader] Failed to import assets:',
+            importError
+          )
+          toast.add({
+            severity: 'error',
+            summary: t('g.error'),
+            detail: t('openSharedWorkflow.importFailed')
+          })
+        }
+      }
+
       try {
-        await workflowShareService.importPublishedAssets(
-          nonOwnedAssets.map((a) => a.id),
-          payload.shareId
+        await app.loadGraphData(
+          payload.workflowJson,
+          true,
+          true,
+          workflowName,
+          {
+            openSource: 'shared_url'
+          }
         )
-      } catch (importError) {
+      } catch (error) {
         console.error(
-          '[useSharedWorkflowUrlLoader] Failed to import assets:',
-          importError
+          '[useSharedWorkflowUrlLoader] Failed to load workflow graph:',
+          error
         )
         toast.add({
           severity: 'error',
           summary: t('g.error'),
-          detail: t('openSharedWorkflow.importFailed')
+          detail: t('shareWorkflow.loadFailed')
         })
-        cleanupUrlParams()
-        clearPreservedQuery(SHARE_NAMESPACE)
-        return 'loaded-without-assets'
+        return 'failed'
       }
-    }
 
-    cleanupUrlParams()
-    clearPreservedQuery(SHARE_NAMESPACE)
-    return 'loaded'
+      cleanupUrlParams()
+      clearPreservedQuery(SHARE_NAMESPACE)
+      return importFailed ? 'loaded-without-assets' : 'loaded'
+    } finally {
+      workspaceStore.spinner = previousSpinner
+    }
   }
 
   return {

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -76,21 +76,10 @@ export function useSharedWorkflowUrlLoader() {
     shareId: string
   ): Promise<DialogResult> {
     function setOpeningAction(openingAction: OpeningAction) {
-      const dialog = dialogStore.dialogStack.find(
-        (item) => item.key === OPEN_SHARED_WORKFLOW_DIALOG_KEY
-      )
-      if (!dialog) return
-
-      dialog.contentProps = {
-        ...dialog.contentProps,
-        openingAction
-      }
-      dialog.dialogComponentProps = {
-        ...dialog.dialogComponentProps,
-        closable: false,
-        closeOnEscape: false,
-        dismissableMask: false
-      }
+      dialogStore.updateDialog({
+        key: OPEN_SHARED_WORKFLOW_DIALOG_KEY,
+        contentProps: { openingAction }
+      })
     }
 
     return new Promise<DialogResult>((resolve) => {

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -65,6 +65,11 @@ export function useSharedWorkflowUrlLoader() {
     void router.replace({ query: newQuery })
   }
 
+  function clearShareIntent() {
+    cleanupUrlParams()
+    clearPreservedQuery(SHARE_NAMESPACE)
+  }
+
   function showOpenSharedWorkflowDialog(
     shareId: string
   ): Promise<DialogResult> {
@@ -110,8 +115,7 @@ export function useSharedWorkflowUrlLoader() {
     }
 
     if (typeof shareParam !== 'string') {
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'not-present'
     }
 
@@ -124,16 +128,14 @@ export function useSharedWorkflowUrlLoader() {
         summary: t('g.error'),
         detail: t('shareWorkflow.loadFailed')
       })
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'failed'
     }
 
     const result = await showOpenSharedWorkflowDialog(shareParam)
 
     if (result.action === 'cancel') {
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'cancelled'
     }
 
@@ -188,11 +190,11 @@ export function useSharedWorkflowUrlLoader() {
           summary: t('g.error'),
           detail: t('shareWorkflow.loadFailed')
         })
+        clearShareIntent()
         return 'failed'
       }
 
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return importFailed ? 'loaded-without-assets' : 'loaded'
     } finally {
       workspaceStore.spinner = previousSpinner

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -30,17 +30,6 @@ type DialogResult =
 
 type OpeningAction = Exclude<DialogResult['action'], 'cancel'>
 
-type OpenSharedWorkflowDialogInstance = {
-  contentProps: {
-    openingAction?: OpeningAction | null
-  }
-  dialogComponentProps: {
-    closable?: boolean
-    closeOnEscape?: boolean
-    dismissableMask?: boolean
-  }
-}
-
 const OPEN_SHARED_WORKFLOW_DIALOG_KEY = 'open-shared-workflow'
 
 export function useSharedWorkflowUrlLoader() {
@@ -86,12 +75,16 @@ export function useSharedWorkflowUrlLoader() {
   function showOpenSharedWorkflowDialog(
     shareId: string
   ): Promise<DialogResult> {
-    let dialog: OpenSharedWorkflowDialogInstance | undefined
-
     function setOpeningAction(openingAction: OpeningAction) {
+      const dialog = dialogStore.dialogStack.find(
+        (item) => item.key === OPEN_SHARED_WORKFLOW_DIALOG_KEY
+      )
       if (!dialog) return
 
-      dialog.contentProps.openingAction = openingAction
+      dialog.contentProps = {
+        ...dialog.contentProps,
+        openingAction
+      }
       dialog.dialogComponentProps = {
         ...dialog.dialogComponentProps,
         closable: false,
@@ -101,7 +94,7 @@ export function useSharedWorkflowUrlLoader() {
     }
 
     return new Promise<DialogResult>((resolve) => {
-      dialog = dialogService.showLayoutDialog({
+      dialogService.showLayoutDialog({
         key: OPEN_SHARED_WORKFLOW_DIALOG_KEY,
         component: OpenSharedWorkflowDialogContent,
         props: {

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/scripts/app', () => ({
 
 const mockGetShareableAssets = vi.fn()
 const mockFetchApi = vi.fn()
+const mockInvalidateInputAssetsIncludingPublic = vi.hoisted(() => vi.fn())
 
 vi.mock(
   '@/platform/workflow/validation/schemas/workflowSchema',
@@ -29,6 +30,13 @@ vi.mock('@/scripts/api', () => ({
     fetchApi: (...args: unknown[]) => mockFetchApi(...args),
     apiURL: (route: string) => `/api${route}`,
     fileURL: (route: string) => route
+  }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    invalidateInputAssetsIncludingPublic:
+      mockInvalidateInputAssetsIncludingPublic
   }
 }))
 
@@ -348,6 +356,7 @@ describe(useWorkflowShareService, () => {
         share_id: 'share-id-1'
       })
     })
+    expect(mockInvalidateInputAssetsIncludingPublic).toHaveBeenCalledTimes(1)
   })
 
   it('omits share_id from the payload when not provided', async () => {
@@ -384,6 +393,7 @@ describe(useWorkflowShareService, () => {
     await expect(
       service.importPublishedAssets(['bad-id'], 'share-id-1')
     ).rejects.toThrow('Failed to import assets: 400')
+    expect(mockInvalidateInputAssetsIncludingPublic).not.toHaveBeenCalled()
   })
 
   it('throws when shared workflow payload is invalid', async () => {

--- a/src/platform/workflow/sharing/services/workflowShareService.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.ts
@@ -6,6 +6,7 @@ import type {
   WorkflowPublishResult,
   WorkflowPublishStatus
 } from '@/platform/workflow/sharing/types/shareTypes'
+import { assetService } from '@/platform/assets/services/assetService'
 import type { ThumbnailType } from '@/platform/workflow/sharing/types/comfyHubTypes'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
@@ -275,6 +276,8 @@ export function useWorkflowShareService() {
     if (!response.ok) {
       throw new Error(`Failed to import assets: ${response.status}`)
     }
+
+    assetService.invalidateInputAssetsIncludingPublic()
   }
 
   return {

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -10,6 +10,17 @@ const MockComponent = defineComponent({
   template: '<div>Mock</div>'
 })
 
+const MockContentPropsComponent = defineComponent({
+  name: 'MockContentPropsComponent',
+  props: {
+    openingAction: {
+      type: String,
+      default: null
+    }
+  },
+  template: '<div>Mock</div>'
+})
+
 describe('dialogStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -171,6 +182,31 @@ describe('dialogStore', () => {
       expect(store.dialogStack).toHaveLength(1)
       expect(store.dialogStack[0].key).toBe('reusable-dialog')
       expect(store.dialogStack[0].title).toBe('Original Title')
+    })
+
+    it('should update existing dialog props by key', () => {
+      const store = useDialogStore()
+
+      store.showDialog({
+        key: 'updatable-dialog',
+        component: MockContentPropsComponent,
+        props: { openingAction: null },
+        dialogComponentProps: { dismissableMask: true }
+      })
+
+      const updated = store.updateDialog({
+        key: 'updatable-dialog',
+        contentProps: { openingAction: 'copy-and-open' },
+        dialogComponentProps: { dismissableMask: false }
+      })
+
+      expect(updated).toBe(true)
+      expect(store.dialogStack[0].contentProps).toMatchObject({
+        openingAction: 'copy-and-open'
+      })
+      expect(store.dialogStack[0].dialogComponentProps.dismissableMask).toBe(
+        false
+      )
     })
   })
 

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -93,6 +93,12 @@ export interface ShowDialogOptions<
   priority?: number
 }
 
+interface UpdateDialogOptions {
+  key: string
+  contentProps?: Partial<DialogInstance['contentProps']>
+  dialogComponentProps?: Partial<DialogComponentProps>
+}
+
 export const useDialogStore = defineStore('dialog', () => {
   const dialogStack = ref<DialogInstance[]>([])
 
@@ -269,6 +275,28 @@ export const useDialogStore = defineStore('dialog', () => {
     return dialogStack.value.some((d) => d.key === key)
   }
 
+  function updateDialog(options: UpdateDialogOptions): boolean {
+    const dialog = dialogStack.value.find((d) => d.key === options.key)
+    if (!dialog) return false
+
+    if (options.contentProps) {
+      dialog.contentProps = {
+        ...dialog.contentProps,
+        ...options.contentProps
+      }
+    }
+
+    if (options.dialogComponentProps) {
+      dialog.dialogComponentProps = {
+        ...dialog.dialogComponentProps,
+        ...options.dialogComponentProps
+      }
+      updateCloseOnEscapeStates()
+    }
+
+    return true
+  }
+
   return {
     dialogStack,
     riseDialog,
@@ -276,6 +304,7 @@ export const useDialogStore = defineStore('dialog', () => {
     closeDialog,
     showExtensionDialog,
     isDialogOpen,
+    updateDialog,
     activeKey
   }
 })


### PR DESCRIPTION
## Summary

Import published media assets for shared workflows before loading the graph so the first missing-media scan sees the user's newly imported references instead of surfacing a false missing asset error. cc FE-773

## Changes

- **What**: Moves the shared workflow import step ahead of `loadGraphData` for the copy-and-open flow, while still allowing the workflow to open with a warning path if asset import fails.
- **What**: Clears the shared workflow URL intent consistently on failure paths, including graph load failure after an import attempt, so reloads do not repeatedly replay the same shared workflow side effects.
- **What**: Invalidates the input asset cache after published asset import so graph loading and missing-media resolution can observe the refreshed media state.
- **What**: Adds a global loading spinner while shared workflow asset import and graph load are in progress, with `role="status"`, `aria-live`, reduced-motion-safe animation, and body teleporting so it stays visible above blocking UI.
- **What**: Adds stable TestIds for the shared workflow dialog and updates existing shared workflow E2E selectors away from copy-dependent role text.
- **What**: Adds a cloud E2E regression fixture and spec covering the critical flow: shared URL opens the dialog, the user confirms asset import, published media is imported before the public-inclusive input asset scan, the workflow loads, the share query is removed, and missing media UI is not surfaced.
- **Breaking**: None.
- **Dependencies**: None.

## Root Cause

Shared workflow graph loading triggered the missing-media pipeline before the user-selected published media import had completed. Because `include_public=true` does not include published assets, the pre-import scan could classify shared media as missing even when the user was about to import those assets into their own library.

## Review Focus

- The ordering in `useSharedWorkflowUrlLoader`: import published assets first, then load the graph, while keeping import failure non-fatal for workflow opening.
- The failure cleanup behavior: the shared URL/preserved query intent is now cleared for graph load failures too, avoiding repeated reload-triggered imports.
- The spinner behavior in `App.vue`: it uses the existing `workspaceStore.spinner` boolean and intentionally keeps broader ref-counted spinner ownership as follow-up work.
- The E2E sentinel in `sharedWorkflowMissingMedia.spec.ts`: it asserts no public-inclusive input asset scan occurs before `/api/assets/import`, then waits for a settling window to ensure the missing-media overlay does not appear.

## Validation

- `pnpm format`
- `pnpm lint` (passed with existing unrelated warnings only)
- `pnpm typecheck`
- `pnpm test:unit`
- Commit hook: lint-staged formatting/linting, `pnpm typecheck`, `pnpm typecheck:browser`
- Push hook: `pnpm knip --cache` (passed with existing tag hint only)

## Follow-Up

- Consider a ref-counted or scoped global spinner API so long-running flows do not directly toggle `workspaceStore.spinner`.
- Consider separating shared workflow load status into orthogonal result fields instead of encoding partial success in a single string union.
- Consider moving published asset import/cache invalidation behind an asset-service-owned API boundary.
- Backend follow-up remains needed for `include_public=true` not including published assets; this PR only removes the frontend false positive when the user explicitly imports the shared media.

## Screenshots

Before 

https://github.com/user-attachments/assets/dc790046-237c-4dd8-b773-2507f9a66650

After 

https://github.com/user-attachments/assets/6517cd38-2c3d-4bfe-a990-35892b7e50ae


https://github.com/user-attachments/assets/d89dc3d3-75d9-4251-998b-0c354414e25b




┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12333-fix-avoid-false-missing-media-errors-after-importing-shared-workflow-assets-3656d73d365081b38634dcb7625cfc32) by [Unito](https://www.unito.io)
