### PR TITLE
Add Desktop telemetry event sink

### DIFF
--- a/src/composables/useAppMode.ts
+++ b/src/composables/useAppMode.ts
@@ -4,6 +4,9 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
 import type { AppMode } from '@/utils/appMode'
 
+export { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
+export type { AppMode } from '@/utils/appMode'
+
 const enableAppBuilder = ref(true)
 
 export function useAppMode() {

--- a/src/composables/useAppMode.ts
+++ b/src/composables/useAppMode.ts
@@ -4,9 +4,6 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
 import type { AppMode } from '@/utils/appMode'
 
-export { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
-export type { AppMode } from '@/utils/appMode'
-
 const enableAppBuilder = ref(true)
 
 export function useAppMode() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,19 +31,25 @@ import App from './App.vue'
 import './assets/css/style.css'
 import { i18n } from './i18n'
 
-/**
- * CRITICAL: Load remote config FIRST for cloud builds to ensure
- * window.__CONFIG__is available for all modules during initialization
- */
 const isCloud = __DISTRIBUTION__ === 'cloud'
+const hasHostTelemetryBridge = Boolean(window.__comfyDesktop2?.Telemetry)
+const requiresRemoteConfigBootstrap = isCloud || hasHostTelemetryBridge
 
-if (isCloud) {
+if (requiresRemoteConfigBootstrap) {
   const { refreshRemoteConfig } =
     await import('@/platform/remoteConfig/refreshRemoteConfig')
   await refreshRemoteConfig({ useAuth: false })
+}
 
+if (isCloud) {
   const { initTelemetry } = await import('@/platform/telemetry/initTelemetry')
   await initTelemetry()
+}
+
+if (hasHostTelemetryBridge) {
+  const { initHostTelemetry } =
+    await import('@/platform/telemetry/initHostTelemetry')
+  initHostTelemetry()
 }
 
 const ComfyUIPreset = definePreset(Aura, {

--- a/src/platform/remoteConfig/refreshRemoteConfig.ts
+++ b/src/platform/remoteConfig/refreshRemoteConfig.ts
@@ -1,5 +1,3 @@
-import { api } from '@/scripts/api'
-
 import {
   cachedTeamWorkspacesEnabled,
   remoteConfig,
@@ -12,6 +10,13 @@ interface RefreshRemoteConfigOptions {
    * Set to false during bootstrap before auth is initialized.
    */
   useAuth?: boolean
+}
+
+async function fetchRemoteConfig(useAuth: boolean): Promise<Response> {
+  if (!useAuth) return fetch('/api/features', { cache: 'no-store' })
+
+  const { api } = await import('@/scripts/api')
+  return api.fetchApi('/features', { cache: 'no-store' })
 }
 
 /**
@@ -29,9 +34,7 @@ export async function refreshRemoteConfig(
   const { useAuth = true } = options
 
   try {
-    const response = useAuth
-      ? await api.fetchApi('/features', { cache: 'no-store' })
-      : await fetch('/api/features', { cache: 'no-store' })
+    const response = await fetchRemoteConfig(useAuth)
 
     if (response.ok) {
       const config = await response.json()

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -94,6 +94,7 @@ export type RemoteConfig = {
   comfy_platform_base_url?: string
   firebase_config?: FirebaseRuntimeConfig
   telemetry_disabled_events?: TelemetryEventName[]
+  enable_telemetry?: boolean
   model_upload_button_enabled?: boolean
   asset_rename_enabled?: boolean
   private_models_enabled?: boolean

--- a/src/platform/telemetry/initHostTelemetry.test.ts
+++ b/src/platform/telemetry/initHostTelemetry.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { setTelemetryRegistry, useTelemetry } from '@/platform/telemetry'
+import { initHostTelemetry } from '@/platform/telemetry/initHostTelemetry'
+import { TelemetryEvents } from '@/platform/telemetry/types'
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+describe('initHostTelemetry', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    remoteConfig.value = {}
+    setTelemetryRegistry(null)
+    localStorage.clear()
+    delete window.__comfyDesktop2
+  })
+
+  it('leaves the registry untouched when enable_telemetry is on but the host Telemetry bridge is absent', () => {
+    remoteConfig.value = { enable_telemetry: true }
+
+    initHostTelemetry()
+
+    expect(useTelemetry()).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves the registry untouched when enable_telemetry is off', () => {
+    window.__comfyDesktop2 = {
+      isRemote: () => false,
+      Telemetry: { capture: vi.fn() }
+    }
+    remoteConfig.value = { enable_telemetry: false }
+
+    initHostTelemetry()
+
+    expect(useTelemetry()).toBeNull()
+  })
+
+  it('registers the host telemetry sink when enable_telemetry and the bridge are present', () => {
+    const capture = vi.fn()
+    window.__comfyDesktop2 = { isRemote: () => false, Telemetry: { capture } }
+    remoteConfig.value = { enable_telemetry: true }
+
+    initHostTelemetry()
+    useTelemetry()?.trackSignupOpened()
+
+    expect(capture).toHaveBeenCalledWith(
+      TelemetryEvents.USER_SIGN_UP_OPENED,
+      undefined
+    )
+  })
+})

--- a/src/platform/telemetry/initHostTelemetry.ts
+++ b/src/platform/telemetry/initHostTelemetry.ts
@@ -1,0 +1,23 @@
+import { setTelemetryRegistry } from './index'
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { getDevOverride } from '@/utils/devFeatureFlagOverride'
+import { TelemetryRegistry } from './TelemetryRegistry'
+import { HostTelemetrySink } from './providers/host/HostTelemetrySink'
+
+const ENABLE_TELEMETRY_FEATURE = 'enable_telemetry'
+
+function isHostTelemetryEnabled(): boolean {
+  const override = getDevOverride<boolean>(ENABLE_TELEMETRY_FEATURE)
+  if (override !== undefined) return override
+
+  return remoteConfig.value.enable_telemetry === true
+}
+
+export function initHostTelemetry(): void {
+  if (!isHostTelemetryEnabled()) return
+  if (!window.__comfyDesktop2?.Telemetry) return
+
+  const registry = new TelemetryRegistry()
+  registry.registerProvider(new HostTelemetrySink())
+  setTelemetryRegistry(registry)
+}

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -29,6 +29,7 @@ import type {
   WorkflowImportMetadata,
   WorkflowSavedMetadata
 } from '../../types'
+import { TelemetryEvents } from '../../types'
 
 /**
  * Google Tag Manager telemetry provider.
@@ -152,7 +153,7 @@ export class GtmTelemetryProvider implements TelemetryProvider {
   }
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {
-    this.pushEvent('begin_checkout', metadata)
+    this.pushEvent(TelemetryEvents.BEGIN_CHECKOUT, metadata)
   }
 
   trackSubscription(

--- a/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TelemetryEvents } from '@/platform/telemetry/types'
+
+import { HostTelemetrySink } from './HostTelemetrySink'
+
+const state = vi.hoisted(() => ({
+  capture: vi.fn()
+}))
+
+describe('HostTelemetrySink', () => {
+  beforeEach(() => {
+    state.capture.mockClear()
+    window.__comfyDesktop2 = {
+      isRemote: () => false,
+      Telemetry: {
+        capture: state.capture
+      }
+    }
+  })
+
+  afterEach(() => {
+    delete window.__comfyDesktop2
+  })
+
+  it('forwards run button telemetry to the host bridge', () => {
+    new HostTelemetrySink().trackRunButton({
+      subscribe_to_run: true,
+      workflow_type: 'custom',
+      workflow_name: 'Host workflow',
+      custom_node_count: 2,
+      total_node_count: 4,
+      subgraph_count: 1,
+      has_api_nodes: true,
+      api_node_names: ['LoadImage'],
+      has_toolkit_nodes: false,
+      toolkit_node_names: [],
+      trigger_source: 'button',
+      view_mode: 'graph',
+      is_app_mode: false,
+      dock_state: 'docked'
+    })
+
+    expect(state.capture).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.RUN_BUTTON_CLICKED,
+      {
+        subscribe_to_run: true,
+        workflow_type: 'custom',
+        workflow_name: 'Host workflow',
+        custom_node_count: 2,
+        total_node_count: 4,
+        subgraph_count: 1,
+        has_api_nodes: true,
+        api_node_names: ['LoadImage'],
+        has_toolkit_nodes: false,
+        toolkit_node_names: [],
+        trigger_source: 'button',
+        view_mode: 'graph',
+        is_app_mode: false,
+        dock_state: 'docked'
+      }
+    )
+  })
+
+  it('keeps primitive arrays and drops nested payloads', () => {
+    new HostTelemetrySink().trackWorkflowImported({
+      missing_node_count: 2,
+      missing_node_types: ['MissingA', 'MissingB'],
+      missing_node_packs: [
+        {
+          pack_id: 'pack',
+          node_types: ['MissingA']
+        }
+      ],
+      open_source: 'file_drop',
+      share_id: 'share-id'
+    })
+
+    expect(state.capture).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.WORKFLOW_IMPORTED,
+      {
+        missing_node_count: 2,
+        missing_node_types: ['MissingA', 'MissingB'],
+        open_source: 'file_drop',
+        share_id: 'share-id'
+      }
+    )
+  })
+
+  it('forwards begin checkout using the existing GA4 event name', () => {
+    new HostTelemetrySink().trackBeginCheckout({
+      user_id: 'user-id',
+      tier: 'pro',
+      cycle: 'monthly',
+      checkout_type: 'new',
+      ecommerce: {
+        items: [
+          {
+            item_name: 'Pro',
+            price: 100,
+            quantity: 1
+          }
+        ]
+      }
+    })
+
+    expect(state.capture).toHaveBeenCalledExactlyOnceWith(
+      TelemetryEvents.BEGIN_CHECKOUT,
+      {
+        user_id: 'user-id',
+        tier: 'pro',
+        cycle: 'monthly',
+        checkout_type: 'new'
+      }
+    )
+  })
+
+  it('does nothing when the host bridge is absent', () => {
+    delete window.__comfyDesktop2
+
+    expect(() =>
+      new HostTelemetrySink().trackNodeSearch({ query: 'k sampler' })
+    ).not.toThrow()
+    expect(state.capture).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/telemetry/providers/host/HostTelemetrySink.ts
+++ b/src/platform/telemetry/providers/host/HostTelemetrySink.ts
@@ -1,0 +1,295 @@
+import type {
+  ComfyDesktop2TelemetryBridge,
+  ComfyDesktop2TelemetryValue
+} from '@comfyorg/comfyui-desktop-bridge-types'
+import {
+  checkForCompletedTopup as checkTopupUtil,
+  clearTopupTracking as clearTopupUtil,
+  startTopupTracking as startTopupUtil
+} from '@/platform/telemetry/topupTracker'
+import type { AuditLog } from '@/services/customerEventsService'
+
+import type {
+  AuthMetadata,
+  BeginCheckoutMetadata,
+  DefaultViewSetMetadata,
+  EnterLinearMetadata,
+  ExecutionErrorMetadata,
+  ExecutionSuccessMetadata,
+  HelpCenterClosedMetadata,
+  HelpCenterOpenedMetadata,
+  HelpResourceClickedMetadata,
+  NodeAddedMetadata,
+  NodeSearchMetadata,
+  NodeSearchResultMetadata,
+  PageViewMetadata,
+  PageVisibilityMetadata,
+  RunButtonProperties,
+  SearchQueryMetadata,
+  SettingChangedMetadata,
+  ShareFlowMetadata,
+  ShareLinkOpenedMetadata,
+  SharedWorkflowRunMetadata,
+  SubscriptionMetadata,
+  SubscriptionSuccessMetadata,
+  SurveyResponses,
+  TabCountMetadata,
+  TelemetryEventName,
+  TelemetryProvider,
+  TemplateFilterMetadata,
+  TemplateLibraryClosedMetadata,
+  TemplateLibraryMetadata,
+  TemplateMetadata,
+  UiButtonClickMetadata,
+  WorkflowCreatedMetadata,
+  WorkflowImportMetadata,
+  WorkflowSavedMetadata
+} from '../../types'
+import { TelemetryEvents } from '../../types'
+import { normalizeSurveyResponses } from '../../utils/surveyNormalization'
+
+type HostTelemetryProperties = Parameters<
+  ComfyDesktop2TelemetryBridge['capture']
+>[1]
+
+function isHostTelemetryPrimitive(
+  value: unknown
+): value is ComfyDesktop2TelemetryValue {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+function toHostTelemetryProperties(
+  properties?: object
+): HostTelemetryProperties {
+  if (!properties) return undefined
+
+  const out: NonNullable<HostTelemetryProperties> = {}
+  for (const [key, value] of Object.entries(properties)) {
+    if (isHostTelemetryPrimitive(value)) {
+      out[key] = value
+    } else if (Array.isArray(value) && value.every(isHostTelemetryPrimitive)) {
+      out[key] = value
+    }
+  }
+
+  return out
+}
+
+export class HostTelemetrySink implements TelemetryProvider {
+  private capture(event: TelemetryEventName, properties?: object): void {
+    window.__comfyDesktop2?.Telemetry?.capture(
+      event,
+      toHostTelemetryProperties(properties)
+    )
+  }
+
+  trackSignupOpened(): void {
+    this.capture(TelemetryEvents.USER_SIGN_UP_OPENED)
+  }
+
+  trackAuth(metadata: AuthMetadata): void {
+    this.capture(TelemetryEvents.USER_AUTH_COMPLETED, metadata)
+  }
+
+  trackUserLoggedIn(): void {
+    this.capture(TelemetryEvents.USER_LOGGED_IN)
+  }
+
+  trackSubscription(
+    event: 'modal_opened' | 'subscribe_clicked',
+    metadata?: SubscriptionMetadata
+  ): void {
+    this.capture(
+      event === 'modal_opened'
+        ? TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED
+        : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED,
+      metadata
+    )
+  }
+
+  trackBeginCheckout(metadata: BeginCheckoutMetadata): void {
+    this.capture(TelemetryEvents.BEGIN_CHECKOUT, metadata)
+  }
+
+  trackMonthlySubscriptionSucceeded(
+    metadata?: SubscriptionSuccessMetadata
+  ): void {
+    this.capture(TelemetryEvents.MONTHLY_SUBSCRIPTION_SUCCEEDED, metadata)
+  }
+
+  trackMonthlySubscriptionCancelled(): void {
+    this.capture(TelemetryEvents.MONTHLY_SUBSCRIPTION_CANCELLED)
+  }
+
+  trackAddApiCreditButtonClicked(): void {
+    this.capture(TelemetryEvents.ADD_API_CREDIT_BUTTON_CLICKED)
+  }
+
+  trackApiCreditTopupButtonPurchaseClicked(amount: number): void {
+    this.capture(TelemetryEvents.API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED, {
+      credit_amount: amount
+    })
+  }
+
+  trackApiCreditTopupSucceeded(): void {
+    this.capture(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED)
+  }
+
+  trackRunButton(properties: RunButtonProperties): void {
+    this.capture(TelemetryEvents.RUN_BUTTON_CLICKED, properties)
+  }
+
+  startTopupTracking(): void {
+    startTopupUtil()
+  }
+
+  checkForCompletedTopup(events: AuditLog[] | undefined | null): boolean {
+    return checkTopupUtil(events)
+  }
+
+  clearTopupTracking(): void {
+    clearTopupUtil()
+  }
+
+  trackSurvey(
+    stage: 'opened' | 'submitted',
+    responses?: SurveyResponses
+  ): void {
+    this.capture(
+      stage === 'opened'
+        ? TelemetryEvents.USER_SURVEY_OPENED
+        : TelemetryEvents.USER_SURVEY_SUBMITTED,
+      responses ? normalizeSurveyResponses(responses) : undefined
+    )
+  }
+
+  trackEmailVerification(stage: 'opened' | 'requested' | 'completed'): void {
+    const event =
+      stage === 'opened'
+        ? TelemetryEvents.USER_EMAIL_VERIFY_OPENED
+        : stage === 'requested'
+          ? TelemetryEvents.USER_EMAIL_VERIFY_REQUESTED
+          : TelemetryEvents.USER_EMAIL_VERIFY_COMPLETED
+    this.capture(event)
+  }
+
+  trackTemplate(metadata: TemplateMetadata): void {
+    this.capture(TelemetryEvents.TEMPLATE_WORKFLOW_OPENED, metadata)
+  }
+
+  trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void {
+    this.capture(TelemetryEvents.TEMPLATE_LIBRARY_OPENED, metadata)
+  }
+
+  trackTemplateLibraryClosed(metadata: TemplateLibraryClosedMetadata): void {
+    this.capture(TelemetryEvents.TEMPLATE_LIBRARY_CLOSED, metadata)
+  }
+
+  trackWorkflowImported(metadata: WorkflowImportMetadata): void {
+    this.capture(TelemetryEvents.WORKFLOW_IMPORTED, metadata)
+  }
+
+  trackWorkflowOpened(metadata: WorkflowImportMetadata): void {
+    this.capture(TelemetryEvents.WORKFLOW_OPENED, metadata)
+  }
+
+  trackWorkflowSaved(metadata: WorkflowSavedMetadata): void {
+    this.capture(TelemetryEvents.WORKFLOW_SAVED, metadata)
+  }
+
+  trackDefaultViewSet(metadata: DefaultViewSetMetadata): void {
+    this.capture(TelemetryEvents.DEFAULT_VIEW_SET, metadata)
+  }
+
+  trackEnterLinear(metadata: EnterLinearMetadata): void {
+    this.capture(TelemetryEvents.ENTER_LINEAR_MODE, metadata)
+  }
+
+  trackShareFlow(metadata: ShareFlowMetadata): void {
+    this.capture(TelemetryEvents.SHARE_FLOW, metadata)
+  }
+
+  trackShareLinkOpened(metadata: ShareLinkOpenedMetadata): void {
+    this.capture(TelemetryEvents.SHARE_LINK_OPENED, metadata)
+  }
+
+  trackPageVisibilityChanged(metadata: PageVisibilityMetadata): void {
+    this.capture(TelemetryEvents.PAGE_VISIBILITY_CHANGED, metadata)
+  }
+
+  trackTabCount(metadata: TabCountMetadata): void {
+    this.capture(TelemetryEvents.TAB_COUNT_TRACKING, metadata)
+  }
+
+  trackNodeSearch(metadata: NodeSearchMetadata): void {
+    this.capture(TelemetryEvents.NODE_SEARCH, metadata)
+  }
+
+  trackNodeSearchResultSelected(metadata: NodeSearchResultMetadata): void {
+    this.capture(TelemetryEvents.NODE_SEARCH_RESULT_SELECTED, metadata)
+  }
+
+  trackSearchQuery(metadata: SearchQueryMetadata): void {
+    this.capture(TelemetryEvents.SEARCH_QUERY, metadata)
+  }
+
+  trackNodeAdded(metadata: NodeAddedMetadata): void {
+    this.capture(TelemetryEvents.NODE_ADDED, metadata)
+  }
+
+  trackTemplateFilterChanged(metadata: TemplateFilterMetadata): void {
+    this.capture(TelemetryEvents.TEMPLATE_FILTER_CHANGED, metadata)
+  }
+
+  trackHelpCenterOpened(metadata: HelpCenterOpenedMetadata): void {
+    this.capture(TelemetryEvents.HELP_CENTER_OPENED, metadata)
+  }
+
+  trackHelpResourceClicked(metadata: HelpResourceClickedMetadata): void {
+    this.capture(TelemetryEvents.HELP_RESOURCE_CLICKED, metadata)
+  }
+
+  trackHelpCenterClosed(metadata: HelpCenterClosedMetadata): void {
+    this.capture(TelemetryEvents.HELP_CENTER_CLOSED, metadata)
+  }
+
+  trackWorkflowCreated(metadata: WorkflowCreatedMetadata): void {
+    this.capture(TelemetryEvents.WORKFLOW_CREATED, metadata)
+  }
+
+  trackWorkflowExecution(): void {
+    this.capture(TelemetryEvents.EXECUTION_START)
+  }
+
+  trackExecutionError(metadata: ExecutionErrorMetadata): void {
+    this.capture(TelemetryEvents.EXECUTION_ERROR, metadata)
+  }
+
+  trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
+    this.capture(TelemetryEvents.EXECUTION_SUCCESS, metadata)
+  }
+
+  trackSharedWorkflowRun(metadata: SharedWorkflowRunMetadata): void {
+    this.capture(TelemetryEvents.SHARED_WORKFLOW_RUN, metadata)
+  }
+
+  trackSettingChanged(metadata: SettingChangedMetadata): void {
+    this.capture(TelemetryEvents.SETTING_CHANGED, metadata)
+  }
+
+  trackUiButtonClicked(metadata: UiButtonClickMetadata): void {
+    this.capture(TelemetryEvents.UI_BUTTON_CLICKED, metadata)
+  }
+
+  trackPageView(pageName: string, properties?: PageViewMetadata): void {
+    this.capture(TelemetryEvents.PAGE_VIEW, {
+      page_name: pageName,
+      ...properties
+    })
+  }
+}

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -589,6 +589,7 @@ export const TelemetryEvents = {
   API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED:
     'app:api_credit_topup_button_purchase_clicked',
   API_CREDIT_TOPUP_SUCCEEDED: 'app:api_credit_topup_succeeded',
+  BEGIN_CHECKOUT: 'begin_checkout',
 
   // Onboarding Survey
   USER_SURVEY_OPENED: 'app:user_survey_opened',

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -1,5 +1,4 @@
 import { useRunButtonTelemetry } from '@/composables/useRunButtonTelemetry'
-import { isCloud } from '@/platform/distribution/types'
 import { extractWorkflow } from '@/platform/remote/comfyui/jobs/fetchJobs'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
 import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
@@ -488,12 +487,10 @@ export class ComfyUI {
           id: 'queue-button',
           textContent: 'Queue Prompt',
           onclick: () => {
-            if (isCloud) {
-              useRunButtonTelemetry().trackRunButton({
-                trigger_source: 'legacy_ui'
-              })
-              useTelemetry()?.trackWorkflowExecution()
-            }
+            useRunButtonTelemetry().trackRunButton({
+              trigger_source: 'legacy_ui'
+            })
+            useTelemetry()?.trackWorkflowExecution()
             app.queuePrompt(0, this.batchCount)
           }
         }),
@@ -598,12 +595,10 @@ export class ComfyUI {
             id: 'queue-front-button',
             textContent: 'Queue Front',
             onclick: () => {
-              if (isCloud) {
-                useRunButtonTelemetry().trackRunButton({
-                  trigger_source: 'legacy_ui'
-                })
-                useTelemetry()?.trackWorkflowExecution()
-              }
+              useRunButtonTelemetry().trackRunButton({
+                trigger_source: 'legacy_ui'
+              })
+              useTelemetry()?.trackWorkflowExecution()
               app.queuePrompt(-1, this.batchCount)
             }
           }),

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -1127,6 +1127,13 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       expect(store.queuedJobs['job-1']).toBeUndefined()
     })
 
+    it('does not track success for jobs this client did not queue', () => {
+      fire('execution_success', { prompt_id: 'foreign-job', timestamp: 0 })
+
+      expect(mockTrackExecutionSuccess).not.toHaveBeenCalled()
+      expect(mockTrackSharedWorkflowRun).not.toHaveBeenCalled()
+    })
+
     it('tracks shared workflow run when the queued workflow has share attribution', () => {
       const workflow = createQueuedWorkflow()
       workflow.shareId = 'share-1'

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -313,8 +313,8 @@ export const useExecutionStore = defineStore('execution', () => {
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
     const jobId = e.detail.prompt_id
     const queuedJob = queuedJobs.value[jobId]
-    if (isCloud && queuedJob) {
-      const telemetry = useTelemetry()
+    const telemetry = useTelemetry()
+    if (queuedJob) {
       telemetry?.trackExecutionSuccess({
         jobId
       })
@@ -424,14 +424,14 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
-    if (isCloud) {
-      useTelemetry()?.trackExecutionError({
-        jobId: e.detail.prompt_id,
-        nodeId: String(e.detail.node_id),
-        nodeType: e.detail.node_type,
-        error: e.detail.exception_message
-      })
+    useTelemetry()?.trackExecutionError({
+      jobId: e.detail.prompt_id,
+      nodeId: String(e.detail.node_id),
+      nodeType: e.detail.node_type,
+      error: e.detail.exception_message
+    })
 
+    if (isCloud) {
       // Cloud wraps validation errors (400) in exception_message as embedded JSON.
       if (handleCloudValidationError(e.detail)) return
     }


### PR DESCRIPTION
## Summary

- initialize a Desktop-only telemetry provider in ComfyUI_frontend
- forward existing typed telemetry events through `window.__comfyDesktop2.Telemetry.capture` using the existing event names
- move the Desktop 2 bridge typing to the shared ambient types and let run/execution telemetry fire when any provider is registered

## Paired change

- Desktop PR: https://github.com/Comfy-Org/Comfy-Desktop/pull/1069

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm knip`
- `pnpm test:unit src/platform/missingModel/missingModelDownload.test.ts src/platform/telemetry/initDesktopTelemetry.test.ts src/platform/telemetry/providers/desktop/DesktopTelemetryProvider.test.ts`
- YAML lint over tracked YAML files with `.yamllint`

[MAR-240](https://linear.app/comfyorg/issue/MAR-240/frontend-telemetry-pipeline-for-desktop-app-eventsink-refactor)
