### PR TITLE
feat(graph): add mask icon to "Open in Mask Editor" context menu option (FE-929)

### DIFF
--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -101,6 +101,23 @@ describe('useImageMenuOptions', () => {
       expect(copyIdx).toBeLessThan(pasteIdx)
       expect(pasteIdx).toBeLessThan(saveIdx)
     })
+
+    it('gives the Open in Mask Editor option the mask icon', () => {
+      const node = createImageNode()
+      const { getImageMenuOptions } = useImageMenuOptions()
+      const options = getImageMenuOptions(node)
+      const maskOption = options.find((o) => o.label === 'Open in Mask Editor')
+
+      expect(maskOption?.icon).toBe('icon-[comfy--mask]')
+    })
+
+    it('gives every image action option an icon so labels stay aligned', () => {
+      const node = createImageNode()
+      const { getImageMenuOptions } = useImageMenuOptions()
+      const options = getImageMenuOptions(node)
+
+      expect(options.every((o) => !!o.icon)).toBe(true)
+    })
   })
 
   describe('pasteImage action', () => {

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -123,6 +123,7 @@ export function useImageMenuOptions() {
         },
         {
           label: t('contextMenu.Open in Mask Editor'),
+          icon: 'icon-[comfy--mask]',
           action: () => openMaskEditor()
         },
         {


### PR DESCRIPTION
## Summary
<img width="1600" height="882" alt="fe-mask-icon-after" src="https://github.com/user-attachments/assets/7ddd6ae3-4c6a-4c4d-9a61-2059851bd4f9" />


Stacked on #12563 (FE-839). Follow-up requested in the FE-839 thread by @AlexisRolland and @alextov: the media-node context menu gives every image action an icon **except** `Open in Mask Editor`, leaving its label misaligned with the rest of the group.

This reuses the existing custom `comfy--mask` icon — the same one shown on the node image overlay / selection-toolbox `MaskEditorButton` — for the `Open in Mask Editor` entry. With it, all five image actions (`Open Image`, `Open in Mask Editor`, `Copy Image`, `Paste Image`, `Save Image`) now carry an icon and their labels line up.

- Follow-up to FE-839
- Context (FE-839 Slack thread): Alexis — *"it would be nice to have an icon for open in mask editor. There is one on the image overlay in the node which could be reused"*; Alex Tov — icon name is `mask`, a custom icon.

> The broader idea of reserving a placeholder/buffer for options that have no icon so **all** menu labels align (Alex Tov) is intentionally out of scope here — this PR only completes the image-action group.

## Implementation

- `useImageMenuOptions.ts`: add `icon: 'icon-[comfy--mask]'` to the `Open in Mask Editor` option.

No rendering changes are needed — `NodeContextMenu.vue` already renders the icon via `<i v-if="item.icon" :class="[item.icon, 'size-4']" />`, and `comfy--mask` is already registered (custom collection loaded from `packages/design-system/src/icons`, used today by `MaskEditorButton.vue` and `linearMode/DropZone.vue`).

## Red-Green Verification (local)

| Step | Result |
|------|--------|
| Test-only commit (`d8b7e2c`) | 🔴 Red — `expected undefined to be 'icon-[comfy--mask]'`; image group not fully iconed |
| Fix commit (`feeb505`) | 🟢 Green — 10/10 passing |

## Before / After

Right-click a media node (Load / Preview / Save Image) → image-action group at the top of the menu:

| Before (base `FE-839`) | After (this PR) |
| --- | --- |
| `Open in Mask Editor` has no icon — its label sits flush-left while the other four image actions are indented past their icons. | `Open in Mask Editor` shows the mask icon; all five image actions line up. |

<!-- drag fe-mask-icon-before.png and fe-mask-icon-after.png into the two cells above -->

Captured locally against a Load Image node with `example.png` (Vue nodes enabled), dev server proxied to a live backend.

https://comfy-organization.slack.com/archives/C0A7ADM4797/p1780467176353799?thread_ts=1779462362.995709&cid=C0A7ADM4797 
## Test Plan

- [x] Local red on the test-only commit
- [x] Local green on the fix commit
- [x] `useImageMenuOptions.test.ts` — 2 new tests (mask icon present on `Open in Mask Editor`; every image action carries an icon)
- [x] eslint clean on changed files
- [ ] Manual: right-click a media node and confirm the mask icon renders next to `Open in Mask Editor`
