### PR TITLE
FE-906 fix(vueNodes): require dragGuard.wasDragged for multi-select drag-start

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.test.ts
@@ -270,6 +270,27 @@ describe('useNodePointerInteractions', () => {
     expect(handleNodeSelect).toHaveBeenCalledTimes(1)
   })
 
+  it('should not start drag on shift+move when pointerdown was stopped by a child', async () => {
+    const { handleNodeSelect } = useNodeEventHandlers()
+    const { startDrag } = useNodeDrag()
+
+    const { pointerHandlers } = useNodePointerInteractions('test-node-123')
+
+    pointerHandlers.onPointermove(
+      createPointerEvent('pointermove', {
+        shiftKey: true,
+        buttons: 1,
+        clientX: 200,
+        clientY: 200
+      })
+    )
+
+    await nextTick()
+    expect(layoutStore.isDraggingVueNodes.value).toBe(false)
+    expect(startDrag).not.toHaveBeenCalled()
+    expect(handleNodeSelect).not.toHaveBeenCalled()
+  })
+
   it('on ctrl+click: calls toggleNodeSelectionAfterPointerUp on pointer up (not pointer down)', async () => {
     const { pointerHandlers } = useNodePointerInteractions('test-node-123')
     const { toggleNodeSelectionAfterPointerUp } = useNodeEventHandlers()

--- a/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
+++ b/src/renderer/extensions/vueNodes/composables/useNodePointerInteractions.ts
@@ -83,7 +83,12 @@ export function useNodePointerInteractions(
     const multiSelect = isMultiSelectKey(event)
 
     const lmbDown = event.buttons & 1
-    if (lmbDown && multiSelect && !layoutStore.isDraggingVueNodes.value) {
+    if (
+      lmbDown &&
+      multiSelect &&
+      !layoutStore.isDraggingVueNodes.value &&
+      dragGuard.wasDragged(event)
+    ) {
       layoutStore.isDraggingVueNodes.value = true
       handleNodeSelect(event, nodeId)
       safeDragStart(event, nodeId)


### PR DESCRIPTION
## Summary
The multi-select branch of onPointermove started a node drag whenever LMB + shift/ctrl/meta was held during pointermove, even when pointerdown had never reached the node (because a child widget swallowed it with @pointerdown.stop). In Preview3D/Load3D, shift+drag inside the threejs scene therefore dragged the underlying Vue node.

Gate the multi-select branch on dragGuard.wasDragged(event) — same gate the regular branch already uses. dragGuard.start is only recorded by onPointerdown, so a widget that swallows pointerdown now naturally opts itself out of node drag-start without having to also swallow pointermove (which would break libraries like three.js OrbitControls that listen for pointermove on document).

## Screenshots (if applicable)
before
https://github.com/user-attachments/assets/b5faa803-5993-4341-a1d0-7ec980362344

after
https://github.com/user-attachments/assets/f7367e61-6194-4e16-9713-c398f989d26b




