### PR TITLE
refactor: extract Cloud-JWT mint + dormant unified refresh lifecycle (FE-950) - step 2

### DIFF
--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -220,4 +220,30 @@ describe('useFeatureFlags', () => {
       expect(flags.teamWorkspacesEnabled).toBe(true)
     })
   })
+
+  describe('unifiedCloudAuthEnabled', () => {
+    afterEach(() => {
+      localStorage.clear()
+    })
+
+    it('reads the unified_cloud_auth server feature when set', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (path, defaultValue) => {
+          if (path === ServerFeatureFlag.UNIFIED_CLOUD_AUTH) return true
+          return defaultValue
+        }
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.unifiedCloudAuthEnabled).toBe(true)
+    })
+
+    it('lets a dev override beat the server value', () => {
+      vi.mocked(api.getServerFeature).mockReturnValue(false)
+      localStorage.setItem('ff:unified_cloud_auth', 'true')
+
+      const { flags } = useFeatureFlags()
+      expect(flags.unifiedCloudAuthEnabled).toBe(true)
+    })
+  })
 })

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -28,7 +28,8 @@ export enum ServerFeatureFlag {
   WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
   COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
-  SHOW_SIGNIN_BUTTON = 'show_signin_button'
+  SHOW_SIGNIN_BUTTON = 'show_signin_button',
+  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth'
 }
 
 /**
@@ -164,6 +165,13 @@ export function useFeatureFlags() {
       return api.getServerFeature<boolean | undefined>(
         ServerFeatureFlag.SHOW_SIGNIN_BUTTON,
         undefined
+      )
+    },
+    get unifiedCloudAuthEnabled() {
+      return resolveFlag(
+        ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
+        remoteConfig.value.unified_cloud_auth,
+        false
       )
     }
   })

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -103,5 +103,6 @@ export type RemoteConfig = {
   workflow_sharing_enabled?: boolean
   comfyhub_upload_enabled?: boolean
   comfyhub_profile_gate_enabled?: boolean
+  unified_cloud_auth?: boolean
   sentry_dsn?: string
 }

--- a/src/platform/workspace/stores/useWorkspaceAuth.test.ts
+++ b/src/platform/workspace/stores/useWorkspaceAuth.test.ts
@@ -9,10 +9,12 @@ import {
 import { WORKSPACE_STORAGE_KEYS } from '@/platform/workspace/workspaceConstants'
 
 const mockGetIdToken = vi.fn()
+const mockNotifyTokenRefreshed = vi.fn()
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
-    getIdToken: mockGetIdToken
+    getIdToken: mockGetIdToken,
+    notifyTokenRefreshed: mockNotifyTokenRefreshed
   })
 }))
 
@@ -27,12 +29,16 @@ vi.mock('@/i18n', () => ({
 }))
 
 const mockTeamWorkspacesEnabled = vi.hoisted(() => ({ value: true }))
+const mockUnifiedCloudAuthEnabled = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     flags: {
       get teamWorkspacesEnabled() {
         return mockTeamWorkspacesEnabled.value
+      },
+      get unifiedCloudAuthEnabled() {
+        return mockUnifiedCloudAuthEnabled.value
       }
     }
   })
@@ -63,6 +69,8 @@ describe('useWorkspaceAuthStore', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     sessionStorage.clear()
+    mockTeamWorkspacesEnabled.value = true
+    mockUnifiedCloudAuthEnabled.value = false
   })
 
   afterEach(() => {
@@ -902,6 +910,316 @@ describe('useWorkspaceAuthStore', () => {
       expect((error.value as WorkspaceAuthError).code).toBe(
         'TOKEN_EXCHANGE_FAILED'
       )
+    })
+  })
+
+  describe('unified Cloud-JWT lifecycle (unified_cloud_auth)', () => {
+    const personalTokenResponse = {
+      token: 'unified-token-1',
+      expires_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      workspace: {
+        id: 'workspace-personal',
+        name: 'Personal',
+        type: 'personal' as const
+      },
+      role: 'owner' as const,
+      permissions: ['owner:*']
+    }
+
+    it('mintAtLogin is a no-op and returns false when the flag is OFF', async () => {
+      mockUnifiedCloudAuthEnabled.value = false
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const { unifiedToken } = storeToRefs(store)
+
+      const result = await store.mintAtLogin()
+
+      expect(result).toBe(false)
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(unifiedToken.value).toBeNull()
+    })
+
+    it('mints the personal default once into the dormant unifiedToken slot when flag ON', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(personalTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const { unifiedToken, workspaceToken } = storeToRefs(store)
+
+      const result = await store.mintAtLogin()
+
+      expect(result).toBe(true)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      // Personal default mints with an id-less empty body.
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/api/auth/token',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({})
+        })
+      )
+      expect(unifiedToken.value).toBe('unified-token-1')
+      // Dormant slot proof: the legacy workspace token is never written.
+      expect(workspaceToken.value).toBeNull()
+    })
+
+    it('does not re-mint when unifiedToken is already populated', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(personalTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+
+      await store.mintAtLogin()
+      const result = await store.mintAtLogin()
+
+      expect(result).toBe(true)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('arms a refresh at expires_at - buffer and re-mints from the parsed expiry (no hardcoded TTL)', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const expiresInMs = 3600 * 1000
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...personalTokenResponse,
+            expires_at: new Date(Date.now() + expiresInMs).toISOString()
+          })
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+
+      await store.mintAtLogin()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      const refreshDelay = expiresInMs - 5 * 60 * 1000
+
+      vi.advanceTimersByTime(refreshDelay - 1)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not bump the rotation trigger on the initial login mint', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(personalTokenResponse)
+        })
+      )
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+
+      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+    })
+
+    it('does not bump the rotation trigger on a workspace switch', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockTokenResponse)
+        })
+      )
+
+      const store = useWorkspaceAuthStore()
+      await store.switchWorkspace('workspace-123')
+
+      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+    })
+
+    it('bumps the rotation trigger exactly once on a refresh re-mint', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const expiresInMs = 3600 * 1000
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...personalTokenResponse,
+              expires_at: new Date(Date.now() + expiresInMs).toISOString()
+            })
+        })
+      )
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+
+      const refreshDelay = expiresInMs - 5 * 60 * 1000
+      await vi.advanceTimersByTimeAsync(refreshDelay)
+
+      expect(mockNotifyTokenRefreshed).toHaveBeenCalledTimes(1)
+    })
+
+    it('remintUnifiedOnce re-mints exactly once and surfaces a persistent failure without looping', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(personalTokenResponse)
+        })
+        .mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          json: () => Promise.resolve({ message: 'Invalid token' })
+        })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      await store.mintAtLogin()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      await expect(store.remintUnifiedOnce()).rejects.toThrow(
+        WorkspaceAuthError
+      )
+
+      // Exactly one re-mint attempt — the primitive does not retry.
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('remintUnifiedOnce returns null without minting when the flag is OFF', async () => {
+      mockUnifiedCloudAuthEnabled.value = false
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+
+      const result = await store.remintUnifiedOnce()
+
+      expect(result).toBeNull()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('discards a stale concurrent mint so unifiedToken reflects the latest mint', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(personalTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const { unifiedToken } = storeToRefs(store)
+
+      await store.mintAtLogin()
+
+      // Re-mint A hangs (it will resolve last and must be discarded as stale).
+      let resolveStale: (value: unknown) => void = () => {}
+      mockFetch.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStale = resolve
+        })
+      )
+      const remintA = store.remintUnifiedOnce()
+
+      // Re-mint B starts later and resolves first with the newest token.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ ...personalTokenResponse, token: 'latest-token' })
+      })
+      await store.remintUnifiedOnce()
+
+      expect(unifiedToken.value).toBe('latest-token')
+
+      // The stale re-mint resolves last and must not clobber the latest token.
+      resolveStale({
+        ok: true,
+        json: () =>
+          Promise.resolve({ ...personalTokenResponse, token: 'stale-token' })
+      })
+      await remintA
+
+      expect(unifiedToken.value).toBe('latest-token')
+    })
+
+    it('clears unifiedToken and stops the unified timer on clearWorkspaceContext', async () => {
+      mockUnifiedCloudAuthEnabled.value = true
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(personalTokenResponse)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const { unifiedToken } = storeToRefs(store)
+
+      await store.mintAtLogin()
+      expect(unifiedToken.value).toBe('unified-token-1')
+
+      store.clearWorkspaceContext()
+      expect(unifiedToken.value).toBeNull()
+
+      // Timer stopped: advancing past the refresh window triggers no re-mint.
+      mockFetch.mockClear()
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('is fully dormant under the flag OFF: no unified network, timer, or rotation', async () => {
+      mockUnifiedCloudAuthEnabled.value = false
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+      const { unifiedToken } = storeToRefs(store)
+
+      await store.mintAtLogin()
+      await store.remintUnifiedOnce()
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(unifiedToken.value).toBeNull()
+      expect(mockNotifyTokenRefreshed).not.toHaveBeenCalled()
+    })
+
+    it('keeps the legacy refresh path gated: both flags OFF ⇒ no network from any timer', async () => {
+      mockTeamWorkspacesEnabled.value = false
+      mockUnifiedCloudAuthEnabled.value = false
+      mockGetIdToken.mockResolvedValue('firebase-token-xyz')
+      const mockFetch = vi.fn()
+      vi.stubGlobal('fetch', mockFetch)
+
+      const store = useWorkspaceAuthStore()
+
+      await store.switchWorkspace('workspace-123')
+      await store.mintAtLogin()
+      await store.refreshToken()
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -43,6 +43,12 @@ export class WorkspaceAuthError extends Error {
   }
 }
 
+interface MintedToken {
+  token: string
+  expiresAt: number
+  workspace: WorkspaceWithRole
+}
+
 export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   const { flags } = useFeatureFlags()
 
@@ -52,11 +58,20 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
   const isLoading = ref(false)
   const error = ref<Error | null>(null)
 
+  // Unified Cloud-JWT slot (flag-gated: unified_cloud_auth). Dormant in this PR:
+  // populated by the unified mint lifecycle below but read by no consumer until
+  // the PR 3 consumer flip, so it cannot change which token requests carry.
+  const unifiedToken = ref<string | null>(null)
+
   // Timer state
   let refreshTimerId: ReturnType<typeof setTimeout> | null = null
+  // The unified lifecycle keeps its own timer + request-id so it never shares
+  // mutable state with the legacy switchWorkspace/refreshToken machinery.
+  let unifiedRefreshTimerId: ReturnType<typeof setTimeout> | null = null
 
   // Request ID to prevent stale refresh operations from overwriting newer workspace contexts
   let refreshRequestId = 0
+  let unifiedRefreshRequestId = 0
 
   // Getters
   const isAuthenticated = computed(
@@ -165,6 +180,92 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     }
   }
 
+  /**
+   * Exchanges the Firebase identity for a Cloud JWT via POST /auth/token.
+   * An id-less body ({}) mints the caller's personal-workspace token; a
+   * concrete workspace_id mints that workspace's token. Pure network + parse:
+   * it writes no store state, schedules no timer, and reads no flag, so both
+   * the legacy switch path and the unified path can reuse it without inheriting
+   * each other's gates.
+   */
+  async function requestToken(workspaceId?: string): Promise<MintedToken> {
+    const firebaseToken = await useAuthStore().getIdToken()
+    if (!firebaseToken) {
+      throw new WorkspaceAuthError(
+        t('workspaceAuth.errors.notAuthenticated'),
+        'NOT_AUTHENTICATED'
+      )
+    }
+
+    const response = await fetch(api.apiURL('/auth/token'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${firebaseToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(workspaceId ? { workspace_id: workspaceId } : {})
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      const message = errorData.message || response.statusText
+
+      if (response.status === 401) {
+        throw new WorkspaceAuthError(
+          t('workspaceAuth.errors.invalidFirebaseToken'),
+          'INVALID_FIREBASE_TOKEN'
+        )
+      }
+      if (response.status === 403) {
+        throw new WorkspaceAuthError(
+          t('workspaceAuth.errors.accessDenied'),
+          'ACCESS_DENIED'
+        )
+      }
+      if (response.status === 404) {
+        throw new WorkspaceAuthError(
+          t('workspaceAuth.errors.workspaceNotFound'),
+          'WORKSPACE_NOT_FOUND'
+        )
+      }
+
+      throw new WorkspaceAuthError(
+        t('workspaceAuth.errors.tokenExchangeFailed', { error: message }),
+        'TOKEN_EXCHANGE_FAILED'
+      )
+    }
+
+    const rawData = await response.json()
+    const parseResult = WorkspaceTokenResponseSchema.safeParse(rawData)
+
+    if (!parseResult.success) {
+      throw new WorkspaceAuthError(
+        t('workspaceAuth.errors.tokenExchangeFailed', {
+          error: fromZodError(parseResult.error).message
+        }),
+        'TOKEN_EXCHANGE_FAILED'
+      )
+    }
+
+    const data = parseResult.data
+    const expiresAt = new Date(data.expires_at).getTime()
+
+    if (isNaN(expiresAt)) {
+      throw new WorkspaceAuthError(
+        t('workspaceAuth.errors.tokenExchangeFailed', {
+          error: 'Invalid expiry timestamp'
+        }),
+        'TOKEN_EXCHANGE_FAILED'
+      )
+    }
+
+    return {
+      token: data.token,
+      expiresAt,
+      workspace: { ...data.workspace, role: data.role }
+    }
+  }
+
   async function switchWorkspace(workspaceId: string): Promise<void> {
     if (!flags.teamWorkspacesEnabled) {
       return
@@ -181,86 +282,12 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     error.value = null
 
     try {
-      const authStore = useAuthStore()
-      const firebaseToken = await authStore.getIdToken()
-      if (!firebaseToken) {
-        throw new WorkspaceAuthError(
-          t('workspaceAuth.errors.notAuthenticated'),
-          'NOT_AUTHENTICATED'
-        )
-      }
+      const { token, expiresAt, workspace } = await requestToken(workspaceId)
 
-      const response = await fetch(api.apiURL('/auth/token'), {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${firebaseToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ workspace_id: workspaceId })
-      })
+      currentWorkspace.value = workspace
+      workspaceToken.value = token
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}))
-        const message = errorData.message || response.statusText
-
-        if (response.status === 401) {
-          throw new WorkspaceAuthError(
-            t('workspaceAuth.errors.invalidFirebaseToken'),
-            'INVALID_FIREBASE_TOKEN'
-          )
-        }
-        if (response.status === 403) {
-          throw new WorkspaceAuthError(
-            t('workspaceAuth.errors.accessDenied'),
-            'ACCESS_DENIED'
-          )
-        }
-        if (response.status === 404) {
-          throw new WorkspaceAuthError(
-            t('workspaceAuth.errors.workspaceNotFound'),
-            'WORKSPACE_NOT_FOUND'
-          )
-        }
-
-        throw new WorkspaceAuthError(
-          t('workspaceAuth.errors.tokenExchangeFailed', { error: message }),
-          'TOKEN_EXCHANGE_FAILED'
-        )
-      }
-
-      const rawData = await response.json()
-      const parseResult = WorkspaceTokenResponseSchema.safeParse(rawData)
-
-      if (!parseResult.success) {
-        throw new WorkspaceAuthError(
-          t('workspaceAuth.errors.tokenExchangeFailed', {
-            error: fromZodError(parseResult.error).message
-          }),
-          'TOKEN_EXCHANGE_FAILED'
-        )
-      }
-
-      const data = parseResult.data
-      const expiresAt = new Date(data.expires_at).getTime()
-
-      if (isNaN(expiresAt)) {
-        throw new WorkspaceAuthError(
-          t('workspaceAuth.errors.tokenExchangeFailed', {
-            error: 'Invalid expiry timestamp'
-          }),
-          'TOKEN_EXCHANGE_FAILED'
-        )
-      }
-
-      const workspaceWithRole: WorkspaceWithRole = {
-        ...data.workspace,
-        role: data.role
-      }
-
-      currentWorkspace.value = workspaceWithRole
-      workspaceToken.value = data.token
-
-      persistToSession(workspaceWithRole, data.token, expiresAt)
+      persistToSession(workspace, token, expiresAt)
       scheduleTokenRefresh(expiresAt)
     } catch (err) {
       error.value = err instanceof Error ? err : new Error(String(err))
@@ -334,6 +361,127 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     }
   }
 
+  // --- Unified Cloud-JWT lifecycle (flag-gated: unified_cloud_auth) ----------
+  //
+  // A parallel mint/refresh lifecycle that writes to the dormant `unifiedToken`
+  // slot. The legacy switchWorkspace/refreshToken machinery above is untouched.
+
+  // The mint body the unified session re-mints against. `{}` is the personal
+  // default (the backend resolves the personal workspace from the Firebase
+  // identity); `{ workspace_id }` targets a concrete workspace. `null` means no
+  // active unified session.
+  type UnifiedMintBody = Record<string, never> | { workspace_id: string }
+  let unifiedTarget: UnifiedMintBody | null = null
+
+  function personalWorkspaceTarget(): UnifiedMintBody {
+    return {}
+  }
+
+  function currentUnifiedTarget(): UnifiedMintBody | null {
+    return unifiedTarget
+  }
+
+  function stopUnifiedRefreshTimer(): void {
+    if (unifiedRefreshTimerId !== null) {
+      clearTimeout(unifiedRefreshTimerId)
+      unifiedRefreshTimerId = null
+    }
+  }
+
+  function scheduleUnifiedRefresh(expiresAt: number): void {
+    stopUnifiedRefreshTimer()
+    const now = Date.now()
+    const refreshAt = expiresAt - TOKEN_REFRESH_BUFFER_MS
+    const delay = Math.max(0, refreshAt - now)
+
+    unifiedRefreshTimerId = setTimeout(() => {
+      void refreshUnified()
+    }, delay)
+  }
+
+  function clearUnifiedContext(): void {
+    unifiedRefreshRequestId++
+    stopUnifiedRefreshTimer()
+    unifiedToken.value = null
+    unifiedTarget = null
+  }
+
+  async function mintUnified(target: UnifiedMintBody): Promise<boolean> {
+    // Stale-guard: bump and capture the request id so a 401-driven re-mint and
+    // a timer-driven re-mint cannot clobber each other's write — the last mint
+    // to start wins.
+    const capturedRequestId = ++unifiedRefreshRequestId
+    const workspaceId =
+      'workspace_id' in target ? target.workspace_id : undefined
+
+    const { token, expiresAt } = await requestToken(workspaceId)
+
+    if (capturedRequestId !== unifiedRefreshRequestId) {
+      return false
+    }
+
+    unifiedToken.value = token
+    unifiedTarget = target
+    scheduleUnifiedRefresh(expiresAt)
+    return true
+  }
+
+  async function refreshUnified(): Promise<void> {
+    if (!flags.unifiedCloudAuthEnabled) {
+      return
+    }
+    const target = currentUnifiedTarget()
+    if (!target) {
+      return
+    }
+
+    try {
+      const minted = await mintUnified(target)
+      // Only a refresh re-mint rotates the session cookie; the initial login
+      // mint and workspace switches do not. A stale (discarded) re-mint does not
+      // rotate either.
+      if (minted) {
+        useAuthStore().notifyTokenRefreshed()
+      }
+    } catch (err) {
+      const isPermanentError =
+        err instanceof WorkspaceAuthError &&
+        (err.code === 'ACCESS_DENIED' ||
+          err.code === 'WORKSPACE_NOT_FOUND' ||
+          err.code === 'INVALID_FIREBASE_TOKEN' ||
+          err.code === 'NOT_AUTHENTICATED')
+
+      if (isPermanentError) {
+        console.error('Unified workspace auth revoked or invalid:', err)
+        clearUnifiedContext()
+      } else {
+        console.warn('Unified token refresh failed:', err)
+      }
+    }
+  }
+
+  const mintAtLogin = async (): Promise<boolean> => {
+    if (!flags.unifiedCloudAuthEnabled) {
+      return false
+    }
+    if (unifiedToken.value) {
+      return true
+    }
+    return mintUnified(personalWorkspaceTarget())
+  }
+
+  const remintUnifiedOnce = async (): Promise<string | null> => {
+    if (!flags.unifiedCloudAuthEnabled) {
+      return null
+    }
+    const target = currentUnifiedTarget()
+    if (!target) {
+      return null
+    }
+    await mintUnified(target)
+    return unifiedToken.value
+  }
+
   function getWorkspaceAuthHeader(): AuthHeader | null {
     if (!workspaceToken.value) {
       return null
@@ -355,12 +503,16 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     workspaceToken.value = null
     error.value = null
     clearSessionStorage()
+    // Drop the unified Cloud JWT and stop its timer on logout. Safe under any
+    // flag state: the slot is null when unified auth is off.
+    clearUnifiedContext()
   }
 
   return {
     // State
     currentWorkspace,
     workspaceToken,
+    unifiedToken,
     isLoading,
     error,
 
@@ -373,6 +525,8 @@ export const useWorkspaceAuthStore = defineStore('workspaceAuth', () => {
     initializeFromSession,
     switchWorkspace,
     refreshToken,
+    mintAtLogin,
+    remintUnifiedOnce,
     getWorkspaceAuthHeader,
     getWorkspaceToken,
     clearWorkspaceContext

--- a/src/stores/__tests__/authTokenPriority.test.ts
+++ b/src/stores/__tests__/authTokenPriority.test.ts
@@ -10,7 +10,8 @@ import { createTestingPinia } from '@pinia/testing'
 
 const { mockFeatureFlags } = vi.hoisted(() => ({
   mockFeatureFlags: {
-    teamWorkspacesEnabled: false
+    teamWorkspacesEnabled: false,
+    unifiedCloudAuthEnabled: false
   }
 }))
 
@@ -24,12 +25,14 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
 const mockWorkspaceAuthHeader = vi.fn().mockReturnValue(null)
 const mockGetWorkspaceToken = vi.fn().mockReturnValue(undefined)
 const mockClearWorkspaceContext = vi.fn()
+const mockMintAtLogin = vi.fn().mockResolvedValue(false)
 
 vi.mock('@/platform/workspace/stores/workspaceAuthStore', () => ({
   useWorkspaceAuthStore: () => ({
     getWorkspaceAuthHeader: mockWorkspaceAuthHeader,
     getWorkspaceToken: mockGetWorkspaceToken,
-    clearWorkspaceContext: mockClearWorkspaceContext
+    clearWorkspaceContext: mockClearWorkspaceContext,
+    mintAtLogin: mockMintAtLogin
   })
 }))
 
@@ -112,8 +115,10 @@ describe('auth token priority chain', () => {
     vi.resetAllMocks()
 
     mockFeatureFlags.teamWorkspacesEnabled = false
+    mockFeatureFlags.unifiedCloudAuthEnabled = false
     mockWorkspaceAuthHeader.mockReturnValue(null)
     mockGetWorkspaceToken.mockReturnValue(undefined)
+    mockMintAtLogin.mockResolvedValue(false)
     mockApiKeyGetAuthHeader.mockReturnValue(null)
     mockUser.getIdToken.mockResolvedValue('firebase-token')
 
@@ -206,6 +211,20 @@ describe('auth token priority chain', () => {
       const token = await store.getAuthToken()
 
       expect(token).toBe('firebase-token')
+    })
+  })
+
+  describe('unified login mint wiring', () => {
+    it('mints the unified Cloud JWT when a cloud user signs in', () => {
+      // beforeEach signs in mockUser via the onAuthStateChanged callback.
+      expect(mockMintAtLogin).toHaveBeenCalled()
+    })
+
+    it('does not mint on sign-out', () => {
+      mockMintAtLogin.mockClear()
+      authStateCallback(null)
+      expect(mockMintAtLogin).not.toHaveBeenCalled()
+      expect(mockClearWorkspaceContext).toHaveBeenCalled()
     })
   })
 })

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -18,6 +18,13 @@ const { mockDistributionTypes } = vi.hoisted(() => ({
   }
 }))
 
+const { mockFeatureFlags } = vi.hoisted(() => ({
+  mockFeatureFlags: {
+    teamWorkspacesEnabled: false,
+    unifiedCloudAuthEnabled: false
+  }
+}))
+
 type MockUser = Omit<User, 'getIdToken'> & {
   getIdToken: Mock
 }
@@ -108,6 +115,11 @@ vi.mock('@/stores/toastStore', () => ({
 // Mock useDialogService
 vi.mock('@/services/dialogService')
 vi.mock('@/platform/distribution/types', () => mockDistributionTypes)
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: mockFeatureFlags
+  })
+}))
 
 // Mock apiKeyAuthStore
 const mockApiKeyGetAuthHeader = vi.fn().mockReturnValue(null)
@@ -139,6 +151,9 @@ describe('useAuthStore', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+
+    mockFeatureFlags.teamWorkspacesEnabled = false
+    mockFeatureFlags.unifiedCloudAuthEnabled = false
 
     // Setup dialog service mock
     vi.mocked(useDialogService, { partial: true }).mockReturnValue({
@@ -237,6 +252,18 @@ describe('useAuthStore', () => {
       idTokenCallback?.(mockUser)
       idTokenCallback?.(otherUser)
       idTokenCallback?.(otherUser)
+      expect(store.tokenRefreshTrigger).toBe(1)
+    })
+
+    it('does not increment on a Firebase token refresh when unified_cloud_auth is ON', () => {
+      mockFeatureFlags.unifiedCloudAuthEnabled = true
+      idTokenCallback?.(mockUser) // initial event (always skipped)
+      idTokenCallback?.(mockUser) // refresh — gated off; the unified lifecycle drives rotation
+      expect(store.tokenRefreshTrigger).toBe(0)
+    })
+
+    it('notifyTokenRefreshed increments the rotation trigger (unified rotation driver)', () => {
+      store.notifyTokenRefreshed()
       expect(store.tokenRefreshTrigger).toBe(1)
     })
   })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -111,6 +111,10 @@ export const useAuthStore = defineStore('auth', () => {
     if (user === null) {
       lastTokenUserId.value = null
       useWorkspaceAuthStore().clearWorkspaceContext()
+    } else if (isCloud) {
+      // Mint the single Cloud JWT at login (flag-guarded inside the store; a
+      // no-op when unified_cloud_auth is off).
+      void useWorkspaceAuthStore().mintAtLogin()
     }
 
     // Reset balance when auth state changes
@@ -126,9 +130,24 @@ export const useAuthStore = defineStore('auth', () => {
         lastTokenUserId.value = user.uid
         return
       }
-      tokenRefreshTrigger.value++
+      // Under unified_cloud_auth the Cloud-JWT refresh lifecycle drives session
+      // cookie rotation (workspaceAuthStore.refreshUnified → notifyTokenRefreshed),
+      // so gate this Firebase-driven bump off to avoid a double rotation.
+      if (!flags.unifiedCloudAuthEnabled) {
+        tokenRefreshTrigger.value++
+      }
     }
   })
+
+  /**
+   * Bumps the token-refresh trigger so downstream consumers (e.g. session
+   * cookie rotation via useCurrentUser) react to a fresh Cloud JWT. Called by
+   * the unified refresh lifecycle; under unified_cloud_auth it replaces the
+   * Firebase onIdTokenChanged bump above as the sole rotation driver.
+   */
+  const notifyTokenRefreshed = (): void => {
+    tokenRefreshTrigger.value++
+  }
 
   const getIdToken = async (): Promise<string | undefined> => {
     if (!currentUser.value) return
@@ -525,6 +544,7 @@ export const useAuthStore = defineStore('auth', () => {
     getAuthHeaderOrThrow,
     getFirebaseAuthHeader,
     getFirebaseAuthHeaderOrThrow,
-    getAuthToken
+    getAuthToken,
+    notifyTokenRefreshed
   }
 })


### PR DESCRIPTION
## Summary

Behind `unified_cloud_auth` (default OFF), extract the `/auth/token` Cloud-JWT mint out of `switchWorkspace` and add a parallel mint/refresh lifecycle that writes a dedicated, **dormant** `unifiedToken` slot — read by no consumer until PR3 — so this PR alone cannot change which token any request carries.

Stacked on #12702 (PR1, flag registration). Base will auto-retarget to `main` once #12702 merges.

## Changes

- **What**:
  - Extract `requestToken(workspaceId?)` (network + parse only) from `switchWorkspace`. An id-less `{}` body mints the personal-workspace token; a concrete `workspace_id` keeps the legacy body byte-identical. The legacy `switchWorkspace`/`refreshToken` path is behaviorally unchanged (still owns its own state writes, `isLoading`, request-id, and `scheduleTokenRefresh`).
  - `mintAtLogin()` mints the personal default into `unifiedToken`, gated on `unifiedCloudAuthEnabled` **only** (decoupled from `teamWorkspacesEnabled`). Silent — no `isLoading` flash.
  - `refreshUnified()` — parallel buffer-based refresh off the parsed `expires_at` (reuses `TOKEN_REFRESH_BUFFER_MS`, no hardcoded TTL). The legacy `refreshToken` is left untouched so its team-workspaces gate is preserved.
  - `remintUnifiedOnce()` — guarded single re-mint primitive for PR3's 401 path; a shared `unifiedRefreshRequestId` stale-guard prevents concurrent mints clobbering each other (last mint to start wins).
  - `clearWorkspaceContext()` tears down the unified slot + timer on logout.
  - `authStore`: mint at login for cloud users; add `notifyTokenRefreshed()` and gate the Firebase `onIdTokenChanged` rotation bump off under the flag (the unified lifecycle becomes the sole rotation driver — no double rotation).
- **Breaking**: None. Every flag-OFF path is byte-for-byte the current cascade.

## Review Focus

- **Dormancy**: `unifiedToken` is written only by the flag-gated mint lifecycle and read by no consumer in this PR (the `getAuthHeader`/`getAuthToken` flip is PR3). Tests assert `workspaceToken` is never touched by `mintAtLogin`.
- **Legacy parity**: the `requestToken` extraction is a pure refactor — the full existing `switchWorkspace`/`refreshToken` suite is the regression net and stays green; flag-OFF + team-workspaces-OFF fires zero network from any timer.
- **Concurrency**: `unifiedRefreshRequestId` stale-guard covers a 401-driven re-mint racing the scheduled refresh.
- **Rotation**: `notifyTokenRefreshed` fires only on a refresh re-mint (never the initial login mint or a switch), and the legacy L129 bump is gated off under the flag.

Tests cover legacy parity, the dormant slot, buffer-based refresh (re-mint fires off parsed expiry), rotation-trigger semantics, the single re-mint primitive (no loop on persistent 401), the concurrency stale-guard, logout teardown, and full flag-OFF dormancy.

Part of FE-950 (single Cloud-JWT provider at login, Phase 1). Follow-up: PR3 flips consumers + adds the 401-retry interceptor.
