### PR TITLE
feat(assets): add "Download with previews" to bulk export

### DIFF
--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -318,7 +318,7 @@ export class AssetsSidebarTab extends SidebarTab {
   public readonly deselectAllButton: Locator
   public readonly deleteSelectedButton: Locator
   public readonly downloadSelectedButton: Locator
-  public readonly downloadWithPreviewsButton: Locator
+  public readonly includePreviewsCheckbox: Locator
 
   // --- Folder view ---
   public readonly backToAssetsButton: Locator
@@ -367,9 +367,7 @@ export class AssetsSidebarTab extends SidebarTab {
       .getByTestId('assets-download-selected')
       .or(page.locator('button:has(.icon-\\[lucide--download\\])').last())
       .first()
-    this.downloadWithPreviewsButton = page.getByTestId(
-      'assets-download-with-previews'
-    )
+    this.includePreviewsCheckbox = page.getByTestId('assets-include-previews')
     this.backToAssetsButton = page.getByText('Back to all assets')
     this.skeletonLoaders = page.locator(
       '.sidebar-content-container .animate-pulse'

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -318,7 +318,6 @@ export class AssetsSidebarTab extends SidebarTab {
   public readonly deselectAllButton: Locator
   public readonly deleteSelectedButton: Locator
   public readonly downloadSelectedButton: Locator
-  public readonly downloadNoPreviewsButton: Locator
   public readonly downloadWithPreviewsButton: Locator
 
   // --- Folder view ---
@@ -368,9 +367,6 @@ export class AssetsSidebarTab extends SidebarTab {
       .getByTestId('assets-download-selected')
       .or(page.locator('button:has(.icon-\\[lucide--download\\])').last())
       .first()
-    this.downloadNoPreviewsButton = page.getByTestId(
-      'assets-download-no-previews'
-    )
     this.downloadWithPreviewsButton = page.getByTestId(
       'assets-download-with-previews'
     )
@@ -378,18 +374,6 @@ export class AssetsSidebarTab extends SidebarTab {
     this.skeletonLoaders = page.locator(
       '.sidebar-content-container .animate-pulse'
     )
-  }
-
-  async downloadSelected() {
-    await this.downloadSelectedButton.click()
-    await this.downloadNoPreviewsButton.waitFor({ state: 'visible' })
-    await this.downloadNoPreviewsButton.click()
-  }
-
-  async downloadSelectedWithPreviews() {
-    await this.downloadSelectedButton.click()
-    await this.downloadWithPreviewsButton.waitFor({ state: 'visible' })
-    await this.downloadWithPreviewsButton.click()
   }
 
   emptyStateTitle(title: string) {

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -318,6 +318,8 @@ export class AssetsSidebarTab extends SidebarTab {
   public readonly deselectAllButton: Locator
   public readonly deleteSelectedButton: Locator
   public readonly downloadSelectedButton: Locator
+  public readonly downloadNoPreviewsButton: Locator
+  public readonly downloadWithPreviewsButton: Locator
 
   // --- Folder view ---
   public readonly backToAssetsButton: Locator
@@ -366,10 +368,26 @@ export class AssetsSidebarTab extends SidebarTab {
       .getByTestId('assets-download-selected')
       .or(page.locator('button:has(.icon-\\[lucide--download\\])').last())
       .first()
+    this.downloadNoPreviewsButton = page.getByTestId(
+      'assets-download-no-previews'
+    )
+    this.downloadWithPreviewsButton = page.getByTestId(
+      'assets-download-with-previews'
+    )
     this.backToAssetsButton = page.getByText('Back to all assets')
     this.skeletonLoaders = page.locator(
       '.sidebar-content-container .animate-pulse'
     )
+  }
+
+  async downloadSelected() {
+    await this.downloadSelectedButton.click()
+    await this.downloadNoPreviewsButton.click()
+  }
+
+  async downloadSelectedWithPreviews() {
+    await this.downloadSelectedButton.click()
+    await this.downloadWithPreviewsButton.click()
   }
 
   emptyStateTitle(title: string) {

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -382,11 +382,13 @@ export class AssetsSidebarTab extends SidebarTab {
 
   async downloadSelected() {
     await this.downloadSelectedButton.click()
+    await this.downloadNoPreviewsButton.waitFor({ state: 'visible' })
     await this.downloadNoPreviewsButton.click()
   }
 
   async downloadSelectedWithPreviews() {
     await this.downloadSelectedButton.click()
+    await this.downloadWithPreviewsButton.waitFor({ state: 'visible' })
     await this.downloadWithPreviewsButton.click()
   }
 

--- a/browser_tests/fixtures/components/SidebarTab.ts
+++ b/browser_tests/fixtures/components/SidebarTab.ts
@@ -318,7 +318,7 @@ export class AssetsSidebarTab extends SidebarTab {
   public readonly deselectAllButton: Locator
   public readonly deleteSelectedButton: Locator
   public readonly downloadSelectedButton: Locator
-  public readonly includePreviewsCheckbox: Locator
+  public readonly includePreviewsToggle: Locator
 
   // --- Folder view ---
   public readonly backToAssetsButton: Locator
@@ -367,7 +367,7 @@ export class AssetsSidebarTab extends SidebarTab {
       .getByTestId('assets-download-selected')
       .or(page.locator('button:has(.icon-\\[lucide--download\\])').last())
       .first()
-    this.includePreviewsCheckbox = page.getByTestId('assets-include-previews')
+    this.includePreviewsToggle = page.getByTestId('assets-include-previews')
     this.backToAssetsButton = page.getByText('Back to all assets')
     this.skeletonLoaders = page.locator(
       '.sidebar-content-container .animate-pulse'

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -743,7 +743,7 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await tab.assetCards.first().click()
       await expect(tab.downloadSelectedButton).toBeVisible()
 
-      await tab.downloadSelectedButton.click()
+      await tab.downloadSelected()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 
@@ -751,6 +751,31 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       expect(payload.job_ids).toEqual(['job-gamma'])
       expect(payload.job_asset_name_filters).toBeUndefined()
       expect(payload.naming_strategy).toBe('preserve')
+      expect('include_previews' in payload).toBe(false)
+    }
+  )
+
+  cloudTest(
+    'Download with previews sets include_previews on the export request',
+    async ({ comfyPage, mockCloudAssetSidebarData }) => {
+      void mockCloudAssetSidebarData
+      const exportRequests = await comfyPage.assets.captureAssetExportRequests()
+
+      const tab = comfyPage.menu.assetsTab
+      await tab.open()
+
+      await tab.assetCards.first().click()
+      await expect(tab.downloadSelectedButton).toBeVisible()
+
+      await tab.downloadSelectedWithPreviews()
+
+      await expect.poll(() => exportRequests).toHaveLength(1)
+
+      const payload = exportRequests[0]
+      expect(payload.job_ids).toEqual(['job-gamma'])
+      expect(
+        'include_previews' in payload ? payload.include_previews : false
+      ).toBe(true)
     }
   )
 
@@ -777,7 +802,7 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await comfyPage.page.keyboard.up('Control')
 
       await expect(tab.selectedCards).toHaveCount(2)
-      await tab.downloadSelectedButton.click()
+      await tab.downloadSelected()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 
@@ -805,7 +830,7 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await comfyPage.page.keyboard.up('Control')
 
       await expect(tab.selectedCards).toHaveCount(2)
-      await tab.downloadSelectedButton.click()
+      await tab.downloadSelected()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -765,9 +765,10 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await tab.open()
 
       await tab.assetCards.first().click()
-      await expect(tab.downloadWithPreviewsButton).toBeVisible()
+      await expect(tab.includePreviewsCheckbox).toBeVisible()
 
-      await tab.downloadWithPreviewsButton.click()
+      await tab.includePreviewsCheckbox.click()
+      await tab.downloadSelectedButton.click()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -765,9 +765,9 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await tab.open()
 
       await tab.assetCards.first().click()
-      await expect(tab.includePreviewsCheckbox).toBeVisible()
+      await expect(tab.includePreviewsToggle).toBeVisible()
 
-      await tab.includePreviewsCheckbox.click()
+      await tab.includePreviewsToggle.click()
       await tab.downloadSelectedButton.click()
 
       await expect.poll(() => exportRequests).toHaveLength(1)

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -743,7 +743,7 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await tab.assetCards.first().click()
       await expect(tab.downloadSelectedButton).toBeVisible()
 
-      await tab.downloadSelected()
+      await tab.downloadSelectedButton.click()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 
@@ -765,9 +765,9 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await tab.open()
 
       await tab.assetCards.first().click()
-      await expect(tab.downloadSelectedButton).toBeVisible()
+      await expect(tab.downloadWithPreviewsButton).toBeVisible()
 
-      await tab.downloadSelectedWithPreviews()
+      await tab.downloadWithPreviewsButton.click()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 
@@ -802,7 +802,7 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await comfyPage.page.keyboard.up('Control')
 
       await expect(tab.selectedCards).toHaveCount(2)
-      await tab.downloadSelected()
+      await tab.downloadSelectedButton.click()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 
@@ -830,7 +830,7 @@ cloudTest.describe('Assets sidebar - cloud exports', { tag: '@cloud' }, () => {
       await comfyPage.page.keyboard.up('Control')
 
       await expect(tab.selectedCards).toHaveCount(2)
-      await tab.downloadSelected()
+      await tab.downloadSelectedButton.click()
 
       await expect.poll(() => exportRequests).toHaveLength(1)
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -101,7 +101,7 @@ const i18n = createI18n({
       assetBrowser: { jobId: 'Job ID' },
       mediaAsset: {
         selection: {
-          includePreviews: 'Include previews',
+          includePreviews: 'Download previews',
           downloadSelected: 'Download',
           deleteSelected: 'Delete',
           deselectAll: 'Deselect all',
@@ -128,7 +128,13 @@ function renderTab() {
         MediaAssetContextMenu: true,
         MediaLightbox: true,
         NoResultsPlaceholder: true,
-        Skeleton: true
+        Skeleton: true,
+        ToggleSwitch: {
+          props: { modelValue: { type: Boolean, default: false } },
+          emits: ['update:modelValue'],
+          template:
+            '<button type="button" role="switch" :aria-checked="modelValue" @click="$emit(\'update:modelValue\', !modelValue)" />'
+        }
       }
     }
   })
@@ -170,10 +176,10 @@ describe('AssetsSidebarTab include-previews toggle', () => {
     renderTab()
 
     const toggle = includePreviewsToggle()!
-    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
 
     await user.click(toggle)
-    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
 
     await user.click(screen.getByTestId('assets-download-selected'))
 

--- a/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.test.ts
@@ -1,0 +1,196 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import AssetsSidebarTab from './AssetsSidebarTab.vue'
+
+const mockDownloadAssets = vi.hoisted(() => vi.fn())
+
+const outputAsset: AssetItem = {
+  id: 'out-1',
+  name: 'render.png',
+  size: 1024,
+  created_at: '2025-01-01T00:00:00Z',
+  tags: ['output']
+}
+
+function createAssetsApi() {
+  return {
+    media: ref<AssetItem[]>([outputAsset]),
+    loading: ref(false),
+    error: ref(null),
+    fetchMediaList: vi.fn(),
+    refresh: vi.fn(),
+    loadMore: vi.fn(),
+    hasMore: ref(false),
+    isLoadingMore: ref(false)
+  }
+}
+
+vi.mock('@/platform/assets/composables/media/useAssetsApi', () => ({
+  useAssetsApi: () => createAssetsApi()
+}))
+
+vi.mock('@/platform/assets/composables/useMediaAssetFiltering', () => ({
+  useMediaAssetFiltering: (assets: { value: AssetItem[] }) => ({
+    searchQuery: ref(''),
+    sortBy: ref('newest'),
+    mediaTypeFilters: ref([]),
+    filteredAssets: computed(() => assets.value)
+  })
+}))
+
+vi.mock('@/platform/assets/composables/useOutputStacks', () => ({
+  useOutputStacks: () => ({
+    assetItems: ref([]),
+    selectableAssets: ref([]),
+    isStackExpanded: () => false,
+    toggleStack: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/assets/composables/useAssetSelection', () => ({
+  useAssetSelection: () => ({
+    isSelected: () => false,
+    handleAssetClick: vi.fn(),
+    hasSelection: ref(true),
+    clearSelection: vi.fn(),
+    getSelectedAssets: (assets: AssetItem[]) => assets,
+    reconcileSelection: vi.fn(),
+    getOutputCount: () => 1,
+    getTotalOutputCount: () => 1,
+    activate: vi.fn(),
+    deactivate: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/assets/composables/useMediaAssetActions', () => ({
+  useMediaAssetActions: () => ({
+    downloadAssets: mockDownloadAssets,
+    deleteAssets: vi.fn().mockResolvedValue(false),
+    addMultipleToWorkflow: vi.fn(),
+    openMultipleWorkflows: vi.fn(),
+    exportMultipleWorkflows: vi.fn()
+  })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({ add: vi.fn() })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    en: {
+      sideToolbar: {
+        mediaAssets: { title: 'Media Assets' },
+        backToAssets: 'Back to all assets',
+        labels: { generated: 'Generated', imported: 'Imported' },
+        noImportedFiles: 'No imported files',
+        noGeneratedFiles: 'No generated files',
+        noFilesFoundMessage: 'No files found'
+      },
+      assetBrowser: { jobId: 'Job ID' },
+      mediaAsset: {
+        selection: {
+          includePreviews: 'Include previews',
+          downloadSelected: 'Download',
+          deleteSelected: 'Delete',
+          deselectAll: 'Deselect all',
+          selectedCount: '{count} selected'
+        }
+      }
+    }
+  }
+})
+
+function renderTab() {
+  return render(AssetsSidebarTab, {
+    global: {
+      plugins: [createTestingPinia({ stubActions: false }), i18n],
+      directives: { tooltip: () => {} },
+      stubs: {
+        SidebarTabTemplate: {
+          template:
+            '<div><slot name="alt-title" /><slot name="header" /><slot name="body" /><slot name="footer" /></div>'
+        },
+        MediaAssetFilterBar: true,
+        AssetsSidebarGridView: true,
+        AssetsSidebarListView: true,
+        MediaAssetContextMenu: true,
+        MediaLightbox: true,
+        NoResultsPlaceholder: true,
+        Skeleton: true
+      }
+    }
+  })
+}
+
+const includePreviewsToggle = () =>
+  screen.queryByTestId('assets-include-previews')
+
+describe('AssetsSidebarTab include-previews toggle', () => {
+  beforeEach(() => {
+    mockDownloadAssets.mockClear()
+  })
+
+  it('shows the toggle on the generated (output) tab and hides it on imported', async () => {
+    const user = userEvent.setup()
+    renderTab()
+
+    expect(includePreviewsToggle()).toBeInTheDocument()
+
+    await user.click(screen.getByRole('tab', { name: 'Imported' }))
+
+    expect(includePreviewsToggle()).not.toBeInTheDocument()
+  })
+
+  it('downloads without previews by default', async () => {
+    const user = userEvent.setup()
+    renderTab()
+
+    await user.click(screen.getByTestId('assets-download-selected'))
+
+    expect(mockDownloadAssets).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 'out-1' })],
+      false
+    )
+  })
+
+  it('forwards include-previews when the toggle is enabled before download', async () => {
+    const user = userEvent.setup()
+    renderTab()
+
+    const toggle = includePreviewsToggle()!
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(screen.getByTestId('assets-download-selected'))
+
+    expect(mockDownloadAssets).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 'out-1' })],
+      true
+    )
+  })
+
+  it('does not forward a stale toggle after switching away from the output tab', async () => {
+    const user = userEvent.setup()
+    renderTab()
+
+    await user.click(includePreviewsToggle()!)
+    await user.click(screen.getByRole('tab', { name: 'Imported' }))
+    await user.click(screen.getByTestId('assets-download-selected'))
+
+    expect(mockDownloadAssets).toHaveBeenCalledWith(expect.anything(), false)
+  })
+})

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -150,38 +150,18 @@
             }}</span>
             <i class="icon-[lucide--trash-2] size-4" />
           </Button>
-          <div
+          <Button
             v-if="canIncludePreviews"
-            v-tooltip.top="
-              isCompact ? $t('mediaAsset.selection.includePreviews') : ''
-            "
-            role="checkbox"
-            :aria-checked="includePreviews"
+            v-tooltip.top="$t('mediaAsset.selection.includePreviews')"
+            :variant="includePreviews ? 'primary' : 'secondary'"
+            size="icon"
+            :aria-pressed="includePreviews"
             :aria-label="$t('mediaAsset.selection.includePreviews')"
-            tabindex="0"
             data-testid="assets-include-previews"
-            class="flex shrink-0 cursor-pointer items-center gap-2 rounded-lg px-2 py-1 hover:bg-secondary-background-hover"
             @click="includePreviews = !includePreviews"
-            @keydown.enter.prevent="includePreviews = !includePreviews"
-            @keydown.space.prevent="includePreviews = !includePreviews"
           >
-            <div
-              class="flex size-4 shrink-0 items-center justify-center rounded-sm transition-all duration-200"
-              :class="
-                includePreviews
-                  ? 'bg-primary-background'
-                  : 'bg-secondary-background'
-              "
-            >
-              <i
-                v-if="includePreviews"
-                class="icon-[lucide--check] size-3 text-white"
-              />
-            </div>
-            <span v-if="!isCompact" class="text-sm whitespace-nowrap">{{
-              $t('mediaAsset.selection.includePreviews')
-            }}</span>
-          </div>
+            <i class="icon-[lucide--images] size-4" />
+          </Button>
           <Button
             :variant="isCompact ? undefined : 'secondary'"
             :size="isCompact ? 'icon' : undefined"

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -150,61 +150,25 @@
             }}</span>
             <i class="icon-[lucide--trash-2] size-4" />
           </Button>
-          <Popover v-if="canIncludePreviews">
-            <template #button>
-              <Button
-                :variant="isCompact ? undefined : 'secondary'"
-                :size="isCompact ? 'icon' : undefined"
-                data-testid="assets-download-selected"
-              >
-                <span v-if="!isCompact">{{
-                  $t('mediaAsset.selection.downloadSelected')
-                }}</span>
-                <i class="icon-[lucide--download] size-4" />
-                <i class="icon-[lucide--chevron-down] size-3" />
-              </Button>
-            </template>
-            <template #default="{ close }">
-              <div role="menu" class="flex flex-col p-1">
-                <button
-                  type="button"
-                  role="menuitem"
-                  data-testid="assets-download-no-previews"
-                  class="my-1 flex w-full cursor-pointer flex-row items-center gap-2 rounded-sm p-2 text-left hover:bg-secondary-background-hover"
-                  @click="
-                    () => {
-                      handleDownloadSelected(false)
-                      close()
-                    }
-                  "
-                >
-                  <i class="icon-[lucide--download] size-4" />
-                  <span class="text-sm">{{
-                    $t('mediaAsset.selection.downloadSelected')
-                  }}</span>
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  data-testid="assets-download-with-previews"
-                  class="my-1 flex w-full cursor-pointer flex-row items-center gap-2 rounded-sm p-2 text-left hover:bg-secondary-background-hover"
-                  @click="
-                    () => {
-                      handleDownloadSelected(true)
-                      close()
-                    }
-                  "
-                >
-                  <i class="icon-[lucide--images] size-4" />
-                  <span class="text-sm">{{
-                    $t('mediaAsset.selection.downloadWithPreviews')
-                  }}</span>
-                </button>
-              </div>
-            </template>
-          </Popover>
           <Button
-            v-else
+            v-if="canIncludePreviews"
+            v-tooltip.top="
+              isCompact ? $t('mediaAsset.selection.downloadWithPreviews') : ''
+            "
+            :variant="isCompact ? undefined : 'secondary'"
+            :size="isCompact ? 'icon' : undefined"
+            :aria-label="
+              isCompact ? $t('mediaAsset.selection.downloadWithPreviews') : null
+            "
+            data-testid="assets-download-with-previews"
+            @click="handleDownloadSelected(true)"
+          >
+            <span v-if="!isCompact">{{
+              $t('mediaAsset.selection.downloadWithPreviews')
+            }}</span>
+            <i class="icon-[lucide--images] size-4" />
+          </Button>
+          <Button
             :variant="isCompact ? undefined : 'secondary'"
             :size="isCompact ? 'icon' : undefined"
             data-testid="assets-download-selected"
@@ -273,7 +237,6 @@ import MediaLightbox from '@/components/sidebar/tabs/queue/MediaLightbox.vue'
 import Tab from '@/components/tab/Tab.vue'
 import TabList from '@/components/tab/TabList.vue'
 import Button from '@/components/ui/button/Button.vue'
-import Popover from '@/components/ui/Popover.vue'
 import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContextMenu.vue'
 import MediaAssetFilterBar from '@/platform/assets/components/MediaAssetFilterBar.vue'
 import { getAssetType } from '@/platform/assets/composables/media/assetMappers'

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -150,29 +150,45 @@
             }}</span>
             <i class="icon-[lucide--trash-2] size-4" />
           </Button>
-          <Button
+          <div
             v-if="canIncludePreviews"
             v-tooltip.top="
-              isCompact ? $t('mediaAsset.selection.downloadWithPreviews') : ''
+              isCompact ? $t('mediaAsset.selection.includePreviews') : ''
             "
-            :variant="isCompact ? undefined : 'secondary'"
-            :size="isCompact ? 'icon' : undefined"
-            :aria-label="
-              isCompact ? $t('mediaAsset.selection.downloadWithPreviews') : null
-            "
-            data-testid="assets-download-with-previews"
-            @click="handleDownloadSelected(true)"
+            role="checkbox"
+            :aria-checked="includePreviews"
+            :aria-label="$t('mediaAsset.selection.includePreviews')"
+            tabindex="0"
+            data-testid="assets-include-previews"
+            class="flex shrink-0 cursor-pointer items-center gap-2 rounded-lg px-2 py-1 hover:bg-secondary-background-hover"
+            @click="includePreviews = !includePreviews"
+            @keydown.enter.prevent="includePreviews = !includePreviews"
+            @keydown.space.prevent="includePreviews = !includePreviews"
           >
-            <span v-if="!isCompact">{{
-              $t('mediaAsset.selection.downloadWithPreviews')
+            <div
+              class="flex size-4 shrink-0 items-center justify-center rounded-sm transition-all duration-200"
+              :class="
+                includePreviews
+                  ? 'bg-primary-background'
+                  : 'bg-secondary-background'
+              "
+            >
+              <i
+                v-if="includePreviews"
+                class="icon-[lucide--check] size-3 text-white"
+              />
+            </div>
+            <span v-if="!isCompact" class="text-sm whitespace-nowrap">{{
+              $t('mediaAsset.selection.includePreviews')
             }}</span>
-            <i class="icon-[lucide--images] size-4" />
-          </Button>
+          </div>
           <Button
             :variant="isCompact ? undefined : 'secondary'"
             :size="isCompact ? 'icon' : undefined"
             data-testid="assets-download-selected"
-            @click="handleDownloadSelected(false)"
+            @click="
+              handleDownloadSelected(canIncludePreviews && includePreviews)
+            "
           >
             <span v-if="!isCompact">{{
               $t('mediaAsset.selection.downloadSelected')
@@ -568,6 +584,7 @@ const handleDownloadSelected = (includePreviews = false) => {
 }
 
 const canIncludePreviews = computed(() => activeTab.value === 'output')
+const includePreviews = ref(false)
 
 const handleDeleteSelected = async () => {
   if (await deleteAssets(selectedAssets.value)) {

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -118,63 +118,68 @@
       <div
         v-if="hasSelection"
         ref="footerRef"
-        class="flex h-18 w-full items-center justify-between gap-1"
+        class="flex w-full flex-col justify-center gap-2 py-2"
       >
-        <div class="flex-1 pl-4">
-          <div ref="selectionCountButtonRef" class="inline-flex w-48">
+        <div class="flex w-full items-center justify-between gap-1">
+          <div class="flex-1 pl-4">
+            <div ref="selectionCountButtonRef" class="inline-flex w-48">
+              <Button
+                variant="secondary"
+                :class="cn(isCompact && 'text-left')"
+                @click="handleDeselectAll"
+              >
+                {{
+                  isHoveringSelectionCount
+                    ? $t('mediaAsset.selection.deselectAll')
+                    : $t('mediaAsset.selection.selectedCount', {
+                        count: totalOutputCount
+                      })
+                }}
+              </Button>
+            </div>
+          </div>
+          <div
+            class="flex shrink items-center-safe justify-end-safe gap-2 pr-4"
+          >
             <Button
-              variant="secondary"
-              :class="cn(isCompact && 'text-left')"
-              @click="handleDeselectAll"
+              v-if="shouldShowDeleteButton"
+              :variant="isCompact ? undefined : 'secondary'"
+              :size="isCompact ? 'icon' : undefined"
+              data-testid="assets-delete-selected"
+              @click="handleDeleteSelected"
             >
-              {{
-                isHoveringSelectionCount
-                  ? $t('mediaAsset.selection.deselectAll')
-                  : $t('mediaAsset.selection.selectedCount', {
-                      count: totalOutputCount
-                    })
-              }}
+              <span v-if="!isCompact">{{
+                $t('mediaAsset.selection.deleteSelected')
+              }}</span>
+              <i class="icon-[lucide--trash-2] size-4" />
+            </Button>
+            <Button
+              :variant="isCompact ? undefined : 'secondary'"
+              :size="isCompact ? 'icon' : undefined"
+              data-testid="assets-download-selected"
+              @click="
+                handleDownloadSelected(canIncludePreviews && includePreviews)
+              "
+            >
+              <span v-if="!isCompact">{{
+                $t('mediaAsset.selection.downloadSelected')
+              }}</span>
+              <i class="icon-[lucide--download] size-4" />
             </Button>
           </div>
         </div>
-        <div class="flex shrink items-center-safe justify-end-safe gap-2 pr-4">
-          <Button
-            v-if="shouldShowDeleteButton"
-            :variant="isCompact ? undefined : 'secondary'"
-            :size="isCompact ? 'icon' : undefined"
-            data-testid="assets-delete-selected"
-            @click="handleDeleteSelected"
-          >
-            <span v-if="!isCompact">{{
-              $t('mediaAsset.selection.deleteSelected')
-            }}</span>
-            <i class="icon-[lucide--trash-2] size-4" />
-          </Button>
-          <Button
-            v-if="canIncludePreviews"
-            v-tooltip.top="$t('mediaAsset.selection.includePreviews')"
-            :variant="includePreviews ? 'primary' : 'secondary'"
-            size="icon"
-            :aria-pressed="includePreviews"
-            :aria-label="$t('mediaAsset.selection.includePreviews')"
+        <div
+          v-if="canIncludePreviews"
+          class="flex items-center justify-end gap-2 pr-4"
+        >
+          <label for="assets-include-previews" class="text-sm">{{
+            $t('mediaAsset.selection.includePreviews')
+          }}</label>
+          <ToggleSwitch
+            v-model="includePreviews"
+            input-id="assets-include-previews"
             data-testid="assets-include-previews"
-            @click="includePreviews = !includePreviews"
-          >
-            <i class="icon-[lucide--images] size-4" />
-          </Button>
-          <Button
-            :variant="isCompact ? undefined : 'secondary'"
-            :size="isCompact ? 'icon' : undefined"
-            data-testid="assets-download-selected"
-            @click="
-              handleDownloadSelected(canIncludePreviews && includePreviews)
-            "
-          >
-            <span v-if="!isCompact">{{
-              $t('mediaAsset.selection.downloadSelected')
-            }}</span>
-            <i class="icon-[lucide--download] size-4" />
-          </Button>
+          />
         </div>
       </div>
     </template>
@@ -212,6 +217,7 @@ import {
   useStorage,
   useTimeoutFn
 } from '@vueuse/core'
+import ToggleSwitch from 'primevue/toggleswitch'
 import { useToast } from 'primevue/usetoast'
 import {
   computed,

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -165,10 +165,12 @@
               </Button>
             </template>
             <template #default="{ close }">
-              <div class="flex flex-col p-1">
-                <div
+              <div role="menu" class="flex flex-col p-1">
+                <button
+                  type="button"
+                  role="menuitem"
                   data-testid="assets-download-no-previews"
-                  class="my-1 flex cursor-pointer flex-row items-center gap-2 rounded-sm p-2 hover:bg-secondary-background-hover"
+                  class="my-1 flex w-full cursor-pointer flex-row items-center gap-2 rounded-sm p-2 text-left hover:bg-secondary-background-hover"
                   @click="
                     () => {
                       handleDownloadSelected(false)
@@ -180,10 +182,12 @@
                   <span class="text-sm">{{
                     $t('mediaAsset.selection.downloadSelected')
                   }}</span>
-                </div>
-                <div
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
                   data-testid="assets-download-with-previews"
-                  class="my-1 flex cursor-pointer flex-row items-center gap-2 rounded-sm p-2 hover:bg-secondary-background-hover"
+                  class="my-1 flex w-full cursor-pointer flex-row items-center gap-2 rounded-sm p-2 text-left hover:bg-secondary-background-hover"
                   @click="
                     () => {
                       handleDownloadSelected(true)
@@ -195,7 +199,7 @@
                   <span class="text-sm">{{
                     $t('mediaAsset.selection.downloadWithPreviews')
                   }}</span>
-                </div>
+                </button>
               </div>
             </template>
           </Popover>

--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -138,44 +138,79 @@
           </div>
         </div>
         <div class="flex shrink items-center-safe justify-end-safe gap-2 pr-4">
-          <template v-if="isCompact">
-            <!-- Compact mode: Icon only -->
-            <Button
-              v-if="shouldShowDeleteButton"
-              size="icon"
-              data-testid="assets-delete-selected"
-              @click="handleDeleteSelected"
-            >
-              <i class="icon-[lucide--trash-2] size-4" />
-            </Button>
-            <Button
-              size="icon"
-              data-testid="assets-download-selected"
-              @click="handleDownloadSelected"
-            >
-              <i class="icon-[lucide--download] size-4" />
-            </Button>
-          </template>
-          <template v-else>
-            <!-- Normal mode: Icon + Text -->
-            <Button
-              v-if="shouldShowDeleteButton"
-              variant="secondary"
-              data-testid="assets-delete-selected"
-              @click="handleDeleteSelected"
-            >
-              <span>{{ $t('mediaAsset.selection.deleteSelected') }}</span>
-              <i class="icon-[lucide--trash-2] size-4" />
-            </Button>
-            <Button
-              variant="secondary"
-              data-testid="assets-download-selected"
-              @click="handleDownloadSelected"
-            >
-              <span>{{ $t('mediaAsset.selection.downloadSelected') }}</span>
-              <i class="icon-[lucide--download] size-4" />
-            </Button>
-          </template>
+          <Button
+            v-if="shouldShowDeleteButton"
+            :variant="isCompact ? undefined : 'secondary'"
+            :size="isCompact ? 'icon' : undefined"
+            data-testid="assets-delete-selected"
+            @click="handleDeleteSelected"
+          >
+            <span v-if="!isCompact">{{
+              $t('mediaAsset.selection.deleteSelected')
+            }}</span>
+            <i class="icon-[lucide--trash-2] size-4" />
+          </Button>
+          <Popover v-if="canIncludePreviews">
+            <template #button>
+              <Button
+                :variant="isCompact ? undefined : 'secondary'"
+                :size="isCompact ? 'icon' : undefined"
+                data-testid="assets-download-selected"
+              >
+                <span v-if="!isCompact">{{
+                  $t('mediaAsset.selection.downloadSelected')
+                }}</span>
+                <i class="icon-[lucide--download] size-4" />
+                <i class="icon-[lucide--chevron-down] size-3" />
+              </Button>
+            </template>
+            <template #default="{ close }">
+              <div class="flex flex-col p-1">
+                <div
+                  data-testid="assets-download-no-previews"
+                  class="my-1 flex cursor-pointer flex-row items-center gap-2 rounded-sm p-2 hover:bg-secondary-background-hover"
+                  @click="
+                    () => {
+                      handleDownloadSelected(false)
+                      close()
+                    }
+                  "
+                >
+                  <i class="icon-[lucide--download] size-4" />
+                  <span class="text-sm">{{
+                    $t('mediaAsset.selection.downloadSelected')
+                  }}</span>
+                </div>
+                <div
+                  data-testid="assets-download-with-previews"
+                  class="my-1 flex cursor-pointer flex-row items-center gap-2 rounded-sm p-2 hover:bg-secondary-background-hover"
+                  @click="
+                    () => {
+                      handleDownloadSelected(true)
+                      close()
+                    }
+                  "
+                >
+                  <i class="icon-[lucide--images] size-4" />
+                  <span class="text-sm">{{
+                    $t('mediaAsset.selection.downloadWithPreviews')
+                  }}</span>
+                </div>
+              </div>
+            </template>
+          </Popover>
+          <Button
+            v-else
+            :variant="isCompact ? undefined : 'secondary'"
+            :size="isCompact ? 'icon' : undefined"
+            data-testid="assets-download-selected"
+            @click="handleDownloadSelected(false)"
+          >
+            <span v-if="!isCompact">{{
+              $t('mediaAsset.selection.downloadSelected')
+            }}</span>
+            <i class="icon-[lucide--download] size-4" />
+          </Button>
         </div>
       </div>
     </template>
@@ -234,6 +269,7 @@ import MediaLightbox from '@/components/sidebar/tabs/queue/MediaLightbox.vue'
 import Tab from '@/components/tab/Tab.vue'
 import TabList from '@/components/tab/TabList.vue'
 import Button from '@/components/ui/button/Button.vue'
+import Popover from '@/components/ui/Popover.vue'
 import MediaAssetContextMenu from '@/platform/assets/components/MediaAssetContextMenu.vue'
 import MediaAssetFilterBar from '@/platform/assets/components/MediaAssetFilterBar.vue'
 import { getAssetType } from '@/platform/assets/composables/media/assetMappers'
@@ -559,10 +595,12 @@ const handleBulkExportWorkflow = async (assets: AssetItem[]) => {
   clearSelection()
 }
 
-const handleDownloadSelected = () => {
-  downloadAssets(selectedAssets.value)
+const handleDownloadSelected = (includePreviews = false) => {
+  downloadAssets(selectedAssets.value, includePreviews)
   clearSelection()
 }
+
+const canIncludePreviews = computed(() => activeTab.value === 'output')
 
 const handleDeleteSelected = async () => {
   if (await deleteAssets(selectedAssets.value)) {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3220,7 +3220,7 @@
       "multipleSelectedAssets": "Multiple assets selected",
       "deselectAll": "Deselect all",
       "downloadSelected": "Download",
-      "downloadWithPreviews": "Download with previews",
+      "includePreviews": "Include previews",
       "downloadSelectedAll": "Download all",
       "deleteSelected": "Delete",
       "deleteSelectedAll": "Delete all",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3220,6 +3220,7 @@
       "multipleSelectedAssets": "Multiple assets selected",
       "deselectAll": "Deselect all",
       "downloadSelected": "Download",
+      "downloadWithPreviews": "Download with previews",
       "downloadSelectedAll": "Download all",
       "deleteSelected": "Delete",
       "deleteSelectedAll": "Delete all",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3220,7 +3220,7 @@
       "multipleSelectedAssets": "Multiple assets selected",
       "deselectAll": "Deselect all",
       "downloadSelected": "Download",
-      "includePreviews": "Include previews",
+      "includePreviews": "Download previews",
       "downloadSelectedAll": "Download all",
       "deleteSelected": "Delete",
       "deleteSelectedAll": "Delete all",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3230,6 +3230,7 @@
       "downloadStarted": "Downloading {count} file... | Downloading {count} files...",
       "downloadsStarted": "Started downloading {count} file | Started downloading {count} files",
       "exportStarted": "Preparing ZIP export for {count} file | Preparing ZIP export for {count} files",
+      "exportStartedJobs": "Downloading assets from {count} job | Downloading assets from {count} jobs",
       "assetsDeletedSuccessfully": "{count} asset deleted successfully | {count} assets deleted successfully",
       "failedToDeleteAssets": "Failed to delete selected assets",
       "partialDeleteSuccess": "{succeeded} deleted successfully, {failed} failed",

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -547,6 +547,35 @@ describe('useMediaAssetActions', () => {
       expect(mockTrackExport).not.toHaveBeenCalled()
     })
 
+    it('forces the ZIP export path for a single asset when previews are requested', async () => {
+      mockIsCloud.value = true
+      mockGetAssetType.mockReturnValue('output')
+      mockGetOutputAssetMetadata.mockReturnValue({
+        jobId: 'job1',
+        outputCount: 1
+      })
+
+      const asset = createMockAsset({
+        id: 'single-output',
+        name: 'single-output.png',
+        preview_url: 'https://example.com/single-output.png',
+        tags: ['output'],
+        user_metadata: { jobId: 'job1', outputCount: 1 }
+      })
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets([asset], true)
+
+      await vi.waitFor(() => {
+        expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
+      })
+
+      expect(mockDownloadFile).not.toHaveBeenCalled()
+      const payload = mockCreateAssetExport.mock.calls[0][0]
+      expect(payload.include_previews).toBe(true)
+      expect(payload.job_ids).toEqual(['job1'])
+    })
+
     it('uses ZIP export for an injected single multi-output asset in cloud', async () => {
       mockIsCloud.value = true
       mockGetAssetType.mockReturnValue('output')

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -827,6 +827,17 @@ describe('useMediaAssetActions', () => {
 
       await expectExportToast('mediaAsset.selection.exportStarted', 6)
     })
+
+    it('reports the file count for a jobless (input) export without previews', async () => {
+      mockGetAssetType.mockReturnValue('input')
+      const a1 = createMockAsset({ id: 'a1', name: 'in1.png', tags: ['input'] })
+      const a2 = createMockAsset({ id: 'a2', name: 'in2.png', tags: ['input'] })
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets([a1, a2])
+
+      await expectExportToast('mediaAsset.selection.exportStarted', 2)
+    })
   })
 
   describe('deleteAssets - model cache invalidation', () => {

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -698,6 +698,34 @@ describe('useMediaAssetActions', () => {
       })
       expect(payload.naming_strategy).toBe('preserve')
     })
+
+    it('omits include_previews by default', async () => {
+      const assets = [createOutputAsset('a1', 'img1.png', 'job1', 3)]
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets(assets)
+
+      await vi.waitFor(() => {
+        expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
+      })
+
+      const payload = mockCreateAssetExport.mock.calls[0][0]
+      expect(payload.include_previews).toBeUndefined()
+    })
+
+    it('sends include_previews when requested', async () => {
+      const assets = [createOutputAsset('a1', 'img1.png', 'job1', 3)]
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets(assets, true)
+
+      await vi.waitFor(() => {
+        expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
+      })
+
+      const payload = mockCreateAssetExport.mock.calls[0][0]
+      expect(payload.include_previews).toBe(true)
+    })
   })
 
   describe('downloadAssets - export toast file count', () => {

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -753,7 +753,7 @@ describe('useMediaAssetActions', () => {
       })
     }
 
-    async function expectExportToastFileCount(count: number) {
+    async function expectExportToast(key: string, count: number) {
       await vi.waitFor(() => {
         expect(mockCreateAssetExport).toHaveBeenCalledTimes(1)
       })
@@ -761,58 +761,42 @@ describe('useMediaAssetActions', () => {
       const { add } = useToast()
       await vi.waitFor(() => {
         expect(add).toHaveBeenCalledWith(
-          expect.objectContaining({
-            detail: 'mediaAsset.selection.exportStarted'
-          })
+          expect.objectContaining({ detail: key })
         )
       })
 
       const { t } = useI18n()
-      expect(t).toHaveBeenCalledWith(
-        'mediaAsset.selection.exportStarted',
-        { count },
-        count
-      )
+      expect(t).toHaveBeenCalledWith(key, { count }, count)
     }
 
-    it('should report total file count, not job count, for multi-output jobs', async () => {
+    it('reports the job count for an output export without previews', async () => {
       const j1 = createOutputAsset('a1', 'img1.png', 'job1', 2)
       const j2 = createOutputAsset('a2', 'img2.png', 'job2', 4)
 
       const actions = useMediaAssetActions()
       actions.downloadAssets([j1, j2])
 
-      await expectExportToastFileCount(6)
+      await expectExportToast('mediaAsset.selection.exportStartedJobs', 2)
     })
 
-    it('should treat assets without outputCount as a single file', async () => {
-      const a1 = createOutputAsset('a1', 'img1.png', 'job1')
-      const a2 = createOutputAsset('a2', 'img2.png', 'job2')
-
-      const actions = useMediaAssetActions()
-      actions.downloadAssets([a1, a2])
-
-      await expectExportToastFileCount(2)
-    })
-
-    it('should mix multi-output and single-output assets correctly', async () => {
-      const j1 = createOutputAsset('a1', 'img1.png', 'job1', 3)
-      const a2 = createOutputAsset('a2', 'img2.png', 'job2')
-
-      const actions = useMediaAssetActions()
-      actions.downloadAssets([j1, a2])
-
-      await expectExportToastFileCount(4)
-    })
-
-    it('should only count duplicate job-level output selections once', async () => {
+    it('counts distinct jobs, not selected assets', async () => {
       const j1 = createOutputAsset('a1', 'img1.png', 'job1', 3)
       const j1Duplicate = createOutputAsset('a2', 'img2.png', 'job1', 3)
 
       const actions = useMediaAssetActions()
       actions.downloadAssets([j1, j1Duplicate])
 
-      await expectExportToastFileCount(3)
+      await expectExportToast('mediaAsset.selection.exportStartedJobs', 1)
+    })
+
+    it('reports the preview-inclusive file count when exporting with previews', async () => {
+      const j1 = createOutputAsset('a1', 'img1.png', 'job1', 2)
+      const j2 = createOutputAsset('a2', 'img2.png', 'job2', 4)
+
+      const actions = useMediaAssetActions()
+      actions.downloadAssets([j1, j2], true)
+
+      await expectExportToast('mediaAsset.selection.exportStarted', 6)
     })
   })
 

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -210,14 +210,27 @@ export function useMediaAssetActions() {
 
       assetExportStore.trackExport(result.task_id)
 
+      // For output exports the precise file count is unknown up front: the
+      // job's output count includes preview/temp assets, which are only in
+      // the archive when include_previews is set. Report the job count
+      // instead so the number is accurate; with previews the count already
+      // matches the archive.
+      const useJobCount = !includePreviews && jobIds.length > 0
+
       toast.add({
         severity: 'info',
         summary: t('exportToast.exportStarted'),
-        detail: t(
-          'mediaAsset.selection.exportStarted',
-          { count: fileCount },
-          fileCount
-        ),
+        detail: useJobCount
+          ? t(
+              'mediaAsset.selection.exportStartedJobs',
+              { count: jobIds.length },
+              jobIds.length
+            )
+          : t(
+              'mediaAsset.selection.exportStarted',
+              { count: fileCount },
+              fileCount
+            ),
         life: 3000
       })
     } catch (error) {

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -105,7 +105,10 @@ export function useMediaAssetActions() {
   /**
    * Download one or more assets.
    * In cloud mode, creates a ZIP export via the backend when called with
-   * 2+ assets or with any asset whose job has `outputCount > 1`.
+   * 2+ assets, with any asset whose job has `outputCount > 1`, or when
+   * `includePreviews` is set. Previews are only retrievable via the export
+   * endpoint, so requesting them must force the ZIP path even for a single
+   * asset; the direct-download branch only fetches visible output URLs.
    * Falls back to direct downloads in OSS mode and for single single-output
    * assets. With no argument, uses the asset from `MediaAssetKey` context.
    */
@@ -119,7 +122,10 @@ export function useMediaAssetActions() {
       return typeof count === 'number' && count > 1
     })
 
-    if (isCloud && (targetAssets.length > 1 || hasMultiOutputJobs)) {
+    if (
+      isCloud &&
+      (includePreviews || targetAssets.length > 1 || hasMultiOutputJobs)
+    ) {
       void downloadAssetsAsZip(targetAssets, includePreviews)
       return
     }

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -109,7 +109,7 @@ export function useMediaAssetActions() {
    * Falls back to direct downloads in OSS mode and for single single-output
    * assets. With no argument, uses the asset from `MediaAssetKey` context.
    */
-  const downloadAssets = (assets?: AssetItem[]) => {
+  const downloadAssets = (assets?: AssetItem[], includePreviews = false) => {
     const targetAssets =
       assets ?? (mediaContext?.asset.value ? [mediaContext.asset.value] : [])
     if (targetAssets.length === 0) return
@@ -120,7 +120,7 @@ export function useMediaAssetActions() {
     })
 
     if (isCloud && (targetAssets.length > 1 || hasMultiOutputJobs)) {
-      void downloadAssetsAsZip(targetAssets)
+      void downloadAssetsAsZip(targetAssets, includePreviews)
       return
     }
 
@@ -147,7 +147,10 @@ export function useMediaAssetActions() {
     }
   }
 
-  async function downloadAssetsAsZip(assets: AssetItem[]) {
+  async function downloadAssetsAsZip(
+    assets: AssetItem[],
+    includePreviews = false
+  ) {
     const assetExportStore = useAssetExportStore()
 
     try {
@@ -201,6 +204,7 @@ export function useMediaAssetActions() {
         ...(Object.keys(jobAssetNameFilters).length > 0
           ? { job_asset_name_filters: jobAssetNameFilters }
           : {}),
+        ...(includePreviews ? { include_previews: true } : {}),
         naming_strategy: namingStrategy
       })
 

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -50,6 +50,7 @@ interface AssetExportOptions {
     | 'preserve'
     | 'asset_id'
   job_asset_name_filters?: Record<string, string[]>
+  include_previews?: boolean
 }
 
 /**


### PR DESCRIPTION
## TL;DR (reviewer triage)

1. **Frontend-only**; backend `include_previews` already shipped to cloud `main` (#4020). This just sends the flag.
2. **Main attention**: a **"Download previews" toggle switch** on its own row below the multi-select actions feeds the Download action (`AssetsSidebarTab.vue`). Output tab only.
3. **Generated `ingest-types` are intentionally untouched** — the dedicated sync PR #12227 adds `include_previews` to them; editing them here would conflict. The request is built from the hand-written `AssetExportOptions` (as all export fields already are), so the functional path is unaffected; e2e assertions use `'include_previews' in payload` narrowing to stay type-safe until #12227 lands.
4. **No feature flag.** Note `jaewon/fe-781` separately gates bulk export behind `asset_bulk_export_enabled`; coordinate merge order if that lands first.

## Summary

Preview/temp assets (e.g. from `PreviewImage` nodes) were never included in ZIP exports. The cloud export endpoint already supports `include_previews`; this wires it up on the frontend.

## Changes

- `AssetExportOptions` gains `include_previews`; `useMediaAssetActions` forwards it through the ZIP export path.
- The Generated tab's footer gains a **Download previews** toggle switch on a dedicated row below the Delete/Download actions. The Download button reads its state. Shown on the output tab only (the flag only widens job-id expansion, no effect on `asset_ids`); the Imported tab is unchanged.
- **Forcing the export path**: requesting previews now forces the ZIP/export path even for a single asset — previews are only retrievable via the export endpoint, so the direct-download branch would silently drop them.
- **Toast accuracy**: a plain (outputs-only) export now reports **"Downloading assets from N jobs"**. The per-job output count is preview-inclusive (backend `outputs_count` mirrors OSS `flatOutputs.length`), so it over-counts an outputs-only archive; the job count is exact. The with-previews export keeps the file count, which matches the archive.
- **Breaking**: none.
- **Dependencies**: none.

## Review Focus

- `include_previews` is opt-in (default off), avoiding surprise large archives from preview-heavy workflows.
- The switch uses PrimeVue `ToggleSwitch`, consistent with the repo's existing switches (`FieldSwitch`, `PackEnableToggle`); there's no reka/shadcn switch wrapper.
- Controls carry `data-testid`s (`assets-include-previews`, `assets-download-selected`) for e2e targeting.

## Tests

- Unit (`useMediaAssetActions.test.ts`): flag omitted by default / sent when requested; job-count vs file-count toast; force-ZIP path for a single asset with previews; jobless (input) export file count.
- Component (`AssetsSidebarTab.test.ts`, normal CI): toggle shown on Generated / hidden on Imported; forwards `includePreviews`; no stale toggle after switching tabs.
- E2E: `includePreviewsToggle` locator + a cloud spec that toggles previews then downloads, asserting `include_previews`. Runs in CI (cloud-mocked browser env).

## Screenshots
<img width="302" height="91" alt="image" src="https://github.com/user-attachments/assets/e7ea423b-d763-4fe6-a683-2af746677c20" />
