### PR TITLE
feat: track paywall_viewed across billing entry points (MAR-204)

### DIFF
--- a/src/platform/assets/components/UploadModelUpgradeModal.vue
+++ b/src/platform/assets/components/UploadModelUpgradeModal.vue
@@ -12,13 +12,16 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import UploadModelUpgradeModalBody from '@/platform/assets/components/UploadModelUpgradeModalBody.vue'
 import UploadModelUpgradeModalFooter from '@/platform/assets/components/UploadModelUpgradeModalFooter.vue'
+import { useTelemetry } from '@/platform/telemetry'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const dialogStore = useDialogStore()
-const { showSubscriptionDialog } = useBillingContext()
+const { showSubscriptionDialog, subscription } = useBillingContext()
 
 function handleClose() {
   dialogStore.closeDialog({ key: 'upload-model-upgrade' })
@@ -27,4 +30,11 @@ function handleClose() {
 function handleSubscribe() {
   showSubscriptionDialog()
 }
+
+onMounted(() => {
+  useTelemetry()?.trackPaywallViewed({
+    surface: 'upload_model_upgrade_modal',
+    current_tier: subscription.value?.tier?.toLowerCase()
+  })
+})
 </script>

--- a/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
+++ b/src/platform/cloud/subscription/components/FreeTierDialogContent.vue
@@ -99,15 +99,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 
 import Button from '@/components/ui/button/Button.vue'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import SubscriptionBenefits from '@/platform/cloud/subscription/components/SubscriptionBenefits.vue'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useTelemetry } from '@/platform/telemetry'
 
-defineProps<{
+const { reason } = defineProps<{
   reason?: SubscriptionDialogReason
 }>()
 
@@ -116,7 +117,15 @@ defineEmits<{
   upgrade: []
 }>()
 
-const { formattedRenewalDate } = useSubscription()
+const { formattedRenewalDate, subscriptionTier } = useSubscription()
 
 const freeTierCredits = computed(() => getTierCredits('free'))
+
+onMounted(() => {
+  useTelemetry()?.trackPaywallViewed({
+    surface: 'free_tier_dialog',
+    current_tier: subscriptionTier.value?.toLowerCase(),
+    reason
+  })
+})
 </script>

--- a/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
+++ b/src/platform/cloud/subscription/components/SubscriptionRequiredDialogContent.vue
@@ -145,7 +145,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 
 import CloudBadge from '@/components/topbar/CloudBadge.vue'
 import Button from '@/components/ui/button/Button.vue'
@@ -169,7 +169,7 @@ const emit = defineEmits<{
   close: [subscribed: boolean]
 }>()
 
-const { isActiveSubscription } = useBillingContext()
+const { isActiveSubscription, subscription } = useBillingContext()
 
 const isSubscriptionEnabled = (): boolean =>
   Boolean(isCloud && window.__CONFIG__?.subscription_required)
@@ -198,6 +198,14 @@ watch(
     }
   }
 )
+
+onMounted(() => {
+  telemetry?.trackPaywallViewed({
+    surface: 'subscription_required_dialog',
+    current_tier: subscription.value?.tier?.toLowerCase(),
+    reason
+  })
+})
 
 const handleSubscribed = () => {
   emit('close', true)

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -15,6 +15,7 @@ import type {
   NodeSearchMetadata,
   NodeSearchResultMetadata,
   PageViewMetadata,
+  PaywallViewedMetadata,
   PageVisibilityMetadata,
   SettingChangedMetadata,
   SubscriptionMetadata,
@@ -75,6 +76,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     metadata?: SubscriptionMetadata
   ): void {
     this.dispatch((provider) => provider.trackSubscription?.(event, metadata))
+  }
+
+  trackPaywallViewed(metadata: PaywallViewedMetadata): void {
+    this.dispatch((provider) => provider.trackPaywallViewed?.(metadata))
   }
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -166,7 +166,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
   }
 
   trackPaywallViewed(metadata: PaywallViewedMetadata): void {
-    this.pushEvent('view_promotion', { ...metadata })
+    this.pushEvent('paywall_viewed', { ...metadata })
   }
 
   trackSignupOpened(): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -15,6 +15,7 @@ import type {
   PageVisibilityMetadata,
   SettingChangedMetadata,
   ShareFlowMetadata,
+  PaywallViewedMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -162,6 +163,10 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     const ga4EventName =
       event === 'modal_opened' ? 'view_promotion' : 'select_promotion'
     this.pushEvent(ga4EventName, metadata ? { ...metadata } : undefined)
+  }
+
+  trackPaywallViewed(metadata: PaywallViewedMetadata): void {
+    this.pushEvent('view_promotion', { ...metadata })
   }
 
   trackSignupOpened(): void {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -30,6 +30,7 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
+  PaywallViewedMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -230,6 +231,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
         : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED
 
     this.trackEvent(eventName, metadata)
+  }
+
+  trackPaywallViewed(metadata: PaywallViewedMetadata): void {
+    this.trackEvent(TelemetryEvents.PAYWALL_VIEWED, metadata)
   }
 
   trackAddApiCreditButtonClicked(): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -179,6 +179,26 @@ describe('PostHogTelemetryProvider', () => {
         {}
       )
     })
+
+    it('captures paywall_viewed with surface and tier metadata', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackPaywallViewed({
+        surface: 'free_tier_dialog',
+        current_tier: 'free',
+        reason: 'out_of_credits'
+      })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.PAYWALL_VIEWED,
+        {
+          surface: 'free_tier_dialog',
+          current_tier: 'free',
+          reason: 'out_of_credits'
+        }
+      )
+    })
   })
 
   describe('disabled events', () => {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -25,6 +25,7 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
+  PaywallViewedMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -250,6 +251,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
         : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED
 
     this.trackEvent(eventName, metadata)
+  }
+
+  trackPaywallViewed(metadata: PaywallViewedMetadata): void {
+    this.trackEvent(TelemetryEvents.PAYWALL_VIEWED, metadata)
   }
 
   trackAddApiCreditButtonClicked(): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -340,6 +340,21 @@ export interface SubscriptionMetadata {
   reason?: SubscriptionDialogReason
 }
 
+/**
+ * Paywall surface identifier — distinguishes which UI entry point triggered
+ * the impression. Used to measure conversion across the various billing
+ * entry points (subscription required dialog, out-of-credits, upsells, etc.).
+ */
+export type PaywallSurface =
+  | 'free_tier_dialog'
+  | 'subscription_required_dialog_workspace'
+  | 'upload_model_upgrade_modal'
+  | 'invite_member_upsell'
+
+export interface PaywallViewedMetadata extends SubscriptionMetadata {
+  surface: PaywallSurface
+}
+
 export interface BeginCheckoutMetadata
   extends Record<string, unknown>, CheckoutAttributionMetadata {
   user_id: string
@@ -390,6 +405,7 @@ export interface TelemetryProvider {
     event: 'modal_opened' | 'subscribe_clicked',
     metadata?: SubscriptionMetadata
   ): void
+  trackPaywallViewed?(metadata: PaywallViewedMetadata): void
   trackBeginCheckout?(metadata: BeginCheckoutMetadata): void
   trackMonthlySubscriptionSucceeded?(
     metadata?: SubscriptionSuccessMetadata
@@ -489,6 +505,7 @@ export const TelemetryEvents = {
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
   MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
   MONTHLY_SUBSCRIPTION_CANCELLED: 'app:monthly_subscription_cancelled',
+  PAYWALL_VIEWED: 'app:paywall_viewed',
   ADD_API_CREDIT_BUTTON_CLICKED: 'app:add_api_credit_button_clicked',
   API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED:
     'app:api_credit_topup_button_purchase_clicked',

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -347,6 +347,7 @@ export interface SubscriptionMetadata {
  */
 export type PaywallSurface =
   | 'free_tier_dialog'
+  | 'subscription_required_dialog'
   | 'subscription_required_dialog_workspace'
   | 'upload_model_upgrade_modal'
   | 'invite_member_upsell'

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentWorkspace.vue
@@ -94,8 +94,12 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+
 import Button from '@/components/ui/button/Button.vue'
+import { useBillingContext } from '@/composables/billing/useBillingContext'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import { useTelemetry } from '@/platform/telemetry'
 import { useSubscriptionCheckout } from '@/platform/workspace/composables/useSubscriptionCheckout'
 
 import PricingTableWorkspace from './PricingTableWorkspace.vue'
@@ -106,6 +110,16 @@ const { onClose, reason } = defineProps<{
   onClose: () => void
   reason?: SubscriptionDialogReason
 }>()
+
+const { subscription } = useBillingContext()
+
+onMounted(() => {
+  useTelemetry()?.trackPaywallViewed({
+    surface: 'subscription_required_dialog_workspace',
+    current_tier: subscription.value?.tier?.toLowerCase(),
+    reason
+  })
+})
 
 const emit = defineEmits<{
   close: [subscribed: boolean]

--- a/src/platform/workspace/components/dialogs/InviteMemberUpsellDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/InviteMemberUpsellDialogContent.vue
@@ -50,12 +50,16 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useTelemetry } from '@/platform/telemetry'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const dialogStore = useDialogStore()
-const { isActiveSubscription, showSubscriptionDialog } = useBillingContext()
+const { isActiveSubscription, showSubscriptionDialog, subscription } =
+  useBillingContext()
 
 function onDismiss() {
   dialogStore.closeDialog({ key: 'invite-member-upsell' })
@@ -65,4 +69,11 @@ function onUpgrade() {
   dialogStore.closeDialog({ key: 'invite-member-upsell' })
   showSubscriptionDialog()
 }
+
+onMounted(() => {
+  useTelemetry()?.trackPaywallViewed({
+    surface: 'invite_member_upsell',
+    current_tier: subscription.value?.tier?.toLowerCase()
+  })
+})
 </script>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Adds an `app:paywall_viewed` impression event fired in `onMounted` of every primary paywall surface so funnel analytics can finally answer "how many people saw the paywall and converted?" per entry point. Today only the existing `subscription_required_modal_opened` event covers part of the personal-tier flow, leaving workspace and upsell paywalls dark.

Event lands in PostHog, Mixpanel, and GA4 (GTM) with `surface`, `current_tier`, and (where applicable) `reason`.

## Surfaces instrumented

- `subscription_required_dialog` — `SubscriptionRequiredDialogContent` (personal-tier)
- `subscription_required_dialog_workspace` — `SubscriptionRequiredDialogContentWorkspace` (team)
- `free_tier_dialog` — `FreeTierDialogContent` (out-of-credits + subscription-required)
- `upload_model_upgrade_modal` — `UploadModelUpgradeModal`
- `invite_member_upsell` — `InviteMemberUpsellDialogContent`

The `/pricing` page in MAR-204 lives in `website/`, not this repo, so it is not in scope here.

## Code review feedback addressed

- Map GTM's `trackPaywallViewed` to a distinct `paywall_viewed` event (not `view_promotion`), since `trackSubscription('modal_opened') → view_promotion` already exists — prevents GTM double-counting on the personal subscription dialog where both fire.
- Add the personal subscription dialog surface that the first pass missed.
- Add dispatch test for PostHog `trackPaywallViewed` payload.

## Verification

- `pnpm typecheck` — clean
- `pnpm exec vitest run src/platform/telemetry` — **147/147 pass** (includes new `trackPaywallViewed` test)
- `pnpm exec eslint` on all changed files — no new errors
- `pnpm exec oxfmt --check` — clean

Manual UI verification (Playwright/tmux) is not applicable: the change is a fire-and-forget analytics call in `onMounted` with **zero rendered output and zero behavioral change** — there is nothing to see, click, or curl. Verification is via the existing telemetry-provider unit-test suite (mocks `posthog.capture`, asserts the exact payload), and the GA4/Mixpanel paths follow the same shape as covered events.

Fixes MAR-204

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12366-feat-track-paywall_viewed-across-billing-entry-points-MAR-204-3666d73d3650817e938aced14a2f9ac1) by [Unito](https://www.unito.io)
