### PR TITLE
fix: address funnel telemetry review feedback

### DIFF
--- a/src/platform/telemetry/utils/getActionbarDockState.test.ts
+++ b/src/platform/telemetry/utils/getActionbarDockState.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getActionbarDockState } from './getActionbarDockState'
 
@@ -19,5 +19,15 @@ describe('getActionbarDockState', () => {
   it('returns floating when the stored preference is false', () => {
     localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
     expect(getActionbarDockState()).toBe('floating')
+  })
+
+  it('returns docked when storage access throws', () => {
+    const spy = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new DOMException('denied', 'SecurityError')
+      })
+    expect(getActionbarDockState()).toBe('docked')
+    spy.mockRestore()
   })
 })

--- a/src/platform/telemetry/utils/getActionbarDockState.test.ts
+++ b/src/platform/telemetry/utils/getActionbarDockState.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { getActionbarDockState } from './getActionbarDockState'
 
@@ -15,5 +15,12 @@ describe('getActionbarDockState', () => {
   it('returns floating when the stored preference is false', () => {
     localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
     expect(getActionbarDockState()).toBe('floating')
+  })
+
+  it('returns docked when storage access throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    expect(getActionbarDockState()).toBe('docked')
   })
 })

--- a/src/platform/telemetry/utils/getActionbarDockState.ts
+++ b/src/platform/telemetry/utils/getActionbarDockState.ts
@@ -1,7 +1,11 @@
 import type { ActionbarDockState } from '@/platform/telemetry/types'
 
 export function getActionbarDockState(): ActionbarDockState {
-  return localStorage.getItem('Comfy.MenuPosition.Docked') === 'false'
-    ? 'floating'
-    : 'docked'
+  try {
+    return localStorage.getItem('Comfy.MenuPosition.Docked') === 'false'
+      ? 'floating'
+      : 'docked'
+  } catch {
+    return 'docked'
+  }
 }

--- a/src/scripts/app.test.ts
+++ b/src/scripts/app.test.ts
@@ -755,6 +755,52 @@ describe('ComfyApp', () => {
       }
     })
 
+    it('attributes a queued job to the mode used when submission started', async () => {
+      prepareEmptyPromptQueue()
+      const workflow = mockWorkspaceWorkflow.activeWorkflow
+      if (!workflow) throw new Error('Expected an active workflow')
+      workflow.activeMode = 'graph'
+
+      const registry = new TelemetryRegistry()
+      registry.registerProvider({ trackExecutionOutcome: vi.fn() })
+      setTelemetryRegistry(registry)
+
+      let finishPromptBuild: () => void = () => {}
+      vi.spyOn(app, 'graphToPrompt').mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishPromptBuild = () =>
+              resolve({
+                output: {},
+                workflow: createWorkflowGraphData()
+              })
+          })
+      )
+      vi.spyOn(api, 'queuePrompt').mockResolvedValue({
+        prompt_id: 'job-1',
+        error: ''
+      })
+
+      try {
+        const submission = app.queuePrompt(0)
+        await vi.waitFor(() => expect(app.graphToPrompt).toHaveBeenCalledOnce())
+
+        workflow.activeMode = 'app'
+        finishPromptBuild()
+        await expect(submission).resolves.toBe(true)
+
+        expect(useExecutionStore().queuedJobs['job-1']).toMatchObject({
+          viewMode: 'graph',
+          isAppMode: false,
+          workflowContext: {
+            view_mode: 'graph'
+          }
+        })
+      } finally {
+        setTelemetryRegistry(null)
+      }
+    })
+
     it('tracks a resolved prompt rejection at the submission stage', async () => {
       prepareEmptyPromptQueue()
       const trackExecutionOutcome = vi.fn()

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -5,6 +5,7 @@ import { reactive, unref } from 'vue'
 import { shallowRef } from 'vue'
 
 import { useCanvasPositionConversion } from '@/composables/element/useCanvasPositionConversion'
+import { getWorkflowMode } from '@/composables/useAppMode'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { syncLayoutStoreNodeBoundsFromGraph } from '@/renderer/core/layout/sync/syncLayoutStoreFromGraph'
 import { flushScheduledSlotLayoutSync } from '@/renderer/extensions/vueNodes/composables/useSlotElementTracking'
@@ -1634,10 +1635,12 @@ export class ComfyApp {
             }
           })
 
-          // Capture workflow before await — activeWorkflow may change if the
-          // user switches tabs while the request is in flight.
+          // Capture workflow and mode before await — both may change if the
+          // user switches tabs or toggles app/graph mode while the request is
+          // in flight.
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
+          const queuedMode = getWorkflowMode(queuedWorkflow)
           const p = await this.graphToPrompt(this.rootGraph)
           const queuedNodes = collectAllNodes(this.rootGraph)
           try {
@@ -1661,7 +1664,8 @@ export class ComfyApp {
                   id: res.prompt_id,
                   nodes: Object.keys(p.output),
                   promptOutput: p.output,
-                  workflow: queuedWorkflow
+                  workflow: queuedWorkflow,
+                  mode: queuedMode
                 })
               }
             } catch (error) {

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1729,10 +1729,12 @@ export class ComfyApp {
             applyPromotedWidgetControl(node, 'beforeQueued')
           })
 
-          // Capture workflow before await — activeWorkflow may change if the
-          // user switches tabs while the request is in flight.
+          // Capture workflow and mode before await — both may change if the
+          // user switches tabs or toggles app/graph mode while the request is
+          // in flight.
           const queuedWorkflow = useWorkspaceStore().workflow
             .activeWorkflow as ComfyWorkflow
+          const queuedMode = getWorkflowMode(queuedWorkflow)
           const startTime = performance.now()
           const p = await this.graphToPrompt(this.rootGraph).catch(
             (error: unknown) => {
@@ -1752,7 +1754,7 @@ export class ComfyApp {
             workflowContext = toWorkflowExecutionContext(executionContext, {
               executableNodeCount: Object.keys(p.output).length,
               executionScope: isPartialExecution ? 'partial' : 'full',
-              viewMode: getWorkflowMode(queuedWorkflow)
+              viewMode: queuedMode
             })
           }
           if (
@@ -1802,6 +1804,7 @@ export class ComfyApp {
                   startTime,
                   submissionAcceptedAt: responseReceivedAt,
                   workflow: queuedWorkflow,
+                  mode: queuedMode,
                   workflowContext,
                   workflowExecutionIntent
                 })

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -786,7 +786,8 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
       promptOutput: {
         '123': createPromptNode('Test Node', 'TestNode')
       },
-      workflow: createQueuedWorkflow()
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
     })
     store.activeJobId = 'test-prompt'
 
@@ -814,7 +815,8 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
       promptOutput: {
         '456:789': createPromptNode('Nested Node', 'NestedNode')
       },
-      workflow: createQueuedWorkflow()
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
     })
     store.activeJobId = 'test-prompt'
 
@@ -848,7 +850,8 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
       promptOutput: {
         '123': createPromptNode('Test Node', 'TestNode')
       },
-      workflow: createQueuedWorkflow()
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
     })
     store.activeJobId = 'test-prompt'
 
@@ -1136,7 +1139,8 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'graph'
       })
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
 
@@ -1162,7 +1166,8 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'graph'
       })
 
       fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
@@ -1184,7 +1189,8 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'graph'
       })
 
       mockAppModeState.mode.value = 'app'
@@ -1199,17 +1205,18 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       })
     })
 
-    it('attributes shared workflow run to the queued workflow, not the active one', () => {
+    it('attributes shared workflow run to the passed mode, not the workflow current mode', () => {
       const workflow = createQueuedWorkflow()
       workflow.shareId = 'share-1'
-      workflow.activeMode = 'app'
+      workflow.activeMode = 'graph'
       store.storeJob({
         nodes: ['a'],
         id: 'job-1',
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'app'
       })
 
       fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
@@ -1378,7 +1385,8 @@ describe('useExecutionStore - storeJob and workflow path tracking', () => {
         a: createPromptNode('Node A', 'NodeA'),
         b: createPromptNode('Node B', 'NodeB')
       },
-      workflow
+      workflow,
+      mode: 'graph'
     })
 
     expect(store.queuedJobs['job-1']?.nodes).toEqual({ a: false, b: false })

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -609,7 +609,8 @@ describe('useExecutionStore - workflowStatus', () => {
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
       startTime: 42,
       submissionAcceptedAt: 62,
-      workflow
+      workflow,
+      mode: 'graph'
     })
   }
 
@@ -774,6 +775,7 @@ describe('useExecutionStore - workflowStatus', () => {
       promptOutput: { '1': createPromptNode('Node', 'TestNode') },
       startTime: 42,
       workflow: workflowA,
+      mode: 'graph',
       workflowContext,
       workflowExecutionIntent: {
         trigger_source: 'button'
@@ -1298,7 +1300,8 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
       promptOutput: {
         '123': createPromptNode('Test Node', 'TestNode')
       },
-      workflow: createQueuedWorkflow()
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
     })
     store.activeJobId = 'test-prompt'
 
@@ -1326,7 +1329,8 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
       promptOutput: {
         '456:789': createPromptNode('Nested Node', 'NestedNode')
       },
-      workflow: createQueuedWorkflow()
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
     })
     store.activeJobId = 'test-prompt'
 
@@ -1360,7 +1364,8 @@ describe('useExecutionStore - executingNode with subgraphs', () => {
       promptOutput: {
         '123': createPromptNode('Test Node', 'TestNode')
       },
-      workflow: createQueuedWorkflow()
+      workflow: createQueuedWorkflow(),
+      mode: 'graph'
     })
     store.activeJobId = 'test-prompt'
 
@@ -2069,7 +2074,8 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'graph'
       })
       fire('execution_start', { prompt_id: 'job-1', timestamp: 0 })
 
@@ -2095,7 +2101,8 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'graph'
       })
 
       fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
@@ -2117,7 +2124,8 @@ describe('useExecutionStore - WebSocket event handlers', () => {
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'graph'
       })
 
       mockAppModeState.mode.value = 'app'
@@ -2132,17 +2140,18 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       })
     })
 
-    it('attributes shared workflow run to the queued workflow, not the active one', () => {
+    it('attributes shared workflow run to the passed mode, not the workflow current mode', () => {
       const workflow = createQueuedWorkflow()
       workflow.shareId = 'share-1'
-      workflow.activeMode = 'app'
+      workflow.activeMode = 'graph'
       store.storeJob({
         nodes: ['a'],
         id: 'job-1',
         promptOutput: {
           a: createPromptNode('Node A', 'NodeA')
         },
-        workflow
+        workflow,
+        mode: 'app'
       })
 
       fire('execution_success', { prompt_id: 'job-1', timestamp: 0 })
@@ -2400,7 +2409,8 @@ describe('useExecutionStore - storeJob and workflow path tracking', () => {
         a: createPromptNode('Node A', 'NodeA'),
         b: createPromptNode('Node B', 'NodeB')
       },
-      workflow
+      workflow,
+      mode: 'graph'
     })
 
     expect(store.queuedJobs['job-1']?.nodes).toEqual({ a: false, b: false })

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -3,11 +3,7 @@ import { computed, ref, shallowRef } from 'vue'
 
 import { useNodeProgressText } from '@/composables/node/useNodeProgressText'
 import type { AppMode } from '@/composables/useAppMode'
-import {
-  getWorkflowMode,
-  isAppModeValue,
-  useAppMode
-} from '@/composables/useAppMode'
+import { isAppModeValue, useAppMode } from '@/composables/useAppMode'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
@@ -590,12 +586,14 @@ export const useExecutionStore = defineStore('execution', () => {
     nodes,
     id,
     promptOutput,
-    workflow
+    workflow,
+    mode
   }: {
     nodes: string[]
     id: JobId
     promptOutput: ComfyApiWorkflow
     workflow: ComfyWorkflow
+    mode: AppMode
   }) {
     queuedJobs.value[id] ??= { nodes: {} }
     const queuedJob = queuedJobs.value[id]
@@ -609,9 +607,8 @@ export const useExecutionStore = defineStore('execution', () => {
     queuedJob.nodeLookup = buildExecutionNodeLookup(promptOutput)
     queuedJob.workflow = workflow
     queuedJob.shareId = workflow?.shareId
-    const queuedMode = getWorkflowMode(workflow)
-    queuedJob.viewMode = queuedMode
-    queuedJob.isAppMode = isAppModeValue(queuedMode)
+    queuedJob.viewMode = mode
+    queuedJob.isAppMode = isAppModeValue(mode)
     const wid = workflow?.activeState?.id ?? workflow?.initialState?.id
     if (wid) {
       jobIdToWorkflowId.value.set(id, wid)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -41,7 +41,7 @@ import { tryNormalizeNodeExecutionId } from '@/types/nodeIdentification'
 import { parseNodeId } from '@/types/nodeId'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import type { AppMode } from '@/utils/appMode'
-import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
+import { isAppModeValue } from '@/utils/appMode'
 import { classifyCloudValidationError } from '@/utils/executionErrorUtil'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
 import { createRafCoalescer } from '@/utils/rafBatch'
@@ -842,6 +842,7 @@ export const useExecutionStore = defineStore('execution', () => {
     startTime,
     submissionAcceptedAt,
     workflow,
+    mode,
     workflowContext,
     workflowExecutionIntent = defaultWorkflowExecutionIntent
   }: {
@@ -851,6 +852,7 @@ export const useExecutionStore = defineStore('execution', () => {
     startTime?: number
     submissionAcceptedAt?: number
     workflow: ComfyWorkflow
+    mode: AppMode
     workflowContext?: WorkflowExecutionContext
     workflowExecutionIntent?: WorkflowExecutionIntent
   }) {
@@ -871,9 +873,8 @@ export const useExecutionStore = defineStore('execution', () => {
     queuedJob.workflow = workflow
     if (workflow) jobIdToWorkflow.set(String(id), workflow)
     queuedJob.shareId = workflow?.shareId
-    const queuedMode = getWorkflowMode(workflow)
-    queuedJob.viewMode = queuedMode
-    queuedJob.isAppMode = isAppModeValue(queuedMode)
+    queuedJob.viewMode = mode
+    queuedJob.isAppMode = isAppModeValue(mode)
     const wid = workflow?.activeState?.id ?? workflow?.initialState?.id
     if (wid) {
       jobIdToWorkflowId.value.set(id, wid)


### PR DESCRIPTION
## Summary

Follow-up to #12778 addressing the two review comments that landed after it entered the merge queue.

## Changes

- **What**:
  - Snapshot the workflow mode in `app.queuePrompt` before the `api.queuePrompt` await (alongside the existing pre-await workflow capture) and pass it into `storeJob`, so toggling app/graph mode on the same workflow while the queue request is in flight no longer misattributes run telemetry ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12778#discussion_r3401161753))
  - Wrap the `localStorage` read in `getActionbarDockState` in try/catch with a `docked` fallback for storage-restricted contexts ([comment](https://github.com/Comfy-Org/ComfyUI_frontend/pull/12778#discussion_r3401161751))

## Review Focus

`storeJob` now requires the mode from the caller instead of deriving it from the workflow at response time; existing store tests were updated to assert the passed snapshot wins over the workflow's current mode.