### PR TITLE
Refactor/replace local canvas mocks

### DIFF
--- a/src/composables/maskeditor/useMaskEditorSaver.test.ts
+++ b/src/composables/maskeditor/useMaskEditorSaver.test.ts
@@ -8,6 +8,7 @@ import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { useMaskEditorSaver } from './useMaskEditorSaver'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 // ---- Module Mocks ----
 
@@ -21,24 +22,11 @@ vi.mock('@/stores/maskEditorDataStore', () => ({
   useMaskEditorDataStore: vi.fn(() => mockDataStore)
 }))
 
-function createMockCtx(): CanvasRenderingContext2D {
-  return fromPartial<CanvasRenderingContext2D>({
-    drawImage: vi.fn(),
-    getImageData: vi.fn(() => ({
-      data: new Uint8ClampedArray(4 * 4 * 4),
-      width: 4,
-      height: 4
-    })),
-    putImageData: vi.fn(),
-    globalCompositeOperation: 'source-over'
-  })
-}
-
 function createMockCanvas(): HTMLCanvasElement {
   return fromPartial<HTMLCanvasElement>({
     width: 4,
     height: 4,
-    getContext: vi.fn(() => createMockCtx()),
+    getContext: vi.fn(() => createMockCanvasRenderingContext2D()),
     toBlob: vi.fn((cb: BlobCallback) => {
       cb(new Blob(['x'], { type: 'image/png' }))
     }),

--- a/src/lib/litegraph/src/LGraphButton.test.ts
+++ b/src/lib/litegraph/src/LGraphButton.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 import { LGraphButton, Rectangle } from '@/lib/litegraph/src/litegraph'
 
 describe('LGraphButton', () => {
@@ -56,18 +56,7 @@ describe('LGraphButton', () => {
         yOffset: 10
       })
 
-      const ctx = {
-        measureText: vi.fn().mockReturnValue({ width: 60 }),
-        fillRect: vi.fn(),
-        fillText: vi.fn(),
-        beginPath: vi.fn(),
-        roundRect: vi.fn(),
-        fill: vi.fn(),
-        font: '',
-        fillStyle: '',
-        globalAlpha: 1
-      } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
-
+      const ctx = createMockCanvasRenderingContext2D()
       const mockGetWidth = vi.fn().mockReturnValue(80)
       button.getWidth = mockGetWidth
 

--- a/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
@@ -11,6 +11,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 const TEST_NODE_TYPE = 'test/CloneZIndex' as const
 
 class TestNode extends LGraphNode {
@@ -27,38 +28,7 @@ function createCanvas(graph: LGraph): LGraphCanvas {
   el.width = 800
   el.height = 600
 
-  const ctx = {
-    save: vi.fn(),
-    restore: vi.fn(),
-    translate: vi.fn(),
-    scale: vi.fn(),
-    fillRect: vi.fn(),
-    strokeRect: vi.fn(),
-    fillText: vi.fn(),
-    measureText: vi.fn().mockReturnValue({ width: 50 }),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    stroke: vi.fn(),
-    fill: vi.fn(),
-    closePath: vi.fn(),
-    arc: vi.fn(),
-    rect: vi.fn(),
-    clip: vi.fn(),
-    clearRect: vi.fn(),
-    setTransform: vi.fn(),
-    roundRect: vi.fn(),
-    getTransform: vi
-      .fn()
-      .mockReturnValue({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
-    font: '',
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-    globalAlpha: 1,
-    textAlign: 'left' as CanvasTextAlign,
-    textBaseline: 'alphabetic' as CanvasTextBaseline
-  } satisfies Partial<CanvasRenderingContext2D>
+  const ctx = createMockCanvasRenderingContext2D()
 
   el.getContext = vi
     .fn()

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -9,7 +9,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import { LLink } from '@/lib/litegraph/src/LLink'
-import { createMockCanvas2DContext } from '@/utils/__tests__/litegraphTestUtils'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
   layoutStore: {
@@ -25,37 +25,6 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
     pendingSlotSync: false
   }
 }))
-
-function createMockCtx(): CanvasRenderingContext2D {
-  return createMockCanvas2DContext({
-    translate: vi.fn(),
-    scale: vi.fn(),
-    fillText: vi.fn(),
-    measureText: vi.fn().mockReturnValue({ width: 50 }),
-    closePath: vi.fn(),
-    rect: vi.fn(),
-    clip: vi.fn(),
-    setTransform: vi.fn(),
-    roundRect: vi.fn(),
-    getTransform: vi
-      .fn()
-      .mockReturnValue({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
-    createLinearGradient: vi.fn().mockReturnValue({
-      addColorStop: vi.fn()
-    }),
-    bezierCurveTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
-    isPointInStroke: vi.fn().mockReturnValue(false),
-    globalAlpha: 1,
-    textAlign: 'left' as CanvasTextAlign,
-    textBaseline: 'alphabetic' as CanvasTextBaseline,
-    shadowColor: '',
-    shadowBlur: 0,
-    shadowOffsetX: 0,
-    shadowOffsetY: 0,
-    imageSmoothingEnabled: true
-  })
-}
 
 /**
  * Creates a link between two nodes by directly mutating graph state,
@@ -96,7 +65,9 @@ describe('drawConnections widget-input slot positioning', () => {
     canvasElement = document.createElement('canvas')
     canvasElement.width = 800
     canvasElement.height = 600
-    canvasElement.getContext = vi.fn().mockReturnValue(createMockCtx())
+    canvasElement.getContext = vi
+      .fn()
+      .mockReturnValue(createMockCanvasRenderingContext2D())
     canvasElement.getBoundingClientRect = vi.fn().mockReturnValue({
       left: 0,
       top: 0,
@@ -136,7 +107,7 @@ describe('drawConnections widget-input slot positioning', () => {
     // Before drawConnections, input.pos should not be set
     expect(input.pos).toBeUndefined()
 
-    canvas.drawConnections(createMockCtx())
+    canvas.drawConnections(createMockCanvasRenderingContext2D())
 
     // After drawConnections, input.pos should be set to the widget row
     expect(input.pos).toBeDefined()
@@ -170,7 +141,7 @@ describe('drawConnections widget-input slot positioning', () => {
 
     const arrangeSpy = vi.spyOn(targetNode, 'arrange')
 
-    canvas.drawConnections(createMockCtx())
+    canvas.drawConnections(createMockCanvasRenderingContext2D())
 
     expect(arrangeSpy).not.toHaveBeenCalled()
   })
@@ -198,7 +169,7 @@ describe('drawConnections widget-input slot positioning', () => {
     graph.add(targetNode)
     createTestLink(graph, sourceNode, 0, targetNode, 0)
 
-    canvas.drawConnections(createMockCtx())
+    canvas.drawConnections(createMockCanvasRenderingContext2D())
 
     expect(input.pos).toBeDefined()
     const offset = LiteGraph.NODE_SLOT_HEIGHT * 0.5

--- a/src/lib/litegraph/src/LGraphCanvas.groupSelection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.groupSelection.test.ts
@@ -8,6 +8,7 @@ import {
   LGraphGroup,
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
   layoutStore: {
@@ -25,38 +26,7 @@ function createCanvas(graph: LGraph): LGraphCanvas {
   el.width = 800
   el.height = 600
 
-  const ctx = {
-    save: vi.fn(),
-    restore: vi.fn(),
-    translate: vi.fn(),
-    scale: vi.fn(),
-    fillRect: vi.fn(),
-    strokeRect: vi.fn(),
-    fillText: vi.fn(),
-    measureText: vi.fn().mockReturnValue({ width: 50 }),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    stroke: vi.fn(),
-    fill: vi.fn(),
-    closePath: vi.fn(),
-    arc: vi.fn(),
-    rect: vi.fn(),
-    clip: vi.fn(),
-    clearRect: vi.fn(),
-    setTransform: vi.fn(),
-    roundRect: vi.fn(),
-    getTransform: vi
-      .fn()
-      .mockReturnValue({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
-    font: '',
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-    globalAlpha: 1,
-    textAlign: 'left' as CanvasTextAlign,
-    textBaseline: 'alphabetic' as CanvasTextBaseline
-  } satisfies Partial<CanvasRenderingContext2D>
+  const ctx = createMockCanvasRenderingContext2D()
 
   el.getContext = vi
     .fn()

--- a/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
@@ -7,6 +7,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
   layoutStore: {
@@ -32,39 +33,7 @@ describe('LGraphCanvas slot hit detection', () => {
     canvasElement.width = 800
     canvasElement.height = 600
 
-    const ctx = {
-      save: vi.fn(),
-      restore: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      fillRect: vi.fn(),
-      strokeRect: vi.fn(),
-      fillText: vi.fn(),
-      measureText: vi.fn().mockReturnValue({ width: 50 }),
-      beginPath: vi.fn(),
-      moveTo: vi.fn(),
-      lineTo: vi.fn(),
-      stroke: vi.fn(),
-      fill: vi.fn(),
-      closePath: vi.fn(),
-      arc: vi.fn(),
-      rect: vi.fn(),
-      clip: vi.fn(),
-      clearRect: vi.fn(),
-      setTransform: vi.fn(),
-      roundRect: vi.fn(),
-      getTransform: vi
-        .fn()
-        .mockReturnValue({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
-      font: '',
-      fillStyle: '',
-      strokeStyle: '',
-      lineWidth: 1,
-      globalAlpha: 1,
-      textAlign: 'left' as CanvasTextAlign,
-      textBaseline: 'alphabetic' as CanvasTextBaseline
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
-
+    const ctx = createMockCanvasRenderingContext2D()
     canvasElement.getContext = vi.fn().mockReturnValue(ctx)
     canvasElement.getBoundingClientRect = vi.fn().mockReturnValue({
       left: 0,

--- a/src/lib/litegraph/src/LGraphCanvas.titleButtons.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.titleButtons.test.ts
@@ -6,6 +6,7 @@ import {
   LGraphNode,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 describe('LGraphCanvas Title Button Rendering', () => {
   let canvas: LGraphCanvas
@@ -15,36 +16,7 @@ describe('LGraphCanvas Title Button Rendering', () => {
   beforeEach(() => {
     // Create a mock canvas element
     const canvasElement = document.createElement('canvas')
-    ctx = {
-      save: vi.fn(),
-      restore: vi.fn(),
-      translate: vi.fn(),
-      scale: vi.fn(),
-      fillRect: vi.fn(),
-      strokeRect: vi.fn(),
-      fillText: vi.fn(),
-      measureText: vi.fn().mockReturnValue({ width: 50 }),
-      beginPath: vi.fn(),
-      moveTo: vi.fn(),
-      lineTo: vi.fn(),
-      stroke: vi.fn(),
-      fill: vi.fn(),
-      closePath: vi.fn(),
-      arc: vi.fn(),
-      rect: vi.fn(),
-      clip: vi.fn(),
-      clearRect: vi.fn(),
-      setTransform: vi.fn(),
-      roundRect: vi.fn(),
-      font: '',
-      fillStyle: '',
-      strokeStyle: '',
-      lineWidth: 1,
-      globalAlpha: 1,
-      textAlign: 'left' as CanvasTextAlign,
-      textBaseline: 'alphabetic' as CanvasTextBaseline
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
-
+    ctx = createMockCanvasRenderingContext2D()
     canvasElement.getContext = vi.fn().mockReturnValue(ctx)
 
     const graph = new LGraph()

--- a/src/lib/litegraph/src/subgraph/SubgraphSlotVisualFeedback.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphSlotVisualFeedback.test.ts
@@ -9,6 +9,7 @@ import {
   createTestSubgraph,
   resetSubgraphFixtureState
 } from './__fixtures__/subgraphHelpers'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 interface MockColorContext {
   defaultInputColor: string
@@ -30,27 +31,8 @@ describe('SubgraphSlot visual feedback', () => {
     globalAlphaValues = []
 
     // Create a mock canvas context that tracks all globalAlpha values
-    const mockContext = {
-      _globalAlpha: 1,
-      get globalAlpha() {
-        return this._globalAlpha
-      },
-      set globalAlpha(value: number) {
-        this._globalAlpha = value
-        globalAlphaValues.push(value)
-      },
-      fillStyle: '',
-      strokeStyle: '',
-      lineWidth: 1,
-      beginPath: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      stroke: vi.fn(),
-      rect: vi.fn(),
-      fillText: vi.fn()
-    }
-    mockCtx =
-      mockContext as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
+
+    mockCtx = createMockCanvasRenderingContext2D()
 
     // Create a mock color context
     mockColorContext = {

--- a/src/lib/litegraph/src/subgraph/SubgraphSlotVisualFeedback.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphSlotVisualFeedback.test.ts
@@ -33,7 +33,11 @@ describe('SubgraphSlot visual feedback', () => {
     // Create a mock canvas context that tracks all globalAlpha values
 
     mockCtx = createMockCanvasRenderingContext2D()
-
+    Object.defineProperty(mockCtx, 'globalAlpha', {
+      get: () => globalAlphaValues.at(-1) ?? 1,
+      set: (value: number) => globalAlphaValues.push(value),
+      configurable: true
+    })
     // Create a mock color context
     mockColorContext = {
       defaultInputColor: '#FF0000',

--- a/src/lib/litegraph/src/utils/textMeasureCache.test.ts
+++ b/src/lib/litegraph/src/utils/textMeasureCache.test.ts
@@ -4,12 +4,22 @@ import { cachedMeasureText, clearTextMeasureCache } from './textMeasureCache'
 import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 describe('textMeasureCache', () => {
+  function createMeasuredCanvasContext(): CanvasRenderingContext2D {
+    return createMockCanvasRenderingContext2D({
+      measureText: vi.fn(
+        (text: string) =>
+          ({
+            width: text.length * 7
+          }) as TextMetrics
+      )
+    })
+  }
   beforeEach(() => {
     clearTextMeasureCache()
   })
 
   it('returns the measured width', () => {
-    const ctx = createMockCanvasRenderingContext2D()
+    const ctx = createMeasuredCanvasContext()
     const width = cachedMeasureText(ctx, 'hello')
     expect(width).toBe(35)
     expect(ctx.measureText).toHaveBeenCalledWith('hello')
@@ -25,15 +35,7 @@ describe('textMeasureCache', () => {
   })
 
   it('uses font as part of the cache key', () => {
-    const ctx1 = createMockCanvasRenderingContext2D({
-      font: '12px sans-serif',
-      measureText: vi.fn(
-        (text: string) =>
-          ({
-            width: text.length * 7
-          }) as TextMetrics
-      )
-    })
+    const ctx1 = createMeasuredCanvasContext()
 
     const ctx2 = createMockCanvasRenderingContext2D({
       font: '24px monospace',
@@ -52,7 +54,7 @@ describe('textMeasureCache', () => {
   })
 
   it('clearTextMeasureCache resets the cache', () => {
-    const ctx = createMockCanvasRenderingContext2D()
+    const ctx = createMeasuredCanvasContext()
     cachedMeasureText(ctx, 'hello')
     expect(ctx.measureText).toHaveBeenCalledTimes(1)
 
@@ -63,7 +65,7 @@ describe('textMeasureCache', () => {
   })
 
   it('caches different text strings separately', () => {
-    const ctx = createMockCanvasRenderingContext2D()
+    const ctx = createMeasuredCanvasContext()
     const w1 = cachedMeasureText(ctx, 'abc')
     const w2 = cachedMeasureText(ctx, 'abcd')
 

--- a/src/lib/litegraph/src/utils/textMeasureCache.test.ts
+++ b/src/lib/litegraph/src/utils/textMeasureCache.test.ts
@@ -1,14 +1,7 @@
-import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { cachedMeasureText, clearTextMeasureCache } from './textMeasureCache'
-
-function createMockCtx(font = '12px sans-serif'): CanvasRenderingContext2D {
-  return fromPartial<CanvasRenderingContext2D>({
-    font,
-    measureText: vi.fn((text: string) => ({ width: text.length * 7 }))
-  })
-}
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 describe('textMeasureCache', () => {
   beforeEach(() => {
@@ -16,14 +9,14 @@ describe('textMeasureCache', () => {
   })
 
   it('returns the measured width', () => {
-    const ctx = createMockCtx()
+    const ctx = createMockCanvasRenderingContext2D()
     const width = cachedMeasureText(ctx, 'hello')
     expect(width).toBe(35)
     expect(ctx.measureText).toHaveBeenCalledWith('hello')
   })
 
   it('returns cached result on second call without re-measuring', () => {
-    const ctx = createMockCtx()
+    const ctx = createMockCanvasRenderingContext2D()
     const first = cachedMeasureText(ctx, 'hello')
     const second = cachedMeasureText(ctx, 'hello')
 
@@ -32,9 +25,25 @@ describe('textMeasureCache', () => {
   })
 
   it('uses font as part of the cache key', () => {
-    const ctx1 = createMockCtx('12px sans-serif')
-    const ctx2 = createMockCtx('24px monospace')
+    const ctx1 = createMockCanvasRenderingContext2D({
+      font: '12px sans-serif',
+      measureText: vi.fn(
+        (text: string) =>
+          ({
+            width: text.length * 7
+          }) as TextMetrics
+      )
+    })
 
+    const ctx2 = createMockCanvasRenderingContext2D({
+      font: '24px monospace',
+      measureText: vi.fn(
+        (text: string) =>
+          ({
+            width: text.length * 7
+          }) as TextMetrics
+      )
+    })
     cachedMeasureText(ctx1, 'hello')
     cachedMeasureText(ctx2, 'hello')
 
@@ -43,7 +52,7 @@ describe('textMeasureCache', () => {
   })
 
   it('clearTextMeasureCache resets the cache', () => {
-    const ctx = createMockCtx()
+    const ctx = createMockCanvasRenderingContext2D()
     cachedMeasureText(ctx, 'hello')
     expect(ctx.measureText).toHaveBeenCalledTimes(1)
 
@@ -54,7 +63,7 @@ describe('textMeasureCache', () => {
   })
 
   it('caches different text strings separately', () => {
-    const ctx = createMockCtx()
+    const ctx = createMockCanvasRenderingContext2D()
     const w1 = cachedMeasureText(ctx, 'abc')
     const w2 = cachedMeasureText(ctx, 'abcd')
 

--- a/src/renderer/core/canvas/pathRenderer.test.ts
+++ b/src/renderer/core/canvas/pathRenderer.test.ts
@@ -57,6 +57,11 @@ function makeContext(overrides: Partial<RenderContext> = {}): RenderContext {
   }
 }
 
+function createPathRendererCtx(): CanvasRenderingContext2D {
+  return createMockCanvasRenderingContext2D({
+    rotate: vi.fn()
+  })
+}
 describe('CanvasPathRenderer', () => {
   let renderer: CanvasPathRenderer
 
@@ -66,7 +71,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('link color determination', () => {
     it('uses highlighted color when link is highlighted', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext({
         highlightedIds: new Set(['link-1'])
@@ -78,7 +83,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses link-specific color over type and default', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ color: '#ff0000' })
       const context = makeContext()
 
@@ -88,7 +93,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses type color when no explicit link color', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ type: 'IMAGE' })
       const context = makeContext({
         colors: {
@@ -104,7 +109,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('falls back to default color', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext()
 
@@ -116,7 +121,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('drawLink border', () => {
     it('draws border when borderWidth is set and not lowQuality', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext({
         style: { mode: 'spline', connectionWidth: 3, borderWidth: 2 }
@@ -129,7 +134,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('skips border in lowQuality mode', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext({
         style: {
@@ -149,7 +154,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('disabled links', () => {
     it('applies disabled pattern when link is disabled', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const disabledPattern = {} as CanvasPattern
       const link = makeLink({ disabled: true })
       const context = makeContext({
@@ -171,7 +176,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('linear path mode', () => {
     it('builds a 4-point path with directional offsets', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startDirection: 'right',
         endDirection: 'left'
@@ -201,7 +206,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('handles up/down directions', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 50, y: 50 },
         endPoint: { x: 50, y: 200 },
@@ -225,7 +230,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('handles none direction (no offset)', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startDirection: 'none',
         endDirection: 'none'
@@ -249,7 +254,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('straight path mode', () => {
     it('builds a 6-point path with mid-X routing', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -279,7 +284,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('handles up direction offset (l=10)', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 100, y: 100 },
         endPoint: { x: 100, y: 300 },
@@ -305,7 +310,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('spline path mode', () => {
     it('uses provided control points for cubic bezier', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const cp: Point[] = [
         { x: 50, y: 10 },
         { x: 150, y: 90 }
@@ -325,7 +330,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('auto-calculates control points when none provided', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext()
 
@@ -340,7 +345,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses quadratic curve for single control point', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ controlPoints: [{ x: 100, y: 50 }] })
       const context = makeContext()
 
@@ -356,7 +361,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('falls back to lineTo when no control points', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ controlPoints: [] })
       const context = makeContext()
 
@@ -374,7 +379,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('auto-calculated control points', () => {
     it('produces control points offset in the start/end directions', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 400, y: 0 },
@@ -400,7 +405,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses minimum controlDist of 30 for short links', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 10, y: 0 },
@@ -458,7 +463,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('center point calculation', () => {
     it('calculates spline center using bezier at t=0.5', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const cp: Point[] = [
         { x: 50, y: 0 },
         { x: 150, y: 100 }
@@ -474,7 +479,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates spline center angle for arrow marker', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const cp: Point[] = [
         { x: 50, y: 0 },
         { x: 150, y: 100 }
@@ -495,7 +500,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates linear center as midpoint of inner control points', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -513,7 +518,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center with l=10 offsets', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -531,7 +536,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center angle = 0 when y diff < 4', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 50 },
         endPoint: { x: 200, y: 52 },
@@ -552,7 +557,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center angle = PI/2 when end is below', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -573,7 +578,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center angle = -PI/2 when end is above', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 100 },
         endPoint: { x: 200, y: 0 },
@@ -594,7 +599,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates linear center angle for arrow marker', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startDirection: 'right',
         endDirection: 'left'
@@ -615,7 +620,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('arrows', () => {
     it('draws arrows at 0.25 and 0.75 positions when showArrows=true', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext({
         style: { mode: 'spline', connectionWidth: 3, showArrows: true }
@@ -631,7 +636,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('does not draw arrows when showArrows=false', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext()
 
@@ -643,7 +648,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('center marker', () => {
     it('draws circle marker when conditions are met', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -667,7 +672,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('draws arrow-shaped marker when centerMarkerShape is arrow', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -693,7 +698,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('skips marker when scale is below 0.6', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -716,7 +721,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('skips marker when highQuality is false', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -739,7 +744,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('applies disabled pattern for center marker', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const disabledPattern = {} as CanvasPattern
       const link = makeLink({
         disabled: true,
@@ -768,7 +773,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('flow animation', () => {
     it('draws 5 circles when flow is enabled', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ flow: true })
       const context = makeContext({
         animation: { time: 0.5 }
@@ -783,7 +788,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('does not animate when flow is false', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ flow: false })
       const context = makeContext({ animation: { time: 0.5 } })
 
@@ -793,7 +798,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('does not animate when no animation context', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({ flow: true })
       const context = makeContext()
 
@@ -805,7 +810,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('drawDraggingLink', () => {
     it('draws a link from fixed to drag point', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const context = makeContext()
 
       const path = renderer.drawDraggingLink(
@@ -823,7 +828,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('swaps points when dragging from input', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const context = makeContext({
         style: { mode: 'linear', connectionWidth: 3 }
       })
@@ -845,7 +850,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses custom dragDirection when provided', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const context = makeContext()
 
       renderer.drawDraggingLink(
@@ -863,7 +868,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('passes color and type through to link rendering', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const context = makeContext({
         colors: {
           default: '#ffffff',
@@ -889,7 +894,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('computeConnectionPoint', () => {
     it('computes arrow positions along the path', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 100, y: 0 },
@@ -908,7 +913,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('drawLink return value', () => {
     it('returns a Path2D for hit detection', () => {
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createPathRendererCtx()
       const link = makeLink()
       const context = makeContext()
 
@@ -928,7 +933,7 @@ describe('CanvasPathRenderer', () => {
     ] as const)(
       'linear mode applies correct offset for $dir direction',
       ({ dir, expectedInnerA }) => {
-        const ctx = createMockCanvasRenderingContext2D()
+        const ctx = createPathRendererCtx()
         const link = makeLink({
           startPoint: { x: 0, y: 0 },
           endPoint: { x: 200, y: 100 },

--- a/src/renderer/core/canvas/pathRenderer.test.ts
+++ b/src/renderer/core/canvas/pathRenderer.test.ts
@@ -6,6 +6,7 @@ import type {
   RenderContext
 } from '@/renderer/core/canvas/pathRenderer'
 import { CanvasPathRenderer } from '@/renderer/core/canvas/pathRenderer'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 class StubPath2D {
   calls: Array<{ method: string; args: unknown[] }> = []
@@ -27,28 +28,6 @@ class StubPath2D {
 }
 
 vi.stubGlobal('Path2D', StubPath2D)
-
-function createMockCtx(): CanvasRenderingContext2D {
-  return {
-    save: vi.fn(),
-    restore: vi.fn(),
-    stroke: vi.fn(),
-    fill: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    arc: vi.fn(),
-    translate: vi.fn(),
-    rotate: vi.fn(),
-    getTransform: vi.fn(() => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 })),
-    setTransform: vi.fn(),
-    strokeStyle: '',
-    fillStyle: '',
-    lineWidth: 0,
-    lineJoin: 'round',
-    globalAlpha: 1
-  } as unknown as CanvasRenderingContext2D
-}
 
 function makeLink(overrides: Partial<LinkRenderData> = {}): LinkRenderData {
   return {
@@ -87,7 +66,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('link color determination', () => {
     it('uses highlighted color when link is highlighted', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext({
         highlightedIds: new Set(['link-1'])
@@ -99,7 +78,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses link-specific color over type and default', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ color: '#ff0000' })
       const context = makeContext()
 
@@ -109,7 +88,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses type color when no explicit link color', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ type: 'IMAGE' })
       const context = makeContext({
         colors: {
@@ -125,7 +104,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('falls back to default color', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext()
 
@@ -137,7 +116,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('drawLink border', () => {
     it('draws border when borderWidth is set and not lowQuality', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext({
         style: { mode: 'spline', connectionWidth: 3, borderWidth: 2 }
@@ -150,7 +129,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('skips border in lowQuality mode', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext({
         style: {
@@ -170,7 +149,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('disabled links', () => {
     it('applies disabled pattern when link is disabled', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const disabledPattern = {} as CanvasPattern
       const link = makeLink({ disabled: true })
       const context = makeContext({
@@ -192,7 +171,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('linear path mode', () => {
     it('builds a 4-point path with directional offsets', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startDirection: 'right',
         endDirection: 'left'
@@ -222,7 +201,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('handles up/down directions', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 50, y: 50 },
         endPoint: { x: 50, y: 200 },
@@ -246,7 +225,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('handles none direction (no offset)', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startDirection: 'none',
         endDirection: 'none'
@@ -270,7 +249,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('straight path mode', () => {
     it('builds a 6-point path with mid-X routing', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -300,7 +279,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('handles up direction offset (l=10)', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 100, y: 100 },
         endPoint: { x: 100, y: 300 },
@@ -326,7 +305,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('spline path mode', () => {
     it('uses provided control points for cubic bezier', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const cp: Point[] = [
         { x: 50, y: 10 },
         { x: 150, y: 90 }
@@ -346,7 +325,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('auto-calculates control points when none provided', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext()
 
@@ -361,7 +340,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses quadratic curve for single control point', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ controlPoints: [{ x: 100, y: 50 }] })
       const context = makeContext()
 
@@ -377,7 +356,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('falls back to lineTo when no control points', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ controlPoints: [] })
       const context = makeContext()
 
@@ -395,7 +374,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('auto-calculated control points', () => {
     it('produces control points offset in the start/end directions', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 400, y: 0 },
@@ -421,7 +400,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses minimum controlDist of 30 for short links', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 10, y: 0 },
@@ -479,7 +458,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('center point calculation', () => {
     it('calculates spline center using bezier at t=0.5', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const cp: Point[] = [
         { x: 50, y: 0 },
         { x: 150, y: 100 }
@@ -495,7 +474,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates spline center angle for arrow marker', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const cp: Point[] = [
         { x: 50, y: 0 },
         { x: 150, y: 100 }
@@ -516,7 +495,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates linear center as midpoint of inner control points', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -534,7 +513,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center with l=10 offsets', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -552,7 +531,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center angle = 0 when y diff < 4', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 50 },
         endPoint: { x: 200, y: 52 },
@@ -573,7 +552,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center angle = PI/2 when end is below', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 200, y: 100 },
@@ -594,7 +573,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates straight center angle = -PI/2 when end is above', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 100 },
         endPoint: { x: 200, y: 0 },
@@ -615,7 +594,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('calculates linear center angle for arrow marker', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startDirection: 'right',
         endDirection: 'left'
@@ -636,7 +615,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('arrows', () => {
     it('draws arrows at 0.25 and 0.75 positions when showArrows=true', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext({
         style: { mode: 'spline', connectionWidth: 3, showArrows: true }
@@ -652,7 +631,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('does not draw arrows when showArrows=false', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext()
 
@@ -664,7 +643,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('center marker', () => {
     it('draws circle marker when conditions are met', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -688,7 +667,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('draws arrow-shaped marker when centerMarkerShape is arrow', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -714,7 +693,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('skips marker when scale is below 0.6', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -737,7 +716,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('skips marker when highQuality is false', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         controlPoints: [
           { x: 50, y: 0 },
@@ -760,7 +739,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('applies disabled pattern for center marker', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const disabledPattern = {} as CanvasPattern
       const link = makeLink({
         disabled: true,
@@ -789,7 +768,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('flow animation', () => {
     it('draws 5 circles when flow is enabled', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ flow: true })
       const context = makeContext({
         animation: { time: 0.5 }
@@ -804,7 +783,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('does not animate when flow is false', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ flow: false })
       const context = makeContext({ animation: { time: 0.5 } })
 
@@ -814,7 +793,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('does not animate when no animation context', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({ flow: true })
       const context = makeContext()
 
@@ -826,7 +805,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('drawDraggingLink', () => {
     it('draws a link from fixed to drag point', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const context = makeContext()
 
       const path = renderer.drawDraggingLink(
@@ -844,7 +823,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('swaps points when dragging from input', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const context = makeContext({
         style: { mode: 'linear', connectionWidth: 3 }
       })
@@ -866,7 +845,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('uses custom dragDirection when provided', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const context = makeContext()
 
       renderer.drawDraggingLink(
@@ -884,7 +863,7 @@ describe('CanvasPathRenderer', () => {
     })
 
     it('passes color and type through to link rendering', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const context = makeContext({
         colors: {
           default: '#ffffff',
@@ -910,7 +889,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('computeConnectionPoint', () => {
     it('computes arrow positions along the path', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink({
         startPoint: { x: 0, y: 0 },
         endPoint: { x: 100, y: 0 },
@@ -929,7 +908,7 @@ describe('CanvasPathRenderer', () => {
 
   describe('drawLink return value', () => {
     it('returns a Path2D for hit detection', () => {
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
       const link = makeLink()
       const context = makeContext()
 
@@ -949,7 +928,7 @@ describe('CanvasPathRenderer', () => {
     ] as const)(
       'linear mode applies correct offset for $dir direction',
       ({ dir, expectedInnerA }) => {
-        const ctx = createMockCtx()
+        const ctx = createMockCanvasRenderingContext2D()
         const link = makeLink({
           startPoint: { x: 0, y: 0 },
           endPoint: { x: 200, y: 100 },

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 
 import {
-  createMockCanvas2DContext,
+  createMockCanvasRenderingContext2D,
   createMockMinimapCanvas
 } from '@/utils/__tests__/litegraphTestUtils'
 
@@ -233,7 +233,7 @@ describe('useMinimap', () => {
     mockPause.mockClear()
     mockResume.mockClear()
 
-    mockContext2D = createMockCanvas2DContext()
+    mockContext2D = createMockCanvasRenderingContext2D()
 
     moduleMockCanvasElement = createMockMinimapCanvas({
       getContext: vi

--- a/src/renderer/extensions/minimap/composables/useMinimapRenderer.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapRenderer.test.ts
@@ -6,6 +6,7 @@ import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import { useMinimapRenderer } from '@/renderer/extensions/minimap/composables/useMinimapRenderer'
 import { renderMinimapToCanvas } from '@/renderer/extensions/minimap/minimapCanvasRenderer'
 import type { UpdateFlags } from '@/renderer/extensions/minimap/types'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 vi.mock('@/renderer/extensions/minimap/minimapCanvasRenderer', () => ({
   renderMinimapToCanvas: vi.fn()
@@ -19,11 +20,7 @@ describe('useMinimapRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockContext = {
-      clearRect: vi.fn(),
-      save: vi.fn(),
-      restore: vi.fn()
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
+    mockContext = createMockCanvasRenderingContext2D()
 
     mockCanvas = {
       getContext: vi.fn().mockReturnValue(mockContext)

--- a/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
+++ b/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
@@ -6,6 +6,7 @@ import { renderMinimapToCanvas } from '@/renderer/extensions/minimap/minimapCanv
 import type { MinimapRenderContext } from '@/renderer/extensions/minimap/types'
 import { adjustColor } from '@/utils/colorUtil'
 import {
+  createMockCanvasRenderingContext2D,
   createMockLGraph,
   createMockLGraphNode,
   createMockLinks,
@@ -36,22 +37,7 @@ describe('minimapCanvasRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockContext = {
-      clearRect: vi.fn(),
-      fillRect: vi.fn(),
-      strokeRect: vi.fn(),
-      beginPath: vi.fn(),
-      moveTo: vi.fn(),
-      lineTo: vi.fn(),
-      stroke: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      fillStyle: '',
-      strokeStyle: '',
-      lineWidth: 1,
-      save: vi.fn(),
-      restore: vi.fn()
-    } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D
+    mockContext = createMockCanvasRenderingContext2D()
 
     mockCanvas = {
       getContext: vi.fn().mockReturnValue(mockContext)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -5,6 +5,7 @@ import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { CanvasPointer, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { BaseWidget } from '@/lib/litegraph/src/widgets/BaseWidget'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { createMockCanvasRenderingContext2D } from '@/utils/__tests__/litegraphTestUtils'
 
 const mockSettingStore = vi.hoisted(() => ({
   get: vi.fn(() => false)
@@ -67,30 +68,6 @@ import { useImagePreviewWidget } from './useImagePreviewWidget'
 // large to migrate to shoehorn fromPartial here without dragging in mountains
 // of unused properties. Leave the `as unknown as` casts in these factories;
 // migrate when the SUT is refactored to depend on a smaller render port.
-function createMockCtx(): CanvasRenderingContext2D {
-  const transform = new DOMMatrix()
-  return {
-    save: vi.fn(),
-    restore: vi.fn(),
-    beginPath: vi.fn(),
-    arc: vi.fn(),
-    stroke: vi.fn(),
-    fill: vi.fn(),
-    fillText: vi.fn(),
-    strokeRect: vi.fn(),
-    roundRect: vi.fn(),
-    drawImage: vi.fn(),
-    getTransform: vi.fn(() => transform),
-    setTransform: vi.fn(),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-    lineCap: 'butt',
-    textAlign: 'left',
-    font: '',
-    filter: 'none'
-  } as unknown as CanvasRenderingContext2D
-}
 
 function createMockNode(overrides: Record<string, unknown> = {}): LGraphNode {
   return {
@@ -213,7 +190,7 @@ describe('useImagePreviewWidget', () => {
       constructor(node, defaultInputSpec)
 
       const widget = getWidget(node)
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -234,7 +211,7 @@ describe('useImagePreviewWidget', () => {
       constructor(node, defaultInputSpec)
 
       const widget = getWidget(node)
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -254,7 +231,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -275,7 +252,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -300,7 +277,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -314,7 +291,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -331,7 +308,7 @@ describe('useImagePreviewWidget', () => {
       constructor(node, defaultInputSpec)
 
       const widget = getWidget(node)
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -353,7 +330,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 235
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -377,7 +354,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -396,7 +373,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -414,7 +391,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -432,7 +409,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -456,7 +433,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -481,7 +458,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -503,7 +480,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCtx()
+      const ctx = createMockCanvasRenderingContext2D()
 
       widget.drawWidget(ctx, {
         width: 300,

--- a/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useImagePreviewWidget.test.ts
@@ -11,6 +11,12 @@ const mockSettingStore = vi.hoisted(() => ({
   get: vi.fn(() => false)
 }))
 
+function createImagePreviewCtx(): CanvasRenderingContext2D {
+  return createMockCanvasRenderingContext2D({
+    drawImage: vi.fn()
+  })
+}
+
 const mockCanvas = vi.hoisted(() => ({
   graph_mouse: [0, 0] as [number, number],
   pointer_is_down: false,
@@ -190,7 +196,7 @@ describe('useImagePreviewWidget', () => {
       constructor(node, defaultInputSpec)
 
       const widget = getWidget(node)
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -211,7 +217,7 @@ describe('useImagePreviewWidget', () => {
       constructor(node, defaultInputSpec)
 
       const widget = getWidget(node)
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -231,7 +237,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -252,7 +258,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -277,7 +283,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -291,7 +297,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -308,7 +314,7 @@ describe('useImagePreviewWidget', () => {
       constructor(node, defaultInputSpec)
 
       const widget = getWidget(node)
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -330,7 +336,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 235
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -354,7 +360,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -373,7 +379,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -391,7 +397,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -409,7 +415,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -433,7 +439,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -458,7 +464,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, { width: 300 })
 
@@ -480,7 +486,7 @@ describe('useImagePreviewWidget', () => {
 
       const widget = getWidget(node)
       widget.computedHeight = 220
-      const ctx = createMockCanvasRenderingContext2D()
+      const ctx = createImagePreviewCtx()
 
       widget.drawWidget(ctx, {
         width: 300,

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -296,7 +296,7 @@ export function createMockMinimapCanvas(
 ): HTMLCanvasElement {
   const mockGetContext = vi.fn()
   mockGetContext.mockImplementation((contextId: string) =>
-    contextId === '2d' ? createMockCanvas2DContext() : null
+    contextId === '2d' ? createMockCanvasRenderingContext2D() : null
   )
 
   const partial: Partial<HTMLCanvasElement> = {
@@ -308,32 +308,6 @@ export function createMockMinimapCanvas(
     ...overrides
   }
   return partial as HTMLCanvasElement
-}
-
-/**
- * Creates a mock CanvasRenderingContext2D for canvas testing
- */
-export function createMockCanvas2DContext(
-  overrides: Partial<CanvasRenderingContext2D> = {}
-): CanvasRenderingContext2D {
-  const partial: Partial<CanvasRenderingContext2D> = {
-    clearRect: vi.fn(),
-    fillRect: vi.fn(),
-    strokeRect: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    stroke: vi.fn(),
-    arc: vi.fn(),
-    fill: vi.fn(),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-    save: vi.fn(),
-    restore: vi.fn(),
-    ...overrides
-  }
-  return partial as CanvasRenderingContext2D
 }
 
 export function createMockLLink(overrides: Partial<LLink> = {}): LLink {


### PR DESCRIPTION
## Summary

This PR consolidates CanvasRenderingContext2D test mocking across the codebase by replacing local mock implementations with the shared `createMockCanvasRenderingContext2D` utility from `src/utils/__tests__/litegraphTestUtils.ts`.

### Changes

* Replaced local `createMockCtx` helpers with `createMockCanvasRenderingContext2D`.
* Replaced local `createMockCanvas2DContext` helpers with the shared utility.
* Replaced inline mock canvas context objects containing duplicated `vi.fn()` implementations with `createMockCanvasRenderingContext2D`.
* Updated tests to use utility overrides where custom behavior was required.
* Removed the now-redundant `createMockCanvas2DContext` helper from `litegraphTestUtils.ts` and migrated remaining usages to `createMockCanvasRenderingContext2D`.

### Result

* Eliminates duplicated CanvasRenderingContext2D mock implementations across test files.
* Centralizes canvas context mocking in a single shared utility.
* Makes future mock updates easier by requiring changes in only one location.
* Preserves existing test behavior while reducing maintenance overhead.

Fixes : #12331 

