### PR TITLE
feat: add switch node to essentials

### DIFF
--- a/src/constants/essentialsDisplayNames.test.ts
+++ b/src/constants/essentialsDisplayNames.test.ts
@@ -12,6 +12,7 @@ describe('resolveEssentialsDisplayName', () => {
       ['LoadImage', 'essentials.loadImage'],
       ['SaveImage', 'essentials.saveImage'],
       ['PrimitiveStringMultiline', 'essentials.text'],
+      ['ComfySwitchNode', 'essentials.switch'],
       ['ImageScale', 'essentials.resizeImage'],
       ['LoraLoader', 'essentials.loadStyleLora'],
       ['OpenAIChatNode', 'essentials.textGenerationLLM'],

--- a/src/constants/essentialsDisplayNames.ts
+++ b/src/constants/essentialsDisplayNames.ts
@@ -16,6 +16,7 @@ const EXACT_NAME_MAP: Record<string, string> = {
   Load3D: 'essentials.load3DModel',
   SaveGLB: 'essentials.save3DModel',
   PrimitiveStringMultiline: 'essentials.text',
+  ComfySwitchNode: 'essentials.switch',
 
   // Image Tools
   BatchImagesNode: 'essentials.batchImage',

--- a/src/constants/essentialsNodes.ts
+++ b/src/constants/essentialsNodes.ts
@@ -15,7 +15,7 @@ export const ESSENTIALS_ICON_OVERRIDES: Record<string, string> = {
   VideoCrop: 'icon-s1.3-[lucide--crop]',
   KlingLipSyncAudioToVideoNode: 'icon-s1.3-[lucide--mic-vocal]',
   WebcamCapture: 'icon-s1.3-[lucide--camera]',
-  ComfySwitchNode: 'icon-s1.3-[lucide--toggle-left]'
+  ComfySwitchNode: 'icon-s1.3-[lucide--merge]'
 }
 
 export const ESSENTIALS_CATEGORIES = [

--- a/src/constants/essentialsNodes.ts
+++ b/src/constants/essentialsNodes.ts
@@ -14,7 +14,8 @@ export const ESSENTIALS_ICON_OVERRIDES: Record<string, string> = {
   ImageCrop: 'icon-s1.3-[lucide--crop]',
   VideoCrop: 'icon-s1.3-[lucide--crop]',
   KlingLipSyncAudioToVideoNode: 'icon-s1.3-[lucide--mic-vocal]',
-  WebcamCapture: 'icon-s1.3-[lucide--camera]'
+  WebcamCapture: 'icon-s1.3-[lucide--camera]',
+  ComfySwitchNode: 'icon-s1.3-[lucide--toggle-left]'
 }
 
 export const ESSENTIALS_CATEGORIES = [
@@ -44,7 +45,8 @@ export const ESSENTIALS_NODES: Record<EssentialsCategory, readonly string[]> = {
     'SaveVideo',
     'SaveGLB',
     'PrimitiveStringMultiline',
-    'PreviewImage'
+    'PreviewImage',
+    'ComfySwitchNode'
   ],
   'text generation': ['OpenAIChatNode'],
   'image generation': [

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -4170,6 +4170,7 @@
     "load3DModel": "Load 3D model",
     "save3DModel": "Save 3D Model",
     "text": "Text",
+    "switch": "Switch",
     "batchImage": "Batch Image",
     "cropImage": "Crop Image",
     "resizeImage": "Resize Image",


### PR DESCRIPTION
## Summary

The volume of usage of the Switch node in workflows suggests it's a fundamental building block worth surfacing more prominently.

## Changes

- **What**: 
- Add the Switch node to the Essentials tab so users can discover it more easily.

## Screenshots (if applicable)

<img width="533" height="332" alt="icon merge" src="https://github.com/user-attachments/assets/b84087a9-baab-475a-a9ad-50057355e058" />
