### PR TITLE
refactor: simplify scanAllModelCandidates mock parameters in tests

### DIFF
--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -10,6 +10,7 @@ import {
   refreshMissingModelPipeline,
   runMissingModelPipeline
 } from '@/platform/missingModel/missingModelPipeline'
+import type { scanAllModelCandidates } from '@/platform/missingModel/missingModelScan'
 
 const { mockHandles } = vi.hoisted(() => {
   const state = {
@@ -114,11 +115,8 @@ vi.mock('@/stores/modelToNodeStore', () => ({
 
 vi.mock('@/platform/missingModel/missingModelScan', () => ({
   scanAllModelCandidates: (
-    graph: LGraph,
-    isAssetSupported: (nodeType: string, widgetName: string) => boolean,
-    getDirectory?: (nodeType: string) => string | undefined
-  ) =>
-    mockHandles.scanAllModelCandidates(graph, isAssetSupported, getDirectory),
+    ...args: Parameters<typeof scanAllModelCandidates>
+  ) => mockHandles.scanAllModelCandidates(...args),
   enrichWithEmbeddedMetadata: (
     candidates: readonly MissingModelCandidate[],
     graphData: ComfyWorkflowJSON,

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -10,6 +10,7 @@ import {
   refreshMissingModelPipeline,
   runMissingModelPipeline
 } from '@/platform/missingModel/missingModelPipeline'
+import type { scanAllModelCandidates } from '@/platform/missingModel/missingModelScan'
 import { createNodeExecutionId } from '@/types/nodeIdentification'
 
 const { mockHandles } = vi.hoisted(() => {
@@ -113,11 +114,8 @@ vi.mock('@/stores/modelToNodeStore', () => ({
 
 vi.mock('@/platform/missingModel/missingModelScan', () => ({
   scanAllModelCandidates: (
-    graph: LGraph,
-    isAssetSupported: (nodeType: string, widgetName: string) => boolean,
-    getDirectory?: (nodeType: string) => string | undefined
-  ) =>
-    mockHandles.scanAllModelCandidates(graph, isAssetSupported, getDirectory),
+    ...args: Parameters<typeof scanAllModelCandidates>
+  ) => mockHandles.scanAllModelCandidates(...args),
   enrichWithEmbeddedMetadata: (
     candidates: readonly MissingModelCandidate[],
     graphData: ComfyWorkflowJSON


### PR DESCRIPTION
## Summary

Reduce duplicated mock function signatures in missingModelPipeline.test.ts by using Parameters<typeof ...> forwarding where type-compatible. This keeps mock wrappers aligned with upstream function signatures and reduces maintenance overhead when APIs change.

## Review Focus
I tried applying the pattern to all three mocks. scanAllModelCandidates works, but enrichWithEmbeddedMetadata and verifyAssetSupportedCandidates expose existing type mismatches between the mock signatures and the exported function signatures, resulting in type errors.

Fixes : #11793  
