### PR TITLE
fix(seo): remove payment routes from robots.txt and apply noindex header

### DIFF
--- a/apps/website/public/robots.txt
+++ b/apps/website/public/robots.txt
@@ -29,6 +29,5 @@ Allow: /
 Disallow: /_astro/
 Disallow: /_website/
 Disallow: /_vercel/
-Disallow: /payment/
 
 Sitemap: https://comfy.org/sitemap-index.xml

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -14,6 +14,14 @@
         { "type": "host", "value": "website-frontend-comfyui.vercel.app" }
       ],
       "headers": [{ "key": "X-Robots-Tag", "value": "index, follow" }]
+    },
+    {
+      "source": "/payment(.*)",
+      "headers": [{ "key": "x-robots-tag", "value": "noindex" }]
+    },
+    {
+      "source": "/zh-CN/payment(.*)",
+      "headers": [{ "key": "x-robots-tag", "value": "noindex" }]
     }
   ],
   "redirects": [


### PR DESCRIPTION
## Summary

Transitioned `/payment/` routes to `noindex` to resolve "Indexed, though blocked" SEO errors while maintaining crawling permissions.

## Changes

- **What**: 
  - Modified `apps/website/public/robots.txt` to remove `Disallow: /payment/`, allowing crawlers to access the pages and read the meta headers.
  - Updated `apps/website/vercel.json` to inject `x-robots-tag: noindex` for both English and Chinese (`/zh-CN/`) payment routes, ensuring they are excluded from search indexing.
- **Breaking**: None.

## Review Focus

- The regex rule `/payment(.*)` in `vercel.json` ensures all sub-routes (e.g., `/payment/success`, `/payment/failed`) are covered.
- Internationalization support (`/zh-CN/`) was explicitly added to ensure the `noindex` header applies globally across language variants.
- Curl verification confirms the `x-robots-tag: noindex` header is successfully returned by the Vercel edge network on both language paths.

