### PR TITLE
[backport core/1.43] fix: avoid false missing media after shared asset import

### DIFF
--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -222,7 +222,7 @@ describe('useSharedWorkflowUrlLoader', () => {
     expect(mockHideTemplateSelector).not.toHaveBeenCalled()
   })
 
-  it('calls import when non-owned assets exist and user confirms', async () => {
+  it('imports non-owned assets before loading graph when user confirms', async () => {
     mockQueryParams = { share: 'share-id-1' }
     const payload = makePayload({
       assets: [
@@ -242,9 +242,13 @@ describe('useSharedWorkflowUrlLoader', () => {
     })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
-    await loadSharedWorkflowFromUrl()
+    const loaded = await loadSharedWorkflowFromUrl()
 
+    expect(loaded).toBe('loaded')
     expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'])
+    expect(mockImportPublishedAssets.mock.invocationCallOrder[0]).toBeLessThan(
+      mockLoadGraphData.mock.invocationCallOrder[0]
+    )
   })
 
   it('does not call import when user chooses open-only', async () => {
@@ -309,11 +313,49 @@ describe('useSharedWorkflowUrlLoader', () => {
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded-without-assets')
+    expect(mockLoadGraphData).toHaveBeenCalledWith(
+      { nodes: [] },
+      true,
+      true,
+      'Test Workflow',
+      { openSource: 'shared_url' }
+    )
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'Failed to import workflow assets'
       })
+    )
+  })
+
+  it('clears share intent when graph load fails after importing assets', async () => {
+    mockQueryParams = { share: 'share-id-1', tab: 'assets' }
+    const payload = makePayload({
+      assets: [
+        {
+          id: 'a1',
+          name: 'img.png',
+          preview_url: '',
+          storage_url: '',
+          model: false,
+          public: false,
+          in_library: false
+        }
+      ]
+    })
+    mockShowLayoutDialog.mockImplementation(() => {
+      resolveDialogWithConfirm(payload)
+    })
+    mockLoadGraphData.mockRejectedValue(new Error('Graph load failed'))
+
+    const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
+    const loaded = await loadSharedWorkflowFromUrl()
+
+    expect(loaded).toBe('failed')
+    expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'])
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: { tab: 'assets' } })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'share'
     )
   })
 

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -63,6 +63,11 @@ export function useSharedWorkflowUrlLoader() {
     void router.replace({ query: newQuery })
   }
 
+  function clearShareIntent() {
+    cleanupUrlParams()
+    clearPreservedQuery(SHARE_NAMESPACE)
+  }
+
   function showOpenSharedWorkflowDialog(
     shareId: string
   ): Promise<DialogResult> {
@@ -108,8 +113,7 @@ export function useSharedWorkflowUrlLoader() {
     }
 
     if (typeof shareParam !== 'string') {
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'not-present'
     }
 
@@ -122,16 +126,14 @@ export function useSharedWorkflowUrlLoader() {
         summary: t('g.error'),
         detail: t('shareWorkflow.loadFailed')
       })
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'failed'
     }
 
     const result = await showOpenSharedWorkflowDialog(shareParam)
 
     if (result.action === 'cancel') {
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'cancelled'
     }
 
@@ -140,6 +142,26 @@ export function useSharedWorkflowUrlLoader() {
     const { payload } = result
     const workflowName = payload.name || t('openSharedWorkflow.dialogTitle')
     const nonOwnedAssets = payload.assets.filter((a) => !a.in_library)
+    let importFailed = false
+
+    if (result.action === 'copy-and-open' && nonOwnedAssets.length > 0) {
+      try {
+        await workflowShareService.importPublishedAssets(
+          nonOwnedAssets.map((a) => a.id)
+        )
+      } catch (importError) {
+        importFailed = true
+        console.error(
+          '[useSharedWorkflowUrlLoader] Failed to import assets:',
+          importError
+        )
+        toast.add({
+          severity: 'error',
+          summary: t('g.error'),
+          detail: t('openSharedWorkflow.importFailed')
+        })
+      }
+    }
 
     try {
       await app.loadGraphData(payload.workflowJson, true, true, workflowName, {
@@ -155,33 +177,12 @@ export function useSharedWorkflowUrlLoader() {
         summary: t('g.error'),
         detail: t('shareWorkflow.loadFailed')
       })
+      clearShareIntent()
       return 'failed'
     }
 
-    if (result.action === 'copy-and-open' && nonOwnedAssets.length > 0) {
-      try {
-        await workflowShareService.importPublishedAssets(
-          nonOwnedAssets.map((a) => a.id)
-        )
-      } catch (importError) {
-        console.error(
-          '[useSharedWorkflowUrlLoader] Failed to import assets:',
-          importError
-        )
-        toast.add({
-          severity: 'error',
-          summary: t('g.error'),
-          detail: t('openSharedWorkflow.importFailed')
-        })
-        cleanupUrlParams()
-        clearPreservedQuery(SHARE_NAMESPACE)
-        return 'loaded-without-assets'
-      }
-    }
-
-    cleanupUrlParams()
-    clearPreservedQuery(SHARE_NAMESPACE)
-    return 'loaded'
+    clearShareIntent()
+    return importFailed ? 'loaded-without-assets' : 'loaded'
   }
 
   return {

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/scripts/app', () => ({
 
 const mockGetShareableAssets = vi.fn()
 const mockFetchApi = vi.fn()
+const mockInvalidateInputAssetsIncludingPublic = vi.hoisted(() => vi.fn())
 
 vi.mock(
   '@/platform/workflow/validation/schemas/workflowSchema',
@@ -29,6 +30,13 @@ vi.mock('@/scripts/api', () => ({
     fetchApi: (...args: unknown[]) => mockFetchApi(...args),
     apiURL: (route: string) => `/api${route}`,
     fileURL: (route: string) => route
+  }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    invalidateInputAssetsIncludingPublic:
+      mockInvalidateInputAssetsIncludingPublic
   }
 }))
 
@@ -345,6 +353,7 @@ describe(useWorkflowShareService, () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ published_asset_ids: ['pa-1', 'pa-2'] })
     })
+    expect(mockInvalidateInputAssetsIncludingPublic).toHaveBeenCalledTimes(1)
   })
 
   it('throws when import request fails', async () => {
@@ -355,6 +364,7 @@ describe(useWorkflowShareService, () => {
     await expect(service.importPublishedAssets(['bad-id'])).rejects.toThrow(
       'Failed to import assets: 400'
     )
+    expect(mockInvalidateInputAssetsIncludingPublic).not.toHaveBeenCalled()
   })
 
   it('throws when shared workflow payload is invalid', async () => {

--- a/src/platform/workflow/sharing/services/workflowShareService.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.ts
@@ -4,6 +4,7 @@ import type {
   WorkflowPublishResult,
   WorkflowPublishStatus
 } from '@/platform/workflow/sharing/types/shareTypes'
+import { assetService } from '@/platform/assets/services/assetService'
 import type { ThumbnailType } from '@/platform/workflow/sharing/types/comfyHubTypes'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
@@ -265,6 +266,8 @@ export function useWorkflowShareService() {
     if (!response.ok) {
       throw new Error(`Failed to import assets: ${response.status}`)
     }
+
+    assetService.invalidateInputAssetsIncludingPublic()
   }
 
   return {


### PR DESCRIPTION
Backport of #12333.

CC FE-773

## Summary
- Minimal stable-branch adaptation for core/1.43.
- Import published shared workflow assets before graph load so the missing media scan sees the imported references.
- Invalidate the public-inclusive input asset cache after a successful import.
- Keep the 1.43 /assets/import request shape unchanged; this does not backport optional share_id validation.
- E2E coverage is intentionally omitted on 1.43 per backport scope; unit coverage was added around the timing and cache invalidation behavior.

## Validation
- pnpm install --frozen-lockfile
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm exec vitest run src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts src/platform/workflow/sharing/services/workflowShareService.test.ts
- git diff --check

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12360-backport-core-1-43-fix-avoid-false-missing-media-after-shared-asset-import-3666d73d3650818ab9c2ded2d408a535) by [Unito](https://www.unito.io)
