### PR TITLE
refactor(assets): wire missing-model wizard UX to asset_model_wizard_enabled (FE-780)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ vitest.config.*.timestamp*
 /output.txt
 
 .amp
+# Local dev TLS certs (mkcert)
+.certs/

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -220,4 +220,33 @@ describe('useFeatureFlags', () => {
       expect(flags.teamWorkspacesEnabled).toBe(true)
     })
   })
+
+  describe('assetModelWizardEnabled', () => {
+    afterEach(() => {
+      vi.mocked(distributionTypes).isCloud = false
+    })
+
+    it('defaults to isCloud until the server serves the flag (BE-997)', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (_path, defaultValue) => defaultValue
+      )
+
+      vi.mocked(distributionTypes).isCloud = false
+      expect(useFeatureFlags().flags.assetModelWizardEnabled).toBe(false)
+
+      vi.mocked(distributionTypes).isCloud = true
+      expect(useFeatureFlags().flags.assetModelWizardEnabled).toBe(true)
+    })
+
+    it('prefers the served flag value over the isCloud default', () => {
+      vi.mocked(distributionTypes).isCloud = true
+      vi.mocked(api.getServerFeature).mockImplementation((path) =>
+        path === ServerFeatureFlag.ASSET_MODEL_WIZARD_ENABLED
+          ? false
+          : undefined
+      )
+
+      expect(useFeatureFlags().flags.assetModelWizardEnabled).toBe(false)
+    })
+  })
 })

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -17,6 +17,7 @@ export enum ServerFeatureFlag {
   MANAGER_SUPPORTS_V4 = 'extension.manager.supports_v4',
   MODEL_UPLOAD_BUTTON_ENABLED = 'model_upload_button_enabled',
   ASSET_RENAME_ENABLED = 'asset_rename_enabled',
+  ASSET_MODEL_WIZARD_ENABLED = 'asset_model_wizard_enabled',
   PRIVATE_MODELS_ENABLED = 'private_models_enabled',
   ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
   LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
@@ -69,6 +70,24 @@ export function useFeatureFlags() {
         ServerFeatureFlag.ASSET_RENAME_ENABLED,
         remoteConfig.value.asset_rename_enabled,
         false
+      )
+    },
+    /**
+     * Whether the model-import wizard and asset-backed missing-model UX are
+     * available. Capability for URL ingestion + the wizard flow (implies, but
+     * is broader than, `asset_url_import_enabled`).
+     *
+     * The default mirrors `isCloud` as a transitional measure: until BE-997
+     * registers this flag on `ServerFeatureFlag` (Cloud `true` / OSS `false`),
+     * the backends don't serve it and the FE preserves today's `isCloud`
+     * behavior. Once served, the server value takes precedence and OSS flips to
+     * `true` when BE-995 lands the URL-ingestion endpoints.
+     */
+    get assetModelWizardEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.ASSET_MODEL_WIZARD_ENABLED,
+        remoteConfig.value.asset_model_wizard_enabled,
+        isCloud
       )
     },
     get privateModelsEnabled() {

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -23,11 +23,15 @@ vi.mock('./MissingModelRow.vue', () => ({
   }
 }))
 
-const mockIsCloud = vi.hoisted(() => ({ value: true }))
-vi.mock('@/platform/distribution/types', () => ({
-  get isCloud() {
-    return mockIsCloud.value
-  }
+const mockWizardEnabled = vi.hoisted(() => ({ value: true }))
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get assetModelWizardEnabled() {
+        return mockWizardEnabled.value
+      }
+    }
+  })
 }))
 
 import MissingModelCard from './MissingModelCard.vue'
@@ -126,7 +130,7 @@ function mountCard(
 
 describe('MissingModelCard', () => {
   beforeEach(() => {
-    mockIsCloud.value = true
+    mockWizardEnabled.value = true
   })
 
   describe('Rendering & Props', () => {
@@ -243,11 +247,11 @@ describe('MissingModelCard', () => {
 
 describe('MissingModelCard (OSS)', () => {
   beforeEach(() => {
-    mockIsCloud.value = false
+    mockWizardEnabled.value = false
   })
 
   afterEach(() => {
-    mockIsCloud.value = true
+    mockWizardEnabled.value = true
   })
 
   it('shows directory name instead of "Import Not Supported" for unsupported groups', () => {

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -58,12 +58,13 @@
         <p
           class="min-w-0 flex-1 truncate text-sm font-medium"
           :class="
-            (isCloud && !group.isAssetSupported) || group.directory === null
+            (flags.assetModelWizardEnabled && !group.isAssetSupported) ||
+            group.directory === null
               ? 'text-warning-background'
               : 'text-destructive-background-hover'
           "
         >
-          <span v-if="isCloud && !group.isAssetSupported">
+          <span v-if="flags.assetModelWizardEnabled && !group.isAssetSupported">
             {{ t('rightSidePanel.missingModels.importNotSupported') }}
             ({{ group.models.length }})
           </span>
@@ -84,7 +85,7 @@
 
       <!-- Asset unsupported group notice -->
       <div
-        v-if="isCloud && !group.isAssetSupported"
+        v-if="flags.assetModelWizardEnabled && !group.isAssetSupported"
         data-testid="missing-model-import-unsupported"
         class="flex items-start gap-1.5 px-0.5 py-1 pl-2"
       >
@@ -117,7 +118,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
-import { isCloud } from '@/platform/distribution/types'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.vue'
 import Button from '@/components/ui/button/Button.vue'
 import DotSpinner from '@/components/common/DotSpinner.vue'
@@ -136,10 +137,11 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { flags } = useFeatureFlags()
 const missingModelStore = useMissingModelStore()
 
 const downloadableModels = computed(() => {
-  if (isCloud) return []
+  if (flags.assetModelWizardEnabled) return []
 
   return getDownloadableModels(missingModelGroups)
 })

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -32,7 +32,11 @@
       </div>
 
       <Button
-        v-if="!isCloud && model.representative.url && !isAssetSupported"
+        v-if="
+          !flags.assetModelWizardEnabled &&
+          model.representative.url &&
+          !isAssetSupported
+        "
         data-testid="missing-model-copy-url"
         variant="secondary"
         size="sm"
@@ -148,7 +152,7 @@
           />
         </div>
         <div
-          v-else-if="!isCloud && downloadable"
+          v-else-if="!flags.assetModelWizardEnabled && downloadable"
           class="flex w-full items-start py-1"
         >
           <Button
@@ -203,7 +207,7 @@ import {
 } from '@/platform/missingModel/composables/useMissingModelInteractions'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
-import { isCloud } from '@/platform/distribution/types'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import {
   downloadModel,
   fetchModelMetadata,
@@ -225,6 +229,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { copyToClipboard } = useCopyToClipboard()
+const { flags } = useFeatureFlags()
 
 const modelKey = computed(() =>
   getModelStateKey(model.name, directory, isAssetSupported)

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -19,6 +19,9 @@ const { mockHandles } = vi.hoisted(() => {
   return {
     mockHandles: {
       state,
+      featureFlags: {
+        assetModelWizardEnabled: false
+      },
       missingModelStore: {
         missingModelCandidates: null as MissingModelCandidate[] | null,
         createVerificationAbortController: vi.fn(() => new AbortController()),
@@ -83,8 +86,10 @@ const { mockHandles } = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/platform/distribution/types', () => ({
-  isCloud: false
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: mockHandles.featureFlags
+  })
 }))
 
 vi.mock('@/platform/assets/services/assetService', () => ({
@@ -180,6 +185,7 @@ function createGraph(graphData = createWorkflowGraphData()): LGraph {
 describe('missingModelPipeline', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockHandles.featureFlags.assetModelWizardEnabled = false
     mockHandles.state.enrichedCandidates = []
     mockHandles.missingModelStore.missingModelCandidates = null
     mockHandles.workspaceWorkflow.activeWorkflow = null
@@ -596,6 +602,40 @@ describe('missingModelPipeline', () => {
       expect(
         mockHandles.executionErrorStore.surfaceMissingModels
       ).not.toHaveBeenCalled()
+    })
+
+    it('verifies asset-supported candidates instead of fetching folder paths when the model wizard is enabled', async () => {
+      mockHandles.featureFlags.assetModelWizardEnabled = true
+      const confirmedCandidate = {
+        nodeId: '1',
+        nodeType: 'CheckpointLoaderSimple',
+        widgetName: 'ckpt_name',
+        name: 'missing.safetensors',
+        url: 'https://example.com/missing.safetensors',
+        directory: 'checkpoints',
+        isMissing: true,
+        isAssetSupported: true
+      } satisfies MissingModelCandidate
+      mockHandles.state.enrichedCandidates = [confirmedCandidate]
+      mockHandles.workspaceWorkflow.activeWorkflow = {
+        activeState: null,
+        pendingWarnings: null
+      }
+
+      await runMissingModelPipeline({
+        graph: createGraph(),
+        graphData: createWorkflowGraphData(),
+        missingModelStore: mockHandles.missingModelStore
+      })
+      await vi.dynamicImportSettled()
+
+      expect(mockHandles.verifyAssetSupportedCandidates).toHaveBeenCalledOnce()
+      expect(mockHandles.api.getFolderPaths).not.toHaveBeenCalled()
+      expect(mockHandles.fetchModelMetadata).not.toHaveBeenCalled()
+      // Asset-browser detection feeds the scan only when the wizard is enabled.
+      const enrichAssetSupportedArg =
+        mockHandles.enrichWithEmbeddedMetadata.mock.calls[0]?.[3]
+      expect(enrichAssetSupportedArg).toBeTypeOf('function')
     })
   })
 })

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -1,7 +1,7 @@
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { st } from '@/i18n'
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { assetService } from '@/platform/assets/services/assetService'
-import { isCloud } from '@/platform/distribution/types'
 import {
   enrichWithEmbeddedMetadata,
   scanAllModelCandidates,
@@ -108,10 +108,12 @@ export async function runMissingModelPipeline({
   silent = false
 }: RunMissingModelPipelineOptions): Promise<MissingModelPipelineResult> {
   const controller = missingModelStore.createVerificationAbortController()
+  const { flags } = useFeatureFlags()
+  const assetModelWizardEnabled = flags.assetModelWizardEnabled
 
   const getDirectory = (nodeType: string) =>
     useModelToNodeStore().getCategoryForNodeType(nodeType)
-  const isAssetBrowserWidget = isCloud
+  const isAssetBrowserWidget = assetModelWizardEnabled
     ? assetService.shouldUseAssetBrowser
     : () => false
 
@@ -133,7 +135,7 @@ export async function runMissingModelPipeline({
         models && Object.values(models).some((m) => m.file_name === name)
       )
     },
-    isCloud ? isAssetBrowserWidget : undefined
+    assetModelWizardEnabled ? isAssetBrowserWidget : undefined
   )
 
   // Drop candidates whose enclosing subgraph is muted/bypassed. Per-node
@@ -161,7 +163,7 @@ export async function runMissingModelPipeline({
   })
 
   if (enrichedCandidates.length) {
-    if (isCloud) {
+    if (assetModelWizardEnabled) {
       void verifyAssetSupportedCandidates(enrichedCandidates, controller.signal)
         .then(() => {
           if (controller.signal.aborted) return

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -91,6 +91,7 @@ export type RemoteConfig = {
   telemetry_disabled_events?: TelemetryEventName[]
   model_upload_button_enabled?: boolean
   asset_rename_enabled?: boolean
+  asset_model_wizard_enabled?: boolean
   private_models_enabled?: boolean
   onboarding_survey_enabled?: boolean
   onboarding_survey?: OnboardingSurvey


### PR DESCRIPTION
## Summary

Replaces the `isCloud` branches at the missing-model wizard / BYOM surfaces with a read of the new `asset_model_wizard_enabled` capability flag (L2 of the [Assets FE Divergence Survey](https://www.notion.so/comfy-org/Assets-FE-Divergence-Survey-M1-Scope-3616d73d365080d0a9cbf5f2394c12f8), §3.1/§3.5–3.7).

## Changes

- **What**:
  - Add `ASSET_MODEL_WIZARD_ENABLED` to `ServerFeatureFlag` + an `assetModelWizardEnabled` getter in `useFeatureFlags`, and `asset_model_wizard_enabled?` to `RemoteConfig`.
  - Replace `isCloud` with `flags.assetModelWizardEnabled` in `missingModelPipeline.ts`, `MissingModelCard.vue`, `MissingModelRow.vue`.
  - (`useModelUpload.ts` / `useUploadModelWizard.ts` from the ticket were already flag-driven on main — no `isCloud` there.)
- **Breaking**: none. The getter defaults to `isCloud`, so behavior is identical to today until the flag is served.
- **Dependencies**: blocked by BE-997 (register the flag) and BE-995 (OSS URL-ingestion endpoints).

## Review Focus

- **Transitional default = `isCloud` (not `false`).** Until BE-997 registers the flag on `ServerFeatureFlag` (Cloud=`true` / OSS=`false`), backends don't serve it and `getServerFeature` returns the `isCloud` default — preserving current behavior with zero regression. Once served, the server value wins; OSS flips to `true` when BE-995 lands. This centralizes the previously-scattered `isCloud` literals into one getter.
- **⚠️ Do not merge before BE-997.** The code is regression-free on its own, but the flag only becomes a real per-backend capability once BE-997 serves it.
- Tests mock `useFeatureFlags` (not `isCloud`); added a Cloud-branch pipeline test and getter default/precedence tests.

## Notes

- Quality gates: unit tests (48), typecheck, lint (0 errors), knip — all green.
- Linear: FE-780