### PR TITLE
fix(cloud): render the OAuth consent view in the dark theme

### DIFF
--- a/src/platform/cloud/oauth/OAuthConsentView.vue
+++ b/src/platform/cloud/oauth/OAuthConsentView.vue
@@ -1,12 +1,4 @@
 <template>
-  <!--
-    The cloud onboarding shell (CloudTemplate) renders on a dark surface but
-    never sets `.dark-theme`, so this view's semantic tokens
-    (secondary-background, base-foreground, muted, primary-background) would
-    otherwise fall back to their light values and render an illegible light
-    card. Scope dark-theme to this view's root so the consent card themes
-    correctly without changing the sibling login/signup/survey views.
-  -->
   <main
     class="dark-theme mx-auto flex min-h-screen max-w-md flex-col justify-center p-6"
   >

--- a/src/platform/cloud/oauth/OAuthConsentView.vue
+++ b/src/platform/cloud/oauth/OAuthConsentView.vue
@@ -1,5 +1,15 @@
 <template>
-  <main class="mx-auto flex min-h-screen max-w-md flex-col justify-center p-6">
+  <!--
+    The cloud onboarding shell (CloudTemplate) renders on a dark surface but
+    never sets `.dark-theme`, so this view's semantic tokens
+    (secondary-background, base-foreground, muted, primary-background) would
+    otherwise fall back to their light values and render an illegible light
+    card. Scope dark-theme to this view's root so the consent card themes
+    correctly without changing the sibling login/signup/survey views.
+  -->
+  <main
+    class="dark-theme mx-auto flex min-h-screen max-w-md flex-col justify-center p-6"
+  >
     <section
       v-if="challenge"
       class="flex flex-col gap-6 rounded-2xl border border-solid border-muted bg-secondary-background p-6 shadow-sm"


### PR DESCRIPTION
## Problem

On the Comfy Cloud login flow, the OAuth / MCP consent modal (`/cloud/oauth/consent`) renders with broken colors: a light-gray card on the dark onboarding background, with a washed-out, barely-legible title, section headers, and permission labels. Reported via internal QA.

## Root cause

The cloud onboarding shell (`CloudTemplate`) paints a dark surface using hardcoded brand tokens (`primary-comfy-ink` / `primary-comfy-canvas`) but never applies `.dark-theme` to the DOM. That class — which flips the design-system **semantic** tokens to their dark values — is only set by `GraphView` / `BaseViewTemplate`, neither of which mounts on the cloud onboarding routes.

`OAuthConsentView` is the first onboarding view whose primary surface (the card) is built on semantic tokens, so without a dark-theme context they fall back to their light values:

| token | fell back to (light) | should be (dark) |
| --- | --- | --- |
| `secondary-background` (card) | `#e9e9e9` | `#262729` |
| inherited foreground (title / headers / labels) | `primary-comfy-canvas` `#c2bfb9` on `#e9e9e9` → illegible | `#c2bfb9` on `#262729` → legible |
| `muted` (subtitle / help / card border) | `#71717a` | `#a1a1aa` |
| `primary-background` (scope checks + CTA) | azure-400 `#31b9f4` | azure-600 `#0b8ce9` |

The card sets no foreground of its own, so its title/headers/labels inherit `primary-comfy-canvas` from the shell — fine on a dark card, illegible on the light fallback one. The component markup is already correct; it just never receives a dark-theme context. (The sibling login/signup pages avoid this because they use hardcoded `primary-comfy` / `brand-yellow` tokens, not semantic ones.)

## Fix

Scope `.dark-theme` to the consent view's own root `<main>` — the same class mechanism `BaseViewTemplate` uses for its `dark` prop. The card's semantic tokens now resolve dark and the text is legible, while the sibling login / signup / survey screens are untouched.

This is intentionally scoped to the reported view. Theming the whole cloud onboarding shell (so any future semantic-token component there is covered automatically) is a reasonable follow-up, but it shifts several other views and has a wider blast radius, so it's left out of this fix.

## Preview (real component)

CI auto-deploys a Storybook preview of this branch to Cloudflare Pages (see the **🎨 Storybook** comment below). The `Cloud/OAuth/Consent` story renders the populated card with no backend — and with this change it themes dark correctly:

**▶ [Cloud/OAuth/Consent — live story](https://fbae9a69.comfy-storybook.pages.dev/?path=/story/cloud-oauth-consent--single-workspace)**

And the fix on the **live app**, captured in a preview environment via a real OAuth flow:

![OAuth consent screen — dark-theme fix](https://raw.githubusercontent.com/Comfy-Org/ComfyUI_frontend/mattmillerai/oauth-consent-screenshot/oauth-consent-fixed.png)

## Verification

The `Cloud/OAuth/Consent` Storybook story renders the real component; switching the Storybook theme global from **light → dark** reproduces this exact before/after. This change makes the live route match the dark rendering. Existing `OAuthConsentView.test.ts` assertions are on text/roles and are unaffected by the added class.

## ELI-5

The "allow access?" popup was wearing light-colored clothes inside a dark room, so the words blended into the card and you couldn't read them. This tells the popup it's in a dark room, so it dresses for the dark and the text shows up again. Nothing else in the room changes.
