### PR TITLE
fix: defer node auto-pan until drag starts

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -54,6 +54,32 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     })
   }
 
+  const getShowAdvancedButton = (node: Locator) =>
+    node.getByTestId('advanced-inputs-button')
+
+  const moveButtonRightEdgePastCanvas = async (
+    comfyPage: ComfyPage,
+    button: Locator,
+    overflow: number
+  ) => {
+    const box = await button.boundingBox()
+    const canvasBox = await comfyPage.canvas.boundingBox()
+    if (!box) throw new Error('Tab button has no bounding box')
+    if (!canvasBox) throw new Error('Canvas has no bounding box')
+
+    const scale = await comfyPage.canvasOps.getScale()
+    const deltaX = canvasBox.x + canvasBox.width + overflow - box.x - box.width
+    await comfyPage.page.evaluate(
+      ({ deltaX, scale }) => {
+        const canvas = window.app!.canvas
+        canvas.ds.offset[0] += deltaX / scale
+        canvas.setDirty(true, true)
+      },
+      { deltaX, scale }
+    )
+    await comfyPage.idleFrames(2)
+  }
+
   test('should allow moving nodes by dragging', async ({ comfyPage }) => {
     const loadCheckpointHeaderPos = await getLoadCheckpointHeaderPos(comfyPage)
     await comfyPage.canvasOps.dragAndDrop(loadCheckpointHeaderPos, {
@@ -123,7 +149,7 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     await comfyPage.vueNodes.waitForNodes()
 
     const node = comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
-    const showButton = node.getByText('Show advanced inputs')
+    const showButton = getShowAdvancedButton(node)
     const widgets = node.locator('.lg-node-widget')
 
     await expect(showButton).toBeVisible()
@@ -142,6 +168,79 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     if (!afterPos) throw new Error('Node missing after drag')
     await expectPosChanged(beforePos, afterPos)
   })
+
+  test(
+    'should not pan while holding the Advanced button without dragging',
+    { tag: ['@canvas', '@widget'] },
+    async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting(
+        'Comfy.Node.AlwaysShowAdvancedWidgets',
+        false
+      )
+      await comfyPage.nodeOps.addNode(
+        'ModelSamplingFlux',
+        {},
+        {
+          x: 500,
+          y: 200
+        }
+      )
+      await comfyPage.vueNodes.waitForNodes()
+
+      const node = comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
+      const showButton = getShowAdvancedButton(node)
+      await expect(showButton).toBeVisible()
+
+      await moveButtonRightEdgePastCanvas(comfyPage, showButton, 24)
+
+      const buttonBox = await showButton.boundingBox()
+      const canvasBox = await comfyPage.canvas.boundingBox()
+      if (!buttonBox) throw new Error('Advanced button has no bounding box')
+      if (!canvasBox) throw new Error('Canvas has no bounding box')
+
+      const canvasRight = canvasBox.x + canvasBox.width
+      const buttonRight = buttonBox.x + buttonBox.width
+      expect(
+        buttonRight,
+        'Advanced button should extend past the canvas right edge'
+      ).toBeGreaterThan(canvasRight)
+
+      const holdPoint = {
+        x: canvasRight - 8,
+        y: buttonBox.y + buttonBox.height / 2
+      }
+      expect(
+        holdPoint.x,
+        'Hold point should stay inside the visible part of the Advanced button'
+      ).toBeGreaterThanOrEqual(buttonBox.x)
+      expect(
+        holdPoint.x,
+        'Hold point should stay inside the visible canvas'
+      ).toBeLessThanOrEqual(canvasRight)
+      expect(
+        holdPoint.y,
+        'Hold point should stay inside the Advanced button height'
+      ).toBeGreaterThanOrEqual(buttonBox.y)
+      expect(
+        holdPoint.y,
+        'Hold point should stay inside the Advanced button height'
+      ).toBeLessThanOrEqual(buttonBox.y + buttonBox.height)
+
+      const beforeOffset = await comfyPage.canvasOps.getOffset()
+
+      await comfyPage.page.mouse.move(holdPoint.x, holdPoint.y)
+      await comfyPage.page.mouse.down()
+      try {
+        await comfyPage.idleFrames(8)
+      } finally {
+        await comfyPage.page.mouse.up()
+      }
+
+      const afterOffset = await comfyPage.canvasOps.getOffset()
+      expect(afterOffset[0]).toBeCloseTo(beforeOffset[0], 3)
+      expect(afterOffset[1]).toBeCloseTo(beforeOffset[1], 3)
+    }
+  )
 
   test('should not enter subgraph when dragging by the Enter Subgraph button', async ({
     comfyPage

--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -54,17 +54,20 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     })
   }
 
-  const getShowAdvancedButton = (node: Locator) =>
+  const advancedButtonOverflowPx = 24
+  const holdPointCanvasInsetPx = 8
+
+  const getAdvancedInputsButton = (node: Locator) =>
     node.getByTestId('advanced-inputs-button')
 
-  const moveButtonRightEdgePastCanvas = async (
+  const moveAdvancedButtonRightEdgePastCanvas = async (
     comfyPage: ComfyPage,
     button: Locator,
     overflow: number
   ) => {
     const box = await button.boundingBox()
     const canvasBox = await comfyPage.canvas.boundingBox()
-    if (!box) throw new Error('Tab button has no bounding box')
+    if (!box) throw new Error('Advanced button has no bounding box')
     if (!canvasBox) throw new Error('Canvas has no bounding box')
 
     const scale = await comfyPage.canvasOps.getScale()
@@ -149,7 +152,7 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     await comfyPage.vueNodes.waitForNodes()
 
     const node = comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
-    const showButton = getShowAdvancedButton(node)
+    const showButton = getAdvancedInputsButton(node)
     const widgets = node.locator('.lg-node-widget')
 
     await expect(showButton).toBeVisible()
@@ -188,10 +191,14 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
       await comfyPage.vueNodes.waitForNodes()
 
       const node = comfyPage.vueNodes.getNodeByTitle('ModelSamplingFlux')
-      const showButton = getShowAdvancedButton(node)
+      const showButton = getAdvancedInputsButton(node)
       await expect(showButton).toBeVisible()
 
-      await moveButtonRightEdgePastCanvas(comfyPage, showButton, 24)
+      await moveAdvancedButtonRightEdgePastCanvas(
+        comfyPage,
+        showButton,
+        advancedButtonOverflowPx
+      )
 
       const buttonBox = await showButton.boundingBox()
       const canvasBox = await comfyPage.canvas.boundingBox()
@@ -206,7 +213,7 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
       ).toBeGreaterThan(canvasRight)
 
       const holdPoint = {
-        x: canvasRight - 8,
+        x: canvasRight - holdPointCanvasInsetPx,
         y: buttonBox.y + buttonBox.height / 2
       }
       expect(

--- a/src/renderer/extensions/vueNodes/components/NodeFooter.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.vue
@@ -73,6 +73,7 @@
 
     <Button
       variant="textonly"
+      data-testid="advanced-inputs-button"
       :class="
         cn(
           tabStyles,
@@ -169,6 +170,7 @@
   >
     <Button
       variant="textonly"
+      data-testid="advanced-inputs-button"
       :class="
         cn(
           tabStyles,

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts
@@ -297,6 +297,7 @@ describe('useNodeDrag auto-pan', () => {
     const drag = useNodeDrag()
 
     drag.startDrag(pointerEvent(750, 300), '1')
+    drag.handleDrag(pointerEvent(760, 300), '1')
     testState.mutationFns.batchMoveNodes.mockClear()
 
     testState.mockDs.offset[0] -= 5
@@ -309,20 +310,46 @@ describe('useNodeDrag auto-pan', () => {
     expect(nodeIds).toContain('2')
   })
 
-  it('updates auto-pan pointer on handleDrag', () => {
+  it('starts auto-pan on handleDrag', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), '1')
 
     drag.handleDrag(pointerEvent(790, 300), '1')
 
-    expect(
-      testState.capturedAutoPanInstance.current!.updatePointer
-    ).toHaveBeenCalledWith(790, 300)
+    const autoPan = testState.capturedAutoPanInstance.current
+    if (!autoPan) throw new Error('Auto-pan controller was not created')
+    expect(autoPan.start).toHaveBeenCalledTimes(1)
+    expect(autoPan.updatePointer).toHaveBeenCalledWith(790, 300)
+  })
+
+  it('reuses auto-pan controller across handleDrag calls', () => {
+    const drag = useNodeDrag()
+    drag.startDrag(pointerEvent(400, 300), '1')
+
+    drag.handleDrag(pointerEvent(790, 300), '1')
+    const autoPan = testState.capturedAutoPanInstance.current
+    if (!autoPan) throw new Error('Auto-pan controller was not created')
+
+    testState.requestAnimationFrameCallback?.(0)
+    drag.handleDrag(pointerEvent(795, 305), '1')
+
+    expect(testState.capturedAutoPanInstance.current).toBe(autoPan)
+    expect(autoPan.start).toHaveBeenCalledTimes(1)
+    expect(autoPan.updatePointer).toHaveBeenLastCalledWith(795, 305)
+  })
+
+  it('does not start auto-pan before handleDrag', () => {
+    const drag = useNodeDrag()
+
+    drag.startDrag(pointerEvent(790, 300), '1')
+
+    expect(testState.capturedAutoPanInstance.current).toBeNull()
   })
 
   it('stops auto-pan on endDrag', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), '1')
+    drag.handleDrag(pointerEvent(400, 300), '1')
     expect(testState.capturedAutoPanInstance.current).not.toBeNull()
 
     drag.endDrag(pointerEvent(400, 300), '1')
@@ -333,6 +360,7 @@ describe('useNodeDrag auto-pan', () => {
   it('does not move nodes if onPan fires after endDrag', () => {
     const drag = useNodeDrag()
     drag.startDrag(pointerEvent(400, 300), '1')
+    drag.handleDrag(pointerEvent(400, 300), '1')
     const onPan = testState.capturedOnPan.current!
 
     drag.endDrag(pointerEvent(400, 300), '1')

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -97,36 +97,41 @@ function useNodeDragIndividual() {
     }
 
     mutations.setSource(LayoutSource.Vue)
+  }
 
-    // Start auto-pan
-    const lgCanvas = canvasStore.canvas
-    if (lgCanvas?.ds) {
-      autoPan = new AutoPanController({
-        canvas: lgCanvas.canvas,
-        ds: lgCanvas.ds,
-        maxPanSpeed: lgCanvas.auto_pan_speed,
-        onPan: (panX, panY) => {
-          if (dragStartPos) {
-            dragStartPos.x += panX
-            dragStartPos.y += panY
-          }
-          if (otherSelectedNodesStartPositions) {
-            for (const pos of otherSelectedNodesStartPositions.values()) {
-              pos.x += panX
-              pos.y += panY
-            }
-          }
-          if (selectedGroups) {
-            for (const group of selectedGroups) {
-              group.move(panX, panY, true)
-            }
-          }
-          updateNodePositions(nodeId)
-        }
-      })
+  function startAutoPan(event: PointerEvent, nodeId: NodeId) {
+    if (autoPan) {
       autoPan.updatePointer(event.clientX, event.clientY)
-      autoPan.start()
+      return
     }
+    const lgCanvas = canvasStore.canvas
+    if (!lgCanvas?.ds) return
+
+    autoPan = new AutoPanController({
+      canvas: lgCanvas.canvas,
+      ds: lgCanvas.ds,
+      maxPanSpeed: lgCanvas.auto_pan_speed,
+      onPan: (panX, panY) => {
+        if (dragStartPos) {
+          dragStartPos.x += panX
+          dragStartPos.y += panY
+        }
+        if (otherSelectedNodesStartPositions) {
+          for (const pos of otherSelectedNodesStartPositions.values()) {
+            pos.x += panX
+            pos.y += panY
+          }
+        }
+        if (selectedGroups) {
+          for (const group of selectedGroups) {
+            group.move(panX, panY, true)
+          }
+        }
+        updateNodePositions(nodeId)
+      }
+    })
+    autoPan.updatePointer(event.clientX, event.clientY)
+    autoPan.start()
   }
 
   /**
@@ -206,7 +211,7 @@ function useNodeDragIndividual() {
 
     lastPointerX = event.clientX
     lastPointerY = event.clientY
-    autoPan?.updatePointer(event.clientX, event.clientY)
+    startAutoPan(event, nodeId)
 
     rafId = requestAnimationFrame(() => {
       rafId = null


### PR DESCRIPTION
## Summary

Fix a Vue node drag edge case where holding the partially off-screen Advanced inputs button could continuously auto-pan the canvas even though the pointer had not moved into an actual drag.

Linear: [FE-938](https://linear.app/comfyorg/issue/FE-938/holding-partially-off-screen-advanced-inputs-causes-continuous)

## Changes

- **What**: Move Vue node auto-pan initialization from `startDrag()` to `handleDrag()`, so auto-pan starts only after the pointer interaction has become a real drag.
- **What**: Keep the existing auto-pan behavior during active drags by creating the controller on the first `handleDrag()` call, updating its pointer position on later drag frames, and preserving the existing `onPan` position adjustments.
- **What**: Add unit coverage for the important drag lifecycle invariants: no auto-pan on pointerdown/startDrag, auto-pan starts on handleDrag, the same controller is reused across handleDrag calls, and cleanup still stops auto-pan on endDrag.
- **What**: Add a Playwright regression that places the Advanced inputs button partially beyond the visible canvas edge, holds the pointer down without moving, and verifies the canvas offset stays stable.
- **What**: Add `data-testid="advanced-inputs-button"` to the Advanced inputs footer button variants so the regression test does not depend on translated button text.
- **Breaking**: None.
- **Dependencies**: None.

## Root Cause

`useNodeDrag.startDrag()` created and started `AutoPanController` immediately on pointerdown. When the Advanced inputs button was partly outside the canvas bounds, a stationary pointer near the visible canvas edge was enough for auto-pan to begin, even before any drag movement occurred.

The pointer interaction layer already distinguishes press/hold from real dragging before calling `handleDrag()`. Deferring auto-pan to `handleDrag()` aligns auto-pan startup with that drag threshold and prevents a plain hold from panning the canvas.

## Review Focus

- Auto-pan should not start from `startDrag()`/pointerdown alone.
- Auto-pan should still start promptly once `handleDrag()` runs for an actual drag.
- Repeated `handleDrag()` calls should reuse the existing controller rather than recreate it.
- Existing `onPan` behavior should continue to update drag start positions, selected node start positions, selected groups, and node positions during active drags.
- The E2E intentionally asserts the canvas offset, not node bounds, because the reported bug is unintended canvas auto-pan while the pointer is stationary.

## Red-Green Verification

- `a00b5d2fb test: add failing advanced button hold pan regression`: adds the Playwright regression and test id plumbing. This was verified red against the pre-fix production code.
- `5c207ae28 fix: defer node auto-pan until drag starts`: adds the production fix and unit coverage. The same regression is verified green with the fix.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm test:unit`
- `pnpm test:unit src/renderer/extensions/vueNodes/layout/useNodeDrag.test.ts`
- `PLAYWRIGHT_SETUP_API_URL=http://127.0.0.1:8188 pnpm test:browser:local browser_tests/tests/vueNodes/interactions/node/move.spec.ts --grep "should not pan while holding the Advanced button without dragging"`
- Pre-push hook: `pnpm knip --cache`

## Screenshots (Before / After)

Before 

https://github.com/user-attachments/assets/6080de2d-e2da-4b38-a1ed-1f1f88548c2d

After 

https://github.com/user-attachments/assets/f331271a-9ea1-41ec-92cb-974bc57be56b


