### PR TITLE
fix: use thumbnail previews for on-node image grid cells (FE-741)

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -379,6 +379,16 @@ describe('ImagePreview', () => {
       expect(gridThumbnails).toHaveLength(2)
     })
 
+    it('requests lightweight thumbnails for grid cells instead of full-resolution images', () => {
+      renderImagePreview()
+
+      const gridImages = screen.getAllByRole('img')
+      expect(gridImages).toHaveLength(2)
+      for (const img of gridImages) {
+        expect(img.getAttribute('src')).toMatch(/[?&]preview=/)
+      }
+    })
+
     it('defaults to gallery mode for single image', () => {
       renderImagePreview({
         imageUrls: [defaultProps.imageUrls[0]]

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -13,7 +13,7 @@
       :style="{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }"
     >
       <Button
-        v-for="(url, index) in imageUrls"
+        v-for="(url, index) in gridImageUrls"
         :key="index"
         size="unset"
         class="ring-ring overflow-hidden rounded-none p-0 hover:ring-1 focus-visible:ring-2"
@@ -179,6 +179,7 @@ import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { getGridThumbnailUrl } from '@/utils/imageUtil'
 import { resolveNode } from '@/utils/litegraphUtil'
 import { cn } from '@comfyorg/tailwind-utils'
 
@@ -227,6 +228,7 @@ const { start: startDelayedLoader, stop: stopDelayedLoader } = useTimeoutFn(
 )
 
 const currentImageUrl = computed(() => imageUrls[currentIndex.value] ?? '')
+const gridImageUrls = computed(() => imageUrls.map(getGridThumbnailUrl))
 const hasMultipleImages = computed(() => imageUrls.length > 1)
 const imageAltText = computed(() =>
   t('g.viewImageOfTotal', {

--- a/src/utils/imageUtil.test.ts
+++ b/src/utils/imageUtil.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseImageWidgetValue } from './imageUtil'
+import { getGridThumbnailUrl, parseImageWidgetValue } from './imageUtil'
+
+describe('getGridThumbnailUrl', () => {
+  it('adds a compact preview format to a full-resolution view URL', () => {
+    const result = getGridThumbnailUrl(
+      '/api/view?filename=image.png&type=output&subfolder='
+    )
+    expect(result).toMatch(/[?&]preview=webp(%3B|;)75/)
+    expect(result).toContain('filename=image.png')
+  })
+
+  it('preserves an existing preview param (user-configured format)', () => {
+    const result = getGridThumbnailUrl(
+      '/api/view?filename=image.png&type=output&preview=jpeg;50'
+    )
+    expect(result).toContain('preview=jpeg')
+    expect(result).not.toMatch(/preview=webp/)
+  })
+
+  it('leaves SVGs untouched since the server cannot rasterize them', () => {
+    const url = '/api/view?filename=diagram.svg&type=output'
+    expect(getGridThumbnailUrl(url)).toBe(url)
+  })
+
+  it('leaves non-view URLs (e.g. blob previews) untouched', () => {
+    const blob = 'blob:http://localhost/abc-123'
+    expect(getGridThumbnailUrl(blob)).toBe(blob)
+  })
+})
 
 describe('parseImageWidgetValue', () => {
   it('parses a plain filename', () => {

--- a/src/utils/imageUtil.ts
+++ b/src/utils/imageUtil.ts
@@ -6,7 +6,8 @@ const GRID_THUMBNAIL_PREVIEW_FORMAT = 'webp;75'
  * Converts a full-resolution `/api/view` image URL into a lightweight
  * thumbnail URL for small on-node grid cells: server-resized on cloud (`res`)
  * and re-encoded to a compact format on every backend (`preview`). Non-view
- * URLs and URLs that already request a preview are returned unchanged.
+ * URLs, SVGs (the server cannot rasterize them into a preview), and URLs that
+ * already request a preview are returned unchanged.
  */
 export function getGridThumbnailUrl(url: string): string {
   if (!url) return url
@@ -19,8 +20,10 @@ export function getGridThumbnailUrl(url: string): string {
   if (!parsed.pathname.endsWith('/view')) return url
 
   const { searchParams } = parsed
-  appendCloudResParam(searchParams, searchParams.get('filename') ?? undefined)
-  if (!searchParams.has('preview'))
+  const filename = searchParams.get('filename') ?? undefined
+  const isSvg = !!filename && filename.toLowerCase().endsWith('.svg')
+  appendCloudResParam(searchParams, filename)
+  if (!isSvg && !searchParams.has('preview'))
     searchParams.set('preview', GRID_THUMBNAIL_PREVIEW_FORMAT)
 
   return url.startsWith('http')

--- a/src/utils/imageUtil.ts
+++ b/src/utils/imageUtil.ts
@@ -1,3 +1,33 @@
+import { appendCloudResParam } from '@/platform/distribution/cloudPreviewUtil'
+
+const GRID_THUMBNAIL_PREVIEW_FORMAT = 'webp;75'
+
+/**
+ * Converts a full-resolution `/api/view` image URL into a lightweight
+ * thumbnail URL for small on-node grid cells: server-resized on cloud (`res`)
+ * and re-encoded to a compact format on every backend (`preview`). Non-view
+ * URLs and URLs that already request a preview are returned unchanged.
+ */
+export function getGridThumbnailUrl(url: string): string {
+  if (!url) return url
+  let parsed: URL
+  try {
+    parsed = new URL(url, window.location.origin)
+  } catch {
+    return url
+  }
+  if (!parsed.pathname.endsWith('/view')) return url
+
+  const { searchParams } = parsed
+  appendCloudResParam(searchParams, searchParams.get('filename') ?? undefined)
+  if (!searchParams.has('preview'))
+    searchParams.set('preview', GRID_THUMBNAIL_PREVIEW_FORMAT)
+
+  return url.startsWith('http')
+    ? parsed.toString()
+    : `${parsed.pathname}${parsed.search}`
+}
+
 /**
  * Parses an image widget value like "subfolder/filename [type]" into its parts.
  */


### PR DESCRIPTION
## Summary

On-node image grids rendered **full-resolution** `/api/view` images into small grid cells. `nodeOutputStore.buildImageUrls` only appends a thumbnail flag via `app.getPreviewFormatParam()`, which returns `''` whenever `Comfy.PreviewFormat` is empty (the default on a fresh install). So each grid `<img>` received the original URL with no `&preview=`, and the browser downloaded + decoded the full asset into a ~98px cell.

Fix: grid cells request a lightweight thumbnail URL via a new `getGridThumbnailUrl` helper — server-resized on cloud (`res`, mirroring `ResultItemImpl.previewUrl`) and re-encoded to a compact format on every backend (`preview=webp;75`). Gallery / full-view URLs stay at full resolution; a URL that already carries a `preview` (user-set `Comfy.PreviewFormat`) and SVGs (the server cannot rasterize them into a preview) are left untouched. Scoped to the Vue `ImagePreview.vue` path; the legacy canvas preview is deprecated.

- Linear: [FE-741](https://linear.app/comfyorg/issue/FE-741)

## Before / After (CDP, localhost:5173 → OSS backend, default settings)

Reproduced by rendering an on-node grid of 3 input images on a `SaveImage` node. Measured the `/api/view` request for `02_tangled_code.png` (2560×1440) in one ~98px grid cell:

| | Grid cell `<img>` src | Transfer | Type |
|---|---|---|---|
| **Before** | `…&filename=02_tangled_code.png&subfolder=&rand=…` | **3,222,654 B (3.07 MB)** | `image/png` |
| **After** | `…&filename=02_tangled_code.png&subfolder=&rand=…&preview=webp;75` | **119,098 B (116 KB)** | `image/webp` |

**~27× less bandwidth** per cell (-96.3%). On cloud the URL additionally gets `res=512` for a true server-side downscale.

| Before | After |
|---|---|
| <img width="430" alt="fe-741-before" src="https://github.com/user-attachments/assets/677b19aa-1b89-4a22-a98f-79c122f5b9d6" /> | <img width="430" alt="fe-741-after" src="https://github.com/user-attachments/assets/6b4b30b0-14bb-4f19-8407-01f8e5de9143" /> |

On-node rendering is pixel-identical (OSS re-encodes rather than downscales) — no visual regression; the win is the transferred bytes/format shown above.

## Red-Green Verification

| Commit | CI | Result |
|--------|----|--------|
| [`test:` `b1b410b5`](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26740459200) | :red_circle: Red | grid `<img>` still used the full-res URL → test fails |
| [`fix:` `2025cbe7`](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26740850069) | :green_circle: Green | grid `<img>` requests a thumbnail → test passes |

Follow-up `4fff42ed` hardens SVG handling and adds `getGridThumbnailUrl` unit tests (CI green).

## Test Plan

- [x] CI red on test-only commit ([run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26740459200))
- [x] CI green on fix commit ([run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26740850069))
- [x] CDP before/after on a live on-node grid (network transfer 3.07 MB → 116 KB per cell)
- [x] Unit suites green: `ImagePreview` 31/31, `imageUtil` 10/10; gallery/full-view URLs unchanged