### PR TITLE
fix: register restored image upload widget values to clear missing-media false positives

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.test.ts
@@ -19,7 +19,8 @@ const mocks = vi.hoisted(() => ({
   capturedUploadOptions: undefined as CapturedImageUploadOptions | undefined,
   openFileSelection: vi.fn(),
   setNodeOutputs: vi.fn(),
-  showPreview: vi.fn()
+  showPreview: vi.fn(),
+  removeMissingMediaByName: vi.fn()
 }))
 
 vi.mock('@/composables/node/useNodeImage', () => ({
@@ -54,6 +55,12 @@ vi.mock('@/utils/litegraphUtil', () => ({
       values.push(value)
     }
   }
+}))
+
+vi.mock('@/platform/missingMedia/missingMediaStore', () => ({
+  useMissingMediaStore: () => ({
+    removeMissingMediaByName: mocks.removeMissingMediaByName
+  })
 }))
 
 function createUploadNode() {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImageUploadWidget.ts
@@ -6,6 +6,7 @@ import type { IComboWidget } from '@/lib/litegraph/src/types/widgets'
 import type { ResultItem, ResultItemType } from '@/schemas/apiSchema'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
 import type { ComfyWidgetConstructor } from '@/scripts/widgets'
+import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { isImageUploadInput } from '@/types/nodeDefAugmentation'
 import { createAnnotatedPath } from '@/utils/createAnnotatedPath'
@@ -123,6 +124,11 @@ export const useImageUploadWidget = () => {
     // The value isn't set immediately so we need to wait a moment
     // No change callbacks seem to be fired on initial setting of the value
     requestAnimationFrame(() => {
+      const restoredValue = fileComboWidget.value
+      if (typeof restoredValue === 'string' && restoredValue) {
+        addToComboValues(fileComboWidget, restoredValue)
+        useMissingMediaStore().removeMissingMediaByName(restoredValue)
+      }
       nodeOutputStore.setNodeOutputs(node, String(fileComboWidget.value), {
         isAnimated
       })


### PR DESCRIPTION
## Summary

LoadImage / LoadVideo / LoadAudio combo options come from INPUT_TYPES, which only lists files at input/ root. A widget value with a subfolder prefix — e.g. a mask-editor save under input/clipspace/ — is therefore absent from options.values on workflow load, so the missing-media scan (#10309) flags the node and the dropdown filter (#11493) hides the synthetic fallback item, leaving the widget visibly blank.

Register the restored value via addToComboValues and clear any matching candidate from the missing-media store after configure restores it.

## Screenshots (if applicable)
before
<img width="1463" height="782" alt="image" src="https://github.com/user-attachments/assets/2c430db8-8b17-42da-9407-8203d8b69845" />

after
<img width="1523" height="958" alt="image" src="https://github.com/user-attachments/assets/e13339f6-af72-4efd-8f9e-c3721f3619d0" />

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12343-fix-register-restored-image-upload-widget-values-to-clear-missing-media-false-positives-3656d73d3650812a9a84f39aeb061af6) by [Unito](https://www.unito.io)
