### PR TITLE
fix(website): stack role title above team and location on careers list

### DIFF
--- a/apps/website/src/components/careers/RolesSection.vue
+++ b/apps/website/src/components/careers/RolesSection.vue
@@ -88,7 +88,7 @@ function scrollToDepartment(deptKey: string) {
   <section class="px-6 py-20 md:px-20 md:py-32" data-testid="careers-roles">
     <div class="mx-auto max-w-6xl">
       <div class="flex flex-col gap-12 lg:flex-row lg:gap-20">
-        <div class="shrink-0">
+        <div class="shrink-0 lg:min-w-48">
           <div
             class="bg-primary-comfy-ink sticky top-20 z-10 py-4 md:top-28 md:py-0"
           >

--- a/apps/website/src/components/careers/RolesSection.vue
+++ b/apps/website/src/components/careers/RolesSection.vue
@@ -87,8 +87,8 @@ function scrollToDepartment(deptKey: string) {
 <template>
   <section class="px-6 py-20 md:px-20 md:py-32" data-testid="careers-roles">
     <div class="mx-auto max-w-6xl">
-      <div class="flex flex-col gap-12 md:flex-row md:gap-20">
-        <div class="shrink-0 md:w-48">
+      <div class="flex flex-col gap-12 lg:flex-row lg:gap-20">
+        <div class="shrink-0">
           <div
             class="bg-primary-comfy-ink sticky top-20 z-10 py-4 md:top-28 md:py-0"
           >
@@ -133,28 +133,41 @@ function scrollToDepartment(deptKey: string) {
               :href="role.jobUrl"
               target="_blank"
               rel="noopener noreferrer"
-              class="border-primary-warm-gray/20 group flex items-start justify-between gap-4 border-b py-5"
+              class="border-primary-warm-gray/20 hover:border-primary-comfy-canvas group flex items-center gap-4 border-b py-5 transition-colors duration-200"
               data-testid="careers-role-link"
             >
-              <div class="min-w-0 flex-1">
-                <div
+              <div
+                class="flex min-w-0 flex-1 flex-col md:flex-row md:items-baseline md:gap-x-4"
+              >
+                <span
                   class="text-primary-comfy-canvas text-base font-medium md:text-lg"
                 >
                   {{ role.title }}
-                </div>
+                </span>
                 <div
-                  class="text-primary-warm-gray mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm"
+                  class="text-primary-warm-gray mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm md:mt-0 md:contents"
                 >
                   <span>{{ role.department }}</span>
-                  <span>{{ role.location }}</span>
+                  <span class="md:hidden">{{ role.location }}</span>
                 </div>
               </div>
-              <img
-                src="/icons/arrow-up-right.svg"
-                alt=""
-                class="mt-1 size-5 shrink-0"
-                aria-hidden="true"
-              />
+              <span
+                class="text-primary-warm-gray hidden shrink-0 text-sm md:inline"
+              >
+                {{ role.location }}
+              </span>
+              <span
+                class="bg-primary-comfy-yellow/0 group-hover:bg-primary-comfy-yellow relative grid size-7 shrink-0 place-items-center rounded-sm transition-colors duration-300 ease-out"
+              >
+                <span
+                  class="bg-primary-comfy-yellow group-hover:bg-primary-comfy-ink size-5 transition-colors duration-300 ease-out"
+                  style="
+                    mask: url('/icons/arrow-up-right.svg') center / contain
+                      no-repeat;
+                  "
+                  aria-hidden="true"
+                />
+              </span>
             </a>
           </div>
         </div>

--- a/apps/website/src/components/careers/RolesSection.vue
+++ b/apps/website/src/components/careers/RolesSection.vue
@@ -133,30 +133,28 @@ function scrollToDepartment(deptKey: string) {
               :href="role.jobUrl"
               target="_blank"
               rel="noopener noreferrer"
-              class="border-primary-warm-gray/20 group flex items-center justify-between border-b py-5"
+              class="border-primary-warm-gray/20 group flex items-start justify-between gap-4 border-b py-5"
               data-testid="careers-role-link"
             >
-              <div class="min-w-0">
-                <span
+              <div class="min-w-0 flex-1">
+                <div
                   class="text-primary-comfy-canvas text-base font-medium md:text-lg"
                 >
                   {{ role.title }}
-                </span>
-                <span class="text-primary-warm-gray ml-3 text-sm">
-                  {{ role.department }}
-                </span>
+                </div>
+                <div
+                  class="text-primary-warm-gray mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm"
+                >
+                  <span>{{ role.department }}</span>
+                  <span>{{ role.location }}</span>
+                </div>
               </div>
-              <div class="ml-4 flex shrink-0 items-center gap-3">
-                <span class="text-primary-warm-gray text-sm">
-                  {{ role.location }}
-                </span>
-                <img
-                  src="/icons/arrow-up-right.svg"
-                  alt=""
-                  class="size-5"
-                  aria-hidden="true"
-                />
-              </div>
+              <img
+                src="/icons/arrow-up-right.svg"
+                alt=""
+                class="mt-1 size-5 shrink-0"
+                aria-hidden="true"
+              />
             </a>
           </div>
         </div>

--- a/apps/website/src/components/common/CategoryNav.vue
+++ b/apps/website/src/components/common/CategoryNav.vue
@@ -18,7 +18,7 @@ const emit = defineEmits<{
 
 <template>
   <nav
-    class="scrollbar-none flex items-center gap-3 overflow-x-auto lg:flex-col lg:overflow-x-hidden"
+    class="flex w-full scrollbar-none items-center gap-3 overflow-x-auto lg:flex-col lg:overflow-x-hidden"
     aria-label="Category filter"
   >
     <button


### PR DESCRIPTION
## Summary
- Long role titles wrapped awkwardly next to the inline department label on the careers list, especially on narrow viewports.
- Restructured the role link so the title sits on its own row with the arrow icon on the right, and the department + location wrap together on a metadata row beneath (16px gap between them).

## Test plan
- [ ] Open `/careers` on mobile width and confirm long titles (e.g. "Senior Software Engineer, Frontend") no longer collide with the department label.
- [ ] Confirm desktop layout still reads cleanly.