### PR TITLE
fix: refresh promoted combo host options after missing model reload

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabModeAware.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabModeAware.spec.ts
@@ -426,7 +426,7 @@ test.describe('Errors tab - Mode-aware errors', { tag: '@ui' }, () => {
     )
 
     test(
-      'Refreshing a resolved promoted missing model clears the combo invalid border',
+      'Refreshing a resolved promoted missing model clears the combo invalid state',
       { tag: ['@widget', '@subgraph'] },
       async ({ comfyPage }) => {
         await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
@@ -447,44 +447,31 @@ test.describe('Errors tab - Mode-aware errors', { tag: '@ui' }, () => {
           .getNodeByTitle('Subgraph with Promoted Missing Model')
           .getByRole('combobox', { name: 'ckpt_name', exact: true })
         await expect(promotedModelCombo).toHaveAttribute('aria-invalid', 'true')
-        await expect(promotedModelCombo).toHaveClass(
-          /ring-destructive-background/
-        )
 
-        await comfyPage.page.route(/\/object_info$/, async (route) => {
-          const response = await route.fetch()
-          const objectInfo = await response.json()
-          const ckptName =
-            objectInfo.CheckpointLoaderSimple.input.required.ckpt_name
-          ckptName[0] = [...ckptName[0], 'fake_model.safetensors']
-          await route.fulfill({ response, json: objectInfo })
-        })
+        const objectInfoRoute = /\/object_info$/
+        try {
+          await comfyPage.page.route(objectInfoRoute, async (route) => {
+            const response = await route.fetch()
+            const objectInfo = await response.json()
+            const ckptName =
+              objectInfo.CheckpointLoaderSimple.input.required.ckpt_name
+            ckptName[0] = [...ckptName[0], 'fake_model.safetensors']
+            await route.fulfill({ response, json: objectInfo })
+          })
 
-        const objectInfoResponse = comfyPage.page.waitForResponse(
-          (response) => {
-            const url = new URL(response.url())
-            return url.pathname.endsWith('/object_info') && response.ok()
-          }
-        )
-        const modelFoldersResponse = comfyPage.page.waitForResponse(
-          (response) => {
-            const url = new URL(response.url())
-            return url.pathname.endsWith('/experiment/models') && response.ok()
-          }
-        )
-
-        await Promise.all([
-          objectInfoResponse,
-          modelFoldersResponse,
-          comfyPage.page
+          await comfyPage.page
             .getByTestId(TestIds.dialogs.missingModelRefresh)
             .click()
-        ])
 
-        await expect(missingModelGroup).toBeHidden()
-        await expect(promotedModelCombo).not.toHaveClass(
-          /ring-destructive-background/
-        )
+          await expect(missingModelGroup).toBeHidden()
+          await expect(promotedModelCombo).toBeVisible()
+          await expect(promotedModelCombo).not.toHaveAttribute(
+            'aria-invalid',
+            'true'
+          )
+        } finally {
+          await comfyPage.page.unroute(objectInfoRoute)
+        }
       }
     )
 

--- a/browser_tests/tests/propertiesPanel/errorsTabModeAware.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabModeAware.spec.ts
@@ -425,6 +425,69 @@ test.describe('Errors tab - Mode-aware errors', { tag: '@ui' }, () => {
       }
     )
 
+    test(
+      'Refreshing a resolved promoted missing model clears the combo invalid border',
+      { tag: ['@widget', '@subgraph'] },
+      async ({ comfyPage }) => {
+        await comfyPage.settings.setSetting('Comfy.VueNodes.Enabled', true)
+        await loadWorkflowAndOpenErrorsTab(
+          comfyPage,
+          'missing/missing_model_promoted_widget'
+        )
+        await comfyPage.vueNodes.waitForNodes()
+
+        const missingModelGroup = comfyPage.page.getByTestId(
+          TestIds.dialogs.missingModelsGroup
+        )
+        await expect(missingModelGroup).toContainText(
+          /fake_model\.safetensors\s*\(1\)/
+        )
+
+        const promotedModelCombo = comfyPage.vueNodes
+          .getNodeByTitle('Subgraph with Promoted Missing Model')
+          .getByRole('combobox', { name: 'ckpt_name', exact: true })
+        await expect(promotedModelCombo).toHaveAttribute('aria-invalid', 'true')
+        await expect(promotedModelCombo).toHaveClass(
+          /ring-destructive-background/
+        )
+
+        await comfyPage.page.route(/\/object_info$/, async (route) => {
+          const response = await route.fetch()
+          const objectInfo = await response.json()
+          const ckptName =
+            objectInfo.CheckpointLoaderSimple.input.required.ckpt_name
+          ckptName[0] = [...ckptName[0], 'fake_model.safetensors']
+          await route.fulfill({ response, json: objectInfo })
+        })
+
+        const objectInfoResponse = comfyPage.page.waitForResponse(
+          (response) => {
+            const url = new URL(response.url())
+            return url.pathname.endsWith('/object_info') && response.ok()
+          }
+        )
+        const modelFoldersResponse = comfyPage.page.waitForResponse(
+          (response) => {
+            const url = new URL(response.url())
+            return url.pathname.endsWith('/experiment/models') && response.ok()
+          }
+        )
+
+        await Promise.all([
+          objectInfoResponse,
+          modelFoldersResponse,
+          comfyPage.page
+            .getByTestId(TestIds.dialogs.missingModelRefresh)
+            .click()
+        ])
+
+        await expect(missingModelGroup).toBeHidden()
+        await expect(promotedModelCombo).not.toHaveClass(
+          /ring-destructive-background/
+        )
+      }
+    )
+
     test('Bypassing a subgraph hides interior errors, un-bypassing restores them', async ({
       comfyPage
     }) => {

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -2,8 +2,12 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LGraph } from '@/lib/litegraph/src/litegraph'
-import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas } from '@/lib/litegraph/src/litegraph'
+import type {
+  IBaseWidget,
+  IStringComboWidget
+} from '@/lib/litegraph/src/types/widgets'
 import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON
@@ -25,6 +29,10 @@ import { api } from '@/scripts/api'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useExecutionStore } from '@/stores/executionStore'
 import type { NodeError } from '@/schemas/apiSchema'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
+import { widgetEntityId } from '@/world/entityIds'
+import type { WidgetEntityId } from '@/world/entityIds'
+import { ensureWidgetState, getWidgetState } from '@/world/widgetValueIO'
 
 const {
   mockApiKeyAuthStore,
@@ -161,6 +169,18 @@ function createWorkflowGraphData(): ComfyWorkflowJSON {
   }
 }
 
+type PromotedComboWidget = IStringComboWidget & {
+  readonly entityId: WidgetEntityId
+  readonly sourceNodeId: string
+  readonly sourceWidgetName: string
+}
+
+type PromotedNumberWidget = IBaseWidget<number, 'number'> & {
+  readonly entityId: WidgetEntityId
+  readonly sourceNodeId: string
+  readonly sourceWidgetName: string
+}
+
 describe('ComfyApp', () => {
   let app: ComfyApp
   let mockCanvas: LGraphCanvas
@@ -267,6 +287,114 @@ describe('ComfyApp', () => {
       )
       expect(mockToastStore.remove).toHaveBeenCalledWith(
         mockToastStore.add.mock.calls[0][0]
+      )
+    })
+  })
+
+  describe('reloadNodeDefs', () => {
+    it('syncs refreshed combo options into promoted widget host state', async () => {
+      const graph = new LGraph()
+      const node = new LGraphNode(
+        'CheckpointLoaderSimple',
+        'CheckpointLoaderSimple'
+      )
+      graph.add(node)
+
+      const initialOptions = ['missing.safetensors']
+      const refreshedOptions = ['missing.safetensors', 'present.safetensors']
+      const promotedEntityId = widgetEntityId(graph.id, node.id, 'ckpt_name')
+      const missingStateEntityId = widgetEntityId(
+        graph.id,
+        node.id,
+        'missing_state_ckpt'
+      )
+      const promotedNumberEntityId = widgetEntityId(graph.id, node.id, 'steps')
+      const plainComboWidget: IStringComboWidget = {
+        name: 'ckpt_name',
+        type: 'combo',
+        value: 'missing.safetensors',
+        options: { values: initialOptions },
+        y: 0
+      }
+      const promotedNumberWidget: PromotedNumberWidget = {
+        name: 'steps',
+        type: 'number',
+        value: 20,
+        options: { min: 1, max: 100 },
+        y: 0,
+        entityId: promotedNumberEntityId,
+        sourceNodeId: '1',
+        sourceWidgetName: 'steps'
+      }
+      const missingStatePromotedWidget: PromotedComboWidget = {
+        name: 'missing_state_ckpt',
+        type: 'combo',
+        value: 'missing.safetensors',
+        options: { values: initialOptions },
+        y: 0,
+        entityId: missingStateEntityId,
+        sourceNodeId: '1',
+        sourceWidgetName: 'missing_state_ckpt'
+      }
+      const promotedWidget: PromotedComboWidget = {
+        name: 'ckpt_name',
+        type: 'combo',
+        value: 'missing.safetensors',
+        options: { values: initialOptions },
+        y: 0,
+        entityId: promotedEntityId,
+        sourceNodeId: '1',
+        sourceWidgetName: 'ckpt_name'
+      }
+      const defs: Record<string, ComfyNodeDef> = {
+        CheckpointLoaderSimple: {
+          name: 'CheckpointLoaderSimple',
+          display_name: 'CheckpointLoaderSimple',
+          category: 'loaders',
+          python_module: 'nodes',
+          description: '',
+          input: {
+            required: {
+              ckpt_name: [refreshedOptions, {}]
+            },
+            optional: {}
+          },
+          output: [],
+          output_name: [],
+          output_tooltips: [],
+          output_node: false,
+          deprecated: false,
+          experimental: false
+        }
+      }
+      node.widgets = [
+        plainComboWidget,
+        promotedNumberWidget,
+        missingStatePromotedWidget,
+        promotedWidget
+      ]
+      Reflect.set(app, 'rootGraphInternal', graph)
+      ensureWidgetState(promotedEntityId, {
+        type: 'combo',
+        value: 'missing.safetensors',
+        options: { values: initialOptions },
+        serialize: false
+      })
+      vi.spyOn(app, 'getNodeDefs').mockResolvedValue(defs)
+      vi.spyOn(app, 'registerNodeDef').mockResolvedValue(undefined)
+
+      await app.reloadNodeDefs()
+
+      expect(plainComboWidget.options.values).toEqual(refreshedOptions)
+      expect(promotedWidget.options.values).toEqual(refreshedOptions)
+      expect(getWidgetState(promotedEntityId)?.options.values).toEqual(
+        refreshedOptions
+      )
+      expect(getWidgetState(missingStateEntityId)).toBeUndefined()
+      expect(getWidgetState(promotedNumberEntityId)).toBeUndefined()
+      expect(mockExtensionService.invokeExtensionsAsync).toHaveBeenCalledWith(
+        'refreshComboInNodes',
+        defs
       )
     })
   })

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -11,6 +11,7 @@ import { flushScheduledSlotLayoutSync } from '@/renderer/extensions/vueNodes/com
 
 import { st, t } from '@/i18n'
 import { ChangeTracker } from '@/scripts/changeTracker'
+import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
 import {
   LGraph,
@@ -127,6 +128,7 @@ import {
   noNativeReroutes
 } from '@/utils/migration/migrateReroute'
 import { deserialiseAndCreate } from '@/utils/vintageClipboard'
+import { getWidgetState } from '@/world/widgetValueIO'
 
 import { type ComfyApi, PromptExecutionError, api } from './api'
 import { defaultGraph } from './defaultGraph'
@@ -167,6 +169,19 @@ export function sanitizeNodeName(string: string) {
   }
   return String(string).replace(/[&<>"'`=]/g, function fromEntityMap(s) {
     return entityMap[s as keyof typeof entityMap]
+  })
+}
+
+function syncPromotedComboHostOptions(rootGraph: LGraph): void {
+  forEachNode(rootGraph, (node) => {
+    for (const widget of node.widgets ?? []) {
+      if (!isPromotedWidgetView(widget) || widget.type !== 'combo') continue
+
+      const state = getWidgetState(widget.entityId)
+      if (!state) continue
+
+      state.options = { ...(widget.options ?? {}) }
+    }
   })
 }
 
@@ -2136,6 +2151,8 @@ export class ComfyApp {
       'refreshComboInNodes',
       defs
     )
+
+    syncPromotedComboHostOptions(this.rootGraph)
 
     if (this.vueAppReady) {
       this.updateVueAppNodeDefs(defs)

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -9,9 +9,9 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { syncLayoutStoreNodeBoundsFromGraph } from '@/renderer/core/layout/sync/syncLayoutStoreFromGraph'
 import { flushScheduledSlotLayoutSync } from '@/renderer/extensions/vueNodes/composables/useSlotElementTracking'
 
+import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
 import { st, t } from '@/i18n'
 import { ChangeTracker } from '@/scripts/changeTracker'
-import { isPromotedWidgetView } from '@/core/graph/subgraph/promotedWidgetTypes'
 import type { IContextMenuValue } from '@/lib/litegraph/src/interfaces'
 import {
   LGraph,
@@ -2152,6 +2152,7 @@ export class ComfyApp {
       defs
     )
 
+    // Promoted widgets keep hosted option snapshots; sync them after source refresh hooks run.
     syncPromotedComboHostOptions(this.rootGraph)
 
     if (this.vueAppReady) {


### PR DESCRIPTION
# NO NEED BACKPORT

## Summary

Fixes a Vue node subgraph case where the missing-model refresh flow clears the missing-model error, but the promoted combo widget remains in an invalid visual state because its hosted options snapshot is stale.

## Changes

- **What**: After `reloadNodeDefs()` refreshes combo option lists and extension `refreshComboInNodes` hooks run, resync hosted options snapshots for promoted combo widgets so Vue-rendered subgraph nodes see the newly available model option.
- **What**: Adds a focused E2E regression for the missing-model refresh path on a subgraph with a promoted `ckpt_name` widget.
- **What**: Hardens the E2E by cleaning up its `/object_info` route override and asserting the widget's `aria-invalid` state rather than a Tailwind implementation class.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

This PR is intentionally a minimal patch for the missing-model refresh path, not a broader subgraph architecture change.

Root cause: `reloadNodeDefs()` updates the live LiteGraph combo widget options, including widgets inside subgraphs. However, Vue nodes render promoted widgets from a hosted `WidgetState.options` snapshot. When a missing model is downloaded and the missing-model refresh button reloads node definitions, the source combo receives the updated model list, but the promoted host snapshot can still contain the old option list. The missing-model error and node-level state are cleared, while the Vue combo still computes itself as invalid from stale options.

The fix keeps the existing host snapshot model intact. It simply resyncs promoted combo host options after the normal combo refresh pipeline finishes. This avoids changing promoted-widget ownership, `useProcessedWidgets` merge precedence, or broader subgraph internals while addressing the reported stale invalid state.

Why the helper is in `app.ts`: this sync is currently a single-call-site post-step of `reloadNodeDefs()`, and the ordering is load-bearing. It must run after the core combo refresh loop and after extension `refreshComboInNodes` hooks so it captures both built-in and extension-provided option changes. Keeping the small private helper next to the refresh orchestration makes that sequence explicit and avoids adding a new public subgraph helper or introducing a more visible dependency cycle through `promotionUtils` for a narrow patch.

This is stacked on `jaeone/fe-942-bug-error-indicators-persist-after-resolving-missing-model`, so it is opened as a draft until the base PR lands.

## Test Plan

- `pnpm knip`
- `pnpm exec oxfmt --check src/scripts/app.ts browser_tests/tests/propertiesPanel/errorsTabModeAware.spec.ts`
- `pnpm exec eslint --cache --no-warn-ignored src/scripts/app.ts browser_tests/tests/propertiesPanel/errorsTabModeAware.spec.ts`
- `pnpm typecheck`
- `pnpm test:browser:local --grep "Refreshing a resolved promoted missing model clears the combo invalid state"`
  - First local run hit a `beforeEach` timeout while the dev server was still warming custom-node/conflict-detection output.
  - Re-running against the warmed dev server passed.

## Screenshots (if applicable)

N/A. The behavioral E2E covers the visible invalid-state regression.
