### PR TITLE
feat(billing): gate cancel/reactivate to the original owner (FE-978)

### DIFF
--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -112,7 +112,11 @@
         button-variant="gradient"
       />
       <Button
-        v-if="showSubscribeAction && !isPersonalWorkspace"
+        v-if="
+          showSubscribeAction &&
+          !isPersonalWorkspace &&
+          (!isCancelled || permissions.canManageSubscriptionLifecycle)
+        "
         variant="primary"
         size="sm"
         @click="handleOpenPlansAndPricing"

--- a/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionPanelContentWorkspace.vue
@@ -128,9 +128,10 @@
                 v-if="isActiveSubscription && permissions.canManageSubscription"
                 class="flex flex-wrap gap-2 md:ml-auto"
               >
-                <!-- Cancelled state: show only Resubscribe button -->
+                <!-- Cancelled state: reactivation is original-owner-only. -->
                 <template v-if="isCancelled">
                   <Button
+                    v-if="permissions.canManageSubscriptionLifecycle"
                     size="lg"
                     variant="primary"
                     class="rounded-lg px-4 text-sm font-normal"
@@ -161,7 +162,7 @@
                     {{ $t('subscription.upgradePlan') }}
                   </Button>
                   <Button
-                    v-if="!isFreeTierPlan"
+                    v-if="!isFreeTierPlan && planMenuItems.length > 0"
                     v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
                     variant="secondary"
                     size="lg"
@@ -513,15 +514,23 @@ const subscriptionTierName = computed(() => {
 
 const planMenu = ref<InstanceType<typeof Menu> | null>(null)
 
-const planMenuItems = computed(() => [
-  {
-    label: t('subscription.cancelSubscription'),
-    icon: 'pi pi-times',
-    command: () => {
-      showCancelSubscriptionDialog(subscription.value?.endDate ?? undefined)
-    }
-  }
-])
+// Cancel is original-owner-only (creator); a promoted owner gets no menu items
+// and the "more options" button is hidden (see template).
+const planMenuItems = computed(() =>
+  permissions.value.canManageSubscriptionLifecycle
+    ? [
+        {
+          label: t('subscription.cancelSubscription'),
+          icon: 'pi pi-times',
+          command: () => {
+            showCancelSubscriptionDialog(
+              subscription.value?.endDate ?? undefined
+            )
+          }
+        }
+      ]
+    : []
+)
 
 const tierKey = computed(() => {
   const tier = subscriptionTier.value


### PR DESCRIPTION
Stacked on the permission infra #12829. Gates owner **Cancel** (plan menu) + **Resubscribe** (panel button + workspace popover re-activate path) on `canManageSubscriptionLifecycle` (original owner only), per the billing-permission matrix (FE SSOT). Promoted owners keep manage-payment / upgrade / top-up; members get none.

**Original-owner signal (repointed).** Rebased onto the updated #12829 (`a51183ae`), so the gate now resolves from the member-list `is_original_owner` field that the cloud cutover (Comfy-Org/cloud #4359) ships: the store getter `isCurrentUserOriginalOwner` matches the current user's member self-row by email, and `useWorkspaceUI` eagerly `fetchMembers()` so billing surfaces have the roster loaded. This replaces the earlier `is_creator`-on-`/api/workspaces` assumption — BE standardized on a per-member `is_original_owner` instead. No `is_creator` remains.

**Merge-gated** on cutover cloud#4359 reaching cloud main: until `GET /api/workspace/members` returns `is_original_owner` in prod, the gate fails closed (lifecycle actions hidden for every owner). Fail-closed = no regression pre-deploy, but do not merge until the field is live.

**Follow-up (non-blocking).** Exposing `is_original_owner` (current-user-relative, sibling of `role`) on `/api/workspaces` — Hunter pre-approved 2026-06-17 — would let us read it directly and drop the eager member fetch. Tracked on #12829 / FE-770.

Part of FE-978 (member run-lock modal shipped separately in #12786).
