### PR TITLE
fix(form-dropdown): stop cancelling native scroll on slow trackpad wheels

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.test.ts
@@ -136,8 +136,12 @@ describe('FormDropdownMenu', () => {
 
   /** Regression: PrimeVue Popover teleports the menu to document.body, so
    *  trackpad pinch-zoom must be guarded on the menu itself — `LGraphNode`
-   *  never sees these events. */
-  it('suppresses browser default for pinch-zoom', () => {
+   *  never sees these events. macOS pinch synthesizes `ctrlKey`; explicit
+   *  `⌘ + wheel` (and Windows/Linux equivalents) come through as `metaKey`. */
+  it.for([
+    { name: 'ctrlKey', modifier: 'ctrlKey' as const },
+    { name: 'metaKey', modifier: 'metaKey' as const }
+  ])('suppresses browser default for pinch-zoom ($name)', ({ modifier }) => {
     render(FormDropdownMenu, {
       props: defaultProps,
       global: globalConfig
@@ -145,7 +149,7 @@ describe('FormDropdownMenu', () => {
 
     const root = screen.getByTestId('form-dropdown-menu')
     const event = new WheelEvent('wheel', { bubbles: true, cancelable: true })
-    Object.defineProperty(event, 'ctrlKey', { value: true })
+    Object.defineProperty(event, modifier, { value: true })
     Object.defineProperty(event, 'deltaY', { value: -10 })
     root.dispatchEvent(event)
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.test.ts
@@ -135,25 +135,18 @@ describe('FormDropdownMenu', () => {
   })
 
   /** Regression: PrimeVue Popover teleports the menu to document.body, so
-   *  trackpad pinch-zoom and horizontal swipes must be guarded on the menu
-   *  itself rather than relying on the LGraphNode wheel handler. */
-  it.for([
-    { name: 'pinch-zoom', overrides: { ctrlKey: true, deltaY: -10 } },
-    { name: 'horizontal swipe', overrides: { deltaX: 30, deltaY: 5 } }
-  ])('suppresses browser default for $name', ({ overrides }) => {
+   *  trackpad pinch-zoom must be guarded on the menu itself — `LGraphNode`
+   *  never sees these events. */
+  it('suppresses browser default for pinch-zoom', () => {
     render(FormDropdownMenu, {
       props: defaultProps,
       global: globalConfig
     })
 
     const root = screen.getByTestId('form-dropdown-menu')
-    const event = new WheelEvent('wheel', {
-      bubbles: true,
-      cancelable: true
-    })
-    Object.entries(overrides).forEach(([key, value]) => {
-      Object.defineProperty(event, key, { value })
-    })
+    const event = new WheelEvent('wheel', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'ctrlKey', { value: true })
+    Object.defineProperty(event, 'deltaY', { value: -10 })
     root.dispatchEvent(event)
 
     expect(event.defaultPrevented).toBe(true)
@@ -211,19 +204,33 @@ describe('FormDropdownMenu', () => {
     expect(emitted('show-picker')).toHaveLength(1)
   })
 
-  /** Vertical scrolling must remain native so the dropdown's own scroll
-   *  container can scroll its content. */
-  it('does not suppress vertical scroll', () => {
+  /** Regression: slow trackpad vertical scrolls emit small-delta frames with
+   *  stray horizontal jitter (`|deltaX| > |deltaY|`). preventDefault-ing those
+   *  cancelled the native scroll and starved the VirtualGrid's `useScroll`,
+   *  leaving rows blank. Horizontal-swipe-to-navigate is blocked at the page
+   *  boundary by `overscroll-behavior: none` on `html, body`, so the local
+   *  handler must NOT preventDefault these events. The `pure vertical` case
+   *  also covers plain native scrolling of the dropdown's own content. */
+  it.for([
+    { name: 'pure vertical', overrides: { deltaY: 30 } },
+    {
+      name: 'slow scroll with horizontal jitter',
+      overrides: { deltaX: 1.5, deltaY: 1.2 }
+    },
+    {
+      name: 'pronounced horizontal swipe',
+      overrides: { deltaX: 30, deltaY: 5 }
+    }
+  ])('does not suppress $name wheel', ({ overrides }) => {
     render(FormDropdownMenu, {
       props: defaultProps,
       global: globalConfig
     })
 
     const root = screen.getByTestId('form-dropdown-menu')
-    const event = new WheelEvent('wheel', {
-      deltaY: 30,
-      bubbles: true,
-      cancelable: true
+    const event = new WheelEvent('wheel', { bubbles: true, cancelable: true })
+    Object.entries(overrides).forEach(([key, value]) => {
+      Object.defineProperty(event, key, { value })
     })
     root.dispatchEvent(event)
 

--- a/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdownMenu.vue
@@ -3,7 +3,6 @@ import type { CSSProperties } from 'vue'
 import { computed } from 'vue'
 
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
-import { isCanvasGestureWheel } from '@/base/wheelGestures'
 
 import type {
   FilterOption,
@@ -109,12 +108,17 @@ const virtualItems = computed<VirtualDropdownItem[]>(() =>
 /**
  * The dropdown content is teleported to `document.body` by PrimeVue Popover,
  * detaching it from the LGraphNode subtree where the canvas wheel guard lives.
- * Suppress only the destructive browser defaults (page zoom on pinch and
- * back/forward on horizontal swipe); regular vertical scrolling still
- * scrolls the dropdown's own content.
+ * Pinch-zoom (`ctrl/meta + wheel`) would otherwise trigger page-level zoom and
+ * push fixed UI off-screen, so it must be suppressed locally. Horizontal
+ * swipe-to-navigate is already blocked at the page boundary by
+ * `overscroll-behavior: none` on `html, body`, so we deliberately do NOT
+ * preventDefault on horizontal-dominant wheels here — doing so cancels the
+ * trackpad's native momentum on slow vertical scrolls (where stray horizontal
+ * jitter frames satisfy `|deltaX| > |deltaY|`), starving the VirtualGrid's
+ * `useScroll` and leaving rows blank until a fast scroll re-pumps samples.
  */
 const onWheel = (event: WheelEvent) => {
-  if (isCanvasGestureWheel(event)) event.preventDefault()
+  if (event.ctrlKey || event.metaKey) event.preventDefault()
 }
 </script>
 


### PR DESCRIPTION
## Summary

Follow-up to #12052. The local wheel guard added in FormDropdownMenu was cancelling native scroll on slow macOS trackpad gestures, leaving image rows blank in the asset picker until a fast scroll re-pumped samples through.

## Changes

- **What**: `FormDropdownMenu.onWheel` now only `preventDefault`s on pinch-zoom (`ctrl/meta + wheel`). The `|deltaX| > |deltaY|` branch of `isCanvasGestureWheel` is no longer used here.
- **Why**: Slow vertical trackpad scrolls emit small-delta frames with stray horizontal jitter (e.g. `deltaY=1.2`, `deltaX=1.5`) that satisfied the horizontal-dominant predicate. Cancelling those frames starved `VirtualGrid`'s throttled `useScroll`, so `Math.floor(scrollY / itemHeight)` never advanced and tiles never mounted.
- Horizontal-swipe-to-navigate is still blocked at the page boundary by `overscroll-behavior: none` on `html, body` (the actual fix from #12052), so dropping the local horizontal guard does not reintroduce the back/forward bug.
- The global `isCanvasGestureWheel` is unchanged — `useCanvasInteractions` still uses it for the canvas wheel handler, where the semantics are different (forward to canvas pan, not preventDefault native scroll).

## Review Focus

- Confirm `overscroll-behavior: none` on `html, body` is sufficient on its own for the horizontal-swipe-to-navigate case inside the teleported dropdown. (It is — overscroll-behavior is decided per scroll container at gesture start, independent of where in the page the gesture originates.)
- Pinch-zoom in the dropdown still preventDefaults correctly.

Tested on macOS trackpad: slow vertical scroll now loads images progressively; fast scroll unchanged; pinch-zoom in dropdown does not zoom the page; horizontal swipe in dropdown does not navigate.

Related: this fixes the slow-scroll repro reported in #bug-dump. The blank-on-reopen class of bug from FE-535 (#11885) is a different issue.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12334-fix-form-dropdown-stop-cancelling-native-scroll-on-slow-trackpad-wheels-3656d73d3650813a987ffa8d6f0eaa9c) by [Unito](https://www.unito.io)
