### PR TITLE
feat: attribute workflow executions to App Mode in telemetry

### DIFF
--- a/src/composables/useAppMode.ts
+++ b/src/composables/useAppMode.ts
@@ -9,6 +9,10 @@ export type AppMode =
   | 'builder:outputs'
   | 'builder:arrange'
 
+export function modeIsAppMode(mode: AppMode): boolean {
+  return mode === 'app' || mode === 'builder:arrange'
+}
+
 const enableAppBuilder = ref(true)
 
 export function useAppMode() {
@@ -29,9 +33,7 @@ export function useAppMode() {
     () => isSelectInputsMode.value || isSelectOutputsMode.value
   )
   const isArrangeMode = computed(() => mode.value === 'builder:arrange')
-  const isAppMode = computed(
-    () => mode.value === 'app' || mode.value === 'builder:arrange'
-  )
+  const isAppMode = computed(() => modeIsAppMode(mode.value))
   const isGraphMode = computed(
     () => mode.value === 'graph' || isSelectMode.value
   )

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -56,6 +56,29 @@ vi.mock('@/platform/cloud/subscription/composables/useSubscription', () => ({
   })
 }))
 
+const mockAppMode = vi.hoisted(() => ({
+  mode: { value: 'app' },
+  isAppMode: { value: false }
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => mockAppMode
+}))
+
+vi.mock('@/platform/telemetry/utils/getExecutionContext', () => ({
+  getExecutionContext: () => ({
+    is_template: false,
+    workflow_name: 'untitled',
+    custom_node_count: 0,
+    total_node_count: 0,
+    subgraph_count: 0,
+    has_api_nodes: false,
+    api_node_names: [],
+    has_toolkit_nodes: false,
+    toolkit_node_names: []
+  })
+}))
+
 import { PostHogTelemetryProvider } from './PostHogTelemetryProvider'
 
 function createProvider(
@@ -72,6 +95,7 @@ describe('PostHogTelemetryProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockRemoteConfig.value = null
+    mockAppMode.isAppMode.value = false
     window.__CONFIG__ = {
       posthog_project_token: 'phc_test_token'
     } as typeof window.__CONFIG__
@@ -260,6 +284,24 @@ describe('PostHogTelemetryProvider', () => {
       expect(hoisted.mockCapture).toHaveBeenCalledWith(
         TelemetryEvents.PAGE_VIEW,
         { page_name: 'workflow_editor', path: '/workflows/123' }
+      )
+    })
+  })
+
+  describe('execution tracking', () => {
+    it('stamps is_app_mode on the execution_start event', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+      mockAppMode.isAppMode.value = true
+
+      provider.trackWorkflowExecution()
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.EXECUTION_START,
+        expect.objectContaining({
+          is_app_mode: true,
+          trigger_source: 'unknown'
+        })
       )
     })
   })

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -427,7 +427,8 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     const context = getExecutionContext()
     const eventContext: ExecutionContext = {
       ...context,
-      trigger_source: this.lastTriggerSource ?? 'unknown'
+      trigger_source: this.lastTriggerSource ?? 'unknown',
+      is_app_mode: useAppMode().isAppMode.value
     }
     this.trackEvent(TelemetryEvents.EXECUTION_START, eventContext)
     this.lastTriggerSource = undefined

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -97,6 +97,7 @@ export interface ExecutionContext {
   toolkit_node_names: string[]
   toolkit_node_count: number
   trigger_source?: ExecutionTriggerSource
+  is_app_mode?: boolean
 }
 
 /**
@@ -107,6 +108,8 @@ export interface ExecutionErrorMetadata {
   nodeId?: string
   nodeType?: string
   error?: string
+  is_app_mode?: boolean
+  workflow_id?: string
 }
 
 /**
@@ -114,6 +117,8 @@ export interface ExecutionErrorMetadata {
  */
 export interface ExecutionSuccessMetadata {
   jobId: string
+  is_app_mode?: boolean
+  workflow_id?: string
 }
 
 /**

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -5,6 +5,7 @@ import { reactive, unref } from 'vue'
 import { shallowRef } from 'vue'
 
 import { useCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
+import { modeIsAppMode } from '@/composables/useAppMode'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { syncLayoutStoreNodeBoundsFromGraph } from '@/renderer/core/layout/sync/syncLayoutStoreFromGraph'
 import { flushScheduledSlotLayoutSync } from '@/renderer/extensions/vueNodes/composables/useSlotElementTracking'
@@ -1612,6 +1613,9 @@ export class ComfyApp {
           // user switches tabs while the request is in flight.
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
+          const queuedIsAppMode = modeIsAppMode(
+            queuedWorkflow?.activeMode ?? queuedWorkflow?.initialMode ?? 'graph'
+          )
           const p = await this.graphToPrompt(this.rootGraph)
           const queuedNodes = collectAllNodes(this.rootGraph)
           try {
@@ -1635,7 +1639,8 @@ export class ComfyApp {
                   id: res.prompt_id,
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
-                  workflow: queuedWorkflow
+                  workflow: queuedWorkflow,
+                  isAppMode: queuedIsAppMode
                 })
               }
             } catch (error) {

--- a/src/stores/executionStore.telemetry.test.ts
+++ b/src/stores/executionStore.telemetry.test.ts
@@ -1,0 +1,155 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as DistributionTypes from '@/platform/distribution/types'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const { mockTrackExecutionSuccess, mockTrackExecutionError } = vi.hoisted(
+  () => ({
+    mockTrackExecutionSuccess: vi.fn(),
+    mockTrackExecutionError: vi.fn()
+  })
+)
+
+vi.mock('@/platform/distribution/types', async (importOriginal) => ({
+  ...(await importOriginal<typeof DistributionTypes>()),
+  isCloud: true
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackExecutionSuccess: mockTrackExecutionSuccess,
+    trackExecutionError: mockTrackExecutionError
+  })
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: vi.fn(() => ({
+    nodeLocatorIdToNodeExecutionId: vi.fn(),
+    executionIdToCurrentId: vi.fn()
+  }))
+}))
+
+type EventHandler = (...args: unknown[]) => void
+const apiEventHandlers = new Map<string, EventHandler>()
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: vi.fn((event: string, handler: EventHandler) => {
+      apiEventHandlers.set(event, handler)
+    }),
+    removeEventListener: vi.fn((event: string) => {
+      apiEventHandlers.delete(event)
+    }),
+    clientId: 'test-client'
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { rootGraph: { getNodeById: vi.fn(), nodes: [] } }
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({ revokePreviewsByExecutionId: vi.fn() })
+}))
+
+vi.mock('@/stores/jobPreviewStore', () => ({
+  useJobPreviewStore: () => ({ clearPreview: vi.fn() })
+}))
+
+vi.mock('@/composables/node/useNodeProgressText', () => ({
+  useNodeProgressText: () => ({ showTextPreview: vi.fn() })
+}))
+
+function createPromptNode(title: string, classType: string) {
+  return {
+    inputs: {},
+    class_type: classType,
+    _meta: { title }
+  }
+}
+
+function createWorkflow(id: string) {
+  return {
+    activeState: { id },
+    initialState: { id },
+    path: `/workflows/${id}.json`
+  } as unknown as Parameters<
+    ReturnType<typeof useExecutionStore>['storeJob']
+  >[0]['workflow']
+}
+
+describe('useExecutionStore - App Mode execution attribution', () => {
+  let store: ReturnType<typeof useExecutionStore>
+
+  function fire<T>(event: string, detail: T) {
+    const handler = apiEventHandlers.get(event)
+    if (!handler) throw new Error(`${event} handler not bound`)
+    handler(new CustomEvent(event, { detail }))
+  }
+
+  function queueJob(id: string, workflowId: string, isAppMode: boolean) {
+    store.storeJob({
+      id,
+      nodes: ['a'],
+      promptOutput: { a: createPromptNode('A', 'X') },
+      workflow: createWorkflow(workflowId),
+      isAppMode
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiEventHandlers.clear()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    store = useExecutionStore()
+    store.bindExecutionEvents()
+  })
+
+  it('attributes execution_success to App Mode with the workflow id', () => {
+    queueJob('job-1', 'wf-1', true)
+    fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+    fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
+
+    expect(mockTrackExecutionSuccess).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      is_app_mode: true,
+      workflow_id: 'wf-1'
+    })
+  })
+
+  it('marks non-App-Mode runs as is_app_mode false', () => {
+    queueJob('job-2', 'wf-2', false)
+    fire('execution_start', { prompt_id: 'job-2', timestamp: 0 })
+
+    fire('execution_success', { prompt_id: 'job-2', timestamp: 0 })
+
+    expect(mockTrackExecutionSuccess).toHaveBeenCalledWith({
+      jobId: 'job-2',
+      is_app_mode: false,
+      workflow_id: 'wf-2'
+    })
+  })
+
+  it('attributes execution_error to App Mode with the workflow id', () => {
+    queueJob('job-3', 'wf-3', true)
+
+    fire('execution_error', {
+      prompt_id: 'job-3',
+      node_id: 'n1',
+      node_type: 'KSampler',
+      exception_message: 'CUDA OOM',
+      traceback: []
+    })
+
+    expect(mockTrackExecutionError).toHaveBeenCalledWith({
+      jobId: 'job-3',
+      nodeId: 'n1',
+      nodeType: 'KSampler',
+      error: 'CUDA OOM',
+      is_app_mode: true,
+      workflow_id: 'wf-3'
+    })
+  })
+})

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -55,6 +55,12 @@ interface QueuedJob {
    * This stays stable even if the user switches workflows or edits the canvas.
    */
   nodeLookup?: Record<string, ExecutionNodeInfo>
+  /**
+   * Whether the run was triggered while the workflow was in App Mode.
+   * Captured at queue time so execution outcome events can be attributed
+   * to App Mode even after the active workflow changes.
+   */
+  isAppMode?: boolean
 }
 
 function buildExecutionNodeLookup(
@@ -297,7 +303,9 @@ export const useExecutionStore = defineStore('execution', () => {
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
     if (isCloud && activeJobId.value) {
       useTelemetry()?.trackExecutionSuccess({
-        jobId: activeJobId.value
+        jobId: activeJobId.value,
+        is_app_mode: activeJob.value?.isAppMode ?? false,
+        workflow_id: jobIdToWorkflowId.value.get(activeJobId.value)
       })
     }
     const jobId = e.detail.prompt_id
@@ -399,11 +407,14 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
     if (isCloud) {
+      const jobId = e.detail.prompt_id
       useTelemetry()?.trackExecutionError({
-        jobId: e.detail.prompt_id,
+        jobId,
         nodeId: String(e.detail.node_id),
         nodeType: e.detail.node_type,
-        error: e.detail.exception_message
+        error: e.detail.exception_message,
+        is_app_mode: queuedJobs.value[jobId]?.isAppMode ?? false,
+        workflow_id: jobIdToWorkflowId.value.get(jobId)
       })
 
       // Cloud wraps validation errors (400) in exception_message as embedded JSON.
@@ -562,12 +573,14 @@ export const useExecutionStore = defineStore('execution', () => {
     nodes,
     id,
     promptOutput,
-    workflow
+    workflow,
+    isAppMode
   }: {
     nodes: string[]
     id: JobId
     promptOutput: ComfyApiWorkflow
     workflow: ComfyWorkflow
+    isAppMode?: boolean
   }) {
     queuedJobs.value[id] ??= { nodes: {} }
     const queuedJob = queuedJobs.value[id]
@@ -580,6 +593,7 @@ export const useExecutionStore = defineStore('execution', () => {
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
     queuedJob.workflow = workflow
+    queuedJob.isAppMode = isAppMode
     const wid = workflow?.activeState?.id ?? workflow?.initialState?.id
     if (wid) {
       jobIdToWorkflowId.value.set(id, wid)


### PR DESCRIPTION
## Summary

Stamp App Mode attribution onto execution telemetry so we can measure the App Mode northstar — workflow executions triggered from App Mode.

## Changes

- **What**: Adds `is_app_mode` to the `execution_start`, `execution_success`, and `execution_error` events, plus `workflow_id` on success/error. `execution_start` reads the live app mode at trigger time; success/error read the value captured at queue time on the job, so attribution survives the user switching workflows mid-run. Extracts `modeIsAppMode()` so `app.ts` can reuse the predicate without the reactive composable.
- **Breaking**: None — all new telemetry fields are optional and additive.

## Review Focus

- **`builder:arrange` is counted as App Mode.** `is_app_mode` preserves the existing `isAppMode` semantics (`'app'` *or* `'builder:arrange'`), so it includes builder-authoring previews, not only end-user app runs. Intentionally shipped as-is; the precise "true app run" cut is available now via the run button's existing `view_mode === 'app'`, and a follow-up can add `view_mode`/`mode` to execution events for a clean cut.
- **Success vs error attribution keying.** `handleExecutionError` keys on the event's `prompt_id`; `handleExecutionSuccess` keys on `activeJobId`. Identical on the happy path; a follow-up will align success to the payload id for robustness.

This is the first of several small PRs for App Mode analytics. Planned follow-ups: success-path keying parity; `view_mode` + `workflow_id` on `execution_start`; `is_app` on workflow open/import (unblocks the quality ratio and "% of Hub opened that are Apps"). Already covered by existing events (no FE work, query-only): apps-created/week (`WORKFLOW_SAVED`), app-mode-opened adoption (`app:app_mode_opened`), virality (`SHARE_FLOW` `source='app_mode'`).

## Screenshots (if applicable)

N/A — telemetry only, no UI change.
