### PR TITLE
refactor(billing): unify cancel-status polling into billingOperationStore (B8 / FE-970)

### DIFF
--- a/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
+++ b/src/components/dialog/content/subscription/CancelSubscriptionDialogContent.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
-import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
 
@@ -44,23 +45,28 @@ const mockSubscription = vi.hoisted(() => ({
   value: null as { endDate: string | null } | null
 }))
 
+const mockCancelSubscription = vi.hoisted(() => vi.fn())
+const mockFetchStatus = vi.hoisted(() => vi.fn())
+const mockCloseDialog = vi.hoisted(() => vi.fn())
+const mockToastAdd = vi.hoisted(() => vi.fn())
+
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: vi.fn(() => ({
-    cancelSubscription: vi.fn(),
-    fetchStatus: vi.fn(),
+    cancelSubscription: mockCancelSubscription,
+    fetchStatus: mockFetchStatus,
     subscription: mockSubscription
   }))
 }))
 
 vi.mock('@/stores/dialogStore', () => ({
   useDialogStore: vi.fn(() => ({
-    closeDialog: vi.fn()
+    closeDialog: mockCloseDialog
   }))
 }))
 
 vi.mock('primevue/usetoast', () => ({
   useToast: vi.fn(() => ({
-    add: vi.fn()
+    add: mockToastAdd
   }))
 }))
 
@@ -86,6 +92,54 @@ function renderComponent(props: { cancelAt?: string } = {}) {
 }
 
 describe('CancelSubscriptionDialogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('cancel flow', () => {
+    it('shows an error toast and keeps the dialog open when cancellation fails', async () => {
+      mockSubscription.value = null
+      mockCancelSubscription.mockRejectedValueOnce(
+        new Error('Subscription cancellation timed out')
+      )
+
+      renderComponent()
+      await userEvent.click(
+        screen.getByRole('button', { name: /^cancel subscription$/i })
+      )
+
+      await waitFor(() =>
+        expect(mockToastAdd).toHaveBeenCalledWith(
+          expect.objectContaining({
+            severity: 'error',
+            detail: 'Subscription cancellation timed out'
+          })
+        )
+      )
+      expect(mockCloseDialog).not.toHaveBeenCalled()
+    })
+
+    it('closes the dialog and shows a success toast when cancellation succeeds', async () => {
+      mockSubscription.value = null
+      mockCancelSubscription.mockResolvedValueOnce(undefined)
+
+      renderComponent()
+      await userEvent.click(
+        screen.getByRole('button', { name: /^cancel subscription$/i })
+      )
+
+      await waitFor(() =>
+        expect(mockCloseDialog).toHaveBeenCalledWith({
+          key: 'cancel-subscription'
+        })
+      )
+      expect(mockFetchStatus).toHaveBeenCalled()
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'success' })
+      )
+    })
+  })
+
   describe('formattedEndDate fallbacks', () => {
     it('uses the localized fallback when no cancel timestamp is available', () => {
       mockSubscription.value = { endDate: null }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2407,7 +2407,9 @@
     "topupProcessing": "Processing payment — adding credits...",
     "topupSuccess": "Credits added successfully",
     "topupFailed": "Top-up failed",
-    "topupTimeout": "Top-up verification timed out"
+    "topupTimeout": "Top-up verification timed out",
+    "cancelFailed": "Failed to cancel subscription",
+    "cancelTimeout": "Subscription cancellation timed out"
   },
   "subscription": {
     "plansForWorkspace": "Plans for {workspace}",

--- a/src/platform/workspace/composables/useSubscriptionCheckout.ts
+++ b/src/platform/workspace/composables/useSubscriptionCheckout.ts
@@ -144,12 +144,12 @@ export function useSubscriptionCheckout(emit: {
         response.payment_method_url
       ) {
         window.open(response.payment_method_url, '_blank')
-        billingOperationStore.startOperation(
+        void billingOperationStore.startOperation(
           response.billing_op_id,
           'subscription'
         )
       } else if (response.status === 'pending_payment') {
-        billingOperationStore.startOperation(
+        void billingOperationStore.startOperation(
           response.billing_op_id,
           'subscription'
         )

--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, effectScope, h } from 'vue'
+import { effectScope } from 'vue'
 
 import { useWorkspaceBilling } from '@/platform/workspace/composables/useWorkspaceBilling'
-import type { BillingActions, BillingState } from '@/composables/billing/types'
 
 const mockWorkspaceApi = vi.hoisted(() => ({
   getBillingStatus: vi.fn(),
@@ -22,7 +21,7 @@ const mockBillingPlans = vi.hoisted(() => ({
 }))
 
 const mockShow = vi.hoisted(() => vi.fn())
-const mockUpdateActiveWorkspace = vi.hoisted(() => vi.fn())
+const mockStartOperation = vi.hoisted(() => vi.fn())
 
 vi.mock('@/platform/workspace/api/workspaceApi', () => ({
   workspaceApi: mockWorkspaceApi
@@ -41,9 +40,9 @@ vi.mock(
   })
 )
 
-vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
-  useTeamWorkspaceStore: () => ({
-    updateActiveWorkspace: mockUpdateActiveWorkspace
+vi.mock('@/platform/workspace/stores/billingOperationStore', () => ({
+  useBillingOperationStore: () => ({
+    startOperation: mockStartOperation
   })
 }))
 
@@ -398,54 +397,44 @@ describe('useWorkspaceBilling', () => {
     })
   })
 
-  describe('cancelSubscription polling', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
+  describe('cancelSubscription', () => {
+    function operation(
+      overrides: Partial<{
+        status: 'pending' | 'succeeded' | 'failed' | 'timeout'
+        errorMessage: string | null
+      }> = {}
+    ) {
+      return {
+        opId: 'op-cancel',
+        type: 'cancel' as const,
+        status: overrides.status ?? ('succeeded' as const),
+        errorMessage: overrides.errorMessage ?? null,
+        startedAt: 0
+      }
+    }
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
-    it('updates workspace store when op succeeds', async () => {
+    it('drives the shared billing operation poller with a cancel op', async () => {
       mockWorkspaceApi.cancelSubscription.mockResolvedValue({
         billing_op_id: 'op-cancel',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockWorkspaceApi.getBillingOpStatus.mockResolvedValue({
-        id: 'op-cancel',
-        status: 'succeeded',
-        started_at: '2026-04-01T00:00:00Z'
-      })
-      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
-        ...activeStatus,
-        is_active: false,
-        subscription_status: 'canceled'
-      })
+      mockStartOperation.mockResolvedValue(operation())
 
       const billing = setupBilling()
       await billing.cancelSubscription()
 
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledWith(
-        'op-cancel'
-      )
-      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
-        isSubscribed: false
-      })
-      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalled()
+      expect(mockStartOperation).toHaveBeenCalledWith('op-cancel', 'cancel')
+      expect(billing.error.value).toBeNull()
     })
 
-    it('rethrows when the op reports failure', async () => {
+    it('throws the op error message when the cancel op fails', async () => {
       mockWorkspaceApi.cancelSubscription.mockResolvedValue({
         billing_op_id: 'op-fail',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      mockWorkspaceApi.getBillingOpStatus.mockResolvedValue({
-        id: 'op-fail',
-        status: 'failed',
-        started_at: '2026-04-01T00:00:00Z',
-        error_message: 'processor rejected'
-      })
+      mockStartOperation.mockResolvedValue(
+        operation({ status: 'failed', errorMessage: 'processor rejected' })
+      )
 
       const billing = setupBilling()
 
@@ -453,88 +442,44 @@ describe('useWorkspaceBilling', () => {
         'processor rejected'
       )
       expect(billing.error.value).toBe('processor rejected')
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
     })
 
-    it('schedules the second poll at the 2000ms backoff boundary', async () => {
+    it('throws when the cancel op times out', async () => {
       mockWorkspaceApi.cancelSubscription.mockResolvedValue({
-        billing_op_id: 'op-slow',
+        billing_op_id: 'op-timeout',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      const pendingResponse = {
-        id: 'op-slow',
-        status: 'pending' as const,
-        started_at: '2026-04-01T00:00:00Z'
-      }
-      mockWorkspaceApi.getBillingOpStatus
-        .mockResolvedValueOnce(pendingResponse)
-        .mockResolvedValueOnce({
-          id: 'op-slow',
-          status: 'succeeded',
-          started_at: '2026-04-01T00:00:00Z'
+      mockStartOperation.mockResolvedValue(
+        operation({
+          status: 'timeout',
+          errorMessage: 'billingOperation.cancelTimeout'
         })
-      mockWorkspaceApi.getBillingStatus.mockResolvedValue({
-        ...activeStatus,
-        is_active: false
-      })
+      )
 
       const billing = setupBilling()
-      const cancelPromise = billing.cancelSubscription()
 
-      // First poll runs synchronously inside cancelSubscription.
-      await cancelPromise
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(1)
-
-      // Boundary check: still only 1 call just before the 2000ms mark.
-      await vi.advanceTimersByTimeAsync(1999)
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(1)
-
-      // Crossing 2000ms total fires the scheduled retry.
-      await vi.advanceTimersByTimeAsync(1)
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(2)
-      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
-        isSubscribed: false
-      })
+      await expect(billing.cancelSubscription()).rejects.toThrow(
+        'billingOperation.cancelTimeout'
+      )
     })
 
-    it('caps the backoff at 5000ms once 2^attempt exceeds the cap', async () => {
+    it('falls back to a generic message when a non-success op omits errorMessage', async () => {
       mockWorkspaceApi.cancelSubscription.mockResolvedValue({
-        billing_op_id: 'op-cap',
+        billing_op_id: 'op-noerr',
         cancel_at: '2026-06-01T00:00:00Z'
       })
-      const pending = {
-        id: 'op-cap',
-        status: 'pending' as const,
-        started_at: '2026-04-01T00:00:00Z'
-      }
-      mockWorkspaceApi.getBillingOpStatus
-        .mockResolvedValueOnce(pending) // #1, schedules +2000ms
-        .mockResolvedValueOnce(pending) // #2 at t=2000, schedules +4000ms
-        .mockResolvedValueOnce(pending) // #3 at t=6000, schedules capped +5000ms
-        .mockResolvedValueOnce({
-          id: 'op-cap',
-          status: 'succeeded',
-          started_at: '2026-04-01T00:00:00Z'
-        })
-      mockWorkspaceApi.getBillingStatus.mockResolvedValue(activeStatus)
+      mockStartOperation.mockResolvedValue(
+        operation({ status: 'failed', errorMessage: null })
+      )
 
       const billing = setupBilling()
-      await billing.cancelSubscription()
 
-      await vi.advanceTimersByTimeAsync(2000) // fires #2
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(2)
-
-      await vi.advanceTimersByTimeAsync(4000) // fires #3 at t=6000
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(3)
-
-      // After #3 attempt=3, next delay should be capped at 5000ms (not 8000).
-      await vi.advanceTimersByTimeAsync(4999)
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(3)
-      await vi.advanceTimersByTimeAsync(1)
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(4)
+      await expect(billing.cancelSubscription()).rejects.toThrow(
+        'Failed to cancel subscription'
+      )
     })
 
-    it('propagates error before polling when the cancel API itself fails', async () => {
+    it('propagates the error and skips polling when the cancel API fails', async () => {
       mockWorkspaceApi.cancelSubscription.mockRejectedValue(
         new Error('API down')
       )
@@ -543,8 +488,7 @@ describe('useWorkspaceBilling', () => {
 
       await expect(billing.cancelSubscription()).rejects.toThrow('API down')
       expect(billing.error.value).toBe('API down')
-      expect(mockWorkspaceApi.getBillingOpStatus).not.toHaveBeenCalled()
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
+      expect(mockStartOperation).not.toHaveBeenCalled()
     })
 
     it('falls back to a generic error message when cancel rejects with a non-Error', async () => {
@@ -554,71 +498,6 @@ describe('useWorkspaceBilling', () => {
 
       await expect(billing.cancelSubscription()).rejects.toBe('boom')
       expect(billing.error.value).toBe('Failed to cancel subscription')
-    })
-
-    it('stops polling after 30 attempts and refreshes status without marking unsubscribed', async () => {
-      mockWorkspaceApi.cancelSubscription.mockResolvedValue({
-        billing_op_id: 'op-stuck',
-        cancel_at: '2026-06-01T00:00:00Z'
-      })
-      mockWorkspaceApi.getBillingOpStatus.mockResolvedValue({
-        id: 'op-stuck',
-        status: 'pending',
-        started_at: '2026-04-01T00:00:00Z'
-      })
-      mockWorkspaceApi.getBillingStatus.mockResolvedValue(activeStatus)
-
-      const billing = setupBilling()
-      await billing.cancelSubscription()
-
-      // Advance well past all scheduled polls (worst-case ~146s).
-      await vi.advanceTimersByTimeAsync(200_000)
-
-      expect(mockWorkspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(30)
-      expect(mockWorkspaceApi.getBillingStatus).toHaveBeenCalledTimes(1)
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
-    })
-
-    it('stops polling when the host component is unmounted', async () => {
-      mockWorkspaceApi.cancelSubscription.mockResolvedValue({
-        billing_op_id: 'op-dispose',
-        cancel_at: '2026-06-01T00:00:00Z'
-      })
-      mockWorkspaceApi.getBillingOpStatus.mockResolvedValue({
-        id: 'op-dispose',
-        status: 'pending',
-        started_at: '2026-04-01T00:00:00Z'
-      })
-
-      let billing: (BillingState & BillingActions) | undefined
-      const HostComponent = defineComponent({
-        setup() {
-          billing = useWorkspaceBilling()
-          return () => h('div')
-        }
-      })
-      const host = document.createElement('div')
-      const app = createApp(HostComponent)
-      app.mount(host)
-
-      if (!billing) throw new Error('composable not initialized')
-      const cancelPromise = billing.cancelSubscription().catch(() => undefined)
-      await cancelPromise
-
-      // Cross one backoff interval so the second poll is actually scheduled
-      // and then confirm that unmount freezes the counter across subsequent ticks.
-      await vi.advanceTimersByTimeAsync(2000)
-      const callsBeforeUnmount =
-        mockWorkspaceApi.getBillingOpStatus.mock.calls.length
-      expect(callsBeforeUnmount).toBeGreaterThanOrEqual(2)
-
-      app.unmount()
-
-      await vi.advanceTimersByTimeAsync(20_000)
-
-      expect(mockWorkspaceApi.getBillingOpStatus.mock.calls.length).toBe(
-        callsBeforeUnmount
-      )
     })
   })
 
@@ -740,44 +619,5 @@ describe('useWorkspaceBilling', () => {
       expect(mockWorkspaceApi.getBillingStatus).not.toHaveBeenCalled()
       expect(mockWorkspaceApi.getBillingBalance).not.toHaveBeenCalled()
     })
-  })
-
-  describe('pollCancelStatus error paths', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
-    it('uses a default error message when failed status omits error_message', async () => {
-      mockWorkspaceApi.cancelSubscription.mockResolvedValue({
-        billing_op_id: 'op-noerr',
-        cancel_at: '2026-06-01T00:00:00Z'
-      })
-      mockWorkspaceApi.getBillingOpStatus.mockResolvedValue({
-        id: 'op-noerr',
-        status: 'failed',
-        started_at: '2026-04-01T00:00:00Z'
-        // intentionally no error_message
-      })
-
-      const billing = setupBilling()
-
-      await expect(billing.cancelSubscription()).rejects.toThrow(
-        'Failed to cancel subscription'
-      )
-      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
-    })
-
-    // Intentionally NOT covered: a rejection on a later scheduled poll is
-    // emitted from a void-discarded poll() inside setTimeout, so it surfaces
-    // as an unhandled rejection that cancelSubscription has already returned
-    // from. Codifying that as "polling stops cleanly" requires installing a
-    // process unhandledRejection handler to hide the evidence — which would
-    // bless a real bug: the dialog can already show success while the
-    // backing op silently fails. Fix in the source (retry transient poll
-    // failures or surface a pending/error state) before adding coverage here.
   })
 })

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -1,4 +1,4 @@
-import { computed, onBeforeUnmount, ref, shallowRef } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 
 import { useBillingPlans } from '@/platform/cloud/subscription/composables/useBillingPlans'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
@@ -9,7 +9,7 @@ import type {
   SubscribeResponse
 } from '@/platform/workspace/api/workspaceApi'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useBillingOperationStore } from '@/platform/workspace/stores/billingOperationStore'
 
 import type {
   BalanceInfo,
@@ -25,7 +25,7 @@ import type {
  */
 export function useWorkspaceBilling(): BillingState & BillingActions {
   const billingPlans = useBillingPlans()
-  const workspaceStore = useTeamWorkspaceStore()
+  const billingOperationStore = useBillingOperationStore()
 
   const isInitialized = ref(false)
   const isLoading = ref(false)
@@ -74,68 +74,6 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
   const currentPlanSlug = computed(
     () => statusData.value?.plan_slug ?? billingPlans.currentPlanSlug.value
   )
-
-  const pendingCancelOpId = ref<string | null>(null)
-  let cancelPollTimeout: number | null = null
-
-  const stopCancelPolling = () => {
-    if (cancelPollTimeout !== null) {
-      window.clearTimeout(cancelPollTimeout)
-      cancelPollTimeout = null
-    }
-  }
-
-  async function pollCancelStatus(opId: string): Promise<void> {
-    stopCancelPolling()
-
-    const maxAttempts = 30
-    let attempt = 0
-    const poll = async () => {
-      if (pendingCancelOpId.value !== opId) return
-
-      try {
-        const response = await workspaceApi.getBillingOpStatus(opId)
-        if (response.status === 'succeeded') {
-          pendingCancelOpId.value = null
-          stopCancelPolling()
-          await fetchStatus()
-          workspaceStore.updateActiveWorkspace({
-            isSubscribed: false
-          })
-          return
-        }
-
-        if (response.status === 'failed') {
-          pendingCancelOpId.value = null
-          stopCancelPolling()
-          throw new Error(
-            response.error_message ?? 'Failed to cancel subscription'
-          )
-        }
-
-        attempt += 1
-        if (attempt >= maxAttempts) {
-          pendingCancelOpId.value = null
-          stopCancelPolling()
-          await fetchStatus()
-          return
-        }
-      } catch (err) {
-        pendingCancelOpId.value = null
-        stopCancelPolling()
-        throw err
-      }
-
-      cancelPollTimeout = window.setTimeout(
-        () => {
-          void poll()
-        },
-        Math.min(1000 * 2 ** attempt, 5000)
-      )
-    }
-
-    await poll()
-  }
 
   async function initialize(): Promise<void> {
     if (isInitialized.value) return
@@ -251,8 +189,16 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
     error.value = null
     try {
       const response = await workspaceApi.cancelSubscription()
-      pendingCancelOpId.value = response.billing_op_id
-      await pollCancelStatus(response.billing_op_id)
+      const operation = await billingOperationStore.startOperation(
+        response.billing_op_id,
+        'cancel'
+      )
+
+      if (operation.status !== 'succeeded') {
+        throw new Error(
+          operation.errorMessage ?? 'Failed to cancel subscription'
+        )
+      }
     } catch (err) {
       error.value =
         err instanceof Error ? err.message : 'Failed to cancel subscription'
@@ -287,10 +233,6 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
   function showSubscriptionDialog(): void {
     subscriptionDialog.show()
   }
-
-  onBeforeUnmount(() => {
-    stopCancelPolling()
-  })
 
   return {
     // State

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -114,6 +114,27 @@ describe('billingOperationStore', () => {
       expect(store.getOperation('op-1')?.type).toBe('subscription')
     })
 
+    it('returns the in-flight terminal promise for duplicate starts', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const first = store.startOperation('op-1', 'cancel')
+      const second = store.startOperation('op-1', 'cancel')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      const [firstOutcome, secondOutcome] = await Promise.all([first, second])
+      expect(firstOutcome.status).toBe('succeeded')
+      expect(secondOutcome.status).toBe('succeeded')
+
+      const afterTerminal = await store.startOperation('op-1', 'cancel')
+      expect(afterTerminal.status).toBe('succeeded')
+    })
+
     it('shows immediate processing toast for subscription operations', () => {
       vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
         id: 'op-1',
@@ -370,6 +391,23 @@ describe('billingOperationStore', () => {
       expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
         isSubscribed: false
       })
+    })
+
+    it('resolves the terminal outcome even when the post-success refresh fails', async () => {
+      mockFetchStatus.mockRejectedValueOnce(new Error('refresh failed'))
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'cancel')
+
+      await vi.advanceTimersByTimeAsync(0)
+      const operation = await terminal
+
+      expect(operation.status).toBe('succeeded')
     })
 
     it('does not open the settings dialog or toast on cancel success', async () => {

--- a/src/platform/workspace/stores/billingOperationStore.test.ts
+++ b/src/platform/workspace/stores/billingOperationStore.test.ts
@@ -33,9 +33,11 @@ vi.mock('@/i18n', () => ({
   t: (key: string) => key
 }))
 
+const mockSettingsDialogShow = vi.fn()
+
 vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
   useSettingsDialog: () => ({
-    show: vi.fn(),
+    show: mockSettingsDialogShow,
     hide: vi.fn(),
     showAbout: vi.fn()
   })
@@ -52,6 +54,14 @@ const mockTrackMonthlySubscriptionSucceeded = vi.fn()
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackMonthlySubscriptionSucceeded: mockTrackMonthlySubscriptionSucceeded
+  })
+}))
+
+const mockUpdateActiveWorkspace = vi.fn()
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    updateActiveWorkspace: mockUpdateActiveWorkspace
   })
 }))
 
@@ -79,7 +89,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       expect(store.operations.size).toBe(1)
       const operation = store.getOperation('op-1')
@@ -97,8 +107,8 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'topup')
 
       expect(store.operations.size).toBe(1)
       expect(store.getOperation('op-1')?.type).toBe('subscription')
@@ -112,7 +122,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'info',
@@ -129,7 +139,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       expect(mockToastAdd).toHaveBeenCalledWith({
         severity: 'info',
@@ -149,7 +159,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -176,7 +186,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -191,7 +201,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -206,7 +216,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -225,7 +235,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       const receivedToast = mockToastAdd.mock.calls[0][0]
 
@@ -246,7 +256,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -270,7 +280,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -291,7 +301,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -316,7 +326,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       await vi.advanceTimersByTimeAsync(121_000)
       await vi.runAllTimersAsync()
@@ -325,6 +335,97 @@ describe('billingOperationStore', () => {
         severity: 'error',
         summary: 'billingOperation.topupTimeout'
       })
+    })
+  })
+
+  describe('cancel operations', () => {
+    it('does not show a processing toast for cancel operations', () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      void store.startOperation('op-1', 'cancel')
+
+      expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('resolves with the succeeded operation and refreshes status', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'cancel')
+
+      await vi.advanceTimersByTimeAsync(0)
+      const operation = await terminal
+
+      expect(operation.status).toBe('succeeded')
+      expect(mockFetchStatus).toHaveBeenCalled()
+      expect(mockUpdateActiveWorkspace).toHaveBeenCalledWith({
+        isSubscribed: false
+      })
+    })
+
+    it('does not open the settings dialog or toast on cancel success', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'succeeded',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'cancel')
+
+      await vi.advanceTimersByTimeAsync(0)
+      await terminal
+
+      expect(mockSettingsDialogShow).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('resolves with a failed operation and default message, no toast', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'failed',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'cancel')
+
+      await vi.advanceTimersByTimeAsync(0)
+      const operation = await terminal
+
+      expect(operation.status).toBe('failed')
+      expect(operation.errorMessage).toBe('billingOperation.cancelFailed')
+      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
+    })
+
+    it('resolves with a timeout operation after 2 minutes, no toast', async () => {
+      vi.mocked(workspaceApi.getBillingOpStatus).mockResolvedValue({
+        id: 'op-1',
+        status: 'pending',
+        started_at: new Date().toISOString()
+      })
+
+      const store = useBillingOperationStore()
+      const terminal = store.startOperation('op-1', 'cancel')
+
+      await vi.advanceTimersByTimeAsync(121_000)
+      await vi.runAllTimersAsync()
+      const operation = await terminal
+
+      expect(operation.status).toBe('timeout')
+      expect(operation.errorMessage).toBe('billingOperation.cancelTimeout')
+      expect(mockUpdateActiveWorkspace).not.toHaveBeenCalled()
+      expect(mockToastAdd).not.toHaveBeenCalled()
     })
   })
 
@@ -337,7 +438,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
       expect(workspaceApi.getBillingOpStatus).toHaveBeenCalledTimes(1)
@@ -357,7 +458,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(60_000)
 
@@ -384,7 +485,7 @@ describe('billingOperationStore', () => {
         } satisfies BillingOpStatusResponse)
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
       expect(store.getOperation('op-1')?.status).toBe('pending')
@@ -406,7 +507,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -430,8 +531,8 @@ describe('billingOperationStore', () => {
       )
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
-      store.startOperation('op-2', 'topup')
+      void store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-2', 'topup')
 
       expect(store.operations.size).toBe(2)
       expect(store.hasPendingOperations).toBe(true)
@@ -462,7 +563,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       expect(store.isSettingUp).toBe(true)
     })
@@ -475,7 +576,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -490,7 +591,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       expect(store.isSettingUp).toBe(false)
     })
@@ -505,7 +606,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       expect(store.isAddingCredits).toBe(true)
     })
@@ -518,7 +619,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'topup')
+      void store.startOperation('op-1', 'topup')
 
       await vi.advanceTimersByTimeAsync(0)
 
@@ -533,7 +634,7 @@ describe('billingOperationStore', () => {
       })
 
       const store = useBillingOperationStore()
-      store.startOperation('op-1', 'subscription')
+      void store.startOperation('op-1', 'subscription')
 
       expect(store.isAddingCredits).toBe(false)
     })

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -35,6 +35,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
   const intervals = new Map<string, number>()
   const receivedToasts = new Map<string, ToastMessageOptions>()
   const terminalResolvers = new Map<string, TerminalResolver>()
+  const terminalPromises = new Map<string, Promise<BillingOperation>>()
 
   const hasPendingOperations = computed(() =>
     [...operations.value.values()].some((op) => op.status === 'pending')
@@ -61,7 +62,9 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     type: OperationType
   ): Promise<BillingOperation> {
     const existing = operations.value.get(opId)
-    if (existing) return Promise.resolve(existing)
+    if (existing) {
+      return terminalPromises.get(opId) ?? Promise.resolve(existing)
+    }
 
     const operation: BillingOperation = {
       opId,
@@ -92,6 +95,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const terminal = new Promise<BillingOperation>((resolve) => {
       terminalResolvers.set(opId, resolve)
     })
+    terminalPromises.set(opId, terminal)
 
     void poll(opId)
 
@@ -154,7 +158,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     }
 
     const billingContext = useBillingContext()
-    await Promise.all([
+    await Promise.allSettled([
       billingContext.fetchStatus(),
       billingContext.fetchBalance()
     ])
@@ -244,6 +248,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       resolve(operation)
     }
     terminalResolvers.delete(opId)
+    terminalPromises.delete(opId)
   }
 
   function updateOperationStatus(
@@ -280,6 +285,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     newMap.delete(opId)
     operations.value = newMap
     terminalResolvers.delete(opId)
+    terminalPromises.delete(opId)
   }
 
   return {

--- a/src/platform/workspace/stores/billingOperationStore.ts
+++ b/src/platform/workspace/stores/billingOperationStore.ts
@@ -4,10 +4,11 @@ import { computed, ref } from 'vue'
 
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { t } from '@/i18n'
+import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
 import { useTelemetry } from '@/platform/telemetry'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
-import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogStore } from '@/stores/dialogStore'
 
 const INITIAL_INTERVAL_MS = 1000
@@ -15,7 +16,7 @@ const MAX_INTERVAL_MS = 8000
 const BACKOFF_MULTIPLIER = 1.5
 const TIMEOUT_MS = 120_000 // 2 minutes
 
-type OperationType = 'subscription' | 'topup'
+type OperationType = 'subscription' | 'topup' | 'cancel'
 type OperationStatus = 'pending' | 'succeeded' | 'failed' | 'timeout'
 
 interface BillingOperation {
@@ -26,11 +27,14 @@ interface BillingOperation {
   startedAt: number
 }
 
+type TerminalResolver = (operation: BillingOperation) => void
+
 export const useBillingOperationStore = defineStore('billingOperation', () => {
   const operations = ref<Map<string, BillingOperation>>(new Map())
   const timeouts = new Map<string, ReturnType<typeof setTimeout>>()
   const intervals = new Map<string, number>()
   const receivedToasts = new Map<string, ToastMessageOptions>()
+  const terminalResolvers = new Map<string, TerminalResolver>()
 
   const hasPendingOperations = computed(() =>
     [...operations.value.values()].some((op) => op.status === 'pending')
@@ -52,8 +56,12 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     return operations.value.get(opId)
   }
 
-  function startOperation(opId: string, type: OperationType) {
-    if (operations.value.has(opId)) return
+  function startOperation(
+    opId: string,
+    type: OperationType
+  ): Promise<BillingOperation> {
+    const existing = operations.value.get(opId)
+    if (existing) return Promise.resolve(existing)
 
     const operation: BillingOperation = {
       opId,
@@ -66,21 +74,28 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     operations.value = new Map(operations.value).set(opId, operation)
     intervals.set(opId, INITIAL_INTERVAL_MS)
 
-    // Show immediate feedback toast (persists until operation completes)
-    const messageKey =
-      type === 'subscription'
-        ? 'billingOperation.subscriptionProcessing'
-        : 'billingOperation.topupProcessing'
+    if (type !== 'cancel') {
+      const messageKey =
+        type === 'subscription'
+          ? 'billingOperation.subscriptionProcessing'
+          : 'billingOperation.topupProcessing'
 
-    const toastMessage: ToastMessageOptions = {
-      severity: 'info',
-      summary: t(messageKey),
-      group: 'billing-operation'
+      const toastMessage: ToastMessageOptions = {
+        severity: 'info',
+        summary: t(messageKey),
+        group: 'billing-operation'
+      }
+      receivedToasts.set(opId, toastMessage)
+      useToastStore().add(toastMessage)
     }
-    receivedToasts.set(opId, toastMessage)
-    useToastStore().add(toastMessage)
+
+    const terminal = new Promise<BillingOperation>((resolve) => {
+      terminalResolvers.set(opId, resolve)
+    })
 
     void poll(opId)
+
+    return terminal
   }
 
   async function poll(opId: string) {
@@ -144,7 +159,12 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       billingContext.fetchBalance()
     ])
 
-    // Close any open billing dialogs and show settings
+    if (operation.type === 'cancel') {
+      useTeamWorkspaceStore().updateActiveWorkspace({ isSubscribed: false })
+      resolveTerminal(opId)
+      return
+    }
+
     const dialogStore = useDialogStore()
     dialogStore.closeDialog({ key: 'subscription-required' })
     dialogStore.closeDialog({ key: 'top-up-credits' })
@@ -161,43 +181,69 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
       summary: t(messageKey),
       life: 5000
     })
+
+    resolveTerminal(opId)
   }
 
   function handleFailure(opId: string, errorMessage: string | null) {
     const operation = operations.value.get(opId)
     if (!operation) return
 
-    const defaultMessage =
-      operation.type === 'subscription'
-        ? t('billingOperation.subscriptionFailed')
-        : t('billingOperation.topupFailed')
+    const defaultMessage = failureMessage(operation.type)
 
     updateOperationStatus(opId, 'failed', errorMessage ?? defaultMessage)
     cleanup(opId)
 
-    useToastStore().add({
-      severity: 'error',
-      summary: defaultMessage,
-      detail: errorMessage ?? undefined
-    })
+    if (operation.type !== 'cancel') {
+      useToastStore().add({
+        severity: 'error',
+        summary: defaultMessage,
+        detail: errorMessage ?? undefined
+      })
+    }
+
+    resolveTerminal(opId)
   }
 
   function handleTimeout(opId: string) {
     const operation = operations.value.get(opId)
     if (!operation) return
 
-    const message =
-      operation.type === 'subscription'
-        ? t('billingOperation.subscriptionTimeout')
-        : t('billingOperation.topupTimeout')
+    const message = timeoutMessage(operation.type)
 
     updateOperationStatus(opId, 'timeout', message)
     cleanup(opId)
 
-    useToastStore().add({
-      severity: 'error',
-      summary: message
-    })
+    if (operation.type !== 'cancel') {
+      useToastStore().add({
+        severity: 'error',
+        summary: message
+      })
+    }
+
+    resolveTerminal(opId)
+  }
+
+  function failureMessage(type: OperationType) {
+    if (type === 'subscription') return t('billingOperation.subscriptionFailed')
+    if (type === 'topup') return t('billingOperation.topupFailed')
+    return t('billingOperation.cancelFailed')
+  }
+
+  function timeoutMessage(type: OperationType) {
+    if (type === 'subscription')
+      return t('billingOperation.subscriptionTimeout')
+    if (type === 'topup') return t('billingOperation.topupTimeout')
+    return t('billingOperation.cancelTimeout')
+  }
+
+  function resolveTerminal(opId: string) {
+    const resolve = terminalResolvers.get(opId)
+    const operation = operations.value.get(opId)
+    if (resolve && operation) {
+      resolve(operation)
+    }
+    terminalResolvers.delete(opId)
   }
 
   function updateOperationStatus(
@@ -233,6 +279,7 @@ export const useBillingOperationStore = defineStore('billingOperation', () => {
     const newMap = new Map(operations.value)
     newMap.delete(opId)
     operations.value = newMap
+    terminalResolvers.delete(opId)
   }
 
   return {


### PR DESCRIPTION
## Motivation

- **Why B8 exists**: two divergent BillingOp pollers poll the same op-status endpoint with different policies (hand-rolled 2× / 5s cap / 30 attempts vs the store's 1.5× / 8s / 120s). Once B1 (FE-966) routes personal flows through the facade, a single cancel op would be polled by **both** — duplicate requests, with two timeout policies racing on the same state.
- **The latent bug — silent failure on a money path**: the bespoke poller treated timeout as a silent return, so `cancelSubscription` resolved and the dialog showed "cancelled successfully" while the backend op could still be pending or fail later. The root cause is structural: the poll outcome was fire-and-forget — no caller consumed it, so there was no channel through which a failure could surface.
- **The fix — outcome as an awaited contract**: `startOperation` returns the terminal outcome as a `Promise<BillingOperation>`; `cancelSubscription` awaits it and throws on any non-`succeeded` terminal. Every outcome must now flow through the caller, making silence structurally impossible (timeout/failure → error toast).
- **The trade-off this creates**: "the terminal promise always settles" becomes load-bearing — the dialog's loading state hangs on it, and a never-settling path would be worse than the old silence (a permanently locked dialog). The terminal-promise hardening below, and its regression tests, enforce that guarantee.

## Summary

Two divergent BillingOp pollers (hand-rolled `useWorkspaceBilling.pollCancelStatus` vs `billingOperationStore`) are unified into one — cancel-status polling now runs through `billingOperationStore`; `pollCancelStatus` and its bespoke backoff/timers/state are removed.

## Changes

- **What**: `billingOperationStore` gains `'cancel'` in `OperationType`; `startOperation` now returns `Promise<BillingOperation>` resolving on the terminal outcome (existing subscription / topup callers unaffected — fire-and-forget preserved). `useWorkspaceBilling.cancelSubscription` awaits the shared poller and throws on any non-`succeeded` terminal. One backoff config = store's 1.5× / 8s / 120s.
- **Terminal-promise hardening**: the terminal promise always settles — a rejected post-success status/balance refresh no longer leaves `cancelSubscription` hanging with the dialog locked open (`Promise.allSettled`), and a duplicate `startOperation` for an in-flight op joins the same terminal promise instead of resolving instantly with a `pending` snapshot (which the cancel path would read as failure).
- **Breaking**: none — the `cancelSubscription(): Promise<void>` contract is unchanged for `CancelSubscriptionDialogContent` / `useBillingContext`.

## Review Focus

- **Intentional behavior change**: a cancel **timeout** is now a terminal outcome that **throws** (`billingOperation.cancelTimeout`), so the dialog surfaces an error toast — instead of the old silent success-ish return (which could show success while the op was still pending). Success / failure semantics otherwise preserved (success → status refresh + `isSubscribed: false`; failure → throw with message).
- FE-only refactor (B8); cleanest after FE-904 but independent of it. Relates FE-932 (shared status-refresh path).

## Tests

90 unit tests green across the four affected suites (fake timers for all polling):

- **`billingOperationStore.test.ts` (33)** — cancel terminal outcomes (succeeded / failed / timeout) resolve the awaited promise with the right status + i18n message; cancel suppresses the store's toasts and settings-dialog side effects; success refreshes status/balance and sets `isSubscribed: false`; backoff progression, 8s cap, 2-min timeout; transient poll errors keep polling. Regression guards for the hardening: post-success refresh failure still settles the terminal promise (reproduced as a hang before the fix), and a duplicate `startOperation` joins the in-flight terminal promise instead of resolving with a `pending` snapshot.
- **`useWorkspaceBilling.test.ts`** — `cancelSubscription` drives the shared poller; throws the op error on `failed`, throws on `timeout`, falls back to a generic message when `errorMessage` is absent; a failing cancel API propagates without starting the poller.
- **`CancelSubscriptionDialogContent.test.ts` (8)** — locks the dialog half of the behavior change: a rejected `cancelSubscription` shows an error toast and keeps the dialog open; success closes the dialog with a success toast.
- **`useSubscriptionCheckout.test.ts`** — unchanged, confirms fire-and-forget callers are unaffected.

Both hardening regressions were proven red→green locally: before the fix the terminal-hang test timed out at 5s and the duplicate-start test resolved `pending`. Gates: vue-tsc / oxlint type-aware / eslint / oxfmt clean; full CI green including all Playwright shards and the cloud project. The existing `cancelSubscriptionDialog.spec.ts` e2e (@ui, open/close/escape flows) is unchanged and green; cloud-backend e2e for billing flows is tracked separately in FE-991.

Fixes FE-970
