### PR TITLE
fix(cloud): stop bouncing working users to /cloud/survey mid-session (FE-739)

### DIFF
--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -1,0 +1,125 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
+import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
+
+/**
+ * Cloud onboarding survey gate — FE-739.
+ *
+ * Regression coverage for the structural half of the fix: the survey is gated
+ * post-login only (UserCheckView), never by a mid-session navigation. Both
+ * cases run with the survey flag ON and the status endpoint reporting "not
+ * completed" (a definitive 200 with empty value — the one signal that still
+ * forces the survey), so the only thing that changes the outcome is *where*
+ * the gate lives.
+ *
+ * - Landing on `/` (the working app) must NOT bounce to the survey. Before the
+ *   fix the router `/` guard ran the gate here and yanked working users out.
+ * - Hitting `/cloud/user-check` (the post-login door) must still gate to the
+ *   survey, proving the consolidation didn't make onboarding unreachable.
+ *
+ * Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
+ * against fully mocked endpoints; `comfyPage` would try to reach the OSS
+ * devtools backend during setup.
+ */
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+const jsonRoute = (body: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body)
+})
+
+async function mockCloudBoot(page: Page) {
+  // `/api/features` is the remote-config source: production builds resolve
+  // `onboardingSurveyEnabled` from it (the `ff:` localStorage override is
+  // dev-only). Enable the survey so the gate is actually live.
+  await page.route('**/api/features', (r) =>
+    r.fulfill(
+      jsonRoute({ onboarding_survey_enabled: true } satisfies RemoteConfig)
+    )
+  )
+  await page.route('**/api/system_stats', (r) =>
+    r.fulfill(jsonRoute(mockSystemStats))
+  )
+  await page.route('**/api/users', (r) =>
+    r.fulfill(
+      jsonRoute({
+        storage: 'server',
+        migrated: true,
+        users: { 'test-user-e2e': 'E2E Test User' }
+      })
+    )
+  )
+  // Cloud user status (getUserCloudStatus) — an active account so UserCheckView
+  // proceeds to the survey check instead of bouncing back to login.
+  await page.route('**/api/user', (r) =>
+    r.fulfill(jsonRoute({ status: 'active' }))
+  )
+  // Survey status (getSurveyCompletedStatus): a definitive 200 with empty value
+  // = "not completed", the only response that still routes to the survey.
+  await page.route('**/api/settings/onboarding_survey', (r) =>
+    r.fulfill(jsonRoute({ value: {} }))
+  )
+  await page.route('**/api/settings', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))
+  await page.route('**/api/extensions', (r) => r.fulfill(jsonRoute([])))
+  await page.route('**/api/object_info', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/global_subgraphs', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/i18n', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/auth/session', (r) =>
+    r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
+  )
+  await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
+}
+
+async function bootCloud(page: Page) {
+  const auth = new CloudAuthHelper(page)
+  await auth.mockAuth()
+  // Pre-select the mock user to skip the user-select screen.
+  await page.addInitScript(() => {
+    localStorage.setItem('Comfy.userId', 'test-user-e2e')
+  })
+}
+
+test.describe(
+  'Cloud onboarding survey gate (FE-739)',
+  { tag: '@cloud' },
+  () => {
+    test('does not bounce a working user on / to the survey', async ({
+      page
+    }) => {
+      test.setTimeout(60_000)
+
+      await mockCloudBoot(page)
+      await bootCloud(page)
+
+      await page.goto(APP_URL)
+
+      // The full app boots — UserCheckView/CloudSurveyView are standalone
+      // onboarding views, so reaching the extension manager proves we landed on
+      // the working app and were never routed to the survey.
+      await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+        timeout: 45_000
+      })
+      await expect(page).not.toHaveURL(/\/cloud\/survey/)
+    })
+
+    test('still gates to the survey from the post-login user-check', async ({
+      page
+    }) => {
+      test.setTimeout(60_000)
+
+      await mockCloudBoot(page)
+      await bootCloud(page)
+
+      await page.goto(`${APP_URL}/cloud/user-check`)
+
+      await expect(page).toHaveURL(/\/cloud\/survey/, { timeout: 45_000 })
+    })
+  }
+)

--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -8,22 +8,11 @@ import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
 import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 
 /**
- * Cloud onboarding survey gate — FE-739.
- *
- * getSurveyCompletedStatus fails safe: a transient auth/backend failure on the
- * survey-status check resolves to "completed" so a working user is never
- * bounced to /cloud/survey, while a genuine "not completed" (the cloud backend
- * returns 404 for a survey key that was never stored) still routes to the
- * survey. Both cases drive the `/` router guard with the survey flag ON.
- *
- * - A transient 401 on the status check must NOT bounce a working user out of
- *   the app — this is the FE-739 regression.
- * - A 404 (survey never submitted) must still route a not-completed user to the
- *   survey, so the fail-safe doesn't make onboarding unreachable.
- *
- * Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
- * against fully mocked endpoints; `comfyPage` would try to reach the OSS
- * devtools backend during setup.
+ * getSurveyCompletedStatus fails safe: a transient 401 on `/` must not bounce a
+ * working user to /cloud/survey, while a genuine 404 (survey never submitted)
+ * must still route a not-completed user there. Drives a raw `page` so the cloud
+ * app boots against fully mocked endpoints (`comfyPage` would reach the OSS
+ * devtools backend during setup).
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
@@ -109,42 +98,38 @@ async function bootCloud(page: Page) {
   })
 }
 
-test.describe(
-  'Cloud onboarding survey gate (FE-739)',
-  { tag: '@cloud' },
-  () => {
-    test('a transient 401 on the survey check does not bounce a working user to the survey', async ({
-      page
-    }) => {
-      test.setTimeout(60_000)
+test.describe('Cloud onboarding survey gate', { tag: '@cloud' }, () => {
+  test('a transient 401 on the survey check does not bounce a working user to the survey', async ({
+    page
+  }) => {
+    test.setTimeout(60_000)
 
-      await mockCloudBoot(page)
-      await mockSurveyTransient401(page)
-      await bootCloud(page)
+    await mockCloudBoot(page)
+    await mockSurveyTransient401(page)
+    await bootCloud(page)
 
-      await page.goto(APP_URL)
+    await page.goto(APP_URL)
 
-      // The full app boots — CloudSurveyView is a standalone onboarding view, so
-      // reaching the extension manager proves we landed on the working app and
-      // the transient 401 was treated as "completed", not a bounce.
-      await page.waitForFunction(() => !!window.app?.extensionManager, null, {
-        timeout: 45_000
-      })
-      await expect(page).not.toHaveURL(/\/cloud\/survey/)
+    // The full app boots — CloudSurveyView is a standalone onboarding view, so
+    // reaching the extension manager proves we landed on the working app and
+    // the transient 401 was treated as "completed", not a bounce.
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
     })
+    await expect(page).not.toHaveURL(/\/cloud\/survey/)
+  })
 
-    test('a not-completed (404) user landing on / is routed to the survey', async ({
-      page
-    }) => {
-      test.setTimeout(60_000)
+  test('a not-completed (404) user landing on / is routed to the survey', async ({
+    page
+  }) => {
+    test.setTimeout(60_000)
 
-      await mockCloudBoot(page)
-      await mockSurveyNotCompleted(page)
-      await bootCloud(page)
+    await mockCloudBoot(page)
+    await mockSurveyNotCompleted(page)
+    await bootCloud(page)
 
-      await page.goto(APP_URL)
+    await page.goto(APP_URL)
 
-      await expect(page).toHaveURL(/\/cloud\/survey/, { timeout: 45_000 })
-    })
-  }
-)
+    await expect(page).toHaveURL(/\/cloud\/survey/, { timeout: 45_000 })
+  })
+})

--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -86,6 +86,22 @@ async function bootCloud(page: Page) {
   })
 }
 
+// The CI cloud backend only serves the SPA shell at the app root; a hard
+// navigation to a deep route returns a file download instead of index.html.
+// Re-serve the root shell for the deep route so a fresh load resolves it as a
+// real post-login entry, mirroring how users actually reach user-check.
+async function serveSpaShell(page: Page, path: string) {
+  await page.route(`**${path}`, async (route) => {
+    if (route.request().resourceType() !== 'document') return route.fallback()
+    const shell = await page.request.get(APP_URL)
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: await shell.text()
+    })
+  })
+}
+
 test.describe(
   'Cloud onboarding survey gate (FE-739)',
   { tag: '@cloud' },
@@ -116,6 +132,7 @@ test.describe(
 
       await mockCloudBoot(page)
       await bootCloud(page)
+      await serveSpaShell(page, '/cloud/user-check')
 
       await page.goto(`${APP_URL}/cloud/user-check`)
 

--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -10,17 +10,16 @@ import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
 /**
  * Cloud onboarding survey gate — FE-739.
  *
- * Regression coverage for the structural half of the fix: the survey is gated
- * post-login only (UserCheckView), never by a mid-session navigation. Both
- * cases run with the survey flag ON and the status endpoint reporting "not
- * completed" (a definitive 200 with empty value — the one signal that still
- * forces the survey), so the only thing that changes the outcome is *where*
- * the gate lives.
+ * getSurveyCompletedStatus fails safe: a transient auth/backend failure on the
+ * survey-status check resolves to "completed" so a working user is never
+ * bounced to /cloud/survey, while a genuine "not completed" (the cloud backend
+ * returns 404 for a survey key that was never stored) still routes to the
+ * survey. Both cases drive the `/` router guard with the survey flag ON.
  *
- * - Landing on `/` (the working app) must NOT bounce to the survey. Before the
- *   fix the router `/` guard ran the gate here and yanked working users out.
- * - Hitting `/cloud/user-check` (the post-login door) must still gate to the
- *   survey, proving the consolidation didn't make onboarding unreachable.
+ * - A transient 401 on the status check must NOT bounce a working user out of
+ *   the app — this is the FE-739 regression.
+ * - A 404 (survey never submitted) must still route a not-completed user to the
+ *   survey, so the fail-safe doesn't make onboarding unreachable.
  *
  * Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
  * against fully mocked endpoints; `comfyPage` would try to reach the OSS
@@ -28,11 +27,13 @@ import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
-const jsonRoute = (body: unknown) => ({
-  status: 200,
-  contentType: 'application/json',
-  body: JSON.stringify(body)
-})
+function jsonRoute(body: unknown) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body)
+  }
+}
 
 async function mockCloudBoot(page: Page) {
   // `/api/features` is the remote-config source: production builds resolve
@@ -55,21 +56,10 @@ async function mockCloudBoot(page: Page) {
       })
     )
   )
-  // Cloud user status (getUserCloudStatus) — an active account so UserCheckView
+  // Cloud user status (getUserCloudStatus) — an active account so the gate
   // proceeds to the survey check instead of bouncing back to login.
   await page.route('**/api/user', (r) =>
     r.fulfill(jsonRoute({ status: 'active' }))
-  )
-  // Survey status (getSurveyCompletedStatus): a 404 = the survey key was never
-  // stored = "not completed". This is what the cloud backend actually returns
-  // for a user who hasn't onboarded, and the response that still routes to the
-  // survey.
-  await page.route('**/api/settings/onboarding_survey', (r) =>
-    r.fulfill({
-      status: 404,
-      contentType: 'application/json',
-      body: JSON.stringify({ code: 'NOT_FOUND', message: 'Setting not found' })
-    })
   )
   await page.route('**/api/settings', (r) => r.fulfill(jsonRoute({})))
   await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))
@@ -83,6 +73,33 @@ async function mockCloudBoot(page: Page) {
   await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
 }
 
+// Genuine "not completed": the cloud backend returns 404 for a survey key that
+// was never stored. This is the response that must still route to the survey.
+async function mockSurveyNotCompleted(page: Page) {
+  await page.route('**/api/settings/onboarding_survey', (r) =>
+    r.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 'NOT_FOUND', message: 'Setting not found' })
+    })
+  )
+}
+
+// Transient auth failure: a stale workspace token makes the authenticated
+// survey check 401 — the hiccup that used to bounce working users.
+async function mockSurveyTransient401(page: Page) {
+  await page.route('**/api/settings/onboarding_survey', (r) =>
+    r.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 'UNAUTHORIZED',
+        message: 'User authentication required'
+      })
+    })
+  )
+}
+
 async function bootCloud(page: Page) {
   const auth = new CloudAuthHelper(page)
   await auth.mockAuth()
@@ -92,55 +109,40 @@ async function bootCloud(page: Page) {
   })
 }
 
-// The CI cloud backend only serves the SPA shell at the app root; a hard
-// navigation to a deep route returns a file download instead of index.html.
-// Re-serve the root shell for the deep route so a fresh load resolves it as a
-// real post-login entry, mirroring how users actually reach user-check.
-async function serveSpaShell(page: Page, path: string) {
-  await page.route(`**${path}`, async (route) => {
-    if (route.request().resourceType() !== 'document') return route.fallback()
-    const shell = await page.request.get(APP_URL)
-    await route.fulfill({
-      status: 200,
-      contentType: 'text/html',
-      body: await shell.text()
-    })
-  })
-}
-
 test.describe(
   'Cloud onboarding survey gate (FE-739)',
   { tag: '@cloud' },
   () => {
-    test('does not bounce a working user on / to the survey', async ({
+    test('a transient 401 on the survey check does not bounce a working user to the survey', async ({
       page
     }) => {
       test.setTimeout(60_000)
 
       await mockCloudBoot(page)
+      await mockSurveyTransient401(page)
       await bootCloud(page)
 
       await page.goto(APP_URL)
 
-      // The full app boots — UserCheckView/CloudSurveyView are standalone
-      // onboarding views, so reaching the extension manager proves we landed on
-      // the working app and were never routed to the survey.
+      // The full app boots — CloudSurveyView is a standalone onboarding view, so
+      // reaching the extension manager proves we landed on the working app and
+      // the transient 401 was treated as "completed", not a bounce.
       await page.waitForFunction(() => !!window.app?.extensionManager, null, {
         timeout: 45_000
       })
       await expect(page).not.toHaveURL(/\/cloud\/survey/)
     })
 
-    test('still gates to the survey from the post-login user-check', async ({
+    test('a not-completed (404) user landing on / is routed to the survey', async ({
       page
     }) => {
       test.setTimeout(60_000)
 
       await mockCloudBoot(page)
+      await mockSurveyNotCompleted(page)
       await bootCloud(page)
-      await serveSpaShell(page, '/cloud/user-check')
 
-      await page.goto(`${APP_URL}/cloud/user-check`)
+      await page.goto(APP_URL)
 
       await expect(page).toHaveURL(/\/cloud\/survey/, { timeout: 45_000 })
     })

--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -60,10 +60,16 @@ async function mockCloudBoot(page: Page) {
   await page.route('**/api/user', (r) =>
     r.fulfill(jsonRoute({ status: 'active' }))
   )
-  // Survey status (getSurveyCompletedStatus): a definitive 200 with empty value
-  // = "not completed", the only response that still routes to the survey.
+  // Survey status (getSurveyCompletedStatus): a 404 = the survey key was never
+  // stored = "not completed". This is what the cloud backend actually returns
+  // for a user who hasn't onboarded, and the response that still routes to the
+  // survey.
   await page.route('**/api/settings/onboarding_survey', (r) =>
-    r.fulfill(jsonRoute({ value: {} }))
+    r.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 'NOT_FOUND', message: 'Setting not found' })
+    })
   )
   await page.route('**/api/settings', (r) => r.fulfill(jsonRoute({})))
   await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))

--- a/src/platform/cloud/onboarding/auth.test.ts
+++ b/src/platform/cloud/onboarding/auth.test.ts
@@ -1,0 +1,91 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { getSurveyCompletedStatus } from './auth'
+
+const fetchApi = vi.fn()
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    fetchApi: (...args: unknown[]) => fetchApi(...args)
+  }
+}))
+
+vi.mock('@sentry/vue', () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn()
+}))
+
+function mockResponse({
+  ok,
+  status,
+  body
+}: {
+  ok: boolean
+  status: number
+  body?: unknown
+}): Response {
+  return fromPartial<Response>({
+    ok,
+    status,
+    statusText: '',
+    json: async () => body
+  })
+}
+
+describe('getSurveyCompletedStatus', () => {
+  beforeEach(() => {
+    fetchApi.mockReset()
+  })
+
+  test('200 with non-empty value → true', async () => {
+    fetchApi.mockResolvedValueOnce(
+      mockResponse({ ok: true, status: 200, body: { value: { q1: 'a' } } })
+    )
+    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+  })
+
+  test('200 with empty value → false (the only "not completed" signal)', async () => {
+    fetchApi.mockResolvedValueOnce(
+      mockResponse({ ok: true, status: 200, body: { value: {} } })
+    )
+    await expect(getSurveyCompletedStatus()).resolves.toBe(false)
+  })
+
+  test('200 with null value → false', async () => {
+    fetchApi.mockResolvedValueOnce(
+      mockResponse({ ok: true, status: 200, body: { value: null } })
+    )
+    await expect(getSurveyCompletedStatus()).resolves.toBe(false)
+  })
+
+  test('404 → true (do not bounce on missing key)', async () => {
+    fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }))
+    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+  })
+
+  test('500 → true (do not bounce on transient backend error)', async () => {
+    fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 500 }))
+    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+  })
+
+  // 401/403 fall under the same "ambiguous => treat as completed" policy.
+  // The dedicated auth layer handles re-authentication on the next API
+  // call; this function deliberately does not try to disambiguate auth
+  // failures from other non-OK responses. Locking with tests so the
+  // policy can't drift back to a "throw on auth error" branch.
+  test('401 → true (auth layer handles re-auth on next call)', async () => {
+    fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 401 }))
+    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+  })
+
+  test('403 → true (auth layer handles re-auth on next call)', async () => {
+    fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 403 }))
+    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+  })
+
+  test('network rejection → true (do not bounce on network error)', async () => {
+    fetchApi.mockRejectedValueOnce(new TypeError('Network request failed'))
+    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+  })
+})

--- a/src/platform/cloud/onboarding/auth.test.ts
+++ b/src/platform/cloud/onboarding/auth.test.ts
@@ -66,9 +66,9 @@ describe('getSurveyCompletedStatus', () => {
     await expect(getSurveyCompletedStatus()).resolves.toBe(false)
   })
 
-  test('404 → true (do not bounce on missing key)', async () => {
+  test('404 → false (key never stored = genuinely not completed)', async () => {
     fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }))
-    await expect(getSurveyCompletedStatus()).resolves.toBe(true)
+    await expect(getSurveyCompletedStatus()).resolves.toBe(false)
   })
 
   test('500 → true (do not bounce on transient backend error)', async () => {
@@ -76,11 +76,12 @@ describe('getSurveyCompletedStatus', () => {
     await expect(getSurveyCompletedStatus()).resolves.toBe(true)
   })
 
-  // 401/403 fall under the same "ambiguous => treat as completed" policy.
-  // The dedicated auth layer handles re-authentication on the next API
-  // call; this function deliberately does not try to disambiguate auth
-  // failures from other non-OK responses. Locking with tests so the
-  // policy can't drift back to a "throw on auth error" branch.
+  // 401/403/5xx stay under the "ambiguous => treat as completed" fail-safe;
+  // 404 is the one non-ok we disambiguate, since it's the real not-completed
+  // signal. The dedicated auth layer handles re-authentication on the next API
+  // call; this function deliberately does not try to recover auth failures
+  // itself. Locking with tests so the policy can't drift back to a "throw on
+  // auth error" branch.
   test('401 → true (auth layer handles re-auth on next call)', async () => {
     fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 401 }))
     await expect(getSurveyCompletedStatus()).resolves.toBe(true)

--- a/src/platform/cloud/onboarding/auth.test.ts
+++ b/src/platform/cloud/onboarding/auth.test.ts
@@ -59,6 +59,13 @@ describe('getSurveyCompletedStatus', () => {
     await expect(getSurveyCompletedStatus()).resolves.toBe(false)
   })
 
+  test('200 with missing value key → false', async () => {
+    fetchApi.mockResolvedValueOnce(
+      mockResponse({ ok: true, status: 200, body: {} })
+    )
+    await expect(getSurveyCompletedStatus()).resolves.toBe(false)
+  })
+
   test('404 → true (do not bounce on missing key)', async () => {
     fetchApi.mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }))
     await expect(getSurveyCompletedStatus()).resolves.toBe(true)

--- a/src/platform/cloud/onboarding/auth.ts
+++ b/src/platform/cloud/onboarding/auth.ts
@@ -96,23 +96,24 @@ export async function getSurveyCompletedStatus(): Promise<boolean> {
       }
     })
     if (!response.ok) {
-      // Not an error case - survey not completed is a valid state
+      // Ambiguous response (404/5xx/401/403): treat as completed so a
+      // transient failure never bounces a working user to /cloud/survey.
+      // Only a definitive 200 with empty value means "not completed".
       Sentry.addBreadcrumb({
         category: 'auth',
         message: 'Survey status check returned non-ok response',
-        level: 'info',
+        level: 'warning',
         data: {
           status: response.status,
           endpoint: `/settings/${ONBOARDING_SURVEY_KEY}`
         }
       })
-      return false
+      return true
     }
     const data = await response.json()
-    // Check if data exists and is not empty
     return !isEmpty(data.value)
   } catch (error) {
-    // Network error - still capture it as it's not thrown from above
+    // Network/parse failure: same fail-safe policy as a non-ok response.
     Sentry.captureException(error, {
       tags: {
         api_endpoint: '/settings/{key}',
@@ -124,7 +125,7 @@ export async function getSurveyCompletedStatus(): Promise<boolean> {
       },
       level: 'warning'
     })
-    return false
+    return true
   }
 }
 

--- a/src/platform/cloud/onboarding/auth.ts
+++ b/src/platform/cloud/onboarding/auth.ts
@@ -95,10 +95,15 @@ export async function getSurveyCompletedStatus(): Promise<boolean> {
         'Content-Type': 'application/json'
       }
     })
+    // 404 = the survey key was never stored = genuinely not completed. Only
+    // reachable after a successful authenticated read (a stale token returns
+    // 401, never 404), so it can't be a transient-auth false signal.
+    if (response.status === 404) {
+      return false
+    }
     if (!response.ok) {
-      // Ambiguous response (404/5xx/401/403): treat as completed so a
-      // transient failure never bounces a working user to /cloud/survey.
-      // Only a definitive 200 with empty value means "not completed".
+      // Other non-ok (401/403/5xx): treat as completed so a transient failure
+      // never bounces a working user to /cloud/survey.
       Sentry.addBreadcrumb({
         category: 'auth',
         message: 'Survey status check returned non-ok response',

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,7 +7,6 @@ import {
 } from 'vue-router'
 import type { RouteLocationNormalized } from 'vue-router'
 
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
@@ -128,7 +127,6 @@ router.afterEach(() => {
 })
 
 if (isCloud) {
-  const { flags } = useFeatureFlags()
   const PUBLIC_ROUTE_NAMES = new Set([
     'cloud-login',
     'cloud-signup',
@@ -218,31 +216,9 @@ if (isCloud) {
       })
     }
 
-    // User is logged in - check if they need onboarding (when enabled)
-    // For root path, check actual user status to handle waitlisted users
-    if (!isDesktop && isLoggedIn && to.path === '/') {
-      if (!flags.onboardingSurveyEnabled) {
-        return next()
-      }
-      // Import auth functions dynamically to avoid circular dependency
-      const { getSurveyCompletedStatus } =
-        await import('@/platform/cloud/onboarding/auth')
-      try {
-        // Check user's actual status
-        const surveyCompleted = await getSurveyCompletedStatus()
-
-        // Survey is required for all users (when feature flag enabled)
-        if (!surveyCompleted) {
-          return next({ name: 'cloud-survey' })
-        }
-      } catch (error) {
-        console.error('Failed to check user status:', error)
-        // On error, redirect to user-check as fallback
-        return next({ name: 'cloud-user-check' })
-      }
-    }
-
-    // User is logged in and accessing protected route
+    // User is logged in and accessing a protected route.
+    // Onboarding survey is gated post-login in UserCheckView, never here, so a
+    // mid-session navigation can't bounce a working user to the survey.
     return next()
   })
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import {
 } from 'vue-router'
 import type { RouteLocationNormalized } from 'vue-router'
 
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
@@ -127,6 +128,7 @@ router.afterEach(() => {
 })
 
 if (isCloud) {
+  const { flags } = useFeatureFlags()
   const PUBLIC_ROUTE_NAMES = new Set([
     'cloud-login',
     'cloud-signup',
@@ -216,9 +218,31 @@ if (isCloud) {
       })
     }
 
-    // User is logged in and accessing a protected route.
-    // Onboarding survey is gated post-login in UserCheckView, never here, so a
-    // mid-session navigation can't bounce a working user to the survey.
+    // User is logged in - check if they need onboarding (when enabled)
+    // For root path, check actual user status to handle waitlisted users
+    if (!isDesktop && isLoggedIn && to.path === '/') {
+      if (!flags.onboardingSurveyEnabled) {
+        return next()
+      }
+      // Import auth functions dynamically to avoid circular dependency
+      const { getSurveyCompletedStatus } =
+        await import('@/platform/cloud/onboarding/auth')
+      try {
+        // Check user's actual status
+        const surveyCompleted = await getSurveyCompletedStatus()
+
+        // Survey is required for all users (when feature flag enabled)
+        if (!surveyCompleted) {
+          return next({ name: 'cloud-survey' })
+        }
+      } catch (error) {
+        console.error('Failed to check user status:', error)
+        // On error, redirect to user-check as fallback
+        return next({ name: 'cloud-user-check' })
+      }
+    }
+
+    // User is logged in and accessing protected route
     return next()
   })
 }


### PR DESCRIPTION
## Summary

Cloud users get yanked to `/cloud/survey` mid-workflow with no user action. The redirect is **downstream of auth**: when the Cloud token is briefly stale (token rotation / auth-refresh / reconnect window), the authenticated survey-status check 401s, and the gate turned that transient 401 into "survey not completed" → redirect.

Surveys are currently disabled for everyone on cloud via dynamicconfig as the live mitigation. This PR lets us re-enable them safely **without** waiting on the auth rework.

## Root cause

`getSurveyCompletedStatus()` returned `false` ("not completed") on **any** non-200 — including a transient 401/403/5xx or network error — and consumers treat `false` as a redirect to the survey. So a stale-token 401 (or the page force-reload a 401 triggers in `GraphCanvas`) bounced a working, already-onboarded user to the survey.

The real root cause of the transient 401s is a separate, still-open effort: **FE-963** (reactive 401 re-mint + single retry), **FE-950/951** (unified Cloud JWT), **BE-1125**. This PR does **not** fix those; it stops the survey from being their user-visible casualty.

## The fix

`getSurveyCompletedStatus` now distinguishes the responses instead of failing closed on all of them:

- **404** → not completed (show survey). This is the genuine signal: the cloud backend (`GetSettingById`) returns 404 for a survey key that was never stored, and a 404 is only reachable after a successful authenticated read (a stale token 401s, never 404s), so it can't be a transient false signal.
- **transient 401/403/5xx/network** → treat as completed (fail-safe), so a working user is never bounced.
- **200** → completed iff `value` is non-empty (unchanged).

**No router change.** The `/` onboarding guard is untouched (router.ts matches main), so the existing UX is preserved — a not-completed user is still gated to the survey on load; only the spurious transient-failure bounce is removed.

## Why #12301 was reverted, and how this differs

#12301 shipped a **blanket** fail-safe (`!response.ok → true`, 404 included), which made the survey unreachable for genuinely-not-completed users (404 → "completed") and was reverted in #12344. This PR special-cases **404 as the real not-completed signal** and fails safe only on transient/ambiguous responses, so onboarding still works.

## Tests

- **Unit** (`auth.test.ts`): 200 non-empty → true; 200 empty / `null` / missing `value` key → false; **404 → false**; 401/403/500/network → true.
- **E2E** (`browser_tests/tests/cloudSurveyGate.spec.ts`, `@cloud`): a transient 401 on `/` does **not** bounce a working user; a genuine 404 on `/` **does** route to the survey.

Linear: FE-739. Root cause (separate): FE-963 / FE-950 / FE-951 / BE-1125.
