### PR TITLE
Fix load3d unused exported camera types

### DIFF
--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -15,21 +15,21 @@ export type UpDirection = 'original' | '-x' | '+x' | '-y' | '+y' | '-z' | '+z'
 export type CameraType = 'perspective' | 'orthographic'
 export type BackgroundRenderModeType = 'tiled' | 'panorama'
 
-export interface CameraQuaternion {
+interface CameraQuaternion {
   x: number
   y: number
   z: number
   w: number
 }
 
-export interface CameraRotation {
+interface CameraRotation {
   x: number
   y: number
   z: number
   order: string
 }
 
-export interface CameraFrustum {
+interface CameraFrustum {
   left: number
   right: number
   top: number


### PR DESCRIPTION
## Summary

This PR fixes a `knip` failure introduced by exported Load3D camera helper interfaces that are only used inside `src/extensions/core/load3d/interfaces.ts`.

## Problem

`knip --cache` reports these exported types as unused exports:

- `CameraQuaternion`
- `CameraRotation`
- `CameraFrustum`

They are implementation details for the local `CameraState` interface and are not imported outside the module.

## Fix

Remove `export` from those three interfaces and keep them as file-local types. This keeps the `CameraState` shape unchanged while avoiding an unnecessary public type surface.

## Validation

Ran successfully:

- `pnpm exec oxfmt --write src/extensions/core/load3d/interfaces.ts`
- `pnpm typecheck`
- `pnpm knip --cache`

Notes:

- `pnpm knip --cache` still reports the existing tag hints for `flac.ts` and `apps/website/src/utils/video.ts`, but no longer reports the Load3D unused exported types.
