### PR TITLE
feat: add missing_node_packs to app:workflow_imported telemetry

### DIFF
--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -139,9 +139,23 @@ export interface CreditTopupMetadata {
 /**
  * Workflow import metadata
  */
+export interface MissingNodePack {
+  /**
+   * Custom node pack identifier (cnrId / aux_id from node properties).
+   * `'unknown'` when the workflow JSON has no pack hint for the node.
+   */
+  pack_id: string
+  node_types: string[]
+}
+
 export interface WorkflowImportMetadata {
   missing_node_count: number
   missing_node_types: string[]
+  /**
+   * Missing nodes grouped by their custom node pack. Populated from the
+   * `cnr_id` / `aux_id` baked into node properties — no network lookups.
+   */
+  missing_node_packs?: MissingNodePack[]
   /**
    * The source of the workflow open/import action
    */

--- a/src/platform/telemetry/utils/groupMissingNodesByPack.test.ts
+++ b/src/platform/telemetry/utils/groupMissingNodesByPack.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MissingNodeType } from '@/types/comfy'
+
+import { groupMissingNodesByPack } from './groupMissingNodesByPack'
+
+describe('groupMissingNodesByPack', () => {
+  it('returns an empty array when no missing nodes', () => {
+    expect(groupMissingNodesByPack([])).toEqual([])
+  })
+
+  it('groups multiple node types under the same pack', () => {
+    const missing: MissingNodeType[] = [
+      { type: 'ImpactSampler', cnrId: 'impact-pack' },
+      { type: 'ImpactDetailer', cnrId: 'impact-pack' },
+      { type: 'WASImageBlend', cnrId: 'was-node-suite' }
+    ]
+
+    const result = groupMissingNodesByPack(missing)
+
+    expect(result).toHaveLength(2)
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          pack_id: 'impact-pack',
+          node_types: ['ImpactSampler', 'ImpactDetailer']
+        },
+        { pack_id: 'was-node-suite', node_types: ['WASImageBlend'] }
+      ])
+    )
+  })
+
+  it('deduplicates the same node type within a pack', () => {
+    const missing: MissingNodeType[] = [
+      { type: 'ImpactSampler', cnrId: 'impact-pack' },
+      { type: 'ImpactSampler', cnrId: 'impact-pack' }
+    ]
+
+    expect(groupMissingNodesByPack(missing)).toEqual([
+      { pack_id: 'impact-pack', node_types: ['ImpactSampler'] }
+    ])
+  })
+
+  it('falls back to "unknown" for nodes without a cnrId', () => {
+    const missing: MissingNodeType[] = [
+      { type: 'MysteryNode' },
+      'LegacyStringNode'
+    ]
+
+    expect(groupMissingNodesByPack(missing)).toEqual([
+      { pack_id: 'unknown', node_types: ['MysteryNode', 'LegacyStringNode'] }
+    ])
+  })
+
+  it('keeps "unknown" separate from identified packs', () => {
+    const missing: MissingNodeType[] = [
+      { type: 'ImpactSampler', cnrId: 'impact-pack' },
+      { type: 'MysteryNode' }
+    ]
+
+    const result = groupMissingNodesByPack(missing)
+
+    expect(result).toHaveLength(2)
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { pack_id: 'impact-pack', node_types: ['ImpactSampler'] },
+        { pack_id: 'unknown', node_types: ['MysteryNode'] }
+      ])
+    )
+  })
+})

--- a/src/platform/telemetry/utils/groupMissingNodesByPack.ts
+++ b/src/platform/telemetry/utils/groupMissingNodesByPack.ts
@@ -1,0 +1,29 @@
+import type { MissingNodeType } from '@/types/comfy'
+
+import type { MissingNodePack } from '../types'
+
+const UNKNOWN_PACK_ID = 'unknown'
+
+export function groupMissingNodesByPack(
+  missingNodes: readonly MissingNodeType[]
+): MissingNodePack[] {
+  const byPack = new Map<string, Set<string>>()
+
+  for (const node of missingNodes) {
+    const type = typeof node === 'string' ? node : node.type
+    const packId =
+      typeof node === 'string' ? UNKNOWN_PACK_ID : node.cnrId || UNKNOWN_PACK_ID
+
+    const existing = byPack.get(packId)
+    if (existing) {
+      existing.add(type)
+    } else {
+      byPack.set(packId, new Set([type]))
+    }
+  }
+
+  return Array.from(byPack, ([pack_id, types]) => ({
+    pack_id,
+    node_types: Array.from(types)
+  }))
+}

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -25,6 +25,7 @@ import { LGraphEventMode } from '@/lib/litegraph/src/types/globalEnums'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
+import { groupMissingNodesByPack } from '@/platform/telemetry/utils/groupMissingNodesByPack'
 import type { WorkflowOpenSource } from '@/platform/telemetry/types'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { updatePendingWarnings } from '@/platform/workflow/core/utils/pendingWarnings'
@@ -1425,6 +1426,7 @@ export class ComfyApp {
         missing_node_types: missingNodeTypes.map((node) =>
           typeof node === 'string' ? node : node.type
         ),
+        missing_node_packs: groupMissingNodesByPack(missingNodeTypes),
         open_source: openSource ?? 'unknown'
       }
       useTelemetry()?.trackWorkflowOpened(telemetryPayload)


### PR DESCRIPTION
## Summary

Adds a `missing_node_packs` property to the existing `app:workflow_imported` PostHog event so we can see *which custom node packs* a workflow depends on, not just the raw node names.

## Changes

- **What**: Group missing-node entries by their `cnrId` (already present on each node's properties) and attach as `missing_node_packs: [{ pack_id, node_types }]`. Pure helper, fully sync, no network calls. Nodes without a `cnrId` bucket under `pack_id: 'unknown'` so we can size that population separately.
- Fires on every import path (drag-drop, file picker, shared URL) — `open_source` already disambiguates.

## Review Focus

- The `'unknown'` bucket is intentional. It tells us how often workflows arrive without pack metadata, which is itself useful.
- No async lookups — if `cnrId` isn't in the JSON, we don't go ask the registry. Keeps import fast and offline-safe.