### PR TITLE
feat: add PreviewGaussianSplat + PreviewPointCloud extensions

### DIFF
--- a/src/components/load3d/Load3D.vue
+++ b/src/components/load3d/Load3D.vue
@@ -44,11 +44,14 @@
       />
     </div>
     <div
-      v-if="canFitToViewer"
-      class="pointer-events-auto absolute top-12 right-2 z-20"
+      class="pointer-events-auto absolute top-12 right-2 z-20 flex flex-col gap-2"
     >
-      <div class="flex flex-col rounded-lg bg-backdrop/30">
+      <div
+        v-if="canFitToViewer || canCenterCameraOnModel"
+        class="flex flex-col rounded-lg bg-backdrop/30"
+      >
         <Button
+          v-if="canFitToViewer"
           v-tooltip.left="{
             value: $t('load3d.fitToViewer'),
             showDelay: 300
@@ -61,25 +64,29 @@
         >
           <i class="pi pi-window-maximize text-lg text-base-foreground" />
         </Button>
+        <Button
+          v-if="canCenterCameraOnModel"
+          v-tooltip.left="{
+            value: $t('load3d.centerCameraOnModel'),
+            showDelay: 300
+          }"
+          size="icon"
+          variant="textonly"
+          class="rounded-full"
+          :aria-label="$t('load3d.centerCameraOnModel')"
+          @click="handleCenterCameraOnModel"
+        >
+          <i class="pi pi-compass text-lg text-base-foreground" />
+        </Button>
       </div>
-    </div>
 
-    <div
-      v-if="enable3DViewer && node"
-      class="pointer-events-auto absolute top-24 right-2 z-20"
-    >
-      <ViewerControls :node="node as LGraphNode" />
-    </div>
+      <ViewerControls
+        v-if="enable3DViewer && node"
+        :node="node as LGraphNode"
+      />
 
-    <div
-      v-if="!isPreview"
-      class="pointer-events-auto absolute right-2 z-20"
-      :class="{
-        'top-24': !enable3DViewer,
-        'top-36': enable3DViewer
-      }"
-    >
       <RecordingControls
+        v-if="!isPreview"
         v-model:is-recording="isRecording"
         v-model:has-recording="hasRecording"
         v-model:recording-duration="recordingDuration"
@@ -142,6 +149,7 @@ const {
   isRecording,
   isPreview,
   canFitToViewer,
+  canCenterCameraOnModel,
   canUseGizmo,
   canUseLighting,
   canExport,
@@ -175,6 +183,7 @@ const {
   handleSetGizmoMode,
   handleResetGizmoTransform,
   handleFitToViewer,
+  handleCenterCameraOnModel,
   cleanup
 } = useLoad3d(node as Ref<LGraphNode | null>)
 

--- a/src/composables/useLoad3d.ts
+++ b/src/composables/useLoad3d.ts
@@ -132,6 +132,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
   const isSplatModel = ref(false)
   const isPlyModel = ref(false)
   const canFitToViewer = ref(true)
+  const canCenterCameraOnModel = ref(false)
   const canUseGizmo = ref(true)
   const canUseLighting = ref(true)
   const canExport = ref(true)
@@ -853,6 +854,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
       loading.value = false
       isSplatModel.value = load3d?.isSplatModel() ?? false
       isPlyModel.value = load3d?.isPlyModel() ?? false
+      canCenterCameraOnModel.value = isSplatModel.value || isPlyModel.value
       const caps = load3d?.getCurrentModelCapabilities()
       canFitToViewer.value = caps?.fitToViewer ?? true
       canUseGizmo.value = caps?.gizmoTransform ?? true
@@ -971,6 +973,10 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     syncSceneModels()
   }
 
+  const handleCenterCameraOnModel = () => {
+    load3d?.centerCameraOnModel()
+  }
+
   const handleResetGizmoTransform = () => {
     if (load3d) {
       load3d.resetGizmoTransform()
@@ -1011,6 +1017,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     isSplatModel,
     isPlyModel,
     canFitToViewer,
+    canCenterCameraOnModel,
     canUseGizmo,
     canUseLighting,
     canExport,
@@ -1046,6 +1053,7 @@ export const useLoad3d = (nodeOrRef: MaybeRef<LGraphNode | null>) => {
     handleSetGizmoMode,
     handleResetGizmoTransform,
     handleFitToViewer,
+    handleCenterCameraOnModel,
     cleanup
   }
 }

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -4,6 +4,7 @@ import QuickLRU from '@alloc/quick-lru'
 import type Load3d from '@/extensions/core/load3d/Load3d'
 import Load3dUtils from '@/extensions/core/load3d/Load3dUtils'
 import { createLoad3d } from '@/extensions/core/load3d/createLoad3d'
+import { isLoad3dPreviewNode } from '@/extensions/core/load3d/nodeTypes'
 import type {
   AnimationItem,
   BackgroundRenderModeType,
@@ -368,10 +369,7 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
         | LightConfig
         | undefined
 
-      isPreview.value =
-        node.type === 'Preview3D' ||
-        node.type === 'PreviewGaussianSplat' ||
-        node.type === 'PreviewPointCloud'
+      isPreview.value = isLoad3dPreviewNode(node.type ?? '')
 
       if (sceneConfig) {
         backgroundColor.value =

--- a/src/composables/useLoad3dViewer.ts
+++ b/src/composables/useLoad3dViewer.ts
@@ -368,7 +368,10 @@ export const useLoad3dViewer = (node?: LGraphNode) => {
         | LightConfig
         | undefined
 
-      isPreview.value = node.type === 'Preview3D'
+      isPreview.value =
+        node.type === 'Preview3D' ||
+        node.type === 'PreviewGaussianSplat' ||
+        node.type === 'PreviewPointCloud'
 
       if (sceneConfig) {
         backgroundColor.value =

--- a/src/extensions/core/load3d.test.ts
+++ b/src/extensions/core/load3d.test.ts
@@ -164,6 +164,7 @@ function makeLoad3DNode(
     constructor: { comfyClass: overrides.comfyClass ?? 'Load3D' },
     size: [300, 600],
     setSize: vi.fn(),
+    addWidget: vi.fn(),
     widgets: overrides.widgets ?? [
       { name: 'model_file', value: '' },
       { name: 'width', value: 512 },

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -226,6 +226,8 @@ useExtensionService().registerExtension({
       type: 'combo',
       options: ['threejs', 'fastply'],
       defaultValue: 'threejs',
+      migrateDeprecatedValue: (value) =>
+        value === 'sparkjs' ? 'threejs' : value,
       experimental: true
     }
   ],

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -219,12 +219,12 @@ useExtensionService().registerExtension({
     },
     {
       id: 'Comfy.Load3D.PLYEngine',
-      category: ['3D', 'PLY', 'PLY Engine'],
-      name: 'PLY Engine',
+      category: ['3D', 'PointCloud', 'Point Cloud Engine'],
+      name: 'Point Cloud Engine',
       tooltip:
-        'Select the engine for loading PLY files. "threejs" uses the native Three.js PLYLoader (best for mesh PLY files). "fastply" uses an optimized loader for ASCII point cloud PLY files. "sparkjs" uses Spark.js for 3D Gaussian Splatting PLY files.',
+        'Select the engine for loading point cloud PLY files. "threejs" uses the native Three.js PLYLoader (handles binary + ASCII, mesh-capable). "fastply" uses an optimized parser for ASCII PLY files. 3D Gaussian Splat PLYs are detected automatically and always rendered via sparkjs regardless of this setting.',
       type: 'combo',
-      options: ['threejs', 'fastply', 'sparkjs'],
+      options: ['threejs', 'fastply'],
       defaultValue: 'threejs',
       experimental: true
     }
@@ -267,40 +267,44 @@ useExtensionService().registerExtension({
   getCustomWidgets() {
     return {
       LOAD_3D(node) {
-        const fileInput = createFileInput(SUPPORTED_EXTENSIONS_ACCEPT, false)
+        if (node.constructor.comfyClass === 'Load3D') {
+          const fileInput = createFileInput(SUPPORTED_EXTENSIONS_ACCEPT, false)
 
-        node.properties['Resource Folder'] = ''
+          node.properties['Resource Folder'] = ''
 
-        fileInput.onchange = async () => {
-          await handleModelUpload(fileInput.files!, node)
-        }
-
-        node.addWidget('button', 'upload 3d model', 'upload3dmodel', () => {
-          fileInput.click()
-        })
-
-        const resourcesInput = createFileInput('*', true)
-
-        resourcesInput.onchange = async () => {
-          await handleResourcesUpload(resourcesInput.files!, node)
-          resourcesInput.value = ''
-        }
-
-        node.addWidget(
-          'button',
-          'upload extra resources',
-          'uploadExtraResources',
-          () => {
-            resourcesInput.click()
+          fileInput.onchange = async () => {
+            await handleModelUpload(fileInput.files!, node)
           }
-        )
 
-        node.addWidget('button', 'clear', 'clear', () => {
-          const modelWidget = node.widgets?.find((w) => w.name === 'model_file')
-          if (modelWidget) {
-            modelWidget.value = LOAD3D_NONE_MODEL
+          node.addWidget('button', 'upload 3d model', 'upload3dmodel', () => {
+            fileInput.click()
+          })
+
+          const resourcesInput = createFileInput('*', true)
+
+          resourcesInput.onchange = async () => {
+            await handleResourcesUpload(resourcesInput.files!, node)
+            resourcesInput.value = ''
           }
-        })
+
+          node.addWidget(
+            'button',
+            'upload extra resources',
+            'uploadExtraResources',
+            () => {
+              resourcesInput.click()
+            }
+          )
+
+          node.addWidget('button', 'clear', 'clear', () => {
+            const modelWidget = node.widgets?.find(
+              (w) => w.name === 'model_file'
+            )
+            if (modelWidget) {
+              modelWidget.value = LOAD3D_NONE_MODEL
+            }
+          })
+        }
 
         const widget = new ComponentWidgetImpl({
           node: node,

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -161,9 +161,29 @@ class Load3d {
     this.handleResize()
     this.startAnimation()
 
+    this.eventManager.addEventListener('modelReady', () => {
+      this.startPostLoadRenderBurst()
+    })
+
     setTimeout(() => {
       this.forceRender()
     }, 100)
+  }
+
+  private postLoadBurstEndsAt = 0
+  private postLoadBurstFrameId: number | null = null
+  private startPostLoadRenderBurst(): void {
+    this.postLoadBurstEndsAt = performance.now() + 2000
+    if (this.postLoadBurstFrameId !== null) return
+    const tick = () => {
+      this.forceRender()
+      if (performance.now() < this.postLoadBurstEndsAt) {
+        this.postLoadBurstFrameId = requestAnimationFrame(tick)
+      } else {
+        this.postLoadBurstFrameId = null
+      }
+    }
+    this.postLoadBurstFrameId = requestAnimationFrame(tick)
   }
 
   private initResizeObserver(container: Element | HTMLElement): void {
@@ -924,10 +944,31 @@ class Load3d {
     this.forceRender()
   }
 
+  public centerCameraOnModel(): void {
+    const bounds = this.modelManager.getCurrentBounds()
+    if (!bounds || bounds.isEmpty()) return
+
+    const center = bounds.getCenter(new THREE.Vector3())
+    const camera = this.cameraManager.activeCamera
+    const controls = this.controlsManager.controls
+    const offset = center.clone().sub(camera.position)
+
+    camera.position.add(offset)
+    controls.target.add(offset)
+    camera.updateMatrixWorld(true)
+    controls.update()
+    this.forceRender()
+  }
+
   public remove(): void {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect()
       this.resizeObserver = null
+    }
+
+    if (this.postLoadBurstFrameId !== null) {
+      cancelAnimationFrame(this.postLoadBurstFrameId)
+      this.postLoadBurstFrameId = null
     }
 
     this.disposeContextMenuGuard?.()

--- a/src/extensions/core/load3d/Load3d.ts
+++ b/src/extensions/core/load3d/Load3d.ts
@@ -162,7 +162,8 @@ class Load3d {
     this.startAnimation()
 
     this.eventManager.addEventListener('modelReady', () => {
-      this.startPostLoadRenderBurst()
+      if (this.adapterRef.current?.kind !== 'splat') return
+      void this.repaintWhenSparkPaintable()
     })
 
     setTimeout(() => {
@@ -170,20 +171,11 @@ class Load3d {
     }, 100)
   }
 
-  private postLoadBurstEndsAt = 0
-  private postLoadBurstFrameId: number | null = null
-  private startPostLoadRenderBurst(): void {
-    this.postLoadBurstEndsAt = performance.now() + 2000
-    if (this.postLoadBurstFrameId !== null) return
-    const tick = () => {
-      this.forceRender()
-      if (performance.now() < this.postLoadBurstEndsAt) {
-        this.postLoadBurstFrameId = requestAnimationFrame(tick)
-      } else {
-        this.postLoadBurstFrameId = null
-      }
-    }
-    this.postLoadBurstFrameId = requestAnimationFrame(tick)
+  private async repaintWhenSparkPaintable(): Promise<void> {
+    const sortComplete = this.sceneManager.awaitNextSparkDirty()
+    this.forceRender()
+    await sortComplete
+    this.forceRender()
   }
 
   private initResizeObserver(container: Element | HTMLElement): void {
@@ -646,7 +638,7 @@ class Load3d {
   }
 
   getCurrentModelCapabilities(): ModelAdapterCapabilities {
-    return this.adapterRef.current?.capabilities ?? DEFAULT_MODEL_CAPABILITIES
+    return this.adapterRef.capabilities ?? DEFAULT_MODEL_CAPABILITIES
   }
 
   clearModel(): void {
@@ -964,11 +956,6 @@ class Load3d {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect()
       this.resizeObserver = null
-    }
-
-    if (this.postLoadBurstFrameId !== null) {
-      cancelAnimationFrame(this.postLoadBurstFrameId)
-      this.postLoadBurstFrameId = null
     }
 
     this.disposeContextMenuGuard?.()

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -41,14 +41,21 @@ function makeModelManagerStub(): ModelManagerStub {
   }
 }
 
-const { meshLoad, splatLoad, pointCloudLoad, getPLYEngineMock, addAlert } =
-  vi.hoisted(() => ({
-    meshLoad: vi.fn(),
-    splatLoad: vi.fn(),
-    pointCloudLoad: vi.fn(),
-    getPLYEngineMock: vi.fn<() => string>(),
-    addAlert: vi.fn()
-  }))
+const {
+  meshLoad,
+  splatLoad,
+  pointCloudLoad,
+  fetchModelDataMock,
+  isGaussianSplatPLYMock,
+  addAlert
+} = vi.hoisted(() => ({
+  meshLoad: vi.fn(),
+  splatLoad: vi.fn(),
+  pointCloudLoad: vi.fn(),
+  fetchModelDataMock: vi.fn<() => Promise<ArrayBuffer>>(),
+  isGaussianSplatPLYMock: vi.fn<(b: ArrayBuffer) => Promise<boolean>>(),
+  addAlert: vi.fn()
+}))
 
 vi.mock('./MeshModelAdapter', () => ({
   MeshModelAdapter: class {
@@ -65,8 +72,7 @@ vi.mock('./PointCloudModelAdapter', () => ({
     readonly extensions = ['ply'] as const
     readonly capabilities = {}
     load = pointCloudLoad
-  },
-  getPLYEngine: () => getPLYEngineMock()
+  }
 }))
 
 vi.mock('./SplatModelAdapter', () => ({
@@ -76,6 +82,16 @@ vi.mock('./SplatModelAdapter', () => ({
     readonly capabilities = {}
     load = splatLoad
   }
+}))
+
+vi.mock('./ModelAdapter', async () => {
+  const actual =
+    await vi.importActual<typeof import('./ModelAdapter')>('./ModelAdapter')
+  return { ...actual, fetchModelData: fetchModelDataMock }
+})
+
+vi.mock('@/scripts/metadata/ply', () => ({
+  isGaussianSplatPLY: isGaussianSplatPLYMock
 }))
 
 vi.mock('@/i18n', () => ({
@@ -109,10 +125,11 @@ function makeLoaderManager() {
 describe('LoaderManager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getPLYEngineMock.mockReturnValue('three')
     meshLoad.mockResolvedValue(null)
     splatLoad.mockResolvedValue(null)
     pointCloudLoad.mockResolvedValue(null)
+    fetchModelDataMock.mockResolvedValue(new ArrayBuffer(0))
+    isGaussianSplatPLYMock.mockResolvedValue(false)
   })
 
   describe('getCurrentAdapter', () => {
@@ -257,22 +274,9 @@ describe('LoaderManager', () => {
       }
     )
 
-    it('routes .ply to the point-cloud adapter for the default three engine', () => {
-      getPLYEngineMock.mockReturnValue('three')
+    it('returns the point-cloud adapter for .ply by extension lookup (the actual .ply load path bypasses pickAdapter and dispatches by header content)', () => {
       const { pick } = makeLoaderManager()
       expect(pick('ply')?.kind).toBe('pointCloud')
-    })
-
-    it('routes .ply to the point-cloud adapter for the fastply engine', () => {
-      getPLYEngineMock.mockReturnValue('fastply')
-      const { pick } = makeLoaderManager()
-      expect(pick('ply')?.kind).toBe('pointCloud')
-    })
-
-    it('routes .ply to the splat adapter when the engine setting is sparkjs', () => {
-      getPLYEngineMock.mockReturnValue('sparkjs')
-      const { pick } = makeLoaderManager()
-      expect(pick('ply')?.kind).toBe('splat')
     })
 
     it('returns null for unknown extensions', () => {
@@ -407,8 +411,20 @@ describe('LoaderManager', () => {
       )
     })
 
-    it('routes .ply through the splat adapter when the engine setting is sparkjs', async () => {
-      getPLYEngineMock.mockReturnValue('sparkjs')
+    it('routes .ply to the point-cloud adapter when the header does not look like 3DGS', async () => {
+      isGaussianSplatPLYMock.mockResolvedValue(false)
+      const { lm } = makeLoaderManager()
+      pointCloudLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(pointCloudLoad).toHaveBeenCalled()
+      expect(splatLoad).not.toHaveBeenCalled()
+      expect(lm.getCurrentAdapter()?.kind).toBe('pointCloud')
+    })
+
+    it('reroutes .ply through the splat adapter when the header looks like 3DGS', async () => {
+      isGaussianSplatPLYMock.mockResolvedValue(true)
       const { lm } = makeLoaderManager()
       splatLoad.mockResolvedValueOnce(new THREE.Object3D())
 
@@ -416,6 +432,61 @@ describe('LoaderManager', () => {
 
       expect(splatLoad).toHaveBeenCalled()
       expect(pointCloudLoad).not.toHaveBeenCalled()
+      expect(lm.getCurrentAdapter()?.kind).toBe('splat')
+    })
+
+    it('forwards the fetched bytes to the chosen adapter so .ply is not re-downloaded', async () => {
+      const buf = new ArrayBuffer(16)
+      fetchModelDataMock.mockResolvedValueOnce(buf)
+      isGaussianSplatPLYMock.mockResolvedValue(true)
+      const { lm } = makeLoaderManager()
+      splatLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(splatLoad).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        'scan.ply',
+        buf
+      )
+      expect(fetchModelDataMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispatches .ply by adapter kind, not extension order — a splat adapter that also claims .ply does NOT bypass detection', async () => {
+      const modelManager =
+        makeModelManagerStub() as unknown as ConstructorParameters<
+          typeof LoaderManager
+        >[0]
+      const eventManager = makeEventManagerStub()
+      // Pathological adapter list: a splat adapter also claims '.ply'
+      // and is listed first. With a plain extension-first match, .ply
+      // would skip the 3DGS detection. The kind-based dispatch should
+      // still run isGaussianSplatPLY and pick the point-cloud adapter.
+      const splatAdapter = {
+        kind: 'splat' as const,
+        extensions: ['ply', 'spz', 'splat', 'ksplat'] as const,
+        capabilities: {} as never,
+        load: splatLoad
+      }
+      const pointCloudAdapter = {
+        kind: 'pointCloud' as const,
+        extensions: ['ply'] as const,
+        capabilities: {} as never,
+        load: pointCloudLoad
+      }
+      const lm = new LoaderManager(modelManager, eventManager, [
+        splatAdapter,
+        pointCloudAdapter
+      ])
+      isGaussianSplatPLYMock.mockResolvedValue(false)
+      pointCloudLoad.mockResolvedValueOnce(new THREE.Object3D())
+
+      await lm.loadModel('api/view?filename=scan.ply')
+
+      expect(pointCloudLoad).toHaveBeenCalled()
+      expect(splatLoad).not.toHaveBeenCalled()
+      expect(lm.getCurrentAdapter()?.kind).toBe('pointCloud')
     })
 
     it('handles adapter errors by alerting and still emitting modelLoadingEnd', async () => {

--- a/src/extensions/core/load3d/LoaderManager.test.ts
+++ b/src/extensions/core/load3d/LoaderManager.test.ts
@@ -7,7 +7,11 @@ import type {
   ModelManagerInterface
 } from './interfaces'
 import { LoaderManager } from './LoaderManager'
-import type { ModelAdapter, ModelLoadContext } from './ModelAdapter'
+import type {
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
+} from './ModelAdapter'
 
 function makeEventManagerStub() {
   return {
@@ -27,6 +31,12 @@ type ModelManagerStub = {
   originalFileName: string | null
   originalURL: string | null
 }
+
+const STUB_CAPS = {} as ModelAdapterCapabilities
+const loadResult = (object: THREE.Object3D) => ({
+  object,
+  capabilities: STUB_CAPS
+})
 
 function makeModelManagerStub(): ModelManagerStub {
   return {
@@ -78,8 +88,15 @@ vi.mock('./PointCloudModelAdapter', () => ({
 vi.mock('./SplatModelAdapter', () => ({
   SplatModelAdapter: class {
     readonly kind = 'splat' as const
-    readonly extensions = ['spz', 'splat', 'ksplat'] as const
+    readonly extensions = ['spz', 'splat', 'ksplat', 'ply'] as const
     readonly capabilities = {}
+    matches = async (
+      ext: string,
+      fetchBytes: () => Promise<ArrayBuffer>
+    ): Promise<boolean> => {
+      if (ext !== 'ply') return true
+      return isGaussianSplatPLYMock(await fetchBytes())
+    }
     load = splatLoad
   }
 }))
@@ -103,7 +120,10 @@ vi.mock('@/platform/updates/common/toastStore', () => ({
 }))
 
 type LoaderManagerInternals = {
-  pickAdapter(extension: string): ModelAdapter | null
+  pickAdapter(
+    extension: string,
+    fetchBytes: () => Promise<ArrayBuffer>
+  ): Promise<ModelAdapter | null>
 }
 
 function makeLoaderManager() {
@@ -114,12 +134,11 @@ function makeLoaderManager() {
     eventManager
   )
   const internals = lm as unknown as LoaderManagerInternals
-  return {
-    lm,
-    modelManager,
-    eventManager,
-    pick: internals.pickAdapter.bind(lm)
-  }
+  const pick = (ext: string) =>
+    internals.pickAdapter.call(lm, ext, () =>
+      fetchModelDataMock()
+    ) as Promise<ModelAdapter | null>
+  return { lm, modelManager, eventManager, pick }
 }
 
 describe('LoaderManager', () => {
@@ -140,7 +159,7 @@ describe('LoaderManager', () => {
 
     it('exposes the picked adapter after a successful load', async () => {
       const { lm } = makeLoaderManager()
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=cube.glb')
 
@@ -149,7 +168,7 @@ describe('LoaderManager', () => {
 
     it('resets to null at the start of a new load', async () => {
       const { lm } = makeLoaderManager()
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=cube.glb')
       expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
@@ -161,7 +180,7 @@ describe('LoaderManager', () => {
     it('stays null when the adapter rejects (does not publish stale adapter)', async () => {
       const { lm } = makeLoaderManager()
 
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
       await lm.loadModel('api/view?filename=cube.glb')
       expect(lm.getCurrentAdapter()?.kind).toBe('mesh')
 
@@ -212,7 +231,10 @@ describe('LoaderManager', () => {
       }
 
       let adapterDuringClear: ModelAdapter | null | undefined
-      const adapterRef = { current: oldAdapter as ModelAdapter | null }
+      const adapterRef = {
+        current: oldAdapter as ModelAdapter | null,
+        capabilities: oldAdapter.capabilities as ModelAdapterCapabilities | null
+      }
       const lm = new LoaderManager(
         modelManager,
         eventManager,
@@ -240,8 +262,8 @@ describe('LoaderManager', () => {
       const slowSplatLoad = new Promise<THREE.Object3D>((resolve) => {
         resolveSplatLoad = resolve
       })
-      splatLoad.mockReturnValueOnce(slowSplatLoad)
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      splatLoad.mockReturnValueOnce(slowSplatLoad.then(loadResult))
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       const aPromise = lm.loadModel('api/view?filename=a.splat')
 
@@ -260,29 +282,36 @@ describe('LoaderManager', () => {
   describe('pickAdapter', () => {
     it.for(['stl', 'fbx', 'obj', 'gltf', 'glb'])(
       'routes %s to the mesh adapter',
-      (ext) => {
+      async (ext) => {
         const { pick } = makeLoaderManager()
-        expect(pick(ext)?.kind).toBe('mesh')
+        expect((await pick(ext))?.kind).toBe('mesh')
       }
     )
 
     it.for(['spz', 'splat', 'ksplat'])(
       'routes %s to the splat adapter',
-      (ext) => {
+      async (ext) => {
         const { pick } = makeLoaderManager()
-        expect(pick(ext)?.kind).toBe('splat')
+        expect((await pick(ext))?.kind).toBe('splat')
       }
     )
 
-    it('returns the point-cloud adapter for .ply by extension lookup (the actual .ply load path bypasses pickAdapter and dispatches by header content)', () => {
+    it('routes .ply to the splat adapter when the bytes look like 3DGS', async () => {
+      isGaussianSplatPLYMock.mockResolvedValue(true)
       const { pick } = makeLoaderManager()
-      expect(pick('ply')?.kind).toBe('pointCloud')
+      expect((await pick('ply'))?.kind).toBe('splat')
     })
 
-    it('returns null for unknown extensions', () => {
+    it('falls back to the point-cloud adapter for .ply that is not 3DGS', async () => {
+      isGaussianSplatPLYMock.mockResolvedValue(false)
       const { pick } = makeLoaderManager()
-      expect(pick('xyz')).toBeNull()
-      expect(pick('')).toBeNull()
+      expect((await pick('ply'))?.kind).toBe('pointCloud')
+    })
+
+    it('returns null for unknown extensions', async () => {
+      const { pick } = makeLoaderManager()
+      expect(await pick('xyz')).toBeNull()
+      expect(await pick('')).toBeNull()
     })
   })
 
@@ -352,7 +381,7 @@ describe('LoaderManager', () => {
     it('passes setupModel the object returned by the adapter', async () => {
       const { lm, modelManager } = makeLoaderManager()
       const loaded = new THREE.Object3D()
-      meshLoad.mockResolvedValueOnce(loaded)
+      meshLoad.mockResolvedValueOnce(loadResult(loaded))
 
       await lm.loadModel('api/view?filename=cube.glb')
 
@@ -370,7 +399,7 @@ describe('LoaderManager', () => {
 
     it('emits modelLoadingEnd when the load completes', async () => {
       const { lm, eventManager } = makeLoaderManager()
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=cube.glb')
 
@@ -382,7 +411,7 @@ describe('LoaderManager', () => {
 
     it('forwards a decoded path and filename to the adapter', async () => {
       const { lm } = makeLoaderManager()
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel(
         'api/view?type=output&subfolder=nested%2Fdir&filename=cube.glb'
@@ -394,27 +423,29 @@ describe('LoaderManager', () => {
           registerOriginalMaterial: expect.any(Function)
         }),
         'api/view?type=output&subfolder=nested%2Fdir&filename=',
-        'cube.glb'
+        'cube.glb',
+        expect.any(Function)
       )
     })
 
     it('defaults the path to type=input when no type param is given', async () => {
       const { lm } = makeLoaderManager()
-      meshLoad.mockResolvedValueOnce(new THREE.Object3D())
+      meshLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=cube.glb')
 
       expect(meshLoad).toHaveBeenCalledWith(
         expect.anything(),
         'api/view?type=input&subfolder=&filename=',
-        'cube.glb'
+        'cube.glb',
+        expect.any(Function)
       )
     })
 
     it('routes .ply to the point-cloud adapter when the header does not look like 3DGS', async () => {
       isGaussianSplatPLYMock.mockResolvedValue(false)
       const { lm } = makeLoaderManager()
-      pointCloudLoad.mockResolvedValueOnce(new THREE.Object3D())
+      pointCloudLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=scan.ply')
 
@@ -426,7 +457,7 @@ describe('LoaderManager', () => {
     it('reroutes .ply through the splat adapter when the header looks like 3DGS', async () => {
       isGaussianSplatPLYMock.mockResolvedValue(true)
       const { lm } = makeLoaderManager()
-      splatLoad.mockResolvedValueOnce(new THREE.Object3D())
+      splatLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=scan.ply')
 
@@ -435,38 +466,42 @@ describe('LoaderManager', () => {
       expect(lm.getCurrentAdapter()?.kind).toBe('splat')
     })
 
-    it('forwards the fetched bytes to the chosen adapter so .ply is not re-downloaded', async () => {
+    it('shares a single fetch between matches() and load() so .ply is not re-downloaded', async () => {
       const buf = new ArrayBuffer(16)
       fetchModelDataMock.mockResolvedValueOnce(buf)
       isGaussianSplatPLYMock.mockResolvedValue(true)
       const { lm } = makeLoaderManager()
-      splatLoad.mockResolvedValueOnce(new THREE.Object3D())
+      splatLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=scan.ply')
 
+      // Adapter receives a fetchBytes function (memoized), not bytes directly.
       expect(splatLoad).toHaveBeenCalledWith(
         expect.anything(),
         expect.any(String),
         'scan.ply',
-        buf
+        expect.any(Function)
       )
+      // matches() called fetchBytes once; load()'s call hit the cached promise.
       expect(fetchModelDataMock).toHaveBeenCalledTimes(1)
     })
 
-    it('dispatches .ply by adapter kind, not extension order — a splat adapter that also claims .ply does NOT bypass detection', async () => {
+    it('dispatches .ply via the adapter matches() tiebreaker, not extension order — a splat adapter whose matches() returns false yields to point-cloud', async () => {
       const modelManager =
         makeModelManagerStub() as unknown as ConstructorParameters<
           typeof LoaderManager
         >[0]
       const eventManager = makeEventManagerStub()
-      // Pathological adapter list: a splat adapter also claims '.ply'
-      // and is listed first. With a plain extension-first match, .ply
-      // would skip the 3DGS detection. The kind-based dispatch should
-      // still run isGaussianSplatPLY and pick the point-cloud adapter.
+      // A splat adapter that ALSO claims '.ply' and is listed first.
+      // Without matches(), it would short-circuit. With matches() returning
+      // false (not a 3DGS PLY), the dispatcher must skip to the next
+      // candidate (point cloud).
       const splatAdapter = {
         kind: 'splat' as const,
         extensions: ['ply', 'spz', 'splat', 'ksplat'] as const,
         capabilities: {} as never,
+        matches: async (ext: string, fetchBytes: () => Promise<ArrayBuffer>) =>
+          ext === 'ply' ? isGaussianSplatPLYMock(await fetchBytes()) : true,
         load: splatLoad
       }
       const pointCloudAdapter = {
@@ -480,7 +515,7 @@ describe('LoaderManager', () => {
         pointCloudAdapter
       ])
       isGaussianSplatPLYMock.mockResolvedValue(false)
-      pointCloudLoad.mockResolvedValueOnce(new THREE.Object3D())
+      pointCloudLoad.mockResolvedValueOnce(loadResult(new THREE.Object3D()))
 
       await lm.loadModel('api/view?filename=scan.ply')
 
@@ -569,8 +604,8 @@ describe('LoaderManager', () => {
       secondModel.name = 'second'
 
       meshLoad
-        .mockImplementationOnce(() => firstLoad)
-        .mockResolvedValueOnce(secondModel)
+        .mockImplementationOnce(() => firstLoad.then(loadResult))
+        .mockResolvedValueOnce(loadResult(secondModel))
 
       const firstPromise = lm.loadModel('api/view?filename=first.glb')
       const secondPromise = lm.loadModel('api/view?filename=second.glb')

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -2,11 +2,12 @@ import type * as THREE from 'three'
 
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { isGaussianSplatPLY } from '@/scripts/metadata/ply'
 
 import { MeshModelAdapter } from './MeshModelAdapter'
-import { createAdapterRef } from './ModelAdapter'
+import { createAdapterRef, fetchModelData } from './ModelAdapter'
 import type { AdapterRef, ModelAdapter, ModelLoadContext } from './ModelAdapter'
-import { PointCloudModelAdapter, getPLYEngine } from './PointCloudModelAdapter'
+import { PointCloudModelAdapter } from './PointCloudModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
 import type {
   EventManagerInterface,
@@ -138,18 +139,10 @@ export class LoaderManager implements LoaderManagerInterface {
   }
 
   private pickAdapter(extension: string): ModelAdapter | null {
-    const match = this.adapters.find((adapter) =>
-      adapter.extensions.includes(extension)
+    return (
+      this.adapters.find((adapter) => adapter.extensions.includes(extension)) ??
+      null
     )
-    if (!match) return null
-
-    // PLY may be routed through the splat adapter when the PLYEngine setting
-    // is sparkjs. Only honor the routing when both adapters are registered.
-    if (match.kind === 'pointCloud' && getPLYEngine() === 'sparkjs') {
-      const splat = this.adapters.find((adapter) => adapter.kind === 'splat')
-      if (splat) return splat
-    }
-    return match
   }
 
   private createLoadContext(): ModelLoadContext {
@@ -187,6 +180,22 @@ export class LoaderManager implements LoaderManagerInterface {
       '&subfolder=' +
       encodeURIComponent(subfolder) +
       '&filename='
+
+    if (fileExtension === 'ply') {
+      const fileBytes = await fetchModelData(path, filename)
+      const targetKind = (await isGaussianSplatPLY(fileBytes))
+        ? 'splat'
+        : 'pointCloud'
+      const chosen = this.adapters.find((a) => a.kind === targetKind)
+      if (!chosen) return null
+      const model = await chosen.load(
+        this.createLoadContext(),
+        path,
+        filename,
+        fileBytes
+      )
+      return model ? { model, adapter: chosen } : null
+    }
 
     const adapter = this.pickAdapter(fileExtension)
     if (!adapter) return null

--- a/src/extensions/core/load3d/LoaderManager.ts
+++ b/src/extensions/core/load3d/LoaderManager.ts
@@ -2,11 +2,15 @@ import type * as THREE from 'three'
 
 import { t } from '@/i18n'
 import { useToastStore } from '@/platform/updates/common/toastStore'
-import { isGaussianSplatPLY } from '@/scripts/metadata/ply'
 
 import { MeshModelAdapter } from './MeshModelAdapter'
 import { createAdapterRef, fetchModelData } from './ModelAdapter'
-import type { AdapterRef, ModelAdapter, ModelLoadContext } from './ModelAdapter'
+import type {
+  AdapterRef,
+  ModelAdapter,
+  ModelAdapterCapabilities,
+  ModelLoadContext
+} from './ModelAdapter'
 import { PointCloudModelAdapter } from './PointCloudModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
 import type {
@@ -37,14 +41,16 @@ function isNotFoundError(error: unknown): boolean {
 }
 
 /**
- * Default adapter set: mesh + pointCloud + splat. Each adapter declares the
- * file extensions it owns; LoaderManager picks one by extension.
+ * Default adapter set: mesh + splat + pointCloud. Each adapter declares the
+ * file extensions it owns. For shared extensions (.ply), the adapter with an
+ * async `matches()` tiebreaker is tried first; the unconditional adapter acts
+ * as the fallback — so SplatModelAdapter precedes PointCloudModelAdapter.
  */
 function defaultAdapters(): ModelAdapter[] {
   return [
     new MeshModelAdapter(),
-    new PointCloudModelAdapter(),
-    new SplatModelAdapter()
+    new SplatModelAdapter(),
+    new PointCloudModelAdapter()
   ]
 }
 
@@ -87,6 +93,7 @@ export class LoaderManager implements LoaderManagerInterface {
 
       this.modelManager.clearModel()
       this.adapterRef.current = null
+      this.adapterRef.capabilities = null
 
       this.modelManager.originalURL = url
 
@@ -123,7 +130,8 @@ export class LoaderManager implements LoaderManagerInterface {
         // can't clobber adapterRef.current that a newer load already
         // wrote (or cleared).
         this.adapterRef.current = result.adapter
-        await this.modelManager.setupModel(result.model)
+        this.adapterRef.capabilities = result.capabilities
+        await this.modelManager.setupModel(result.object)
       }
 
       this.eventManager.emitEvent('modelLoadingEnd', null)
@@ -138,11 +146,18 @@ export class LoaderManager implements LoaderManagerInterface {
     }
   }
 
-  private pickAdapter(extension: string): ModelAdapter | null {
-    return (
-      this.adapters.find((adapter) => adapter.extensions.includes(extension)) ??
-      null
+  private async pickAdapter(
+    extension: string,
+    fetchBytes: () => Promise<ArrayBuffer>
+  ): Promise<ModelAdapter | null> {
+    const candidates = this.adapters.filter((a) =>
+      a.extensions.includes(extension)
     )
+    for (const adapter of candidates) {
+      if (!adapter.matches) return adapter
+      if (await adapter.matches(extension, fetchBytes)) return adapter
+    }
+    return null
   }
 
   private createLoadContext(): ModelLoadContext {
@@ -163,7 +178,11 @@ export class LoaderManager implements LoaderManagerInterface {
   private async loadModelInternal(
     url: string,
     fileExtension: string
-  ): Promise<{ model: THREE.Object3D; adapter: ModelAdapter } | null> {
+  ): Promise<{
+    object: THREE.Object3D
+    adapter: ModelAdapter
+    capabilities: ModelAdapterCapabilities
+  } | null> {
     const params = new URLSearchParams(url.split('?')[1])
     const filename = params.get('filename')
 
@@ -181,26 +200,24 @@ export class LoaderManager implements LoaderManagerInterface {
       encodeURIComponent(subfolder) +
       '&filename='
 
-    if (fileExtension === 'ply') {
-      const fileBytes = await fetchModelData(path, filename)
-      const targetKind = (await isGaussianSplatPLY(fileBytes))
-        ? 'splat'
-        : 'pointCloud'
-      const chosen = this.adapters.find((a) => a.kind === targetKind)
-      if (!chosen) return null
-      const model = await chosen.load(
-        this.createLoadContext(),
-        path,
-        filename,
-        fileBytes
-      )
-      return model ? { model, adapter: chosen } : null
-    }
+    let bytesPromise: Promise<ArrayBuffer> | null = null
+    const fetchBytes = () => (bytesPromise ??= fetchModelData(path, filename))
 
-    const adapter = this.pickAdapter(fileExtension)
+    const adapter = await this.pickAdapter(fileExtension, fetchBytes)
     if (!adapter) return null
 
-    const model = await adapter.load(this.createLoadContext(), path, filename)
-    return model ? { model, adapter } : null
+    const loadResult = await adapter.load(
+      this.createLoadContext(),
+      path,
+      filename,
+      fetchBytes
+    )
+    return loadResult
+      ? {
+          object: loadResult.object,
+          capabilities: loadResult.capabilities,
+          adapter
+        }
+      : null
   }
 }

--- a/src/extensions/core/load3d/MeshModelAdapter.test.ts
+++ b/src/extensions/core/load3d/MeshModelAdapter.test.ts
@@ -160,8 +160,8 @@ describe('MeshModelAdapter', () => {
       expect(stlLoaderStub.setPath).toHaveBeenCalledWith('/api/view/')
       expect(stlLoaderStub.loadAsync).toHaveBeenCalledWith('model.stl')
       expect(ctx.setOriginalModel).toHaveBeenCalledWith(geometry)
-      expect(result).toBeInstanceOf(THREE.Group)
-      expect(result!.children[0]).toBeInstanceOf(THREE.Mesh)
+      expect(result!.object).toBeInstanceOf(THREE.Group)
+      expect(result!.object.children[0]).toBeInstanceOf(THREE.Mesh)
     })
   })
 
@@ -179,7 +179,7 @@ describe('MeshModelAdapter', () => {
       expect(fbxLoaderStub.loadAsync).toHaveBeenCalledWith('rig.fbx')
       expect(ctx.setOriginalModel).toHaveBeenCalledWith(fbxModel)
       expect(ctx.registerOriginalMaterial).toHaveBeenCalledTimes(1)
-      expect(result).toBe(fbxModel)
+      expect(result!.object).toBe(fbxModel)
     })
 
     it('disables frustum culling on SkinnedMesh children', async () => {
@@ -224,7 +224,7 @@ describe('MeshModelAdapter', () => {
         'cube.obj'
       )
 
-      expect(result).toBeInstanceOf(THREE.Group)
+      expect(result!.object).toBeInstanceOf(THREE.Group)
       expect(objLoaderStub.setMaterials).not.toHaveBeenCalled()
     })
 
@@ -271,7 +271,7 @@ describe('MeshModelAdapter', () => {
       expect(ctx.setOriginalModel).toHaveBeenCalledWith(gltf)
       expect(computeNormals).toHaveBeenCalled()
       expect(ctx.registerOriginalMaterial).toHaveBeenCalledTimes(1)
-      expect(result).toBe(scene)
+      expect(result!.object).toBe(scene)
     })
 
     it('also handles .gltf filenames', async () => {

--- a/src/extensions/core/load3d/MeshModelAdapter.ts
+++ b/src/extensions/core/load3d/MeshModelAdapter.ts
@@ -11,7 +11,8 @@ import OBJLoader2WorkerUrl from 'wwobjloader2/bundle/worker/module?url'
 import type {
   ModelAdapter,
   ModelAdapterCapabilities,
-  ModelLoadContext
+  ModelLoadContext,
+  ModelLoadResult
 } from './ModelAdapter'
 
 export class MeshModelAdapter implements ModelAdapter {
@@ -45,20 +46,18 @@ export class MeshModelAdapter implements ModelAdapter {
     ctx: ModelLoadContext,
     path: string,
     filename: string
-  ): Promise<THREE.Object3D | null> {
+  ): Promise<ModelLoadResult | null> {
     const extension = filename.split('.').pop()?.toLowerCase()
-    switch (extension) {
-      case 'stl':
-        return this.loadSTL(ctx, path, filename)
-      case 'fbx':
-        return this.loadFBX(ctx, path, filename)
-      case 'obj':
-        return this.loadOBJ(ctx, path, filename)
-      case 'gltf':
-      case 'glb':
-        return this.loadGLTF(ctx, path, filename)
-    }
-    return null
+    const object = await (extension === 'stl'
+      ? this.loadSTL(ctx, path, filename)
+      : extension === 'fbx'
+        ? this.loadFBX(ctx, path, filename)
+        : extension === 'obj'
+          ? this.loadOBJ(ctx, path, filename)
+          : extension === 'gltf' || extension === 'glb'
+            ? this.loadGLTF(ctx, path, filename)
+            : Promise.resolve(null))
+    return object ? { object, capabilities: this.capabilities } : null
   }
 
   private async loadSTL(

--- a/src/extensions/core/load3d/ModelAdapter.ts
+++ b/src/extensions/core/load3d/ModelAdapter.ts
@@ -65,25 +65,59 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelAdapterCapabilities = {
 }
 
 /**
- * Mutable handle to the currently active ModelAdapter. A single ref is
- * created in `createLoad3d` and shared between LoaderManager (writer) and
- * SceneModelManager + Load3d (readers), so capability/bounds/dispose lookups
- * don't depend on construction order between those collaborators.
+ * Result returned by `ModelAdapter.load()`. Capabilities ride with the model
+ * because some adapters (notably PLY) produce different capability sets
+ * depending on the file contents — face-less point clouds expose only the
+ * 'pointCloud' material mode, indexed meshes expose the full set. Keeping
+ * capabilities per-load (not per-adapter) prevents stale state on the
+ * adapter instance between two successive loads.
  */
-export type AdapterRef = { current: ModelAdapter | null }
+export type ModelLoadResult = {
+  object: THREE.Object3D
+  capabilities: ModelAdapterCapabilities
+}
 
-export const createAdapterRef = (): AdapterRef => ({ current: null })
+/**
+ * Mutable handle to the currently active ModelAdapter plus the capabilities
+ * reported by its most recent load. A single ref is created in `createLoad3d`
+ * and shared between LoaderManager (writer) and SceneModelManager + Load3d
+ * (readers), so capability/bounds/dispose lookups don't depend on
+ * construction order between those collaborators.
+ */
+export type AdapterRef = {
+  current: ModelAdapter | null
+  capabilities: ModelAdapterCapabilities | null
+}
+
+export const createAdapterRef = (): AdapterRef => ({
+  current: null,
+  capabilities: null
+})
 
 export interface ModelAdapter {
   readonly kind: ModelAdapterKind
   readonly extensions: readonly string[]
+  /**
+   * Default capabilities for this adapter family. `load()` may return a
+   * narrowed set for a specific model — read `adapterRef.capabilities` for
+   * the live per-model value rather than this.
+   */
   readonly capabilities: ModelAdapterCapabilities
+  /**
+   * Async tiebreaker when multiple adapters claim the same extension
+   * (e.g. .ply is shared by Gaussian splats and classic point clouds).
+   * Adapters that uniquely own their extensions can omit this.
+   */
+  matches?(
+    extension: string,
+    fetchBytes: () => Promise<ArrayBuffer>
+  ): Promise<boolean>
   load(
     ctx: ModelLoadContext,
     path: string,
     filename: string,
-    fileBytes?: ArrayBuffer
-  ): Promise<THREE.Object3D | null>
+    fetchBytes?: () => Promise<ArrayBuffer>
+  ): Promise<ModelLoadResult | null>
   /**
    * Optional. Return a world-space AABB for the given model. Adapters for
    * renderers whose geometry is not walked by `Box3.setFromObject` (e.g.

--- a/src/extensions/core/load3d/ModelAdapter.ts
+++ b/src/extensions/core/load3d/ModelAdapter.ts
@@ -81,7 +81,8 @@ export interface ModelAdapter {
   load(
     ctx: ModelLoadContext,
     path: string,
-    filename: string
+    filename: string,
+    fileBytes?: ArrayBuffer
   ): Promise<THREE.Object3D | null>
   /**
    * Optional. Return a world-space AABB for the given model. Adapters for

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -15,30 +15,39 @@ vi.mock('@/scripts/metadata/ply', () => ({
   isPLYAsciiFormat: vi.fn().mockReturnValue(false)
 }))
 
+const plyLoaderParse = vi.fn(() => makePLYGeometry({ withFaces: true }))
+const fastPlyLoaderParse = vi.fn(() => makePLYGeometry({ withFaces: true }))
+
 vi.mock('three/examples/jsm/loaders/PLYLoader', () => ({
   PLYLoader: class {
     setPath = vi.fn()
-    parse = vi.fn(() => makePLYGeometry(false))
+    parse = plyLoaderParse
   }
 }))
 
 vi.mock('./loader/FastPLYLoader', () => ({
   FastPLYLoader: class {
-    parse = vi.fn(() => makePLYGeometry(false))
+    parse = fastPlyLoaderParse
   }
 }))
 
-function makePLYGeometry(withColors: boolean): THREE.BufferGeometry {
+function makePLYGeometry(opts: {
+  withColors?: boolean
+  withFaces?: boolean
+}): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry()
   geometry.setAttribute(
     'position',
     new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3)
   )
-  if (withColors) {
+  if (opts.withColors) {
     geometry.setAttribute(
       'color',
       new THREE.Float32BufferAttribute([1, 0, 0, 0, 1, 0, 0, 0, 1], 3)
     )
+  }
+  if (opts.withFaces) {
+    geometry.setIndex([0, 1, 2])
   }
   return geometry
 }
@@ -111,6 +120,42 @@ describe('PointCloudModelAdapter', () => {
       expect(result).toBeInstanceOf(THREE.Group)
       const child = result!.children[0]
       expect(child).toBeInstanceOf(THREE.Points)
+    })
+
+    it('forces Points rendering for a face-less PLY even on materialMode=original', async () => {
+      plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: false }))
+      const adapter = new PointCloudModelAdapter()
+      const ctx = makeContext('original')
+
+      const result = await adapter.load(ctx, '/api/view?', 'cloud.ply')
+
+      const child = result!.children[0]
+      expect(child).toBeInstanceOf(THREE.Points)
+    })
+
+    it('narrows capabilities.materialModes to [pointCloud] after loading a face-less PLY', async () => {
+      plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: false }))
+      const adapter = new PointCloudModelAdapter()
+
+      await adapter.load(makeContext('original'), '/api/view?', 'cloud.ply')
+
+      expect([...adapter.capabilities.materialModes]).toEqual(['pointCloud'])
+    })
+
+    it('restores full materialModes when a face-bearing PLY is loaded after a face-less one', async () => {
+      const adapter = new PointCloudModelAdapter()
+      plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: false }))
+      await adapter.load(makeContext('original'), '/api/view?', 'cloud.ply')
+      expect([...adapter.capabilities.materialModes]).toEqual(['pointCloud'])
+
+      plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: true }))
+      await adapter.load(makeContext('original'), '/api/view?', 'mesh.ply')
+      expect([...adapter.capabilities.materialModes]).toEqual([
+        'original',
+        'pointCloud',
+        'normal',
+        'wireframe'
+      ])
     })
   })
 })

--- a/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.test.ts
@@ -105,8 +105,8 @@ describe('PointCloudModelAdapter', () => {
 
       const result = await adapter.load(ctx, '/api/view?', 'cloud.ply')
 
-      expect(result).toBeInstanceOf(THREE.Group)
-      const child = result!.children[0]
+      expect(result!.object).toBeInstanceOf(THREE.Group)
+      const child = result!.object.children[0]
       expect(child).toBeInstanceOf(THREE.Mesh)
       expect(ctx.setOriginalModel).toHaveBeenCalledTimes(1)
     })
@@ -117,8 +117,8 @@ describe('PointCloudModelAdapter', () => {
 
       const result = await adapter.load(ctx, '/api/view?', 'cloud.ply')
 
-      expect(result).toBeInstanceOf(THREE.Group)
-      const child = result!.children[0]
+      expect(result!.object).toBeInstanceOf(THREE.Group)
+      const child = result!.object.children[0]
       expect(child).toBeInstanceOf(THREE.Points)
     })
 
@@ -129,28 +129,40 @@ describe('PointCloudModelAdapter', () => {
 
       const result = await adapter.load(ctx, '/api/view?', 'cloud.ply')
 
-      const child = result!.children[0]
+      const child = result!.object.children[0]
       expect(child).toBeInstanceOf(THREE.Points)
     })
 
-    it('narrows capabilities.materialModes to [pointCloud] after loading a face-less PLY', async () => {
+    it('returns narrowed materialModes capability for a face-less PLY', async () => {
       plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: false }))
       const adapter = new PointCloudModelAdapter()
 
-      await adapter.load(makeContext('original'), '/api/view?', 'cloud.ply')
+      const result = await adapter.load(
+        makeContext('original'),
+        '/api/view?',
+        'cloud.ply'
+      )
 
-      expect([...adapter.capabilities.materialModes]).toEqual(['pointCloud'])
+      expect([...result!.capabilities.materialModes]).toEqual(['pointCloud'])
     })
 
-    it('restores full materialModes when a face-bearing PLY is loaded after a face-less one', async () => {
+    it('returns full materialModes capability for a face-bearing PLY (independent of prior loads)', async () => {
       const adapter = new PointCloudModelAdapter()
       plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: false }))
-      await adapter.load(makeContext('original'), '/api/view?', 'cloud.ply')
-      expect([...adapter.capabilities.materialModes]).toEqual(['pointCloud'])
+      const faceless = await adapter.load(
+        makeContext('original'),
+        '/api/view?',
+        'cloud.ply'
+      )
+      expect([...faceless!.capabilities.materialModes]).toEqual(['pointCloud'])
 
       plyLoaderParse.mockReturnValueOnce(makePLYGeometry({ withFaces: true }))
-      await adapter.load(makeContext('original'), '/api/view?', 'mesh.ply')
-      expect([...adapter.capabilities.materialModes]).toEqual([
+      const faceful = await adapter.load(
+        makeContext('original'),
+        '/api/view?',
+        'mesh.ply'
+      )
+      expect([...faceful!.capabilities.materialModes]).toEqual([
         'original',
         'pointCloud',
         'normal',

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -8,7 +8,8 @@ import { fetchModelData } from './ModelAdapter'
 import type {
   ModelAdapter,
   ModelAdapterCapabilities,
-  ModelLoadContext
+  ModelLoadContext,
+  ModelLoadResult
 } from './ModelAdapter'
 import type { MaterialMode } from './interfaces'
 import { FastPLYLoader } from './loader/FastPLYLoader'
@@ -17,25 +18,20 @@ function getPLYEngine(): string {
   return useSettingStore().get('Comfy.Load3D.PLYEngine') as string
 }
 
+const POINT_CLOUD_CAPABILITIES: ModelAdapterCapabilities = {
+  fitToViewer: true,
+  requiresMaterialRebuild: true,
+  gizmoTransform: false,
+  lighting: true,
+  exportable: true,
+  materialModes: ['original', 'pointCloud', 'normal', 'wireframe'],
+  fitTargetSize: 5
+}
+
 export class PointCloudModelAdapter implements ModelAdapter {
   readonly kind = 'pointCloud' as const
   readonly extensions = ['ply'] as const
-
-  private hasFaces: boolean = true
-
-  get capabilities(): ModelAdapterCapabilities {
-    return {
-      fitToViewer: true,
-      requiresMaterialRebuild: true,
-      gizmoTransform: false,
-      lighting: true,
-      exportable: true,
-      materialModes: this.hasFaces
-        ? ['original', 'pointCloud', 'normal', 'wireframe']
-        : ['pointCloud'],
-      fitTargetSize: 5
-    }
-  }
+  readonly capabilities = POINT_CLOUD_CAPABILITIES
 
   private readonly plyLoader = new PLYLoader()
   private readonly fastPlyLoader = new FastPLYLoader()
@@ -44,9 +40,9 @@ export class PointCloudModelAdapter implements ModelAdapter {
     ctx: ModelLoadContext,
     path: string,
     filename: string,
-    fileBytes?: ArrayBuffer
-  ): Promise<THREE.Object3D | null> {
-    const arrayBuffer = fileBytes ?? (await fetchModelData(path, filename))
+    fetchBytes?: () => Promise<ArrayBuffer>
+  ): Promise<ModelLoadResult | null> {
+    const arrayBuffer = await (fetchBytes?.() ?? fetchModelData(path, filename))
     const isASCII = isPLYAsciiFormat(arrayBuffer)
 
     const plyGeometry =
@@ -58,13 +54,18 @@ export class PointCloudModelAdapter implements ModelAdapter {
     plyGeometry.computeVertexNormals()
 
     const hasVertexColors = plyGeometry.attributes.color !== undefined
-    this.hasFaces = (plyGeometry.index?.count ?? 0) > 0
+    const hasFaces = (plyGeometry.index?.count ?? 0) > 0
 
-    if (ctx.materialMode === 'pointCloud' || !this.hasFaces) {
-      return buildPointsGroup(ctx, plyGeometry, hasVertexColors)
-    }
+    const object =
+      ctx.materialMode === 'pointCloud' || !hasFaces
+        ? buildPointsGroup(ctx, plyGeometry, hasVertexColors)
+        : buildMeshGroup(ctx, plyGeometry, hasVertexColors)
 
-    return buildMeshGroup(ctx, plyGeometry, hasVertexColors)
+    const capabilities = hasFaces
+      ? POINT_CLOUD_CAPABILITIES
+      : { ...POINT_CLOUD_CAPABILITIES, materialModes: ['pointCloud'] as const }
+
+    return { object, capabilities }
   }
 }
 

--- a/src/extensions/core/load3d/PointCloudModelAdapter.ts
+++ b/src/extensions/core/load3d/PointCloudModelAdapter.ts
@@ -13,21 +13,28 @@ import type {
 import type { MaterialMode } from './interfaces'
 import { FastPLYLoader } from './loader/FastPLYLoader'
 
-export function getPLYEngine(): string {
+function getPLYEngine(): string {
   return useSettingStore().get('Comfy.Load3D.PLYEngine') as string
 }
 
 export class PointCloudModelAdapter implements ModelAdapter {
   readonly kind = 'pointCloud' as const
   readonly extensions = ['ply'] as const
-  readonly capabilities: ModelAdapterCapabilities = {
-    fitToViewer: true,
-    requiresMaterialRebuild: true,
-    gizmoTransform: false,
-    lighting: true,
-    exportable: true,
-    materialModes: ['original', 'pointCloud', 'normal', 'wireframe'],
-    fitTargetSize: 5
+
+  private hasFaces: boolean = true
+
+  get capabilities(): ModelAdapterCapabilities {
+    return {
+      fitToViewer: true,
+      requiresMaterialRebuild: true,
+      gizmoTransform: false,
+      lighting: true,
+      exportable: true,
+      materialModes: this.hasFaces
+        ? ['original', 'pointCloud', 'normal', 'wireframe']
+        : ['pointCloud'],
+      fitTargetSize: 5
+    }
   }
 
   private readonly plyLoader = new PLYLoader()
@@ -36,9 +43,10 @@ export class PointCloudModelAdapter implements ModelAdapter {
   async load(
     ctx: ModelLoadContext,
     path: string,
-    filename: string
+    filename: string,
+    fileBytes?: ArrayBuffer
   ): Promise<THREE.Object3D | null> {
-    const arrayBuffer = await fetchModelData(path, filename)
+    const arrayBuffer = fileBytes ?? (await fetchModelData(path, filename))
     const isASCII = isPLYAsciiFormat(arrayBuffer)
 
     const plyGeometry =
@@ -50,8 +58,9 @@ export class PointCloudModelAdapter implements ModelAdapter {
     plyGeometry.computeVertexNormals()
 
     const hasVertexColors = plyGeometry.attributes.color !== undefined
+    this.hasFaces = (plyGeometry.index?.count ?? 0) > 0
 
-    if (ctx.materialMode === 'pointCloud') {
+    if (ctx.materialMode === 'pointCloud' || !this.hasFaces) {
       return buildPointsGroup(ctx, plyGeometry, hasVertexColors)
     }
 

--- a/src/extensions/core/load3d/SceneManager.ts
+++ b/src/extensions/core/load3d/SceneManager.ts
@@ -14,6 +14,17 @@ export class SceneManager implements SceneManagerInterface {
   gridHelper: THREE.GridHelper
   private sparkRenderer: SparkRenderer
 
+  private nextSparkDirtyPromise: Promise<void> | null = null
+  private nextSparkDirtyResolve: (() => void) | null = null
+
+  awaitNextSparkDirty(): Promise<void> {
+    if (this.nextSparkDirtyPromise) return this.nextSparkDirtyPromise
+    this.nextSparkDirtyPromise = new Promise<void>((resolve) => {
+      this.nextSparkDirtyResolve = resolve
+    })
+    return this.nextSparkDirtyPromise
+  }
+
   backgroundScene!: THREE.Scene
   backgroundCamera: THREE.OrthographicCamera
   backgroundMesh: THREE.Mesh | null = null
@@ -46,7 +57,22 @@ export class SceneManager implements SceneManagerInterface {
 
     // Spark 2.x requires a SparkRenderer in the scene tree to render SplatMesh
     // instances; without it splats are silent no-ops.
-    this.sparkRenderer = new SparkRenderer({ renderer })
+    //
+    // onDirty fires twice per splat first-paint cycle: once from updateInternal
+    // (data uploaded) and again from driveSort (sort completed; line 1105 in
+    // SparkRenderer.ts). We expose it as a passive promise — awaiters get
+    // notified, but the callback itself does NOT trigger a render. Wiring
+    // forceRender directly into onDirty caused a per-frame render-setDirty
+    // cascade that made splats visibly "balloon" during camera interaction.
+    this.sparkRenderer = new SparkRenderer({
+      renderer,
+      onDirty: () => {
+        const resolve = this.nextSparkDirtyResolve
+        this.nextSparkDirtyResolve = null
+        this.nextSparkDirtyPromise = null
+        resolve?.()
+      }
+    })
     this.scene.add(this.sparkRenderer)
 
     this.gridHelper = new THREE.GridHelper(20, 20)

--- a/src/extensions/core/load3d/SceneManager.ts
+++ b/src/extensions/core/load3d/SceneManager.ts
@@ -45,8 +45,7 @@ export class SceneManager implements SceneManagerInterface {
     this.getActiveCamera = getActiveCamera
 
     // Spark 2.x requires a SparkRenderer in the scene tree to render SplatMesh
-    // (Gaussian splat) instances; without it splats are silent no-ops. Kept
-    // alive across model reloads by SceneModelManager.clearModel.
+    // instances; without it splats are silent no-ops.
     this.sparkRenderer = new SparkRenderer({ renderer })
     this.scene.add(this.sparkRenderer)
 

--- a/src/extensions/core/load3d/SceneModelManager.ts
+++ b/src/extensions/core/load3d/SceneModelManager.ts
@@ -435,6 +435,11 @@ export class SceneModelManager implements ModelManagerInterface {
     )
   }
 
+  getCurrentBounds(): THREE.Box3 | null {
+    if (!this.currentModel) return null
+    return this.computeWorldBounds(this.currentModel)
+  }
+
   async setupModel(model: THREE.Object3D): Promise<void> {
     this.currentModel = model
     model.name = 'MainModel'
@@ -454,6 +459,12 @@ export class SceneModelManager implements ModelManagerInterface {
 
     if (pendingMaterialMode !== 'original') {
       this.setMaterialMode(pendingMaterialMode)
+    }
+
+    const validModes = this.getCurrentCapabilities().materialModes
+    if (validModes.length > 0 && !validModes.includes(this.materialMode)) {
+      this.materialMode = validModes[0]
+      this.eventManager.emitEvent('materialModeChange', this.materialMode)
     }
 
     if (this.currentUpDirection !== 'original') {

--- a/src/extensions/core/load3d/SplatModelAdapter.test.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.test.ts
@@ -69,7 +69,7 @@ describe('SplatModelAdapter', () => {
 
   it('handles the Gaussian splat extensions', () => {
     const adapter = new SplatModelAdapter()
-    expect([...adapter.extensions]).toEqual(['spz', 'splat', 'ksplat'])
+    expect([...adapter.extensions]).toEqual(['spz', 'splat', 'ksplat', 'ply'])
   })
 
   it('fetches the file, builds a SplatMesh, and wraps it in a Group', async () => {
@@ -89,11 +89,14 @@ describe('SplatModelAdapter', () => {
       fileBytes: buf,
       fileName: 'scene.splat'
     })
-    expect(result).toBeInstanceOf(THREE.Group)
-    expect(result.children).toHaveLength(1)
+    expect(result!.object).toBeInstanceOf(THREE.Group)
+    expect(result!.object.children).toHaveLength(1)
+    expect(result!.capabilities.lighting).toBe(false)
 
     expect(ctx.setOriginalModel).toHaveBeenCalledTimes(1)
-    expect(ctx.setOriginalModel).toHaveBeenCalledWith(result.children[0])
+    expect(ctx.setOriginalModel).toHaveBeenCalledWith(
+      result!.object.children[0]
+    )
   })
 
   it('rotates the splat 180° around X (OpenCV → three.js convention)', async () => {
@@ -103,7 +106,7 @@ describe('SplatModelAdapter', () => {
       'scene.splat'
     )
 
-    const splat = result.children[0]
+    const splat = result!.object.children[0]
     expect(splat.quaternion.x).toBe(1)
     expect(splat.quaternion.y).toBe(0)
     expect(splat.quaternion.z).toBe(0)
@@ -124,11 +127,12 @@ describe('SplatModelAdapter', () => {
   describe('computeBounds', () => {
     it('returns the SplatMesh bounding box transformed to world space', async () => {
       const adapter = new SplatModelAdapter()
-      const group = await adapter.load(
+      const result = await adapter.load(
         makeContext(),
         '/api/view?',
         'scene.splat'
       )
+      const group = result!.object
       const splat = group.children[0]
       splat.position.set(10, 0, 0)
 
@@ -155,13 +159,13 @@ describe('SplatModelAdapter', () => {
   describe('disposeModel', () => {
     it('calls dispose on every SplatMesh in the model tree', async () => {
       const adapter = new SplatModelAdapter()
-      const group = await adapter.load(
+      const result = await adapter.load(
         makeContext(),
         '/api/view?',
         'scene.splat'
       )
 
-      adapter.disposeModel(group)
+      adapter.disposeModel(result!.object)
 
       expect(splatMeshSpies.dispose).toHaveBeenCalledOnce()
     })

--- a/src/extensions/core/load3d/SplatModelAdapter.test.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.test.ts
@@ -6,7 +6,7 @@ import type { ModelLoadContext } from './ModelAdapter'
 import { SplatModelAdapter } from './SplatModelAdapter'
 
 const splatMeshSpies = {
-  ctor: vi.fn<(opts: { fileBytes: ArrayBuffer }) => void>(),
+  ctor: vi.fn<(opts: { fileBytes: ArrayBuffer; fileName?: string }) => void>(),
   dispose: vi.fn(),
   getBoundingBox: vi.fn(
     () =>
@@ -23,7 +23,7 @@ vi.mock('@sparkjsdev/spark', async () => {
       dispose = splatMeshSpies.dispose
       getBoundingBox = splatMeshSpies.getBoundingBox
 
-      constructor(opts: { fileBytes: ArrayBuffer }) {
+      constructor(opts: { fileBytes: ArrayBuffer; fileName?: string }) {
         super()
         splatMeshSpies.ctor(opts)
       }
@@ -85,7 +85,10 @@ describe('SplatModelAdapter', () => {
       '/api/view?',
       'scene.splat'
     )
-    expect(splatMeshSpies.ctor).toHaveBeenCalledWith({ fileBytes: buf })
+    expect(splatMeshSpies.ctor).toHaveBeenCalledWith({
+      fileBytes: buf,
+      fileName: 'scene.splat'
+    })
     expect(result).toBeInstanceOf(THREE.Group)
     expect(result.children).toHaveLength(1)
 

--- a/src/extensions/core/load3d/SplatModelAdapter.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.ts
@@ -1,16 +1,19 @@
 import { SplatMesh } from '@sparkjsdev/spark'
 import * as THREE from 'three'
 
+import { isGaussianSplatPLY } from '@/scripts/metadata/ply'
+
 import { fetchModelData } from './ModelAdapter'
 import type {
   ModelAdapter,
   ModelAdapterCapabilities,
-  ModelLoadContext
+  ModelLoadContext,
+  ModelLoadResult
 } from './ModelAdapter'
 
 export class SplatModelAdapter implements ModelAdapter {
   readonly kind = 'splat' as const
-  readonly extensions = ['spz', 'splat', 'ksplat'] as const
+  readonly extensions = ['spz', 'splat', 'ksplat', 'ply'] as const
   readonly capabilities: ModelAdapterCapabilities = {
     fitToViewer: true,
     requiresMaterialRebuild: false,
@@ -21,13 +24,21 @@ export class SplatModelAdapter implements ModelAdapter {
     fitTargetSize: 20
   }
 
+  async matches(
+    extension: string,
+    fetchBytes: () => Promise<ArrayBuffer>
+  ): Promise<boolean> {
+    if (extension !== 'ply') return true
+    return isGaussianSplatPLY(await fetchBytes())
+  }
+
   async load(
     ctx: ModelLoadContext,
     path: string,
     filename: string,
-    fileBytes?: ArrayBuffer
-  ): Promise<THREE.Object3D> {
-    const arrayBuffer = fileBytes ?? (await fetchModelData(path, filename))
+    fetchBytes?: () => Promise<ArrayBuffer>
+  ): Promise<ModelLoadResult> {
+    const arrayBuffer = await (fetchBytes?.() ?? fetchModelData(path, filename))
 
     const splatMesh = new SplatMesh({
       fileBytes: arrayBuffer,
@@ -39,7 +50,7 @@ export class SplatModelAdapter implements ModelAdapter {
 
     const splatGroup = new THREE.Group()
     splatGroup.add(splatMesh)
-    return splatGroup
+    return { object: splatGroup, capabilities: this.capabilities }
   }
 
   computeBounds(model: THREE.Object3D): THREE.Box3 | null {

--- a/src/extensions/core/load3d/SplatModelAdapter.ts
+++ b/src/extensions/core/load3d/SplatModelAdapter.ts
@@ -24,11 +24,15 @@ export class SplatModelAdapter implements ModelAdapter {
   async load(
     ctx: ModelLoadContext,
     path: string,
-    filename: string
+    filename: string,
+    fileBytes?: ArrayBuffer
   ): Promise<THREE.Object3D> {
-    const arrayBuffer = await fetchModelData(path, filename)
+    const arrayBuffer = fileBytes ?? (await fetchModelData(path, filename))
 
-    const splatMesh = new SplatMesh({ fileBytes: arrayBuffer })
+    const splatMesh = new SplatMesh({
+      fileBytes: arrayBuffer,
+      fileName: filename
+    })
     await splatMesh.initialized
     splatMesh.quaternion.set(1, 0, 0, 0)
     ctx.setOriginalModel(splatMesh)

--- a/src/extensions/core/load3d/createLoad3d.test.ts
+++ b/src/extensions/core/load3d/createLoad3d.test.ts
@@ -125,7 +125,11 @@ vi.mock('./Load3d', () => ({
   }
 }))
 
-type FakeLoaderManager = { adapterRefArg: { current: ModelAdapter | null } }
+type FakeAdapterRef = {
+  current: ModelAdapter | null
+  capabilities: ModelAdapterCapabilities | null
+}
+type FakeLoaderManager = { adapterRefArg: FakeAdapterRef }
 type FakeSceneModelManager = {
   getCurrentCapabilities: () => unknown
   getBoundsFromAdapter: (model: unknown) => unknown
@@ -134,7 +138,7 @@ type FakeSceneModelManager = {
 }
 type FakeLoad3d = {
   deps: {
-    adapterRef: { current: ModelAdapter | null }
+    adapterRef: FakeAdapterRef
     loaderManager: FakeLoaderManager
     modelManager: FakeSceneModelManager
   }
@@ -222,6 +226,7 @@ describe('createLoad3d', () => {
     function withAdapter(adapter: ModelAdapter) {
       const instance = createLoad3d(createContainer()) as unknown as FakeLoad3d
       instance.deps.adapterRef.current = adapter
+      instance.deps.adapterRef.capabilities = adapter.capabilities
       return instance
     }
 

--- a/src/extensions/core/load3d/createLoad3d.ts
+++ b/src/extensions/core/load3d/createLoad3d.ts
@@ -84,7 +84,7 @@ function buildLoad3dDeps(container: Element | HTMLElement): Load3dDeps {
     getActiveCamera,
     (size, center) => cameraManager.setupForModel(size, center),
     (model) => gizmoManager.setupForModel(model),
-    () => adapterRef.current?.capabilities ?? DEFAULT_MODEL_CAPABILITIES,
+    () => adapterRef.capabilities ?? DEFAULT_MODEL_CAPABILITIES,
     (model) => adapterRef.current?.computeBounds?.(model) ?? null,
     (model) => adapterRef.current?.disposeModel?.(model),
     () => adapterRef.current?.defaultCameraPose?.() ?? null

--- a/src/extensions/core/load3d/nodeTypes.ts
+++ b/src/extensions/core/load3d/nodeTypes.ts
@@ -1,0 +1,18 @@
+/**
+ * Canonical lists of node types backed by the Load3D viewer infrastructure.
+ * Adding a new node type that uses the viewer = one line change here.
+ */
+
+const LOAD3D_PREVIEW_NODES = new Set([
+  'Preview3D',
+  'PreviewGaussianSplat',
+  'PreviewPointCloud'
+])
+
+const LOAD3D_ALL_NODES = new Set([...LOAD3D_PREVIEW_NODES, 'Load3D', 'SaveGLB'])
+
+export const isLoad3dPreviewNode = (nodeType: string): boolean =>
+  LOAD3D_PREVIEW_NODES.has(nodeType)
+
+export const isLoad3dNode = (nodeType: string): boolean =>
+  LOAD3D_ALL_NODES.has(nodeType)

--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 vi.mock('@/extensions/core/load3d', () => ({}))
+vi.mock('@/extensions/core/load3dPreviewExtensions', () => ({}))
 vi.mock('@/extensions/core/saveMesh', () => ({}))
 
 type Hook = (
@@ -83,7 +84,13 @@ describe('load3dLazy', () => {
     expect(enabledExtensionsGetter).not.toHaveBeenCalled()
   })
 
-  it.for(['Load3D', 'Preview3D', 'SaveGLB'])(
+  it.for([
+    'Load3D',
+    'Preview3D',
+    'PreviewGaussianSplat',
+    'PreviewPointCloud',
+    'SaveGLB'
+  ])(
     'recognizes %s as a 3D node type and triggers the lazy-load path',
     async (nodeType) => {
       const { hook } = await loadLazyExtensionFresh()

--- a/src/extensions/core/load3dLazy.ts
+++ b/src/extensions/core/load3dLazy.ts
@@ -15,7 +15,13 @@ import { useExtensionStore } from '@/stores/extensionStore'
 
 import type { ComfyExtension } from '@/types/comfy'
 
-const LOAD3D_NODE_TYPES = new Set(['Load3D', 'Preview3D', 'SaveGLB'])
+const LOAD3D_NODE_TYPES = new Set([
+  'Load3D',
+  'Preview3D',
+  'PreviewGaussianSplat',
+  'PreviewPointCloud',
+  'SaveGLB'
+])
 
 let load3dExtensionsLoaded = false
 let load3dExtensionsLoading: Promise<ComfyExtension[]> | null = null
@@ -34,8 +40,12 @@ async function loadLoad3dExtensions(): Promise<ComfyExtension[]> {
 
   load3dExtensionsLoading = (async () => {
     const before = new Set(useExtensionStore().enabledExtensions)
-    // Import both extensions - they will self-register via useExtensionService()
-    await Promise.all([import('./load3d'), import('./saveMesh')])
+    // Import extensions - they self-register via useExtensionService()
+    await Promise.all([
+      import('./load3d'),
+      import('./load3dPreviewExtensions'),
+      import('./saveMesh')
+    ])
     load3dExtensionsLoaded = true
     return useExtensionStore().enabledExtensions.filter(
       (ext) => !before.has(ext)

--- a/src/extensions/core/load3dLazy.ts
+++ b/src/extensions/core/load3dLazy.ts
@@ -15,13 +15,7 @@ import { useExtensionStore } from '@/stores/extensionStore'
 
 import type { ComfyExtension } from '@/types/comfy'
 
-const LOAD3D_NODE_TYPES = new Set([
-  'Load3D',
-  'Preview3D',
-  'PreviewGaussianSplat',
-  'PreviewPointCloud',
-  'SaveGLB'
-])
+import { isLoad3dNode } from './load3d/nodeTypes'
 
 let load3dExtensionsLoaded = false
 let load3dExtensionsLoading: Promise<ComfyExtension[]> | null = null
@@ -55,13 +49,6 @@ async function loadLoad3dExtensions(): Promise<ComfyExtension[]> {
   return load3dExtensionsLoading
 }
 
-/**
- * Check if a node type is a 3D node that requires THREE.js
- */
-function isLoad3dNodeType(nodeTypeName: string): boolean {
-  return LOAD3D_NODE_TYPES.has(nodeTypeName)
-}
-
 // Register a lightweight extension that triggers lazy loading
 useExtensionService().registerExtension({
   name: 'Comfy.Load3DLazy',
@@ -70,7 +57,7 @@ useExtensionService().registerExtension({
     nodeType: typeof LGraphNode,
     nodeData: ComfyNodeDef
   ) {
-    if (isLoad3dNodeType(nodeData.name)) {
+    if (isLoad3dNode(nodeData.name)) {
       // Inject mesh_upload spec flags so WidgetSelect.vue can detect
       // Load3D's model_file as a mesh upload widget without hardcoding.
       if (nodeData.name === 'Load3D') {

--- a/src/extensions/core/load3dPreviewExtensions.test.ts
+++ b/src/extensions/core/load3dPreviewExtensions.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { ComfyExtension } from '@/types/comfy'
+
+const {
+  registerExtensionMock,
+  waitForLoad3dMock,
+  onLoad3dReadyMock,
+  configureForSaveMeshMock,
+  getLoad3dMock,
+  toastAddAlertMock,
+  getNodeByLocatorIdMock,
+  nodeToLoad3dMapMock
+} = vi.hoisted(() => ({
+  registerExtensionMock: vi.fn(),
+  waitForLoad3dMock: vi.fn(),
+  onLoad3dReadyMock: vi.fn(),
+  configureForSaveMeshMock: vi.fn(),
+  getLoad3dMock: vi.fn(),
+  toastAddAlertMock: vi.fn(),
+  getNodeByLocatorIdMock: vi.fn(),
+  nodeToLoad3dMapMock: new Map()
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({ registerExtension: registerExtensionMock })
+}))
+
+vi.mock('@/services/load3dService', () => ({
+  useLoad3dService: () => ({ getLoad3d: getLoad3dMock })
+}))
+
+vi.mock('@/composables/useLoad3d', () => ({
+  useLoad3d: () => ({
+    waitForLoad3d: waitForLoad3dMock,
+    onLoad3dReady: onLoad3dReadyMock
+  }),
+  nodeToLoad3dMap: nodeToLoad3dMapMock
+}))
+
+vi.mock('@/extensions/core/load3d/Load3DConfiguration', () => ({
+  default: class {
+    configureForSaveMesh = configureForSaveMeshMock
+  }
+}))
+
+vi.mock('@/extensions/core/load3d/exportMenuHelper', () => ({
+  createExportMenuItems: vi.fn(() => [{ content: 'Export' }])
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: { rootGraph: {} }
+}))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  getNodeByLocatorId: getNodeByLocatorIdMock
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert: toastAddAlertMock })
+}))
+
+type ExtCreated = ComfyExtension & {
+  nodeCreated: (node: LGraphNode) => Promise<void>
+  getNodeMenuItems: (node: LGraphNode) => unknown[]
+  onNodeOutputsUpdated: (
+    nodeOutputs: Record<string, Record<string, unknown>>
+  ) => void
+}
+
+async function loadExtensionsFresh(): Promise<{
+  splatExt: ExtCreated
+  pointCloudExt: ExtCreated
+}> {
+  vi.resetModules()
+  registerExtensionMock.mockClear()
+  await import('@/extensions/core/load3dPreviewExtensions')
+  const [splatCall, pointCloudCall] = registerExtensionMock.mock.calls
+  return {
+    splatExt: splatCall[0] as ExtCreated,
+    pointCloudExt: pointCloudCall[0] as ExtCreated
+  }
+}
+
+interface FakeLoad3d {
+  whenLoadIdle: () => Promise<void>
+  isSplatModel: ReturnType<typeof vi.fn>
+  forceRender: ReturnType<typeof vi.fn>
+  setCameraState: ReturnType<typeof vi.fn>
+  setTargetSize: ReturnType<typeof vi.fn>
+  getCurrentCameraType: ReturnType<typeof vi.fn>
+  getCameraState: ReturnType<typeof vi.fn>
+  getModelInfo: ReturnType<typeof vi.fn>
+  cameraManager: { perspectiveCamera: { fov: number } }
+  currentLoadGeneration: number
+}
+
+function makeLoad3dMock(): FakeLoad3d {
+  return {
+    whenLoadIdle: vi.fn().mockResolvedValue(undefined),
+    isSplatModel: vi.fn(() => false),
+    forceRender: vi.fn(),
+    setCameraState: vi.fn(),
+    setTargetSize: vi.fn(),
+    getCurrentCameraType: vi.fn(() => 'perspective'),
+    getCameraState: vi.fn(() => ({ position: { x: 0, y: 0, z: 0 } })),
+    getModelInfo: vi.fn(() => null),
+    cameraManager: { perspectiveCamera: { fov: 75 } },
+    currentLoadGeneration: 0
+  }
+}
+
+interface FakeWidget {
+  name: string
+  value: unknown
+}
+
+function makePreviewNode(
+  overrides: Partial<{
+    comfyClass: string
+    properties: Record<string, unknown>
+    widgets: FakeWidget[]
+  }> = {}
+): LGraphNode {
+  return {
+    constructor: {
+      comfyClass: overrides.comfyClass ?? 'PreviewGaussianSplat'
+    },
+    size: [400, 550],
+    setSize: vi.fn(),
+    widgets: overrides.widgets ?? [{ name: 'model_file', value: '' }],
+    properties: overrides.properties ?? {}
+  } as unknown as LGraphNode
+}
+
+function setupBaseMocks() {
+  vi.clearAllMocks()
+  waitForLoad3dMock.mockImplementation((cb: (load3d: FakeLoad3d) => void) => {
+    cb(makeLoad3dMock())
+  })
+  onLoad3dReadyMock.mockImplementation((cb: (load3d: FakeLoad3d) => void) => {
+    cb(makeLoad3dMock())
+  })
+}
+
+describe('load3dPreviewExtensions module registration', () => {
+  beforeEach(setupBaseMocks)
+
+  it('registers both preview extensions on import', async () => {
+    const { splatExt, pointCloudExt } = await loadExtensionsFresh()
+
+    expect(registerExtensionMock).toHaveBeenCalledTimes(2)
+    expect(splatExt.name).toBe('Comfy.PreviewGaussianSplat')
+    expect(pointCloudExt.name).toBe('Comfy.PreviewPointCloud')
+  })
+})
+
+describe('Comfy.PreviewGaussianSplat.nodeCreated', () => {
+  beforeEach(setupBaseMocks)
+
+  it('skips nodes whose comfyClass is not PreviewGaussianSplat', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const node = makePreviewNode({ comfyClass: 'OtherNode' })
+
+    await splatExt.nodeCreated(node)
+
+    expect(waitForLoad3dMock).not.toHaveBeenCalled()
+    expect(configureForSaveMeshMock).not.toHaveBeenCalled()
+  })
+
+  it('triggers a model load against the output folder on execute', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const load3d = makeLoad3dMock()
+    waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
+      cb(load3d)
+    )
+    const node = makePreviewNode()
+
+    await splatExt.nodeCreated(node)
+    node.onExecuted!({ result: ['scene.ply'] })
+
+    expect(node.properties['Last Time Model File']).toBe('scene.ply')
+    expect(configureForSaveMeshMock).toHaveBeenLastCalledWith(
+      'output',
+      'scene.ply',
+      expect.objectContaining({ silentOnNotFound: true })
+    )
+  })
+
+  it('persists backend-provided camera_info into node.properties so onLoad3dReady can restore it after remount', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const load3d = makeLoad3dMock()
+    waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
+      cb(load3d)
+    )
+    const node = makePreviewNode()
+    const cameraState = {
+      position: { x: 1, y: 2, z: 3 },
+      target: { x: 0, y: 0, z: 0 },
+      zoom: 1
+    }
+
+    await splatExt.nodeCreated(node)
+    node.onExecuted!({ result: ['scene.ply', cameraState] })
+
+    const cameraConfig = node.properties['Camera Config'] as
+      | { state?: typeof cameraState }
+      | undefined
+    expect(cameraConfig?.state).toEqual(cameraState)
+  })
+
+  it('syncs width/height widgets to load3d.setTargetSize and registers callbacks', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const load3d = makeLoad3dMock()
+    waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
+      cb(load3d)
+    )
+    const widthWidget: FakeWidget & { callback?: (v: number) => void } = {
+      name: 'width',
+      value: 800
+    }
+    const heightWidget: FakeWidget & { callback?: (v: number) => void } = {
+      name: 'height',
+      value: 600
+    }
+    const node = makePreviewNode({
+      widgets: [
+        { name: 'model_file', value: '' },
+        { name: 'image', value: '' },
+        widthWidget,
+        heightWidget
+      ]
+    })
+
+    await splatExt.nodeCreated(node)
+
+    expect(load3d.setTargetSize).toHaveBeenCalledWith(800, 600)
+    expect(typeof widthWidget.callback).toBe('function')
+    expect(typeof heightWidget.callback).toBe('function')
+
+    widthWidget.callback!(1024)
+    expect(load3d.setTargetSize).toHaveBeenLastCalledWith(1024, 600)
+  })
+
+  it("installs a sceneWidget.serializeValue that returns the viewer's current camera_info + model_3d_info", async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const load3d = makeLoad3dMock()
+    const cameraState = { position: { x: 1, y: 2, z: 3 } }
+    load3d.getCameraState = vi.fn(() => cameraState)
+    load3d.getModelInfo = vi.fn(() => ({
+      position: { x: 0, y: 0, z: 0 },
+      quaternion: { x: 0, y: 0, z: 0, w: 1 },
+      scale: { x: 1, y: 1, z: 1 }
+    }))
+    waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
+      cb(load3d)
+    )
+    const sceneWidget: FakeWidget & {
+      serializeValue?: () => Promise<unknown>
+    } = { name: 'image', value: '' }
+    const node = makePreviewNode({
+      widgets: [{ name: 'model_file', value: '' }, sceneWidget]
+    })
+    nodeToLoad3dMapMock.set(node, load3d)
+
+    await splatExt.nodeCreated(node)
+
+    expect(typeof sceneWidget.serializeValue).toBe('function')
+    const payload = (await sceneWidget.serializeValue!()) as {
+      camera_info: unknown
+      model_3d_info: unknown[]
+    }
+    expect(payload.camera_info).toEqual(cameraState)
+    expect(payload.model_3d_info).toHaveLength(1)
+  })
+
+  it('shows an error toast when onExecuted has no file path', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const node = makePreviewNode()
+
+    await splatExt.nodeCreated(node)
+    node.onExecuted!({ result: [] })
+
+    expect(toastAddAlertMock).toHaveBeenCalledWith(
+      'toastMessages.unableToGetModelFilePath'
+    )
+  })
+})
+
+describe('Comfy.PreviewPointCloud.nodeCreated', () => {
+  beforeEach(setupBaseMocks)
+
+  it('skips nodes whose comfyClass is not PreviewPointCloud', async () => {
+    const { pointCloudExt } = await loadExtensionsFresh()
+    const node = makePreviewNode({ comfyClass: 'OtherNode' })
+
+    await pointCloudExt.nodeCreated(node)
+
+    expect(waitForLoad3dMock).not.toHaveBeenCalled()
+    expect(configureForSaveMeshMock).not.toHaveBeenCalled()
+  })
+
+  it('triggers a model load against the output folder on execute', async () => {
+    const { pointCloudExt } = await loadExtensionsFresh()
+    const load3d = makeLoad3dMock()
+    waitForLoad3dMock.mockImplementation((cb: (l: FakeLoad3d) => void) =>
+      cb(load3d)
+    )
+    const node = makePreviewNode({ comfyClass: 'PreviewPointCloud' })
+
+    await pointCloudExt.nodeCreated(node)
+    node.onExecuted!({ result: ['pointcloud.ply'] })
+
+    expect(node.properties['Last Time Model File']).toBe('pointcloud.ply')
+    expect(configureForSaveMeshMock).toHaveBeenLastCalledWith(
+      'output',
+      'pointcloud.ply',
+      expect.objectContaining({ silentOnNotFound: true })
+    )
+  })
+})
+
+describe('Comfy.PreviewGaussianSplat.onNodeOutputsUpdated', () => {
+  beforeEach(setupBaseMocks)
+
+  it('skips entries whose comfyClass is not PreviewGaussianSplat', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    getNodeByLocatorIdMock.mockReturnValue(makePreviewNode({ comfyClass: 'X' }))
+
+    splatExt.onNodeOutputsUpdated({
+      'node:1': { result: ['scene.ply'] }
+    })
+
+    expect(waitForLoad3dMock).not.toHaveBeenCalled()
+  })
+
+  it('skips entries with no result file path', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    getNodeByLocatorIdMock.mockReturnValue(makePreviewNode())
+
+    splatExt.onNodeOutputsUpdated({ 'node:1': { result: [] } })
+
+    expect(waitForLoad3dMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('Comfy.PreviewGaussianSplat.getNodeMenuItems', () => {
+  beforeEach(setupBaseMocks)
+
+  it('returns [] for non-PreviewGaussianSplat nodes', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const items = splatExt.getNodeMenuItems(
+      makePreviewNode({ comfyClass: 'OtherNode' })
+    )
+    expect(items).toEqual([])
+  })
+
+  it('returns [] for splat models', async () => {
+    const { splatExt } = await loadExtensionsFresh()
+    const load3d = makeLoad3dMock()
+    load3d.isSplatModel = vi.fn(() => true)
+    getLoad3dMock.mockReturnValue(load3d)
+
+    const items = splatExt.getNodeMenuItems(makePreviewNode())
+    expect(items).toEqual([])
+  })
+})

--- a/src/extensions/core/load3dPreviewExtensions.ts
+++ b/src/extensions/core/load3dPreviewExtensions.ts
@@ -1,0 +1,211 @@
+import { nextTick } from 'vue'
+
+import { nodeToLoad3dMap, useLoad3d } from '@/composables/useLoad3d'
+import { createExportMenuItems } from '@/extensions/core/load3d/exportMenuHelper'
+import type {
+  CameraConfig,
+  CameraState,
+  Model3DInfo
+} from '@/extensions/core/load3d/interfaces'
+import type Load3d from '@/extensions/core/load3d/Load3d'
+import Load3DConfiguration from '@/extensions/core/load3d/Load3DConfiguration'
+import { t } from '@/i18n'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import type { NodeExecutionOutput, NodeOutputWith } from '@/schemas/apiSchema'
+import { app } from '@/scripts/app'
+import { useExtensionService } from '@/services/extensionService'
+import { useLoad3dService } from '@/services/load3dService'
+import type { ComfyExtension } from '@/types/comfy'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
+
+type PreviewOutput = NodeOutputWith<{
+  result?: [string?, CameraState?, Model3DInfo?]
+}>
+
+function applyResultToLoad3d(
+  node: LGraphNode,
+  load3d: Load3d,
+  filePath: string,
+  cameraState: CameraState | undefined
+): void {
+  const normalizedPath = filePath.replaceAll('\\', '/')
+  node.properties['Last Time Model File'] = normalizedPath
+  if (cameraState) {
+    const existing = node.properties['Camera Config'] as
+      | CameraConfig
+      | undefined
+    node.properties['Camera Config'] = {
+      cameraType: existing?.cameraType ?? load3d.getCurrentCameraType(),
+      fov: existing?.fov ?? 75,
+      ...existing,
+      state: cameraState
+    }
+  }
+
+  const config = new Load3DConfiguration(load3d, node.properties)
+  config.configureForSaveMesh('output', normalizedPath, {
+    silentOnNotFound: true
+  })
+
+  const targetGeneration = load3d.currentLoadGeneration
+  void load3d.whenLoadIdle().then(() => {
+    if (load3d.currentLoadGeneration !== targetGeneration) return
+    if (cameraState) load3d.setCameraState(cameraState)
+    load3d.forceRender()
+  })
+}
+
+function createPreview3DExtension(
+  comfyClass: string,
+  extensionName: string
+): ComfyExtension {
+  const applyPreviewOutput = (
+    node: LGraphNode,
+    result: NonNullable<PreviewOutput['result']>
+  ): void => {
+    const filePath = result[0]
+    const cameraState = result[1]
+    if (!filePath) return
+
+    useLoad3d(node).waitForLoad3d((load3d) => {
+      applyResultToLoad3d(node, load3d, filePath, cameraState)
+    })
+  }
+
+  return {
+    name: extensionName,
+
+    onNodeOutputsUpdated(
+      nodeOutputs: Record<NodeLocatorId, NodeExecutionOutput>
+    ) {
+      for (const [locatorId, output] of Object.entries(nodeOutputs)) {
+        const result = (output as PreviewOutput).result
+        if (!result?.[0]) continue
+
+        const node = getNodeByLocatorId(app.rootGraph, locatorId)
+        if (!node || node.constructor.comfyClass !== comfyClass) continue
+
+        applyPreviewOutput(node, result)
+      }
+    },
+
+    getNodeMenuItems(node: LGraphNode): (IContextMenuValue | null)[] {
+      if (node.constructor.comfyClass !== comfyClass) return []
+
+      const load3d = useLoad3dService().getLoad3d(node)
+      if (!load3d) return []
+
+      if (load3d.isSplatModel()) return []
+
+      return createExportMenuItems(load3d)
+    },
+
+    async nodeCreated(node: LGraphNode) {
+      if (node.constructor.comfyClass !== comfyClass) return
+
+      const [oldWidth, oldHeight] = node.size
+      node.setSize([Math.max(oldWidth, 400), Math.max(oldHeight, 550)])
+
+      await nextTick()
+
+      const onExecuted = node.onExecuted
+
+      useLoad3d(node).onLoad3dReady((load3d) => {
+        const lastTimeModelFile = node.properties['Last Time Model File']
+        if (!lastTimeModelFile) return
+
+        const config = new Load3DConfiguration(load3d, node.properties)
+        config.configureForSaveMesh('output', lastTimeModelFile as string, {
+          silentOnNotFound: true
+        })
+
+        const cameraConfig = node.properties['Camera Config'] as
+          | CameraConfig
+          | undefined
+        const cameraState = cameraConfig?.state
+        const targetGeneration = load3d.currentLoadGeneration
+        void load3d.whenLoadIdle().then(() => {
+          if (load3d.currentLoadGeneration !== targetGeneration) return
+          if (cameraState) load3d.setCameraState(cameraState)
+          load3d.forceRender()
+        })
+      })
+
+      useLoad3d(node).waitForLoad3d((load3d) => {
+        const sceneWidget = node.widgets?.find((w) => w.name === 'image')
+        const widthWidget = node.widgets?.find((w) => w.name === 'width')
+        const heightWidget = node.widgets?.find((w) => w.name === 'height')
+
+        if (widthWidget && heightWidget) {
+          load3d.setTargetSize(
+            widthWidget.value as number,
+            heightWidget.value as number
+          )
+          widthWidget.callback = (value: number) => {
+            load3d.setTargetSize(value, heightWidget.value as number)
+          }
+          heightWidget.callback = (value: number) => {
+            load3d.setTargetSize(widthWidget.value as number, value)
+          }
+        }
+
+        if (sceneWidget) {
+          sceneWidget.serializeValue = async () => {
+            const currentLoad3d = nodeToLoad3dMap.get(node)
+            if (!currentLoad3d) {
+              console.error('No load3d instance found for node')
+              return null
+            }
+
+            const cameraConfig: CameraConfig = (node.properties[
+              'Camera Config'
+            ] as CameraConfig | undefined) || {
+              cameraType: currentLoad3d.getCurrentCameraType(),
+              fov: currentLoad3d.cameraManager.perspectiveCamera.fov
+            }
+            cameraConfig.state = currentLoad3d.getCameraState()
+            node.properties['Camera Config'] = cameraConfig
+
+            const modelInfo = currentLoad3d.getModelInfo()
+            const model_3d_info: Model3DInfo = modelInfo ? [modelInfo] : []
+
+            return {
+              image: '',
+              mask: '',
+              normal: '',
+              camera_info: cameraConfig.state || null,
+              recording: '',
+              model_3d_info
+            }
+          }
+        }
+
+        node.onExecuted = function (output: PreviewOutput) {
+          onExecuted?.call(this, output)
+
+          const result = output.result
+          const filePath = result?.[0]
+
+          if (!filePath) {
+            const msg = t('toastMessages.unableToGetModelFilePath')
+            console.error(msg)
+            useToastStore().addAlert(msg)
+            return
+          }
+
+          applyResultToLoad3d(node, load3d, filePath, result?.[1])
+        }
+      })
+    }
+  }
+}
+
+useExtensionService().registerExtension(
+  createPreview3DExtension('PreviewGaussianSplat', 'Comfy.PreviewGaussianSplat')
+)
+useExtensionService().registerExtension(
+  createPreview3DExtension('PreviewPointCloud', 'Comfy.PreviewPointCloud')
+)

--- a/src/extensions/core/load3dPreviewExtensions.ts
+++ b/src/extensions/core/load3dPreviewExtensions.ts
@@ -38,8 +38,8 @@ function applyResultToLoad3d(
       | CameraConfig
       | undefined
     node.properties['Camera Config'] = {
-      cameraType: existing?.cameraType ?? load3d.getCurrentCameraType(),
-      fov: existing?.fov ?? 75,
+      cameraType: load3d.getCurrentCameraType(),
+      fov: 75,
       ...existing,
       state: cameraState
     }
@@ -112,8 +112,9 @@ function createPreview3DExtension(
       await nextTick()
 
       const onExecuted = node.onExecuted
+      const { onLoad3dReady, waitForLoad3d } = useLoad3d(node)
 
-      useLoad3d(node).onLoad3dReady((load3d) => {
+      onLoad3dReady((load3d) => {
         const lastTimeModelFile = node.properties['Last Time Model File']
         if (!lastTimeModelFile) return
 
@@ -134,7 +135,7 @@ function createPreview3DExtension(
         })
       })
 
-      useLoad3d(node).waitForLoad3d((load3d) => {
+      waitForLoad3d((load3d) => {
         const sceneWidget = node.widgets?.find((w) => w.name === 'image')
         const widthWidget = node.widgets?.find((w) => w.name === 'width')
         const heightWidget = node.widgets?.find((w) => w.name === 'height')

--- a/src/locales/ar/settings.json
+++ b/src/locales/ar/settings.json
@@ -199,7 +199,6 @@
     "name": "محرك PLY",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "اختر المحرك لتحميل ملفات PLY. \"threejs\" يستخدم محمل Three.js PLY الأصلي (الأفضل لملفات الشبكة). \"fastply\" يستخدم محملًا محسنًا لملفات PLY السحابية النقطية بنسق ASCII. \"sparkjs\" يستخدم Spark.js لملفات PLY الخاصة بتقنية Gaussian Splatting ثلاثية الأبعاد."

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1971,6 +1971,7 @@
     "materialMode": "Material Mode",
     "showSkeleton": "Show Skeleton",
     "fitToViewer": "Fit to Viewer",
+    "centerCameraOnModel": "Center Camera on Model",
     "scene": "Scene",
     "model": "Model",
     "camera": "Camera",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -196,12 +196,11 @@
     "tooltip": "Sets the minimum allowable light intensity value for 3D scenes. This defines the lower brightness limit that can be set when adjusting lighting in any 3D widget."
   },
   "Comfy_Load3D_PLYEngine": {
-    "name": "PLY Engine",
-    "tooltip": "Select the engine for loading PLY files. \"threejs\" uses the native Three.js PLYLoader (best for mesh PLY files). \"fastply\" uses an optimized loader for ASCII point cloud PLY files. \"sparkjs\" uses Spark.js for 3D Gaussian Splatting PLY files.",
+    "name": "Point Cloud Engine",
+    "tooltip": "Select the engine for loading point cloud PLY files. \"threejs\" uses the native Three.js PLYLoader (handles binary + ASCII, mesh-capable). \"fastply\" uses an optimized parser for ASCII PLY files. 3D Gaussian Splat PLYs are detected automatically and always rendered via sparkjs regardless of this setting.",
     "options": {
       "threejs": "threejs",
-      "fastply": "fastply",
-      "sparkjs": "sparkjs"
+      "fastply": "fastply"
     }
   },
   "Comfy_Load3D_ShowGrid": {

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -199,7 +199,6 @@
     "name": "Motor PLY",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "Selecciona el motor para cargar archivos PLY. \"threejs\" utiliza el cargador nativo Three.js PLYLoader (mejor para archivos PLY de malla). \"fastply\" utiliza un cargador optimizado para archivos PLY de nube de puntos ASCII. \"sparkjs\" utiliza Spark.js para archivos PLY de Gaussian Splatting 3D."

--- a/src/locales/fa/settings.json
+++ b/src/locales/fa/settings.json
@@ -199,7 +199,6 @@
     "name": "موتور PLY",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "موتور بارگذاری فایل‌های PLY را انتخاب کنید. «threejs» از PLYLoader بومی Three.js استفاده می‌کند (مناسب برای فایل‌های مش PLY). «fastply» از یک بارگذار بهینه‌شده برای فایل‌های point cloud PLY به صورت ASCII استفاده می‌کند. «sparkjs» از Spark.js برای فایل‌های 3D Gaussian Splatting PLY استفاده می‌کند."

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -199,7 +199,6 @@
     "name": "Moteur PLY",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "Sélectionnez le moteur pour charger les fichiers PLY. « threejs » utilise le PLYLoader natif de Three.js (idéal pour les fichiers PLY de maillage). « fastply » utilise un chargeur optimisé pour les fichiers PLY de nuages de points ASCII. « sparkjs » utilise Spark.js pour les fichiers PLY de Gaussian Splatting 3D."

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -199,7 +199,6 @@
     "name": "PLYエンジン",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "PLYファイルを読み込むエンジンを選択します。「threejs」はネイティブのThree.js PLYLoaderを使用（メッシュPLYファイルに最適）。「fastply」はASCIIポイントクラウドPLYファイル用の最適化ローダーを使用。「sparkjs」は3DガウシアンスプラッティングPLYファイル用にSpark.jsを使用します。"

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -199,7 +199,6 @@
     "name": "PLY 엔진",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "PLY 파일을 불러올 엔진을 선택합니다. \"threejs\"는 네이티브 Three.js PLYLoader를 사용하며(메시 PLY 파일에 적합), \"fastply\"는 ASCII 포인트 클라우드 PLY 파일에 최적화된 로더를 사용합니다. \"sparkjs\"는 3D Gaussian Splatting PLY 파일에 Spark.js를 사용합니다."

--- a/src/locales/pt-BR/settings.json
+++ b/src/locales/pt-BR/settings.json
@@ -199,7 +199,6 @@
     "name": "Engine PLY",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "Selecione a engine para carregar arquivos PLY. \"threejs\" usa o PLYLoader nativo do Three.js (melhor para arquivos PLY de malha). \"fastply\" usa um carregador otimizado para arquivos PLY de nuvem de pontos ASCII. \"sparkjs\" usa Spark.js para arquivos PLY de Gaussian Splatting 3D."

--- a/src/locales/ru/settings.json
+++ b/src/locales/ru/settings.json
@@ -199,7 +199,6 @@
     "name": "Движок PLY",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "Выберите движок для загрузки PLY файлов. \"threejs\" использует встроенный загрузчик Three.js PLYLoader (лучше всего подходит для файлов сетки PLY). \"fastply\" использует оптимизированный загрузчик для ASCII PLY файлов облака точек. \"sparkjs\" использует Spark.js для PLY файлов с 3D Gaussian Splatting."

--- a/src/locales/tr/settings.json
+++ b/src/locales/tr/settings.json
@@ -199,7 +199,6 @@
     "name": "PLY Motoru",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "PLY dosyalarını yüklemek için motoru seçin. \"threejs\" yerel Three.js PLYLoader'ı kullanır (ağ PLY dosyaları için en iyisi). \"fastply\" ASCII nokta bulutu PLY dosyaları için optimize edilmiş bir yükleyici kullanır. \"sparkjs\" ise 3D Gaussian Splatting PLY dosyaları için Spark.js kullanır."

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -199,7 +199,6 @@
     "name": "PLY 引擎",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
     "tooltip": "選擇用於載入 PLY 檔案的引擎。「threejs」使用原生 Three.js PLYLoader（適合網格 PLY 檔案）。「fastply」使用優化的 ASCII 點雲 PLY 檔案載入器。「sparkjs」使用 Spark.js 處理 3D Gaussian Splatting PLY 檔案。"

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -2009,6 +2009,7 @@
     "exportRecording": "导出录制",
     "exportingModel": "正在导出模型...",
     "fitToViewer": "适应视图",
+    "centerCameraOnModel": "将相机居中到模型",
     "fov": "视场",
     "gizmo": {
       "label": "控件",

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -196,13 +196,12 @@
     "tooltip": "设置3D场景允许的最小光照强度值。此值定义在任何3D组件中调整光照时可设置的最小亮度。"
   },
   "Comfy_Load3D_PLYEngine": {
-    "name": "PLY引擎",
+    "name": "点云引擎",
     "options": {
       "fastply": "fastply",
-      "sparkjs": "sparkjs",
       "threejs": "threejs"
     },
-    "tooltip": "选择用于加载PLY文件的引擎。\"threejs\" 使用原生Three.js PLYLoader（适合网格PLY文件）。\"fastply\" 用于优化的ASCII点云PLY文件加载。\"sparkjs\" 用于3D高斯斑点PLY文件的Spark.js。"
+    "tooltip": "选择用于加载点云PLY文件的引擎。\"threejs\" 使用原生Three.js PLYLoader（支持二进制和ASCII，可处理网格）。\"fastply\" 使用针对ASCII PLY的优化解析器。3D高斯泼溅PLY会自动识别并始终通过sparkjs渲染，不受此设置影响。"
   },
   "Comfy_Load3D_ShowGrid": {
     "name": "初始网格可见性",

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -446,7 +446,7 @@ const zSettings = z.object({
   'Comfy.Load3D.LightAdjustmentIncrement': z.number(),
   'Comfy.Load3D.CameraType': z.enum(['perspective', 'orthographic']),
   'Comfy.Load3D.3DViewerEnable': z.boolean(),
-  'Comfy.Load3D.PLYEngine': z.enum(['threejs', 'fastply', 'sparkjs']),
+  'Comfy.Load3D.PLYEngine': z.enum(['threejs', 'fastply']),
   'Comfy.Memory.AllowManualUnload': z.boolean(),
   'pysssss.SnapToGrid': z.boolean(),
   /** VHS setting is used for queue video preview support. */

--- a/src/scripts/metadata/ply.test.ts
+++ b/src/scripts/metadata/ply.test.ts
@@ -1,94 +1,98 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// vitest.setup.ts globally mocks @sparkjsdev/spark without exporting
-// PlyReader (the real one pulls in WASM that doesn't run under Node).
-// Override the global mock here with a header-only PlyReader stub that
-// mirrors the real parseHeader() — same accepted formats, same element /
-// property dictionary shape — so isGaussianSplatPLY exercises the real
-// reuse path in tests.
-vi.mock('@sparkjsdev/spark', () => {
-  type StubProperty = { isList: boolean; type: string }
-  type StubElement = {
-    name: string
-    count: number
-    properties: Record<string, StubProperty>
-  }
+// Override the global @sparkjsdev/spark mock from vitest.setup.ts (the real
+// PlyReader pulls in WASM that doesn't run under Node) with a thin stub
+// driven by per-test fixtures — see `mockNextParseHeader` below. Keeping the
+// PLY-format parsing out of the test file because (a) it would be a parallel
+// implementation that can drift from sparkjs, and (b) sparkjs's PlyReader
+// already has its own coverage. We're only testing what isGaussianSplatPLY
+// does with the parsed result.
+type StubProperty = { isList: boolean; type: string }
+type StubElement = {
+  name: string
+  count: number
+  properties: Record<string, StubProperty>
+}
 
-  class PlyReader {
-    fileBytes: Uint8Array
-    elements: Record<string, StubElement> = {}
-
-    constructor({ fileBytes }: { fileBytes: ArrayBuffer | Uint8Array }) {
-      this.fileBytes =
-        fileBytes instanceof ArrayBuffer ? new Uint8Array(fileBytes) : fileBytes
+const {
+  nextHeaderResultMock,
+  resetParseHeaderMock,
+  mockNextParseHeader,
+  mockNextParseHeaderError
+} = vi.hoisted(() => {
+  let next: { elements?: Record<string, StubElement>; error?: Error } = {}
+  return {
+    nextHeaderResultMock: () => next,
+    resetParseHeaderMock: () => {
+      next = {}
+    },
+    mockNextParseHeader: (elements: Record<string, StubElement>) => {
+      next = { elements }
+    },
+    mockNextParseHeaderError: (error: Error) => {
+      next = { error }
     }
+  }
+})
 
+vi.mock('@sparkjsdev/spark', () => ({
+  PlyReader: class {
+    elements: Record<string, StubElement> = {}
+    constructor(_: unknown) {}
     parseHeader(): Promise<void> {
-      const text = new TextDecoder().decode(this.fileBytes.slice(0, 65536))
-      const terminator = 'end_header\n'
-      const endIdx = text.indexOf(terminator)
-      if (endIdx < 0) {
-        return Promise.reject(new Error('Failed to read header'))
-      }
-      const header = text.slice(0, endIdx)
-      const lines = header.split('\n')
-      if (lines[0]?.trim() !== 'ply') {
-        return Promise.reject(new Error('Invalid PLY header'))
-      }
-      let curElement: StubElement | null = null
-      for (const line of lines.slice(1)) {
-        const fields = line.trim().split(' ')
-        switch (fields[0]) {
-          case 'format':
-            if (
-              fields[1] !== 'binary_little_endian' &&
-              fields[1] !== 'binary_big_endian'
-            ) {
-              return Promise.reject(
-                new Error(`Unsupported PLY format: ${fields[1]}`)
-              )
-            }
-            break
-          case 'element':
-            curElement = {
-              name: fields[1],
-              count: Number.parseInt(fields[2]),
-              properties: {}
-            }
-            this.elements[fields[1]] = curElement
-            break
-          case 'property':
-            if (!curElement) {
-              return Promise.reject(
-                new Error('Property must be inside an element')
-              )
-            }
-            if (fields[1] === 'list') {
-              curElement.properties[fields[4]] = {
-                isList: true,
-                type: fields[3]
-              }
-            } else {
-              curElement.properties[fields[2]] = {
-                isList: false,
-                type: fields[1]
-              }
-            }
-            break
-        }
-      }
+      const { elements, error } = nextHeaderResultMock()
+      if (error) return Promise.reject(error)
+      this.elements = elements ?? {}
       return Promise.resolve()
     }
   }
-
-  return { PlyReader }
-})
+}))
 
 import {
   isGaussianSplatPLY,
   isPLYAsciiFormat,
   parseASCIIPLY
 } from '@/scripts/metadata/ply'
+
+const FLOAT = { isList: false, type: 'float' }
+const UCHAR = { isList: false, type: 'uchar' }
+const vertex = (
+  props: Record<string, StubProperty>
+): Record<string, StubElement> => ({
+  vertex: { name: 'vertex', count: 1, properties: props }
+})
+const GAUSSIAN_SPLAT_PROPS = {
+  x: FLOAT,
+  y: FLOAT,
+  z: FLOAT,
+  f_dc_0: FLOAT,
+  f_dc_1: FLOAT,
+  f_dc_2: FLOAT,
+  opacity: FLOAT,
+  scale_0: FLOAT,
+  scale_1: FLOAT,
+  scale_2: FLOAT,
+  rot_0: FLOAT,
+  rot_1: FLOAT,
+  rot_2: FLOAT,
+  rot_3: FLOAT
+}
+const POINT_CLOUD_PROPS = {
+  x: FLOAT,
+  y: FLOAT,
+  z: FLOAT,
+  red: UCHAR,
+  green: UCHAR,
+  blue: UCHAR
+}
+const DC_ONLY_PROPS = {
+  x: FLOAT,
+  y: FLOAT,
+  z: FLOAT,
+  f_dc_0: FLOAT,
+  f_dc_1: FLOAT,
+  f_dc_2: FLOAT
+}
 
 function createPLYBuffer(content: string): ArrayBuffer {
   return new TextEncoder().encode(content).buffer
@@ -142,85 +146,30 @@ end_header`
   })
 
   describe('isGaussianSplatPLY', () => {
+    beforeEach(resetParseHeaderMock)
+
     it('detects a 3DGS PLY by scale_0..2 + rot_0..3 properties on the vertex element', async () => {
-      const ply = `ply
-format binary_little_endian 1.0
-element vertex 1
-property float x
-property float y
-property float z
-property float nx
-property float ny
-property float nz
-property float f_dc_0
-property float f_dc_1
-property float f_dc_2
-property float opacity
-property float scale_0
-property float scale_1
-property float scale_2
-property float rot_0
-property float rot_1
-property float rot_2
-property float rot_3
-end_header
-`
-      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(true)
+      mockNextParseHeader(vertex(GAUSSIAN_SPLAT_PROPS))
+      expect(await isGaussianSplatPLY(new ArrayBuffer(0))).toBe(true)
     })
 
-    it('returns false for a binary point-cloud PLY with no scale/rot properties', async () => {
-      const ply = `ply
-format binary_little_endian 1.0
-element vertex 1
-property float x
-property float y
-property float z
-property uchar red
-property uchar green
-property uchar blue
-end_header
-`
-      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(false)
+    it('returns false for a point-cloud PLY with no scale/rot properties', async () => {
+      mockNextParseHeader(vertex(POINT_CLOUD_PROPS))
+      expect(await isGaussianSplatPLY(new ArrayBuffer(0))).toBe(false)
     })
 
     it('returns false when only the f_dc_* DC term is present (no scale/rot)', async () => {
-      const ply = `ply
-format binary_little_endian 1.0
-element vertex 1
-property float x
-property float y
-property float z
-property float f_dc_0
-property float f_dc_1
-property float f_dc_2
-end_header
-`
-      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(false)
+      mockNextParseHeader(vertex(DC_ONLY_PROPS))
+      expect(await isGaussianSplatPLY(new ArrayBuffer(0))).toBe(false)
     })
 
-    it('returns false for an ASCII PLY (sparkjs PlyReader rejects ASCII by design)', async () => {
-      const ply = `ply
-format ascii 1.0
-element vertex 3
-property float x
-property float y
-property float z
-end_header
-0 0 0
-1 0 0
-0 1 0`
-      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(false)
+    it('returns false when parseHeader rejects (malformed / unsupported PLY)', async () => {
+      mockNextParseHeaderError(new Error('Failed to read header'))
+      expect(await isGaussianSplatPLY(new ArrayBuffer(0))).toBe(false)
     })
 
-    it('returns false when end_header is missing', async () => {
-      expect(
-        await isGaussianSplatPLY(
-          createPLYBuffer('ply\nformat binary_little_endian 1.0\n')
-        )
-      ).toBe(false)
-    })
-
-    it('returns false for an empty buffer', async () => {
+    it('returns false when the vertex element is missing entirely', async () => {
+      mockNextParseHeader({})
       expect(await isGaussianSplatPLY(new ArrayBuffer(0))).toBe(false)
     })
   })

--- a/src/scripts/metadata/ply.test.ts
+++ b/src/scripts/metadata/ply.test.ts
@@ -1,6 +1,94 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { isPLYAsciiFormat, parseASCIIPLY } from '@/scripts/metadata/ply'
+// vitest.setup.ts globally mocks @sparkjsdev/spark without exporting
+// PlyReader (the real one pulls in WASM that doesn't run under Node).
+// Override the global mock here with a header-only PlyReader stub that
+// mirrors the real parseHeader() — same accepted formats, same element /
+// property dictionary shape — so isGaussianSplatPLY exercises the real
+// reuse path in tests.
+vi.mock('@sparkjsdev/spark', () => {
+  type StubProperty = { isList: boolean; type: string }
+  type StubElement = {
+    name: string
+    count: number
+    properties: Record<string, StubProperty>
+  }
+
+  class PlyReader {
+    fileBytes: Uint8Array
+    elements: Record<string, StubElement> = {}
+
+    constructor({ fileBytes }: { fileBytes: ArrayBuffer | Uint8Array }) {
+      this.fileBytes =
+        fileBytes instanceof ArrayBuffer ? new Uint8Array(fileBytes) : fileBytes
+    }
+
+    parseHeader(): Promise<void> {
+      const text = new TextDecoder().decode(this.fileBytes.slice(0, 65536))
+      const terminator = 'end_header\n'
+      const endIdx = text.indexOf(terminator)
+      if (endIdx < 0) {
+        return Promise.reject(new Error('Failed to read header'))
+      }
+      const header = text.slice(0, endIdx)
+      const lines = header.split('\n')
+      if (lines[0]?.trim() !== 'ply') {
+        return Promise.reject(new Error('Invalid PLY header'))
+      }
+      let curElement: StubElement | null = null
+      for (const line of lines.slice(1)) {
+        const fields = line.trim().split(' ')
+        switch (fields[0]) {
+          case 'format':
+            if (
+              fields[1] !== 'binary_little_endian' &&
+              fields[1] !== 'binary_big_endian'
+            ) {
+              return Promise.reject(
+                new Error(`Unsupported PLY format: ${fields[1]}`)
+              )
+            }
+            break
+          case 'element':
+            curElement = {
+              name: fields[1],
+              count: Number.parseInt(fields[2]),
+              properties: {}
+            }
+            this.elements[fields[1]] = curElement
+            break
+          case 'property':
+            if (!curElement) {
+              return Promise.reject(
+                new Error('Property must be inside an element')
+              )
+            }
+            if (fields[1] === 'list') {
+              curElement.properties[fields[4]] = {
+                isList: true,
+                type: fields[3]
+              }
+            } else {
+              curElement.properties[fields[2]] = {
+                isList: false,
+                type: fields[1]
+              }
+            }
+            break
+        }
+      }
+      return Promise.resolve()
+    }
+  }
+
+  return { PlyReader }
+})
+
+import {
+  isGaussianSplatPLY,
+  isPLYAsciiFormat,
+  parseASCIIPLY
+} from '@/scripts/metadata/ply'
 
 function createPLYBuffer(content: string): ArrayBuffer {
   return new TextEncoder().encode(content).buffer
@@ -50,6 +138,90 @@ end_header`
     it('should handle empty buffer', () => {
       const buffer = new ArrayBuffer(0)
       expect(isPLYAsciiFormat(buffer)).toBe(false)
+    })
+  })
+
+  describe('isGaussianSplatPLY', () => {
+    it('detects a 3DGS PLY by scale_0..2 + rot_0..3 properties on the vertex element', async () => {
+      const ply = `ply
+format binary_little_endian 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float nx
+property float ny
+property float nz
+property float f_dc_0
+property float f_dc_1
+property float f_dc_2
+property float opacity
+property float scale_0
+property float scale_1
+property float scale_2
+property float rot_0
+property float rot_1
+property float rot_2
+property float rot_3
+end_header
+`
+      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(true)
+    })
+
+    it('returns false for a binary point-cloud PLY with no scale/rot properties', async () => {
+      const ply = `ply
+format binary_little_endian 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+end_header
+`
+      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(false)
+    })
+
+    it('returns false when only the f_dc_* DC term is present (no scale/rot)', async () => {
+      const ply = `ply
+format binary_little_endian 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float f_dc_0
+property float f_dc_1
+property float f_dc_2
+end_header
+`
+      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(false)
+    })
+
+    it('returns false for an ASCII PLY (sparkjs PlyReader rejects ASCII by design)', async () => {
+      const ply = `ply
+format ascii 1.0
+element vertex 3
+property float x
+property float y
+property float z
+end_header
+0 0 0
+1 0 0
+0 1 0`
+      expect(await isGaussianSplatPLY(createPLYBuffer(ply))).toBe(false)
+    })
+
+    it('returns false when end_header is missing', async () => {
+      expect(
+        await isGaussianSplatPLY(
+          createPLYBuffer('ply\nformat binary_little_endian 1.0\n')
+        )
+      ).toBe(false)
+    })
+
+    it('returns false for an empty buffer', async () => {
+      expect(await isGaussianSplatPLY(new ArrayBuffer(0))).toBe(false)
     })
   })
 

--- a/src/scripts/metadata/ply.ts
+++ b/src/scripts/metadata/ply.ts
@@ -2,6 +2,7 @@
  * PLY (Polygon File Format) decoder
  * Parses ASCII PLY files and extracts vertex positions and colors
  */
+import { PlyReader } from '@sparkjsdev/spark'
 
 interface PLYHeader {
   vertexCount: number
@@ -150,4 +151,28 @@ export function parseASCIIPLY(arrayBuffer: ArrayBuffer): PLYData | null {
 export function isPLYAsciiFormat(arrayBuffer: ArrayBuffer): boolean {
   const header = new TextDecoder().decode(arrayBuffer.slice(0, 500))
   return header.includes('format ascii')
+}
+
+/**
+ * Mirrors sparkjs's own check (PlyReader.parseSplats:
+ * `hasScales && hasRots`), we delegate header parsing to sparkjs's
+ * PlyReader so the property dictionary we inspect is exactly the one
+ * sparkjs would see if asked to render the file. parseHeader rejects
+ * ASCII PLYs by design; we catch and treat them as not-3DGS (no real
+ * 3DGS export uses ASCII PLY).
+ */
+export async function isGaussianSplatPLY(
+  arrayBuffer: ArrayBuffer
+): Promise<boolean> {
+  try {
+    const reader = new PlyReader({ fileBytes: arrayBuffer })
+    await reader.parseHeader()
+    const props = reader.elements.vertex?.properties
+    if (!props) return false
+    const hasScales = !!(props.scale_0 && props.scale_1 && props.scale_2)
+    const hasRots = !!(props.rot_0 && props.rot_1 && props.rot_2 && props.rot_3)
+    return hasScales && hasRots
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## Summary
Two dedicated 3D viewer extensions for the splat / point-cloud.

- Comfy.PreviewGaussianSplat targets backend node 'PreviewGaussianSplat'  (.ply / .spz / .splat / .ksplat).
- Comfy.PreviewPointCloud targets backend node 'PreviewPointCloud'  (.ply point clouds).

PLY auto-dispatch, no more user-facing engine choice for 3DGS:

**Please be aware that I have not yet implemented any UI optimizations on the frontend for world models such as World Labs' Marble, no WSAD controls, no scale optimization yet**

BE: https://github.com/Comfy-Org/ComfyUI/pull/14194

## Screenshots (if applicable)
ksplat file:
<img width="2714" height="1391" alt="image" src="https://github.com/user-attachments/assets/9024db9d-20e9-44ea-ab14-500810d2946a" />
splat file:
<img width="2938" height="1410" alt="image" src="https://github.com/user-attachments/assets/de768fa5-9d55-4560-9fb3-b218b96ea0c7" />
spz file:
<img width="1729" height="845" alt="image" src="https://github.com/user-attachments/assets/cc09e568-77c9-45b3-a6cc-8f5d1062f3ec" />
ply (splat) file:
<img width="1702" height="843" alt="image" src="https://github.com/user-attachments/assets/2a51c2ce-046b-4843-9e58-634bc45cbcce" />
ply (point cloud) file:
<img width="1701" height="842" alt="image" src="https://github.com/user-attachments/assets/db75808e-3481-4ecc-8582-e4fec21163fd" />
