### PR TITLE
Milesryan/asset star rating

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -13,6 +13,8 @@
           :selected="isSelected(item.asset.id)"
           :show-output-count="showOutputCount(item.asset)"
           :output-count="getOutputCount(item.asset)"
+          :rating="getRating(item.asset.id)"
+          @update:rating="handleRatingUpdate(item.asset.id, $event)"
           @click="emit('select-asset', item.asset)"
           @context-menu="emit('context-menu', $event, item.asset)"
           @zoom="emit('zoom', item.asset)"
@@ -24,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
@@ -46,6 +48,18 @@ const emit = defineEmits<{
 }>()
 
 type AssetGridItem = { key: string; asset: AssetItem }
+
+const ratingsByAssetId = ref<Record<string, number>>({})
+
+function getRating(assetId: string) {
+  return ratingsByAssetId.value[assetId] ?? 0
+}
+
+function handleRatingUpdate(assetId: string, rating: number | undefined) {
+  if (rating === undefined) return
+  ratingsByAssetId.value = { ...ratingsByAssetId.value, [assetId]: rating }
+  console.warn('[AssetsSidebarGridView] rating updated', { assetId, rating })
+}
 
 const assetItems = computed<AssetGridItem[]>(() =>
   assets.map((asset) => ({

--- a/src/components/sidebar/tabs/AssetsSidebarGridView.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarGridView.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="flex h-full flex-col">
-    <!-- Assets Grid -->
     <VirtualGrid
       class="flex-1"
       :items="assetItems"
@@ -13,8 +12,8 @@
           :selected="isSelected(item.asset.id)"
           :show-output-count="showOutputCount(item.asset)"
           :output-count="getOutputCount(item.asset)"
-          :rating="getRating(item.asset.id)"
-          @update:rating="handleRatingUpdate(item.asset.id, $event)"
+          :rating="getAssetRating(item.asset)"
+          @update:rating="handleRatingUpdate(item.asset, $event)"
           @click="emit('select-asset', item.asset)"
           @context-menu="emit('context-menu', $event, item.asset)"
           @zoom="emit('zoom', item.asset)"
@@ -26,11 +25,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import VirtualGrid from '@/components/common/VirtualGrid.vue'
 import MediaAssetCard from '@/platform/assets/components/MediaAssetCard.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { getAssetRating } from '@/platform/assets/utils/assetMetadataUtils'
+import { useAssetsStore } from '@/stores/assetsStore'
 
 const { assets, isSelected, showOutputCount, getOutputCount } = defineProps<{
   assets: AssetItem[]
@@ -45,21 +46,15 @@ const emit = defineEmits<{
   (e: 'approach-end'): void
   (e: 'zoom', asset: AssetItem): void
   (e: 'output-count-click', asset: AssetItem): void
+  (
+    e: 'asset-metadata-updated',
+    payload: { assetId: string; user_metadata: Record<string, unknown> }
+  ): void
 }>()
 
+const assetsStore = useAssetsStore()
+
 type AssetGridItem = { key: string; asset: AssetItem }
-
-const ratingsByAssetId = ref<Record<string, number>>({})
-
-function getRating(assetId: string) {
-  return ratingsByAssetId.value[assetId] ?? 0
-}
-
-function handleRatingUpdate(assetId: string, rating: number | undefined) {
-  if (rating === undefined) return
-  ratingsByAssetId.value = { ...ratingsByAssetId.value, [assetId]: rating }
-  console.warn('[AssetsSidebarGridView] rating updated', { assetId, rating })
-}
 
 const assetItems = computed<AssetGridItem[]>(() =>
   assets.map((asset) => ({
@@ -73,5 +68,22 @@ const gridStyle = {
   gridTemplateColumns: 'repeat(auto-fill, minmax(min(200px, 30vw), 1fr))',
   padding: '0 0.5rem',
   gap: '0.5rem'
+}
+
+async function handleRatingUpdate(
+  asset: AssetItem,
+  rating: number | undefined
+) {
+  if (rating === undefined) return
+
+  const savedMetadata = await assetsStore.updateMediaAssetUserMetadata(asset, {
+    rating
+  })
+  if (!savedMetadata) return
+
+  emit('asset-metadata-updated', {
+    assetId: asset.id,
+    user_metadata: savedMetadata
+  })
 }
 </script>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -111,6 +111,7 @@
           @approach-end="handleApproachEnd"
           @zoom="handleZoomClick"
           @output-count-click="enterFolderView"
+          @asset-metadata-updated="handleAssetMetadataUpdated"
         />
       </div>
     </template>
@@ -510,6 +511,21 @@ function handleAssetSelect(asset: AssetItem, assets?: AssetItem[]) {
   const index = assetList.findIndex((a) => a.id === asset.id)
   emit('assetSelected', asset)
   handleAssetClick(asset, index, assetList)
+}
+
+function handleAssetMetadataUpdated(payload: {
+  assetId: string
+  user_metadata: Record<string, unknown>
+}) {
+  if (!isInFolderView.value) return
+
+  const idx = folderAssets.value.findIndex((a) => a.id === payload.assetId)
+  if (idx < 0) return
+
+  folderAssets.value[idx] = {
+    ...folderAssets.value[idx],
+    user_metadata: payload.user_metadata
+  }
 }
 
 const { start: scheduleCleanup, stop: cancelCleanup } = useTimeoutFn(

--- a/src/components/ui/star-rating/StarRating.stories.ts
+++ b/src/components/ui/star-rating/StarRating.stories.ts
@@ -1,0 +1,113 @@
+import type {
+  ComponentPropsAndSlots,
+  Meta,
+  StoryObj
+} from '@storybook/vue3-vite'
+import { ref, toRefs } from 'vue'
+
+import StarRating from './StarRating.vue'
+
+type StoryArgs = ComponentPropsAndSlots<typeof StarRating>
+
+const meta: Meta<StoryArgs> = {
+  title: 'Components/StarRating',
+  component: StarRating,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    showCount: { control: 'boolean' },
+    max: { control: 'number' }
+  },
+  args: {
+    disabled: false,
+    readonly: false,
+    showCount: false,
+    max: 5
+  },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: '<div class="w-fit"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { StarRating },
+    setup() {
+      const { disabled, readonly, showCount, max } = toRefs(args)
+      const value = ref(0)
+      return { value, disabled, readonly, showCount, max }
+    },
+    template:
+      '<StarRating v-model="value" :disabled :readonly :show-count :max />'
+  })
+}
+
+export const WithCount: Story = {
+  args: { showCount: true },
+  render: (args) => ({
+    components: { StarRating },
+    setup() {
+      const { disabled, readonly, showCount, max } = toRefs(args)
+      const value = ref(3)
+      return { value, disabled, readonly, showCount, max }
+    },
+    template:
+      '<StarRating v-model="value" :disabled :readonly :show-count :max />'
+  })
+}
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: (args) => ({
+    components: { StarRating },
+    setup() {
+      const { disabled, readonly, max } = toRefs(args)
+      const value = ref(3)
+      return { value, disabled, readonly, max }
+    },
+    template: '<StarRating v-model="value" :disabled :readonly :max />'
+  })
+}
+
+export const Readonly: Story = {
+  args: { readonly: true },
+  render: (args) => ({
+    components: { StarRating },
+    setup() {
+      const { disabled, readonly, max } = toRefs(args)
+      const value = ref(3)
+      return { value, disabled, readonly, max }
+    },
+    template: '<StarRating v-model="value" :disabled :readonly :max />'
+  })
+}
+
+export const ThreeStars: Story = {
+  render: () => ({
+    components: { StarRating },
+    setup() {
+      const value = ref(3)
+      return { value }
+    },
+    template: '<StarRating v-model="value" />'
+  })
+}
+
+export const FiveStars: Story = {
+  render: () => ({
+    components: { StarRating },
+    setup() {
+      const value = ref(5)
+      return { value }
+    },
+    template: '<StarRating v-model="value" />'
+  })
+}

--- a/src/components/ui/star-rating/StarRating.stories.ts
+++ b/src/components/ui/star-rating/StarRating.stories.ts
@@ -6,6 +6,7 @@ import type {
 import { ref, toRefs } from 'vue'
 
 import StarRating from './StarRating.vue'
+import { provideStarRatingHost } from './starRatingHost'
 
 type StoryArgs = ComponentPropsAndSlots<typeof StarRating>
 
@@ -110,4 +111,36 @@ export const FiveStars: Story = {
     },
     template: '<StarRating v-model="value" />'
   })
+}
+
+export const OverlayHostHover: Story = {
+  render: () => ({
+    components: { StarRating },
+    setup() {
+      const value = ref(0)
+      const hostRef = ref<HTMLElement>()
+      provideStarRatingHost(hostRef)
+      return { value, hostRef }
+    },
+    template: `
+      <div
+        ref="hostRef"
+        class="relative size-64 rounded-lg bg-modal-card-placeholder-background"
+      >
+        <StarRating
+          v-model="value"
+          presentation="overlay"
+          class="absolute right-2 bottom-2"
+        />
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Overlay on a hoverable host: stars appear at 60% when the host is hovered (unrated); hover stars to rate at full opacity. Set a rating to keep stars visible.'
+      }
+    }
+  }
 }

--- a/src/components/ui/star-rating/StarRating.test.ts
+++ b/src/components/ui/star-rating/StarRating.test.ts
@@ -1,0 +1,201 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import StarRating from './StarRating.vue'
+import {
+  clampRating,
+  getDisplayRating,
+  getRatingFromDigitKey,
+  getRatingFromStarClick,
+  isStarFilled
+} from './starRating'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      starRating: {
+        groupLabel: 'Star rating',
+        rateStars: 'Rate {count} star | Rate {count} stars'
+      }
+    }
+  }
+})
+
+async function flush() {
+  await nextTick()
+  await nextTick()
+}
+
+function renderStarRating(props: Record<string, unknown> = {}) {
+  return render(StarRating, {
+    props: { modelValue: 0, ...props },
+    global: { plugins: [i18n] }
+  })
+}
+
+function getStarButtons() {
+  return screen.getAllByRole('button')
+}
+
+function filledStarCount(container: HTMLElement) {
+  return container.querySelectorAll('.text-warning-background').length
+}
+
+describe('starRating helpers', () => {
+  it('clamps rating to 0 through max', () => {
+    expect(clampRating(-1, 5)).toBe(0)
+    expect(clampRating(3.7, 5)).toBe(4)
+    expect(clampRating(9, 5)).toBe(5)
+  })
+
+  it('uses hover rating for display when hovering', () => {
+    expect(getDisplayRating(1, 4)).toBe(4)
+    expect(getDisplayRating(1, null)).toBe(1)
+  })
+
+  it('toggles off when clicking the current star', () => {
+    expect(getRatingFromStarClick(3, 3)).toBe(0)
+    expect(getRatingFromStarClick(2, 4)).toBe(4)
+  })
+
+  it('maps digit keys to ratings', () => {
+    expect(getRatingFromDigitKey('0', 5)).toBe(0)
+    expect(getRatingFromDigitKey('4', 5)).toBe(4)
+    expect(getRatingFromDigitKey('6', 5)).toBeNull()
+    expect(getRatingFromDigitKey('a', 5)).toBeNull()
+  })
+
+  it('fills stars up to the display rating', () => {
+    expect(isStarFilled(1, 3)).toBe(true)
+    expect(isStarFilled(4, 3)).toBe(false)
+  })
+})
+
+describe('StarRating', () => {
+  it('sets rating when a star is clicked', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({ modelValue: 0, 'onUpdate:modelValue': onUpdate })
+    await flush()
+
+    await user.click(getStarButtons()[2])
+
+    expect(onUpdate).toHaveBeenCalledWith(3)
+  })
+
+  it('clears rating when the active star is clicked again', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({ modelValue: 3, 'onUpdate:modelValue': onUpdate })
+    await flush()
+
+    await user.click(getStarButtons()[2])
+
+    expect(onUpdate).toHaveBeenCalledWith(0)
+  })
+
+  it('sets rating from digit keys when focused', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({ modelValue: 0, 'onUpdate:modelValue': onUpdate })
+    await flush()
+
+    screen.getByRole('group').focus()
+    await user.keyboard('4')
+
+    expect(onUpdate).toHaveBeenCalledWith(4)
+  })
+
+  it('clears rating when 0 is pressed', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({ modelValue: 2, 'onUpdate:modelValue': onUpdate })
+    await flush()
+
+    screen.getByRole('group').focus()
+    await user.keyboard('0')
+
+    expect(onUpdate).toHaveBeenCalledWith(0)
+  })
+
+  it('does not update when disabled', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({
+      modelValue: 0,
+      disabled: true,
+      'onUpdate:modelValue': onUpdate
+    })
+    await flush()
+
+    await user.click(getStarButtons()[2])
+
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does not update when readonly', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({
+      modelValue: 0,
+      readonly: true,
+      'onUpdate:modelValue': onUpdate
+    })
+    await flush()
+
+    await user.click(getStarButtons()[2])
+
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('shows numeric count when showCount is enabled', async () => {
+    renderStarRating({ modelValue: 3, showCount: true })
+    await flush()
+
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('hides numeric count when showCount is disabled', async () => {
+    renderStarRating({ modelValue: 3, showCount: false })
+    await flush()
+
+    expect(screen.queryByText('3')).not.toBeInTheDocument()
+  })
+
+  it('previews hover fill without committing the rating', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    renderStarRating({
+      modelValue: 1,
+      'onUpdate:modelValue': onUpdate
+    })
+    await flush()
+
+    const group = screen.getByRole('group')
+
+    expect(filledStarCount(group)).toBe(1)
+
+    await user.hover(getStarButtons()[3])
+    await flush()
+
+    expect(filledStarCount(group)).toBe(4)
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    await user.unhover(group)
+    await flush()
+
+    expect(filledStarCount(group)).toBe(1)
+  })
+})

--- a/src/components/ui/star-rating/StarRating.test.ts
+++ b/src/components/ui/star-rating/StarRating.test.ts
@@ -7,11 +7,14 @@ import { createI18n } from 'vue-i18n'
 import StarRating from './StarRating.vue'
 import {
   clampRating,
+  getDefaultRevealForPresentation,
   getDisplayRating,
   getRatingFromDigitKey,
   getRatingFromStarClick,
+  getStarRatingRevealState,
   isStarFilled
 } from './starRating'
+import StarRatingHostHarness from './StarRatingHostHarness.vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -73,6 +76,95 @@ describe('starRating helpers', () => {
   it('fills stars up to the display rating', () => {
     expect(isStarFilled(1, 3)).toBe(true)
     expect(isStarFilled(4, 3)).toBe(false)
+  })
+
+  it('defaults reveal from presentation', () => {
+    expect(getDefaultRevealForPresentation('inline')).toBe('always')
+    expect(getDefaultRevealForPresentation('overlay')).toBe('host-hover')
+  })
+})
+
+describe('getStarRatingRevealState', () => {
+  it('is always visible and interactive when reveal is always', () => {
+    expect(
+      getStarRatingRevealState({
+        reveal: 'always',
+        hostHovered: false,
+        selfHovered: false,
+        rating: 0,
+        disabled: false,
+        explicitlyReadonly: false
+      })
+    ).toEqual({
+      visible: true,
+      opacityClass: 'opacity-100',
+      pointerEventsClass: 'pointer-events-auto',
+      effectivelyReadonly: false
+    })
+  })
+
+  it('is hidden when unrated and host is not hovered', () => {
+    expect(
+      getStarRatingRevealState({
+        reveal: 'host-hover',
+        hostHovered: false,
+        selfHovered: false,
+        rating: 0,
+        disabled: false,
+        explicitlyReadonly: false
+      }).visible
+    ).toBe(false)
+  })
+
+  it('is dimmed and readonly when unrated and host is hovered', () => {
+    expect(
+      getStarRatingRevealState({
+        reveal: 'host-hover',
+        hostHovered: true,
+        selfHovered: false,
+        rating: 0,
+        disabled: false,
+        explicitlyReadonly: false
+      })
+    ).toMatchObject({
+      visible: true,
+      opacityClass: 'opacity-60',
+      effectivelyReadonly: true
+    })
+  })
+
+  it('is interactive when stars are hovered on host-hover reveal', () => {
+    expect(
+      getStarRatingRevealState({
+        reveal: 'host-hover',
+        hostHovered: true,
+        selfHovered: true,
+        rating: 0,
+        disabled: false,
+        explicitlyReadonly: false
+      })
+    ).toMatchObject({
+      visible: true,
+      opacityClass: 'opacity-100',
+      effectivelyReadonly: false
+    })
+  })
+
+  it('stays visible when rated even if host is not hovered', () => {
+    expect(
+      getStarRatingRevealState({
+        reveal: 'host-hover',
+        hostHovered: false,
+        selfHovered: false,
+        rating: 3,
+        disabled: false,
+        explicitlyReadonly: false
+      })
+    ).toMatchObject({
+      visible: true,
+      opacityClass: 'opacity-100',
+      effectivelyReadonly: true
+    })
   })
 })
 
@@ -197,5 +289,35 @@ describe('StarRating', () => {
     await flush()
 
     expect(filledStarCount(group)).toBe(1)
+  })
+
+  it('is readonly on host-hover until the star group is hovered', async () => {
+    const user = userEvent.setup()
+    const onUpdate = vi.fn()
+
+    render(StarRatingHostHarness, {
+      props: {
+        modelValue: 0,
+        'onUpdate:modelValue': onUpdate
+      },
+      global: { plugins: [i18n] }
+    })
+    await flush()
+
+    const host = screen.getByTestId('star-rating-host')
+    const starButtons = () => screen.getAllByRole('button')
+
+    await user.hover(host)
+    await flush()
+
+    expect(starButtons()[0]).toBeDisabled()
+
+    await user.hover(screen.getByRole('group'))
+    await flush()
+
+    expect(starButtons()[0]).not.toBeDisabled()
+
+    await user.click(starButtons()[2])
+    expect(onUpdate).toHaveBeenCalledWith(3)
   })
 })

--- a/src/components/ui/star-rating/StarRating.vue
+++ b/src/components/ui/star-rating/StarRating.vue
@@ -1,38 +1,79 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
-import { computed, ref } from 'vue'
-import type { HTMLAttributes } from 'vue'
+import { useElementHover } from '@vueuse/core'
+import { computed, ref, toValue } from 'vue'
+import type { HTMLAttributes, Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
   clampRating,
+  getDefaultRevealForPresentation,
   getDisplayRating,
   getRatingFromDigitKey,
   getRatingFromStarClick,
+  getStarRatingRevealState,
   isStarFilled
 } from './starRating'
+import type { StarRatingReveal } from './starRating'
+import { useStarRatingHost } from './starRatingHost'
 
 const modelValue = defineModel<number>({ default: 0 })
 
 const {
   disabled = false,
-  readonly = false,
+  readonly: explicitlyReadonly = false,
   showCount = false,
   max = 5,
+  presentation = 'inline',
+  reveal: revealProp,
+  hostRef: hostRefProp,
   class: className
 } = defineProps<{
   disabled?: boolean
   readonly?: boolean
   showCount?: boolean
   max?: number
+  presentation?: 'inline' | 'overlay'
+  reveal?: StarRatingReveal
+  hostRef?: Ref<HTMLElement | undefined>
   class?: HTMLAttributes['class']
 }>()
 
 const { t } = useI18n()
 
+const rootRef = ref<HTMLElement>()
 const hoverRating = ref<number | null>(null)
 
-const isInteractive = computed(() => !disabled && !readonly)
+const effectiveReveal = computed(
+  () => revealProp ?? getDefaultRevealForPresentation(presentation)
+)
+
+const injectedHostRef = useStarRatingHost()
+
+const isSelfHovered = useElementHover(rootRef)
+const isHostHovered = useElementHover(
+  computed(() => {
+    if (effectiveReveal.value !== 'host-hover') return null
+    return toValue(hostRefProp ?? injectedHostRef) ?? null
+  })
+)
+
+const revealState = computed(() =>
+  getStarRatingRevealState({
+    reveal: effectiveReveal.value,
+    hostHovered: isHostHovered.value,
+    selfHovered: isSelfHovered.value,
+    rating: modelValue.value,
+    disabled,
+    explicitlyReadonly
+  })
+)
+
+const effectivelyReadonly = computed(
+  () => revealState.value.effectivelyReadonly
+)
+
+const isInteractive = computed(() => !disabled && !effectivelyReadonly.value)
 
 const starIndices = computed(() =>
   Array.from({ length: max }, (_, index) => index + 1)
@@ -87,10 +128,16 @@ function handleKeydown(event: KeyboardEvent) {
 function starAriaLabel(starIndex: number) {
   return t('starRating.rateStars', { count: starIndex })
 }
+
+function handleRootClick(event: MouseEvent) {
+  if (presentation === 'overlay') event.stopPropagation()
+}
 </script>
 
 <template>
   <div
+    v-show="revealState.visible"
+    ref="rootRef"
     role="group"
     :aria-label="t('starRating.groupLabel')"
     :aria-valuenow="modelValue"
@@ -99,14 +146,16 @@ function starAriaLabel(starIndex: number) {
     :tabindex="groupTabIndex"
     :class="
       cn(
-        'inline-flex items-center',
+        'inline-flex items-center transition-opacity duration-150 ease-out',
         showCount && 'gap-2',
-        isInteractive &&
-          'opacity-60 transition-opacity duration-150 ease-out hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none',
+        revealState.opacityClass,
+        revealState.pointerEventsClass,
+        isInteractive && 'focus-visible:outline-none',
         disabled && 'opacity-50',
         className
       )
     "
+    @click="handleRootClick"
     @pointerleave="handleGroupPointerLeave"
     @keydown="handleKeydown"
   >

--- a/src/components/ui/star-rating/StarRating.vue
+++ b/src/components/ui/star-rating/StarRating.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { computed, ref } from 'vue'
+import type { HTMLAttributes } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import {
+  clampRating,
+  getDisplayRating,
+  getRatingFromDigitKey,
+  getRatingFromStarClick,
+  isStarFilled
+} from './starRating'
+
+const modelValue = defineModel<number>({ default: 0 })
+
+const {
+  disabled = false,
+  readonly = false,
+  showCount = false,
+  max = 5,
+  class: className
+} = defineProps<{
+  disabled?: boolean
+  readonly?: boolean
+  showCount?: boolean
+  max?: number
+  class?: HTMLAttributes['class']
+}>()
+
+const { t } = useI18n()
+
+const hoverRating = ref<number | null>(null)
+
+const isInteractive = computed(() => !disabled && !readonly)
+
+const starIndices = computed(() =>
+  Array.from({ length: max }, (_, index) => index + 1)
+)
+
+const displayRating = computed(() =>
+  getDisplayRating(modelValue.value, hoverRating.value)
+)
+
+const groupTabIndex = computed(() => (isInteractive.value ? 0 : undefined))
+
+function commitRating(next: number) {
+  if (!isInteractive.value) return
+  modelValue.value = clampRating(next, max)
+}
+
+function handleStarClick(starIndex: number) {
+  commitRating(getRatingFromStarClick(modelValue.value, starIndex))
+}
+
+function handleStarPointerEnter(starIndex: number) {
+  if (!isInteractive.value) return
+  hoverRating.value = starIndex
+}
+
+function handleGroupPointerLeave() {
+  hoverRating.value = null
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (!isInteractive.value) return
+
+  const digitRating = getRatingFromDigitKey(event.key, max)
+  if (digitRating !== null) {
+    event.preventDefault()
+    commitRating(digitRating)
+    return
+  }
+
+  if (event.key === 'ArrowLeft') {
+    event.preventDefault()
+    commitRating(modelValue.value - 1)
+    return
+  }
+
+  if (event.key === 'ArrowRight') {
+    event.preventDefault()
+    commitRating(modelValue.value + 1)
+  }
+}
+
+function starAriaLabel(starIndex: number) {
+  return t('starRating.rateStars', { count: starIndex })
+}
+</script>
+
+<template>
+  <div
+    role="group"
+    :aria-label="t('starRating.groupLabel')"
+    :aria-valuenow="modelValue"
+    :aria-valuemin="0"
+    :aria-valuemax="max"
+    :tabindex="groupTabIndex"
+    :class="
+      cn(
+        'inline-flex items-center',
+        showCount && 'gap-2',
+        isInteractive &&
+          'opacity-60 transition-opacity duration-150 ease-out hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none',
+        disabled && 'opacity-50',
+        className
+      )
+    "
+    @pointerleave="handleGroupPointerLeave"
+    @keydown="handleKeydown"
+  >
+    <div class="inline-flex items-center gap-px">
+      <button
+        v-for="starIndex in starIndices"
+        :key="starIndex"
+        type="button"
+        :disabled="!isInteractive"
+        :tabindex="isInteractive ? -1 : undefined"
+        :aria-label="starAriaLabel(starIndex)"
+        :class="
+          cn(
+            'inline-flex appearance-none items-center justify-center border-0 bg-transparent p-0 shadow-none outline-none',
+            isInteractive && 'cursor-pointer',
+            !isInteractive && 'cursor-default'
+          )
+        "
+        @click="handleStarClick(starIndex)"
+        @pointerenter="handleStarPointerEnter(starIndex)"
+      >
+        <i
+          :class="
+            cn(
+              'size-4',
+              isStarFilled(starIndex, displayRating)
+                ? 'icon-[ph--star-fill] text-warning-background'
+                : 'icon-[lucide--star] text-muted-foreground'
+            )
+          "
+        />
+      </button>
+    </div>
+    <span
+      v-if="showCount"
+      aria-hidden="true"
+      class="min-w-3 text-sm text-muted-foreground tabular-nums"
+    >
+      {{ displayRating }}
+    </span>
+  </div>
+</template>

--- a/src/components/ui/star-rating/StarRatingHostHarness.vue
+++ b/src/components/ui/star-rating/StarRatingHostHarness.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import StarRating from './StarRating.vue'
+import { provideStarRatingHost } from './starRatingHost'
+
+const modelValue = defineModel<number>({ default: 0 })
+
+const hostRef = ref<HTMLElement>()
+provideStarRatingHost(hostRef)
+</script>
+
+<template>
+  <div
+    ref="hostRef"
+    data-testid="star-rating-host"
+    class="size-48 rounded-lg bg-modal-card-placeholder-background p-4"
+  >
+    <StarRating v-model="modelValue" presentation="overlay" />
+  </div>
+</template>

--- a/src/components/ui/star-rating/starRating.ts
+++ b/src/components/ui/star-rating/starRating.ts
@@ -29,3 +29,91 @@ export function getRatingFromDigitKey(key: string, max: number): number | null {
   if (Number.isNaN(digit) || digit < 1 || digit > max) return null
   return digit
 }
+
+export type StarRatingReveal = 'always' | 'host-hover'
+
+export type StarRatingRevealState = {
+  visible: boolean
+  opacityClass: string
+  pointerEventsClass: string
+  effectivelyReadonly: boolean
+}
+
+export function getStarRatingRevealState(input: {
+  reveal: StarRatingReveal
+  hostHovered: boolean
+  selfHovered: boolean
+  rating: number
+  disabled: boolean
+  explicitlyReadonly: boolean
+}): StarRatingRevealState {
+  const {
+    reveal,
+    hostHovered,
+    selfHovered,
+    rating,
+    disabled,
+    explicitlyReadonly
+  } = input
+
+  if (reveal === 'always') {
+    return {
+      visible: true,
+      opacityClass: 'opacity-100',
+      pointerEventsClass: 'pointer-events-auto',
+      effectivelyReadonly: explicitlyReadonly
+    }
+  }
+
+  const isRated = rating > 0
+  const visible = isRated || hostHovered
+
+  if (!visible) {
+    return {
+      visible: false,
+      opacityClass: 'opacity-0',
+      pointerEventsClass: 'pointer-events-none',
+      effectivelyReadonly: true
+    }
+  }
+
+  if (disabled) {
+    return {
+      visible: true,
+      opacityClass: 'opacity-100',
+      pointerEventsClass: 'pointer-events-none',
+      effectivelyReadonly: true
+    }
+  }
+
+  if (selfHovered && !explicitlyReadonly) {
+    return {
+      visible: true,
+      opacityClass: 'opacity-100',
+      pointerEventsClass: 'pointer-events-auto',
+      effectivelyReadonly: false
+    }
+  }
+
+  if (!isRated && hostHovered) {
+    return {
+      visible: true,
+      opacityClass: 'opacity-60',
+      pointerEventsClass: 'pointer-events-auto',
+      effectivelyReadonly: true
+    }
+  }
+
+  return {
+    visible: true,
+    opacityClass: 'opacity-100',
+    pointerEventsClass: 'pointer-events-auto',
+    effectivelyReadonly: true
+  }
+}
+
+export function getDefaultRevealForPresentation(
+  presentation: 'inline' | 'overlay'
+): StarRatingReveal {
+  return presentation === 'overlay' ? 'host-hover' : 'always'
+}

--- a/src/components/ui/star-rating/starRating.ts
+++ b/src/components/ui/star-rating/starRating.ts
@@ -1,0 +1,31 @@
+export function clampRating(value: number, max: number): number {
+  return Math.min(Math.max(0, Math.round(value)), max)
+}
+
+export function getDisplayRating(
+  committed: number,
+  hover: number | null
+): number {
+  return hover ?? committed
+}
+
+export function getRatingFromStarClick(
+  committed: number,
+  clicked: number
+): number {
+  return committed === clicked ? 0 : clicked
+}
+
+export function isStarFilled(
+  starIndex: number,
+  displayRating: number
+): boolean {
+  return starIndex <= displayRating
+}
+
+export function getRatingFromDigitKey(key: string, max: number): number | null {
+  if (key === '0') return 0
+  const digit = Number.parseInt(key, 10)
+  if (Number.isNaN(digit) || digit < 1 || digit > max) return null
+  return digit
+}

--- a/src/components/ui/star-rating/starRating.ts
+++ b/src/components/ui/star-rating/starRating.ts
@@ -32,7 +32,7 @@ export function getRatingFromDigitKey(key: string, max: number): number | null {
 
 export type StarRatingReveal = 'always' | 'host-hover'
 
-export type StarRatingRevealState = {
+type StarRatingRevealState = {
   visible: boolean
   opacityClass: string
   pointerEventsClass: string

--- a/src/components/ui/star-rating/starRatingHost.ts
+++ b/src/components/ui/star-rating/starRatingHost.ts
@@ -1,0 +1,13 @@
+import type { InjectionKey, Ref } from 'vue'
+import { inject, provide } from 'vue'
+
+export const starRatingHostKey: InjectionKey<Ref<HTMLElement | undefined>> =
+  Symbol('starRatingHost')
+
+export function provideStarRatingHost(hostRef: Ref<HTMLElement | undefined>) {
+  provide(starRatingHostKey, hostRef)
+}
+
+export function useStarRatingHost() {
+  return inject(starRatingHostKey, undefined)
+}

--- a/src/components/ui/star-rating/starRatingHost.ts
+++ b/src/components/ui/star-rating/starRatingHost.ts
@@ -1,7 +1,7 @@
 import type { InjectionKey, Ref } from 'vue'
 import { inject, provide } from 'vue'
 
-export const starRatingHostKey: InjectionKey<Ref<HTMLElement | undefined>> =
+const starRatingHostKey: InjectionKey<Ref<HTMLElement | undefined>> =
   Symbol('starRatingHost')
 
 export function provideStarRatingHost(hostRef: Ref<HTMLElement | undefined>) {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -564,6 +564,10 @@
     "hue": "Hue",
     "alpha": "Alpha"
   },
+  "starRating": {
+    "groupLabel": "Star rating",
+    "rateStars": "Rate {count} star | Rate {count} stars"
+  },
   "contextMenu": {
     "Inputs": "Inputs",
     "Outputs": "Outputs",

--- a/src/platform/assets/components/MediaAssetCard.stories.ts
+++ b/src/platform/assets/components/MediaAssetCard.stories.ts
@@ -108,8 +108,47 @@ export const WithStarRating: Story = {
     docs: {
       description: {
         story:
-          'Image asset card with star rating overlaid on the bottom-right of the preview.'
+          'Rated image asset: stars stay visible at full opacity. Hover the stars to edit.'
       }
+    }
+  }
+}
+
+export const WithStarRatingUnrated: Story = {
+  decorators: [
+    () => ({
+      template: '<div style="max-width: 280px;"><story /></div>'
+    })
+  ],
+  render: () => ({
+    components: { MediaAssetCard },
+    setup() {
+      const rating = ref(0)
+      return { rating, asset: sampleAsset }
+    },
+    template: '<MediaAssetCard :asset="asset" v-model:rating="rating" />'
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Unrated image asset: stars appear at 60% opacity on card hover; hover stars to rate at full opacity.'
+      }
+    }
+  }
+}
+
+const videoSampleAsset: AssetItem = {
+  ...sampleAsset,
+  id: 'asset-2',
+  name: 'Big_Buck_Bunny.mp4',
+  size: 10485760,
+  preview_url: SAMPLE_MEDIA.videoThumbnail,
+  user_metadata: {
+    duration: 13425,
+    dimensions: {
+      width: 1280,
+      height: 720
     }
   }
 }
@@ -120,19 +159,19 @@ export const VideoAsset: Story = {
       template: '<div style="max-width: 280px;"><story /></div>'
     })
   ],
-  args: {
-    asset: {
-      ...sampleAsset,
-      id: 'asset-2',
-      name: 'Big_Buck_Bunny.mp4',
-      size: 10485760,
-      preview_url: SAMPLE_MEDIA.videoThumbnail,
-      user_metadata: {
-        duration: 13425,
-        dimensions: {
-          width: 1280,
-          height: 720
-        }
+  render: () => ({
+    components: { MediaAssetCard },
+    setup() {
+      const rating = ref(4)
+      return { rating, asset: videoSampleAsset }
+    },
+    template: '<MediaAssetCard :asset="asset" v-model:rating="rating" />'
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Video assets do not show star rating, even when a rating value is bound.'
       }
     }
   }
@@ -304,6 +343,23 @@ export const GridLayout: Story = {
   render: () => ({
     components: { MediaAssetCard },
     setup() {
+      const ratingsByAssetId = ref<Record<string, number>>({
+        'grid-1': 3,
+        'grid-2': 0
+      })
+
+      function getRating(assetId: string) {
+        return ratingsByAssetId.value[assetId] ?? 0
+      }
+
+      function setRating(assetId: string, rating: number | undefined) {
+        if (rating === undefined) return
+        ratingsByAssetId.value = {
+          ...ratingsByAssetId.value,
+          [assetId]: rating
+        }
+      }
+
       const assets: AssetItem[] = [
         {
           id: 'grid-1',
@@ -389,7 +445,7 @@ export const GridLayout: Story = {
           }
         }
       ]
-      return { assets }
+      return { assets, getRating, setRating }
     },
     template: `
       <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 16px; padding: 16px;">
@@ -397,6 +453,8 @@ export const GridLayout: Story = {
           v-for="asset in assets"
           :key="asset.id"
           :asset="asset"
+          :rating="getRating(asset.id)"
+          @update:rating="setRating(asset.id, $event)"
         />
       </div>
     `

--- a/src/platform/assets/components/MediaAssetCard.stories.ts
+++ b/src/platform/assets/components/MediaAssetCard.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
 
 import MediaLightbox from '@/components/sidebar/tabs/queue/MediaLightbox.vue'
 import { getMediaTypeFromFilename } from '@/utils/formatUtil'
@@ -86,6 +87,30 @@ export const ImageAsset: Story = {
   args: {
     asset: sampleAsset,
     loading: false
+  }
+}
+
+export const WithStarRating: Story = {
+  decorators: [
+    () => ({
+      template: '<div style="max-width: 280px;"><story /></div>'
+    })
+  ],
+  render: () => ({
+    components: { MediaAssetCard },
+    setup() {
+      const rating = ref(4)
+      return { rating, asset: sampleAsset }
+    },
+    template: '<MediaAssetCard :asset="asset" v-model:rating="rating" />'
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Image asset card with star rating overlaid on the bottom-right of the preview.'
+      }
+    }
   }
 }
 

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -54,6 +54,14 @@
         <i class="icon-[lucide--trash-2] size-5" />
       </LoadingOverlay>
 
+      <div
+        v-if="!loading && rating !== undefined"
+        class="absolute right-2 bottom-2 z-10 flex justify-end"
+        @click.stop
+      >
+        <StarRating v-model="rating" readonly />
+      </div>
+
       <!-- Action buttons overlay (top-left) -->
       <div
         v-if="showActionsOverlay"
@@ -143,6 +151,7 @@ import { computed, defineAsyncComponent, provide, ref, toRef } from 'vue'
 import IconGroup from '@/components/button/IconGroup.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import Button from '@/components/ui/button/Button.vue'
+import StarRating from '@/components/ui/star-rating/StarRating.vue'
 import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import { isCloud } from '@/platform/distribution/types'
 import { useAssetsStore } from '@/stores/assetsStore'
@@ -179,6 +188,8 @@ const mediaComponents = {
 function getTopComponent(kind: PreviewKind) {
   return mediaComponents.top[kind] || mediaComponents.top.other
 }
+
+const rating = defineModel<number | undefined>('rating')
 
 const { asset, loading, selected, showOutputCount, outputCount } = defineProps<{
   asset?: AssetItem

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -145,7 +145,7 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import { useElementHover } from '@vueuse/core'
-import { computed, defineAsyncComponent, provide, ref, toRef, watch } from 'vue'
+import { computed, defineAsyncComponent, provide, ref, toRef } from 'vue'
 
 import IconGroup from '@/components/button/IconGroup.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
@@ -238,14 +238,6 @@ const fileKind = computed((): MediaKind => {
 })
 
 const supportsStarRating = computed(() => fileKind.value !== 'video')
-
-watch(rating, (value, oldValue) => {
-  if (value === oldValue || !asset) return
-  console.warn('[MediaAssetCard] rating updated', {
-    assetId: asset.id,
-    rating: value
-  })
-})
 
 const previewKind = computed((): PreviewKind => {
   return getMediaTypeFromFilename(asset?.name || '')

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -54,13 +54,12 @@
         <i class="icon-[lucide--trash-2] size-5" />
       </LoadingOverlay>
 
-      <div
-        v-if="!loading && rating !== undefined"
+      <StarRating
+        v-if="!loading && supportsStarRating && rating !== undefined"
+        v-model="rating"
+        presentation="overlay"
         class="absolute right-2 bottom-2 z-10 flex justify-end"
-        @click.stop
-      >
-        <StarRating v-model="rating" readonly />
-      </div>
+      />
 
       <!-- Action buttons overlay (top-left) -->
       <div
@@ -146,12 +145,13 @@
 <script setup lang="ts">
 import { cn } from '@comfyorg/tailwind-utils'
 import { useElementHover } from '@vueuse/core'
-import { computed, defineAsyncComponent, provide, ref, toRef } from 'vue'
+import { computed, defineAsyncComponent, provide, ref, toRef, watch } from 'vue'
 
 import IconGroup from '@/components/button/IconGroup.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import Button from '@/components/ui/button/Button.vue'
 import StarRating from '@/components/ui/star-rating/StarRating.vue'
+import { provideStarRatingHost } from '@/components/ui/star-rating/starRatingHost'
 import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import { isCloud } from '@/platform/distribution/types'
 import { useAssetsStore } from '@/stores/assetsStore'
@@ -215,6 +215,8 @@ const emit = defineEmits<{
 
 const cardContainerRef = ref<HTMLElement>()
 
+provideStarRatingHost(cardContainerRef)
+
 const isVideoPlaying = ref(false)
 const showVideoControls = ref(false)
 
@@ -233,6 +235,16 @@ const assetType = computed(() => {
 // Determine file type from extension
 const fileKind = computed((): MediaKind => {
   return getMediaTypeFromFilename(asset?.name || '')
+})
+
+const supportsStarRating = computed(() => fileKind.value !== 'video')
+
+watch(rating, (value, oldValue) => {
+  if (value === oldValue || !asset) return
+  console.warn('[MediaAssetCard] rating updated', {
+    assetId: asset.id,
+    rating: value
+  })
 })
 
 const previewKind = computed((): PreviewKind => {

--- a/src/platform/assets/composables/media/assetMappers.ts
+++ b/src/platform/assets/composables/media/assetMappers.ts
@@ -2,8 +2,22 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { OutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataSchema'
 import type { AssetContext } from '@/platform/assets/schemas/mediaAssetSchema'
 import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
+import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { api } from '@/scripts/api'
 import type { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
+
+function getRecordUserMetadata(
+  value: unknown
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  return value as Record<string, unknown>
+}
+
+function getJobUserMetadata(job: JobListItem): Record<string, unknown> {
+  return getRecordUserMetadata(job.user_metadata) ?? {}
+}
 
 /**
  * Extract asset type from tags array
@@ -47,7 +61,10 @@ export function mapTaskOutputToAssetItem(
     tags: ['output'],
     thumbnail_url: output.previewUrl,
     preview_url: output.url,
-    user_metadata: metadata
+    user_metadata: {
+      ...getJobUserMetadata(taskItem.job),
+      ...metadata
+    }
   }
 }
 

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -113,7 +113,8 @@ const zAssetUserMetadata = z.object({
   name: z.string().optional(),
   base_model: z.array(z.string()).optional(),
   additional_tags: z.array(z.string()).optional(),
-  user_description: z.string().optional()
+  user_description: z.string().optional(),
+  rating: z.number().int().min(0).max(5).optional()
 })
 
 export type AssetUserMetadata = z.infer<typeof zAssetUserMetadata>

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -13,6 +13,7 @@ import {
   getAssetModelType,
   getAssetSourceUrl,
   getAssetTriggerPhrases,
+  getAssetRating,
   getAssetUserDescription,
   getSourceName
 } from '@/platform/assets/utils/assetMetadataUtils'
@@ -381,6 +382,36 @@ describe('assetMetadataUtils', () => {
         display_name: 'pretty.png'
       }
       expect(getAssetCardTitle(asset)).toBe('pretty.png')
+    })
+  })
+
+  describe('getAssetRating', () => {
+    it('returns the stored rating when it is a number', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { rating: 4 }
+      }
+      expect(getAssetRating(asset)).toBe(4)
+    })
+
+    it('returns 0 when rating is missing', () => {
+      expect(getAssetRating(mockAsset)).toBe(0)
+    })
+
+    it('returns 0 for invalid rating values', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { rating: 'four' }
+      }
+      expect(getAssetRating(asset)).toBe(0)
+    })
+
+    it('clamps ratings above the maximum', () => {
+      const asset = {
+        ...mockAsset,
+        user_metadata: { rating: 9 }
+      }
+      expect(getAssetRating(asset)).toBe(5)
     })
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -1,5 +1,8 @@
+import { clampRating } from '@/components/ui/star-rating/starRating'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { isCivitaiUrl } from '@/utils/formatUtil'
+
+const ASSET_RATING_MAX = 5
 
 /**
  * Type-safe utilities for extracting metadata from assets.
@@ -197,4 +200,15 @@ export function getAssetCardTitle(asset: AssetItem): string {
   const curatedName = getStringProperty(asset, 'name')
   if (curatedName && curatedName !== asset.name) return curatedName
   return getAssetDisplayFilename(asset)
+}
+
+/**
+ * Reads the user star rating from asset user_metadata.
+ * @param asset - The asset to read the rating from
+ * @returns Rating from 0 to 5, or 0 when absent or invalid
+ */
+export function getAssetRating(asset: AssetItem): number {
+  const rating = asset.user_metadata?.rating
+  if (typeof rating !== 'number' || Number.isNaN(rating)) return 0
+  return clampRating(rating, ASSET_RATING_MAX)
 }

--- a/src/platform/assets/utils/outputAssetUtil.ts
+++ b/src/platform/assets/utils/outputAssetUtil.ts
@@ -63,6 +63,24 @@ export function getOutputKey({
   return `${nodeId}-${subfolder}-${filename}`
 }
 
+function getOutputPersistedUserMetadata(
+  output: ResultItemImpl
+): Record<string, unknown> {
+  const metadata = getRecordUserMetadata(
+    (output as { user_metadata?: unknown }).user_metadata
+  )
+  return metadata ?? {}
+}
+
+function getRecordUserMetadata(
+  value: unknown
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  return value as Record<string, unknown>
+}
+
 function mapOutputsToAssetItems({
   jobId,
   outputs,
@@ -89,6 +107,7 @@ function mapOutputsToAssetItems({
       thumbnail_url: output.previewUrl,
       preview_url: output.url,
       user_metadata: {
+        ...getOutputPersistedUserMetadata(output),
         jobId,
         nodeId: output.nodeId,
         subfolder: output.subfolder,

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/scripts/api', () => ({
 vi.mock('@/platform/assets/services/assetService', () => ({
   assetService: {
     getAssetsByTag: vi.fn(),
+    getAssetsPageByTag: vi.fn(),
     getAllAssetsByTag: vi.fn(),
     getAssetsForNodeType: vi.fn(),
     invalidateInputAssetsIncludingPublic: vi.fn(),
@@ -1177,6 +1178,127 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       const cached = store.getAssets('CheckpointLoaderSimple')[0]
       expect(cached.user_metadata).toEqual({ note: 'before' })
       consoleSpy.mockRestore()
+    })
+  })
+
+  describe('updateMediaAssetUserMetadata', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('optimistically patches inputAssets and applies the server response', async () => {
+      const store = useAssetsStore()
+      const asset = {
+        id: 'input-1',
+        name: 'test.png',
+        size: 100,
+        tags: ['input'],
+        is_immutable: false,
+        user_metadata: { filename: 'test.png' }
+      }
+
+      vi.mocked(assetService.getAssetsByTag).mockResolvedValueOnce([asset])
+      mockIsCloud.value = true
+      await store.updateInputs()
+
+      const serverResponse = {
+        ...asset,
+        user_metadata: { filename: 'test.png', rating: 4 }
+      }
+      vi.mocked(assetService.updateAsset).mockResolvedValueOnce(serverResponse)
+
+      const promise = store.updateMediaAssetUserMetadata(asset, { rating: 4 })
+      expect(store.inputAssets[0].user_metadata?.rating).toBe(4)
+
+      await vi.advanceTimersByTimeAsync(400)
+      const result = await promise
+
+      expect(result).toEqual(serverResponse.user_metadata)
+      expect(store.inputAssets[0].user_metadata).toEqual(
+        serverResponse.user_metadata
+      )
+      expect(assetService.updateAsset).toHaveBeenCalledWith('input-1', {
+        user_metadata: { filename: 'test.png', rating: 4 }
+      })
+    })
+
+    it('rolls back inputAssets metadata when the server rejects', async () => {
+      const store = useAssetsStore()
+      const asset = {
+        id: 'input-2',
+        name: 'rollback.png',
+        size: 100,
+        tags: ['input'],
+        is_immutable: false,
+        user_metadata: { rating: 2 }
+      }
+
+      vi.mocked(assetService.getAssetsByTag).mockResolvedValueOnce([asset])
+      mockIsCloud.value = true
+      await store.updateInputs()
+
+      vi.mocked(assetService.updateAsset).mockRejectedValueOnce(
+        new Error('500 Internal Error')
+      )
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const promise = store.updateMediaAssetUserMetadata(asset, { rating: 5 })
+      expect(store.inputAssets[0].user_metadata?.rating).toBe(5)
+
+      await vi.advanceTimersByTimeAsync(400)
+      const result = await promise
+
+      expect(result).toBeNull()
+      expect(store.inputAssets[0].user_metadata?.rating).toBe(2)
+      consoleSpy.mockRestore()
+    })
+
+    it('skips explicitly immutable assets', async () => {
+      const store = useAssetsStore()
+      const asset = {
+        id: 'immutable-1',
+        name: 'locked.png',
+        size: 100,
+        tags: ['input'],
+        is_immutable: true,
+        user_metadata: { rating: 1 }
+      }
+
+      const result = await store.updateMediaAssetUserMetadata(asset, {
+        rating: 3
+      })
+
+      expect(result).toBeNull()
+      expect(assetService.updateAsset).not.toHaveBeenCalled()
+    })
+
+    it('persists when is_immutable is undefined (sidebar media assets)', async () => {
+      const store = useAssetsStore()
+      const asset = {
+        id: 'output-uuid',
+        name: 'output.png',
+        size: 100,
+        tags: ['output'],
+        user_metadata: { jobId: 'job-1' }
+      }
+
+      vi.mocked(assetService.updateAsset).mockResolvedValueOnce({
+        ...asset,
+        user_metadata: { jobId: 'job-1', rating: 4 }
+      })
+
+      const promise = store.updateMediaAssetUserMetadata(asset, { rating: 4 })
+      await vi.advanceTimersByTimeAsync(400)
+      const result = await promise
+
+      expect(result).toEqual({ jobId: 'job-1', rating: 4 })
+      expect(assetService.updateAsset).toHaveBeenCalledWith('output-uuid', {
+        user_metadata: { jobId: 'job-1', rating: 4 }
+      })
     })
   })
 

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -1,4 +1,4 @@
-import { useAsyncState, whenever } from '@vueuse/core'
+import { useAsyncState, useDebounceFn, whenever } from '@vueuse/core'
 import { difference } from 'es-toolkit'
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, shallowReactive } from 'vue'
@@ -141,12 +141,52 @@ export const useAssetsStore = defineStore('assets', () => {
     return result
   }
 
+  function mergePaginatedHistoryAssets(
+    newAssets: AssetItem[],
+    loadMore: boolean,
+    hasMore: boolean,
+    offsetIncrement: number
+  ): AssetItem[] {
+    if (loadMore) {
+      for (const asset of newAssets) {
+        if (loadedIds.has(asset.id)) {
+          continue
+        }
+        loadedIds.add(asset.id)
+
+        const assetTime = new Date(asset.created_at ?? 0).getTime()
+        const insertIndex = allHistoryItems.value.findIndex(
+          (item) => new Date(item.created_at ?? 0).getTime() < assetTime
+        )
+
+        if (insertIndex === -1) {
+          allHistoryItems.value.push(asset)
+        } else {
+          allHistoryItems.value.splice(insertIndex, 0, asset)
+        }
+      }
+    } else {
+      allHistoryItems.value = newAssets
+      newAssets.forEach((asset) => loadedIds.add(asset.id))
+    }
+
+    historyOffset.value += offsetIncrement
+    hasMoreHistory.value = hasMore
+
+    if (allHistoryItems.value.length > MAX_HISTORY_ITEMS) {
+      const removed = allHistoryItems.value.slice(MAX_HISTORY_ITEMS)
+      allHistoryItems.value = allHistoryItems.value.slice(0, MAX_HISTORY_ITEMS)
+      removed.forEach((item) => loadedIds.delete(item.id))
+    }
+
+    return allHistoryItems.value
+  }
+
   /**
    * Fetch history assets with pagination support
    * @param loadMore - true for pagination (append), false for initial load (replace)
    */
   const fetchHistoryAssets = async (loadMore = false): Promise<AssetItem[]> => {
-    // Reset state for initial load
     if (!loadMore) {
       historyOffset.value = 0
       hasMoreHistory.value = true
@@ -154,55 +194,31 @@ export const useAssetsStore = defineStore('assets', () => {
       loadedIds.clear()
     }
 
-    // Fetch from server with offset
+    if (isCloud) {
+      const page = await assetService.getAssetsPageByTag('output', true, {
+        limit: BATCH_SIZE,
+        offset: historyOffset.value
+      })
+      return mergePaginatedHistoryAssets(
+        page.assets,
+        loadMore,
+        page.has_more ?? false,
+        page.assets.length
+      )
+    }
+
     const history = await api.getHistory(BATCH_SIZE, {
       offset: historyOffset.value
     })
 
-    // Convert JobListItems to AssetItems
     const newAssets = mapHistoryToAssets(history)
 
-    if (loadMore) {
-      // Filter out duplicates and insert in sorted order
-      for (const asset of newAssets) {
-        if (loadedIds.has(asset.id)) {
-          continue // Skip duplicates
-        }
-        loadedIds.add(asset.id)
-
-        // Find insertion index to maintain sorted order (newest first)
-        const assetTime = new Date(asset.created_at ?? 0).getTime()
-        const insertIndex = allHistoryItems.value.findIndex(
-          (item) => new Date(item.created_at ?? 0).getTime() < assetTime
-        )
-
-        if (insertIndex === -1) {
-          // Asset is oldest, append to end
-          allHistoryItems.value.push(asset)
-        } else {
-          // Insert at the correct position
-          allHistoryItems.value.splice(insertIndex, 0, asset)
-        }
-      }
-    } else {
-      // Initial load: replace all
-      allHistoryItems.value = newAssets
-      newAssets.forEach((asset) => loadedIds.add(asset.id))
-    }
-
-    // Update pagination state
-    historyOffset.value += BATCH_SIZE
-    hasMoreHistory.value = history.length === BATCH_SIZE
-
-    if (allHistoryItems.value.length > MAX_HISTORY_ITEMS) {
-      const removed = allHistoryItems.value.slice(MAX_HISTORY_ITEMS)
-      allHistoryItems.value = allHistoryItems.value.slice(0, MAX_HISTORY_ITEMS)
-
-      // Clean up Set
-      removed.forEach((item) => loadedIds.delete(item.id))
-    }
-
-    return allHistoryItems.value
+    return mergePaginatedHistoryAssets(
+      newAssets,
+      loadMore,
+      history.length === BATCH_SIZE,
+      BATCH_SIZE
+    )
   }
 
   const historyAssets = ref<AssetItem[]>([])
@@ -715,7 +731,11 @@ export const useAssetsStore = defineStore('assets', () => {
         invalidateCategory,
         updateAssetMetadata,
         updateAssetTags,
-        invalidateModelsForCategory
+        invalidateModelsForCategory,
+        patchAssetInModelCaches: (
+          assetId: string,
+          updates: Partial<AssetItem>
+        ) => updateAssetInCache(assetId, updates)
       }
     }
 
@@ -732,7 +752,8 @@ export const useAssetsStore = defineStore('assets', () => {
       updateModelsForTag: async () => {},
       updateAssetMetadata: async () => {},
       updateAssetTags: async () => {},
-      invalidateModelsForCategory: () => {}
+      invalidateModelsForCategory: () => {},
+      patchAssetInModelCaches: undefined
     }
   }
 
@@ -748,8 +769,109 @@ export const useAssetsStore = defineStore('assets', () => {
     invalidateCategory,
     updateAssetMetadata,
     updateAssetTags,
-    invalidateModelsForCategory
+    invalidateModelsForCategory,
+    patchAssetInModelCaches
   } = getModelState()
+
+  function patchAssetInMediaLists(
+    assetId: string,
+    updates: Partial<AssetItem>
+  ): void {
+    const patch = (list: AssetItem[]) => {
+      const idx = list.findIndex((a) => a.id === assetId)
+      if (idx < 0) return
+      list[idx] = { ...list[idx], ...updates }
+    }
+    patch(historyAssets.value)
+    patch(allHistoryItems.value)
+    patch(inputAssets.value)
+  }
+
+  const MEDIA_METADATA_DEBOUNCE_MS = 400
+  const latestUserMetadataByAssetId = new Map<string, Record<string, unknown>>()
+  const rollbackUserMetadataByAssetId = new Map<
+    string,
+    Record<string, unknown> | undefined
+  >()
+  const flushResolversByAssetId = new Map<
+    string,
+    Array<(result: Record<string, unknown> | null) => void>
+  >()
+  const debouncedMediaMetadataFlushByAssetId = new Map<
+    string,
+    ReturnType<typeof useDebounceFn<() => Promise<void>>>
+  >()
+
+  function getMediaMetadataDebouncedFlush(assetId: string) {
+    let debounced = debouncedMediaMetadataFlushByAssetId.get(assetId)
+    if (!debounced) {
+      debounced = useDebounceFn(async () => {
+        const merged = latestUserMetadataByAssetId.get(assetId)
+        if (!merged) return
+
+        const originalMetadata = rollbackUserMetadataByAssetId.get(assetId)
+        const resolvers = flushResolversByAssetId.get(assetId) ?? []
+        flushResolversByAssetId.delete(assetId)
+
+        try {
+          const updatedAsset = await assetService.updateAsset(assetId, {
+            user_metadata: merged
+          })
+          patchAssetInMediaLists(assetId, updatedAsset)
+          patchAssetInModelCaches?.(assetId, updatedAsset)
+          const savedMetadata = updatedAsset.user_metadata ?? merged
+          for (const resolve of resolvers) {
+            resolve(savedMetadata)
+          }
+        } catch (error) {
+          console.error('Failed to update media asset metadata:', error)
+          patchAssetInMediaLists(assetId, {
+            user_metadata: originalMetadata
+          })
+          patchAssetInModelCaches?.(assetId, {
+            user_metadata: originalMetadata
+          })
+          for (const resolve of resolvers) {
+            resolve(null)
+          }
+        } finally {
+          latestUserMetadataByAssetId.delete(assetId)
+          rollbackUserMetadataByAssetId.delete(assetId)
+          debouncedMediaMetadataFlushByAssetId.delete(assetId)
+        }
+      }, MEDIA_METADATA_DEBOUNCE_MS)
+      debouncedMediaMetadataFlushByAssetId.set(assetId, debounced)
+    }
+    return debounced
+  }
+
+  function updateMediaAssetUserMetadata(
+    asset: AssetItem,
+    partialUserMetadata: Record<string, unknown>
+  ): Promise<Record<string, unknown> | null> {
+    if (Object.keys(partialUserMetadata).length === 0) {
+      return Promise.resolve(null)
+    }
+    if (asset.is_immutable === true) {
+      return Promise.resolve(null)
+    }
+
+    if (!rollbackUserMetadataByAssetId.has(asset.id)) {
+      rollbackUserMetadataByAssetId.set(asset.id, asset.user_metadata)
+    }
+
+    const merged = { ...(asset.user_metadata ?? {}), ...partialUserMetadata }
+    latestUserMetadataByAssetId.set(asset.id, merged)
+    patchAssetInMediaLists(asset.id, { user_metadata: merged })
+    patchAssetInModelCaches?.(asset.id, { user_metadata: merged })
+
+    return new Promise((resolve) => {
+      const resolvers = flushResolversByAssetId.get(asset.id) ?? []
+      resolvers.push(resolve)
+      flushResolversByAssetId.set(asset.id, resolvers)
+      void getMediaMetadataDebouncedFlush(asset.id)()
+    })
+  }
 
   // Watch for completed downloads and refresh model caches
   whenever(
@@ -809,6 +931,7 @@ export const useAssetsStore = defineStore('assets', () => {
     updateHistory,
     loadMoreHistory,
     setAssetPreview,
+    updateMediaAssetUserMetadata,
 
     // Input mapping helpers
     inputAssetsByFilename,


### PR DESCRIPTION
# Overview

The implementation is a three-tier design: a reusable, accessible StarRating primitive with extracted pure logic and overlay reveal semantics; a thin MediaAssetCard + grid integration via v-model:rating; and generic debounced metadata persistence in assetsStore keyed on user_metadata.rating. That separation keeps the widget reusable (Storybook, tests, future surfaces) while fitting established patterns for Vue 3.5 components, platform UI composition, asset metadata helpers, Pinia optimistic updates, and sidebar local cache patching.

https://github.com/user-attachments/assets/d0db712e-94c2-4d63-96ff-2d05bcdae23c

# Implementation Overview

Unidirectional flow: read from store-backed AssetItem → display in card → user interaction updates local model → grid handler persists → store patches lists → tab handler syncs folder-local cache when applicable.

## Reusable UI (src/components/ui/star-rating/)

Rating behavior is extracted into testable pure functions, matching the project preference for logic outside SFCs (Single File Components). This mirrors patterns like small util modules next to UI primitives, and is covered directly in unit tests (not only through the component).

### Component (StarRating.vue)
Aligns with shadcn-style UI guidelines and Vue 3.5 conventions:
* defineModel<number> for v-model (preferred over separate prop + emit).
* Reactive props destructuring with defaults (disabled, readonly, max, presentation, etc.).
* cn() from @comfyorg/tailwind-utils for class merging (no :class="[]").
* Design tokens: text-warning-background, text-muted-foreground (no dark: variants).
* Iconify: icon-[ph--star-fill], icon-[lucide--star] with explicit size-4 (not font-size sizing).
* VueUse: useElementHover for host/self hover detection.
* vue-i18n: starRating.groupLabel, starRating.rateStars in src/locales/en/main.json.
* A11y: role="group", aria-valuenow/min/max, per-star aria-label, roving tabindex on the group when interactive.

### Interaction model:
* Click star N: set to N, or 0 if N equals current (clear rating).
* Arrow keys increment/decrement; digit keys set rating directly.
* Hover previews fill without committing until click.

### Host injection (starRatingHost.ts)
Overlay mode needs hover on the card, not only the star strip. A minimal provide/inject API avoids prop-drilling.

## Platform integration

### MediaAssetCard.vue
* defineModel<number | undefined>('rating') — parent owns persistence; card stays presentational.
* Renders StarRating only when !loading && supportsStarRating && rating !== undefined.
* supportsStarRating: fileKind !== 'video' (videos never show stars, even with a bound rating).
* Overlay placement: absolute right-2 bottom-2, presentation="overlay".
provideStarRatingHost(cardContainerRef) ties reveal behavior to the whole card.
* This matches existing card patterns: optional models, cn() + Tailwind, platform importing @/components/ui/* (same as Button, Dialog, etc.).

assetMetadataUtils.ts + schema
* getAssetRating(asset) reads user_metadata.rating, returns 0 for missing/invalid values, clamps via shared clampRating (max 5).
* Fits the established “user_metadata first” metadata helper family (getAssetDisplayName, getUserDescription, etc.).

## Persistence (assetsStore.updateMediaAssetUserMetadata)

Generic metadata updater (not rating-specific), reused for star rating:
* Guards: empty partial → no-op; is_immutable === true → no-op (with explicit test for undefined immutability on sidebar media).
* Optimistic patch: merge partial into user_metadata, update historyAssets / inputAssets (and model caches when applicable).
* Debounce (400ms per asset via useDebounceFn): coalesce rapid rating changes into one assetService.updateAsset call.
* Rollback on API failure to pre-edit metadata.
* Promise resolves with saved user_metadata or null on failure.
* This matches how the codebase handles responsive UI + batched writes elsewhere in the assets store, and is regression-tested in assetsStore.test.ts (optimistic apply, rollback, immutability, cloud output assets).

<img width="581" height="392" alt="Screenshot 2026-05-19 at 1 51 14 PM" src="https://github.com/user-attachments/assets/0721d809-a261-4966-87e5-7b8777bad266" />

# Testing Coverage
* starRating.ts — clamp, click-toggle, keyboard mapping, reveal state machine, presentation defaults.
* StarRating.test.ts — click/hover/keyboard, disabled/readonly, showCount, overlay host-hover readonly → interactive transition (StarRatingHostHarness).
* assetMetadataUtils.test.ts — getAssetRating valid/missing/invalid/clamp cases.
* assetsStore.test.ts — updateMediaAssetUserMetadata optimistic update, rollback, immutability, typical output asset.
Tests favor behavior (rating changes, rollback, interaction gating) over snapshot/style checks, per project testing guidelines.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12342-Milesryan-asset-star-rating-3656d73d3650818fb038f23fe10020b9) by [Unito](https://www.unito.io)
