### PR TITLE
[backport cloud/1.45] Add share id attribution across share and run telemetry

### DIFF
--- a/src/platform/navigation/preservedQueryManager.test.ts
+++ b/src/platform/navigation/preservedQueryManager.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   capturePreservedQuery,
   clearPreservedQuery,
+  getPreservedQueryParam,
   hydratePreservedQuery,
   mergePreservedQueryIntoQuery
 } from '@/platform/navigation/preservedQueryManager'
@@ -27,6 +28,22 @@ describe('preservedQueryManager', () => {
 
     expect(merged).toEqual({ template: 'flux', source: 'custom' })
     expect(sessionStorage.getItem('Comfy.PreservedQuery.template')).toBeTruthy()
+  })
+
+  it('reads a preserved query param by key', () => {
+    capturePreservedQuery(NAMESPACE, { template: 'flux' }, ['template'])
+
+    expect(getPreservedQueryParam(NAMESPACE, 'template')).toBe('flux')
+    expect(getPreservedQueryParam(NAMESPACE, 'source')).toBeUndefined()
+  })
+
+  it('hydrates from sessionStorage when reading a param', () => {
+    sessionStorage.setItem(
+      'Comfy.PreservedQuery.template',
+      JSON.stringify({ template: 'flux' })
+    )
+
+    expect(getPreservedQueryParam(NAMESPACE, 'template')).toBe('flux')
   })
 
   it('hydrates cached payload from sessionStorage once', () => {

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -87,6 +87,14 @@ export const capturePreservedQuery = (
   writeToStorage(namespace, payload)
 }
 
+export function getPreservedQueryParam(
+  namespace: string,
+  key: string
+): string | undefined {
+  hydratePreservedQuery(namespace)
+  return preservedQueries.get(namespace)?.[key]
+}
+
 export const mergePreservedQueryIntoQuery = (
   namespace: string,
   query?: LocationQueryRaw

--- a/src/platform/navigation/preservedQueryNamespaces.ts
+++ b/src/platform/navigation/preservedQueryNamespaces.ts
@@ -2,6 +2,7 @@ export const PRESERVED_QUERY_NAMESPACES = {
   TEMPLATE: 'template',
   INVITE: 'invite',
   SHARE: 'share',
+  SHARE_AUTH: 'share_auth',
   CREATE_WORKSPACE: 'create_workspace',
   OAUTH: 'oauth'
 } as const

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -6,6 +6,7 @@ import type {
   DefaultViewSetMetadata,
   EnterLinearMetadata,
   ShareFlowMetadata,
+  ShareLinkOpenedMetadata,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
   ExecutionTriggerSource,
@@ -19,6 +20,7 @@ import type {
   PageViewMetadata,
   PageVisibilityMetadata,
   SettingChangedMetadata,
+  SharedWorkflowRunMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -182,6 +184,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackShareFlow?.(metadata))
   }
 
+  trackShareLinkOpened(metadata: ShareLinkOpenedMetadata): void {
+    this.dispatch((provider) => provider.trackShareLinkOpened?.(metadata))
+  }
+
   trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void {
     this.dispatch((provider) => provider.trackPageVisibilityChanged?.(metadata))
   }
@@ -238,6 +244,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
     this.dispatch((provider) => provider.trackExecutionSuccess?.(metadata))
+  }
+
+  trackSharedWorkflowRun(metadata: SharedWorkflowRunMetadata): void {
+    this.dispatch((provider) => provider.trackSharedWorkflowRun?.(metadata))
   }
 
   trackSettingChanged(metadata: SettingChangedMetadata): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -305,13 +305,31 @@ describe('GtmTelemetryProvider', () => {
       const provider = createInitializedProvider()
       provider.trackShareFlow({
         step: 'link_copied',
-        source: 'app_mode'
+        source: 'app_mode',
+        share_id: 'share-1'
       })
       expect(lastDataLayerEntry()).toMatchObject({
         event: 'share_flow',
         step: 'link_copied',
         source: 'app_mode'
       })
+      expect(lastDataLayerEntry()).not.toHaveProperty('share_id')
+    })
+
+    it('omits share_id from workflow import events', () => {
+      const provider = createInitializedProvider()
+      provider.trackWorkflowImported({
+        missing_node_count: 0,
+        missing_node_types: [],
+        open_source: 'shared_url',
+        share_id: 'share-1'
+      })
+
+      expect(lastDataLayerEntry()).toMatchObject({
+        event: 'workflow_import',
+        open_source: 'shared_url'
+      })
+      expect(lastDataLayerEntry()).not.toHaveProperty('share_id')
     })
 
     it('pushes normalized email inside the auth event payload', () => {
@@ -321,7 +339,8 @@ describe('GtmTelemetryProvider', () => {
         method: 'email',
         is_new_user: true,
         user_id: 'uid-123',
-        email: '  Test@Example.com  '
+        email: '  Test@Example.com  ',
+        share_id: 'share-1'
       })
 
       const dl = window.dataLayer as Record<string, unknown>[]
@@ -334,6 +353,7 @@ describe('GtmTelemetryProvider', () => {
           email: 'test@example.com'
         }
       })
+      expect(authEvent).not.toHaveProperty('share_id')
       expect(
         dl.some((entry) => 'user_data' in entry && !('event' in entry))
       ).toBe(false)

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
@@ -443,6 +443,45 @@ describe('MixpanelTelemetryProvider — direct event tracking methods', () => {
       expect.objectContaining({ trigger_source: 'unknown' })
     )
   })
+
+  it('omits share_id from existing Mixpanel events', async () => {
+    const provider = new MixpanelTelemetryProvider()
+    await waitForMixpanelInit()
+    mockMixpanel.track.mockClear()
+
+    provider.trackAuth({ method: 'google', share_id: 'share-1' })
+    provider.trackWorkflowImported({
+      missing_node_count: 0,
+      missing_node_types: [],
+      open_source: 'shared_url',
+      share_id: 'share-1'
+    })
+    provider.trackShareFlow({
+      step: 'link_copied',
+      source: 'app_mode',
+      share_id: 'share-1'
+    })
+
+    expect(mockMixpanel.track).toHaveBeenCalledWith(
+      TelemetryEvents.USER_AUTH_COMPLETED,
+      { method: 'google' }
+    )
+    expect(mockMixpanel.track).toHaveBeenCalledWith(
+      TelemetryEvents.WORKFLOW_IMPORTED,
+      {
+        missing_node_count: 0,
+        missing_node_types: [],
+        open_source: 'shared_url'
+      }
+    )
+    expect(mockMixpanel.track).toHaveBeenCalledWith(
+      TelemetryEvents.SHARE_FLOW,
+      {
+        step: 'link_copied',
+        source: 'app_mode'
+      }
+    )
+  })
 })
 
 describe('MixpanelTelemetryProvider — topup delegation', () => {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -1,4 +1,5 @@
 import type { OverridedMixpanel } from 'mixpanel-browser'
+import { omit } from 'es-toolkit'
 import { watch } from 'vue'
 
 import { useAppMode } from '@/composables/useAppMode'
@@ -17,11 +18,10 @@ import type {
   CreditTopupMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
-  ShareFlowMetadata,
   ExecutionContext,
-  ExecutionTriggerSource,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
+  ExecutionTriggerSource,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -30,6 +30,7 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
+  ShareFlowMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -213,7 +214,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
   }
 
   trackAuth(metadata: AuthMetadata): void {
-    this.trackEvent(TelemetryEvents.USER_AUTH_COMPLETED, metadata)
+    this.trackEvent(
+      TelemetryEvents.USER_AUTH_COMPLETED,
+      omit(metadata, ['share_id'])
+    )
   }
 
   trackUserLoggedIn(): void {
@@ -361,11 +365,17 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
   }
 
   trackWorkflowImported(metadata: WorkflowImportMetadata): void {
-    this.trackEvent(TelemetryEvents.WORKFLOW_IMPORTED, metadata)
+    this.trackEvent(
+      TelemetryEvents.WORKFLOW_IMPORTED,
+      omit(metadata, ['share_id'])
+    )
   }
 
   trackWorkflowOpened(metadata: WorkflowImportMetadata): void {
-    this.trackEvent(TelemetryEvents.WORKFLOW_OPENED, metadata)
+    this.trackEvent(
+      TelemetryEvents.WORKFLOW_OPENED,
+      omit(metadata, ['share_id'])
+    )
   }
 
   trackWorkflowSaved(metadata: WorkflowSavedMetadata): void {
@@ -381,7 +391,7 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
   }
 
   trackShareFlow(metadata: ShareFlowMetadata): void {
-    this.trackEvent(TelemetryEvents.SHARE_FLOW, metadata)
+    this.trackEvent(TelemetryEvents.SHARE_FLOW, omit(metadata, ['share_id']))
   }
 
   trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -270,6 +270,35 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
+    it('captures share attribution events', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackShareLinkOpened({
+        share_id: 'share-1',
+        is_authenticated: true
+      })
+      provider.trackSharedWorkflowRun({
+        job_id: 'job-1',
+        share_id: 'share-1'
+      })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.SHARE_LINK_OPENED,
+        {
+          share_id: 'share-1',
+          is_authenticated: true
+        }
+      )
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.SHARED_WORKFLOW_RUN,
+        {
+          job_id: 'job-1',
+          share_id: 'share-1'
+        }
+      )
+    })
+
     it('captures search queries with surface, query, length, and result count', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -13,11 +13,12 @@ import type {
   AuthMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
-  ShareFlowMetadata,
   ExecutionContext,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
   ExecutionTriggerSource,
+  ShareFlowMetadata,
+  ShareLinkOpenedMetadata,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -29,6 +30,7 @@ import type {
   PageVisibilityMetadata,
   RunButtonProperties,
   SettingChangedMetadata,
+  SharedWorkflowRunMetadata,
   SubscriptionMetadata,
   SubscriptionSuccessMetadata,
   SurveyResponses,
@@ -488,6 +490,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.SHARE_FLOW, metadata)
   }
 
+  trackShareLinkOpened(metadata: ShareLinkOpenedMetadata): void {
+    this.trackEvent(TelemetryEvents.SHARE_LINK_OPENED, metadata)
+  }
+
   trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void {
     this.trackEvent(TelemetryEvents.PAGE_VISIBILITY_CHANGED, metadata)
   }
@@ -548,6 +554,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
     this.trackEvent(TelemetryEvents.EXECUTION_SUCCESS, metadata)
+  }
+
+  trackSharedWorkflowRun(metadata: SharedWorkflowRunMetadata): void {
+    this.trackEvent(TelemetryEvents.SHARED_WORKFLOW_RUN, metadata)
   }
 
   trackSettingChanged(metadata: SettingChangedMetadata): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -25,6 +25,7 @@ export interface AuthMetadata {
   is_new_user?: boolean
   user_id?: string
   email?: string
+  share_id?: string
   referrer_url?: string
   utm_source?: string
   utm_medium?: string
@@ -116,6 +117,11 @@ export interface ExecutionSuccessMetadata {
   jobId: string
 }
 
+export interface SharedWorkflowRunMetadata {
+  job_id: string
+  share_id: string
+}
+
 /**
  * Template metadata for workflow tracking
  */
@@ -165,6 +171,7 @@ export interface WorkflowImportMetadata {
     | 'template'
     | 'shared_url'
     | 'unknown'
+  share_id?: string
 }
 
 export interface EnterLinearMetadata {
@@ -189,6 +196,12 @@ type ShareFlowStep =
 export interface ShareFlowMetadata {
   step: ShareFlowStep
   source?: 'app_mode' | 'graph_mode'
+  share_id?: string
+}
+
+export interface ShareLinkOpenedMetadata {
+  share_id: string
+  is_authenticated: boolean
 }
 
 /**
@@ -477,6 +490,7 @@ export interface TelemetryProvider {
   trackDefaultViewSet?(metadata: DefaultViewSetMetadata): void
   trackEnterLinear?(metadata: EnterLinearMetadata): void
   trackShareFlow?(metadata: ShareFlowMetadata): void
+  trackShareLinkOpened?(metadata: ShareLinkOpenedMetadata): void
 
   // Page visibility events
   trackPageVisibilityChanged?(metadata: PageVisibilityMetadata): void
@@ -509,6 +523,7 @@ export interface TelemetryProvider {
   trackWorkflowExecution?(): void
   trackExecutionError?(metadata: ExecutionErrorMetadata): void
   trackExecutionSuccess?(metadata: ExecutionSuccessMetadata): void
+  trackSharedWorkflowRun?(metadata: SharedWorkflowRunMetadata): void
 
   // Settings events
   trackSettingChanged?(metadata: SettingChangedMetadata): void
@@ -570,6 +585,7 @@ export const TelemetryEvents = {
   WORKFLOW_OPENED: 'app:workflow_opened',
   ENTER_LINEAR_MODE: 'app:app_mode_opened',
   SHARE_FLOW: 'app:share_flow',
+  SHARE_LINK_OPENED: 'app:share_link_opened',
 
   // Page Visibility
   PAGE_VISIBILITY_CHANGED: 'app:page_visibility_changed',
@@ -603,6 +619,7 @@ export const TelemetryEvents = {
   EXECUTION_START: 'execution_start',
   EXECUTION_ERROR: 'execution_error',
   EXECUTION_SUCCESS: 'execution_success',
+  SHARED_WORKFLOW_RUN: 'app:shared_workflow_run',
   // Generic UI Button Click
   UI_BUTTON_CLICKED: 'app:ui_button_clicked',
 
@@ -631,6 +648,7 @@ export type TelemetryEventProperties =
   | RunButtonProperties
   | ExecutionErrorMetadata
   | ExecutionSuccessMetadata
+  | SharedWorkflowRunMetadata
   | CreditTopupMetadata
   | WorkflowImportMetadata
   | TemplateLibraryMetadata
@@ -649,6 +667,7 @@ export type TelemetryEventProperties =
   | WorkflowCreatedMetadata
   | EnterLinearMetadata
   | ShareFlowMetadata
+  | ShareLinkOpenedMetadata
   | WorkflowSavedMetadata
   | DefaultViewSetMetadata
   | SubscriptionMetadata

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -636,6 +636,71 @@ describe('useWorkflowService', () => {
 
       expect(workflowStore.createNewTemporary).toHaveBeenCalled()
     })
+
+    it('stores share attribution on shared temporary workflows', async () => {
+      vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
+      const tempWorkflow = createModeTestWorkflow({
+        path: 'workflows/shared.json'
+      })
+      vi.mocked(workflowStore.createNewTemporary).mockReturnValue(tempWorkflow)
+      vi.mocked(workflowStore.openWorkflow).mockResolvedValue(tempWorkflow)
+
+      await useWorkflowService().afterLoadNewGraph(
+        'shared',
+        { nodes: [] } as never,
+        'share-1'
+      )
+
+      expect(tempWorkflow.shareId).toBe('share-1')
+    })
+
+    it('preserves share attribution on repeated same-path loads', async () => {
+      existingWorkflow.shareId = 'share-1'
+
+      await useWorkflowService().afterLoadNewGraph('repeat', {
+        nodes: [{ id: 1, type: 'TestNode', pos: [0, 0], size: [100, 100] }]
+      } as never)
+
+      expect(existingWorkflow.shareId).toBe('share-1')
+    })
+
+    it('preserves share attribution on workflow object reloads', async () => {
+      existingWorkflow.shareId = 'share-1'
+
+      await useWorkflowService().afterLoadNewGraph(existingWorkflow, {
+        nodes: [{ id: 1, type: 'TestNode', pos: [0, 0], size: [100, 100] }]
+      } as never)
+
+      expect(existingWorkflow.shareId).toBe('share-1')
+    })
+
+    it('overwrites share attribution on repeated same-path loads with a new share id', async () => {
+      existingWorkflow.shareId = 'share-1'
+
+      await useWorkflowService().afterLoadNewGraph(
+        'repeat',
+        {
+          nodes: [{ id: 1, type: 'TestNode', pos: [0, 0], size: [100, 100] }]
+        } as never,
+        'share-2'
+      )
+
+      expect(existingWorkflow.shareId).toBe('share-2')
+    })
+
+    it('overwrites share attribution on workflow object reloads with a new share id', async () => {
+      existingWorkflow.shareId = 'share-1'
+
+      await useWorkflowService().afterLoadNewGraph(
+        existingWorkflow,
+        {
+          nodes: [{ id: 1, type: 'TestNode', pos: [0, 0], size: [100, 100] }]
+        } as never,
+        'share-2'
+      )
+
+      expect(existingWorkflow.shareId).toBe('share-2')
+    })
   })
 
   describe('per-workflow mode switching', () => {

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -445,7 +445,8 @@ export const useWorkflowService = () => {
    */
   const afterLoadNewGraph = async (
     value: string | ComfyWorkflow | null,
-    workflowData: ComfyWorkflowJSON
+    workflowData: ComfyWorkflowJSON,
+    shareId?: string
   ) => {
     const workflowStore = useWorkspaceStore().workflow
     const { isAppMode } = useAppMode()
@@ -499,6 +500,9 @@ export const useWorkflowService = () => {
               ) ?? freshLoadMode
             trackIfEnteringApp(loadedWorkflow)
           }
+          if (shareId) {
+            loadedWorkflow.shareId = shareId
+          }
           loadedWorkflow.changeTracker.reset(workflowData)
           loadedWorkflow.changeTracker.restore()
           return
@@ -510,12 +514,18 @@ export const useWorkflowService = () => {
         workflowData
       )
       tempWorkflow.initialMode = freshLoadMode
+      if (shareId) {
+        tempWorkflow.shareId = shareId
+      }
       trackIfEnteringApp(tempWorkflow)
       await workflowStore.openWorkflow(tempWorkflow)
       return
     }
 
     const loadedWorkflow = await workflowStore.openWorkflow(value)
+    if (shareId) {
+      loadedWorkflow.shareId = shareId
+    }
     if (loadedWorkflow.initialMode === undefined) {
       loadedWorkflow.initialMode = freshLoadMode
       trackIfEnteringApp(loadedWorkflow)

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -55,6 +55,7 @@ export class ComfyWorkflow extends UserFile {
    * Takes precedence over initialMode when present.
    */
   activeMode: AppMode | null = null
+  shareId?: string
   /**
    * @param options The path, modified, and size of the workflow.
    * Note: path is the full path, including the 'workflows/' prefix.

--- a/src/platform/workflow/sharing/components/ShareUrlCopyField.vue
+++ b/src/platform/workflow/sharing/components/ShareUrlCopyField.vue
@@ -30,8 +30,9 @@ import { useAppMode } from '@/composables/useAppMode'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { useTelemetry } from '@/platform/telemetry'
 
-const { url } = defineProps<{
+const { url, shareId } = defineProps<{
   url: string
+  shareId: string
 }>()
 
 const { copyToClipboard } = useCopyToClipboard()
@@ -43,7 +44,8 @@ async function handleCopy() {
   copied.value = true
   useTelemetry()?.trackShareFlow({
     step: 'link_copied',
-    source: isAppMode.value ? 'app_mode' : 'graph_mode'
+    source: isAppMode.value ? 'app_mode' : 'graph_mode',
+    share_id: shareId
   })
 }
 </script>

--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts
@@ -23,6 +23,14 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
   useWorkflowStore: () => mockWorkflowStore
 }))
 
+const mockTrackShareFlow = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackShareFlow: mockTrackShareFlow
+  })
+}))
+
 const mockToast = vi.hoisted(() => ({ add: vi.fn() }))
 
 vi.mock('primevue/usetoast', () => ({
@@ -112,7 +120,10 @@ const i18n = createI18n({
         saveButton: 'Save workflow',
         createLinkButton: 'Create link',
         creatingLink: 'Creating link...',
+        copyLink: 'Copy link',
+        linkCopied: 'Copied',
         checkingAssets: 'Checking assets...',
+        shareUrlLabel: 'Share URL',
         successDescription: 'Anyone with this link...',
         hasChangesDescription: 'You have made changes...',
         updateLinkButton: 'Update link',
@@ -373,6 +384,31 @@ describe('ShareWorkflowDialogContent', () => {
       'workflows/test.json',
       initialShareableAssets
     )
+    expect(mockTrackShareFlow).toHaveBeenCalledWith({
+      step: 'link_created',
+      source: 'graph_mode',
+      share_id: 'test-123'
+    })
+  })
+
+  it('tracks copied share link with share id', async () => {
+    mockGetPublishStatus.mockResolvedValue({
+      isPublished: true,
+      shareId: 'copy-123',
+      shareUrl: 'https://comfy.org/shared/copy-123',
+      publishedAt: new Date('2026-01-15')
+    })
+
+    renderComponent()
+    await flushPromises()
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy link/i }))
+
+    expect(mockTrackShareFlow).toHaveBeenCalledWith({
+      step: 'link_copied',
+      source: 'graph_mode',
+      share_id: 'copy-123'
+    })
   })
 
   it('shows update button when workflow was saved after last publish', async () => {

--- a/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue
+++ b/src/platform/workflow/sharing/components/ShareWorkflowDialogContent.vue
@@ -112,7 +112,10 @@
         </template>
 
         <template v-if="dialogState === 'shared' && publishResult">
-          <ShareUrlCopyField :url="publishResult.shareUrl" />
+          <ShareUrlCopyField
+            :url="publishResult.shareUrl"
+            :share-id="publishResult.shareId"
+          />
           <div class="flex flex-col gap-1">
             <p
               v-if="publishResult.publishedAt"
@@ -437,7 +440,8 @@ const {
     acknowledged.value = false
     useTelemetry()?.trackShareFlow({
       step: 'link_created',
-      source: getShareSource()
+      source: getShareSource(),
+      share_id: result.shareId
     })
 
     return result

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -5,6 +5,7 @@ import { useSharedWorkflowUrlLoader } from '@/platform/workflow/sharing/composab
 import type { SharedWorkflowPayload } from '@/platform/workflow/sharing/types/shareTypes'
 
 const preservedQueryMocks = vi.hoisted(() => ({
+  capturePreservedQuery: vi.fn(),
   clearPreservedQuery: vi.fn(),
   hydratePreservedQuery: vi.fn(),
   mergePreservedQueryIntoQuery: vi.fn()
@@ -28,6 +29,20 @@ vi.mock('vue-router', () => ({
 }))
 
 const mockImportPublishedAssets = vi.fn()
+const mockIsLoggedIn = vi.hoisted(() => ({ value: false }))
+const mockTrackShareLinkOpened = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    isLoggedIn: mockIsLoggedIn
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackShareLinkOpened: mockTrackShareLinkOpened
+  })
+}))
 
 vi.mock('@/platform/workflow/sharing/services/workflowShareService', () => ({
   SharedWorkflowLoadError: class extends Error {
@@ -174,6 +189,7 @@ describe('useSharedWorkflowUrlLoader', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockQueryParams = {}
+    mockIsLoggedIn.value = false
     mockDialogStack.length = 0
     mockShowLayoutDialog.mockImplementation(createDialogInstance)
     mockUpdateDialog.mockImplementation(
@@ -213,6 +229,7 @@ describe('useSharedWorkflowUrlLoader', () => {
     expect(loaded).toBe('not-present')
     expect(mockShowLayoutDialog).not.toHaveBeenCalled()
     expect(mockLoadGraphData).not.toHaveBeenCalled()
+    expect(mockTrackShareLinkOpened).not.toHaveBeenCalled()
   })
 
   it('opens dialog immediately with shareId and loads graph on confirm', async () => {
@@ -234,12 +251,39 @@ describe('useSharedWorkflowUrlLoader', () => {
       true,
       true,
       'Test Workflow',
-      { openSource: 'shared_url' }
+      { openSource: 'shared_url', shareId: 'share-id-1' }
+    )
+    expect(mockTrackShareLinkOpened).toHaveBeenCalledWith({
+      share_id: 'share-id-1',
+      is_authenticated: false
+    })
+    expect(preservedQueryMocks.capturePreservedQuery).toHaveBeenCalledWith(
+      'share_auth',
+      { share: 'share-id-1' },
+      ['share']
     )
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
     expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
       'share'
     )
+  })
+
+  it('does not capture share auth attribution for authenticated users', async () => {
+    mockQueryParams = { share: 'share-id-1' }
+    mockIsLoggedIn.value = true
+    mockShowLayoutDialog.mockImplementation(() => {
+      resolveDialogWithConfirm(makePayload())
+    })
+
+    const { loadSharedWorkflowFromUrl } = useSharedWorkflowUrlLoader()
+    const loaded = await loadSharedWorkflowFromUrl()
+
+    expect(loaded).toBe('loaded')
+    expect(mockTrackShareLinkOpened).toHaveBeenCalledWith({
+      share_id: 'share-id-1',
+      is_authenticated: true
+    })
+    expect(preservedQueryMocks.capturePreservedQuery).not.toHaveBeenCalled()
   })
 
   it('hides template selector when user confirms opening shared workflow', async () => {
@@ -300,6 +344,9 @@ describe('useSharedWorkflowUrlLoader', () => {
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
     expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
       'share'
+    )
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'share_auth'
     )
   })
 
@@ -411,7 +458,7 @@ describe('useSharedWorkflowUrlLoader', () => {
       true,
       true,
       'Test Workflow',
-      { openSource: 'shared_url' }
+      { openSource: 'shared_url', shareId: 'share-id-1' }
     )
     expect(mockToastAdd).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -541,7 +588,7 @@ describe('useSharedWorkflowUrlLoader', () => {
       true,
       true,
       'Open shared workflow',
-      { openSource: 'shared_url' }
+      { openSource: 'shared_url', shareId: 'share-id-1' }
     )
   })
 })

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -2,10 +2,13 @@ import { useToast } from 'primevue/usetoast'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useWorkflowTemplateSelectorDialog } from '@/composables/useWorkflowTemplateSelectorDialog'
+import { useTelemetry } from '@/platform/telemetry'
 import OpenSharedWorkflowDialogContent from '@/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue'
 import type { SharedWorkflowPayload } from '@/platform/workflow/sharing/types/shareTypes'
 import {
+  capturePreservedQuery,
   clearPreservedQuery,
   hydratePreservedQuery,
   mergePreservedQueryIntoQuery
@@ -41,6 +44,7 @@ export function useSharedWorkflowUrlLoader() {
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
   const templateSelectorDialog = useWorkflowTemplateSelectorDialog()
+  const { isLoggedIn } = useCurrentUser()
   const SHARE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.SHARE
 
   function isValidParameter(param: string): boolean {
@@ -140,9 +144,22 @@ export function useSharedWorkflowUrlLoader() {
       return 'failed'
     }
 
+    useTelemetry()?.trackShareLinkOpened({
+      share_id: shareParam,
+      is_authenticated: isLoggedIn.value
+    })
+    if (!isLoggedIn.value) {
+      capturePreservedQuery(
+        PRESERVED_QUERY_NAMESPACES.SHARE_AUTH,
+        { share: shareParam },
+        ['share']
+      )
+    }
+
     const result = await showOpenSharedWorkflowDialog(shareParam)
 
     if (result.action === 'cancel') {
+      clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
       clearShareIntent()
       return 'cancelled'
     }
@@ -182,7 +199,8 @@ export function useSharedWorkflowUrlLoader() {
           true,
           workflowName,
           {
-            openSource: 'shared_url'
+            openSource: 'shared_url',
+            shareId: payload.shareId
           }
         )
       } catch (error) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1138,6 +1138,7 @@ export class ComfyApp {
     options: {
       checkForRerouteMigration?: boolean
       openSource?: WorkflowOpenSource
+      shareId?: string
       deferWarnings?: boolean
       skipAssetScans?: boolean
       silentAssetErrors?: boolean
@@ -1146,6 +1147,7 @@ export class ComfyApp {
     const {
       checkForRerouteMigration = false,
       openSource,
+      shareId,
       deferWarnings = false,
       skipAssetScans = false,
       silentAssetErrors = false
@@ -1423,19 +1425,24 @@ export class ComfyApp {
         missingNodeTypes
       )
 
+      const effectiveShareId =
+        shareId ??
+        (workflow instanceof ComfyWorkflow ? workflow.shareId : undefined)
       const telemetryPayload = {
         missing_node_count: missingNodeTypes.length,
         missing_node_types: missingNodeTypes.map((node) =>
           typeof node === 'string' ? node : node.type
         ),
         missing_node_packs: groupMissingNodesByPack(missingNodeTypes),
-        open_source: openSource ?? 'unknown'
+        open_source: openSource ?? 'unknown',
+        ...(effectiveShareId ? { share_id: effectiveShareId } : {})
       }
       useTelemetry()?.trackWorkflowOpened(telemetryPayload)
       useTelemetry()?.trackWorkflowImported(telemetryPayload)
       await useWorkflowService().afterLoadNewGraph(
         workflow,
-        this.rootGraph.serialize() as unknown as ComfyWorkflowJSON
+        this.rootGraph.serialize() as unknown as ComfyWorkflowJSON,
+        effectiveShareId
       )
 
       // If the canvas was not visible and we're a fresh load, resize the canvas and fit the view

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -6,6 +6,8 @@ import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
+import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useDialogService } from '@/services/dialogService'
 import { useAuthStore } from '@/stores/authStore'
 import { createTestingPinia } from '@pinia/testing'
@@ -139,6 +141,8 @@ describe('useAuthStore', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    sessionStorage.clear()
+    clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
 
     // Setup dialog service mock
     vi.mocked(useDialogService, { partial: true }).mockReturnValue({
@@ -656,6 +660,30 @@ describe('useAuthStore', () => {
           )
         }
       )
+
+      it('includes preserved share id on new-user social auth', async () => {
+        sessionStorage.setItem(
+          'Comfy.PreservedQuery.share_auth',
+          JSON.stringify({ share: 'share-1' })
+        )
+        vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
+          isNewUser: true,
+          providerId: 'google.com',
+          profile: null
+        })
+
+        await store.loginWithGoogle()
+
+        expect(mockTrackAuth).toHaveBeenCalledWith(
+          expect.objectContaining({
+            is_new_user: true,
+            share_id: 'share-1'
+          })
+        )
+        expect(
+          sessionStorage.getItem('Comfy.PreservedQuery.share_auth')
+        ).toBeNull()
+      })
     })
   })
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -23,6 +23,11 @@ import { useFirebaseAuth } from 'vuefire'
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
 import { isCloud } from '@/platform/distribution/types'
+import {
+  clearPreservedQuery,
+  getPreservedQueryParam
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useTelemetry } from '@/platform/telemetry'
 import { useDialogService } from '@/services/dialogService'
 import { useWorkspaceAuthStore } from '@/platform/workspace/stores/workspaceAuthStore'
@@ -96,6 +101,15 @@ export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = computed(() => !!currentUser.value)
   const userEmail = computed(() => currentUser.value?.email)
   const userId = computed(() => currentUser.value?.uid)
+
+  function getShareAuthMetadata() {
+    const shareId = getPreservedQueryParam(
+      PRESERVED_QUERY_NAMESPACES.SHARE_AUTH,
+      'share'
+    )
+    if (shareId) clearPreservedQuery(PRESERVED_QUERY_NAMESPACES.SHARE_AUTH)
+    return shareId ? { share_id: shareId } : {}
+  }
 
   // Get auth from VueFire and listen for auth state changes
   // From useFirebaseAuth docs:
@@ -333,7 +347,8 @@ export const useAuthStore = defineStore('auth', () => {
         method: 'email',
         is_new_user: false,
         user_id: result.user.uid,
-        email: result.user.email ?? undefined
+        email: result.user.email ?? undefined,
+        ...getShareAuthMetadata()
       })
     }
 
@@ -355,7 +370,8 @@ export const useAuthStore = defineStore('auth', () => {
         method: 'email',
         is_new_user: true,
         user_id: result.user.uid,
-        email: result.user.email ?? undefined
+        email: result.user.email ?? undefined,
+        ...getShareAuthMetadata()
       })
     }
 
@@ -377,7 +393,8 @@ export const useAuthStore = defineStore('auth', () => {
         is_new_user:
           options?.isNewUser || additionalUserInfo?.isNewUser || false,
         user_id: result.user.uid,
-        email: result.user.email ?? undefined
+        email: result.user.email ?? undefined,
+        ...getShareAuthMetadata()
       })
     }
 
@@ -399,7 +416,8 @@ export const useAuthStore = defineStore('auth', () => {
         is_new_user:
           options?.isNewUser || additionalUserInfo?.isNewUser || false,
         user_id: result.user.uid,
-        email: result.user.email ?? undefined
+        email: result.user.email ?? undefined,
+        ...getShareAuthMetadata()
       })
     }
 

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -6,6 +6,7 @@ import { MAX_PROGRESS_JOBS, useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
+import type * as DistributionTypes from '@/platform/distribution/types'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type * as WorkflowStoreModule from '@/platform/workflow/management/stores/workflowStore'
 import type { NodeProgressState } from '@/schemas/apiSchema'
@@ -15,12 +16,18 @@ const {
   mockNodeExecutionIdToNodeLocatorId,
   mockNodeIdToNodeLocatorId,
   mockNodeLocatorIdToNodeExecutionId,
-  mockShowTextPreview
+  mockShowTextPreview,
+  mockTrackExecutionError,
+  mockTrackExecutionSuccess,
+  mockTrackSharedWorkflowRun
 } = vi.hoisted(() => ({
   mockNodeExecutionIdToNodeLocatorId: vi.fn(),
   mockNodeIdToNodeLocatorId: vi.fn(),
   mockNodeLocatorIdToNodeExecutionId: vi.fn(),
-  mockShowTextPreview: vi.fn()
+  mockShowTextPreview: vi.fn(),
+  mockTrackExecutionError: vi.fn(),
+  mockTrackExecutionSuccess: vi.fn(),
+  mockTrackSharedWorkflowRun: vi.fn()
 }))
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 import { createTestingPinia } from '@pinia/testing'
@@ -39,6 +46,21 @@ vi.mock('@/platform/workflow/management/stores/workflowStore', async () => {
     }))
   }
 })
+
+vi.mock('@/platform/distribution/types', async () => ({
+  ...(await vi.importActual<typeof DistributionTypes>(
+    '@/platform/distribution/types'
+  )),
+  isCloud: true
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackExecutionError: mockTrackExecutionError,
+    trackExecutionSuccess: mockTrackExecutionSuccess,
+    trackSharedWorkflowRun: mockTrackSharedWorkflowRun
+  })
+}))
 
 // Remove any previous global types
 declare global {
@@ -1085,6 +1107,50 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       expect(store.activeJobId).toBeNull()
       expect(store.queuedJobs['job-1']).toBeUndefined()
     })
+
+    it('tracks shared workflow run when the queued workflow has share attribution', () => {
+      const workflow = createQueuedWorkflow()
+      workflow.shareId = 'share-1'
+      store.storeJob({
+        nodes: ['a'],
+        id: 'job-1',
+        promptOutput: {
+          a: createPromptNode('Node A', 'NodeA')
+        },
+        workflow
+      })
+      fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
+
+      fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(mockTrackExecutionSuccess).toHaveBeenCalledWith({
+        jobId: 'job-1'
+      })
+      expect(mockTrackSharedWorkflowRun).toHaveBeenCalledWith({
+        job_id: 'job-1',
+        share_id: 'share-1'
+      })
+    })
+
+    it('tracks shared workflow run from the success event job', () => {
+      const workflow = createQueuedWorkflow()
+      workflow.shareId = 'share-1'
+      store.storeJob({
+        nodes: ['a'],
+        id: 'job-1',
+        promptOutput: {
+          a: createPromptNode('Node A', 'NodeA')
+        },
+        workflow
+      })
+
+      fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
+
+      expect(mockTrackSharedWorkflowRun).toHaveBeenCalledWith({
+        job_id: 'job-1',
+        share_id: 'share-1'
+      })
+    })
   })
 
   describe('executing', () => {
@@ -1251,6 +1317,7 @@ describe('useExecutionStore - storeJob and workflow path tracking', () => {
       b: { title: 'Node B', type: 'NodeB' }
     })
     expect(store.queuedJobs['job-1']?.workflow).toStrictEqual(workflow)
+    expect(store.queuedJobs['job-1']?.shareId).toBeUndefined()
     expect(store.jobIdToWorkflowId.get('job-1')).toBe('wf-1')
     expect(store.jobIdToSessionWorkflowPath.get('job-1')).toBe(
       '/workflows/foo.json'

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -55,6 +55,11 @@ interface QueuedJob {
    * This stays stable even if the user switches workflows or edits the canvas.
    */
   nodeLookup?: Record<string, ExecutionNodeInfo>
+  /**
+   * Share attribution snapshotted at queue time. Read this instead of
+   * `workflow.shareId`, which can gain attribution after the job was queued.
+   */
+  shareId?: string
 }
 
 function buildExecutionNodeLookup(
@@ -295,12 +300,20 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
-    if (isCloud && activeJobId.value) {
-      useTelemetry()?.trackExecutionSuccess({
-        jobId: activeJobId.value
-      })
-    }
     const jobId = e.detail.prompt_id
+    const queuedJob = queuedJobs.value[jobId]
+    if (isCloud && queuedJob) {
+      const telemetry = useTelemetry()
+      telemetry?.trackExecutionSuccess({
+        jobId
+      })
+      if (queuedJob.shareId) {
+        telemetry?.trackSharedWorkflowRun({
+          job_id: jobId,
+          share_id: queuedJob.shareId
+        })
+      }
+    }
     resetExecutionState(jobId)
   }
 
@@ -580,6 +593,7 @@ export const useExecutionStore = defineStore('execution', () => {
     }
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
     queuedJob.workflow = workflow
+    queuedJob.shareId = workflow?.shareId
     const wid = workflow?.activeState?.id ?? workflow?.initialState?.id
     if (wid) {
       jobIdToWorkflowId.value.set(id, wid)


### PR DESCRIPTION
## Summary

Backports #12741 to `cloud/1.45` so share id attribution telemetry is included in the cloud 1.45 release lane.

## Changes

- **What**: Cherry-picked `c190784307a33574fdb082131f73e71f64067797` and resolved conflicts with existing `cloud/1.45` execution telemetry.
- **Dependencies**: None.

## Review Focus

Confirm the telemetry provider conflict resolution keeps both execution telemetry and shared workflow attribution telemetry.

## Testing

- `pnpm exec vitest run src/platform/navigation/preservedQueryManager.test.ts src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts src/platform/workflow/core/services/workflowService.test.ts src/platform/workflow/sharing/components/ShareWorkflowDialogContent.test.ts src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts src/stores/authStore.test.ts src/stores/executionStore.test.ts`