### PR TITLE
refactor: drop redundant rotation field from Load3D camera_info

### DIFF
--- a/src/extensions/core/load3d/CameraManager.test.ts
+++ b/src/extensions/core/load3d/CameraManager.test.ts
@@ -178,21 +178,6 @@ describe('CameraManager', () => {
       expect(Object.keys(quaternion ?? {})).not.toContain('_x')
     })
 
-    it('captures the active camera orientation as a serializable euler rotation', () => {
-      manager.perspectiveCamera.position.set(5, 0, 0)
-      manager.perspectiveCamera.lookAt(0, 0, 0)
-
-      const { rotation } = manager.getCameraState()
-
-      expect(rotation).toEqual({
-        x: manager.perspectiveCamera.rotation.x,
-        y: manager.perspectiveCamera.rotation.y,
-        z: manager.perspectiveCamera.rotation.z,
-        order: manager.perspectiveCamera.rotation.order
-      })
-      expect(Object.keys(rotation ?? {})).not.toContain('_x')
-    })
-
     it('captures the configured perspective fov regardless of active camera', () => {
       manager.perspectiveCamera.fov = 42
       manager.toggleCamera('orthographic')

--- a/src/extensions/core/load3d/CameraManager.ts
+++ b/src/extensions/core/load3d/CameraManager.ts
@@ -145,7 +145,6 @@ export class CameraManager implements CameraManagerInterface {
 
   getCameraState(): CameraState {
     const { x, y, z, w } = this.activeCamera.quaternion
-    const rotation = this.activeCamera.rotation
     const activeCamera = this.activeCamera as
       | THREE.PerspectiveCamera
       | THREE.OrthographicCamera
@@ -158,12 +157,6 @@ export class CameraManager implements CameraManagerInterface {
           : (this.activeCamera as THREE.PerspectiveCamera).zoom,
       cameraType: this.getCurrentCameraType(),
       quaternion: { x, y, z, w },
-      rotation: {
-        x: rotation.x,
-        y: rotation.y,
-        z: rotation.z,
-        order: rotation.order
-      },
       fov: this.perspectiveCamera.fov,
       aspect: this.perspectiveCamera.aspect,
       near: activeCamera.near,

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -22,13 +22,6 @@ interface CameraQuaternion {
   w: number
 }
 
-interface CameraRotation {
-  x: number
-  y: number
-  z: number
-  order: string
-}
-
 interface CameraFrustum {
   left: number
   right: number
@@ -42,7 +35,6 @@ export interface CameraState {
   zoom: number
   cameraType: CameraType
   quaternion?: CameraQuaternion
-  rotation?: CameraRotation
   fov?: number
   aspect?: number
   near?: number


### PR DESCRIPTION
## Summary
As discussed in slack, we would like to remove rotation field