### PR TITLE
[bugfix] Truncate long workspace names in workspace switcher

### DIFF
--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from '@playwright/test'
+
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+
+const PERSONAL_WORKSPACE_NAME = 'Personal Workspace'
+const LONG_WORKSPACE_NAME =
+  'Quantum Renaissance Collective for Hyperdimensional Latent Diffusion Research and Experimental Workflow Engineering'
+
+// text-sm rows render a single 20px line; a wrapped name is 40px+.
+const SINGLE_LINE_MAX_HEIGHT_PX = 28
+
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    await page.route('**/api/features', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ team_workspaces_enabled: true })
+      })
+    )
+
+    await page.route('**/api/workspaces', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.fallback()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          workspaces: [
+            {
+              id: 'ws-personal',
+              name: PERSONAL_WORKSPACE_NAME,
+              type: 'personal',
+              created_at: '2026-01-01T00:00:00Z',
+              joined_at: '2026-01-01T00:00:00Z',
+              role: 'owner'
+            },
+            {
+              id: 'ws-team-long',
+              name: LONG_WORKSPACE_NAME,
+              type: 'team',
+              created_at: '2026-01-02T00:00:00Z',
+              joined_at: '2026-01-02T00:00:00Z',
+              role: 'member'
+            }
+          ]
+        })
+      })
+    })
+
+    await page.route('**/api/auth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          token: 'mock-workspace-token',
+          expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          workspace: {
+            id: 'ws-personal',
+            name: PERSONAL_WORKSPACE_NAME,
+            type: 'personal'
+          },
+          role: 'owner',
+          permissions: []
+        })
+      })
+    )
+
+    await use(page)
+  }
+})
+
+test.describe('Workspace switcher', { tag: '@cloud' }, () => {
+  test('renders a long team workspace name on a single line', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+
+    await comfyPage.toast.closeToasts()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByText(PERSONAL_WORKSPACE_NAME).click()
+
+    const longName = page.getByText(LONG_WORKSPACE_NAME)
+    await expect(longName).toBeVisible()
+
+    const box = await longName.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.height).toBeLessThan(SINGLE_LINE_MAX_HEIGHT_PX)
+  })
+})

--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from '@playwright/test'
 
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
 import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
 
 const PERSONAL_WORKSPACE_NAME = 'Personal Workspace'
@@ -9,13 +12,48 @@ const LONG_WORKSPACE_NAME =
 // text-sm rows render a single 20px line; a wrapped name is 40px+.
 const SINGLE_LINE_MAX_HEIGHT_PX = 28
 
+const mockRemoteConfig: RemoteConfig = { team_workspaces_enabled: true }
+
+const mockListWorkspacesResponse: { workspaces: WorkspaceWithRole[] } = {
+  workspaces: [
+    {
+      id: 'ws-personal',
+      name: PERSONAL_WORKSPACE_NAME,
+      type: 'personal',
+      created_at: '2026-01-01T00:00:00Z',
+      joined_at: '2026-01-01T00:00:00Z',
+      role: 'owner'
+    },
+    {
+      id: 'ws-team-long',
+      name: LONG_WORKSPACE_NAME,
+      type: 'team',
+      created_at: '2026-01-02T00:00:00Z',
+      joined_at: '2026-01-02T00:00:00Z',
+      role: 'member'
+    }
+  ]
+}
+
+const mockTokenResponse: WorkspaceTokenResponse = {
+  token: 'mock-workspace-token',
+  expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  workspace: {
+    id: 'ws-personal',
+    name: PERSONAL_WORKSPACE_NAME,
+    type: 'personal'
+  },
+  role: 'owner',
+  permissions: []
+}
+
 const test = comfyPageFixture.extend({
   page: async ({ page }, use) => {
     await page.route('**/api/features', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ team_workspaces_enabled: true })
+        body: JSON.stringify(mockRemoteConfig)
       })
     )
 
@@ -27,26 +65,7 @@ const test = comfyPageFixture.extend({
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          workspaces: [
-            {
-              id: 'ws-personal',
-              name: PERSONAL_WORKSPACE_NAME,
-              type: 'personal',
-              created_at: '2026-01-01T00:00:00Z',
-              joined_at: '2026-01-01T00:00:00Z',
-              role: 'owner'
-            },
-            {
-              id: 'ws-team-long',
-              name: LONG_WORKSPACE_NAME,
-              type: 'team',
-              created_at: '2026-01-02T00:00:00Z',
-              joined_at: '2026-01-02T00:00:00Z',
-              role: 'member'
-            }
-          ]
-        })
+        body: JSON.stringify(mockListWorkspacesResponse)
       })
     })
 
@@ -54,17 +73,7 @@ const test = comfyPageFixture.extend({
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          token: 'mock-workspace-token',
-          expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-          workspace: {
-            id: 'ws-personal',
-            name: PERSONAL_WORKSPACE_NAME,
-            type: 'personal'
-          },
-          role: 'owner',
-          permissions: []
-        })
+        body: JSON.stringify(mockTokenResponse)
       })
     )
 

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -84,11 +84,11 @@ function renderComponent() {
 }
 
 describe('WorkspaceSwitcherPopover', () => {
-  it('renders a long team workspace name truncated to a single line', () => {
+  it('exposes the full team workspace name as a tooltip on the row', () => {
     renderComponent()
 
     const name = screen.getByText(LONG_WORKSPACE_NAME)
 
-    expect(name).toHaveClass('truncate')
+    expect(name).toHaveAttribute('title', LONG_WORKSPACE_NAME)
   })
 })

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -1,0 +1,94 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import WorkspaceSwitcherPopover from './WorkspaceSwitcherPopover.vue'
+
+vi.mock('@/platform/workspace/composables/useWorkspaceSwitch', () => ({
+  useWorkspaceSwitch: () => ({ switchWorkspace: vi.fn() })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({ subscription: ref(null) })
+}))
+
+const LONG_WORKSPACE_NAME =
+  'Quantum Renaissance Collective for Hyperdimensional Latent Diffusion Research and Experimental Workflow Engineering'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      workspaceSwitcher: {
+        personal: 'Personal',
+        roleOwner: 'Owner',
+        roleMember: 'Member',
+        createWorkspace: 'Create new workspace',
+        maxWorkspacesReached:
+          'You can only own 10 workspaces. Delete one to create a new one.'
+      }
+    }
+  }
+})
+
+function createWorkspaceState(overrides: Record<string, unknown>) {
+  return {
+    created_at: '2026-01-01T00:00:00Z',
+    joined_at: '2026-01-01T00:00:00Z',
+    isSubscribed: false,
+    subscriptionPlan: null,
+    subscriptionTier: null,
+    members: [],
+    pendingInvites: [],
+    ...overrides
+  }
+}
+
+function renderComponent() {
+  return render(WorkspaceSwitcherPopover, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            teamWorkspace: {
+              activeWorkspaceId: 'ws-personal',
+              isFetchingWorkspaces: false,
+              workspaces: [
+                createWorkspaceState({
+                  id: 'ws-personal',
+                  name: 'Personal Workspace',
+                  type: 'personal',
+                  role: 'owner'
+                }),
+                createWorkspaceState({
+                  id: 'ws-team-long',
+                  name: LONG_WORKSPACE_NAME,
+                  type: 'team',
+                  role: 'member'
+                })
+              ]
+            }
+          }
+        }),
+        i18n
+      ],
+      stubs: {
+        WorkspaceProfilePic: true
+      }
+    }
+  })
+}
+
+describe('WorkspaceSwitcherPopover', () => {
+  it('renders a long team workspace name truncated to a single line', () => {
+    renderComponent()
+
+    const name = screen.getByText(LONG_WORKSPACE_NAME)
+
+    expect(name).toHaveClass('truncate')
+  })
+})

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -39,12 +39,11 @@
                 />
                 <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
                   <div class="flex max-w-full items-center gap-1.5">
-                    <span class="truncate text-sm text-base-foreground">
-                      {{
-                        workspace.type === 'personal'
-                          ? $t('workspaceSwitcher.personal')
-                          : workspace.name
-                      }}
+                    <span
+                      :title="getDisplayName(workspace)"
+                      class="truncate text-sm text-base-foreground"
+                    >
+                      {{ getDisplayName(workspace) }}
                     </span>
                     <span
                       v-if="resolveTierLabel(workspace)"
@@ -169,6 +168,12 @@ const availableWorkspaces = computed<AvailableWorkspace[]>(() =>
 
 function isCurrentWorkspace(workspace: AvailableWorkspace): boolean {
   return workspace.id === workspaceId.value
+}
+
+function getDisplayName(workspace: AvailableWorkspace): string {
+  return workspace.type === 'personal'
+    ? t('workspaceSwitcher.personal')
+    : workspace.name
 }
 
 function getRoleLabel(role: AvailableWorkspace['role']): string {

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -34,12 +34,12 @@
                 @click="handleSelectWorkspace(workspace)"
               >
                 <WorkspaceProfilePic
-                  class="size-8 text-sm"
+                  class="size-8 shrink-0 text-sm"
                   :workspace-name="workspace.name"
                 />
                 <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
-                  <div class="flex items-center gap-1.5">
-                    <span class="text-sm text-base-foreground">
+                  <div class="flex max-w-full items-center gap-1.5">
+                    <span class="truncate text-sm text-base-foreground">
                       {{
                         workspace.type === 'personal'
                           ? $t('workspaceSwitcher.personal')
@@ -48,7 +48,7 @@
                     </span>
                     <span
                       v-if="resolveTierLabel(workspace)"
-                      class="rounded-full bg-base-foreground px-1 py-0.5 text-2xs font-bold text-base-background uppercase"
+                      class="shrink-0 rounded-full bg-base-foreground px-1 py-0.5 text-2xs font-bold text-base-background uppercase"
                     >
                       {{ resolveTierLabel(workspace) }}
                     </span>
@@ -59,7 +59,7 @@
                 </div>
                 <i
                   v-if="isCurrentWorkspace(workspace)"
-                  class="pi pi-check text-sm text-base-foreground"
+                  class="pi pi-check shrink-0 text-sm text-base-foreground"
                 />
               </button>
             </div>

--- a/src/platform/workspace/stores/workspaceAuthStore.ts
+++ b/src/platform/workspace/stores/workspaceAuthStore.ts
@@ -33,6 +33,10 @@ const WorkspaceTokenResponseSchema = z.object({
   permissions: z.array(z.string())
 })
 
+export type WorkspaceTokenResponse = z.infer<
+  typeof WorkspaceTokenResponseSchema
+>
+
 export class WorkspaceAuthError extends Error {
   constructor(
     message: string,


### PR DESCRIPTION
## Summary

Long team workspace names wrapped onto multiple lines in the user-menu workspace switcher, overflowing the fixed 54px rows and breaking the dropdown layout. Applies the same single-line ellipsis pattern already used by the current-workspace header (`CurrentUserPopoverWorkspace.vue`).

## Changes

- **What**: `truncate` on the switcher name span, `max-w-full` on the name row, `shrink-0` on avatar/tier badge/check icon so only the name shrinks (`WorkspaceSwitcherPopover.vue`, 5 lines)
- Regression tests: Vitest component test + `@cloud` Playwright e2e measuring single-line render height

Fixes [FE-778](https://linear.app/comfyorg/issue/FE-778/bug-team-workspace-names-wrapping-to-multiple-lines-display-poorly-in)

## Red-Green Verification

| Commit | CI | Result |
|---|---|---|
| `30e04e2` test only | [Tests Unit](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27278378157) / [Tests E2E](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27278378213) | :red_circle: new unit test + cloud e2e fail (proves tests catch the bug) |
| `d8f9a5c` fix | [Tests Unit](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27279508881) / [Tests E2E](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27279508715) | :green_circle: same tests pass |

## Screenshots

| Before | After |
|---|---|
| <img width="320" alt="before — name wraps to 4 lines, rows collide" src="https://github.com/user-attachments/assets/90f3286a-5b50-4477-9b5c-9d32d0b026e4" /> | <img width="320" alt="after — single line with ellipsis, row height intact" src="https://github.com/user-attachments/assets/8e47bbb2-b5b1-4945-a008-68491f39dc46" /> |

## Review Focus

- Truncation chain: the name span is a flex item, so `truncate` (overflow-hidden) zeroes its automatic min size; `max-w-full` caps the `items-start` row at the container width. Mirrors the header pattern — no new component.
- Figma `Team Plan - Workspaces` (Workspaces Menu component, node 2045-14413) specifies compact single-line rows; long-name overflow was undesigned, truncation preserves the spec'd layout.