### PR TITLE
fix: unify node selection source onto canonical selectedItems (FE-891)

### DIFF
--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -240,13 +240,16 @@ describe('useSelectedLiteGraphItems', () => {
       const { getSelectedNodes } = useSelectedLiteGraphItems()
       const node1 = makeNode(LGraphEventMode.ALWAYS, 1)
       const node2 = makeNode(LGraphEventMode.NEVER, 2)
+      const reroute = new MockReroute()
 
-      mockCanvas.selectedItems = new Set([node1, node2])
+      // The non-node (reroute) must be filtered out by isLGraphNode.
+      mockCanvas.selectedItems = new Set([node1, reroute, node2])
 
       const selectedNodes = getSelectedNodes()
       expect(selectedNodes).toHaveLength(2)
       expect(selectedNodes[0]).toBe(node1)
       expect(selectedNodes[1]).toBe(node2)
+      expect(selectedNodes).not.toContain(reroute)
     })
 
     it('getSelectedNodes should return empty array when no nodes selected', () => {

--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -5,12 +5,12 @@ import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteG
 import type { LGraphNode, Positionable } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode, Reroute } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { app } from '@/scripts/app'
 import type { NodeId } from '@/renderer/core/layout/types'
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
 import { createMockSubgraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
-// Mock the app module
+// canvasStore transitively imports the app singleton; stub it so the real
+// ComfyApp module never loads during these unit tests.
 vi.mock('@/scripts/app', () => ({
   app: {
     canvas: {
@@ -27,6 +27,18 @@ vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
     Reroute: class Reroute {
       constructor() {}
     }
+  }
+})
+
+// The node accessors filter the canonical selectedItems set via isLGraphNode.
+// Treat any object carrying a `mode` as a node so the lightweight fixtures below
+// (groups/reroutes have no `mode`) are recognised without real LGraphNode instances.
+vi.mock('@/utils/litegraphUtil', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    isLGraphNode: (item: unknown): boolean =>
+      item != null && typeof item === 'object' && 'mode' in item
   }
 })
 
@@ -210,8 +222,7 @@ describe('useSelectedLiteGraphItems', () => {
       const node1 = { id: 1, mode: LGraphEventMode.ALWAYS } as LGraphNode
       const node2 = { id: 2, mode: LGraphEventMode.NEVER } as LGraphNode
 
-      // Mock app.canvas.selected_nodes
-      app.canvas.selected_nodes = { '0': node1, '1': node2 }
+      mockCanvas.selectedItems = new Set([node1, node2])
 
       const selectedNodes = getSelectedNodes()
       expect(selectedNodes).toHaveLength(2)
@@ -222,8 +233,7 @@ describe('useSelectedLiteGraphItems', () => {
     it('getSelectedNodes should return empty array when no nodes selected', () => {
       const { getSelectedNodes } = useSelectedLiteGraphItems()
 
-      // @ts-expect-error - Testing null case
-      app.canvas.selected_nodes = null
+      mockCanvas.selectedItems = new Set()
 
       const selectedNodes = getSelectedNodes()
       expect(selectedNodes).toHaveLength(0)
@@ -234,7 +244,7 @@ describe('useSelectedLiteGraphItems', () => {
       const node1 = { id: 1, mode: LGraphEventMode.ALWAYS } as LGraphNode
       const node2 = { id: 2, mode: LGraphEventMode.NEVER } as LGraphNode
 
-      app.canvas.selected_nodes = { '0': node1, '1': node2 }
+      mockCanvas.selectedItems = new Set([node1, node2])
 
       // Toggle to NEVER mode
       toggleSelectedNodesMode(LGraphEventMode.NEVER)
@@ -249,7 +259,7 @@ describe('useSelectedLiteGraphItems', () => {
       const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
       const node = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
 
-      app.canvas.selected_nodes = { '0': node }
+      mockCanvas.selectedItems = new Set([node])
 
       // Toggle to BYPASS mode (node is already BYPASS)
       toggleSelectedNodesMode(LGraphEventMode.BYPASS)
@@ -263,7 +273,7 @@ describe('useSelectedLiteGraphItems', () => {
       const node1 = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
       const node2 = { id: 2, mode: LGraphEventMode.BYPASS } as LGraphNode
 
-      app.canvas.selected_nodes = { '0': node1, '1': node2 }
+      mockCanvas.selectedItems = new Set([node1, node2])
 
       expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(true)
     })
@@ -273,7 +283,7 @@ describe('useSelectedLiteGraphItems', () => {
       const bypassed = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
       const active = { id: 2, mode: LGraphEventMode.ALWAYS } as LGraphNode
 
-      app.canvas.selected_nodes = { '0': bypassed, '1': active }
+      mockCanvas.selectedItems = new Set([bypassed, active])
 
       expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(false)
     })
@@ -281,7 +291,7 @@ describe('useSelectedLiteGraphItems', () => {
     it('areAllSelectedNodesInMode returns false for empty selection', () => {
       const { areAllSelectedNodesInMode } = useSelectedLiteGraphItems()
 
-      app.canvas.selected_nodes = {}
+      mockCanvas.selectedItems = new Set()
 
       expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(false)
     })
@@ -293,7 +303,7 @@ describe('useSelectedLiteGraphItems', () => {
       const subgraphNode = createMockSubgraphNode([subNode1, subNode2])
       const regularNode = { id: 2, mode: LGraphEventMode.NEVER } as LGraphNode
 
-      app.canvas.selected_nodes = { '0': subgraphNode, '1': regularNode }
+      mockCanvas.selectedItems = new Set([subgraphNode, regularNode])
 
       const selectedNodes = getSelectedNodes()
       expect(selectedNodes).toHaveLength(4) // subgraphNode + 2 sub nodes + regularNode
@@ -310,7 +320,7 @@ describe('useSelectedLiteGraphItems', () => {
       const subgraphNode = createMockSubgraphNode([subNode1, subNode2])
       const regularNode = { id: 2, mode: LGraphEventMode.BYPASS } as LGraphNode
 
-      app.canvas.selected_nodes = { '0': subgraphNode, '1': regularNode }
+      mockCanvas.selectedItems = new Set([subgraphNode, regularNode])
 
       // Toggle to NEVER mode
       toggleSelectedNodesMode(LGraphEventMode.NEVER)
@@ -335,7 +345,7 @@ describe('useSelectedLiteGraphItems', () => {
         mode: LGraphEventMode.NEVER // Already in NEVER mode
       })
 
-      app.canvas.selected_nodes = { '0': subgraphNode }
+      mockCanvas.selectedItems = new Set([subgraphNode])
 
       // Toggle to NEVER mode (but subgraphNode is already NEVER)
       toggleSelectedNodesMode(LGraphEventMode.NEVER)
@@ -346,6 +356,19 @@ describe('useSelectedLiteGraphItems', () => {
       // All children should be unchanged
       expect(subNode1.mode).toBe(LGraphEventMode.ALWAYS)
       expect(subNode2.mode).toBe(LGraphEventMode.BYPASS)
+    })
+
+    it('sources node selection from the canonical selectedItems set', () => {
+      const { getSelectedNodes, areAllSelectedNodesInMode } =
+        useSelectedLiteGraphItems()
+      const node = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
+
+      // Only the canonical selection set is populated; the legacy
+      // app.canvas.selected_nodes dict stays empty to prove it is no longer read.
+      mockCanvas.selectedItems = new Set([node])
+
+      expect(getSelectedNodes()).toEqual([node])
+      expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(true)
     })
   })
 

--- a/src/composables/canvas/useSelectedLiteGraphItems.test.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.test.ts
@@ -1,23 +1,27 @@
 import { createPinia, setActivePinia } from 'pinia'
+import { markRaw } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteGraphItems'
-import type { LGraphNode, Positionable } from '@/lib/litegraph/src/litegraph'
-import { LGraphEventMode, Reroute } from '@/lib/litegraph/src/litegraph'
+import type { Positionable } from '@/lib/litegraph/src/litegraph'
+import {
+  LGraphEventMode,
+  LGraphNode,
+  Reroute
+} from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { NodeId } from '@/renderer/core/layout/types'
 import type { ReadOnlyRect } from '@/lib/litegraph/src/interfaces'
-import { createMockSubgraphNode } from '@/utils/__tests__/litegraphTestUtils'
+
+const mockApp = vi.hoisted(() => ({
+  canvas: {
+    selected_nodes: null as Record<string, LGraphNode> | null
+  }
+}))
 
 // canvasStore transitively imports the app singleton; stub it so the real
 // ComfyApp module never loads during these unit tests.
-vi.mock('@/scripts/app', () => ({
-  app: {
-    canvas: {
-      selected_nodes: null
-    }
-  }
-}))
+vi.mock('@/scripts/app', () => ({ app: mockApp }))
 
 // Mock the litegraph module
 vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
@@ -30,17 +34,26 @@ vi.mock('@/lib/litegraph/src/litegraph', async (importOriginal) => {
   }
 })
 
-// The node accessors filter the canonical selectedItems set via isLGraphNode.
-// Treat any object carrying a `mode` as a node so the lightweight fixtures below
-// (groups/reroutes have no `mode`) are recognised without real LGraphNode instances.
-vi.mock('@/utils/litegraphUtil', async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>
-  return {
-    ...actual,
-    isLGraphNode: (item: unknown): boolean =>
-      item != null && typeof item === 'object' && 'mode' in item
-  }
-})
+// Real LGraphNode instances so the production isLGraphNode (instanceof) guard runs
+// unmodified — the node accessors filter selectedItems with the real predicate.
+const makeNode = (mode: LGraphEventMode, id = 1): LGraphNode => {
+  const node = new LGraphNode('Test')
+  node.id = id
+  node.mode = mode
+  return node
+}
+
+const makeSubgraphNode = (
+  children: LGraphNode[],
+  overrides: { id?: number; mode?: LGraphEventMode } = {}
+): LGraphNode =>
+  Object.assign(
+    makeNode(overrides.mode ?? LGraphEventMode.ALWAYS, overrides.id ?? 1),
+    {
+      isSubgraphNode: () => true,
+      subgraph: { nodes: children }
+    }
+  )
 
 // Mock Positionable objects
 
@@ -89,14 +102,20 @@ describe('useSelectedLiteGraphItems', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     canvasStore = useCanvasStore()
+    mockApp.canvas.selected_nodes = null
 
-    // Mock canvas with selectedItems Set
-    mockCanvas = {
+    // markRaw so the spied getter's return is not reactive-wrapped by the Pinia
+    // store proxy — production reads a shallowRef, so nodes stay raw references.
+    mockCanvas = markRaw({
       selectedItems: new Set<Positionable>()
-    }
+    })
 
-    // Mock getCanvas to return our mock canvas
+    // getSelectableItems reads getCanvas(); the node accessors read canvasStore.canvas.
+    // Point both at the same mock canvas.
     vi.spyOn(canvasStore, 'getCanvas').mockReturnValue(
+      mockCanvas as ReturnType<typeof canvasStore.getCanvas>
+    )
+    vi.spyOn(canvasStore, 'canvas', 'get').mockReturnValue(
       mockCanvas as ReturnType<typeof canvasStore.getCanvas>
     )
   })
@@ -219,8 +238,8 @@ describe('useSelectedLiteGraphItems', () => {
   describe('node-specific methods', () => {
     it('getSelectedNodes should return only LGraphNode instances', () => {
       const { getSelectedNodes } = useSelectedLiteGraphItems()
-      const node1 = { id: 1, mode: LGraphEventMode.ALWAYS } as LGraphNode
-      const node2 = { id: 2, mode: LGraphEventMode.NEVER } as LGraphNode
+      const node1 = makeNode(LGraphEventMode.ALWAYS, 1)
+      const node2 = makeNode(LGraphEventMode.NEVER, 2)
 
       mockCanvas.selectedItems = new Set([node1, node2])
 
@@ -241,8 +260,8 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('toggleSelectedNodesMode should toggle node modes correctly', () => {
       const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
-      const node1 = { id: 1, mode: LGraphEventMode.ALWAYS } as LGraphNode
-      const node2 = { id: 2, mode: LGraphEventMode.NEVER } as LGraphNode
+      const node1 = makeNode(LGraphEventMode.ALWAYS, 1)
+      const node2 = makeNode(LGraphEventMode.NEVER, 2)
 
       mockCanvas.selectedItems = new Set([node1, node2])
 
@@ -257,7 +276,7 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('toggleSelectedNodesMode should set mode to ALWAYS when already in target mode', () => {
       const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
-      const node = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
+      const node = makeNode(LGraphEventMode.BYPASS, 1)
 
       mockCanvas.selectedItems = new Set([node])
 
@@ -270,8 +289,8 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('areAllSelectedNodesInMode returns true when every selected node matches', () => {
       const { areAllSelectedNodesInMode } = useSelectedLiteGraphItems()
-      const node1 = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
-      const node2 = { id: 2, mode: LGraphEventMode.BYPASS } as LGraphNode
+      const node1 = makeNode(LGraphEventMode.BYPASS, 1)
+      const node2 = makeNode(LGraphEventMode.BYPASS, 2)
 
       mockCanvas.selectedItems = new Set([node1, node2])
 
@@ -280,8 +299,8 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('areAllSelectedNodesInMode returns false on mixed selection', () => {
       const { areAllSelectedNodesInMode } = useSelectedLiteGraphItems()
-      const bypassed = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
-      const active = { id: 2, mode: LGraphEventMode.ALWAYS } as LGraphNode
+      const bypassed = makeNode(LGraphEventMode.BYPASS, 1)
+      const active = makeNode(LGraphEventMode.ALWAYS, 2)
 
       mockCanvas.selectedItems = new Set([bypassed, active])
 
@@ -298,27 +317,27 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('getSelectedNodes should include nodes from subgraphs', () => {
       const { getSelectedNodes } = useSelectedLiteGraphItems()
-      const subNode1 = { id: 11, mode: LGraphEventMode.ALWAYS } as LGraphNode
-      const subNode2 = { id: 12, mode: LGraphEventMode.NEVER } as LGraphNode
-      const subgraphNode = createMockSubgraphNode([subNode1, subNode2])
-      const regularNode = { id: 2, mode: LGraphEventMode.NEVER } as LGraphNode
+      const subNode1 = makeNode(LGraphEventMode.ALWAYS, 11)
+      const subNode2 = makeNode(LGraphEventMode.NEVER, 12)
+      const subgraphNode = makeSubgraphNode([subNode1, subNode2])
+      const regularNode = makeNode(LGraphEventMode.NEVER, 2)
 
       mockCanvas.selectedItems = new Set([subgraphNode, regularNode])
 
       const selectedNodes = getSelectedNodes()
       expect(selectedNodes).toHaveLength(4) // subgraphNode + 2 sub nodes + regularNode
-      expect(selectedNodes).toContainEqual(subgraphNode)
-      expect(selectedNodes).toContainEqual(regularNode)
-      expect(selectedNodes).toContainEqual(subNode1)
-      expect(selectedNodes).toContainEqual(subNode2)
+      expect(selectedNodes).toContain(subgraphNode)
+      expect(selectedNodes).toContain(regularNode)
+      expect(selectedNodes).toContain(subNode1)
+      expect(selectedNodes).toContain(subNode2)
     })
 
     it('toggleSelectedNodesMode should not apply state to subgraph children', () => {
       const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
-      const subNode1 = { id: 11, mode: LGraphEventMode.ALWAYS } as LGraphNode
-      const subNode2 = { id: 12, mode: LGraphEventMode.NEVER } as LGraphNode
-      const subgraphNode = createMockSubgraphNode([subNode1, subNode2])
-      const regularNode = { id: 2, mode: LGraphEventMode.BYPASS } as LGraphNode
+      const subNode1 = makeNode(LGraphEventMode.ALWAYS, 11)
+      const subNode2 = makeNode(LGraphEventMode.NEVER, 12)
+      const subgraphNode = makeSubgraphNode([subNode1, subNode2])
+      const regularNode = makeNode(LGraphEventMode.BYPASS, 2)
 
       mockCanvas.selectedItems = new Set([subgraphNode, regularNode])
 
@@ -338,9 +357,9 @@ describe('useSelectedLiteGraphItems', () => {
 
     it('toggleSelectedNodesMode should toggle to ALWAYS when subgraph is already in target mode', () => {
       const { toggleSelectedNodesMode } = useSelectedLiteGraphItems()
-      const subNode1 = { id: 11, mode: LGraphEventMode.ALWAYS } as LGraphNode
-      const subNode2 = { id: 12, mode: LGraphEventMode.BYPASS } as LGraphNode
-      const subgraphNode = createMockSubgraphNode([subNode1, subNode2], {
+      const subNode1 = makeNode(LGraphEventMode.ALWAYS, 11)
+      const subNode2 = makeNode(LGraphEventMode.BYPASS, 12)
+      const subgraphNode = makeSubgraphNode([subNode1, subNode2], {
         id: 1,
         mode: LGraphEventMode.NEVER // Already in NEVER mode
       })
@@ -358,17 +377,30 @@ describe('useSelectedLiteGraphItems', () => {
       expect(subNode2.mode).toBe(LGraphEventMode.BYPASS)
     })
 
-    it('sources node selection from the canonical selectedItems set', () => {
+    it('reads only the canonical selectedItems set, ignoring the legacy dict', () => {
       const { getSelectedNodes, areAllSelectedNodesInMode } =
         useSelectedLiteGraphItems()
-      const node = { id: 1, mode: LGraphEventMode.BYPASS } as LGraphNode
+      const selected = makeNode(LGraphEventMode.BYPASS, 1)
+      const legacyOnly = makeNode(LGraphEventMode.ALWAYS, 99)
 
-      // Only the canonical selection set is populated; the legacy
-      // app.canvas.selected_nodes dict stays empty to prove it is no longer read.
-      mockCanvas.selectedItems = new Set([node])
+      mockCanvas.selectedItems = new Set([selected])
+      // A different node lives only in the legacy dict; it must be ignored.
+      mockApp.canvas.selected_nodes = { '0': legacyOnly }
 
-      expect(getSelectedNodes()).toEqual([node])
+      const selectedNodes = getSelectedNodes()
+      expect(selectedNodes).toHaveLength(1)
+      expect(selectedNodes).toContain(selected)
+      expect(selectedNodes).not.toContain(legacyOnly)
       expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(true)
+    })
+
+    it('returns empty without throwing when the canvas is unavailable', () => {
+      vi.spyOn(canvasStore, 'canvas', 'get').mockReturnValue(null)
+      const { getSelectedNodes, areAllSelectedNodesInMode } =
+        useSelectedLiteGraphItems()
+
+      expect(getSelectedNodes()).toEqual([])
+      expect(areAllSelectedNodesInMode(LGraphEventMode.BYPASS)).toBe(false)
     })
   })
 

--- a/src/composables/canvas/useSelectedLiteGraphItems.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.ts
@@ -67,10 +67,11 @@ export function useSelectedLiteGraphItems() {
    * The top-level selected nodes from the canonical selection set.
    * Shallow — does NOT expand subgraph children, unlike {@link getSelectedNodes}.
    * Mode toggles use this so they apply to the selected subgraph node, not its
-   * descendants.
+   * descendants. Returns `[]` when the canvas is not yet available, preserving
+   * the prior null-tolerance for callers wired to early-firing commands.
    */
   const getSelectedNodesShallow = (): LGraphNode[] =>
-    Array.from(canvasStore.getCanvas().selectedItems).filter(isLGraphNode)
+    Array.from(canvasStore.canvas?.selectedItems ?? []).filter(isLGraphNode)
 
   /**
    * Get only the selected nodes (LGraphNode instances) from the canvas.

--- a/src/composables/canvas/useSelectedLiteGraphItems.ts
+++ b/src/composables/canvas/useSelectedLiteGraphItems.ts
@@ -1,8 +1,8 @@
 import type { LGraphNode, Positionable } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode, Reroute } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { app } from '@/scripts/app'
 import { collectFromNodes } from '@/utils/graphTraversalUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 /**
  * Composable for handling selected LiteGraph items filtering and operations.
@@ -64,37 +64,30 @@ export function useSelectedLiteGraphItems() {
   }
 
   /**
+   * The top-level selected nodes from the canonical selection set.
+   * Shallow — does NOT expand subgraph children, unlike {@link getSelectedNodes}.
+   * Mode toggles use this so they apply to the selected subgraph node, not its
+   * descendants.
+   */
+  const getSelectedNodesShallow = (): LGraphNode[] =>
+    Array.from(canvasStore.getCanvas().selectedItems).filter(isLGraphNode)
+
+  /**
    * Get only the selected nodes (LGraphNode instances) from the canvas.
    * This filters out other types of selected items like groups or reroutes.
    * If a selected node is a subgraph, this also includes all nodes within it.
    * @returns Array of selected LGraphNode instances and their descendants.
    */
   const getSelectedNodes = (): LGraphNode[] => {
-    const selectedNodes = app.canvas.selected_nodes
-    if (!selectedNodes) return []
+    const nodeArray = getSelectedNodesShallow()
 
-    // Convert selected_nodes object to array, preserving order
-    const nodeArray: LGraphNode[] = []
-    for (const i in selectedNodes) {
-      nodeArray.push(selectedNodes[i])
-    }
-
-    // Check if any selected nodes are subgraphs
     const hasSubgraphs = nodeArray.some(
       (node) => node.isSubgraphNode?.() && node.subgraph
     )
+    if (!hasSubgraphs) return nodeArray
 
-    // If no subgraphs, just return the array directly to preserve order
-    if (!hasSubgraphs) {
-      return nodeArray
-    }
-
-    // Use collectFromNodes to get all nodes including those in subgraphs
     return collectFromNodes(nodeArray)
   }
-
-  const getSelectedNodesShallow = (): LGraphNode[] =>
-    Object.values(app.canvas.selected_nodes ?? {})
 
   /**
    * True iff every selected node is in `mode`. Mirrors the predicate used by

--- a/src/composables/graph/useNodeMenuOptions.test.ts
+++ b/src/composables/graph/useNodeMenuOptions.test.ts
@@ -5,16 +5,27 @@ import { createI18n } from 'vue-i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNodeMenuOptions } from '@/composables/graph/useNodeMenuOptions'
-import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphNode, Positionable } from '@/lib/litegraph/src/litegraph'
 import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
-const mockApp = vi.hoisted(() => ({
-  canvas: {
-    selected_nodes: null as Record<string, LGraphNode> | null
-  }
+// canvasStore transitively imports the app singleton; stub it so the real
+// ComfyApp module never loads during these unit tests.
+vi.mock('@/scripts/app', () => ({
+  app: { canvas: { selected_nodes: null } }
 }))
 
-vi.mock('@/scripts/app', () => ({ app: mockApp }))
+// The Bypass label filters the canonical selectedItems set via isLGraphNode.
+// Treat any object carrying a `mode` as a node so the lightweight fixtures below
+// are recognised without real LGraphNode instances.
+vi.mock('@/utils/litegraphUtil', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    isLGraphNode: (item: unknown): boolean =>
+      item != null && typeof item === 'object' && 'mode' in item
+  }
+})
 
 vi.mock('@/composables/graph/useNodeCustomization', () => ({
   useNodeCustomization: () => ({
@@ -44,18 +55,15 @@ const i18n = createI18n({
   fallbackWarn: false
 })
 
-const setSelectedNodes = (nodes: LGraphNode[]) => {
-  const dict: Record<string, LGraphNode> = {}
-  nodes.forEach((n, i) => {
-    dict[String(i)] = n
-  })
-  mockApp.canvas.selected_nodes = dict
-}
-
 const nodeWithMode = (mode: LGraphEventMode, id = 1): LGraphNode =>
   ({ id, mode }) as LGraphNode
 
-const getBypassLabel = (): string => {
+const getBypassLabel = (selected: LGraphNode[]): string => {
+  const canvasStore = useCanvasStore()
+  vi.spyOn(canvasStore, 'getCanvas').mockReturnValue({
+    selectedItems: new Set<Positionable>(selected)
+  } as ReturnType<typeof canvasStore.getCanvas>)
+
   let label = ''
   const Wrapper = defineComponent({
     setup() {
@@ -71,27 +79,29 @@ const getBypassLabel = (): string => {
 describe('useNodeMenuOptions.getBypassOption', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    mockApp.canvas.selected_nodes = null
   })
 
   it('labels as "Bypass" when no node is bypassed', () => {
-    setSelectedNodes([nodeWithMode(LGraphEventMode.ALWAYS, 1)])
-    expect(getBypassLabel()).toBe('contextMenu.Bypass')
+    expect(getBypassLabel([nodeWithMode(LGraphEventMode.ALWAYS, 1)])).toBe(
+      'contextMenu.Bypass'
+    )
   })
 
   it('labels as "Remove Bypass" when every selected node is bypassed', () => {
-    setSelectedNodes([
-      nodeWithMode(LGraphEventMode.BYPASS, 1),
-      nodeWithMode(LGraphEventMode.BYPASS, 2)
-    ])
-    expect(getBypassLabel()).toBe('contextMenu.Remove Bypass')
+    expect(
+      getBypassLabel([
+        nodeWithMode(LGraphEventMode.BYPASS, 1),
+        nodeWithMode(LGraphEventMode.BYPASS, 2)
+      ])
+    ).toBe('contextMenu.Remove Bypass')
   })
 
   it('labels as "Bypass" on mixed selection so it matches the toggle action', () => {
-    setSelectedNodes([
-      nodeWithMode(LGraphEventMode.BYPASS, 1),
-      nodeWithMode(LGraphEventMode.ALWAYS, 2)
-    ])
-    expect(getBypassLabel()).toBe('contextMenu.Bypass')
+    expect(
+      getBypassLabel([
+        nodeWithMode(LGraphEventMode.BYPASS, 1),
+        nodeWithMode(LGraphEventMode.ALWAYS, 2)
+      ])
+    ).toBe('contextMenu.Bypass')
   })
 })

--- a/src/composables/graph/useNodeMenuOptions.test.ts
+++ b/src/composables/graph/useNodeMenuOptions.test.ts
@@ -5,8 +5,8 @@ import { createI18n } from 'vue-i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNodeMenuOptions } from '@/composables/graph/useNodeMenuOptions'
-import type { LGraphNode, Positionable } from '@/lib/litegraph/src/litegraph'
-import { LGraphEventMode } from '@/lib/litegraph/src/litegraph'
+import type { Positionable } from '@/lib/litegraph/src/litegraph'
+import { LGraphEventMode, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 // canvasStore transitively imports the app singleton; stub it so the real
@@ -14,18 +14,6 @@ import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 vi.mock('@/scripts/app', () => ({
   app: { canvas: { selected_nodes: null } }
 }))
-
-// The Bypass label filters the canonical selectedItems set via isLGraphNode.
-// Treat any object carrying a `mode` as a node so the lightweight fixtures below
-// are recognised without real LGraphNode instances.
-vi.mock('@/utils/litegraphUtil', async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>
-  return {
-    ...actual,
-    isLGraphNode: (item: unknown): boolean =>
-      item != null && typeof item === 'object' && 'mode' in item
-  }
-})
 
 vi.mock('@/composables/graph/useNodeCustomization', () => ({
   useNodeCustomization: () => ({
@@ -55,12 +43,16 @@ const i18n = createI18n({
   fallbackWarn: false
 })
 
-const nodeWithMode = (mode: LGraphEventMode, id = 1): LGraphNode =>
-  ({ id, mode }) as LGraphNode
+const nodeWithMode = (mode: LGraphEventMode, id = 1): LGraphNode => {
+  const node = new LGraphNode('Test')
+  node.id = id
+  node.mode = mode
+  return node
+}
 
 const getBypassLabel = (selected: LGraphNode[]): string => {
   const canvasStore = useCanvasStore()
-  vi.spyOn(canvasStore, 'getCanvas').mockReturnValue({
+  vi.spyOn(canvasStore, 'canvas', 'get').mockReturnValue({
     selectedItems: new Set<Positionable>(selected)
   } as ReturnType<typeof canvasStore.getCanvas>)
 


### PR DESCRIPTION
## Summary

Migrate the node-menu action path off the legacy `app.canvas.selected_nodes` dict onto the canonical `canvas.selectedItems` set so the Pin and Bypass context-menu options read their selection state from one source.

## Changes

- **What**: `getSelectedNodes` and `getSelectedNodesShallow` in `useSelectedLiteGraphItems` now derive from `canvasStore.canvas?.selectedItems` filtered by `isLGraphNode` — the same source the Pin label already uses via `useSelectionState`. The Bypass label (`areAllSelectedNodesInMode`) and all node actions (pin/collapse/bypass/mute/size/runBranch) now share that canonical source. Subgraph expansion (`getSelectedNodes` → `collectFromNodes`) and the no-expansion all-match mode toggle are preserved unchanged. The accessor returns `[]` when the canvas is unavailable, preserving the prior null-tolerance.
- **Breaking**: None. `app.canvas.selected_nodes` is untouched (still maintained by LiteGraph, still read by extensions). For every selection reachable through normal canvas interaction the two collections hold the identical top-level node set and order, so behavior is preserved.

## Review Focus

- Resolves the dual-source-of-truth flagged by @DrJKL in #12500 (`useNodeMenuOptions.ts:99`): the Pin label read `selectedItems` while the Bypass label read `selected_nodes`. Both now read `selectedItems`.
- Follow-up to #12500 (FE-720), which merged into `main`.
- **Scope is source-unification only.** Pre-existing semantic gaps are left as follow-ups: Pin per-node-flip vs Bypass all-match toggle; Pin expands subgraph children while Bypass does not; reroute-only selection still renders no-op Pin/Bypass items.
- The legacy `selected_nodes` dict still has direct readers in the extension layer — tracked in **FE-896** so the dict can eventually be retired.

## Testing

Unit-only by design — this is a pure composable-layer source swap with **no user-visible behavior change** (the node set and ordering are identical to `selected_nodes` for every canvas-originated selection). An E2E test would only re-exercise existing Pin/Bypass menu flows that already pass unchanged. Coverage:

- `useSelectedLiteGraphItems.test.ts`: node accessors source from the canonical `selectedItems`; a decoy node in the legacy `selected_nodes` dict is asserted *not* to be read; canvas-unavailable returns `[]` without throwing; subgraph expansion + all-match toggle preserved.
- `useNodeMenuOptions.test.ts`: the Bypass label derives from `selectedItems`.
- Red→green: `c0bfc94c0a` adds the canonical-source tests (fail against the legacy-source base); `f7f7176683` migrates the source (all green).

Linear: FE-891