### PR TITLE
fix(assets): tolerate null text array in cloud job-detail (FE-844)

### DIFF
--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -318,6 +318,38 @@ describe('fetchJobs', () => {
 
       expect(result).toBeUndefined()
     })
+
+    it('FE-844: tolerates text:[null] from subgraph empty text outputs', async () => {
+      // Cloud serializes empty text outputs of subgraph promoted nodes as
+      // `text: [null]` (node IDs use `parent:child` form). The previous
+      // schema declared `text` as `string | string[]`, so the union failed
+      // on the null element and the entire job-detail response was dropped,
+      // collapsing expanded folder view to the cover preview only.
+      // parseTaskOutput already filters `text` via METADATA_KEYS, so the
+      // runtime never needed this field in zOutputs.
+      const jobDetail = {
+        ...createMockJob('job1', 'completed'),
+        workflow: { extra_data: { extra_pnginfo: { workflow: {} } } },
+        outputs: {
+          '1': {
+            images: [{ filename: 'cover.png', subfolder: '', type: 'output' }]
+          },
+          '165:160': { text: [null] },
+          '166:161': { text: [null] }
+        }
+      }
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(jobDetail)
+      })
+
+      const result = await fetchJobDetail(mockFetch, 'job1')
+
+      expect(result).toBeDefined()
+      expect(result?.outputs).toBeDefined()
+      expect(result?.outputs?.['1']).toBeDefined()
+      expect(result?.outputs?.['165:160']).toBeDefined()
+    })
   })
 
   describe('extractWorkflow', () => {

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -25,17 +25,26 @@ export const zResultItem = z.object({
 export type ResultItem = z.infer<typeof zResultItem>
 // Uses .passthrough() because custom nodes can output arbitrary keys.
 // See docs/adr/0007-node-execution-output-passthrough-schema.md
+//
+// `text` is intentionally not declared in the runtime schema. Cloud
+// `/api/jobs/{id}` serializes empty subgraph text outputs as `[null]`,
+// which a strict `string | string[]` union rejects — collapsing the whole
+// job-detail response (FE-844). Downstream parseTaskOutput already filters
+// `text` via METADATA_KEYS, so the field has no runtime consumer in the
+// asset-resolution path. We retain the static typing for custom node
+// `onExecuted` ergonomics via the intersection on NodeExecutionOutput.
 const zOutputs = z
   .object({
     audio: z.array(zResultItem).optional(),
     images: z.array(zResultItem).optional(),
     video: z.array(zResultItem).optional(),
-    animated: z.array(z.boolean()).optional(),
-    text: z.union([z.string(), z.array(z.string())]).optional()
+    animated: z.array(z.boolean()).optional()
   })
   .passthrough()
 
-export type NodeExecutionOutput = z.infer<typeof zOutputs>
+export type NodeExecutionOutput = z.infer<typeof zOutputs> & {
+  text?: string | string[]
+}
 
 export type NodeOutputWith<T extends Record<string, unknown>> =
   NodeExecutionOutput & T


### PR DESCRIPTION
## Summary

Cloud `/api/jobs/{id}` occasionally returns `outputs.<nodeId>.text = [null]` (array containing a `null` element). The FE Zod schema rejects this, `fetchJobDetail` returns `undefined`, and the expanded folder view in the asset sidebar collapses from `outputCount` tiles down to the cover preview only — every other previewable output on the same job (`images`, `video`, etc.) becomes unreachable because the entire job-detail response is discarded due to one unrelated field on one node.

Fix: drop `text` from the runtime `zOutputs` schema. Restore the `onExecuted` typing benefit via a type-only intersection on `NodeExecutionOutput`. Downstream code never needed `text` validated at the schema boundary — `parseTaskOutput` filters it via `METADATA_KEYS` already.

## Why this change

### Failing path on FE

`src/schemas/apiSchema.ts:34` (before this PR):

```ts
text: z.union([z.string(), z.array(z.string())]).optional()
```

`[null]` matches neither branch of the union. `zJobDetail.parse` throws `ZodError`, `fetchJobDetail` swallows and returns `undefined`, `resolveOutputAssetItems` falls back to `metadata.allOutputs ?? []` (cover thumb only).

This field was added in #7337 to type the `onExecuted` callback. The same `zOutputs` is reachable via `zTaskOutput → zJobDetail`, so HTTP responses get strict-validated against a union that doesn't reflect what cloud actually emits. Downstream `parseTaskOutput` in `src/stores/resultItemParsing.ts:5` already filters `text` via `METADATA_KEYS = new Set(['animated', 'text'])`, so no consumer in the asset-resolution path reads the validated value. The strictness gates a payload that has no runtime consumer.

### How `[null]` originates upstream

Traced through both repos.

**core/ComfyUI** — `comfy_api/latest/_ui.py:455`:

```python
class PreviewText(_UIOutput):
    def __init__(self, value: str, **kwargs):
        self.value = value  # type hint only — not enforced at runtime

    def as_dict(self):
        return {"text": (self.value,)}
```

If a v3 node instantiates `PreviewText(value=None)`, `as_dict()` returns `{"text": (None,)}`, and `execution.py:404`'s merge logic flattens it to `{"text": [None]}`.

### Core's stance: `null` in outputs is leaked artifact, not spec

`comfy_execution/jobs.py:51 normalize_outputs`:

```python
for item in items:
    if item is None:
        continue   # explicit None drop
```

Docstring: *"removes None items"*. Core's `/history/{id}` endpoint (`get_job` → `normalize_history_item` → `normalize_outputs`) sanitizes outputs before serving. Local-core consumers therefore never observe `[null]`.

### Backend follow-up (separate)

Filed for upstream:
1. **core** — guard `PreviewText.__init__` against `None` (or coerce to `""`).
2. **cloud** — apply core's sanitization

This PR is the FE-side defensive measure that unblocks affected jobs immediately; backend cleanup is tracked separately.

## Changes

- `src/schemas/apiSchema.ts`: remove `text` from `zOutputs`. Re-add `text?: string | string[]` to `NodeExecutionOutput` via intersection so `onExecuted` callbacks keep typed access.
- `src/platform/remote/comfyui/jobs/fetchJobs.test.ts`: regression test asserting `fetchJobDetail` tolerates `text: [null]`.

## Review Focus

- Existing consumers of `NodeExecutionOutput` / `NodeOutputWith` (e.g. `previewAny.ts`, `flattenNodeOutput.ts`, `load3d.ts`, `imageCompare.ts`, `saveMesh.ts`, `uploadAudio.ts`) still see `text?: string | string[]` via the intersection — no consumer-side migration needed. `previewAny.ts:89` already defends against array `text` with `Array.isArray(text) ? text.join('\n\n') : text`, and `[null].join('\n\n')` coerces to `""`.
- The change is purely runtime-loosening — `.passthrough()` continues to pass `text` through unchanged regardless of shape. We do not coerce nulls; the field is simply not validated.
- Other media types (`images`, `audio`, `video`) remain strictly validated because they ARE runtime contracts the FE depends on.

## Red-Green Verification

| Commit | Purpose | Verification |
| --- | --- | --- |
| `7b7c8ec1c` test: FE-844 add failing test for text:[null] in fetchJobDetail | Proves the test catches the regression | :red_circle: Local — `pnpm vitest run src/platform/remote/comfyui/jobs/fetchJobs.test.ts -t "FE-844"` fails with `AssertionError: expected undefined to be defined` (push-triggered CI did not register a run on this intermediate sha; subsequent green push superseded it) |
| `78ff1de51` fix: FE-844 drop text field from zOutputs runtime schema | Proves the fix resolves it | :green_circle: CI — [Tests Unit run 26382342674](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26382342674), [Tests E2E run 26382342672](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26382342672), all 49 checks pass |

Local on green: `pnpm test:unit` → 10,895 pass / 8 skipped; `pnpm typecheck`, `pnpm lint`, `pnpm knip` → clean.

Fixes FE-844


## screenshot /video 

### before

https://github.com/user-attachments/assets/6a5fd87b-033f-4a2d-b4b0-7f70f4c061f3

### after

https://github.com/user-attachments/assets/819ef039-e350-498f-b208-f06e1b7df17f
