### PR TITLE
fix: resolve missing resource error messages

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -54,6 +54,7 @@ export const TestIds = {
     errorDialogFindIssues: 'error-dialog-find-issues',
     about: 'about-panel',
     whatsNewSection: 'whats-new-section',
+    errorGroupDisplayMessage: 'error-group-display-message',
     missingNodePacksGroup: 'error-group-missing-node',
     missingModelsGroup: 'error-group-missing-model',
     missingModelExpand: 'missing-model-expand',

--- a/browser_tests/tests/nodeReplacement.spec.ts
+++ b/browser_tests/tests/nodeReplacement.spec.ts
@@ -11,6 +11,7 @@ import {
   getSwapNodesGroup,
   setupNodeReplacement
 } from '@e2e/fixtures/helpers/NodeReplacementHelper'
+import { TestIds } from '@e2e/fixtures/selectors'
 
 const renderModes = [
   { name: 'vue nodes', vueNodesEnabled: true },
@@ -38,6 +39,9 @@ test.describe('Node replacement', { tag: ['@node', '@ui'] }, () => {
         }) => {
           const swapGroup = getSwapNodesGroup(comfyPage.page)
           await expect(swapGroup).toBeVisible()
+          await expect(
+            swapGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+          ).toHaveText(/\S/)
           await expect(swapGroup).toContainText('E2E_OldSampler')
           await expect(
             swapGroup.getByRole('button', { name: 'Replace All', exact: true })

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMedia.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMedia.spec.ts
@@ -36,6 +36,10 @@ function getDropzone(comfyPage: ComfyPage) {
   return comfyPage.page.getByTestId(TestIds.dialogs.missingMediaUploadDropzone)
 }
 
+function getErrorOverlay(comfyPage: ComfyPage) {
+  return comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
+}
+
 test.describe('Errors tab - Missing media', { tag: '@ui' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.settings.setSetting(
@@ -46,14 +50,24 @@ test.describe('Errors tab - Missing media', { tag: '@ui' }, () => {
 
   test.describe('Detection', () => {
     test('Shows missing media group in errors tab', async ({ comfyPage }) => {
-      await loadWorkflowAndOpenErrorsTab(
-        comfyPage,
-        'missing/missing_media_single'
-      )
+      await comfyPage.workflow.loadWorkflow('missing/missing_media_single')
 
+      const overlay = getErrorOverlay(comfyPage)
+      await expect(overlay).toBeVisible()
       await expect(
-        comfyPage.page.getByTestId(TestIds.dialogs.missingMediaGroup)
-      ).toBeVisible()
+        overlay.getByTestId(TestIds.dialogs.errorOverlayMessages)
+      ).toContainText(/Load Image/)
+
+      await overlay.getByTestId(TestIds.dialogs.errorOverlaySeeErrors).click()
+      await expect(overlay).toBeHidden()
+
+      const missingMediaGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingMediaGroup
+      )
+      await expect(missingMediaGroup).toBeVisible()
+      await expect(
+        missingMediaGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
     })
 
     test('Shows correct number of missing media rows', async ({

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
@@ -25,9 +25,13 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
   }) => {
     await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
 
+    const missingModelsGroup = comfyPage.page.getByTestId(
+      TestIds.dialogs.missingModelsGroup
+    )
+    await expect(missingModelsGroup).toBeVisible()
     await expect(
-      comfyPage.page.getByTestId(TestIds.dialogs.missingModelsGroup)
-    ).toBeVisible()
+      missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+    ).toHaveText(/\S/)
   })
 
   test('Should display model name with referencing node count', async ({

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -23,9 +23,13 @@ test.describe('Errors tab - Missing nodes', { tag: '@ui' }, () => {
   test('Should show missing node packs group', async ({ comfyPage }) => {
     await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
 
+    const missingNodeGroup = comfyPage.page.getByTestId(
+      TestIds.dialogs.missingNodePacksGroup
+    )
+    await expect(missingNodeGroup).toBeVisible()
     await expect(
-      comfyPage.page.getByTestId(TestIds.dialogs.missingNodePacksGroup)
-    ).toBeVisible()
+      missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+    ).toHaveText(/\S/)
   })
 
   test('Should expand pack group to reveal node type names', async ({

--- a/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.test.ts
@@ -90,8 +90,6 @@ const i18n = createI18n({
     en: {
       rightSidePanel: {
         missingNodePacks: {
-          ossMessage: 'Missing node packs detected. Install them.',
-          cloudMessage: 'Unsupported node packs detected.',
           ossManagerDisabledHint:
             'To install missing nodes, first run {pipCmd} in your Python environment to install Node Manager, then restart ComfyUI with the {flag} flag.',
           applyChanges: 'Apply Changes'
@@ -159,21 +157,6 @@ describe('MissingNodeCard', () => {
   })
 
   describe('Rendering & Props', () => {
-    it('renders cloud message when isCloud is true', () => {
-      mockIsCloud.value = true
-      renderCard()
-      expect(
-        screen.getByText('Unsupported node packs detected.')
-      ).toBeInTheDocument()
-    })
-
-    it('renders OSS message when isCloud is false', () => {
-      renderCard()
-      expect(
-        screen.getByText('Missing node packs detected. Install them.')
-      ).toBeInTheDocument()
-    })
-
     it('renders correct number of MissingPackGroupRow components', () => {
       renderCard({ missingPackGroups: makePackGroups(3) })
       expect(screen.getAllByTestId('pack-row')).toHaveLength(3)

--- a/src/components/rightSidePanel/errors/MissingNodeCard.vue
+++ b/src/components/rightSidePanel/errors/MissingNodeCard.vue
@@ -36,19 +36,6 @@
         </div>
       </div>
     </div>
-
-    <!-- Sub-label: cloud or OSS message shown above all pack groups -->
-    <p
-      class="m-0 text-sm/relaxed text-muted-foreground"
-      :class="showManagerHint ? 'pb-3' : 'pb-5'"
-    >
-      {{
-        isCloud
-          ? t('rightSidePanel.missingNodePacks.cloudMessage')
-          : t('rightSidePanel.missingNodePacks.ossMessage')
-      }}
-    </p>
-
     <!-- Manager disabled hint: shown on OSS when manager is not active -->
     <i18n-t
       v-if="showManagerHint"

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -326,11 +326,6 @@ describe('TabErrors.vue', () => {
     expect(
       screen.getByText('Download a model, or open the node to replace it.')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByText(
-        'ComfyUI needs local-only.safetensors in checkpoints. Referenced by 1 node.'
-      )
-    ).not.toBeInTheDocument()
   })
 
   it('renders missing media display message below the section title', () => {
@@ -353,11 +348,6 @@ describe('TabErrors.vue', () => {
     expect(
       screen.getByText('A required media input has no file selected.')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByText(
-        'Load Image node needs a selected image. Referenced by 1 node.'
-      )
-    ).not.toBeInTheDocument()
   })
 
   it('keeps missing model Refresh in the card actions when models are downloadable', () => {

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -7,6 +7,7 @@ import { createI18n } from 'vue-i18n'
 import TabErrors from './TabErrors.vue'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
+import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 
 vi.mock('@/scripts/app', () => ({
   app: {
@@ -36,6 +37,16 @@ vi.mock('@/services/litegraphService', () => ({
   }))
 }))
 
+vi.mock('@/platform/missingModel/missingModelDownload', () => ({
+  downloadModel: vi.fn(),
+  fetchModelMetadata: vi.fn().mockResolvedValue({
+    fileSize: null,
+    gatedRepoUrl: null
+  }),
+  isModelDownloadable: vi.fn(() => true),
+  toBrowsableUrl: vi.fn((url: string) => url)
+}))
+
 describe('TabErrors.vue', () => {
   let i18n: ReturnType<typeof createI18n>
 
@@ -57,6 +68,18 @@ describe('TabErrors.vue', () => {
               downloadAll: 'Download all',
               refresh: 'Refresh',
               refreshing: 'Refreshing missing models.'
+            },
+            missingMedia: {
+              missingMediaTitle: 'Missing Inputs',
+              image: 'Images',
+              uploadFile: 'Upload {type}',
+              useFromLibrary: 'Use from Library',
+              confirmSelection: 'Confirm selection',
+              locateNode: 'Locate node',
+              expandNodes: 'Show referencing nodes',
+              collapseNodes: 'Hide referencing nodes',
+              cancelSelection: 'Cancel selection',
+              or: 'OR'
             }
           }
         }
@@ -280,6 +303,61 @@ describe('TabErrors.vue', () => {
     await user.click(screen.getByTestId('missing-model-header-refresh'))
 
     expect(missingModelStore.refreshMissingModels).toHaveBeenCalled()
+  })
+
+  it('renders missing model display message below the section title', () => {
+    const missingModel = {
+      nodeId: '1',
+      nodeType: 'CheckpointLoaderSimple',
+      widgetName: 'ckpt_name',
+      name: 'local-only.safetensors',
+      directory: 'checkpoints',
+      isMissing: true,
+      isAssetSupported: true
+    } satisfies MissingModelCandidate
+
+    renderComponent({
+      missingModel: {
+        missingModelCandidates: [missingModel]
+      }
+    })
+
+    expect(screen.getByText('Missing Models (1)')).toBeInTheDocument()
+    expect(
+      screen.getByText('Download a model, or open the node to replace it.')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'ComfyUI needs local-only.safetensors in checkpoints. Referenced by 1 node.'
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders missing media display message below the section title', () => {
+    const missingMedia = {
+      nodeId: '3',
+      nodeType: 'LoadImage',
+      widgetName: 'image',
+      mediaType: 'image',
+      name: 'portrait.png',
+      isMissing: true
+    } satisfies MissingMediaCandidate
+
+    renderComponent({
+      missingMedia: {
+        missingMediaCandidates: [missingMedia]
+      }
+    })
+
+    expect(screen.getByText('Missing Inputs (1)')).toBeInTheDocument()
+    expect(
+      screen.getByText('A required media input has no file selected.')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Load Image node needs a selected image. Referenced by 1 node.'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('keeps missing model Refresh in the card actions when models are downloadable', () => {

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -8,6 +8,7 @@ import TabErrors from './TabErrors.vue'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
+import type { MissingNodeType } from '@/types/comfy'
 
 vi.mock('@/scripts/app', () => ({
   app: {
@@ -347,6 +348,40 @@ describe('TabErrors.vue', () => {
     expect(screen.getByText('Missing Inputs (1)')).toBeInTheDocument()
     expect(
       screen.getByText('A required media input has no file selected.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders swap node rows below the section display message', () => {
+    const swapNode = {
+      type: 'OldSampler',
+      nodeId: '1',
+      isReplaceable: true,
+      replacement: {
+        old_node_id: 'OldSampler',
+        new_node_id: 'KSampler',
+        old_widget_ids: null,
+        input_mapping: null,
+        output_mapping: null
+      }
+    } satisfies MissingNodeType
+
+    renderComponent({
+      missingNodesError: {
+        missingNodesError: {
+          message: 'Missing Node Packs',
+          nodeTypes: [swapNode]
+        }
+      }
+    })
+
+    expect(screen.getByText('Swap Nodes (1)')).toBeInTheDocument()
+    expect(
+      screen.getByText('Some nodes can be replaced with alternatives')
+    ).toBeInTheDocument()
+    expect(screen.getByText('OldSampler (1)')).toBeInTheDocument()
+    expect(screen.getByText('KSampler')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Replace Node/ })
     ).toBeInTheDocument()
   })
 

--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -156,6 +156,7 @@
 
           <div
             v-if="group.type !== 'execution' && group.displayMessage"
+            data-testid="error-group-display-message"
             class="px-4 pt-1 pb-3"
           >
             <p

--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -154,6 +154,17 @@
             </div>
           </template>
 
+          <div
+            v-if="group.type !== 'execution' && group.displayMessage"
+            class="px-4 pt-1 pb-3"
+          >
+            <p
+              class="m-0 text-sm/relaxed wrap-break-word whitespace-pre-wrap text-muted-foreground"
+            >
+              {{ group.displayMessage }}
+            </p>
+          </div>
+
           <!-- Missing Node Packs -->
           <MissingNodeCard
             v-if="group.type === 'missing_node'"

--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -177,7 +177,7 @@
 
           <!-- Swap Nodes -->
           <SwapNodesCard
-            v-else-if="group.type === 'swap_nodes'"
+            v-if="group.type === 'swap_nodes'"
             :swap-node-groups="swapNodeGroups"
             :show-node-id-badge="showNodeIdBadge"
             @locate-node="handleLocateMissingNode"
@@ -185,7 +185,7 @@
           />
 
           <!-- Execution Errors -->
-          <div v-else-if="group.type === 'execution'" class="space-y-3 px-4">
+          <div v-if="group.type === 'execution'" class="space-y-3 px-4">
             <ErrorNodeCard
               v-for="card in group.cards"
               :key="card.id"
@@ -200,7 +200,7 @@
 
           <!-- Missing Models -->
           <MissingModelCard
-            v-else-if="group.type === 'missing_model'"
+            v-if="group.type === 'missing_model'"
             :missing-model-groups="missingModelGroups"
             :show-node-id-badge="showNodeIdBadge"
             @locate-model="handleLocateAssetNode"
@@ -208,7 +208,7 @@
 
           <!-- Missing Media -->
           <MissingMediaCard
-            v-else-if="group.type === 'missing_media'"
+            v-if="group.type === 'missing_media'"
             :missing-media-groups="missingMediaGroups"
             :show-node-id-badge="showNodeIdBadge"
             @locate-node="handleLocateAssetNode"

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -304,9 +304,6 @@ describe('useErrorGroups', () => {
       expect(missingGroup?.displayMessage).toBe(
         'Install missing packs to use this workflow.'
       )
-      expect(missingGroup?.displayDetails).toBe(
-        'NodeA is missing. Referenced by 1 node.'
-      )
     })
 
     it('uses Cloud copy for missing_node group in Cloud', async () => {
@@ -341,9 +338,6 @@ describe('useErrorGroups', () => {
         (g) => g.type === 'swap_nodes'
       )
       expect(swapGroup).toBeDefined()
-      expect(swapGroup?.displayDetails).toBe(
-        'OldNode can be replaced with NewNode.'
-      )
     })
 
     it('includes both swap_nodes and missing_node when both exist', async () => {

--- a/src/components/rightSidePanel/errors/useErrorGroups.test.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.test.ts
@@ -302,7 +302,27 @@ describe('useErrorGroups', () => {
       expect(missingGroup?.groupKey).toBe('missing_node')
       expect(missingGroup?.displayTitle).toBe('Missing Node Packs (1)')
       expect(missingGroup?.displayMessage).toBe(
-        'Some nodes are missing and need to be installed'
+        'Install missing packs to use this workflow.'
+      )
+      expect(missingGroup?.displayDetails).toBe(
+        'NodeA is missing. Referenced by 1 node.'
+      )
+    })
+
+    it('uses Cloud copy for missing_node group in Cloud', async () => {
+      mockIsCloud.value = true
+      const { groups } = createErrorGroups()
+      const missingNodesStore = useMissingNodesErrorStore()
+      missingNodesStore.setMissingNodeTypes([
+        makeMissingNodeType('NodeA', { cnrId: 'pack-1' })
+      ])
+      await nextTick()
+
+      const missingGroup = groups.allErrorGroups.value.find(
+        (g) => g.type === 'missing_node'
+      )
+      expect(missingGroup?.displayMessage).toBe(
+        "Required custom nodes aren't supported on Cloud. Replace them with supported nodes."
       )
     })
 
@@ -321,6 +341,9 @@ describe('useErrorGroups', () => {
         (g) => g.type === 'swap_nodes'
       )
       expect(swapGroup).toBeDefined()
+      expect(swapGroup?.displayDetails).toBe(
+        'OldNode can be replaced with NewNode.'
+      )
     })
 
     it('includes both swap_nodes and missing_node when both exist', async () => {

--- a/src/components/rightSidePanel/errors/useErrorGroups.ts
+++ b/src/components/rightSidePanel/errors/useErrorGroups.ts
@@ -723,7 +723,6 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
           kind: 'missing_media',
           groups: missingMediaGroups.value,
           count: totalItems,
-          mediaTypes: missingMediaGroups.value.map((group) => group.mediaType),
           isCloud
         })
       }
@@ -840,9 +839,6 @@ export function useErrorGroups(searchQuery: MaybeRefOrGetter<string>) {
           kind: 'missing_media',
           groups: filteredMissingMediaGroups.value,
           count: totalItems,
-          mediaTypes: filteredMissingMediaGroups.value.map(
-            (group) => group.mediaType
-          ),
           isCloud
         })
       }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3533,7 +3533,6 @@
     "skipForNow": "Skip for Now",
     "installMissingNodes": "Install Missing Nodes",
     "replaceWarning": "This will permanently modify the workflow. Save a copy first if unsure.",
-    "swapNodesGuide": "The following nodes can be automatically replaced with compatible alternatives.",
     "willBeReplacedBy": "This node will be replaced by:",
     "replaceNode": "Replace Node",
     "replaceAll": "Replace All",
@@ -3615,8 +3614,8 @@
     "missingNodePacks": {
       "title": "Missing Node Packs",
       "unsupportedTitle": "Unsupported Node Packs",
-      "cloudMessage": "This workflow requires custom nodes not yet available on Comfy Cloud.",
-      "ossMessage": "This workflow uses custom nodes you haven't installed yet.",
+      "cloudMessage": "Required custom nodes aren't supported on Cloud. Replace them with supported nodes.",
+      "ossMessage": "Install missing packs to use this workflow.",
       "ossManagerDisabledHint": "To install missing nodes, first run {pipCmd} in your Python environment to install Node Manager, then restart ComfyUI with the {flag} flag.",
       "installAll": "Install All",
       "installNodePack": "Install node pack",
@@ -3693,6 +3692,77 @@
     "fallbacks": {
       "nodeName": "This node",
       "inputName": "unknown input"
+    },
+    "missingErrors": {
+      "listWithMore": "{itemNames}, and {remainingCount} more",
+      "referenceOne": "1 node",
+      "referenceMany": "{count} nodes",
+      "referenceWorkflow": "workflow metadata",
+      "nodeLabel": "{nodeName} node",
+      "missing_node": {
+        "displayMessageCloud": "Required custom nodes aren't supported on Cloud. Replace them with supported nodes.",
+        "displayMessageOss": "Install missing packs to use this workflow.",
+        "detailsSingle": "{nodeType} is missing. Referenced by {referenceLabel}.",
+        "detailsMany": "Missing nodes: {itemNames}.",
+        "detailsUnavailable": "Missing node details are unavailable.",
+        "itemLabelOne": "1 missing node",
+        "itemLabelMany": "{count} missing nodes",
+        "toastTitleOneCloud": "{nodeType} isn't available on Cloud",
+        "toastTitleOneOss": "Missing node: {nodeType}",
+        "toastTitleManyCloud": "Nodes aren't available on Cloud",
+        "toastTitleManyOss": "Missing nodes",
+        "toastMessageOneCloud": "This node isn't supported on Cloud.",
+        "toastMessageOneOss": "This workflow uses a custom node that isn't installed. Install it from the registry or replace the node.",
+        "toastMessageManyCloud": "This workflow uses nodes that aren't supported on Cloud.",
+        "toastMessageManyOss": "{count} nodes require missing node packs."
+      },
+      "swap_nodes": {
+        "detailsSingle": "{nodeType} can be replaced with {replacementNodeType}.",
+        "detailsSingleWithoutReplacement": "{nodeType} can be replaced with a compatible alternative.",
+        "detailsMany": "Replaceable nodes: {itemNames}.",
+        "detailsUnavailable": "Swap node details are unavailable.",
+        "itemLabelOne": "1 replaceable node",
+        "itemLabelMany": "{count} replaceable nodes",
+        "toastTitleOne": "{nodeType} can be replaced",
+        "toastTitleMany": "Nodes can be replaced",
+        "toastMessageOne": "Replace it with {replacementNodeType} from the error panel.",
+        "toastMessageMany": "{count} node types can be replaced with compatible alternatives."
+      },
+      "mediaFileTypes": {
+        "image": "image",
+        "video": "video",
+        "audio": "audio file"
+      },
+      "missing_model": {
+        "displayMessageCloud": "Import a model, or open the node to replace it.",
+        "displayMessageOss": "Download a model, or open the node to replace it.",
+        "detailsSingle": "ComfyUI needs {modelName}. Referenced by {referenceLabel}.",
+        "detailsSingleWithCategory": "ComfyUI needs {modelName} in {directory}. Referenced by {referenceLabel}.",
+        "detailsMany": "Required models: {itemNames}.",
+        "detailsUnavailable": "Missing model details are unavailable.",
+        "itemLabelOne": "1 missing model",
+        "itemLabelMany": "{count} missing models",
+        "toastTitleOneCloud": "{modelName} isn't available on Cloud",
+        "toastTitleOneOss": "{modelName} is missing",
+        "toastTitleMany": "Missing models",
+        "toastTitleManyCloud": "Models aren't available on Cloud",
+        "toastMessageOneCloud": "This model isn't supported. Choose a different one.",
+        "toastMessageOneOss": "{nodeName} is missing a required model file.",
+        "toastMessageManyCloud": "Some models aren't supported. Choose different ones.",
+        "toastMessageManyOss": "{count} model files are missing."
+      },
+      "missing_media": {
+        "displayMessage": "A required media input has no file selected.",
+        "detailsSingle": "{nodeLabel} needs a selected {mediaType}. Referenced by {referenceLabel}.",
+        "detailsMany": "Missing media inputs are referenced by {referenceLabel}.",
+        "detailsUnavailable": "Missing input details are unavailable.",
+        "itemLabelOne": "1 missing input",
+        "itemLabelMany": "{count} missing inputs",
+        "toastTitleOne": "Media input missing",
+        "toastTitleMany": "Missing media inputs",
+        "toastMessageWithNode": "{nodeName} is missing a required media file.",
+        "toastMessageMany": "Please select the missing media inputs before running this workflow."
+      }
     },
     "validationErrors": {
       "required_input_missing": {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3614,8 +3614,6 @@
     "missingNodePacks": {
       "title": "Missing Node Packs",
       "unsupportedTitle": "Unsupported Node Packs",
-      "cloudMessage": "Required custom nodes aren't supported on Cloud. Replace them with supported nodes.",
-      "ossMessage": "Install missing packs to use this workflow.",
       "ossManagerDisabledHint": "To install missing nodes, first run {pipCmd} in your Python environment to install Node Manager, then restart ComfyUI with the {flag} flag.",
       "installAll": "Install All",
       "installNodePack": "Install node pack",
@@ -3685,7 +3683,6 @@
     "viewDetails": "View details",
     "missingNodes": "Some nodes are missing and need to be installed",
     "missingModels": "{count} required model is missing | {count} required models are missing",
-    "swapNodes": "Some nodes can be replaced with alternatives",
     "missingMedia": "Some nodes are missing required inputs"
   },
   "errorCatalog": {
@@ -3694,19 +3691,9 @@
       "inputName": "unknown input"
     },
     "missingErrors": {
-      "listWithMore": "{itemNames}, and {remainingCount} more",
-      "referenceOne": "1 node",
-      "referenceMany": "{count} nodes",
-      "referenceWorkflow": "workflow metadata",
-      "nodeLabel": "{nodeName} node",
       "missing_node": {
         "displayMessageCloud": "Required custom nodes aren't supported on Cloud. Replace them with supported nodes.",
         "displayMessageOss": "Install missing packs to use this workflow.",
-        "detailsSingle": "{nodeType} is missing. Referenced by {referenceLabel}.",
-        "detailsMany": "Missing nodes: {itemNames}.",
-        "detailsUnavailable": "Missing node details are unavailable.",
-        "itemLabelOne": "1 missing node",
-        "itemLabelMany": "{count} missing nodes",
         "toastTitleOneCloud": "{nodeType} isn't available on Cloud",
         "toastTitleOneOss": "Missing node: {nodeType}",
         "toastTitleManyCloud": "Nodes aren't available on Cloud",
@@ -3717,31 +3704,15 @@
         "toastMessageManyOss": "{count} nodes require missing node packs."
       },
       "swap_nodes": {
-        "detailsSingle": "{nodeType} can be replaced with {replacementNodeType}.",
-        "detailsSingleWithoutReplacement": "{nodeType} can be replaced with a compatible alternative.",
-        "detailsMany": "Replaceable nodes: {itemNames}.",
-        "detailsUnavailable": "Swap node details are unavailable.",
-        "itemLabelOne": "1 replaceable node",
-        "itemLabelMany": "{count} replaceable nodes",
+        "displayMessage": "Some nodes can be replaced with alternatives",
         "toastTitleOne": "{nodeType} can be replaced",
         "toastTitleMany": "Nodes can be replaced",
         "toastMessageOne": "Replace it with {replacementNodeType} from the error panel.",
         "toastMessageMany": "{count} node types can be replaced with compatible alternatives."
       },
-      "mediaFileTypes": {
-        "image": "image",
-        "video": "video",
-        "audio": "audio file"
-      },
       "missing_model": {
         "displayMessageCloud": "Import a model, or open the node to replace it.",
         "displayMessageOss": "Download a model, or open the node to replace it.",
-        "detailsSingle": "ComfyUI needs {modelName}. Referenced by {referenceLabel}.",
-        "detailsSingleWithCategory": "ComfyUI needs {modelName} in {directory}. Referenced by {referenceLabel}.",
-        "detailsMany": "Required models: {itemNames}.",
-        "detailsUnavailable": "Missing model details are unavailable.",
-        "itemLabelOne": "1 missing model",
-        "itemLabelMany": "{count} missing models",
         "toastTitleOneCloud": "{modelName} isn't available on Cloud",
         "toastTitleOneOss": "{modelName} is missing",
         "toastTitleMany": "Missing models",
@@ -3753,11 +3724,6 @@
       },
       "missing_media": {
         "displayMessage": "A required media input has no file selected.",
-        "detailsSingle": "{nodeLabel} needs a selected {mediaType}. Referenced by {referenceLabel}.",
-        "detailsMany": "Missing media inputs are referenced by {referenceLabel}.",
-        "detailsUnavailable": "Missing input details are unavailable.",
-        "itemLabelOne": "1 missing input",
-        "itemLabelMany": "{count} missing inputs",
         "toastTitleOne": "Media input missing",
         "toastTitleMany": "Missing media inputs",
         "toastMessageWithNode": "{nodeName} is missing a required media file.",

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -58,6 +58,59 @@ function executionError(
   }
 }
 
+function missingNodeType(
+  type: string,
+  nodeId: string,
+  cnrId?: string
+): MissingNodeType {
+  return {
+    type,
+    nodeId,
+    cnrId,
+    isReplaceable: false
+  }
+}
+
+function replaceableNodeType(
+  type: string,
+  nodeId: string,
+  replacementNodeType: string
+): MissingNodeType {
+  return {
+    type,
+    nodeId,
+    isReplaceable: true,
+    replacement: {
+      old_node_id: type,
+      new_node_id: replacementNodeType,
+      old_widget_ids: null,
+      input_mapping: null,
+      output_mapping: null
+    }
+  }
+}
+
+function missingModelGroups(...names: string[]): MissingModelGroup[] {
+  return [
+    {
+      directory: 'checkpoints',
+      isAssetSupported: true,
+      models: names.map((name) => ({
+        name,
+        representative: {
+          name,
+          nodeType: 'CheckpointLoaderSimple',
+          widgetName: 'ckpt_name',
+          directory: 'checkpoints',
+          isAssetSupported: true,
+          isMissing: true
+        },
+        referencingNodes: []
+      }))
+    }
+  ]
+}
+
 describe('errorMessageResolver', () => {
   it('resolves required_input_missing to missing connection display copy', () => {
     const result = resolveRunErrorMessage({
@@ -1310,14 +1363,7 @@ describe('errorMessageResolver', () => {
   })
 
   it('resolves missing error group display copy', () => {
-    const missingNodeTypes: MissingNodeType[] = [
-      {
-        type: 'FooNode',
-        nodeId: '7',
-        cnrId: 'foo-pack',
-        isReplaceable: false
-      }
-    ]
+    const missingNodeTypes = [missingNodeType('FooNode', '7', 'foo-pack')]
     expect(
       resolveMissingErrorMessage({
         kind: 'missing_node',
@@ -1329,8 +1375,6 @@ describe('errorMessageResolver', () => {
       catalogId: 'missing_node',
       displayTitle: 'Missing Node Packs (1)',
       displayMessage: 'Install missing packs to use this workflow.',
-      displayDetails: 'FooNode is missing. Referenced by 1 node.',
-      displayItemLabel: 'FooNode',
       toastTitle: 'Missing node: FooNode',
       toastMessage:
         "This workflow uses a custom node that isn't installed. Install it from the registry or replace the node."
@@ -1342,25 +1386,61 @@ describe('errorMessageResolver', () => {
         nodeTypes: missingNodeTypes,
         count: 1,
         isCloud: true
-      }).displayMessage
-    ).toBe(
-      "Required custom nodes aren't supported on Cloud. Replace them with supported nodes."
-    )
+      })
+    ).toEqual({
+      catalogId: 'missing_node',
+      displayTitle: 'Unsupported Node Packs (1)',
+      displayMessage:
+        "Required custom nodes aren't supported on Cloud. Replace them with supported nodes.",
+      toastTitle: "FooNode isn't available on Cloud",
+      toastMessage: "This node isn't supported on Cloud."
+    })
 
-    const swapNodeTypes: MissingNodeType[] = [
-      {
-        type: 'OldNode',
-        nodeId: '8',
-        isReplaceable: true,
-        replacement: {
-          old_node_id: 'OldNode',
-          new_node_id: 'NewNode',
-          old_widget_ids: null,
-          input_mapping: null,
-          output_mapping: null
-        }
-      }
+    const multipleMissingNodeTypes = [
+      missingNodeType('FooNode', '7', 'foo-pack'),
+      missingNodeType('BarNode', '9', 'bar-pack')
     ]
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_node',
+        nodeTypes: multipleMissingNodeTypes,
+        count: 2,
+        isCloud: false
+      })
+    ).toMatchObject({
+      toastTitle: 'Missing nodes',
+      toastMessage: '2 nodes require missing node packs.'
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_node',
+        nodeTypes: multipleMissingNodeTypes,
+        count: 2,
+        isCloud: true
+      })
+    ).toMatchObject({
+      toastTitle: "Nodes aren't available on Cloud",
+      toastMessage: "This workflow uses nodes that aren't supported on Cloud."
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_node',
+        nodeTypes: [
+          missingNodeType('FooNode', '7', 'foo-pack'),
+          missingNodeType('FooNode', '8', 'foo-pack')
+        ],
+        count: 1,
+        isCloud: false
+      })
+    ).toMatchObject({
+      toastTitle: 'Missing node: FooNode',
+      toastMessage:
+        "This workflow uses a custom node that isn't installed. Install it from the registry or replace the node."
+    })
+
+    const swapNodeTypes = [replaceableNodeType('OldNode', '8', 'NewNode')]
     expect(
       resolveMissingErrorMessage({
         kind: 'swap_nodes',
@@ -1372,33 +1452,43 @@ describe('errorMessageResolver', () => {
       catalogId: 'swap_nodes',
       displayTitle: 'Swap Nodes (1)',
       displayMessage: 'Some nodes can be replaced with alternatives',
-      displayDetails: 'OldNode can be replaced with NewNode.',
-      displayItemLabel: 'OldNode',
       toastTitle: 'OldNode can be replaced',
       toastMessage: 'Replace it with NewNode from the error panel.'
     })
 
-    const groups: MissingModelGroup[] = [
-      {
-        directory: 'checkpoints',
-        isAssetSupported: true,
-        models: [
-          {
-            name: 'sdxl.safetensors',
-            representative: {
-              name: 'sdxl.safetensors',
-              nodeId: '1',
-              nodeType: 'CheckpointLoaderSimple',
-              widgetName: 'ckpt_name',
-              directory: 'checkpoints',
-              isAssetSupported: true,
-              isMissing: true
-            },
-            referencingNodes: [{ nodeId: '1', widgetName: 'ckpt_name' }]
-          }
-        ]
-      }
+    const multipleSwapNodeTypes = [
+      replaceableNodeType('OldNodeA', '8', 'NewNodeA'),
+      replaceableNodeType('OldNodeB', '9', 'NewNodeB')
     ]
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'swap_nodes',
+        nodeTypes: multipleSwapNodeTypes,
+        count: 2,
+        isCloud: false
+      })
+    ).toMatchObject({
+      displayMessage: 'Some nodes can be replaced with alternatives',
+      toastTitle: 'Nodes can be replaced',
+      toastMessage: '2 node types can be replaced with compatible alternatives.'
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'swap_nodes',
+        nodeTypes: [
+          replaceableNodeType('OldNode', '8', 'NewNode'),
+          replaceableNodeType('OldNode', '9', 'NewNode')
+        ],
+        count: 1,
+        isCloud: false
+      })
+    ).toMatchObject({
+      toastTitle: 'OldNode can be replaced',
+      toastMessage: 'Replace it with NewNode from the error panel.'
+    })
+
+    const groups = missingModelGroups('sdxl.safetensors')
 
     expect(
       resolveMissingErrorMessage({
@@ -1411,9 +1501,6 @@ describe('errorMessageResolver', () => {
       catalogId: 'missing_model',
       displayTitle: 'Missing Models (1)',
       displayMessage: 'Download a model, or open the node to replace it.',
-      displayDetails:
-        'ComfyUI needs sdxl.safetensors in checkpoints. Referenced by 1 node.',
-      displayItemLabel: 'sdxl.safetensors',
       toastTitle: 'sdxl.safetensors is missing',
       toastMessage: 'Checkpoint Loader Simple is missing a required model file.'
     })
@@ -1429,15 +1516,12 @@ describe('errorMessageResolver', () => {
       catalogId: 'missing_model',
       displayTitle: 'Missing Models (1)',
       displayMessage: 'Import a model, or open the node to replace it.',
-      displayDetails:
-        'ComfyUI needs sdxl.safetensors in checkpoints. Referenced by 1 node.',
-      displayItemLabel: 'sdxl.safetensors',
       toastTitle: "sdxl.safetensors isn't available on Cloud",
       toastMessage: "This model isn't supported. Choose a different one."
     })
   })
 
-  it('resolves missing media group detail and item label copy', () => {
+  it('resolves missing media group display and toast copy', () => {
     const groups: MissingMediaGroup[] = [
       {
         mediaType: 'image',
@@ -1464,16 +1548,12 @@ describe('errorMessageResolver', () => {
         kind: 'missing_media',
         groups,
         count: 1,
-        mediaTypes: ['image'],
         isCloud: false
       })
     ).toEqual({
       catalogId: 'missing_media',
       displayTitle: 'Missing Inputs (1)',
       displayMessage: 'A required media input has no file selected.',
-      displayDetails:
-        'Load Image node needs a selected image. Referenced by 1 node.',
-      displayItemLabel: 'portrait.png',
       toastTitle: 'Media input missing',
       toastMessage: 'Load Image is missing a required media file.'
     })
@@ -1540,7 +1620,6 @@ describe('errorMessageResolver', () => {
           kind: 'missing_media',
           groups,
           count: 1,
-          mediaTypes: [mediaType],
           isCloud: false
         })
       ).toMatchObject({
@@ -1551,49 +1630,30 @@ describe('errorMessageResolver', () => {
   )
 
   it('summarizes multiple missing model and media items', () => {
+    const modelGroups = missingModelGroups('a.safetensors', 'b.safetensors')
+
     expect(
       resolveMissingErrorMessage({
         kind: 'missing_model',
-        groups: [
-          {
-            directory: 'checkpoints',
-            isAssetSupported: true,
-            models: [
-              {
-                name: 'a.safetensors',
-                representative: {
-                  name: 'a.safetensors',
-                  nodeType: 'CheckpointLoaderSimple',
-                  widgetName: 'ckpt_name',
-                  directory: 'checkpoints',
-                  isAssetSupported: true,
-                  isMissing: true
-                },
-                referencingNodes: []
-              },
-              {
-                name: 'b.safetensors',
-                representative: {
-                  name: 'b.safetensors',
-                  nodeType: 'CheckpointLoaderSimple',
-                  widgetName: 'ckpt_name',
-                  directory: 'checkpoints',
-                  isAssetSupported: true,
-                  isMissing: true
-                },
-                referencingNodes: []
-              }
-            ]
-          }
-        ],
+        groups: modelGroups,
         count: 2,
         isCloud: false
       })
     ).toMatchObject({
-      displayDetails: 'Required models: a.safetensors, b.safetensors.',
-      displayItemLabel: '2 missing models',
       toastTitle: 'Missing models',
       toastMessage: '2 model files are missing.'
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_model',
+        groups: modelGroups,
+        count: 2,
+        isCloud: true
+      })
+    ).toMatchObject({
+      toastTitle: "Models aren't available on Cloud",
+      toastMessage: "Some models aren't supported. Choose different ones."
     })
 
     expect(
@@ -1633,12 +1693,9 @@ describe('errorMessageResolver', () => {
           }
         ],
         count: 2,
-        mediaTypes: ['image'],
         isCloud: false
       })
     ).toMatchObject({
-      displayDetails: 'Missing media inputs are referenced by 2 nodes.',
-      displayItemLabel: '2 missing inputs',
       toastTitle: 'Missing media inputs',
       toastMessage:
         'Please select the missing media inputs before running this workflow.'

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -6,6 +6,9 @@ import {
 } from './errorMessageResolver'
 import type { NodeValidationError } from './types'
 import type { ExecutionErrorWsMessage } from '@/schemas/apiSchema'
+import type { MissingMediaGroup } from '@/platform/missingMedia/types'
+import type { MissingModelGroup } from '@/platform/missingModel/types'
+import type { MissingNodeType } from '@/types/comfy'
 import { i18n } from '@/i18n'
 
 function nodeValidationError(
@@ -1307,17 +1310,338 @@ describe('errorMessageResolver', () => {
   })
 
   it('resolves missing error group display copy', () => {
+    const missingNodeTypes: MissingNodeType[] = [
+      {
+        type: 'FooNode',
+        nodeId: '7',
+        cnrId: 'foo-pack',
+        isReplaceable: false
+      }
+    ]
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_node',
+        nodeTypes: missingNodeTypes,
+        count: 1,
+        isCloud: false
+      })
+    ).toEqual({
+      catalogId: 'missing_node',
+      displayTitle: 'Missing Node Packs (1)',
+      displayMessage: 'Install missing packs to use this workflow.',
+      displayDetails: 'FooNode is missing. Referenced by 1 node.',
+      displayItemLabel: 'FooNode',
+      toastTitle: 'Missing node: FooNode',
+      toastMessage:
+        "This workflow uses a custom node that isn't installed. Install it from the registry or replace the node."
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_node',
+        nodeTypes: missingNodeTypes,
+        count: 1,
+        isCloud: true
+      }).displayMessage
+    ).toBe(
+      "Required custom nodes aren't supported on Cloud. Replace them with supported nodes."
+    )
+
+    const swapNodeTypes: MissingNodeType[] = [
+      {
+        type: 'OldNode',
+        nodeId: '8',
+        isReplaceable: true,
+        replacement: {
+          old_node_id: 'OldNode',
+          new_node_id: 'NewNode',
+          old_widget_ids: null,
+          input_mapping: null,
+          output_mapping: null
+        }
+      }
+    ]
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'swap_nodes',
+        nodeTypes: swapNodeTypes,
+        count: 1,
+        isCloud: false
+      })
+    ).toEqual({
+      catalogId: 'swap_nodes',
+      displayTitle: 'Swap Nodes (1)',
+      displayMessage: 'Some nodes can be replaced with alternatives',
+      displayDetails: 'OldNode can be replaced with NewNode.',
+      displayItemLabel: 'OldNode',
+      toastTitle: 'OldNode can be replaced',
+      toastMessage: 'Replace it with NewNode from the error panel.'
+    })
+
+    const groups: MissingModelGroup[] = [
+      {
+        directory: 'checkpoints',
+        isAssetSupported: true,
+        models: [
+          {
+            name: 'sdxl.safetensors',
+            representative: {
+              name: 'sdxl.safetensors',
+              nodeId: '1',
+              nodeType: 'CheckpointLoaderSimple',
+              widgetName: 'ckpt_name',
+              directory: 'checkpoints',
+              isAssetSupported: true,
+              isMissing: true
+            },
+            referencingNodes: [{ nodeId: '1', widgetName: 'ckpt_name' }]
+          }
+        ]
+      }
+    ]
+
     expect(
       resolveMissingErrorMessage({
         kind: 'missing_model',
-        groups: [],
+        groups,
         count: 1,
         isCloud: false
       })
     ).toEqual({
       catalogId: 'missing_model',
       displayTitle: 'Missing Models (1)',
-      displayMessage: '1 required model is missing'
+      displayMessage: 'Download a model, or open the node to replace it.',
+      displayDetails:
+        'ComfyUI needs sdxl.safetensors in checkpoints. Referenced by 1 node.',
+      displayItemLabel: 'sdxl.safetensors',
+      toastTitle: 'sdxl.safetensors is missing',
+      toastMessage: 'Checkpoint Loader Simple is missing a required model file.'
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_model',
+        groups,
+        count: 1,
+        isCloud: true
+      })
+    ).toEqual({
+      catalogId: 'missing_model',
+      displayTitle: 'Missing Models (1)',
+      displayMessage: 'Import a model, or open the node to replace it.',
+      displayDetails:
+        'ComfyUI needs sdxl.safetensors in checkpoints. Referenced by 1 node.',
+      displayItemLabel: 'sdxl.safetensors',
+      toastTitle: "sdxl.safetensors isn't available on Cloud",
+      toastMessage: "This model isn't supported. Choose a different one."
+    })
+  })
+
+  it('resolves missing media group detail and item label copy', () => {
+    const groups: MissingMediaGroup[] = [
+      {
+        mediaType: 'image',
+        items: [
+          {
+            name: 'portrait.png',
+            mediaType: 'image',
+            representative: {
+              nodeId: '4',
+              nodeType: 'LoadImage',
+              widgetName: 'image',
+              mediaType: 'image',
+              name: 'portrait.png',
+              isMissing: true
+            },
+            referencingNodes: [{ nodeId: '4', widgetName: 'image' }]
+          }
+        ]
+      }
+    ]
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_media',
+        groups,
+        count: 1,
+        mediaTypes: ['image'],
+        isCloud: false
+      })
+    ).toEqual({
+      catalogId: 'missing_media',
+      displayTitle: 'Missing Inputs (1)',
+      displayMessage: 'A required media input has no file selected.',
+      displayDetails:
+        'Load Image node needs a selected image. Referenced by 1 node.',
+      displayItemLabel: 'portrait.png',
+      toastTitle: 'Media input missing',
+      toastMessage: 'Load Image is missing a required media file.'
+    })
+  })
+
+  it.for([
+    [
+      'image',
+      'LoadImage',
+      'image',
+      'portrait.png',
+      'Media input missing',
+      'Load Image is missing a required media file.'
+    ],
+    [
+      'video',
+      'LoadVideo',
+      'file',
+      'clip.mp4',
+      'Media input missing',
+      'Load Video is missing a required media file.'
+    ],
+    [
+      'audio',
+      'LoadAudio',
+      'audio',
+      'voice.wav',
+      'Media input missing',
+      'Load Audio is missing a required media file.'
+    ]
+  ] as const)(
+    'resolves missing %s toast copy from media type and node type',
+    ([
+      mediaType,
+      nodeType,
+      widgetName,
+      mediaName,
+      toastTitle,
+      toastMessage
+    ]) => {
+      const groups: MissingMediaGroup[] = [
+        {
+          mediaType,
+          items: [
+            {
+              name: mediaName,
+              mediaType,
+              representative: {
+                nodeId: '4',
+                nodeType,
+                widgetName,
+                mediaType,
+                name: mediaName,
+                isMissing: true
+              },
+              referencingNodes: [{ nodeId: '4', widgetName }]
+            }
+          ]
+        }
+      ]
+
+      expect(
+        resolveMissingErrorMessage({
+          kind: 'missing_media',
+          groups,
+          count: 1,
+          mediaTypes: [mediaType],
+          isCloud: false
+        })
+      ).toMatchObject({
+        toastTitle,
+        toastMessage
+      })
+    }
+  )
+
+  it('summarizes multiple missing model and media items', () => {
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_model',
+        groups: [
+          {
+            directory: 'checkpoints',
+            isAssetSupported: true,
+            models: [
+              {
+                name: 'a.safetensors',
+                representative: {
+                  name: 'a.safetensors',
+                  nodeType: 'CheckpointLoaderSimple',
+                  widgetName: 'ckpt_name',
+                  directory: 'checkpoints',
+                  isAssetSupported: true,
+                  isMissing: true
+                },
+                referencingNodes: []
+              },
+              {
+                name: 'b.safetensors',
+                representative: {
+                  name: 'b.safetensors',
+                  nodeType: 'CheckpointLoaderSimple',
+                  widgetName: 'ckpt_name',
+                  directory: 'checkpoints',
+                  isAssetSupported: true,
+                  isMissing: true
+                },
+                referencingNodes: []
+              }
+            ]
+          }
+        ],
+        count: 2,
+        isCloud: false
+      })
+    ).toMatchObject({
+      displayDetails: 'Required models: a.safetensors, b.safetensors.',
+      displayItemLabel: '2 missing models',
+      toastTitle: 'Missing models',
+      toastMessage: '2 model files are missing.'
+    })
+
+    expect(
+      resolveMissingErrorMessage({
+        kind: 'missing_media',
+        groups: [
+          {
+            mediaType: 'image',
+            items: [
+              {
+                name: 'a.png',
+                mediaType: 'image',
+                representative: {
+                  nodeId: '1',
+                  nodeType: 'LoadImage',
+                  widgetName: 'image',
+                  mediaType: 'image',
+                  name: 'a.png',
+                  isMissing: true
+                },
+                referencingNodes: [{ nodeId: '1', widgetName: 'image' }]
+              },
+              {
+                name: 'b.png',
+                mediaType: 'image',
+                representative: {
+                  nodeId: '2',
+                  nodeType: 'LoadImage',
+                  widgetName: 'image',
+                  mediaType: 'image',
+                  name: 'b.png',
+                  isMissing: true
+                },
+                referencingNodes: [{ nodeId: '2', widgetName: 'image' }]
+              }
+            ]
+          }
+        ],
+        count: 2,
+        mediaTypes: ['image'],
+        isCloud: false
+      })
+    ).toMatchObject({
+      displayDetails: 'Missing media inputs are referenced by 2 nodes.',
+      displayItemLabel: '2 missing inputs',
+      toastTitle: 'Missing media inputs',
+      toastMessage:
+        'Please select the missing media inputs before running this workflow.'
     })
   })
 })

--- a/src/platform/errorCatalog/missingErrorResolver.ts
+++ b/src/platform/errorCatalog/missingErrorResolver.ts
@@ -2,26 +2,541 @@ import type {
   MissingErrorMessageSource,
   ResolvedMissingErrorMessage
 } from './types'
-import { st, t } from '@/i18n'
+import { translateCatalogMessage } from './catalogI18n'
+import { st } from '@/i18n'
 
-// Resolves pre-run missing-resource groups (nodes, models, media, swaps). These
-// are grouped catalog messages rather than individual execution error items.
+const MAX_DETAIL_ITEMS = 3
+
 function formatCountTitle(title: string, count: number): string {
   return `${title} (${count})`
 }
 
-function translateMissingModelOverlayMessage(count: number): string {
-  const translated = t('errorOverlay.missingModels', { count }, count)
-  return translated === 'errorOverlay.missingModels'
-    ? `${count} required ${count === 1 ? 'model is' : 'models are'} missing`
-    : translated
+function formatListedNames(names: string[]): string {
+  const visibleNames = names.slice(0, MAX_DETAIL_ITEMS).join(', ')
+  const remainingCount = names.length - MAX_DETAIL_ITEMS
+  if (remainingCount <= 0) return visibleNames
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.listWithMore',
+    '{itemNames}, and {remainingCount} more',
+    { itemNames: visibleNames, remainingCount }
+  )
+}
+
+function formatReferenceLabel(count: number): string {
+  if (count <= 0) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.referenceWorkflow',
+      'workflow metadata'
+    )
+  }
+
+  const key =
+    count === 1
+      ? 'errorCatalog.missingErrors.referenceOne'
+      : 'errorCatalog.missingErrors.referenceMany'
+  const fallback = count === 1 ? '1 node' : '{count} nodes'
+  return translateCatalogMessage(key, fallback, { count })
+}
+
+function formatNodeTypeName(nodeType: string): string | null {
+  const trimmed = nodeType.trim()
+  if (!trimmed) return null
+
+  return trimmed
+    .replace(/[_-]+/g, ' ')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+type NodeTypeErrorSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_node' | 'swap_nodes' }
+>
+type NodeTypeErrorItem = NodeTypeErrorSource['nodeTypes'][number]
+
+function getNodeTypeLabel(nodeType: NodeTypeErrorItem): string {
+  return typeof nodeType === 'string' ? nodeType : nodeType.type
+}
+
+function getFilteredNodeTypeLabels(
+  source: NodeTypeErrorSource,
+  isIncluded: (nodeType: NodeTypeErrorItem) => boolean
+): string[] {
+  return source.nodeTypes.filter(isIncluded).map(getNodeTypeLabel)
+}
+
+function getNodeTypeReferenceCount(nodeTypes: NodeTypeErrorItem[]): number {
+  const nodeIdCount = nodeTypes.filter(
+    (nodeType) => typeof nodeType !== 'string' && nodeType.nodeId != null
+  ).length
+  return nodeIdCount || nodeTypes.length
+}
+
+function resolveItemLabel(
+  keyPrefix: string,
+  labels: string[],
+  count: number,
+  fallbackLabel: string
+): string {
+  if (labels.length === 1) return labels[0]
+
+  const key =
+    count === 1 ? `${keyPrefix}.itemLabelOne` : `${keyPrefix}.itemLabelMany`
+  const fallback =
+    count === 1 ? `1 ${fallbackLabel}` : `{count} ${fallbackLabel}s`
+  return translateCatalogMessage(key, fallback, { count })
+}
+
+type MissingNodeSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_node' }
+>
+
+function isMissingNodeType(nodeType: NodeTypeErrorItem): boolean {
+  return typeof nodeType === 'string' || !nodeType.isReplaceable
+}
+
+function getMissingNodeTypes(source: MissingNodeSource): NodeTypeErrorItem[] {
+  return source.nodeTypes.filter(isMissingNodeType)
+}
+
+function resolveMissingNodeDisplayMessage(source: MissingNodeSource): string {
+  const key = source.isCloud
+    ? 'errorCatalog.missingErrors.missing_node.displayMessageCloud'
+    : 'errorCatalog.missingErrors.missing_node.displayMessageOss'
+  const fallback = source.isCloud
+    ? "Required custom nodes aren't supported on Cloud. Replace them with supported nodes."
+    : 'Install missing packs to use this workflow.'
+  return translateCatalogMessage(key, fallback)
+}
+
+function resolveMissingNodeDisplayDetails(source: MissingNodeSource): string {
+  const nodeTypes = getMissingNodeTypes(source)
+  const labels = nodeTypes.map(getNodeTypeLabel)
+  const [firstLabel] = labels
+  if (!firstLabel) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_node.detailsUnavailable',
+      'Missing node details are unavailable.'
+    )
+  }
+
+  if (labels.length === 1) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_node.detailsSingle',
+      '{nodeType} is missing. Referenced by {referenceLabel}.',
+      {
+        nodeType: firstLabel,
+        referenceLabel: formatReferenceLabel(
+          getNodeTypeReferenceCount(nodeTypes)
+        )
+      }
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_node.detailsMany',
+    'Missing nodes: {itemNames}.',
+    { itemNames: formatListedNames(labels) }
+  )
+}
+
+function resolveMissingNodeToastTitle(source: MissingNodeSource): string {
+  const labels = getFilteredNodeTypeLabels(source, isMissingNodeType)
+  const [firstLabel] = labels
+  if (labels.length === 1 && firstLabel) {
+    const key = source.isCloud
+      ? 'errorCatalog.missingErrors.missing_node.toastTitleOneCloud'
+      : 'errorCatalog.missingErrors.missing_node.toastTitleOneOss'
+    const fallback = source.isCloud
+      ? "{nodeType} isn't available on Cloud"
+      : 'Missing node: {nodeType}'
+    return translateCatalogMessage(key, fallback, { nodeType: firstLabel })
+  }
+
+  const key = source.isCloud
+    ? 'errorCatalog.missingErrors.missing_node.toastTitleManyCloud'
+    : 'errorCatalog.missingErrors.missing_node.toastTitleManyOss'
+  const fallback = source.isCloud
+    ? "Nodes aren't available on Cloud"
+    : 'Missing nodes'
+  return translateCatalogMessage(key, fallback)
+}
+
+function resolveMissingNodeToastMessage(source: MissingNodeSource): string {
+  const labels = getFilteredNodeTypeLabels(source, isMissingNodeType)
+  const count = labels.length || source.count
+
+  if (count === 1) {
+    const key = source.isCloud
+      ? 'errorCatalog.missingErrors.missing_node.toastMessageOneCloud'
+      : 'errorCatalog.missingErrors.missing_node.toastMessageOneOss'
+    const fallback = source.isCloud
+      ? "This node isn't supported on Cloud."
+      : "This workflow uses a custom node that isn't installed. Install it from the registry or replace the node."
+    return translateCatalogMessage(key, fallback)
+  }
+
+  const key = source.isCloud
+    ? 'errorCatalog.missingErrors.missing_node.toastMessageManyCloud'
+    : 'errorCatalog.missingErrors.missing_node.toastMessageManyOss'
+  const fallback = source.isCloud
+    ? "This workflow uses nodes that aren't supported on Cloud."
+    : '{count} nodes require missing node packs.'
+  return translateCatalogMessage(key, fallback, { count })
+}
+
+type SwapNodeSource = Extract<MissingErrorMessageSource, { kind: 'swap_nodes' }>
+
+function isSwapNodeType(nodeType: NodeTypeErrorItem): nodeType is Exclude<
+  NodeTypeErrorItem,
+  string
+> & {
+  isReplaceable: true
+} {
+  return typeof nodeType !== 'string' && nodeType.isReplaceable === true
+}
+
+function getSwapNodeTypes(source: SwapNodeSource) {
+  return source.nodeTypes.filter(isSwapNodeType)
+}
+
+function resolveSwapNodeDisplayDetails(source: SwapNodeSource): string {
+  const nodeTypes = getSwapNodeTypes(source)
+  const labels = nodeTypes.map(getNodeTypeLabel)
+  const [firstNodeType] = nodeTypes
+  const [firstLabel] = labels
+  if (!firstNodeType || !firstLabel) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.swap_nodes.detailsUnavailable',
+      'Swap node details are unavailable.'
+    )
+  }
+
+  if (labels.length === 1) {
+    const replacement = firstNodeType.replacement?.new_node_id
+    const key = replacement
+      ? 'errorCatalog.missingErrors.swap_nodes.detailsSingle'
+      : 'errorCatalog.missingErrors.swap_nodes.detailsSingleWithoutReplacement'
+    const fallback = replacement
+      ? '{nodeType} can be replaced with {replacementNodeType}.'
+      : '{nodeType} can be replaced with a compatible alternative.'
+    return translateCatalogMessage(key, fallback, {
+      nodeType: firstLabel,
+      replacementNodeType: replacement ?? ''
+    })
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.swap_nodes.detailsMany',
+    'Replaceable nodes: {itemNames}.',
+    { itemNames: formatListedNames(labels) }
+  )
+}
+
+function resolveSwapNodeToastTitle(source: SwapNodeSource): string {
+  const labels = getSwapNodeTypes(source).map(getNodeTypeLabel)
+  const [firstLabel] = labels
+  if (labels.length === 1 && firstLabel) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.swap_nodes.toastTitleOne',
+      '{nodeType} can be replaced',
+      { nodeType: firstLabel }
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.swap_nodes.toastTitleMany',
+    'Nodes can be replaced'
+  )
+}
+
+function resolveSwapNodeToastMessage(source: SwapNodeSource): string {
+  const nodeTypes = getSwapNodeTypes(source)
+  const [firstNodeType] = nodeTypes
+  if (nodeTypes.length === 1 && firstNodeType?.replacement?.new_node_id) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.swap_nodes.toastMessageOne',
+      'Replace it with {replacementNodeType} from the error panel.',
+      { replacementNodeType: firstNodeType.replacement.new_node_id }
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.swap_nodes.toastMessageMany',
+    '{count} node types can be replaced with compatible alternatives.',
+    { count: nodeTypes.length || source.count }
+  )
+}
+
+type MissingModelSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_model' }
+>
+
+function getMissingModelNames(groups: MissingModelSource['groups']): string[] {
+  return groups.flatMap((group) => group.models.map((model) => model.name))
+}
+
+function getMissingModelCount(source: MissingModelSource): number {
+  return getMissingModelNames(source.groups).length || source.count
+}
+
+function resolveMissingModelDisplayMessage(source: MissingModelSource): string {
+  const key = source.isCloud
+    ? 'errorCatalog.missingErrors.missing_model.displayMessageCloud'
+    : 'errorCatalog.missingErrors.missing_model.displayMessageOss'
+  const fallback = source.isCloud
+    ? 'Import a model, or open the node to replace it.'
+    : 'Download a model, or open the node to replace it.'
+  return translateCatalogMessage(key, fallback)
+}
+
+function resolveMissingModelDisplayDetails(source: MissingModelSource): string {
+  const [firstGroup] = source.groups
+  const [firstModel] = firstGroup?.models ?? []
+  if (!firstModel) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_model.detailsUnavailable',
+      'Missing model details are unavailable.'
+    )
+  }
+
+  const modelNames = getMissingModelNames(source.groups)
+  if (modelNames.length === 1) {
+    const referenceLabel = formatReferenceLabel(
+      firstModel.referencingNodes.length
+    )
+    if (firstGroup.directory) {
+      return translateCatalogMessage(
+        'errorCatalog.missingErrors.missing_model.detailsSingleWithCategory',
+        'ComfyUI needs {modelName} in {directory}. Referenced by {referenceLabel}.',
+        {
+          modelName: firstModel.name,
+          directory: firstGroup.directory,
+          referenceLabel
+        }
+      )
+    }
+
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_model.detailsSingle',
+      'ComfyUI needs {modelName}. Referenced by {referenceLabel}.',
+      { modelName: firstModel.name, referenceLabel }
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_model.detailsMany',
+    'Required models: {itemNames}.',
+    { itemNames: formatListedNames(modelNames) }
+  )
+}
+
+function resolveMissingModelToastTitle(source: MissingModelSource): string {
+  const [firstModel] = source.groups.flatMap((group) => group.models)
+  const count = getMissingModelCount(source)
+
+  if (count === 1 && firstModel) {
+    const key = source.isCloud
+      ? 'errorCatalog.missingErrors.missing_model.toastTitleOneCloud'
+      : 'errorCatalog.missingErrors.missing_model.toastTitleOneOss'
+    const fallback = source.isCloud
+      ? "{modelName} isn't available on Cloud"
+      : '{modelName} is missing'
+    return translateCatalogMessage(key, fallback, {
+      modelName: firstModel.name
+    })
+  }
+
+  const key =
+    source.isCloud && count > 1
+      ? 'errorCatalog.missingErrors.missing_model.toastTitleManyCloud'
+      : 'errorCatalog.missingErrors.missing_model.toastTitleMany'
+  const fallback =
+    source.isCloud && count > 1
+      ? "Models aren't available on Cloud"
+      : 'Missing models'
+  return translateCatalogMessage(key, fallback)
+}
+
+function getMissingModelNodeName(
+  model: MissingModelSource['groups'][number]['models'][number]
+): string {
+  return (
+    formatNodeTypeName(model.representative.nodeType) ??
+    translateCatalogMessage('errorCatalog.fallbacks.nodeName', 'This node')
+  )
+}
+
+function resolveMissingModelToastMessage(source: MissingModelSource): string {
+  const [firstModel] = source.groups.flatMap((group) => group.models)
+  const count = getMissingModelCount(source)
+
+  if (!firstModel || count !== 1) {
+    const key = source.isCloud
+      ? 'errorCatalog.missingErrors.missing_model.toastMessageManyCloud'
+      : 'errorCatalog.missingErrors.missing_model.toastMessageManyOss'
+    const fallback = source.isCloud
+      ? "Some models aren't supported. Choose different ones."
+      : '{count} model files are missing.'
+    return translateCatalogMessage(key, fallback, { count })
+  }
+
+  if (source.isCloud) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_model.toastMessageOneCloud',
+      "This model isn't supported. Choose a different one."
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_model.toastMessageOneOss',
+    '{nodeName} is missing a required model file.',
+    { nodeName: getMissingModelNodeName(firstModel) }
+  )
+}
+
+type MissingMediaSource = Extract<
+  MissingErrorMessageSource,
+  { kind: 'missing_media' }
+>
+
+function getMissingMediaItems(source: MissingMediaSource) {
+  return source.groups.flatMap((group) => group.items)
+}
+
+function getMissingMediaReferenceCount(source: MissingMediaSource): number {
+  return getMissingMediaItems(source).reduce(
+    (count, item) => count + item.referencingNodes.length,
+    0
+  )
+}
+
+function formatMediaFileType(
+  mediaType: MissingMediaSource['mediaTypes'][number]
+) {
+  const fallback = mediaType === 'audio' ? 'audio file' : mediaType
+  return translateCatalogMessage(
+    `errorCatalog.missingErrors.mediaFileTypes.${mediaType}`,
+    fallback
+  )
+}
+
+function getMissingMediaNodeName(
+  item: ReturnType<typeof getMissingMediaItems>[number]
+): string | null {
+  return formatNodeTypeName(item.representative.nodeType)
+}
+
+function formatNodeLabel(
+  item: ReturnType<typeof getMissingMediaItems>[number]
+): string {
+  const nodeName = getMissingMediaNodeName(item)
+  if (!nodeName) {
+    return translateCatalogMessage(
+      'errorCatalog.fallbacks.nodeName',
+      'This node'
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.nodeLabel',
+    '{nodeName} node',
+    { nodeName }
+  )
+}
+
+function resolveMissingMediaDisplayMessage(): string {
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_media.displayMessage',
+    'A required media input has no file selected.'
+  )
+}
+
+function resolveMissingMediaDisplayDetails(source: MissingMediaSource): string {
+  const items = getMissingMediaItems(source)
+  const [firstItem] = items
+  if (!firstItem) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_media.detailsUnavailable',
+      'Missing input details are unavailable.'
+    )
+  }
+
+  if (items.length === 1) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_media.detailsSingle',
+      '{nodeLabel} needs a selected {mediaType}. Referenced by {referenceLabel}.',
+      {
+        nodeLabel: formatNodeLabel(firstItem),
+        mediaType: formatMediaFileType(firstItem.mediaType),
+        referenceLabel: formatReferenceLabel(firstItem.referencingNodes.length)
+      }
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_media.detailsMany',
+    'Missing media inputs are referenced by {referenceLabel}.',
+    {
+      referenceLabel: formatReferenceLabel(
+        getMissingMediaReferenceCount(source)
+      )
+    }
+  )
+}
+
+function resolveMissingMediaToastTitle(source: MissingMediaSource): string {
+  const items = getMissingMediaItems(source)
+  if (items.length !== 1) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_media.toastTitleMany',
+      'Missing media inputs'
+    )
+  }
+
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_media.toastTitleOne',
+    'Media input missing'
+  )
+}
+
+function resolveMissingMediaToastMessage(source: MissingMediaSource): string {
+  const items = getMissingMediaItems(source)
+  const [firstItem] = items
+  if (!firstItem || items.length !== 1) {
+    return translateCatalogMessage(
+      'errorCatalog.missingErrors.missing_media.toastMessageMany',
+      'Please select the missing media inputs before running this workflow.'
+    )
+  }
+
+  const nodeName = getMissingMediaNodeName(firstItem)
+  const displayNodeName =
+    nodeName ??
+    translateCatalogMessage('errorCatalog.fallbacks.nodeName', 'This node')
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.missing_media.toastMessageWithNode',
+    '{nodeName} is missing a required media file.',
+    {
+      nodeName: displayNodeName
+    }
+  )
 }
 
 export function resolveMissingErrorMessage(
   source: MissingErrorMessageSource
 ): ResolvedMissingErrorMessage {
   switch (source.kind) {
-    case 'missing_node':
+    case 'missing_node': {
+      const missingNodeLabels = getFilteredNodeTypeLabels(
+        source,
+        isMissingNodeType
+      )
       return {
         catalogId: 'missing_node',
         displayTitle: formatCountTitle(
@@ -33,12 +548,20 @@ export function resolveMissingErrorMessage(
             : st('rightSidePanel.missingNodePacks.title', 'Missing Node Packs'),
           source.count
         ),
-        displayMessage: st(
-          'errorOverlay.missingNodes',
-          'Some nodes are missing and need to be installed'
-        )
+        displayMessage: resolveMissingNodeDisplayMessage(source),
+        displayDetails: resolveMissingNodeDisplayDetails(source),
+        displayItemLabel: resolveItemLabel(
+          'errorCatalog.missingErrors.missing_node',
+          missingNodeLabels,
+          missingNodeLabels.length || source.count,
+          'missing node'
+        ),
+        toastTitle: resolveMissingNodeToastTitle(source),
+        toastMessage: resolveMissingNodeToastMessage(source)
       }
-    case 'swap_nodes':
+    }
+    case 'swap_nodes': {
+      const swapNodeLabels = getSwapNodeTypes(source).map(getNodeTypeLabel)
       return {
         catalogId: 'swap_nodes',
         displayTitle: formatCountTitle(
@@ -48,9 +571,20 @@ export function resolveMissingErrorMessage(
         displayMessage: st(
           'errorOverlay.swapNodes',
           'Some nodes can be replaced with alternatives'
-        )
+        ),
+        displayDetails: resolveSwapNodeDisplayDetails(source),
+        displayItemLabel: resolveItemLabel(
+          'errorCatalog.missingErrors.swap_nodes',
+          swapNodeLabels,
+          swapNodeLabels.length || source.count,
+          'replaceable node'
+        ),
+        toastTitle: resolveSwapNodeToastTitle(source),
+        toastMessage: resolveSwapNodeToastMessage(source)
       }
-    case 'missing_model':
+    }
+    case 'missing_model': {
+      const modelNames = getMissingModelNames(source.groups)
       return {
         catalogId: 'missing_model',
         displayTitle: formatCountTitle(
@@ -60,19 +594,37 @@ export function resolveMissingErrorMessage(
           ),
           source.count
         ),
-        displayMessage: translateMissingModelOverlayMessage(source.count)
+        displayMessage: resolveMissingModelDisplayMessage(source),
+        displayDetails: resolveMissingModelDisplayDetails(source),
+        displayItemLabel: resolveItemLabel(
+          'errorCatalog.missingErrors.missing_model',
+          modelNames,
+          modelNames.length || source.count,
+          'missing model'
+        ),
+        toastTitle: resolveMissingModelToastTitle(source),
+        toastMessage: resolveMissingModelToastMessage(source)
       }
-    case 'missing_media':
+    }
+    case 'missing_media': {
+      const itemNames = getMissingMediaItems(source).map((item) => item.name)
       return {
         catalogId: 'missing_media',
         displayTitle: formatCountTitle(
           st('rightSidePanel.missingMedia.missingMediaTitle', 'Missing Inputs'),
           source.count
         ),
-        displayMessage: st(
-          'errorOverlay.missingMedia',
-          'Some nodes are missing required inputs'
-        )
+        displayMessage: resolveMissingMediaDisplayMessage(),
+        displayDetails: resolveMissingMediaDisplayDetails(source),
+        displayItemLabel: resolveItemLabel(
+          'errorCatalog.missingErrors.missing_media',
+          itemNames,
+          itemNames.length || source.count,
+          'missing input'
+        ),
+        toastTitle: resolveMissingMediaToastTitle(source),
+        toastMessage: resolveMissingMediaToastMessage(source)
       }
+    }
   }
 }

--- a/src/platform/errorCatalog/missingErrorResolver.ts
+++ b/src/platform/errorCatalog/missingErrorResolver.ts
@@ -5,38 +5,8 @@ import type {
 import { translateCatalogMessage } from './catalogI18n'
 import { st } from '@/i18n'
 
-const MAX_DETAIL_ITEMS = 3
-
 function formatCountTitle(title: string, count: number): string {
   return `${title} (${count})`
-}
-
-function formatListedNames(names: string[]): string {
-  const visibleNames = names.slice(0, MAX_DETAIL_ITEMS).join(', ')
-  const remainingCount = names.length - MAX_DETAIL_ITEMS
-  if (remainingCount <= 0) return visibleNames
-
-  return translateCatalogMessage(
-    'errorCatalog.missingErrors.listWithMore',
-    '{itemNames}, and {remainingCount} more',
-    { itemNames: visibleNames, remainingCount }
-  )
-}
-
-function formatReferenceLabel(count: number): string {
-  if (count <= 0) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.referenceWorkflow',
-      'workflow metadata'
-    )
-  }
-
-  const key =
-    count === 1
-      ? 'errorCatalog.missingErrors.referenceOne'
-      : 'errorCatalog.missingErrors.referenceMany'
-  const fallback = count === 1 ? '1 node' : '{count} nodes'
-  return translateCatalogMessage(key, fallback, { count })
 }
 
 function formatNodeTypeName(nodeType: string): string | null {
@@ -61,33 +31,10 @@ function getNodeTypeLabel(nodeType: NodeTypeErrorItem): string {
   return typeof nodeType === 'string' ? nodeType : nodeType.type
 }
 
-function getFilteredNodeTypeLabels(
-  source: NodeTypeErrorSource,
-  isIncluded: (nodeType: NodeTypeErrorItem) => boolean
-): string[] {
-  return source.nodeTypes.filter(isIncluded).map(getNodeTypeLabel)
-}
-
-function getNodeTypeReferenceCount(nodeTypes: NodeTypeErrorItem[]): number {
-  const nodeIdCount = nodeTypes.filter(
-    (nodeType) => typeof nodeType !== 'string' && nodeType.nodeId != null
-  ).length
-  return nodeIdCount || nodeTypes.length
-}
-
-function resolveItemLabel(
-  keyPrefix: string,
-  labels: string[],
-  count: number,
-  fallbackLabel: string
-): string {
-  if (labels.length === 1) return labels[0]
-
-  const key =
-    count === 1 ? `${keyPrefix}.itemLabelOne` : `${keyPrefix}.itemLabelMany`
-  const fallback =
-    count === 1 ? `1 ${fallbackLabel}` : `{count} ${fallbackLabel}s`
-  return translateCatalogMessage(key, fallback, { count })
+function getDistinctNodeTypeLabels(nodeTypes: NodeTypeErrorItem[]): string[] {
+  const labels = new Set<string>()
+  for (const nodeType of nodeTypes) labels.add(getNodeTypeLabel(nodeType))
+  return Array.from(labels)
 }
 
 type MissingNodeSource = Extract<
@@ -97,10 +44,6 @@ type MissingNodeSource = Extract<
 
 function isMissingNodeType(nodeType: NodeTypeErrorItem): boolean {
   return typeof nodeType === 'string' || !nodeType.isReplaceable
-}
-
-function getMissingNodeTypes(source: MissingNodeSource): NodeTypeErrorItem[] {
-  return source.nodeTypes.filter(isMissingNodeType)
 }
 
 function resolveMissingNodeDisplayMessage(source: MissingNodeSource): string {
@@ -113,39 +56,10 @@ function resolveMissingNodeDisplayMessage(source: MissingNodeSource): string {
   return translateCatalogMessage(key, fallback)
 }
 
-function resolveMissingNodeDisplayDetails(source: MissingNodeSource): string {
-  const nodeTypes = getMissingNodeTypes(source)
-  const labels = nodeTypes.map(getNodeTypeLabel)
-  const [firstLabel] = labels
-  if (!firstLabel) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_node.detailsUnavailable',
-      'Missing node details are unavailable.'
-    )
-  }
-
-  if (labels.length === 1) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_node.detailsSingle',
-      '{nodeType} is missing. Referenced by {referenceLabel}.',
-      {
-        nodeType: firstLabel,
-        referenceLabel: formatReferenceLabel(
-          getNodeTypeReferenceCount(nodeTypes)
-        )
-      }
-    )
-  }
-
-  return translateCatalogMessage(
-    'errorCatalog.missingErrors.missing_node.detailsMany',
-    'Missing nodes: {itemNames}.',
-    { itemNames: formatListedNames(labels) }
-  )
-}
-
 function resolveMissingNodeToastTitle(source: MissingNodeSource): string {
-  const labels = getFilteredNodeTypeLabels(source, isMissingNodeType)
+  const labels = getDistinctNodeTypeLabels(
+    source.nodeTypes.filter(isMissingNodeType)
+  )
   const [firstLabel] = labels
   if (labels.length === 1 && firstLabel) {
     const key = source.isCloud
@@ -167,7 +81,9 @@ function resolveMissingNodeToastTitle(source: MissingNodeSource): string {
 }
 
 function resolveMissingNodeToastMessage(source: MissingNodeSource): string {
-  const labels = getFilteredNodeTypeLabels(source, isMissingNodeType)
+  const labels = getDistinctNodeTypeLabels(
+    source.nodeTypes.filter(isMissingNodeType)
+  )
   const count = labels.length || source.count
 
   if (count === 1) {
@@ -204,41 +120,9 @@ function getSwapNodeTypes(source: SwapNodeSource) {
   return source.nodeTypes.filter(isSwapNodeType)
 }
 
-function resolveSwapNodeDisplayDetails(source: SwapNodeSource): string {
-  const nodeTypes = getSwapNodeTypes(source)
-  const labels = nodeTypes.map(getNodeTypeLabel)
-  const [firstNodeType] = nodeTypes
-  const [firstLabel] = labels
-  if (!firstNodeType || !firstLabel) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.swap_nodes.detailsUnavailable',
-      'Swap node details are unavailable.'
-    )
-  }
-
-  if (labels.length === 1) {
-    const replacement = firstNodeType.replacement?.new_node_id
-    const key = replacement
-      ? 'errorCatalog.missingErrors.swap_nodes.detailsSingle'
-      : 'errorCatalog.missingErrors.swap_nodes.detailsSingleWithoutReplacement'
-    const fallback = replacement
-      ? '{nodeType} can be replaced with {replacementNodeType}.'
-      : '{nodeType} can be replaced with a compatible alternative.'
-    return translateCatalogMessage(key, fallback, {
-      nodeType: firstLabel,
-      replacementNodeType: replacement ?? ''
-    })
-  }
-
-  return translateCatalogMessage(
-    'errorCatalog.missingErrors.swap_nodes.detailsMany',
-    'Replaceable nodes: {itemNames}.',
-    { itemNames: formatListedNames(labels) }
-  )
-}
-
 function resolveSwapNodeToastTitle(source: SwapNodeSource): string {
-  const labels = getSwapNodeTypes(source).map(getNodeTypeLabel)
+  const nodeTypes = getSwapNodeTypes(source)
+  const labels = getDistinctNodeTypeLabels(nodeTypes)
   const [firstLabel] = labels
   if (labels.length === 1 && firstLabel) {
     return translateCatalogMessage(
@@ -256,8 +140,9 @@ function resolveSwapNodeToastTitle(source: SwapNodeSource): string {
 
 function resolveSwapNodeToastMessage(source: SwapNodeSource): string {
   const nodeTypes = getSwapNodeTypes(source)
+  const labels = getDistinctNodeTypeLabels(nodeTypes)
   const [firstNodeType] = nodeTypes
-  if (nodeTypes.length === 1 && firstNodeType?.replacement?.new_node_id) {
+  if (labels.length === 1 && firstNodeType?.replacement?.new_node_id) {
     return translateCatalogMessage(
       'errorCatalog.missingErrors.swap_nodes.toastMessageOne',
       'Replace it with {replacementNodeType} from the error panel.',
@@ -268,7 +153,14 @@ function resolveSwapNodeToastMessage(source: SwapNodeSource): string {
   return translateCatalogMessage(
     'errorCatalog.missingErrors.swap_nodes.toastMessageMany',
     '{count} node types can be replaced with compatible alternatives.',
-    { count: nodeTypes.length || source.count }
+    { count: labels.length || source.count }
+  )
+}
+
+function resolveSwapNodeDisplayMessage(): string {
+  return translateCatalogMessage(
+    'errorCatalog.missingErrors.swap_nodes.displayMessage',
+    'Some nodes can be replaced with alternatives'
   )
 }
 
@@ -277,12 +169,12 @@ type MissingModelSource = Extract<
   { kind: 'missing_model' }
 >
 
-function getMissingModelNames(groups: MissingModelSource['groups']): string[] {
-  return groups.flatMap((group) => group.models.map((model) => model.name))
-}
-
 function getMissingModelCount(source: MissingModelSource): number {
-  return getMissingModelNames(source.groups).length || source.count
+  const count = source.groups.reduce(
+    (total, group) => total + group.models.length,
+    0
+  )
+  return count || source.count
 }
 
 function resolveMissingModelDisplayMessage(source: MissingModelSource): string {
@@ -293,47 +185,6 @@ function resolveMissingModelDisplayMessage(source: MissingModelSource): string {
     ? 'Import a model, or open the node to replace it.'
     : 'Download a model, or open the node to replace it.'
   return translateCatalogMessage(key, fallback)
-}
-
-function resolveMissingModelDisplayDetails(source: MissingModelSource): string {
-  const [firstGroup] = source.groups
-  const [firstModel] = firstGroup?.models ?? []
-  if (!firstModel) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_model.detailsUnavailable',
-      'Missing model details are unavailable.'
-    )
-  }
-
-  const modelNames = getMissingModelNames(source.groups)
-  if (modelNames.length === 1) {
-    const referenceLabel = formatReferenceLabel(
-      firstModel.referencingNodes.length
-    )
-    if (firstGroup.directory) {
-      return translateCatalogMessage(
-        'errorCatalog.missingErrors.missing_model.detailsSingleWithCategory',
-        'ComfyUI needs {modelName} in {directory}. Referenced by {referenceLabel}.',
-        {
-          modelName: firstModel.name,
-          directory: firstGroup.directory,
-          referenceLabel
-        }
-      )
-    }
-
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_model.detailsSingle',
-      'ComfyUI needs {modelName}. Referenced by {referenceLabel}.',
-      { modelName: firstModel.name, referenceLabel }
-    )
-  }
-
-  return translateCatalogMessage(
-    'errorCatalog.missingErrors.missing_model.detailsMany',
-    'Required models: {itemNames}.',
-    { itemNames: formatListedNames(modelNames) }
-  )
 }
 
 function resolveMissingModelToastTitle(source: MissingModelSource): string {
@@ -352,14 +203,13 @@ function resolveMissingModelToastTitle(source: MissingModelSource): string {
     })
   }
 
-  const key =
-    source.isCloud && count > 1
-      ? 'errorCatalog.missingErrors.missing_model.toastTitleManyCloud'
-      : 'errorCatalog.missingErrors.missing_model.toastTitleMany'
-  const fallback =
-    source.isCloud && count > 1
-      ? "Models aren't available on Cloud"
-      : 'Missing models'
+  const useCloudPluralTitle = source.isCloud && count > 1
+  const key = useCloudPluralTitle
+    ? 'errorCatalog.missingErrors.missing_model.toastTitleManyCloud'
+    : 'errorCatalog.missingErrors.missing_model.toastTitleMany'
+  const fallback = useCloudPluralTitle
+    ? "Models aren't available on Cloud"
+    : 'Missing models'
   return translateCatalogMessage(key, fallback)
 }
 
@@ -409,84 +259,16 @@ function getMissingMediaItems(source: MissingMediaSource) {
   return source.groups.flatMap((group) => group.items)
 }
 
-function getMissingMediaReferenceCount(source: MissingMediaSource): number {
-  return getMissingMediaItems(source).reduce(
-    (count, item) => count + item.referencingNodes.length,
-    0
-  )
-}
-
-function formatMediaFileType(
-  mediaType: MissingMediaSource['mediaTypes'][number]
-) {
-  const fallback = mediaType === 'audio' ? 'audio file' : mediaType
-  return translateCatalogMessage(
-    `errorCatalog.missingErrors.mediaFileTypes.${mediaType}`,
-    fallback
-  )
-}
-
 function getMissingMediaNodeName(
   item: ReturnType<typeof getMissingMediaItems>[number]
 ): string | null {
   return formatNodeTypeName(item.representative.nodeType)
 }
 
-function formatNodeLabel(
-  item: ReturnType<typeof getMissingMediaItems>[number]
-): string {
-  const nodeName = getMissingMediaNodeName(item)
-  if (!nodeName) {
-    return translateCatalogMessage(
-      'errorCatalog.fallbacks.nodeName',
-      'This node'
-    )
-  }
-
-  return translateCatalogMessage(
-    'errorCatalog.missingErrors.nodeLabel',
-    '{nodeName} node',
-    { nodeName }
-  )
-}
-
 function resolveMissingMediaDisplayMessage(): string {
   return translateCatalogMessage(
     'errorCatalog.missingErrors.missing_media.displayMessage',
     'A required media input has no file selected.'
-  )
-}
-
-function resolveMissingMediaDisplayDetails(source: MissingMediaSource): string {
-  const items = getMissingMediaItems(source)
-  const [firstItem] = items
-  if (!firstItem) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_media.detailsUnavailable',
-      'Missing input details are unavailable.'
-    )
-  }
-
-  if (items.length === 1) {
-    return translateCatalogMessage(
-      'errorCatalog.missingErrors.missing_media.detailsSingle',
-      '{nodeLabel} needs a selected {mediaType}. Referenced by {referenceLabel}.',
-      {
-        nodeLabel: formatNodeLabel(firstItem),
-        mediaType: formatMediaFileType(firstItem.mediaType),
-        referenceLabel: formatReferenceLabel(firstItem.referencingNodes.length)
-      }
-    )
-  }
-
-  return translateCatalogMessage(
-    'errorCatalog.missingErrors.missing_media.detailsMany',
-    'Missing media inputs are referenced by {referenceLabel}.',
-    {
-      referenceLabel: formatReferenceLabel(
-        getMissingMediaReferenceCount(source)
-      )
-    }
   )
 }
 
@@ -532,11 +314,7 @@ export function resolveMissingErrorMessage(
   source: MissingErrorMessageSource
 ): ResolvedMissingErrorMessage {
   switch (source.kind) {
-    case 'missing_node': {
-      const missingNodeLabels = getFilteredNodeTypeLabels(
-        source,
-        isMissingNodeType
-      )
+    case 'missing_node':
       return {
         catalogId: 'missing_node',
         displayTitle: formatCountTitle(
@@ -549,42 +327,21 @@ export function resolveMissingErrorMessage(
           source.count
         ),
         displayMessage: resolveMissingNodeDisplayMessage(source),
-        displayDetails: resolveMissingNodeDisplayDetails(source),
-        displayItemLabel: resolveItemLabel(
-          'errorCatalog.missingErrors.missing_node',
-          missingNodeLabels,
-          missingNodeLabels.length || source.count,
-          'missing node'
-        ),
         toastTitle: resolveMissingNodeToastTitle(source),
         toastMessage: resolveMissingNodeToastMessage(source)
       }
-    }
-    case 'swap_nodes': {
-      const swapNodeLabels = getSwapNodeTypes(source).map(getNodeTypeLabel)
+    case 'swap_nodes':
       return {
         catalogId: 'swap_nodes',
         displayTitle: formatCountTitle(
           st('nodeReplacement.swapNodesTitle', 'Swap Nodes'),
           source.count
         ),
-        displayMessage: st(
-          'errorOverlay.swapNodes',
-          'Some nodes can be replaced with alternatives'
-        ),
-        displayDetails: resolveSwapNodeDisplayDetails(source),
-        displayItemLabel: resolveItemLabel(
-          'errorCatalog.missingErrors.swap_nodes',
-          swapNodeLabels,
-          swapNodeLabels.length || source.count,
-          'replaceable node'
-        ),
+        displayMessage: resolveSwapNodeDisplayMessage(),
         toastTitle: resolveSwapNodeToastTitle(source),
         toastMessage: resolveSwapNodeToastMessage(source)
       }
-    }
-    case 'missing_model': {
-      const modelNames = getMissingModelNames(source.groups)
+    case 'missing_model':
       return {
         catalogId: 'missing_model',
         displayTitle: formatCountTitle(
@@ -595,19 +352,10 @@ export function resolveMissingErrorMessage(
           source.count
         ),
         displayMessage: resolveMissingModelDisplayMessage(source),
-        displayDetails: resolveMissingModelDisplayDetails(source),
-        displayItemLabel: resolveItemLabel(
-          'errorCatalog.missingErrors.missing_model',
-          modelNames,
-          modelNames.length || source.count,
-          'missing model'
-        ),
         toastTitle: resolveMissingModelToastTitle(source),
         toastMessage: resolveMissingModelToastMessage(source)
       }
-    }
-    case 'missing_media': {
-      const itemNames = getMissingMediaItems(source).map((item) => item.name)
+    case 'missing_media':
       return {
         catalogId: 'missing_media',
         displayTitle: formatCountTitle(
@@ -615,16 +363,8 @@ export function resolveMissingErrorMessage(
           source.count
         ),
         displayMessage: resolveMissingMediaDisplayMessage(),
-        displayDetails: resolveMissingMediaDisplayDetails(source),
-        displayItemLabel: resolveItemLabel(
-          'errorCatalog.missingErrors.missing_media',
-          itemNames,
-          itemNames.length || source.count,
-          'missing input'
-        ),
         toastTitle: resolveMissingMediaToastTitle(source),
         toastMessage: resolveMissingMediaToastMessage(source)
       }
-    }
   }
 }

--- a/src/platform/errorCatalog/types.ts
+++ b/src/platform/errorCatalog/types.ts
@@ -3,10 +3,7 @@ import type {
   NodeError,
   PromptError
 } from '@/schemas/apiSchema'
-import type {
-  MissingMediaGroup,
-  MediaType
-} from '@/platform/missingMedia/types'
+import type { MissingMediaGroup } from '@/platform/missingMedia/types'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
 import type { MissingNodeType } from '@/types/comfy'
 
@@ -73,6 +70,5 @@ export type MissingErrorMessageSource =
       kind: 'missing_media'
       groups: MissingMediaGroup[]
       count: number
-      mediaTypes: MediaType[]
       isCloud: boolean
     }

--- a/src/platform/missingMedia/missingMediaScan.test.ts
+++ b/src/platform/missingMedia/missingMediaScan.test.ts
@@ -422,6 +422,7 @@ describe('groupCandidatesByName', () => {
     const photoGroup = result.find((g) => g.name === 'photo.png')
     expect(photoGroup?.referencingNodes).toHaveLength(2)
     expect(photoGroup?.mediaType).toBe('image')
+    expect(photoGroup?.representative.nodeType).toBe('LoadImage')
 
     const otherGroup = result.find((g) => g.name === 'other.png')
     expect(otherGroup?.referencingNodes).toHaveLength(1)

--- a/src/platform/missingMedia/missingMediaScan.ts
+++ b/src/platform/missingMedia/missingMediaScan.ts
@@ -262,6 +262,7 @@ export function groupCandidatesByName(
       map.set(c.name, {
         name: c.name,
         mediaType: c.mediaType,
+        representative: c,
         referencingNodes: [{ nodeId: c.nodeId, widgetName: c.widgetName }]
       })
     }

--- a/src/platform/missingMedia/types.ts
+++ b/src/platform/missingMedia/types.ts
@@ -27,6 +27,7 @@ export interface MissingMediaCandidate {
 export interface MissingMediaViewModel {
   name: string
   mediaType: MediaType
+  representative: MissingMediaCandidate
   referencingNodes: Array<{
     nodeId: NodeId
     widgetName: string

--- a/src/platform/nodeReplacement/components/SwapNodesCard.test.ts
+++ b/src/platform/nodeReplacement/components/SwapNodesCard.test.ts
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event'
 import { createTestingPinia } from '@pinia/testing'
 import PrimeVue from 'primevue/config'
 import { describe, expect, it, vi } from 'vitest'
-import { createI18n } from 'vue-i18n'
 
 import type { SwapNodeGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
 
@@ -18,14 +17,6 @@ vi.mock('./SwapNodeGroupRow.vue', () => ({
 }))
 
 import SwapNodesCard from './SwapNodesCard.vue'
-
-const i18n = createI18n({
-  legacy: false,
-  locale: 'en',
-  messages: { en: {} },
-  missingWarn: false,
-  fallbackWarn: false
-})
 
 function makeGroups(count = 2): SwapNodeGroup[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -56,19 +47,13 @@ function mountCard(
       ...(callbacks?.onReplace ? { onReplace: callbacks.onReplace } : {})
     },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue, i18n]
+      plugins: [createTestingPinia({ createSpy: vi.fn }), PrimeVue]
     }
   })
 }
 
 describe('SwapNodesCard', () => {
   describe('Rendering', () => {
-    it('renders guidance message', () => {
-      const { container } = mountCard()
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-      expect(container.querySelector('p')).not.toBeNull()
-    })
-
     it('renders correct number of SwapNodeGroupRow components', () => {
       const { container } = mountCard({ swapNodeGroups: makeGroups(3) })
       // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access

--- a/src/platform/nodeReplacement/components/SwapNodesCard.vue
+++ b/src/platform/nodeReplacement/components/SwapNodesCard.vue
@@ -1,15 +1,5 @@
 <template>
   <div class="mt-2 px-4 pb-2">
-    <!-- Sub-label: guidance message shown above all swap groups -->
-    <p class="m-0 pb-5 text-sm/relaxed text-muted-foreground">
-      {{
-        t(
-          'nodeReplacement.swapNodesGuide',
-          'The following nodes can be automatically replaced with compatible alternatives.'
-        )
-      }}
-    </p>
-    <!-- Group Rows -->
     <SwapNodeGroupRow
       v-for="group in swapNodeGroups"
       :key="group.type"
@@ -22,11 +12,8 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
 import type { SwapNodeGroup } from '@/components/rightSidePanel/errors/useErrorGroups'
 import SwapNodeGroupRow from '@/platform/nodeReplacement/components/SwapNodeGroupRow.vue'
-
-const { t } = useI18n()
 
 const { swapNodeGroups, showNodeIdBadge } = defineProps<{
   swapNodeGroups: SwapNodeGroup[]


### PR DESCRIPTION
## Summary

Resolve missing resource error groups through the error catalog so missing nodes, replaceable nodes, missing models, and missing media use consistent panel and single-error overlay copy.

## Changes

- **What**: Adds missing-resource resolvers for `missing_node`, `swap_nodes`, `missing_model`, and `missing_media` that provide `displayMessage`, `toastTitle`, and `toastMessage` alongside the existing group titles. The Errors tab now renders a group-level `displayMessage` under non-execution group headers, which gives grouped missing-resource cards the same explanatory message path used by validation/runtime errors without adding per-row detail fields that these grouped cards do not need.
- **What**: Moves missing node and swap node explanatory copy out of card-local hardcoded text and into `errorCatalog.missingErrors.*` keys. `MissingNodeCard` and `SwapNodesCard` now focus on rendering their grouped rows and actions, while the shared error group header owns the explanatory copy.
- **What**: Adds environment-aware copy for missing node packs and missing models. Cloud messages explain unsupported resources and replacement/import paths without suggesting local execution, while OSS messages point users toward installing or downloading the missing resources.
- **What**: Adds single-error overlay/toast copy for missing resources. Missing media uses a concise input-focused title/message, missing models distinguish Cloud unsupported models from OSS missing files, and missing nodes/swap nodes use node-type-aware copy.
- **What**: Deduplicates missing node and swap node toast decisions by distinct node type so repeated instances of the same missing/replaceable node do not accidentally switch the single-error copy to plural copy.
- **What**: Preserves representative missing media candidate metadata so missing media toast copy can use a human-readable node name such as `Load Image is missing a required media file.`
- **What**: Removes unused missing-resource resolver fields such as grouped `displayDetails`, grouped `displayItemLabel`, and the unused `mediaTypes` source parameter after deciding those fields do not fit grouped missing-resource cards.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

- Missing resource groups are still grouped cards. This PR intentionally gives them group-level display and toast copy, but does not split missing resources into one error item per underlying candidate.
- Missing resource count semantics are intentionally not normalized here. Error overlay totals, store counts, and grouped card counts still follow the existing behavior; a follow-up PR can define those count units separately.
- The Cloud/OSS message variants remain explicit in the resolver instead of being abstracted into a generic variant helper. That keeps this PR focused on the messaging behavior and avoids a broader resolver refactor.
- Only `src/locales/en/main.json` is updated directly. Other locales should be synced by the existing localization flow.

## Screenshots (if applicable)

<img width="668" height="245" alt="스크린샷 2026-06-05 오전 3 16 49" src="https://github.com/user-attachments/assets/98b50ac3-67e1-438d-8c37-e06c7bf465ee" />
<img width="666" height="195" alt="스크린샷 2026-06-05 오전 3 16 58" src="https://github.com/user-attachments/assets/92da95b1-03d6-4739-97e6-c573982bfec9" />
<img width="505" height="358" alt="스크린샷 2026-06-05 오전 3 17 27" src="https://github.com/user-attachments/assets/4d0e1a6e-13b9-4097-9fb5-19fe0c5331dc" />
<img width="507" height="324" alt="스크린샷 2026-06-05 오전 3 17 44" src="https://github.com/user-attachments/assets/054e42f8-0d0c-44b5-8a67-e467fc04f1fc" />


## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm test:unit src/platform/errorCatalog/errorMessageResolver.test.ts src/components/rightSidePanel/errors/useErrorGroups.test.ts src/components/rightSidePanel/errors/TabErrors.test.ts`
- `pnpm typecheck`
- push hook: `knip --cache`
