### PR TITLE
fix: keep top-level hidden widgets hidden in Nodes 2.0 FE-630

### DIFF
--- a/src/composables/graph/useGraphNodeManager.test.ts
+++ b/src/composables/graph/useGraphNodeManager.test.ts
@@ -776,3 +776,49 @@ describe('reconcileNodeErrorFlags (via lastNodeErrors watcher)', () => {
     expect(subgraphNode.has_errors).toBe(true)
   })
 })
+
+describe('Widget display options reflect litegraph visibility flags', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  function createNodeWithWidget() {
+    const graph = new LGraph()
+    const node = new LGraphNode('test')
+    node.addWidget('number', 'secret', 1, () => undefined, {})
+    graph.add(node)
+    return { graph, node }
+  }
+
+  function getWidgetData(graph: LGraph, node: LGraphNode) {
+    const { vueNodeData } = useGraphNodeManager(graph)
+    return vueNodeData
+      .get(String(node.id))
+      ?.widgets?.find((w) => w.name === 'secret')
+  }
+
+  // FE-630: SAM3 collector nodes hide widgets via the top-level
+  // `widget.hidden`, matching litegraph's isWidgetVisible. Vue Nodes 2.0 must
+  // honor it, not only `widget.options.hidden`.
+  it('marks a widget hidden when only the top-level hidden flag is set', () => {
+    const { graph, node } = createNodeWithWidget()
+    node.widgets![0].hidden = true
+
+    expect(getWidgetData(graph, node)?.options?.hidden).toBe(true)
+  })
+
+  it('marks a widget advanced when only the top-level advanced flag is set', () => {
+    const { graph, node } = createNodeWithWidget()
+    node.widgets![0].advanced = true
+
+    expect(getWidgetData(graph, node)?.options?.advanced).toBe(true)
+  })
+
+  it('keeps a plain widget visible', () => {
+    const { graph, node } = createNodeWithWidget()
+
+    const data = getWidgetData(graph, node)
+    expect(data?.options?.hidden).toBeFalsy()
+    expect(data?.options?.advanced).toBeFalsy()
+  })
+})

--- a/src/composables/graph/useGraphNodeManager.ts
+++ b/src/composables/graph/useGraphNodeManager.ts
@@ -218,16 +218,24 @@ function safeWidgetMapper(
   node: LGraphNode,
   slotMetadata: Map<string, WidgetSlotMetadata>
 ): (widget: IBaseWidget) => SafeWidgetData {
+  /**
+   * Mirrors litegraph's visibility check (LGraphNode.isWidgetVisible): both
+   * `hidden` and `advanced` may live on the widget itself, not just its
+   * `options`. Custom nodes (e.g. SAM3 collectors) commonly hide widgets via
+   * the top-level `widget.hidden`, so fall back to it when reading options.
+   */
   function extractWidgetDisplayOptions(
     widget: IBaseWidget
   ): SafeWidgetData['options'] {
-    if (!widget.options) return undefined
+    const advanced = widget.options?.advanced ?? widget.advanced
+    const hidden = widget.options?.hidden ?? widget.hidden
+    if (!widget.options && !advanced && !hidden) return undefined
 
     return {
-      canvasOnly: widget.options.canvasOnly,
-      advanced: widget.options?.advanced ?? widget.advanced,
-      hidden: widget.options.hidden,
-      read_only: widget.options.read_only
+      canvasOnly: widget.options?.canvasOnly,
+      advanced,
+      hidden,
+      read_only: widget.options?.read_only
     }
   }
 


### PR DESCRIPTION
## Summary

Hidden widgets on SAM3 collector nodes leaked into Vue Nodes 2.0 because the visibility check only read `widget.options.hidden`, while litegraph (and custom nodes) hide via the top-level `widget.hidden`.

## Changes

- **What**: `extractWidgetDisplayOptions` in `useGraphNodeManager.ts` now falls back to the top-level `widget.hidden` (mirroring the existing `advanced` handling and `LGraphNode.isWidgetVisible`), so widgets hidden via either mechanism stay hidden in Nodes 2.0. Added regression tests in `useGraphNodeManager.test.ts`.

## Review Focus

- The fix is at the single data-extraction entry point (`SafeWidgetData`), so downstream `isWidgetVisible`/`NodeWidgets.vue` are unchanged.
- Edge case handled: a widget with no `options` object but a top-level `hidden`/`advanced` flag now still produces an `options` object instead of returning `undefined`.

## Testing

The regression is in the data-extraction layer (`extractWidgetDisplayOptions`), so the tightest regression test lives there: `useGraphNodeManager.test.ts` asserts that a widget hidden via the top-level `widget.hidden` (the SAM3 mechanism) is reflected in `SafeWidgetData.options.hidden`. The downstream `v-if="widget.visible"` rendering path is already covered by `NodeWidgets.test.ts`. A `browser_tests/` E2E test is not added because reproducing it end-to-end requires fabricating a custom node that sets a top-level hidden widget, which is disproportionate to a one-line data-mapping fix already covered at the exact layer it occurs.

Fixes FE-630
