### PR TITLE
Prevent desktop touch scubbing of number widgets

### DIFF
--- a/src/components/common/ScrubableNumberInput.vue
+++ b/src/components/common/ScrubableNumberInput.vue
@@ -66,7 +66,13 @@
 </template>
 
 <script setup lang="ts">
-import { onClickOutside, usePointerSwipe, whenever } from '@vueuse/core'
+import {
+  breakpointsTailwind,
+  onClickOutside,
+  usePointerSwipe,
+  useBreakpoints,
+  whenever
+} from '@vueuse/core'
 import { computed, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -94,6 +100,8 @@ const {
 
 const { t } = useI18n()
 const modelValue = defineModel<number>({ default: 0 })
+
+const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
 
 const container = useTemplateRef<HTMLDivElement>('container')
 const inputField = useTemplateRef<HTMLInputElement>('inputField')
@@ -137,7 +145,8 @@ function handlePointerUp() {
 }
 
 const { distanceX, isSwiping } = usePointerSwipe(swipeElement, {
-  onSwipeEnd: () => (dragDelta = 0)
+  onSwipeEnd: () => (dragDelta = 0),
+  pointerTypes: isMobile.value ? ['mouse', 'touch'] : ['mouse']
 })
 
 whenever(distanceX, () => {


### PR DESCRIPTION
There were reports that attempting to pan on touch devices (A magic mouse, in the original report) would unintentionally scrub numeric inputs.

This first pass just disables touch by touch if the device is a non-mobile resolution. This doesn't quite sit right with me. It seems like it'd have too high a risk for false positives. I plan to explore further options. Perhaps disabling numeric scrubbing by touch if the user is sufficiently zoomed out?