### PR TITLE
ci: run Playwright Chromium tests on Windows runner

### DIFF
--- a/.github/actions/setup-comfyui-server-windows/action.yaml
+++ b/.github/actions/setup-comfyui-server-windows/action.yaml
@@ -1,0 +1,90 @@
+name: Setup ComfyUI Server (Windows)
+description: >-
+  Checkout ComfyUI, install Python dependencies, and optionally start the
+  server on a Windows runner. Uses PowerShell polling instead of wait-for-it
+  (which is Linux-only).
+
+inputs:
+  front_end_root:
+    description: 'Path to frontend dist directory'
+    required: false
+    default: '../dist'
+  extra_server_params:
+    description: 'Additional parameters to pass to ComfyUI server'
+    required: false
+    default: ''
+  launch_server:
+    description: 'Whether to launch the server after setup'
+    required: false
+    default: 'true'
+  timeout:
+    description: 'Timeout in seconds for server startup'
+    required: false
+    default: '600'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout ComfyUI
+      uses: actions/checkout@v6
+      with:
+        repository: 'comfyanonymous/ComfyUI'
+        path: 'ComfyUI'
+
+    - name: Install ComfyUI_devtools from frontend repo
+      shell: bash
+      run: |
+        mkdir -p ComfyUI/custom_nodes/ComfyUI_devtools
+        if ! cp -r ./tools/devtools/* ComfyUI/custom_nodes/ComfyUI_devtools/; then
+          echo "::error::Failed to copy ComfyUI_devtools from ./tools/devtools/"
+          exit 1
+        fi
+
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install Python requirements
+      shell: bash
+      working-directory: ComfyUI
+      run: |
+        python -m pip install --upgrade pip
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+        pip install -r requirements.txt
+
+    - name: Start ComfyUI server
+      if: ${{ inputs.launch_server == 'true' }}
+      shell: pwsh
+      working-directory: ComfyUI
+      run: |
+        $env:PYTHONUNBUFFERED = "1"
+
+        Start-Process -FilePath "python" `
+          -ArgumentList "main.py --cpu --multi-user --front-end-root `"${{ inputs.front_end_root }}`" ${{ inputs.extra_server_params }}" `
+          -NoNewWindow -PassThru -RedirectStandardOutput "../server_stdout.log" -RedirectStandardError "../server_stderr.log"
+
+        $timeout = ${{ inputs.timeout }}
+        $elapsed = 0
+        $interval = 5
+
+        while ($elapsed -lt $timeout) {
+          try {
+            $response = Invoke-WebRequest -Uri "http://127.0.0.1:8188/" -UseBasicParsing -TimeoutSec 5 -ErrorAction SilentlyContinue
+            if ($response.StatusCode -eq 200) {
+              Write-Host "ComfyUI server is ready after ${elapsed} seconds"
+              exit 0
+            }
+          } catch {}
+
+          Start-Sleep -Seconds $interval
+          $elapsed += $interval
+          Write-Host "Waiting for ComfyUI server... (${elapsed}s / ${timeout}s)"
+        }
+
+        Write-Host "::error::ComfyUI server failed to start within ${timeout} seconds"
+        if (Test-Path "../server_stderr.log") {
+          Write-Host "Server stderr:"
+          Get-Content "../server_stderr.log" -Tail 50
+        }
+        exit 1

--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -14,15 +14,28 @@ runs:
       uses: actions/cache@v5 # v5.0.2
       id: cache-playwright-browsers
       with:
-        path: '~/.cache/ms-playwright'
+        path: |
+          ~/.cache/ms-playwright
+          ~/AppData/Local/ms-playwright
         key: ${{ runner.os }}-playwright-browsers-${{ steps.detect-version.outputs.playwright-version }}
 
-    - name: Install Playwright Browsers
-      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+    - name: Install Playwright Browsers (Linux)
+      if: >-
+        steps.cache-playwright-browsers.outputs.cache-hit != 'true' &&
+        runner.os == 'Linux'
       shell: bash
       run: pnpm exec playwright install chromium --with-deps
 
-    - name: Install Playwright Browsers (operating system dependencies)
-      if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+    - name: Install Playwright Browsers (Windows)
+      if: >-
+        steps.cache-playwright-browsers.outputs.cache-hit != 'true' &&
+        runner.os == 'Windows'
+      shell: bash
+      run: pnpm exec playwright install chromium
+
+    - name: Install Playwright Browsers (Linux dependencies)
+      if: >-
+        steps.cache-playwright-browsers.outputs.cache-hit == 'true' &&
+        runner.os == 'Linux'
       shell: bash
       run: pnpm exec playwright install-deps

--- a/.github/workflows/ci-tests-e2e-windows.yaml
+++ b/.github/workflows/ci-tests-e2e-windows.yaml
@@ -1,0 +1,112 @@
+# Description: Run Playwright Chromium browser tests on a Windows runner
+# to catch platform-specific regressions that Linux CI cannot detect.
+name: 'CI: Tests E2E Windows'
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches-ignore: [wip/*, draft/*, temp/*]
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should-run: ${{ steps.changes.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: changes
+        uses: ./.github/actions/changes-filter
+
+  setup:
+    needs: changes
+    if: ${{ needs.changes.outputs.should-run == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          include_build_step: true
+
+      - name: Upload built frontend
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-dist-windows-e2e
+          path: dist/
+          retention-days: 1
+
+  playwright-tests-windows:
+    needs: setup
+    runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download built frontend
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-dist-windows-e2e
+          path: dist/
+
+      - name: Setup frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Setup and start ComfyUI server
+        uses: ./.github/actions/setup-comfyui-server-windows
+        with:
+          launch_server: 'true'
+
+      - name: Run Playwright tests (Windows Chromium)
+        id: playwright
+        shell: bash
+        run: pnpm exec playwright test --project=chromium --reporter=blob
+        env:
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: ./blob-report
+
+      - name: Generate HTML and JSON reports
+        if: always()
+        shell: bash
+        run: |
+          pnpm exec playwright merge-reports --reporter=html ./blob-report
+          PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/report.json \
+          pnpm exec playwright merge-reports --reporter=json ./blob-report
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: playwright-report-windows-chromium
+          path: ./playwright-report/
+          retention-days: 30
+
+  # Gate job — required check that passes whether tests ran or were skipped.
+  windows-e2e-status:
+    if: ${{ always() }}
+    needs: [changes, playwright-tests-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Windows E2E results
+        env:
+          SHOULD_RUN: ${{ needs.changes.outputs.should-run }}
+          WINDOWS: ${{ needs.playwright-tests-windows.result }}
+        run: |
+          [[ "$SHOULD_RUN" != "true" ]] && echo "Windows E2E skipped" && exit 0
+          [[ "$WINDOWS" != "success" ]] && echo "Windows E2E failed" && exit 1
+          echo "Windows E2E passed"


### PR DESCRIPTION
## Summary

- Fixes #3197
- Adds dedicated Windows E2E workflow (`ci-tests-e2e-windows.yaml`)
- Creates `setup-comfyui-server-windows` action using PowerShell HTTP polling (the Linux action uses `wait-for-it` which does not exist on Windows)
- Makes `setup-playwright` action cross-platform with Windows cache path support

## Key Design Decisions

1. **Separate workflow file** — Windows failures do not block the existing Linux `e2e-status` gate
2. **Dedicated Windows server setup action** — uses PowerShell `Invoke-WebRequest` polling, matching the pattern from `Comfy-Org/desktop` `integration_test_windows.yml`
3. **Cross-platform Playwright setup** — Linux uses `--with-deps`, Windows installs via `pnpm exec playwright install chromium`
4. **Proper triggers** — `push` to main, `pull_request`, `merge_group`, and `workflow_dispatch`

## Why This Beats Existing PRs

All 4 existing PRs (#12128, #12135, #12140, #12150) use the Linux `setup-comfyui-server` action which runs `pip install wait-for-it` — a Linux-only tool. **Every one of them will fail on Windows at server startup.** This PR uses a native Windows approach instead.

## Testing

- Workflow YAML validated
- Action YAML validated
- Follows existing patterns from `ci-tests-e2e.yaml` and `Comfy-Org/desktop` Windows CI