### PR TITLE
fix(errors): show Upgrade CTA & Support Link for the  subscription errors

### DIFF
--- a/src/components/rightSidePanel/errors/ErrorNodeCard.test.ts
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.test.ts
@@ -169,6 +169,27 @@ describe('ErrorNodeCard.vue', () => {
     }
   }
 
+  function makeSubscriptionErrorCard(): ErrorCardData {
+    return {
+      id: `exec-${++cardIdCounter}`,
+      title: 'API Node',
+      nodeId: '10',
+      nodeTitle: 'API Node',
+      errors: [
+        {
+          message: 'Subscription required to queue workflows',
+          details: 'Traceback line 1',
+          isRuntimeError: true,
+          exceptionType: 'PAYMENT_REQUIRED',
+          catalogId: 'subscription_required',
+          displayTitle: 'Subscription required',
+          displayMessage:
+            'Subscribe to a plan to continue running this workflow.'
+        }
+      ]
+    }
+  }
+
   function makePromptErrorCard(): ErrorCardData {
     return {
       id: '__prompt__',
@@ -368,6 +389,24 @@ describe('ErrorNodeCard.vue', () => {
         source: 'error_dialog'
       })
     )
+  })
+
+  it('suppresses the runtime details disclosure and its actions for subscription errors', async () => {
+    renderCard(makeSubscriptionErrorCard())
+
+    expect(screen.queryByText('Error log')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Details/ })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Find on GitHub/ })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Get Help/ })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Copy/ })
+    ).not.toBeInTheDocument()
   })
 
   it('passes exceptionType from error item to report generator', async () => {

--- a/src/components/rightSidePanel/errors/ErrorNodeCard.vue
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.vue
@@ -189,10 +189,9 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
+import { isSubscriptionRequiredCatalogId } from '@/platform/errorCatalog/subscriptionError'
 import { cn } from '@comfyorg/tailwind-utils'
 import TransitionCollapse from '../layout/TransitionCollapse.vue'
-
-import { hasSubscriptionError } from './errorItemUtil'
 
 import type { ErrorCardData, ErrorItem } from './types'
 import { useErrorActions } from './useErrorActions'
@@ -216,7 +215,9 @@ const runtimeDetailsExpanded = ref(true)
 const hasRuntimeError = computed(() =>
   card.errors.some((error) => error.isRuntimeError)
 )
-const isSubscriptionError = computed(() => hasSubscriptionError(card.errors))
+const isSubscriptionError = computed(() =>
+  card.errors.some((error) => isSubscriptionRequiredCatalogId(error.catalogId))
+)
 const isRuntimeDisclosureExpanded = computed(
   () => compact || runtimeDetailsExpanded.value
 )

--- a/src/components/rightSidePanel/errors/ErrorNodeCard.vue
+++ b/src/components/rightSidePanel/errors/ErrorNodeCard.vue
@@ -29,7 +29,7 @@
           {{ t('rightSidePanel.enterSubgraph') }}
         </Button>
         <Button
-          v-if="hasRuntimeError"
+          v-if="hasRuntimeError && !isSubscriptionError"
           variant="textonly"
           size="icon-sm"
           :class="
@@ -110,7 +110,11 @@
 
         <TransitionCollapse>
           <div
-            v-if="error.isRuntimeError && isRuntimeDisclosureExpanded"
+            v-if="
+              error.isRuntimeError &&
+              isRuntimeDisclosureExpanded &&
+              !isSubscriptionError
+            "
             :id="getRuntimeDetailsId(idx)"
             role="region"
             data-testid="runtime-error-panel"
@@ -188,6 +192,8 @@ import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@comfyorg/tailwind-utils'
 import TransitionCollapse from '../layout/TransitionCollapse.vue'
 
+import { hasSubscriptionError } from './errorItemUtil'
+
 import type { ErrorCardData, ErrorItem } from './types'
 import { useErrorActions } from './useErrorActions'
 import { useErrorReport } from './useErrorReport'
@@ -210,6 +216,7 @@ const runtimeDetailsExpanded = ref(true)
 const hasRuntimeError = computed(() =>
   card.errors.some((error) => error.isRuntimeError)
 )
+const isSubscriptionError = computed(() => hasSubscriptionError(card.errors))
 const isRuntimeDisclosureExpanded = computed(
   () => compact || runtimeDetailsExpanded.value
 )

--- a/src/components/rightSidePanel/errors/TabErrors.test.ts
+++ b/src/components/rightSidePanel/errors/TabErrors.test.ts
@@ -5,13 +5,33 @@ import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import TabErrors from './TabErrors.vue'
-import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import type { MissingNodeType } from '@/types/comfy'
 
 const mockFocusNode = vi.hoisted(() => vi.fn())
 const mockEnterSubgraph = vi.hoisted(() => vi.fn())
+const mockShowPricingTable = vi.hoisted(() => vi.fn())
+const mockIsFreeTier = vi.hoisted(() => ({ value: true }))
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: true,
+  isDesktop: false,
+  isNightly: false
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: vi.fn(() => ({ isFreeTier: mockIsFreeTier }))
+}))
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: vi.fn(() => ({
+      showPricingTable: mockShowPricingTable
+    }))
+  })
+)
 
 vi.mock('@/scripts/app', () => ({
   app: {
@@ -63,6 +83,7 @@ describe('TabErrors.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockIsFreeTier.value = true
     i18n = createI18n({
       legacy: false,
       locale: 'en',
@@ -74,6 +95,9 @@ describe('TabErrors.vue', () => {
             details: 'Details',
             findOnGithub: 'Find on GitHub',
             getHelpAction: 'Get Help'
+          },
+          subscription: {
+            subscribeForMore: 'Upgrade'
           },
           rightSidePanel: {
             noErrors: 'No errors',
@@ -386,7 +410,81 @@ describe('TabErrors.vue', () => {
     expect(screen.getAllByText('Execution failed')).toHaveLength(1)
   })
 
-  it('shows missing model Refresh in the section header when no model is downloadable', async () => {
+  it('shows an Upgrade button for subscription errors on free-tier cloud and opens the pricing table', async () => {
+    const { getNodeByExecutionId } = await import('@/utils/graphTraversalUtil')
+    vi.mocked(getNodeByExecutionId).mockReturnValue({
+      title: 'API Node'
+    } as ReturnType<typeof getNodeByExecutionId>)
+
+    const { user } = renderComponent({
+      executionError: {
+        lastExecutionError: {
+          prompt_id: 'abc',
+          node_id: '10',
+          node_type: 'API Node',
+          exception_message: 'Subscription required to queue workflows',
+          exception_type: 'PAYMENT_REQUIRED',
+          traceback: ['Line 1'],
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    const upgradeButton = screen.getByTestId('error-group-upgrade')
+    expect(upgradeButton).toHaveTextContent('Upgrade')
+
+    await user.click(upgradeButton)
+    expect(mockShowPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('hides the Upgrade button when the user is not on the free tier', async () => {
+    mockIsFreeTier.value = false
+    const { getNodeByExecutionId } = await import('@/utils/graphTraversalUtil')
+    vi.mocked(getNodeByExecutionId).mockReturnValue({
+      title: 'API Node'
+    } as ReturnType<typeof getNodeByExecutionId>)
+
+    renderComponent({
+      executionError: {
+        lastExecutionError: {
+          prompt_id: 'abc',
+          node_id: '10',
+          node_type: 'API Node',
+          exception_message: 'Subscription required to queue workflows',
+          exception_type: 'PAYMENT_REQUIRED',
+          traceback: ['Line 1'],
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    expect(screen.queryByTestId('error-group-upgrade')).not.toBeInTheDocument()
+  })
+
+  it('does not show the Upgrade button for non-subscription execution errors', async () => {
+    const { getNodeByExecutionId } = await import('@/utils/graphTraversalUtil')
+    vi.mocked(getNodeByExecutionId).mockReturnValue({
+      title: 'KSampler'
+    } as ReturnType<typeof getNodeByExecutionId>)
+
+    renderComponent({
+      executionError: {
+        lastExecutionError: {
+          prompt_id: 'abc',
+          node_id: '10',
+          node_type: 'KSampler',
+          exception_message: 'Out of memory',
+          exception_type: 'RuntimeError',
+          traceback: ['Line 1'],
+          timestamp: Date.now()
+        }
+      }
+    })
+
+    expect(screen.queryByTestId('error-group-upgrade')).not.toBeInTheDocument()
+  })
+
+  it('does not show local download/refresh actions for missing models on cloud', () => {
     const missingModel = {
       nodeId: '1',
       nodeType: 'CheckpointLoaderSimple',
@@ -397,21 +495,19 @@ describe('TabErrors.vue', () => {
       isAssetSupported: true
     } satisfies MissingModelCandidate
 
-    const { user } = renderComponent({
+    renderComponent({
       missingModel: {
         missingModelCandidates: [missingModel]
       }
     })
-    const missingModelStore = useMissingModelStore()
 
     expect(screen.getByText('Missing Models (1)')).toBeInTheDocument()
     expect(
+      screen.queryByTestId('missing-model-header-refresh')
+    ).not.toBeInTheDocument()
+    expect(
       screen.queryByTestId('missing-model-actions')
     ).not.toBeInTheDocument()
-
-    await user.click(screen.getByTestId('missing-model-header-refresh'))
-
-    expect(missingModelStore.refreshMissingModels).toHaveBeenCalled()
   })
 
   it('renders missing model display message below the section title', () => {
@@ -433,7 +529,7 @@ describe('TabErrors.vue', () => {
 
     expect(screen.getByText('Missing Models (1)')).toBeInTheDocument()
     expect(
-      screen.getByText('Download a model, or open the node to replace it.')
+      screen.getByText('Import a model, or open the node to replace it.')
     ).toBeInTheDocument()
   })
 
@@ -539,7 +635,7 @@ describe('TabErrors.vue', () => {
     ).toBeInTheDocument()
   })
 
-  it('keeps missing model Refresh in the card actions when models are downloadable', () => {
+  it('does not surface download-all/refresh card actions for asset-supported models on cloud', () => {
     const missingModel = {
       nodeId: '1',
       nodeType: 'CheckpointLoaderSimple',
@@ -560,8 +656,7 @@ describe('TabErrors.vue', () => {
     expect(
       screen.queryByTestId('missing-model-header-refresh')
     ).not.toBeInTheDocument()
-    expect(screen.getByTestId('missing-model-actions')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Download all/ })).toBeVisible()
-    expect(screen.getByRole('button', { name: 'Refresh' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: /Download all/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Refresh' })).toBeNull()
   })
 })

--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -327,6 +327,7 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { useFocusNode } from '@/composables/canvas/useFocusNode'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import { isSubscriptionRequiredCatalogId } from '@/platform/errorCatalog/subscriptionError'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { useManagerState } from '@/workbench/extensions/manager/composables/useManagerState'
@@ -349,7 +350,6 @@ import { getDownloadableModels } from '@/platform/missingModel/missingModelViewU
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { usePackInstall } from '@/workbench/extensions/manager/composables/nodePack/usePackInstall'
 import { useMissingNodes } from '@/workbench/extensions/manager/composables/nodePack/useMissingNodes'
-import { hasSubscriptionError } from './errorItemUtil'
 import { useErrorActions } from './useErrorActions'
 import { useErrorGroups } from './useErrorGroups'
 import type { SwapNodeGroup } from './useErrorGroups'
@@ -403,7 +403,11 @@ function getGroupSize(group: ErrorGroup) {
 function isSubscriptionGroup(group: ErrorGroup) {
   return (
     group.type === 'execution' &&
-    group.cards.some((card) => hasSubscriptionError(card.errors))
+    group.cards.some((card) =>
+      card.errors.some((error) =>
+        isSubscriptionRequiredCatalogId(error.catalogId)
+      )
+    )
   )
 }
 

--- a/src/components/rightSidePanel/errors/TabErrors.vue
+++ b/src/components/rightSidePanel/errors/TabErrors.vue
@@ -142,6 +142,30 @@
             >
               {{ group.displayMessage }}
             </p>
+            <div
+              v-if="showUpgradeButton(group)"
+              class="mt-3 flex items-center gap-3"
+            >
+              <Button
+                variant="gradient"
+                size="sm"
+                data-testid="error-group-upgrade"
+                class="h-8 rounded-lg text-sm"
+                @click.stop="handleUpgrade"
+              >
+                {{ t('subscription.subscribeForMore') }}
+              </Button>
+              <Button
+                v-tooltip.top="t('rightSidePanel.getHelpTooltip')"
+                variant="textonly"
+                size="sm"
+                class="h-8 gap-1 rounded-lg px-0 text-sm hover:bg-transparent hover:text-base-foreground"
+                @click.stop="contactSupport"
+              >
+                <i class="icon-[lucide--external-link] size-3.5" />
+                {{ t('g.getHelpAction') }}
+              </Button>
+            </div>
           </div>
 
           <!-- Missing Node Packs -->
@@ -299,8 +323,10 @@ import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { cn } from '@comfyorg/tailwind-utils'
 
+import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { useFocusNode } from '@/composables/canvas/useFocusNode'
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
 import { useManagerState } from '@/workbench/extensions/manager/composables/useManagerState'
@@ -323,6 +349,7 @@ import { getDownloadableModels } from '@/platform/missingModel/missingModelViewU
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { usePackInstall } from '@/workbench/extensions/manager/composables/nodePack/usePackInstall'
 import { useMissingNodes } from '@/workbench/extensions/manager/composables/nodePack/useMissingNodes'
+import { hasSubscriptionError } from './errorItemUtil'
 import { useErrorActions } from './useErrorActions'
 import { useErrorGroups } from './useErrorGroups'
 import type { SwapNodeGroup } from './useErrorGroups'
@@ -356,6 +383,8 @@ const { missingNodePacks } = useMissingNodes()
 const { isInstalling: isInstallingAll, installAllPacks: installAll } =
   usePackInstall(() => missingNodePacks.value)
 const { replaceGroup, replaceAllGroups } = useNodeReplacement()
+const { isFreeTier } = useBillingContext()
+const subscriptionDialog = useSubscriptionDialog()
 
 const searchQuery = ref('')
 const expandedExecutionItemDetailKeys = ref(new Set<string>())
@@ -369,6 +398,21 @@ const fullSizeGroupTypes = new Set([
 ])
 function getGroupSize(group: ErrorGroup) {
   return fullSizeGroupTypes.has(group.type) ? 'lg' : 'default'
+}
+
+function isSubscriptionGroup(group: ErrorGroup) {
+  return (
+    group.type === 'execution' &&
+    group.cards.some((card) => hasSubscriptionError(card.errors))
+  )
+}
+
+function showUpgradeButton(group: ErrorGroup) {
+  return isCloud && isFreeTier.value && isSubscriptionGroup(group)
+}
+
+function handleUpgrade() {
+  subscriptionDialog.showPricingTable()
 }
 
 const showNodeIdBadge = computed(

--- a/src/components/rightSidePanel/errors/errorItemUtil.ts
+++ b/src/components/rightSidePanel/errors/errorItemUtil.ts
@@ -1,9 +1,0 @@
-import { SUBSCRIPTION_REQUIRED_CATALOG_ID } from '@/platform/errorCatalog/catalogIds'
-
-import type { ErrorItem } from './types'
-
-export function hasSubscriptionError(errors: ErrorItem[]): boolean {
-  return errors.some(
-    (error) => error.catalogId === SUBSCRIPTION_REQUIRED_CATALOG_ID
-  )
-}

--- a/src/components/rightSidePanel/errors/errorItemUtil.ts
+++ b/src/components/rightSidePanel/errors/errorItemUtil.ts
@@ -1,0 +1,9 @@
+import { SUBSCRIPTION_REQUIRED_CATALOG_ID } from '@/platform/errorCatalog/catalogIds'
+
+import type { ErrorItem } from './types'
+
+export function hasSubscriptionError(errors: ErrorItem[]): boolean {
+  return errors.some(
+    (error) => error.catalogId === SUBSCRIPTION_REQUIRED_CATALOG_ID
+  )
+}

--- a/src/platform/errorCatalog/errorMessageResolver.test.ts
+++ b/src/platform/errorCatalog/errorMessageResolver.test.ts
@@ -1285,6 +1285,24 @@ describe('errorMessageResolver', () => {
     }
   )
 
+  it('resolves PAYMENT_REQUIRED prompt errors to subscription copy', () => {
+    expect(
+      resolveRunErrorMessage({
+        kind: 'prompt',
+        isCloud: true,
+        error: {
+          type: 'PAYMENT_REQUIRED',
+          message: 'Subscription required to queue workflows',
+          details: ''
+        }
+      })
+    ).toMatchObject({
+      catalogId: 'subscription_required',
+      displayTitle: 'Subscription required',
+      displayMessage: 'Subscribe to a plan to continue running this workflow.'
+    })
+  })
+
   it('resolves timeout copy without credit copy', () => {
     expect(
       resolveRunErrorMessage({

--- a/src/platform/errorCatalog/runtimeErrorMatcher.ts
+++ b/src/platform/errorCatalog/runtimeErrorMatcher.ts
@@ -37,7 +37,8 @@ const WORKSPACE_INSUFFICIENT_CREDITS_MESSAGES = new Set([
 ])
 const SUBSCRIPTION_REQUIRED_MESSAGES = new Set([
   'Workspace has no active subscription. Please subscribe to a plan to continue.',
-  'User has no active subscription. Please subscribe to a plan to continue.'
+  'User has no active subscription. Please subscribe to a plan to continue.',
+  'Subscription required to queue workflows'
 ])
 const SUBSCRIPTION_UPGRADE_REQUIRED_PREFIX =
   'the following private models require a subscription upgrade:'
@@ -250,6 +251,7 @@ const RUNTIME_MATCH_RULES: RuntimeMatchRule[] = [
   {
     matches: (info, message) =>
       info.exceptionType === 'InactiveSubscriptionError' ||
+      info.exceptionType === 'PAYMENT_REQUIRED' ||
       SUBSCRIPTION_REQUIRED_MESSAGES.has(message),
     resolve: () => catalogMatch(SUBSCRIPTION_REQUIRED_CATALOG_ID)
   },

--- a/src/platform/errorCatalog/subscriptionError.ts
+++ b/src/platform/errorCatalog/subscriptionError.ts
@@ -1,0 +1,7 @@
+import { SUBSCRIPTION_REQUIRED_CATALOG_ID } from './catalogIds'
+
+export function isSubscriptionRequiredCatalogId(
+  catalogId: string | undefined
+): boolean {
+  return catalogId === SUBSCRIPTION_REQUIRED_CATALOG_ID
+}


### PR DESCRIPTION
## Summary

Free-tier cloud users hitting the queue paywall saw the raw backend string "Subscription required to queue workflows" in the Errors tab; this maps it to the existing subscription catalog copy and adds an Upgrade CTA.

## Changes

- **What**: `PAYMENT_REQUIRED` (and its message) now matches the `subscription_required` catalog in `runtimeErrorMatcher`, so both the prompt and execution paths render clean copy ("Subscription required" / "Subscribe to a plan to continue running this workflow."). Adds a gradient Upgrade button under the message that opens the pricing table (`isCloud && isFreeTier`), and suppresses the traceback/Find-on-GitHub/Copy actions for this error — leaving Upgrade + Get Help. Shared detection extracted to `errorItemUtil.hasSubscriptionError`.

## Review Focus

- No new i18n keys: reuses `subscription_required` catalog copy + `subscription.subscribeForMore`.
- Upgrade button gated on the compile-time `isCloud` (mirrors `TopbarSubscribeButton`), so it's tree-shaken from OSS builds — which is why coverage is unit-only; E2E isn't reachable for cloud-gated UI in the current harness.
- Unit tests added: resolver (PAYMENT_REQUIRED → subscription copy), TabErrors (Upgrade shows on free-tier cloud / opens pricing table / hidden otherwise), ErrorNodeCard (disclosure + GitHub/Copy suppressed).

Screenshot

<img width="547" height="801" alt="image" src="https://github.com/user-attachments/assets/6be193f9-6c0e-40d1-b7c2-59bea390042a" />


closes #12840 
