### PR TITLE
refactor(load3d): simplify model_info schema and align naming to model_3d

### DIFF
--- a/src/composables/useLoad3d.test.ts
+++ b/src/composables/useLoad3d.test.ts
@@ -1357,16 +1357,9 @@ describe('useLoad3d', () => {
 
     it('gizmoTransformChange mirrors the live scene into Scene Config models', async () => {
       const modelTransform = {
-        uuid: 'abc',
-        name: 'mesh',
-        type: 'Mesh',
         position: { x: 5, y: 6, z: 7 },
-        rotation: { x: 0.5, y: 0.6, z: 0.7, order: 'XYZ' },
         quaternion: { x: 0, y: 0, z: 0, w: 1 },
-        scale: { x: 3, y: 3, z: 3 },
-        up: { x: 0, y: 1, z: 0 },
-        visible: true,
-        matrix: new Array(16).fill(0)
+        scale: { x: 3, y: 3, z: 3 }
       }
       vi.mocked(mockLoad3d.getModelInfo!).mockReturnValue(modelTransform)
 

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -7,7 +7,7 @@ import { createExportMenuItems } from '@/extensions/core/load3d/exportMenuHelper
 import type {
   CameraConfig,
   CameraState,
-  ModelInfo
+  Model3DInfo
 } from '@/extensions/core/load3d/interfaces'
 import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
 import {
@@ -404,7 +404,7 @@ useExtensionService().registerExtension({
           currentLoad3d.handleResize()
 
           const modelInfo = currentLoad3d.getModelInfo()
-          const model_info: ModelInfo = modelInfo ? [modelInfo] : []
+          const model_3d_info: Model3DInfo = modelInfo ? [modelInfo] : []
 
           const returnVal = {
             image: `threed/${data.name} [temp]`,
@@ -414,7 +414,7 @@ useExtensionService().registerExtension({
               (node.properties['Camera Config'] as CameraConfig | undefined)
                 ?.state || null,
             recording: '',
-            model_info
+            model_3d_info
           }
 
           const recordingData = currentLoad3d.getRecordingData()

--- a/src/extensions/core/load3d/GizmoManager.test.ts
+++ b/src/extensions/core/load3d/GizmoManager.test.ts
@@ -327,17 +327,9 @@ describe('GizmoManager', () => {
       const info = manager.getModelInfo()
 
       expect(info).not.toBeNull()
-      expect(info!.uuid).toBe(model.uuid)
-      expect(info!.name).toBe('my-model')
-      expect(info!.type).toBe('Object3D')
       expect(info!.position).toEqual({ x: 1, y: 2, z: 3 })
-      expect(info!.rotation.x).toBeCloseTo(0.1)
-      expect(info!.rotation.order).toBe(model.rotation.order)
       expect(info!.quaternion.w).toBeCloseTo(model.quaternion.w)
       expect(info!.scale).toEqual({ x: 4, y: 5, z: 6 })
-      expect(info!.up).toEqual({ x: 0, y: 1, z: 0 })
-      expect(info!.visible).toBe(true)
-      expect(info!.matrix).toHaveLength(16)
     })
 
     it('returns null when there is no target', () => {

--- a/src/extensions/core/load3d/GizmoManager.ts
+++ b/src/extensions/core/load3d/GizmoManager.ts
@@ -3,7 +3,7 @@ import { TransformControls } from 'three/examples/jsm/controls/TransformControls
 
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
-import type { GizmoMode, ModelTransform } from './interfaces'
+import type { GizmoMode, Model3DTransform } from './interfaces'
 
 export class GizmoManager {
   private transformControls: TransformControls | null = null
@@ -215,26 +215,15 @@ export class GizmoManager {
     }
   }
 
-  getModelInfo(): ModelTransform | null {
+  getModelInfo(): Model3DTransform | null {
     const object = this.targetObject
     if (!object) return null
 
-    object.updateMatrix()
-
     return {
-      uuid: object.uuid,
-      name: object.name,
-      type: object.type,
       position: {
         x: object.position.x,
         y: object.position.y,
         z: object.position.z
-      },
-      rotation: {
-        x: object.rotation.x,
-        y: object.rotation.y,
-        z: object.rotation.z,
-        order: object.rotation.order
       },
       quaternion: {
         x: object.quaternion.x,
@@ -246,14 +235,7 @@ export class GizmoManager {
         x: object.scale.x,
         y: object.scale.y,
         z: object.scale.z
-      },
-      up: {
-        x: object.up.x,
-        y: object.up.y,
-        z: object.up.z
-      },
-      visible: object.visible,
-      matrix: object.matrix.toArray()
+      }
     }
   }
 

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -25,7 +25,7 @@ import type {
   Load3DOptions,
   LoadModelOptions,
   MaterialMode,
-  ModelTransform,
+  Model3DTransform,
   UpDirection
 } from './interfaces'
 import { attachContextMenuGuard } from './load3dContextMenuGuard'
@@ -915,7 +915,7 @@ class Load3d {
     return this.gizmoManager.getTransform()
   }
 
-  public getModelInfo(): ModelTransform | null {
+  public getModelInfo(): Model3DTransform | null {
     return this.gizmoManager.getModelInfo()
   }
 

--- a/src/extensions/core/load3d/interfaces.ts
+++ b/src/extensions/core/load3d/interfaces.ts
@@ -50,27 +50,21 @@ export interface CameraState {
   frustum?: CameraFrustum
 }
 
-export interface ModelTransform {
-  uuid: string
-  name: string
-  type: string
-  position: { x: number; y: number; z: number }
-  rotation: { x: number; y: number; z: number; order: string }
-  quaternion: { x: number; y: number; z: number; w: number }
-  scale: { x: number; y: number; z: number }
-  up: { x: number; y: number; z: number }
-  visible: boolean
-  matrix: number[]
+// Coordinate system: right-handed, Y-up, world space
+export interface Model3DTransform {
+  position: { x: number; y: number; z: number } // scene units
+  quaternion: { x: number; y: number; z: number; w: number } // normalized, dimensionless; world rotation
+  scale: { x: number; y: number; z: number } // dimensionless multiplier
 }
 
-export type ModelInfo = ModelTransform[]
+export type Model3DInfo = Model3DTransform[]
 
 export interface SceneConfig {
   showGrid: boolean
   backgroundColor: string
   backgroundImage?: string
   backgroundRenderMode?: BackgroundRenderModeType
-  models?: ModelInfo
+  models?: Model3DInfo
 }
 
 export type GizmoMode = 'translate' | 'rotate' | 'scale'


### PR DESCRIPTION
## Summary
1. Drop multi-object identity fields (uuid, name, type) since multi-object support is not yet in scope, these are renderer-side identifiers with no link back to the ComfyUI asset.
2. Drop rotation and matrix as redundant encodings of the same transform, applying the same Jacob-redundancy point used on camera_info
3. Rename ModelTransform -> Model3DTransform and ModelInfo -> Model3DInfo to align with the existing Load3D / File3D / model_3d naming and disambiguate from AI 'model' (per Alexis). 
4. The output key also moves from model_info to model_3d_info to match.
