### PR TITLE
fix(widgets): refresh model assets and skip output refresh on asset-mode dropdown open (FE-732 fix)

### DIFF
--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts
@@ -14,6 +14,9 @@ import { createMockWidget } from './widgetTestUtils'
 
 const mockCheckState = vi.hoisted(() => vi.fn())
 const mockAssetsData = vi.hoisted(() => ({ items: [] as AssetItem[] }))
+const mockAssetDataRefresh = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
+)
 
 vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
   const actual = await vi.importActual(
@@ -47,7 +50,8 @@ vi.mock(
       category: computed(() => 'checkpoints'),
       assets: computed(() => mockAssetsData.items),
       isLoading: computed(() => false),
-      error: computed(() => null)
+      error: computed(() => null),
+      refresh: mockAssetDataRefresh
     })
   })
 )
@@ -76,6 +80,26 @@ vi.mock('@/platform/assets/composables/media/useAssetsApi', () => ({
 vi.mock('@/platform/assets/utils/outputAssetUtil', () => ({
   resolveOutputAssetItems: vi.fn().mockResolvedValue([])
 }))
+
+vi.mock(
+  '@/renderer/extensions/vueNodes/widgets/components/form/dropdown/FormDropdown.vue',
+  () => ({
+    default: {
+      name: 'FormDropdownStub',
+      props: ['items', 'displayItems', 'selected', 'placeholder'],
+      emits: ['update:is-open', 'update:selected', 'update:files'],
+      template: `
+        <div>
+          <button type="button" data-testid="fd-open" @click="$emit('update:is-open', true)">open</button>
+          <button type="button" data-testid="fd-close" @click="$emit('update:is-open', false)">close</button>
+          <span v-for="item in (displayItems || items || [])" :key="item.id">
+            <span v-if="(selected || new Set()).has(item.id)">{{ item.name }}</span>
+          </span>
+        </div>
+      `
+    }
+  })
+)
 
 const mockUpdateSelectedItems = vi.hoisted(() => vi.fn())
 const mockHandleFilesUpdate = vi.hoisted(() => vi.fn())
@@ -144,6 +168,8 @@ describe('WidgetSelectDropdown', () => {
     mockFilterSelectedRef.value = 'all'
     mockUpdateSelectedItems.mockClear()
     mockHandleFilesUpdate.mockClear()
+    mockMediaAssets.refresh.mockClear()
+    mockAssetDataRefresh.mockClear()
   })
 
   function renderComponent(
@@ -255,6 +281,74 @@ describe('WidgetSelectDropdown', () => {
 
       expect(screen.getByText('dog.png')).toBeDefined()
       expect(screen.queryByText('cat.png')).toBeNull()
+    })
+  })
+
+  describe('handleIsOpenUpdate', () => {
+    function renderAssetMode() {
+      const widget = createMockWidget<string | undefined>({
+        value: 'model_a.safetensors',
+        name: 'ckpt_name',
+        type: 'combo',
+        options: { values: [], nodeType: 'CheckpointLoaderSimple' }
+      })
+      return renderComponent(widget, 'model_a.safetensors', {
+        assetKind: 'model',
+        isAssetMode: true,
+        nodeType: 'CheckpointLoaderSimple'
+      })
+    }
+
+    function renderNonAssetMode() {
+      const widget = createMockWidget<string | undefined>({
+        value: 'cat.png',
+        name: 'image',
+        type: 'combo',
+        options: { values: ['cat.png', 'dog.png'] }
+      })
+      return renderComponent(widget, 'cat.png')
+    }
+
+    async function fireOpen() {
+      const { default: userEvent } = await import('@testing-library/user-event')
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('fd-open'))
+    }
+
+    async function fireClose() {
+      const { default: userEvent } = await import('@testing-library/user-event')
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId('fd-close'))
+    }
+
+    it('skips outputMediaAssets refresh and triggers assetData refresh when asset-mode dropdown opens', async () => {
+      renderAssetMode()
+      await fireOpen()
+      expect(mockMediaAssets.refresh).not.toHaveBeenCalled()
+      expect(mockAssetDataRefresh).toHaveBeenCalledTimes(1)
+    })
+
+    it('refetches model assets on every asset-mode dropdown reopen (no stale cache)', async () => {
+      renderAssetMode()
+      await fireOpen()
+      await fireClose()
+      await fireOpen()
+      expect(mockAssetDataRefresh).toHaveBeenCalledTimes(2)
+      expect(mockMediaAssets.refresh).not.toHaveBeenCalled()
+    })
+
+    it('refreshes outputMediaAssets when non-asset-mode dropdown opens (preserved behavior)', async () => {
+      renderNonAssetMode()
+      await fireOpen()
+      expect(mockMediaAssets.refresh).toHaveBeenCalledTimes(1)
+      expect(mockAssetDataRefresh).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when the dropdown is closed', async () => {
+      renderNonAssetMode()
+      await fireClose()
+      expect(mockMediaAssets.refresh).not.toHaveBeenCalled()
+      expect(mockAssetDataRefresh).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.vue
@@ -146,7 +146,12 @@ const acceptTypes = computed(() => {
 const layoutMode = ref<LayoutMode>(props.defaultLayoutMode ?? 'grid')
 
 function handleIsOpenUpdate(isOpen: boolean) {
-  if (isOpen && !outputMediaAssets.loading.value) {
+  if (!isOpen) return
+  if (props.isAssetMode) {
+    void assetData?.refresh()
+    return
+  }
+  if (!outputMediaAssets.loading.value) {
     void outputMediaAssets.refresh()
   }
 }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts
@@ -242,4 +242,55 @@ describe('useAssetWidgetData', () => {
       expect(error.value).toBeNull()
     })
   })
+
+  describe('refresh()', () => {
+    it('refetches assets for the current node type, bypassing the initial-load cache guard', async () => {
+      mockGetCategoryForNodeType.mockReturnValue('checkpoints')
+      mockUpdateModelsForNodeType.mockImplementation(
+        async (_nodeType: string): Promise<AssetItem[]> => {
+          mockInitializedKeys.add(_nodeType)
+          mockLoadingByKey.set(_nodeType, false)
+          return []
+        }
+      )
+
+      const { refresh, isLoading } = useAssetWidgetData(
+        'CheckpointLoaderSimple'
+      )
+
+      await nextTick()
+      await vi.waitFor(() => !isLoading.value)
+      expect(mockUpdateModelsForNodeType).toHaveBeenCalledTimes(1)
+
+      await refresh()
+      expect(mockUpdateModelsForNodeType).toHaveBeenCalledTimes(2)
+      expect(mockUpdateModelsForNodeType).toHaveBeenLastCalledWith(
+        'CheckpointLoaderSimple'
+      )
+    })
+
+    it('skips refresh when a fetch is already in flight', async () => {
+      mockGetCategoryForNodeType.mockReturnValue('checkpoints')
+      mockUpdateModelsForNodeType.mockImplementation(
+        async (_nodeType: string): Promise<AssetItem[]> => {
+          mockInitializedKeys.add(_nodeType)
+          return []
+        }
+      )
+
+      const { refresh } = useAssetWidgetData('CheckpointLoaderSimple')
+      await nextTick()
+
+      mockLoadingByKey.set('CheckpointLoaderSimple', true)
+      mockUpdateModelsForNodeType.mockClear()
+      await refresh()
+      expect(mockUpdateModelsForNodeType).not.toHaveBeenCalled()
+    })
+
+    it('no-ops when node type is undefined', async () => {
+      const { refresh } = useAssetWidgetData(undefined)
+      await refresh()
+      expect(mockUpdateModelsForNodeType).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.ts
@@ -59,10 +59,18 @@ export function useAssetWidgetData(
     { immediate: true }
   )
 
+  async function refresh(): Promise<void> {
+    const currentNodeType = toValue(nodeType)
+    if (!currentNodeType) return
+    if (assetsStore.isModelLoading(currentNodeType)) return
+    await assetsStore.updateModelsForNodeType(currentNodeType)
+  }
+
   return {
     category,
     assets,
     isLoading,
-    error
+    error,
+    refresh
   }
 }

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -319,7 +319,8 @@ describe('useWidgetSelectItems', () => {
         category: computed(() => 'checkpoints'),
         assets: computed(() => mockAssetsData.items),
         isLoading: computed(() => false),
-        error: computed(() => null)
+        error: computed(() => null),
+        refresh: async () => {}
       }
 
       const { dropdownItems } = useWidgetSelectItems(
@@ -354,7 +355,8 @@ describe('useWidgetSelectItems', () => {
         category: computed(() => 'checkpoints'),
         assets: computed(() => mockAssetsData.items),
         isLoading: computed(() => false),
-        error: computed(() => null)
+        error: computed(() => null),
+        refresh: async () => {}
       }
 
       const { dropdownItems } = useWidgetSelectItems(
@@ -379,7 +381,8 @@ describe('useWidgetSelectItems', () => {
         category: computed(() => 'checkpoints'),
         assets: computed(() => [] as AssetItem[]),
         isLoading: computed(() => false),
-        error: computed(() => null)
+        error: computed(() => null),
+        refresh: async () => {}
       }
 
       const { dropdownItems } = useWidgetSelectItems(
@@ -408,7 +411,8 @@ describe('useWidgetSelectItems', () => {
         category: computed(() => 'checkpoints'),
         assets: computed(() => mockAssetsData.items),
         isLoading: computed(() => false),
-        error: computed(() => null)
+        error: computed(() => null),
+        refresh: async () => {}
       }
 
       const { displayItems, selectedSet } = useWidgetSelectItems(


### PR DESCRIPTION


https://github.com/user-attachments/assets/1baf8283-8170-4d50-aa22-25c05598874d



Stacks on #12417 (FE-732). The isCloud guard removal in the M1 stack (FE-731/FE-732) exposed two latent regressions on the inline `FormDropdown` asset path; this PR fixes both.

## Symptoms (verified via CDP against `pr-3809.testenvs.comfy.org` cloud BE and a local `synap5e/assets-m1 --enable-assets` OSS BE)

Reported by Simon in #m1-fe-integration testing against PR #12411:

1. **Model dropdown stale list** — `r` to refresh doesn't update the dropdown; the model list is fetched once on first dropdown open (`/api/assets?include_tags=models,checkpoints&limit=500&exclude_tags=missing`) and cached. Reopening shows stale data. Newly imported models don't appear until full page reload.
2. **`/api/jobs` per dropdown open** — each model dropdown open hits `/api/jobs?status=completed,failed,cancelled&limit=200&offset=0` for no reason. This is the OSS history path being triggered by the output-media refresh hook in the dropdown.

## Root cause

- `useAssetWidgetData.watch(immediate:true)` is the only trigger for model fetch; once `assetsStore.hasAssetKey(...)` returns true, the watch short-circuits forever. Dropdown reopen has no refresh hook.
- `WidgetSelectDropdown.handleIsOpenUpdate` calls `outputMediaAssets.refresh()` on every open regardless of widget kind. For asset-mode (model) dropdowns this is irrelevant — but the call still routes through `useAssetsApi('output')` → `assetsStore.updateHistory` → `api.getHistory` → `/jobs?status=completed,failed,cancelled` on OSS. Cloud distribution swaps the provider for `useFlatOutputAssets` which hits `/api/assets?include_tags=output` — still wasted work, just a different URL.

The handler and cache guard are pre-existing (#6734, #8090), but were only reachable from cloud distributions before FE-731 unwrapped `if (isCloud)` in `useAssetWidgetData`.

## Fix

- `useAssetWidgetData`: expose `refresh()` that re-invokes `assetsStore.updateModelsForNodeType` for the current node type, guarded against re-entry while a fetch is in flight.
- `WidgetSelectDropdown.handleIsOpenUpdate`: branch on `props.isAssetMode` — asset-mode dropdowns refresh model assets via `assetData.refresh()`; non-asset-mode dropdowns continue to refresh `outputMediaAssets` as before (preserved cloud / OSS behavior).

## Verification

**CDP — Vue Nodes 2.0 ON**

Same dropdown opened twice (`qwen_image_vae` VAELoader widget):

| Open # | `/api/jobs?status=...` | `/api/assets?include_tags=models,vae` |
|---|---|---|
| 1st | 0 | 1 (fresh fetch) |
| 2nd | 0 | 1 (fresh fetch — newly added models would appear) |

**Before the fix** (same setup): 1st open fired both `/api/jobs` and the model fetch; 2nd open fired only `/api/jobs` (model list stale).

**Other paths preserved (verified empirically + by code)**:
- OSS + non-asset-mode dropdown → `/api/jobs` still fires (existing OSS behavior).
- Cloud + non-asset-mode dropdown → `/api/assets?include_tags=output` still fires (existing cloud behavior; branch in `WidgetSelectDropdown.vue` outputMediaAssets ternary is untouched).
- WS-status queue/history polling (`limit=64` `/api/jobs`) still fires on page load — unrelated to dropdown.

## Test plan

- [x] `pnpm vitest run src/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData.test.ts` — 10/10 (3 new tests for `refresh()`).
- [x] `pnpm vitest run src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDropdown.test.ts` — 9/9 (4 new tests cover handleIsOpenUpdate branches: asset-mode skips outputMediaAssets.refresh, asset-mode reopen refetches model assets, non-asset-mode preserves outputMediaAssets.refresh, close event is no-op).
- [x] `pnpm typecheck` clean.
- [ ] Re-test in `m1-fe-integration` once stacked PRs merge: import a new model via cloud import flow → reopen dropdown → new model appears without page reload.

Uploading Screen Recording 2026-05-27 at 12.43.13 AM.mov…

