### PR TITLE
chore: tidy up retain-view-on-reload follow-ups

### DIFF
--- a/src/components/load3d/controls/CameraControls.vue
+++ b/src/components/load3d/controls/CameraControls.vue
@@ -11,7 +11,7 @@
       :aria-label="$t('load3d.switchCamera')"
       @click="switchCamera"
     >
-      <i :class="cn('pi pi-camera text-lg text-base-foreground')" />
+      <i class="pi pi-camera text-lg text-base-foreground" />
     </Button>
     <PopupSlider
       v-if="showFOVButton"

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -566,12 +566,6 @@ class Load3d {
     }
   }
 
-  /**
-   * Toggles whether `_loadModelInternal` preserves the current camera state
-   * across model loads. When enabled and a model has previously loaded, the
-   * camera position/target/zoom (and camera type) are captured before the
-   * scene clears and restored after the new model is in place.
-   */
   public setRetainViewOnReload(value: boolean): void {
     this.retainViewOnReload = value
   }
@@ -581,9 +575,7 @@ class Load3d {
     originalFileName?: string,
     options?: LoadModelOptions
   ): Promise<void> {
-    // Retain view only kicks in after a successful first load — on the very
-    // first load there's no meaningful "current" framing to preserve, so the
-    // default `setupForModel` framing wins.
+    // First load always uses default framing; retain only applies on reload.
     const shouldRetainView = this.retainViewOnReload && this.hasLoadedModel
     const savedCameraState = shouldRetainView
       ? this.cameraManager.getCameraState()
@@ -609,8 +601,7 @@ class Load3d {
     }
 
     if (savedCameraState) {
-      // SceneModelManager.setupModel called setupForModel which clobbered the
-      // camera. Restore the captured state on top of that.
+      // setupForModel runs during loadModel and clobbers the camera; restore on top.
       if (
         savedCameraState.cameraType !==
         this.cameraManager.getCurrentCameraType()


### PR DESCRIPTION
## Summary
Drop a no-op cn() wrapper on the static camera-switch icon and trim the two over-long comments around setRetainViewOnReload / _loadModelInternal down to one line each.