### PR TITLE
fix: handle pre-init PostHog logout reset

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -243,9 +243,8 @@ describe('PostHogTelemetryProvider', () => {
   })
 
   describe('logout', () => {
-    it('registers onUserLogout watcher after init', async () => {
+    it('registers onUserLogout watcher before init', () => {
       createProvider()
-      await vi.dynamicImportSettled()
 
       expect(hoisted.mockOnUserLogout).toHaveBeenCalledOnce()
     })
@@ -260,11 +259,30 @@ describe('PostHogTelemetryProvider', () => {
       expect(hoisted.mockReset).toHaveBeenCalledWith(true)
     })
 
-    it('does not register the watcher before init resolves', () => {
-      createProvider()
+    it('resets before flushing events queued after a pre-init logout', async () => {
+      const provider = createProvider()
+      const callback = hoisted.mockOnUserLogout.mock.calls[0][0]
 
-      expect(hoisted.mockOnUserLogout).not.toHaveBeenCalled()
+      provider.trackUserLoggedIn()
+      callback()
+      provider.trackAuth({ method: 'google' })
+
       expect(hoisted.mockReset).not.toHaveBeenCalled()
+
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockReset).toHaveBeenCalledWith(true)
+      expect(hoisted.mockCapture).not.toHaveBeenCalledWith(
+        TelemetryEvents.USER_LOGGED_IN,
+        expect.anything()
+      )
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.USER_AUTH_COMPLETED,
+        { method: 'google' }
+      )
+      expect(hoisted.mockReset.mock.invocationCallOrder[0]).toBeLessThan(
+        hoisted.mockCapture.mock.invocationCallOrder[0]
+      )
     })
   })
 

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -83,6 +83,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
   private posthog: PostHog | null = null
   private eventQueue: QueuedEvent[] = []
   private isInitialized = false
+  private shouldResetOnInit = false
   private lastTriggerSource: ExecutionTriggerSource | undefined
   private disabledEvents = new Set<TelemetryEventName>(DEFAULT_DISABLED_EVENTS)
 
@@ -101,6 +102,17 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     const apiKey = window.__CONFIG__?.posthog_project_token
     if (apiKey) {
       try {
+        const currentUser = useCurrentUser()
+        currentUser.onUserLogout(() => {
+          if (this.isInitialized && this.posthog) {
+            this.posthog.reset(true)
+            return
+          }
+
+          this.shouldResetOnInit = true
+          this.eventQueue = []
+        })
+
         void import('posthog-js')
           .then((posthogModule) => {
             this.posthog = posthogModule.default
@@ -117,26 +129,17 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
               ...serverConfig
             })
             this.isInitialized = true
+            if (this.shouldResetOnInit) {
+              this.posthog.reset(true)
+              this.shouldResetOnInit = false
+            }
             this.flushEventQueue()
 
-            const currentUser = useCurrentUser()
             currentUser.onUserResolved((user) => {
               if (this.posthog && user.id) {
                 this.posthog.identify(user.id)
                 this.setSubscriptionProperties()
               }
-            })
-            // Anchored to session state rather than the logout button so it
-            // also covers token revocation, account deletion, and cross-tab
-            // sign-out (browserLocalPersistence). A logout that lands during
-            // the posthog-js dynamic-import window will not be observed here:
-            // events buffered pre-init are intentionally NOT queue-cleared on
-            // logout, which leaves a narrow race where a logout + different
-            // login both inside the import window would flush pre-init events
-            // under the new identity. Accepted as a known edge — re-adding
-            // pre-init logout handling would defeat the simplification.
-            currentUser.onUserLogout(() => {
-              this.posthog?.reset(true)
             })
           })
           .catch((error) => {


### PR DESCRIPTION
## Summary

Close the PostHog startup logout race in #12599 by registering the session-end watcher before the dynamic import can resolve.

## Changes

- **What**: Adds a pre-init reset flag that clears events queued before logout, resets once PostHog initializes, then flushes later queued events.
- **Dependencies**: None

## Review Focus

- Stacked on #12599 (`pr-12480`) so the diff is only the startup race fix.
- The regression test simulates logout before `posthog-js` import settles and verifies reset happens before queued post-logout events flush.
