### PR TITLE
fix: respect API base for media view URLs

### DIFF
--- a/src/extensions/core/load3d/SceneManager.test.ts
+++ b/src/extensions/core/load3d/SceneManager.test.ts
@@ -3,6 +3,8 @@ import * as THREE from 'three'
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { api } from '@/scripts/api'
+
 import type { EventManagerInterface } from './interfaces'
 import Load3dUtils from './Load3dUtils'
 import { SceneManager } from './SceneManager'
@@ -116,6 +118,7 @@ describe('SceneManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    api.api_base = ''
     renderer = makeRenderer()
     camera = new THREE.PerspectiveCamera()
     events = makeMockEventManager()
@@ -261,7 +264,8 @@ describe('SceneManager', () => {
       )
     })
 
-    it('prefixes /api when getResourceURL returns a non-/api URL', async () => {
+    it('prefixes background image URLs with the configured API base', async () => {
+      api.api_base = '/comfy'
       vi.mocked(Load3dUtils.splitFilePath).mockReturnValue(['', 'bg.png'])
       vi.mocked(Load3dUtils.getResourceURL).mockReturnValue('/view?bg.png')
       const captured: string[] = []
@@ -274,7 +278,7 @@ describe('SceneManager', () => {
 
       await manager.setBackgroundImage('bg.png')
 
-      expect(captured[0]).toBe('/api/view?bg.png')
+      expect(captured[0]).toBe('/comfy/api/view?bg.png')
     })
 
     it('in tiled mode, swaps the background mesh material to use the new texture', async () => {

--- a/src/extensions/core/load3d/SceneManager.ts
+++ b/src/extensions/core/load3d/SceneManager.ts
@@ -1,6 +1,8 @@
 import { SparkRenderer } from '@sparkjsdev/spark'
 import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+
+import { api } from '@/scripts/api'
 
 import Load3dUtils from './Load3dUtils'
 import {
@@ -187,8 +189,8 @@ export class SceneManager implements SceneManagerInterface {
 
     let type = 'input'
     let pathParts = Load3dUtils.splitFilePath(uploadPath)
-    let subfolder = pathParts[0]
-    let filename = pathParts[1]
+    const subfolder = pathParts[0]
+    const filename = pathParts[1]
 
     if (subfolder === 'temp') {
       type = 'temp'
@@ -198,11 +200,7 @@ export class SceneManager implements SceneManagerInterface {
       pathParts = ['', filename]
     }
 
-    let imageUrl = Load3dUtils.getResourceURL(...pathParts, type)
-
-    if (!imageUrl.startsWith('/api')) {
-      imageUrl = '/api' + imageUrl
-    }
+    const imageUrl = api.apiURL(Load3dUtils.getResourceURL(...pathParts, type))
 
     try {
       const textureLoader = new THREE.TextureLoader()

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts
@@ -5,8 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useWidgetSelectItems } from '@/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems'
+import { api } from '@/scripts/api'
 
 const mockAssetsData = vi.hoisted(() => ({ items: [] as AssetItem[] }))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
 
 vi.mock(
   '@/renderer/extensions/vueNodes/widgets/composables/useAssetWidgetData',
@@ -138,6 +143,7 @@ describe('useWidgetSelectItems', () => {
     mockMediaAssets = createMockMediaAssets()
     mockResolveOutputAssetItems.mockReset()
     mockAssetsData.items = []
+    api.api_base = ''
   })
 
   describe('dropdownItems', () => {
@@ -291,6 +297,22 @@ describe('useWidgetSelectItems', () => {
         'filename=img_001.png'
       )
       expect(dropdownItems.value[0].preview_url).toContain('type=input')
+    })
+
+    it('prefixes preview URLs with the configured API base', () => {
+      api.api_base = '/comfy'
+
+      const { dropdownItems } = useWidgetSelectItems(
+        createDefaultOptions({
+          values: () => ['img_001.png'],
+          modelValue: ref('img_001.png'),
+          assetKind: () => 'image'
+        })
+      )
+
+      expect(dropdownItems.value[0].preview_url).toBe(
+        '/comfy/api/view?filename=img_001.png&type=input'
+      )
     })
   })
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts
@@ -27,6 +27,7 @@ import { getOutputAssetMetadata } from '@/platform/assets/schemas/assetMetadataS
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { resolveOutputAssetItems } from '@/platform/assets/utils/outputAssetUtil'
 import type { IAssetsProvider } from '@/platform/assets/composables/media/IAssetsProvider'
+import { api } from '@/scripts/api'
 import type { AssetKind } from '@/types/widgetTypes'
 import { getMediaTypeFromFilename } from '@/utils/formatUtil'
 
@@ -56,7 +57,7 @@ function getMediaUrl(
   if (!['image', 'video', 'audio'].includes(assetKind ?? '')) return ''
   const params = new URLSearchParams({ filename, type })
   appendCloudResParam(params, filename)
-  return `/api/view?${params}`
+  return api.apiURL(`/view?${params}`)
 }
 
 interface UseWidgetSelectItemsOptions {


### PR DESCRIPTION
## Summary

- route widget media preview URLs through the configured API base
- route 3D background image view URLs through the same API URL helper
- add focused regression coverage for subpath-prefixed deployments

## Why

When ComfyUI is served behind a reverse proxy under a subpath, absolute `/api/view` URLs resolve from the domain root and bypass the proxy prefix. The existing API URL helper already preserves `api_base`, so this uses that path for the affected media view URLs without changing their query semantics.

Fixes Comfy-Org/ComfyUI#14455.

Related: #12438 covers a separate subfolder parsing issue in the same widget helper. This PR intentionally keeps that behavior unchanged and only applies the configured API base.

## E2E coverage note

I did not add a `browser_tests/` regression because this bug depends on serving the frontend behind a reverse-proxy subpath and asserting that generated media request URLs preserve that configured base path. The current browser test setup does not exercise that deployment topology directly without adding proxy-specific infrastructure. The regression is covered at the URL-construction boundary instead: the WidgetSelect and 3D SceneManager unit tests set `api.api_base` and assert the produced `/api/view` URLs include the configured base path.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts --network-concurrency 1 --fetch-timeout 300000 --reporter append-only`
- `pnpm test:unit src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts src/extensions/core/load3d/SceneManager.test.ts`
- `pnpm typecheck`
- `pnpm lint:unstaged`
- `pnpm exec oxfmt --check src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts src/extensions/core/load3d/SceneManager.ts src/extensions/core/load3d/SceneManager.test.ts`
- `pnpm exec oxlint src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.ts src/renderer/extensions/vueNodes/widgets/composables/useWidgetSelectItems.test.ts src/extensions/core/load3d/SceneManager.ts src/extensions/core/load3d/SceneManager.test.ts --type-aware`
- `pnpm build`

Note: `pnpm lint:unstaged` reports two warnings because `src/extensions/core/*` is ignored by the repo ESLint config; it exits successfully with no errors.
