### PR TITLE
fix: show cloud models in IC-LoRA Loader Model Only node (FE-838)

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -236,5 +236,8 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   ['optical_flow', 'OpticalFlowLoader', 'model_name'],
 
   // ---- WanVideo (ComfyUI-WanVideoWrapper) ----
-  ['loras', 'WanVideoLoraSelect', 'lora']
+  ['loras', 'WanVideoLoraSelect', 'lora'],
+
+  // ---- LTX-Video IC-LoRA (ComfyUI-LTXVideo) ----
+  ['loras', 'LTXICLoRALoaderModelOnly', 'lora_name']
 ] as const satisfies ReadonlyArray<readonly [string, string, string]>

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -87,7 +87,8 @@ const MOCK_NODE_NAMES = [
   'IPAdapterModelLoader',
   'LS_LoadSegformerModel',
   'LoadNLFModel',
-  'FlashVSRNode'
+  'FlashVSRNode',
+  'LTXICLoRALoaderModelOnly'
 ] as const
 
 const mockNodeDefsByName = Object.fromEntries(
@@ -307,7 +308,22 @@ describe('useModelToNodeStore', () => {
       )
 
       const loraProviders = modelToNodeStore.getAllNodeProviders('loras')
-      expect(loraProviders).toHaveLength(2)
+      expect(loraProviders).toHaveLength(3)
+      expect(loraProviders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            nodeDef: expect.objectContaining({ name: 'LoraLoader' })
+          }),
+          expect.objectContaining({
+            nodeDef: expect.objectContaining({ name: 'LoraLoaderModelOnly' })
+          }),
+          expect.objectContaining({
+            nodeDef: expect.objectContaining({
+              name: 'LTXICLoRALoaderModelOnly'
+            })
+          })
+        ])
+      )
     })
 
     it('should return single provider for model type with one node', () => {
@@ -559,6 +575,18 @@ describe('useModelToNodeStore', () => {
         modelToNodeStore.getCategoryForNodeType('NonExistentNode')
       ).toBeUndefined()
       expect(modelToNodeStore.getCategoryForNodeType('')).toBeUndefined()
+    })
+
+    it('maps the IC-LoRA Loader Model Only node to loras so its lora_name dropdown uses the cloud asset browser (FE-838)', () => {
+      const modelToNodeStore = useModelToNodeStore()
+      modelToNodeStore.registerDefaults()
+
+      expect(
+        modelToNodeStore.getCategoryForNodeType('LTXICLoRALoaderModelOnly')
+      ).toBe('loras')
+      expect(
+        modelToNodeStore.getRegisteredNodeTypes()['LTXICLoRALoaderModelOnly']
+      ).toBe('lora_name')
     })
 
     it('should return first category when node type exists in multiple categories', () => {


### PR DESCRIPTION
## Summary

### before
<img width="1107" height="958" alt="before-buggy" src="https://github.com/user-attachments/assets/1fcbd909-e008-4bd3-967f-87cdabb2baf6" />

### after
<img width="1107" height="958" alt="after-fixed" src="https://github.com/user-attachments/assets/0d3c6f3f-36d6-4556-bd29-b3826ae20216" />


The **IC-LoRA Loader Model Only** node (`LTXICLoRALoaderModelOnly`, from ComfyUI-LTXVideo) didn't show cloud models from `supported_models.json`, while the native **Load LoRA** node did.

## Changes

- **What**: Add `['loras', 'LTXICLoRALoaderModelOnly', 'lora_name']` to `MODEL_NODE_MAPPINGS`. Whether a combo widget swaps to the cloud asset browser is gated by `assetService.shouldUseAssetBrowser` → `isAssetBrowserEligible`, which only returns true for node types registered in `MODEL_NODE_MAPPINGS` (via `modelToNodeStore`). The custom IC-LoRA loader was absent from that list, so its `lora_name` widget fell back to the plain combo that lists only filesystem models — never the cloud-injected ones.
- **Breaking**: none

## Review Focus

Root cause verified live on `cloud.comfy.org` (asset API enabled, custom node installed) via CDP:
- `LoraLoaderModelOnly` (native) → registry `lora_name`, eligible `true` → cloud models shown
- `LTXICLoRALoaderModelOnly` (bug) → not in registry, eligible `false` → cloud models missing
- After registering the mapping live → eligible `true`, category `loras` → cloud models shown

Same class of bug as FE-492 (custom loaders missing from the mapping); long-term, auto-detecting model-folder-backed combos would remove the need to register each custom loader by hand.

Fixes FE-838

## Red-Green Verification

| Commit | CI | Purpose |
|--------|-----|---------|
| [`test:` 64d099f6c](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26508637513) | :red_circle: Red (failure) | Proves the test catches the bug |
| [`fix:` 6b91a570d](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26509067631) | :green_circle: Green (success) | Proves the fix resolves it |

## Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [x] Unit regression in `src/stores/modelToNodeStore.test.ts`
- [ ] E2E not applicable (custom node + cloud asset API not available in CI)