### PR TITLE
feat: add Image Grid Slice node UI (dynamic preview + batch output)

### DIFF
--- a/src/components/imageGridSlice/WidgetImageGridSlice.vue
+++ b/src/components/imageGridSlice/WidgetImageGridSlice.vue
@@ -1,0 +1,86 @@
+<template>
+  <div
+    class="widget-expands flex size-full flex-col gap-1"
+    @pointerdown.stop
+    @pointermove.stop
+    @pointerup.stop
+  >
+    <div
+      class="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-node-component-surface"
+    >
+      <div
+        v-if="inputImageUrl"
+        class="relative max-h-full w-full"
+        data-testid="grid-slice-preview"
+      >
+        <img
+          :src="inputImageUrl"
+          class="block size-full object-contain"
+          draggable="false"
+          @dragstart.prevent
+        />
+        <svg
+          class="pointer-events-none absolute inset-0 size-full"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <line
+            v-for="x in verticalLines"
+            :key="`v-${x}`"
+            :x1="x * 100"
+            :x2="x * 100"
+            y1="0"
+            y2="100"
+            class="stroke-blue-400"
+            stroke-width="0.5"
+            vector-effect="non-scaling-stroke"
+          />
+          <line
+            v-for="y in horizontalLines"
+            :key="`h-${y}`"
+            x1="0"
+            x2="100"
+            :y1="y * 100"
+            :y2="y * 100"
+            class="stroke-blue-400"
+            stroke-width="0.5"
+            vector-effect="non-scaling-stroke"
+          />
+        </svg>
+      </div>
+      <div
+        v-else
+        class="flex flex-col items-center gap-2 p-4 text-center text-xs text-muted-foreground"
+        data-testid="grid-slice-empty"
+      >
+        <i class="icon-[lucide--grid-3x3] size-6" />
+        {{ $t('imageGridSlice.connectImage') }}
+      </div>
+    </div>
+
+    <div
+      class="text-center text-xs text-muted-foreground"
+      data-testid="grid-slice-dimensions"
+    >
+      {{
+        $t('imageGridSlice.gridSummary', {
+          rows,
+          columns,
+          tiles: rows * columns
+        })
+      }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useImageGridSlice } from '@/composables/imageGridSlice/useImageGridSlice'
+
+const { nodeId } = defineProps<{
+  nodeId: string
+}>()
+
+const { rows, columns, horizontalLines, verticalLines, inputImageUrl } =
+  useImageGridSlice(nodeId)
+</script>

--- a/src/composables/imageGridSlice/useImageGridSlice.test.ts
+++ b/src/composables/imageGridSlice/useImageGridSlice.test.ts
@@ -1,0 +1,116 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render } from '@testing-library/vue'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+
+import { useImageGridSlice } from './useImageGridSlice'
+
+const mockWidgets: IBaseWidget[] = []
+const mockIsInputConnected = vi.fn(() => false)
+const mockGetInputNode = vi.fn(() => null as unknown)
+const mockGetNodeImageUrls = vi.fn(() => undefined as string[] | undefined)
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({
+    getNodeImageUrls: mockGetNodeImageUrls,
+    nodeOutputs: {},
+    nodePreviewImages: {}
+  })
+}))
+
+vi.mock('@/scripts/app', () => ({
+  app: {
+    canvas: {
+      graph: {
+        getNodeById: vi.fn(() => ({
+          get widgets() {
+            return mockWidgets
+          },
+          isInputConnected: mockIsInputConnected,
+          getInputNode: mockGetInputNode
+        }))
+      }
+    }
+  }
+}))
+
+function makeWidget(name: string, value: unknown): IBaseWidget {
+  return { name, value } as unknown as IBaseWidget
+}
+
+type Result = ReturnType<typeof useImageGridSlice>
+
+function mount(nodeId = 'node-1') {
+  let result!: Result
+  const Wrapper = defineComponent({
+    setup() {
+      result = useImageGridSlice(nodeId)
+      return {}
+    },
+    render: () => null
+  })
+  render(Wrapper)
+  return result
+}
+
+describe('useImageGridSlice', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.clearAllMocks()
+    mockWidgets.length = 0
+    mockIsInputConnected.mockReturnValue(false)
+    mockGetInputNode.mockReturnValue(null)
+    mockGetNodeImageUrls.mockReturnValue(undefined)
+  })
+
+  it('derives split line fractions from rows and columns widgets', () => {
+    mockWidgets.push(makeWidget('rows', 3), makeWidget('columns', 4))
+
+    const result = mount()
+
+    expect(result.rows.value).toBe(3)
+    expect(result.columns.value).toBe(4)
+    expect(result.horizontalLines.value).toEqual([1 / 3, 2 / 3])
+    expect(result.verticalLines.value).toEqual([1 / 4, 2 / 4, 3 / 4])
+  })
+
+  it('produces no split lines for a 1x1 grid', () => {
+    mockWidgets.push(makeWidget('rows', 1), makeWidget('columns', 1))
+
+    const result = mount()
+
+    expect(result.horizontalLines.value).toEqual([])
+    expect(result.verticalLines.value).toEqual([])
+  })
+
+  it('clamps grid counts to the supported range', () => {
+    mockWidgets.push(makeWidget('rows', 99), makeWidget('columns', 0))
+
+    const result = mount()
+
+    expect(result.rows.value).toBe(16)
+    expect(result.columns.value).toBe(1)
+  })
+
+  it('resolves the input image url from the upstream node output', () => {
+    mockIsInputConnected.mockReturnValue(true)
+    const upstream = {}
+    mockGetInputNode.mockReturnValue(upstream)
+    mockGetNodeImageUrls.mockReturnValue(['http://localhost/view?img=1'])
+
+    const result = mount()
+
+    expect(result.isImageInputConnected.value).toBe(true)
+    expect(result.inputImageUrl.value).toBe('http://localhost/view?img=1')
+  })
+
+  it('leaves the preview empty when no upstream node is connected', () => {
+    const result = mount()
+
+    expect(result.isImageInputConnected.value).toBe(false)
+    expect(result.inputImageUrl.value).toBeNull()
+  })
+})

--- a/src/composables/imageGridSlice/useImageGridSlice.ts
+++ b/src/composables/imageGridSlice/useImageGridSlice.ts
@@ -1,0 +1,84 @@
+import { computed, ref, watch } from 'vue'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { app } from '@/scripts/app'
+import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+
+const GRID_SLICE_MIN = 1
+const GRID_SLICE_MAX = 16
+const IMAGE_INPUT_SLOT = 0
+
+function clampGridCount(value: unknown): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) return GRID_SLICE_MIN
+  return Math.min(GRID_SLICE_MAX, Math.max(GRID_SLICE_MIN, Math.floor(numeric)))
+}
+
+function lineFractions(count: number): number[] {
+  const fractions: number[] = []
+  for (let i = 1; i < count; i++) {
+    fractions.push(i / count)
+  }
+  return fractions
+}
+
+export function useImageGridSlice(nodeId: string) {
+  const nodeOutputStore = useNodeOutputStore()
+
+  const inputImageUrl = ref<string | null>(null)
+  const isImageInputConnected = ref(false)
+
+  const litegraphNode = computed(() => {
+    if (!nodeId || !app.canvas.graph) return null
+    return app.canvas.graph.getNodeById(nodeId) as LGraphNode | null
+  })
+
+  function getWidgetByName(name: string): IBaseWidget | undefined {
+    return litegraphNode.value?.widgets?.find((w) => w.name === name)
+  }
+
+  const rows = computed(() => clampGridCount(getWidgetByName('rows')?.value))
+  const columns = computed(() =>
+    clampGridCount(getWidgetByName('columns')?.value)
+  )
+
+  const horizontalLines = computed(() => lineFractions(rows.value))
+  const verticalLines = computed(() => lineFractions(columns.value))
+
+  function updateInputImageUrl() {
+    const node = litegraphNode.value
+    if (!node) {
+      inputImageUrl.value = null
+      isImageInputConnected.value = false
+      return
+    }
+
+    isImageInputConnected.value = node.isInputConnected(IMAGE_INPUT_SLOT)
+
+    const inputNode = node.getInputNode(IMAGE_INPUT_SLOT)
+    if (!inputNode) {
+      inputImageUrl.value = null
+      return
+    }
+
+    const urls = nodeOutputStore.getNodeImageUrls(inputNode)
+    inputImageUrl.value = urls?.[0] ?? null
+  }
+
+  watch(() => nodeOutputStore.nodeOutputs, updateInputImageUrl, { deep: true })
+  watch(() => nodeOutputStore.nodePreviewImages, updateInputImageUrl, {
+    deep: true
+  })
+
+  updateInputImageUrl()
+
+  return {
+    rows,
+    columns,
+    horizontalLines,
+    verticalLines,
+    inputImageUrl,
+    isImageInputConnected
+  }
+}

--- a/src/extensions/core/imageGridSlice.test.ts
+++ b/src/extensions/core/imageGridSlice.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyExtension } from '@/types/comfy'
+
+const { capturedExtensions } = vi.hoisted(() => ({
+  capturedExtensions: [] as ComfyExtension[]
+}))
+
+vi.mock('@/services/extensionService', () => ({
+  useExtensionService: () => ({
+    registerExtension: (ext: ComfyExtension) => {
+      capturedExtensions.push(ext)
+    }
+  })
+}))
+
+interface MockWidget {
+  name: string
+  type?: string
+  value?: unknown
+  serialize?: boolean
+}
+
+function makeNode() {
+  const widgets: MockWidget[] = [
+    { name: 'rows', value: 2 },
+    { name: 'columns', value: 2 }
+  ]
+
+  return {
+    constructor: { comfyClass: 'ImageGridSlice' },
+    size: [200, 200] as [number, number],
+    widgets,
+    addCustomWidget(widget: MockWidget) {
+      widgets.push(widget)
+      return widget
+    },
+    setSize: vi.fn()
+  }
+}
+
+const extension = () =>
+  capturedExtensions.find((e) => e.name === 'Comfy.ImageGridSlice')!
+
+describe('Comfy.ImageGridSlice extension', () => {
+  beforeAll(async () => {
+    await import('./imageGridSlice')
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers under the expected name', () => {
+    expect(extension()).toBeDefined()
+  })
+
+  it('ignores nodes of other types', () => {
+    const node = makeNode()
+    node.constructor.comfyClass = 'SomethingElse'
+    extension().nodeCreated?.(node as never, undefined as never)
+    expect(node.widgets).toHaveLength(2)
+  })
+
+  it('injects a non-serialized preview widget at the top of the node', () => {
+    const node = makeNode()
+    extension().nodeCreated?.(node as never, undefined as never)
+
+    const preview = node.widgets[0]
+    expect(preview.name).toBe('grid_preview')
+    expect(preview.type).toBe('imagegridslice')
+    expect(preview.serialize).toBe(false)
+    expect(node.widgets.map((w) => w.name)).toEqual([
+      'grid_preview',
+      'rows',
+      'columns'
+    ])
+  })
+
+  it('does not add a second preview widget on repeat creation', () => {
+    const node = makeNode()
+    extension().nodeCreated?.(node as never, undefined as never)
+    extension().nodeCreated?.(node as never, undefined as never)
+
+    expect(node.widgets.filter((w) => w.name === 'grid_preview')).toHaveLength(
+      1
+    )
+  })
+})

--- a/src/extensions/core/imageGridSlice.ts
+++ b/src/extensions/core/imageGridSlice.ts
@@ -1,0 +1,43 @@
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import { useExtensionService } from '@/services/extensionService'
+
+const COMFY_CLASS = 'ImageGridSlice'
+const PREVIEW_WIDGET_NAME = 'grid_preview'
+const PREVIEW_WIDGET_HEIGHT = 200
+const MIN_NODE_WIDTH = 320
+const MIN_NODE_HEIGHT = 360
+
+function addPreviewWidget(node: LGraphNode) {
+  if (node.widgets?.some((w) => w.name === PREVIEW_WIDGET_NAME)) return
+
+  const widget = node.addCustomWidget({
+    name: PREVIEW_WIDGET_NAME,
+    type: 'imagegridslice',
+    value: '',
+    options: { serialize: false },
+    serialize: false,
+    computeSize: () => [0, PREVIEW_WIDGET_HEIGHT]
+  } as unknown as IBaseWidget)
+
+  if (node.widgets && node.widgets.at(-1) === widget) {
+    node.widgets.pop()
+    node.widgets.unshift(widget)
+  }
+}
+
+useExtensionService().registerExtension({
+  name: 'Comfy.ImageGridSlice',
+
+  nodeCreated(node) {
+    if (node.constructor.comfyClass !== COMFY_CLASS) return
+
+    const [width, height] = node.size
+    node.setSize([
+      Math.max(width, MIN_NODE_WIDTH),
+      Math.max(height, MIN_NODE_HEIGHT)
+    ])
+
+    addPreviewWidget(node)
+  }
+})

--- a/src/extensions/core/index.ts
+++ b/src/extensions/core/index.ts
@@ -11,6 +11,7 @@ import './groupNodeManage'
 import './groupOptions'
 import './imageCompare'
 import './imageCrop'
+import './imageGridSlice'
 // load3d and saveMesh are loaded on-demand to defer THREE.js (~1.8MB)
 // The lazy loader triggers loading when a 3D node is used
 import './load3dLazy'

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2054,6 +2054,10 @@
     "unlockRatio": "Unlock aspect ratio",
     "custom": "Custom"
   },
+  "imageGridSlice": {
+    "connectImage": "Connect an image to preview the grid",
+    "gridSummary": "{rows} × {columns} grid · {tiles} tiles"
+  },
   "painter": {
     "tool": "Tool",
     "brush": "Brush",

--- a/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
+++ b/src/renderer/extensions/vueNodes/widgets/registry/widgetRegistry.ts
@@ -66,6 +66,9 @@ const WidgetPainter = defineAsyncComponent(
 const WidgetRange = defineAsyncComponent(
   () => import('@/components/range/WidgetRange.vue')
 )
+const WidgetImageGridSlice = defineAsyncComponent(
+  () => import('@/components/imageGridSlice/WidgetImageGridSlice.vue')
+)
 
 export const FOR_TESTING = {
   WidgetButton,
@@ -208,6 +211,14 @@ const coreWidgetDefinitions: Array<[string, WidgetDefinition]> = [
       aliases: ['RANGE'],
       essential: false
     }
+  ],
+  [
+    'imagegridslice',
+    {
+      component: WidgetImageGridSlice,
+      aliases: ['IMAGE_GRID_SLICE'],
+      essential: false
+    }
   ]
 ]
 
@@ -246,7 +257,8 @@ const EXPANDING_TYPES = [
   'curve',
   'painter',
   'imagecompare',
-  'range'
+  'range',
+  'imagegridslice'
 ] as const
 
 export function shouldExpand(type: string): boolean {


### PR DESCRIPTION
## Summary

Adds the frontend for an `ImageGridSlice` node that slices an image into a rows × columns grid, with an in-node preview that overlays the slice lines on the connected input image.

## Changes

- **What**:
  - New Vue widget `WidgetImageGridSlice.vue` + `useImageGridSlice` composable that render the connected input image with an SVG overlay of the slice lines, driven by the node's `rows`/`columns` widgets.
  - Registered an `imagegridslice` (`IMAGE_GRID_SLICE`) widget type in the Vue-node widget registry (expanding type).
  - `Comfy.ImageGridSlice` extension injects the preview as a non-serialized, frontend-only widget on node creation (no phantom backend input), mirroring how the image-crop preview is generated on the node.
  - i18n strings for the empty state and grid summary.
- **Breaking**: none
- **Dependencies**: none

## Review Focus

- The preview widget is injected client-side via `addCustomWidget` with `serialize: false` so it is never persisted to the workflow or sent to the backend; prompt building keys off `INPUT_TYPES` by name, so the extra widget is ignored. Please sanity-check that approach vs. declaring a backend `component` input.
- Pairs with the backend node: Comfy-Org/ComfyUI#14288. The UI is inert without that node registered.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm knip` clean.
- Unit tests: `useImageGridSlice` (line fractions, clamping, input-image resolution) and the extension (preview-widget injection, idempotency).

## Screenshots (if applicable)

<!-- Video demo to be added. -->
