### PR TITLE
General execution error messaging

### DIFF
--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -109,7 +109,9 @@ describe('TabErrors.vue', () => {
       }
     })
 
-    expect(screen.getByText('Server Error: No outputs')).toBeInTheDocument()
+    expect(screen.getAllByText('Prompt has no outputs').length).toBeGreaterThan(
+      0
+    )
     expect(
       screen.getByText(
         'The workflow does not contain any output nodes (e.g. Save Image, Preview Image) to produce a result.'

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -448,6 +448,8 @@ describe('useErrorGroups', () => {
         isRuntimeError: true,
         exceptionType: 'RuntimeError'
       })
+      // TODO(FE-816 overlay-redesign): Runtime execution errors intentionally
+      // bypass catalog display fields until targeted runtime handling lands.
       expect(execGroups[0].cards[0].errors[0].displayItemLabel).toBeUndefined()
       expect(execGroups[0].cards[0].errors[0].toastTitle).toBeUndefined()
     })

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -29,17 +29,47 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-vi.mock('@/i18n', () => ({
-  te: vi.fn(() => false),
-  st: vi.fn((_key: string, fallback: string) => fallback),
-  t: vi.fn((key: string, params?: { count?: number }) => {
-    if (key === 'errorOverlay.missingModels') {
-      const count = params?.count ?? 0
-      return `${count} required ${count === 1 ? 'model is' : 'models are'} missing`
-    }
-    return key
-  })
-}))
+vi.mock('@/i18n', () => {
+  const messages: Record<string, string> = {
+    'errorCatalog.validationErrors.required_input_missing.title':
+      'Missing connection',
+    'errorCatalog.validationErrors.required_input_missing.message':
+      'Required input slots have no connection feeding them.',
+    'errorCatalog.validationErrors.required_input_missing.details':
+      '{nodeName} is missing a required input: {inputName}',
+    'errorCatalog.validationErrors.required_input_missing.itemLabel':
+      '{nodeName} - {inputName}',
+    'errorCatalog.validationErrors.required_input_missing.toastTitle':
+      'Required input missing',
+    'errorCatalog.validationErrors.required_input_missing.toastMessage':
+      '{nodeName} is missing a required input: {inputName}',
+    'errorCatalog.promptErrors.prompt_no_outputs.title':
+      'Prompt has no outputs',
+    'errorCatalog.promptErrors.prompt_no_outputs.desc':
+      'The workflow does not contain any output nodes (e.g. Save Image, Preview Image) to produce a result.'
+  }
+
+  const interpolate = (
+    message: string,
+    params?: Record<string, string | number>
+  ) =>
+    message.replace(/\{(\w+)\}/g, (match, paramName) =>
+      params?.[paramName] === undefined ? match : String(params[paramName])
+    )
+
+  return {
+    te: vi.fn((key: string) => key in messages),
+    st: vi.fn((key: string, fallback: string) => messages[key] ?? fallback),
+    t: vi.fn((key: string, params?: Record<string, string | number>) => {
+      if (key === 'errorOverlay.missingModels') {
+        const count = Number(params?.count ?? 0)
+        return `${count} required ${count === 1 ? 'model is' : 'models are'} missing`
+      }
+
+      return interpolate(messages[key] ?? key, params)
+    })
+  }
+})
 
 vi.mock('@/stores/comfyRegistryStore', () => ({
   useComfyRegistryStore: () => ({
@@ -412,10 +442,14 @@ describe('useErrorGroups', () => {
       )
       expect(execGroups.length).toBeGreaterThan(0)
       if (execGroups[0].type !== 'execution') return
-      expect(execGroups[0].cards[0].errors[0].displayItemLabel).toBe('KSampler')
-      expect(execGroups[0].cards[0].errors[0].toastTitle).toBe(
-        'KSampler failed'
-      )
+      expect(execGroups[0].cards[0].errors[0]).toMatchObject({
+        message: 'RuntimeError: CUDA out of memory',
+        details: 'line 1\nline 2',
+        isRuntimeError: true,
+        exceptionType: 'RuntimeError'
+      })
+      expect(execGroups[0].cards[0].errors[0].displayItemLabel).toBeUndefined()
+      expect(execGroups[0].cards[0].errors[0].toastTitle).toBeUndefined()
     })
 
     it('includes prompt error when present', async () => {
@@ -428,7 +462,8 @@ describe('useErrorGroups', () => {
       await nextTick()
 
       const promptGroup = groups.allErrorGroups.value.find(
-        (g) => g.type === 'execution' && g.displayTitle === 'No outputs'
+        (g) =>
+          g.type === 'execution' && g.displayTitle === 'Prompt has no outputs'
       )
       expect(promptGroup).toBeDefined()
     })

--- a/src/components/rightSidePanel/errors/useErrorGroups.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.ts
@@ -417,12 +417,6 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
     if (!executionErrorStore.lastExecutionError) return
 
     const e = executionErrorStore.lastExecutionError
-    const resolvedDisplay = resolveRunErrorMessage({
-      kind: 'execution',
-      error: e,
-      nodeDisplayName: e.node_type,
-      isCloud
-    })
     addNodeErrorToGroup(
       groupsMap,
       String(e.node_id),
@@ -433,8 +427,7 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
           message: `${e.exception_type}: ${e.exception_message}`,
           details: e.traceback.join('\n'),
           isRuntimeError: true,
-          exceptionType: e.exception_type,
-          ...resolvedDisplay
+          exceptionType: e.exception_type
         }
       ],
       filterBySelection

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3758,33 +3758,6 @@
         "toastMessage": "The image for {nodeName} couldn't be loaded. Try adding it again."
       }
     },
-    "runtimeErrors": {
-      "execution_failed": {
-        "title": "Execution failed",
-        "messageLocal": "Node threw an error during execution.",
-        "messageCloud": "Node threw an error during execution. No credits charged.",
-        "itemLabel": "{nodeName}",
-        "toastTitle": "{nodeName} failed",
-        "toastMessageLocal": "This node threw an error during execution. Check its inputs or try a different configuration.",
-        "toastMessageCloud": "This node threw an error during execution. Check its inputs or try a different configuration. No credits charged."
-      },
-      "image_not_loaded": {
-        "title": "Image not loaded",
-        "message": "The system couldn't load this image.",
-        "itemLabel": "{nodeName}",
-        "toastTitle": "Input image couldn't be loaded",
-        "toastMessage": "The image for {nodeName} couldn't be loaded. Try adding it again."
-      },
-      "out_of_memory": {
-        "title": "Generation failed",
-        "messageLocal": "Not enough GPU memory. Try reducing complexity and run again.",
-        "messageCloud": "Not enough GPU memory. Try reducing complexity and run again. No credits charged.",
-        "itemLabel": "{nodeName}",
-        "toastTitle": "Generation failed",
-        "toastMessageLocal": "Not enough GPU memory. Try reducing complexity and run again.",
-        "toastMessageCloud": "Not enough GPU memory. Try reducing complexity and run again. No credits charged."
-      }
-    },
     "promptErrors": {
       "prompt_no_outputs": {
         "title": "Prompt has no outputs",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3787,15 +3787,19 @@
     },
     "promptErrors": {
       "prompt_no_outputs": {
+        "title": "Prompt has no outputs",
         "desc": "The workflow does not contain any output nodes (e.g. Save Image, Preview Image) to produce a result."
       },
       "no_prompt": {
+        "title": "Workflow data is empty",
         "desc": "The workflow data sent to the server is empty. This may be an unexpected system error."
       },
       "server_error_local": {
+        "title": "Server error",
         "desc": "The server encountered an unexpected error. Please check the server logs."
       },
       "server_error_cloud": {
+        "title": "Server error",
         "desc": "The server encountered an unexpected error. Please try again later."
       },
       "missing_node_type": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3668,14 +3668,121 @@
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Required input missing",
         "toastMessage": "{nodeName} is missing a required input: {inputName}"
+      },
+      "bad_linked_input": {
+        "title": "Invalid connection",
+        "message": "A linked input connection is malformed.",
+        "details": "{nodeName} has an invalid connection for {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Invalid connection",
+        "toastMessage": "{nodeName} has an invalid connection for {inputName}."
+      },
+      "return_type_mismatch": {
+        "title": "Invalid connection",
+        "message": "Connected nodes are using incompatible input and output types.",
+        "details": "{nodeName} has an incompatible connection for {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Invalid connection",
+        "toastMessage": "{nodeName} has an incompatible connection for {inputName}."
+      },
+      "invalid_input_type": {
+        "title": "Invalid input",
+        "message": "An input value has the wrong type.",
+        "details": "{nodeName} couldn't convert {inputName} to the expected type.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Invalid input",
+        "toastMessage": "{nodeName} couldn't convert {inputName} to the expected type."
+      },
+      "value_smaller_than_min": {
+        "title": "Input out of range",
+        "message": "Some input values are outside the allowed range.",
+        "details": "{nodeName} has a value below the minimum for {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Input out of range",
+        "toastMessage": "{nodeName} has a value below the minimum for {inputName}."
+      },
+      "value_bigger_than_max": {
+        "title": "Input out of range",
+        "message": "Some input values are outside the allowed range.",
+        "details": "{nodeName} has a value above the maximum for {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Input out of range",
+        "toastMessage": "{nodeName} has a value above the maximum for {inputName}."
+      },
+      "value_not_in_list": {
+        "title": "Invalid input",
+        "message": "Some input values are not available for this node.",
+        "details": "{nodeName} has an unsupported value for {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Invalid input",
+        "toastMessage": "{nodeName} has an unsupported value for {inputName}."
+      },
+      "custom_validation_failed": {
+        "title": "Invalid input",
+        "message": "A node rejected one or more input values.",
+        "details": "{nodeName} rejected the value for {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Invalid input",
+        "toastMessage": "{nodeName} rejected the value for {inputName}."
+      },
+      "exception_during_inner_validation": {
+        "title": "Validation failed",
+        "message": "The workflow couldn't validate a connected node.",
+        "details": "{nodeName} couldn't validate {inputName}.",
+        "itemLabel": "{nodeName} - {inputName}",
+        "toastTitle": "Validation failed",
+        "toastMessage": "{nodeName} couldn't validate {inputName}."
+      },
+      "exception_during_validation": {
+        "title": "Validation failed",
+        "message": "The node could not be validated.",
+        "details": "{nodeName} could not be validated.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Validation failed",
+        "toastMessage": "{nodeName} could not be validated."
+      },
+      "dependency_cycle": {
+        "title": "Invalid workflow",
+        "message": "The workflow has a circular node connection.",
+        "details": "{nodeName} is part of a circular connection.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Invalid workflow",
+        "toastMessage": "{nodeName} is part of a circular connection."
+      },
+      "image_not_loaded": {
+        "title": "Image not loaded",
+        "message": "The system couldn't load this image.",
+        "details": "The image for {nodeName} couldn't be loaded. Try adding it again.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Input image couldn't be loaded",
+        "toastMessage": "The image for {nodeName} couldn't be loaded. Try adding it again."
       }
     },
     "runtimeErrors": {
       "execution_failed": {
+        "title": "Execution failed",
+        "messageLocal": "Node threw an error during execution.",
+        "messageCloud": "Node threw an error during execution. No credits charged.",
         "itemLabel": "{nodeName}",
         "toastTitle": "{nodeName} failed",
         "toastMessageLocal": "This node threw an error during execution. Check its inputs or try a different configuration.",
         "toastMessageCloud": "This node threw an error during execution. Check its inputs or try a different configuration. No credits charged."
+      },
+      "image_not_loaded": {
+        "title": "Image not loaded",
+        "message": "The system couldn't load this image.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Input image couldn't be loaded",
+        "toastMessage": "The image for {nodeName} couldn't be loaded. Try adding it again."
+      },
+      "out_of_memory": {
+        "title": "Generation failed",
+        "messageLocal": "Not enough GPU memory. Try reducing complexity and run again.",
+        "messageCloud": "Not enough GPU memory. Try reducing complexity and run again. No credits charged.",
+        "itemLabel": "{nodeName}",
+        "toastTitle": "Generation failed",
+        "toastMessageLocal": "Not enough GPU memory. Try reducing complexity and run again.",
+        "toastMessageCloud": "Not enough GPU memory. Try reducing complexity and run again. No credits charged."
       }
     },
     "promptErrors": {
@@ -3690,6 +3797,23 @@
       },
       "server_error_cloud": {
         "desc": "The server encountered an unexpected error. Please try again later."
+      },
+      "missing_node_type": {
+        "title": "Missing node type",
+        "desc": "A node type is missing or unavailable. The workflow may be corrupted or require a custom node."
+      },
+      "prompt_outputs_failed_validation": {
+        "title": "Prompt validation failed",
+        "desc": "The workflow has invalid node inputs. Fix the highlighted nodes before running it again."
+      },
+      "image_not_loaded": {
+        "title": "Image not loaded",
+        "desc": "The system couldn't load this image."
+      },
+      "out_of_memory": {
+        "title": "Generation failed",
+        "descLocal": "Not enough GPU memory. Try reducing complexity and run again.",
+        "descCloud": "Not enough GPU memory. Try reducing complexity and run again. No credits charged."
       }
     }
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3671,7 +3671,7 @@
       },
       "bad_linked_input": {
         "title": "Invalid connection",
-        "message": "A linked input connection is malformed.",
+        "message": "A node connection could not be read correctly.",
         "details": "{nodeName} has an invalid connection for {inputName}.",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Invalid connection",
@@ -3681,46 +3681,57 @@
         "title": "Invalid connection",
         "message": "Connected nodes are using incompatible input and output types.",
         "details": "{nodeName} has an incompatible connection for {inputName}.",
+        "detailsWithTypes": "{nodeName}'s {inputName} input expects {expectedType}, but the connected output is {receivedType}.",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Invalid connection",
-        "toastMessage": "{nodeName} has an incompatible connection for {inputName}."
+        "toastMessage": "{nodeName} has an incompatible connection for {inputName}.",
+        "toastMessageWithTypes": "{nodeName}'s {inputName} input expects {expectedType}, but the connected output is {receivedType}."
       },
       "invalid_input_type": {
         "title": "Invalid input",
         "message": "An input value has the wrong type.",
         "details": "{nodeName} couldn't convert {inputName} to the expected type.",
+        "detailsWithValue": "The value {receivedValue} for {nodeName}'s {inputName} couldn't be converted to {expectedType}.",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Invalid input",
-        "toastMessage": "{nodeName} couldn't convert {inputName} to the expected type."
+        "toastMessage": "{nodeName} couldn't convert {inputName} to the expected type.",
+        "toastMessageWithValue": "The value {receivedValue} for {nodeName}'s {inputName} couldn't be converted to {expectedType}."
       },
       "value_smaller_than_min": {
         "title": "Input out of range",
         "message": "Some input values are outside the allowed range.",
         "details": "{nodeName} has a value below the minimum for {inputName}.",
+        "detailsWithValue": "The value {receivedValue} for {nodeName}'s {inputName} is below the minimum {minValue}.",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Input out of range",
-        "toastMessage": "{nodeName} has a value below the minimum for {inputName}."
+        "toastMessage": "{nodeName} has a value below the minimum for {inputName}.",
+        "toastMessageWithValue": "The value {receivedValue} for {nodeName}'s {inputName} is below the minimum {minValue}."
       },
       "value_bigger_than_max": {
         "title": "Input out of range",
         "message": "Some input values are outside the allowed range.",
         "details": "{nodeName} has a value above the maximum for {inputName}.",
+        "detailsWithValue": "The value {receivedValue} for {nodeName}'s {inputName} is above the maximum {maxValue}.",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Input out of range",
-        "toastMessage": "{nodeName} has a value above the maximum for {inputName}."
+        "toastMessage": "{nodeName} has a value above the maximum for {inputName}.",
+        "toastMessageWithValue": "The value {receivedValue} for {nodeName}'s {inputName} is above the maximum {maxValue}."
       },
       "value_not_in_list": {
         "title": "Invalid input",
         "message": "Some input values are not available for this node.",
         "details": "{nodeName} has an unsupported value for {inputName}.",
+        "detailsWithValue": "The value {receivedValue} for {nodeName}'s {inputName} is not available.",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Invalid input",
-        "toastMessage": "{nodeName} has an unsupported value for {inputName}."
+        "toastMessage": "{nodeName} has an unsupported value for {inputName}.",
+        "toastMessageWithValue": "The value {receivedValue} for {nodeName}'s {inputName} is not available."
       },
       "custom_validation_failed": {
         "title": "Invalid input",
         "message": "A node rejected one or more input values.",
         "details": "{nodeName} rejected the value for {inputName}.",
+        "detailsWithRawDetails": "{nodeName} failed custom validation: {rawDetails}",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Invalid input",
         "toastMessage": "{nodeName} rejected the value for {inputName}."
@@ -3729,22 +3740,27 @@
         "title": "Validation failed",
         "message": "The workflow couldn't validate a connected node.",
         "details": "{nodeName} couldn't validate {inputName}.",
+        "detailsWithRawDetails": "{nodeName} couldn't validate {inputName}: {rawDetails}",
         "itemLabel": "{nodeName} - {inputName}",
         "toastTitle": "Validation failed",
-        "toastMessage": "{nodeName} couldn't validate {inputName}."
+        "toastMessage": "{nodeName} couldn't validate {inputName}.",
+        "toastMessageWithRawDetails": "{nodeName} couldn't validate {inputName}: {rawDetails}"
       },
       "exception_during_validation": {
         "title": "Validation failed",
-        "message": "The node could not be validated.",
-        "details": "{nodeName} could not be validated.",
+        "message": "The workflow could not be validated because a node validation check failed unexpectedly.",
+        "details": "{nodeName} failed during validation.",
+        "detailsWithRawDetails": "{nodeName} failed during validation: {rawDetails}",
         "itemLabel": "{nodeName}",
         "toastTitle": "Validation failed",
-        "toastMessage": "{nodeName} could not be validated."
+        "toastMessage": "{nodeName} failed during validation.",
+        "toastMessageWithRawDetails": "{nodeName} failed during validation: {rawDetails}"
       },
       "dependency_cycle": {
         "title": "Invalid workflow",
         "message": "The workflow has a circular node connection.",
         "details": "{nodeName} is part of a circular connection.",
+        "detailsWithRawDetails": "{nodeName} is part of a circular connection: {rawDetails}",
         "itemLabel": "{nodeName}",
         "toastTitle": "Invalid workflow",
         "toastMessage": "{nodeName} is part of a circular connection."

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -5,7 +5,6 @@ import {
   resolveRunErrorMessage
 } from './errorMessageResolver'
 import type { NodeValidationError } from './types'
-import type { ExecutionErrorWsMessage } from '@/schemas/apiSchema'
 import { i18n } from '@/i18n'
 
 function nodeValidationError(
@@ -34,24 +33,6 @@ function requiredInputMissing(inputName?: string): NodeValidationError {
   return {
     ...nodeValidationError('required_input_missing', inputName),
     message: 'Required input is missing'
-  }
-}
-
-function runtimeError(
-  overrides: Partial<ExecutionErrorWsMessage> = {}
-): ExecutionErrorWsMessage {
-  return {
-    prompt_id: 'test',
-    timestamp: Date.now(),
-    node_id: 1,
-    node_type: 'KSampler',
-    executed: [],
-    exception_type: 'RuntimeError',
-    exception_message: 'CUDA out of memory',
-    traceback: [],
-    current_inputs: {},
-    current_outputs: {},
-    ...overrides
   }
 }
 
@@ -103,11 +84,11 @@ describe('errorMessageResolver', () => {
           nodeDisplayName: '0'
         })
       ).toMatchObject({
-        displayTitle: 'required_input_missing',
+        displayTitle: 'Required input is missing',
         displayMessage: 'Required input is missing',
         displayDetails: 'seed',
         displayItemLabel: '0 - seed',
-        toastTitle: 'required_input_missing',
+        toastTitle: 'Required input is missing',
         toastMessage: 'Required input is missing'
       })
     } finally {
@@ -116,20 +97,20 @@ describe('errorMessageResolver', () => {
     }
   })
 
-  it('leaves execution errors unresolved so raw runtime copy is preserved', () => {
-    expect(
-      resolveRunErrorMessage({
-        kind: 'execution',
-        isCloud: true,
-        nodeDisplayName: 'KSampler',
-        error: runtimeError({
-          exception_message: 'mat1 and mat2 shapes cannot be multiplied'
-        })
-      })
-    ).toEqual({})
-  })
-
   it.for([
+    {
+      type: 'bad_linked_input',
+      inputName: 'model',
+      expected: {
+        catalogId: 'bad_linked_input',
+        displayTitle: 'Invalid connection',
+        displayMessage: 'A node connection could not be read correctly.',
+        displayDetails: 'KSampler has an invalid connection for model.',
+        displayItemLabel: 'KSampler - model',
+        toastTitle: 'Invalid connection',
+        toastMessage: 'KSampler has an invalid connection for model.'
+      }
+    },
     {
       type: 'value_not_in_list',
       inputName: 'scheduler',
@@ -274,6 +255,30 @@ describe('errorMessageResolver', () => {
     })
   })
 
+  it('falls back to generic copy when structured values cannot be formatted', () => {
+    const circularValue: Record<string, unknown> = {}
+    circularValue.self = circularValue
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'invalid_input_type',
+          'steps',
+          "steps, [object Object], invalid literal for int() with base 10: 'abc'",
+          {
+            input_config: ['INT', {}],
+            received_value: circularValue
+          }
+        ),
+        nodeDisplayName: 'KSampler'
+      })
+    ).toMatchObject({
+      displayDetails: "KSampler couldn't convert steps to the expected type.",
+      toastMessage: "KSampler couldn't convert steps to the expected type."
+    })
+  })
+
   it('includes raw details when validation itself fails unexpectedly', () => {
     expect(
       resolveRunErrorMessage({
@@ -354,6 +359,23 @@ describe('errorMessageResolver', () => {
       displayItemLabel: 'Load Image',
       toastTitle: "Input image couldn't be loaded"
     })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'custom_validation_failed',
+          'image',
+          "[Errno 21] Is a directory: '/app/comfyui/input'"
+        ),
+        nodeDisplayName: 'Load Image'
+      })
+    ).toMatchObject({
+      catalogId: 'image_not_loaded',
+      displayTitle: 'Image not loaded',
+      displayMessage: "The system couldn't load this image.",
+      displayItemLabel: 'Load Image'
+    })
   })
 
   it('includes raw details for generic custom validation failures', () => {
@@ -376,6 +398,24 @@ describe('errorMessageResolver', () => {
       displayItemLabel: 'Custom Validation Error - setting',
       toastTitle: 'Invalid input',
       toastMessage: 'Custom Validation Error rejected the value for setting.'
+    })
+  })
+
+  it('does not treat raw details as the input name when input metadata is missing', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'custom_validation_failed',
+          undefined,
+          'Traceback line 1\nTraceback line 2'
+        ),
+        nodeDisplayName: 'Custom Validation Error'
+      })
+    ).toMatchObject({
+      displayItemLabel: 'Custom Validation Error - unknown input',
+      toastMessage:
+        'Custom Validation Error rejected the value for unknown input.'
     })
   })
 
@@ -510,6 +550,22 @@ describe('errorMessageResolver', () => {
       catalogId: 'image_not_loaded',
       displayTitle: 'Image not loaded',
       displayMessage: "The system couldn't load this image."
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'prompt_outputs_failed_validation',
+          message: 'Prompt outputs failed validation',
+          details: ''
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Prompt validation failed',
+      displayMessage:
+        'The workflow has invalid node inputs. Fix the highlighted nodes before running it again.'
     })
   })
 

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -11,17 +11,22 @@ import { i18n } from '@/i18n'
 function nodeValidationError(
   type: string,
   inputName?: string,
-  details = inputName ?? ''
+  details = inputName ?? '',
+  extraInfo: Record<string, unknown> = {}
 ): NodeValidationError {
+  const extra_info =
+    inputName || Object.keys(extraInfo).length > 0
+      ? {
+          ...(inputName ? { input_name: inputName } : {}),
+          ...extraInfo
+        }
+      : undefined
+
   return {
     type,
     message: 'Validation failed',
     details,
-    extra_info: inputName
-      ? {
-          input_name: inputName
-        }
-      : undefined
+    extra_info
   }
 }
 
@@ -175,6 +180,160 @@ describe('errorMessageResolver', () => {
     ).toEqual(expected)
   })
 
+  it('includes received values in validation range and option details', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'return_type_mismatch',
+          'images',
+          'images, received_type(LATENT) mismatch input_type(IMAGE)',
+          {
+            input_config: ['IMAGE', {}],
+            received_type: 'LATENT'
+          }
+        ),
+        nodeDisplayName: 'Preview Image'
+      })
+    ).toMatchObject({
+      displayDetails:
+        "Preview Image's images input expects IMAGE, but the connected output is LATENT.",
+      toastMessage:
+        "Preview Image's images input expects IMAGE, but the connected output is LATENT."
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'invalid_input_type',
+          'steps',
+          "steps, abc, invalid literal for int() with base 10: 'abc'",
+          {
+            input_config: ['INT', {}],
+            received_value: 'abc'
+          }
+        ),
+        nodeDisplayName: 'KSampler'
+      })
+    ).toMatchObject({
+      displayDetails:
+        "The value abc for KSampler's steps couldn't be converted to INT.",
+      toastMessage:
+        "The value abc for KSampler's steps couldn't be converted to INT."
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError('value_smaller_than_min', 'steps', 'steps', {
+          input_config: ['INT', { min: 1 }],
+          received_value: 0
+        }),
+        nodeDisplayName: 'KSampler'
+      })
+    ).toMatchObject({
+      displayDetails:
+        "The value 0 for KSampler's steps is below the minimum 1.",
+      toastMessage: "The value 0 for KSampler's steps is below the minimum 1."
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError('value_bigger_than_max', 'cfg', 'cfg', {
+          input_config: ['FLOAT', { max: 30 }],
+          received_value: 40
+        }),
+        nodeDisplayName: 'KSampler'
+      })
+    ).toMatchObject({
+      displayDetails:
+        "The value 40 for KSampler's cfg is above the maximum 30.",
+      toastMessage: "The value 40 for KSampler's cfg is above the maximum 30."
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'value_not_in_list',
+          'scheduler',
+          'scheduler',
+          {
+            received_value: 'not-a-scheduler'
+          }
+        ),
+        nodeDisplayName: 'KSampler'
+      })
+    ).toMatchObject({
+      displayDetails:
+        "The value not-a-scheduler for KSampler's scheduler is not available.",
+      toastMessage:
+        "The value not-a-scheduler for KSampler's scheduler is not available."
+    })
+  })
+
+  it('includes raw details when validation itself fails unexpectedly', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'exception_during_inner_validation',
+          'images',
+          'list index out of range'
+        ),
+        nodeDisplayName: 'Image Scale'
+      })
+    ).toMatchObject({
+      displayTitle: 'Validation failed',
+      displayMessage: "The workflow couldn't validate a connected node.",
+      displayDetails:
+        "Image Scale couldn't validate images: list index out of range",
+      displayItemLabel: 'Image Scale - images',
+      toastTitle: 'Validation failed',
+      toastMessage:
+        "Image Scale couldn't validate images: list index out of range"
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'exception_during_validation',
+          undefined,
+          'tuple index out of range'
+        ),
+        nodeDisplayName: 'Preview Image'
+      })
+    ).toMatchObject({
+      displayTitle: 'Validation failed',
+      displayMessage:
+        'The workflow could not be validated because a node validation check failed unexpectedly.',
+      displayDetails:
+        'Preview Image failed during validation: tuple index out of range',
+      displayItemLabel: 'Preview Image',
+      toastTitle: 'Validation failed',
+      toastMessage:
+        'Preview Image failed during validation: tuple index out of range'
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'exception_during_validation',
+          undefined,
+          ''
+        ),
+        nodeDisplayName: 'Preview Image'
+      })
+    ).toMatchObject({
+      displayDetails: 'Preview Image failed during validation.',
+      toastMessage: 'Preview Image failed during validation.'
+    })
+  })
+
   it('resolves custom validation image failures as image-not-loaded copy', () => {
     expect(
       resolveRunErrorMessage({
@@ -194,6 +353,51 @@ describe('errorMessageResolver', () => {
         "The image for Load Image couldn't be loaded. Try adding it again.",
       displayItemLabel: 'Load Image',
       toastTitle: "Input image couldn't be loaded"
+    })
+  })
+
+  it('includes raw details for generic custom validation failures', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'custom_validation_failed',
+          'setting',
+          'setting - Unsupported lab value: bad-value'
+        ),
+        nodeDisplayName: 'Custom Validation Error'
+      })
+    ).toMatchObject({
+      catalogId: 'custom_validation_failed',
+      displayTitle: 'Invalid input',
+      displayMessage: 'A node rejected one or more input values.',
+      displayDetails:
+        'Custom Validation Error failed custom validation: setting - Unsupported lab value: bad-value',
+      displayItemLabel: 'Custom Validation Error - setting',
+      toastTitle: 'Invalid input',
+      toastMessage: 'Custom Validation Error rejected the value for setting.'
+    })
+  })
+
+  it('includes raw cycle paths for dependency cycle details', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'dependency_cycle',
+          undefined,
+          '7 (ImageScale) -> 7 (ImageScale)'
+        ),
+        nodeDisplayName: 'Image Scale'
+      })
+    ).toMatchObject({
+      displayTitle: 'Invalid workflow',
+      displayMessage: 'The workflow has a circular node connection.',
+      displayDetails:
+        'Image Scale is part of a circular connection: 7 (ImageScale) to 7 (ImageScale)',
+      displayItemLabel: 'Image Scale',
+      toastTitle: 'Invalid workflow',
+      toastMessage: 'Image Scale is part of a circular connection.'
     })
   })
 

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -5,13 +5,18 @@ import {
   resolveRunErrorMessage
 } from './errorMessageResolver'
 import type { NodeValidationError } from './types'
+import type { ExecutionErrorWsMessage } from '@/schemas/apiSchema'
 import { i18n } from '@/i18n'
 
-function requiredInputMissing(inputName?: string): NodeValidationError {
+function nodeValidationError(
+  type: string,
+  inputName?: string,
+  details = inputName ?? ''
+): NodeValidationError {
   return {
-    type: 'required_input_missing',
-    message: 'Required input is missing',
-    details: inputName ?? '',
+    type,
+    message: 'Validation failed',
+    details,
     extra_info: inputName
       ? {
           input_name: inputName
@@ -20,7 +25,16 @@ function requiredInputMissing(inputName?: string): NodeValidationError {
   }
 }
 
-function runtimeError() {
+function requiredInputMissing(inputName?: string): NodeValidationError {
+  return {
+    ...nodeValidationError('required_input_missing', inputName),
+    message: 'Required input is missing'
+  }
+}
+
+function runtimeError(
+  overrides: Partial<ExecutionErrorWsMessage> = {}
+): ExecutionErrorWsMessage {
   return {
     prompt_id: 'test',
     timestamp: Date.now(),
@@ -31,7 +45,8 @@ function runtimeError() {
     exception_message: 'CUDA out of memory',
     traceback: [],
     current_inputs: {},
-    current_outputs: {}
+    current_outputs: {},
+    ...overrides
   }
 }
 
@@ -99,10 +114,15 @@ describe('errorMessageResolver', () => {
         kind: 'execution',
         isCloud: true,
         nodeDisplayName: 'KSampler',
-        error: runtimeError()
+        error: runtimeError({
+          exception_message: 'mat1 and mat2 shapes cannot be multiplied'
+        })
       })
     ).toEqual({
       catalogId: 'execution_failed',
+      displayTitle: 'Execution failed',
+      displayMessage:
+        'Node threw an error during execution. No credits charged.',
       displayItemLabel: 'KSampler',
       toastTitle: 'KSampler failed',
       toastMessage:
@@ -116,11 +136,151 @@ describe('errorMessageResolver', () => {
         kind: 'execution',
         isCloud: false,
         nodeDisplayName: 'KSampler',
-        error: runtimeError()
+        error: runtimeError({
+          exception_message: 'mat1 and mat2 shapes cannot be multiplied'
+        })
       }).toastMessage
     ).toBe(
       'This node threw an error during execution. Check its inputs or try a different configuration.'
     )
+  })
+
+  it.for([
+    {
+      type: 'value_not_in_list',
+      inputName: 'scheduler',
+      expected: {
+        catalogId: 'value_not_in_list',
+        displayTitle: 'Invalid input',
+        displayMessage: 'Some input values are not available for this node.',
+        displayDetails: 'KSampler has an unsupported value for scheduler.',
+        displayItemLabel: 'KSampler - scheduler',
+        toastTitle: 'Invalid input',
+        toastMessage: 'KSampler has an unsupported value for scheduler.'
+      }
+    },
+    {
+      type: 'value_smaller_than_min',
+      inputName: 'steps',
+      expected: {
+        catalogId: 'value_smaller_than_min',
+        displayTitle: 'Input out of range',
+        displayMessage: 'Some input values are outside the allowed range.',
+        displayDetails: 'KSampler has a value below the minimum for steps.',
+        displayItemLabel: 'KSampler - steps',
+        toastTitle: 'Input out of range',
+        toastMessage: 'KSampler has a value below the minimum for steps.'
+      }
+    },
+    {
+      type: 'return_type_mismatch',
+      inputName: 'model',
+      expected: {
+        catalogId: 'return_type_mismatch',
+        displayTitle: 'Invalid connection',
+        displayMessage:
+          'Connected nodes are using incompatible input and output types.',
+        displayDetails: 'KSampler has an incompatible connection for model.',
+        displayItemLabel: 'KSampler - model',
+        toastTitle: 'Invalid connection',
+        toastMessage: 'KSampler has an incompatible connection for model.'
+      }
+    }
+  ])('resolves $type validation errors', ({ type, inputName, expected }) => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(type, inputName),
+        nodeDisplayName: 'KSampler'
+      })
+    ).toEqual(expected)
+  })
+
+  it('resolves custom validation image failures as image-not-loaded copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'node_validation',
+        error: nodeValidationError(
+          'custom_validation_failed',
+          'image',
+          'image - Invalid image file: broken.png'
+        ),
+        nodeDisplayName: 'Load Image'
+      })
+    ).toMatchObject({
+      catalogId: 'image_not_loaded',
+      displayTitle: 'Image not loaded',
+      displayMessage: "The system couldn't load this image.",
+      displayDetails:
+        "The image for Load Image couldn't be loaded. Try adding it again.",
+      displayItemLabel: 'Load Image',
+      toastTitle: "Input image couldn't be loaded"
+    })
+  })
+
+  it('resolves runtime image load failures by exception type or high-confidence message', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'execution',
+        isCloud: true,
+        nodeDisplayName: 'Load Image',
+        error: runtimeError({
+          exception_type: 'ImageDownloadError',
+          exception_message: 'Failed to validate images'
+        })
+      })
+    ).toMatchObject({
+      catalogId: 'image_not_loaded',
+      displayTitle: 'Image not loaded',
+      displayMessage: "The system couldn't load this image.",
+      displayItemLabel: 'Load Image',
+      toastMessage:
+        "The image for Load Image couldn't be loaded. Try adding it again."
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'execution',
+        isCloud: true,
+        nodeDisplayName: 'Load Image',
+        error: runtimeError({
+          exception_message: "[Errno 21] Is a directory: '/app/comfyui/input'"
+        })
+      }).catalogId
+    ).toBe('image_not_loaded')
+  })
+
+  it('resolves runtime OOM failures from cloud type and local message patterns', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'execution',
+        isCloud: true,
+        nodeDisplayName: 'KSampler',
+        error: runtimeError({
+          exception_type: 'OOMError',
+          exception_message:
+            'Workflow execution failed due to insufficient memory (OOM).'
+        })
+      })
+    ).toMatchObject({
+      catalogId: 'out_of_memory',
+      displayTitle: 'Generation failed',
+      displayMessage:
+        'Not enough GPU memory. Try reducing complexity and run again. No credits charged.',
+      displayItemLabel: 'KSampler',
+      toastTitle: 'Generation failed'
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'execution',
+        isCloud: false,
+        nodeDisplayName: 'KSampler',
+        error: runtimeError({
+          exception_message: 'torch.cuda.OutOfMemoryError: CUDA out of memory'
+        })
+      }).displayMessage
+    ).toBe('Not enough GPU memory. Try reducing complexity and run again.')
   })
 
   it('resolves known prompt errors with run error rules', () => {
@@ -180,6 +340,58 @@ describe('errorMessageResolver', () => {
         }
       })
     ).toEqual({})
+  })
+
+  it('resolves newly cataloged prompt-level errors', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'missing_node_type',
+          message:
+            "Node 'ID #4' has no class_type. The workflow may be corrupted or a custom node is missing.",
+          details: "Node ID '#4'"
+        }
+      })
+    ).toEqual({
+      displayTitle: 'Missing node type',
+      displayMessage:
+        'A node type is missing or unavailable. The workflow may be corrupted or require a custom node.'
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'OOMError',
+          message: 'OOMError: Workflow execution failed',
+          details: ''
+        }
+      })
+    ).toEqual({
+      catalogId: 'out_of_memory',
+      displayTitle: 'Generation failed',
+      displayMessage:
+        'Not enough GPU memory. Try reducing complexity and run again. No credits charged.'
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'ImageDownloadError',
+          message: 'ImageDownloadError: Failed to validate images',
+          details: ''
+        }
+      })
+    ).toEqual({
+      catalogId: 'image_not_loaded',
+      displayTitle: 'Image not loaded',
+      displayMessage: "The system couldn't load this image."
+    })
   })
 
   it('resolves missing error group display copy', () => {

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -83,7 +83,7 @@ describe('errorMessageResolver', () => {
     })
   })
 
-  it('interpolates fallback templates when catalog keys are missing in the active locale', () => {
+  it('falls back to raw API copy when catalog keys are missing in the active locale', () => {
     const originalLocale = i18n.global.locale.value
     const originalKoMessages = i18n.global.getLocaleMessage('ko')
 
@@ -98,9 +98,12 @@ describe('errorMessageResolver', () => {
           nodeDisplayName: '0'
         })
       ).toMatchObject({
-        displayDetails: '0 is missing a required input: seed',
+        displayTitle: 'required_input_missing',
+        displayMessage: 'Required input is missing',
+        displayDetails: 'seed',
         displayItemLabel: '0 - seed',
-        toastMessage: '0 is missing a required input: seed'
+        toastTitle: 'required_input_missing',
+        toastMessage: 'Required input is missing'
       })
     } finally {
       i18n.global.setLocaleMessage('ko', originalKoMessages)
@@ -295,6 +298,7 @@ describe('errorMessageResolver', () => {
         }
       })
     ).toEqual({
+      displayTitle: 'Prompt has no outputs',
       displayMessage:
         'The workflow does not contain any output nodes (e.g. Save Image, Preview Image) to produce a result.'
     })

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -539,6 +539,23 @@ describe('errorMessageResolver', () => {
     expect(
       resolveRunErrorMessage({
         kind: 'prompt',
+        isCloud: false,
+        error: {
+          type: 'OOMError',
+          message: 'OOMError: Workflow execution failed',
+          details: ''
+        }
+      })
+    ).toEqual({
+      catalogId: 'out_of_memory',
+      displayTitle: 'Generation failed',
+      displayMessage:
+        'Not enough GPU memory. Try reducing complexity and run again.'
+    })
+
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
         isCloud: true,
         error: {
           type: 'ImageDownloadError',

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -111,7 +111,7 @@ describe('errorMessageResolver', () => {
     }
   })
 
-  it('resolves runtime errors with item labels and toast copy', () => {
+  it('leaves execution errors unresolved so raw runtime copy is preserved', () => {
     expect(
       resolveRunErrorMessage({
         kind: 'execution',
@@ -121,31 +121,7 @@ describe('errorMessageResolver', () => {
           exception_message: 'mat1 and mat2 shapes cannot be multiplied'
         })
       })
-    ).toEqual({
-      catalogId: 'execution_failed',
-      displayTitle: 'Execution failed',
-      displayMessage:
-        'Node threw an error during execution. No credits charged.',
-      displayItemLabel: 'KSampler',
-      toastTitle: 'KSampler failed',
-      toastMessage:
-        'This node threw an error during execution. Check its inputs or try a different configuration. No credits charged.'
-    })
-  })
-
-  it('resolves local runtime errors without cloud credit copy', () => {
-    expect(
-      resolveRunErrorMessage({
-        kind: 'execution',
-        isCloud: false,
-        nodeDisplayName: 'KSampler',
-        error: runtimeError({
-          exception_message: 'mat1 and mat2 shapes cannot be multiplied'
-        })
-      }).toastMessage
-    ).toBe(
-      'This node threw an error during execution. Check its inputs or try a different configuration.'
-    )
+    ).toEqual({})
   })
 
   it.for([
@@ -219,71 +195,6 @@ describe('errorMessageResolver', () => {
       displayItemLabel: 'Load Image',
       toastTitle: "Input image couldn't be loaded"
     })
-  })
-
-  it('resolves runtime image load failures by exception type or high-confidence message', () => {
-    expect(
-      resolveRunErrorMessage({
-        kind: 'execution',
-        isCloud: true,
-        nodeDisplayName: 'Load Image',
-        error: runtimeError({
-          exception_type: 'ImageDownloadError',
-          exception_message: 'Failed to validate images'
-        })
-      })
-    ).toMatchObject({
-      catalogId: 'image_not_loaded',
-      displayTitle: 'Image not loaded',
-      displayMessage: "The system couldn't load this image.",
-      displayItemLabel: 'Load Image',
-      toastMessage:
-        "The image for Load Image couldn't be loaded. Try adding it again."
-    })
-
-    expect(
-      resolveRunErrorMessage({
-        kind: 'execution',
-        isCloud: true,
-        nodeDisplayName: 'Load Image',
-        error: runtimeError({
-          exception_message: "[Errno 21] Is a directory: '/app/comfyui/input'"
-        })
-      }).catalogId
-    ).toBe('image_not_loaded')
-  })
-
-  it('resolves runtime OOM failures from cloud type and local message patterns', () => {
-    expect(
-      resolveRunErrorMessage({
-        kind: 'execution',
-        isCloud: true,
-        nodeDisplayName: 'KSampler',
-        error: runtimeError({
-          exception_type: 'OOMError',
-          exception_message:
-            'Workflow execution failed due to insufficient memory (OOM).'
-        })
-      })
-    ).toMatchObject({
-      catalogId: 'out_of_memory',
-      displayTitle: 'Generation failed',
-      displayMessage:
-        'Not enough GPU memory. Try reducing complexity and run again. No credits charged.',
-      displayItemLabel: 'KSampler',
-      toastTitle: 'Generation failed'
-    })
-
-    expect(
-      resolveRunErrorMessage({
-        kind: 'execution',
-        isCloud: false,
-        nodeDisplayName: 'KSampler',
-        error: runtimeError({
-          exception_message: 'torch.cuda.OutOfMemoryError: CUDA out of memory'
-        })
-      }).displayMessage
-    ).toBe('Not enough GPU memory. Try reducing complexity and run again.')
   })
 
   it('resolves known prompt errors with run error rules', () => {

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -9,7 +9,6 @@ import { st, t, te } from '@/i18n'
 
 const REQUIRED_INPUT_MISSING_TYPE = 'required_input_missing'
 const REQUIRED_INPUT_MISSING_CATALOG_ID = 'missing_connection'
-const EXECUTION_FAILED_CATALOG_ID = 'execution_failed'
 const IMAGE_NOT_LOADED_CATALOG_ID = 'image_not_loaded'
 const OUT_OF_MEMORY_CATALOG_ID = 'out_of_memory'
 const KNOWN_PROMPT_ERROR_TYPES = new Set([
@@ -24,13 +23,6 @@ interface ValidationCatalogRule {
   catalogId: string
   key: string
   itemLabel: 'node' | 'nodeInput'
-}
-
-interface RuntimeCatalogRule {
-  catalogId: string
-  key: string
-  messageKey: 'message' | 'messageByEnvironment'
-  toastMessageKey: 'toastMessage' | 'toastMessageByEnvironment'
 }
 
 interface ErrorResolveContext {
@@ -75,14 +67,10 @@ function getInputName(error: NodeValidationError): string {
   )
 }
 
-function getErrorText(
-  error: NodeValidationError | RunErrorMessageSource['error']
-) {
+function getErrorText(error: NodeValidationError) {
   return [
     'message' in error ? error.message : undefined,
-    'details' in error ? error.details : undefined,
-    'exception_message' in error ? error.exception_message : undefined,
-    'exception_type' in error ? error.exception_type : undefined
+    'details' in error ? error.details : undefined
   ]
     .filter(Boolean)
     .join('\n')
@@ -90,12 +78,6 @@ function getErrorText(
 
 function isImageNotLoadedText(text: string): boolean {
   return /invalid image file|\[errno 21\].*is a directory/i.test(text)
-}
-
-function isOutOfMemoryText(text: string): boolean {
-  return /outofmemoryerror|out of memory|allocation on device|insufficient memory \(oom\)/i.test(
-    text
-  )
 }
 
 function isImageNotLoadedValidationError(error: NodeValidationError): boolean {
@@ -107,14 +89,6 @@ function isImageNotLoadedValidationError(error: NodeValidationError): boolean {
 
 function nodeInputItemLabel(nodeName: string, inputName: string): string {
   return `${nodeName} - ${inputName}`
-}
-
-function rawExecutionMessage(
-  error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error']
-): string {
-  return error.exception_type
-    ? `${error.exception_type}: ${error.exception_message}`
-    : error.exception_message
 }
 
 const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
@@ -180,27 +154,6 @@ const IMAGE_NOT_LOADED_VALIDATION_RULE = {
   key: 'image_not_loaded',
   itemLabel: 'node'
 } satisfies ValidationCatalogRule
-
-const RUNTIME_ERROR_RULES = {
-  execution_failed: {
-    catalogId: EXECUTION_FAILED_CATALOG_ID,
-    key: 'execution_failed',
-    messageKey: 'messageByEnvironment',
-    toastMessageKey: 'toastMessageByEnvironment'
-  },
-  image_not_loaded: {
-    catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
-    key: 'image_not_loaded',
-    messageKey: 'message',
-    toastMessageKey: 'toastMessage'
-  },
-  out_of_memory: {
-    catalogId: OUT_OF_MEMORY_CATALOG_ID,
-    key: 'out_of_memory',
-    messageKey: 'messageByEnvironment',
-    toastMessageKey: 'toastMessageByEnvironment'
-  }
-} satisfies Record<string, RuntimeCatalogRule>
 
 function resolveValidationCatalogCopy(
   error: NodeValidationError,
@@ -270,88 +223,9 @@ function resolveNodeValidationErrorMessage(
   return resolveValidationCatalogCopy(error, context, rule)
 }
 
-function resolveRuntimeCatalogCopy(
-  error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error'],
-  rule: RuntimeCatalogRule,
-  context: ErrorResolveContext
-): ResolvedErrorMessage {
-  const nodeName = normalizeNodeName(context.nodeDisplayName)
-  const params = { nodeName }
-  const keyPrefix = `errorCatalog.runtimeErrors.${rule.key}`
-  const messageKey =
-    rule.messageKey === 'message'
-      ? 'message'
-      : context.isCloud
-        ? 'messageCloud'
-        : 'messageLocal'
-  const toastMessageKey =
-    rule.toastMessageKey === 'toastMessage'
-      ? 'toastMessage'
-      : context.isCloud
-        ? 'toastMessageCloud'
-        : 'toastMessageLocal'
-  const titleFallback = error.exception_type || error.exception_message
-  const messageFallback = rawExecutionMessage(error)
-
-  return {
-    catalogId: rule.catalogId,
-    displayTitle: translateCatalogMessage(
-      `${keyPrefix}.title`,
-      titleFallback,
-      params
-    ),
-    displayMessage: translateCatalogMessage(
-      `${keyPrefix}.${messageKey}`,
-      messageFallback,
-      params
-    ),
-    displayItemLabel: translateCatalogMessage(
-      `${keyPrefix}.itemLabel`,
-      nodeName,
-      params
-    ),
-    toastTitle: translateCatalogMessage(
-      `${keyPrefix}.toastTitle`,
-      titleFallback,
-      params
-    ),
-    toastMessage: translateCatalogMessage(
-      `${keyPrefix}.${toastMessageKey}`,
-      messageFallback,
-      params
-    )
-  }
-}
-
-function resolveExecutionErrorMessage(
-  error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error'],
-  context: ErrorResolveContext
-): ResolvedErrorMessage {
-  const errorText = getErrorText(error)
-  if (
-    error.exception_type === 'ImageDownloadError' ||
-    isImageNotLoadedText(errorText)
-  ) {
-    return resolveRuntimeCatalogCopy(
-      error,
-      RUNTIME_ERROR_RULES.image_not_loaded,
-      context
-    )
-  }
-
-  if (error.exception_type === 'OOMError' || isOutOfMemoryText(errorText)) {
-    return resolveRuntimeCatalogCopy(
-      error,
-      RUNTIME_ERROR_RULES.out_of_memory,
-      context
-    )
-  }
-
-  return resolveRuntimeCatalogCopy(
-    error,
-    RUNTIME_ERROR_RULES.execution_failed,
-    context
-  )
+function resolveExecutionErrorMessage(): ResolvedErrorMessage {
+  // Runtime catalog copy is deferred so actionable service errors stay raw.
+  return {}
 }
 
 function resolvePromptErrorMessage(
@@ -488,10 +362,7 @@ export function resolveRunErrorMessage(
         nodeDisplayName: source.nodeDisplayName
       })
     case 'execution':
-      return resolveExecutionErrorMessage(source.error, {
-        isCloud: source.isCloud,
-        nodeDisplayName: source.nodeDisplayName
-      })
+      return resolveExecutionErrorMessage()
     case 'prompt':
       return resolvePromptErrorMessage(source.error, {
         isCloud: source.isCloud

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -22,6 +22,7 @@ const KNOWN_PROMPT_ERROR_TYPES = new Set([
 interface ValidationCatalogRule {
   catalogId: string
   itemLabel: 'node' | 'nodeInput'
+  copyKeys?: CopyKeys
 }
 
 interface ErrorResolveContext {
@@ -215,19 +216,11 @@ function getRawDetailsCopyKeys(error: NodeValidationError): CopyKeys {
         detailsKey: 'detailsWithRawDetails',
         toastMessageKey: 'toastMessageWithRawDetails'
       }
-    : {
-        detailsKey: 'details',
-        toastMessageKey: 'toastMessage'
-      }
+    : DEFAULT_COPY_KEYS
 }
 
 function getRawDetailsOnlyCopyKeys(error: NodeValidationError): CopyKeys {
-  if (!error.details.trim()) {
-    return {
-      detailsKey: 'details',
-      toastMessageKey: 'toastMessage'
-    }
-  }
+  if (!error.details.trim()) return DEFAULT_COPY_KEYS
 
   return {
     detailsKey: 'detailsWithRawDetails',
@@ -305,15 +298,18 @@ const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
   }
 }
 
+// Image-not-loaded shares the custom_validation_failed type, so it needs a
+// predicate override to use image_not_loaded locale copy and default copy keys.
 const IMAGE_NOT_LOADED_VALIDATION_RULE = {
   catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
-  itemLabel: 'node'
+  itemLabel: 'node',
+  copyKeys: DEFAULT_COPY_KEYS
 } satisfies ValidationCatalogRule
 
 function resolveValidationCatalogCopy(
   error: NodeValidationError,
   context: ErrorResolveContext,
-  errorKey: string,
+  localeKey: string,
   rule: ValidationCatalogRule
 ): ResolvedErrorMessage {
   const nodeName = normalizeNodeName(context.nodeDisplayName)
@@ -323,19 +319,13 @@ function resolveValidationCatalogCopy(
     ...getValidationParams(error, nodeName, inputName),
     rawDetails
   }
-  const keyPrefix = `errorCatalog.validationErrors.${errorKey}`
-  const titleFallback = error.message
+  const keyPrefix = `errorCatalog.validationErrors.${localeKey}`
+  const titleFallback = error.message || error.type
   const itemLabelFallback =
     rule.itemLabel === 'node'
       ? nodeName
       : nodeInputItemLabel(nodeName, inputName)
-  const copyKeys =
-    errorKey === 'image_not_loaded'
-      ? {
-          detailsKey: 'details',
-          toastMessageKey: 'toastMessage'
-        }
-      : getValidationCopyKeys(error, params)
+  const copyKeys = rule.copyKeys ?? getValidationCopyKeys(error, params)
 
   return {
     catalogId: rule.catalogId,

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -10,11 +10,38 @@ import { st, t, te } from '@/i18n'
 const REQUIRED_INPUT_MISSING_TYPE = 'required_input_missing'
 const REQUIRED_INPUT_MISSING_CATALOG_ID = 'missing_connection'
 const EXECUTION_FAILED_CATALOG_ID = 'execution_failed'
+const IMAGE_NOT_LOADED_CATALOG_ID = 'image_not_loaded'
+const OUT_OF_MEMORY_CATALOG_ID = 'out_of_memory'
 const KNOWN_PROMPT_ERROR_TYPES = new Set([
   'prompt_no_outputs',
   'no_prompt',
-  'server_error'
+  'server_error',
+  'missing_node_type',
+  'prompt_outputs_failed_validation'
 ])
+
+interface CatalogCopyFallbacks {
+  catalogId: string
+  title: string
+  message: string
+  details?: string
+  itemLabel?: string
+  toastTitle?: string
+  toastMessage?: string
+}
+
+interface RuntimeCopyFallbacks {
+  catalogId: string
+  title: string
+  messageLocal?: string
+  messageCloud?: string
+  message?: string
+  itemLabel?: string
+  toastTitle?: string
+  toastMessageLocal?: string
+  toastMessageCloud?: string
+  toastMessage?: string
+}
 
 interface ErrorResolveContext {
   isCloud?: boolean
@@ -49,92 +76,413 @@ function getInputName(error: NodeValidationError): string {
   )
 }
 
-function isRequiredInputMissing(
-  error: NodeValidationError
-): error is NodeValidationError & { type: typeof REQUIRED_INPUT_MISSING_TYPE } {
-  return error.type === REQUIRED_INPUT_MISSING_TYPE
+function getErrorText(
+  error: NodeValidationError | RunErrorMessageSource['error']
+) {
+  return [
+    'message' in error ? error.message : undefined,
+    'details' in error ? error.details : undefined,
+    'exception_message' in error ? error.exception_message : undefined,
+    'exception_type' in error ? error.exception_type : undefined
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function isImageNotLoadedText(text: string): boolean {
+  return /invalid image file|\[errno 21\].*is a directory/i.test(text)
+}
+
+function isOutOfMemoryText(text: string): boolean {
+  return /outofmemoryerror|out of memory|allocation on device|insufficient memory \(oom\)/i.test(
+    text
+  )
+}
+
+function isImageNotLoadedValidationError(error: NodeValidationError): boolean {
+  return (
+    error.type === 'custom_validation_failed' &&
+    isImageNotLoadedText(getErrorText(error))
+  )
+}
+
+function resolveCatalogCopy(
+  keyPrefix: string,
+  fallback: CatalogCopyFallbacks,
+  params?: Record<string, string | number>
+): ResolvedErrorMessage {
+  return {
+    catalogId: fallback.catalogId,
+    displayTitle: translateCatalogMessage(
+      `${keyPrefix}.title`,
+      fallback.title,
+      params
+    ),
+    displayMessage: translateCatalogMessage(
+      `${keyPrefix}.message`,
+      fallback.message,
+      params
+    ),
+    ...(fallback.details
+      ? {
+          displayDetails: translateCatalogMessage(
+            `${keyPrefix}.details`,
+            fallback.details,
+            params
+          )
+        }
+      : {}),
+    ...(fallback.itemLabel
+      ? {
+          displayItemLabel: translateCatalogMessage(
+            `${keyPrefix}.itemLabel`,
+            fallback.itemLabel,
+            params
+          )
+        }
+      : {}),
+    ...(fallback.toastTitle
+      ? {
+          toastTitle: translateCatalogMessage(
+            `${keyPrefix}.toastTitle`,
+            fallback.toastTitle,
+            params
+          )
+        }
+      : {}),
+    ...(fallback.toastMessage
+      ? {
+          toastMessage: translateCatalogMessage(
+            `${keyPrefix}.toastMessage`,
+            fallback.toastMessage,
+            params
+          )
+        }
+      : {})
+  }
+}
+
+function resolveRuntimeCatalogCopy(
+  keyPrefix: string,
+  fallback: RuntimeCopyFallbacks,
+  params: Record<string, string | number>,
+  isCloud?: boolean
+): ResolvedErrorMessage {
+  const messageKey = isCloud ? 'messageCloud' : 'messageLocal'
+  const toastMessageKey = isCloud ? 'toastMessageCloud' : 'toastMessageLocal'
+  const messageFallback =
+    (isCloud ? fallback.messageCloud : fallback.messageLocal) ??
+    fallback.message ??
+    ''
+  const toastMessageFallback =
+    (isCloud ? fallback.toastMessageCloud : fallback.toastMessageLocal) ??
+    fallback.toastMessage
+
+  return {
+    catalogId: fallback.catalogId,
+    displayTitle: translateCatalogMessage(
+      `${keyPrefix}.title`,
+      fallback.title,
+      params
+    ),
+    ...(messageFallback
+      ? {
+          displayMessage: translateCatalogMessage(
+            `${keyPrefix}.${fallback.message ? 'message' : messageKey}`,
+            messageFallback,
+            params
+          )
+        }
+      : {}),
+    ...(fallback.itemLabel
+      ? {
+          displayItemLabel: translateCatalogMessage(
+            `${keyPrefix}.itemLabel`,
+            fallback.itemLabel,
+            params
+          )
+        }
+      : {}),
+    ...(fallback.toastTitle
+      ? {
+          toastTitle: translateCatalogMessage(
+            `${keyPrefix}.toastTitle`,
+            fallback.toastTitle,
+            params
+          )
+        }
+      : {}),
+    ...(toastMessageFallback
+      ? {
+          toastMessage: translateCatalogMessage(
+            `${keyPrefix}.${fallback.toastMessage ? 'toastMessage' : toastMessageKey}`,
+            toastMessageFallback,
+            params
+          )
+        }
+      : {})
+  }
+}
+
+const VALIDATION_ERROR_COPY: Record<string, CatalogCopyFallbacks> = {
+  [REQUIRED_INPUT_MISSING_TYPE]: {
+    catalogId: REQUIRED_INPUT_MISSING_CATALOG_ID,
+    title: 'Missing connection',
+    message: 'Required input slots have no connection feeding them.',
+    details: '{nodeName} is missing a required input: {inputName}',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Required input missing',
+    toastMessage: '{nodeName} is missing a required input: {inputName}'
+  },
+  bad_linked_input: {
+    catalogId: 'bad_linked_input',
+    title: 'Invalid connection',
+    message: 'A linked input connection is malformed.',
+    details: '{nodeName} has an invalid connection for {inputName}.',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Invalid connection',
+    toastMessage: '{nodeName} has an invalid connection for {inputName}.'
+  },
+  return_type_mismatch: {
+    catalogId: 'return_type_mismatch',
+    title: 'Invalid connection',
+    message: 'Connected nodes are using incompatible input and output types.',
+    details: '{nodeName} has an incompatible connection for {inputName}.',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Invalid connection',
+    toastMessage: '{nodeName} has an incompatible connection for {inputName}.'
+  },
+  invalid_input_type: {
+    catalogId: 'invalid_input_type',
+    title: 'Invalid input',
+    message: 'An input value has the wrong type.',
+    details: "{nodeName} couldn't convert {inputName} to the expected type.",
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Invalid input',
+    toastMessage:
+      "{nodeName} couldn't convert {inputName} to the expected type."
+  },
+  value_smaller_than_min: {
+    catalogId: 'value_smaller_than_min',
+    title: 'Input out of range',
+    message: 'Some input values are outside the allowed range.',
+    details: '{nodeName} has a value below the minimum for {inputName}.',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Input out of range',
+    toastMessage: '{nodeName} has a value below the minimum for {inputName}.'
+  },
+  value_bigger_than_max: {
+    catalogId: 'value_bigger_than_max',
+    title: 'Input out of range',
+    message: 'Some input values are outside the allowed range.',
+    details: '{nodeName} has a value above the maximum for {inputName}.',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Input out of range',
+    toastMessage: '{nodeName} has a value above the maximum for {inputName}.'
+  },
+  value_not_in_list: {
+    catalogId: 'value_not_in_list',
+    title: 'Invalid input',
+    message: 'Some input values are not available for this node.',
+    details: '{nodeName} has an unsupported value for {inputName}.',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Invalid input',
+    toastMessage: '{nodeName} has an unsupported value for {inputName}.'
+  },
+  custom_validation_failed: {
+    catalogId: 'custom_validation_failed',
+    title: 'Invalid input',
+    message: 'A node rejected one or more input values.',
+    details: '{nodeName} rejected the value for {inputName}.',
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Invalid input',
+    toastMessage: '{nodeName} rejected the value for {inputName}.'
+  },
+  exception_during_inner_validation: {
+    catalogId: 'exception_during_inner_validation',
+    title: 'Validation failed',
+    message: "The workflow couldn't validate a connected node.",
+    details: "{nodeName} couldn't validate {inputName}.",
+    itemLabel: '{nodeName} - {inputName}',
+    toastTitle: 'Validation failed',
+    toastMessage: "{nodeName} couldn't validate {inputName}."
+  },
+  exception_during_validation: {
+    catalogId: 'exception_during_validation',
+    title: 'Validation failed',
+    message: 'The node could not be validated.',
+    details: '{nodeName} could not be validated.',
+    itemLabel: '{nodeName}',
+    toastTitle: 'Validation failed',
+    toastMessage: '{nodeName} could not be validated.'
+  },
+  dependency_cycle: {
+    catalogId: 'dependency_cycle',
+    title: 'Invalid workflow',
+    message: 'The workflow has a circular node connection.',
+    details: '{nodeName} is part of a circular connection.',
+    itemLabel: '{nodeName}',
+    toastTitle: 'Invalid workflow',
+    toastMessage: '{nodeName} is part of a circular connection.'
+  }
+}
+
+const IMAGE_NOT_LOADED_VALIDATION_COPY = {
+  catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
+  title: 'Image not loaded',
+  message: "The system couldn't load this image.",
+  details: "The image for {nodeName} couldn't be loaded. Try adding it again.",
+  itemLabel: '{nodeName}',
+  toastTitle: "Input image couldn't be loaded",
+  toastMessage:
+    "The image for {nodeName} couldn't be loaded. Try adding it again."
+} satisfies CatalogCopyFallbacks
+
+const RUNTIME_ERROR_COPY = {
+  execution_failed: {
+    catalogId: EXECUTION_FAILED_CATALOG_ID,
+    title: 'Execution failed',
+    messageLocal: 'Node threw an error during execution.',
+    messageCloud: 'Node threw an error during execution. No credits charged.',
+    itemLabel: '{nodeName}',
+    toastTitle: '{nodeName} failed',
+    toastMessageLocal:
+      'This node threw an error during execution. Check its inputs or try a different configuration.',
+    toastMessageCloud:
+      'This node threw an error during execution. Check its inputs or try a different configuration. No credits charged.'
+  },
+  image_not_loaded: {
+    catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
+    title: 'Image not loaded',
+    message: "The system couldn't load this image.",
+    itemLabel: '{nodeName}',
+    toastTitle: "Input image couldn't be loaded",
+    toastMessage:
+      "The image for {nodeName} couldn't be loaded. Try adding it again."
+  },
+  out_of_memory: {
+    catalogId: OUT_OF_MEMORY_CATALOG_ID,
+    title: 'Generation failed',
+    messageLocal:
+      'Not enough GPU memory. Try reducing complexity and run again.',
+    messageCloud:
+      'Not enough GPU memory. Try reducing complexity and run again. No credits charged.',
+    itemLabel: '{nodeName}',
+    toastTitle: 'Generation failed',
+    toastMessageLocal:
+      'Not enough GPU memory. Try reducing complexity and run again.',
+    toastMessageCloud:
+      'Not enough GPU memory. Try reducing complexity and run again. No credits charged.'
+  }
+} satisfies Record<string, RuntimeCopyFallbacks>
+
+function resolveValidationCatalogCopy(
+  error: NodeValidationError,
+  context: ErrorResolveContext,
+  errorTypeKey: string,
+  fallback: CatalogCopyFallbacks
+): ResolvedErrorMessage {
+  const nodeName = normalizeNodeName(context.nodeDisplayName)
+  const inputName = getInputName(error)
+  return resolveCatalogCopy(
+    `errorCatalog.validationErrors.${errorTypeKey}`,
+    fallback,
+    { nodeName, inputName }
+  )
 }
 
 function resolveNodeValidationErrorMessage(
   error: NodeValidationError,
   context: ErrorResolveContext
 ): ResolvedErrorMessage {
-  if (!isRequiredInputMissing(error)) return {}
-
-  const nodeName = normalizeNodeName(context.nodeDisplayName)
-  const inputName = getInputName(error)
-  const keyPrefix = 'errorCatalog.validationErrors.required_input_missing'
-
-  return {
-    catalogId: REQUIRED_INPUT_MISSING_CATALOG_ID,
-    displayTitle: translateCatalogMessage(
-      `${keyPrefix}.title`,
-      'Missing connection'
-    ),
-    displayMessage: translateCatalogMessage(
-      `${keyPrefix}.message`,
-      'Required input slots have no connection feeding them.'
-    ),
-    displayDetails: translateCatalogMessage(
-      `${keyPrefix}.details`,
-      '{nodeName} is missing a required input: {inputName}',
-      { nodeName, inputName }
-    ),
-    displayItemLabel: translateCatalogMessage(
-      `${keyPrefix}.itemLabel`,
-      '{nodeName} - {inputName}',
-      { nodeName, inputName }
-    ),
-    toastTitle: translateCatalogMessage(
-      `${keyPrefix}.toastTitle`,
-      'Required input missing'
-    ),
-    toastMessage: translateCatalogMessage(
-      `${keyPrefix}.toastMessage`,
-      '{nodeName} is missing a required input: {inputName}',
-      { nodeName, inputName }
+  if (isImageNotLoadedValidationError(error)) {
+    return resolveValidationCatalogCopy(
+      error,
+      context,
+      'image_not_loaded',
+      IMAGE_NOT_LOADED_VALIDATION_COPY
     )
   }
+
+  const fallback = VALIDATION_ERROR_COPY[error.type]
+  if (!fallback) return {}
+
+  return resolveValidationCatalogCopy(error, context, error.type, fallback)
 }
 
 function resolveExecutionErrorMessage(
+  error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error'],
   context: ErrorResolveContext
 ): ResolvedErrorMessage {
   const nodeName = normalizeNodeName(context.nodeDisplayName)
-  const keyPrefix = 'errorCatalog.runtimeErrors.execution_failed'
-  const toastMessageKey = context.isCloud
-    ? `${keyPrefix}.toastMessageCloud`
-    : `${keyPrefix}.toastMessageLocal`
-  const toastMessageFallback = context.isCloud
-    ? 'This node threw an error during execution. Check its inputs or try a different configuration. No credits charged.'
-    : 'This node threw an error during execution. Check its inputs or try a different configuration.'
+  const params = { nodeName }
+  const errorText = getErrorText(error)
 
-  return {
-    catalogId: EXECUTION_FAILED_CATALOG_ID,
-    displayItemLabel: translateCatalogMessage(
-      `${keyPrefix}.itemLabel`,
-      nodeName,
-      {
-        nodeName
-      }
-    ),
-    toastTitle: translateCatalogMessage(
-      `${keyPrefix}.toastTitle`,
-      '{nodeName} failed',
-      { nodeName }
-    ),
-    toastMessage: translateCatalogMessage(
-      toastMessageKey,
-      toastMessageFallback,
-      { nodeName }
+  if (
+    error.exception_type === 'ImageDownloadError' ||
+    isImageNotLoadedText(errorText)
+  ) {
+    return resolveRuntimeCatalogCopy(
+      'errorCatalog.runtimeErrors.image_not_loaded',
+      RUNTIME_ERROR_COPY.image_not_loaded,
+      params,
+      context.isCloud
     )
   }
+
+  if (error.exception_type === 'OOMError' || isOutOfMemoryText(errorText)) {
+    return resolveRuntimeCatalogCopy(
+      'errorCatalog.runtimeErrors.out_of_memory',
+      RUNTIME_ERROR_COPY.out_of_memory,
+      params,
+      context.isCloud
+    )
+  }
+
+  return resolveRuntimeCatalogCopy(
+    'errorCatalog.runtimeErrors.execution_failed',
+    RUNTIME_ERROR_COPY.execution_failed,
+    params,
+    context.isCloud
+  )
 }
 
 function resolvePromptErrorMessage(
   error: Extract<RunErrorMessageSource, { kind: 'prompt' }>['error'],
   context: ErrorResolveContext
 ): ResolvedErrorMessage {
+  if (error.type === 'ImageDownloadError') {
+    return {
+      catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
+      displayTitle: st(
+        'errorCatalog.promptErrors.image_not_loaded.title',
+        'Image not loaded'
+      ),
+      displayMessage: st(
+        'errorCatalog.promptErrors.image_not_loaded.desc',
+        "The system couldn't load this image."
+      )
+    }
+  }
+
+  if (error.type === 'OOMError') {
+    const messageKey = context.isCloud
+      ? 'errorCatalog.promptErrors.out_of_memory.descCloud'
+      : 'errorCatalog.promptErrors.out_of_memory.descLocal'
+    const messageFallback = context.isCloud
+      ? 'Not enough GPU memory. Try reducing complexity and run again. No credits charged.'
+      : 'Not enough GPU memory. Try reducing complexity and run again.'
+
+    return {
+      catalogId: OUT_OF_MEMORY_CATALOG_ID,
+      displayTitle: st(
+        'errorCatalog.promptErrors.out_of_memory.title',
+        'Generation failed'
+      ),
+      displayMessage: st(messageKey, messageFallback)
+    }
+  }
+
   if (!KNOWN_PROMPT_ERROR_TYPES.has(error.type)) return {}
 
   const errorTypeKey =
@@ -145,6 +493,11 @@ function resolvePromptErrorMessage(
       : error.type
 
   return {
+    ...(te(`errorCatalog.promptErrors.${errorTypeKey}.title`)
+      ? {
+          displayTitle: t(`errorCatalog.promptErrors.${errorTypeKey}.title`)
+        }
+      : {}),
     displayMessage: st(
       `errorCatalog.promptErrors.${errorTypeKey}.desc`,
       error.message
@@ -232,7 +585,7 @@ export function resolveRunErrorMessage(
         nodeDisplayName: source.nodeDisplayName
       })
     case 'execution':
-      return resolveExecutionErrorMessage({
+      return resolveExecutionErrorMessage(source.error, {
         isCloud: source.isCloud,
         nodeDisplayName: source.nodeDisplayName
       })

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -30,10 +30,12 @@ interface ErrorResolveContext {
   nodeDisplayName?: string
 }
 
+type CatalogParams = Record<string, string | number>
+
 function translateCatalogMessage(
   key: string,
   fallback: string,
-  params?: Record<string, string | number>
+  params?: CatalogParams
 ): string {
   if (te(key)) return params ? t(key, params) : t(key)
   if (!params) return fallback
@@ -46,7 +48,7 @@ function translateCatalogMessage(
 function translateOptionalCatalogMessage(
   key: string,
   fallback?: string,
-  params?: Record<string, string | number>
+  params?: CatalogParams
 ): string | undefined {
   if (te(key)) return params ? t(key, params) : t(key)
   return fallback?.trim() ? fallback : undefined
@@ -89,6 +91,190 @@ function isImageNotLoadedValidationError(error: NodeValidationError): boolean {
 
 function nodeInputItemLabel(nodeName: string, inputName: string): string {
   return `${nodeName} - ${inputName}`
+}
+
+function formatRawDetailsForCatalog(details: string): string {
+  return details.replace(/\s*->\s*/g, ' to ')
+}
+
+function formatCatalogValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function getInputConfigValue(
+  error: NodeValidationError,
+  key: 'min' | 'max'
+): string | undefined {
+  const inputConfig = error.extra_info?.input_config
+  if (!Array.isArray(inputConfig)) return undefined
+
+  const config = inputConfig[1]
+  if (!config || typeof config !== 'object') return undefined
+
+  return formatCatalogValue((config as Record<string, unknown>)[key])
+}
+
+function getInputConfigType(error: NodeValidationError): string | undefined {
+  const inputConfig = error.extra_info?.input_config
+  if (!Array.isArray(inputConfig)) return undefined
+
+  return formatCatalogValue(inputConfig[0])
+}
+
+function getValidationParams(
+  error: NodeValidationError,
+  nodeName: string,
+  inputName: string
+): CatalogParams {
+  const params: CatalogParams = { nodeName, inputName }
+  const receivedValue = formatCatalogValue(error.extra_info?.received_value)
+  const receivedType = formatCatalogValue(error.extra_info?.received_type)
+  const expectedType = getInputConfigType(error)
+  const minValue = getInputConfigValue(error, 'min')
+  const maxValue = getInputConfigValue(error, 'max')
+
+  if (receivedValue !== undefined) params.receivedValue = receivedValue
+  if (receivedType !== undefined) params.receivedType = receivedType
+  if (expectedType !== undefined) params.expectedType = expectedType
+  if (minValue !== undefined) params.minValue = minValue
+  if (maxValue !== undefined) params.maxValue = maxValue
+
+  return params
+}
+
+function hasParams(params: CatalogParams, keys: string[]): boolean {
+  return keys.every((key) => params[key] !== undefined)
+}
+
+function getValueSpecificCopyKeys(
+  errorType: string,
+  params: CatalogParams
+): {
+  detailsKey: string
+  toastMessageKey: string
+} {
+  switch (errorType) {
+    case 'return_type_mismatch':
+      if (hasParams(params, ['expectedType', 'receivedType'])) {
+        return {
+          detailsKey: 'detailsWithTypes',
+          toastMessageKey: 'toastMessageWithTypes'
+        }
+      }
+      break
+    case 'invalid_input_type':
+      if (hasParams(params, ['receivedValue', 'expectedType'])) {
+        return {
+          detailsKey: 'detailsWithValue',
+          toastMessageKey: 'toastMessageWithValue'
+        }
+      }
+      break
+    case 'value_smaller_than_min':
+      if (hasParams(params, ['receivedValue', 'minValue'])) {
+        return {
+          detailsKey: 'detailsWithValue',
+          toastMessageKey: 'toastMessageWithValue'
+        }
+      }
+      break
+    case 'value_bigger_than_max':
+      if (hasParams(params, ['receivedValue', 'maxValue'])) {
+        return {
+          detailsKey: 'detailsWithValue',
+          toastMessageKey: 'toastMessageWithValue'
+        }
+      }
+      break
+    case 'value_not_in_list':
+      if (hasParams(params, ['receivedValue'])) {
+        return {
+          detailsKey: 'detailsWithValue',
+          toastMessageKey: 'toastMessageWithValue'
+        }
+      }
+      break
+  }
+
+  return {
+    detailsKey: 'details',
+    toastMessageKey: 'toastMessage'
+  }
+}
+
+function getRawDetailsCopyKeys(error: NodeValidationError): {
+  detailsKey: string
+  toastMessageKey: string
+} {
+  return error.details.trim()
+    ? {
+        detailsKey: 'detailsWithRawDetails',
+        toastMessageKey: 'toastMessageWithRawDetails'
+      }
+    : {
+        detailsKey: 'details',
+        toastMessageKey: 'toastMessage'
+      }
+}
+
+function getExceptionDuringValidationCopyKeys(error: NodeValidationError): {
+  detailsKey: string
+  toastMessageKey: string
+} {
+  return getRawDetailsCopyKeys(error)
+}
+
+function getRawDetailsOnlyCopyKeys(error: NodeValidationError): {
+  detailsKey: string
+  toastMessageKey: string
+} {
+  if (!error.details.trim()) {
+    return {
+      detailsKey: 'details',
+      toastMessageKey: 'toastMessage'
+    }
+  }
+
+  return {
+    detailsKey: 'detailsWithRawDetails',
+    toastMessageKey: 'toastMessage'
+  }
+}
+
+function getValidationCopyKeys(
+  error: NodeValidationError,
+  params: CatalogParams
+): {
+  detailsKey: string
+  toastMessageKey: string
+} {
+  if (error.type === 'exception_during_validation') {
+    return getExceptionDuringValidationCopyKeys(error)
+  }
+
+  if (error.type === 'exception_during_inner_validation') {
+    return getRawDetailsCopyKeys(error)
+  }
+
+  if (error.type === 'custom_validation_failed') {
+    return getRawDetailsOnlyCopyKeys(error)
+  }
+
+  if (error.type === 'dependency_cycle') {
+    return getRawDetailsOnlyCopyKeys(error)
+  }
+
+  return getValueSpecificCopyKeys(error.type, params)
 }
 
 const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
@@ -162,13 +348,24 @@ function resolveValidationCatalogCopy(
 ): ResolvedErrorMessage {
   const nodeName = normalizeNodeName(context.nodeDisplayName)
   const inputName = getInputName(error)
-  const params = { nodeName, inputName }
+  const rawDetails = formatRawDetailsForCatalog(error.details.trim())
+  const params = {
+    ...getValidationParams(error, nodeName, inputName),
+    rawDetails
+  }
   const keyPrefix = `errorCatalog.validationErrors.${rule.key}`
   const titleFallback = error.type || error.message
   const itemLabelFallback =
     rule.itemLabel === 'node'
       ? nodeName
       : nodeInputItemLabel(nodeName, inputName)
+  const copyKeys =
+    rule.key === 'image_not_loaded'
+      ? {
+          detailsKey: 'details',
+          toastMessageKey: 'toastMessage'
+        }
+      : getValidationCopyKeys(error, params)
 
   return {
     catalogId: rule.catalogId,
@@ -183,7 +380,7 @@ function resolveValidationCatalogCopy(
       params
     ),
     displayDetails: translateOptionalCatalogMessage(
-      `${keyPrefix}.details`,
+      `${keyPrefix}.${copyKeys.detailsKey}`,
       error.details,
       params
     ),
@@ -198,7 +395,7 @@ function resolveValidationCatalogCopy(
       params
     ),
     toastMessage: translateCatalogMessage(
-      `${keyPrefix}.toastMessage`,
+      `${keyPrefix}.${copyKeys.toastMessageKey}`,
       error.message,
       params
     )

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -20,27 +20,17 @@ const KNOWN_PROMPT_ERROR_TYPES = new Set([
   'prompt_outputs_failed_validation'
 ])
 
-interface CatalogCopyFallbacks {
+interface ValidationCatalogRule {
   catalogId: string
-  title: string
-  message: string
-  details?: string
-  itemLabel?: string
-  toastTitle?: string
-  toastMessage?: string
+  key: string
+  itemLabel: 'node' | 'nodeInput'
 }
 
-interface RuntimeCopyFallbacks {
+interface RuntimeCatalogRule {
   catalogId: string
-  title: string
-  messageLocal?: string
-  messageCloud?: string
-  message?: string
-  itemLabel?: string
-  toastTitle?: string
-  toastMessageLocal?: string
-  toastMessageCloud?: string
-  toastMessage?: string
+  key: string
+  messageKey: 'message' | 'messageByEnvironment'
+  toastMessageKey: 'toastMessage' | 'toastMessageByEnvironment'
 }
 
 interface ErrorResolveContext {
@@ -59,6 +49,15 @@ function translateCatalogMessage(
   return fallback.replace(/\{(\w+)\}/g, (match, paramName) =>
     params[paramName] === undefined ? match : String(params[paramName])
   )
+}
+
+function translateOptionalCatalogMessage(
+  key: string,
+  fallback?: string,
+  params?: Record<string, string | number>
+): string | undefined {
+  if (te(key)) return params ? t(key, params) : t(key)
+  return fallback?.trim() ? fallback : undefined
 }
 
 function normalizeNodeName(nodeDisplayName: string | undefined): string {
@@ -106,289 +105,151 @@ function isImageNotLoadedValidationError(error: NodeValidationError): boolean {
   )
 }
 
-function resolveCatalogCopy(
-  keyPrefix: string,
-  fallback: CatalogCopyFallbacks,
-  params?: Record<string, string | number>
-): ResolvedErrorMessage {
-  return {
-    catalogId: fallback.catalogId,
-    displayTitle: translateCatalogMessage(
-      `${keyPrefix}.title`,
-      fallback.title,
-      params
-    ),
-    displayMessage: translateCatalogMessage(
-      `${keyPrefix}.message`,
-      fallback.message,
-      params
-    ),
-    ...(fallback.details
-      ? {
-          displayDetails: translateCatalogMessage(
-            `${keyPrefix}.details`,
-            fallback.details,
-            params
-          )
-        }
-      : {}),
-    ...(fallback.itemLabel
-      ? {
-          displayItemLabel: translateCatalogMessage(
-            `${keyPrefix}.itemLabel`,
-            fallback.itemLabel,
-            params
-          )
-        }
-      : {}),
-    ...(fallback.toastTitle
-      ? {
-          toastTitle: translateCatalogMessage(
-            `${keyPrefix}.toastTitle`,
-            fallback.toastTitle,
-            params
-          )
-        }
-      : {}),
-    ...(fallback.toastMessage
-      ? {
-          toastMessage: translateCatalogMessage(
-            `${keyPrefix}.toastMessage`,
-            fallback.toastMessage,
-            params
-          )
-        }
-      : {})
-  }
+function nodeInputItemLabel(nodeName: string, inputName: string): string {
+  return `${nodeName} - ${inputName}`
 }
 
-function resolveRuntimeCatalogCopy(
-  keyPrefix: string,
-  fallback: RuntimeCopyFallbacks,
-  params: Record<string, string | number>,
-  isCloud?: boolean
-): ResolvedErrorMessage {
-  const messageKey = isCloud ? 'messageCloud' : 'messageLocal'
-  const toastMessageKey = isCloud ? 'toastMessageCloud' : 'toastMessageLocal'
-  const messageFallback =
-    (isCloud ? fallback.messageCloud : fallback.messageLocal) ??
-    fallback.message ??
-    ''
-  const toastMessageFallback =
-    (isCloud ? fallback.toastMessageCloud : fallback.toastMessageLocal) ??
-    fallback.toastMessage
-
-  return {
-    catalogId: fallback.catalogId,
-    displayTitle: translateCatalogMessage(
-      `${keyPrefix}.title`,
-      fallback.title,
-      params
-    ),
-    ...(messageFallback
-      ? {
-          displayMessage: translateCatalogMessage(
-            `${keyPrefix}.${fallback.message ? 'message' : messageKey}`,
-            messageFallback,
-            params
-          )
-        }
-      : {}),
-    ...(fallback.itemLabel
-      ? {
-          displayItemLabel: translateCatalogMessage(
-            `${keyPrefix}.itemLabel`,
-            fallback.itemLabel,
-            params
-          )
-        }
-      : {}),
-    ...(fallback.toastTitle
-      ? {
-          toastTitle: translateCatalogMessage(
-            `${keyPrefix}.toastTitle`,
-            fallback.toastTitle,
-            params
-          )
-        }
-      : {}),
-    ...(toastMessageFallback
-      ? {
-          toastMessage: translateCatalogMessage(
-            `${keyPrefix}.${fallback.toastMessage ? 'toastMessage' : toastMessageKey}`,
-            toastMessageFallback,
-            params
-          )
-        }
-      : {})
-  }
+function rawExecutionMessage(
+  error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error']
+): string {
+  return error.exception_type
+    ? `${error.exception_type}: ${error.exception_message}`
+    : error.exception_message
 }
 
-const VALIDATION_ERROR_COPY: Record<string, CatalogCopyFallbacks> = {
+const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
   [REQUIRED_INPUT_MISSING_TYPE]: {
     catalogId: REQUIRED_INPUT_MISSING_CATALOG_ID,
-    title: 'Missing connection',
-    message: 'Required input slots have no connection feeding them.',
-    details: '{nodeName} is missing a required input: {inputName}',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Required input missing',
-    toastMessage: '{nodeName} is missing a required input: {inputName}'
+    key: REQUIRED_INPUT_MISSING_TYPE,
+    itemLabel: 'nodeInput'
   },
   bad_linked_input: {
     catalogId: 'bad_linked_input',
-    title: 'Invalid connection',
-    message: 'A linked input connection is malformed.',
-    details: '{nodeName} has an invalid connection for {inputName}.',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Invalid connection',
-    toastMessage: '{nodeName} has an invalid connection for {inputName}.'
+    key: 'bad_linked_input',
+    itemLabel: 'nodeInput'
   },
   return_type_mismatch: {
     catalogId: 'return_type_mismatch',
-    title: 'Invalid connection',
-    message: 'Connected nodes are using incompatible input and output types.',
-    details: '{nodeName} has an incompatible connection for {inputName}.',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Invalid connection',
-    toastMessage: '{nodeName} has an incompatible connection for {inputName}.'
+    key: 'return_type_mismatch',
+    itemLabel: 'nodeInput'
   },
   invalid_input_type: {
     catalogId: 'invalid_input_type',
-    title: 'Invalid input',
-    message: 'An input value has the wrong type.',
-    details: "{nodeName} couldn't convert {inputName} to the expected type.",
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Invalid input',
-    toastMessage:
-      "{nodeName} couldn't convert {inputName} to the expected type."
+    key: 'invalid_input_type',
+    itemLabel: 'nodeInput'
   },
   value_smaller_than_min: {
     catalogId: 'value_smaller_than_min',
-    title: 'Input out of range',
-    message: 'Some input values are outside the allowed range.',
-    details: '{nodeName} has a value below the minimum for {inputName}.',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Input out of range',
-    toastMessage: '{nodeName} has a value below the minimum for {inputName}.'
+    key: 'value_smaller_than_min',
+    itemLabel: 'nodeInput'
   },
   value_bigger_than_max: {
     catalogId: 'value_bigger_than_max',
-    title: 'Input out of range',
-    message: 'Some input values are outside the allowed range.',
-    details: '{nodeName} has a value above the maximum for {inputName}.',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Input out of range',
-    toastMessage: '{nodeName} has a value above the maximum for {inputName}.'
+    key: 'value_bigger_than_max',
+    itemLabel: 'nodeInput'
   },
   value_not_in_list: {
     catalogId: 'value_not_in_list',
-    title: 'Invalid input',
-    message: 'Some input values are not available for this node.',
-    details: '{nodeName} has an unsupported value for {inputName}.',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Invalid input',
-    toastMessage: '{nodeName} has an unsupported value for {inputName}.'
+    key: 'value_not_in_list',
+    itemLabel: 'nodeInput'
   },
   custom_validation_failed: {
     catalogId: 'custom_validation_failed',
-    title: 'Invalid input',
-    message: 'A node rejected one or more input values.',
-    details: '{nodeName} rejected the value for {inputName}.',
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Invalid input',
-    toastMessage: '{nodeName} rejected the value for {inputName}.'
+    key: 'custom_validation_failed',
+    itemLabel: 'nodeInput'
   },
   exception_during_inner_validation: {
     catalogId: 'exception_during_inner_validation',
-    title: 'Validation failed',
-    message: "The workflow couldn't validate a connected node.",
-    details: "{nodeName} couldn't validate {inputName}.",
-    itemLabel: '{nodeName} - {inputName}',
-    toastTitle: 'Validation failed',
-    toastMessage: "{nodeName} couldn't validate {inputName}."
+    key: 'exception_during_inner_validation',
+    itemLabel: 'nodeInput'
   },
   exception_during_validation: {
     catalogId: 'exception_during_validation',
-    title: 'Validation failed',
-    message: 'The node could not be validated.',
-    details: '{nodeName} could not be validated.',
-    itemLabel: '{nodeName}',
-    toastTitle: 'Validation failed',
-    toastMessage: '{nodeName} could not be validated.'
+    key: 'exception_during_validation',
+    itemLabel: 'node'
   },
   dependency_cycle: {
     catalogId: 'dependency_cycle',
-    title: 'Invalid workflow',
-    message: 'The workflow has a circular node connection.',
-    details: '{nodeName} is part of a circular connection.',
-    itemLabel: '{nodeName}',
-    toastTitle: 'Invalid workflow',
-    toastMessage: '{nodeName} is part of a circular connection.'
+    key: 'dependency_cycle',
+    itemLabel: 'node'
   }
 }
 
-const IMAGE_NOT_LOADED_VALIDATION_COPY = {
+const IMAGE_NOT_LOADED_VALIDATION_RULE = {
   catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
-  title: 'Image not loaded',
-  message: "The system couldn't load this image.",
-  details: "The image for {nodeName} couldn't be loaded. Try adding it again.",
-  itemLabel: '{nodeName}',
-  toastTitle: "Input image couldn't be loaded",
-  toastMessage:
-    "The image for {nodeName} couldn't be loaded. Try adding it again."
-} satisfies CatalogCopyFallbacks
+  key: 'image_not_loaded',
+  itemLabel: 'node'
+} satisfies ValidationCatalogRule
 
-const RUNTIME_ERROR_COPY = {
+const RUNTIME_ERROR_RULES = {
   execution_failed: {
     catalogId: EXECUTION_FAILED_CATALOG_ID,
-    title: 'Execution failed',
-    messageLocal: 'Node threw an error during execution.',
-    messageCloud: 'Node threw an error during execution. No credits charged.',
-    itemLabel: '{nodeName}',
-    toastTitle: '{nodeName} failed',
-    toastMessageLocal:
-      'This node threw an error during execution. Check its inputs or try a different configuration.',
-    toastMessageCloud:
-      'This node threw an error during execution. Check its inputs or try a different configuration. No credits charged.'
+    key: 'execution_failed',
+    messageKey: 'messageByEnvironment',
+    toastMessageKey: 'toastMessageByEnvironment'
   },
   image_not_loaded: {
     catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
-    title: 'Image not loaded',
-    message: "The system couldn't load this image.",
-    itemLabel: '{nodeName}',
-    toastTitle: "Input image couldn't be loaded",
-    toastMessage:
-      "The image for {nodeName} couldn't be loaded. Try adding it again."
+    key: 'image_not_loaded',
+    messageKey: 'message',
+    toastMessageKey: 'toastMessage'
   },
   out_of_memory: {
     catalogId: OUT_OF_MEMORY_CATALOG_ID,
-    title: 'Generation failed',
-    messageLocal:
-      'Not enough GPU memory. Try reducing complexity and run again.',
-    messageCloud:
-      'Not enough GPU memory. Try reducing complexity and run again. No credits charged.',
-    itemLabel: '{nodeName}',
-    toastTitle: 'Generation failed',
-    toastMessageLocal:
-      'Not enough GPU memory. Try reducing complexity and run again.',
-    toastMessageCloud:
-      'Not enough GPU memory. Try reducing complexity and run again. No credits charged.'
+    key: 'out_of_memory',
+    messageKey: 'messageByEnvironment',
+    toastMessageKey: 'toastMessageByEnvironment'
   }
-} satisfies Record<string, RuntimeCopyFallbacks>
+} satisfies Record<string, RuntimeCatalogRule>
 
 function resolveValidationCatalogCopy(
   error: NodeValidationError,
   context: ErrorResolveContext,
-  errorTypeKey: string,
-  fallback: CatalogCopyFallbacks
+  rule: ValidationCatalogRule
 ): ResolvedErrorMessage {
   const nodeName = normalizeNodeName(context.nodeDisplayName)
   const inputName = getInputName(error)
-  return resolveCatalogCopy(
-    `errorCatalog.validationErrors.${errorTypeKey}`,
-    fallback,
-    { nodeName, inputName }
-  )
+  const params = { nodeName, inputName }
+  const keyPrefix = `errorCatalog.validationErrors.${rule.key}`
+  const titleFallback = error.type || error.message
+  const itemLabelFallback =
+    rule.itemLabel === 'node'
+      ? nodeName
+      : nodeInputItemLabel(nodeName, inputName)
+
+  return {
+    catalogId: rule.catalogId,
+    displayTitle: translateCatalogMessage(
+      `${keyPrefix}.title`,
+      titleFallback,
+      params
+    ),
+    displayMessage: translateCatalogMessage(
+      `${keyPrefix}.message`,
+      error.message,
+      params
+    ),
+    displayDetails: translateOptionalCatalogMessage(
+      `${keyPrefix}.details`,
+      error.details,
+      params
+    ),
+    displayItemLabel: translateCatalogMessage(
+      `${keyPrefix}.itemLabel`,
+      itemLabelFallback,
+      params
+    ),
+    toastTitle: translateCatalogMessage(
+      `${keyPrefix}.toastTitle`,
+      titleFallback,
+      params
+    ),
+    toastMessage: translateCatalogMessage(
+      `${keyPrefix}.toastMessage`,
+      error.message,
+      params
+    )
+  }
 }
 
 function resolveNodeValidationErrorMessage(
@@ -399,51 +260,97 @@ function resolveNodeValidationErrorMessage(
     return resolveValidationCatalogCopy(
       error,
       context,
-      'image_not_loaded',
-      IMAGE_NOT_LOADED_VALIDATION_COPY
+      IMAGE_NOT_LOADED_VALIDATION_RULE
     )
   }
 
-  const fallback = VALIDATION_ERROR_COPY[error.type]
-  if (!fallback) return {}
+  const rule = VALIDATION_ERROR_RULES[error.type]
+  if (!rule) return {}
 
-  return resolveValidationCatalogCopy(error, context, error.type, fallback)
+  return resolveValidationCatalogCopy(error, context, rule)
+}
+
+function resolveRuntimeCatalogCopy(
+  error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error'],
+  rule: RuntimeCatalogRule,
+  context: ErrorResolveContext
+): ResolvedErrorMessage {
+  const nodeName = normalizeNodeName(context.nodeDisplayName)
+  const params = { nodeName }
+  const keyPrefix = `errorCatalog.runtimeErrors.${rule.key}`
+  const messageKey =
+    rule.messageKey === 'message'
+      ? 'message'
+      : context.isCloud
+        ? 'messageCloud'
+        : 'messageLocal'
+  const toastMessageKey =
+    rule.toastMessageKey === 'toastMessage'
+      ? 'toastMessage'
+      : context.isCloud
+        ? 'toastMessageCloud'
+        : 'toastMessageLocal'
+  const titleFallback = error.exception_type || error.exception_message
+  const messageFallback = rawExecutionMessage(error)
+
+  return {
+    catalogId: rule.catalogId,
+    displayTitle: translateCatalogMessage(
+      `${keyPrefix}.title`,
+      titleFallback,
+      params
+    ),
+    displayMessage: translateCatalogMessage(
+      `${keyPrefix}.${messageKey}`,
+      messageFallback,
+      params
+    ),
+    displayItemLabel: translateCatalogMessage(
+      `${keyPrefix}.itemLabel`,
+      nodeName,
+      params
+    ),
+    toastTitle: translateCatalogMessage(
+      `${keyPrefix}.toastTitle`,
+      titleFallback,
+      params
+    ),
+    toastMessage: translateCatalogMessage(
+      `${keyPrefix}.${toastMessageKey}`,
+      messageFallback,
+      params
+    )
+  }
 }
 
 function resolveExecutionErrorMessage(
   error: Extract<RunErrorMessageSource, { kind: 'execution' }>['error'],
   context: ErrorResolveContext
 ): ResolvedErrorMessage {
-  const nodeName = normalizeNodeName(context.nodeDisplayName)
-  const params = { nodeName }
   const errorText = getErrorText(error)
-
   if (
     error.exception_type === 'ImageDownloadError' ||
     isImageNotLoadedText(errorText)
   ) {
     return resolveRuntimeCatalogCopy(
-      'errorCatalog.runtimeErrors.image_not_loaded',
-      RUNTIME_ERROR_COPY.image_not_loaded,
-      params,
-      context.isCloud
+      error,
+      RUNTIME_ERROR_RULES.image_not_loaded,
+      context
     )
   }
 
   if (error.exception_type === 'OOMError' || isOutOfMemoryText(errorText)) {
     return resolveRuntimeCatalogCopy(
-      'errorCatalog.runtimeErrors.out_of_memory',
-      RUNTIME_ERROR_COPY.out_of_memory,
-      params,
-      context.isCloud
+      error,
+      RUNTIME_ERROR_RULES.out_of_memory,
+      context
     )
   }
 
   return resolveRuntimeCatalogCopy(
-    'errorCatalog.runtimeErrors.execution_failed',
-    RUNTIME_ERROR_COPY.execution_failed,
-    params,
-    context.isCloud
+    error,
+    RUNTIME_ERROR_RULES.execution_failed,
+    context
   )
 }
 
@@ -456,11 +363,11 @@ function resolvePromptErrorMessage(
       catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
       displayTitle: st(
         'errorCatalog.promptErrors.image_not_loaded.title',
-        'Image not loaded'
+        error.type || error.message
       ),
       displayMessage: st(
         'errorCatalog.promptErrors.image_not_loaded.desc',
-        "The system couldn't load this image."
+        error.message
       )
     }
   }
@@ -469,17 +376,14 @@ function resolvePromptErrorMessage(
     const messageKey = context.isCloud
       ? 'errorCatalog.promptErrors.out_of_memory.descCloud'
       : 'errorCatalog.promptErrors.out_of_memory.descLocal'
-    const messageFallback = context.isCloud
-      ? 'Not enough GPU memory. Try reducing complexity and run again. No credits charged.'
-      : 'Not enough GPU memory. Try reducing complexity and run again.'
 
     return {
       catalogId: OUT_OF_MEMORY_CATALOG_ID,
       displayTitle: st(
         'errorCatalog.promptErrors.out_of_memory.title',
-        'Generation failed'
+        error.type || error.message
       ),
-      displayMessage: st(messageKey, messageFallback)
+      displayMessage: st(messageKey, error.message)
     }
   }
 
@@ -493,11 +397,10 @@ function resolvePromptErrorMessage(
       : error.type
 
   return {
-    ...(te(`errorCatalog.promptErrors.${errorTypeKey}.title`)
-      ? {
-          displayTitle: t(`errorCatalog.promptErrors.${errorTypeKey}.title`)
-        }
-      : {}),
+    displayTitle: translateCatalogMessage(
+      `errorCatalog.promptErrors.${errorTypeKey}.title`,
+      error.type || error.message
+    ),
     displayMessage: st(
       `errorCatalog.promptErrors.${errorTypeKey}.desc`,
       error.message

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -93,7 +93,7 @@ function nodeInputItemLabel(nodeName: string, inputName: string): string {
   return `${nodeName} - ${inputName}`
 }
 
-function formatRawDetailsForCatalog(details: string): string {
+function formatDependencyCycleDetails(details: string): string {
   // Core reports dependency cycle paths as "node -> node"; catalog copy embeds
   // those paths in prose, where "to" reads more naturally.
   return details.replace(/\s*->\s*/g, ' to ')
@@ -314,7 +314,11 @@ function resolveValidationCatalogCopy(
 ): ResolvedErrorMessage {
   const nodeName = normalizeNodeName(context.nodeDisplayName)
   const inputName = getInputName(error)
-  const rawDetails = formatRawDetailsForCatalog(error.details.trim())
+  const trimmedDetails = error.details.trim()
+  const rawDetails =
+    error.type === 'dependency_cycle'
+      ? formatDependencyCycleDetails(trimmedDetails)
+      : trimmedDetails
   const params = {
     ...getValidationParams(error, nodeName, inputName),
     rawDetails

--- a/src/platform/errorCatalog/errorMessageResolver.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.ts
@@ -21,7 +21,6 @@ const KNOWN_PROMPT_ERROR_TYPES = new Set([
 
 interface ValidationCatalogRule {
   catalogId: string
-  key: string
   itemLabel: 'node' | 'nodeInput'
 }
 
@@ -62,7 +61,7 @@ function normalizeNodeName(nodeDisplayName: string | undefined): string {
 }
 
 function getInputName(error: NodeValidationError): string {
-  const inputName = error.extra_info?.input_name ?? error.details
+  const inputName = error.extra_info?.input_name
   return (
     inputName?.trim() ||
     translateCatalogMessage('errorCatalog.fallbacks.inputName', 'unknown input')
@@ -94,6 +93,8 @@ function nodeInputItemLabel(nodeName: string, inputName: string): string {
 }
 
 function formatRawDetailsForCatalog(details: string): string {
+  // Core reports dependency cycle paths as "node -> node"; catalog copy embeds
+  // those paths in prose, where "to" reads more naturally.
   return details.replace(/\s*->\s*/g, ' to ')
 }
 
@@ -107,7 +108,7 @@ function formatCatalogValue(value: unknown): string | undefined {
   try {
     return JSON.stringify(value)
   } catch {
-    return String(value)
+    return undefined
   }
 }
 
@@ -156,66 +157,59 @@ function hasParams(params: CatalogParams, keys: string[]): boolean {
   return keys.every((key) => params[key] !== undefined)
 }
 
-function getValueSpecificCopyKeys(
-  errorType: string,
-  params: CatalogParams
-): {
+interface CopyKeys {
   detailsKey: string
   toastMessageKey: string
-} {
-  switch (errorType) {
-    case 'return_type_mismatch':
-      if (hasParams(params, ['expectedType', 'receivedType'])) {
-        return {
-          detailsKey: 'detailsWithTypes',
-          toastMessageKey: 'toastMessageWithTypes'
-        }
-      }
-      break
-    case 'invalid_input_type':
-      if (hasParams(params, ['receivedValue', 'expectedType'])) {
-        return {
-          detailsKey: 'detailsWithValue',
-          toastMessageKey: 'toastMessageWithValue'
-        }
-      }
-      break
-    case 'value_smaller_than_min':
-      if (hasParams(params, ['receivedValue', 'minValue'])) {
-        return {
-          detailsKey: 'detailsWithValue',
-          toastMessageKey: 'toastMessageWithValue'
-        }
-      }
-      break
-    case 'value_bigger_than_max':
-      if (hasParams(params, ['receivedValue', 'maxValue'])) {
-        return {
-          detailsKey: 'detailsWithValue',
-          toastMessageKey: 'toastMessageWithValue'
-        }
-      }
-      break
-    case 'value_not_in_list':
-      if (hasParams(params, ['receivedValue'])) {
-        return {
-          detailsKey: 'detailsWithValue',
-          toastMessageKey: 'toastMessageWithValue'
-        }
-      }
-      break
-  }
+}
 
-  return {
-    detailsKey: 'details',
-    toastMessageKey: 'toastMessage'
+const DEFAULT_COPY_KEYS: CopyKeys = {
+  detailsKey: 'details',
+  toastMessageKey: 'toastMessage'
+}
+
+const VALUE_SPECIFIC_COPY_RULES: Record<
+  string,
+  {
+    requiredParams: string[]
+    suffix: 'WithTypes' | 'WithValue'
+  }
+> = {
+  return_type_mismatch: {
+    requiredParams: ['expectedType', 'receivedType'],
+    suffix: 'WithTypes'
+  },
+  invalid_input_type: {
+    requiredParams: ['receivedValue', 'expectedType'],
+    suffix: 'WithValue'
+  },
+  value_smaller_than_min: {
+    requiredParams: ['receivedValue', 'minValue'],
+    suffix: 'WithValue'
+  },
+  value_bigger_than_max: {
+    requiredParams: ['receivedValue', 'maxValue'],
+    suffix: 'WithValue'
+  },
+  value_not_in_list: {
+    requiredParams: ['receivedValue'],
+    suffix: 'WithValue'
   }
 }
 
-function getRawDetailsCopyKeys(error: NodeValidationError): {
-  detailsKey: string
-  toastMessageKey: string
-} {
+function getValueSpecificCopyKeys(
+  errorType: string,
+  params: CatalogParams
+): CopyKeys {
+  const rule = VALUE_SPECIFIC_COPY_RULES[errorType]
+  if (!rule || !hasParams(params, rule.requiredParams)) return DEFAULT_COPY_KEYS
+
+  return {
+    detailsKey: `details${rule.suffix}`,
+    toastMessageKey: `toastMessage${rule.suffix}`
+  }
+}
+
+function getRawDetailsCopyKeys(error: NodeValidationError): CopyKeys {
   return error.details.trim()
     ? {
         detailsKey: 'detailsWithRawDetails',
@@ -227,17 +221,7 @@ function getRawDetailsCopyKeys(error: NodeValidationError): {
       }
 }
 
-function getExceptionDuringValidationCopyKeys(error: NodeValidationError): {
-  detailsKey: string
-  toastMessageKey: string
-} {
-  return getRawDetailsCopyKeys(error)
-}
-
-function getRawDetailsOnlyCopyKeys(error: NodeValidationError): {
-  detailsKey: string
-  toastMessageKey: string
-} {
+function getRawDetailsOnlyCopyKeys(error: NodeValidationError): CopyKeys {
   if (!error.details.trim()) {
     return {
       detailsKey: 'details',
@@ -254,12 +238,9 @@ function getRawDetailsOnlyCopyKeys(error: NodeValidationError): {
 function getValidationCopyKeys(
   error: NodeValidationError,
   params: CatalogParams
-): {
-  detailsKey: string
-  toastMessageKey: string
-} {
+): CopyKeys {
   if (error.type === 'exception_during_validation') {
-    return getExceptionDuringValidationCopyKeys(error)
+    return getRawDetailsCopyKeys(error)
   }
 
   if (error.type === 'exception_during_inner_validation') {
@@ -280,70 +261,59 @@ function getValidationCopyKeys(
 const VALIDATION_ERROR_RULES: Record<string, ValidationCatalogRule> = {
   [REQUIRED_INPUT_MISSING_TYPE]: {
     catalogId: REQUIRED_INPUT_MISSING_CATALOG_ID,
-    key: REQUIRED_INPUT_MISSING_TYPE,
     itemLabel: 'nodeInput'
   },
   bad_linked_input: {
     catalogId: 'bad_linked_input',
-    key: 'bad_linked_input',
     itemLabel: 'nodeInput'
   },
   return_type_mismatch: {
     catalogId: 'return_type_mismatch',
-    key: 'return_type_mismatch',
     itemLabel: 'nodeInput'
   },
   invalid_input_type: {
     catalogId: 'invalid_input_type',
-    key: 'invalid_input_type',
     itemLabel: 'nodeInput'
   },
   value_smaller_than_min: {
     catalogId: 'value_smaller_than_min',
-    key: 'value_smaller_than_min',
     itemLabel: 'nodeInput'
   },
   value_bigger_than_max: {
     catalogId: 'value_bigger_than_max',
-    key: 'value_bigger_than_max',
     itemLabel: 'nodeInput'
   },
   value_not_in_list: {
     catalogId: 'value_not_in_list',
-    key: 'value_not_in_list',
     itemLabel: 'nodeInput'
   },
   custom_validation_failed: {
     catalogId: 'custom_validation_failed',
-    key: 'custom_validation_failed',
     itemLabel: 'nodeInput'
   },
   exception_during_inner_validation: {
     catalogId: 'exception_during_inner_validation',
-    key: 'exception_during_inner_validation',
     itemLabel: 'nodeInput'
   },
   exception_during_validation: {
     catalogId: 'exception_during_validation',
-    key: 'exception_during_validation',
     itemLabel: 'node'
   },
   dependency_cycle: {
     catalogId: 'dependency_cycle',
-    key: 'dependency_cycle',
     itemLabel: 'node'
   }
 }
 
 const IMAGE_NOT_LOADED_VALIDATION_RULE = {
   catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
-  key: 'image_not_loaded',
   itemLabel: 'node'
 } satisfies ValidationCatalogRule
 
 function resolveValidationCatalogCopy(
   error: NodeValidationError,
   context: ErrorResolveContext,
+  errorKey: string,
   rule: ValidationCatalogRule
 ): ResolvedErrorMessage {
   const nodeName = normalizeNodeName(context.nodeDisplayName)
@@ -353,14 +323,14 @@ function resolveValidationCatalogCopy(
     ...getValidationParams(error, nodeName, inputName),
     rawDetails
   }
-  const keyPrefix = `errorCatalog.validationErrors.${rule.key}`
-  const titleFallback = error.type || error.message
+  const keyPrefix = `errorCatalog.validationErrors.${errorKey}`
+  const titleFallback = error.message
   const itemLabelFallback =
     rule.itemLabel === 'node'
       ? nodeName
       : nodeInputItemLabel(nodeName, inputName)
   const copyKeys =
-    rule.key === 'image_not_loaded'
+    errorKey === 'image_not_loaded'
       ? {
           detailsKey: 'details',
           toastMessageKey: 'toastMessage'
@@ -410,6 +380,7 @@ function resolveNodeValidationErrorMessage(
     return resolveValidationCatalogCopy(
       error,
       context,
+      'image_not_loaded',
       IMAGE_NOT_LOADED_VALIDATION_RULE
     )
   }
@@ -417,12 +388,7 @@ function resolveNodeValidationErrorMessage(
   const rule = VALIDATION_ERROR_RULES[error.type]
   if (!rule) return {}
 
-  return resolveValidationCatalogCopy(error, context, rule)
-}
-
-function resolveExecutionErrorMessage(): ResolvedErrorMessage {
-  // Runtime catalog copy is deferred so actionable service errors stay raw.
-  return {}
+  return resolveValidationCatalogCopy(error, context, error.type, rule)
 }
 
 function resolvePromptErrorMessage(
@@ -434,7 +400,7 @@ function resolvePromptErrorMessage(
       catalogId: IMAGE_NOT_LOADED_CATALOG_ID,
       displayTitle: st(
         'errorCatalog.promptErrors.image_not_loaded.title',
-        error.type || error.message
+        error.message
       ),
       displayMessage: st(
         'errorCatalog.promptErrors.image_not_loaded.desc',
@@ -452,7 +418,7 @@ function resolvePromptErrorMessage(
       catalogId: OUT_OF_MEMORY_CATALOG_ID,
       displayTitle: st(
         'errorCatalog.promptErrors.out_of_memory.title',
-        error.type || error.message
+        error.message
       ),
       displayMessage: st(messageKey, error.message)
     }
@@ -470,7 +436,7 @@ function resolvePromptErrorMessage(
   return {
     displayTitle: translateCatalogMessage(
       `errorCatalog.promptErrors.${errorTypeKey}.title`,
-      error.type || error.message
+      error.message
     ),
     displayMessage: st(
       `errorCatalog.promptErrors.${errorTypeKey}.desc`,
@@ -558,8 +524,6 @@ export function resolveRunErrorMessage(
       return resolveNodeValidationErrorMessage(source.error, {
         nodeDisplayName: source.nodeDisplayName
       })
-    case 'execution':
-      return resolveExecutionErrorMessage()
     case 'prompt':
       return resolvePromptErrorMessage(source.error, {
         isCloud: source.isCloud

--- a/src/platform/errorCatalog/types.ts
+++ b/src/platform/errorCatalog/types.ts
@@ -1,8 +1,4 @@
-import type {
-  ExecutionErrorWsMessage,
-  NodeError,
-  PromptError
-} from '@/schemas/apiSchema'
+import type { NodeError, PromptError } from '@/schemas/apiSchema'
 import type {
   MissingMediaGroup,
   MediaType
@@ -38,12 +34,6 @@ export type RunErrorMessageSource =
       kind: 'node_validation'
       error: NodeValidationError
       nodeDisplayName: string
-    }
-  | {
-      kind: 'execution'
-      error: ExecutionErrorWsMessage
-      nodeDisplayName?: string
-      isCloud: boolean
     }
   | {
       kind: 'prompt'


### PR DESCRIPTION
## Summary

This PR builds on the error catalog display resolver foundation from #12402 and adds the first broader catalog pass for general execution-related messaging. The goal is to keep the raw API contract intact (`message` / `details`) while adding resolved display fields that the UI can prefer when catalog copy exists.

The main functional sample in this PR is validation error messaging. It expands the resolver beyond `required_input_missing` so common node validation failures can show friendlier titles, grouped messages, detail copy, item labels, and toast copy without overwriting the original backend payload.

## What changed

- Added catalog copy for known node validation errors:
  - `required_input_missing` as `missing_connection`
  - `bad_linked_input`
  - `return_type_mismatch`
  - `invalid_input_type`
  - `value_smaller_than_min`
  - `value_bigger_than_max`
  - `value_not_in_list`
  - `custom_validation_failed`
  - `exception_during_inner_validation`
  - `exception_during_validation`
  - `dependency_cycle`
- Added an `image_not_loaded` validation override for `custom_validation_failed` messages that indicate invalid image files or directory paths.
- Added value-aware validation details when Core provides structured `extra_info`, including received values, expected/received types, and min/max bounds.
- Added prompt-level catalog handling for known prompt errors that already have stable types/copy, including missing node type, prompt output validation, image download, and OOM prompt errors.
- Preserved runtime execution errors as raw API copy for now, so service-level or actionable runtime failures are not hidden behind generic catalog text before targeted runtime handling lands.
- Added/updated English `errorCatalog` i18n keys for the new validation and prompt catalog copy.
- Added resolver and grouping tests for the new catalog paths, raw fallback behavior, runtime raw preservation, prompt copy, and image-not-loaded detection.

## Screenshots (diff)
### Before  
<img width="371" height="346" alt="Old_1" src="https://github.com/user-attachments/assets/bd474869-7428-4f68-a067-bb412aa95d3b" />
<img width="373" height="296" alt="Old_2" src="https://github.com/user-attachments/assets/fc393792-dc6d-46fb-b7df-20290b35e30e" />
<img width="370" height="292" alt="Old_3" src="https://github.com/user-attachments/assets/bcb867ea-12ba-49b7-887a-ce06afa60475" />
<img width="370" height="269" alt="Old_4" src="https://github.com/user-attachments/assets/05caeff8-2597-4c95-97cf-2736825b85f3" />
<img width="371" height="292" alt="Old_5" src="https://github.com/user-attachments/assets/dd58113e-5953-4701-b597-d59cb6e124e9" />
<img width="373" height="282" alt="Old_6" src="https://github.com/user-attachments/assets/60fb02c0-4ed6-4734-926c-f8a20f0aeb1c" />
<img width="371" height="279" alt="Old_7" src="https://github.com/user-attachments/assets/a3453b5c-c779-4f43-af27-97cc9a083480" />
<img width="370" height="292" alt="Old_8" src="https://github.com/user-attachments/assets/59d08636-c1b3-4cde-a340-befb48726ee8" />
<img width="371" height="276" alt="Old_9" src="https://github.com/user-attachments/assets/7a94465b-ed5c-4ad9-a40a-cfe3c08d3dc7" />
<img width="368" height="279" alt="Old_10" src="https://github.com/user-attachments/assets/3f791ff3-e3e3-4cb7-aab1-640ec1cee751" />
<img width="370" height="276" alt="Old_11" src="https://github.com/user-attachments/assets/9c0f28c2-4f60-4f38-b3c4-5560609e329e" />
<img width="370" height="279" alt="Old_12" src="https://github.com/user-attachments/assets/4b61545e-db7e-4512-b300-e883ab37f347" />

### After
<img width="426" height="301" alt="New_1" src="https://github.com/user-attachments/assets/9874c036-2b3d-4b7c-ac3d-cb9c396c597f" />
<img width="421" height="301" alt="New_2" src="https://github.com/user-attachments/assets/38cd0f35-53a4-490a-b47f-da21eaa44fc8" />
<img width="418" height="347" alt="New_3" src="https://github.com/user-attachments/assets/db5ab3cc-f246-407d-b80b-9ad92c95c7ad" />
<img width="425" height="327" alt="New_4" src="https://github.com/user-attachments/assets/4333c2b8-3077-4122-9719-21d56a7b2230" />
<img width="424" height="325" alt="New_5" src="https://github.com/user-attachments/assets/6616d61f-fa90-4d2f-b8fd-50ac5a3f32cb" />
<img width="423" height="326" alt="New_6" src="https://github.com/user-attachments/assets/02a4f97a-708e-4c00-b061-d8e4dcaacd8f" />
<img width="424" height="323" alt="New_7" src="https://github.com/user-attachments/assets/9d1e96c9-69de-4e26-a152-1a101675c5eb" />
<img width="425" height="327" alt="New_8" src="https://github.com/user-attachments/assets/ffa66faf-1a33-43a3-b604-25352195f28c" />
<img width="425" height="323" alt="New_9" src="https://github.com/user-attachments/assets/f7eb5f0c-4d0c-4f1b-aa3d-30358fbc9943" />
<img width="423" height="328" alt="New_10" src="https://github.com/user-attachments/assets/72665c97-ec61-4e5a-b702-379baf919822" />
<img width="423" height="351" alt="New_11" src="https://github.com/user-attachments/assets/c5376f02-7a62-42e6-9cda-e50ab6d41b04" />
<img width="425" height="326" alt="New_12" src="https://github.com/user-attachments/assets/413df105-dc7e-4289-90b0-30ecaa417c84" />


## Intentional boundaries


This PR does not add targeted runtime/cloud-specific message matching yet. Runtime execution errors still use the original exception message and traceback in the error panel. This is intentional because cloud/service runtime errors can include actionable strings such as auth, payment, rate limit, timeout, moderation, or infrastructure failures, and collapsing those too early would make the UX worse.

This PR also does not change the overlay or right-side panel design. It only prepares and fills resolved display fields so the next stacked PRs can consume them with much less plumbing.

## Follow-up PR plan

- Add targeted runtime/cloud-specific messaging for high-volume errors such as credits, timeouts, disallowed content, rate limit, sign-in/payment requirements, and server crash style failures.
- Revisit runtime execution grouping once runtime catalog IDs are explicit enough to group by message category rather than node class or raw exception text.
- Update the error overlay to use single-error toast title/message fields and multi-error aggregate copy.
- Update the right-side error panel design, including item labels such as `Node name - input/widget name`.
- Consider splitting `errorMessageResolver.ts` by error family (`validation`, `prompt`, `runtime`, `cloud-specific`) before adding more runtime-specific rules.

## Validation

- `pnpm exec vitest run src/platform/errorCatalog/errorMessageResolver.test.ts src/components/rightSidePanel/errors/useErrorGroups.test.ts`
- `pnpm typecheck`
- Commit hooks ran staged formatting, lint fixes, and `pnpm typecheck`.
- Push hook ran `knip --cache`; it completed with an existing tag-hint warning for `src/scripts/metadata/flac.ts`.
