### PR TITLE
feat(assets): include previews in bulk asset export

### DIFF
--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -573,7 +573,8 @@ describe('useMediaAssetActions', () => {
       expect(mockDownloadFile).not.toHaveBeenCalled()
       expect(mockCreateAssetExport).toHaveBeenCalledWith({
         job_ids: ['job1'],
-        naming_strategy: 'preserve'
+        naming_strategy: 'preserve',
+        include_previews: true
       })
       expect(mockTrackExport).toHaveBeenCalledWith('test-task-id')
 

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -201,7 +201,8 @@ export function useMediaAssetActions() {
         ...(Object.keys(jobAssetNameFilters).length > 0
           ? { job_asset_name_filters: jobAssetNameFilters }
           : {}),
-        naming_strategy: namingStrategy
+        naming_strategy: namingStrategy,
+        include_previews: true
       })
 
       assetExportStore.trackExport(result.task_id)

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -50,6 +50,7 @@ interface AssetExportOptions {
     | 'preserve'
     | 'asset_id'
   job_asset_name_filters?: Record<string, string[]>
+  include_previews?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Set `include_previews: true` on bulk asset export so exported zips include preview files, using the new option added to the cloud export API.

## Changes

- **What**: Added `include_previews` to `AssetExportOptions` and pass `true` from the bulk export path in `useMediaAssetActions`.

## Review Focus

Field name matches the updated cloud `AssetExportOptions` contract.