### PR TITLE
feat: track active time spent per app mode (app:mode_time_spent)

### DIFF
--- a/src/composables/useModeTimeTracking.test.ts
+++ b/src/composables/useModeTimeTracking.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
+import { effectScope, nextTick, ref } from 'vue'
+
+import type { AppMode } from './useAppMode'
+
+const hoisted = vi.hoisted(() => ({
+  telemetry: null as { trackModeTimeSpent: ReturnType<typeof vi.fn> } | null,
+  mode: null as unknown as Ref<AppMode>
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => hoisted.telemetry
+}))
+
+vi.mock('./useAppMode', () => ({
+  useAppMode: () => ({ mode: hoisted.mode })
+}))
+
+import { useModeTimeTracking } from './useModeTimeTracking'
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('useModeTimeTracking', () => {
+  let scope: ReturnType<typeof effectScope>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    hoisted.telemetry = { trackModeTimeSpent: vi.fn() }
+    hoisted.mode = ref<AppMode>('graph')
+    setVisibility('visible')
+    scope = effectScope()
+  })
+
+  afterEach(() => {
+    scope.stop()
+    vi.useRealTimers()
+  })
+
+  const track = () => hoisted.telemetry!.trackModeTimeSpent
+
+  it('emits the elapsed seconds for the previous mode on mode change', async () => {
+    scope.run(() => useModeTimeTracking())
+
+    vi.setSystemTime(5000)
+    hoisted.mode.value = 'app'
+    await nextTick()
+
+    expect(track()).toHaveBeenCalledWith({
+      mode: 'graph',
+      duration_seconds: 5
+    })
+  })
+
+  it('excludes time while the tab is hidden', async () => {
+    hoisted.mode = ref<AppMode>('app')
+    scope.run(() => useModeTimeTracking())
+
+    vi.setSystemTime(2000)
+    setVisibility('hidden')
+    expect(track()).toHaveBeenCalledWith({ mode: 'app', duration_seconds: 2 })
+
+    track().mockClear()
+    vi.setSystemTime(10_000)
+    setVisibility('visible')
+    vi.setSystemTime(11_000)
+
+    hoisted.mode.value = 'graph'
+    await nextTick()
+
+    expect(track()).toHaveBeenCalledTimes(1)
+    expect(track()).toHaveBeenCalledWith({ mode: 'app', duration_seconds: 1 })
+  })
+
+  it('does not emit sub-second durations', async () => {
+    scope.run(() => useModeTimeTracking())
+
+    vi.setSystemTime(300)
+    hoisted.mode.value = 'app'
+    await nextTick()
+
+    expect(track()).not.toHaveBeenCalled()
+  })
+
+  it('flushes the final mode when the scope is disposed', () => {
+    hoisted.mode = ref<AppMode>('app')
+    scope.run(() => useModeTimeTracking())
+
+    vi.setSystemTime(3000)
+    scope.stop()
+
+    expect(track()).toHaveBeenCalledWith({ mode: 'app', duration_seconds: 3 })
+  })
+
+  it('no-ops without a telemetry provider', async () => {
+    hoisted.telemetry = null
+    expect(() => scope.run(() => useModeTimeTracking())).not.toThrow()
+
+    vi.setSystemTime(5000)
+    hoisted.mode.value = 'app'
+    await expect(nextTick()).resolves.not.toThrow()
+  })
+})

--- a/src/composables/useModeTimeTracking.ts
+++ b/src/composables/useModeTimeTracking.ts
@@ -1,0 +1,65 @@
+import { tryOnScopeDispose, useEventListener } from '@vueuse/core'
+import { watch } from 'vue'
+
+import { useTelemetry } from '@/platform/telemetry'
+
+import type { AppMode } from './useAppMode'
+import { useAppMode } from './useAppMode'
+
+/**
+ * Tracks active (tab-visible) time spent in each {@link AppMode} and emits an
+ * `app:mode_time_spent` event whenever the user leaves a mode, backgrounds the
+ * tab, or tears down. Hidden-tab time is excluded, and flushing on tab-hide
+ * means a closing tab is still captured (`visibilitychange` fires before
+ * unload). Summing `duration_seconds` grouped by `mode` yields time per mode.
+ *
+ * Side-effecting composable: call once from a long-lived scope (GraphView).
+ */
+export function useModeTimeTracking() {
+  const dispatcher = useTelemetry()
+  if (!dispatcher) return
+  const trackModeTimeSpent = dispatcher.trackModeTimeSpent.bind(dispatcher)
+
+  const { mode } = useAppMode()
+
+  const isVisible = () => document.visibilityState === 'visible'
+
+  let trackedMode: AppMode = mode.value
+  let accumulatedMs = 0
+  let segmentStart: number | null = isVisible() ? Date.now() : null
+
+  function closeSegment() {
+    if (segmentStart !== null) {
+      accumulatedMs += Date.now() - segmentStart
+      segmentStart = null
+    }
+  }
+
+  function flush() {
+    closeSegment()
+    const durationSeconds = Math.round(accumulatedMs / 1000)
+    accumulatedMs = 0
+    if (durationSeconds >= 1) {
+      trackModeTimeSpent({
+        mode: trackedMode,
+        duration_seconds: durationSeconds
+      })
+    }
+  }
+
+  watch(mode, (newMode) => {
+    flush()
+    trackedMode = newMode
+    segmentStart = isVisible() ? Date.now() : null
+  })
+
+  useEventListener(document, 'visibilitychange', () => {
+    if (isVisible()) {
+      segmentStart = Date.now()
+    } else {
+      flush()
+    }
+  })
+
+  tryOnScopeDispose(flush)
+}

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -5,6 +5,7 @@ import type {
   BeginCheckoutMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  ModeTimeSpentMetadata,
   ShareFlowMetadata,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
@@ -174,6 +175,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackEnterLinear(metadata: EnterLinearMetadata): void {
     this.dispatch((provider) => provider.trackEnterLinear?.(metadata))
+  }
+
+  trackModeTimeSpent(metadata: ModeTimeSpentMetadata): void {
+    this.dispatch((provider) => provider.trackModeTimeSpent?.(metadata))
   }
 
   trackShareFlow(metadata: ShareFlowMetadata): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -3,6 +3,7 @@ import type {
   BeginCheckoutMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  ModeTimeSpentMetadata,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
   ExecutionTriggerSource,
@@ -282,6 +283,13 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     this.pushEvent('app_mode_opened', {
       source: metadata.source,
       open_source: metadata.open_source
+    })
+  }
+
+  trackModeTimeSpent(metadata: ModeTimeSpentMetadata): void {
+    this.pushEvent('mode_time_spent', {
+      mode: metadata.mode,
+      duration_seconds: metadata.duration_seconds
     })
   }
 

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
@@ -61,6 +61,7 @@ import type {
   EnterLinearMetadata,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
+  ModeTimeSpentMetadata,
   ShareFlowMetadata,
   SurveyResponses,
   TemplateLibraryClosedMetadata,
@@ -287,6 +288,10 @@ describe('MixpanelTelemetryProvider — direct event tracking methods', () => {
     default_view: 'graph'
   }
   const enterLinearMetadata: EnterLinearMetadata = {}
+  const modeTimeSpentMetadata: ModeTimeSpentMetadata = {
+    mode: 'app',
+    duration_seconds: 42
+  }
   const shareFlowMetadata: ShareFlowMetadata = { step: 'dialog_opened' }
   const executionErrorMetadata: ExecutionErrorMetadata = { jobId: 'job-1' }
   const executionSuccessMetadata: ExecutionSuccessMetadata = { jobId: 'job-1' }
@@ -349,6 +354,11 @@ describe('MixpanelTelemetryProvider — direct event tracking methods', () => {
       'trackEnterLinear',
       (p) => p.trackEnterLinear(enterLinearMetadata),
       TelemetryEvents.ENTER_LINEAR_MODE
+    ],
+    [
+      'trackModeTimeSpent',
+      (p) => p.trackModeTimeSpent(modeTimeSpentMetadata),
+      TelemetryEvents.MODE_TIME_SPENT
     ],
     [
       'trackShareFlow',

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -17,6 +17,7 @@ import type {
   CreditTopupMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  ModeTimeSpentMetadata,
   ShareFlowMetadata,
   ExecutionContext,
   ExecutionTriggerSource,
@@ -378,6 +379,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
 
   trackEnterLinear(metadata: EnterLinearMetadata): void {
     this.trackEvent(TelemetryEvents.ENTER_LINEAR_MODE, metadata)
+  }
+
+  trackModeTimeSpent(metadata: ModeTimeSpentMetadata): void {
+    this.trackEvent(TelemetryEvents.MODE_TIME_SPENT, metadata)
   }
 
   trackShareFlow(metadata: ShareFlowMetadata): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -11,6 +11,7 @@ import type {
   AuthMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  ModeTimeSpentMetadata,
   ShareFlowMetadata,
   ExecutionContext,
   ExecutionErrorMetadata,
@@ -381,6 +382,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackEnterLinear(metadata: EnterLinearMetadata): void {
     this.trackEvent(TelemetryEvents.ENTER_LINEAR_MODE, metadata)
+  }
+
+  trackModeTimeSpent(metadata: ModeTimeSpentMetadata): void {
+    this.trackEvent(TelemetryEvents.MODE_TIME_SPENT, metadata)
   }
 
   trackShareFlow(metadata: ShareFlowMetadata): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -12,6 +12,7 @@
  * 3. Check dist/assets/*.js files contain no tracking code
  */
 
+import type { AppMode } from '@/composables/useAppMode'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
@@ -166,6 +167,16 @@ export interface EnterLinearMetadata {
 export interface WorkflowSavedMetadata {
   is_app: boolean
   is_new: boolean
+}
+
+/**
+ * Mode time-spent metadata. Emitted when leaving a mode (or hiding the tab),
+ * reporting the active (tab-visible) seconds spent in that mode. Summing
+ * `duration_seconds` grouped by `mode` yields time spent per mode.
+ */
+export interface ModeTimeSpentMetadata {
+  mode: AppMode
+  duration_seconds: number
 }
 
 export interface DefaultViewSetMetadata {
@@ -431,6 +442,7 @@ export interface TelemetryProvider {
   trackWorkflowSaved?(metadata: WorkflowSavedMetadata): void
   trackDefaultViewSet?(metadata: DefaultViewSetMetadata): void
   trackEnterLinear?(metadata: EnterLinearMetadata): void
+  trackModeTimeSpent?(metadata: ModeTimeSpentMetadata): void
   trackShareFlow?(metadata: ShareFlowMetadata): void
 
   // Page visibility events
@@ -518,6 +530,7 @@ export const TelemetryEvents = {
   WORKFLOW_IMPORTED: 'app:workflow_imported',
   WORKFLOW_OPENED: 'app:workflow_opened',
   ENTER_LINEAR_MODE: 'app:app_mode_opened',
+  MODE_TIME_SPENT: 'app:mode_time_spent',
   SHARE_FLOW: 'app:share_flow',
 
   // Page Visibility
@@ -594,6 +607,7 @@ export type TelemetryEventProperties =
   | HelpCenterClosedMetadata
   | WorkflowCreatedMetadata
   | EnterLinearMetadata
+  | ModeTimeSpentMetadata
   | ShareFlowMetadata
   | WorkflowSavedMetadata
   | DefaultViewSetMetadata

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -54,6 +54,7 @@ import InviteAcceptedToast from '@/platform/workspace/components/toasts/InviteAc
 import RerouteMigrationToast from '@/components/toast/RerouteMigrationToast.vue'
 import { useBrowserTabTitle } from '@/composables/useBrowserTabTitle'
 import { useCoreCommands } from '@/composables/useCoreCommands'
+import { useModeTimeTracking } from '@/composables/useModeTimeTracking'
 import { useQueuePolling } from '@/platform/remote/comfyui/useQueuePolling'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import { useReconnectQueueRefresh } from '@/composables/useReconnectQueueRefresh'
@@ -307,6 +308,11 @@ const onGraphReady = () => {
           visibility_state: document.visibilityState as 'visible' | 'hidden'
         })
       })
+    }
+
+    // Track active time spent in each mode (cloud only)
+    if (isCloud && telemetry) {
+      useModeTimeTracking()
     }
 
     // Set up tab count tracking (cloud only)


### PR DESCRIPTION
## Summary

Add an `app:mode_time_spent` telemetry event so we can measure how long users spend in App Mode vs. graph/builder modes — today we only track *entering* App Mode (`app:app_mode_opened`), with no exit or duration signal.

## Changes

- **What**: New `trackModeTimeSpent` event emitting `{ mode, duration_seconds }` across the registry and all three cloud providers (PostHog/Mixpanel/Gtm). New `useModeTimeTracking` composable accumulates *tab-visible* time for the current mode and flushes (emits + resets) on mode change, tab-hide, and scope dispose. Wired into `GraphView` behind the existing cloud gate; no-ops in OSS builds.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- **Active-time semantics**: hidden-tab time is excluded (timer pauses on `visibilitychange` → hidden). Flushing on tab-hide also means a closing tab is still captured, since `visibilitychange` fires reliably before unload — no separate `unload`/`pagehide` handler needed.
- **Fragmented durations**: one event is emitted per mode-segment (between switches/tab-hides), so analysis should **sum** `duration_seconds` grouped by `mode` rather than treating each event as a full session.
- **Mode granularity**: emits the actual mode string (`graph` / `app` / `builder:*`) so app-vs-graph and builder time are both sliceable.

> Stacked on `feat/app-mode-shared-link-telemetry` (unmerged, shares `types.ts`/`GtmTelemetryProvider.ts`). Retarget to `main` once that merges.