### PR TITLE
fix(oauth): allow reverse-DNS custom-scheme redirects on consent

### DIFF
--- a/src/platform/cloud/oauth/OAuthConsentView.test.ts
+++ b/src/platform/cloud/oauth/OAuthConsentView.test.ts
@@ -147,7 +147,8 @@ describe('OAuthConsentView', () => {
       oauthRequestId: '550e8400-e29b-41d4-a716-446655440000',
       csrfToken: 'csrf-token',
       decision: 'allow',
-      workspaceId: 'personal-workspace'
+      workspaceId: 'personal-workspace',
+      expectedRedirectUri: 'http://127.0.0.1:50632/cb'
     })
   })
 

--- a/src/platform/cloud/oauth/OAuthConsentView.vue
+++ b/src/platform/cloud/oauth/OAuthConsentView.vue
@@ -283,7 +283,8 @@ async function submit(decision: 'allow' | 'deny') {
       oauthRequestId: challenge.value.oauth_request_id,
       csrfToken: challenge.value.csrf_token,
       decision,
-      workspaceId
+      workspaceId,
+      expectedRedirectUri: challenge.value.redirect_uri
     })
     clearOAuthRequestId()
   } catch (error) {

--- a/src/platform/cloud/oauth/oauthApi.test.ts
+++ b/src/platform/cloud/oauth/oauthApi.test.ts
@@ -270,31 +270,44 @@ describe('submitOAuthConsentDecision', () => {
   })
 
   it.for([
-    // Custom scheme with no expectedRedirectUri: unbindable, falls back
-    // to the http(s)-only rule.
-    ['org.comfy.ios://oauth-callback?code=xyz', undefined, 'unsafe scheme'],
-    // Bound challenge, different scheme: wrong-client redirect.
+    [
+      'org.comfy.ios://oauth-callback?code=xyz',
+      undefined,
+      'unsafe scheme',
+      'custom scheme with no expectedRedirectUri is unbindable, falls back to the http(s)-only rule'
+    ],
     [
       'com.evil.app://oauth-callback?code=xyz',
       'org.comfy.ios://oauth-callback',
-      'does not match'
+      'does not match',
+      'bound challenge, different scheme: wrong-client redirect'
     ],
-    // Bound challenge, same scheme but different path.
     [
       'org.comfy.ios://oauth-callback/../steal?code=xyz',
       'org.comfy.ios://oauth-callback',
-      'does not match'
+      'does not match',
+      'bound challenge, same scheme but different path'
     ],
-    // Executable schemes are rejected even if the challenge claims them.
-    ['javascript:alert(1)', 'javascript:alert(1)', 'unsafe scheme'],
+    [
+      'javascript:alert(1)',
+      'javascript:alert(1)',
+      'unsafe scheme',
+      'executable schemes are rejected even if the challenge claims them'
+    ],
     [
       'data:text/html,<script>alert(1)</script>',
       'data:text/html,x',
-      'unsafe scheme'
+      'unsafe scheme',
+      'data: scheme rejected even if the challenge claims it'
     ],
-    ['blob:https://cloud.comfy.org/abc', undefined, 'unsafe scheme']
+    [
+      'blob:https://cloud.comfy.org/abc',
+      undefined,
+      'unsafe scheme',
+      'blob: scheme is unsafe'
+    ]
   ] as const)(
-    'rejects redirect_url %s (expected registration: %s)',
+    'rejects redirect_url %s (registration %s, expects %s): %s',
     async ([redirectUrl, expectedRedirectUri, expectedError]) => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         okResponse({ redirect_url: redirectUrl })

--- a/src/platform/cloud/oauth/oauthApi.test.ts
+++ b/src/platform/cloud/oauth/oauthApi.test.ts
@@ -253,7 +253,8 @@ describe('submitOAuthConsentDecision', () => {
         oauthRequestId: validChallenge.oauth_request_id,
         csrfToken: validChallenge.csrf_token,
         decision: 'allow',
-        workspaceId: 'personal-workspace'
+        workspaceId: 'personal-workspace',
+        expectedRedirectUri: 'org.comfy.ios://oauth-callback'
       })
 
       expect(hrefSetter).toHaveBeenCalledWith(
@@ -269,32 +270,47 @@ describe('submitOAuthConsentDecision', () => {
   })
 
   it.for([
-    // Bare custom scheme — rejected because it is not an allowlisted
-    // native scheme (there is no denylist; absence from the allowlist
-    // is the rejection).
-    'comfy://oauth-callback?code=xyz',
-    // Dotted but unknown scheme — must NOT ride in on a "looks like
-    // reverse-DNS" heuristic; only exact allowlist entries pass.
-    'com.evil.app://oauth-callback?code=xyz',
-    // Dotted executable-adjacent scheme (the heuristic bypass class).
-    'ja.vascript://alert(1)',
-    // Executable schemes that must never reach location.href.
-    'data:text/html,<script>alert(1)</script>',
-    'blob:https://cloud.comfy.org/abc'
-  ])('rejects non-allowlisted redirect_url scheme: %s', async (redirectUrl) => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      okResponse({ redirect_url: redirectUrl })
-    )
+    // Custom scheme with no expectedRedirectUri: unbindable, falls back
+    // to the http(s)-only rule.
+    ['org.comfy.ios://oauth-callback?code=xyz', undefined, 'unsafe scheme'],
+    // Bound challenge, different scheme: wrong-client redirect.
+    [
+      'com.evil.app://oauth-callback?code=xyz',
+      'org.comfy.ios://oauth-callback',
+      'does not match'
+    ],
+    // Bound challenge, same scheme but different path.
+    [
+      'org.comfy.ios://oauth-callback/../steal?code=xyz',
+      'org.comfy.ios://oauth-callback',
+      'does not match'
+    ],
+    // Executable schemes are rejected even if the challenge claims them.
+    ['javascript:alert(1)', 'javascript:alert(1)', 'unsafe scheme'],
+    [
+      'data:text/html,<script>alert(1)</script>',
+      'data:text/html,x',
+      'unsafe scheme'
+    ],
+    ['blob:https://cloud.comfy.org/abc', undefined, 'unsafe scheme']
+  ] as const)(
+    'rejects redirect_url %s (expected registration: %s)',
+    async ([redirectUrl, expectedRedirectUri, expectedError]) => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        okResponse({ redirect_url: redirectUrl })
+      )
 
-    await expect(
-      submitOAuthConsentDecision({
-        oauthRequestId: validChallenge.oauth_request_id,
-        csrfToken: validChallenge.csrf_token,
-        decision: 'allow',
-        workspaceId: 'personal-workspace'
-      })
-    ).rejects.toThrow('unsafe scheme')
-  })
+      await expect(
+        submitOAuthConsentDecision({
+          oauthRequestId: validChallenge.oauth_request_id,
+          csrfToken: validChallenge.csrf_token,
+          decision: 'allow',
+          workspaceId: 'personal-workspace',
+          expectedRedirectUri
+        })
+      ).rejects.toThrow(expectedError)
+    }
+  )
 
   it('rejects an unsafe redirect_url scheme', async () => {
     // Defense in depth: even though the cloud backend is trusted, never

--- a/src/platform/cloud/oauth/oauthApi.test.ts
+++ b/src/platform/cloud/oauth/oauthApi.test.ts
@@ -220,6 +220,71 @@ describe('submitOAuthConsentDecision', () => {
     ).rejects.toThrow('redirect_url')
   })
 
+  it('navigates to a reverse-DNS custom-scheme redirect_url (native clients)', async () => {
+    // RFC 8252 native-app callback — the comfy-ios client returns the
+    // authorization code via org.comfy.ios://oauth-callback. The backend
+    // has already validated the URL byte-identically against the client's
+    // registered redirect_uris.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({
+        redirect_url: 'org.comfy.ios://oauth-callback?code=xyz&state=s'
+      })
+    )
+    const originalLocation = globalThis.location
+    const hrefSetter = vi.fn()
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(_target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value)
+            return true
+          }
+          return Reflect.set(originalLocation, prop, value)
+        },
+        get(_target, prop) {
+          return Reflect.get(originalLocation, prop)
+        }
+      })
+    })
+
+    try {
+      await submitOAuthConsentDecision({
+        oauthRequestId: validChallenge.oauth_request_id,
+        csrfToken: validChallenge.csrf_token,
+        decision: 'allow',
+        workspaceId: 'personal-workspace'
+      })
+
+      expect(hrefSetter).toHaveBeenCalledWith(
+        'org.comfy.ios://oauth-callback?code=xyz&state=s'
+      )
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation
+      })
+    }
+  })
+
+  it('rejects a dotless custom-scheme redirect_url', async () => {
+    // Dotless schemes are exactly the executable class (javascript:,
+    // data:, blob:) plus denylisted bare schemes (comfy:) — mirrors the
+    // backend's dot-in-scheme rule for native clients.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({ redirect_url: 'comfy://oauth-callback?code=xyz' })
+    )
+
+    await expect(
+      submitOAuthConsentDecision({
+        oauthRequestId: validChallenge.oauth_request_id,
+        csrfToken: validChallenge.csrf_token,
+        decision: 'allow',
+        workspaceId: 'personal-workspace'
+      })
+    ).rejects.toThrow('unsafe scheme')
+  })
+
   it('rejects an unsafe redirect_url scheme', async () => {
     // Defense in depth: even though the cloud backend is trusted, never
     // hand the browser off to a non-http(s) URL.

--- a/src/platform/cloud/oauth/oauthApi.test.ts
+++ b/src/platform/cloud/oauth/oauthApi.test.ts
@@ -259,6 +259,7 @@ describe('submitOAuthConsentDecision', () => {
       expect(hrefSetter).toHaveBeenCalledWith(
         'org.comfy.ios://oauth-callback?code=xyz&state=s'
       )
+      expect(hrefSetter).toHaveBeenCalledTimes(1)
     } finally {
       Object.defineProperty(globalThis, 'location', {
         configurable: true,
@@ -267,12 +268,22 @@ describe('submitOAuthConsentDecision', () => {
     }
   })
 
-  it('rejects a dotless custom-scheme redirect_url', async () => {
-    // Dotless schemes are exactly the executable class (javascript:,
-    // data:, blob:) plus denylisted bare schemes (comfy:) — mirrors the
-    // backend's dot-in-scheme rule for native clients.
+  it.for([
+    // Bare custom scheme — rejected because it is not an allowlisted
+    // native scheme (there is no denylist; absence from the allowlist
+    // is the rejection).
+    'comfy://oauth-callback?code=xyz',
+    // Dotted but unknown scheme — must NOT ride in on a "looks like
+    // reverse-DNS" heuristic; only exact allowlist entries pass.
+    'com.evil.app://oauth-callback?code=xyz',
+    // Dotted executable-adjacent scheme (the heuristic bypass class).
+    'ja.vascript://alert(1)',
+    // Executable schemes that must never reach location.href.
+    'data:text/html,<script>alert(1)</script>',
+    'blob:https://cloud.comfy.org/abc'
+  ])('rejects non-allowlisted redirect_url scheme: %s', async (redirectUrl) => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      okResponse({ redirect_url: 'comfy://oauth-callback?code=xyz' })
+      okResponse({ redirect_url: redirectUrl })
     )
 
     await expect(

--- a/src/platform/cloud/oauth/oauthApi.ts
+++ b/src/platform/cloud/oauth/oauthApi.ts
@@ -46,6 +46,16 @@ export type OAuthConsentDecision = (
   params: OAuthConsentDecisionParams
 ) => Promise<void>
 
+// Exact allowlist of custom-scheme protocols (URL.protocol form, trailing
+// colon) that the post-consent redirect may navigate to. These are the
+// RFC 8252 reverse-DNS callback schemes of first-party native clients,
+// mirroring their backend OAuth client registrations. Keep this exact —
+// an allowlist of one is a smaller attack surface than any heuristic
+// over "safe-looking" schemes.
+const NATIVE_REDIRECT_SCHEMES: ReadonlySet<string> = new Set([
+  'org.comfy.ios:' // comfy-ios (Comfy iOS app)
+])
+
 export class OAuthApiError extends Error {
   constructor(
     message: string,
@@ -144,20 +154,27 @@ export async function submitOAuthConsentDecision({
     throw new Error('OAuth consent response did not include redirect_url')
   }
 
-  // Defense in depth: even though the cloud backend is trusted, never hand
-  // the browser off to a scheme that can execute in our origin
-  // (javascript:/data:/blob:). Allowed: http(s) — the loopback redirects
-  // desktop/CLI register — and RFC 8252 reverse-DNS custom schemes
-  // (e.g. org.comfy.ios:), which native-app clients use to return the
-  // authorization code. The dot requirement mirrors the backend's
-  // redirect policy (redirect_policy.go: native custom schemes must
-  // contain a dot); no executable scheme contains one.
-  const target = new URL(redirectUrl, globalThis.location.origin)
+  // Defense in depth: even though the cloud backend already validates the
+  // redirect byte-identically against the client's registration, never hand
+  // the browser off to an unexpected scheme. Two risks at this sink:
+  // schemes that execute in our origin (javascript:/data:/blob:), and the
+  // OS routing the authorization code + state to whichever installed app
+  // claims an arbitrary custom scheme. Allowed: http(s) — the loopback
+  // redirects desktop/CLI register — plus the exact RFC 8252 reverse-DNS
+  // schemes of known first-party native clients. New native clients must
+  // be added here alongside their backend client registration.
+  let target: URL
+  try {
+    target = new URL(redirectUrl, globalThis.location.origin)
+  } catch {
+    throw new Error('OAuth consent redirect_url is not a valid URL')
+  }
   const isHttp = target.protocol === 'http:' || target.protocol === 'https:'
-  const isReverseDnsScheme = target.protocol.slice(0, -1).includes('.')
-  if (!isHttp && !isReverseDnsScheme) {
+  if (!isHttp && !NATIVE_REDIRECT_SCHEMES.has(target.protocol)) {
     throw new Error('OAuth consent redirect_url has an unsafe scheme')
   }
 
-  globalThis.location.href = redirectUrl
+  // Navigate the parsed URL, not the raw string, so the value validated
+  // above is byte-for-byte the value the browser receives.
+  globalThis.location.href = target.href
 }

--- a/src/platform/cloud/oauth/oauthApi.ts
+++ b/src/platform/cloud/oauth/oauthApi.ts
@@ -175,22 +175,31 @@ export async function submitOAuthConsentDecision({
   // to the registered URI, so scheme, authority, and path must match
   // exactly. No per-client scheme list lives in the frontend — new native
   // clients need only their backend registration.
-  let target: URL
-  try {
-    target = new URL(redirectUrl, globalThis.location.origin)
-  } catch {
-    throw new Error('OAuth consent redirect_url is not a valid URL')
+  const parseTarget = () => {
+    try {
+      return new URL(redirectUrl, globalThis.location.origin)
+    } catch (err) {
+      throw new Error('OAuth consent redirect_url is not a valid URL', {
+        cause: err
+      })
+    }
   }
+  const target = parseTarget()
   if (EXECUTABLE_SCHEMES.has(target.protocol)) {
     throw new Error('OAuth consent redirect_url has an unsafe scheme')
   }
   if (expectedRedirectUri) {
-    let expected: URL
-    try {
-      expected = new URL(expectedRedirectUri)
-    } catch {
-      throw new Error('OAuth consent challenge redirect_uri is not a valid URL')
+    const parseExpected = () => {
+      try {
+        return new URL(expectedRedirectUri)
+      } catch (err) {
+        throw new Error(
+          'OAuth consent challenge redirect_uri is not a valid URL',
+          { cause: err }
+        )
+      }
     }
+    const expected = parseExpected()
     const matchesRegistration =
       target.protocol === expected.protocol &&
       target.host === expected.host &&

--- a/src/platform/cloud/oauth/oauthApi.ts
+++ b/src/platform/cloud/oauth/oauthApi.ts
@@ -40,20 +40,31 @@ export type OAuthConsentDecisionParams = {
   csrfToken: string
   decision: 'allow' | 'deny'
   workspaceId: string
+  /**
+   * The challenge's registered `redirect_uri`. When present, the
+   * post-consent navigation must match it (scheme, authority, path) —
+   * the server only appends `code`/`state` query params to the
+   * registered URI, so any other destination is rejected. When absent
+   * (challenges from backends that don't surface it yet), only http(s)
+   * redirects are navigable.
+   */
+  expectedRedirectUri?: string
 }
 
 export type OAuthConsentDecision = (
   params: OAuthConsentDecisionParams
 ) => Promise<void>
 
-// Exact allowlist of custom-scheme protocols (URL.protocol form, trailing
-// colon) that the post-consent redirect may navigate to. These are the
-// RFC 8252 reverse-DNS callback schemes of first-party native clients,
-// mirroring their backend OAuth client registrations. Keep this exact —
-// an allowlist of one is a smaller attack surface than any heuristic
-// over "safe-looking" schemes.
-const NATIVE_REDIRECT_SCHEMES: ReadonlySet<string> = new Set([
-  'org.comfy.ios:' // comfy-ios (Comfy iOS app)
+// Schemes that execute in our origin if navigated. Never navigable,
+// regardless of what the backend returns. Everything else is governed
+// by binding to the challenge's registered redirect_uri — no per-client
+// scheme knowledge lives in the frontend.
+const EXECUTABLE_SCHEMES: ReadonlySet<string> = new Set([
+  'javascript:',
+  'data:',
+  'blob:',
+  'vbscript:',
+  'about:'
 ])
 
 export class OAuthApiError extends Error {
@@ -128,7 +139,8 @@ export async function submitOAuthConsentDecision({
   oauthRequestId,
   csrfToken,
   decision,
-  workspaceId
+  workspaceId,
+  expectedRedirectUri
 }: OAuthConsentDecisionParams): Promise<void> {
   const response = await fetch('/oauth/authorize', {
     method: 'POST',
@@ -154,23 +166,43 @@ export async function submitOAuthConsentDecision({
     throw new Error('OAuth consent response did not include redirect_url')
   }
 
-  // Defense in depth: even though the cloud backend already validates the
-  // redirect byte-identically against the client's registration, never hand
-  // the browser off to an unexpected scheme. Two risks at this sink:
-  // schemes that execute in our origin (javascript:/data:/blob:), and the
-  // OS routing the authorization code + state to whichever installed app
-  // claims an arbitrary custom scheme. Allowed: http(s) — the loopback
-  // redirects desktop/CLI register — plus the exact RFC 8252 reverse-DNS
-  // schemes of known first-party native clients. New native clients must
-  // be added here alongside their backend client registration.
+  // Defense in depth at this sink. Two risks: schemes that execute in our
+  // origin (always rejected, below), and the OS routing the authorization
+  // code + state to whichever installed app claims an arbitrary custom
+  // scheme. For the latter we hold the navigation to the redirect the
+  // backend registered for THIS auth request (the challenge's
+  // redirect_uri): the server only ever appends code/state query params
+  // to the registered URI, so scheme, authority, and path must match
+  // exactly. No per-client scheme list lives in the frontend — new native
+  // clients need only their backend registration.
   let target: URL
   try {
     target = new URL(redirectUrl, globalThis.location.origin)
   } catch {
     throw new Error('OAuth consent redirect_url is not a valid URL')
   }
-  const isHttp = target.protocol === 'http:' || target.protocol === 'https:'
-  if (!isHttp && !NATIVE_REDIRECT_SCHEMES.has(target.protocol)) {
+  if (EXECUTABLE_SCHEMES.has(target.protocol)) {
+    throw new Error('OAuth consent redirect_url has an unsafe scheme')
+  }
+  if (expectedRedirectUri) {
+    let expected: URL
+    try {
+      expected = new URL(expectedRedirectUri)
+    } catch {
+      throw new Error('OAuth consent challenge redirect_uri is not a valid URL')
+    }
+    const matchesRegistration =
+      target.protocol === expected.protocol &&
+      target.host === expected.host &&
+      target.pathname === expected.pathname
+    if (!matchesRegistration) {
+      throw new Error(
+        'OAuth consent redirect_url does not match the registered redirect_uri'
+      )
+    }
+  } else if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    // Challenges that don't surface redirect_uri can't be bound; hold the
+    // pre-existing http(s)-only line for them.
     throw new Error('OAuth consent redirect_url has an unsafe scheme')
   }
 

--- a/src/platform/cloud/oauth/oauthApi.ts
+++ b/src/platform/cloud/oauth/oauthApi.ts
@@ -145,10 +145,17 @@ export async function submitOAuthConsentDecision({
   }
 
   // Defense in depth: even though the cloud backend is trusted, never hand
-  // the browser off to a non-http(s) scheme. javascript:/data: URLs would
-  // execute in our origin.
+  // the browser off to a scheme that can execute in our origin
+  // (javascript:/data:/blob:). Allowed: http(s) — the loopback redirects
+  // desktop/CLI register — and RFC 8252 reverse-DNS custom schemes
+  // (e.g. org.comfy.ios:), which native-app clients use to return the
+  // authorization code. The dot requirement mirrors the backend's
+  // redirect policy (redirect_policy.go: native custom schemes must
+  // contain a dot); no executable scheme contains one.
   const target = new URL(redirectUrl, globalThis.location.origin)
-  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+  const isHttp = target.protocol === 'http:' || target.protocol === 'https:'
+  const isReverseDnsScheme = target.protocol.slice(0, -1).includes('.')
+  if (!isHttp && !isReverseDnsScheme) {
     throw new Error('OAuth consent redirect_url has an unsafe scheme')
   }
 


### PR DESCRIPTION
## ELI-5

After you click Continue on the sign-in consent page, the page sends your browser back to the app that asked. Our safety check only knew about web-style addresses (`http://...`), so when the iOS app — whose return address looks like `org.comfy.ios://...` — finished sign-in, the page refused to deliver and showed "OAuth request failed." The fix: instead of the page keeping a list of address styles it trusts, it now asks the backend "what return address did this app register?" and goes exactly there or nowhere. Truly dangerous addresses (ones that run code in the page) stay banned outright.

## Problem

The consent success handler hard-allowlists `http(s)` for the post-consent redirect (`oauthApi.ts`). That covers the loopback redirects `comfy-desktop`/`comfy-cli` register, but rejects RFC 8252 reverse-DNS custom schemes — the callback shape native-app OAuth clients use.

Live failure (prod, 2026-06-11, first `comfy-ios` sign-in test): user approves consent → backend persists consent, consumes the auth request, and mints an authorization code for `org.comfy.ios://oauth-callback` → frontend throws `'unsafe scheme'` → user sees the generic **"OAuth request failed"** → the code expires unused 60s later. Verified end-to-end in the prod DB.

## Fix (final design — binding, not scheme lists)

Bind the post-consent navigation to the **challenge's registered `redirect_uri`** (scheme + authority + path equality; the server only appends `code`/`state` query params to the registered URI). The backend supplies that field per-request — Comfy-Org/cloud#4230 — so the frontend carries **zero per-client knowledge**: registering a future native client is a backend-only change.

Layers:
1. **Executable-scheme denylist** (`javascript:`/`data:`/`blob:`/`vbscript:`/`about:`) — unconditional; the actual XSS line.
2. **Registration binding** when `challenge.redirect_uri` is present — also rejects wrong-client redirects, which no scheme policy could.
3. **http(s)-only fallback** when the challenge doesn't surface `redirect_uri` (older backend) — preserves today's behavior; the two PRs can land in either order, but iOS sign-in needs both.

Also per the earlier review pass: navigation uses the parsed URL (parser/sink consistency), malformed URLs throw structured errors, single-navigation asserted.

## History

This PR went through three designs: dotted-scheme heuristic → four-lab adversarial review (68 findings, Opus-judge consolidated) flagged the heuristic as bypassable → exact scheme allowlist → product feedback (hardcoding per-client schemes in shared frontend code doesn't scale and shouldn't exist for non-product test apps) → registration binding, which the review panel had independently flagged as the strongest option. 41/41 oauth tests passing.

## Tests
- Navigates: bound custom-scheme redirect (`org.comfy.ios://oauth-callback?code=…` vs registered `org.comfy.ios://oauth-callback`), http loopback (legacy fallback)
- Rejects: unbound custom scheme (fallback), wrong-client redirect (`com.evil.app://…` vs registered iOS URI), path mutation, executable schemes even when 'registered', malformed URLs

Related: BE-1341, BE-1350, Comfy-Org/cloud#4230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)