### PR TITLE
fix: improve read only vue node widget contrast

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -406,9 +406,7 @@
     --secondary-background-selected
   );
   --component-node-widget-background-selected: var(--color-charcoal-100);
-  --component-node-widget-background-disabled: var(
-    --color-alpha-charcoal-600-30
-  );
+  --component-node-widget-background-disabled: var(--color-charcoal-800);
   --component-node-widget-background-highlighted: var(--color-smoke-800);
   --component-node-widget-promoted: var(--color-purple-700);
   --component-node-widget-advanced: var(--color-azure-600);

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
@@ -2,8 +2,9 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 export const WidgetInputBaseClass = cn([
   // Background
-  'not-disabled:bg-component-node-widget-background',
-  'not-disabled:text-component-node-foreground',
+  'bg-component-node-widget-background',
+  'text-component-node-foreground',
+  'read-only:bg-component-node-widget-background-disabled',
   // Outline
   'border-none',
   // Rounded

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
@@ -4,7 +4,7 @@ export const WidgetInputBaseClass = cn([
   // Background
   'not-disabled:bg-component-node-widget-background',
   'not-disabled:text-component-node-foreground',
-  'read-only:bg-component-node-widget-background-disabled',
+  '[[readonly]]:bg-component-node-widget-background-disabled',
   // Outline
   'border-none',
   // Rounded

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
@@ -2,8 +2,8 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 export const WidgetInputBaseClass = cn([
   // Background
-  'bg-component-node-widget-background',
-  'text-component-node-foreground',
+  'not-disabled:bg-component-node-widget-background',
+  'not-disabled:text-component-node-foreground',
   'read-only:bg-component-node-widget-background-disabled',
   // Outline
   'border-none',


### PR DESCRIPTION
## Summary

When a text widget in Vue nodes has an upstream node connected to it, the widget becomes read-only. However, the disabled state token color is virtually the same as the default node background color, making it difficult to visually distinguish that the widget is disabled.

This update changes readonly widgets to use a darker background

## Changes

- **What**: 
- add read only widget bg style

## Screenshots (if applicable)

Before
<img width="2556" height="1858" alt="Screen Shot 2026-05-25 at 06 05 43" src="https://github.com/user-attachments/assets/897a5157-8d4a-4258-9bca-41ca0289bfb6" />

After
<img width="2556" height="1858" alt="Screen Shot 2026-05-25 at 06 04 59" src="https://github.com/user-attachments/assets/a052d040-8a26-4bea-a998-9dde1734a71a" />

Light theme:
<img width="550" height="654" alt="image" src="https://github.com/user-attachments/assets/52d898c7-0c71-4bd8-a5bd-426e8dc5e8b0" />


