### PR TITLE
docs: drop misleading `pnpm test:unit --` examples

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,12 +32,12 @@
           {
             "type": "command",
             "if": "Bash(npx vitest *)",
-            "command": "echo 'Use `pnpm test:unit` (or `pnpm test:unit -- <path>`) instead of npx vitest.' >&2 && exit 2"
+            "command": "echo 'Use `pnpm test:unit` (or `pnpm test:unit <path>`) instead of npx vitest.' >&2 && exit 2"
           },
           {
             "type": "command",
             "if": "Bash(pnpx vitest *)",
-            "command": "echo 'Use `pnpm test:unit` (or `pnpm test:unit -- <path>`) instead of pnpx vitest.' >&2 && exit 2"
+            "command": "echo 'Use `pnpm test:unit` (or `pnpm test:unit <path>`) instead of pnpx vitest.' >&2 && exit 2"
           },
           {
             "type": "command",

--- a/.claude/skills/backport-management/reference/execution.md
+++ b/.claude/skills/backport-management/reference/execution.md
@@ -139,13 +139,13 @@ for PR in ${CONFLICT_PRS[@]}; do
   # ───────────────────────────────────────────────────────────────────────
 
   # Per-PR validation BEFORE push (catches issues earlier than wave verification).
-  # Guard each targeted command against empty file lists — running `pnpm test:unit -- run`
-  # with no arg matchers would run the full suite, and `pnpm exec eslint` with no args errors.
+  # Guard each targeted command against empty file lists — running `pnpm test:unit`
+  # with no path filter would run the full suite, and `pnpm exec eslint` with no args errors.
   pnpm typecheck
 
   mapfile -t TEST_FILES < <(git diff --name-only HEAD~1 | grep -E '\.test\.ts$' || true)
   if [ ${#TEST_FILES[@]} -gt 0 ]; then
-    pnpm test:unit -- run "${TEST_FILES[@]}"
+    pnpm test:unit "${TEST_FILES[@]}"
   else
     echo "No changed test files — skipping targeted unit tests"
   fi
@@ -368,7 +368,7 @@ Cherry-picked from upstream merge commit `SHORT_SHA`.
 ## Validation
 
 - `pnpm typecheck` ✅
-- `pnpm test:unit -- run <targeted suites>` ✅ (N/N passing)
+- `pnpm test:unit <targeted suites>` ✅ (N/N passing)
 - `pnpm exec eslint <changed files>` ✅ (0 errors)
 - `pnpm exec oxfmt --check` ✅ (clean)
 

--- a/.claude/skills/red-green-fix/SKILL.md
+++ b/.claude/skills/red-green-fix/SKILL.md
@@ -95,7 +95,7 @@ Run the test locally before pushing to confirm it fails for the right reason:
 
 ```bash
 # Vitest
-pnpm test:unit -- <test-file>
+pnpm test:unit <test-file>
 
 # Playwright
 pnpm test:browser:local -- --grep "<test name>"

--- a/.claude/skills/red-green-fix/reference/testing-anti-patterns.md
+++ b/.claude/skills/red-green-fix/reference/testing-anti-patterns.md
@@ -169,7 +169,7 @@ expect(result).toBeDefined() // This proves nothing
 
 ```bash
 # Instead of fixing the code, just updating the snapshot to match buggy output
-pnpm test:unit -- --update
+pnpm test:unit --update
 ```
 
 If a snapshot needs updating, the fix should change the code behavior, not the expected output.

--- a/docs/guidance/vitest.md
+++ b/docs/guidance/vitest.md
@@ -30,7 +30,9 @@ See `docs/testing/*.md` for detailed patterns.
 ## Running Tests
 
 ```bash
-pnpm test:unit                    # Run all unit tests
-pnpm test:unit -- path/to/file    # Run specific test
-pnpm test:unit -- --watch         # Watch mode
+pnpm test:unit                       # Run all unit tests
+pnpm test:unit path/to/file          # Filter by substring of test file path
+pnpm test:unit foo.test.ts -t "name" # Filter by test name (regex; it()/test() only, not describe())
 ```
+
+Do not use the `--` separator before vitest args; pnpm forwards extra args automatically, and `--` mangles quoted args (e.g. `-t "two words"`) on Windows PowerShell.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -43,10 +43,10 @@ To run the tests locally:
 pnpm test:unit
 
 # Run a specific test file
-pnpm test:unit -- src/path/to/file.test.ts
+pnpm test:unit src/path/to/file.test.ts
 
 # Run unit tests in watch mode
-pnpm test:unit -- --watch
+pnpm test:unit --watch
 ```
 
 Refer to the specific guides for more detailed information on each testing type.


### PR DESCRIPTION
## Summary

- Drop the `--` separator from all in-repo `pnpm test:unit -- <args>` examples. The separator is unnecessary (pnpm forwards extra args automatically) and on Windows PowerShell it mangles quoted args like `-t "restores host values by input name"`, splitting them into multiple tokens.
- Add a short note in `docs/guidance/vitest.md` explaining the substring-match semantics of the positional filter and that `-t` matches `it()`/`test()` names only (not `describe()` blocks).
- Fix `pnpm test:unit -- run <files>` in the backport-management skill: because `test:unit` is already `vitest run`, the literal `run` token was a positional path filter that silently narrowed the suite to files whose paths contain "run".

## Test plan

- [ ] `pnpm test:unit useConflictAcknowledgment` matches `useConflictAcknowledgment.test.ts`
- [ ] `pnpm test:unit SubgraphWidgetPromotion.test.ts -t "restores host values"` filters to a single test
- [ ] `git grep "pnpm test:unit -- "` returns no in-repo matches