### PR TITLE
fix(widgetStore): tolerate null/undefined custom widgets from extensions

### DIFF
--- a/src/stores/widgetStore.test.ts
+++ b/src/stores/widgetStore.test.ts
@@ -41,16 +41,10 @@ describe('widgetStore', () => {
 
     it('does not throw when an extension returns null/undefined widgets', () => {
       const store = useWidgetStore()
-      // A misbehaving extension can resolve getCustomWidgets() to nullish even
-      // though the type says it returns a record. This must not break app init.
-      expect(() =>
-        store.registerCustomWidgets(
-          undefined as unknown as Record<string, never>
-        )
-      ).not.toThrow()
-      expect(() =>
-        store.registerCustomWidgets(null as unknown as Record<string, never>)
-      ).not.toThrow()
+      // Regression: a misbehaving extension can resolve getCustomWidgets() to
+      // nullish, which must not break app init.
+      expect(() => store.registerCustomWidgets(undefined)).not.toThrow()
+      expect(() => store.registerCustomWidgets(null)).not.toThrow()
     })
   })
 

--- a/src/stores/widgetStore.test.ts
+++ b/src/stores/widgetStore.test.ts
@@ -42,9 +42,10 @@ describe('widgetStore', () => {
     it('does not throw when an extension returns null/undefined widgets', () => {
       const store = useWidgetStore()
       // Regression: a misbehaving extension can resolve getCustomWidgets() to
-      // nullish, which must not break app init.
-      expect(() => store.registerCustomWidgets(undefined)).not.toThrow()
-      expect(() => store.registerCustomWidgets(null)).not.toThrow()
+      // nullish, which must not break app init. The `!` casts deliberately
+      // violate the non-null parameter type to simulate that untrusted input.
+      expect(() => store.registerCustomWidgets(undefined!)).not.toThrow()
+      expect(() => store.registerCustomWidgets(null!)).not.toThrow()
     })
   })
 

--- a/src/stores/widgetStore.test.ts
+++ b/src/stores/widgetStore.test.ts
@@ -38,6 +38,20 @@ describe('widgetStore', () => {
       store.registerCustomWidgets({ INT: override })
       expect(store.widgets.get('INT')).toBe(ComfyWidgets.INT)
     })
+
+    it('does not throw when an extension returns null/undefined widgets', () => {
+      const store = useWidgetStore()
+      // A misbehaving extension can resolve getCustomWidgets() to nullish even
+      // though the type says it returns a record. This must not break app init.
+      expect(() =>
+        store.registerCustomWidgets(
+          undefined as unknown as Record<string, never>
+        )
+      ).not.toThrow()
+      expect(() =>
+        store.registerCustomWidgets(null as unknown as Record<string, never>)
+      ).not.toThrow()
+    })
   })
 
   describe('inputIsWidget', () => {

--- a/src/stores/widgetStore.ts
+++ b/src/stores/widgetStore.ts
@@ -20,8 +20,13 @@ export const useWidgetStore = defineStore('widget', () => {
   }
 
   function registerCustomWidgets(
-    newWidgets: Record<string, ComfyWidgetConstructor>
+    // Extensions are untrusted code: `getCustomWidgets` is typed to return
+    // `Record<string, ...>`, but in practice an extension can resolve it to
+    // null/undefined. Guard here so a single misbehaving custom node can't
+    // throw "Cannot convert undefined or null to object" and break app init.
+    newWidgets: Record<string, ComfyWidgetConstructor> | null | undefined
   ) {
+    if (!newWidgets) return
     for (const [type, widget] of Object.entries(newWidgets)) {
       customWidgets.value.set(type, widget)
     }

--- a/src/stores/widgetStore.ts
+++ b/src/stores/widgetStore.ts
@@ -20,12 +20,12 @@ export const useWidgetStore = defineStore('widget', () => {
   }
 
   function registerCustomWidgets(
+    newWidgets: Record<string, ComfyWidgetConstructor>
+  ) {
     // Extensions are untrusted code: `getCustomWidgets` is typed to return
     // `Record<string, ...>`, but in practice an extension can resolve it to
     // null/undefined. Guard here so a single misbehaving custom node can't
     // throw "Cannot convert undefined or null to object" and break app init.
-    newWidgets: Record<string, ComfyWidgetConstructor> | null | undefined
-  ) {
     if (!newWidgets) return
     for (const [type, widget] of Object.entries(newWidgets)) {
       customWidgets.value.set(type, widget)


### PR DESCRIPTION
## ELI-5

Some custom nodes have a `getCustomWidgets()` function that's *supposed* to hand
us a list of widgets. A few of them hand us back nothing (null/undefined)
instead. We were trying to read that "nothing" like a list, which crashes with
*"Cannot convert undefined or null to object"* — and because it happens while
the app is still starting up, it can break the whole page. This PR just says
"if there's nothing to register, skip it."

## What

`registerCustomWidgets` called `Object.entries(newWidgets)` directly. When an
extension's `getCustomWidgets()` resolves to `null`/`undefined` (it's typed
non-null, but extensions are untrusted and routinely violate the type), this
throws `TypeError: Cannot convert undefined or null to object`.

The call site in `extensionService.ts` runs this inside a bare async IIFE,
*outside* the `wrapWithErrorHandling` wrappers used for keybindings/settings, so
the throw is unhandled and surfaces during app initialization.

## Why it matters

In production this is one of the highest-volume unhandled frontend errors —
~2.6k events across **~1,160 distinct sessions/day**, all funneling through this
one `Object.entries` call. Guarding the choke point silences it for every
caller.

## Fix

- Keep `registerCustomWidgets` typed `Record<string, ComfyWidgetConstructor>`
  (the correct internal contract) and early-return on nullish input. The runtime
  guard defends against untrusted extensions that violate the type at the
  boundary, without weakening the signature for legitimate callers.
- Add a regression test asserting `registerCustomWidgets(null!/undefined!)` does
  not throw (the `!` casts simulate the boundary violation).

## Test plan

- [x] `npx vitest run src/stores/widgetStore.test.ts` — 8 passing, including the
  new null/undefined case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

