### PR TITLE
fix: keep connected advanced inputs visible

### DIFF
--- a/browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts
@@ -72,6 +72,50 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
     await expect(widgets).toHaveCount(2)
   })
 
+  test('should keep connected advanced widgets visible when advanced inputs are hidden', async ({
+    comfyPage
+  }) => {
+    const node = getNode(comfyPage)
+    const widgets = getWidgets(comfyPage)
+
+    await node.getByText(SHOW_ADVANCED_INPUTS).click()
+    await expect(widgets).toHaveCount(4)
+
+    const primitive = await comfyPage.nodeOps.addNode(
+      'PrimitiveFloat',
+      {},
+      { x: 100, y: 200 }
+    )
+    const [target] =
+      await comfyPage.nodeOps.getNodeRefsByType('ModelSamplingFlux')
+    const originSlot = await primitive.getOutput(0)
+    const targetWidget = await target.getWidgetByName('max_shift')
+    await comfyPage.canvasOps.dragAndDrop(
+      await originSlot.getPosition(),
+      await targetWidget.getSocketPosition()
+    )
+
+    await expect
+      .poll(() =>
+        comfyPage.page.evaluate(() => {
+          const node = window.app!.graph.nodes.find(
+            (node) => node.type === 'ModelSamplingFlux'
+          )
+          return (
+            node?.inputs.find((input) => input.widget?.name === 'max_shift')
+              ?.link ?? null
+          )
+        })
+      )
+      .not.toBeNull()
+
+    await node.getByText(HIDE_ADVANCED_INPUTS).click()
+
+    await expect(node.getByLabel('max_shift', { exact: true })).toBeVisible()
+    await expect(widgets).toHaveCount(3)
+    await expect(node.getByLabel('base_shift', { exact: true })).toBeHidden()
+  })
+
   test('should hide advanced footer button while collapsed', async ({
     comfyPage
   }) => {

--- a/browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts
+++ b/browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts
@@ -6,6 +6,7 @@ import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 
 const SHOW_ADVANCED_INPUTS = 'Show advanced inputs'
 const HIDE_ADVANCED_INPUTS = 'Hide advanced inputs'
+const FLOAT_SOURCE_POSITION_LEFT_OF_NODE = { x: 100, y: 200 }
 
 test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
@@ -30,6 +31,20 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
 
   function getWidgets(comfyPage: ComfyPage) {
     return getNode(comfyPage).locator('.lg-node-widget')
+  }
+
+  async function getWidgetIndex(comfyPage: ComfyPage, widgetName: string) {
+    const index = await comfyPage.page.evaluate((name) => {
+      const node = window.app!.graph.nodes.find(
+        (node) => node.type === 'ModelSamplingFlux'
+      )
+      return node?.widgets?.findIndex((widget) => widget.name === name) ?? -1
+    }, widgetName)
+    expect(
+      index,
+      `${widgetName} widget should exist on ModelSamplingFlux`
+    ).toBeGreaterThanOrEqual(0)
+    return index
   }
 
   test('should hide advanced widgets by default', async ({ comfyPage }) => {
@@ -76,24 +91,22 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
     comfyPage
   }) => {
     const node = getNode(comfyPage)
-    const widgets = getWidgets(comfyPage)
+    const maxShiftWidget = node.getByLabel('max_shift', { exact: true })
+    const baseShiftWidget = node.getByLabel('base_shift', { exact: true })
 
     await node.getByText(SHOW_ADVANCED_INPUTS).click()
-    await expect(widgets).toHaveCount(4)
+    await expect(maxShiftWidget).toBeVisible()
+    await expect(baseShiftWidget).toBeVisible()
 
     const primitive = await comfyPage.nodeOps.addNode(
       'PrimitiveFloat',
       {},
-      { x: 100, y: 200 }
+      FLOAT_SOURCE_POSITION_LEFT_OF_NODE
     )
     const [target] =
       await comfyPage.nodeOps.getNodeRefsByType('ModelSamplingFlux')
-    const originSlot = await primitive.getOutput(0)
-    const targetWidget = await target.getWidgetByName('max_shift')
-    await comfyPage.canvasOps.dragAndDrop(
-      await originSlot.getPosition(),
-      await targetWidget.getSocketPosition()
-    )
+    const maxShiftIndex = await getWidgetIndex(comfyPage, 'max_shift')
+    await primitive.connectWidget(0, target, maxShiftIndex)
 
     await expect
       .poll(() =>
@@ -111,9 +124,8 @@ test.describe('Advanced Widget Visibility', { tag: '@vue-nodes' }, () => {
 
     await node.getByText(HIDE_ADVANCED_INPUTS).click()
 
-    await expect(node.getByLabel('max_shift', { exact: true })).toBeVisible()
-    await expect(widgets).toHaveCount(3)
-    await expect(node.getByLabel('base_shift', { exact: true })).toBeHidden()
+    await expect(maxShiftWidget).toBeVisible()
+    await expect(baseShiftWidget).toBeHidden()
   })
 
   test('should hide advanced footer button while collapsed', async ({

--- a/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeWidgets.vue
@@ -24,7 +24,7 @@
   >
     <template v-for="widget in processedWidgets" :key="widget.renderKey">
       <div
-        v-if="!widget.hidden && (!widget.advanced || showAdvanced)"
+        v-if="widget.visible"
         data-testid="node-widget"
         class="lg-node-widget group col-span-full grid grid-cols-subgrid items-stretch"
       >
@@ -128,13 +128,8 @@ onErrorCaptured((error) => {
   return false
 })
 
-const {
-  canSelectInputs,
-  gridTemplateRows,
-  nodeType,
-  processedWidgets,
-  showAdvanced
-} = useProcessedWidgets(() => nodeData)
+const { canSelectInputs, gridTemplateRows, nodeType, processedWidgets } =
+  useProcessedWidgets(() => nodeData)
 
 // Tracks widget-row growth that the node-level RO can't see
 if (nodeData?.id != null) {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -102,6 +102,14 @@ describe('isWidgetVisible', () => {
   it('returns true for advanced widgets when showAdvanced is true', () => {
     expect(isWidgetVisible({ advanced: true }, true)).toBe(true)
   })
+
+  it('keeps advanced widgets visible when linked and showAdvanced is false', () => {
+    expect(isWidgetVisible({ advanced: true }, false, true)).toBe(true)
+  })
+
+  it('keeps hidden widgets hidden when linked', () => {
+    expect(isWidgetVisible({ hidden: true }, false, true)).toBe(false)
+  })
 })
 
 describe('hasWidgetError', () => {

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -59,6 +59,7 @@ interface ProcessedWidget {
   type: string
   updateHandler: (value: WidgetValue) => void
   value: WidgetValue
+  visible: boolean
   vueComponent: Component
   slotMetadata?: WidgetSlotMetadata
 }
@@ -154,11 +155,12 @@ export function getWidgetIdentity(
 
 export function isWidgetVisible(
   options: IWidgetOptions,
-  showAdvanced: boolean
+  showAdvanced: boolean,
+  linked = false
 ): boolean {
   const hidden = options.hidden ?? false
   const advanced = options.advanced ?? false
-  return !hidden && (!advanced || showAdvanced)
+  return !hidden && (!advanced || showAdvanced || linked)
 }
 
 export function computeProcessedWidgets({
@@ -211,7 +213,11 @@ export function computeProcessedWidgets({
       ...(widget.options ?? {}),
       ...(widgetState?.options ?? {})
     }
-    const visible = isWidgetVisible(mergedOptions, showAdvanced)
+    const visible = isWidgetVisible(
+      mergedOptions,
+      showAdvanced,
+      widget.slotMetadata?.linked
+    )
     if (!identity.dedupeIdentity) {
       uniqueWidgets.push({
         widget,
@@ -252,6 +258,7 @@ export function computeProcessedWidgets({
     widget,
     mergedOptions,
     widgetState,
+    isVisible: visible,
     identity: { renderKey }
   } of uniqueWidgets) {
     const bareWidgetId = String(stripGraphPrefix(widget.nodeId ?? nodeId ?? ''))
@@ -343,6 +350,7 @@ export function computeProcessedWidgets({
       vueComponent,
       simplified,
       value,
+      visible,
       updateHandler,
       tooltipConfig,
       slotMetadata
@@ -396,12 +404,7 @@ export function useProcessedWidgets(
   )
 
   const visibleWidgets = computed(() =>
-    processedWidgets.value.filter((w) =>
-      isWidgetVisible(
-        { hidden: w.hidden, advanced: w.advanced },
-        showAdvanced.value
-      )
-    )
+    processedWidgets.value.filter((w) => w.visible)
   )
 
   const gridTemplateRows = computed((): string =>
@@ -417,7 +420,6 @@ export function useProcessedWidgets(
     gridTemplateRows,
     nodeType,
     processedWidgets,
-    showAdvanced,
     visibleWidgets
   }
 }


### PR DESCRIPTION
## Summary

Keep connected advanced widget inputs visible on Vue-rendered nodes when advanced inputs are collapsed.

This fixes Linear [FE-924](https://linear.app/comfyorg/issue/FE-924/bug-connected-advanced-input-parameters-become-hidden-when-advanced), where a user could connect a noodle to an advanced input, collapse advanced inputs, and then lose visual access to the connected parameter even though it was actively used by the workflow.

## Changes

- **What**: Treat a widget-backed input as visible when its slot is linked, even if the widget is advanced and the node-level advanced section is collapsed.
- **What**: Move Vue node widget rendering to use the processed `widget.visible` value instead of reimplementing visibility in `NodeWidgets.vue`.
- **What**: Keep the visibility decision as a single source of truth during widget processing, including the existing deduplication path.
- **What**: Add unit coverage for the new linked-widget visibility behavior and the precedence rule that explicit hidden state still wins.
- **What**: Add an E2E regression that connects a `PrimitiveFloat` to the advanced `max_shift` input on `ModelSamplingFlux`, collapses advanced inputs, and verifies the connected input remains visible while an unconnected advanced input remains hidden.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

The key behavior is that linked advanced widgets should be promoted into the visible widget set only while they are connected. Explicitly hidden widgets must remain hidden even when linked.

The fix uses existing slot metadata from `useGraphNodeManager`; no new graph state is introduced. This keeps the change scoped to Vue node widget processing and rendering.

## Red-Green Verification

| Commit | Purpose | Local result |
| --- | --- | --- |
| `4fa5932c6` | Adds the E2E regression only | Red: `max_shift` was not found after collapsing advanced inputs |
| `e5d1ee06a` | Adds the production fix and focused unit coverage | Green: targeted E2E passed |

## Test Plan

- `pnpm test:unit src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts`
- `PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://127.0.0.1:5175 PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:8188 pnpm test:browser -g "should keep connected advanced widgets visible when advanced inputs are hidden" browser_tests/tests/vueNodes/widgets/advancedWidgets.spec.ts`
- `pnpm typecheck && pnpm typecheck:browser`

## Screenshots (Before / After)
Before 

https://github.com/user-attachments/assets/bf1e88f3-2983-4bef-9cef-48ffe6dbfd6d



After 

https://github.com/user-attachments/assets/4dee7766-0252-478f-9b1c-4b801fc20eb2


