### PR TITLE
refactor: consolidate middle-button pan handling

### DIFF
--- a/browser_tests/fixtures/ComfyMouse.ts
+++ b/browser_tests/fixtures/ComfyMouse.ts
@@ -66,6 +66,34 @@ export class ComfyMouse implements Omit<Mouse, 'move'> {
     await this.drop(options)
   }
 
+  async middleDrag(
+    from: Position,
+    to: Position,
+    options: Omit<DragOptions, 'button'> = {}
+  ) {
+    await this.dragAndDrop(from, to, { ...options, button: 'middle' })
+  }
+
+  async middleDragFromCenter(
+    locator: Locator,
+    delta: { x: number; y: number },
+    options: Omit<DragOptions, 'button'> = {}
+  ) {
+    await locator.waitFor({ state: 'visible' })
+    const box = await locator.boundingBox()
+    if (!box) throw new Error('middleDragFromCenter: bounding box not found')
+
+    const start = {
+      x: box.x + box.width / 2,
+      y: box.y + box.height / 2
+    }
+    await this.middleDrag(
+      start,
+      { x: start.x + delta.x, y: start.y + delta.y },
+      options
+    )
+  }
+
   /** @see {@link Mouse.move} */
   async move(to: Position, options = ComfyMouse.defaultOptions) {
     await this.mouse.move(to.x, to.y, options)

--- a/browser_tests/tests/maskEditor.spec.ts
+++ b/browser_tests/tests/maskEditor.spec.ts
@@ -76,6 +76,34 @@ test.describe('Mask Editor', { tag: '@vue-nodes' }, () => {
     await maskEditor.drawStrokeAndExpectPixels(dialog)
   })
 
+  test(
+    'Middle-click drag should pan the mask editor canvas',
+    { tag: ['@canvas'] },
+    async ({ comfyPage, comfyMouse, maskEditor }) => {
+      const dialog = await maskEditor.openDialog()
+      const pointerZone = dialog.getByTestId('pointer-zone')
+      const getCanvasPosition = () =>
+        comfyPage.page.evaluate(() => {
+          const container = document.querySelector('#maskEditorCanvasContainer')
+          if (!(container instanceof HTMLElement)) return null
+
+          return {
+            left: container.style.left,
+            top: container.style.top
+          }
+        })
+      const canvasPositionBefore = await getCanvasPosition()
+
+      await comfyMouse.middleDragFromCenter(
+        pointerZone,
+        { x: 140, y: 90 },
+        { steps: 10 }
+      )
+
+      await expect.poll(getCanvasPosition).not.toEqual(canvasPositionBefore)
+    }
+  )
+
   test('undo reverts a brush stroke', async ({ maskEditor }) => {
     const dialog = await maskEditor.openDialog()
 

--- a/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts
@@ -4,6 +4,29 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Vue Nodes Canvas Pan', { tag: '@vue-nodes' }, () => {
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.canvasOps.resetView()
+  })
+
+  test(
+    'Middle-click drag on a Vue node pans canvas',
+    { tag: ['@canvas'] },
+    async ({ comfyPage, comfyMouse }) => {
+      const node = comfyPage.vueNodes.getNodeByTitle('Load Checkpoint')
+      const offsetBefore = await comfyPage.canvasOps.getOffset()
+
+      await comfyMouse.middleDragFromCenter(
+        node,
+        { x: 140, y: 90 },
+        { steps: 10 }
+      )
+
+      await expect
+        .poll(() => comfyPage.canvasOps.getOffset())
+        .not.toEqual(offsetBefore)
+    }
+  )
+
   test(
     '@mobile Can pan with touch',
     { tag: '@screenshot' },

--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -5,6 +5,10 @@ import {
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 
 test.describe('Vue Multiline String Widget', { tag: '@vue-nodes' }, () => {
+  test.afterEach(async ({ comfyPage }) => {
+    await comfyPage.canvasOps.resetView()
+  })
+
   const getFirstClipNode = (comfyPage: ComfyPage) =>
     comfyPage.vueNodes.getNodeByTitle('CLIP Text Encode (Prompt)').first()
 
@@ -54,4 +58,23 @@ test.describe('Vue Multiline String Widget', { tag: '@vue-nodes' }, () => {
     await textarea.click({ button: 'right' })
     await expect(vueContextMenu).toBeVisible()
   })
+
+  test(
+    'Middle-click drag on textarea should pan canvas',
+    { tag: ['@canvas', '@widget'] },
+    async ({ comfyPage, comfyMouse }) => {
+      const textarea = getFirstMultilineStringWidget(comfyPage)
+      const offsetBefore = await comfyPage.canvasOps.getOffset()
+
+      await comfyMouse.middleDragFromCenter(
+        textarea,
+        { x: 140, y: 90 },
+        { steps: 10 }
+      )
+
+      await expect
+        .poll(() => comfyPage.canvasOps.getOffset())
+        .not.toEqual(offsetBefore)
+    }
+  )
 })

--- a/src/base/pointerUtils.test.ts
+++ b/src/base/pointerUtils.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 import {
   isMiddleButtonEvent,
   isMiddleButtonHeld,
-  isMiddleForPointerEvent,
   isMiddlePointerInput
 } from '@/base/pointerUtils'
 
@@ -51,39 +50,6 @@ describe('pointerUtils', () => {
       expect(
         isMiddleButtonEvent(
           new MouseEvent('auxclick', { button: 2, buttons: 4 })
-        )
-      ).toBe(false)
-    })
-  })
-
-  describe('isMiddleForPointerEvent', () => {
-    it('dispatches by pointer event type', () => {
-      expect(
-        isMiddleForPointerEvent(
-          new PointerEvent('pointerdown', { button: 0, buttons: 5 })
-        )
-      ).toBe(false)
-      expect(
-        isMiddleForPointerEvent(
-          new PointerEvent('pointermove', { button: 0, buttons: 5 })
-        )
-      ).toBe(true)
-      expect(
-        isMiddleForPointerEvent(
-          new PointerEvent('pointerup', { button: 1, buttons: 0 })
-        )
-      ).toBe(true)
-    })
-
-    it('treats pointercancel like a held-button event', () => {
-      expect(
-        isMiddleForPointerEvent(
-          new PointerEvent('pointercancel', { buttons: 5 })
-        )
-      ).toBe(true)
-      expect(
-        isMiddleForPointerEvent(
-          new PointerEvent('pointercancel', { buttons: 1 })
         )
       ).toBe(false)
     })

--- a/src/base/pointerUtils.test.ts
+++ b/src/base/pointerUtils.test.ts
@@ -74,5 +74,18 @@ describe('pointerUtils', () => {
         )
       ).toBe(true)
     })
+
+    it('treats pointercancel like a held-button event', () => {
+      expect(
+        isMiddleForPointerEvent(
+          new PointerEvent('pointercancel', { buttons: 5 })
+        )
+      ).toBe(true)
+      expect(
+        isMiddleForPointerEvent(
+          new PointerEvent('pointercancel', { buttons: 1 })
+        )
+      ).toBe(false)
+    })
   })
 })

--- a/src/base/pointerUtils.test.ts
+++ b/src/base/pointerUtils.test.ts
@@ -8,50 +8,68 @@ import {
 
 describe('pointerUtils', () => {
   describe('isMiddlePointerInput', () => {
-    it('accepts middle-button pointerdown and strict middle-only buttons', () => {
-      expect(
-        isMiddlePointerInput(
-          new PointerEvent('pointerdown', { button: 1, buttons: 4 })
-        )
-      ).toBe(true)
-      expect(
-        isMiddlePointerInput(new PointerEvent('pointermove', { buttons: 4 }))
-      ).toBe(true)
-    })
-
-    it('rejects chorded pointerdown when middle is only incidentally held', () => {
-      expect(
-        isMiddlePointerInput(
-          new PointerEvent('pointerdown', { button: 0, buttons: 5 })
-        )
-      ).toBe(false)
+    it.for([
+      {
+        name: 'accepts a middle-button pointerdown',
+        event: new PointerEvent('pointerdown', { button: 1, buttons: 4 }),
+        expected: true
+      },
+      {
+        name: 'accepts strict middle-only held buttons',
+        event: new PointerEvent('pointermove', { buttons: 4 }),
+        expected: true
+      },
+      {
+        name: 'rejects chorded pointerdown when middle is only incidentally held',
+        event: new PointerEvent('pointerdown', { button: 0, buttons: 5 }),
+        expected: false
+      }
+    ])('$name', ({ event, expected }) => {
+      expect(isMiddlePointerInput(event)).toBe(expected)
     })
   })
 
   describe('isMiddleButtonHeld', () => {
-    it('uses the middle-button bit so chorded moves stay active', () => {
-      expect(
-        isMiddleButtonHeld(new PointerEvent('pointermove', { buttons: 4 }))
-      ).toBe(true)
-      expect(
-        isMiddleButtonHeld(new PointerEvent('pointermove', { buttons: 5 }))
-      ).toBe(true)
-      expect(
-        isMiddleButtonHeld(new PointerEvent('pointermove', { buttons: 1 }))
-      ).toBe(false)
+    it.for([
+      {
+        name: 'accepts the middle-button bit alone',
+        event: new PointerEvent('pointermove', { buttons: 4 }),
+        expected: true
+      },
+      {
+        name: 'accepts chorded moves that include the middle-button bit',
+        event: new PointerEvent('pointermove', { buttons: 5 }),
+        expected: true
+      },
+      {
+        name: 'accepts pointercancel when the middle-button bit is still held',
+        event: new PointerEvent('pointercancel', { buttons: 4 }),
+        expected: true
+      },
+      {
+        name: 'rejects primary-button-only moves',
+        event: new PointerEvent('pointermove', { buttons: 1 }),
+        expected: false
+      }
+    ])('$name', ({ event, expected }) => {
+      expect(isMiddleButtonHeld(event)).toBe(expected)
     })
   })
 
   describe('isMiddleButtonEvent', () => {
-    it('uses the changed button instead of the held-button bitmask', () => {
-      expect(
-        isMiddleButtonEvent(new PointerEvent('pointerup', { button: 1 }))
-      ).toBe(true)
-      expect(
-        isMiddleButtonEvent(
-          new MouseEvent('auxclick', { button: 2, buttons: 4 })
-        )
-      ).toBe(false)
+    it.for([
+      {
+        name: 'accepts a middle-button pointerup',
+        event: new PointerEvent('pointerup', { button: 1 }),
+        expected: true
+      },
+      {
+        name: 'rejects a non-middle changed button even when middle is held',
+        event: new MouseEvent('auxclick', { button: 2, buttons: 4 }),
+        expected: false
+      }
+    ])('$name', ({ event, expected }) => {
+      expect(isMiddleButtonEvent(event)).toBe(expected)
     })
   })
 })

--- a/src/base/pointerUtils.test.ts
+++ b/src/base/pointerUtils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isMiddleButtonEvent,
+  isMiddleButtonHeld,
+  isMiddleForPointerEvent,
+  isMiddlePointerInput
+} from '@/base/pointerUtils'
+
+describe('pointerUtils', () => {
+  describe('isMiddlePointerInput', () => {
+    it('accepts middle-button pointerdown and strict middle-only buttons', () => {
+      expect(
+        isMiddlePointerInput(
+          new PointerEvent('pointerdown', { button: 1, buttons: 4 })
+        )
+      ).toBe(true)
+      expect(
+        isMiddlePointerInput(new PointerEvent('pointermove', { buttons: 4 }))
+      ).toBe(true)
+    })
+
+    it('rejects chorded pointerdown when middle is only incidentally held', () => {
+      expect(
+        isMiddlePointerInput(
+          new PointerEvent('pointerdown', { button: 0, buttons: 5 })
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('isMiddleButtonHeld', () => {
+    it('uses the middle-button bit so chorded moves stay active', () => {
+      expect(
+        isMiddleButtonHeld(new PointerEvent('pointermove', { buttons: 4 }))
+      ).toBe(true)
+      expect(
+        isMiddleButtonHeld(new PointerEvent('pointermove', { buttons: 5 }))
+      ).toBe(true)
+      expect(
+        isMiddleButtonHeld(new PointerEvent('pointermove', { buttons: 1 }))
+      ).toBe(false)
+    })
+  })
+
+  describe('isMiddleButtonEvent', () => {
+    it('uses the changed button instead of the held-button bitmask', () => {
+      expect(
+        isMiddleButtonEvent(new PointerEvent('pointerup', { button: 1 }))
+      ).toBe(true)
+      expect(
+        isMiddleButtonEvent(
+          new MouseEvent('auxclick', { button: 2, buttons: 4 })
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('isMiddleForPointerEvent', () => {
+    it('dispatches by pointer event type', () => {
+      expect(
+        isMiddleForPointerEvent(
+          new PointerEvent('pointerdown', { button: 0, buttons: 5 })
+        )
+      ).toBe(false)
+      expect(
+        isMiddleForPointerEvent(
+          new PointerEvent('pointermove', { button: 0, buttons: 5 })
+        )
+      ).toBe(true)
+      expect(
+        isMiddleForPointerEvent(
+          new PointerEvent('pointerup', { button: 1, buttons: 0 })
+        )
+      ).toBe(true)
+    })
+  })
+})

--- a/src/base/pointerUtils.ts
+++ b/src/base/pointerUtils.ts
@@ -2,11 +2,6 @@
  * Utilities for pointer event handling
  */
 
-/**
- * Checks if a pointer or mouse event is a middle button input
- * @param event - The pointer or mouse event to check
- * @returns true if the event is from the middle button/wheel
- */
 export function isMiddlePointerInput(
   event: PointerEvent | MouseEvent
 ): boolean {
@@ -19,4 +14,26 @@ export function isMiddlePointerInput(
   }
 
   return false
+}
+
+export function isMiddleButtonHeld(event: PointerEvent | MouseEvent): boolean {
+  if ('buttons' in event && typeof event.buttons === 'number') {
+    return (event.buttons & 4) === 4
+  }
+
+  return false
+}
+
+export function isMiddleButtonEvent(event: PointerEvent | MouseEvent): boolean {
+  return 'button' in event && event.button === 1
+}
+
+export function isMiddleForPointerEvent(
+  event: PointerEvent | MouseEvent
+): boolean {
+  if (event.type === 'pointerdown') return isMiddlePointerInput(event)
+  if (event.type === 'pointermove' || event.type === 'pointercancel') {
+    return isMiddleButtonHeld(event)
+  }
+  return isMiddleButtonEvent(event)
 }

--- a/src/base/pointerUtils.ts
+++ b/src/base/pointerUtils.ts
@@ -27,13 +27,3 @@ export function isMiddleButtonHeld(event: PointerEvent | MouseEvent): boolean {
 export function isMiddleButtonEvent(event: PointerEvent | MouseEvent): boolean {
   return 'button' in event && event.button === 1
 }
-
-export function isMiddleForPointerEvent(
-  event: PointerEvent | MouseEvent
-): boolean {
-  if (event.type === 'pointerdown') return isMiddlePointerInput(event)
-  if (event.type === 'pointermove' || event.type === 'pointercancel') {
-    return isMiddleButtonHeld(event)
-  }
-  return isMiddleButtonEvent(event)
-}

--- a/src/base/pointerUtils.ts
+++ b/src/base/pointerUtils.ts
@@ -2,28 +2,14 @@
  * Utilities for pointer event handling
  */
 
-export function isMiddlePointerInput(
-  event: PointerEvent | MouseEvent
-): boolean {
-  if ('button' in event && event.button === 1) {
-    return true
-  }
-
-  if ('buttons' in event && typeof event.buttons === 'number') {
-    return event.buttons === 4
-  }
-
-  return false
+export function isMiddlePointerInput(event: MouseEvent): boolean {
+  return event.button === 1 || event.buttons === 4
 }
 
-export function isMiddleButtonHeld(event: PointerEvent | MouseEvent): boolean {
-  if ('buttons' in event && typeof event.buttons === 'number') {
-    return (event.buttons & 4) === 4
-  }
-
-  return false
+export function isMiddleButtonHeld(event: MouseEvent): boolean {
+  return (event.buttons & 4) === 4
 }
 
-export function isMiddleButtonEvent(event: PointerEvent | MouseEvent): boolean {
-  return 'button' in event && event.button === 1
+export function isMiddleButtonEvent(event: MouseEvent): boolean {
+  return event.button === 1
 }

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -63,9 +63,9 @@
     v-if="shouldRenderVueNodes && comfyApp.canvas && comfyAppReady"
     :canvas="comfyApp.canvas"
     @wheel.capture="canvasInteractions.forwardEventToCanvas"
-    @pointerdown.capture="forwardPanEvent"
-    @pointerup.capture="forwardPanEvent"
-    @pointermove.capture="forwardPanEvent"
+    @pointerdown.capture="forwardPointerDownPanEvent"
+    @pointerup.capture="forwardPointerUpPanEvent"
+    @pointermove.capture="forwardPointerMovePanEvent"
   >
     <!-- Vue nodes rendered based on graph nodes -->
     <LGraphNode
@@ -120,7 +120,11 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { isMiddleForPointerEvent } from '@/base/pointerUtils'
+import {
+  isMiddleButtonEvent,
+  isMiddleButtonHeld,
+  isMiddlePointerInput
+} from '@/base/pointerUtils'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import TopMenuSection from '@/components/TopMenuSection.vue'
 import BottomPanel from '@/components/bottomPanel/BottomPanel.vue'
@@ -593,8 +597,23 @@ onUnmounted(() => {
   cleanupErrorHooks = null
   vueNodeLifecycle.cleanup()
 })
-function forwardPanEvent(e: PointerEvent) {
-  if (!isMiddleForPointerEvent(e)) return
+function forwardPointerDownPanEvent(e: PointerEvent) {
+  forwardPanEvent(e, isMiddlePointerInput)
+}
+
+function forwardPointerMovePanEvent(e: PointerEvent) {
+  forwardPanEvent(e, isMiddleButtonHeld)
+}
+
+function forwardPointerUpPanEvent(e: PointerEvent) {
+  forwardPanEvent(e, isMiddleButtonEvent)
+}
+
+function forwardPanEvent(
+  e: PointerEvent,
+  isMiddleInput: (event: PointerEvent) => boolean
+) {
+  if (!isMiddleInput(e)) return
   if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
     return
 

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -120,7 +120,7 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { isMiddlePointerInput } from '@/base/pointerUtils'
+import { isMiddleForPointerEvent } from '@/base/pointerUtils'
 import LiteGraphCanvasSplitterOverlay from '@/components/LiteGraphCanvasSplitterOverlay.vue'
 import TopMenuSection from '@/components/TopMenuSection.vue'
 import BottomPanel from '@/components/bottomPanel/BottomPanel.vue'
@@ -594,7 +594,7 @@ onUnmounted(() => {
   vueNodeLifecycle.cleanup()
 })
 function forwardPanEvent(e: PointerEvent) {
-  if (!isMiddlePointerInput(e)) return
+  if (!isMiddleForPointerEvent(e)) return
   if (shouldIgnoreCopyPaste(e.target) && document.activeElement === e.target)
     return
 

--- a/src/components/graph/SelectionToolbox.test.ts
+++ b/src/components/graph/SelectionToolbox.test.ts
@@ -472,7 +472,9 @@ describe('SelectionToolbox', () => {
       const forwardEventToCanvasSpy = vi.fn()
       mockCanvasInteractions.mockReturnValue({
         handleWheel: vi.fn(),
-        handlePointer: vi.fn(),
+        handlePointerDown: vi.fn(),
+        handlePointerMove: vi.fn(),
+        handlePointerUp: vi.fn(),
         forwardEventToCanvas: forwardEventToCanvasSpy,
         shouldHandleNodePointerEvents: { value: true } as ReturnType<
           typeof useCanvasInteractions

--- a/src/composables/maskeditor/useToolManager.test.ts
+++ b/src/composables/maskeditor/useToolManager.test.ts
@@ -16,7 +16,7 @@ type MockStore = {
   isPanning: boolean
 }
 
-const mockStore: MockStore = reactive({
+const mockStore = reactive<MockStore>({
   currentTool: Tools.MaskPen,
   activeLayer: 'mask',
   pointerZone: null,
@@ -24,7 +24,7 @@ const mockStore: MockStore = reactive({
   brushPreviewGradientVisible: false,
   isAdjustingBrush: false,
   isPanning: false
-}) as MockStore
+})
 
 const mockBrushDrawing = {
   startDrawing: vi.fn().mockResolvedValue(undefined),
@@ -82,7 +82,7 @@ const mockKeyboard = {
   isKeyDown: vi.fn().mockReturnValue(false),
   addListeners: vi.fn(),
   removeListeners: vi.fn()
-}
+} satisfies Parameters<typeof useToolManager>[0]
 
 const mockPanZoom = {
   initializeCanvasPanZoom: vi.fn(),
@@ -96,36 +96,43 @@ const mockPanZoom = {
   invalidatePanZoom: vi.fn(),
   addPenPointerId: vi.fn(),
   removePenPointerId: vi.fn()
+} satisfies Parameters<typeof useToolManager>[1]
+
+type TestPointerEventInit = PointerEventInit & {
+  offsetX?: number
+  offsetY?: number
+  type?: string
 }
 
-const pointerEvent = (
-  init: Partial<PointerEvent> & { pointerType?: string }
-): PointerEvent => {
-  return {
-    preventDefault: vi.fn(),
+const pointerEvent = ({
+  offsetX = 0,
+  offsetY = 0,
+  type = 'pointerdown',
+  ...init
+}: TestPointerEventInit = {}): PointerEvent => {
+  const event = new PointerEvent(type, {
     pointerId: 1,
     pointerType: 'mouse',
     button: 0,
     buttons: 0,
     clientX: 0,
     clientY: 0,
-    offsetX: 0,
-    offsetY: 0,
     altKey: false,
     ...init
-  } as unknown as PointerEvent
+  })
+  vi.spyOn(event, 'preventDefault')
+  Object.defineProperties(event, {
+    offsetX: { value: offsetX },
+    offsetY: { value: offsetY }
+  })
+  return event
 }
 
 let scope: EffectScope | null = null
 
 const setup = (): ReturnType<typeof useToolManager> => {
   scope = effectScope()
-  return scope.run(() =>
-    useToolManager(
-      mockKeyboard as unknown as Parameters<typeof useToolManager>[0],
-      mockPanZoom as unknown as Parameters<typeof useToolManager>[1]
-    )
-  )!
+  return scope.run(() => useToolManager(mockKeyboard, mockPanZoom))!
 }
 
 describe('useToolManager', () => {
@@ -307,7 +314,9 @@ describe('useToolManager', () => {
 
     it('should start panning on middle mouse button (buttons===4)', async () => {
       const tm = setup()
-      await tm.handlePointerDown(pointerEvent({ buttons: 4 }))
+      await tm.handlePointerDown(
+        pointerEvent({ type: 'pointerdown', buttons: 4 })
+      )
 
       expect(mockPanZoom.handlePanStart).toHaveBeenCalled()
       expect(mockStore.brushVisible).toBe(false)
@@ -434,7 +443,19 @@ describe('useToolManager', () => {
 
     it('should pan on middle button drag', async () => {
       const tm = setup()
-      await tm.handlePointerMove(pointerEvent({ buttons: 4 }))
+      await tm.handlePointerMove(
+        pointerEvent({ type: 'pointermove', buttons: 4 })
+      )
+
+      expect(mockPanZoom.handlePanMove).toHaveBeenCalled()
+      expect(mockBrushDrawing.handleDrawing).not.toHaveBeenCalled()
+    })
+
+    it('should keep panning when middle button is held with another button', async () => {
+      const tm = setup()
+      await tm.handlePointerMove(
+        pointerEvent({ type: 'pointermove', buttons: 5 })
+      )
 
       expect(mockPanZoom.handlePanMove).toHaveBeenCalled()
       expect(mockBrushDrawing.handleDrawing).not.toHaveBeenCalled()

--- a/src/composables/maskeditor/useToolManager.ts
+++ b/src/composables/maskeditor/useToolManager.ts
@@ -1,18 +1,19 @@
 import { ref, watch } from 'vue'
+
+import { isMiddleButtonHeld, isMiddlePointerInput } from '@/base/pointerUtils'
 import type {
   Point,
   ImageLayer,
   ToolInternalSettings
 } from '@/extensions/core/maskeditor/types'
 import { Tools } from '@/extensions/core/maskeditor/types'
+import { app } from '@/scripts/app'
 import { useMaskEditorStore } from '@/stores/maskEditorStore'
 import { useBrushDrawing } from './useBrushDrawing'
 import { useCanvasTools } from './useCanvasTools'
 import { useCoordinateTransform } from './useCoordinateTransform'
 import type { useKeyboard } from './useKeyboard'
 import type { usePanAndZoom } from './usePanAndZoom'
-import { isMiddleForPointerEvent } from '@/base/pointerUtils'
-import { app } from '@/scripts/app'
 
 export function useToolManager(
   keyboard: ReturnType<typeof useKeyboard>,
@@ -119,10 +120,7 @@ export function useToolManager(
       panZoom.addPenPointerId(event.pointerId)
     }
 
-    if (
-      isMiddleForPointerEvent(event) ||
-      (event.buttons === 1 && keyboard.isKeyDown(' '))
-    ) {
+    if (shouldStartPan(event)) {
       panZoom.handlePanStart(event)
 
       store.brushVisible = false
@@ -179,10 +177,7 @@ export function useToolManager(
     const newCursorPoint = { x: event.clientX, y: event.clientY }
     panZoom.updateCursorPosition(newCursorPoint)
 
-    if (
-      isMiddleForPointerEvent(event) ||
-      (event.buttons === 1 && keyboard.isKeyDown(' '))
-    ) {
+    if (shouldContinuePan(event)) {
       await panZoom.handlePanMove(event)
       return
     }
@@ -224,6 +219,18 @@ export function useToolManager(
     store.isAdjustingBrush = false
     await brushDrawing.drawEnd(event)
     mouseDownPoint.value = null
+  }
+
+  function isLeftButtonSpacePan(event: PointerEvent) {
+    return event.buttons === 1 && keyboard.isKeyDown(' ')
+  }
+
+  function shouldStartPan(event: PointerEvent) {
+    return isMiddlePointerInput(event) || isLeftButtonSpacePan(event)
+  }
+
+  function shouldContinuePan(event: PointerEvent) {
+    return isMiddleButtonHeld(event) || isLeftButtonSpacePan(event)
   }
 
   return {

--- a/src/composables/maskeditor/useToolManager.ts
+++ b/src/composables/maskeditor/useToolManager.ts
@@ -11,6 +11,7 @@ import { useCanvasTools } from './useCanvasTools'
 import { useCoordinateTransform } from './useCoordinateTransform'
 import type { useKeyboard } from './useKeyboard'
 import type { usePanAndZoom } from './usePanAndZoom'
+import { isMiddleForPointerEvent } from '@/base/pointerUtils'
 import { app } from '@/scripts/app'
 
 export function useToolManager(
@@ -118,9 +119,10 @@ export function useToolManager(
       panZoom.addPenPointerId(event.pointerId)
     }
 
-    const isSpacePressed = keyboard.isKeyDown(' ')
-
-    if (event.buttons === 4 || (event.buttons === 1 && isSpacePressed)) {
+    if (
+      isMiddleForPointerEvent(event) ||
+      (event.buttons === 1 && keyboard.isKeyDown(' '))
+    ) {
       panZoom.handlePanStart(event)
 
       store.brushVisible = false
@@ -177,9 +179,10 @@ export function useToolManager(
     const newCursorPoint = { x: event.clientX, y: event.clientY }
     panZoom.updateCursorPosition(newCursorPoint)
 
-    const isSpacePressed = keyboard.isKeyDown(' ')
-
-    if (event.buttons === 4 || (event.buttons === 1 && isSpacePressed)) {
+    if (
+      isMiddleForPointerEvent(event) ||
+      (event.buttons === 1 && keyboard.isKeyDown(' '))
+    ) {
       await panZoom.handlePanMove(event)
       return
     }

--- a/src/composables/node/useNodeAnimatedImage.test.ts
+++ b/src/composables/node/useNodeAnimatedImage.test.ts
@@ -6,7 +6,9 @@ import { createMockMediaNode } from '@/renderer/extensions/vueNodes/widgets/comp
 const { canvasInteractionsMock } = vi.hoisted(() => ({
   canvasInteractionsMock: {
     handleWheel: vi.fn(),
-    handlePointer: vi.fn(),
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn(),
+    handlePointerUp: vi.fn(),
     forwardEventToCanvas: vi.fn()
   }
 }))
@@ -41,16 +43,18 @@ describe('useNodeAnimatedImage', () => {
     element.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }))
 
     expect(canvasInteractionsMock.handleWheel).toHaveBeenCalledTimes(1)
-    expect(canvasInteractionsMock.handlePointer).toHaveBeenCalledTimes(3)
+    expect(canvasInteractionsMock.handlePointerMove).toHaveBeenCalledTimes(1)
+    expect(canvasInteractionsMock.handlePointerUp).toHaveBeenCalledTimes(1)
+    expect(canvasInteractionsMock.handlePointerDown).toHaveBeenCalledTimes(1)
     expect(canvasInteractionsMock.forwardEventToCanvas).not.toHaveBeenCalled()
   })
 
-  it('routes right-click pointerdown through forwardEventToCanvas, not handlePointer', () => {
+  it('routes right-click pointerdown through forwardEventToCanvas, not handlePointerDown', () => {
     const { element } = setup()
     element.dispatchEvent(new PointerEvent('pointerdown', { button: 2 }))
 
     expect(canvasInteractionsMock.forwardEventToCanvas).toHaveBeenCalledTimes(1)
-    expect(canvasInteractionsMock.handlePointer).not.toHaveBeenCalled()
+    expect(canvasInteractionsMock.handlePointerDown).not.toHaveBeenCalled()
   })
 
   it('detaches every listener when the preview is removed', () => {
@@ -64,7 +68,9 @@ describe('useNodeAnimatedImage', () => {
     element.dispatchEvent(new PointerEvent('pointerdown', { button: 2 }))
 
     expect(canvasInteractionsMock.handleWheel).not.toHaveBeenCalled()
-    expect(canvasInteractionsMock.handlePointer).not.toHaveBeenCalled()
+    expect(canvasInteractionsMock.handlePointerMove).not.toHaveBeenCalled()
+    expect(canvasInteractionsMock.handlePointerUp).not.toHaveBeenCalled()
+    expect(canvasInteractionsMock.handlePointerDown).not.toHaveBeenCalled()
     expect(canvasInteractionsMock.forwardEventToCanvas).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/node/useNodeAnimatedImage.ts
+++ b/src/composables/node/useNodeAnimatedImage.ts
@@ -37,17 +37,23 @@ export function useNodeAnimatedImage() {
       node.overIndex = 0
 
       // Add event listeners for canvas interactions
-      const { handleWheel, handlePointer, forwardEventToCanvas } =
-        useCanvasInteractions()
+      const {
+        handleWheel,
+        handlePointerDown,
+        handlePointerMove,
+        handlePointerUp,
+        forwardEventToCanvas
+      } = useCanvasInteractions()
       node.imgs[0].style.pointerEvents = 'none'
       const controller = new AbortController()
       const { signal } = controller
       element.addEventListener('wheel', handleWheel, { signal })
-      element.addEventListener('pointermove', handlePointer, { signal })
-      element.addEventListener('pointerup', handlePointer, { signal })
+      element.addEventListener('pointermove', handlePointerMove, { signal })
+      element.addEventListener('pointerup', handlePointerUp, { signal })
       element.addEventListener(
         'pointerdown',
-        (e) => (e.button !== 2 ? handlePointer(e) : forwardEventToCanvas(e)),
+        (e) =>
+          e.button !== 2 ? handlePointerDown(e) : forwardEventToCanvas(e),
         { capture: true, signal }
       )
 

--- a/src/composables/node/useNodeImage.test.ts
+++ b/src/composables/node/useNodeImage.test.ts
@@ -6,7 +6,8 @@ import { createMockMediaNode } from '@/renderer/extensions/vueNodes/widgets/comp
 const { canvasInteractionsMock, nodeOutputStoreMock } = vi.hoisted(() => ({
   canvasInteractionsMock: {
     handleWheel: vi.fn(),
-    handlePointer: vi.fn()
+    handlePointerDown: vi.fn(),
+    handlePointerMove: vi.fn()
   },
   nodeOutputStoreMock: {
     getNodeImageUrls: vi.fn<(node: unknown) => string[] | undefined>()
@@ -75,7 +76,8 @@ describe('useNodeVideo', () => {
     video.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
 
     expect(canvasInteractionsMock.handleWheel).toHaveBeenCalledTimes(1)
-    expect(canvasInteractionsMock.handlePointer).toHaveBeenCalledTimes(2)
+    expect(canvasInteractionsMock.handlePointerMove).toHaveBeenCalledTimes(1)
+    expect(canvasInteractionsMock.handlePointerDown).toHaveBeenCalledTimes(1)
   })
 
   it('detaches every listener when the widget is removed', async () => {
@@ -88,6 +90,7 @@ describe('useNodeVideo', () => {
     video.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
 
     expect(canvasInteractionsMock.handleWheel).not.toHaveBeenCalled()
-    expect(canvasInteractionsMock.handlePointer).not.toHaveBeenCalled()
+    expect(canvasInteractionsMock.handlePointerMove).not.toHaveBeenCalled()
+    expect(canvasInteractionsMock.handlePointerDown).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/node/useNodeImage.ts
+++ b/src/composables/node/useNodeImage.ts
@@ -133,7 +133,8 @@ export const useNodeVideo = (node: LGraphNode, callback?: () => void) => {
   let minHeight = DEFAULT_VIDEO_SIZE
   let minWidth = DEFAULT_VIDEO_SIZE
 
-  const { handleWheel, handlePointer } = useCanvasInteractions()
+  const { handleWheel, handlePointerDown, handlePointerMove } =
+    useCanvasInteractions()
 
   const setMinDimensions = (video: HTMLVideoElement) => {
     const { minHeight: calculatedHeight, minWidth: calculatedWidth } =
@@ -176,8 +177,8 @@ export const useNodeVideo = (node: LGraphNode, callback?: () => void) => {
       const controller = new AbortController()
       const { signal } = controller
       container.addEventListener('wheel', handleWheel, { signal })
-      container.addEventListener('pointermove', handlePointer, { signal })
-      container.addEventListener('pointerdown', handlePointer, { signal })
+      container.addEventListener('pointermove', handlePointerMove, { signal })
+      container.addEventListener('pointerdown', handlePointerDown, { signal })
 
       widget.onRemove = useChainCallback(widget.onRemove, () => {
         controller.abort()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1,6 +1,7 @@
 import { toString } from 'es-toolkit/compat'
 import { toValue } from 'vue'
 
+import { isMiddleButtonEvent, isMiddlePointerInput } from '@/base/pointerUtils'
 import { MovingInputLink } from '@/lib/litegraph/src/canvas/MovingInputLink'
 import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
 import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
@@ -1987,7 +1988,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
   /** Prevents default for middle-click auxclick only. */
   _preventMiddleAuxClick(e: MouseEvent): void {
-    if (e.button === 1) e.preventDefault()
+    if (isMiddleButtonEvent(e)) e.preventDefault()
   }
 
   /** Captures an event and prevents default - returns true. */
@@ -2313,7 +2314,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     // left button mouse / single finger
     if (e.button === 0 && !pointer.isDouble) {
       this._processPrimaryButton(e, node)
-    } else if (e.button === 1) {
+    } else if (isMiddlePointerInput(e)) {
       this._processMiddleButton(e, node)
     } else if (
       (e.button === 2 || pointer.isDouble) &&
@@ -3864,7 +3865,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           this
         )
       }
-    } else if (e.button === 1) {
+    } else if (isMiddleButtonEvent(e)) {
       // middle button
       this.dirty_canvas = true
       this.dragging_canvas = false

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -1,7 +1,7 @@
 import { toString } from 'es-toolkit/compat'
 import { toValue } from 'vue'
 
-import { isMiddleButtonEvent, isMiddlePointerInput } from '@/base/pointerUtils'
+import { isMiddleButtonEvent } from '@/base/pointerUtils'
 import { MovingInputLink } from '@/lib/litegraph/src/canvas/MovingInputLink'
 import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
 import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
@@ -2314,7 +2314,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     // left button mouse / single finger
     if (e.button === 0 && !pointer.isDouble) {
       this._processPrimaryButton(e, node)
-    } else if (isMiddlePointerInput(e)) {
+    } else if (isMiddleButtonEvent(e)) {
       this._processMiddleButton(e, node)
     } else if (
       (e.button === 2 || pointer.isDouble) &&

--- a/src/lib/litegraph/src/canvas/InputIndicators.ts
+++ b/src/lib/litegraph/src/canvas/InputIndicators.ts
@@ -1,3 +1,4 @@
+import { isMiddleButtonHeld } from '@/base/pointerUtils'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 
 /**
@@ -71,7 +72,7 @@ export class InputIndicators implements Disposable {
   private _onPointerDownOrMove = this.onPointerDownOrMove.bind(this)
   onPointerDownOrMove(e: MouseEvent): void {
     this.mouse0Down = (e.buttons & 1) === 1
-    this.mouse1Down = (e.buttons & 4) === 4
+    this.mouse1Down = isMiddleButtonHeld(e)
     this.mouse2Down = (e.buttons & 2) === 2
 
     this.x = e.clientX

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -4,6 +4,7 @@ import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
+import { app } from '@/scripts/app'
 
 // Mock stores
 vi.mock('@/renderer/core/canvas/canvasStore', () => {
@@ -87,17 +88,24 @@ describe('useCanvasInteractions', () => {
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
     })
 
-    it('should forward middle mouse button events to canvas', () => {
+    it('should forward middle pointerdown events to canvas', () => {
       const { getCanvas } = useCanvasStore()
       const mockCanvas = createMockLGraphCanvas(false)
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
       const { handlePointer } = useCanvasInteractions()
 
-      const mockEvent = createMockPointerEvent({ buttons: 4 })
+      const mockEvent = createMockPointerEvent({
+        type: 'pointerdown',
+        button: 1,
+        buttons: 4
+      })
       handlePointer(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
+      expect(app.canvas.canvas.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'pointerdown' })
+      )
     })
 
     it('should forward chorded middle-button drags to canvas', () => {
@@ -111,6 +119,9 @@ describe('useCanvasInteractions', () => {
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
+      expect(app.canvas.canvas.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'pointermove' })
+      )
     })
 
     it('should not prevent default when canvas is not in read_only mode and not middle button', () => {

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -73,16 +73,16 @@ describe('useCanvasInteractions', () => {
     vi.resetAllMocks()
   })
 
-  describe('handlePointer', () => {
+  describe('pointer handlers', () => {
     it('should intercept left mouse events when canvas is read_only to enable space+drag navigation', () => {
       const { getCanvas } = useCanvasStore()
       const mockCanvas = createMockLGraphCanvas(true)
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
 
-      const { handlePointer } = useCanvasInteractions()
+      const { handlePointerMove } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent({ buttons: 1 })
-      handlePointer(mockEvent)
+      handlePointerMove(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
@@ -92,14 +92,14 @@ describe('useCanvasInteractions', () => {
       const { getCanvas } = useCanvasStore()
       const mockCanvas = createMockLGraphCanvas(false)
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
-      const { handlePointer } = useCanvasInteractions()
+      const { handlePointerDown } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent({
         type: 'pointerdown',
         button: 1,
         buttons: 4
       })
-      handlePointer(mockEvent)
+      handlePointerDown(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
@@ -112,10 +112,10 @@ describe('useCanvasInteractions', () => {
       const { getCanvas } = useCanvasStore()
       const mockCanvas = createMockLGraphCanvas(false)
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
-      const { handlePointer } = useCanvasInteractions()
+      const { handlePointerMove } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent({ buttons: 5 })
-      handlePointer(mockEvent)
+      handlePointerMove(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
       expect(mockEvent.stopPropagation).toHaveBeenCalled()
@@ -128,10 +128,10 @@ describe('useCanvasInteractions', () => {
       const { getCanvas } = useCanvasStore()
       const mockCanvas = createMockLGraphCanvas(false)
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
-      const { handlePointer } = useCanvasInteractions()
+      const { handlePointerMove } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent({ buttons: 1 })
-      handlePointer(mockEvent)
+      handlePointerMove(mockEvent)
 
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
       expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
@@ -140,10 +140,10 @@ describe('useCanvasInteractions', () => {
     it('should return early when canvas is null', () => {
       const { getCanvas } = useCanvasStore()
       vi.mocked(getCanvas).mockReturnValue(null!)
-      const { handlePointer } = useCanvasInteractions()
+      const { handlePointerMove } = useCanvasInteractions()
 
       const mockEvent = createMockPointerEvent({ buttons: 1 })
-      handlePointer(mockEvent)
+      handlePointerMove(mockEvent)
 
       expect(getCanvas).toHaveBeenCalled()
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()

--- a/src/renderer/core/canvas/useCanvasInteractions.test.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.test.ts
@@ -35,15 +35,19 @@ function createMockLGraphCanvas(read_only = true): LGraphCanvas {
   return mockCanvas as LGraphCanvas
 }
 
-function createMockPointerEvent(
-  buttons: PointerEvent['buttons'] = 1
-): PointerEvent {
-  const mockEvent: Partial<PointerEvent> = {
-    buttons,
-    preventDefault: vi.fn(),
-    stopPropagation: vi.fn()
-  }
-  return mockEvent as PointerEvent
+function createMockPointerEvent({
+  type = 'pointermove',
+  button = 0,
+  buttons = 1
+}: {
+  type?: string
+  button?: PointerEvent['button']
+  buttons?: PointerEvent['buttons']
+} = {}): PointerEvent {
+  const event = new PointerEvent(type, { button, buttons })
+  vi.spyOn(event, 'preventDefault')
+  vi.spyOn(event, 'stopPropagation')
+  return event
 }
 
 function createMockWheelEvent(
@@ -76,7 +80,7 @@ describe('useCanvasInteractions', () => {
 
       const { handlePointer } = useCanvasInteractions()
 
-      const mockEvent = createMockPointerEvent(1) // Left Mouse Button
+      const mockEvent = createMockPointerEvent({ buttons: 1 })
       handlePointer(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -89,7 +93,20 @@ describe('useCanvasInteractions', () => {
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
       const { handlePointer } = useCanvasInteractions()
 
-      const mockEvent = createMockPointerEvent(4) // Middle mouse button
+      const mockEvent = createMockPointerEvent({ buttons: 4 })
+      handlePointer(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockEvent.stopPropagation).toHaveBeenCalled()
+    })
+
+    it('should forward chorded middle-button drags to canvas', () => {
+      const { getCanvas } = useCanvasStore()
+      const mockCanvas = createMockLGraphCanvas(false)
+      vi.mocked(getCanvas).mockReturnValue(mockCanvas)
+      const { handlePointer } = useCanvasInteractions()
+
+      const mockEvent = createMockPointerEvent({ buttons: 5 })
       handlePointer(mockEvent)
 
       expect(mockEvent.preventDefault).toHaveBeenCalled()
@@ -102,7 +119,7 @@ describe('useCanvasInteractions', () => {
       vi.mocked(getCanvas).mockReturnValue(mockCanvas)
       const { handlePointer } = useCanvasInteractions()
 
-      const mockEvent = createMockPointerEvent(1)
+      const mockEvent = createMockPointerEvent({ buttons: 1 })
       handlePointer(mockEvent)
 
       expect(mockEvent.preventDefault).not.toHaveBeenCalled()
@@ -114,7 +131,7 @@ describe('useCanvasInteractions', () => {
       vi.mocked(getCanvas).mockReturnValue(null!)
       const { handlePointer } = useCanvasInteractions()
 
-      const mockEvent = createMockPointerEvent(1)
+      const mockEvent = createMockPointerEvent({ buttons: 1 })
       handlePointer(mockEvent)
 
       expect(getCanvas).toHaveBeenCalled()

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -1,6 +1,10 @@
 import { computed } from 'vue'
 
-import { isMiddleForPointerEvent } from '@/base/pointerUtils'
+import {
+  isMiddleButtonEvent,
+  isMiddleButtonHeld,
+  isMiddlePointerInput
+} from '@/base/pointerUtils'
 import { isCanvasGestureWheel } from '@/base/wheelGestures'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -76,12 +80,19 @@ export function useCanvasInteractions() {
    * Handles pointer events from media elements that should potentially
    * be forwarded to canvas (e.g., space+drag for panning)
    */
-  const handlePointer = (event: PointerEvent) => {
-    if (isMiddleForPointerEvent(event)) {
+  const forwardMiddlePointerIfNeeded = (
+    event: PointerEvent,
+    isMiddleInput: (event: PointerEvent) => boolean
+  ) => {
+    if (isMiddleInput(event)) {
       forwardEventToCanvas(event)
-      return
+      return true
     }
 
+    return false
+  }
+
+  const handleLeftButtonReadOnlyPointer = (event: PointerEvent) => {
     // Check if canvas exists using established pattern
     const canvas = getCanvas()
     if (!canvas) return
@@ -91,6 +102,21 @@ export function useCanvasInteractions() {
       event.stopPropagation()
       forwardEventToCanvas(event)
     }
+  }
+
+  const handlePointerDown = (event: PointerEvent) => {
+    if (forwardMiddlePointerIfNeeded(event, isMiddlePointerInput)) return
+    handleLeftButtonReadOnlyPointer(event)
+  }
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (forwardMiddlePointerIfNeeded(event, isMiddleButtonHeld)) return
+    handleLeftButtonReadOnlyPointer(event)
+  }
+
+  const handlePointerUp = (event: PointerEvent) => {
+    if (forwardMiddlePointerIfNeeded(event, isMiddleButtonEvent)) return
+    handleLeftButtonReadOnlyPointer(event)
   }
 
   /**
@@ -134,7 +160,9 @@ export function useCanvasInteractions() {
 
   return {
     handleWheel,
-    handlePointer,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
     forwardEventToCanvas,
     shouldHandleNodePointerEvents
   }

--- a/src/renderer/core/canvas/useCanvasInteractions.ts
+++ b/src/renderer/core/canvas/useCanvasInteractions.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 
-import { isMiddlePointerInput } from '@/base/pointerUtils'
+import { isMiddleForPointerEvent } from '@/base/pointerUtils'
 import { isCanvasGestureWheel } from '@/base/wheelGestures'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -77,7 +77,7 @@ export function useCanvasInteractions() {
    * be forwarded to canvas (e.g., space+drag for panning)
    */
   const handlePointer = (event: PointerEvent) => {
-    if (isMiddlePointerInput(event)) {
+    if (isMiddleForPointerEvent(event)) {
       forwardEventToCanvas(event)
       return
     }
@@ -86,15 +86,10 @@ export function useCanvasInteractions() {
     const canvas = getCanvas()
     if (!canvas) return
 
-    // Check conditions for forwarding events to canvas
-    const isSpacePanningDrag = canvas.read_only && event.buttons === 1 // Space key pressed + left mouse drag
-    const isMiddleMousePanning = event.buttons === 4 // Middle mouse button for panning
-
-    if (isSpacePanningDrag || isMiddleMousePanning) {
+    if (canvas.read_only && event.buttons === 1) {
       event.preventDefault()
       event.stopPropagation()
       forwardEventToCanvas(event)
-      return
     }
   }
 

--- a/src/renderer/core/layout/transform/useTransformSettling.ts
+++ b/src/renderer/core/layout/transform/useTransformSettling.ts
@@ -2,6 +2,8 @@ import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { ref } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
+import { isMiddlePointerInput } from '@/base/pointerUtils'
+
 interface TransformSettlingOptions {
   /**
    * Delay in ms before transform is considered "settled" after last interaction
@@ -85,7 +87,7 @@ function usePointerDrag(
     'pointerdown',
     (e: PointerEvent) => {
       // Only primary (0) and middle (1) buttons trigger canvas pan.
-      if (e.button === 0 || e.button === 1) pointerCount.value++
+      if (e.button === 0 || isMiddlePointerInput(e)) pointerCount.value++
     },
     eventOptions
   )

--- a/src/renderer/core/layout/transform/useTransformSettling.ts
+++ b/src/renderer/core/layout/transform/useTransformSettling.ts
@@ -2,7 +2,7 @@ import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { ref } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
-import { isMiddlePointerInput } from '@/base/pointerUtils'
+import { isMiddleButtonEvent } from '@/base/pointerUtils'
 
 interface TransformSettlingOptions {
   /**
@@ -87,7 +87,7 @@ function usePointerDrag(
     'pointerdown',
     (e: PointerEvent) => {
       // Only primary (0) and middle (1) buttons trigger canvas pan.
-      if (e.button === 0 || isMiddlePointerInput(e)) pointerCount.value++
+      if (e.button === 0 || isMiddleButtonEvent(e)) pointerCount.value++
     },
     eventOptions
   )

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -1,7 +1,7 @@
 import { onScopeDispose, toValue } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
-import { isMiddlePointerInput } from '@/base/pointerUtils'
+import { isMiddleForPointerEvent } from '@/base/pointerUtils'
 import { useClickDragGuard } from '@/composables/useClickDragGuard'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
@@ -22,7 +22,7 @@ export function useNodePointerInteractions(
   const { nodeManager } = useVueNodeLifecycle()
 
   const forwardMiddlePointerIfNeeded = (event: PointerEvent) => {
-    if (!isMiddlePointerInput(event)) return false
+    if (!isMiddleForPointerEvent(event)) return false
     forwardEventToCanvas(event)
     return true
   }

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -1,7 +1,11 @@
 import { onScopeDispose, toValue } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 
-import { isMiddleForPointerEvent } from '@/base/pointerUtils'
+import {
+  isMiddleButtonEvent,
+  isMiddleButtonHeld,
+  isMiddlePointerInput
+} from '@/base/pointerUtils'
 import { useClickDragGuard } from '@/composables/useClickDragGuard'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
@@ -21,8 +25,11 @@ export function useNodePointerInteractions(
     useNodeEventHandlers()
   const { nodeManager } = useVueNodeLifecycle()
 
-  const forwardMiddlePointerIfNeeded = (event: PointerEvent) => {
-    if (!isMiddleForPointerEvent(event)) return false
+  const forwardMiddlePointerIfNeeded = (
+    event: PointerEvent,
+    isMiddleInput: (event: PointerEvent) => boolean
+  ) => {
+    if (!isMiddleInput(event)) return false
     forwardEventToCanvas(event)
     return true
   }
@@ -32,7 +39,7 @@ export function useNodePointerInteractions(
   const dragGuard = useClickDragGuard(3)
 
   function onPointerdown(event: PointerEvent) {
-    if (forwardMiddlePointerIfNeeded(event)) return
+    if (forwardMiddlePointerIfNeeded(event, isMiddlePointerInput)) return
 
     // Only start drag on left-click (button 0)
     if (event.button !== 0) return
@@ -62,7 +69,7 @@ export function useNodePointerInteractions(
   }
 
   function onPointermove(event: PointerEvent) {
-    if (forwardMiddlePointerIfNeeded(event)) return
+    if (forwardMiddlePointerIfNeeded(event, isMiddleButtonHeld)) return
 
     // Don't activate drag while resizing
     if (layoutStore.isResizingVueNodes.value) return
@@ -120,7 +127,7 @@ export function useNodePointerInteractions(
   }
 
   function onPointerup(event: PointerEvent) {
-    if (forwardMiddlePointerIfNeeded(event)) return
+    if (forwardMiddlePointerIfNeeded(event, isMiddleButtonEvent)) return
     // Don't handle pointer events when canvas is in panning mode - forward to canvas instead
     const canHandlePointer = shouldHandleNodePointerEvents.value
     if (!canHandlePointer) {

--- a/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.ts
@@ -10,6 +10,7 @@ import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import { resolveNodeRootGraphId } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { forwardMiddleButtonToCanvas } from '@/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
 import type { ComfyWidgetConstructorV2 } from '@/scripts/widgets'
@@ -105,29 +106,7 @@ function addMarkdownWidget(
     signal
   })
 
-  inputEl.addEventListener(
-    'pointerdown',
-    (event) => {
-      if (event.button === 1) app.canvas.processMouseDown(event)
-    },
-    { signal }
-  )
-
-  inputEl.addEventListener(
-    'pointermove',
-    (event) => {
-      if ((event.buttons & 4) === 4) app.canvas.processMouseMove(event)
-    },
-    { signal }
-  )
-
-  inputEl.addEventListener(
-    'pointerup',
-    (event) => {
-      if (event.button === 1) app.canvas.processMouseUp(event)
-    },
-    { signal }
-  )
+  forwardMiddleButtonToCanvas(inputEl, signal)
 
   widget.onRemove = useChainCallback(widget.onRemove, () => {
     controller.abort()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -3,6 +3,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { resolveNodeRootGraphId } from '@/lib/litegraph/src/litegraph'
 import { defineDeprecatedProperty } from '@/lib/litegraph/src/utils/feedback'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { forwardMiddleButtonToCanvas } from '@/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas'
 import { isStringInputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
 import { app } from '@/scripts/app'
@@ -66,30 +67,7 @@ function addMultilineWidget(
     { signal }
   )
 
-  // Allow middle mouse button panning
-  inputEl.addEventListener(
-    'pointerdown',
-    (event: PointerEvent) => {
-      if (event.button === 1) app.canvas.processMouseDown(event)
-    },
-    { signal }
-  )
-
-  inputEl.addEventListener(
-    'pointermove',
-    (event: PointerEvent) => {
-      if ((event.buttons & 4) === 4) app.canvas.processMouseMove(event)
-    },
-    { signal }
-  )
-
-  inputEl.addEventListener(
-    'pointerup',
-    (event: PointerEvent) => {
-      if (event.button === 1) app.canvas.processMouseUp(event)
-    },
-    { signal }
-  )
+  forwardMiddleButtonToCanvas(inputEl, signal)
 
   inputEl.addEventListener(
     'wheel',

--- a/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.test.ts
@@ -42,16 +42,4 @@ describe('forwardMiddleButtonToCanvas', () => {
     expect(processMouseMove).toHaveBeenCalledTimes(1)
     expect(processMouseUp).toHaveBeenCalledTimes(1)
   })
-
-  it('detaches listeners through the provided signal', () => {
-    controller.abort()
-
-    inputEl.dispatchEvent(new PointerEvent('pointerdown', { button: 1 }))
-    inputEl.dispatchEvent(new PointerEvent('pointermove', { buttons: 4 }))
-    inputEl.dispatchEvent(new PointerEvent('pointerup', { button: 1 }))
-
-    expect(processMouseDown).not.toHaveBeenCalled()
-    expect(processMouseMove).not.toHaveBeenCalled()
-    expect(processMouseUp).not.toHaveBeenCalled()
-  })
 })

--- a/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { forwardMiddleButtonToCanvas } from '@/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas'
+
+const { processMouseDown, processMouseMove, processMouseUp } = vi.hoisted(
+  () => ({
+    processMouseDown: vi.fn(),
+    processMouseMove: vi.fn(),
+    processMouseUp: vi.fn()
+  })
+)
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: {
+      processMouseDown,
+      processMouseMove,
+      processMouseUp
+    }
+  }
+}))
+
+describe('forwardMiddleButtonToCanvas', () => {
+  let inputEl: HTMLElement
+  let controller: AbortController
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    inputEl = document.createElement('div')
+    controller = new AbortController()
+    forwardMiddleButtonToCanvas(inputEl, controller.signal)
+  })
+
+  it('uses event-specific middle-button semantics', () => {
+    inputEl.dispatchEvent(
+      new PointerEvent('pointerdown', { button: 0, buttons: 5 })
+    )
+    inputEl.dispatchEvent(new PointerEvent('pointermove', { buttons: 5 }))
+    inputEl.dispatchEvent(new PointerEvent('pointerup', { button: 1 }))
+
+    expect(processMouseDown).not.toHaveBeenCalled()
+    expect(processMouseMove).toHaveBeenCalledTimes(1)
+    expect(processMouseUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('detaches listeners through the provided signal', () => {
+    controller.abort()
+
+    inputEl.dispatchEvent(new PointerEvent('pointerdown', { button: 1 }))
+    inputEl.dispatchEvent(new PointerEvent('pointermove', { buttons: 4 }))
+    inputEl.dispatchEvent(new PointerEvent('pointerup', { button: 1 }))
+
+    expect(processMouseDown).not.toHaveBeenCalled()
+    expect(processMouseMove).not.toHaveBeenCalled()
+    expect(processMouseUp).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.ts
@@ -1,0 +1,33 @@
+import { isMiddleForPointerEvent } from '@/base/pointerUtils'
+import { app } from '@/scripts/app'
+
+export function forwardMiddleButtonToCanvas(
+  inputEl: HTMLElement,
+  signal?: AbortSignal
+): void {
+  const options = signal ? { signal } : undefined
+
+  inputEl.addEventListener(
+    'pointerdown',
+    (event: PointerEvent) => {
+      if (isMiddleForPointerEvent(event)) app.canvas.processMouseDown(event)
+    },
+    options
+  )
+
+  inputEl.addEventListener(
+    'pointermove',
+    (event: PointerEvent) => {
+      if (isMiddleForPointerEvent(event)) app.canvas.processMouseMove(event)
+    },
+    options
+  )
+
+  inputEl.addEventListener(
+    'pointerup',
+    (event: PointerEvent) => {
+      if (isMiddleForPointerEvent(event)) app.canvas.processMouseUp(event)
+    },
+    options
+  )
+}

--- a/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.ts
@@ -1,33 +1,35 @@
-import { isMiddleForPointerEvent } from '@/base/pointerUtils'
+import {
+  isMiddleButtonEvent,
+  isMiddleButtonHeld,
+  isMiddlePointerInput
+} from '@/base/pointerUtils'
 import { app } from '@/scripts/app'
 
 export function forwardMiddleButtonToCanvas(
   inputEl: HTMLElement,
-  signal?: AbortSignal
+  signal: AbortSignal
 ): void {
-  const options = signal ? { signal } : undefined
-
   inputEl.addEventListener(
     'pointerdown',
-    (event: PointerEvent) => {
-      if (isMiddleForPointerEvent(event)) app.canvas.processMouseDown(event)
+    (event) => {
+      if (isMiddlePointerInput(event)) app.canvas.processMouseDown(event)
     },
-    options
+    { signal }
   )
 
   inputEl.addEventListener(
     'pointermove',
-    (event: PointerEvent) => {
-      if (isMiddleForPointerEvent(event)) app.canvas.processMouseMove(event)
+    (event) => {
+      if (isMiddleButtonHeld(event)) app.canvas.processMouseMove(event)
     },
-    options
+    { signal }
   )
 
   inputEl.addEventListener(
     'pointerup',
-    (event: PointerEvent) => {
-      if (isMiddleForPointerEvent(event)) app.canvas.processMouseUp(event)
+    (event) => {
+      if (isMiddleButtonEvent(event)) app.canvas.processMouseUp(event)
     },
-    options
+    { signal }
   )
 }


### PR DESCRIPTION
## Summary

Refactors middle mouse button pan handling around the intent of #11409, dropping the outdated implementation details from that PR and aligning the core behavior with the current main branch.

## Changes

- **What**: Centralized phase-specific middle mouse button handling in `src/base/pointerUtils.ts`, added a shared Vue widget forwarding helper, and updated canvas, LiteGraph, Vue node, and mask editor call sites to use the same semantics.
- **Breaking**: None expected. This keeps existing middle-click pan behavior while making pointerdown, pointermove, pointerup, and auxclick checks explicit for their event phases.
- **Dependencies**: None.

## Review Focus

This PR is intentionally narrower than #11409. That PR had the right goal, but its implementation became outdated against main: mask editor tests now have helper coverage on main, Vue node/widget code has shifted, and a blanket replacement with `isMiddlePointerInput` would lose the bitmask behavior needed during pointermove drags.

The core difference is that this PR preserves the useful part of #11409, namely removing scattered ad-hoc MMB checks, while avoiding stale changes that no longer fit the current codebase.

Key behavior changes:

- `isMiddlePointerInput` is the conservative pointerdown-style check: changed middle button or strict middle-only `buttons === 4`.
- `isMiddleButtonHeld` handles pointermove-style held-button bitmasks so chorded drags with the middle button still pan.
- `isMiddleButtonEvent` handles pointerup/auxclick-style changed-button events.
- Call sites now choose the phase-specific helper directly instead of routing through an event-type dispatcher.
- String and markdown widgets now share `forwardMiddleButtonToCanvas(...)` instead of duplicating three pointer listeners each.
- The widget helper intentionally keeps the existing `app.canvas.processMouseDown/Move/Up` forwarding route and only centralizes the duplicated listener logic.
- Mask editor pan handling, Vue node pointer forwarding, graph canvas pan forwarding, LiteGraph middle-click checks, input indicators, and transform settling now use the centralized helpers.

Coverage added or updated:

- Unit coverage for middle-button helper semantics, including chorded pointermove drags and pointercancel held-bit behavior.
- Unit coverage for widget forwarding helper down/move/up routing.
- Regression coverage for canvas, mask editor, Vue node media preview, and transform-settling pointer handling.
- Browser coverage for middle-click drag panning on a Vue node, a multiline string widget, and the mask editor canvas.

Validation run:

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit src/base/pointerUtils.test.ts src/renderer/extensions/vueNodes/widgets/utils/forwardMiddleButtonToCanvas.test.ts src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts src/renderer/extensions/vueNodes/widgets/composables/useMarkdownWidget.test.ts src/renderer/core/canvas/useCanvasInteractions.test.ts src/composables/maskeditor/useToolManager.test.ts src/renderer/core/layout/transform/useTransformSettling.test.ts src/composables/node/useNodeImage.test.ts src/composables/node/useNodeAnimatedImage.test.ts src/components/graph/SelectionToolbox.test.ts src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts`
- `pnpm typecheck:browser`
- `pnpm test:browser:local browser_tests/tests/vueNodes/interactions/canvas/pan.spec.ts browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts browser_tests/tests/maskEditor.spec.ts --project chromium --grep "Middle-click drag"`
- Commit hook: staged file format/lint, `pnpm typecheck`

## Screenshots (if applicable)

Not applicable; this is interaction behavior covered by unit and browser tests.