### PR TITLE
Add asset rating component

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3005,6 +3005,11 @@
   "cloudSurvey_steps_familiarity": "How familiar are you with ComfyUI?",
   "cloudSurvey_steps_intent": "What do you want to create with ComfyUI?",
   "cloudSurvey_steps_source": "Where did you hear about ComfyUI?",
+  "assetRating": {
+    "label": "Asset rating",
+    "rateAsset": "Rate {rating} out of {max}",
+    "clearRating": "Clear {rating} out of {max} rating"
+  },
   "assetBrowser": {
     "allCategory": "All {category}",
     "allModels": "All Models",

--- a/src/platform/assets/components/AssetRating.stories.ts
+++ b/src/platform/assets/components/AssetRating.stories.ts
@@ -1,0 +1,416 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
+
+import type { AssetDisplayItem } from '@/platform/assets/composables/useAssetBrowser'
+import { mockAssets } from '@/platform/assets/fixtures/ui-mock-assets'
+
+import AssetCard from './AssetCard.vue'
+import AssetRating from './AssetRating.vue'
+
+const baseAsset = mockAssets[0]
+const GENERATED_OUTPUT_PREVIEW = '/assets/images/default-template.png'
+
+function createAssetCardData(
+  overrides: Partial<AssetDisplayItem> = {}
+): AssetDisplayItem {
+  return {
+    ...baseAsset,
+    name: 'workflow-output.png',
+    preview_url: GENERATED_OUTPUT_PREVIEW,
+    secondaryText:
+      'High-quality realistic images with perfect detail and natural lighting effects for professional photography',
+    badges: [
+      { label: 'checkpoints', type: 'type' },
+      { label: '2.1 GB', type: 'size' }
+    ],
+    stats: {
+      downloadCount: '1.8k',
+      stars: '4.2k'
+    },
+    ...overrides
+  }
+}
+
+const meta: Meta<typeof AssetRating> = {
+  title: 'Platform/Assets/AssetRating',
+  component: AssetRating,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'AssetRating is a persistence-agnostic control for rating individual generated output assets. It uses a clearable 1-5 scale so unrated remains distinct from low quality, supports quick keyboard triage, and leaves project-shared storage, notes, tags, and workflow-level aggregation to the asset integration layer.'
+      }
+    }
+  },
+  decorators: [
+    () => ({
+      template: '<div class="bg-base-background p-8"><story /></div>'
+    })
+  ],
+  argTypes: {
+    modelValue: {
+      control: { type: 'number', min: 1, max: 5 }
+    },
+    max: {
+      control: { type: 'number', min: 1, max: 10 }
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg']
+    },
+    variant: {
+      control: 'select',
+      options: ['stars', 'paintbrushes', 'comfy']
+    }
+  },
+  args: {
+    modelValue: null,
+    max: 5,
+    size: 'sm',
+    variant: 'stars',
+    disabled: false,
+    readOnly: false
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function renderInteractive(args: Story['args']) {
+  return {
+    components: { AssetRating },
+    setup() {
+      const rating = ref<number | null>(args?.modelValue ?? null)
+
+      return {
+        args,
+        rating
+      }
+    },
+    template: `
+      <div class="flex flex-col gap-3">
+        <AssetRating
+          v-model="rating"
+          :aria-label="args?.ariaLabel"
+          :disabled="args?.disabled"
+          :max="args?.max"
+          :read-only="args?.readOnly"
+          :size="args?.size"
+          :variant="args?.variant"
+        />
+        <p class="m-0 text-xs text-muted-foreground">
+          Selected: {{ rating ?? 'Unrated' }}
+        </p>
+      </div>
+    `
+  }
+}
+
+export const Unrated: Story = {
+  args: {
+    modelValue: null
+  }
+}
+
+export const Rated: Story = {
+  args: {
+    modelValue: 4
+  }
+}
+
+export const Interactive: Story = {
+  render: renderInteractive,
+  args: {
+    modelValue: 2
+  }
+}
+
+export const Clearable: Story = {
+  render: renderInteractive,
+  args: {
+    modelValue: 3
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Click the selected rating again to return the asset to unrated.'
+      }
+    }
+  }
+}
+
+export const ReadOnly: Story = {
+  args: {
+    modelValue: 4,
+    readOnly: true
+  }
+}
+
+export const Disabled: Story = {
+  args: {
+    modelValue: 3,
+    disabled: true
+  }
+}
+
+export const Sizes: Story = {
+  render: () => ({
+    components: { AssetRating },
+    template: `
+      <div class="flex flex-col gap-4">
+        <AssetRating :model-value="3" size="sm" />
+        <AssetRating :model-value="3" size="md" />
+        <AssetRating :model-value="3" size="lg" />
+      </div>
+    `
+  })
+}
+
+export const Variants: Story = {
+  render: () => ({
+    components: { AssetRating },
+    template: `
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Stars</span>
+          <AssetRating :model-value="4" size="md" variant="stars" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Paintbrushes</span>
+          <AssetRating :model-value="4" size="md" variant="paintbrushes" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Comfy C</span>
+          <AssetRating :model-value="4" size="md" variant="comfy" />
+        </div>
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Stars are the familiar default rating glyph. Paintbrushes and the Comfy C mark explore more distinctive creative-tool cues without changing the rating behavior.'
+      }
+    }
+  }
+}
+
+export const AllStates: Story = {
+  render: () => ({
+    components: { AssetRating },
+    template: `
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Unrated</span>
+          <AssetRating :model-value="null" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Rated</span>
+          <AssetRating :model-value="5" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Read-only</span>
+          <AssetRating :model-value="4" read-only />
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-muted-foreground">Disabled</span>
+          <AssetRating :model-value="2" disabled />
+        </div>
+      </div>
+    `
+  })
+}
+
+export const AssetCardContext: Story = {
+  render: () => ({
+    components: { AssetCard, AssetRating },
+    setup() {
+      const rating = ref<number | null>(null)
+      const asset = createAssetCardData()
+
+      return {
+        asset,
+        rating
+      }
+    },
+    template: `
+      <div class="relative w-72">
+        <AssetCard :asset="asset" interactive />
+        <div class="absolute top-4 left-4 rounded-md bg-base-background/90 p-1 shadow-interface">
+          <AssetRating v-model="rating" size="sm" />
+        </div>
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Storybook-only composition showing how rating could sit over the preview area of the existing AssetCard without competing with bottom metadata or changing production card APIs.'
+      }
+    }
+  }
+}
+
+export const AssetCardComfyVariant: Story = {
+  render: () => ({
+    components: { AssetCard, AssetRating },
+    setup() {
+      const rating = ref<number | null>(4)
+      const asset = createAssetCardData({
+        id: 'comfy-variant-output',
+        name: 'workflow-output-comfy.png'
+      })
+
+      return {
+        asset,
+        rating
+      }
+    },
+    template: `
+      <div class="relative w-72">
+        <AssetCard :asset="asset" interactive />
+        <div class="absolute top-4 left-4 rounded-md bg-base-background/90 p-1 shadow-interface">
+          <AssetRating v-model="rating" size="sm" variant="comfy" />
+        </div>
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Storybook-only card context using the Comfy C mark as an exploratory rating glyph while preserving the same rating behavior.'
+      }
+    }
+  }
+}
+
+export const FirstRunDiscoverability: Story = {
+  render: () => ({
+    components: { AssetCard, AssetRating },
+    setup() {
+      const firstRating = ref<number | null>(null)
+      const savedRating = ref<number | null>(4)
+      const firstAsset = createAssetCardData({
+        id: 'first-run-output',
+        name: 'first-run.png'
+      })
+      const savedAsset = createAssetCardData({
+        id: 'reviewed-output',
+        name: 'reviewed.png'
+      })
+
+      return {
+        firstAsset,
+        firstRating,
+        savedAsset,
+        savedRating
+      }
+    },
+    template: `
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="group/card relative w-72">
+          <AssetCard :asset="firstAsset" interactive />
+          <div class="absolute top-4 left-4 rounded-md bg-base-background/90 p-1 opacity-0 shadow-interface transition-opacity group-hover/card:opacity-100 group-focus-within/card:opacity-100">
+            <AssetRating v-model="firstRating" size="sm" />
+          </div>
+        </div>
+
+        <div class="relative w-72">
+          <AssetCard :asset="savedAsset" interactive />
+          <div class="absolute top-4 left-4 rounded-md bg-base-background/90 p-1 shadow-interface">
+            <AssetRating v-model="savedRating" size="sm" />
+          </div>
+        </div>
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Storybook-only exploration of the intended asset-card behavior: keep unrated cards visually quiet, reveal the control on hover/focus, and keep rated assets visible for scanning.'
+      }
+    }
+  }
+}
+
+interface BatchAsset {
+  asset: AssetDisplayItem
+  rating: number | null
+}
+
+export const BatchTriage: Story = {
+  render: () => ({
+    components: { AssetCard, AssetRating },
+    setup() {
+      const assets = ref<BatchAsset[]>([
+        {
+          asset: createAssetCardData({
+            id: 'asset-1',
+            name: 'output-001.png',
+            secondaryText: 'Seed 314159'
+          }),
+          rating: 5
+        },
+        {
+          asset: createAssetCardData({
+            id: 'asset-2',
+            name: 'output-002.png',
+            secondaryText: 'Seed 314160'
+          }),
+          rating: 3
+        },
+        {
+          asset: createAssetCardData({
+            id: 'asset-3',
+            name: 'output-003.png',
+            secondaryText: 'Seed 314161'
+          }),
+          rating: null
+        },
+        {
+          asset: createAssetCardData({
+            id: 'asset-4',
+            name: 'output-004.png',
+            secondaryText: 'Seed 314162'
+          }),
+          rating: null
+        }
+      ])
+
+      return { assets }
+    },
+    template: `
+      <div class="flex max-w-5xl flex-col gap-3">
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div
+            v-for="item in assets"
+            :key="item.asset.id"
+            class="relative w-64"
+          >
+            <AssetCard :asset="item.asset" interactive />
+            <div class="absolute top-4 left-4 rounded-md bg-base-background/90 p-1 shadow-interface">
+              <AssetRating v-model="item.rating" size="sm" />
+            </div>
+          </div>
+        </div>
+        <p class="m-0 text-xs text-muted-foreground">
+          Tab through assets and use arrow keys or number keys to triage a batch.
+        </p>
+      </div>
+    `
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Storybook-only batch example showing independent per-asset ratings for outputs from the same workflow run.'
+      }
+    }
+  }
+}

--- a/src/platform/assets/components/AssetRating.test.ts
+++ b/src/platform/assets/components/AssetRating.test.ts
@@ -1,0 +1,196 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import AssetRating from './AssetRating.vue'
+
+const messages = {
+  en: {
+    assetRating: {
+      label: 'Asset rating',
+      rateAsset: 'Rate {rating} out of {max}',
+      clearRating: 'Clear {rating} out of {max} rating'
+    }
+  }
+}
+
+interface RenderOptions {
+  initialRating?: number | null
+  disabled?: boolean
+  readOnly?: boolean
+  max?: number
+  size?: 'sm' | 'md' | 'lg'
+  variant?: 'stars' | 'paintbrushes' | 'comfy'
+}
+
+function renderRating(options: RenderOptions = {}) {
+  const handleChange = vi.fn()
+  const user = userEvent.setup()
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages
+  })
+
+  const TestHarness = defineComponent({
+    components: { AssetRating },
+    setup() {
+      const rating = ref<number | null>(options.initialRating ?? null)
+
+      return {
+        handleChange,
+        options,
+        rating
+      }
+    },
+    template: `
+      <div>
+        <AssetRating
+          v-model="rating"
+          :disabled="options.disabled"
+          :max="options.max"
+          :read-only="options.readOnly"
+          :size="options.size"
+          :variant="options.variant"
+          @change="handleChange"
+        />
+        <output data-testid="rating-value">
+          {{ rating === null ? 'null' : rating }}
+        </output>
+      </div>
+    `
+  })
+
+  return {
+    handleChange,
+    user,
+    ...render(TestHarness, {
+      global: {
+        plugins: [i18n]
+      }
+    })
+  }
+}
+
+describe('AssetRating', () => {
+  it('renders an unrated asset rating control', () => {
+    renderRating()
+
+    expect(screen.getByRole('group', { name: 'Asset rating' })).toBeVisible()
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('null')
+    expect(
+      screen.getByRole('button', { name: 'Rate 1 out of 5' })
+    ).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('rates an asset when a star is clicked', async () => {
+    const { handleChange, user } = renderRating()
+
+    await user.click(screen.getByRole('button', { name: 'Rate 4 out of 5' }))
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('4')
+    expect(handleChange).toHaveBeenCalledWith(4)
+    expect(
+      screen.getByRole('button', { name: 'Clear 4 out of 5 rating' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('clears the rating when the selected star is clicked again', async () => {
+    const { handleChange, user } = renderRating({ initialRating: 3 })
+
+    await user.click(
+      screen.getByRole('button', { name: 'Clear 3 out of 5 rating' })
+    )
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('null')
+    expect(handleChange).toHaveBeenCalledWith(null)
+  })
+
+  it('previews ratings on hover without committing a value', async () => {
+    const { handleChange, user } = renderRating()
+
+    await user.hover(screen.getByRole('button', { name: 'Rate 5 out of 5' }))
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('null')
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('updates the rating with arrow keys', async () => {
+    const { handleChange, user } = renderRating()
+    screen.getByRole('button', { name: 'Rate 1 out of 5' }).focus()
+
+    await user.keyboard('{ArrowRight}{ArrowRight}{ArrowLeft}')
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('1')
+    expect(handleChange).toHaveBeenLastCalledWith(1)
+  })
+
+  it('sets the rating from a number key', async () => {
+    const { handleChange, user } = renderRating()
+    screen.getByRole('button', { name: 'Rate 1 out of 5' }).focus()
+
+    await user.keyboard('4')
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('4')
+    expect(handleChange).toHaveBeenCalledWith(4)
+  })
+
+  it.for(['paintbrushes', 'comfy'] as const)(
+    'supports the %s variant with the same rating behavior',
+    async (variant) => {
+      const { handleChange, user } = renderRating({ variant })
+
+      await user.click(screen.getByRole('button', { name: 'Rate 5 out of 5' }))
+
+      expect(screen.getByTestId('rating-value')).toHaveTextContent('5')
+      expect(handleChange).toHaveBeenCalledWith(5)
+    }
+  )
+
+  it('clears the rating with delete and backspace', async () => {
+    const { handleChange, user } = renderRating({ initialRating: 4 })
+    screen.getByRole('button', { name: 'Clear 4 out of 5 rating' }).focus()
+
+    await user.keyboard('{Delete}')
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('null')
+    expect(handleChange).toHaveBeenCalledWith(null)
+
+    await user.click(screen.getByRole('button', { name: 'Rate 2 out of 5' }))
+    await user.keyboard('{Backspace}')
+
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('null')
+    expect(handleChange).toHaveBeenLastCalledWith(null)
+  })
+
+  it('does not update when disabled', async () => {
+    const { handleChange, user } = renderRating({ disabled: true })
+    const firstStar = screen.getByRole('button', {
+      name: 'Rate 1 out of 5'
+    })
+
+    await user.click(firstStar)
+
+    expect(firstStar).toBeDisabled()
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('null')
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('does not update when read-only', async () => {
+    const { handleChange, user } = renderRating({
+      initialRating: 2,
+      readOnly: true
+    })
+    const selectedStar = screen.getByRole('button', {
+      name: 'Clear 2 out of 5 rating'
+    })
+
+    await user.click(selectedStar)
+
+    expect(selectedStar).toBeDisabled()
+    expect(screen.getByTestId('rating-value')).toHaveTextContent('2')
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/assets/components/AssetRating.vue
+++ b/src/platform/assets/components/AssetRating.vue
@@ -1,0 +1,243 @@
+<template>
+  <div
+    role="group"
+    :aria-label="accessibleLabel"
+    :class="
+      cn(
+        'inline-flex items-center',
+        disabled && 'opacity-60',
+        readOnly && 'cursor-default'
+      )
+    "
+  >
+    <div class="inline-flex items-center">
+      <button
+        v-for="value in ratingValues"
+        :key="value"
+        type="button"
+        :disabled="isInteractionDisabled"
+        :aria-label="getRatingLabel(value)"
+        :aria-pressed="selectedRating === value"
+        :class="
+          cn(
+            'group/rating-star flex touch-manipulation appearance-none items-center justify-center rounded-sm border-none bg-transparent p-0 transition-transform',
+            'focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-none',
+            sizeClasses.button,
+            isInteractionDisabled
+              ? 'cursor-default'
+              : 'cursor-pointer hover:scale-110 hover:bg-secondary-background-hover active:scale-95'
+          )
+        "
+        @click="toggleRating(value)"
+        @focus="previewRating(value)"
+        @mouseenter="previewRating(value)"
+        @mouseleave="clearPreview"
+        @blur="clearPreview"
+        @keydown="handleKeydown"
+      >
+        <i
+          aria-hidden="true"
+          :class="
+            cn(
+              'shrink-0 transition-colors',
+              sizeClasses.icon,
+              getRatingGlyphClass(value),
+              !isInteractionDisabled &&
+                'group-hover/rating-star:text-warning-background'
+            )
+          "
+        />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { cn } from '@comfyorg/tailwind-utils'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+type RatingSize = 'sm' | 'md' | 'lg'
+type RatingVariant = 'stars' | 'paintbrushes' | 'comfy'
+
+const ratingGlyphClasses: Record<
+  RatingVariant,
+  { filled: string; empty: string }
+> = {
+  stars: {
+    filled: 'icon-[ph--star-fill] text-warning-background',
+    empty: 'icon-[lucide--star] text-muted-foreground'
+  },
+  paintbrushes: {
+    filled: 'icon-[lucide--paintbrush] text-warning-background',
+    empty: 'icon-[lucide--paintbrush] text-muted-foreground'
+  },
+  comfy: {
+    filled: 'icon-[comfy--comfy-c] text-warning-background',
+    empty: 'icon-[comfy--comfy-c] text-muted-foreground'
+  }
+}
+
+const {
+  max = 5,
+  disabled = false,
+  readOnly = false,
+  size = 'md',
+  variant = 'stars',
+  ariaLabel
+} = defineProps<{
+  max?: number
+  disabled?: boolean
+  readOnly?: boolean
+  size?: RatingSize
+  variant?: RatingVariant
+  ariaLabel?: string
+}>()
+
+const emit = defineEmits<{
+  change: [rating: number | null]
+}>()
+
+// Local interaction only; asset persistence belongs to the owning surface.
+const rating = defineModel<number | null>({ default: null })
+
+const { t } = useI18n()
+const previewedRating = ref<number | null>(null)
+
+const ratingMax = computed(() => normalizeMax(max))
+
+const ratingValues = computed(() =>
+  Array.from({ length: ratingMax.value }, (_, index) => index + 1)
+)
+
+const selectedRating = computed(() =>
+  normalizeRating(rating.value, ratingMax.value)
+)
+
+const visibleRating = computed(
+  () => previewedRating.value ?? selectedRating.value
+)
+
+const isInteractionDisabled = computed(() => disabled || readOnly)
+
+const accessibleLabel = computed(() => ariaLabel ?? t('assetRating.label'))
+
+const sizeClasses = computed(() => {
+  switch (size) {
+    case 'sm':
+      return { button: 'size-4', icon: 'size-3' }
+    case 'lg':
+      return { button: 'size-8', icon: 'size-5' }
+    case 'md':
+    default:
+      return { button: 'size-6', icon: 'size-3.5' }
+  }
+})
+
+function normalizeMax(value: number): number {
+  if (!Number.isFinite(value)) return 5
+  return Math.max(1, Math.trunc(value))
+}
+
+function normalizeRating(
+  value: number | null | undefined,
+  maxValue: number
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+
+  const integerValue = Math.trunc(value)
+  if (integerValue < 1) return null
+
+  return Math.min(maxValue, integerValue)
+}
+
+function getRatingLabel(value: number): string {
+  if (selectedRating.value === value) {
+    return t('assetRating.clearRating', {
+      rating: value,
+      max: ratingMax.value
+    })
+  }
+
+  return t('assetRating.rateAsset', {
+    rating: value,
+    max: ratingMax.value
+  })
+}
+
+function isRatingFilled(value: number): boolean {
+  return visibleRating.value !== null && value <= visibleRating.value
+}
+
+function getRatingGlyphClass(value: number): string {
+  const glyphClass = ratingGlyphClasses[variant]
+  return isRatingFilled(value) ? glyphClass.filled : glyphClass.empty
+}
+
+function previewRating(value: number) {
+  if (isInteractionDisabled.value) return
+  previewedRating.value = value
+}
+
+function clearPreview() {
+  previewedRating.value = null
+}
+
+function commitRating(value: number | null) {
+  if (isInteractionDisabled.value) return
+
+  const nextRating = normalizeRating(value, ratingMax.value)
+  if (nextRating === rating.value) return
+
+  clearPreview()
+  rating.value = nextRating
+  emit('change', nextRating)
+}
+
+function toggleRating(value: number) {
+  const nextRating = selectedRating.value === value ? null : value
+  commitRating(nextRating)
+}
+
+function nudgeRating(delta: 1 | -1) {
+  const currentRating = selectedRating.value ?? 0
+  commitRating(currentRating + delta)
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (isInteractionDisabled.value) return
+
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowUp':
+      event.preventDefault()
+      nudgeRating(1)
+      return
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      event.preventDefault()
+      nudgeRating(-1)
+      return
+    case 'Home':
+    case 'Backspace':
+    case 'Delete':
+      event.preventDefault()
+      commitRating(null)
+      return
+    case 'End':
+      event.preventDefault()
+      commitRating(ratingMax.value)
+      return
+  }
+
+  const numericKey = Number(event.key)
+  if (
+    Number.isInteger(numericKey) &&
+    numericKey >= 1 &&
+    numericKey <= ratingMax.value
+  ) {
+    event.preventDefault()
+    commitRating(numericKey)
+  }
+}
+</script>


### PR DESCRIPTION
## Summary

Adds a standalone Storybook `AssetRating` component for clearable 1-5 ratings on generated output assets.

## Changes

- **What**: Added a controlled, persistence-agnostic `AssetRating` component with compact rating glyphs, hover/focus preview, click-to-rate, click-selected-to-clear, keyboard shortcuts, disabled/read-only states, i18n labels, and unit coverage.
- **What**: Added Storybook coverage for isolated states, sizing, interactivity, clearability, glyph exploration, first-run discoverability, and batch triage across individual workflow output assets.
- **Breaking**: None.
- **Dependencies**: None.

## Decisions

- I chose a clearable 1-5 scale because it gives better downstream signal than favorite/unfavorite or thumbs up/down while keeping `null` available for “not reviewed yet.”
- Ratings target individual output assets, including assets generated in one job batch, because outputs from the same workflow/run can vary significantly by seed.
- The component intentionally owns only local interaction behavior. Project-shared persistence, user attribution, notes/tags, and workflow-level aggregation should live in the asset integration layer.
- I kept visible rating text out of the component. Dense asset cards need a compact affordance; accessible button labels still communicate rate and clear behavior.
- Stars remain the default because they are the clearest rating metaphor. Paintbrush and Comfy C variants are included in Storybook as visual explorations for cases where stars could be confused with existing favorite/popularity stats.
- The card and batch stories compose around the existing `AssetCard` without changing production card APIs or stores.
## Review Focus

- Interaction model: click to rate, click selected value to clear, hover/focus preview, arrow keys to adjust, number keys to set, Delete/Backspace/Home to clear.
- Accessibility: each rating value is a real button with explicit labels; disabled/read-only states block mutation - Accessible keyboard and screen-reader behavior so the control works for hover, focus, and non-pointer users.
- Scope boundary: this is a UI primitive and Storybook exploration, not a persistence or asset schema change.
- Asset card fit: unrated controls can be revealed on hover/focus; rated controls can remain visible for scanning.

## Assumptions

- Ratings are eventually project-shared because assets are project-visible.
- Any user in a project can manage an asset rating unless a future permissions model says otherwise.
- Notes/tags such as “best hands” or “bad face” are useful future signal, but should be adjacent to this primitive rather than coupled to it. - didn't do it for now. 

## With More Time

- Validate the default glyph treatment with designers and users, especially because `AssetCard` already uses a star stat for popularity/favorites.
- Add a production integration spike around the asset store/API contract, including `assetId`, `rating`, `updatedBy`, and `updatedAt`.
- Explore a details-panel treatment for rating history, notes/tags, and project-shared attribution.
- Add visual regression coverage once the production asset-card integration exists.

## Validation

- `pnpm test:unit src/platform/assets/components/AssetRating.test.ts`
- `pnpm exec eslint --cache src/platform/assets/components/AssetRating.vue src/platform/assets/components/AssetRating.stories.ts src/platform/assets/components/AssetRating.test.ts`
- `pnpm typecheck`
- `pnpm exec oxfmt --check src/platform/assets/components/AssetRating.vue src/platform/assets/components/AssetRating.stories.ts src/platform/assets/components/AssetRating.test.ts src/locales/en/main.json`

## Screenshots

Storybook: `Platform/Assets/AssetRating`