### PR TITLE
feat: focus 3D viewer on point under cursor

### DIFF
--- a/src/extensions/core/load3d/ControlsManager.test.ts
+++ b/src/extensions/core/load3d/ControlsManager.test.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ControlsManager } from './ControlsManager'
 import type { EventManagerInterface } from './interfaces'
@@ -26,6 +26,12 @@ vi.mock('three/examples/jsm/controls/OrbitControls', () => {
     addEventListener(event: string, cb: Listener) {
       if (!this.listeners.has(event)) this.listeners.set(event, [])
       this.listeners.get(event)!.push(cb)
+    }
+    removeEventListener(event: string, cb: Listener) {
+      const list = this.listeners.get(event)
+      if (!list) return
+      const idx = list.indexOf(cb)
+      if (idx >= 0) list.splice(idx, 1)
     }
     fire(event: string) {
       this.listeners.get(event)?.forEach((cb) => cb())
@@ -60,6 +66,10 @@ describe('ControlsManager', () => {
     vi.clearAllMocks()
     events = makeMockEventManager()
     camera = new THREE.PerspectiveCamera()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('construction', () => {
@@ -133,6 +143,71 @@ describe('ControlsManager', () => {
       expect(newCamera.position.toArray()).toEqual([7, 8, 9])
       expect(manager.controls.target.toArray()).toEqual([1, 1, 1])
       expect(manager.controls.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('setTarget', () => {
+    it('moves the orbit pivot and translates the camera by the same delta so distance is preserved', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+      camera.position.set(0, 0, 5)
+      camera.zoom = 1
+      manager.controls.target.set(0, 0, 0)
+
+      manager.setTarget(new THREE.Vector3(1, 2, 3))
+
+      expect(manager.controls.target.toArray()).toEqual([1, 2, 3])
+      expect(camera.position.toArray()).toEqual([1, 2, 8])
+      expect(manager.controls.update).toHaveBeenCalled()
+      expect(events.emitEvent).toHaveBeenCalledWith('cameraChanged', {
+        position: expect.objectContaining({ x: 1, y: 2, z: 8 }),
+        target: expect.objectContaining({ x: 1, y: 2, z: 3 }),
+        zoom: 1,
+        cameraType: 'perspective'
+      })
+    })
+
+    it('moves the camera to the specified distance from the new pivot along the previous direction', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+      camera.position.set(0, 0, 100)
+      manager.controls.target.set(0, 0, 0)
+
+      manager.setTarget(new THREE.Vector3(2, 0, 0), 10)
+
+      expect(camera.position.toArray()).toEqual([2, 0, 10])
+    })
+  })
+
+  describe('animateTarget', () => {
+    it('lerps camera position and target over time and emits cameraChanged on completion', () => {
+      manager = new ControlsManager(makeRenderer(), camera, events)
+      camera.position.set(0, 0, 10)
+      manager.controls.target.set(0, 0, 0)
+
+      let now = 1000
+      vi.spyOn(performance, 'now').mockImplementation(() => now)
+      const rafQueue: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafQueue.push(cb)
+        return rafQueue.length
+      })
+      vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+
+      manager.animateTarget(new THREE.Vector3(0, 0, 0), 2, 100)
+      // Halfway through
+      now = 1050
+      rafQueue.shift()?.(now)
+      expect(camera.position.z).toBeGreaterThan(2)
+      expect(camera.position.z).toBeLessThan(10)
+      // Past end
+      now = 1200
+      rafQueue.shift()?.(now)
+      expect(camera.position.toArray()).toEqual([0, 0, 2])
+      expect(events.emitEvent).toHaveBeenCalledWith(
+        'cameraChanged',
+        expect.objectContaining({
+          position: expect.objectContaining({ x: 0, y: 0, z: 2 })
+        })
+      )
     })
   })
 

--- a/src/extensions/core/load3d/ControlsManager.ts
+++ b/src/extensions/core/load3d/ControlsManager.ts
@@ -10,6 +10,9 @@ export class ControlsManager implements ControlsManagerInterface {
   controls: OrbitControls
   private eventManager: EventManagerInterface
   private camera: THREE.Camera
+  private requestRender: (() => void) | null = null
+  private animationRafId: number | null = null
+  private animationCleanup: (() => void) | null = null
 
   constructor(
     renderer: THREE.WebGLRenderer,
@@ -24,26 +27,109 @@ export class ControlsManager implements ControlsManagerInterface {
     this.controls.enableDamping = true
   }
 
+  setRequestRender(callback: () => void): void {
+    this.requestRender = callback
+  }
+
   init(): void {
     this.controls.addEventListener('end', () => {
-      const cameraState = {
-        position: this.camera.position.clone(),
-        target: this.controls.target.clone(),
-        zoom:
-          this.camera instanceof THREE.OrthographicCamera
-            ? (this.camera as THREE.OrthographicCamera).zoom
-            : (this.camera as THREE.PerspectiveCamera).zoom,
-        cameraType:
-          this.camera instanceof THREE.PerspectiveCamera
-            ? 'perspective'
-            : 'orthographic'
-      }
-
-      this.eventManager.emitEvent('cameraChanged', cameraState)
+      this.eventManager.emitEvent('cameraChanged', this.buildCameraState())
     })
   }
 
+  setTarget(point: THREE.Vector3, distance?: number): void {
+    this.animateTarget(point, distance, 0)
+  }
+
+  animateTarget(
+    point: THREE.Vector3,
+    distance?: number,
+    durationMs: number = 450
+  ): void {
+    this.cancelAnimation()
+    const { endTarget, endPosition } = this.computeFocusEnd(point, distance)
+
+    if (durationMs <= 0) {
+      this.controls.target.copy(endTarget)
+      this.camera.position.copy(endPosition)
+      this.controls.update()
+      this.eventManager.emitEvent('cameraChanged', this.buildCameraState())
+      return
+    }
+
+    const startTarget = this.controls.target.clone()
+    const startPosition = this.camera.position.clone()
+
+    // If a user grabs the controls mid-animation, abandon the tween so we
+    // don't fight their input.
+    const cancelOnInteract = () => this.cancelAnimation()
+    this.controls.addEventListener('start', cancelOnInteract)
+    this.animationCleanup = () => {
+      this.controls.removeEventListener('start', cancelOnInteract)
+    }
+
+    const startTime = performance.now()
+    const tick = () => {
+      const t = Math.min((performance.now() - startTime) / durationMs, 1)
+      const eased = 1 - Math.pow(1 - t, 3) // easeOutCubic
+      this.controls.target.lerpVectors(startTarget, endTarget, eased)
+      this.camera.position.lerpVectors(startPosition, endPosition, eased)
+      this.controls.update()
+      this.requestRender?.()
+
+      if (t >= 1) {
+        this.cancelAnimation()
+        this.eventManager.emitEvent('cameraChanged', this.buildCameraState())
+        return
+      }
+      this.animationRafId = requestAnimationFrame(tick)
+    }
+    this.animationRafId = requestAnimationFrame(tick)
+  }
+
+  private computeFocusEnd(
+    point: THREE.Vector3,
+    distance?: number
+  ): { endTarget: THREE.Vector3; endPosition: THREE.Vector3 } {
+    const offset = this.camera.position.clone().sub(this.controls.target)
+    const currentDistance = offset.length()
+    const newDistance = distance ?? currentDistance
+    const direction =
+      currentDistance > 1e-6
+        ? offset.divideScalar(currentDistance)
+        : new THREE.Vector3(0, 0, 1)
+    return {
+      endTarget: point.clone(),
+      endPosition: point.clone().addScaledVector(direction, newDistance)
+    }
+  }
+
+  private cancelAnimation(): void {
+    if (this.animationRafId !== null) {
+      cancelAnimationFrame(this.animationRafId)
+      this.animationRafId = null
+    }
+    this.animationCleanup?.()
+    this.animationCleanup = null
+  }
+
+  private buildCameraState() {
+    return {
+      position: this.camera.position.clone(),
+      target: this.controls.target.clone(),
+      zoom:
+        this.camera instanceof THREE.OrthographicCamera
+          ? (this.camera as THREE.OrthographicCamera).zoom
+          : (this.camera as THREE.PerspectiveCamera).zoom,
+      cameraType:
+        this.camera instanceof THREE.PerspectiveCamera
+          ? 'perspective'
+          : 'orthographic'
+    }
+  }
+
   dispose(): void {
+    this.cancelAnimation()
     this.controls.dispose()
   }
 

--- a/src/extensions/core/load3d/ControlsManager.ts
+++ b/src/extensions/core/load3d/ControlsManager.ts
@@ -53,6 +53,7 @@ export class ControlsManager implements ControlsManagerInterface {
       this.controls.target.copy(endTarget)
       this.camera.position.copy(endPosition)
       this.controls.update()
+      this.requestRender?.()
       this.eventManager.emitEvent('cameraChanged', this.buildCameraState())
       return
     }

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -28,6 +28,7 @@ import type {
   UpDirection
 } from './interfaces'
 import { attachContextMenuGuard } from './load3dContextMenuGuard'
+import { attachFocusUnderCursor } from './load3dFocusUnderCursor'
 import type { RenderLoopHandle } from './load3dRenderLoop'
 import { startRenderLoop } from './load3dRenderLoop'
 import { computeLetterboxedViewport, isLoad3dActive } from './load3dViewport'
@@ -102,6 +103,7 @@ class Load3d {
   isViewerMode: boolean = false
 
   private disposeContextMenuGuard: (() => void) | null = null
+  private disposeFocusUnderCursor: (() => void) | null = null
   private resizeObserver: ResizeObserver | null = null
   private getZoomScaleCallback: (() => number) | undefined
 
@@ -137,6 +139,8 @@ class Load3d {
     this.gizmoManager = deps.gizmoManager
     this.adapterRef = deps.adapterRef
 
+    this.controlsManager.setRequestRender(() => this.forceRender())
+
     this.sceneManager.init()
     this.cameraManager.init()
     this.controlsManager.init()
@@ -153,6 +157,7 @@ class Load3d {
     this.STATUS_MOUSE_ON_VIEWER = false
 
     this.initContextMenu()
+    this.initFocusUnderCursor()
     this.initResizeObserver(container)
 
     this.handleResize()
@@ -179,6 +184,26 @@ class Load3d {
       (event) => this.onContextMenuCallback?.(event),
       { isDisabled: () => this.isViewerMode }
     )
+  }
+
+  private initFocusUnderCursor(): void {
+    this.disposeFocusUnderCursor = attachFocusUnderCursor({
+      canvas: this.renderer.domElement,
+      getModel: () => this.modelManager.currentModel,
+      getCamera: () => this.cameraManager.activeCamera,
+      getRenderRegion: () => {
+        const w = this.renderer.domElement.clientWidth
+        const h = this.renderer.domElement.clientHeight
+        return this.shouldMaintainAspectRatio()
+          ? computeLetterboxedViewport(
+              { width: w, height: h },
+              this.targetAspectRatio
+            )
+          : { offsetX: 0, offsetY: 0, width: w, height: h }
+      },
+      focusOn: (point, distance) =>
+        this.controlsManager.animateTarget(point, distance)
+    })
   }
 
   getEventManager(): EventManager {
@@ -900,6 +925,9 @@ class Load3d {
 
     this.disposeContextMenuGuard?.()
     this.disposeContextMenuGuard = null
+
+    this.disposeFocusUnderCursor?.()
+    this.disposeFocusUnderCursor = null
 
     this.renderer.forceContextLoss()
     const canvas = this.renderer.domElement

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -134,6 +134,13 @@ export interface CameraManagerInterface extends BaseManager {
 export interface ControlsManagerInterface extends BaseManager {
   controls: OrbitControls
   handleResize(): void
+  setRequestRender(callback: () => void): void
+  setTarget(point: THREE.Vector3, distance?: number): void
+  animateTarget(
+    point: THREE.Vector3,
+    distance?: number,
+    durationMs?: number
+  ): void
 }
 
 export interface LightingManagerInterface extends BaseManager {

--- a/src/extensions/core/load3d/load3dFocusUnderCursor.test.ts
+++ b/src/extensions/core/load3d/load3dFocusUnderCursor.test.ts
@@ -1,0 +1,264 @@
+import * as THREE from 'three'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  attachFocusUnderCursor,
+  getNDCFromPointer
+} from './load3dFocusUnderCursor'
+
+type Rect = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+function makeCanvas(opts: { rect?: Partial<Rect>; clientSize?: number } = {}) {
+  const canvas = document.createElement('canvas')
+  const rect: Rect = {
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    ...opts.rect
+  }
+  const clientSize = opts.clientSize ?? 100
+  canvas.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        left: rect.left,
+        top: rect.top,
+        right: rect.left + rect.width,
+        bottom: rect.top + rect.height,
+        width: rect.width,
+        height: rect.height,
+        x: rect.left,
+        y: rect.top,
+        toJSON: () => ({})
+      }) as DOMRect
+  )
+  Object.defineProperty(canvas, 'clientWidth', {
+    value: clientSize,
+    configurable: true
+  })
+  Object.defineProperty(canvas, 'clientHeight', {
+    value: clientSize,
+    configurable: true
+  })
+  return canvas
+}
+
+function dispatchPointer(
+  canvas: HTMLCanvasElement,
+  type: 'pointermove' | 'pointerleave',
+  x = 50,
+  y = 50
+) {
+  const event = new Event(type) as Event & { clientX: number; clientY: number }
+  event.clientX = x
+  event.clientY = y
+  canvas.dispatchEvent(event)
+}
+
+function dispatchKey(key: string, mods: Partial<KeyboardEventInit> = {}) {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...mods
+    })
+  )
+}
+
+const fullRegion = { offsetX: 0, offsetY: 0, width: 100, height: 100 }
+
+describe('getNDCFromPointer', () => {
+  it('maps the region center to NDC (0, 0)', () => {
+    const canvas = makeCanvas()
+    const ndc = getNDCFromPointer(canvas, fullRegion, { x: 50, y: 50 })
+    expect(ndc).not.toBeNull()
+    expect(ndc!.x).toBeCloseTo(0)
+    expect(ndc!.y).toBeCloseTo(0)
+  })
+
+  it('maps corners to NDC (±1, ∓1)', () => {
+    const canvas = makeCanvas()
+    expect(
+      getNDCFromPointer(canvas, fullRegion, { x: 0, y: 0 })?.toArray()
+    ).toEqual([-1, 1])
+    expect(
+      getNDCFromPointer(canvas, fullRegion, { x: 100, y: 100 })?.toArray()
+    ).toEqual([1, -1])
+  })
+
+  it('returns null when the pointer is outside the render region', () => {
+    const canvas = makeCanvas()
+    expect(getNDCFromPointer(canvas, fullRegion, { x: -5, y: 50 })).toBeNull()
+    expect(getNDCFromPointer(canvas, fullRegion, { x: 50, y: 105 })).toBeNull()
+  })
+
+  it('returns null when the region has zero width or height', () => {
+    const canvas = makeCanvas()
+    expect(
+      getNDCFromPointer(
+        canvas,
+        { offsetX: 0, offsetY: 0, width: 0, height: 100 },
+        { x: 0, y: 0 }
+      )
+    ).toBeNull()
+    expect(
+      getNDCFromPointer(
+        canvas,
+        { offsetX: 0, offsetY: 0, width: 100, height: 0 },
+        { x: 0, y: 0 }
+      )
+    ).toBeNull()
+  })
+
+  it('respects letterboxed render region offsets', () => {
+    const canvas = makeCanvas()
+    const region = { offsetX: 10, offsetY: 10, width: 80, height: 80 }
+    // Pointer at canvas center (50, 50) is the center of the rendered region.
+    const center = getNDCFromPointer(canvas, region, { x: 50, y: 50 })
+    expect(center!.x).toBeCloseTo(0)
+    expect(center!.y).toBeCloseTo(0)
+    // Pointer inside the letterbox bar (x = 5) is outside the rendered region.
+    expect(getNDCFromPointer(canvas, region, { x: 5, y: 50 })).toBeNull()
+  })
+
+  it('corrects for ancestor CSS scale (graph zoom)', () => {
+    // Graph zoomed 2× — bounding rect is 200 wide, but clientWidth stays 100.
+    const canvas = makeCanvas({
+      rect: { width: 200, height: 200 },
+      clientSize: 100
+    })
+    // Pointer at visual center (100, 100) of the 200×200 visual rect should
+    // still map to NDC (0, 0).
+    const ndc = getNDCFromPointer(canvas, fullRegion, { x: 100, y: 100 })
+    expect(ndc!.x).toBeCloseTo(0)
+    expect(ndc!.y).toBeCloseTo(0)
+  })
+})
+
+type FocusOn = (point: THREE.Vector3, distance?: number) => void
+
+describe('attachFocusUnderCursor', () => {
+  let canvas: HTMLCanvasElement
+  let focusOn: ReturnType<typeof vi.fn<FocusOn>>
+  let dispose: (() => void) | null
+  let camera: THREE.PerspectiveCamera
+  let model: THREE.Mesh | null
+
+  beforeEach(() => {
+    canvas = makeCanvas()
+    focusOn = vi.fn<FocusOn>()
+    dispose = null
+    camera = new THREE.PerspectiveCamera(35, 1, 0.1, 1000)
+    camera.position.set(0, 0, 5)
+    camera.lookAt(0, 0, 0)
+    camera.updateMatrixWorld()
+    model = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 1),
+      new THREE.MeshBasicMaterial()
+    )
+    model.updateMatrixWorld()
+  })
+
+  afterEach(() => {
+    dispose?.()
+  })
+
+  const attach = (extra: { isDisabled?: () => boolean } = {}) => {
+    dispose = attachFocusUnderCursor({
+      canvas,
+      getModel: () => model,
+      getCamera: () => camera,
+      getRenderRegion: () => fullRegion,
+      focusOn,
+      ...extra
+    })
+  }
+
+  it('triggers focusOn when F is pressed with the pointer over the canvas', () => {
+    attach()
+    dispatchPointer(canvas, 'pointermove', 50, 50)
+    dispatchKey('f')
+    expect(focusOn).toHaveBeenCalledTimes(1)
+    const [point, distance] = focusOn.mock.calls[0]
+    expect(point).toBeInstanceOf(THREE.Vector3)
+    expect(typeof distance).toBe('number')
+  })
+
+  it('ignores keys other than F', () => {
+    attach()
+    dispatchPointer(canvas, 'pointermove')
+    dispatchKey('a')
+    dispatchKey('Enter')
+    dispatchKey(' ')
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+
+  it('ignores F when any modifier key is held', () => {
+    attach()
+    dispatchPointer(canvas, 'pointermove')
+    dispatchKey('f', { ctrlKey: true })
+    dispatchKey('f', { metaKey: true })
+    dispatchKey('f', { altKey: true })
+    dispatchKey('f', { shiftKey: true })
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+
+  it('ignores F when the pointer is not over the canvas', () => {
+    attach()
+    // never dispatch pointermove
+    dispatchKey('f')
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+
+  it('ignores F after the pointer leaves the canvas', () => {
+    attach()
+    dispatchPointer(canvas, 'pointermove')
+    dispatchPointer(canvas, 'pointerleave')
+    dispatchKey('f')
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+
+  it('ignores F when an editable element has focus', () => {
+    attach()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    try {
+      input.focus()
+      dispatchPointer(canvas, 'pointermove')
+      dispatchKey('f')
+      expect(focusOn).not.toHaveBeenCalled()
+    } finally {
+      document.body.removeChild(input)
+    }
+  })
+
+  it('ignores F when there is no model loaded', () => {
+    attach()
+    model = null
+    dispatchPointer(canvas, 'pointermove')
+    dispatchKey('f')
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+
+  it('respects isDisabled', () => {
+    attach({ isDisabled: () => true })
+    dispatchPointer(canvas, 'pointermove')
+    dispatchKey('f')
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+
+  it('stops responding after dispose', () => {
+    attach()
+    dispatchPointer(canvas, 'pointermove')
+    dispose?.()
+    dispose = null
+    dispatchKey('f')
+    expect(focusOn).not.toHaveBeenCalled()
+  })
+})

--- a/src/extensions/core/load3d/load3dFocusUnderCursor.ts
+++ b/src/extensions/core/load3d/load3dFocusUnderCursor.ts
@@ -1,0 +1,137 @@
+import * as THREE from 'three'
+
+type RenderRegion = {
+  offsetX: number
+  offsetY: number
+  width: number
+  height: number
+}
+
+type FocusUnderCursorDeps = {
+  canvas: HTMLCanvasElement
+  getModel: () => THREE.Object3D | null
+  getCamera: () => THREE.Camera
+  getRenderRegion: () => RenderRegion
+  focusOn: (point: THREE.Vector3, distance?: number) => void
+  isDisabled?: () => boolean
+}
+
+// Camera lands `HIT_OBJECT_FOCUS_FACTOR × hit-object-bounding-radius` away
+// (FOV-corrected). Idempotent: distance is derived from the hit object's own
+// size, so repeated F presses settle to the same distance instead of
+// compounding closer.
+const HIT_OBJECT_FOCUS_FACTOR = 0.35
+
+function isEditableElement(el: Element | null): boolean {
+  if (!el) return false
+  const tag = el.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  return el instanceof HTMLElement && el.isContentEditable
+}
+
+function computeFocusDistance(
+  hit: THREE.Intersection,
+  camera: THREE.Camera
+): number | undefined {
+  if (!(hit.object instanceof THREE.Mesh)) return undefined
+  const geo = hit.object.geometry
+  if (!geo.boundingSphere) geo.computeBoundingSphere()
+  if (!geo.boundingSphere) return undefined
+
+  const radius = geo.boundingSphere
+    .clone()
+    .applyMatrix4(hit.object.matrixWorld).radius
+  if (radius <= 0) return undefined
+
+  const fovScale =
+    camera instanceof THREE.PerspectiveCamera
+      ? 1 / Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2)
+      : 1
+  return radius * HIT_OBJECT_FOCUS_FACTOR * fovScale
+}
+
+function getNDCFromPointer(
+  canvas: HTMLCanvasElement,
+  region: RenderRegion,
+  pointer: { x: number; y: number }
+): THREE.Vector2 | null {
+  const rect = canvas.getBoundingClientRect()
+  // rect dimensions reflect any ancestor CSS transforms (e.g. graph zoom),
+  // while clientWidth/Height stay in logical CSS px. Convert the pointer back
+  // to logical CSS so it lines up with the render region.
+  const scaleX = rect.width === 0 ? 1 : canvas.clientWidth / rect.width
+  const scaleY = rect.height === 0 ? 1 : canvas.clientHeight / rect.height
+  const localX = (pointer.x - rect.left) * scaleX - region.offsetX
+  const localY = (pointer.y - rect.top) * scaleY - region.offsetY
+  if (
+    localX < 0 ||
+    localY < 0 ||
+    localX > region.width ||
+    localY > region.height
+  ) {
+    return null
+  }
+  return new THREE.Vector2(
+    (localX / region.width) * 2 - 1,
+    -(localY / region.height) * 2 + 1
+  )
+}
+
+export function attachFocusUnderCursor(deps: FocusUnderCursorDeps): () => void {
+  const controller = new AbortController()
+  const { signal } = controller
+
+  let pointerOnCanvas: { x: number; y: number } | null = null
+  const raycaster = new THREE.Raycaster()
+  // Only matters if the model contains a THREE.Points (e.g. PLY point cloud).
+  // For ordinary meshes this has no effect.
+  raycaster.params.Points.threshold = 0.1
+
+  deps.canvas.addEventListener(
+    'pointermove',
+    (e) => {
+      pointerOnCanvas = { x: e.clientX, y: e.clientY }
+    },
+    { signal }
+  )
+
+  deps.canvas.addEventListener(
+    'pointerleave',
+    () => {
+      pointerOnCanvas = null
+    },
+    { signal }
+  )
+
+  window.addEventListener(
+    'keydown',
+    (e) => {
+      if (e.key !== 'f' && e.key !== 'F') return
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
+      if (deps.isDisabled?.()) return
+      if (!pointerOnCanvas) return
+      if (isEditableElement(document.activeElement)) return
+
+      const model = deps.getModel()
+      if (!model) return
+
+      const ndc = getNDCFromPointer(
+        deps.canvas,
+        deps.getRenderRegion(),
+        pointerOnCanvas
+      )
+      if (!ndc) return
+
+      raycaster.setFromCamera(ndc, deps.getCamera())
+      const intersects = raycaster.intersectObject(model, true)
+      if (intersects.length === 0) return
+
+      e.preventDefault()
+      const hit = intersects[0]
+      deps.focusOn(hit.point, computeFocusDistance(hit, deps.getCamera()))
+    },
+    { signal }
+  )
+
+  return () => controller.abort()
+}

--- a/src/extensions/core/load3d/load3dFocusUnderCursor.ts
+++ b/src/extensions/core/load3d/load3dFocusUnderCursor.ts
@@ -55,6 +55,7 @@ function getNDCFromPointer(
   region: RenderRegion,
   pointer: { x: number; y: number }
 ): THREE.Vector2 | null {
+  if (region.width <= 0 || region.height <= 0) return null
   const rect = canvas.getBoundingClientRect()
   // rect dimensions reflect any ancestor CSS transforms (e.g. graph zoom),
   // while clientWidth/Height stay in logical CSS px. Convert the pointer back

--- a/src/extensions/core/load3d/load3dFocusUnderCursor.ts
+++ b/src/extensions/core/load3d/load3dFocusUnderCursor.ts
@@ -50,7 +50,7 @@ function computeFocusDistance(
   return radius * HIT_OBJECT_FOCUS_FACTOR * fovScale
 }
 
-function getNDCFromPointer(
+export function getNDCFromPointer(
   canvas: HTMLCanvasElement,
   region: RenderRegion,
   pointer: { x: number; y: number }


### PR DESCRIPTION
This is personally really important QoL feature for me after years of Blender use, extremely helpful when inspecting generated meshes etc. The code is generated by Claude, but I've done multiple iterations of reviews and also tested this quite a bit in practice. Future features could include configurable hotkey and snap distance.

## Summary

Adds Blender-style "focus under cursor" — pressing **F** while hovering a 3D viewer raycasts to the surface under the cursor, then smoothly dollies the camera so the new pivot is the hit point and the camera lands at a tight close-up distance derived from the hit object's bounding sphere.

## Changes

- **What**: New `attachFocusUnderCursor` helper in `src/extensions/core/load3d/load3dFocusUnderCursor.ts` (window keydown gated by pointer-over-canvas, NDC-from-pointer math that accounts for graph zoom, `THREE.Raycaster` against the loaded model). New `ControlsManager.animateTarget(point, distance, durationMs)` that tweens both `camera.position` and `controls.target` with easeOutCubic and cancels on user interaction; `setTarget` collapses to `animateTarget(...0)` for snap. `setRequestRender` setter wires `Load3d.forceRender` into the tween. `ControlsManagerInterface` updated to reflect the new public methods.

## Review Focus

- **NDC math under graph zoom**: `getNDCFromPointer` corrects for ancestor CSS transforms (`rect.width !== clientWidth`). Without this, F lands off-target when the LiteGraph canvas is zoomed in/out. Worth a careful read.
- **Multi-Load3d safety**: window keydown listener gated by per-instance `pointerOnCanvas` closure ensures only the hovered viewer responds. N instances on a graph = N listeners, each bails early except the hovered one.
- **Animation cancel-on-interact**: if the user grabs orbit controls mid-tween, `cancelAnimation` removes the `start` listener and aborts the RAF chain so we don't fight user input. `cancelAnimation` nulls the cleanup ref after invocation so it can't double-fire.
- **Idempotent focus distance**: `computeFocusDistance` derives the landing distance from the hit *object's* bounding sphere (FOV-corrected), not from the current camera distance. Repeated F presses on the same area settle, not compound.
- **Dispose ordering** in `Load3d.remove()`: `disposeFocusUnderCursor` and `controlsManager.dispose()` both run before `renderer.dispose()`, so the in-flight RAF can't touch a torn-down WebGL context.
- **Test mocks**: extended the existing `OrbitControls` mock with `removeEventListener`; `animateTarget` test stubs `performance.now` + `requestAnimationFrame` and restores via `afterEach`.


## Screenshots

https://github.com/user-attachments/assets/00adb164-8838-47e7-82ce-afda27d9f005
