### PR TITLE
fix: stop Add Secret dialog rendering behind Settings modal (FE-939)

### DIFF
--- a/src/platform/secrets/components/SecretFormDialog.vue
+++ b/src/platform/secrets/components/SecretFormDialog.vue
@@ -1,8 +1,9 @@
 <template>
   <Dialog v-model:open="visible">
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay v-reka-z-index />
       <DialogContent
+        v-reka-z-index
         size="md"
         :aria-labelledby="titleId"
         @pointer-down-outside.prevent
@@ -125,6 +126,7 @@ import DialogHeader from '@/components/ui/dialog/DialogHeader.vue'
 import DialogOverlay from '@/components/ui/dialog/DialogOverlay.vue'
 import DialogPortal from '@/components/ui/dialog/DialogPortal.vue'
 import DialogTitle from '@/components/ui/dialog/DialogTitle.vue'
+import { vRekaZIndex } from '@/components/dialog/vRekaZIndex'
 import Select from '@/components/ui/select/Select.vue'
 import SelectContent from '@/components/ui/select/SelectContent.vue'
 import SelectItem from '@/components/ui/select/SelectItem.vue'

--- a/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
+++ b/src/platform/secrets/components/SecretFormDialog.zindex.test.ts
@@ -1,0 +1,77 @@
+import { ZIndex } from '@primeuix/utils/zindex'
+import { cleanup, render, screen } from '@testing-library/vue'
+import PrimeVue from 'primevue/config'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SecretFormDialog from './SecretFormDialog.vue'
+
+vi.mock('../composables/useSecretForm', () => ({
+  useSecretForm: () => ({
+    form: { provider: '', name: '', secretValue: '' },
+    errors: {},
+    loading: false,
+    apiError: '',
+    providerOptions: [],
+    handleSubmit: vi.fn()
+  })
+}))
+
+vi.mock('primevue/inputtext', () => ({
+  default: { name: 'InputText', template: '<input />' }
+}))
+vi.mock('primevue/password', () => ({
+  default: { name: 'Password', template: '<input type="password" />' }
+}))
+
+vi.mock('@/components/ui/button/Button.vue', () => ({
+  default: { name: 'Button', template: '<button><slot /></button>' }
+}))
+vi.mock('@/components/ui/select/Select.vue', () => ({
+  default: { name: 'Select', template: '<div><slot /></div>' }
+}))
+vi.mock('@/components/ui/select/SelectContent.vue', () => ({
+  default: { name: 'SelectContent', template: '<div><slot /></div>' }
+}))
+vi.mock('@/components/ui/select/SelectItem.vue', () => ({
+  default: { name: 'SelectItem', template: '<div><slot /></div>' }
+}))
+vi.mock('@/components/ui/select/SelectTrigger.vue', () => ({
+  default: { name: 'SelectTrigger', template: '<div><slot /></div>' }
+}))
+vi.mock('@/components/ui/select/SelectValue.vue', () => ({
+  default: { name: 'SelectValue', template: '<span />' }
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+describe('SecretFormDialog z-index stacking', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  let openModalZIndex: number
+
+  beforeEach(() => {
+    const openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 1700)
+    openModalZIndex = Number(openModal.style.zIndex)
+  })
+
+  it('renders above a modal that is already open', async () => {
+    render(SecretFormDialog, {
+      global: { plugins: [PrimeVue, i18n] },
+      props: { visible: true }
+    })
+
+    const content = await screen.findByRole('dialog')
+
+    expect(Number(content.style.zIndex)).toBeGreaterThan(openModalZIndex)
+  })
+})


### PR DESCRIPTION
## Summary

The "Add Secret" dialog (Settings → Secrets) opens but renders **behind** the Settings modal because it never joins the shared dialog z-index stack. This is the intermittent "dialog doesn't show" report in FE-939.

## Changes

- **What**: Apply the existing `v-reka-z-index` directive to `SecretFormDialog`'s `DialogOverlay` and `DialogContent`, mirroring `GlobalDialog.vue`. This registers the dialog with the shared `@primeuix` `ZIndex` `'modal'` sequence instead of relying on the static `z-1700` Tailwind class, which always lost to the Settings modal once the shared counter climbed past 1700.

## Review Focus

Root cause: `@primeuix` `ZIndex.set` runs with `autoZIndex=true`, so every registered modal lands above the last in the shared `'modal'` sequence — "whichever dialog opens last wins." The Settings modal registers in that sequence (via `GlobalDialog`'s `v-reka-z-index` in the reka renderer, or as a PrimeVue `p-dialog-mask` in the cloud build). `SecretFormDialog` is a standalone reka dialog whose overlay/content carried only the **static** `z-1700` class and never joined the sequence, so it sat at a fixed `1700`. Whenever the shared counter has climbed past 1700 (the report's `2102/2103` state, reached through repeated dialog/section navigation) the Settings modal paints on top — hence the intermittency. The ~3-line fix lets Add Secret join the same sequence so it always opens above.

Scope is intentionally limited to `SecretFormDialog`. Two related items are filed as follow-ups: FE-940 (durable self-registration in the shared dialog primitives so static `z-1700` can be dropped everywhere) and FE-941 (`VideoHelpDialog`, same bug class under the primevue-renderer `UploadModelDialog`).

Linear: [FE-939](https://linear.app/comfyorg/issue/FE-939/add-secret-dialog-renders-behind-settings-modal)

## Test plan

New `SecretFormDialog.zindex.test.ts` proves the fix red→green: with a modal already registered at `1700`, the unfixed dialog content exposes no inline z-index (`0`, fails the ordering assertion) and the fixed dialog registers strictly above it (passes). It asserts a **relative** ordering against a real prior registration, not a hardcoded constant, so it is a behavioral regression guard rather than a change-detector. (`@cloud` e2e deferred to FE-940/FE-941 follow-up work — the unit test is the regression guard.)

CI red→green proof (Tests Unit):
- 🔴 test-only commit `f68d28b6` — [run failed](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27001789061) (`AssertionError: expected 0 to be greater than 1701`)
- 🟢 fix commit `add1862db1` — [run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27002203164)

## Screenshots

Reproduced on cloud with the shared PrimeVue `'modal'` counter driven to the reported climbed state (`z-2102`); the only difference between the two is whether Add Secret joins the sequence.

| Before (bug) — Add Secret hidden behind Settings | After (fix) — Add Secret on top |
| --- | --- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/c0357dcd-5554-450e-8d4f-5a589a1566f6" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/80b7dd3f-5a73-4bfb-ae38-1eaed115bb8d" /> |
