### PR TITLE
Support fast disco on subgraph IO

### DIFF
--- a/browser_tests/fixtures/ComfyMouse.ts
+++ b/browser_tests/fixtures/ComfyMouse.ts
@@ -100,10 +100,7 @@ export class ComfyMouse implements Omit<Mouse, 'move'> {
     await this.nextFrame()
   }
 
-  async resizeByDragging(
-    element: Locator,
-    { x, y }: { x?: number; y?: number }
-  ) {
+  async dragElementBy(element: Locator, { x, y }: { x?: number; y?: number }) {
     const elementBox = await element.boundingBox()
     if (!elementBox) throw new Error('element should have layout')
 

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1240,12 +1240,12 @@ test(
     async function performDisconnect(slot: Locator, isFast: boolean) {
       await comfyMouse.resizeByDragging(slot, { x: isFast ? -25 : -80 })
 
-      if (isFast) {
-        await comfyPage.nextFrame()
-      } else {
+      if (!isFast) {
         await expect(comfyPage.contextMenu.litegraphContextMenu).toBeVisible()
         await comfyMouse.click(100, 100)
       }
+      const isConnected = () => comfyPage.vueNodes.isSlotConnected(slot)
+      await expect.poll(isConnected).toBe(false)
       await expect(comfyPage.contextMenu.litegraphContextMenu).toBeHidden()
     }
 

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -1238,7 +1238,7 @@ test(
   { tag: '@vue-nodes' },
   async ({ comfyMouse, comfyPage }) => {
     async function performDisconnect(slot: Locator, isFast: boolean) {
-      await comfyMouse.resizeByDragging(slot, { x: isFast ? -25 : -80 })
+      await comfyMouse.dragElementBy(slot, { x: isFast ? -25 : -80 })
 
       if (!isFast) {
         await expect(comfyPage.contextMenu.litegraphContextMenu).toBeVisible()
@@ -1251,7 +1251,7 @@ test(
 
     const ksamplerLocator = comfyPage.vueNodes.getNodeByTitle('KSampler')
     const ksampler = new VueNodeFixture(ksamplerLocator)
-    await comfyMouse.resizeByDragging(ksamplerLocator, { x: 100 })
+    await comfyMouse.dragElementBy(ksamplerLocator, { x: 100 })
 
     await test.step('Disconnection with normal links', async () => {
       await performDisconnect(ksampler.getSlot('model'), true)

--- a/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/linkInteraction.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import { getMiddlePoint } from '@e2e/fixtures/utils/litegraphUtils'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
+import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 
 async function getCenter(locator: Locator): Promise<{ x: number; y: number }> {
   const box = await locator.boundingBox()
@@ -1231,3 +1232,41 @@ test.describe('Vue Node Widget Link Position', { tag: '@vue-nodes' }, () => {
     }).toPass({ timeout: 5000 })
   })
 })
+
+test(
+  'Fast disconnection support',
+  { tag: '@vue-nodes' },
+  async ({ comfyMouse, comfyPage }) => {
+    async function performDisconnect(slot: Locator, isFast: boolean) {
+      await comfyMouse.resizeByDragging(slot, { x: isFast ? -25 : -80 })
+
+      if (isFast) {
+        await comfyPage.nextFrame()
+      } else {
+        await expect(comfyPage.contextMenu.litegraphContextMenu).toBeVisible()
+        await comfyMouse.click(100, 100)
+      }
+      await expect(comfyPage.contextMenu.litegraphContextMenu).toBeHidden()
+    }
+
+    const ksamplerLocator = comfyPage.vueNodes.getNodeByTitle('KSampler')
+    const ksampler = new VueNodeFixture(ksamplerLocator)
+    await comfyMouse.resizeByDragging(ksamplerLocator, { x: 100 })
+
+    await test.step('Disconnection with normal links', async () => {
+      await performDisconnect(ksampler.getSlot('model'), true)
+      await performDisconnect(ksampler.getSlot('positive'), false)
+    })
+
+    await test.step('Create subgraph', async () => {
+      await ksampler.title.click()
+      await comfyPage.page.keyboard.press('Control+Shift+e')
+      await comfyPage.vueNodes.enterSubgraph()
+    })
+
+    await test.step('Disconnection with subgraph IO', async () => {
+      await performDisconnect(ksampler.getSlot('negative'), true)
+      await performDisconnect(ksampler.getSlot('latent_image'), false)
+    })
+  }
+)

--- a/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/imagePreview.spec.ts
@@ -174,9 +174,9 @@ test.describe('Vue Nodes Batch Image Preview', { tag: '@vue-nodes' }, () => {
 
       const { bottomRight } = node.resize
       await expect.poll(() => countColumns(node.imageGrid)).toBe(10)
-      await comfyMouse.resizeByDragging(bottomRight, { x: 200 })
+      await comfyMouse.dragElementBy(bottomRight, { x: 200 })
       await expect.poll(() => countColumns(node.imageGrid)).toBeGreaterThan(10)
-      await comfyMouse.resizeByDragging(bottomRight, { x: -200, y: 200 })
+      await comfyMouse.dragElementBy(bottomRight, { x: -200, y: 200 })
       await expect.poll(() => countColumns(node.imageGrid)).toBeLessThan(10)
     }
   )

--- a/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/legacy.spec.ts
@@ -40,11 +40,11 @@ test('@vue-nodes In App Mode, widget width updates with panel size', async ({
     const gutter = comfyPage.page.getByRole('separator')
 
     await expect(gutter).toBeVisible()
-    await comfyMouse.resizeByDragging(gutter, { x: -200 })
+    await comfyMouse.dragElementBy(gutter, { x: -200 })
     await expect.poll(getWidth).toBeGreaterThan(initialWidth)
     const intermediateWidth = await getWidth()
 
-    await comfyMouse.resizeByDragging(gutter, { x: 100 })
+    await comfyMouse.dragElementBy(gutter, { x: 100 })
     await expect.poll(getWidth).toBeLessThan(intermediateWidth)
   })
 })

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6155,10 +6155,25 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       if (!this.pointer.isDown) reroute.drawSlots(ctx)
     }
 
-    const highlightPos = this._getHighlightPosition()
-    this.linkConnector.renderLinks.forEach((rl: RenderLink) =>
-      rl.drawConnectionCircle?.(ctx, highlightPos)
-    )
+    this.linkConnector.renderLinks.forEach((link: RenderLink) => {
+      if (!link.disconnectOnDrop || !link.disconnectOrigin) return
+
+      const [originX, originY] = link.disconnectOrigin
+      const radius = 35
+      const to = this._getHighlightPosition()
+      const distSquared = (originX - to[0]) ** 2 + (originY - to[1]) ** 2
+
+      ctx.save()
+      ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.moveTo(originX + radius, originY)
+      ctx.arc(originX, originY, radius, 0, Math.PI * 2)
+      ctx.stroke()
+      ctx.restore()
+
+      link.disconnectOnDrop = distSquared < radius ** 2
+    })
 
     ctx.globalAlpha = 1
   }

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -6156,9 +6156,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     }
 
     const highlightPos = this._getHighlightPosition()
-    this.linkConnector.renderLinks
-      .filter((rl) => rl instanceof MovingInputLink)
-      .forEach((rl) => rl.drawConnectionCircle(ctx, highlightPos))
+    this.linkConnector.renderLinks.forEach((rl: RenderLink) =>
+      rl.drawConnectionCircle?.(ctx, highlightPos)
+    )
 
     ctx.globalAlpha = 1
   }

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -873,10 +873,10 @@ export class LinkConnector {
   }
 
   dropOnNothing(event: CanvasPointerEvent): void {
-    remove(
+    remove<RenderLinkUnion>(
       this.renderLinks,
-      (link) => link instanceof MovingInputLink && link.disconnectOnDrop
-    ).forEach((link) => (link as MovingLinkBase).disconnect())
+      (link: RenderLink) => !!link.disconnectOnDrop
+    ).forEach((link) => (link as { disconnect(): void }).disconnect())
     if (this.renderLinks.length === 0) return
     // For external event only.
     const mayContinue = this.events.dispatch('dropped-on-canvas', event)

--- a/src/lib/litegraph/src/canvas/MovingInputLink.ts
+++ b/src/lib/litegraph/src/canvas/MovingInputLink.ts
@@ -1,5 +1,4 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -27,7 +26,7 @@ export class MovingInputLink extends MovingLinkBase {
   readonly fromDirection: LinkDirection
   readonly fromSlotIndex: SlotIndex
   disconnectOnDrop: boolean
-  readonly disconnectOrigin: Point
+  readonly disconnectOrigin?: Point
 
   constructor(
     network: LinkNetwork,
@@ -136,24 +135,5 @@ export class MovingInputLink extends MovingLinkBase {
 
   disconnect(): boolean {
     return this.inputNode.disconnectInput(this.inputIndex, true)
-  }
-
-  drawConnectionCircle(ctx: CanvasRenderingContext2D, to: Readonly<Point>) {
-    if (!this.disconnectOnDrop) return
-
-    const [originX, originY] = this.disconnectOrigin
-    const radius = 35
-    const distSquared = (originX - to[0]) ** 2 + (originY - to[1]) ** 2
-
-    ctx.save()
-    ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR
-    ctx.lineWidth = 2
-    ctx.beginPath()
-    ctx.moveTo(originX + radius, originY)
-    ctx.arc(originX, originY, radius, 0, Math.PI * 2)
-    ctx.stroke()
-    ctx.restore()
-
-    this.disconnectOnDrop = distSquared < radius ** 2
   }
 }

--- a/src/lib/litegraph/src/canvas/RenderLink.ts
+++ b/src/lib/litegraph/src/canvas/RenderLink.ts
@@ -95,9 +95,4 @@ export interface RenderLink {
     output: INodeOutputSlot,
     events: CustomEventTarget<LinkConnectorEventMap>
   ): void
-
-  drawConnectionCircle?(
-    ctx: CanvasRenderingContext2D,
-    to: Readonly<Point>
-  ): void
 }

--- a/src/lib/litegraph/src/canvas/RenderLink.ts
+++ b/src/lib/litegraph/src/canvas/RenderLink.ts
@@ -46,6 +46,7 @@ export interface RenderLink {
   readonly isIoNodeLink?: boolean
 
   disconnectOnDrop?: boolean
+  readonly disconnectOrigin?: Point
 
   /**
    * Capability checks used for hit-testing and validation during drag.

--- a/src/lib/litegraph/src/canvas/RenderLink.ts
+++ b/src/lib/litegraph/src/canvas/RenderLink.ts
@@ -45,6 +45,8 @@ export interface RenderLink {
 
   readonly isIoNodeLink?: boolean
 
+  disconnectOnDrop?: boolean
+
   /**
    * Capability checks used for hit-testing and validation during drag.
    * Implementations should return `false` when a connection is not possible
@@ -91,5 +93,10 @@ export interface RenderLink {
     outputNode: LGraphNode,
     output: INodeOutputSlot,
     events: CustomEventTarget<LinkConnectorEventMap>
+  ): void
+
+  drawConnectionCircle?(
+    ctx: CanvasRenderingContext2D,
+    to: Readonly<Point>
   ): void
 }

--- a/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
+++ b/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
@@ -1,4 +1,5 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -24,6 +25,8 @@ export class ToInputFromIoNodeLink implements RenderLink {
   readonly fromPos: Point
   fromDirection: LinkDirection = LinkDirection.RIGHT
   readonly existingLink?: LLink
+  disconnectOnDrop: boolean
+  readonly disconnectOrigin: Point | undefined
   readonly isIoNodeLink = true
 
   constructor(
@@ -44,6 +47,11 @@ export class ToInputFromIoNodeLink implements RenderLink {
     this.fromSlotIndex = outputIndex
     this.fromPos = fromReroute ? fromReroute.pos : fromSlot.pos
     this.existingLink = existingLink
+    this.disconnectOnDrop = true
+
+    if (!existingLink) return
+    const toNode = network.getNodeById(existingLink.target_id)
+    this.disconnectOrigin = toNode?.getInputPos(existingLink.target_slot)
   }
 
   canConnectToInput(inputNode: NodeLike, input: INodeInputSlot): boolean {
@@ -161,5 +169,23 @@ export class ToInputFromIoNodeLink implements RenderLink {
       })
 
     return true
+  }
+  drawConnectionCircle(ctx: CanvasRenderingContext2D, to: Readonly<Point>) {
+    if (!this.disconnectOnDrop || !this.disconnectOrigin) return
+
+    const [originX, originY] = this.disconnectOrigin
+    const radius = 35
+    const distSquared = (originX - to[0]) ** 2 + (originY - to[1]) ** 2
+
+    ctx.save()
+    ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    ctx.moveTo(originX + radius, originY)
+    ctx.arc(originX, originY, radius, 0, Math.PI * 2)
+    ctx.stroke()
+    ctx.restore()
+
+    this.disconnectOnDrop = distSquared < radius ** 2
   }
 }

--- a/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
+++ b/src/lib/litegraph/src/canvas/ToInputFromIoNodeLink.ts
@@ -1,5 +1,4 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { LLink } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
@@ -26,7 +25,7 @@ export class ToInputFromIoNodeLink implements RenderLink {
   fromDirection: LinkDirection = LinkDirection.RIGHT
   readonly existingLink?: LLink
   disconnectOnDrop: boolean
-  readonly disconnectOrigin: Point | undefined
+  readonly disconnectOrigin?: Point
   readonly isIoNodeLink = true
 
   constructor(
@@ -169,23 +168,5 @@ export class ToInputFromIoNodeLink implements RenderLink {
       })
 
     return true
-  }
-  drawConnectionCircle(ctx: CanvasRenderingContext2D, to: Readonly<Point>) {
-    if (!this.disconnectOnDrop || !this.disconnectOrigin) return
-
-    const [originX, originY] = this.disconnectOrigin
-    const radius = 35
-    const distSquared = (originX - to[0]) ** 2 + (originY - to[1]) ** 2
-
-    ctx.save()
-    ctx.strokeStyle = LiteGraph.WIDGET_OUTLINE_COLOR
-    ctx.lineWidth = 2
-    ctx.beginPath()
-    ctx.moveTo(originX + radius, originY)
-    ctx.arc(originX, originY, radius, 0, Math.PI * 2)
-    ctx.stroke()
-    ctx.restore()
-
-    this.disconnectOnDrop = distSquared < radius ** 2
   }
 }


### PR DESCRIPTION
Because subgraph links don't follow the normal link logic, the fast disconnection circle would not function when dragging input links that originate from a subgraph IO node. There's some sad duplication of state, but I think the flow is marginally cleaner now by not requiring `instanceof` checks.

The test added by this PR also verifies behavior for the node-to-node case.