### PR TITLE
fix(assets): cloud Generated tab uses /api/assets so deleted outputs disappear (FE-740)

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -238,6 +238,7 @@ import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContex
 import MediaAssetFilterBar from '@/platform/assets/components/MediaAssetFilterBar.vue'
 import { getAssetType } from '@/platform/assets/composables/media/assetMappers'
 import { useAssetsApi } from '@/platform/assets/composables/media/useAssetsApi'
+import { useFlatOutputAssetsGrouped } from '@/platform/assets/composables/media/useFlatOutputAssetsGrouped'
 import { useAssetSelection } from '@/platform/assets/composables/useAssetSelection'
 import { useMediaAssetActions } from '@/platform/assets/composables/useMediaAssetActions'
 import { useMediaAssetFiltering } from '@/platform/assets/composables/useMediaAssetFiltering'
@@ -311,7 +312,12 @@ const formattedExecutionTime = computed(() => {
 const toast = useToast()
 
 const inputAssets = useAssetsApi('input')
-const outputAssets = useAssetsApi('output')
+// Cloud: source the Generated tab from `/api/assets?include_tags=output` so
+// deleted assets actually disappear (history-soft-delete keeps stale entries
+// in `/api/jobs`). FE-740.
+const outputAssets = isCloud
+  ? useFlatOutputAssetsGrouped()
+  : useAssetsApi('output')
 
 // Asset selection
 const {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -312,12 +312,7 @@ const formattedExecutionTime = computed(() => {
 const toast = useToast()
 
 const inputAssets = useAssetsApi('input')
-// Cloud: source the Generated tab from `/api/assets?include_tags=output` so
-// deleted assets actually disappear (history-soft-delete keeps stale entries
-// in `/api/jobs`). FE-740.
-const outputAssets = isCloud
-  ? useFlatOutputAssetsGrouped()
-  : useAssetsApi('output')
+const outputAssets = useFlatOutputAssetsGrouped()
 
 // Asset selection
 const {

--- a/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.test.ts
+++ b/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import { useFlatOutputAssetsGrouped } from './useFlatOutputAssetsGrouped'
+
+const mediaRef: Ref<AssetItem[]> = ref([])
+
+vi.mock('./useFlatOutputAssets', () => ({
+  useFlatOutputAssets: () => ({
+    media: mediaRef,
+    loading: ref(false),
+    error: ref(null),
+    hasMore: ref(false),
+    isLoadingMore: ref(false),
+    fetchMediaList: vi.fn(),
+    refresh: vi.fn(),
+    loadMore: vi.fn()
+  })
+}))
+
+function asset(overrides: Partial<AssetItem> = {}): AssetItem {
+  return {
+    id: 'asset-id',
+    name: 'output.png',
+    tags: ['output'],
+    ...overrides
+  }
+}
+
+describe('useFlatOutputAssetsGrouped', () => {
+  it('collapses rows with the same job_id into a single representative', () => {
+    mediaRef.value = [
+      asset({ id: 'a', name: 'out1.png', job_id: 'job-1' }),
+      asset({ id: 'b', name: 'out2.png', job_id: 'job-1' }),
+      asset({ id: 'c', name: 'out3.png', job_id: 'job-1' }),
+      asset({ id: 'd', name: 'solo.png', job_id: 'job-2' })
+    ]
+
+    const { media } = useFlatOutputAssetsGrouped()
+
+    expect(media.value.map((a) => a.id)).toEqual(['a', 'd'])
+  })
+
+  it('exposes the group size as user_metadata.outputCount', () => {
+    mediaRef.value = [
+      asset({ id: 'a', job_id: 'job-1' }),
+      asset({ id: 'b', job_id: 'job-1' }),
+      asset({ id: 'c', job_id: 'job-1' }),
+      asset({ id: 'd', job_id: 'job-2' })
+    ]
+
+    const { media } = useFlatOutputAssetsGrouped()
+
+    expect(media.value[0].user_metadata?.outputCount).toBe(3)
+    expect(media.value[0].user_metadata?.jobId).toBe('job-1')
+    expect(media.value[1].user_metadata?.outputCount).toBe(1)
+  })
+
+  it('falls back to prompt_id when job_id is absent (legacy)', () => {
+    mediaRef.value = [
+      asset({ id: 'a', prompt_id: 'job-legacy' }),
+      asset({ id: 'b', prompt_id: 'job-legacy' })
+    ]
+
+    const { media } = useFlatOutputAssetsGrouped()
+
+    expect(media.value).toHaveLength(1)
+    expect(media.value[0].user_metadata?.jobId).toBe('job-legacy')
+    expect(media.value[0].user_metadata?.outputCount).toBe(2)
+  })
+
+  it('passes through rows that have neither job_id nor prompt_id', () => {
+    mediaRef.value = [asset({ id: 'orphan-a' }), asset({ id: 'orphan-b' })]
+
+    const { media } = useFlatOutputAssetsGrouped()
+
+    expect(media.value.map((a) => a.id)).toEqual(['orphan-a', 'orphan-b'])
+  })
+
+  it('preserves the order of the first occurrence per job_id', () => {
+    mediaRef.value = [
+      asset({ id: 'a', job_id: 'job-A' }),
+      asset({ id: 'b', job_id: 'job-B' }),
+      asset({ id: 'c', job_id: 'job-A' }),
+      asset({ id: 'd', job_id: 'job-C' })
+    ]
+
+    const { media } = useFlatOutputAssetsGrouped()
+
+    expect(media.value.map((a) => a.id)).toEqual(['a', 'b', 'd'])
+  })
+
+  it('does not mutate the underlying assets', () => {
+    const original = asset({ id: 'a', job_id: 'job-1' })
+    mediaRef.value = [original, asset({ id: 'b', job_id: 'job-1' })]
+
+    const { media } = useFlatOutputAssetsGrouped()
+    void media.value
+
+    expect(original.user_metadata).toBeUndefined()
+  })
+})

--- a/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.ts
+++ b/src/platform/assets/composables/media/useFlatOutputAssetsGrouped.ts
@@ -1,0 +1,58 @@
+import { computed } from 'vue'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import type { IAssetsProvider } from './IAssetsProvider'
+import { useFlatOutputAssets } from './useFlatOutputAssets'
+
+/**
+ * Cloud `/api/assets?include_tags=output` returns one row per individual output
+ * file. The asset sidebar's stack UX expects one card per job with an
+ * `outputCount` badge, so collapse rows that share a `job_id` into a single
+ * representative (the first occurrence — assets are returned newest-first).
+ *
+ * The siblings remain reachable through the existing stack-expand path via
+ * `resolveOutputAssetItems(metadata)`.
+ */
+export function useFlatOutputAssetsGrouped(): IAssetsProvider {
+  const inner = useFlatOutputAssets()
+
+  const media = computed(() => groupByJobId(inner.media.value))
+
+  return {
+    ...inner,
+    media
+  }
+}
+
+function groupByJobId(assets: AssetItem[]): AssetItem[] {
+  const countsByJobId = new Map<string, number>()
+  for (const asset of assets) {
+    const jobId = asset.job_id ?? asset.prompt_id
+    if (!jobId) continue
+    countsByJobId.set(jobId, (countsByJobId.get(jobId) ?? 0) + 1)
+  }
+
+  const seenJobIds = new Set<string>()
+  const grouped: AssetItem[] = []
+  for (const asset of assets) {
+    const jobId = asset.job_id ?? asset.prompt_id ?? null
+    if (!jobId) {
+      grouped.push(asset)
+      continue
+    }
+    if (seenJobIds.has(jobId)) continue
+    seenJobIds.add(jobId)
+
+    const outputCount = countsByJobId.get(jobId) ?? 1
+    grouped.push({
+      ...asset,
+      user_metadata: {
+        ...asset.user_metadata,
+        jobId,
+        outputCount
+      }
+    })
+  }
+  return grouped
+}

--- a/src/platform/assets/composables/useOutputStacks.ts
+++ b/src/platform/assets/composables/useOutputStacks.ts
@@ -56,7 +56,7 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
 
   function getStackJobId(asset: AssetItem): string | null {
     const metadata = getOutputAssetMetadata(asset.user_metadata)
-    return metadata?.jobId ?? null
+    return metadata?.jobId ?? asset.job_id ?? null
   }
 
   function isStackExpanded(asset: AssetItem): boolean {

--- a/src/platform/assets/schemas/assetMetadataSchema.ts
+++ b/src/platform/assets/schemas/assetMetadataSchema.ts
@@ -2,13 +2,14 @@ import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/w
 import type { ResultItemImpl } from '@/stores/queueStore'
 
 /**
- * Metadata for output assets from queue store
- * Extends Record<string, unknown> for compatibility with AssetItem schema
+ * Metadata for output assets. Originates from the queue/history mapping but
+ * also surfaces on assets sourced directly from `/api/assets?include_tags=output`,
+ * which carry `jobId` only (no per-output `nodeId` / `subfolder`).
  */
 export interface OutputAssetMetadata extends Record<string, unknown> {
   jobId: string
-  nodeId: string | number
-  subfolder: string
+  nodeId?: string | number
+  subfolder?: string
   executionTimeInSeconds?: number
   format?: string
   workflow?: ComfyWorkflowJSON
@@ -16,17 +17,11 @@ export interface OutputAssetMetadata extends Record<string, unknown> {
   allOutputs?: ResultItemImpl[]
 }
 
-/**
- * Type guard to check if metadata is OutputAssetMetadata
- */
 function isOutputAssetMetadata(
   metadata: Record<string, unknown> | undefined
 ): metadata is OutputAssetMetadata {
   if (!metadata) return false
-  return (
-    typeof metadata.jobId === 'string' &&
-    (typeof metadata.nodeId === 'string' || typeof metadata.nodeId === 'number')
-  )
+  return typeof metadata.jobId === 'string'
 }
 
 /**

--- a/src/platform/assets/schemas/assetSchema.ts
+++ b/src/platform/assets/schemas/assetSchema.ts
@@ -18,7 +18,10 @@ const zAsset = z.object({
   is_immutable: z.boolean().optional(),
   last_access_time: z.string().optional(),
   metadata: z.record(z.unknown()).optional(), // API allows arbitrary key-value pairs
-  user_metadata: z.record(z.unknown()).optional() // API allows arbitrary key-value pairs
+  user_metadata: z.record(z.unknown()).optional(), // API allows arbitrary key-value pairs
+  job_id: z.string().nullish(),
+  // Deprecated alias of job_id. See ingest-types Asset schema; both backends emit this during the L6 transition.
+  prompt_id: z.string().nullish()
 })
 
 const zAssetResponse = zListAssetsResponse


### PR DESCRIPTION
## Summary

- Cloud + OSS asset sidebar's **Generated** tab now reads from `/api/assets?include_tags=output` (via `useFlatOutputAssetsGrouped()`) instead of `historyAssets` (`api.getHistory()`). Deleting an asset via the Asset API now removes it from the sidebar — `historyAssets` was "history-soft-delete" and kept stale entries forever
- New `useFlatOutputAssetsGrouped` collapses individual outputs sharing `job_id` into one card per job with an `outputCount` badge, so the existing stack UX is preserved
- `zAsset` schema gains `job_id` / `prompt_id` (both `nullish`) to match core + cloud `ingest-types` Asset and the in-flight L6 rename (`prompt_id` -> `job_id`)
- `OutputAssetMetadata` relaxes `nodeId` / `subfolder` to optional; the type guard only requires `jobId`, so flat-output rows pass downstream consumers (delete, download, stack expand) without further plumbing
- **No `isCloud` fallback** — same stance as FE-730 (#12335). OSS resolves to the same asset-API path as cloud once BE-786 lands

Linear: FE-740

## Root cause

`AssetsSidebarTab.vue:314` was sourcing both Input and Output via `useAssetsApi`, but `useAssetsApi('output')` reads from `historyAssets`, populated by `api.getHistory()` (the queue/history endpoint), not from the Asset API. Cloud's `DELETE /api/assets/{id}` removes the asset record, but the history job entry remains — so the sidebar kept rendering the deleted asset, falling back to the truncated content-hash name once `display_name` was no longer resolvable.

The fix is consistent with the [M1 L1](https://www.notion.so/comfy-org/Assets-FE-Divergence-Survey-M1-Scope-3616d73d365080d0a9cbf5f2394c12f8) direction (single Asset API path) and L6 field rename (BE-39/40/41). It mirrors the dispatch already in `WidgetSelectDropdown.vue:52-54` (FE-227), which moved the LoadImage dropdown to `useFlatOutputAssets` but explicitly left the sidebar alone.

## Stack alignment

Same pattern as the rest of the L1 down-payment stack:

```
main
 └── FE-729 #12322  delete isAssetAPIEnabled
      └── FE-730 #12335  remove isCloud forks in assetsStore
           └── FE-731 #12375  remove isCloud guards in widget composables
                └── FE-732 #12417  remove isCloud guards on L1 UI surfaces
                     └── FE-740   (this PR)  retire historyAssets-as-output-source
```

Depends on **BE-786** (OSS removes `--enable-assets` so `/api/assets` is always on) before this can ship to production. Until BE-786 + a `comfyui-ci-container` bump, OSS e2e + the cloud Playwright project hit 503 on `/api/assets?include_tags=output`. This matches FE-730's stance: *"no temporary `isCloud` fallback was added"*.

## Verification (against prod cloud session)

Direct CDP-driven verification on `https://cloud.comfy.org` (prod, `main`) vs `https://local.comfy.org:5173/` (this branch, `pnpm dev:cloud-prod`):

| Metric | prod (main) | this branch |
|---|---|---|
| `assetsStore.historyAssets.length` | 45 (includes 9 stale) | 0 (path retired) |
| `assetsStore.flatOutputAssets.length` | n/a | 200 (first page) |
| Unique `job_id` after grouping | n/a | 79 |
| `outputCount` for known multi-output job `22dda683-...` | n/a | 18 (page-1 portion) |
| Stale `job_id`s surviving in the sidebar source | 9 | 0 |

The 9 stale jobs (`ComfyUI_temp_epprf_*`, `ComfyUI_temp_ccxpc_*` x4, `ComfyUI_temp_klafe_*` x4) were jobs whose underlying assets had been removed from `/api/assets` by the cloud BE (temp-file expiration / direct asset deletion); they remained visible on the **Generated** tab solely because `historyAssets` (= `/api/jobs`) still listed them.

Rendered sidebar after fix (excerpt of `aside.innerText`):

```
Media Assets
Generated  Imported

video/ComfyUI-vid_6_00001_     [badge: 18]
ComfyUI-image_2_00002_         [badge: 11]
Grok_00002_
Grok_00004_
ComfyUI_00009_
ComfyUI_00008_
ComfyUI_00247_
ComfyUI_00246_
```

No `ComfyUI_temp_*` entries — confirming the stale set is gone.

## Multi-output job semantics

`/api/assets?include_tags=output` returns one row per output file. For a 35-output job, that's 35 rows. The grouping helper collapses these into one card per `job_id`, with `outputCount` = group size. The existing `useOutputStacks` expansion path (`resolveOutputAssetItems`) continues to fetch siblings when a card is expanded.

Known limitation (documented in helper): if a job's outputs span multiple pages of pagination, `outputCount` reflects only the portion currently loaded. Acceptable for v1; full counts can be reconciled in a follow-up if needed.

## Schema compatibility

`zAsset` previously omitted `job_id` / `prompt_id` even though both are emitted by the cloud BE today (verified live: `job_id: "22dda683-1634-4120-8a7d-233cff28e07e"`). Adding them as `nullish` is forward-compatible with:
- The current cloud OpenAPI (already declares both fields)
- The core OpenAPI (`Comfy-Org/ComfyUI:app/assets/api/schemas_out.py`, identical shape including the `# deprecated: use job_id` annotation)
- The pending `ingest-types` SOT flip to core (PR #12409) — `Asset.job_id` survives the migration unchanged

## Test plan

- [x] `pnpm vitest run src/platform/assets/ src/components/sidebar/tabs/` — 48 files / 539 tests pass
- [x] `pnpm vitest run src/stores/assetsStore.test.ts src/platform/assets/composables/useMediaAssetActions.test.ts` — 99/99 pass
- [x] New `useFlatOutputAssetsGrouped.test.ts` — 6 cases (grouping, outputCount, prompt_id fallback, passthrough, ordering, immutability)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm format:check` clean
- [x] CDP-driven visual verification against prod workspace `64759302-c98f-4f1c-8f18-5798aa64833e`
- [ ] OSS e2e against `/api/assets?include_tags=output` — gated on BE-786 + CI container bump (same as #12335)

## Dependencies

- **Blocks-merge**: BE-786 — OSS asset routes unconditionally registered (same dependency as #12322 / #12335 / #12375 / #12417)
- **Coordinates with**: the L1 stack above; this PR is functionally orthogonal but assumes the same post-BE-786 environment

## Out of scope (separate Linear)

- BE: long-term cleanup of orphaned history entries when assets are deleted via `/api/assets` (real fix to the dual-source-of-truth problem; will retire even more FE branches)
- FE: `WidgetSelectDropdown.vue:52-54` and `useOutputHistory.ts:28` still call `useAssetsApi('output')` — those are widget / linearMode scope and ride along with the rest of the L1 widget stack

## Screenshots

before / after screenshots (drag-drop in the GH web UI from `temp/in_progress/fe740-before-fix.png` and `temp/in_progress/fe740-after-fix-v2.png`)