### PR TITLE
Fix scroll event leak in text preview widget

### DIFF
--- a/src/components/graph/widgets/TextPreviewWidget.test.ts
+++ b/src/components/graph/widgets/TextPreviewWidget.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue'
+import { fireEvent, render, screen } from '@testing-library/vue'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick, ref } from 'vue'
@@ -48,6 +48,29 @@ function renderPreview(
       plugins: [PrimeVue],
       stubs: { Skeleton: SkeletonStub }
     }
+  })
+}
+
+function getScrollContainer(container: HTMLElement): HTMLElement {
+  // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+  const element = container.firstElementChild
+  if (!(element instanceof HTMLElement)) {
+    throw new Error('Expected text preview root element')
+  }
+  return element
+}
+
+function mockScrollMetrics(
+  element: HTMLElement,
+  { clientHeight, scrollHeight }: { clientHeight: number; scrollHeight: number }
+) {
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    value: clientHeight
+  })
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    value: scrollHeight
   })
 }
 
@@ -200,6 +223,48 @@ describe('TextPreviewWidget', () => {
       await nextTick()
 
       expect(screen.queryByTestId('skeleton')).toBeNull()
+    })
+  })
+
+  describe('Wheel event handling', () => {
+    it('keeps wheel events inside a scrollable text preview', async () => {
+      const { container } = renderPreview('long text')
+      const preview = getScrollContainer(container)
+      const parentWheel = vi.fn()
+      mockScrollMetrics(preview, { clientHeight: 100, scrollHeight: 200 })
+      container.addEventListener('wheel', parentWheel)
+
+      await fireEvent.wheel(preview, { deltaY: 40 })
+
+      expect(parentWheel).not.toHaveBeenCalled()
+    })
+
+    it('lets wheel events reach the canvas when text preview is not scrollable', async () => {
+      const { container } = renderPreview('short text')
+      const preview = getScrollContainer(container)
+      const parentWheel = vi.fn()
+      mockScrollMetrics(preview, { clientHeight: 100, scrollHeight: 100 })
+      container.addEventListener('wheel', parentWheel)
+
+      await fireEvent.wheel(preview, { deltaY: 40 })
+
+      expect(parentWheel).toHaveBeenCalledTimes(1)
+    })
+
+    it('prevents default browser handling for intercepted canvas wheel gestures', async () => {
+      const { container } = renderPreview('long text')
+      const preview = getScrollContainer(container)
+      mockScrollMetrics(preview, { clientHeight: 100, scrollHeight: 200 })
+
+      const event = new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        ctrlKey: true,
+        deltaY: 40
+      })
+      preview.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
     })
   })
 })

--- a/src/components/graph/widgets/TextPreviewWidget.vue
+++ b/src/components/graph/widgets/TextPreviewWidget.vue
@@ -1,6 +1,8 @@
 <template>
   <div
+    ref="scrollContainer"
     class="relative max-h-[200px] min-h-[28px] w-full overflow-y-auto rounded-lg px-4 py-2 text-xs"
+    @wheel="handleWheel"
   >
     <div class="flex items-center gap-2">
       <div class="flex flex-1 items-center gap-2 break-all">
@@ -14,8 +16,9 @@
 <script setup lang="ts">
 import { default as DOMPurify } from 'dompurify'
 import Skeleton from 'primevue/skeleton'
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 
+import { isCanvasGestureWheel } from '@/base/wheelGestures'
 import type { NodeId } from '@/lib/litegraph/src/litegraph'
 import { useExecutionStore } from '@/stores/executionStore'
 import { linkifyHtml, nl2br } from '@/utils/formatUtil'
@@ -24,6 +27,7 @@ const modelValue = defineModel<string>({ required: true })
 const props = defineProps<{
   nodeId: NodeId
 }>()
+const scrollContainer = ref<HTMLElement | null>(null)
 
 const executionStore = useExecutionStore()
 const isParentNodeExecuting = computed(() => {
@@ -64,6 +68,20 @@ const formattedText = computed(() => {
     ALLOWED_ATTR: ['href', 'target', 'rel']
   })
 })
+
+const handleWheel = (event: WheelEvent) => {
+  const element = scrollContainer.value
+  if (!element) return
+
+  const isScrollable = element.scrollHeight > element.clientHeight
+  if (!isScrollable) return
+
+  event.stopPropagation()
+
+  if (isCanvasGestureWheel(event)) {
+    event.preventDefault()
+  }
+}
 
 let parentNodeId: NodeId | null = null
 onMounted(() => {


### PR DESCRIPTION
## Summary

- stop wheel events from bubbling from scrollable text preview widgets into the canvas
- keep short/non-scrollable text previews transparent to canvas wheel handling
- prevent default browser behavior for intercepted canvas wheel gestures
- add unit coverage for scrollable, non-scrollable, and canvas-gesture wheel cases

## Issue

Fixes #3990

## Testing

- Not run locally in this workspace because the full repository checkout could not complete over the current network connection.
- Patch adds focused Vitest coverage in `TextPreviewWidget.test.ts`.