### PR TITLE
[backport core/1.44] fix: preserve validation errors on execution start

### DIFF
--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -2,12 +2,13 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraph } from '@/lib/litegraph/src/litegraph'
+import type { LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { ComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
 import type {
-  LGraph,
-  LGraphCanvas,
-  LGraphNode
-} from '@/lib/litegraph/src/litegraph'
-import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
+  ComfyApiWorkflow,
+  ComfyWorkflowJSON
+} from '@/platform/workflow/validation/schemas/workflowSchema'
 import { ComfyApp } from './app'
 import { createNode } from '@/utils/litegraphUtil'
 import {
@@ -20,31 +21,62 @@ import {
 } from '@/composables/usePaste'
 import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { api } from '@/scripts/api'
+import type { NodeError } from '@/schemas/apiSchema'
+import { useExecutionErrorStore } from '@/stores/executionErrorStore'
+import { useExecutionStore } from '@/stores/executionStore'
 
 const {
+  mockApiKeyAuthStore,
+  mockAuthStore,
+  mockSettingStore,
   mockToastStore,
   mockExtensionService,
   mockNodeOutputStore,
   mockWorkspaceWorkflow,
   mockRefreshMissingModelPipeline
-} = vi.hoisted(() => ({
-  mockToastStore: {
-    addAlert: vi.fn(),
-    add: vi.fn(),
-    remove: vi.fn()
-  },
-  mockExtensionService: {
-    invokeExtensions: vi.fn(),
-    invokeExtensionsAsync: vi.fn()
-  },
-  mockNodeOutputStore: {
-    refreshNodeOutputs: vi.fn()
-  },
-  mockWorkspaceWorkflow: {
-    activeWorkflow: null
-  },
-  mockRefreshMissingModelPipeline: vi.fn()
-}))
+} = vi.hoisted(() => {
+  const mockLocalStorage = {
+    clear: vi.fn(),
+    getItem: vi.fn(() => null),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+    length: 0
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: mockLocalStorage
+  })
+
+  return {
+    mockApiKeyAuthStore: {
+      getApiKey: vi.fn()
+    },
+    mockAuthStore: {
+      getAuthToken: vi.fn()
+    },
+    mockSettingStore: {
+      get: vi.fn()
+    },
+    mockToastStore: {
+      addAlert: vi.fn(),
+      add: vi.fn(),
+      remove: vi.fn()
+    },
+    mockExtensionService: {
+      invokeExtensions: vi.fn(),
+      invokeExtensionsAsync: vi.fn()
+    },
+    mockNodeOutputStore: {
+      refreshNodeOutputs: vi.fn()
+    },
+    mockWorkspaceWorkflow: {
+      activeWorkflow: null as ComfyWorkflow | null
+    },
+    mockRefreshMissingModelPipeline: vi.fn()
+  }
+})
 
 vi.mock('@/utils/litegraphUtil', () => ({
   createNode: vi.fn(),
@@ -53,6 +85,18 @@ vi.mock('@/utils/litegraphUtil', () => ({
   isAudioNode: vi.fn(),
   executeWidgetsCallback: vi.fn(),
   fixLinkInputSlots: vi.fn()
+}))
+
+vi.mock('@/stores/apiKeyAuthStore', () => ({
+  useApiKeyAuthStore: vi.fn(() => mockApiKeyAuthStore)
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore)
+}))
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: vi.fn(() => mockSettingStore)
 }))
 
 vi.mock('@/composables/usePaste', () => ({
@@ -110,6 +154,7 @@ function createMockCanvas(): Partial<LGraphCanvas> {
 
   return {
     graph: mockGraph as LGraph,
+    draw: vi.fn(),
     selectItems: vi.fn()
   }
 }
@@ -141,8 +186,70 @@ describe('ComfyApp', () => {
     app = new ComfyApp()
     mockCanvas = createMockCanvas() as LGraphCanvas
     app.canvas = mockCanvas as LGraphCanvas
+    mockWorkspaceWorkflow.activeWorkflow = null
+    mockApiKeyAuthStore.getApiKey.mockReturnValue(undefined)
+    mockAuthStore.getAuthToken.mockResolvedValue(undefined)
     mockExtensionService.invokeExtensions.mockReturnValue([])
     mockExtensionService.invokeExtensionsAsync.mockResolvedValue(undefined)
+    mockSettingStore.get.mockImplementation((key: string) =>
+      key === 'Comfy.RightSidePanel.ShowErrorsTab' ? true : undefined
+    )
+  })
+
+  describe('queuePrompt', () => {
+    it('shows the error overlay for successful prompt responses with node errors', async () => {
+      const graph = new LGraph()
+      const workflow = new ComfyWorkflow({
+        path: 'workflows/review.json',
+        modified: 0,
+        size: 0
+      })
+      const promptOutput: ComfyApiWorkflow = {
+        '1': {
+          class_type: 'PreviewAny',
+          inputs: {},
+          _meta: { title: 'PreviewAny' }
+        }
+      }
+      const nodeErrors: Record<string, NodeError> = {
+        '1': {
+          class_type: 'PreviewAny',
+          dependent_outputs: ['1'],
+          errors: [
+            {
+              type: 'required_input_missing',
+              message: 'Required input is missing: source',
+              details: '',
+              extra_info: { input_name: 'source' }
+            }
+          ]
+        }
+      }
+      Reflect.set(app, 'rootGraphInternal', graph)
+      mockWorkspaceWorkflow.activeWorkflow = workflow
+      vi.spyOn(app, 'graphToPrompt').mockResolvedValue({
+        output: promptOutput,
+        workflow: createWorkflowGraphData()
+      })
+      vi.spyOn(api, 'dispatchCustomEvent').mockImplementation(() => true)
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        node_errors: nodeErrors,
+        error: ''
+      })
+
+      await expect(app.queuePrompt(0)).resolves.toBe(false)
+
+      const errorStore = useExecutionErrorStore()
+      const executionStore = useExecutionStore()
+      expect(errorStore.lastNodeErrors).toEqual(nodeErrors)
+      expect(errorStore.isErrorOverlayOpen).toBe(true)
+      expect(executionStore.queuedJobs['job-1']?.nodes).toEqual({ '1': false })
+      expect(executionStore.jobIdToSessionWorkflowPath.get('job-1')).toBe(
+        'workflows/review.json'
+      )
+      expect(mockCanvas.draw).toHaveBeenCalledWith(true, true)
+    })
   })
 
   describe('refreshComboInNodes', () => {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1615,19 +1615,31 @@ export class ComfyApp {
             })
             delete api.authToken
             delete api.apiKey
-            executionErrorStore.lastNodeErrors = res.node_errors ?? null
-            if (executionErrorStore.lastNodeErrors?.length) {
+            const nodeErrors = res.node_errors
+            const hasNodeErrors =
+              nodeErrors && Object.keys(nodeErrors).length > 0
+            executionErrorStore.lastNodeErrors = hasNodeErrors
+              ? nodeErrors
+              : null
+            try {
+              if (res.prompt_id) {
+                executionStore.storeJob({
+                  id: res.prompt_id,
+                  nodes: Object.keys(p.output),
+                  workflow: queuedWorkflow
+                })
+              }
+            } catch (error) {
+              console.warn('Failed to store queued job metadata', {
+                promptId: res.prompt_id,
+                error
+              })
+            }
+            if (hasNodeErrors) {
+              if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
+                executionErrorStore.showErrorOverlay()
+              }
               this.canvas.draw(true, true)
-            } else {
-              try {
-                if (res.prompt_id) {
-                  executionStore.storeJob({
-                    id: res.prompt_id,
-                    nodes: Object.keys(p.output),
-                    workflow: queuedWorkflow
-                  })
-                }
-              } catch (error) {}
             }
           } catch (error: unknown) {
             if (

--- a/src/stores/executionErrorStore.ts
+++ b/src/stores/executionErrorStore.ts
@@ -52,7 +52,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     isErrorOverlayOpen.value = false
   }
 
-  /** Clear all error state. Called at execution start and workflow changes.
+  /** Clear all error state.
    *  Missing model state is intentionally preserved here to avoid wiping
    *  in-progress model repairs (importTaskIds, URL inputs, etc.).
    *  Missing models are cleared separately during workflow load/clean paths. */
@@ -62,6 +62,17 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
     lastNodeErrors.value = null
     missingNodesStore.setMissingNodeTypes([])
     isErrorOverlayOpen.value = false
+  }
+
+  function clearExecutionStartErrors() {
+    lastExecutionError.value = null
+    lastPromptError.value = null
+    if (
+      !lastNodeErrors.value ||
+      Object.keys(lastNodeErrors.value).length === 0
+    ) {
+      isErrorOverlayOpen.value = false
+    }
   }
 
   /** Clear only prompt-level errors. Called during resetExecutionState. */
@@ -360,6 +371,7 @@ export const useExecutionErrorStore = defineStore('executionError', () => {
 
     // Clearing
     clearAllErrors,
+    clearExecutionStartErrors,
     clearPromptError,
 
     // Overlay UI

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -790,6 +790,48 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       expect(store.initializingJobIds.has('job-1')).toBe(false)
       expect(store.initializingJobIds.has('job-2')).toBe(true)
     })
+
+    it('preserves validation node errors and overlay state', () => {
+      const errorStore = useExecutionErrorStore()
+      const nodeErrors = {
+        '123': {
+          errors: [
+            {
+              type: 'validation_error',
+              message: 'Required input is missing',
+              details: '',
+              extra_info: { input_name: 'image' }
+            }
+          ],
+          class_type: 'TestNode',
+          dependent_outputs: []
+        }
+      }
+      errorStore.lastNodeErrors = nodeErrors
+      errorStore.lastExecutionError = {
+        prompt_id: 'job-1',
+        timestamp: 0,
+        node_id: '456',
+        node_type: 'RuntimeNode',
+        exception_message: 'Runtime failed',
+        exception_type: 'RuntimeError',
+        executed: [],
+        traceback: []
+      }
+      errorStore.lastPromptError = {
+        type: 'prompt_error',
+        message: 'Prompt failed',
+        details: ''
+      }
+      errorStore.showErrorOverlay()
+
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(errorStore.lastNodeErrors).toEqual(nodeErrors)
+      expect(errorStore.lastExecutionError).toBeNull()
+      expect(errorStore.lastPromptError).toBeNull()
+      expect(errorStore.isErrorOverlayOpen).toBe(true)
+    })
   })
 
   describe('execution_cached', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -248,7 +248,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleExecutionStart(e: CustomEvent<ExecutionStartWsMessage>) {
     executionIdToLocatorCache.clear()
-    executionErrorStore.clearAllErrors()
+    executionErrorStore.clearExecutionStartErrors()
     activeJobId.value = e.detail.prompt_id
     queuedJobs.value[activeJobId.value] ??= { nodes: {} }
     clearInitializationByJobId(activeJobId.value)


### PR DESCRIPTION
## Summary

Manual backport of #12493 to `core/1.44`.

## Changes

- **What**: Preserve validation node errors and the error overlay when `execution_start` fires.
- **What**: Treat successful prompt `node_errors` as an object and keep queued job metadata tracking on that response path.
- **What**: Added the 1.44-adapted `queuePrompt()` unit regression from #12493.
- **Dependencies**: None.

## Review Focus

This keeps the 1.44 `storeJob({ id, nodes, workflow })` call shape instead of bringing over the newer `promptOutput` job metadata contract from 1.45/main.

Original PR: #12493

## Test Plan

- `pnpm test:coverage src/scripts/app.test.ts src/stores/executionStore.test.ts`
- `pnpm typecheck`
- `pnpm exec oxfmt --check src/scripts/app.test.ts src/scripts/app.ts src/stores/executionErrorStore.ts src/stores/executionStore.ts src/stores/executionStore.test.ts`
- `pnpm exec oxlint src/scripts/app.test.ts src/scripts/app.ts src/stores/executionErrorStore.ts src/stores/executionStore.ts src/stores/executionStore.test.ts --type-aware`
- `pnpm exec eslint --no-warn-ignored src/scripts/app.test.ts src/scripts/app.ts src/stores/executionErrorStore.ts src/stores/executionStore.ts src/stores/executionStore.test.ts`