### PR TITLE
chore: update contact email from hello@comfy.org to support@comfy.org

### DIFF
--- a/apps/website/src/components/contact/HubspotFormEmbed.vue
+++ b/apps/website/src/components/contact/HubspotFormEmbed.vue
@@ -101,15 +101,15 @@ onMounted(() => {
   <div class="min-h-[640px] w-full">
     <p
       v-if="hasEmbedLoadError"
-      class="text-primary-comfy-canvas text-sm/6"
+      class="text-sm/6 text-primary-comfy-canvas"
       role="status"
     >
       {{ t('contact.form.embedLoadErrorPrefix', locale) }}
       <a
         class="text-primary-comfy-yellow underline"
-        href="mailto:hello@comfy.org"
+        href="mailto:support@comfy.org"
       >
-        hello@comfy.org
+        support@comfy.org
       </a>
       {{ t('contact.form.embedLoadErrorSuffix', locale) }}
     </p>

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -133,8 +133,8 @@
           {{ t('auth.login.privacyLink') }} </a
         >.
         {{ t('auth.login.questionsContactPrefix') }}
-        <a href="mailto:hello@comfy.org" class="cursor-pointer text-blue-500">
-          hello@comfy.org</a
+        <a href="mailto:support@comfy.org" class="cursor-pointer text-blue-500">
+          support@comfy.org</a
         >.
       </p>
     </template>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Replaces the public-facing `hello@comfy.org` contact address with `support@comfy.org` in the two user-visible surfaces in this repo:

- `src/components/dialog/content/SignInContent.vue` — sign-in dialog "Questions? Contact ..." link, shown to every user on the auth flow
- `apps/website/src/components/contact/HubspotFormEmbed.vue` — fallback email link rendered when the Hubspot contact form fails to embed

Both the `href="mailto:..."` target and the visible link text are updated.

## Why

Requested in #support: route public inbound mail to the support inbox instead of the catch-all `hello@`.

## Notes

- `oxfmt` reordered Tailwind class order on one adjacent line in `HubspotFormEmbed.vue` (`text-primary-comfy-canvas text-sm/6` → `text-sm/6 text-primary-comfy-canvas`) via the repo's lint-staged pre-commit hook. Kept as-is — it matches the canonical format the hook enforces and reverting would just re-trigger on the next commit.
- No i18n keys reference the email — it's a hardcoded `<a>` in both templates.
- Format check, oxlint, and the dialog component test suite (65 tests) all pass on the touched files.