### PR TITLE
On subgraph conversion, always unpack group nodes

### DIFF
--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -371,5 +371,5 @@ test('Convert to subgraph unpacks the group Node @vue-nodes', async ({
   await expect(comfyPage.vueNodes.getNodeByTitle('New Subgraph')).toBeVisible()
 
   await comfyPage.vueNodes.enterSubgraph()
-  await expect.poll(() => comfyPage.vueNodes.getNodeCount()).toBe(2)
+  await expect(comfyPage.vueNodes.getNodeByTitle('')).toHaveCount(2)
 })

--- a/browser_tests/tests/groupNode.spec.ts
+++ b/browser_tests/tests/groupNode.spec.ts
@@ -361,3 +361,15 @@ test.describe('Group Node', { tag: '@node' }, () => {
     })
   })
 })
+
+test('Convert to subgraph unpacks the group Node @vue-nodes', async ({
+  comfyPage
+}) => {
+  await comfyPage.workflow.loadWorkflow('groupnodes/legacy_group_node')
+  await (await comfyPage.vueNodes.getFixtureByTitle('hello')).title.click()
+  await comfyPage.page.keyboard.press('Control+Shift+e')
+  await expect(comfyPage.vueNodes.getNodeByTitle('New Subgraph')).toBeVisible()
+
+  await comfyPage.vueNodes.enterSubgraph()
+  await expect.poll(() => comfyPage.vueNodes.getNodeCount()).toBe(2)
+})

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1,4 +1,4 @@
-import { toString } from 'es-toolkit/compat'
+import { remove, toString } from 'es-toolkit/compat'
 
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import {
@@ -1672,7 +1672,15 @@ export class LGraph
     this.beforeChange()
 
     try {
-      return this._convertToSubgraphImpl(items)
+      const itemsArray = [...items]
+      const isGroupNode = (i: Positionable) =>
+        i instanceof LGraphNode && !!i.convertToNodes
+      for (const groupNode of remove(itemsArray, isGroupNode) as LGraphNode[])
+        for (const innerNode of groupNode.convertToNodes!()) {
+          innerNode.updateArea()
+          itemsArray.push(innerNode)
+        }
+      return this._convertToSubgraphImpl(new Set(itemsArray))
     } finally {
       // Mark state change complete for proper undo support
       this.afterChange()

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1672,14 +1672,15 @@ export class LGraph
     this.beforeChange()
 
     try {
-      const mapper = (item: Positionable): Positionable[] => {
+      function extractNodes(item: Positionable): Positionable[] {
         if (!(item instanceof LGraphNode) || !item.convertToNodes) return [item]
 
         const innerNodes = item.convertToNodes()
         for (const innerNode of innerNodes) innerNode.updateArea()
         return innerNodes
       }
-      return this._convertToSubgraphImpl(new Set([...items].flatMap(mapper)))
+      const processedItems = new Set([...items].flatMap(extractNodes))
+      return this._convertToSubgraphImpl(processedItems)
     } finally {
       // Mark state change complete for proper undo support
       this.afterChange()

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1,4 +1,4 @@
-import { remove, toString } from 'es-toolkit/compat'
+import { toString } from 'es-toolkit/compat'
 
 import type { PromotedWidgetSource } from '@/core/graph/subgraph/promotedWidgetTypes'
 import {
@@ -1672,15 +1672,14 @@ export class LGraph
     this.beforeChange()
 
     try {
-      const itemsArray = [...items]
-      const isGroupNode = (i: Positionable) =>
-        i instanceof LGraphNode && !!i.convertToNodes
-      for (const groupNode of remove(itemsArray, isGroupNode) as LGraphNode[])
-        for (const innerNode of groupNode.convertToNodes!()) {
-          innerNode.updateArea()
-          itemsArray.push(innerNode)
-        }
-      return this._convertToSubgraphImpl(new Set(itemsArray))
+      const mapper = (item: Positionable): Positionable[] => {
+        if (!(item instanceof LGraphNode) || !item.convertToNodes) return [item]
+
+        const innerNodes = item.convertToNodes()
+        for (const innerNode of innerNodes) innerNode.updateArea()
+        return innerNodes
+      }
+      return this._convertToSubgraphImpl(new Set([...items].flatMap(mapper)))
     } finally {
       // Mark state change complete for proper undo support
       this.afterChange()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1,7 +1,6 @@
 import { toString } from 'es-toolkit/compat'
 import { toValue } from 'vue'
 
-import { PREFIX, SEPARATOR } from '@/constants/groupNodeConstants'
 import { MovingInputLink } from '@/lib/litegraph/src/canvas/MovingInputLink'
 import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
 import { LitegraphLinkAdapter } from '@/renderer/core/canvas/litegraph/litegraphLinkAdapter'
@@ -8503,40 +8502,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       options = [
         {
           content: 'Convert to Subgraph',
-          callback: () => {
-            // find groupnodes, degroup and select children
-            if (this.selectedItems.size) {
-              let hasGroups = false
-              for (const item of this.selectedItems) {
-                const node = item as LGraphNode
-                const isGroup =
-                  typeof node.type === 'string' &&
-                  node.type.startsWith(`${PREFIX}${SEPARATOR}`)
-                if (isGroup && node.convertToNodes) {
-                  hasGroups = true
-                  const nodes = node.convertToNodes()
-
-                  requestAnimationFrame(() => {
-                    this.selectItems(nodes, true)
-
-                    if (!this.selectedItems.size)
-                      throw new Error('Convert to Subgraph: Nothing selected.')
-                    this._graph.convertToSubgraph(this.selectedItems)
-                  })
-                  return
-                }
-              }
-
-              // If no groups were found, continue normally
-              if (!hasGroups) {
-                if (!this.selectedItems.size)
-                  throw new Error('Convert to Subgraph: Nothing selected.')
-                this._graph.convertToSubgraph(this.selectedItems)
-              }
-            } else {
-              throw new Error('Convert to Subgraph: Nothing selected.')
-            }
-          }
+          callback: () => this._graph.convertToSubgraph(this.selectedItems)
         },
         {
           content: 'Properties',


### PR DESCRIPTION
This is a targeted small scope change to improve the availability for converting group nodes into a subgraph.

The prior implementation would only apply on the litegraph context menu option for converting a node to a subgraph. It failed to apply on any of the other more common methods. The code for unpacking group nodes has been moved directly into the setup for converting a group of nodes into a subgraph and drastically simplified.

Of note, several other long lived bugs were found while working on this fix, but they are out of scope for this targeted PR.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12356-On-subgraph-conversion-always-unpack-group-nodes-3666d73d365081d09774c00a851b8198) by [Unito](https://www.unito.io)
