### PR TITLE
feat: track is_app and workflow_id on workflow open/import

### DIFF
--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -151,6 +151,8 @@ export interface WorkflowImportMetadata {
     | 'template'
     | 'shared_url'
     | 'unknown'
+  is_app?: boolean
+  workflow_id?: string
 }
 
 export interface EnterLinearMetadata {

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -11,7 +11,10 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
-import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+import {
+  linearModeToAppMode,
+  useWorkflowService
+} from '@/platform/workflow/core/services/workflowService'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
@@ -1331,5 +1334,17 @@ describe('useWorkflowService', () => {
       expect(workflowStore.renameWorkflow).not.toHaveBeenCalled()
       expect(workflowStore.saveWorkflow).toHaveBeenCalledWith(workflow)
     })
+  })
+})
+
+describe('linearModeToAppMode', () => {
+  it('maps the serialized linearMode boolean to an app mode', () => {
+    expect(linearModeToAppMode(true)).toBe('app')
+    expect(linearModeToAppMode(false)).toBe('graph')
+  })
+
+  it('returns null when linearMode is absent or not a boolean', () => {
+    expect(linearModeToAppMode(undefined)).toBeNull()
+    expect(linearModeToAppMode('app')).toBeNull()
   })
 })

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -38,7 +38,7 @@ import {
   generateUUID
 } from '@/utils/formatUtil'
 
-function linearModeToAppMode(linearMode: unknown): AppMode | null {
+export function linearModeToAppMode(linearMode: unknown): AppMode | null {
   if (typeof linearMode !== 'boolean') return null
   return linearMode ? 'app' : 'graph'
 }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -28,7 +28,10 @@ import { useTelemetry } from '@/platform/telemetry'
 import type { WorkflowOpenSource } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { updatePendingWarnings } from '@/platform/workflow/core/utils/pendingWarnings'
-import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
+import {
+  linearModeToAppMode,
+  useWorkflowService
+} from '@/platform/workflow/core/services/workflowService'
 import { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowValidation } from '@/platform/workflow/validation/composables/useWorkflowValidation'
 import type {
@@ -1425,7 +1428,9 @@ export class ComfyApp {
         missing_node_types: missingNodeTypes.map((node) =>
           typeof node === 'string' ? node : node.type
         ),
-        open_source: openSource ?? 'unknown'
+        open_source: openSource ?? 'unknown',
+        is_app: linearModeToAppMode(graphData?.extra?.linearMode) === 'app',
+        workflow_id: graphData?.id
       }
       useTelemetry()?.trackWorkflowOpened(telemetryPayload)
       useTelemetry()?.trackWorkflowImported(telemetryPayload)


### PR DESCRIPTION
## Summary

Add `is_app` and `workflow_id` to the workflow open/import telemetry so we can measure what share of opened workflows are Apps and complete the App Mode quality ratio.

## Changes

- **What**: `WorkflowImportMetadata` gains optional `is_app` + `workflow_id`; `loadGraphData` stamps them on `app:workflow_opened`/`app:workflow_imported`. `is_app` is derived from the serialized `extra.linearMode` via the now-exported `linearModeToAppMode` (the same interpretation the loader uses); `workflow_id` comes from `graphData.id`, matching `execution_success.workflow_id`.
- **Breaking**: None — both fields are optional and additive.

## Review Focus

- The signal is read from `graphData` (the workflow being loaded), not from `workflow.initialMode` — `initialMode` is resolved later inside `afterLoadNewGraph`, which runs *after* this telemetry fires. `graphData.extra.linearMode` is the authoritative serialized source, so there's no timing dependency.
- Unlocks two App Mode metrics: Adoption "% of opened workflows that are Apps" (`open_source` + `is_app`) and the Quality denominator `apps_opened` (distinct app `workflow_id`s opened), counted in the same unit as the numerator (`execution_success where is_app_mode`).
- Part of the App Mode analytics series (follows #12528).

## Screenshots (if applicable)

N/A — telemetry only, no UI change.
