### PR TITLE
feat: output model_info from Load3D node

### DIFF
--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -192,6 +192,7 @@ describe('useLoad3d', () => {
         rotation: { x: 0, y: 0, z: 0 },
         scale: { x: 1, y: 1, z: 1 }
       }),
+      getModelInfo: vi.fn().mockReturnValue(null),
       captureThumbnail: vi.fn().mockResolvedValue('data:image/png;base64,test'),
       setAnimationTime: vi.fn(),
       renderer: {
@@ -1352,6 +1353,46 @@ describe('useLoad3d', () => {
       })
       expect(composable.modelConfig.value.gizmo!.enabled).toBe(true)
       expect(composable.modelConfig.value.gizmo!.mode).toBe('rotate')
+    })
+
+    it('gizmoTransformChange mirrors the live scene into Scene Config models', async () => {
+      const modelTransform = {
+        uuid: 'abc',
+        name: 'mesh',
+        type: 'Mesh',
+        position: { x: 5, y: 6, z: 7 },
+        rotation: { x: 0.5, y: 0.6, z: 0.7, order: 'XYZ' },
+        quaternion: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 3, y: 3, z: 3 },
+        up: { x: 0, y: 1, z: 0 },
+        visible: true,
+        matrix: new Array(16).fill(0)
+      }
+      vi.mocked(mockLoad3d.getModelInfo!).mockReturnValue(modelTransform)
+
+      const composable = useLoad3d(mockNode)
+      const containerRef = document.createElement('div')
+      await composable.initializeLoad3d(containerRef)
+
+      const addEventCalls = vi.mocked(mockLoad3d.addEventListener!).mock.calls
+      const handler = addEventCalls.find(
+        ([event]) => event === 'gizmoTransformChange'
+      )![1] as (data: unknown) => void
+
+      handler({
+        position: { x: 5, y: 6, z: 7 },
+        rotation: { x: 0.5, y: 0.6, z: 0.7 },
+        scale: { x: 3, y: 3, z: 3 },
+        enabled: true,
+        mode: 'rotate'
+      })
+      await nextTick()
+
+      expect(composable.sceneConfig.value.models).toEqual([modelTransform])
+      const savedScene = mockNode.properties['Scene Config'] as {
+        models: unknown[]
+      }
+      expect(savedScene.models).toEqual([modelTransform])
     })
 
     it('should reset gizmo config on model switch (not first load)', async () => {

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -789,6 +789,11 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     }
   }
 
+  const syncSceneModels = () => {
+    const modelInfo = load3d?.getModelInfo()
+    sceneConfig.value.models = modelInfo ? [modelInfo] : []
+  }
+
   const eventConfig = {
     materialModeChange: (value: string) => {
       modelConfig.value.materialMode = value as MaterialMode
@@ -860,6 +865,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       ]
       hasSkeleton.value = load3d?.hasSkeleton() ?? false
       applyGizmoConfigToLoad3d()
+      syncSceneModels()
       isFirstModelLoad = false
     },
     modelReady: () => {
@@ -936,6 +942,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
         modelConfig.value.gizmo.enabled = data.enabled
         modelConfig.value.gizmo.mode = data.mode
       }
+      syncSceneModels()
     }
   } as const
 
@@ -961,6 +968,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     const transform = load3d.getGizmoTransform()
     modelConfig.value.gizmo.position = transform.position
     modelConfig.value.gizmo.scale = transform.scale
+    syncSceneModels()
   }
 
   const handleResetGizmoTransform = () => {

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -6,7 +6,8 @@ import { nodeToLoad3dMap, useLoad3d } from '@/composables/useLoad3d'
 import { createExportMenuItems } from '@/extensions/core/load3d/exportMenuHelper'
 import type {
   CameraConfig,
-  CameraState
+  CameraState,
+  ModelInfo
 } from '@/extensions/core/load3d/interfaces'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
 import {
@@ -402,6 +403,9 @@ useExtensionService().registerExtension({
 
           currentLoad3d.handleResize()
 
+          const modelInfo = currentLoad3d.getModelInfo()
+          const model_info: ModelInfo = modelInfo ? [modelInfo] : []
+
           const returnVal = {
             image: `threed/${data.name} [temp]`,
             mask: `threed/${dataMask.name} [temp]`,
@@ -409,7 +413,8 @@ useExtensionService().registerExtension({
             camera_info:
               (node.properties['Camera Config'] as CameraConfig | undefined)
                 ?.state || null,
-            recording: ''
+            recording: '',
+            model_info
           }
 
           const recordingData = currentLoad3d.getRecordingData()

--- a/src/extensions/core/load3d/GizmoManager.test.ts
+++ b/src/extensions/core/load3d/GizmoManager.test.ts
@@ -314,6 +314,38 @@ describe('GizmoManager', () => {
     })
   })
 
+  describe('getModelInfo', () => {
+    it('returns the full transform payload for the target object', () => {
+      manager.init()
+      const model = new THREE.Object3D()
+      model.name = 'my-model'
+      model.position.set(1, 2, 3)
+      model.rotation.set(0.1, 0.2, 0.3)
+      model.scale.set(4, 5, 6)
+      manager.setupForModel(model)
+
+      const info = manager.getModelInfo()
+
+      expect(info).not.toBeNull()
+      expect(info!.uuid).toBe(model.uuid)
+      expect(info!.name).toBe('my-model')
+      expect(info!.type).toBe('Object3D')
+      expect(info!.position).toEqual({ x: 1, y: 2, z: 3 })
+      expect(info!.rotation.x).toBeCloseTo(0.1)
+      expect(info!.rotation.order).toBe(model.rotation.order)
+      expect(info!.quaternion.w).toBeCloseTo(model.quaternion.w)
+      expect(info!.scale).toEqual({ x: 4, y: 5, z: 6 })
+      expect(info!.up).toEqual({ x: 0, y: 1, z: 0 })
+      expect(info!.visible).toBe(true)
+      expect(info!.matrix).toHaveLength(16)
+    })
+
+    it('returns null when there is no target', () => {
+      manager.init()
+      expect(manager.getModelInfo()).toBeNull()
+    })
+  })
+
   describe('removeFromScene / ensureHelperInScene', () => {
     it('removes helper from scene', () => {
       manager.init()

--- a/src/extensions/core/load3d/GizmoManager.ts
+++ b/src/extensions/core/load3d/GizmoManager.ts
@@ -3,7 +3,7 @@ import { TransformControls } from 'three/examples/jsm/controls/TransformControls
 
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
-import type { GizmoMode } from './interfaces'
+import type { GizmoMode, ModelTransform } from './interfaces'
 
 export class GizmoManager {
   private transformControls: TransformControls | null = null
@@ -212,6 +212,48 @@ export class GizmoManager {
         y: this.targetObject.scale.y,
         z: this.targetObject.scale.z
       }
+    }
+  }
+
+  getModelInfo(): ModelTransform | null {
+    const object = this.targetObject
+    if (!object) return null
+
+    object.updateMatrix()
+
+    return {
+      uuid: object.uuid,
+      name: object.name,
+      type: object.type,
+      position: {
+        x: object.position.x,
+        y: object.position.y,
+        z: object.position.z
+      },
+      rotation: {
+        x: object.rotation.x,
+        y: object.rotation.y,
+        z: object.rotation.z,
+        order: object.rotation.order
+      },
+      quaternion: {
+        x: object.quaternion.x,
+        y: object.quaternion.y,
+        z: object.quaternion.z,
+        w: object.quaternion.w
+      },
+      scale: {
+        x: object.scale.x,
+        y: object.scale.y,
+        z: object.scale.z
+      },
+      up: {
+        x: object.up.x,
+        y: object.up.y,
+        z: object.up.z
+      },
+      visible: object.visible,
+      matrix: object.matrix.toArray()
     }
   }
 

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -25,6 +25,7 @@ import type {
   Load3DOptions,
   LoadModelOptions,
   MaterialMode,
+  ModelTransform,
   UpDirection
 } from './interfaces'
 import { attachContextMenuGuard } from './load3dContextMenuGuard'
@@ -912,6 +913,10 @@ class Load3d {
     scale: { x: number; y: number; z: number }
   } {
     return this.gizmoManager.getTransform()
+  }
+
+  public getModelInfo(): ModelTransform | null {
+    return this.gizmoManager.getModelInfo()
   }
 
   public fitToViewer(): void {

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -22,11 +22,27 @@ export interface CameraState {
   cameraType: CameraType
 }
 
+export interface ModelTransform {
+  uuid: string
+  name: string
+  type: string
+  position: { x: number; y: number; z: number }
+  rotation: { x: number; y: number; z: number; order: string }
+  quaternion: { x: number; y: number; z: number; w: number }
+  scale: { x: number; y: number; z: number }
+  up: { x: number; y: number; z: number }
+  visible: boolean
+  matrix: number[]
+}
+
+export type ModelInfo = ModelTransform[]
+
 export interface SceneConfig {
   showGrid: boolean
   backgroundColor: string
   backgroundImage?: string
   backgroundRenderMode?: BackgroundRenderModeType
+  models?: ModelInfo
 }
 
 export type GizmoMode = 'translate' | 'rotate' | 'scale'


### PR DESCRIPTION
Expose per-object gizmo transforms (uuid, name, type, position, rotation, quaternion, scale, up, visible, matrix) as a new `model_info` output on the Load3D node.

`GizmoManager.getModelInfo()` reads the live target object and the Load3D widget `serializeValue` writes it into the node payload. The payload is a list to support multiple objects later; the viewer currently renders a single main object, so it emits a one-element list.

Requires backend Comfy-Org/ComfyUI#14144 (adds the `LOAD3D_MODEL_INFO` type and the output socket).