### PR TITLE
chore: gitignore .nx daemon workspace data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn.lock
 
 node_modules
 .pnpm-store
+.nx
 dist
 dist-ssr
 *.local


### PR DESCRIPTION
## Summary
add .nx to gitignore as it causes some workspace-cache now
