### PR TITLE
fix: hide duplicate LiteGraph Resize/Collapse/Expand entries from Vue node menu (FE-867)

### DIFF
--- a/browser_tests/tests/nodeContextMenuOverflow.spec.ts
+++ b/browser_tests/tests/nodeContextMenuOverflow.spec.ts
@@ -9,7 +9,7 @@ test.describe(
   () => {
     test.beforeEach(async ({ comfyPage }) => {
       // Keep the viewport well below the menu content height so overflow is guaranteed.
-      await comfyPage.page.setViewportSize({ width: 1280, height: 420 })
+      await comfyPage.page.setViewportSize({ width: 1280, height: 300 })
       await comfyPage.settings.setSetting('Comfy.UseNewMenu', 'Disabled')
       await comfyPage.settings.setSetting('Comfy.Canvas.SelectionToolbox', true)
       await comfyPage.workflow.loadWorkflow('nodes/single_ksampler')

--- a/browser_tests/tests/selectionToolboxMoreActions.spec.ts
+++ b/browser_tests/tests/selectionToolboxMoreActions.spec.ts
@@ -56,6 +56,30 @@ test.describe('Selection Toolbox - More Options', { tag: '@ui' }, () => {
       await expect(nodeRef).not.toBeCollapsed()
     })
 
+    test('More Options menu does not surface duplicate LiteGraph Resize / Collapse / Expand entries', async ({
+      comfyPage
+    }) => {
+      const nodeRef = (
+        await comfyPage.nodeOps.getNodeRefsByTitle('KSampler')
+      )[0]
+      await comfyPage.nodeOps.selectNodeWithPan(nodeRef)
+
+      const menu = await openMoreOptions(comfyPage)
+
+      await expect(
+        menu.getByText('Minimize Node', { exact: true })
+      ).toBeVisible()
+      await expect(
+        menu.getByRole('menuitem', { name: 'Resize', exact: true })
+      ).toHaveCount(0)
+      await expect(
+        menu.getByRole('menuitem', { name: 'Collapse', exact: true })
+      ).toHaveCount(0)
+      await expect(
+        menu.getByRole('menuitem', { name: 'Expand', exact: true })
+      ).toHaveCount(0)
+    })
+
     test('copy via More Options menu', async ({ comfyPage }) => {
       const nodeRef = (
         await comfyPage.nodeOps.getNodeRefsByTitle('KSampler')

--- a/browser_tests/tests/selectionToolboxMoreActions.spec.ts
+++ b/browser_tests/tests/selectionToolboxMoreActions.spec.ts
@@ -75,6 +75,10 @@ test.describe('Selection Toolbox - More Options', { tag: '@ui' }, () => {
       await expect(
         menu.getByRole('menuitem', { name: 'Collapse', exact: true })
       ).toHaveCount(0)
+
+      await menu.getByText('Minimize Node', { exact: true }).click()
+      await openMoreOptions(comfyPage)
+
       await expect(
         menu.getByRole('menuitem', { name: 'Expand', exact: true })
       ).toHaveCount(0)

--- a/src/composables/graph/contextMenuConverter.test.ts
+++ b/src/composables/graph/contextMenuConverter.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
+import { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+
 import type { MenuOption } from './useMoreOptionsMenu'
 import {
   buildStructuredMenu,
@@ -174,6 +176,28 @@ describe('contextMenuConverter', () => {
       const result = convertContextMenuToOptions(items, undefined, false)
       expect(result.find((opt) => opt.label === 'Properties')).toBeUndefined()
     })
+
+    it.for([
+      { label: 'Resize', callback: LGraphCanvas.onMenuResizeNode },
+      { label: 'Collapse', callback: LGraphCanvas.onMenuNodeCollapse },
+      { label: 'Expand', callback: LGraphCanvas.onMenuNodeCollapse }
+    ])(
+      'should skip built-in LiteGraph $label entry by callback identity',
+      ({ label, callback }) => {
+        const items = [{ content: label, callback }]
+        const result = convertContextMenuToOptions(items, undefined, false)
+        expect(result.find((opt) => opt.label === label)).toBeUndefined()
+      }
+    )
+
+    it.for(['Resize', 'Collapse', 'Expand'])(
+      'should keep extension-provided %s entries (different callback identity)',
+      (label) => {
+        const items = [{ content: label, callback: () => {} }]
+        const result = convertContextMenuToOptions(items, undefined, false)
+        expect(result.find((opt) => opt.label === label)).toBeDefined()
+      }
+    )
 
     it('should convert basic menu items with content', () => {
       const items = [{ content: 'Test Item', callback: () => {} }]

--- a/src/composables/graph/contextMenuConverter.ts
+++ b/src/composables/graph/contextMenuConverter.ts
@@ -1,6 +1,6 @@
 import { default as DOMPurify } from 'dompurify'
 
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type {
   IContextMenuValue,
   LGraphNode,
@@ -25,6 +25,17 @@ const HARD_BLACKLIST = new Set([
 ])
 
 /**
+ * Callbacks of built-in LiteGraph node menu items that are superseded by
+ * the Vue node menu (Minimize Node / Expand Node) or have no working
+ * Vue-side equivalent. Matched by callback identity so that extensions
+ * providing their own items with the same labels are not affected.
+ */
+const SUPPRESSED_LITEGRAPH_CALLBACKS = new Set<unknown>([
+  LGraphCanvas.onMenuResizeNode,
+  LGraphCanvas.onMenuNodeCollapse
+])
+
+/**
  * Core menu items - items that should appear in the main menu, not under Extensions
  * Includes both LiteGraph base menu items and ComfyUI built-in functionality
  */
@@ -46,11 +57,9 @@ const CORE_MENU_ITEMS = new Set([
   'Frame selection',
   'Frame Nodes',
   'Minimize Node',
-  'Expand',
-  'Collapse',
+  'Expand Node',
   // Info and adjustments
   'Node Info',
-  'Resize',
   'Title',
   'Properties Panel',
   'Adjust Size',
@@ -231,9 +240,7 @@ const MENU_ORDER: string[] = [
   'Frame selection',
   'Frame Nodes',
   'Minimize Node',
-  'Expand',
-  'Collapse',
-  'Resize',
+  'Expand Node',
   'Clone',
   // Section 4: Node properties
   'Node Info',
@@ -301,14 +308,14 @@ export function buildStructuredMenu(options: MenuOption[]): MenuOption[] {
   // Section boundaries based on MENU_ORDER indices
   // Section 1: 0-2 (Rename, Copy, Duplicate)
   // Section 2: 3-8 (Run Branch, Pin, Unpin, Bypass, Remove Bypass, Mute)
-  // Section 3: 9-15 (Convert to Subgraph, Frame selection, Minimize Node, Expand, Collapse, Resize, Clone)
-  // Section 4: 16-17 (Node Info, Color)
-  // Section 5: 18+ (Image operations and fallback items)
+  // Section 3: 9-14 (Convert to Subgraph, Frame selection, Frame Nodes, Minimize Node, Expand Node, Clone)
+  // Section 4: 15-16 (Node Info, Color)
+  // Section 5: 17+ (Image operations and fallback items)
   const getSectionNumber = (index: number): number => {
     if (index <= 2) return 1
     if (index <= 8) return 2
-    if (index <= 15) return 3
-    if (index <= 17) return 4
+    if (index <= 14) return 3
+    if (index <= 16) return 4
     return 5
   }
 
@@ -386,6 +393,13 @@ export function convertContextMenuToOptions(
 
     // Skip hard blacklisted items
     if (HARD_BLACKLIST.has(item.content)) {
+      continue
+    }
+
+    // Skip built-in LiteGraph items that the Vue menu replaces.
+    // Matched by callback identity, not label, to avoid suppressing
+    // extension-provided items that happen to share a label.
+    if (item.callback && SUPPRESSED_LITEGRAPH_CALLBACKS.has(item.callback)) {
       continue
     }
 


### PR DESCRIPTION
## Summary
https://linear.app/comfyorg/issue/FE-867/bug-node-expand-menu-doesnt-work-nodes-immediately-collapse-after 
Recreates #12175 on a fresh `main` base (original branch's CI failed only because its `frontend-dist` artifact had expired — not a code issue). Original work by @christian-byrne / Glary-Bot, cherry-picked here so it can land while he's offline.

The Vue right-click "More Options" node menu shows duplicates for collapse/expand functionality:

- **Vue source**: `Minimize Node` / `Expand Node` (works)
- **LiteGraph source**: `Resize`, `Collapse`, `Expand` (silently no-op in this menu — the converter wrapper invokes `LGraphCanvas.onMenuNodeCollapse` without the `node` arg it expects)

Suppress the LiteGraph duplicates in `convertContextMenuToOptions` by matching the built-in **callback identity** (`LGraphCanvas.onMenuResizeNode`, `LGraphCanvas.onMenuNodeCollapse`), not the raw label. Matching by identity avoids accidentally hiding extension-provided items that share those labels.

Also align `CORE_MENU_ITEMS` / `MENU_ORDER` on the Vue label `Expand Node` so the toggled Minimize/Expand pair sorts correctly.

## Scope of suppression

Only the Vue node menu (via `convertContextMenuToOptions`) is affected. The raw `LGraphCanvas.getNodeMenuOptions` output is untouched, so:

- The legacy right-click menu (`Comfy.UseNewMenu` disabled) still has `Collapse` / `Resize`.
- `useLoad3d.ts`, which calls `new LiteGraph.ContextMenu(app.canvas.getNodeMenuOptions(node), ...)`, is unaffected.
- Extensions that monkey-patch `getNodeMenuOptions` continue to receive the full option list.

## Tests

- `contextMenuConverter.test.ts`: covers both that built-in entries are dropped by identity AND that extension-provided items with the same labels survive.
- E2E `selectionToolboxMoreActions.spec.ts`: asserts the Vue "More Options" menu shows `Minimize Node` but no `Resize`/`Collapse`/`Expand`.
- `pnpm typecheck` clean.

Supersedes #12175.
