### PR TITLE
feat(website): rename "Comfy Local" to "Comfy Desktop" on homepage

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -182,8 +182,8 @@ const translations = {
     'zh-CN': '在您自己的硬件上运行 ComfyUI。'
   },
   'products.local.cta': {
-    en: 'SEE LOCAL FEATURES',
-    'zh-CN': '查看本地版属性'
+    en: 'SEE DESKTOP FEATURES',
+    'zh-CN': '查看桌面版属性'
   },
   'products.cloud.title': {
     en: 'Comfy\nCloud',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -174,8 +174,8 @@ const translations = {
     'zh-CN': '掌控每个模型、每个节点、每个步骤、每个输出。'
   },
   'products.local.title': {
-    en: 'Comfy\nLocal',
-    'zh-CN': 'Comfy\n本地版'
+    en: 'Comfy\nDesktop',
+    'zh-CN': 'Comfy\n桌面版'
   },
   'products.local.description': {
     en: 'Run ComfyUI on your own hardware.',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Renames the first product card on the comfy.org homepage from "Comfy Local" to "Comfy Desktop" per request in #website-and-docs. Matches the existing `nav.comfyLocal` label which already reads "Comfy Desktop" / "Comfy 桌面版".

Changes (en + zh-CN), both in `apps/website/src/i18n/translations.ts`:
- `products.local.title`: `Comfy\nLocal` → `Comfy\nDesktop` (`Comfy\n本地版` → `Comfy\n桌面版`)
- `products.local.cta`: `SEE LOCAL FEATURES` → `SEE DESKTOP FEATURES` (`查看本地版属性` → `查看桌面版属性`) — keeps card title and CTA consistent (raised in code review).

Scope intentionally limited to the homepage product card. Storybook fixtures and comparative copy ("Local vs Cloud" in FAQ) are left as-is.

## Verification
- `pnpm typecheck` — 0 errors
- Pre-commit hooks (oxfmt, oxlint, eslint, typecheck, typecheck:website) — all pass
- Visual check via `pnpm dev` — card renders as "Comfy Desktop" with "SEE DESKTOP FEATURES" CTA (screenshot attached)

## Screenshots

![Homepage product cards section: first card now shows Comfy Desktop with SEE DESKTOP FEATURES CTA, alongside Comfy Cloud, Comfy API, and Comfy Enterprise](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/7adaab5686ccaac3834072ba38747b5d3614d99caa990d7e70e569a3811ce832/pr-images/1781060553743-9ce3fa9c-db1b-4eac-b785-7fb7b93db1ef.png)