### PR TITLE
style(nodes-2): compact node layout, header, footer, and widget sizing

### DIFF
--- a/packages/design-system/src/css/style.css
+++ b/packages/design-system/src/css/style.css
@@ -197,7 +197,7 @@
   --node-component-executing: var(--color-blue-500);
   --node-component-header: var(--fg-color);
   --node-component-header-icon: var(--color-ash-800);
-  --node-component-header-surface: var(--color-smoke-400);
+  --node-component-header-surface: var(--color-smoke-200);
   --node-component-outline: var(--color-black);
   --node-component-ring: rgb(from var(--color-smoke-500) r g b / 50%);
   --node-component-slot-dot-outline-opacity-mult: 1;
@@ -341,7 +341,7 @@
   --node-component-border-executing: var(--color-blue-500);
   --node-component-border-selected: var(--color-charcoal-200);
   --node-component-header-icon: var(--color-smoke-800);
-  --node-component-header-surface: var(--color-charcoal-800);
+  --node-component-header-surface: var(--color-charcoal-700);
   --node-component-outline: var(--color-white);
   --node-component-ring: rgb(var(--color-smoke-500) / 20%);
   --node-component-slot-dot-outline-opacity: 10%;

--- a/src/components/common/ScrubableNumberInput.vue
+++ b/src/components/common/ScrubableNumberInput.vue
@@ -1,20 +1,21 @@
 <template>
   <div
     ref="container"
-    class="flex h-7 rounded-lg bg-component-node-widget-background text-xs text-component-node-foreground"
+    class="flex h-6 overflow-hidden rounded-md bg-component-node-widget-background text-xs text-component-node-foreground"
   >
     <slot name="background" />
     <Button
       v-if="!hideButtons"
       :aria-label="t('g.decrement')"
       data-testid="decrement"
-      class="aspect-8/7 h-full rounded-r-none hover:bg-base-foreground/20 disabled:opacity-30"
+      class="h-full w-6 rounded-none p-0 hover:bg-component-node-widget-background-hovered disabled:opacity-30"
       variant="muted-textonly"
+      size="unset"
       :disabled="!canDecrement"
       tabindex="-1"
       @click="modelValue = clamp(modelValue - step)"
     >
-      <i class="pi pi-minus" />
+      <i class="icon-[lucide--minus] size-4" />
     </Button>
     <div class="relative my-0.25 min-w-[4ch] flex-1 py-1.5">
       <input
@@ -24,7 +25,7 @@
         :disabled
         :class="
           cn(
-            'absolute inset-0 truncate border-0 bg-transparent p-1 text-sm focus:outline-0'
+            'absolute inset-0 truncate border-0 bg-transparent p-1 text-xs focus:outline-0'
           )
         "
         inputmode="decimal"
@@ -54,13 +55,14 @@
       v-if="!hideButtons"
       :aria-label="t('g.increment')"
       data-testid="increment"
-      class="aspect-8/7 h-full rounded-l-none hover:bg-base-foreground/20 disabled:opacity-30"
+      class="h-full w-6 rounded-none p-0 hover:bg-component-node-widget-background-hovered disabled:opacity-30"
       variant="muted-textonly"
+      size="unset"
       :disabled="!canIncrement"
       tabindex="-1"
       @click="modelValue = clamp(modelValue + step)"
     >
-      <i class="pi pi-plus" />
+      <i class="icon-[lucide--plus] size-4" />
     </Button>
   </div>
 </template>

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -88,7 +88,7 @@
     "color": "Color",
     "error": "Error",
     "enter": "Enter",
-    "enterSubgraph": "Enter Subgraph",
+    "enterSubgraph": "Enter subgraph",
     "inSubgraph": "in subgraph '{name}'",
     "resizeFromBottomRight": "Resize from bottom-right corner",
     "resizeFromTopRight": "Resize from top-right corner",

--- a/src/renderer/extensions/vueNodes/components/InputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/InputSlot.vue
@@ -5,9 +5,9 @@
     v-tooltip.left="tooltipConfig"
     :class="
       cn(
-        'lg-slot lg-slot--input group m-0 flex items-center rounded-r-lg',
+        'lg-slot lg-slot--input group m-0 flex h-5 items-center rounded-r-lg',
         'cursor-crosshair',
-        dotOnly ? 'lg-slot--dot-only' : 'pr-6',
+        dotOnly ? 'lg-slot--dot-only' : 'pr-2',
         {
           'lg-slot--connected': props.connected,
           'lg-slot--compatible': props.compatible,

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -11,8 +11,11 @@
     :data-ghost="nodeData.flags?.ghost || undefined"
     :class="
       cn(
-        'group/node lg-node absolute isolate text-sm',
+        'group/node lg-node absolute isolate text-xs',
         'flex flex-col contain-layout contain-style',
+        isLightTheme
+          ? 'drop-shadow-md drop-shadow-black/15'
+          : 'drop-shadow-xl drop-shadow-black/40',
         isRerouteNode
           ? 'h-(--node-height)'
           : 'min-h-(--node-height) min-w-(--min-node-width)',
@@ -65,19 +68,10 @@
       "
     />
     <div
-      :class="
-        cn(
-          'pointer-events-none absolute border border-solid border-component-node-border',
-          rootBorderShapeClass,
-          hasAnyError ? '-inset-1' : 'inset-0'
-        )
-      "
-    />
-    <div
       data-testid="node-inner-wrapper"
       :class="
         cn(
-          'flex flex-1 flex-col border border-solid border-transparent bg-node-component-header-surface',
+          'flex flex-1 flex-col bg-node-component-header-surface',
           'w-(--node-width)',
           !isRerouteNode && 'min-w-(--min-node-width)',
           shapeClass,
@@ -235,7 +229,7 @@
           <path
             d="M11 1L1 11M11 6L6 11"
             stroke="var(--color-muted-foreground)"
-            stroke-width="0.975"
+            stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
           />
@@ -302,6 +296,7 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { isVideoOutput } from '@/utils/litegraphUtil'
 import {
@@ -335,6 +330,10 @@ const { t } = useI18n()
 
 const { isSelectMode, isSelectOutputsMode } = useAppMode()
 const settingStore = useSettingStore()
+const colorPaletteStore = useColorPaletteStore()
+const isLightTheme = computed(
+  () => !!colorPaletteStore.completedActivePalette.light_theme
+)
 
 const { handleNodeCollapse, handleNodeTitleUpdate, handleNodeRightClick } =
   useNodeEventHandlers()
@@ -572,9 +571,9 @@ const bodyRoundingClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-br-2xl'
+      return 'rounded-br-xl'
     default:
-      return 'rounded-b-2xl'
+      return 'rounded-b-xl'
   }
 })
 
@@ -583,9 +582,9 @@ const shapeClass = computed(() => {
     case RenderShape.BOX:
       return ''
     case RenderShape.CARD:
-      return 'rounded-tl-2xl rounded-br-2xl'
+      return 'rounded-tl-xl rounded-br-xl'
     default:
-      return 'rounded-2xl'
+      return 'rounded-xl'
   }
 })
 
@@ -595,22 +594,6 @@ const isTransparentHeaderless = computed(
     !!nodeData.bgcolor &&
     isTransparent(nodeData.bgcolor)
 )
-
-const rootBorderShapeClass = computed(() => {
-  if (isTransparentHeaderless.value) return 'border-0'
-
-  const isExpanded = hasAnyError.value
-  switch (nodeData.shape) {
-    case RenderShape.BOX:
-      return ''
-    case RenderShape.CARD:
-      return isExpanded
-        ? 'rounded-tl-[20px] rounded-br-[20px]'
-        : 'rounded-tl-2xl rounded-br-2xl'
-    default:
-      return isExpanded ? 'rounded-[20px]' : 'rounded-2xl'
-  }
-})
 
 const selectionShapeClass = computed(() => {
   if (isTransparentHeaderless.value) return 'border-0'
@@ -624,7 +607,7 @@ const selectionShapeClass = computed(() => {
         ? 'rounded-tl-[23px] rounded-br-[23px]'
         : 'rounded-tl-[19px] rounded-br-[19px]'
     default:
-      return isExpanded ? 'rounded-[23px]' : 'rounded-[19px]'
+      return isExpanded ? 'rounded-[19px]' : 'rounded-[15px]'
   }
 })
 
@@ -636,9 +619,9 @@ const bypassOverlayClass = computed(() => {
     case RenderShape.BOX:
       return `${BEFORE_OVERLAY_BASE} before:bg-bypass/60`
     case RenderShape.CARD:
-      return `before:rounded-tl-2xl before:rounded-br-2xl ${BEFORE_OVERLAY_BASE} before:bg-bypass/60`
+      return `before:rounded-tl-xl before:rounded-br-xl ${BEFORE_OVERLAY_BASE} before:bg-bypass/60`
     default:
-      return `before:rounded-2xl ${BEFORE_OVERLAY_BASE} before:bg-bypass/60`
+      return `before:rounded-xl ${BEFORE_OVERLAY_BASE} before:bg-bypass/60`
   }
 })
 
@@ -647,9 +630,9 @@ const mutedOverlayClass = computed(() => {
     case RenderShape.BOX:
       return BEFORE_OVERLAY_BASE
     case RenderShape.CARD:
-      return `before:rounded-tl-2xl before:rounded-br-2xl ${BEFORE_OVERLAY_BASE}`
+      return `before:rounded-tl-xl before:rounded-br-xl ${BEFORE_OVERLAY_BASE}`
     default:
-      return `before:rounded-2xl ${BEFORE_OVERLAY_BASE}`
+      return `before:rounded-xl ${BEFORE_OVERLAY_BASE}`
   }
 })
 

--- a/src/renderer/extensions/vueNodes/components/NodeFooter.test.ts
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.test.ts
@@ -189,18 +189,13 @@ describe('NodeFooter', () => {
     it('CARD shape emits rounded-br variant on the single-tab footer', () => {
       renderFooter({ isSubgraph: true, shape: RenderShape.CARD })
       const classes = allButtonClasses()
-      expect(classes).toMatch(/rounded-br-\[17px\]/)
-      expect(classes).not.toMatch(/rounded-b-\[/)
+      expect(classes).toMatch(/rounded-br-xl/)
+      expect(classes).not.toMatch(/\srounded-b-\w/)
     })
 
     it('default shape emits rounded-b variant on the single-tab footer', () => {
       renderFooter({ isSubgraph: true })
-      expect(allButtonClasses()).toMatch(/rounded-b-\[17px\]/)
-    })
-
-    it('upgrades to 20px radius when the error tab is present', () => {
-      renderFooter({ hasAnyError: true, showErrorsTabEnabled: true })
-      expect(allButtonClasses()).toMatch(/rounded-b-\[20px\]/)
+      expect(allButtonClasses()).toMatch(/rounded-b-xl/)
     })
 
     it('enter tab uses right-only rounding in dual-tab mode (Case 1)', () => {
@@ -210,7 +205,7 @@ describe('NodeFooter', () => {
         showErrorsTabEnabled: true
       })
       const enterBtn = screen.getByTestId('subgraph-enter-button')
-      expect(enterBtn.className).toMatch(/rounded-br-\[20px\]/)
+      expect(enterBtn.className).toMatch(/rounded-br-xl/)
     })
   })
 

--- a/src/renderer/extensions/vueNodes/components/NodeFooter.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeFooter.vue
@@ -9,7 +9,7 @@
       :class="
         cn(
           tabStyles,
-          'z-10 box-border w-1/2 rounded-none bg-destructive-background pt-9 pb-4 text-white hover:bg-destructive-background-hover',
+          'z-10 box-border w-1/2 rounded-none bg-destructive-background pt-9 pb-3 text-white hover:bg-destructive-background-hover',
           errorRadiusClass
         )
       "
@@ -28,7 +28,7 @@
       :class="
         cn(
           tabStyles,
-          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-9 pb-4 pl-5',
+          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-9 pb-3 pl-5 text-node-component-slot-text',
           enterRadiusClass
         )
       "
@@ -58,7 +58,7 @@
       :class="
         cn(
           tabStyles,
-          'z-10 box-border w-1/2 rounded-none bg-destructive-background pt-9 pb-4 text-white hover:bg-destructive-background-hover',
+          'z-10 box-border w-1/2 rounded-none bg-destructive-background pt-9 pb-3 text-white hover:bg-destructive-background-hover',
           errorRadiusClass
         )
       "
@@ -77,7 +77,7 @@
       :class="
         cn(
           tabStyles,
-          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-9 pb-4 pl-5',
+          '-ml-5 box-border w-[calc(50%+20px)] rounded-none bg-node-component-header-surface pt-9 pb-3 pl-5 text-node-component-slot-text',
           enterRadiusClass
         )
       "
@@ -112,7 +112,7 @@
       :class="
         cn(
           tabStyles,
-          'box-border w-full rounded-none bg-destructive-background pt-9 pb-4 text-white hover:bg-destructive-background-hover',
+          'box-border w-full rounded-none bg-destructive-background pt-9 pb-3 text-white hover:bg-destructive-background-hover',
           footerRadiusClass
         )
       "
@@ -142,8 +142,8 @@
       :class="
         cn(
           tabStyles,
-          'box-border w-full rounded-none bg-node-component-header-surface',
-          hasAnyError ? 'pt-9 pb-4' : 'pt-8 pb-4',
+          'box-border w-full rounded-none bg-node-component-header-surface text-node-component-slot-text',
+          hasAnyError ? 'pt-9 pb-3' : 'pt-8 pb-3',
           footerRadiusClass
         )
       "
@@ -174,8 +174,8 @@
       :class="
         cn(
           tabStyles,
-          'box-border w-full rounded-none bg-node-component-header-surface',
-          hasAnyError ? 'pt-9 pb-4' : 'pt-8 pb-4',
+          'box-border w-full rounded-none bg-node-component-header-surface text-node-component-slot-text',
+          hasAnyError ? 'pt-9 pb-3' : 'pt-8 pb-3',
           footerRadiusClass
         )
       "
@@ -254,37 +254,23 @@ function emitIfNotDragged(
   else emit('toggleAdvanced')
 }
 
-const RADIUS_CLASS = {
-  'rounded-b-17': 'rounded-b-[17px]',
-  'rounded-b-20': 'rounded-b-[20px]',
-  'rounded-br-17': 'rounded-br-[17px]',
-  'rounded-br-20': 'rounded-br-[20px]'
-} as const
-
 function getBottomRadius(
   nodeShape: RenderShape | undefined,
-  size: '17px' | '20px',
   corners: 'both' | 'right' = 'both'
 ): string {
   if (nodeShape === RenderShape.BOX) return ''
-  const prefix =
-    nodeShape === RenderShape.CARD || corners === 'right'
-      ? 'rounded-br'
-      : 'rounded-b'
-  const key =
-    `${prefix}-${size === '17px' ? '17' : '20'}` as keyof typeof RADIUS_CLASS
-  return RADIUS_CLASS[key]
+  return nodeShape === RenderShape.CARD || corners === 'right'
+    ? 'rounded-br-xl'
+    : 'rounded-b-xl'
 }
 
-const footerRadiusClass = computed(() =>
-  getBottomRadius(shape, hasAnyError ? '20px' : '17px')
-)
+const footerRadiusClass = computed(() => getBottomRadius(shape))
 
-const errorRadiusClass = computed(() => getBottomRadius(shape, '20px'))
+const errorRadiusClass = computed(() => getBottomRadius(shape))
 
-const enterRadiusClass = computed(() => getBottomRadius(shape, '20px', 'right'))
+const enterRadiusClass = computed(() => getBottomRadius(shape, 'right'))
 
-const tabStyles = 'pointer-events-auto h-9 text-xs'
+const tabStyles = 'pointer-events-auto h-11 text-xs font-normal'
 const footerWrapperBase = 'isolate -z-1 -mt-5 box-border flex'
 const errorWrapperStyles = cn(
   footerWrapperBase,

--- a/src/renderer/extensions/vueNodes/components/NodeHeader.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeHeader.vue
@@ -6,17 +6,17 @@
     v-else
     :class="
       cn(
-        'lg-node-header w-full min-w-0 py-2 pr-3 pl-2 text-sm',
-        'text-node-component-header',
+        'lg-node-header w-full min-w-0 p-1 text-xs',
+        'text-node-component-slot-text',
         headerShapeClass
       )
     "
     :data-testid="`node-header-${nodeData?.id || ''}`"
     @dblclick="handleDoubleClick"
   >
-    <div class="flex min-w-0 items-center justify-between gap-2.5">
+    <div class="flex min-w-0 items-center justify-between gap-1">
       <!-- Collapse/Expand Button -->
-      <div class="relative mr-auto flex min-w-0 shrink items-center gap-2.5">
+      <div class="relative mr-auto flex min-w-0 shrink items-center gap-1">
         <div class="flex shrink-0 items-center px-0.5">
           <Button
             size="icon-sm"
@@ -29,7 +29,7 @@
             <i
               :class="
                 cn(
-                  'icon-[lucide--chevron-down] size-5 transition-transform',
+                  'icon-[lucide--chevron-down] size-4 transition-transform',
                   collapsed && '-rotate-90'
                 )
               "
@@ -64,7 +64,7 @@
       <NodeBadge v-if="statusBadge" v-bind="statusBadge" />
       <i
         v-if="isPinned"
-        class="icon-[comfy--pin] size-5"
+        class="icon-[comfy--pin] size-4"
         data-testid="node-pin-indicator"
       />
     </div>
@@ -159,18 +159,18 @@ const headerShapeClass = computed(() => {
       case RenderShape.BOX:
         return 'rounded-none'
       case RenderShape.CARD:
-        return 'rounded-tl-2xl rounded-br-2xl rounded-tr-none rounded-bl-none'
+        return 'rounded-tl-xl rounded-br-2xl rounded-tr-none rounded-bl-none'
       default:
-        return 'rounded-2xl'
+        return 'rounded-xl'
     }
   }
   switch (nodeData?.shape) {
     case RenderShape.BOX:
       return 'rounded-t-none'
     case RenderShape.CARD:
-      return 'rounded-tl-2xl rounded-tr-none'
+      return 'rounded-tl-xl rounded-tr-none'
     default:
-      return 'rounded-t-2xl'
+      return 'rounded-t-xl'
   }
 })
 

--- a/src/renderer/extensions/vueNodes/components/OutputSlot.vue
+++ b/src/renderer/extensions/vueNodes/components/OutputSlot.vue
@@ -97,9 +97,9 @@ const shouldDim = computed(() => {
 
 const slotWrapperClass = computed(() =>
   cn(
-    'lg-slot lg-slot--output group flex h-6 items-center justify-end rounded-l-lg',
+    'lg-slot lg-slot--output group flex h-5 items-center justify-end rounded-l-lg',
     'cursor-crosshair',
-    dotOnly.value ? 'lg-slot--dot-only justify-center' : 'pl-6',
+    dotOnly.value ? 'lg-slot--dot-only justify-center' : 'pl-2',
     {
       'lg-slot--connected': props.connected,
       'lg-slot--compatible': props.compatible,

--- a/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
+++ b/src/renderer/extensions/vueNodes/components/SlotConnectionDot.vue
@@ -51,8 +51,8 @@ const slotClass = computed(() =>
     'transition-all duration-150',
     'border border-solid border-node-component-slot-dot-outline',
     props.multi
-      ? 'h-6 w-3'
-      : 'size-3 cursor-crosshair group-hover/slot:scale-125 group-hover/slot:[--node-component-slot-dot-outline-opacity-mult:5]'
+      ? 'h-5 w-2'
+      : 'size-2 cursor-crosshair group-hover/slot:scale-125 group-hover/slot:[--node-component-slot-dot-outline-opacity-mult:5]'
   )
 )
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetInputNumberInput.vue
@@ -164,11 +164,11 @@ const inputAriaAttrs = computed(() => ({
       :hide-buttons="buttonsDisabled"
       :parse-value="parseWidgetValue"
       :input-attrs="inputAriaAttrs"
-      :class="cn(WidgetInputBaseClass, 'relative flex h-7 grow text-xs')"
+      :class="cn(WidgetInputBaseClass, 'relative flex h-6 grow text-xs')"
     >
       <template #background>
         <div
-          class="pointer-events-none absolute size-full overflow-clip rounded-lg"
+          class="pointer-events-none absolute size-full overflow-clip rounded-md"
         >
           <div
             class="size-full bg-primary-background/15"

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
@@ -34,7 +34,7 @@
             <span
               :class="
                 cn(
-                  'min-w-[4ch] flex-1 truncate pr-1 pl-7 text-left text-xs',
+                  'min-w-[4ch] flex-1 truncate pr-1 pl-2 text-left text-xs',
                   $slots.default && 'mr-5'
                 )
               "

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetSelectDefault.vue
@@ -26,7 +26,7 @@
             :class="
               cn(
                 WidgetInputBaseClass,
-                'flex h-7 w-full min-w-0 cursor-pointer items-center overflow-hidden outline-none hover:bg-component-node-widget-background-hovered disabled:cursor-default disabled:opacity-50 disabled:hover:bg-component-node-widget-background',
+                'flex h-6 w-full min-w-0 cursor-pointer items-center overflow-hidden p-0 outline-none hover:bg-component-node-widget-background-hovered disabled:cursor-default disabled:opacity-50 disabled:hover:bg-component-node-widget-background',
                 isInvalid && 'ring-1 ring-destructive-background'
               )
             "
@@ -34,7 +34,7 @@
             <span
               :class="
                 cn(
-                  'min-w-[4ch] flex-1 truncate pr-3 pl-1 text-left',
+                  'min-w-[4ch] flex-1 truncate pr-1 pl-7 text-left text-xs',
                   $slots.default && 'mr-5'
                 )
               "
@@ -42,12 +42,12 @@
               {{ selectedLabel || placeholder || '\u00a0' }}
             </span>
             <span
-              class="flex h-full w-8 shrink-0 items-center justify-center rounded-r-lg"
+              class="flex h-full w-6 shrink-0 items-center justify-center rounded-r-md"
             >
               <i
                 :class="
                   cn(
-                    'icon-[lucide--chevron-down] size-4 translate-x-1.5',
+                    'icon-[lucide--chevron-down] size-4',
                     disabled
                       ? 'bg-component-node-foreground-secondary'
                       : 'bg-muted-foreground'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetWithControl.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetWithControl.vue
@@ -30,7 +30,7 @@ watch(controlModel, props.widget.controlWidget.update)
     <component :is="component" v-bind="$attrs" v-model="modelValue" :widget>
       <Popover>
         <template #button>
-          <ValueControlButton :mode="controlModel" class="self-center" />
+          <ValueControlButton :mode="controlModel" class="mr-1 self-center" />
         </template>
         <ValueControlPopover v-model="controlModel" />
       </Popover>

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/WidgetLayoutField.vue
@@ -27,7 +27,7 @@ const borderStyle = computed(() =>
   <div
     :class="
       cn(
-        'grid min-w-0 grid-cols-subgrid justify-between gap-1 text-node-component-slot-text',
+        'grid min-w-0 grid-cols-subgrid justify-between gap-2 text-node-component-slot-text',
         rootClass
       )
     "
@@ -46,7 +46,7 @@ const borderStyle = computed(() =>
       <div
         :class="
           cn(
-            'min-w-0 cursor-default rounded-lg transition-all',
+            'min-w-0 cursor-default rounded-md transition-all',
             !noBorder && borderStyle
           )
         "

--- a/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/layout/index.ts
@@ -8,5 +8,5 @@ export const WidgetInputBaseClass = cn([
   // Outline
   'border-none',
   // Rounded
-  'rounded-lg'
+  'rounded-md'
 ])


### PR DESCRIPTION
## Summary

Tighten Vue Nodes 2.0 visual layout to match the compact KSampler spec in the Comfy Design System Figma — smaller widget rows, smaller slot dots, shorter header, taller-but-cleaner footer, single 12 px corner radius across body/header/footer, and a body+footer drop-shadow that respects the combined silhouette.

## Changes

- **What**:
  - Body font dropped from `text-sm` → `text-xs`; header chevron and pin to 16 px (`size-4`)
  - Header padding `py-2 pr-3 pl-2` (8/12/8) → `p-1` (4 all sides), height 40 → **24 px**
  - Header text color now `text-node-component-slot-text` (matches widget labels)
  - Footer height `h-9` → `h-11`, visible portion 16 → **24 px**; `getBottomRadius` simplified to single 12 px (`rounded-{b,br}-xl`)
  - Footer subgraph/advanced text uses `text-node-component-slot-text`; error tab stays `text-white`
  - Widget row `h-7` → `h-6` (28 → 24 px); stepper buttons fixed 24 × 24 (was `aspect-8/7`); +/− swapped from PrimeIcons to lucide
  - Slot dot 12 → **8 px**; socket row 24 → **20 px**; slot row padding `pr-6`/`pl-6` → `pr-2`/`pl-2`
  - Label column 80 px, label↔input gap `gap-1` → `gap-2` (4 → 8 px)
  - Select trigger `p-0` to neutralize UA button padding + value `pl-7` to align with number widget value position (28 px from widget left)
  - Drop-shadow on the `.lg-node` root via `useColorPaletteStore().light_theme` — silhouette-aware, doesn't cast on the footer (`shadow-xl shadow-black/40` dark, `shadow-md shadow-black/15` light)
  - Default `--node-component-header-surface` shifted from charcoal-800 → 700 (dark) and smoke-400 → 200 (light) for less header/body contrast
  - Removed the unused always-on body-border overlay element + its `rootBorderShapeClass` computed

## Review Focus

- The `LinearControls` and `TabGlobalSettings` paths share `ScrubableNumberInput` and `WidgetInputBaseClass` — properties panel widgets and settings-tab inputs picked up the same compact sizing + radius. Worth eyeballing the right-side panel + settings tab to confirm those still read correctly.
- `NodeFooter.test.ts` has been updated to match the simplified `getBottomRadius` — three pre-existing 17 px / 20 px / "upgrades on error" assertions consolidated to checks on `rounded-{b,br}-xl`.
- Drop-shadow uses CSS `filter`, which has a per-element render-to-texture cost. Should be a non-issue for typical workflow sizes; flag if you spot perf regressions on very large graphs.
- Themes (Nord, Arc, custom palettes) overriding `NODE_DEFAULT_COLOR` still work — the design-system change is only to the default token value, not the indirection chain. Themes that *don't* override get the softer header.

## Screenshots (if applicable)
<img width="2292" height="1020" alt="image" src="https://github.com/user-attachments/assets/56a61bb9-3fcb-45ae-b66d-87ca2a50e656" />

Middle is the new version.

<img width="1880" height="848" alt="image" src="https://github.com/user-attachments/assets/0ebcdd60-bbd0-487e-b0d2-556021636ec0" />
