### PR TITLE
fix: surface image actions at top of node context menu (FE-839)

### DIFF
--- a/src/composables/graph/contextMenuConverter.test.ts
+++ b/src/composables/graph/contextMenuConverter.test.ts
@@ -159,6 +159,90 @@ describe('contextMenuConverter', () => {
     })
   })
 
+  describe('media node ordering (FE-839)', () => {
+    const IMAGE_GROUP = [
+      'Open Image',
+      'Open in Mask Editor',
+      'Copy Image',
+      'Paste Image',
+      'Save Image'
+    ]
+
+    // Input order is intentionally scrambled to prove the rendered order is
+    // governed by MENU_ORDER, not by the order options are passed in.
+    const mediaNodeOptions = (): MenuOption[] => [
+      { label: 'Rename', source: 'vue' },
+      { label: 'Copy', source: 'vue' },
+      { label: 'Pin', source: 'vue' },
+      { label: 'Node Info', source: 'vue' },
+      { label: 'Open in Mask Editor', source: 'vue' },
+      { label: 'Open Image', source: 'vue' },
+      { label: 'Copy Image', source: 'vue' },
+      { label: 'Paste Image', source: 'vue' },
+      { label: 'Save Image', source: 'vue' }
+    ]
+
+    const firstActionLabel = (result: MenuOption[]) =>
+      result.find((opt) => opt.type !== 'divider' && opt.type !== 'category')
+        ?.label
+    const indexOfLabel = (result: MenuOption[], label: string) =>
+      result.findIndex((opt) => opt.label === label)
+
+    it('places Open Image as the first item for media nodes', () => {
+      expect(firstActionLabel(buildStructuredMenu(mediaNodeOptions()))).toBe(
+        'Open Image'
+      )
+    })
+
+    it('surfaces the whole image action group above generic node actions', () => {
+      const result = buildStructuredMenu(mediaNodeOptions())
+      const renameIndex = indexOfLabel(result, 'Rename')
+      for (const label of IMAGE_GROUP) {
+        expect(indexOfLabel(result, label)).toBeLessThan(renameIndex)
+      }
+    })
+
+    it('keeps Copy Image, Paste Image, Save Image in that relative order', () => {
+      const result = buildStructuredMenu(mediaNodeOptions())
+      expect(indexOfLabel(result, 'Copy Image')).toBeLessThan(
+        indexOfLabel(result, 'Paste Image')
+      )
+      expect(indexOfLabel(result, 'Paste Image')).toBeLessThan(
+        indexOfLabel(result, 'Save Image')
+      )
+    })
+
+    it('separates the image group from core actions with a divider', () => {
+      const result = buildStructuredMenu(mediaNodeOptions())
+      const saveIndex = indexOfLabel(result, 'Save Image')
+      const renameIndex = indexOfLabel(result, 'Rename')
+      const hasDividerBetween = result
+        .slice(saveIndex + 1, renameIndex)
+        .some((opt) => opt.type === 'divider')
+      expect(hasDividerBetween).toBe(true)
+    })
+
+    it('preserves the relative order of core actions below the image group', () => {
+      const result = buildStructuredMenu(mediaNodeOptions())
+      expect(indexOfLabel(result, 'Rename')).toBeLessThan(
+        indexOfLabel(result, 'Pin')
+      )
+      expect(indexOfLabel(result, 'Pin')).toBeLessThan(
+        indexOfLabel(result, 'Node Info')
+      )
+    })
+
+    it('leaves non-media node menus starting with Rename', () => {
+      const result = buildStructuredMenu([
+        { label: 'Node Info', source: 'vue' },
+        { label: 'Pin', source: 'vue' },
+        { label: 'Rename', source: 'vue' },
+        { label: 'Copy', source: 'vue' }
+      ])
+      expect(firstActionLabel(result)).toBe('Rename')
+    })
+  })
+
   describe('convertContextMenuToOptions', () => {
     it('should convert empty array to empty result', () => {
       const result = convertContextMenuToOptions([])

--- a/src/composables/graph/contextMenuConverter.ts
+++ b/src/composables/graph/contextMenuConverter.ts
@@ -224,6 +224,12 @@ function removeDuplicateMenuOptions(options: MenuOption[]): MenuOption[] {
  * Order groups for menu items - defines the display order of sections
  */
 const MENU_ORDER: string[] = [
+  // Section 0: Media operations (surfaced at the top for media nodes)
+  'Open Image',
+  'Open in Mask Editor',
+  'Copy Image',
+  'Paste Image',
+  'Save Image',
   // Section 1: Basic operations
   'Rename',
   'Copy',
@@ -245,12 +251,7 @@ const MENU_ORDER: string[] = [
   // Section 4: Node properties
   'Node Info',
   'Color',
-  // Section 5: Node-specific operations
-  'Open in Mask Editor',
-  'Open Image',
-  'Copy Image',
-  'Paste Image',
-  'Save Image',
+  // Section 5: Clipspace operations
   'Copy (Clipspace)',
   'Paste (Clipspace)'
 ]
@@ -306,27 +307,29 @@ export function buildStructuredMenu(options: MenuOption[]): MenuOption[] {
   coreLabels.sort((a, b) => getMenuItemOrder(a) - getMenuItemOrder(b))
 
   // Section boundaries based on MENU_ORDER indices
-  // Section 1: 0-2 (Rename, Copy, Duplicate)
-  // Section 2: 3-8 (Run Branch, Pin, Unpin, Bypass, Remove Bypass, Mute)
-  // Section 3: 9-14 (Convert to Subgraph, Frame selection, Frame Nodes, Minimize Node, Expand Node, Clone)
-  // Section 4: 15-16 (Node Info, Color)
-  // Section 5: 17+ (Image operations and fallback items)
+  // Section 0: 0-4 (Open Image, Open in Mask Editor, Copy Image, Paste Image, Save Image)
+  // Section 1: 5-7 (Rename, Copy, Duplicate)
+  // Section 2: 8-13 (Run Branch, Pin, Unpin, Bypass, Remove Bypass, Mute)
+  // Section 3: 14-19 (Convert to Subgraph, Frame selection, Frame Nodes, Minimize Node, Expand Node, Clone)
+  // Section 4: 20-21 (Node Info, Color)
+  // Section 5: 22+ (Clipspace and fallback items)
   const getSectionNumber = (index: number): number => {
-    if (index <= 2) return 1
-    if (index <= 8) return 2
-    if (index <= 14) return 3
-    if (index <= 16) return 4
+    if (index <= 4) return 0
+    if (index <= 7) return 1
+    if (index <= 13) return 2
+    if (index <= 19) return 3
+    if (index <= 21) return 4
     return 5
   }
 
-  let lastSection = 0
+  let lastSection = -1
   for (const label of coreLabels) {
     const item = coreItemsMap.get(label)!
     const itemIndex = getMenuItemOrder(label)
     const currentSection = getSectionNumber(itemIndex)
 
     // Add divider when moving to a new section
-    if (lastSection > 0 && currentSection !== lastSection) {
+    if (lastSection !== -1 && currentSection !== lastSection) {
       orderedCoreItems.push({ type: 'divider' })
     }
 

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -117,13 +117,13 @@ export function useImageMenuOptions() {
     if (hasImages) {
       options.push(
         {
-          label: t('contextMenu.Open in Mask Editor'),
-          action: () => openMaskEditor()
-        },
-        {
           label: t('contextMenu.Open Image'),
           icon: 'icon-[lucide--external-link]',
           action: () => openImage(node)
+        },
+        {
+          label: t('contextMenu.Open in Mask Editor'),
+          action: () => openMaskEditor()
         },
         {
           label: t('contextMenu.Copy Image'),


### PR DESCRIPTION
## Summary

On media nodes (Load/Preview/Save Image), the right-click context menu buried the image actions at the very bottom — and `Open Image` sat *second* within that group, behind `Open in Mask Editor`. In legacy LiteGraph (Node 1.x) `Open Image` was the first menu item (`options.unshift`), so the Vue menu was a regression in muscle memory.

This hoists the image-action group (`Open Image`, `Open in Mask Editor`, `Copy Image`, `Paste Image`, `Save Image`) to a new top section of the menu, with `Open Image` first. Because these labels only ever appear for media nodes, non-media node menus are unchanged (keeps the core menu order stable — per Alex Tov's request in the FE-839 thread).

- FE-839
- Related: DES-368 (lightbox idea this replaces)

## Implementation

- `contextMenuConverter.ts`: move the image group to the front of `MENU_ORDER` (new "Section 0"), shift `getSectionNumber` boundaries, and change the section-divider sentinel `lastSection` from `0` to `-1` (Section 0 is now a real section, so the old `> 0` guard would have dropped the divider before `Rename`).
- `useImageMenuOptions.ts`: push `Open Image` before `Open in Mask Editor` for source/display consistency.

## Red-Green Verification

| Commit | Unit CI | Result |
|--------|---------|--------|
| `test: add failing tests …` | [run 26749384308](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26749384308) | Red — fails on `expected 'Rename' to be 'Open Image'` |
| `fix: surface image actions …` | [run 26749817184](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26749817184) | Green — passing |

## Before / After

Right-click on a media node (Load Image with `example.png`):

- **Before:** `Open Image` buried near the bottom, second within its group.
- **After:** image actions group surfaced at the top, `Open Image` first; core order (Rename/Copy/…) unchanged below the divider.

| Before (`main`) | After (this PR) |
| --- | --- |
| <img width="460" alt="Before: image actions buried at the bottom of the menu, Open in Mask Editor above Open Image" src="https://github.com/user-attachments/assets/2d0a6345-6cbb-4391-8cee-60632a6af72f" /> | <img width="460" alt="After: image actions hoisted to the top of the menu, Open Image first" src="https://github.com/user-attachments/assets/6af0840f-0623-41f2-9fa1-b4a16798f9a5" /> |

## Test Plan

- [x] CI red on test-only commit
- [x] CI green on fix commit
- [x] Unit regression in `contextMenuConverter.test.ts` (6 tests: Open Image first / image group above Rename / divider between / Copy<Paste<Save / core order preserved / non-media unchanged)
- [x] Manual verification in live app (before/after)
