### PR TITLE
ci: skip PR Unified Report on main branch

### DIFF
--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -5,6 +5,8 @@ on:
     workflows: ['CI: Size Data', 'CI: Performance Report', 'CI: E2E Coverage']
     types:
       - completed
+    branches-ignore:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The [`pr-report.yaml`](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/.github/workflows/pr-report.yaml) workflow is dispatched via `workflow_run` after `CI: Size Data`, `CI: Performance Report`, or `CI: E2E Coverage` complete. Those upstream workflows also run on push to `main`, which dispatches `PR: Unified Report` on the `main` branch head, producing failed runs like [run 26913874399](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/26913874399/job/79398707144).

The existing job-level guard (`github.event.workflow_run.event == 'pull_request'`) doesn't always prevent the runner from spinning up, so noisy failed runs still appear under the workflow's history on `main`.

## Change

Add `branches-ignore: [main]` to the `workflow_run` trigger so the workflow no longer dispatches when the upstream run's head branch is `main`.

```yaml
on:
  workflow_run:
    workflows: ['CI: Size Data', 'CI: Performance Report', 'CI: E2E Coverage']
    types:
      - completed
    branches-ignore:
      - main
```

## Tradeoff to flag

`workflow_run.branches-ignore` filters on the triggering workflow run's head branch. For PRs, that's the PR's source branch. A fork PR whose source branch is literally named `main` (e.g., a fork opened from its default branch) will no longer get a unified report comment. This is uncommon for contributors who follow the usual feature-branch workflow, but if preserving comments for fork-from-`main` PRs matters, the alternative is to leave the dispatch in place and rely solely on the existing job-level `if` guard.