### PR TITLE
fix: redirect /privacy to /privacy-policy on comfy.org

### DIFF
--- a/apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue
+++ b/apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue
@@ -1,23 +1,23 @@
 <template>
-  <div class="flex flex-col gap-6 w-[600px]">
+  <div class="flex w-[600px] flex-col gap-6">
     <div class="flex flex-col gap-4">
       <h2 class="text-2xl font-semibold text-neutral-100">
         {{ $t('install.desktopAppSettings') }}
       </h2>
 
-      <p class="text-neutral-400 my-0">
+      <p class="my-0 text-neutral-400">
         {{ $t('install.desktopAppSettingsDescription') }}
       </p>
     </div>
 
-    <div class="flex flex-col bg-neutral-800 p-4 rounded-lg text-sm">
+    <div class="flex flex-col rounded-lg bg-neutral-800 p-4 text-sm">
       <!-- Auto Update Setting -->
       <div class="flex items-center gap-4">
         <div class="flex-1">
           <h3 class="text-lg font-medium text-neutral-100">
             {{ $t('install.settings.autoUpdate') }}
           </h3>
-          <p class="text-neutral-400 mt-1">
+          <p class="mt-1 text-neutral-400">
             {{ $t('install.settings.autoUpdateDescription') }}
           </p>
         </div>
@@ -52,10 +52,10 @@
       class="select-none"
     >
       <div class="text-neutral-300">
-        <h4 class="font-medium mb-2">
+        <h4 class="mb-2 font-medium">
           {{ $t('install.settings.dataCollectionDialog.whatWeCollect') }}
         </h4>
-        <ul class="list-disc pl-6 space-y-1">
+        <ul class="list-disc space-y-1 pl-6">
           <li>
             {{
               $t('install.settings.dataCollectionDialog.collect.errorReports')
@@ -73,10 +73,10 @@
           </li>
         </ul>
 
-        <h4 class="font-medium mt-4 mb-2">
+        <h4 class="mt-4 mb-2 font-medium">
           {{ $t('install.settings.dataCollectionDialog.whatWeDoNotCollect') }}
         </h4>
-        <ul class="list-disc pl-6 space-y-1">
+        <ul class="list-disc space-y-1 pl-6">
           <li>
             {{
               $t(
@@ -108,7 +108,7 @@
         </ul>
 
         <div class="mt-4">
-          <a href="https://comfy.org/privacy" target="_blank">
+          <a href="https://comfy.org/privacy-policy" target="_blank">
             {{ $t('install.settings.dataCollectionDialog.viewFullPolicy') }}
           </a>
         </div>

--- a/apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue
+++ b/apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue
@@ -108,7 +108,11 @@
         </ul>
 
         <div class="mt-4">
-          <a href="https://comfy.org/privacy-policy" target="_blank">
+          <a
+            href="https://comfy.org/privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             {{ $t('install.settings.dataCollectionDialog.viewFullPolicy') }}
           </a>
         </div>

--- a/apps/desktop-ui/src/views/MetricsConsentView.vue
+++ b/apps/desktop-ui/src/views/MetricsConsentView.vue
@@ -13,7 +13,7 @@
         <p class="text-neutral-400">
           {{ $t('install.moreInfo') }}
           <a
-            href="https://comfy.org/privacy"
+            href="https://comfy.org/privacy-policy"
             target="_blank"
             class="text-blue-400 underline hover:text-blue-300"
           >

--- a/apps/desktop-ui/src/views/MetricsConsentView.vue
+++ b/apps/desktop-ui/src/views/MetricsConsentView.vue
@@ -15,6 +15,7 @@
           <a
             href="https://comfy.org/privacy-policy"
             target="_blank"
+            rel="noopener noreferrer"
             class="text-blue-400 underline hover:text-blue-300"
           >
             {{ $t('install.privacyPolicy') }} </a

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -23,6 +23,11 @@
       "permanent": true
     },
     {
+      "source": "/privacy",
+      "destination": "/privacy-policy",
+      "permanent": true
+    },
+    {
       "source": "/enterprise",
       "destination": "/cloud/enterprise",
       "permanent": true

--- a/browser_tests/tests/dialogs/signInDialog.spec.ts
+++ b/browser_tests/tests/dialogs/signInDialog.spec.ts
@@ -68,7 +68,7 @@ test.describe('Sign In dialog', { tag: '@ui' }, () => {
     await expect(dialog.privacyLink).toBeVisible()
     await expect(dialog.privacyLink).toHaveAttribute(
       'href',
-      'https://www.comfy.org/privacy'
+      'https://www.comfy.org/privacy-policy'
     )
   })
 

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -126,7 +126,7 @@
         </a>
         {{ t('auth.login.andText') }}
         <a
-          href="https://www.comfy.org/privacy"
+          href="https://www.comfy.org/privacy-policy"
           target="_blank"
           class="cursor-pointer text-blue-500"
         >

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -128,6 +128,7 @@
         <a
           href="https://www.comfy.org/privacy-policy"
           target="_blank"
+          rel="noopener noreferrer"
           class="cursor-pointer text-blue-500"
         >
           {{ t('auth.login.privacyLink') }} </a

--- a/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue
@@ -132,7 +132,7 @@
           </template>
           <template #privacy>
             <a
-              href="https://www.comfy.org/privacy"
+              href="https://www.comfy.org/privacy-policy"
               target="_blank"
               rel="noopener noreferrer"
               class="underline hover:text-base-foreground"


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

`https://www.comfy.org/privacy` was returning a 404 because the privacy page lives at `/privacy-policy`. This fixes the broken URL two ways:

1. **Adds a permanent (308) redirect** `/privacy → /privacy-policy` in `apps/website/vercel.json` — catches any external links, bookmarks, or future typos that point at `/privacy`.
2. **Updates four hardcoded `/privacy` links** in the in-app frontend (and the browser test that asserted the broken URL) to use `/privacy-policy` directly — so internal links don't take an unnecessary redirect hop.

The correct path (`/privacy-policy`) was already used in three other places in the codebase (cloud onboarding flow), so this brings the rest of the codebase in line with the established convention.

## Changes

**Website redirect** (`apps/website/vercel.json`):
- Add `/privacy → /privacy-policy` to the existing `redirects` array (sits alongside `/pricing → /cloud/pricing` and friends).

**Hardcoded link fixes** (`https://www.comfy.org/privacy` and `https://comfy.org/privacy` → `…/privacy-policy`):
- `src/components/dialog/content/SignInContent.vue:129`
- `src/platform/workspace/components/SubscriptionAddPaymentPreviewWorkspace.vue:135`
- `apps/desktop-ui/src/components/install/DesktopSettingsConfiguration.vue:111`
- `apps/desktop-ui/src/views/MetricsConsentView.vue:16`
- `browser_tests/tests/dialogs/signInDialog.spec.ts:71` (test assertion updated to match)

**Note on `DesktopSettingsConfiguration.vue` diff size**: the project's `lint-staged` pre-commit hook ran `eslint --fix` against this file when I edited it, and the auto-fix reordered eight pre-existing tailwind class-order violations to satisfy `better-tailwindcss/enforce-consistent-class-order`. These reorderings are semantically identical (pure class shuffling) and were not authored by me — they're enforced by the repo's own tooling. Reverting them would just re-trigger the hook.

## Verification

- `python -m json.tool apps/website/vercel.json` — valid JSON; redirect entry parses with `source=/privacy`, `destination=/privacy-policy`, `permanent=true` (308).
- `pnpm --filter @comfyorg/website build` — 379 pages built successfully; `dist/privacy-policy/index.html` renders with the full policy content, `dist/privacy/` correctly does NOT exist (proves the 404 root cause and that the vercel.json redirect is the right fix layer).
- `pnpm typecheck` — passes.
- `pnpm exec vitest run src/components/dialog/content src/platform/workspace/components` — 104/104 unit tests pass.
- `pnpm exec eslint` on changed files — no new lint errors (the 8 pre-existing tailwind class-order errors in `DesktopSettingsConfiguration.vue` were auto-fixed by the lint-staged hook).
- `pnpm exec oxfmt --check` on all changed files — clean.
- Pre-commit hooks (stylelint, oxlint --type-aware, eslint, typecheck, typecheck:browser, typecheck:website) — all passed.
- Code review (`/review`) — 0 critical / 0 warning / 0 suggestion. Oracle independently re-ran format/lint/typecheck/build and confirmed no remaining `comfy.org/privacy` references outside the new redirect rule.

**What cannot be tested locally**: Vercel `redirects` are applied by the Vercel edge layer at request time, not by Astro's build or dev server. The 308 will only become active once Vercel deploys this PR. The redirect rule's structure has been validated against the existing entries in the same file (`/pricing`, `/enterprise`, `/blog`, `/press`), all of which currently work in production.