### PR TITLE
fix: serialize widgets_values densely to keep values aligned on reload

### DIFF
--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -587,6 +587,34 @@ describe('LGraphNode', () => {
       expect(node.widgets![0].value).toBe(1)
       expect(node.widgets![1].value).toBe(100)
     })
+
+    test('round-trips values across a serialize:false widget in the middle', () => {
+      const node = new LGraphNode('TestNode')
+      node.serialize_widgets = true
+      node.addWidget('number', 'a', 1, null)
+      node.addWidget('number', 'shim', 0, null)
+      node.addWidget('number', 'b', 2, null)
+      node.widgets![1].serialize = false
+
+      const serialized = node.serialize()
+      // Dense: the middle serialize:false widget must not leave a gap.
+      expect(serialized.widgets_values).toEqual([1, 2])
+
+      node.widgets![0].value = 0
+      node.widgets![2].value = 0
+      node.configure(
+        getMockISerialisedNode({
+          id: 1,
+          type: 'TestNode',
+          pos: [0, 0],
+          size: [100, 100],
+          properties: {},
+          widgets_values: serialized.widgets_values
+        })
+      )
+      expect(node.widgets![0].value).toBe(1)
+      expect(node.widgets![2].value).toBe(2)
+    })
   })
 
   describe('getInputSlotPos', () => {

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -973,14 +973,15 @@ export class LGraphNode
     const { widgets } = this
     if (widgets && this.serialize_widgets) {
       o.widgets_values = []
-      for (const [i, widget] of widgets.entries()) {
+      for (const widget of widgets) {
         if (widget.serialize === false) continue
         const val = widget?.value
         // Ensure object values are plain (not reactive proxies) for structuredClone compatibility.
-        o.widgets_values[i] =
+        o.widgets_values.push(
           val != null && typeof val === 'object'
             ? JSON.parse(JSON.stringify(val))
             : (val ?? null)
+        )
       }
     }
 


### PR DESCRIPTION
## Summary
LGraphNode.serialize wrote widgets_values by physical widget index (widgets_values[i]), which leaves a gap whenever a serialize:false widget sits between serialized ones. configure() reads densely (skipping serialize:false without advancing the index), so any serialize:false widget in the middle shifted every later value onto the wrong widget on reload.

This surfaces with composite autogrow rows, where each socket adds an interleaved serialize:false shim widget: e.g. a key/value dict node would load with keys shifted by one row (key1's value landing on key2).

Serialize densely (push) to mirror configure's dense read. Widgets with a trailing serialize:false widget are unaffected (no gap was produced before either); only the middle-gap case changes. 

Adds a round-trip test.

## Screenshots (if applicable)
before

https://github.com/user-attachments/assets/753deb3c-2e00-4328-9d11-2f23c34394db


after
https://github.com/user-attachments/assets/6ae58226-47f3-4f40-8d91-13126e8e2919


