### PR TITLE
feat: register unified_cloud_auth feature flag (FE-950) - step 1

### DIFF
--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -220,4 +220,30 @@ describe('useFeatureFlags', () => {
       expect(flags.teamWorkspacesEnabled).toBe(true)
     })
   })
+
+  describe('unifiedCloudAuthEnabled', () => {
+    afterEach(() => {
+      localStorage.clear()
+    })
+
+    it('reads the unified_cloud_auth server feature when set', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (path, defaultValue) => {
+          if (path === ServerFeatureFlag.UNIFIED_CLOUD_AUTH) return true
+          return defaultValue
+        }
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.unifiedCloudAuthEnabled).toBe(true)
+    })
+
+    it('lets a dev override beat the server value', () => {
+      vi.mocked(api.getServerFeature).mockReturnValue(false)
+      localStorage.setItem('ff:unified_cloud_auth', 'true')
+
+      const { flags } = useFeatureFlags()
+      expect(flags.unifiedCloudAuthEnabled).toBe(true)
+    })
+  })
 })

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -28,7 +28,8 @@ export enum ServerFeatureFlag {
   WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
   COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
-  SHOW_SIGNIN_BUTTON = 'show_signin_button'
+  SHOW_SIGNIN_BUTTON = 'show_signin_button',
+  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth'
 }
 
 /**
@@ -164,6 +165,13 @@ export function useFeatureFlags() {
       return api.getServerFeature<boolean | undefined>(
         ServerFeatureFlag.SHOW_SIGNIN_BUTTON,
         undefined
+      )
+    },
+    get unifiedCloudAuthEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
+        remoteConfig.value.unified_cloud_auth,
+        false
       )
     }
   })

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -103,5 +103,6 @@ export type RemoteConfig = {
   workflow_sharing_enabled?: boolean
   comfyhub_upload_enabled?: boolean
   comfyhub_profile_gate_enabled?: boolean
+  unified_cloud_auth?: boolean
   sentry_dsn?: string
 }


### PR DESCRIPTION
## Summary
https://us.posthog.com/project/204330/feature_flags/706651 

Register the `unified_cloud_auth` server feature flag (default **off**) so the upcoming single Cloud-JWT auth provider (FE-950/FE-951) can be gated behind it. Pure plumbing — no behavior change.

## Changes

- **What**: Adds `ServerFeatureFlag.UNIFIED_CLOUD_AUTH`, the `unifiedCloudAuthEnabled` getter in `useFeatureFlags` (via `resolveFlag`, precedence: dev override > `remoteConfig` > server feature), and the `unified_cloud_auth?: boolean` field on the `RemoteConfig` type. Unit tests cover the server-feature wiring and the dev-override toggle.
- This is PR 1 of 3 for FE-950. Nothing reads the flag yet; it resolves `false` by default, so this is inert in every environment until a later PR wires consumers.

## Review Focus

- Mirrors the existing `resolveFlag`-based flags (e.g. `userSecretsEnabled`, `workflowSharingEnabled`) — deliberately the plain shape, **not** the cloud-gated `teamWorkspacesEnabled` shape, since the flag is only read from paths already `isCloud`-gated.
- Local toggle for development: `localStorage.setItem('ff:unified_cloud_auth', 'true')` (DEV-only dev override).
- Production delivery of the flag value (and staged % rollout) is backend work — Comfy-Org/cloud#4139 (BE-1258), already adds `unified_cloud_auth` to `/api/features`. This FE PR is independent of it; with no server value the flag stays `false`.

Linear: FE-950

## Screenshots (if applicable)

N/A — no user-facing change (flag registration only).