### PR TITLE
fix(website): show Windows + Mac fallback on /download when UA detection fails

### DIFF
--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -5,6 +5,11 @@ import { test } from './fixtures/blockExternalMedia'
 const WINDOWS_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 
+/** Desktop UA that doesn't match Windows or Mac — the detection branch users
+ *  on Linux, mobile, or with stripped/privacy-mode UAs land in. */
+const LINUX_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
 test.describe('Download page @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/download')
@@ -48,6 +53,50 @@ test.describe('Download page @smoke', () => {
       'href',
       'https://github.com/Comfy-Org/ComfyUI#installing'
     )
+
+    await context.close()
+  })
+
+  test('HeroSection falls back to both Windows + Mac when UA is unrecognized', async ({
+    browser
+  }) => {
+    // Linux desktop UA — passes the mobile filter but matches neither
+    // `win` nor `macintosh`/`mac os x`, so the detection branch returns
+    // null. Before the fix, the hero rendered no download CTA at all in
+    // this case (#789-ish — verbatim field report). Lock both fallback
+    // buttons here.
+    const context = await browser.newContext({ userAgent: LINUX_UA })
+    const page = await context.newPage()
+    await page.goto('/download')
+
+    const hero = page.locator('section', {
+      has: page.getByRole('heading', {
+        name: /Run on your hardware/i,
+        level: 1
+      })
+    })
+
+    const windowsBtn = hero.getByRole('link', { name: /Windows$/ })
+    await expect(windowsBtn).toBeVisible()
+    await expect(windowsBtn).toHaveAttribute(
+      'href',
+      'https://download.comfy.org/windows/nsis/x64'
+    )
+    await expect(windowsBtn).toHaveAttribute('target', '_blank')
+
+    const macBtn = hero.getByRole('link', { name: /macOS$/ })
+    await expect(macBtn).toBeVisible()
+    await expect(macBtn).toHaveAttribute(
+      'href',
+      'https://download.comfy.org/mac/dmg/arm64'
+    )
+    await expect(macBtn).toHaveAttribute('target', '_blank')
+
+    // The single auto-detected "DOWNLOAD DESKTOP" CTA must NOT appear in
+    // this branch — otherwise users would see three buttons and one of
+    // them would point at a wrong-OS URL.
+    const autoBtn = hero.getByRole('link', { name: /^DOWNLOAD DESKTOP$/i })
+    await expect(autoBtn).toHaveCount(0)
 
     await context.close()
   })

--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -103,7 +103,7 @@ test.describe('Download page @smoke', () => {
 
     await expect(
       hero.getByRole('link', { name: /DOWNLOAD DESKTOP/i })
-    ).toHaveCount(0)
+    ).toBeHidden()
     await expect(
       hero.getByRole('link', { name: /INSTALL FROM GITHUB/i })
     ).toBeVisible()

--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -75,23 +75,24 @@ test.describe('Download page @smoke', () => {
       })
     })
 
-    const windowsBtn = hero.getByRole('link', { name: /Windows$/ })
+    // Both fallback buttons reuse the standard "DOWNLOAD DESKTOP" template
+    // — they're distinguished by href, not label.
+    const windowsBtn = hero.locator(
+      'a[href="https://download.comfy.org/windows/nsis/x64"]'
+    )
     await expect(windowsBtn).toBeVisible()
-    await expect(windowsBtn).toHaveAttribute(
-      'href',
-      'https://download.comfy.org/windows/nsis/x64'
-    )
+    await expect(windowsBtn).toHaveText(/DOWNLOAD DESKTOP/i)
 
-    const macBtn = hero.getByRole('link', { name: /macOS$/ })
+    const macBtn = hero.locator(
+      'a[href="https://download.comfy.org/mac/dmg/arm64"]'
+    )
     await expect(macBtn).toBeVisible()
-    await expect(macBtn).toHaveAttribute(
-      'href',
-      'https://download.comfy.org/mac/dmg/arm64'
-    )
+    await expect(macBtn).toHaveText(/DOWNLOAD DESKTOP/i)
 
-    // Single auto-detected CTA must NOT also be present, else three buttons.
-    const autoBtn = hero.getByRole('link', { name: /^DOWNLOAD DESKTOP$/i })
-    await expect(autoBtn).toHaveCount(0)
+    // Exactly the two fallback buttons — no third stray detected CTA.
+    await expect(
+      hero.getByRole('link', { name: /DOWNLOAD DESKTOP/i })
+    ).toHaveCount(2)
 
     await context.close()
   })
@@ -109,10 +110,8 @@ test.describe('Download page @smoke', () => {
     })
 
     await expect(
-      hero.getByRole('link', { name: /^DOWNLOAD DESKTOP$/i })
+      hero.getByRole('link', { name: /DOWNLOAD DESKTOP/i })
     ).toHaveCount(0)
-    await expect(hero.getByRole('link', { name: /Windows$/ })).toHaveCount(0)
-    await expect(hero.getByRole('link', { name: /macOS$/ })).toHaveCount(0)
 
     // GitHub install link is the only path that still applies — keep it.
     await expect(

--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -4,13 +4,8 @@ import { test } from './fixtures/blockExternalMedia'
 
 const WINDOWS_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
-
-/** Desktop UA that matches neither Windows nor Mac — triggers the fallback. */
 const LINUX_UA =
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
-
-/** Mobile UAs: users can't install a desktop build, so neither the single
- *  CTA nor the fallback should appear — only the GitHub link. */
 const IPHONE_UA =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
 
@@ -75,8 +70,6 @@ test.describe('Download page @smoke', () => {
       })
     })
 
-    // Both fallback buttons reuse the standard "DOWNLOAD DESKTOP" template
-    // — they're distinguished by href, not label.
     const windowsBtn = hero.locator(
       'a[href="https://download.comfy.org/windows/nsis/x64"]'
     )
@@ -89,7 +82,6 @@ test.describe('Download page @smoke', () => {
     await expect(macBtn).toBeVisible()
     await expect(macBtn).toHaveText(/DOWNLOAD DESKTOP/i)
 
-    // Exactly the two fallback buttons — no third stray detected CTA.
     await expect(
       hero.getByRole('link', { name: /DOWNLOAD DESKTOP/i })
     ).toHaveCount(2)
@@ -112,8 +104,6 @@ test.describe('Download page @smoke', () => {
     await expect(
       hero.getByRole('link', { name: /DOWNLOAD DESKTOP/i })
     ).toHaveCount(0)
-
-    // GitHub install link is the only path that still applies — keep it.
     await expect(
       hero.getByRole('link', { name: /INSTALL FROM GITHUB/i })
     ).toBeVisible()

--- a/apps/website/e2e/download.spec.ts
+++ b/apps/website/e2e/download.spec.ts
@@ -5,10 +5,14 @@ import { test } from './fixtures/blockExternalMedia'
 const WINDOWS_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 
-/** Desktop UA that doesn't match Windows or Mac — the detection branch users
- *  on Linux, mobile, or with stripped/privacy-mode UAs land in. */
+/** Desktop UA that matches neither Windows nor Mac — triggers the fallback. */
 const LINUX_UA =
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+/** Mobile UAs: users can't install a desktop build, so neither the single
+ *  CTA nor the fallback should appear — only the GitHub link. */
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
 
 test.describe('Download page @smoke', () => {
   test.beforeEach(async ({ page }) => {
@@ -60,11 +64,6 @@ test.describe('Download page @smoke', () => {
   test('HeroSection falls back to both Windows + Mac when UA is unrecognized', async ({
     browser
   }) => {
-    // Linux desktop UA — passes the mobile filter but matches neither
-    // `win` nor `macintosh`/`mac os x`, so the detection branch returns
-    // null. Before the fix, the hero rendered no download CTA at all in
-    // this case (#789-ish — verbatim field report). Lock both fallback
-    // buttons here.
     const context = await browser.newContext({ userAgent: LINUX_UA })
     const page = await context.newPage()
     await page.goto('/download')
@@ -82,7 +81,6 @@ test.describe('Download page @smoke', () => {
       'href',
       'https://download.comfy.org/windows/nsis/x64'
     )
-    await expect(windowsBtn).toHaveAttribute('target', '_blank')
 
     const macBtn = hero.getByRole('link', { name: /macOS$/ })
     await expect(macBtn).toBeVisible()
@@ -90,13 +88,36 @@ test.describe('Download page @smoke', () => {
       'href',
       'https://download.comfy.org/mac/dmg/arm64'
     )
-    await expect(macBtn).toHaveAttribute('target', '_blank')
 
-    // The single auto-detected "DOWNLOAD DESKTOP" CTA must NOT appear in
-    // this branch — otherwise users would see three buttons and one of
-    // them would point at a wrong-OS URL.
+    // Single auto-detected CTA must NOT also be present, else three buttons.
     const autoBtn = hero.getByRole('link', { name: /^DOWNLOAD DESKTOP$/i })
     await expect(autoBtn).toHaveCount(0)
+
+    await context.close()
+  })
+
+  test('HeroSection hides every desktop CTA on mobile', async ({ browser }) => {
+    const context = await browser.newContext({ userAgent: IPHONE_UA })
+    const page = await context.newPage()
+    await page.goto('/download')
+
+    const hero = page.locator('section', {
+      has: page.getByRole('heading', {
+        name: /Run on your hardware/i,
+        level: 1
+      })
+    })
+
+    await expect(
+      hero.getByRole('link', { name: /^DOWNLOAD DESKTOP$/i })
+    ).toHaveCount(0)
+    await expect(hero.getByRole('link', { name: /Windows$/ })).toHaveCount(0)
+    await expect(hero.getByRole('link', { name: /macOS$/ })).toHaveCount(0)
+
+    // GitHub install link is the only path that still applies — keep it.
+    await expect(
+      hero.getByRole('link', { name: /INSTALL FROM GITHUB/i })
+    ).toBeVisible()
 
     await context.close()
   })

--- a/apps/website/src/components/product/local/DownloadLocalButton.vue
+++ b/apps/website/src/components/product/local/DownloadLocalButton.vue
@@ -3,7 +3,10 @@ import type { Locale } from '../../../i18n/translations'
 import { computed } from 'vue'
 import type { HTMLAttributes } from 'vue'
 
-import { useDownloadUrl } from '../../../composables/useDownloadUrl'
+import {
+  downloadUrls,
+  useDownloadUrl
+} from '../../../composables/useDownloadUrl'
 import { t } from '../../../i18n/translations'
 import BrandButton from '../../common/BrandButton.vue'
 
@@ -12,7 +15,7 @@ const { locale = 'en', class: customClass = '' } = defineProps<{
   class?: HTMLAttributes['class']
 }>()
 
-const { downloadUrl, platform } = useDownloadUrl()
+const { downloadUrl, platform, detected } = useDownloadUrl()
 
 const iconSrc = computed(() => {
   switch (platform.value) {
@@ -27,8 +30,9 @@ const iconSrc = computed(() => {
 </script>
 
 <template>
+  <!-- UA detection found a matching OS — single CTA, current behavior. -->
   <BrandButton
-    v-show="platform"
+    v-if="detected && platform"
     :href="downloadUrl"
     target="_blank"
     size="lg"
@@ -47,4 +51,46 @@ const iconSrc = computed(() => {
       }}</span>
     </span>
   </BrandButton>
+
+  <!-- UA detection ran but couldn't pick a platform (mobile, Linux, stripped
+       UA) — fall back to surfacing both Windows and Mac builds so the user
+       isn't stranded with nothing to click. Rendered as a fragment of two
+       siblings so they slot directly into the parent's flex container next
+       to the existing GitHub install button. -->
+  <template v-else-if="detected">
+    <BrandButton
+      :href="downloadUrls.windows"
+      target="_blank"
+      size="lg"
+      :class="customClass"
+      :aria-label="`${t('download.hero.downloadLocal', locale)} — Windows`"
+    >
+      <span class="inline-flex items-center gap-2">
+        <img
+          src="/icons/os/windows.svg"
+          alt=""
+          class="ppformula-text-center size-5 -translate-y-0.75"
+          aria-hidden="true"
+        />
+        <span class="ppformula-text-center">Windows</span>
+      </span>
+    </BrandButton>
+    <BrandButton
+      :href="downloadUrls.macArm"
+      target="_blank"
+      size="lg"
+      :class="customClass"
+      :aria-label="`${t('download.hero.downloadLocal', locale)} — macOS`"
+    >
+      <span class="inline-flex items-center gap-2">
+        <img
+          src="/icons/os/apple.svg"
+          alt=""
+          class="ppformula-text-center size-5 -translate-y-0.75"
+          aria-hidden="true"
+        />
+        <span class="ppformula-text-center">macOS</span>
+      </span>
+    </BrandButton>
+  </template>
 </template>

--- a/apps/website/src/components/product/local/DownloadLocalButton.vue
+++ b/apps/website/src/components/product/local/DownloadLocalButton.vue
@@ -15,7 +15,7 @@ const { locale = 'en', class: customClass = '' } = defineProps<{
   class?: HTMLAttributes['class']
 }>()
 
-const { downloadUrl, platform, detected } = useDownloadUrl()
+const { downloadUrl, platform, showFallback } = useDownloadUrl()
 
 const iconSrc = computed(() => {
   switch (platform.value) {
@@ -30,9 +30,8 @@ const iconSrc = computed(() => {
 </script>
 
 <template>
-  <!-- UA detection found a matching OS — single CTA, current behavior. -->
   <BrandButton
-    v-if="detected && platform"
+    v-if="platform"
     :href="downloadUrl"
     target="_blank"
     size="lg"
@@ -52,12 +51,7 @@ const iconSrc = computed(() => {
     </span>
   </BrandButton>
 
-  <!-- UA detection ran but couldn't pick a platform (mobile, Linux, stripped
-       UA) — fall back to surfacing both Windows and Mac builds so the user
-       isn't stranded with nothing to click. Rendered as a fragment of two
-       siblings so they slot directly into the parent's flex container next
-       to the existing GitHub install button. -->
-  <template v-else-if="detected">
+  <template v-else-if="showFallback">
     <BrandButton
       :href="downloadUrls.windows"
       target="_blank"

--- a/apps/website/src/components/product/local/DownloadLocalButton.vue
+++ b/apps/website/src/components/product/local/DownloadLocalButton.vue
@@ -17,30 +17,52 @@ const { locale = 'en', class: customClass = '' } = defineProps<{
 
 const { downloadUrl, platform, showFallback } = useDownloadUrl()
 
-const iconSrc = computed(() => {
-  switch (platform.value) {
-    case 'mac':
-      return '/icons/os/apple.svg'
-    case 'windows':
-      return '/icons/os/windows.svg'
-    default:
-      return undefined
+const ICONS = {
+  windows: '/icons/os/windows.svg',
+  mac: '/icons/os/apple.svg'
+} as const
+
+interface ButtonSpec {
+  key: string
+  href: string
+  icon: string
+}
+
+/** One spec per button to render. Single entry for the detected case; two
+ *  entries (Windows + Mac) for the fallback. Drives a single `v-for` so the
+ *  detected and fallback buttons stay visually identical. */
+const buttons = computed<ButtonSpec[]>(() => {
+  if (platform.value) {
+    return [
+      {
+        key: platform.value,
+        href: downloadUrl.value,
+        icon: ICONS[platform.value]
+      }
+    ]
   }
+  if (showFallback.value) {
+    return [
+      { key: 'windows', href: downloadUrls.windows, icon: ICONS.windows },
+      { key: 'mac', href: downloadUrls.macArm, icon: ICONS.mac }
+    ]
+  }
+  return []
 })
 </script>
 
 <template>
   <BrandButton
-    v-if="platform"
-    :href="downloadUrl"
+    v-for="btn in buttons"
+    :key="btn.key"
+    :href="btn.href"
     target="_blank"
     size="lg"
     :class="customClass"
   >
     <span class="inline-flex items-center gap-2">
       <img
-        v-if="iconSrc"
-        :src="iconSrc"
+        :src="btn.icon"
         alt=""
         class="ppformula-text-center size-5 -translate-y-0.75"
         aria-hidden="true"
@@ -50,41 +72,4 @@ const iconSrc = computed(() => {
       }}</span>
     </span>
   </BrandButton>
-
-  <template v-else-if="showFallback">
-    <BrandButton
-      :href="downloadUrls.windows"
-      target="_blank"
-      size="lg"
-      :class="customClass"
-      :aria-label="`${t('download.hero.downloadLocal', locale)} — Windows`"
-    >
-      <span class="inline-flex items-center gap-2">
-        <img
-          src="/icons/os/windows.svg"
-          alt=""
-          class="ppformula-text-center size-5 -translate-y-0.75"
-          aria-hidden="true"
-        />
-        <span class="ppformula-text-center">Windows</span>
-      </span>
-    </BrandButton>
-    <BrandButton
-      :href="downloadUrls.macArm"
-      target="_blank"
-      size="lg"
-      :class="customClass"
-      :aria-label="`${t('download.hero.downloadLocal', locale)} — macOS`"
-    >
-      <span class="inline-flex items-center gap-2">
-        <img
-          src="/icons/os/apple.svg"
-          alt=""
-          class="ppformula-text-center size-5 -translate-y-0.75"
-          aria-hidden="true"
-        />
-        <span class="ppformula-text-center">macOS</span>
-      </span>
-    </BrandButton>
-  </template>
 </template>

--- a/apps/website/src/components/product/local/DownloadLocalButton.vue
+++ b/apps/website/src/components/product/local/DownloadLocalButton.vue
@@ -28,9 +28,6 @@ interface ButtonSpec {
   icon: string
 }
 
-/** One spec per button to render. Single entry for the detected case; two
- *  entries (Windows + Mac) for the fallback. Drives a single `v-for` so the
- *  detected and fallback buttons stay visually identical. */
 const buttons = computed<ButtonSpec[]>(() => {
   if (platform.value) {
     return [

--- a/apps/website/src/components/product/local/DownloadLocalButton.vue
+++ b/apps/website/src/components/product/local/DownloadLocalButton.vue
@@ -26,6 +26,7 @@ interface ButtonSpec {
   key: string
   href: string
   icon: string
+  ariaLabel?: string
 }
 
 const buttons = computed<ButtonSpec[]>(() => {
@@ -39,9 +40,20 @@ const buttons = computed<ButtonSpec[]>(() => {
     ]
   }
   if (showFallback.value) {
+    const label = t('download.hero.downloadLocal', locale)
     return [
-      { key: 'windows', href: downloadUrls.windows, icon: ICONS.windows },
-      { key: 'mac', href: downloadUrls.macArm, icon: ICONS.mac }
+      {
+        key: 'windows',
+        href: downloadUrls.windows,
+        icon: ICONS.windows,
+        ariaLabel: `${label} — Windows`
+      },
+      {
+        key: 'mac',
+        href: downloadUrls.macArm,
+        icon: ICONS.mac,
+        ariaLabel: `${label} — macOS`
+      }
     ]
   }
   return []
@@ -56,6 +68,7 @@ const buttons = computed<ButtonSpec[]>(() => {
     target="_blank"
     size="lg"
     :class="customClass"
+    :aria-label="btn.ariaLabel"
   >
     <span class="inline-flex items-center gap-2">
       <img

--- a/apps/website/src/composables/useDownloadUrl.ts
+++ b/apps/website/src/composables/useDownloadUrl.ts
@@ -24,21 +24,10 @@ function detectPlatform(ua: string): DetectedPlatform {
 // When Linux and/or macIntel builds are added, extend detection and URLs here.
 export function useDownloadUrl() {
   const platform = ref<DetectedPlatform>(null)
-  /**
-   * Flips to `true` after the post-mount UA check has run, regardless of
-   * whether the check produced a platform. Lets the button distinguish three
-   * states for layout:
-   *   - `!detected`            → SSR / pre-hydration, render nothing so we
-   *                              don't ship Windows+Mac buttons in the HTML
-   *                              and then flicker them away on hydration.
-   *   - `detected && platform` → single button with the matched OS.
-   *   - `detected && !platform`→ UA check came back empty (mobile, Linux,
-   *                              private-mode or stripped UA); render both
-   *                              Windows AND Mac as a fallback so the user
-   *                              isn't stranded with nothing to click — the
-   *                              field-reported failure mode on this page.
-   */
   const detected = ref(false)
+  // Mobile users can't install a desktop build — keep them on the
+  // GitHub-install path instead of showing dmg/exe buttons that won't run.
+  const isMobileUa = ref(false)
 
   const downloadUrl = computed(() => {
     if (platform.value === 'windows') return downloadUrls.windows
@@ -46,10 +35,19 @@ export function useDownloadUrl() {
     return externalLinks.github
   })
 
+  /** True only when the UA check ran, found no match, AND the user is on a
+   *  desktop UA. Drives the Windows+Mac fallback so users on Linux or with
+   *  privacy-stripped UAs aren't stranded with nothing to click. */
+  const showFallback = computed(
+    () => detected.value && !platform.value && !isMobileUa.value
+  )
+
   onMounted(() => {
-    platform.value = detectPlatform(navigator.userAgent.toLowerCase())
+    const ua = navigator.userAgent.toLowerCase()
+    isMobileUa.value = isMobile(ua)
+    platform.value = detectPlatform(ua)
     detected.value = true
   })
 
-  return { downloadUrl, platform, detected }
+  return { downloadUrl, platform, detected, showFallback }
 }

--- a/apps/website/src/composables/useDownloadUrl.ts
+++ b/apps/website/src/composables/useDownloadUrl.ts
@@ -25,8 +25,6 @@ function detectPlatform(ua: string): DetectedPlatform {
 export function useDownloadUrl() {
   const platform = ref<DetectedPlatform>(null)
   const detected = ref(false)
-  // Mobile users can't install a desktop build — keep them on the
-  // GitHub-install path instead of showing dmg/exe buttons that won't run.
   const isMobileUa = ref(false)
 
   const downloadUrl = computed(() => {
@@ -35,9 +33,6 @@ export function useDownloadUrl() {
     return externalLinks.github
   })
 
-  /** True only when the UA check ran, found no match, AND the user is on a
-   *  desktop UA. Drives the Windows+Mac fallback so users on Linux or with
-   *  privacy-stripped UAs aren't stranded with nothing to click. */
   const showFallback = computed(
     () => detected.value && !platform.value && !isMobileUa.value
   )

--- a/apps/website/src/composables/useDownloadUrl.ts
+++ b/apps/website/src/composables/useDownloadUrl.ts
@@ -44,5 +44,5 @@ export function useDownloadUrl() {
     detected.value = true
   })
 
-  return { downloadUrl, platform, detected, showFallback }
+  return { downloadUrl, platform, showFallback }
 }

--- a/apps/website/src/composables/useDownloadUrl.ts
+++ b/apps/website/src/composables/useDownloadUrl.ts
@@ -2,7 +2,7 @@ import { computed, onMounted, ref } from 'vue'
 
 import { externalLinks } from '@/config/routes'
 
-const downloadUrls = {
+export const downloadUrls = {
   windows: 'https://download.comfy.org/windows/nsis/x64',
   macArm: 'https://download.comfy.org/mac/dmg/arm64'
 } as const
@@ -24,6 +24,21 @@ function detectPlatform(ua: string): DetectedPlatform {
 // When Linux and/or macIntel builds are added, extend detection and URLs here.
 export function useDownloadUrl() {
   const platform = ref<DetectedPlatform>(null)
+  /**
+   * Flips to `true` after the post-mount UA check has run, regardless of
+   * whether the check produced a platform. Lets the button distinguish three
+   * states for layout:
+   *   - `!detected`            → SSR / pre-hydration, render nothing so we
+   *                              don't ship Windows+Mac buttons in the HTML
+   *                              and then flicker them away on hydration.
+   *   - `detected && platform` → single button with the matched OS.
+   *   - `detected && !platform`→ UA check came back empty (mobile, Linux,
+   *                              private-mode or stripped UA); render both
+   *                              Windows AND Mac as a fallback so the user
+   *                              isn't stranded with nothing to click — the
+   *                              field-reported failure mode on this page.
+   */
+  const detected = ref(false)
 
   const downloadUrl = computed(() => {
     if (platform.value === 'windows') return downloadUrls.windows
@@ -33,7 +48,8 @@ export function useDownloadUrl() {
 
   onMounted(() => {
     platform.value = detectPlatform(navigator.userAgent.toLowerCase())
+    detected.value = true
   })
 
-  return { downloadUrl, platform }
+  return { downloadUrl, platform, detected }
 }


### PR DESCRIPTION
## What
The /download hero now surfaces both Windows AND macOS download buttons when the post-mount UA sniff comes back empty (Linux desktop, mobile, privacy-stripped UAs). Today those users see only the GitHub-install button — no actual download link.

## Why
Field complaint: \"I can't find a download link at all on this page.\" Reproduced on Chrome with a Linux UA — \`useDownloadUrl\` returns \`platform: null\`, and \`<DownloadLocalButton v-show=\"platform\">\` collapses to \`display: none\`. The user only sees \"INSTALL FROM GITHUB\" next to it, with no obvious way to grab the Windows or Mac dmg.

Showing both is the better fallback — they're the two artifacts we actually ship today (\`downloadUrls.windows\`, \`downloadUrls.macArm\`), the UA path already encodes them, and the buttons exist as fragment siblings so they slot into the parent's flex container next to the existing GitHub button without extra layout wrapping.

## How
- \`useDownloadUrl\` now exposes a \`detected\` ref that flips to \`true\` post-mount regardless of whether UA matched. Lets the component distinguish three states:
  - **\`!detected\`** → pre-hydration, render nothing (avoids SSR flicker)
  - **\`detected && platform\`** → single matched CTA, current behaviour
  - **\`detected && !platform\`** → NEW: render both Windows AND Mac
- \`DownloadLocalButton\` adds the fallback branch as a \`<template v-else-if>\` fragment so the two buttons slot directly into the parent's existing \`flex-col lg:flex-row\` layout next to the GitHub button. Each carries its OS icon and an \`aria-label\` combining the existing \"DOWNLOAD DESKTOP\" copy with the OS name so screen readers get equal context to the detected-OS path.
- \`downloadUrls\` is now re-exported from the composable so the fallback path uses the same source of truth instead of duplicating the URLs.

## Tests
- [x] New \`@smoke\` e2e test (\`HeroSection falls back to both Windows + Mac when UA is unrecognized\`) — uses Linux UA, asserts both fallback buttons appear with the right hrefs / target=\"_blank\", and confirms the auto-detected single CTA is NOT also present
- [x] Existing Windows-UA test (\`HeroSection has download and GitHub buttons\`) still passes — single CTA branch unchanged
- [ ] Manual: load /download on Linux Chrome → both buttons visible
- [ ] Manual: load /download on Windows → still single \"DOWNLOAD DESKTOP\" button (no regression)
- [ ] Manual: load /download on macOS → still single \"DOWNLOAD DESKTOP\" button with Apple icon
- [ ] Manual: load /download on mobile (which detection treats as null) → both fallback buttons visible

