### PR TITLE
feat: connect multiple selected nodes with one link drag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ dist-ssr
 .claude/worktrees
 CLAUDE.local.md
 
-# Local agent skills (not checked in)
-.agents/skills/
-
 # Editor directories and files
 .vscode/*
 *.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ dist-ssr
 .claude/worktrees
 CLAUDE.local.md
 
+# Local agent skills (not checked in)
+.agents/skills/
+
 # Editor directories and files
 .vscode/*
 *.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ dist-ssr
 .claude/worktrees
 CLAUDE.local.md
 
-# Local agent skills (not checked in)
-.agents/skills/
-
 # Editor directories and files
 .vscode/*
 *.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ dist-ssr
 .claude/worktrees
 CLAUDE.local.md
 
+# Local agent skills (not checked in)
+.agents/skills/
+
 # Editor directories and files
 .vscode/*
 *.code-workspace

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -446,6 +446,13 @@ export class ComfyPage {
     }, focusMode)
     await this.nextFrame()
   }
+  async centerPoint(locator: Locator) {
+    const bounding = await locator.boundingBox()
+    if (!bounding) throw new Error('failed to resolve bounding box')
+
+    const { x, y, width, height } = bounding
+    return { x: x + width / 2, y: y + height / 2 }
+  }
 }
 
 class ComfyFiles {

--- a/browser_tests/fixtures/ComfyPage.ts
+++ b/browser_tests/fixtures/ComfyPage.ts
@@ -527,6 +527,13 @@ export class ComfyPage {
     }, focusMode)
     await this.nextFrame()
   }
+  async centerPoint(locator: Locator) {
+    const bounding = await locator.boundingBox()
+    if (!bounding) throw new Error('failed to resolve bounding box')
+
+    const { x, y, width, height } = bounding
+    return { x: x + width / 2, y: y + height / 2 }
+  }
 }
 
 class ComfyFiles {

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -142,22 +142,20 @@ export class VueNodeHelpers {
     await this.page.locator('#graph-canvas').focus()
     await this.page.keyboard.press('Backspace')
   }
+  async getNodeId(node: Locator) {
+    await node.waitFor({ state: 'visible' })
+    const nodeId = await node.evaluate((el) => el.getAttribute('data-node-id'))
+    if (!nodeId)
+      throw new Error('Vue node is missing its data-node-id attribute')
+
+    return nodeId
+  }
 
   /**
    * Resolve the data-node-id of the first rendered node matching the title.
    */
   async getNodeIdByTitle(title: string | RegExp): Promise<string> {
-    const node = this.getNodeByTitle(title).first()
-    await node.waitFor({ state: 'visible' })
-
-    const nodeId = await node.evaluate((el) => el.getAttribute('data-node-id'))
-    if (!nodeId) {
-      throw new Error(
-        `Vue node titled "${title}" is missing its data-node-id attribute`
-      )
-    }
-
-    return nodeId
+    return await this.getNodeId(this.getNodeByTitle(title).first())
   }
 
   /**

--- a/browser_tests/fixtures/VueNodeHelpers.ts
+++ b/browser_tests/fixtures/VueNodeHelpers.ts
@@ -187,22 +187,20 @@ export class VueNodeHelpers {
     await this.page.locator('#graph-canvas').focus()
     await this.page.keyboard.press('Backspace')
   }
+  async getNodeId(node: Locator) {
+    await node.waitFor({ state: 'visible' })
+    const nodeId = await node.evaluate((el) => el.getAttribute('data-node-id'))
+    if (!nodeId)
+      throw new Error('Vue node is missing its data-node-id attribute')
+
+    return nodeId
+  }
 
   /**
    * Resolve the data-node-id of the first rendered node matching the title.
    */
   async getNodeIdByTitle(title: string | RegExp): Promise<string> {
-    const node = this.getNodeByTitle(title).first()
-    await node.waitFor({ state: 'visible' })
-
-    const nodeId = await node.evaluate((el) => el.getAttribute('data-node-id'))
-    if (!nodeId) {
-      throw new Error(
-        `Vue node titled "${title}" is missing its data-node-id attribute`
-      )
-    }
-
-    return nodeId
+    return await this.getNodeId(this.getNodeByTitle(title).first())
   }
 
   /**

--- a/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
@@ -122,8 +122,9 @@ export class ComfyNodeSearchBoxV2 {
     await this.comfyPage.page.mouse.click(position.x, position.y)
 
     const { vueNodes } = this.comfyPage
-    const selectedNode = vueNodes.selectedNodes.first()
-    const nodeId = await vueNodes.getNodeId(selectedNode)
+    const nodeId = await this.comfyPage.page.evaluate(
+      () => graph!.nodes.at(-1)!.id
+    )
     return new VueNodeFixture(vueNodes.getNodeLocator(nodeId))
   }
 }

--- a/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
+++ b/browser_tests/fixtures/components/ComfyNodeSearchBoxV2.ts
@@ -4,6 +4,7 @@ import type { Locator } from '@playwright/test'
 import type { RootCategoryId } from '@/components/searchbox/v2/rootCategories'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { TestIds } from '@e2e/fixtures/selectors'
+import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 import type { Position } from '@e2e/fixtures/types'
 
 const { searchBoxV2 } = TestIds
@@ -119,5 +120,10 @@ export class ComfyNodeSearchBoxV2 {
     await this.comfyPage.page.keyboard.press('Enter')
     await expect(this.dialog).toBeHidden()
     await this.comfyPage.page.mouse.click(position.x, position.y)
+
+    const { vueNodes } = this.comfyPage
+    const selectedNode = vueNodes.selectedNodes.first()
+    const nodeId = await vueNodes.getNodeId(selectedNode)
+    return new VueNodeFixture(vueNodes.getNodeLocator(nodeId))
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test'
 import type { Locator } from '@playwright/test'
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import { toNodeId } from '@/types/nodeId'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
@@ -205,7 +206,7 @@ export class VueNodeFixture {
         }
         return false
       },
-      [await this.getId(), await target.getId(), atSlotIndex] as const
+      [await this.getId(), toNodeId(await target.getId()), atSlotIndex] as const
     )
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -46,6 +46,11 @@ export class VueNodeFixture {
   async getTitle(): Promise<string> {
     return (await this.title.textContent()) ?? ''
   }
+  async getId() {
+    const id = await this.locator.getAttribute('data-node-id')
+    if (!id) throw new Error('Failed to get id')
+    return id
+  }
 
   async setTitle(value: string): Promise<void> {
     await this.header.dblclick()
@@ -79,12 +84,12 @@ export class VueNodeFixture {
     return this.locator.boundingBox()
   }
 
-  getSlot(nameOrLocator: string | Locator) {
+  getSlot(nameOrLocator: string | RegExp | Locator = '') {
     const slotLocators = this.root
       .getByTestId('node-widget')
       .or(this.root.locator('.lg-slot'))
     const filteredLocator =
-      typeof nameOrLocator === 'string'
+      typeof nameOrLocator === 'string' || nameOrLocator instanceof RegExp
         ? slotLocators.filter({ hasText: nameOrLocator })
         : slotLocators.filter({ has: nameOrLocator })
     return filteredLocator.getByTestId('slot-dot').locator('..')
@@ -184,5 +189,23 @@ export class VueNodeFixture {
       steps: 5
     })
     await page.mouse.up()
+  }
+
+  async isConnectedTo(target: VueNodeFixture, atSlotIndex?: number) {
+    return await this.locator.page().evaluate(
+      ([originId, targetId, slot]) => {
+        const graph = app!.canvas.graph!
+        const targetNode = graph.getNodeById(targetId)
+        if (!targetNode) return false
+
+        const inputs =
+          slot !== undefined ? [targetNode.inputs[slot]] : targetNode.inputs
+        for (const input of inputs) {
+          if (graph.getLink(input.link)?.origin_id == originId) return true
+        }
+        return false
+      },
+      [await this.getId(), await target.getId(), atSlotIndex] as const
+    )
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -54,6 +54,11 @@ export class VueNodeFixture {
   async getTitle(): Promise<string> {
     return (await this.title.textContent()) ?? ''
   }
+  async getId() {
+    const id = await this.locator.getAttribute('data-node-id')
+    if (!id) throw new Error('Failed to get id')
+    return id
+  }
 
   async setTitle(value: string): Promise<void> {
     await this.header.dblclick()
@@ -87,12 +92,12 @@ export class VueNodeFixture {
     return this.locator.boundingBox()
   }
 
-  getSlot(nameOrLocator: string | Locator) {
+  getSlot(nameOrLocator: string | RegExp | Locator = '') {
     const slotLocators = this.root
       .getByTestId('node-widget')
       .or(this.root.locator('.lg-slot'))
     const filteredLocator =
-      typeof nameOrLocator === 'string'
+      typeof nameOrLocator === 'string' || nameOrLocator instanceof RegExp
         ? slotLocators.filter({ hasText: nameOrLocator })
         : slotLocators.filter({ has: nameOrLocator })
     return filteredLocator.getByTestId('slot-dot').locator('..')
@@ -132,5 +137,23 @@ export class VueNodeFixture {
       steps: 5
     })
     await page.mouse.up()
+  }
+
+  async isConnectedTo(target: VueNodeFixture, atSlotIndex?: number) {
+    return await this.locator.page().evaluate(
+      ([originId, targetId, slot]) => {
+        const graph = app!.canvas.graph!
+        const targetNode = graph.getNodeById(targetId)
+        if (!targetNode) return false
+
+        const inputs =
+          slot !== undefined ? [targetNode.inputs[slot]] : targetNode.inputs
+        for (const input of inputs) {
+          if (graph.getLink(input.link)?.origin_id == originId) return true
+        }
+        return false
+      },
+      [await this.getId(), await target.getId(), atSlotIndex] as const
+    )
   }
 }

--- a/browser_tests/fixtures/utils/vueNodeFixtures.ts
+++ b/browser_tests/fixtures/utils/vueNodeFixtures.ts
@@ -1,5 +1,6 @@
 import type { Locator } from '@playwright/test'
 import type { CompassCorners } from '@/lib/litegraph/src/interfaces'
+import { toNodeId } from '@/types/nodeId'
 
 import { TitleEditor } from '@e2e/fixtures/components/TitleEditor'
 import { TestIds } from '@e2e/fixtures/selectors'
@@ -153,7 +154,7 @@ export class VueNodeFixture {
         }
         return false
       },
-      [await this.getId(), await target.getId(), atSlotIndex] as const
+      [await this.getId(), toNodeId(await target.getId()), atSlotIndex] as const
     )
   }
 }

--- a/browser_tests/tests/vueNodes/interactions/links/multiNodeFanout.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/multiNodeFanout.spec.ts
@@ -1,0 +1,254 @@
+import type { Page } from '@playwright/test'
+
+import type { NodeId } from '@/platform/workflow/validation/schemas/workflowSchema'
+import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
+
+function addNodeAt(comfyPage: ComfyPage, type: string, x: number, y: number) {
+  return comfyPage.nodeOps.addNode(type, undefined, { x, y })
+}
+
+function slotLocator(
+  page: Page,
+  nodeId: NodeId,
+  slotIndex: number,
+  isInput: boolean
+) {
+  const key = getSlotKey(String(nodeId), slotIndex, isInput)
+  return page.locator(`[data-slot-key="${key}"]`)
+}
+
+async function dragSlotToSlot(
+  page: Page,
+  from: { nodeId: NodeId; index: number; isInput: boolean },
+  to: { nodeId: NodeId; index: number; isInput: boolean },
+  nextFrame: () => Promise<void>
+) {
+  const fromLoc = slotLocator(page, from.nodeId, from.index, from.isInput)
+  const toLoc = slotLocator(page, to.nodeId, to.index, to.isInput)
+  await expect(fromLoc).toBeVisible()
+  await expect(toLoc).toBeVisible()
+  // oxlint-disable-next-line playwright/no-force-option -- slot dot's parent wrapper intercepts actionability checks on the inner dot
+  await fromLoc.dragTo(toLoc, { force: true })
+  await nextFrame()
+}
+
+async function slotCenter(
+  page: Page,
+  nodeId: NodeId,
+  slotIndex: number,
+  isInput: boolean
+) {
+  const locator = slotLocator(page, nodeId, slotIndex, isInput)
+  await expect(locator).toBeVisible()
+  const box = await locator.boundingBox()
+  if (!box) throw new Error('Slot bounding box not available')
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+async function getDraggingLinkCount(page: Page): Promise<number> {
+  return await page.evaluate(
+    () => window.app?.canvas?.linkConnector?.renderLinks.length ?? 0
+  )
+}
+
+async function countNodesByType(page: Page, type: string): Promise<number> {
+  return await page.evaluate((nodeType) => {
+    const graph = window.app?.canvas?.graph ?? window.app?.graph
+    return graph?.nodes.filter((node) => node.type === nodeType).length ?? 0
+  }, type)
+}
+
+async function getInputOriginId(
+  page: Page,
+  nodeId: NodeId,
+  slotIndex: number
+): Promise<NodeId | null> {
+  return await page.evaluate(
+    ([targetNodeId, targetSlot]) => {
+      const graph = window.app?.canvas?.graph ?? window.app?.graph
+      const node = graph?.getNodeById(targetNodeId)
+      const linkId = node?.inputs?.[targetSlot]?.link
+      if (linkId == null) return null
+      return graph?.getLink?.(linkId)?.origin_id ?? null
+    },
+    [nodeId, slotIndex] as const
+  )
+}
+
+async function getConnectedInputOriginIds(
+  page: Page,
+  nodeId: NodeId
+): Promise<NodeId[]> {
+  return await page.evaluate((targetNodeId) => {
+    const graph = window.app?.canvas?.graph ?? window.app?.graph
+    const node = graph?.getNodeById(targetNodeId)
+    if (!node) return []
+    const origins: NodeId[] = []
+    for (const input of node.inputs ?? []) {
+      const linkId = input.link
+      if (linkId == null) continue
+      const link = graph?.getLink?.(linkId)
+      if (link) origins.push(link.origin_id)
+    }
+    return origins
+  }, nodeId)
+}
+
+function sortedNumbers(ids: NodeId[]): number[] {
+  return ids.map(Number).sort((a, b) => a - b)
+}
+
+test.describe(
+  'Multi-node fan-out link connections',
+  { tag: ['@vue-nodes', '@canvas'] },
+  () => {
+    test.beforeEach(async ({ comfyPage }) => {
+      await comfyPage.nodeOps.clearGraph()
+    })
+
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.canvasOps.resetView()
+    })
+
+    test('forward: dragging one selected image output onto an input batches all selected outputs', async ({
+      comfyPage
+    }) => {
+      const page = comfyPage.page
+      const loadImage1 = await addNodeAt(comfyPage, 'LoadImage', 0, 0)
+      const loadImage2 = await addNodeAt(comfyPage, 'LoadImage', 0, 450)
+      const loadImage3 = await addNodeAt(comfyPage, 'LoadImage', 0, 900)
+      const preview = await addNodeAt(comfyPage, 'PreviewImage', 600, 300)
+
+      await comfyPage.vueNodes.waitForNodes(4)
+      await fitToViewInstant(comfyPage)
+
+      await comfyPage.vueNodes.selectNodes([
+        String(loadImage1.id),
+        String(loadImage2.id),
+        String(loadImage3.id)
+      ])
+
+      await dragSlotToSlot(
+        page,
+        { nodeId: loadImage1.id, index: 0, isInput: false },
+        { nodeId: preview.id, index: 0, isInput: true },
+        () => comfyPage.nextFrame()
+      )
+
+      await expect.poll(() => countNodesByType(page, 'BatchImagesNode')).toBe(1)
+
+      const batchNode = (
+        await comfyPage.nodeOps.getNodeRefsByType('BatchImagesNode')
+      )[0]
+
+      await expect
+        .poll(() => getInputOriginId(page, preview.id, 0))
+        .toBe(batchNode.id)
+
+      await expect
+        .poll(() =>
+          getConnectedInputOriginIds(page, batchNode.id).then(sortedNumbers)
+        )
+        .toEqual(sortedNumbers([loadImage1.id, loadImage2.id, loadImage3.id]))
+    })
+
+    test('reverse: dragging one selected input onto an upstream output connects every selected input', async ({
+      comfyPage
+    }) => {
+      const page = comfyPage.page
+      const loadImage = await addNodeAt(comfyPage, 'LoadImage', 0, 450)
+      const preview1 = await addNodeAt(comfyPage, 'PreviewImage', 600, 0)
+      const preview2 = await addNodeAt(comfyPage, 'PreviewImage', 600, 450)
+      const preview3 = await addNodeAt(comfyPage, 'PreviewImage', 600, 900)
+
+      await comfyPage.vueNodes.waitForNodes(4)
+      await fitToViewInstant(comfyPage)
+
+      await comfyPage.vueNodes.selectNodes([
+        String(preview1.id),
+        String(preview2.id),
+        String(preview3.id)
+      ])
+
+      await dragSlotToSlot(
+        page,
+        { nodeId: preview1.id, index: 0, isInput: true },
+        { nodeId: loadImage.id, index: 0, isInput: false },
+        () => comfyPage.nextFrame()
+      )
+
+      const loadOutput = await loadImage.getOutput(0)
+      await expect.poll(() => loadOutput.getLinkCount()).toBe(3)
+
+      for (const preview of [preview1, preview2, preview3]) {
+        await expect
+          .poll(() => getInputOriginId(page, preview.id, 0))
+          .toBe(loadImage.id)
+      }
+    })
+
+    test('does not fan the drag UI when dragging a non-image output', async ({
+      comfyPage,
+      comfyMouse
+    }) => {
+      const page = comfyPage.page
+      const clip1 = await addNodeAt(comfyPage, 'CLIPTextEncode', 0, 0)
+      const clip2 = await addNodeAt(comfyPage, 'CLIPTextEncode', 0, 450)
+
+      await comfyPage.vueNodes.waitForNodes(2)
+      await fitToViewInstant(comfyPage)
+
+      await comfyPage.vueNodes.selectNodes([String(clip1.id), String(clip2.id)])
+
+      const start = await slotCenter(page, clip1.id, 0, false)
+      await comfyMouse.move(start)
+      await comfyMouse.drag({ x: start.x + 200, y: start.y + 80 })
+      await comfyPage.nextFrame()
+
+      try {
+        await expect.poll(() => getDraggingLinkCount(page)).toBe(1)
+      } finally {
+        await comfyMouse.drop()
+      }
+    })
+
+    test('forward: connects directly into a dynamic input instead of creating a batch node', async ({
+      comfyPage
+    }) => {
+      const page = comfyPage.page
+      const batch = await addNodeAt(comfyPage, 'BatchImagesNode', 600, 200)
+      const loadImage1 = await addNodeAt(comfyPage, 'LoadImage', 0, 0)
+      const loadImage2 = await addNodeAt(comfyPage, 'LoadImage', 0, 450)
+      const loadImage3 = await addNodeAt(comfyPage, 'LoadImage', 0, 900)
+
+      await comfyPage.vueNodes.waitForNodes(4)
+      await fitToViewInstant(comfyPage)
+
+      await comfyPage.vueNodes.selectNodes([
+        String(loadImage1.id),
+        String(loadImage2.id),
+        String(loadImage3.id)
+      ])
+
+      await dragSlotToSlot(
+        page,
+        { nodeId: loadImage1.id, index: 0, isInput: false },
+        { nodeId: batch.id, index: 0, isInput: true },
+        () => comfyPage.nextFrame()
+      )
+
+      await expect.poll(() => countNodesByType(page, 'BatchImagesNode')).toBe(1)
+      await expect
+        .poll(() =>
+          getConnectedInputOriginIds(page, batch.id).then(sortedNumbers)
+        )
+        .toEqual(sortedNumbers([loadImage1.id, loadImage2.id, loadImage3.id]))
+    })
+  }
+)

--- a/browser_tests/tests/vueNodes/interactions/links/multiNodeFanout.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/links/multiNodeFanout.spec.ts
@@ -1,55 +1,11 @@
 import type { Page } from '@playwright/test'
 
-import type { NodeId } from '@/platform/workflow/validation/schemas/workflowSchema'
-import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
-import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import {
   comfyExpect as expect,
   comfyPageFixture as test
 } from '@e2e/fixtures/ComfyPage'
+import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import { fitToViewInstant } from '@e2e/fixtures/utils/fitToView'
-
-function addNodeAt(comfyPage: ComfyPage, type: string, x: number, y: number) {
-  return comfyPage.nodeOps.addNode(type, undefined, { x, y })
-}
-
-function slotLocator(
-  page: Page,
-  nodeId: NodeId,
-  slotIndex: number,
-  isInput: boolean
-) {
-  const key = getSlotKey(String(nodeId), slotIndex, isInput)
-  return page.locator(`[data-slot-key="${key}"]`)
-}
-
-async function dragSlotToSlot(
-  page: Page,
-  from: { nodeId: NodeId; index: number; isInput: boolean },
-  to: { nodeId: NodeId; index: number; isInput: boolean },
-  nextFrame: () => Promise<void>
-) {
-  const fromLoc = slotLocator(page, from.nodeId, from.index, from.isInput)
-  const toLoc = slotLocator(page, to.nodeId, to.index, to.isInput)
-  await expect(fromLoc).toBeVisible()
-  await expect(toLoc).toBeVisible()
-  // oxlint-disable-next-line playwright/no-force-option -- slot dot's parent wrapper intercepts actionability checks on the inner dot
-  await fromLoc.dragTo(toLoc, { force: true })
-  await nextFrame()
-}
-
-async function slotCenter(
-  page: Page,
-  nodeId: NodeId,
-  slotIndex: number,
-  isInput: boolean
-) {
-  const locator = slotLocator(page, nodeId, slotIndex, isInput)
-  await expect(locator).toBeVisible()
-  const box = await locator.boundingBox()
-  if (!box) throw new Error('Slot bounding box not available')
-  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
-}
 
 async function getDraggingLinkCount(page: Page): Promise<number> {
   return await page.evaluate(
@@ -57,51 +13,8 @@ async function getDraggingLinkCount(page: Page): Promise<number> {
   )
 }
 
-async function countNodesByType(page: Page, type: string): Promise<number> {
-  return await page.evaluate((nodeType) => {
-    const graph = window.app?.canvas?.graph ?? window.app?.graph
-    return graph?.nodes.filter((node) => node.type === nodeType).length ?? 0
-  }, type)
-}
-
-async function getInputOriginId(
-  page: Page,
-  nodeId: NodeId,
-  slotIndex: number
-): Promise<NodeId | null> {
-  return await page.evaluate(
-    ([targetNodeId, targetSlot]) => {
-      const graph = window.app?.canvas?.graph ?? window.app?.graph
-      const node = graph?.getNodeById(targetNodeId)
-      const linkId = node?.inputs?.[targetSlot]?.link
-      if (linkId == null) return null
-      return graph?.getLink?.(linkId)?.origin_id ?? null
-    },
-    [nodeId, slotIndex] as const
-  )
-}
-
-async function getConnectedInputOriginIds(
-  page: Page,
-  nodeId: NodeId
-): Promise<NodeId[]> {
-  return await page.evaluate((targetNodeId) => {
-    const graph = window.app?.canvas?.graph ?? window.app?.graph
-    const node = graph?.getNodeById(targetNodeId)
-    if (!node) return []
-    const origins: NodeId[] = []
-    for (const input of node.inputs ?? []) {
-      const linkId = input.link
-      if (linkId == null) continue
-      const link = graph?.getLink?.(linkId)
-      if (link) origins.push(link.origin_id)
-    }
-    return origins
-  }, nodeId)
-}
-
-function sortedNumbers(ids: NodeId[]): number[] {
-  return ids.map(Number).sort((a, b) => a - b)
+async function addNode(cpage: ComfyPage, name: string, x: number, y: number) {
+  return await cpage.searchBoxV2.addNode(name, { position: { x, y } })
 }
 
 test.describe(
@@ -112,143 +25,100 @@ test.describe(
       await comfyPage.nodeOps.clearGraph()
     })
 
-    test.afterEach(async ({ comfyPage }) => {
-      await comfyPage.canvasOps.resetView()
-    })
-
     test('forward: dragging one selected image output onto an input batches all selected outputs', async ({
       comfyPage
     }) => {
-      const page = comfyPage.page
-      const loadImage1 = await addNodeAt(comfyPage, 'LoadImage', 0, 0)
-      const loadImage2 = await addNodeAt(comfyPage, 'LoadImage', 0, 450)
-      const loadImage3 = await addNodeAt(comfyPage, 'LoadImage', 0, 900)
-      const preview = await addNodeAt(comfyPage, 'PreviewImage', 600, 300)
-
-      await comfyPage.vueNodes.waitForNodes(4)
+      const loadImage1 = await addNode(comfyPage, 'Load Image', 100, 100)
+      const loadImage2 = await addNode(comfyPage, 'Load Image', 400, 100)
+      const loadImage3 = await addNode(comfyPage, 'Load Image', 100, 500)
+      const preview = await addNode(comfyPage, 'Preview Image', 900, 300)
       await fitToViewInstant(comfyPage)
 
-      await comfyPage.vueNodes.selectNodes([
-        String(loadImage1.id),
-        String(loadImage2.id),
-        String(loadImage3.id)
-      ])
+      await loadImage1.select()
+      await comfyPage.page.keyboard.down('Shift')
+      await loadImage2.select()
+      await loadImage3.select()
+      await comfyPage.page.keyboard.up('Shift')
 
-      await dragSlotToSlot(
-        page,
-        { nodeId: loadImage1.id, index: 0, isInput: false },
-        { nodeId: preview.id, index: 0, isInput: true },
-        () => comfyPage.nextFrame()
-      )
+      await loadImage1.getSlot(/IMAGE/).dragTo(preview.getSlot())
 
-      await expect.poll(() => countNodesByType(page, 'BatchImagesNode')).toBe(1)
+      const batchNode =
+        await comfyPage.vueNodes.getFixtureByTitle('Batch Images')
+      await expect(batchNode.root).toBeVisible()
 
-      const batchNode = (
-        await comfyPage.nodeOps.getNodeRefsByType('BatchImagesNode')
-      )[0]
-
-      await expect
-        .poll(() => getInputOriginId(page, preview.id, 0))
-        .toBe(batchNode.id)
-
-      await expect
-        .poll(() =>
-          getConnectedInputOriginIds(page, batchNode.id).then(sortedNumbers)
-        )
-        .toEqual(sortedNumbers([loadImage1.id, loadImage2.id, loadImage3.id]))
+      expect(await batchNode.isConnectedTo(preview)).toBe(true)
+      expect(await loadImage1.isConnectedTo(batchNode)).toBe(true)
+      expect(await loadImage2.isConnectedTo(batchNode)).toBe(true)
+      expect(await loadImage3.isConnectedTo(batchNode)).toBe(true)
     })
 
     test('reverse: dragging one selected input onto an upstream output connects every selected input', async ({
       comfyPage
     }) => {
-      const page = comfyPage.page
-      const loadImage = await addNodeAt(comfyPage, 'LoadImage', 0, 450)
-      const preview1 = await addNodeAt(comfyPage, 'PreviewImage', 600, 0)
-      const preview2 = await addNodeAt(comfyPage, 'PreviewImage', 600, 450)
-      const preview3 = await addNodeAt(comfyPage, 'PreviewImage', 600, 900)
-
-      await comfyPage.vueNodes.waitForNodes(4)
+      const loadImage = await addNode(comfyPage, 'Load Image', 100, 100)
+      const preview1 = await addNode(comfyPage, 'Preview Image', 600, 100)
+      const preview2 = await addNode(comfyPage, 'Preview Image', 900, 100)
+      const preview3 = await addNode(comfyPage, 'Preview Image', 900, 500)
       await fitToViewInstant(comfyPage)
 
-      await comfyPage.vueNodes.selectNodes([
-        String(preview1.id),
-        String(preview2.id),
-        String(preview3.id)
-      ])
+      await preview1.select()
+      await comfyPage.page.keyboard.down('Shift')
+      await preview2.select()
+      await preview3.select()
+      await comfyPage.page.keyboard.up('Shift')
 
-      await dragSlotToSlot(
-        page,
-        { nodeId: preview1.id, index: 0, isInput: true },
-        { nodeId: loadImage.id, index: 0, isInput: false },
-        () => comfyPage.nextFrame()
-      )
-
-      const loadOutput = await loadImage.getOutput(0)
-      await expect.poll(() => loadOutput.getLinkCount()).toBe(3)
-
-      for (const preview of [preview1, preview2, preview3]) {
-        await expect
-          .poll(() => getInputOriginId(page, preview.id, 0))
-          .toBe(loadImage.id)
-      }
+      await preview1.getSlot().dragTo(loadImage.getSlot(/IMAGE/))
+      await expect.poll(() => loadImage.isConnectedTo(preview1)).toBe(true)
+      expect(await loadImage.isConnectedTo(preview2)).toBe(true)
+      expect(await loadImage.isConnectedTo(preview3)).toBe(true)
+      await expect(comfyPage.vueNodes.nodes).toHaveCount(4)
     })
 
     test('does not fan the drag UI when dragging a non-image output', async ({
       comfyPage,
       comfyMouse
     }) => {
-      const page = comfyPage.page
-      const clip1 = await addNodeAt(comfyPage, 'CLIPTextEncode', 0, 0)
-      const clip2 = await addNodeAt(comfyPage, 'CLIPTextEncode', 0, 450)
-
-      await comfyPage.vueNodes.waitForNodes(2)
+      const clip1 = await addNode(comfyPage, 'CLIP Text Encode', 100, 100)
+      const clip2 = await addNode(comfyPage, 'CLIP Text Encode', 100, 500)
       await fitToViewInstant(comfyPage)
 
-      await comfyPage.vueNodes.selectNodes([String(clip1.id), String(clip2.id)])
+      await clip1.select()
+      await comfyPage.page.keyboard.down('Shift')
+      await clip2.select()
+      await comfyPage.page.keyboard.up('Shift')
 
-      const start = await slotCenter(page, clip1.id, 0, false)
+      const start = await comfyPage.centerPoint(clip1.getSlot('CONDITIONING'))
       await comfyMouse.move(start)
       await comfyMouse.drag({ x: start.x + 200, y: start.y + 80 })
       await comfyPage.nextFrame()
 
-      try {
-        await expect.poll(() => getDraggingLinkCount(page)).toBe(1)
-      } finally {
-        await comfyMouse.drop()
-      }
+      await expect.poll(() => getDraggingLinkCount(comfyPage.page)).toBe(1)
     })
 
     test('forward: connects directly into a dynamic input instead of creating a batch node', async ({
       comfyPage
     }) => {
-      const page = comfyPage.page
-      const batch = await addNodeAt(comfyPage, 'BatchImagesNode', 600, 200)
-      const loadImage1 = await addNodeAt(comfyPage, 'LoadImage', 0, 0)
-      const loadImage2 = await addNodeAt(comfyPage, 'LoadImage', 0, 450)
-      const loadImage3 = await addNodeAt(comfyPage, 'LoadImage', 0, 900)
+      const batch = await addNode(comfyPage, 'Batch Images', 900, 300)
+      const loadImage1 = await addNode(comfyPage, 'Load Image', 100, 100)
+      const loadImage2 = await addNode(comfyPage, 'Load Image', 400, 100)
+      const loadImage3 = await addNode(comfyPage, 'Load Image', 100, 500)
 
       await comfyPage.vueNodes.waitForNodes(4)
       await fitToViewInstant(comfyPage)
 
-      await comfyPage.vueNodes.selectNodes([
-        String(loadImage1.id),
-        String(loadImage2.id),
-        String(loadImage3.id)
-      ])
+      await loadImage1.select()
+      await comfyPage.page.keyboard.down('Shift')
+      await loadImage2.select()
+      await loadImage3.select()
+      await comfyPage.page.keyboard.up('Shift')
 
-      await dragSlotToSlot(
-        page,
-        { nodeId: loadImage1.id, index: 0, isInput: false },
-        { nodeId: batch.id, index: 0, isInput: true },
-        () => comfyPage.nextFrame()
-      )
+      await loadImage1.getSlot(/IMAGE/).dragTo(batch.getSlot('image0'))
 
-      await expect.poll(() => countNodesByType(page, 'BatchImagesNode')).toBe(1)
-      await expect
-        .poll(() =>
-          getConnectedInputOriginIds(page, batch.id).then(sortedNumbers)
-        )
-        .toEqual(sortedNumbers([loadImage1.id, loadImage2.id, loadImage3.id]))
+      const batchNode = comfyPage.vueNodes.getNodeByTitle('Batch Images')
+      await expect(batchNode).toBeVisible()
+      await expect.poll(() => loadImage1.isConnectedTo(batch)).toBe(true)
+      expect(await loadImage2.isConnectedTo(batch)).toBe(true)
+      expect(await loadImage3.isConnectedTo(batch)).toBe(true)
     })
   }
 )

--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -69,6 +69,7 @@ import { useSurveyFeatureTracking } from '@/platform/surveys/useSurveyFeatureTra
 import { withNodeAddSource } from '@/platform/telemetry/nodeAdded/nodeAddSource'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { connectImageBatchToCreatedNode } from '@/renderer/core/canvas/links/multiNodeLinkConnect'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { ComfyNodeDefImpl } from '@/stores/nodeDefStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
@@ -141,7 +142,10 @@ function addNode(nodeDef: ComfyNodeDefImpl, dragEvent?: MouseEvent) {
   if (!node) return
 
   if (disconnectOnReset && triggerEvent) {
-    canvasStore.getCanvas().linkConnector.connectToNode(node, triggerEvent)
+    const canvas = canvasStore.getCanvas()
+    if (!connectImageBatchToCreatedNode(canvas, node)) {
+      canvas.linkConnector.connectToNode(node, triggerEvent)
+    }
   } else if (!triggerEvent) {
     console.warn('The trigger event was undefined when addNode was called.')
   }

--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -1,9 +1,12 @@
 import type { SlotLayout } from '@/renderer/core/layout/types'
 import type { Point } from '@/lib/litegraph/src/interfaces'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
+import { ToInputRenderLink } from '@/lib/litegraph/src/canvas/ToInputRenderLink'
+import { ToOutputRenderLink } from '@/lib/litegraph/src/canvas/ToOutputRenderLink'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import { app } from '@/scripts/app'
 import type { NodeId } from '@/types/nodeId'
@@ -61,6 +64,38 @@ export class LinkConnectorAdapter {
         node,
         output,
         fromReroute
+      )
+    }
+  }
+
+  /**
+   * Adds extra output→input render links for a multi-node fan-out drag, so
+   * every selected node's output renders while a single drag is in progress.
+   */
+  addOutputRenderLinks(
+    sources: ReadonlyArray<{ node: LGraphNode; outputIndex: number }>
+  ): void {
+    for (const { node, outputIndex } of sources) {
+      const output = node.outputs?.[outputIndex]
+      if (!output) continue
+      this.linkConnector.renderLinks.push(
+        new ToInputRenderLink(this.network, node, output)
+      )
+    }
+  }
+
+  /**
+   * Adds extra input→output render links for a multi-node fan-out drag, so
+   * every selected node's input renders while a single drag is in progress.
+   */
+  addInputRenderLinks(
+    sources: ReadonlyArray<{ node: LGraphNode; inputIndex: number }>
+  ): void {
+    for (const { node, inputIndex } of sources) {
+      const input = node.inputs?.[inputIndex]
+      if (!input) continue
+      this.linkConnector.renderLinks.push(
+        new ToOutputRenderLink(this.network, node, input)
       )
     }
   }

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
@@ -368,4 +368,20 @@ describe('connectImagesToDynamicInput', () => {
       ])
     ).toBe(false)
   })
+
+  it('does not report success when the connection is rejected', () => {
+    const graph = new LGraph()
+    const node = addAutogrowImageNode(graph)
+
+    const maskSource = new LGraphNode('Mask')
+    maskSource.addOutput('MASK', 'MASK')
+    graph.add(maskSource)
+
+    const handled = connectImagesToDynamicInput(node, node.inputs[0], [
+      { node: maskSource, outputIndex: 0 }
+    ])
+
+    expect(handled).toBe(false)
+    expect(node.inputs[0].link).toBeNull()
+  })
 })

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+
+vi.mock('@/utils/litegraphUtil', () => ({
+  createNode: vi.fn(),
+  isLGraphNode: (item: unknown) => item instanceof LGraphNode
+}))
+
+import { createNode } from '@/utils/litegraphUtil'
+
+import {
+  collectFanInputs,
+  collectFanOutputs,
+  connectImageBatchToCreatedNode,
+  connectImagesToDynamicInput,
+  createBatchImagesNode,
+  getSelectedNodes,
+  isImageType,
+  toImageBatchSources
+} from './multiNodeLinkConnect'
+
+function addImageSource(graph: LGraph): LGraphNode {
+  const node = new LGraphNode('LoadImage')
+  node.addOutput('IMAGE', 'IMAGE')
+  graph.add(node)
+  return node
+}
+
+function addImageTarget(graph: LGraph): LGraphNode {
+  const node = new LGraphNode('Target')
+  node.addInput('image', 'IMAGE')
+  graph.add(node)
+  return node
+}
+
+function addAutogrowImageNode(graph: LGraph, slotCount = 3): LGraphNode {
+  const node = new LGraphNode('BatchImagesNode')
+  node.comfyDynamic = { autogrow: { images: {} } }
+  for (let i = 0; i < slotCount; i++) {
+    node.addInput(`images.${i}`, 'IMAGE')
+  }
+  graph.add(node)
+  return node
+}
+
+describe('isImageType', () => {
+  it('matches the IMAGE type case-insensitively', () => {
+    expect(isImageType('IMAGE')).toBe(true)
+    expect(isImageType('image')).toBe(true)
+  })
+
+  it('rejects other types', () => {
+    expect(isImageType('MASK')).toBe(false)
+    expect(isImageType(0)).toBe(false)
+  })
+})
+
+describe('getSelectedNodes', () => {
+  it('returns only LGraphNode items from the canvas selection', () => {
+    const graph = new LGraph()
+    const a = addImageSource(graph)
+    const b = addImageSource(graph)
+    const canvas = {
+      selectedItems: new Set([a, {}, b])
+    } as unknown as LGraphCanvas
+
+    expect(getSelectedNodes(canvas)).toEqual([a, b])
+  })
+})
+
+describe('collectFanOutputs', () => {
+  it('returns the grabbed source first, then matching selected nodes', () => {
+    const graph = new LGraph()
+    const grabbed = addImageSource(graph)
+    const other = addImageSource(graph)
+
+    const sources = collectFanOutputs(grabbed, 0, [grabbed, other])
+
+    expect(sources).toEqual([
+      { node: grabbed, outputIndex: 0 },
+      { node: other, outputIndex: 0 }
+    ])
+  })
+
+  it('falls back to the first type-compatible output when the index differs', () => {
+    const graph = new LGraph()
+    const grabbed = addImageSource(graph)
+
+    const other = new LGraphNode('Mixed')
+    other.addOutput('MASK', 'MASK')
+    other.addOutput('IMAGE', 'IMAGE')
+    graph.add(other)
+
+    const sources = collectFanOutputs(grabbed, 0, [grabbed, other])
+
+    expect(sources).toEqual([
+      { node: grabbed, outputIndex: 0 },
+      { node: other, outputIndex: 1 }
+    ])
+  })
+
+  it('skips selected nodes without a type-compatible output', () => {
+    const graph = new LGraph()
+    const grabbed = addImageSource(graph)
+
+    const incompatible = new LGraphNode('Latent')
+    incompatible.addOutput('LATENT', 'LATENT')
+    graph.add(incompatible)
+
+    const sources = collectFanOutputs(grabbed, 0, [grabbed, incompatible])
+
+    expect(sources).toEqual([{ node: grabbed, outputIndex: 0 }])
+  })
+})
+
+describe('toImageBatchSources', () => {
+  it('keeps LGraphNode candidates and drops non-node origins', () => {
+    const graph = new LGraph()
+    const node = addImageSource(graph)
+
+    const sources = toImageBatchSources([
+      { node, fromSlotIndex: 0 },
+      { node: { id: 'io' }, fromSlotIndex: 2 }
+    ])
+
+    expect(sources).toEqual([{ node, outputIndex: 0 }])
+  })
+})
+
+describe('collectFanInputs', () => {
+  it('returns the grabbed input first, then matching selected nodes', () => {
+    const graph = new LGraph()
+    const grabbed = addImageTarget(graph)
+    const other = addImageTarget(graph)
+
+    const sources = collectFanInputs(grabbed, 0, [grabbed, other])
+
+    expect(sources).toEqual([
+      { node: grabbed, inputIndex: 0 },
+      { node: other, inputIndex: 0 }
+    ])
+  })
+
+  it('falls back to the first type-compatible input when the index differs', () => {
+    const graph = new LGraph()
+    const grabbed = addImageTarget(graph)
+
+    const other = new LGraphNode('Mixed')
+    other.addInput('mask', 'MASK')
+    other.addInput('image', 'IMAGE')
+    graph.add(other)
+
+    const sources = collectFanInputs(grabbed, 0, [grabbed, other])
+
+    expect(sources).toEqual([
+      { node: grabbed, inputIndex: 0 },
+      { node: other, inputIndex: 1 }
+    ])
+  })
+
+  it('skips selected nodes without a type-compatible input', () => {
+    const graph = new LGraph()
+    const grabbed = addImageTarget(graph)
+
+    const incompatible = new LGraphNode('Latent')
+    incompatible.addInput('latent', 'LATENT')
+    graph.add(incompatible)
+
+    const sources = collectFanInputs(grabbed, 0, [grabbed, incompatible])
+
+    expect(sources).toEqual([{ node: grabbed, inputIndex: 0 }])
+  })
+})
+
+describe('createBatchImagesNode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('wires every source into the batch node and connects it to the target input', async () => {
+    const graph = new LGraph()
+    const source1 = addImageSource(graph)
+    const source2 = addImageSource(graph)
+    source1.pos = [0, 0]
+    source2.pos = [0, 300]
+
+    const target = new LGraphNode('TargetNode')
+    target.addInput('image', 'IMAGE')
+    target.pos = [500, 200]
+    graph.add(target)
+
+    const batch = new LGraphNode('BatchImagesNode')
+    batch.addInput('image_1', 'IMAGE')
+    batch.addInput('image_2', 'IMAGE')
+    batch.addOutput('IMAGE', 'IMAGE')
+    graph.add(batch)
+    vi.mocked(createNode).mockResolvedValue(batch)
+
+    const setDirty = vi.fn()
+    const canvas = { setDirty } as unknown as LGraphCanvas
+
+    const result = await createBatchImagesNode(
+      canvas,
+      [
+        { node: source1, outputIndex: 0 },
+        { node: source2, outputIndex: 0 }
+      ],
+      target,
+      0
+    )
+
+    expect(result).toBe(batch)
+    expect(batch.inputs[0].link).not.toBeNull()
+    expect(batch.inputs[1].link).not.toBeNull()
+    expect(target.inputs[0].link).not.toBeNull()
+
+    const targetLink = graph.links[target.inputs[0].link!]
+    expect(targetLink.origin_id).toBe(batch.id)
+
+    // Positioned to the right of the source nodes, aligned to the topmost.
+    expect(batch.pos[0]).toBeGreaterThan(source1.pos[0] + source1.size[0])
+    expect(batch.pos[0]).toBeGreaterThan(source2.pos[0] + source2.size[0])
+    expect(batch.pos[1]).toBe(0)
+    expect(setDirty).toHaveBeenCalledWith(true, true)
+  })
+
+  it('returns null when the batch node cannot be created', async () => {
+    vi.mocked(createNode).mockResolvedValue(null)
+    const target = new LGraphNode('TargetNode')
+
+    const result = await createBatchImagesNode(
+      { setDirty: vi.fn() } as unknown as LGraphCanvas,
+      [],
+      target,
+      0
+    )
+
+    expect(result).toBeNull()
+  })
+})
+
+function fakeCanvas(
+  renderLinks: unknown[],
+  connectingTo: 'input' | 'output'
+): LGraphCanvas {
+  return {
+    linkConnector: { renderLinks, state: { connectingTo } },
+    setDirty: vi.fn()
+  } as unknown as LGraphCanvas
+}
+
+function imageOutputLink(node: LGraphNode) {
+  return { toType: 'input', node, fromSlot: node.outputs[0], fromSlotIndex: 0 }
+}
+
+describe('connectImageBatchToCreatedNode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes a multi-image fan-out through a batch node into the created node', async () => {
+    const graph = new LGraph()
+    const source1 = addImageSource(graph)
+    const source2 = addImageSource(graph)
+    const created = addImageTarget(graph)
+
+    const batch = new LGraphNode('BatchImagesNode')
+    batch.addInput('image_1', 'IMAGE')
+    batch.addInput('image_2', 'IMAGE')
+    batch.addOutput('IMAGE', 'IMAGE')
+    graph.add(batch)
+    vi.mocked(createNode).mockResolvedValue(batch)
+
+    const canvas = fakeCanvas(
+      [imageOutputLink(source1), imageOutputLink(source2)],
+      'input'
+    )
+
+    expect(connectImageBatchToCreatedNode(canvas, created)).toBe(true)
+
+    await vi.waitFor(() => expect(created.inputs[0].link).not.toBeNull())
+    expect(graph.links[created.inputs[0].link!].origin_id).toBe(batch.id)
+    expect(batch.inputs[0].link).not.toBeNull()
+    expect(batch.inputs[1].link).not.toBeNull()
+  })
+
+  it('ignores a single dragged link', () => {
+    const graph = new LGraph()
+    const source = addImageSource(graph)
+    const created = addImageTarget(graph)
+    const canvas = fakeCanvas([imageOutputLink(source)], 'input')
+
+    expect(connectImageBatchToCreatedNode(canvas, created)).toBe(false)
+  })
+
+  it('ignores reverse (output) drags', () => {
+    const graph = new LGraph()
+    const source1 = addImageSource(graph)
+    const source2 = addImageSource(graph)
+    const created = addImageTarget(graph)
+    const canvas = fakeCanvas(
+      [imageOutputLink(source1), imageOutputLink(source2)],
+      'output'
+    )
+
+    expect(connectImageBatchToCreatedNode(canvas, created)).toBe(false)
+  })
+
+  it('connects directly to a dynamic input without creating a batch node', () => {
+    const graph = new LGraph()
+    const source1 = addImageSource(graph)
+    const source2 = addImageSource(graph)
+    const created = addAutogrowImageNode(graph)
+    const canvas = fakeCanvas(
+      [imageOutputLink(source1), imageOutputLink(source2)],
+      'input'
+    )
+
+    expect(connectImageBatchToCreatedNode(canvas, created)).toBe(true)
+    expect(createNode).not.toHaveBeenCalled()
+    expect(graph.links[created.inputs[0].link!].origin_id).toBe(source1.id)
+    expect(graph.links[created.inputs[1].link!].origin_id).toBe(source2.id)
+  })
+})
+
+describe('connectImagesToDynamicInput', () => {
+  it('fills successive autogrow group slots from the sources', () => {
+    const graph = new LGraph()
+    const source1 = addImageSource(graph)
+    const source2 = addImageSource(graph)
+    const node = addAutogrowImageNode(graph)
+
+    const handled = connectImagesToDynamicInput(node, node.inputs[0], [
+      { node: source1, outputIndex: 0 },
+      { node: source2, outputIndex: 0 }
+    ])
+
+    expect(handled).toBe(true)
+    expect(graph.links[node.inputs[0].link!].origin_id).toBe(source1.id)
+    expect(graph.links[node.inputs[1].link!].origin_id).toBe(source2.id)
+  })
+
+  it('returns false for a node without a dynamic input', () => {
+    const graph = new LGraph()
+    const source = addImageSource(graph)
+    const target = addImageTarget(graph)
+
+    expect(
+      connectImagesToDynamicInput(target, target.inputs[0], [
+        { node: source, outputIndex: 0 }
+      ])
+    ).toBe(false)
+    expect(target.inputs[0].link).toBeNull()
+  })
+
+  it('returns false when the dynamic group has no free slot', () => {
+    const graph = new LGraph()
+    const occupier = addImageSource(graph)
+    const newSource = addImageSource(graph)
+    const node = addAutogrowImageNode(graph, 1)
+    occupier.connect(0, node, 0)
+
+    expect(
+      connectImagesToDynamicInput(node, node.inputs[0], [
+        { node: newSource, outputIndex: 0 }
+      ])
+    ).toBe(false)
+  })
+})

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
@@ -1,5 +1,7 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ToInputRenderLink } from '@/lib/litegraph/src/canvas/ToInputRenderLink'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 
@@ -16,8 +18,6 @@ import {
   connectImageBatchToCreatedNode,
   connectImagesToDynamicInput,
   createBatchImagesNode,
-  getSelectedNodes,
-  isImageType,
   toImageBatchSources
 } from './multiNodeLinkConnect'
 
@@ -44,31 +44,6 @@ function addAutogrowImageNode(graph: LGraph, slotCount = 3): LGraphNode {
   graph.add(node)
   return node
 }
-
-describe('isImageType', () => {
-  it('matches the IMAGE type case-insensitively', () => {
-    expect(isImageType('IMAGE')).toBe(true)
-    expect(isImageType('image')).toBe(true)
-  })
-
-  it('rejects other types', () => {
-    expect(isImageType('MASK')).toBe(false)
-    expect(isImageType(0)).toBe(false)
-  })
-})
-
-describe('getSelectedNodes', () => {
-  it('returns only LGraphNode items from the canvas selection', () => {
-    const graph = new LGraph()
-    const a = addImageSource(graph)
-    const b = addImageSource(graph)
-    const canvas = {
-      selectedItems: new Set([a, {}, b])
-    } as unknown as LGraphCanvas
-
-    expect(getSelectedNodes(canvas)).toEqual([a, b])
-  })
-})
 
 describe('collectFanOutputs', () => {
   it('returns the grabbed source first, then matching selected nodes', () => {
@@ -231,7 +206,7 @@ describe('createBatchImagesNode', () => {
     const target = new LGraphNode('TargetNode')
 
     const result = await createBatchImagesNode(
-      { setDirty: vi.fn() } as unknown as LGraphCanvas,
+      fromPartial({ setDirty: vi.fn() }),
       [],
       target,
       0
@@ -242,16 +217,16 @@ describe('createBatchImagesNode', () => {
 })
 
 function fakeCanvas(
-  renderLinks: unknown[],
+  renderLinks: Partial<ToInputRenderLink>[],
   connectingTo: 'input' | 'output'
 ): LGraphCanvas {
-  return {
+  return fromPartial({
     linkConnector: { renderLinks, state: { connectingTo } },
     setDirty: vi.fn()
-  } as unknown as LGraphCanvas
+  })
 }
 
-function imageOutputLink(node: LGraphNode) {
+function imageOutputLink(node: LGraphNode): Partial<ToInputRenderLink> {
   return { toType: 'input', node, fromSlot: node.outputs[0], fromSlotIndex: 0 }
 }
 

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ToInputRenderLink } from '@/lib/litegraph/src/canvas/ToInputRenderLink'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
@@ -150,10 +150,6 @@ describe('collectFanInputs', () => {
 })
 
 describe('createBatchImagesNode', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('wires every source into the batch node and connects it to the target input', async () => {
     const graph = new LGraph()
     const source1 = addImageSource(graph)
@@ -231,10 +227,6 @@ function imageOutputLink(node: LGraphNode): Partial<ToInputRenderLink> {
 }
 
 describe('connectImageBatchToCreatedNode', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('routes a multi-image fan-out through a batch node into the created node', async () => {
     const graph = new LGraph()
     const source1 = addImageSource(graph)

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.ts
@@ -1,6 +1,7 @@
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { INodeInputSlot, ISlotType } from '@/lib/litegraph/src/interfaces'
+import { LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { createNode, isLGraphNode } from '@/utils/litegraphUtil'
 
 export interface FanSource {
@@ -13,21 +14,8 @@ export interface FanInput {
   inputIndex: number
 }
 
-const IMAGE_SLOT_TYPE = 'IMAGE'
 const BATCH_IMAGES_NODE = 'BatchImagesNode'
 const BATCH_NODE_GAP_X = 100
-
-export function isImageType(type: ISlotType): boolean {
-  return typeof type === 'string' && type.toUpperCase() === IMAGE_SLOT_TYPE
-}
-
-export function getSelectedNodes(canvas: LGraphCanvas): LGraphNode[] {
-  return Array.from(canvas.selectedItems).filter(isLGraphNode)
-}
-
-function typesMatch(a: ISlotType, b: ISlotType): boolean {
-  return String(a).toLowerCase() === String(b).toLowerCase()
-}
 
 function findMatchingSlotIndex(
   slots: ReadonlyArray<{ type: ISlotType }> | undefined,
@@ -35,9 +23,12 @@ function findMatchingSlotIndex(
   type: ISlotType
 ): number | undefined {
   const preferred = slots?.[preferredIndex]
-  if (preferred && typesMatch(preferred.type, type)) return preferredIndex
+  if (preferred && LiteGraph.isValidConnection(preferred.type, type))
+    return preferredIndex
 
-  const index = slots?.findIndex((slot) => typesMatch(slot.type, type))
+  const index = slots?.findIndex((slot) =>
+    LiteGraph.isValidConnection(slot.type, type)
+  )
   return index !== undefined && index >= 0 ? index : undefined
 }
 
@@ -226,10 +217,10 @@ export function connectImageBatchToCreatedNode(
   if (state.connectingTo !== 'input' || renderLinks.length <= 1) return false
 
   const fromSlot = renderLinks[0]?.fromSlot
-  if (!fromSlot || !isImageType(fromSlot.type)) return false
+  if (!fromSlot || fromSlot.type !== 'IMAGE') return false
 
   const target = createdNode.findInputByType(fromSlot.type)
-  if (!target || !isImageType(target.slot.type)) return false
+  if (!target || target.slot.type !== 'IMAGE') return false
 
   const sources = toImageBatchSources(renderLinks)
   if (sources.length <= 1) return false

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.ts
@@ -173,8 +173,8 @@ export function connectImagesToDynamicInput(
   for (const source of sources) {
     const slotIndex = firstFreeGroupInputIndex(targetNode, groupName)
     if (slotIndex === undefined) break
-    source.node.connect(source.outputIndex, targetNode, slotIndex)
-    connected = true
+    const link = source.node.connect(source.outputIndex, targetNode, slotIndex)
+    if (link) connected = true
   }
   return connected
 }
@@ -196,10 +196,17 @@ export async function createBatchImagesNode(
 
   batchNode.pos = positionRightOfNodes(sources.map((source) => source.node))
 
+  let allConnected = true
   sources.forEach((source, index) => {
-    source.node.connect(source.outputIndex, batchNode, index)
+    const link = source.node.connect(source.outputIndex, batchNode, index)
+    if (!link) allConnected = false
   })
-  batchNode.connect(0, targetNode, targetInputIndex)
+  const targetLink = batchNode.connect(0, targetNode, targetInputIndex)
+  if (!targetLink) allConnected = false
+
+  if (!allConnected) {
+    console.warn('Some batch image connections could not be wired')
+  }
 
   canvas.setDirty(true, true)
   return batchNode

--- a/src/renderer/core/canvas/links/multiNodeLinkConnect.ts
+++ b/src/renderer/core/canvas/links/multiNodeLinkConnect.ts
@@ -1,0 +1,239 @@
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { INodeInputSlot, ISlotType } from '@/lib/litegraph/src/interfaces'
+import { createNode, isLGraphNode } from '@/utils/litegraphUtil'
+
+export interface FanSource {
+  node: LGraphNode
+  outputIndex: number
+}
+
+export interface FanInput {
+  node: LGraphNode
+  inputIndex: number
+}
+
+const IMAGE_SLOT_TYPE = 'IMAGE'
+const BATCH_IMAGES_NODE = 'BatchImagesNode'
+const BATCH_NODE_GAP_X = 100
+
+export function isImageType(type: ISlotType): boolean {
+  return typeof type === 'string' && type.toUpperCase() === IMAGE_SLOT_TYPE
+}
+
+export function getSelectedNodes(canvas: LGraphCanvas): LGraphNode[] {
+  return Array.from(canvas.selectedItems).filter(isLGraphNode)
+}
+
+function typesMatch(a: ISlotType, b: ISlotType): boolean {
+  return String(a).toLowerCase() === String(b).toLowerCase()
+}
+
+function findMatchingSlotIndex(
+  slots: ReadonlyArray<{ type: ISlotType }> | undefined,
+  preferredIndex: number,
+  type: ISlotType
+): number | undefined {
+  const preferred = slots?.[preferredIndex]
+  if (preferred && typesMatch(preferred.type, type)) return preferredIndex
+
+  const index = slots?.findIndex((slot) => typesMatch(slot.type, type))
+  return index !== undefined && index >= 0 ? index : undefined
+}
+
+/**
+ * Resolves which output on each selected node should fan out alongside the
+ * grabbed slot. The grabbed source is always returned first; selected nodes
+ * without a type-compatible output are skipped.
+ */
+export function collectFanOutputs(
+  grabbedNode: LGraphNode,
+  grabbedOutputIndex: number,
+  selectedNodes: LGraphNode[]
+): FanSource[] {
+  const grabbedOutput = grabbedNode.outputs?.[grabbedOutputIndex]
+  if (!grabbedOutput) return []
+
+  const grabbedType = grabbedOutput.type
+  const sources: FanSource[] = [
+    { node: grabbedNode, outputIndex: grabbedOutputIndex }
+  ]
+
+  for (const node of selectedNodes) {
+    if (node === grabbedNode) continue
+    const outputIndex = findMatchingSlotIndex(
+      node.outputs,
+      grabbedOutputIndex,
+      grabbedType
+    )
+    if (outputIndex !== undefined) sources.push({ node, outputIndex })
+  }
+
+  return sources
+}
+
+/**
+ * Resolves which input on each selected node should fan out alongside the
+ * grabbed input. The grabbed source is always returned first; selected nodes
+ * without a type-compatible input are skipped.
+ */
+export function collectFanInputs(
+  grabbedNode: LGraphNode,
+  grabbedInputIndex: number,
+  selectedNodes: LGraphNode[]
+): FanInput[] {
+  const grabbedInput = grabbedNode.inputs?.[grabbedInputIndex]
+  if (!grabbedInput) return []
+
+  const grabbedType = grabbedInput.type
+  const sources: FanInput[] = [
+    { node: grabbedNode, inputIndex: grabbedInputIndex }
+  ]
+
+  for (const node of selectedNodes) {
+    if (node === grabbedNode) continue
+    const inputIndex = findMatchingSlotIndex(
+      node.inputs,
+      grabbedInputIndex,
+      grabbedType
+    )
+    if (inputIndex !== undefined) sources.push({ node, inputIndex })
+  }
+
+  return sources
+}
+
+/**
+ * Narrows dragged render-link candidates to concrete node sources, dropping
+ * any whose origin is not an LGraphNode (e.g. subgraph IO nodes).
+ */
+export function toImageBatchSources(
+  candidates: ReadonlyArray<{ node: unknown; fromSlotIndex: number }>
+): FanSource[] {
+  const sources: FanSource[] = []
+  for (const candidate of candidates) {
+    if (isLGraphNode(candidate.node)) {
+      sources.push({
+        node: candidate.node,
+        outputIndex: candidate.fromSlotIndex
+      })
+    }
+  }
+  return sources
+}
+
+function positionRightOfNodes(nodes: LGraphNode[]): [number, number] {
+  const rightEdge = Math.max(...nodes.map((node) => node.pos[0] + node.size[0]))
+  const top = Math.min(...nodes.map((node) => node.pos[1]))
+  return [rightEdge + BATCH_NODE_GAP_X, top]
+}
+
+/**
+ * The autogrow group an input belongs to, if its node grows that group's slots
+ * on connection (e.g. Batch Images, partner nodes like Nano Banana 2).
+ */
+function autogrowGroupName(
+  node: LGraphNode,
+  input: INodeInputSlot
+): string | undefined {
+  const autogrow = node.comfyDynamic?.autogrow
+  if (!autogrow) return undefined
+
+  const lastDot = input.name.lastIndexOf('.')
+  if (lastDot === -1) return undefined
+
+  const groupName = input.name.slice(0, lastDot)
+  return groupName in autogrow ? groupName : undefined
+}
+
+function firstFreeGroupInputIndex(
+  node: LGraphNode,
+  groupName: string
+): number | undefined {
+  const index = node.inputs.findIndex(
+    (input) => input.name.startsWith(`${groupName}.`) && input.link == null
+  )
+  return index >= 0 ? index : undefined
+}
+
+/**
+ * When the target input belongs to a dynamic (autogrow) group, connect every
+ * source directly into successive group slots — the node grows to fit — instead
+ * of inserting a batch node. Returns `true` when it handled the connection.
+ */
+export function connectImagesToDynamicInput(
+  targetNode: LGraphNode,
+  inputSlot: INodeInputSlot,
+  sources: FanSource[]
+): boolean {
+  const groupName = autogrowGroupName(targetNode, inputSlot)
+  if (groupName === undefined) return false
+
+  let connected = false
+  for (const source of sources) {
+    const slotIndex = firstFreeGroupInputIndex(targetNode, groupName)
+    if (slotIndex === undefined) break
+    source.node.connect(source.outputIndex, targetNode, slotIndex)
+    connected = true
+  }
+  return connected
+}
+
+/**
+ * Creates a `BatchImagesNode` to the right of the source nodes, wires every fan
+ * source output into it, and connects its output to the target input —
+ * mirroring the filesystem multi-image drop. Returns the created node, or
+ * `null` if creation failed.
+ */
+export async function createBatchImagesNode(
+  canvas: LGraphCanvas,
+  sources: FanSource[],
+  targetNode: LGraphNode,
+  targetInputIndex: number
+): Promise<LGraphNode | null> {
+  const batchNode = await createNode(canvas, BATCH_IMAGES_NODE)
+  if (!batchNode) return null
+
+  batchNode.pos = positionRightOfNodes(sources.map((source) => source.node))
+
+  sources.forEach((source, index) => {
+    source.node.connect(source.outputIndex, batchNode, index)
+  })
+  batchNode.connect(0, targetNode, targetInputIndex)
+
+  canvas.setDirty(true, true)
+  return batchNode
+}
+
+/**
+ * Handles the connect-after-search step for a multi-node image fan-out dropped
+ * on empty canvas: routes every dragged image output through an auto-created
+ * BatchImagesNode into the chosen node's image input. Returns `true` when it
+ * handled the connection so the caller can skip the default single connect.
+ */
+export function connectImageBatchToCreatedNode(
+  canvas: LGraphCanvas,
+  createdNode: LGraphNode
+): boolean {
+  const { renderLinks, state } = canvas.linkConnector
+  if (state.connectingTo !== 'input' || renderLinks.length <= 1) return false
+
+  const fromSlot = renderLinks[0]?.fromSlot
+  if (!fromSlot || !isImageType(fromSlot.type)) return false
+
+  const target = createdNode.findInputByType(fromSlot.type)
+  if (!target || !isImageType(target.slot.type)) return false
+
+  const sources = toImageBatchSources(renderLinks)
+  if (sources.length <= 1) return false
+
+  if (connectImagesToDynamicInput(createdNode, target.slot, sources))
+    return true
+
+  void createBatchImagesNode(canvas, sources, createdNode, target.index).catch(
+    (error) => {
+      console.error('Failed to create batch images node', error)
+    }
+  )
+  return true
+}

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -177,6 +177,16 @@ vi.mock('@/renderer/core/canvas/links/linkDropOrchestrator', () => ({
   resolveNodeSurfaceSlotCandidate: () => null
 }))
 
+vi.mock('@/renderer/core/canvas/links/multiNodeLinkConnect', () => ({
+  getSelectedNodes: () => [],
+  collectFanOutputs: () => [],
+  collectFanInputs: () => [],
+  toImageBatchSources: () => [],
+  createBatchImagesNode: vi.fn(),
+  connectImagesToDynamicInput: () => false,
+  isImageType: () => false
+}))
+
 vi.mock('@vueuse/core', () => ({
   useEventListener: (event: string, handler: (...args: unknown[]) => void) => {
     capturedHandlers[event] = handler

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -68,6 +68,7 @@ vi.mock('@/scripts/app', () => ({
         getReroute: () => null
       },
       linkConnector: mockLinkConnector,
+      selectedItems: new Set(),
       canvas: {
         getBoundingClientRect: () => ({
           left: 0,
@@ -197,10 +198,6 @@ vi.mock('@vueuse/core', () => ({
 
 vi.mock('@/lib/litegraph/src/LLink', () => ({
   LLink: { getReroutes: () => [] }
-}))
-
-vi.mock('@/lib/litegraph/src/types/globalEnums', () => ({
-  LinkDirection: { LEFT: 0, RIGHT: 1, NONE: -1 }
 }))
 
 vi.mock('@/utils/rafBatch', () => ({

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -76,6 +76,7 @@ vi.mock('@/scripts/app', () => ({
         getReroute: () => null
       },
       linkConnector: mockLinkConnector,
+      selectedItems: new Set(),
       canvas: {
         getBoundingClientRect: () => ({
           left: 0,
@@ -208,10 +209,6 @@ vi.mock('@vueuse/core', () => ({
 vi.mock('@/lib/litegraph/src/LLink', () => ({
   LLink: { getReroutes: () => [] },
   slotFloatingLinks: () => []
-}))
-
-vi.mock('@/lib/litegraph/src/types/globalEnums', () => ({
-  LinkDirection: { LEFT: 0, RIGHT: 1, NONE: -1 }
 }))
 
 vi.mock('@/utils/rafBatch', () => ({

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -187,6 +187,16 @@ vi.mock('@/renderer/core/canvas/links/linkDropOrchestrator', () => ({
   resolveNodeSurfaceSlotCandidate: () => null
 }))
 
+vi.mock('@/renderer/core/canvas/links/multiNodeLinkConnect', () => ({
+  getSelectedNodes: () => [],
+  collectFanOutputs: () => [],
+  collectFanInputs: () => [],
+  toImageBatchSources: () => [],
+  createBatchImagesNode: vi.fn(),
+  connectImagesToDynamicInput: () => false,
+  isImageType: () => false
+}))
+
 vi.mock('@vueuse/core', () => ({
   useEventListener: (event: string, handler: (...args: unknown[]) => void) => {
     capturedHandlers[event] = handler

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -23,6 +23,15 @@ import {
   resolveNodeSurfaceSlotCandidate,
   resolveSlotTargetCandidate
 } from '@/renderer/core/canvas/links/linkDropOrchestrator'
+import {
+  collectFanInputs,
+  collectFanOutputs,
+  connectImagesToDynamicInput,
+  createBatchImagesNode,
+  getSelectedNodes,
+  isImageType,
+  toImageBatchSources
+} from '@/renderer/core/canvas/links/multiNodeLinkConnect'
 import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import type { SlotDropCandidate } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
@@ -188,11 +197,41 @@ export function useSlotLinkInteraction({
       .filter(isToInputLink)
       .filter((link) => link.canConnectToInput(node, inputSlot))
 
-    for (const link of validCandidates) {
-      link.connectToInput(node, inputSlot, activeAdapter?.linkConnector.events)
+    if (validCandidates.length === 0) return false
+
+    const events = activeAdapter?.linkConnector.events
+    const grabbedLink = validCandidates[0]
+
+    if (validCandidates.length === 1) {
+      grabbedLink.connectToInput(node, inputSlot, events)
+      return true
     }
 
-    return validCandidates.length > 0
+    // Multi-node fan-out. A dynamic (autogrow) input takes every image directly;
+    // a static single-link input aggregates them through an auto-created
+    // BatchImagesNode; other types degrade to connecting only the grabbed slot.
+    const sources = toImageBatchSources(validCandidates)
+
+    if (connectImagesToDynamicInput(node, inputSlot, sources)) return true
+
+    const canvas = app.canvas
+    const inputIndex = node.inputs.indexOf(inputSlot)
+    if (
+      canvas &&
+      inputIndex >= 0 &&
+      isImageType(inputSlot.type) &&
+      isImageType(grabbedLink.fromSlot.type)
+    ) {
+      void createBatchImagesNode(canvas, sources, node, inputIndex).catch(
+        (error) => {
+          console.error('Failed to create batch images node', error)
+        }
+      )
+      return true
+    }
+
+    grabbedLink.connectToInput(node, inputSlot, events)
+    return true
   }
 
   function connectLinksToOutput(
@@ -684,15 +723,40 @@ export function useSlotLinkInteraction({
     const shouldMoveExistingInput =
       isInputSlot && !shouldBreakExistingInputLink && hasExistingInputLink
 
+    const addFanLinks = (slotKind: 'input' | 'output') => {
+      const adapter = activeAdapter
+      if (!adapter || !resolvedNode) return
+
+      const selectedNodes = getSelectedNodes(canvas)
+      if (selectedNodes.length <= 1 || !selectedNodes.includes(resolvedNode)) {
+        return
+      }
+
+      if (slotKind === 'output') {
+        // Forward fan-out only resolves for images (auto-created batch node),
+        // so only show the multi-link UI when dragging an image output.
+        const grabbedOutput = resolvedNode.outputs?.[index]
+        if (!grabbedOutput || !isImageType(grabbedOutput.type)) return
+
+        const fanSources = collectFanOutputs(resolvedNode, index, selectedNodes)
+        adapter.addOutputRenderLinks(fanSources.slice(1))
+      } else {
+        const fanInputs = collectFanInputs(resolvedNode, index, selectedNodes)
+        adapter.addInputRenderLinks(fanInputs.slice(1))
+      }
+    }
+
     if (isOutputSlot) {
       activeAdapter.beginFromOutput(localNodeId, index, {
         moveExisting: shouldMoveExistingOutput
       })
+      if (!shouldMoveExistingOutput) addFanLinks('output')
     } else {
       activeAdapter.beginFromInput(localNodeId, index, {
         moveExisting: shouldMoveExistingInput,
         layout
       })
+      if (!shouldMoveExistingInput) addFanLinks('input')
     }
 
     if (shouldMoveExistingInput && existingInputLink) {

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -28,8 +28,6 @@ import {
   collectFanOutputs,
   connectImagesToDynamicInput,
   createBatchImagesNode,
-  getSelectedNodes,
-  isImageType,
   toImageBatchSources
 } from '@/renderer/core/canvas/links/multiNodeLinkConnect'
 import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
@@ -44,6 +42,7 @@ import { app } from '@/scripts/app'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import { createRafBatch } from '@/utils/rafBatch'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 interface SlotInteractionOptions {
   nodeId?: NodeId
@@ -219,8 +218,8 @@ export function useSlotLinkInteraction({
     if (
       canvas &&
       inputIndex >= 0 &&
-      isImageType(inputSlot.type) &&
-      isImageType(grabbedLink.fromSlot.type)
+      inputSlot.type === 'IMAGE' &&
+      grabbedLink.fromSlot.type === 'IMAGE'
     ) {
       void createBatchImagesNode(canvas, sources, node, inputIndex).catch(
         (error) => {
@@ -727,7 +726,7 @@ export function useSlotLinkInteraction({
       const adapter = activeAdapter
       if (!adapter || !resolvedNode) return
 
-      const selectedNodes = getSelectedNodes(canvas)
+      const selectedNodes = [...canvas.selectedItems].filter(isLGraphNode)
       if (selectedNodes.length <= 1 || !selectedNodes.includes(resolvedNode)) {
         return
       }
@@ -736,7 +735,7 @@ export function useSlotLinkInteraction({
         // Forward fan-out only resolves for images (auto-created batch node),
         // so only show the multi-link UI when dragging an image output.
         const grabbedOutput = resolvedNode.outputs?.[index]
-        if (!grabbedOutput || !isImageType(grabbedOutput.type)) return
+        if (!grabbedOutput || grabbedOutput.type !== 'IMAGE') return
 
         const fanSources = collectFanOutputs(resolvedNode, index, selectedNodes)
         adapter.addOutputRenderLinks(fanSources.slice(1))

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -25,6 +25,15 @@ import {
   resolveSlotTargetCandidate
 } from '@/renderer/core/canvas/links/linkDropOrchestrator'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import {
+  collectFanInputs,
+  collectFanOutputs,
+  connectImagesToDynamicInput,
+  createBatchImagesNode,
+  getSelectedNodes,
+  isImageType,
+  toImageBatchSources
+} from '@/renderer/core/canvas/links/multiNodeLinkConnect'
 import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import type { SlotDropCandidate } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
@@ -199,11 +208,41 @@ export function useSlotLinkInteraction({
       .filter(isToInputLink)
       .filter((link) => link.canConnectToInput(node, inputSlot))
 
-    for (const link of validCandidates) {
-      link.connectToInput(node, inputSlot, activeAdapter?.linkConnector.events)
+    if (validCandidates.length === 0) return false
+
+    const events = activeAdapter?.linkConnector.events
+    const grabbedLink = validCandidates[0]
+
+    if (validCandidates.length === 1) {
+      grabbedLink.connectToInput(node, inputSlot, events)
+      return true
     }
 
-    return validCandidates.length > 0
+    // Multi-node fan-out. A dynamic (autogrow) input takes every image directly;
+    // a static single-link input aggregates them through an auto-created
+    // BatchImagesNode; other types degrade to connecting only the grabbed slot.
+    const sources = toImageBatchSources(validCandidates)
+
+    if (connectImagesToDynamicInput(node, inputSlot, sources)) return true
+
+    const canvas = app.canvas
+    const inputIndex = node.inputs.indexOf(inputSlot)
+    if (
+      canvas &&
+      inputIndex >= 0 &&
+      isImageType(inputSlot.type) &&
+      isImageType(grabbedLink.fromSlot.type)
+    ) {
+      void createBatchImagesNode(canvas, sources, node, inputIndex).catch(
+        (error) => {
+          console.error('Failed to create batch images node', error)
+        }
+      )
+      return true
+    }
+
+    grabbedLink.connectToInput(node, inputSlot, events)
+    return true
   }
 
   function connectLinksToOutput(
@@ -701,15 +740,40 @@ export function useSlotLinkInteraction({
     const shouldMoveExistingInput =
       isInputSlot && !shouldBreakExistingInputLink && hasExistingInputLink
 
+    const addFanLinks = (slotKind: 'input' | 'output') => {
+      const adapter = activeAdapter
+      if (!adapter || !resolvedNode) return
+
+      const selectedNodes = getSelectedNodes(canvas)
+      if (selectedNodes.length <= 1 || !selectedNodes.includes(resolvedNode)) {
+        return
+      }
+
+      if (slotKind === 'output') {
+        // Forward fan-out only resolves for images (auto-created batch node),
+        // so only show the multi-link UI when dragging an image output.
+        const grabbedOutput = resolvedNode.outputs?.[index]
+        if (!grabbedOutput || !isImageType(grabbedOutput.type)) return
+
+        const fanSources = collectFanOutputs(resolvedNode, index, selectedNodes)
+        adapter.addOutputRenderLinks(fanSources.slice(1))
+      } else {
+        const fanInputs = collectFanInputs(resolvedNode, index, selectedNodes)
+        adapter.addInputRenderLinks(fanInputs.slice(1))
+      }
+    }
+
     if (isOutputSlot) {
       activeAdapter.beginFromOutput(localNodeId, index, {
         moveExisting: shouldMoveExistingOutput
       })
+      if (!shouldMoveExistingOutput) addFanLinks('output')
     } else {
       activeAdapter.beginFromInput(localNodeId, index, {
         moveExisting: shouldMoveExistingInput,
         layout
       })
+      if (!shouldMoveExistingInput) addFanLinks('input')
     }
 
     if (shouldMoveExistingInput && existingInputLink) {

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -30,8 +30,6 @@ import {
   collectFanOutputs,
   connectImagesToDynamicInput,
   createBatchImagesNode,
-  getSelectedNodes,
-  isImageType,
   toImageBatchSources
 } from '@/renderer/core/canvas/links/multiNodeLinkConnect'
 import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
@@ -49,6 +47,7 @@ import { graphScopeOf } from '@/types/graphScopeId'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import { createRafBatch } from '@/utils/rafBatch'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 interface SlotInteractionOptions {
   nodeId?: NodeId
@@ -230,8 +229,8 @@ export function useSlotLinkInteraction({
     if (
       canvas &&
       inputIndex >= 0 &&
-      isImageType(inputSlot.type) &&
-      isImageType(grabbedLink.fromSlot.type)
+      inputSlot.type === 'IMAGE' &&
+      grabbedLink.fromSlot.type === 'IMAGE'
     ) {
       void createBatchImagesNode(canvas, sources, node, inputIndex).catch(
         (error) => {
@@ -744,7 +743,7 @@ export function useSlotLinkInteraction({
       const adapter = activeAdapter
       if (!adapter || !resolvedNode) return
 
-      const selectedNodes = getSelectedNodes(canvas)
+      const selectedNodes = [...canvas.selectedItems].filter(isLGraphNode)
       if (selectedNodes.length <= 1 || !selectedNodes.includes(resolvedNode)) {
         return
       }
@@ -753,7 +752,7 @@ export function useSlotLinkInteraction({
         // Forward fan-out only resolves for images (auto-created batch node),
         // so only show the multi-link UI when dragging an image output.
         const grabbedOutput = resolvedNode.outputs?.[index]
-        if (!grabbedOutput || !isImageType(grabbedOutput.type)) return
+        if (!grabbedOutput || grabbedOutput.type !== 'IMAGE') return
 
         const fanSources = collectFanOutputs(resolvedNode, index, selectedNodes)
         adapter.addOutputRenderLinks(fanSources.slice(1))


### PR DESCRIPTION
## Summary

Connect multiple selected nodes to a target with a single link drag on the Vue-nodes canvas.

https://github.com/user-attachments/assets/ceafe1f4-c360-4f5e-b442-c2bf00670d02


## Changes

- **What**: With 2+ nodes selected, dragging from a slot of one node fans the connection to every selected node. Forward (output drag): image outputs route through an auto-created Batch Images node, or connect directly into a dynamic/autogrow input (e.g. Nano Banana 2); the multi-link UI appears only for image outputs. Reverse (input drag): every selected node's matching input connects to the upstream output. Dropping on empty canvas and choosing a node from search builds the batch the same way. Vue-nodes path only (`Comfy.VueNodes.Enabled`).

## Review Focus

- Logic lives in the new `multiNodeLinkConnect.ts`; integration is thin (`linkConnectorAdapter`, `useSlotLinkInteraction`, `NodeSearchBoxPopover`) with no litegraph-core changes.
- Forward many-to-one only completes for images (Batch Images node) or dynamic inputs; other types degrade to connecting only the grabbed slot. Reverse works for all types.
- e2e specs (`multiNodeFanout.spec.ts`) require a live backend to run.