### PR TITLE
Fix mask editor sometimes showing wrong image

### DIFF
--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -301,3 +301,30 @@ test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
     }
   )
 })
+
+test('Will not use stale litegraph previews', async ({ comfyPage }) => {
+  await comfyPage.menu.topbar.newWorkflowButton.click()
+  await comfyPage.searchBoxV2.addNode('Preview Image')
+
+  async function simulateExecuted(image: object) {
+    await comfyPage.page.evaluate((pageImage) => {
+      const output = { images: [pageImage] }
+      const detail = { node: '1', output, prompt_id: '', display_node: '1' }
+      console.error(JSON.stringify(detail))
+      app!.api.dispatchCustomEvent('executed', detail)
+    }, image)
+  }
+  async function getNodeOutput() {
+    return await comfyPage.page.evaluate(
+      () => graph!.getNodeById('1')!.images?.[0]?.filename
+    )
+  }
+
+  await simulateExecuted({ filename: 'test1.png' })
+  await expect.poll(getNodeOutput).toBe('test1.png')
+
+  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
+  await simulateExecuted({ filename: 'test2.png' })
+  await expect.poll(getNodeOutput).toBe('test2.png')
+})

--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -310,7 +310,6 @@ test('Will not use stale litegraph previews', async ({ comfyPage }) => {
     await comfyPage.page.evaluate((pageImage) => {
       const output = { images: [pageImage] }
       const detail = { node: '1', output, prompt_id: '', display_node: '1' }
-      console.error(JSON.stringify(detail))
       app!.api.dispatchCustomEvent('executed', detail)
       app!.canvas.setDirty(true)
     }, image)

--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -1,6 +1,10 @@
-import { expect } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
 
+import { ExecutionHelper } from '@e2e/fixtures/helpers/ExecutionHelper'
 import { maskEditorTest as test } from '@e2e/fixtures/helpers/MaskEditorHelper'
+import { webSocketFixture } from '@e2e/fixtures/ws'
+
+const wstest = mergeTests(test, webSocketFixture)
 
 test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
   test(
@@ -302,29 +306,38 @@ test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
   )
 })
 
-test('Will not use stale litegraph previews', async ({ comfyPage }) => {
-  await comfyPage.menu.topbar.newWorkflowButton.click()
-  await comfyPage.searchBoxV2.addNode('Preview Image')
+wstest(
+  'Will not use stale litegraph previews',
+  async ({ comfyPage, getWebSocket }) => {
+    const executionHelper = new ExecutionHelper(comfyPage, await getWebSocket())
+    await comfyPage.menu.topbar.newWorkflowButton.click()
+    await comfyPage.searchBoxV2.addNode('Preview Image')
 
-  async function simulateExecuted(image: object) {
-    await comfyPage.page.evaluate((pageImage) => {
-      const output = { images: [pageImage] }
-      const detail = { node: '1', output, prompt_id: '', display_node: '1' }
-      app!.api.dispatchCustomEvent('executed', detail)
-      app!.canvas.setDirty(true)
-    }, image)
+    async function getNodeOutput() {
+      return await comfyPage.page.evaluate(
+        () => graph!.getNodeById('1')!.images?.[0]?.filename
+      )
+    }
+
+    executionHelper.executed('', '1', { images: [{ filename: 'test1.png' }] })
+    await comfyPage.page.evaluate(() => app!.canvas.setDirty(true))
+    await expect.poll(getNodeOutput).toBe('test1.png')
+
+    await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+
+    const resolvableFile = { filename: 'example.png', type: 'input' }
+    executionHelper.executed('', '1', { images: [resolvableFile] })
+    await expect.poll(getNodeOutput).toBe('example.png')
+
+    const node = await comfyPage.vueNodes.getFixtureByTitle('Preview Image')
+    await node.imagePreview.hover()
+    await node.imagePreview
+      .getByRole('button', { name: 'Edit or mask image' })
+      .click()
+
+    // On previous versions, attempting to open the mask editor here would
+    // incorrectly reference the non-existant test1.png
+    // This causes the mask editor to throw in setup and not display
+    await expect(comfyPage.page.locator('.mask-editor-dialog')).toBeVisible()
   }
-  async function getNodeOutput() {
-    return await comfyPage.page.evaluate(
-      () => graph!.getNodeById('1')!.images?.[0]?.filename
-    )
-  }
-
-  await simulateExecuted({ filename: 'test1.png' })
-  await expect.poll(getNodeOutput).toBe('test1.png')
-
-  await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
-
-  await simulateExecuted({ filename: 'example.png', type: 'input' })
-  await expect.poll(getNodeOutput).toBe('example.png')
-})
+)

--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -312,6 +312,7 @@ test('Will not use stale litegraph previews', async ({ comfyPage }) => {
       const detail = { node: '1', output, prompt_id: '', display_node: '1' }
       console.error(JSON.stringify(detail))
       app!.api.dispatchCustomEvent('executed', detail)
+      app!.canvas.setDirty(true)
     }, image)
   }
   async function getNodeOutput() {
@@ -325,6 +326,6 @@ test('Will not use stale litegraph previews', async ({ comfyPage }) => {
 
   await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
 
-  await simulateExecuted({ filename: 'test2.png' })
-  await expect.poll(getNodeOutput).toBe('test2.png')
+  await simulateExecuted({ filename: 'example.png', type: 'input' })
+  await expect.poll(getNodeOutput).toBe('example.png')
 })

--- a/src/stores/nodeOutputStore.ts
+++ b/src/stores/nodeOutputStore.ts
@@ -473,6 +473,9 @@ export const useNodeOutputStore = defineStore('nodeOutput', () => {
 
     node.imgs = [element]
     node.imageIndex = activeIndex
+
+    const outputs = getNodeOutputs(node)
+    if (outputs?.images) node.images = outputs.images
   }
 
   return {


### PR DESCRIPTION
Mask editor checks `node.images` to determine the image which is edited. If the user generates an output image in litegraph mode, swaps to vue mode, then generates a new image, the mask editor will incorrectly display the image last shown in litegraph mode.

This is resolved by having `syncLegacyNodeImgs` also synchronize node outputs to `node.images`.