### PR TITLE
feat: add model-to-node mappings for geometry_estimation and optical_flow

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -210,5 +210,11 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
 
   // ---- Ultralytics YOLO detectors (ComfyUI-Impact-Pack) ----
   ['ultralytics/bbox', 'UltralyticsDetectorProvider', 'model_name'],
-  ['ultralytics/segm', 'UltralyticsDetectorProvider', 'model_name']
+  ['ultralytics/segm', 'UltralyticsDetectorProvider', 'model_name'],
+
+  // ---- ComfyUI core geometry estimation (MoGe) ----
+  ['geometry_estimation', 'LoadMoGeModel', 'model_name'],
+
+  // ---- ComfyUI core optical flow (RAFT) ----
+  ['optical_flow', 'OpticalFlowLoader', 'model_name']
 ] as const satisfies ReadonlyArray<readonly [string, string, string]>


### PR DESCRIPTION
## Summary

Add entries to `MODEL_NODE_MAPPINGS` so the model browser's "Use" button creates the correct loader node for two model directories introduced in recent node-pack updates.

## Changes

- **What**: 2 new entries in `src/platform/assets/mappings/modelNodeMappings.ts`:
  - `geometry_estimation` → `LoadMoGeModel` / `model_name`
  - `optical_flow` → `OpticalFlowLoader` / `model_name`
- **Breaking**: none

## Review Focus

- Node class names and input keys cross-checked against the published node definitions:
  - `LoadMoGeModel` is the MoGe geometry-estimation loader (companion nodes: `MoGeInference`, `MoGeRender`, `MoGeContextStrandModel`)
  - `OpticalFlowLoader` is the RAFT optical-flow loader
- Both directories accept a single model file via a COMBO widget on the loader node

## Test plan

- [ ] Verify "Use" button works for each new model directory in the model browser:
  - One `geometry_estimation` model (e.g. `moge_2_vitl_normal_fp16.safetensors`) → creates a `LoadMoGeModel` node with the file preselected
  - One `optical_flow` model → creates an `OpticalFlowLoader` node with the file preselected

┆Issue is synchronized with this [Notion page](https://www.notion.so/PR-12389-feat-add-model-to-node-mappings-for-geometry_estimation-and-optical_flow-3666d73d36508190981fcaf77f9d2ee4) by [Unito](https://www.unito.io)
