### PR TITLE
fix: remove broken throttle from VirtualGrid scroll tracking

### DIFF
--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -33,7 +33,6 @@ const {
   items,
   gridStyle,
   bufferRows = 1,
-  scrollThrottle = 64,
   resizeDebounce = 64,
   defaultItemHeight = 200,
   defaultItemWidth = 200,
@@ -42,7 +41,6 @@ const {
   items: (T & { key: string })[]
   gridStyle: CSSProperties
   bufferRows?: number
-  scrollThrottle?: number
   resizeDebounce?: number
   defaultItemHeight?: number
   defaultItemWidth?: number
@@ -60,8 +58,11 @@ const itemHeight = ref(defaultItemHeight)
 const itemWidth = ref(defaultItemWidth)
 const container = ref<HTMLElement | null>(null)
 const { width, height } = useElementSize(container)
+// No throttle: VueUse >=14 throttleFilter drops scroll events spaced wider
+// than the throttle window when leading=false (vueuse regression of #2390),
+// freezing scrollY for discrete mouse-wheel input. Scroll events are already
+// frame-aligned and this handler is cheap, so throttling buys nothing.
 const { y: scrollY } = useScroll(container, {
-  throttle: scrollThrottle,
   eventListenerOptions: { passive: true }
 })
 

--- a/src/components/common/VirtualGrid.vue
+++ b/src/components/common/VirtualGrid.vue
@@ -58,10 +58,6 @@ const itemHeight = ref(defaultItemHeight)
 const itemWidth = ref(defaultItemWidth)
 const container = ref<HTMLElement | null>(null)
 const { width, height } = useElementSize(container)
-// No throttle: VueUse >=14 throttleFilter drops scroll events spaced wider
-// than the throttle window when leading=false (vueuse regression of #2390),
-// freezing scrollY for discrete mouse-wheel input. Scroll events are already
-// frame-aligned and this handler is cheap, so throttling buys nothing.
 const { y: scrollY } = useScroll(container, {
   eventListenerOptions: { passive: true }
 })


### PR DESCRIPTION
## Summary

Every `VirtualGrid` consumer (assets sidebar, manager dialog, widget select dropdown) is blind to discrete mouse-wheel scrolling: `useScroll`'s `throttle: 64` never reports scroll position, so the virtualization window stays frozen — users see blank space below the first viewport of items and `approach-end` (infinite scroll) never fires. Trackpad scrolling masks the bug by emitting events faster than the throttle window.

## Changes

- **What**: drop the `throttle` option from `useScroll` in `VirtualGrid` and remove the `scrollThrottle` prop (no consumer passes it). Scroll events are frame-aligned and the handler is cheap, so the throttle bought nothing even when it worked.
- **Root cause**: VueUse ≥14 `throttleFilter` with `leading=false` (what `useScroll` uses) marks spaced-out events as executed without executing them — each event re-arms an `isLeading` restore timer that makes the next event skip its invoke, and the trailing branch is unreachable when `elapsed > duration`. Regression of vueuse#2390; still present on vueuse `main`.

## Review Focus

- Verified live against staging: with the throttle, sidebar scrolled to `scrollTop` 1250 while `scrollY` stayed 0 and the render window stayed at `[0..3)` of 27 (blank viewport); with this fix, `scrollY` tracks 1:1 and the window advances. Bare-vs-throttled `useScroll` compared side-by-side on the same element to isolate the cause.
- Unblocks wheel-scroll for #12780's dropdown infinite scroll with no changes there.

- Fixes FE-990

🤖 Generated with [Claude Code](https://claude.com/claude-code)