### PR TITLE
feat(website): add Affiliate Program link to footer Resources

### DIFF
--- a/apps/website/src/components/common/SiteFooter.vue
+++ b/apps/website/src/components/common/SiteFooter.vue
@@ -67,6 +67,10 @@ const topColumns: { title: string; links: FooterLink[] }[] = [
         label: t('nav.youtube', locale),
         href: externalLinks.youtube,
         external: true
+      },
+      {
+        label: t('footer.affiliateProgram', locale),
+        href: routes.affiliates
       }
     ]
   }

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1775,6 +1775,10 @@ const translations = {
   'footer.press': { en: 'Press', 'zh-CN': '媒体' },
   'footer.cloudStatus': { en: 'Cloud Status', 'zh-CN': '云端状态' },
   'footer.blog': { en: 'Blog', 'zh-CN': '博客' },
+  'footer.affiliateProgram': {
+    en: 'Affiliate Program',
+    'zh-CN': 'Affiliate Program'
+  },
   'footer.location': {
     en: 'San Francisco, USA',
     'zh-CN': '美国旧金山'


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Adds an **Affiliate Program** entry under the Resources column of the site footer, positioned immediately after the YouTube link. Links to `/affiliates` via the existing locale-invariant `routes.affiliates` helper.

### Stacked on #12002

This PR is branched off `glary/affiliates-landing-page` (PR #12002), not `main`, because:

- `routes.affiliates` and the `/affiliates` page itself are added by #12002 and aren't on `main` yet.
- Linking to `/affiliates` from the footer before #12002 merges would 404 in production.

GitHub will auto-rebase this PR onto `main` once #12002 merges. **Re-target this PR's base from `glary/affiliates-landing-page` to `main` before reviewing for merge** (or simply merge #12002 first and GitHub will switch the base for you).

### Diff

```
apps/website/src/components/common/SiteFooter.vue  +4
apps/website/src/i18n/translations.ts              +4
```

- New `footer.affiliateProgram` i18n key. English-only per the go-live direction for affiliate-related copy (zh-CN mirrors EN to satisfy the dictionary's `Record<Locale, string>` shape; matches how `nav.youtube` and other proper-noun footer entries handle this).
- New `FooterLink` entry in `topColumns[1].links` (the Resources column), after the YouTube entry. Internal route, so no `external: true`.

### Local verification

- `pnpm typecheck`: 0 errors
- `pnpm build`: 380 pages, footer renders `Affiliate Program` → `/affiliates` in both desktop and mobile layouts, on `/`, `/about`, `/zh-CN/`, etc. Link ordering in Resources: `Blog → Discord → GitHub → Docs → YouTube → Affiliate Program` (verified by parsing the built HTML)
- `pnpm test:unit`: passing (no SiteFooter unit test exists; it's exercised through e2e/visual coverage)
- `pnpm lint`: no new warnings (3 pre-existing on unrelated files)
- `pnpm format:check`: clean
- `pnpm knip`: clean
- `pnpm exec tsx scripts/check-unused-i18n-keys.ts`: clean (new key is used)

### Out of scope

- No new Linear ticket (this is a follow-up to the affiliate-program go-live work tracked under FE-704).
- Header nav / mobile menu changes — only the footer was requested.
