### PR TITLE
fix: show workflow refresh loading state

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -139,6 +139,7 @@ export class WorkflowsSidebarTab extends SidebarTab {
   public readonly root: Locator
   public readonly activeWorkflowLabel: Locator
   public readonly searchInput: Locator
+  public readonly refreshButton: Locator
 
   constructor(public override readonly page: Page) {
     super(page, 'workflows')
@@ -147,6 +148,9 @@ export class WorkflowsSidebarTab extends SidebarTab {
       '.comfyui-workflows-open .p-tree-node-selected .node-label'
     )
     this.searchInput = this.root.getByRole('combobox').first()
+    this.refreshButton = this.root.getByTestId(
+      TestIds.sidebar.workflowsRefreshButton
+    )
   }
 
   async getOpenedWorkflowNames() {

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -10,6 +10,7 @@ export const TestIds = {
     nodeLibrarySearch: 'node-library-search',
     nodePreviewCard: 'node-preview-card',
     workflows: 'workflows-sidebar',
+    workflowsRefreshButton: 'workflows-refresh-button',
     modeToggle: 'mode-toggle'
   },
   tree: {

--- a/browser_tests/tests/sidebar/workflows.spec.ts
+++ b/browser_tests/tests/sidebar/workflows.spec.ts
@@ -1,8 +1,10 @@
 import { expect } from '@playwright/test'
+import type { Route } from '@playwright/test'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
 import { openErrorsTab } from '@e2e/fixtures/helpers/ErrorsTabHelper'
+import type { UserDataFullInfo } from '@/schemas/apiSchema'
 
 test.describe('Workflows sidebar', () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -44,6 +46,56 @@ test.describe('Workflows sidebar', () => {
       .poll(() => tab.getTopLevelSavedWorkflowNames())
       .toEqual(expect.arrayContaining(['workflow1', 'workflow2']))
   })
+
+  test(
+    'Shows loading state while refreshing workflows',
+    { tag: '@smoke' },
+    async ({ comfyPage }) => {
+      const tab = comfyPage.menu.workflowsTab
+      const workflowsSyncRoute = /\/api\/userdata\?[^#]*\bdir=workflows\b/
+      const emptyWorkflowList: UserDataFullInfo[] = []
+
+      let releaseSync!: () => void
+      const syncBlocked = new Promise<void>((resolve) => {
+        releaseSync = resolve
+      })
+      const syncFulfillments: Promise<void>[] = []
+
+      const holdSyncResponse = async (route: Route) => {
+        if (route.request().method() !== 'GET') {
+          await route.fallback()
+          return
+        }
+
+        const syncFulfilled = syncBlocked.then(() =>
+          route.fulfill({ json: emptyWorkflowList })
+        )
+        syncFulfillments.push(syncFulfilled)
+        await syncFulfilled
+      }
+
+      await comfyPage.page.route(workflowsSyncRoute, holdSyncResponse)
+
+      try {
+        const syncRequest = comfyPage.page.waitForRequest((request) =>
+          workflowsSyncRoute.test(request.url())
+        )
+
+        await tab.refreshButton.click()
+        await syncRequest
+
+        await expect(tab.refreshButton).toBeDisabled()
+        await expect(tab.refreshButton).toHaveAttribute('aria-busy', 'true')
+      } finally {
+        releaseSync()
+        await Promise.all(syncFulfillments)
+        await comfyPage.page.unroute(workflowsSyncRoute, holdSyncResponse)
+      }
+
+      await expect(tab.refreshButton).toBeEnabled()
+      await expect(tab.refreshButton).toHaveAttribute('aria-busy', 'false')
+    }
+  )
 
   test('Can duplicate workflow', async ({ comfyPage }) => {
     const tab = comfyPage.menu.workflowsTab

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
@@ -300,9 +300,6 @@ describe('BaseWorkflowsSidebarTab', () => {
 
     expect(refreshButton).toBeDisabled()
     expect(refreshButton).toHaveAttribute('aria-busy', 'true')
-    expect(screen.getByTestId('workflows-refresh-icon')).toHaveClass(
-      'animate-spin'
-    )
 
     mockWorkflowStore.isSyncLoading = false
     await nextTick()

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from '@pinia/testing'
 import { fromPartial } from '@total-typescript/shoehorn'
-import { render } from '@testing-library/vue'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import { nextTick, reactive, ref, watchEffect } from 'vue'
@@ -34,6 +35,7 @@ const {
     bookmarkedWorkflows: [] as ComfyWorkflow[],
     openWorkflows: [] as ComfyWorkflow[],
     activeWorkflow: null as ComfyWorkflow | null,
+    isSyncLoading: false,
     syncWorkflows: vi.fn().mockResolvedValue(undefined)
   }
 
@@ -232,6 +234,7 @@ describe('BaseWorkflowsSidebarTab', () => {
     mockWorkflowStore.bookmarkedWorkflows = []
     mockWorkflowStore.openWorkflows = []
     mockWorkflowStore.activeWorkflow = null
+    mockWorkflowStore.isSyncLoading = false
   })
 
   const renderComponent = () =>
@@ -277,6 +280,39 @@ describe('BaseWorkflowsSidebarTab', () => {
     await nextTick()
 
     expect(getLeafPaths(getSearchRoot())).toEqual(['workflows/test-alpha.json'])
+  })
+
+  it('refreshes when idle and exposes busy state while workflows are syncing', async () => {
+    const user = userEvent.setup()
+
+    renderComponent()
+
+    const refreshButton = screen.getByRole('button', { name: 'g.refresh' })
+    expect(refreshButton).toBeEnabled()
+    expect(refreshButton).toHaveAttribute('aria-busy', 'false')
+
+    await user.click(refreshButton)
+
+    expect(mockWorkflowStore.syncWorkflows).toHaveBeenCalledTimes(1)
+
+    mockWorkflowStore.isSyncLoading = true
+    await nextTick()
+
+    expect(refreshButton).toBeDisabled()
+    expect(refreshButton).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByTestId('workflows-refresh-icon')).toHaveClass(
+      'animate-spin'
+    )
+
+    mockWorkflowStore.isSyncLoading = false
+    await nextTick()
+
+    expect(refreshButton).toBeEnabled()
+    expect(refreshButton).toHaveAttribute('aria-busy', 'false')
+
+    await user.click(refreshButton)
+
+    expect(mockWorkflowStore.syncWorkflows).toHaveBeenCalledTimes(2)
   })
 
   it('reactively updates filtered workflows when a workflow is removed', async () => {

--- a/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue
+++ b/src/components/sidebar/tabs/BaseWorkflowsSidebarTab.vue
@@ -11,12 +11,24 @@
     <template #tool-buttons>
       <Button
         v-tooltip.bottom="$t('g.refresh')"
+        data-testid="workflows-refresh-button"
         variant="muted-textonly"
         size="icon"
         :aria-label="$t('g.refresh')"
+        :aria-busy="workflowStore.isSyncLoading"
+        :disabled="workflowStore.isSyncLoading"
         @click="workflowStore.syncWorkflows()"
       >
-        <i class="icon-[lucide--refresh-cw] size-4" />
+        <i
+          aria-hidden="true"
+          data-testid="workflows-refresh-icon"
+          :class="
+            cn(
+              'icon-[lucide--refresh-cw] size-4',
+              workflowStore.isSyncLoading && 'animate-spin'
+            )
+          "
+        />
       </Button>
     </template>
     <template #header>
@@ -170,6 +182,7 @@ import {
   getWorkflowSuffix
 } from '@/utils/formatUtil'
 import { buildTree, sortedTree } from '@/utils/treeUtil'
+import { cn } from '@comfyorg/tailwind-utils'
 
 const { title, filter, searchSubject, dataTestid, hideLeafIcon } = defineProps<{
   title: string

--- a/src/platform/workflow/management/stores/workflowStore.ts
+++ b/src/platform/workflow/management/stores/workflowStore.ts
@@ -72,6 +72,7 @@ interface WorkflowStore {
   modifiedWorkflows: ComfyWorkflow[]
   getWorkflowByPath: (path: string) => ComfyWorkflow | null
   syncWorkflows: (dir?: string) => Promise<void>
+  isSyncLoading: boolean
   reorderWorkflows: (from: number, to: number) => void
 
   /** `true` if any subgraph is currently being viewed. */
@@ -785,6 +786,7 @@ export const useWorkflowStore = defineStore('workflow', () => {
     modifiedWorkflows,
     getWorkflowByPath,
     syncWorkflows,
+    isSyncLoading,
     loadWorkflows,
 
     isSubgraphActive,


### PR DESCRIPTION
## Summary

Adds visible loading feedback to the Workflows sidebar refresh button so users can tell when a workflow sync request is in flight.

## Changes

- **What**: Exposes `isSyncLoading` from the workflow store and binds the Workflows sidebar refresh button to disabled, `aria-busy`, and spinning icon states while sync is pending.
- **What**: Adds stable E2E selectors for the workflows refresh button and covers the loading state with unit and browser tests.
- **Dependencies**: None.

## Review Focus

Please verify the refresh control behavior while `/api/userdata?dir=workflows` is pending, especially that the button is disabled, exposes busy state, and returns to idle after sync completes.

## Validation

- `pnpm format`
- `pnpm test:unit src/components/sidebar/tabs/BaseWorkflowsSidebarTab.test.ts`
- `pnpm test:browser:local browser_tests/tests/sidebar/workflows.spec.ts -g "Shows loading state while refreshing workflows"`
- `pnpm lint`
- Commit hooks: `oxfmt`, `oxlint`, `eslint`, `typecheck`, `typecheck:browser`

## Screenshots (if applicable)

https://github.com/user-attachments/assets/e8b893ae-a91d-45c9-81ea-adaf164de227

