### PR TITLE
fix: stop scroll events leaking to canvas at textarea boundaries

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/text/multilineStringWidget.spec.ts
@@ -54,4 +54,65 @@ test.describe('Vue Multiline String Widget', { tag: '@vue-nodes' }, () => {
     await textarea.click({ button: 'right' })
     await expect(vueContextMenu).toBeVisible()
   })
+
+  test.describe('wheel scroll boundary', () => {
+    async function fillScrollable(
+      textarea: ReturnType<typeof getFirstMultilineStringWidget>
+    ) {
+      await textarea.fill(
+        Array.from({ length: 50 }, () => 'Lorem ipsum dolor sit amet').join(
+          '\n'
+        )
+      )
+      await expect
+        .poll(() =>
+          textarea.evaluate((el) => el.scrollHeight > el.clientHeight)
+        )
+        .toBe(true)
+    }
+
+    test('does not zoom canvas when scrolling mid-content', async ({
+      comfyPage
+    }) => {
+      const textarea = getFirstMultilineStringWidget(comfyPage)
+      await fillScrollable(textarea)
+      await textarea.evaluate((el) => {
+        el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2)
+      })
+
+      const scaleBefore = await comfyPage.canvasOps.getScale()
+      const box = await textarea.boundingBox()
+      if (!box) throw new Error('textarea has no bounding box')
+      await comfyPage.page.mouse.move(
+        box.x + box.width / 2,
+        box.y + box.height / 2
+      )
+      await comfyPage.page.mouse.wheel(0, 120)
+      await comfyPage.nextFrame()
+
+      expect(await comfyPage.canvasOps.getScale()).toBeCloseTo(scaleBefore, 3)
+    })
+
+    test('passes wheel through to canvas at the bottom boundary', async ({
+      comfyPage
+    }) => {
+      const textarea = getFirstMultilineStringWidget(comfyPage)
+      await fillScrollable(textarea)
+      await textarea.evaluate((el) => {
+        el.scrollTop = el.scrollHeight
+      })
+
+      const scaleBefore = await comfyPage.canvasOps.getScale()
+      const box = await textarea.boundingBox()
+      if (!box) throw new Error('textarea has no bounding box')
+      await comfyPage.page.mouse.move(
+        box.x + box.width / 2,
+        box.y + box.height / 2
+      )
+      await comfyPage.page.mouse.wheel(0, 120)
+      await expect
+        .poll(() => comfyPage.canvasOps.getScale())
+        .not.toBeCloseTo(scaleBefore, 3)
+    })
+  })
 })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
@@ -7,13 +7,14 @@ import type { DOMWidget } from '@/scripts/domWidget'
 import { useStringWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useStringWidget'
 import { createMockDOMWidgetNode } from '@/renderer/extensions/vueNodes/widgets/composables/domWidgetTestUtils'
 
-const { canvasMock } = vi.hoisted(() => ({
+const { canvasMock, settingsMock } = vi.hoisted(() => ({
   canvasMock: {
     processMouseDown: vi.fn(),
     processMouseMove: vi.fn(),
     processMouseUp: vi.fn(),
     processMouseWheel: vi.fn()
-  }
+  },
+  settingsMock: { get: vi.fn((_key: string) => false as boolean) }
 }))
 
 vi.mock('@/scripts/app', () => ({
@@ -27,7 +28,7 @@ vi.mock('@/stores/widgetValueStore', () => ({
   useWidgetValueStore: () => ({ getWidget: () => undefined })
 }))
 vi.mock('@/platform/settings/settingStore', () => ({
-  useSettingStore: () => ({ get: () => false })
+  useSettingStore: () => settingsMock
 }))
 
 function createStringWidget(node: LGraphNode) {
@@ -107,10 +108,15 @@ describe('useStringWidget (multiline)', () => {
         scrollHeight: 500,
         clientHeight: 100
       })
-      inputEl.dispatchEvent(
-        new WheelEvent('wheel', { deltaY: 100, bubbles: true })
-      )
+      const event = new WheelEvent('wheel', {
+        deltaY: 100,
+        bubbles: true,
+        cancelable: true
+      })
+      const stopPropSpy = vi.spyOn(event, 'stopPropagation')
+      inputEl.dispatchEvent(event)
       expect(canvasMock.processMouseWheel).not.toHaveBeenCalled()
+      expect(stopPropSpy).toHaveBeenCalledOnce()
     })
 
     it('passes scroll to canvas when scrollable textarea reaches bottom boundary', () => {
@@ -121,7 +127,28 @@ describe('useStringWidget (multiline)', () => {
         clientHeight: 100
       })
       inputEl.dispatchEvent(
-        new WheelEvent('wheel', { deltaY: 100, bubbles: true })
+        new WheelEvent('wheel', {
+          deltaY: 100,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+      expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes scroll to canvas at bottom boundary with sub-pixel scrollTop (HiDPI)', () => {
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 399.6,
+        scrollHeight: 500,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY: 100,
+          bubbles: true,
+          cancelable: true
+        })
       )
       expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
     })
@@ -134,7 +161,11 @@ describe('useStringWidget (multiline)', () => {
         clientHeight: 100
       })
       inputEl.dispatchEvent(
-        new WheelEvent('wheel', { deltaY: -100, bubbles: true })
+        new WheelEvent('wheel', {
+          deltaY: -100,
+          bubbles: true,
+          cancelable: true
+        })
       )
       expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
     })
@@ -146,10 +177,35 @@ describe('useStringWidget (multiline)', () => {
         scrollHeight: 500,
         clientHeight: 100
       })
-      inputEl.dispatchEvent(
-        new WheelEvent('wheel', { deltaY: -100, bubbles: true })
-      )
+      const event = new WheelEvent('wheel', {
+        deltaY: -100,
+        bubbles: true,
+        cancelable: true
+      })
+      const stopPropSpy = vi.spyOn(event, 'stopPropagation')
+      inputEl.dispatchEvent(event)
       expect(canvasMock.processMouseWheel).not.toHaveBeenCalled()
+      expect(stopPropSpy).toHaveBeenCalledOnce()
+    })
+
+    it('passes scroll to canvas when mouse wheel (not trackpad) scrolls at boundary with gestures enabled', () => {
+      settingsMock.get.mockImplementation(
+        (key: string) => key === 'LiteGraph.Pointer.TrackpadGestures'
+      )
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 400,
+        scrollHeight: 500,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY: 100,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+      expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
     })
 
     it('passes scroll to canvas when textarea is not scrollable', () => {
@@ -160,7 +216,11 @@ describe('useStringWidget (multiline)', () => {
         clientHeight: 100
       })
       inputEl.dispatchEvent(
-        new WheelEvent('wheel', { deltaY: 100, bubbles: true })
+        new WheelEvent('wheel', {
+          deltaY: 100,
+          bubbles: true,
+          cancelable: true
+        })
       )
       expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
     })

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.test.ts
@@ -76,6 +76,96 @@ describe('useStringWidget (multiline)', () => {
     expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
   })
 
+  describe('wheel event — scroll boundary handling', () => {
+    function makeScrollableTextarea(
+      inputEl: HTMLTextAreaElement,
+      overrides: {
+        scrollTop?: number
+        scrollHeight?: number
+        clientHeight?: number
+      } = {}
+    ) {
+      Object.defineProperty(inputEl, 'scrollHeight', {
+        configurable: true,
+        get: () => overrides.scrollHeight ?? 500
+      })
+      Object.defineProperty(inputEl, 'clientHeight', {
+        configurable: true,
+        get: () => overrides.clientHeight ?? 100
+      })
+      Object.defineProperty(inputEl, 'scrollTop', {
+        configurable: true,
+        get: () => overrides.scrollTop ?? 200,
+        set: () => {}
+      })
+    }
+
+    it('does not pass scroll to canvas when mid-content scrollable textarea scrolls down', () => {
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 100,
+        scrollHeight: 500,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: 100, bubbles: true })
+      )
+      expect(canvasMock.processMouseWheel).not.toHaveBeenCalled()
+    })
+
+    it('passes scroll to canvas when scrollable textarea reaches bottom boundary', () => {
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 400,
+        scrollHeight: 500,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: 100, bubbles: true })
+      )
+      expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes scroll to canvas when scrollable textarea reaches top boundary', () => {
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 0,
+        scrollHeight: 500,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -100, bubbles: true })
+      )
+      expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not pass scroll to canvas when scrollable textarea has room to scroll up', () => {
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 200,
+        scrollHeight: 500,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -100, bubbles: true })
+      )
+      expect(canvasMock.processMouseWheel).not.toHaveBeenCalled()
+    })
+
+    it('passes scroll to canvas when textarea is not scrollable', () => {
+      const { inputEl } = setup()
+      makeScrollableTextarea(inputEl, {
+        scrollTop: 0,
+        scrollHeight: 100,
+        clientHeight: 100
+      })
+      inputEl.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: 100, bubbles: true })
+      )
+      expect(canvasMock.processMouseWheel).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('detaches every listener when the widget is removed', () => {
     const { widget, inputEl, callback } = setup()
     widget.onRemove?.()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -139,7 +139,7 @@ function addMultilineWidget(
         const atTop = deltaY < 0 && inputEl.scrollTop === 0
         const atBottom =
           deltaY > 0 &&
-          inputEl.scrollTop + inputEl.clientHeight >= inputEl.scrollHeight
+          inputEl.scrollHeight - inputEl.scrollTop - inputEl.clientHeight < 1
         if (!atTop && !atBottom) {
           event.stopPropagation()
           return

--- a/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useStringWidget.ts
@@ -134,12 +134,19 @@ function addMultilineWidget(
       }
 
       // Vertical scrolling when gestures disabled: let textarea scroll if scrollable
+      // and not at a boundary in the direction of the scroll
       if (canScrollY) {
-        event.stopPropagation()
-        return
+        const atTop = deltaY < 0 && inputEl.scrollTop === 0
+        const atBottom =
+          deltaY > 0 &&
+          inputEl.scrollTop + inputEl.clientHeight >= inputEl.scrollHeight
+        if (!atTop && !atBottom) {
+          event.stopPropagation()
+          return
+        }
       }
 
-      // If textarea can't scroll vertically, pass to canvas
+      // If textarea can't scroll vertically (or is at a boundary), pass to canvas
       event.preventDefault()
       app.canvas.processMouseWheel(event)
     },


### PR DESCRIPTION
## Summary

Fixes #3990

When a multiline text widget is scrollable, wheel events were unconditionally swallowed via `stopPropagation()` — even when the textarea reached the top or bottom of its content. This caused scroll events to be lost instead of passing through to the canvas.

## Root cause

In `useStringWidget.ts`, the vertical scroll handler checked only whether the textarea *could* scroll (`canScrollY`), without checking whether it had *reached a boundary* in the direction of the scroll. So `stopPropagation()` was always called for any scrollable textarea, regardless of position.

## Changes

- **`useStringWidget.ts`**: Added boundary checks — `atTop` (`scrollTop === 0`, scrolling up) and `atBottom` (`scrollHeight - scrollTop - clientHeight < 1`, scrolling down). The sub-pixel formula handles HiDPI displays where Chromium can report fractional `scrollTop` values (e.g. 399.6 instead of 400). Only stop propagation when the textarea still has room to scroll in that direction.
- **`useStringWidget.test.ts`**: 10 unit tests covering mid-content, top boundary, bottom boundary, non-scrollable textarea, room-to-scroll-up, HiDPI sub-pixel boundary, `stopPropagation` spy, and `TrackpadGestures` mode.
- **`browser_tests/.../multilineStringWidget.spec.ts`**: 2 Playwright E2E tests verifying mid-content wheel does not change canvas scale, and boundary wheel does change canvas scale.