### PR TITLE
refactor(dialog): delete the PrimeVue Dialog branch (Phase 6b)

### DIFF
--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -66,7 +66,7 @@ function mountDialog() {
   })
 }
 
-describe('GlobalDialog renderer branching', () => {
+describe('GlobalDialog rendering', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
@@ -75,13 +75,13 @@ describe('GlobalDialog renderer branching', () => {
     cleanup()
   })
 
-  it('renders the Reka branch when renderer is omitted (default)', async () => {
+  it('renders a dialog through the Reka primitives (no PrimeVue DOM)', async () => {
     mountDialog()
     const store = useDialogStore()
 
     store.showDialog({
-      key: 'renderer-default',
-      title: 'Default renderer dialog',
+      key: 'reka-dialog',
+      title: 'Reka dialog',
       component: Body
     })
 
@@ -89,56 +89,9 @@ describe('GlobalDialog renderer branching', () => {
     expect(dialogs.length).toBeGreaterThan(0)
     expect(dialogs.some((el) => el.classList.contains('p-dialog'))).toBe(false)
   })
-
-  it("renders the legacy PrimeVue branch when renderer is 'primevue'", async () => {
-    mountDialog()
-    const store = useDialogStore()
-
-    store.showDialog({
-      key: 'primevue-escape-hatch',
-      title: 'PrimeVue dialog',
-      component: Body,
-      dialogComponentProps: { renderer: 'primevue' }
-    })
-
-    const dialogs = await screen.findAllByRole('dialog')
-    expect(dialogs.some((el) => el.classList.contains('p-dialog'))).toBe(true)
-  })
-
-  it('renders the Reka branch when renderer is reka', async () => {
-    mountDialog()
-    const store = useDialogStore()
-
-    store.showDialog({
-      key: 'reka-opt-in',
-      title: 'Reka dialog',
-      component: Body,
-      dialogComponentProps: { renderer: 'reka' }
-    })
-
-    const dialogs = await screen.findAllByRole('dialog')
-    expect(dialogs.length).toBeGreaterThan(0)
-    expect(dialogs.some((el) => el.classList.contains('p-dialog'))).toBe(false)
-  })
-
-  it('preserves the renderer flag on the dialog stack item', async () => {
-    mountDialog()
-    const store = useDialogStore()
-
-    store.showDialog({
-      key: 'reka-flag-check',
-      title: 'Reka',
-      component: Body,
-      dialogComponentProps: { renderer: 'reka' }
-    })
-
-    await screen.findByRole('dialog')
-    const item = store.dialogStack.find((d) => d.key === 'reka-flag-check')
-    expect(item?.dialogComponentProps.renderer).toBe('reka')
-  })
 })
 
-describe('GlobalDialog Reka parity with PrimeVue', () => {
+describe('GlobalDialog Reka behavior', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
@@ -155,7 +108,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       key: 'reka-not-closable',
       title: 'No close',
       component: Body,
-      dialogComponentProps: { renderer: 'reka', closable: false }
+      dialogComponentProps: { closable: false }
     })
 
     await screen.findByRole('dialog')
@@ -170,7 +123,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       key: 'reka-closable',
       title: 'Closable',
       component: Body,
-      dialogComponentProps: { renderer: 'reka' }
+      dialogComponentProps: {}
     })
 
     await screen.findByRole('dialog')
@@ -185,7 +138,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       key: 'reka-headless',
       title: 'Hidden title',
       component: Body,
-      dialogComponentProps: { renderer: 'reka', headless: true }
+      dialogComponentProps: { headless: true }
     })
 
     await screen.findByRole('dialog')
@@ -200,7 +153,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       key: 'reka-titled',
       title: 'Visible title',
       component: Body,
-      dialogComponentProps: { renderer: 'reka' }
+      dialogComponentProps: {}
     })
 
     await screen.findByRole('dialog')
@@ -220,7 +173,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
         creditsUsed: 645,
         currentLimit: 3000
       },
-      dialogComponentProps: { renderer: 'reka', headless: true }
+      dialogComponentProps: { headless: true }
     })
 
     expect(
@@ -239,7 +192,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       key: 'reka-esc-default',
       title: 'Esc closes',
       component: Body,
-      dialogComponentProps: { renderer: 'reka' }
+      dialogComponentProps: {}
     })
 
     await screen.findByRole('dialog')
@@ -257,7 +210,7 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       key: 'reka-esc-blocked',
       title: 'Esc blocked',
       component: Body,
-      dialogComponentProps: { renderer: 'reka', closable: false }
+      dialogComponentProps: { closable: false }
     })
 
     await screen.findByRole('dialog')
@@ -275,7 +228,6 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       title: 'Section classes',
       component: Body,
       dialogComponentProps: {
-        renderer: 'reka',
         headerClass: 'p-2',
         bodyClass: 'p-0'
       }
@@ -305,7 +257,6 @@ describe('GlobalDialog Reka parity with PrimeVue', () => {
       title: 'Maximize wins',
       component: Body,
       dialogComponentProps: {
-        renderer: 'reka',
         maximizable: true,
         contentClass:
           'w-[80vw] max-w-[80vw] sm:max-w-[80vw] h-[80vh] max-h-[80vh]'
@@ -345,8 +296,7 @@ describe('GlobalDialog Reka overlay scrim', () => {
     store.showDialog({
       key: 'reka-modal-scrim',
       title: 'Modal',
-      component: Body,
-      dialogComponentProps: { renderer: 'reka' }
+      component: Body
     })
 
     await screen.findByRole('dialog')
@@ -363,7 +313,7 @@ describe('GlobalDialog Reka overlay scrim', () => {
       key: 'reka-non-modal-scrim',
       title: 'Non-modal',
       component: Body,
-      dialogComponentProps: { renderer: 'reka', modal: false }
+      dialogComponentProps: { modal: false }
     })
 
     await screen.findByRole('dialog')
@@ -392,7 +342,7 @@ describe('GlobalDialog Reka overlay scrim', () => {
       key: 'reka-scrim-dismiss',
       title: 'Non-modal',
       component: Body,
-      dialogComponentProps: { renderer: 'reka', modal: false }
+      dialogComponentProps: { modal: false }
     })
 
     await screen.findByRole('dialog')

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -2,7 +2,6 @@
 <template>
   <template v-for="item in dialogStore.dialogStack" :key="item.key">
     <Dialog
-      v-if="isRekaItem(item)"
       :open="item.visible"
       :modal="item.dialogComponentProps.modal ?? true"
       @update:open="(open) => onRekaOpenChange(item.key, open)"
@@ -90,43 +89,10 @@
         </DialogContent>
       </DialogPortal>
     </Dialog>
-    <PrimeDialog
-      v-else
-      v-model:visible="item.visible"
-      class="global-dialog"
-      v-bind="item.dialogComponentProps"
-      :aria-labelledby="item.key"
-    >
-      <template #header>
-        <div v-if="!item.dialogComponentProps?.headless">
-          <component
-            :is="item.headerComponent"
-            v-if="item.headerComponent"
-            v-bind="item.headerProps"
-            :id="item.key"
-          />
-          <h3 v-else :id="item.key">
-            {{ item.title || ' ' }}
-          </h3>
-        </div>
-      </template>
-
-      <component
-        :is="item.component"
-        v-bind="item.contentProps"
-        :maximized="item.dialogComponentProps.maximized"
-      />
-
-      <template v-if="item.footerComponent" #footer>
-        <component :is="item.footerComponent" v-bind="item.footerProps" />
-      </template>
-    </PrimeDialog>
   </template>
 </template>
 
 <script setup lang="ts">
-import PrimeDialog from 'primevue/dialog'
-
 import { cn } from '@comfyorg/tailwind-utils'
 
 import Dialog from '@/components/ui/dialog/Dialog.vue'
@@ -147,10 +113,6 @@ import type { DialogInstance } from '@/stores/dialogStore'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const dialogStore = useDialogStore()
-
-function isRekaItem(item: DialogInstance) {
-  return item.dialogComponentProps.renderer === 'reka'
-}
 
 function onRekaOpenChange(key: string, open: boolean) {
   if (!open) dialogStore.closeDialog({ key })
@@ -178,32 +140,6 @@ function toggleMaximize(item: DialogInstance) {
 </script>
 
 <style>
-.global-dialog {
-  max-width: calc(100vw - 1rem);
-}
-
-.global-dialog .p-dialog-header {
-  padding: calc(var(--spacing) * 2);
-  padding-bottom: 0;
-}
-
-.global-dialog .p-dialog-content {
-  padding: calc(var(--spacing) * 2);
-  padding-top: 0;
-}
-
-@media (min-width: 1536px) {
-  .global-dialog .p-dialog-header {
-    padding: var(--p-dialog-header-padding);
-    padding-bottom: 0;
-  }
-
-  .global-dialog .p-dialog-content {
-    padding: var(--p-dialog-content-padding);
-    padding-top: 0;
-  }
-}
-
 .manager-dialog {
   height: 80vh;
   max-width: 1724px;

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -1,8 +1,7 @@
 /**
- * Dialog migration regression net: the showConfirmDialog helper must open
- * its dialog through the Reka renderer with zeroed section padding (the
- * Confirm* sections carry their own). Catches accidental reverts of the
- * Phase 6 renderer flip.
+ * The showConfirmDialog helper must open its dialog with zeroed section
+ * padding (the Confirm* sections carry their own) and forward the caller's
+ * header/body/footer props to the Confirm* components.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -17,16 +16,15 @@ import ConfirmFooter from '@/components/dialog/confirm/ConfirmFooter.vue'
 import ConfirmHeader from '@/components/dialog/confirm/ConfirmHeader.vue'
 import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
 
-describe('showConfirmDialog Reka renderer opt-in', () => {
+describe('showConfirmDialog configuration', () => {
   beforeEach(() => {
     showDialog.mockReset()
   })
 
-  it("sets renderer 'reka' with size 'md' and zeroed section padding", () => {
+  it("sets size 'md' and zeroed section padding", () => {
     showConfirmDialog()
 
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
     expect(args.dialogComponentProps.headerClass).toBe('p-0')
     expect(args.dialogComponentProps.bodyClass).toBe('p-0')

--- a/src/components/dialog/confirm/confirmDialog.ts
+++ b/src/components/dialog/confirm/confirmDialog.ts
@@ -26,7 +26,6 @@ export function showConfirmDialog(
     props,
     footerProps,
     dialogComponentProps: {
-      renderer: 'reka',
       size: 'md',
       // Confirm sections carry their own padding — zero out the dialog
       // chrome padding, like the PrimeVue `pt` overrides did.

--- a/src/components/dialog/rekaPrimeVueBridge.ts
+++ b/src/components/dialog/rekaPrimeVueBridge.ts
@@ -3,6 +3,10 @@
 // elements as outside its dialog and would auto-dismiss on the first
 // interaction, tearing the overlay down mid-interaction. Treat any
 // PrimeVue overlay click as inside.
+// `.p-dialog` stays until NodeSearchBox(Popover) — the last standalone
+// PrimeVue `Dialog` consumers in src/ — are migrated; otherwise interacting
+// with one of those dialogs while a non-modal Reka dialog is open would
+// dismiss the Reka dialog.
 const PRIMEVUE_OVERLAY_SELECTORS =
   '.p-select-overlay, .p-colorpicker-panel, .p-popover, .p-autocomplete-overlay, .p-overlay, .p-overlay-mask, .p-dialog'
 

--- a/src/components/load3d/controls/ViewerControls.vue
+++ b/src/components/load3d/controls/ViewerControls.vue
@@ -41,7 +41,6 @@ const openIn3DViewer = () => {
     component: Load3DViewerContent,
     props: props,
     dialogComponentProps: {
-      renderer: 'reka',
       size: 'full',
       contentClass: 'w-[80vw] h-[80vh] max-h-[80vh]',
       maximizable: true,

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -537,7 +537,6 @@ const handleZoomClick = (asset: AssetItem) => {
         modelUrl: asset.preview_url || getAssetUrl(asset)
       },
       dialogComponentProps: {
-        renderer: 'reka',
         size: 'full',
         contentClass: 'w-[80vw] h-[80vh] max-h-[80vh]',
         maximizable: true

--- a/src/components/sidebar/tabs/JobHistorySidebarTab.vue
+++ b/src/components/sidebar/tabs/JobHistorySidebarTab.vue
@@ -189,7 +189,6 @@ const onViewItem = wrapWithErrorHandlingAsync(async (item: JobListItem) => {
         modelUrl: previewOutput.url || ''
       },
       dialogComponentProps: {
-        renderer: 'reka',
         size: 'full',
         contentClass: 'w-[80vw] h-[80vh] max-h-[80vh]',
         maximizable: true

--- a/src/composables/maskeditor/useMaskEditor.ts
+++ b/src/composables/maskeditor/useMaskEditor.ts
@@ -23,7 +23,6 @@ export function useMaskEditor() {
         node
       },
       dialogComponentProps: {
-        renderer: 'reka',
         size: 'full',
         // `mask-editor-dialog` is a styling-free hook class consumed by
         // browser_tests (MaskEditorHelper, maskEditor.spec).

--- a/src/composables/queue/useQueueClearHistoryDialog.ts
+++ b/src/composables/queue/useQueueClearHistoryDialog.ts
@@ -9,7 +9,6 @@ export const useQueueClearHistoryDialog = () => {
       key: 'queue-clear-history',
       component: QueueClearHistoryDialog,
       dialogComponentProps: {
-        renderer: 'reka',
         headless: true,
         closable: false,
         closeOnEscape: true,

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -274,7 +274,6 @@ useExtensionService().registerExtension({
           component: Load3DViewerContent,
           props: props,
           dialogComponentProps: {
-            renderer: 'reka',
             size: 'full',
             contentClass:
               'w-[80vw] max-w-[80vw] sm:max-w-[80vw] h-[80vh] max-h-[80vh]',

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -840,7 +840,6 @@ export function useMediaAssetActions() {
           }
         },
         dialogComponentProps: {
-          renderer: 'reka',
           size: 'md'
         }
       })

--- a/src/platform/assets/composables/useModelUpload.ts
+++ b/src/platform/assets/composables/useModelUpload.ts
@@ -16,7 +16,6 @@ type UploadModelContextResolver = () => UploadModelDialogContext | undefined
 // Contents bring their own width and padding — shrink-wrap the chrome and
 // zero the section padding (the PrimeVue `pt` overrides this replaces).
 const uploadDialogComponentProps = {
-  renderer: 'reka',
   contentClass: 'w-fit max-w-[calc(100vw-1rem)]',
   headerClass: 'py-0 pl-0',
   bodyClass: 'p-0 overflow-y-hidden'

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -93,13 +93,10 @@ vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
   })
 }))
 
-function expectRekaPricingDialogProps(
+function expectPricingDialogProps(
   dialogComponentProps: Record<string, unknown>
 ) {
-  expect(dialogComponentProps).toMatchObject({
-    renderer: 'reka',
-    size: 'full'
-  })
+  expect(dialogComponentProps).toMatchObject({ size: 'full' })
   expect(dialogComponentProps).not.toHaveProperty('style')
   expect(dialogComponentProps).not.toHaveProperty('pt')
 }
@@ -164,7 +161,7 @@ describe('useSubscriptionDialog', () => {
       showPricingTable()
 
       const { dialogComponentProps } = mockShowLayoutDialog.mock.calls[0][0]
-      expectRekaPricingDialogProps(dialogComponentProps)
+      expectPricingDialogProps(dialogComponentProps)
     })
 
     it('defaults to the personal tab in a personal workspace', () => {
@@ -289,7 +286,7 @@ describe('useSubscriptionDialog', () => {
       expect(props).toHaveProperty('onChooseTeam')
       expect(props).not.toHaveProperty('initialCheckout')
       const { dialogComponentProps } = mockShowLayoutDialog.mock.calls[0][0]
-      expectRekaPricingDialogProps(dialogComponentProps)
+      expectPricingDialogProps(dialogComponentProps)
       expect(mockTrackSubscription).toHaveBeenCalledWith(
         'modal_opened',
         expect.objectContaining({ reason: 'deep_link' })
@@ -339,7 +336,7 @@ describe('useSubscriptionDialog', () => {
       expect(dialogComponentProps).toMatchObject({
         modal: false
       })
-      expectRekaPricingDialogProps(dialogComponentProps)
+      expectPricingDialogProps(dialogComponentProps)
     })
 
     it('defaults an unsubscribed team workspace to the team tab', () => {

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -75,7 +75,6 @@ export const useSubscriptionDialog = () => {
       ),
       props: { onClose: hide },
       dialogComponentProps: {
-        renderer: 'reka',
         contentClass:
           'w-[min(360px,95vw)] max-w-[min(360px,95vw)] sm:max-w-[min(360px,95vw)] border-0 bg-transparent shadow-none'
       }
@@ -90,7 +89,6 @@ export const useSubscriptionDialog = () => {
     trackModalOpened(options?.reason)
 
     const legacyPricingDialogProps = {
-      renderer: 'reka',
       size: 'full',
       contentClass:
         'sm:max-w-7xl max-h-[90vh] rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
@@ -158,12 +156,9 @@ export const useSubscriptionDialog = () => {
           )
         },
         dialogComponentProps: {
-          // Reka (the default renderer) sizes via size/contentClass; a PrimeVue
-          // `style` width is ignored here and collapses the table to the default
-          // `md` frame. `w-fit` lets each step hug its content -- the pricing
-          // table fills its 1280px content while the compact confirm/success
-          // steps shrink (the content root sets its own width per checkoutStep).
-          renderer: 'reka',
+          // `w-fit` lets each step hug its content -- the pricing table fills
+          // its 1280px content while the compact confirm/success steps shrink
+          // (the content root sets its own width per checkoutStep).
           size: 'full',
           contentClass:
             'w-fit max-w-[min(1280px,95vw)] sm:max-w-[min(1280px,95vw)] max-h-[90vh] rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
@@ -214,7 +209,6 @@ export const useSubscriptionDialog = () => {
           }
         },
         dialogComponentProps: {
-          renderer: 'reka',
           size: 'full',
           contentClass:
             'w-[min(640px,95vw)] max-w-[min(640px,95vw)] sm:max-w-[min(640px,95vw)] overflow-hidden rounded-2xl border-border-default bg-base-background/60 shadow-[0_25px_80px_rgba(5,6,12,0.45)] backdrop-blur-md'

--- a/src/platform/settings/composables/useSettingsDialog.test.ts
+++ b/src/platform/settings/composables/useSettingsDialog.test.ts
@@ -1,9 +1,3 @@
-/**
- * Settings dialog migration regression net: `useSettingsDialog().show()` must
- * open the Reka-renderer path with sizing that matches the previous
- * `BaseModalLayout size="sm"` (960px × 80vh). Catches accidental reverts of
- * the Phase 3 renderer flip.
- */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
@@ -53,11 +47,10 @@ describe('useSettingsDialog', () => {
     isCloudRef.value = false
   })
 
-  it("show() opens the Reka renderer with size 'full' and 1280px content sizing", () => {
+  it("show() opens with size 'full' and 1280px content sizing", () => {
     useSettingsDialog().show()
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('global-settings')
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('full')
     expect(args.dialogComponentProps.contentClass).toContain('max-w-[1280px]')
     expect(args.dialogComponentProps.contentClass).not.toContain(

--- a/src/platform/settings/composables/useSettingsDialog.ts
+++ b/src/platform/settings/composables/useSettingsDialog.ts
@@ -32,7 +32,6 @@ export function useSettingsDialog() {
         ...(settingId ? { scrollToSettingId: settingId } : {})
       },
       dialogComponentProps: {
-        renderer: 'reka',
         // Settings hosts nested PrimeVue dialogs (Edit Keybinding, Overwrite
         // confirm, etc.) that teleport to body. Reka's modal mode traps focus
         // inside the Settings content and disables body pointer-events, which

--- a/src/platform/surveys/openTypeformDialog.test.ts
+++ b/src/platform/surveys/openTypeformDialog.test.ts
@@ -11,7 +11,7 @@ describe('openTypeformDialog', () => {
     setActivePinia(createPinia())
   })
 
-  it('opens the form embed in a Reka dialog with the given id and hidden fields', () => {
+  it('opens the form embed with the given id and hidden fields', () => {
     const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
 
     openTypeformDialog({
@@ -26,7 +26,7 @@ describe('openTypeformDialog', () => {
         title: 'A Form',
         component: TypeformDialogContent,
         props: { typeformId: 'abc123', hiddenFields: 'foo=bar' },
-        dialogComponentProps: expect.objectContaining({ renderer: 'reka' })
+        dialogComponentProps: expect.objectContaining({ size: 'lg' })
       })
     )
   })

--- a/src/platform/surveys/openTypeformDialog.ts
+++ b/src/platform/surveys/openTypeformDialog.ts
@@ -22,7 +22,6 @@ export function openTypeformDialog({
     component: TypeformDialogContent,
     props: { typeformId, hiddenFields },
     dialogComponentProps: {
-      renderer: 'reka',
       size: 'lg'
     }
   })

--- a/src/services/dialogService.dialogConfig.test.ts
+++ b/src/services/dialogService.dialogConfig.test.ts
@@ -1,8 +1,3 @@
-/**
- * Dialog migration regression net: when callers in `dialogService` open a
- * Reka-migrated dialog, the dialog stack item must carry `renderer: 'reka'`.
- * Catches accidental reverts of the Reka renderer flip.
- */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
@@ -33,34 +28,31 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
 
 import { useDialogService } from '@/services/dialogService'
 
-describe('dialogService Reka renderer opt-in', () => {
+describe('dialogService dialog configuration', () => {
   beforeEach(() => {
     showDialog.mockReset()
   })
 
-  it("prompt() sets renderer 'reka' and size 'md'", () => {
+  it("prompt() sets size 'md'", () => {
     void useDialogService().prompt({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
   })
 
-  it("confirm() sets renderer 'reka' and size 'md'", () => {
+  it("confirm() sets size 'md'", () => {
     void useDialogService().confirm({ title: 'T', message: 'M' })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
   })
 
-  it("showBillingComingSoonDialog() sets renderer 'reka', size 'sm', and 360px contentClass", () => {
+  it("showBillingComingSoonDialog() sets size 'sm', and 360px contentClass", () => {
     useDialogService().showBillingComingSoonDialog()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('sm')
     expect(args.dialogComponentProps.contentClass).toBe('max-w-[360px]')
   })
 
-  it("showExecutionErrorDialog() sets renderer 'reka' and size 'lg'", () => {
+  it("showExecutionErrorDialog() sets size 'lg'", () => {
     useDialogService().showExecutionErrorDialog({
       exception_type: 'RuntimeError',
       exception_message: 'boom',
@@ -69,28 +61,25 @@ describe('dialogService Reka renderer opt-in', () => {
       traceback: ['line 1', 'line 2']
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('lg')
   })
 
-  it("showErrorDialog() sets renderer 'reka' and size 'lg'", () => {
+  it("showErrorDialog() sets size 'lg'", () => {
     useDialogService().showErrorDialog(new Error('boom'))
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('lg')
   })
 
-  it("showTopUpCreditsDialog() sets renderer 'reka' with a transparent shrink-wrapped chrome", async () => {
+  it('showTopUpCreditsDialog() sets a transparent shrink-wrapped chrome', async () => {
     await useDialogService().showTopUpCreditsDialog()
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.headless).toBe(true)
     expect(args.dialogComponentProps.pt).toBeUndefined()
     expect(args.dialogComponentProps.contentClass).toContain('w-fit')
     expect(args.dialogComponentProps.contentClass).toContain('bg-transparent')
   })
 
-  it("showLayoutDialog() defaults to renderer 'reka' headless without pt", () => {
+  it('showLayoutDialog() defaults to headless without pt', () => {
     const Component = { template: '<div />' }
     useDialogService().showLayoutDialog({
       key: 'layout-test',
@@ -98,7 +87,6 @@ describe('dialogService Reka renderer opt-in', () => {
       props: {}
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.headless).toBe(true)
     expect(args.dialogComponentProps.pt).toBeUndefined()
   })
@@ -112,19 +100,17 @@ describe('dialogService Reka renderer opt-in', () => {
       dialogComponentProps: { closable: false, contentClass: 'w-170' }
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.closable).toBe(false)
     expect(args.dialogComponentProps.contentClass).toBe('w-170')
   })
 
-  it("showSmallLayoutDialog() sets renderer 'reka' with zeroed section padding", () => {
+  it('showSmallLayoutDialog() sets zeroed section padding', () => {
     const Component = { template: '<div />' }
     useDialogService().showSmallLayoutDialog({
       key: 'small-layout-test',
       component: Component
     })
     const [args] = showDialog.mock.calls[0]
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.pt).toBeUndefined()
     expect(args.dialogComponentProps.contentClass).toContain('w-fit')
     expect(args.dialogComponentProps.headerClass).toBe('p-0')

--- a/src/services/dialogService.topUpCredits.test.ts
+++ b/src/services/dialogService.topUpCredits.test.ts
@@ -89,7 +89,6 @@ describe('showTopUpCreditsDialog', () => {
     // The member notice draws its own header + close button, so it must open
     // headless or Reka wraps it in duplicate chrome.
     expect(args.dialogComponentProps.headless).toBe(true)
-    expect(args.dialogComponentProps.renderer).toBe('reka')
 
     args.props.onClose()
     expect(closeDialog).toHaveBeenCalledWith({

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -119,7 +119,6 @@ export const useDialogService = () => {
       component: ErrorDialogContent,
       props,
       dialogComponentProps: {
-        renderer: 'reka',
         size: 'lg',
         onClose: () => {
           useTelemetry()?.trackUiButtonClicked({
@@ -186,7 +185,6 @@ export const useDialogService = () => {
       component: ErrorDialogContent,
       props,
       dialogComponentProps: {
-        renderer: 'reka',
         size: 'lg',
         onClose: () => {
           useTelemetry()?.trackUiButtonClicked({
@@ -219,7 +217,6 @@ export const useDialogService = () => {
         },
         headerComponent: ComfyOrgHeader,
         dialogComponentProps: {
-          renderer: 'reka',
           contentClass: HUG_CONTENT_CLASS,
           closable: false,
           onClose: () => resolve(false)
@@ -244,7 +241,6 @@ export const useDialogService = () => {
           onSuccess: () => resolve(true)
         },
         dialogComponentProps: {
-          renderer: 'reka',
           // SignInContent is a fixed w-96 — size 'sm' (max-w-sm) leaves only
           // 352px after the body padding; hug the intrinsic width instead.
           contentClass: HUG_CONTENT_CLASS,
@@ -283,7 +279,6 @@ export const useDialogService = () => {
           placeholder
         },
         dialogComponentProps: {
-          renderer: 'reka',
           size: 'md',
           onClose: () => {
             resolve(null)
@@ -320,7 +315,6 @@ export const useDialogService = () => {
           denyLabel
         },
         dialogComponentProps: {
-          renderer: 'reka',
           size: 'md',
           onClose: () => resolve(null)
         }
@@ -357,7 +351,6 @@ export const useDialogService = () => {
             dialogStore.closeDialog({ key: 'insufficient-credits-member' })
         },
         dialogComponentProps: {
-          renderer: 'reka',
           headless: true,
           contentClass:
             'w-[min(360px,95vw)] max-w-[min(360px,95vw)] sm:max-w-[min(360px,95vw)] border-0 bg-transparent shadow-none'
@@ -375,7 +368,6 @@ export const useDialogService = () => {
       component,
       props: options,
       dialogComponentProps: {
-        renderer: 'reka',
         headless: true,
         contentClass: SELF_STYLED_PANEL_CONTENT_CLASS
       }
@@ -398,7 +390,6 @@ export const useDialogService = () => {
           dialogStore.closeDialog({ key: 'global-update-password' })
       },
       dialogComponentProps: {
-        renderer: 'reka',
         contentClass: HUG_CONTENT_CLASS
       }
     })
@@ -429,7 +420,6 @@ export const useDialogService = () => {
     dialogComponentProps?: DialogComponentProps
   }) {
     const layoutDefaultProps: DialogComponentProps = {
-      renderer: 'reka',
       headless: true,
       modal: true,
       closable: true
@@ -454,7 +444,6 @@ export const useDialogService = () => {
     return dialogStore.showDialog({
       ...rest,
       dialogComponentProps: {
-        renderer: 'reka',
         closable: true,
         // Contents bring their own width and separators — shrink-wrap the
         // chrome and zero the section padding.
@@ -483,7 +472,6 @@ export const useDialogService = () => {
 
   // Workspace dialogs - dynamically imported to avoid bundling when feature flag is off
   const workspaceDialogProps = {
-    renderer: 'reka',
     headless: true,
     contentClass: SELF_STYLED_PANEL_CONTENT_CLASS
   } as const
@@ -646,7 +634,6 @@ export const useDialogService = () => {
         onConfirm: () => {}
       },
       dialogComponentProps: {
-        renderer: 'reka',
         size: 'sm',
         contentClass: 'max-w-[360px]'
       }

--- a/src/services/hdrViewerService.ts
+++ b/src/services/hdrViewerService.ts
@@ -19,7 +19,6 @@ export function openHdrViewer(url: string) {
     component: HdrViewerContent,
     props: { imageUrl: fullResUrl },
     dialogComponentProps: {
-      renderer: 'reka',
       size: 'full',
       contentClass: 'w-[80vw] h-[80vh] max-h-[80vh]',
       maximizable: true

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -1,32 +1,12 @@
-// We should consider moving to https://primevue.org/dynamicdialog/ once everything is in Vue.
-// Currently we need to bridge between legacy app code and Vue app with a Pinia store.
-import { merge } from 'es-toolkit/compat'
+// Bridges legacy app code and the Vue app: callers push dialogs through this
+// Pinia store and `GlobalDialog` renders them with the Reka-UI primitives
+// under `src/components/ui/dialog/`.
 import { defineStore } from 'pinia'
-import type { DialogPassThroughOptions } from 'primevue/dialog'
 import { markRaw, ref } from 'vue'
 import type { Component, HTMLAttributes, Ref } from 'vue'
 
 import type { DialogContentSize } from '@/components/ui/dialog/dialog.variants'
 import type { ComponentAttrs } from 'vue-component-type-helpers'
-
-type DialogPosition =
-  | 'center'
-  | 'top'
-  | 'bottom'
-  | 'left'
-  | 'right'
-  | 'topleft'
-  | 'topright'
-  | 'bottomleft'
-  | 'bottomright'
-
-/**
- * Selects the dialog renderer used by `GlobalDialog`. `'reka'` (the default)
- * renders the Reka-UI primitive set under `src/components/ui/dialog/`.
- * `'primevue'` is the legacy PrimeVue `Dialog` escape hatch, kept only until
- * the branch is deleted in the Phase 6 cleanup (FE-578).
- */
-type DialogRenderer = 'primevue' | 'reka'
 
 interface CustomDialogComponentProps {
   maximizable?: boolean
@@ -34,8 +14,6 @@ interface CustomDialogComponentProps {
   onClose?: () => void
   closable?: boolean
   modal?: boolean
-  position?: DialogPosition
-  pt?: DialogPassThroughOptions
   closeOnEscape?: boolean
   dismissableMask?: boolean
   /**
@@ -46,34 +24,25 @@ interface CustomDialogComponentProps {
    * outside-pointer dismissal are unaffected. Defaults to `true`.
    */
   dismissOnFocusOutside?: boolean
-  unstyled?: boolean
   headless?: boolean
-  renderer?: DialogRenderer
   size?: DialogContentSize
-  /**
-   * Class applied to the Reka-UI `DialogContent` element. Ignored on the
-   * PrimeVue path — use `pt` for that renderer.
-   */
+  /** Class applied to the Reka-UI `DialogContent` element. */
   contentClass?: HTMLAttributes['class']
-  /**
-   * Class applied to the Reka-UI `DialogOverlay` element. Ignored on the
-   * PrimeVue path — use `pt.mask` for that renderer.
-   */
+  /** Class applied to the Reka-UI `DialogOverlay` element. */
   overlayClass?: HTMLAttributes['class']
   /**
    * Class applied to the Reka-UI `DialogHeader` element on the non-headless
-   * path. Ignored on the PrimeVue path — use `pt.header` for that renderer.
+   * path.
    */
   headerClass?: HTMLAttributes['class']
   /**
    * Class applied to the wrapper around the content component on the Reka-UI
-   * non-headless path. Ignored on the PrimeVue path — use `pt.content` for
-   * that renderer.
+   * non-headless path.
    */
   bodyClass?: HTMLAttributes['class']
   /**
    * Class applied to the Reka-UI `DialogFooter` element on the non-headless
-   * path. Ignored on the PrimeVue path — use `pt.footer` for that renderer.
+   * path.
    */
   footerClass?: HTMLAttributes['class']
 }
@@ -209,25 +178,8 @@ export const useDialogStore = defineStore('dialog', () => {
         closable: true,
         closeOnEscape: true,
         dismissableMask: true,
-        renderer: 'reka' as DialogRenderer,
         ...options.dialogComponentProps,
-        maximized: false,
-        onMaximize: () => {
-          dialog.dialogComponentProps.maximized = true
-        },
-        onUnmaximize: () => {
-          dialog.dialogComponentProps.maximized = false
-        },
-        onAfterHide: () => {
-          closeDialog(dialog)
-        },
-        pt: merge(options.dialogComponentProps?.pt || {}, {
-          root: {
-            onMousedown: () => {
-              riseDialog(dialog)
-            }
-          }
-        })
+        maximized: false
       }
     }
 
@@ -240,8 +192,6 @@ export const useDialogStore = defineStore('dialog', () => {
 
   /**
    * Ensures only the top-most dialog in the stack can be closed with the Escape key.
-   * This is necessary because PrimeVue Dialogs do not handle `closeOnEscape` prop
-   * correctly when multiple dialogs are open.
    */
   function updateCloseOnEscapeStates() {
     const topDialog = dialogStack.value.find((d) => d.key === activeKey.value)

--- a/src/workbench/extensions/manager/components/manager/PackVersionBadge.vue
+++ b/src/workbench/extensions/manager/components/manager/PackVersionBadge.vue
@@ -111,7 +111,6 @@ const fixPopoverIntoViewport = async () => {
 
   requestAnimationFrame(() => {
     const boundaryEl =
-      targetEl.closest('.p-dialog') ??
       targetEl.closest('.manager-dialog') ??
       targetEl.closest('[role="dialog"]') ??
       document.documentElement

--- a/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerDialog.test.ts
@@ -1,9 +1,3 @@
-/**
- * Manager dialog migration regression net: `useManagerDialog().show()` must
- * route through the Reka renderer at the legacy Manager dimensions (1724px
- * max-width × 80vh, expanding at 3000px). Catches accidental reverts of the
- * Phase 4 renderer flip.
- */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const showDialog = vi.hoisted(() => vi.fn())
@@ -22,11 +16,10 @@ describe('useManagerDialog', () => {
     closeDialog.mockReset()
   })
 
-  it("show() opens the Reka renderer with size 'full' and Manager content sizing", () => {
+  it("show() opens with size 'full' and Manager content sizing", () => {
     useManagerDialog().show()
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('global-manager')
-    expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('full')
     expect(args.dialogComponentProps.contentClass).toContain('max-w-[1724px]')
     expect(args.dialogComponentProps.contentClass).toContain('h-[80vh]')

--- a/src/workbench/extensions/manager/composables/useManagerDialog.ts
+++ b/src/workbench/extensions/manager/composables/useManagerDialog.ts
@@ -26,7 +26,6 @@ export function useManagerDialog() {
         initialPackId
       },
       dialogComponentProps: {
-        renderer: 'reka',
         // Manager hosts PrimeVue overlays (SingleSelect, SearchAutocomplete)
         // teleported to body. Reka's modal mode traps focus and disables body
         // pointer-events, breaking those overlays. Mirrors Settings.

--- a/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/composables/useManagerSurveyDialog.test.ts
@@ -15,11 +15,10 @@ describe('useManagerSurveyDialog', () => {
     closeDialog.mockReset()
   })
 
-  it('show() opens the survey dialog under its own key via the Reka layout renderer', () => {
+  it('show() opens the survey dialog under its own key', () => {
     useManagerSurveyDialog().show()
     const [args] = showDialog.mock.calls[0]
     expect(args.key).toBe('global-manager-survey')
-    expect(args.dialogComponentProps.renderer).toBe('reka')
   })
 
   it('show() wires onClose to close the survey dialog', () => {


### PR DESCRIPTION
## Summary

**Phase 6b — pure deletion.** Now that Phase 6a (#12593) renders every dialog through the Reka-UI path, the PrimeVue `Dialog` branch in `GlobalDialog.vue` is unreachable. This PR removes it and the dead coupling it leaves behind.

Parent: [FE-571](https://linear.app/comfyorg/issue/FE-571/dialog-system-migration-primevue-reka-ui-parent) · This phase: [FE-578](https://linear.app/comfyorg/issue/FE-578/phase-6-remove-primevue-dialogconfirmdialog-imports-clean-up-css)

> ⛔️ **DO NOT MERGE until #12593 (Phase 6a) lands and soaks one cloud deploy cycle.** Stacked on `jaewon/fe-578-dialog-reka-migration-phase-6` — rebase onto `main` after 6a merges. **Revert order is strictly 6b → 6a**: once this deletes the fallback branch, 6a can no longer be reverted alone.

## Changes (all deletions / dead-code removal)

- **`GlobalDialog.vue`** — drop the `<PrimeDialog v-else>` block, the `primevue/dialog` import, `isRekaItem()`, and the `.global-dialog .p-dialog-*` `<style>`. The template now always renders the Reka primitives. `.manager-dialog` CSS **stays** (applied to the reka `ManagerDialog`, read by `PackVersionBadge`).
- **`dialogStore.ts`** — drop the `DialogPassThroughOptions` import, the `DialogPosition`/`DialogRenderer` types, the `pt`/`position`/`unstyled`/`renderer` fields, and `createDialog`'s PrimeVue-only injections (`onMaximize`/`onUnmaximize`/`onAfterHide`/`pt`-merge, `es-toolkit` `merge`). `DialogComponentProps` stays a `Record<string, unknown>` intersection so stray extension props are still silently ignored.
- **~25 callers + the store default** — drop the now-redundant `renderer: 'reka'`. Reka is the only renderer.
- **`PackVersionBadge.vue`** — drop the dead `.closest('.p-dialog')` boundary arm (the Manager dialog is reka now; falls through to `.manager-dialog`).
- **Tests** — `GlobalDialog` / `dialogService.renderer` / `confirmDialog` / `useManagerDialog` / `useSettingsDialog` drop the `renderer` assertions and the PrimeVue-branch render test; `GlobalDialog.test.ts` keeps the stacked-dismiss + maximize-wins + `.p-dialog` bridge-guard cases.

## Intentionally KEPT

PrimeVue `Dialog` is **not** gone from the app — `NodeSearchBox.vue` / `NodeSearchBoxPopover.vue` are standalone `primevue/dialog` consumers (out of FE-578 scope, separate ticket). Therefore:

- the **`primevue/dialog` dependency** stays in the bundle;
- the **`.p-dialog` / `.p-dialog-mask` guards** in `rekaPrimeVueBridge.ts` and `usePopoverSizing.ts` stay — they stop a Reka dialog from dismissing (or a Reka child from sitting under) *any* PrimeVue Dialog/overlay, which still exist. Stripping these waits until NodeSearchBox is migrated.
- `var(--p-dialog-background)` (`SubscriptionPanel`, `SubscriptionRequiredDialogContent`) stays — resolves while the PrimeVue Dialog theme preset is registered; theme-preset cleanup is a follow-up.

## Verification

- [x] `pnpm typecheck` — clean (per-commit via lint-staged)
- [x] **Full unit suite: 822 files / 11,121 tests passing** (8 skipped)
- [x] **CDP (local dev)**: app boots with no PrimeDialog/renderer console errors; Settings renders through Reka (`0` `.p-dialog` in DOM); nested **Edit Keybinding** still opens both dialogs (the 6a stacked-dismiss fix holds with the branch gone); confirm dialogs unaffected
- [ ] CI Playwright matrix — `maskEditor` screenshot baselines still expected to need a refresh (chrome change inherited from 6a)
- [ ] Manual cloud verification (top-up / workspace / subscription) — inherits 6a coverage; see **📸 Screenshots** below + [#12593](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12593)

## Out of scope (follow-ups)

- Migrate `NodeSearchBox(Popover)` off `primevue/dialog`, then strip the residual `.p-dialog*` guards and drop `primevue/dialog` from the bundle.
- Remove the `var(--p-dialog-background)` theme-token dependency.
- `apps/desktop-ui` (own ConfirmationService / `TaskListPanel` `useConfirm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## 📸 Screenshots — CDP verification

Captured via Chrome DevTools (CDP) from this branch (`jaewon/fe-578-dialog-reka-migration-phase-6b`, PrimeVue `Dialog` branch deleted) running locally in **cloud mode** (`cloud.comfy.org` backend). The app boots clean and every dialog renders through Reka — identical to Phase 6a, now with the dead `<PrimeDialog v-else>` branch gone.

**Settings** — renders through Reka (`0` `.p-dialog` in the DOM)
<img width="880" alt="settings" src="https://github.com/user-attachments/assets/44e3fd3f-8d9b-4322-8fbe-8ce8d94ed15d" />

**Edit Keybinding**, stacked on Settings — both dialogs still open; closing the inner one leaves Settings open, so the 6a stacked-dismiss fix holds with the fallback branch removed
<img width="880" alt="edit-keybinding-nested" src="https://github.com/user-attachments/assets/d0875c00-7b9c-439d-b24d-ba6770009d08" />

**Confirm dialog** — unaffected
<img width="880" alt="confirm-dialog" src="https://github.com/user-attachments/assets/5d9953c1-4d0c-4ff9-adc7-88dd370c6a24" />

The remaining cloud dialogs (subscription pricing `modal:false`, share/publish, workspace, template selector) render identically to [#12593](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12593) — see that PR's screenshots.
