### PR TITLE
fix(image): handle useImage load errors instead of reporting them as unhandled

### DIFF
--- a/src/components/common/ComfyImage.vue
+++ b/src/components/common/ComfyImage.vue
@@ -51,5 +51,11 @@ const {
   alt?: string
 }>()
 
-const { error } = useImage(computed(() => ({ src, alt })))
+const { error } = useImage(computed(() => ({ src, alt })), {
+  onError: () => {
+    // Load failures are surfaced via `error` (fallback UI). Swallow here so
+    // vueuse does not re-report them to the global handler (Datadog RUM) as
+    // unhandled errors — broken images are expected, not bugs.
+  }
+})
 </script>

--- a/src/components/common/ComfyImage.vue
+++ b/src/components/common/ComfyImage.vue
@@ -51,11 +51,14 @@ const {
   alt?: string
 }>()
 
-const { error } = useImage(computed(() => ({ src, alt })), {
-  onError: () => {
-    // Load failures are surfaced via `error` (fallback UI). Swallow here so
-    // vueuse does not re-report them to the global handler (Datadog RUM) as
-    // unhandled errors — broken images are expected, not bugs.
+const { error } = useImage(
+  computed(() => ({ src, alt })),
+  {
+    onError: () => {
+      // Load failures are surfaced via `error` (fallback UI). Swallow here so
+      // vueuse does not re-report them to the global handler (Datadog RUM) as
+      // unhandled errors — broken images are expected, not bugs.
+    }
   }
-})
+)
 </script>

--- a/src/components/common/ComfyImage.vue
+++ b/src/components/common/ComfyImage.vue
@@ -31,9 +31,9 @@
 </template>
 
 <script setup lang="ts">
-import { useImage } from '@vueuse/core'
 import { computed } from 'vue'
 
+import { useImageQuiet } from '@/composables/useImageQuiet'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const {
@@ -51,14 +51,5 @@ const {
   alt?: string
 }>()
 
-const { error } = useImage(
-  computed(() => ({ src, alt })),
-  {
-    onError: () => {
-      // Load failures are surfaced via `error` (fallback UI). Swallow here so
-      // vueuse does not re-report them to the global handler (Datadog RUM) as
-      // unhandled errors — broken images are expected, not bugs.
-    }
-  }
-)
+const { error } = useImageQuiet(computed(() => ({ src, alt })))
 </script>

--- a/src/composables/useImageQuiet.ts
+++ b/src/composables/useImageQuiet.ts
@@ -1,0 +1,20 @@
+import { useImage } from '@vueuse/core'
+
+/**
+ * `useImage()` that handles load failures quietly.
+ *
+ * `useImage()` already surfaces failures via its returned `error` ref (callers
+ * render a fallback). By default vueuse ALSO forwards the error to
+ * `globalThis.reportError`, which our error monitoring (Datadog RUM) captures as
+ * an unhandled error for every broken image — 404'd thumbnails, expired share
+ * links, in-app browsers that re-fetch in a loop. Broken images are expected,
+ * not bugs, so handle the failure here instead of letting it surface globally.
+ * The returned `error` ref behaviour is unchanged.
+ */
+export function useImageQuiet(options: Parameters<typeof useImage>[0]) {
+  return useImage(options, {
+    onError: () => {
+      // Surfaced via the returned `error` ref; see the doc comment above.
+    }
+  })
+}

--- a/src/composables/useImageQuiet.ts
+++ b/src/composables/useImageQuiet.ts
@@ -10,9 +10,16 @@ import { useImage } from '@vueuse/core'
  * links, in-app browsers that re-fetch in a loop. Broken images are expected,
  * not bugs, so handle the failure here instead of letting it surface globally.
  * The returned `error` ref behaviour is unchanged.
+ *
+ * `asyncStateOptions` is forwarded to `useImage`, so callers can still tune the
+ * other `useAsyncState` fields; only `onError` is fixed to the quiet default.
  */
-export function useImageQuiet(options: Parameters<typeof useImage>[0]) {
+export function useImageQuiet(
+  options: Parameters<typeof useImage>[0],
+  asyncStateOptions?: Parameters<typeof useImage>[1]
+) {
   return useImage(options, {
+    ...asyncStateOptions,
     onError: () => {
       // Surfaced via the returned `error` ref; see the doc comment above.
     }

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -190,10 +190,19 @@ const tooltipDelay = computed<number>(() =>
   settingStore.get('LiteGraph.Node.TooltipDelay')
 )
 
-const { isLoading, error } = useImage({
-  src: asset.preview_url ?? '',
-  alt: displayName.value
-})
+const { isLoading, error } = useImage(
+  {
+    src: asset.preview_url ?? '',
+    alt: displayName.value
+  },
+  {
+    onError: () => {
+      // Load failures are surfaced via `error` (fallback UI). Swallow here so
+      // vueuse does not re-report them to the global handler (Datadog RUM) as
+      // unhandled errors — broken images are expected, not bugs.
+    }
+  }
+)
 
 function handleSelect() {
   acknowledgeAsset(asset.id)

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -128,10 +128,10 @@
 </template>
 
 <script setup lang="ts">
-import { useImage } from '@vueuse/core'
 import { computed, ref, toValue, useId, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useImageQuiet } from '@/composables/useImageQuiet'
 import IconGroup from '@/components/button/IconGroup.vue'
 import MoreButton from '@/components/button/MoreButton.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
@@ -190,19 +190,10 @@ const tooltipDelay = computed<number>(() =>
   settingStore.get('LiteGraph.Node.TooltipDelay')
 )
 
-const { isLoading, error } = useImage(
-  {
-    src: asset.preview_url ?? '',
-    alt: displayName.value
-  },
-  {
-    onError: () => {
-      // Load failures are surfaced via `error` (fallback UI). Swallow here so
-      // vueuse does not re-report them to the global handler (Datadog RUM) as
-      // unhandled errors — broken images are expected, not bugs.
-    }
-  }
-)
+const { isLoading, error } = useImageQuiet({
+  src: asset.preview_url ?? '',
+  alt: displayName.value
+})
 
 function handleSelect() {
   acknowledgeAsset(asset.id)

--- a/src/platform/assets/components/MediaImageTop.vue
+++ b/src/platform/assets/components/MediaImageTop.vue
@@ -20,8 +20,9 @@
 </template>
 
 <script setup lang="ts">
-import { useImage, whenever } from '@vueuse/core'
+import { whenever } from '@vueuse/core'
 
+import { useImageQuiet } from '@/composables/useImageQuiet'
 import type { AssetMeta } from '../schemas/mediaAssetSchema'
 import { getAssetDisplayName } from '../utils/assetMetadataUtils'
 
@@ -34,19 +35,10 @@ const emit = defineEmits<{
   view: []
 }>()
 
-const { state, error, isReady } = useImage(
-  {
-    src: asset.src ?? '',
-    alt: getAssetDisplayName(asset)
-  },
-  {
-    onError: () => {
-      // Load failures are surfaced via `error` (fallback UI). Swallow here so
-      // vueuse does not re-report them to the global handler (Datadog RUM) as
-      // unhandled errors — broken images are expected, not bugs.
-    }
-  }
-)
+const { state, error, isReady } = useImageQuiet({
+  src: asset.src ?? '',
+  alt: getAssetDisplayName(asset)
+})
 
 whenever(
   () =>

--- a/src/platform/assets/components/MediaImageTop.vue
+++ b/src/platform/assets/components/MediaImageTop.vue
@@ -34,10 +34,19 @@ const emit = defineEmits<{
   view: []
 }>()
 
-const { state, error, isReady } = useImage({
-  src: asset.src ?? '',
-  alt: getAssetDisplayName(asset)
-})
+const { state, error, isReady } = useImage(
+  {
+    src: asset.src ?? '',
+    alt: getAssetDisplayName(asset)
+  },
+  {
+    onError: () => {
+      // Load failures are surfaced via `error` (fallback UI). Swallow here so
+      // vueuse does not re-report them to the global handler (Datadog RUM) as
+      // unhandled errors — broken images are expected, not bugs.
+    }
+  }
+)
 
 whenever(
   () =>

--- a/src/platform/workflow/sharing/components/ShareAssetThumbnail.vue
+++ b/src/platform/workflow/sharing/components/ShareAssetThumbnail.vue
@@ -63,5 +63,11 @@ const imageOptions = computed(() => ({
   src: normalizedPreviewUrl.value ?? ''
 }))
 
-const { isReady, isLoading, error } = useImage(imageOptions)
+const { isReady, isLoading, error } = useImage(imageOptions, {
+  onError: () => {
+    // Load failures are surfaced via `error` (fallback UI). Swallow here so
+    // vueuse does not re-report them to the global handler (Datadog RUM) as
+    // unhandled errors — broken images are expected, not bugs.
+  }
+})
 </script>

--- a/src/platform/workflow/sharing/components/ShareAssetThumbnail.vue
+++ b/src/platform/workflow/sharing/components/ShareAssetThumbnail.vue
@@ -28,10 +28,10 @@
 </template>
 
 <script setup lang="ts">
-import { useImage } from '@vueuse/core'
 import { computed } from 'vue'
 
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
+import { useImageQuiet } from '@/composables/useImageQuiet'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const { name, previewUrl } = defineProps<{
@@ -63,11 +63,5 @@ const imageOptions = computed(() => ({
   src: normalizedPreviewUrl.value ?? ''
 }))
 
-const { isReady, isLoading, error } = useImage(imageOptions, {
-  onError: () => {
-    // Load failures are surfaced via `error` (fallback UI). Swallow here so
-    // vueuse does not re-report them to the global handler (Datadog RUM) as
-    // unhandled errors — broken images are expected, not bugs.
-  }
-})
+const { isReady, isLoading, error } = useImageQuiet(imageOptions)
 </script>


### PR DESCRIPTION
## ELI-5

When an image on the page fails to load — a broken thumbnail, an expired share
link, a flaky in-app browser — the app already handles it and shows a fallback.
But under the hood, the image helper was *also* shouting "uncaught error!" to the
browser's global error channel every time. Our monitoring hears that shout and
logs it as a crash. With enough broken images (some in-app browsers retry in a
loop), it became the single loudest "error" in our telemetry — for something
that isn't actually broken. This tells the helper to handle the failure quietly
instead of shouting.

## What

`useImage()` (from `@vueuse/core`) exposes load failures via its `error` ref,
which every call site here already uses to render a fallback. But vueuse's
default `onError` forwards the error to `globalThis.reportError`, so each failed
`<img>` load also surfaces as an **unhandled** error to global error monitoring.

This makes failed image loads — 404'd thumbnails, expired share links, in-app
webviews that re-fetch on a loop — the highest-volume unhandled frontend error
in our production telemetry, despite being expected and already handled in the UI.

## Fix

Pass an explicit `onError` (a documented no-op) as the `useAsyncState` options
argument at all four `useImage()` call sites:

- `components/common/ComfyImage.vue`
- `platform/workflow/sharing/components/ShareAssetThumbnail.vue`
- `platform/assets/components/MediaImageTop.vue`
- `platform/assets/components/AssetCard.vue`

The `error` ref is still set by `useAsyncState` before `onError` runs, so the
fallback-UI behaviour is unchanged — the only difference is we stop re-reporting
handled failures to the global error handler.

## Test plan

- [x] No behavioural change to the `error` ref / fallback rendering (verified
  against vueuse `useImage`/`useAsyncState` semantics: `error.value` is assigned
  independently of `onError`).
- [ ] CI lint/format/type checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
