### PR TITLE
[backport core/1.44] fix: avoid false missing media after shared asset import

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -76,7 +76,15 @@ export const TestIds = {
     publishTabPanel: 'publish-tab-panel',
     apiSignin: 'api-signin-dialog',
     updatePassword: 'update-password-dialog',
-    cloudNotification: 'cloud-notification-dialog'
+    cloudNotification: 'cloud-notification-dialog',
+    openSharedWorkflow: 'open-shared-workflow-dialog',
+    openSharedWorkflowTitle: 'open-shared-workflow-title',
+    openSharedWorkflowClose: 'open-shared-workflow-close',
+    openSharedWorkflowErrorClose: 'open-shared-workflow-error-close',
+    openSharedWorkflowCancel: 'open-shared-workflow-cancel',
+    openSharedWorkflowOpenWithoutImporting:
+      'open-shared-workflow-open-without-importing',
+    openSharedWorkflowConfirm: 'open-shared-workflow-confirm'
   },
   keybindings: {
     presetMenu: 'keybinding-preset-menu'

--- a/browser_tests/fixtures/sharedWorkflowImportFixture.ts
+++ b/browser_tests/fixtures/sharedWorkflowImportFixture.ts
@@ -1,0 +1,250 @@
+import { test as base } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import type {
+  Asset,
+  ImportPublishedAssetsRequest,
+  ListAssetsResponse
+} from '@comfyorg/ingest-types'
+import type { z } from 'zod'
+
+import type { zSharedWorkflowResponse } from '@/platform/workflow/sharing/schemas/shareSchemas'
+import type { AssetInfo } from '@/schemas/apiSchema'
+
+type SharedWorkflowResponse = z.input<typeof zSharedWorkflowResponse>
+
+export const sharedWorkflowImportScenario = {
+  shareId: 'shared-missing-media-e2e',
+  workflowId: 'shared-missing-media-workflow',
+  publishedAssetId: 'published-input-asset-1',
+  inputFileName: 'shared_imported_image.png'
+} as const
+
+export type SharedWorkflowRequestEvent =
+  | 'import'
+  | 'input-assets-including-public-before-import'
+  | 'input-assets-including-public-after-import'
+
+export interface SharedWorkflowImportMocks {
+  resetAndStartRecording: () => void
+  getImportBody: () => ImportPublishedAssetsRequest | undefined
+  getRequestEvents: () => SharedWorkflowRequestEvent[]
+  waitForPublicInclusiveInputAssetResponseAfterImport: () => Promise<void>
+}
+
+const defaultInputFileName = '00000000000000000000000Aexample.png'
+
+const sharedWorkflowAsset: AssetInfo = {
+  id: sharedWorkflowImportScenario.publishedAssetId,
+  name: sharedWorkflowImportScenario.inputFileName,
+  preview_url: '',
+  storage_url: '',
+  model: false,
+  public: false,
+  in_library: false
+}
+
+const defaultInputAsset: Asset = {
+  id: 'default-input-asset',
+  name: defaultInputFileName,
+  asset_hash: defaultInputFileName,
+  size: 1_024,
+  mime_type: 'image/png',
+  tags: ['input'],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  last_access_time: '2026-05-01T00:00:00Z'
+}
+
+const importedInputAsset: Asset = {
+  id: 'imported-input-asset',
+  name: sharedWorkflowImportScenario.inputFileName,
+  asset_hash: sharedWorkflowImportScenario.inputFileName,
+  size: 1_024,
+  mime_type: 'image/png',
+  tags: ['input'],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  last_access_time: '2026-05-01T00:00:00Z'
+}
+
+const sharedWorkflowResponse: SharedWorkflowResponse = {
+  share_id: sharedWorkflowImportScenario.shareId,
+  workflow_id: sharedWorkflowImportScenario.workflowId,
+  name: 'Shared Missing Media Workflow',
+  listed: true,
+  publish_time: '2026-05-01T00:00:00Z',
+  workflow_json: {
+    version: 0.4,
+    last_node_id: 10,
+    last_link_id: 0,
+    nodes: [
+      {
+        id: 10,
+        type: 'LoadImage',
+        pos: [50, 200],
+        size: [315, 314],
+        flags: {},
+        order: 0,
+        mode: 0,
+        inputs: [],
+        outputs: [
+          {
+            name: 'IMAGE',
+            type: 'IMAGE',
+            links: null
+          },
+          {
+            name: 'MASK',
+            type: 'MASK',
+            links: null
+          }
+        ],
+        properties: {
+          'Node name for S&R': 'LoadImage'
+        },
+        widgets_values: [sharedWorkflowImportScenario.inputFileName, 'image']
+      }
+    ],
+    links: [],
+    groups: [],
+    config: {},
+    extra: {
+      ds: {
+        offset: [0, 0],
+        scale: 1
+      }
+    }
+  },
+  assets: [sharedWorkflowAsset]
+}
+
+export const sharedWorkflowImportFixture = base.extend<{
+  sharedWorkflowImportMocks: SharedWorkflowImportMocks
+}>({
+  sharedWorkflowImportMocks: async ({ page }, use) => {
+    const mocks = await mockSharedWorkflowImportFlow(page)
+    await use(mocks)
+  }
+})
+
+async function mockSharedWorkflowImportFlow(
+  page: Page
+): Promise<SharedWorkflowImportMocks> {
+  let isRecording = false
+  let importEndpointCalled = false
+  let importBody: ImportPublishedAssetsRequest | undefined
+  let resolvePublicInclusiveInputAssetResponseAfterImport: () => void = () => {}
+  let publicInclusiveInputAssetResponseAfterImport = new Promise<void>(
+    (resolve) => {
+      resolvePublicInclusiveInputAssetResponseAfterImport = resolve
+    }
+  )
+  const requestEvents: SharedWorkflowRequestEvent[] = []
+
+  function resetPublicInclusiveInputAssetResponseWaiter() {
+    publicInclusiveInputAssetResponseAfterImport = new Promise<void>(
+      (resolve) => {
+        resolvePublicInclusiveInputAssetResponseAfterImport = resolve
+      }
+    )
+  }
+
+  function recordRequestEvent(event: SharedWorkflowRequestEvent) {
+    if (isRecording) requestEvents.push(event)
+  }
+
+  await page.route(
+    `**/workflows/published/${sharedWorkflowImportScenario.shareId}`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(sharedWorkflowResponse)
+      })
+    }
+  )
+
+  await page.route('**/api/assets/import', async (route) => {
+    recordRequestEvent('import')
+    importBody = route.request().postDataJSON() as ImportPublishedAssetsRequest
+    importEndpointCalled = true
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({})
+    })
+  })
+
+  // Excludes `/api/assets/import` so the specific route above
+  // remains isolated from the general asset listing mock.
+  await page.route(/\/api\/assets(?=\?|$)/, async (route) => {
+    const url = new URL(route.request().url())
+    const includeTags = getTagParam(url, 'include_tags')
+    const isInputAssetRequest = includeTags.includes('input')
+    const includesPublicAssets =
+      url.searchParams.get('include_public') === 'true'
+    const isPublicInclusiveInputAssetRequest =
+      isInputAssetRequest && includesPublicAssets
+    const isAfterImportPublicInclusiveInputAssetRequest =
+      isPublicInclusiveInputAssetRequest && importEndpointCalled
+
+    if (isPublicInclusiveInputAssetRequest) {
+      recordRequestEvent(
+        importEndpointCalled
+          ? 'input-assets-including-public-after-import'
+          : 'input-assets-including-public-before-import'
+      )
+    }
+
+    const allAssets = [
+      defaultInputAsset,
+      ...(importEndpointCalled ? [importedInputAsset] : [])
+    ]
+    const assets = includeTags.length
+      ? allAssets.filter((asset) =>
+          includeTags.every((tag) => asset.tags?.includes(tag))
+        )
+      : allAssets
+
+    const response: ListAssetsResponse = {
+      assets,
+      total: assets.length,
+      has_more: false
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response)
+    })
+
+    if (isAfterImportPublicInclusiveInputAssetRequest) {
+      resolvePublicInclusiveInputAssetResponseAfterImport()
+    }
+  })
+
+  return {
+    resetAndStartRecording: () => {
+      isRecording = true
+      importEndpointCalled = false
+      importBody = undefined
+      requestEvents.length = 0
+      resetPublicInclusiveInputAssetResponseWaiter()
+    },
+    getImportBody: () => importBody,
+    getRequestEvents: () => [...requestEvents],
+    waitForPublicInclusiveInputAssetResponseAfterImport: () =>
+      publicInclusiveInputAssetResponseAfterImport
+  }
+}
+
+function getTagParam(url: URL, key: string): string[] {
+  return (
+    url.searchParams
+      .get(key)
+      ?.split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean) ?? []
+  )
+}

--- a/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
+++ b/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
@@ -1,0 +1,148 @@
+import { expect, mergeTests } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import { TestIds } from '@e2e/fixtures/selectors'
+import {
+  sharedWorkflowImportFixture,
+  sharedWorkflowImportScenario
+} from '@e2e/fixtures/sharedWorkflowImportFixture'
+import type { SharedWorkflowImportMocks } from '@e2e/fixtures/sharedWorkflowImportFixture'
+import { PropertiesPanelHelper } from '@e2e/tests/propertiesPanel/PropertiesPanelHelper'
+import type { WorkspaceStore } from '@e2e/types/globals'
+
+const IMPORT_ORDER_TIMEOUT_MS = 5_000
+
+async function expectImportPrecedesPublicInclusiveInputAssetScan(
+  mocks: SharedWorkflowImportMocks
+): Promise<void> {
+  await expect(async () => {
+    const events = mocks.getRequestEvents()
+    const importIndex = events.indexOf('import')
+    const afterImportIndex = events.indexOf(
+      'input-assets-including-public-after-import'
+    )
+
+    expect(
+      events,
+      'public-inclusive input assets must not be scanned before import'
+    ).not.toContain('input-assets-including-public-before-import')
+    expect(importIndex, `events: ${events.join(',')}`).toBeGreaterThanOrEqual(0)
+    expect(afterImportIndex, `events: ${events.join(',')}`).toBeGreaterThan(
+      importIndex
+    )
+  }).toPass({ timeout: IMPORT_ORDER_TIMEOUT_MS })
+}
+
+async function getCachedMissingMediaWarningNames(
+  comfyPage: ComfyPage
+): Promise<string[] | null> {
+  return await comfyPage.page.evaluate(() => {
+    const workflow = (window.app!.extensionManager as WorkspaceStore).workflow
+      .activeWorkflow
+    if (!workflow) return null
+
+    return (
+      workflow.pendingWarnings?.missingMediaCandidates?.map(
+        (candidate) => candidate.name
+      ) ?? []
+    )
+  })
+}
+
+async function expectNoMissingMediaAfterPublicInclusiveAssetScan(
+  comfyPage: ComfyPage,
+  mocks: SharedWorkflowImportMocks
+): Promise<void> {
+  await mocks.waitForPublicInclusiveInputAssetResponseAfterImport()
+  await comfyPage.nextFrame()
+
+  await expect(
+    comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
+  ).toBeHidden()
+  await expect
+    .poll(() => getCachedMissingMediaWarningNames(comfyPage))
+    .toEqual([])
+}
+
+async function openPanelAndExpectNoMissingMedia(
+  comfyPage: ComfyPage
+): Promise<void> {
+  const page = comfyPage.page
+  const errorOverlay = page.getByTestId(TestIds.dialogs.errorOverlay)
+  await expect(errorOverlay).toBeHidden()
+
+  const panel = new PropertiesPanelHelper(page)
+  await panel.open(comfyPage.actionbar.propertiesButton)
+  await expect(
+    panel.root.getByTestId(TestIds.propertiesPanel.errorsTab)
+  ).toBeHidden()
+  await expect(page.getByTestId(TestIds.dialogs.missingMediaGroup)).toHaveCount(
+    0
+  )
+}
+
+const test = mergeTests(comfyPageFixture, sharedWorkflowImportFixture)
+
+test.describe('Shared workflow missing media', { tag: '@cloud' }, () => {
+  // Missing media only surfaces the overlay when the Errors tab is enabled
+  // (src/stores/executionErrorStore.ts).
+  test.beforeEach(async ({ comfyPage, sharedWorkflowImportMocks }) => {
+    await comfyPage.settings.setSetting(
+      'Comfy.RightSidePanel.ShowErrorsTab',
+      true
+    )
+    sharedWorkflowImportMocks.resetAndStartRecording()
+    await comfyPage.page.goto(
+      new URL(
+        `/?share=${sharedWorkflowImportScenario.shareId}`,
+        comfyPage.url
+      ).toString()
+    )
+    await comfyPage.waitForAppReady()
+  })
+
+  test('imports shared media before loading workflow so missing media is not surfaced', async ({
+    comfyPage,
+    sharedWorkflowImportMocks
+  }) => {
+    const { page } = comfyPage
+
+    const dialog = page.getByTestId(TestIds.dialogs.openSharedWorkflow)
+    await expect(
+      dialog.getByTestId(TestIds.dialogs.openSharedWorkflowTitle)
+    ).toBeVisible()
+
+    await dialog.getByTestId(TestIds.dialogs.openSharedWorkflowConfirm).click()
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.app!.graph.nodes.map((node) => ({
+            type: node.type,
+            value: node.widgets?.[0]?.value
+          }))
+        )
+      )
+      .toEqual([
+        {
+          type: 'LoadImage',
+          value: sharedWorkflowImportScenario.inputFileName
+        }
+      ])
+    await expectImportPrecedesPublicInclusiveInputAssetScan(
+      sharedWorkflowImportMocks
+    )
+    await expectNoMissingMediaAfterPublicInclusiveAssetScan(
+      comfyPage,
+      sharedWorkflowImportMocks
+    )
+
+    expect(sharedWorkflowImportMocks.getImportBody()).toEqual({
+      published_asset_ids: [sharedWorkflowImportScenario.publishedAssetId],
+      share_id: sharedWorkflowImportScenario.shareId
+    })
+    expect(new URL(page.url()).searchParams.has('share')).toBe(false)
+    await openPanelAndExpectNoMissingMedia(comfyPage)
+  })
+})

--- a/browser_tests/tests/templates.spec.ts
+++ b/browser_tests/tests/templates.spec.ts
@@ -106,6 +106,54 @@ test.describe('Templates', { tag: ['@slow', '@workflow'] }, () => {
     await expect(comfyPage.templates.content).toBeVisible()
   })
 
+  test('dialog should not be shown when first-time user opens a shared workflow link', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.route(
+      '**/workflows/published/test-share-id',
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            share_id: 'test-share-id',
+            workflow_id: 'wf-1',
+            name: 'Shared Workflow',
+            listed: true,
+            publish_time: new Date().toISOString(),
+            workflow_json: {
+              version: 0.4,
+              nodes: [],
+              links: [],
+              groups: [],
+              config: {},
+              extra: {}
+            },
+            assets: []
+          })
+        })
+      }
+    )
+
+    await comfyPage.settings.setSetting('Comfy.TutorialCompleted', false)
+    await comfyPage.page.goto(`${comfyPage.url}/api/users`)
+    await comfyPage.page.evaluate((id) => {
+      localStorage.clear()
+      sessionStorage.clear()
+      localStorage.setItem('Comfy.userId', id)
+    }, comfyPage.id)
+    await comfyPage.page.goto(
+      new URL('/?share=test-share-id', comfyPage.url).toString()
+    )
+    await comfyPage.waitForAppReady()
+
+    await expect(
+      comfyPage.page.getByTestId(TestIds.dialogs.openSharedWorkflowTitle)
+    ).toBeVisible()
+
+    await expect(comfyPage.templates.content).toBeHidden()
+  })
+
   test('Uses proper locale files for templates', async ({ comfyPage }) => {
     await comfyPage.settings.setSetting('Comfy.Locale', 'fr')
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3214,6 +3214,7 @@
     "copyAssetsAndOpen": "Import assets & open workflow",
     "openWorkflow": "Open workflow",
     "openWithoutImporting": "Open without importing",
+    "opening": "Opening shared workflow...",
     "importFailed": "Failed to import workflow assets",
     "loadError": "Could not load this shared workflow. Please try again later."
   },

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts
@@ -34,6 +34,7 @@ const i18n = createI18n({
         copyAssetsAndOpen: 'Copy assets & open workflow',
         openWorkflow: 'Open workflow',
         openWithoutImporting: 'Open without importing',
+        opening: 'Opening shared workflow...',
         loadError:
           'Could not load this shared workflow. Please try again later.'
       },
@@ -290,6 +291,25 @@ describe('OpenSharedWorkflowDialogContent', () => {
       const buttons = container.querySelectorAll('footer button')
       await userEvent.click(buttons[buttons.length - 1] as HTMLElement)
       expect(onConfirm).toHaveBeenCalledWith(assetsPayload)
+    })
+
+    it('shows opening status and disables actions while opening', async () => {
+      mockGetSharedWorkflow.mockResolvedValue(assetsPayload)
+      const { container } = renderComponent({ openingAction: 'copy-and-open' })
+      await flushPromises()
+
+      expect(screen.getByRole('status').textContent).toContain(
+        'Opening shared workflow...'
+      )
+      expect(container.textContent).not.toContain(
+        'Opening the workflow will create a new copy in your workspace'
+      )
+      expect(screen.getByTestId('open-shared-workflow-close')).toBeEnabled()
+      expect(screen.getByTestId('open-shared-workflow-cancel')).toBeDisabled()
+      expect(
+        screen.getByTestId('open-shared-workflow-open-without-importing')
+      ).toBeDisabled()
+      expect(screen.getByTestId('open-shared-workflow-confirm')).toBeDisabled()
     })
 
     it('filters out assets already in library', async () => {

--- a/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue
@@ -1,12 +1,24 @@
 <template>
-  <div class="flex w-full flex-col">
+  <div
+    data-testid="open-shared-workflow-dialog"
+    class="flex w-full flex-col"
+    :aria-busy="isOpening"
+  >
     <header
       class="flex h-12 items-center justify-between gap-2 border-b border-border-default px-4"
     >
-      <h2 class="text-sm text-base-foreground">
+      <h2
+        data-testid="open-shared-workflow-title"
+        class="text-sm text-base-foreground"
+      >
         {{ $t('openSharedWorkflow.dialogTitle') }}
       </h2>
-      <Button size="icon" :aria-label="$t('g.close')" @click="onCancel">
+      <Button
+        data-testid="open-shared-workflow-close"
+        size="icon"
+        :aria-label="$t('g.close')"
+        @click="onCancel"
+      >
         <i class="icon-[lucide--x] size-4" />
       </Button>
     </header>
@@ -43,7 +55,12 @@
       <footer
         class="flex items-center justify-end gap-2.5 border-t border-border-default px-8 py-4"
       >
-        <Button variant="secondary" size="lg" @click="onCancel">
+        <Button
+          data-testid="open-shared-workflow-error-close"
+          variant="secondary"
+          size="lg"
+          @click="onCancel"
+        >
           {{ $t('g.close') }}
         </Button>
       </footer>
@@ -55,8 +72,23 @@
           <h2 class="m-0 text-2xl font-semibold text-base-foreground">
             {{ workflowName }}
           </h2>
-          <p class="m-0 text-sm text-muted-foreground">
-            {{ $t('openSharedWorkflow.copyDescription') }}
+          <p
+            role="status"
+            aria-live="polite"
+            class="m-0 flex items-center gap-2 text-sm text-muted-foreground"
+          >
+            <i
+              v-if="isOpening"
+              class="icon-[lucide--loader-circle] size-4 motion-safe:animate-spin"
+              aria-hidden="true"
+            />
+            <span>
+              {{
+                isOpening
+                  ? $t('openSharedWorkflow.opening')
+                  : $t('openSharedWorkflow.copyDescription')
+              }}
+            </span>
           </p>
         </div>
 
@@ -102,18 +134,34 @@
       <footer
         class="flex items-center justify-end gap-2.5 border-t border-border-default px-8 py-4"
       >
-        <Button variant="secondary" size="lg" @click="onCancel">
+        <Button
+          data-testid="open-shared-workflow-cancel"
+          variant="secondary"
+          size="lg"
+          :disabled="isOpening"
+          @click="onCancel"
+        >
           {{ $t('g.cancel') }}
         </Button>
         <Button
           v-if="hasAssets"
+          data-testid="open-shared-workflow-open-without-importing"
           variant="secondary"
           size="lg"
+          :loading="openingAction === 'open-only'"
+          :disabled="isOpening"
           @click="onOpenWithoutImporting(sharedWorkflow)"
         >
           {{ $t('openSharedWorkflow.openWithoutImporting') }}
         </Button>
-        <Button variant="primary" size="lg" @click="onConfirm(sharedWorkflow)">
+        <Button
+          data-testid="open-shared-workflow-confirm"
+          variant="primary"
+          size="lg"
+          :loading="openingAction === 'copy-and-open'"
+          :disabled="isOpening"
+          @click="onConfirm(sharedWorkflow)"
+        >
           {{
             hasAssets
               ? $t('openSharedWorkflow.copyAssetsAndOpen')
@@ -141,8 +189,17 @@ import Button from '@/components/ui/button/Button.vue'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import { cn } from '@comfyorg/tailwind-utils'
 
-const { shareId, onConfirm, onOpenWithoutImporting, onCancel } = defineProps<{
+type OpeningAction = 'copy-and-open' | 'open-only'
+
+const {
+  shareId,
+  openingAction = null,
+  onConfirm,
+  onOpenWithoutImporting,
+  onCancel
+} = defineProps<{
   shareId: string
+  openingAction?: OpeningAction | null
   onConfirm: (payload: SharedWorkflowPayload) => void
   onOpenWithoutImporting: (payload: SharedWorkflowPayload) => void
   onCancel: () => void
@@ -162,6 +219,7 @@ const nonOwnedAssets = computed(
 )
 
 const hasAssets = computed(() => nonOwnedAssets.value.length > 0)
+const isOpening = computed(() => openingAction !== null)
 
 const workflowName = computed(() => {
   if (!sharedWorkflow.value) return ''

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -80,6 +80,15 @@ vi.mock('vue-i18n', () => ({
 const mockShowLayoutDialog = vi.hoisted(() => vi.fn())
 const mockCloseDialog = vi.hoisted(() => vi.fn())
 const mockHideTemplateSelector = vi.hoisted(() => vi.fn())
+const mockDialogStack = vi.hoisted(
+  () =>
+    [] as Array<{
+      key: string
+      contentProps: Record<string, unknown>
+      dialogComponentProps: Record<string, unknown>
+    }>
+)
+const mockUpdateDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
@@ -89,7 +98,9 @@ vi.mock('@/services/dialogService', () => ({
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: () => ({
-    closeDialog: mockCloseDialog
+    dialogStack: mockDialogStack,
+    closeDialog: mockCloseDialog,
+    updateDialog: mockUpdateDialog
   })
 }))
 
@@ -117,17 +128,11 @@ function makePayload(
 }
 
 function resolveDialogWithConfirm(payload: SharedWorkflowPayload) {
-  const call = mockShowLayoutDialog.mock.calls.at(-1)
-  if (!call) throw new Error('showLayoutDialog was not called')
-  const options = call[0]
-  options.props.onConfirm(payload)
+  getLastDialogOptions().props.onConfirm(payload)
 }
 
 function resolveDialogWithOpenOnly(payload: SharedWorkflowPayload) {
-  const call = mockShowLayoutDialog.mock.calls.at(-1)
-  if (!call) throw new Error('showLayoutDialog was not called')
-  const options = call[0]
-  options.props.onOpenWithoutImporting(payload)
+  getLastDialogOptions().props.onOpenWithoutImporting(payload)
 }
 
 function resolveDialogWithCancel() {
@@ -137,10 +142,66 @@ function resolveDialogWithCancel() {
   options.props.onCancel()
 }
 
+function getLastDialogOptions() {
+  const call = mockShowLayoutDialog.mock.calls.at(-1)
+  if (!call) throw new Error('showLayoutDialog was not called')
+  return call[0]
+}
+
+function createDialogInstance(options: {
+  key: string
+  props: Record<string, unknown>
+  dialogComponentProps?: Record<string, unknown>
+}) {
+  const dialog = {
+    key: options.key,
+    contentProps: { ...options.props },
+    dialogComponentProps: { ...options.dialogComponentProps }
+  }
+  mockDialogStack.push(dialog)
+  return dialog
+}
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     mockQueryParams = {}
+    mockDialogStack.length = 0
+    mockShowLayoutDialog.mockImplementation(createDialogInstance)
+    mockUpdateDialog.mockImplementation(
+      (options: {
+        key: string
+        contentProps?: Record<string, unknown>
+        dialogComponentProps?: Record<string, unknown>
+      }) => {
+        const dialog = mockDialogStack.find((item) => item.key === options.key)
+        if (!dialog) return false
+
+        if (options.contentProps) {
+          dialog.contentProps = {
+            ...dialog.contentProps,
+            ...options.contentProps
+          }
+        }
+
+        if (options.dialogComponentProps) {
+          dialog.dialogComponentProps = {
+            ...dialog.dialogComponentProps,
+            ...options.dialogComponentProps
+          }
+        }
+
+        return true
+      }
+    )
     preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
   })
 
@@ -193,6 +254,38 @@ describe('useSharedWorkflowUrlLoader', () => {
     expect(mockHideTemplateSelector).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps dialog open with opening state while shared workflow loads', async () => {
+    mockQueryParams = { share: 'share-id-1' }
+    const graphLoad = createDeferred()
+    mockLoadGraphData.mockReturnValue(graphLoad.promise)
+
+    const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
+    const loadPromise = loadSharedWorkflowFromUrl()
+    await Promise.resolve()
+    const dialogOptions = getLastDialogOptions()
+    const dialogInstance = mockShowLayoutDialog.mock.results[0].value
+
+    dialogOptions.props.onConfirm(makePayload())
+    await Promise.resolve()
+
+    expect(dialogInstance.contentProps.openingAction).toBe('copy-and-open')
+    expect(mockUpdateDialog).toHaveBeenCalledWith({
+      key: 'open-shared-workflow',
+      contentProps: { openingAction: 'copy-and-open' }
+    })
+    expect(dialogInstance.dialogComponentProps.closable).toBeUndefined()
+    expect(dialogInstance.dialogComponentProps.closeOnEscape).toBeUndefined()
+    expect(dialogInstance.dialogComponentProps.dismissableMask).toBeUndefined()
+    expect(mockCloseDialog).not.toHaveBeenCalled()
+
+    graphLoad.resolve()
+    await loadPromise
+
+    expect(mockCloseDialog).toHaveBeenLastCalledWith({
+      key: 'open-shared-workflow'
+    })
+  })
+
   it('does not load graph when user cancels dialog', async () => {
     mockQueryParams = { share: 'share-id-1' }
     mockShowLayoutDialog.mockImplementation(() => {
@@ -222,7 +315,7 @@ describe('useSharedWorkflowUrlLoader', () => {
     expect(mockHideTemplateSelector).not.toHaveBeenCalled()
   })
 
-  it('calls import when non-owned assets exist and user confirms', async () => {
+  it('imports non-owned assets before loading graph when user confirms', async () => {
     mockQueryParams = { share: 'share-id-1' }
     const payload = makePayload({
       assets: [
@@ -242,9 +335,13 @@ describe('useSharedWorkflowUrlLoader', () => {
     })
 
     const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
-    await loadSharedWorkflowFromUrl()
+    const loaded = await loadSharedWorkflowFromUrl()
 
+    expect(loaded).toBe('loaded')
     expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'], 'share-id-1')
+    expect(mockImportPublishedAssets.mock.invocationCallOrder[0]).toBeLessThan(
+      mockLoadGraphData.mock.invocationCallOrder[0]
+    )
   })
 
   it('does not call import when user chooses open-only', async () => {
@@ -309,11 +406,49 @@ describe('useSharedWorkflowUrlLoader', () => {
     const loaded = await loadSharedWorkflowFromUrl()
 
     expect(loaded).toBe('loaded-without-assets')
+    expect(mockLoadGraphData).toHaveBeenCalledWith(
+      { nodes: [] },
+      true,
+      true,
+      'Test Workflow',
+      { openSource: 'shared_url' }
+    )
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({
         severity: 'error',
         detail: 'Failed to import workflow assets'
       })
+    )
+  })
+
+  it('clears share intent when graph load fails after importing assets', async () => {
+    mockQueryParams = { share: 'share-id-1', tab: 'assets' }
+    const payload = makePayload({
+      assets: [
+        {
+          id: 'a1',
+          name: 'img.png',
+          preview_url: '',
+          storage_url: '',
+          model: false,
+          public: false,
+          in_library: false
+        }
+      ]
+    })
+    mockShowLayoutDialog.mockImplementation(() => {
+      resolveDialogWithConfirm(payload)
+    })
+    mockLoadGraphData.mockRejectedValue(new Error('Graph load failed'))
+
+    const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
+    const loaded = await loadSharedWorkflowFromUrl()
+
+    expect(loaded).toBe('failed')
+    expect(mockImportPublishedAssets).toHaveBeenCalledWith(['a1'], 'share-id-1')
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: { tab: 'assets' } })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'share'
     )
   })
 

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -28,6 +28,10 @@ type DialogResult =
   | { action: 'open-only'; payload: SharedWorkflowPayload }
   | { action: 'cancel' }
 
+type OpeningAction = Exclude<DialogResult['action'], 'cancel'>
+
+const OPEN_SHARED_WORKFLOW_DIALOG_KEY = 'open-shared-workflow'
+
 export function useSharedWorkflowUrlLoader() {
   const route = useRoute()
   const router = useRouter()
@@ -63,28 +67,39 @@ export function useSharedWorkflowUrlLoader() {
     void router.replace({ query: newQuery })
   }
 
+  function clearShareIntent() {
+    cleanupUrlParams()
+    clearPreservedQuery(SHARE_NAMESPACE)
+  }
+
   function showOpenSharedWorkflowDialog(
     shareId: string
   ): Promise<DialogResult> {
-    const dialogKey = 'open-shared-workflow'
+    function setOpeningAction(openingAction: OpeningAction) {
+      dialogStore.updateDialog({
+        key: OPEN_SHARED_WORKFLOW_DIALOG_KEY,
+        contentProps: { openingAction }
+      })
+    }
 
     return new Promise<DialogResult>((resolve) => {
       dialogService.showLayoutDialog({
-        key: dialogKey,
+        key: OPEN_SHARED_WORKFLOW_DIALOG_KEY,
         component: OpenSharedWorkflowDialogContent,
         props: {
           shareId,
+          openingAction: null,
           onConfirm: (payload: SharedWorkflowPayload) => {
+            setOpeningAction('copy-and-open')
             resolve({ action: 'copy-and-open', payload })
-            dialogStore.closeDialog({ key: dialogKey })
           },
           onOpenWithoutImporting: (payload: SharedWorkflowPayload) => {
+            setOpeningAction('open-only')
             resolve({ action: 'open-only', payload })
-            dialogStore.closeDialog({ key: dialogKey })
           },
           onCancel: () => {
             resolve({ action: 'cancel' })
-            dialogStore.closeDialog({ key: dialogKey })
+            dialogStore.closeDialog({ key: OPEN_SHARED_WORKFLOW_DIALOG_KEY })
           }
         },
         dialogComponentProps: {
@@ -108,8 +123,7 @@ export function useSharedWorkflowUrlLoader() {
     }
 
     if (typeof shareParam !== 'string') {
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'not-present'
     }
 
@@ -122,67 +136,74 @@ export function useSharedWorkflowUrlLoader() {
         summary: t('g.error'),
         detail: t('shareWorkflow.loadFailed')
       })
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'failed'
     }
 
     const result = await showOpenSharedWorkflowDialog(shareParam)
 
     if (result.action === 'cancel') {
-      cleanupUrlParams()
-      clearPreservedQuery(SHARE_NAMESPACE)
+      clearShareIntent()
       return 'cancelled'
     }
 
     templateSelectorDialog.hide()
 
-    const { payload } = result
-    const workflowName = payload.name || t('openSharedWorkflow.dialogTitle')
-    const nonOwnedAssets = payload.assets.filter((a) => !a.in_library)
-
     try {
-      await app.loadGraphData(payload.workflowJson, true, true, workflowName, {
-        openSource: 'shared_url'
-      })
-    } catch (error) {
-      console.error(
-        '[useSharedWorkflowUrlLoader] Failed to load workflow graph:',
-        error
-      )
-      toast.add({
-        severity: 'error',
-        summary: t('g.error'),
-        detail: t('shareWorkflow.loadFailed')
-      })
-      return 'failed'
-    }
+      const { payload } = result
+      const workflowName = payload.name || t('openSharedWorkflow.dialogTitle')
+      const nonOwnedAssets = payload.assets.filter((a) => !a.in_library)
+      let importFailed = false
 
-    if (result.action === 'copy-and-open' && nonOwnedAssets.length > 0) {
+      if (result.action === 'copy-and-open' && nonOwnedAssets.length > 0) {
+        try {
+          await workflowShareService.importPublishedAssets(
+            nonOwnedAssets.map((a) => a.id),
+            payload.shareId
+          )
+        } catch (importError) {
+          importFailed = true
+          console.error(
+            '[useSharedWorkflowUrlLoader] Failed to import assets:',
+            importError
+          )
+          toast.add({
+            severity: 'error',
+            summary: t('g.error'),
+            detail: t('openSharedWorkflow.importFailed')
+          })
+        }
+      }
+
       try {
-        await workflowShareService.importPublishedAssets(
-          nonOwnedAssets.map((a) => a.id),
-          payload.shareId
+        await app.loadGraphData(
+          payload.workflowJson,
+          true,
+          true,
+          workflowName,
+          {
+            openSource: 'shared_url'
+          }
         )
-      } catch (importError) {
+      } catch (error) {
         console.error(
-          '[useSharedWorkflowUrlLoader] Failed to import assets:',
-          importError
+          '[useSharedWorkflowUrlLoader] Failed to load workflow graph:',
+          error
         )
         toast.add({
           severity: 'error',
           summary: t('g.error'),
-          detail: t('openSharedWorkflow.importFailed')
+          detail: t('shareWorkflow.loadFailed')
         })
-        cleanupUrlParams()
-        clearPreservedQuery(SHARE_NAMESPACE)
-        return 'loaded-without-assets'
+        clearShareIntent()
+        return 'failed'
       }
-    }
 
-    cleanupUrlParams()
-    clearPreservedQuery(SHARE_NAMESPACE)
-    return 'loaded'
+      clearShareIntent()
+      return importFailed ? 'loaded-without-assets' : 'loaded'
+    } finally {
+      dialogStore.closeDialog({ key: OPEN_SHARED_WORKFLOW_DIALOG_KEY })
+    }
   }
 
   return {

--- a/src/platform/workflow/sharing/services/workflowShareService.test.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/scripts/app', () => ({
 
 const mockGetShareableAssets = vi.fn()
 const mockFetchApi = vi.fn()
+const mockInvalidateInputAssetsIncludingPublic = vi.hoisted(() => vi.fn())
 
 vi.mock(
   '@/platform/workflow/validation/schemas/workflowSchema',
@@ -29,6 +30,13 @@ vi.mock('@/scripts/api', () => ({
     fetchApi: (...args: unknown[]) => mockFetchApi(...args),
     apiURL: (route: string) => `/api${route}`,
     fileURL: (route: string) => route
+  }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: {
+    invalidateInputAssetsIncludingPublic:
+      mockInvalidateInputAssetsIncludingPublic
   }
 }))
 
@@ -348,6 +356,7 @@ describe(useWorkflowShareService, () => {
         share_id: 'share-id-1'
       })
     })
+    expect(mockInvalidateInputAssetsIncludingPublic).toHaveBeenCalledTimes(1)
   })
 
   it('omits share_id from the payload when not provided', async () => {
@@ -384,6 +393,7 @@ describe(useWorkflowShareService, () => {
     await expect(
       service.importPublishedAssets(['bad-id'], 'share-id-1')
     ).rejects.toThrow('Failed to import assets: 400')
+    expect(mockInvalidateInputAssetsIncludingPublic).not.toHaveBeenCalled()
   })
 
   it('throws when shared workflow payload is invalid', async () => {

--- a/src/platform/workflow/sharing/services/workflowShareService.ts
+++ b/src/platform/workflow/sharing/services/workflowShareService.ts
@@ -6,6 +6,7 @@ import type {
   WorkflowPublishResult,
   WorkflowPublishStatus
 } from '@/platform/workflow/sharing/types/shareTypes'
+import { assetService } from '@/platform/assets/services/assetService'
 import type { ThumbnailType } from '@/platform/workflow/sharing/types/comfyHubTypes'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { validateComfyWorkflow } from '@/platform/workflow/validation/schemas/workflowSchema'
@@ -275,6 +276,8 @@ export function useWorkflowShareService() {
     if (!response.ok) {
       throw new Error(`Failed to import assets: ${response.status}`)
     }
+
+    assetService.invalidateInputAssetsIncludingPublic()
   }
 
   return {

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -10,6 +10,17 @@ const MockComponent = defineComponent({
   template: '<div>Mock</div>'
 })
 
+const MockContentPropsComponent = defineComponent({
+  name: 'MockContentPropsComponent',
+  props: {
+    openingAction: {
+      type: String,
+      default: null
+    }
+  },
+  template: '<div>Mock</div>'
+})
+
 describe('dialogStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -171,6 +182,31 @@ describe('dialogStore', () => {
       expect(store.dialogStack).toHaveLength(1)
       expect(store.dialogStack[0].key).toBe('reusable-dialog')
       expect(store.dialogStack[0].title).toBe('Original Title')
+    })
+
+    it('should update existing dialog props by key', () => {
+      const store = useDialogStore()
+
+      store.showDialog({
+        key: 'updatable-dialog',
+        component: MockContentPropsComponent,
+        props: { openingAction: null },
+        dialogComponentProps: { dismissableMask: true }
+      })
+
+      const updated = store.updateDialog({
+        key: 'updatable-dialog',
+        contentProps: { openingAction: 'copy-and-open' },
+        dialogComponentProps: { dismissableMask: false }
+      })
+
+      expect(updated).toBe(true)
+      expect(store.dialogStack[0].contentProps).toMatchObject({
+        openingAction: 'copy-and-open'
+      })
+      expect(store.dialogStack[0].dialogComponentProps.dismissableMask).toBe(
+        false
+      )
     })
   })
 

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -88,6 +88,12 @@ export interface ShowDialogOptions<
   priority?: number
 }
 
+interface UpdateDialogOptions {
+  key: string
+  contentProps?: Partial<DialogInstance['contentProps']>
+  dialogComponentProps?: Partial<DialogComponentProps>
+}
+
 export const useDialogStore = defineStore('dialog', () => {
   const dialogStack = ref<DialogInstance[]>([])
 
@@ -264,6 +270,28 @@ export const useDialogStore = defineStore('dialog', () => {
     return dialogStack.value.some((d) => d.key === key)
   }
 
+  function updateDialog(options: UpdateDialogOptions): boolean {
+    const dialog = dialogStack.value.find((d) => d.key === options.key)
+    if (!dialog) return false
+
+    if (options.contentProps) {
+      dialog.contentProps = {
+        ...dialog.contentProps,
+        ...options.contentProps
+      }
+    }
+
+    if (options.dialogComponentProps) {
+      dialog.dialogComponentProps = {
+        ...dialog.dialogComponentProps,
+        ...options.dialogComponentProps
+      }
+      updateCloseOnEscapeStates()
+    }
+
+    return true
+  }
+
   return {
     dialogStack,
     riseDialog,
@@ -271,6 +299,7 @@ export const useDialogStore = defineStore('dialog', () => {
     closeDialog,
     showExtensionDialog,
     isDialogOpen,
+    updateDialog,
     activeKey
   }
 })


### PR DESCRIPTION
Backport of #12333.

CC FE-773

## Summary
- Cherry-pick #12333 to core/1.44.
- Resolve the templates.spec conflict by keeping the shared workflow first-time user coverage.
- Adapt the shared workflow browser regression test to the 1.44 ComfyPage fixture API.
- Preserve the production behavior from #12333: import shared workflow assets before graph load, invalidate the public-inclusive input asset cache, and show dialog-local loading feedback while the import/load action is pending.

## Validation
- pnpm install --frozen-lockfile
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm typecheck:browser
- pnpm exec vitest run src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts src/platform/workflow/sharing/services/workflowShareService.test.ts src/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.test.ts src/stores/dialogStore.test.ts
- git diff --check

Note: pre-push knip completed with an existing tag-hint warning for src/scripts/metadata/flac.ts.

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12362-backport-core-1-44-fix-avoid-false-missing-media-after-shared-asset-import-3666d73d365081459018c03b413e78ee) by [Unito](https://www.unito.io)
