### PR TITLE
fix(assets): delete only the selected output within a job stack (FE-814)

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -29,12 +29,10 @@ vi.mock('@/platform/distribution/types', () => ({
   }
 }))
 
-vi.mock('primevue/usetoast', () => {
-  const add = vi.fn()
-  return {
-    useToast: () => ({ add })
-  }
-})
+const mockToastAdd = vi.hoisted(() => vi.fn())
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: mockToastAdd })
+}))
 
 vi.mock('vue-i18n', () => {
   const t = vi.fn((key: string) => key)
@@ -1155,6 +1153,16 @@ describe('useMediaAssetActions', () => {
       // that is precisely the bug we are fixing.
       expect(api.deleteItem).not.toHaveBeenCalled()
       expect(mockDeleteAsset).not.toHaveBeenCalled()
+
+      await vi.waitFor(() => {
+        expect(mockToastAdd).toHaveBeenCalled()
+      })
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+          detail: 'mediaAsset.failedToDeleteAsset'
+        })
+      )
     })
   })
 })

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -174,6 +174,11 @@ vi.mock('@/scripts/api', () => ({
   }
 }))
 
+const mockInvalidateJobOutputs = vi.hoisted(() => vi.fn())
+vi.mock('@/services/jobOutputCache', () => ({
+  invalidateJobOutputs: mockInvalidateJobOutputs
+}))
+
 const mockAppGraph = vi.hoisted(() => ({ value: { _nodes: [] as unknown[] } }))
 vi.mock('@/scripts/app', () => ({
   app: {
@@ -1084,6 +1089,7 @@ describe('useMediaAssetActions', () => {
 
     it('routes cloud output deletion through assetService.deleteAsset using the resolved UUID', async () => {
       mockIsCloud.value = true
+      mockGetOutputAssetMetadata.mockReturnValue({ jobId: 'job-abc' })
       mockFindOutputAssetIdByHash.mockResolvedValue(
         'real-output-asset-uuid-1234'
       )
@@ -1111,6 +1117,10 @@ describe('useMediaAssetActions', () => {
 
       const { api } = await import('@/scripts/api')
       expect(api.deleteItem).not.toHaveBeenCalled()
+
+      // Stack/folder/job-detail caches must be invalidated so the deleted
+      // child does not linger in the rendered list after success.
+      expect(mockInvalidateJobOutputs).toHaveBeenCalledWith('job-abc')
     })
 
     it('falls back to history delete in OSS mode (no per-asset endpoint available)', async () => {

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -146,12 +146,14 @@ vi.mock('../schemas/assetMetadataSchema', () => ({
 }))
 
 const mockDeleteAsset = vi.hoisted(() => vi.fn())
+const mockFindOutputAssetIdByHash = vi.hoisted(() => vi.fn())
 const mockCreateAssetExport = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ task_id: 'test-task-id', status: 'pending' })
 )
 vi.mock('../services/assetService', () => ({
   assetService: {
     deleteAsset: mockDeleteAsset,
+    findOutputAssetIdByHash: mockFindOutputAssetIdByHash,
     createAssetExport: mockCreateAssetExport
   }
 }))
@@ -283,6 +285,8 @@ describe('useMediaAssetActions', () => {
     mockGetOutputAssetMetadata.mockReset()
     mockGetOutputAssetMetadata.mockReturnValue(null)
     mockGetAssetType.mockReset()
+    mockFindOutputAssetIdByHash.mockReset()
+    mockFindOutputAssetIdByHash.mockResolvedValue('resolved-cloud-asset-id')
   })
 
   describe('addWorkflow', () => {
@@ -1063,6 +1067,94 @@ describe('useMediaAssetActions', () => {
       expect(mockClearWidgetValues).not.toHaveBeenCalled()
       expect(mockMarkMissingMedia).not.toHaveBeenCalled()
       expect(mockCaptureCanvasState).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteAssets — FE-814 individual output deletion', () => {
+    beforeEach(() => {
+      mockGetAssetType.mockReturnValue('output')
+      mockShowDialog.mockImplementation(
+        (opts: {
+          props: {
+            onConfirm: () => Promise<void> | void
+          }
+        }) => {
+          void opts.props.onConfirm()
+        }
+      )
+    })
+
+    it('routes cloud output deletion through assetService.deleteAsset using the resolved UUID', async () => {
+      mockIsCloud.value = true
+      mockFindOutputAssetIdByHash.mockResolvedValue(
+        'real-output-asset-uuid-1234'
+      )
+      mockDeleteAsset.mockResolvedValue(undefined)
+
+      const actions = useMediaAssetActions()
+      const stackChild = createMockAsset({
+        id: 'job-abc-1-output-key',
+        name: 'c885097ab185ced82f017bcbc98948918499f7480315fd5b928b5bb8d4951efc.png',
+        tags: ['output'],
+        user_metadata: { jobId: 'job-abc' }
+      })
+
+      await actions.deleteAssets(stackChild)
+
+      await vi.waitFor(() => {
+        expect(mockDeleteAsset).toHaveBeenCalledTimes(1)
+      })
+      expect(mockFindOutputAssetIdByHash).toHaveBeenCalledWith(
+        'c885097ab185ced82f017bcbc98948918499f7480315fd5b928b5bb8d4951efc.png'
+      )
+      expect(mockDeleteAsset).toHaveBeenCalledWith(
+        'real-output-asset-uuid-1234'
+      )
+
+      const { api } = await import('@/scripts/api')
+      expect(api.deleteItem).not.toHaveBeenCalled()
+    })
+
+    it('falls back to history delete in OSS mode (no per-asset endpoint available)', async () => {
+      mockIsCloud.value = false
+      mockGetOutputAssetMetadata.mockReturnValue({ jobId: 'job-oss-1' })
+
+      const actions = useMediaAssetActions()
+      const ossOutput = createMockAsset({
+        id: 'job-oss-1',
+        name: 'ComfyUI_00009_.png',
+        tags: ['output']
+      })
+
+      await actions.deleteAssets(ossOutput)
+
+      const { api } = await import('@/scripts/api')
+      await vi.waitFor(() => {
+        expect(api.deleteItem).toHaveBeenCalled()
+      })
+      expect(api.deleteItem).toHaveBeenCalledWith('history', 'job-oss-1')
+      expect(mockFindOutputAssetIdByHash).not.toHaveBeenCalled()
+      expect(mockDeleteAsset).not.toHaveBeenCalled()
+    })
+
+    it('surfaces an error instead of widening the delete to the whole job when no cloud record matches', async () => {
+      mockIsCloud.value = true
+      mockFindOutputAssetIdByHash.mockResolvedValue(null)
+
+      const actions = useMediaAssetActions()
+      const orphanedChild = createMockAsset({
+        id: 'job-zzz-1-output-key',
+        name: 'orphaned-hash.png',
+        tags: ['output']
+      })
+
+      await actions.deleteAssets(orphanedChild)
+
+      const { api } = await import('@/scripts/api')
+      // The whole-job delete endpoint must never run as a fallback —
+      // that is precisely the bug we are fixing.
+      expect(api.deleteItem).not.toHaveBeenCalled()
+      expect(mockDeleteAsset).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -14,6 +14,7 @@ import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { getOutputAssetMetadata } from '../schemas/assetMetadataSchema'
+import { invalidateJobOutputs } from '@/services/jobOutputCache'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
@@ -684,6 +685,16 @@ export function useMediaAssetActions() {
               )
 
               if (hasOutputAssets) {
+                // Drop cached job-detail/task entries so the next stack
+                // expand or folder open sees the post-delete output list.
+                assetArray.forEach((asset, index) => {
+                  if (results[index].status !== 'fulfilled') return
+                  if (getAssetType(asset) !== 'output') return
+                  const jobId =
+                    getOutputAssetMetadata(asset.user_metadata)?.jobId ??
+                    asset.id
+                  if (jobId) invalidateJobOutputs(jobId)
+                })
                 await assetsStore.updateHistory()
               }
               if (hasInputAssets) {

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -85,6 +85,17 @@ export function useMediaAssetActions() {
     assetType: string
   ): Promise<void> => {
     if (assetType === 'output') {
+      if (isCloud) {
+        // FE-814: deleting via /history wipes every sibling output in the job.
+        const realAssetId = await assetService.findOutputAssetIdByHash(
+          asset.name
+        )
+        if (!realAssetId) {
+          throw new Error(t('mediaAsset.failedToDeleteAsset'))
+        }
+        await assetService.deleteAsset(realAssetId)
+        return
+      }
       const jobId =
         getOutputAssetMetadata(asset.user_metadata)?.jobId || asset.id
       if (!jobId) {

--- a/src/platform/assets/composables/useOutputStacks.test.ts
+++ b/src/platform/assets/composables/useOutputStacks.test.ts
@@ -202,4 +202,65 @@ describe('useOutputStacks', () => {
       child.id
     ])
   })
+
+  it('drops cached children whose filename is no longer in the cover.allOutputs (FE-814)', async () => {
+    const childKept = createAsset({
+      id: 'child-keep',
+      name: 'keep.png',
+      user_metadata: undefined
+    })
+    const childDeleted = createAsset({
+      id: 'child-gone',
+      name: 'gone.png',
+      user_metadata: undefined
+    })
+
+    vi.mocked(mocks.resolveOutputAssetItems).mockResolvedValue([
+      childKept,
+      childDeleted
+    ])
+
+    const initialCover = createAsset({
+      id: 'parent',
+      name: 'parent.png',
+      user_metadata: {
+        jobId: 'job-1',
+        nodeId: 'node-1',
+        subfolder: 'outputs',
+        allOutputs: [
+          { filename: 'parent.png' },
+          { filename: 'keep.png' },
+          { filename: 'gone.png' }
+        ]
+      }
+    })
+    const assets = ref<AssetItem[]>([initialCover])
+
+    const { assetItems, toggleStack } = useOutputStacks({ assets })
+    await toggleStack(initialCover)
+
+    expect(assetItems.value.map((i) => i.asset.id)).toEqual([
+      initialCover.id,
+      childKept.id,
+      childDeleted.id
+    ])
+
+    // Simulate a successful per-output delete: updateHistory() refreshes the
+    // cover with a shorter allOutputs. The previously cached child whose
+    // filename is no longer present must vanish from the rendered list.
+    assets.value = [
+      createAsset({
+        ...initialCover,
+        user_metadata: {
+          ...initialCover.user_metadata!,
+          allOutputs: [{ filename: 'parent.png' }, { filename: 'keep.png' }]
+        }
+      })
+    ]
+
+    expect(assetItems.value.map((i) => i.asset.id)).toEqual([
+      'parent',
+      childKept.id
+    ])
+  })
 })

--- a/src/platform/assets/composables/useOutputStacks.ts
+++ b/src/platform/assets/composables/useOutputStacks.ts
@@ -7,6 +7,7 @@ import {
   getOutputKey,
   resolveOutputAssetItems
 } from '@/platform/assets/utils/outputAssetUtil'
+import type { ResultItemImpl } from '@/stores/queueStore'
 
 export type OutputStackListItem = {
   key: string
@@ -38,7 +39,8 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
       }
 
       const children = stackChildrenByJobId.value[jobId] ?? []
-      for (const child of children) {
+      const filteredChildren = filterChildrenAgainstCover(asset, children)
+      for (const child of filteredChildren) {
         items.push({
           key: `asset-${child.id}`,
           asset: child,
@@ -57,6 +59,25 @@ export function useOutputStacks({ assets }: UseOutputStacksOptions) {
   function getStackJobId(asset: AssetItem): string | null {
     const metadata = getOutputAssetMetadata(asset.user_metadata)
     return metadata?.jobId ?? null
+  }
+
+  // Drops cached children whose underlying output is no longer present on the
+  // cover's refreshed `allOutputs` list. Lets per-output deletes disappear
+  // immediately after `updateHistory()` re-fetches the cover, without waiting
+  // for the user to collapse/expand the stack.
+  function filterChildrenAgainstCover(
+    cover: AssetItem,
+    children: AssetItem[]
+  ): AssetItem[] {
+    const metadata = getOutputAssetMetadata(cover.user_metadata)
+    const allOutputs = metadata?.allOutputs as
+      | readonly ResultItemImpl[]
+      | undefined
+    if (!allOutputs?.length) return children
+    const validFilenames = new Set(
+      allOutputs.map((output) => output.filename).filter(Boolean)
+    )
+    return children.filter((child) => validFilenames.has(child.name))
   }
 
   function isStackExpanded(asset: AssetItem): boolean {

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -601,6 +601,7 @@ function createAssetService() {
     const queryParams = new URLSearchParams({
       asset_hash: hash,
       include_tags: OUTPUT_TAG,
+      exclude_tags: MISSING_TAG,
       limit: '1',
       include_public: 'false'
     })

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -588,6 +588,30 @@ function createAssetService() {
   }
 
   /**
+   * Resolves the cloud asset id for an output identified by its storage hash.
+   * Output assets in cloud are addressed by `asset_hash` (which equals the
+   * stored filename), while history-derived AssetItems carry that hash as
+   * `name`. Returns `null` when no matching record exists so callers can
+   * surface a meaningful error instead of falling back to a job-wide delete.
+   */
+  async function findOutputAssetIdByHash(
+    hash: string
+  ): Promise<AssetId | null> {
+    if (!hash) return null
+    const queryParams = new URLSearchParams({
+      asset_hash: hash,
+      include_tags: OUTPUT_TAG,
+      limit: '1',
+      include_public: 'false'
+    })
+    const res = await api.fetchApi(`${ASSETS_ENDPOINT}?${queryParams}`)
+    if (!res.ok) return null
+    const parsed = assetResponseSchema.safeParse(await res.json())
+    if (!parsed.success) return null
+    return parsed.data.assets[0]?.id ?? null
+  }
+
+  /**
    * Deletes an asset by ID
    * Only available in cloud environment
    *
@@ -952,6 +976,7 @@ function createAssetService() {
     getInputAssetsIncludingPublic,
     invalidateInputAssetsIncludingPublic,
     deleteAsset,
+    findOutputAssetIdByHash,
     updateAsset,
     addAssetTags,
     removeAssetTags,

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -608,7 +608,8 @@ function createAssetService() {
     if (!res.ok) return null
     const parsed = assetResponseSchema.safeParse(await res.json())
     if (!parsed.success) return null
-    return parsed.data.assets[0]?.id ?? null
+    const exactMatch = parsed.data.assets.find((a) => a.asset_hash === hash)
+    return exactMatch?.id ?? null
   }
 
   /**

--- a/src/services/jobOutputCache.ts
+++ b/src/services/jobOutputCache.ts
@@ -114,3 +114,12 @@ export async function getJobWorkflow(
   const detail = await getJobDetail(jobId)
   return await extractWorkflow(detail)
 }
+
+/**
+ * Drops cached task and detail entries for a job so subsequent reads pick up
+ * server-side changes (e.g. an output deleted via DELETE /assets/{id}).
+ */
+export function invalidateJobOutputs(jobId: string): void {
+  taskCache.delete(jobId)
+  jobDetailCache.delete(jobId)
+}


### PR DESCRIPTION
## Summary

Right-clicking a single image inside a job stack and choosing **Delete** removed every sibling output from the same job in cloud. The confirmation dialog still said *"This asset will be permanently removed"*, so the broader deletion was silent. Route output deletion through the per-asset endpoint so only the selected file is removed.

## Changes

- **What**: In cloud, `useMediaAssetActions.deleteAssetApi` now resolves the cloud asset id for an output via the new `assetService.findOutputAssetIdByHash` (using the storage hash that history-derived `AssetItem.name` already carries) and calls `DELETE /assets/{id}`. OSS keeps the existing `POST /history { delete: [jobId] }` path since no per-output endpoint exists there. When no cloud record matches in cloud mode, the call now throws instead of falling back to the job-wide delete.

## Review Focus

- `assetService.findOutputAssetIdByHash` queries `/assets?asset_hash=<hash>&include_tags=output&limit=1&include_public=false`. Confirmed against prod cloud that cloud output filenames equal `asset_hash` (e.g. `0fbbc907….png`), so passing `asset.name` is sufficient.
- The OSS branch is unchanged on purpose. OSS history items conceptually map 1:1 to the saved file, and there is no individual-output deletion endpoint to use.
- Stack children built in `mapOutputsToAssetItems` carry synthetic ids like `${jobId}-${outputKey}`, so we deliberately do not call `assetService.deleteAsset(asset.id)` — only the hash-resolved real UUID is used.
- Three Vitest cases lock in: cloud routes through `deleteAsset` with the resolved UUID, OSS still routes through `api.deleteItem('history', ...)`, and a cloud lookup miss does **not** fall back to `api.deleteItem` (the precise widening behaviour the bug describes).

## Reproduction (before this PR)

Environment: cloud.comfy.org, any user with a completed job that produced more than one output (e.g. a Save Image batch ≥ 2).

1. Open the **Assets** sidebar → *Generated* tab.
2. Find a job stack — the cover thumbnail with a *"See more outputs"* affordance (cloud assigns this when the job has multiple previewable outputs).
3. Click the cover to drill into the job stack view, or expand the stack inline in list view.
4. Right-click any individual image inside the stack → **Delete**.
5. Confirmation dialog shows *"Delete this asset? This asset will be permanently removed. <filename>"* — one image, singular.
6. Click **Delete** in the dialog.
7. Inspect the Network panel: the FE issues `POST /history` with body \`{ delete: [<jobId>] }\` instead of `DELETE /assets/{uuid}\`. Every output of the job disappears, not just the clicked one.

Root cause: `useMediaAssetActions.deleteAssetApi` always extracted the jobId via \`getOutputAssetMetadata(asset.user_metadata)?.jobId || asset.id\` and routed the request through \`api.deleteItem('history', jobId)\` for outputs. In cloud, that endpoint removes the entire job's history entry — every sibling output goes with it.

## Verification (after this PR)

- `pnpm vitest run src/platform/assets/composables/useMediaAssetActions.test.ts` → 37 passed (3 new FE-814 cases).
- `pnpm typecheck` → clean.

Fixes FE-814