### PR TITLE
feat(telemetry): capture desktop entry props in cloud build

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TelemetryEvents } from '../../types'
 
@@ -7,6 +7,8 @@ const hoisted = vi.hoisted(() => {
   const mockInit = vi.fn()
   const mockIdentify = vi.fn()
   const mockPeopleSet = vi.fn()
+  const mockPeopleSetOnce = vi.fn()
+  const mockRegister = vi.fn()
   const mockReset = vi.fn()
   const mockOnUserResolved = vi.fn()
   const mockOnUserLogout = vi.fn()
@@ -16,6 +18,8 @@ const hoisted = vi.hoisted(() => {
     mockInit,
     mockIdentify,
     mockPeopleSet,
+    mockPeopleSetOnce,
+    mockRegister,
     mockReset,
     mockOnUserResolved,
     mockOnUserLogout,
@@ -24,7 +28,8 @@ const hoisted = vi.hoisted(() => {
         init: mockInit,
         capture: mockCapture,
         identify: mockIdentify,
-        people: { set: mockPeopleSet },
+        register: mockRegister,
+        people: { set: mockPeopleSet, set_once: mockPeopleSetOnce },
         reset: mockReset
       }
     }
@@ -144,6 +149,99 @@ describe('PostHogTelemetryProvider', () => {
       callback({ id: 'user-123' })
 
       expect(hoisted.mockIdentify).toHaveBeenCalledWith('user-123')
+    })
+  })
+
+  describe('desktop entry capture', () => {
+    function setLocation(search: string): void {
+      Object.defineProperty(window.location, 'search', {
+        configurable: true,
+        value: search,
+        writable: true
+      })
+    }
+
+    afterEach(() => {
+      setLocation('')
+    })
+
+    it('does not register desktop props when utm_source is absent', async () => {
+      setLocation('')
+      createProvider()
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockRegister).not.toHaveBeenCalled()
+    })
+
+    it('does not register desktop props when utm_source is not comfy.desktop', async () => {
+      setLocation('?utm_source=google&desktop_device_id=should-be-ignored')
+      createProvider()
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockRegister).not.toHaveBeenCalled()
+    })
+
+    it('registers source_app and desktop_device_id when arriving from desktop', async () => {
+      setLocation(
+        '?utm_source=comfy.desktop&utm_medium=app_feature&desktop_device_id=device-abc'
+      )
+      createProvider()
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockRegister).toHaveBeenCalledWith({
+        source_app: 'desktop',
+        desktop_device_id: 'device-abc'
+      })
+    })
+
+    it('registers source_app alone when desktop_device_id is missing', async () => {
+      setLocation('?utm_source=comfy.desktop')
+      createProvider()
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockRegister).toHaveBeenCalledWith({
+        source_app: 'desktop'
+      })
+    })
+
+    it('persists desktop props to the person on identify so backend events inherit them', async () => {
+      setLocation('?utm_source=comfy.desktop&desktop_device_id=device-xyz')
+      createProvider()
+      await vi.dynamicImportSettled()
+
+      const callback = hoisted.mockOnUserResolved.mock.calls[0][0]
+      callback({ id: 'user-456' })
+
+      const setCall = hoisted.mockPeopleSet.mock.calls.find(
+        ([props]) => props && 'desktop_device_id' in props
+      )
+      expect(setCall?.[0]).toEqual(
+        expect.objectContaining({
+          source_app: 'desktop',
+          desktop_device_id: 'device-xyz',
+          last_seen_via_desktop: expect.any(String)
+        })
+      )
+      expect(hoisted.mockPeopleSetOnce).toHaveBeenCalledWith(
+        expect.objectContaining({ first_seen_via_desktop: expect.any(String) })
+      )
+    })
+
+    it('does not touch the person profile on identify for non-desktop visitors', async () => {
+      setLocation('')
+      createProvider()
+      await vi.dynamicImportSettled()
+
+      const callback = hoisted.mockOnUserResolved.mock.calls[0][0]
+      callback({ id: 'user-789' })
+
+      const desktopSetCall = hoisted.mockPeopleSet.mock.calls.find(
+        ([props]) =>
+          props &&
+          ('desktop_device_id' in props || 'last_seen_via_desktop' in props)
+      )
+      expect(desktopSetCall).toBeUndefined()
+      expect(hoisted.mockPeopleSetOnce).not.toHaveBeenCalled()
     })
   })
 

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -72,30 +72,11 @@ interface QueuedEvent {
   properties?: TelemetryEventProperties
 }
 
-/**
- * PostHog Telemetry Provider - Cloud Build Implementation
- *
- * Sends all telemetry events to PostHog so they can be correlated
- * with session recordings. Follows the same pattern as MixpanelTelemetryProvider.
- *
- * CRITICAL: OSS Build Safety
- * Entire file is tree-shaken away in OSS builds (DISTRIBUTION unset).
- */
 interface DesktopEntryProps {
   source_app: 'desktop'
   desktop_device_id?: string
 }
 
-/**
- * Read `?utm_source=comfy.desktop&desktop_device_id=<id>` from the current URL.
- * Returns null when the visitor did not arrive from the desktop app.
- *
- * Why both fields are needed: `utm_source` is captured automatically by
- * posthog-js as a super-property on this browser session, but `desktop_device_id`
- * is an arbitrary param that posthog-js ignores. We have to explicitly read it
- * and register it so backend events (Stripe webhooks → billing:subscription_created)
- * can be joined back to the originating desktop install via person-on-events.
- */
 function readDesktopEntryProps(): DesktopEntryProps | null {
   const params = new URLSearchParams(window.location.search)
   if (params.get('utm_source') !== 'comfy.desktop') return null
@@ -105,6 +86,15 @@ function readDesktopEntryProps(): DesktopEntryProps | null {
   return props
 }
 
+/**
+ * PostHog Telemetry Provider - Cloud Build Implementation
+ *
+ * Sends all telemetry events to PostHog so they can be correlated
+ * with session recordings. Follows the same pattern as MixpanelTelemetryProvider.
+ *
+ * CRITICAL: OSS Build Safety
+ * Entire file is tree-shaken away in OSS builds (DISTRIBUTION unset).
+ */
 export class PostHogTelemetryProvider implements TelemetryProvider {
   private isEnabled = true
   private posthog: PostHog | null = null
@@ -294,15 +284,6 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     )
   }
 
-  /**
-   * Register desktop-entry props as super-properties on every event from this
-   * browser session. Caches the props on the instance so we can re-apply them
-   * to the person profile once the user authenticates.
-   *
-   * Fires regardless of whether a person profile exists yet — super-properties
-   * are session-scoped, not person-scoped, so they survive the
-   * `person_profiles: 'identified_only'` gate.
-   */
   private registerDesktopEntryProps(): void {
     if (!this.posthog) return
     const props = readDesktopEntryProps()
@@ -315,13 +296,8 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     }
   }
 
-  /**
-   * Persist the desktop-entry props onto the person profile once `identify` has
-   * created one. Backend-fired events (Stripe webhook → billing:subscription_created)
-   * pick `desktop_device_id` up via person-on-events at ingest, so the join
-   * "subs where person.properties.desktop_device_id is not null" gives accurate
-   * Desktop → Cloud attribution even when the sub fires from outside the browser.
-   */
+  // Persisted onto the person so backend-fired billing events inherit
+  // desktop_device_id via person-on-events at ingest.
   private setDesktopEntryPersonProperties(): void {
     if (!this.posthog || !this.desktopEntryProps) return
     const now = new Date().toISOString()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -81,6 +81,30 @@ interface QueuedEvent {
  * CRITICAL: OSS Build Safety
  * Entire file is tree-shaken away in OSS builds (DISTRIBUTION unset).
  */
+interface DesktopEntryProps {
+  source_app: 'desktop'
+  desktop_device_id?: string
+}
+
+/**
+ * Read `?utm_source=comfy.desktop&desktop_device_id=<id>` from the current URL.
+ * Returns null when the visitor did not arrive from the desktop app.
+ *
+ * Why both fields are needed: `utm_source` is captured automatically by
+ * posthog-js as a super-property on this browser session, but `desktop_device_id`
+ * is an arbitrary param that posthog-js ignores. We have to explicitly read it
+ * and register it so backend events (Stripe webhooks → billing:subscription_created)
+ * can be joined back to the originating desktop install via person-on-events.
+ */
+function readDesktopEntryProps(): DesktopEntryProps | null {
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('utm_source') !== 'comfy.desktop') return null
+  const props: DesktopEntryProps = { source_app: 'desktop' }
+  const deviceId = params.get('desktop_device_id')
+  if (deviceId) props.desktop_device_id = deviceId
+  return props
+}
+
 export class PostHogTelemetryProvider implements TelemetryProvider {
   private isEnabled = true
   private posthog: PostHog | null = null
@@ -89,6 +113,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
   private isInitialized = false
   private lastTriggerSource: ExecutionTriggerSource | undefined
   private disabledEvents = new Set<TelemetryEventName>(DEFAULT_DISABLED_EVENTS)
+  private desktopEntryProps: DesktopEntryProps | null = null
 
   constructor() {
     this.configureDisabledEvents(
@@ -128,11 +153,13 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
             })
             this.isInitialized = true
             this.flushEventQueue()
+            this.registerDesktopEntryProps()
 
             const currentUser = useCurrentUser()
             currentUser.onUserResolved((user) => {
               if (this.posthog && user.id) {
                 this.posthog.identify(user.id)
+                this.setDesktopEntryPersonProperties()
                 this.setSubscriptionProperties()
               }
             })
@@ -265,6 +292,48 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
         return isValid
       })
     )
+  }
+
+  /**
+   * Register desktop-entry props as super-properties on every event from this
+   * browser session. Caches the props on the instance so we can re-apply them
+   * to the person profile once the user authenticates.
+   *
+   * Fires regardless of whether a person profile exists yet — super-properties
+   * are session-scoped, not person-scoped, so they survive the
+   * `person_profiles: 'identified_only'` gate.
+   */
+  private registerDesktopEntryProps(): void {
+    if (!this.posthog) return
+    const props = readDesktopEntryProps()
+    if (!props) return
+    this.desktopEntryProps = props
+    try {
+      this.posthog.register(props)
+    } catch (error) {
+      console.error('Failed to register desktop entry props:', error)
+    }
+  }
+
+  /**
+   * Persist the desktop-entry props onto the person profile once `identify` has
+   * created one. Backend-fired events (Stripe webhook → billing:subscription_created)
+   * pick `desktop_device_id` up via person-on-events at ingest, so the join
+   * "subs where person.properties.desktop_device_id is not null" gives accurate
+   * Desktop → Cloud attribution even when the sub fires from outside the browser.
+   */
+  private setDesktopEntryPersonProperties(): void {
+    if (!this.posthog || !this.desktopEntryProps) return
+    const now = new Date().toISOString()
+    try {
+      this.posthog.people.set({
+        ...this.desktopEntryProps,
+        last_seen_via_desktop: now
+      })
+      this.posthog.people.set_once({ first_seen_via_desktop: now })
+    } catch (error) {
+      console.error('Failed to set desktop entry person properties:', error)
+    }
   }
 
   private setSubscriptionProperties(): void {


### PR DESCRIPTION
## Summary

When a visitor arrives at the cloud product with `utm_source=comfy.desktop`, register `source_app` and `desktop_device_id` as PostHog super-properties and persist them onto the person on identify.

Backend-fired billing events (Stripe webhook → `billing:subscription_created`) then inherit the desktop attribution via person-on-events, closing the cross-session gap where browser-side utm capture and backend webhook events live on different `distinct_id`s.

## Why

The desktop app appends `?desktop_device_id=<id>&utm_source=comfy.desktop` to its cloud links. `utm_source` is auto-captured by posthog-js as a session super-property, but arbitrary query params like `desktop_device_id` are ignored. Without this, cross-session Desktop→Cloud sub attribution silently shows zero.

Confirmed empirically: across 24h of recent billing events, `person.$initial_utm_source = 'comfy.desktop'` matched 0 rows, because users had visited the cloud surface before they ever launched desktop. Person-property based join via this PR is the durable fix.

## Test plan

- [x] Unit tests for: no utm, wrong utm, utm with device id, utm without device id, person.set after identify, no-op for non-desktop visitors
- [x] `pnpm vitest run PostHogTelemetryProvider.test.ts` — 28/28 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual verification post-merge: visit cloud.comfy.org with `?utm_source=comfy.desktop&desktop_device_id=test-abc`, log in, check PostHog person profile gains `desktop_device_id`, `last_seen_via_desktop`, `first_seen_via_desktop`, `source_app`