### PR TITLE
feat: download missing models on server for remote web sessions

### DIFF
--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -10,6 +10,8 @@
         variant="secondary"
         size="sm"
         class="h-8 min-w-0 flex-1 rounded-lg text-sm"
+        :disabled="isDownloadingAll"
+        :aria-busy="isDownloadingAll"
         @click="downloadAllModels"
       >
         <i aria-hidden="true" class="icon-[lucide--download] size-4 shrink-0" />
@@ -114,7 +116,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
 import { isCloud } from '@/platform/distribution/types'
@@ -144,7 +146,12 @@ const downloadableModels = computed(() => {
   return getDownloadableModels(missingModelGroups)
 })
 
+const isDownloadingAll = ref(false)
+
 const downloadAllLabel = computed(() => {
+  if (isDownloadingAll.value) {
+    return t('rightSidePanel.missingModels.importing')
+  }
   const base = t('rightSidePanel.missingModels.downloadAll')
   const total = downloadableModels.value.reduce(
     (sum, model) => sum + (missingModelStore.fileSizes[model.url] ?? 0),
@@ -153,9 +160,16 @@ const downloadAllLabel = computed(() => {
   return total > 0 ? `${base} (${formatSize(total)})` : base
 })
 
-function downloadAllModels() {
-  for (const model of downloadableModels.value) {
-    downloadModel(model, missingModelStore.folderPaths)
+async function downloadAllModels() {
+  if (isDownloadingAll.value) return
+  isDownloadingAll.value = true
+  try {
+    for (const model of downloadableModels.value) {
+      const stateKey = `unsupported::${model.directory}::${model.name}`
+      await downloadModel(model, missingModelStore.folderPaths, stateKey)
+    }
+  } finally {
+    isDownloadingAll.value = false
   }
 }
 

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -74,6 +74,8 @@
         variant="secondary"
         size="sm"
         class="h-8 min-w-0 flex-1 rounded-md text-xs"
+        :disabled="isDownloadingAll"
+        :aria-busy="isDownloadingAll"
         :aria-describedby="showGatedModelsHint ? gatedHintId : undefined"
         @click="downloadAllModels"
       >
@@ -92,7 +94,11 @@ import { isCloud } from '@/platform/distribution/types'
 import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useMissingModelDownload } from '@/platform/missingModel/composables/useMissingModelDownload'
-import { isTrustedHuggingFaceUrl } from '@/platform/missingModel/missingModelDownload'
+import {
+  downloadModel,
+  isTrustedHuggingFaceUrl
+} from '@/platform/missingModel/missingModelDownload'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { getDownloadableModels } from '@/platform/missingModel/missingModelViewUtils'
 import { formatSize } from '@/utils/formatUtil'
 
@@ -123,8 +129,9 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const gatedHintId = useId()
-const { downloadMissingModel, fileSizeFor, gatedRepoUrlFor } =
-  useMissingModelDownload()
+const { fileSizeFor, gatedRepoUrlFor } = useMissingModelDownload()
+const missingModelStore = useMissingModelStore()
+const isDownloadingAll = ref(false)
 
 const sortedModelRows = computed(() =>
   missingModelGroups
@@ -179,6 +186,9 @@ watch(showGatedModelsHint, (isVisible, wasVisible) => {
 })
 
 const downloadAllLabel = computed(() => {
+  if (isDownloadingAll.value) {
+    return t('rightSidePanel.missingModels.importing')
+  }
   const base = t('rightSidePanel.missingModels.downloadAll')
   const total = downloadableModels.value.reduce(
     (sum, model) => sum + (fileSizeFor(model.url) ?? 0),
@@ -187,9 +197,16 @@ const downloadAllLabel = computed(() => {
   return total > 0 ? `${base} (${formatSize(total)})` : base
 })
 
-function downloadAllModels() {
-  for (const model of downloadableModels.value) {
-    downloadMissingModel(model)
+async function downloadAllModels() {
+  if (isDownloadingAll.value) return
+  isDownloadingAll.value = true
+  try {
+    for (const model of downloadableModels.value) {
+      const stateKey = `unsupported::${model.directory}::${model.name}`
+      await downloadModel(model, missingModelStore.folderPaths, stateKey)
+    }
+  } finally {
+    isDownloadingAll.value = false
   }
 }
 

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -125,8 +125,8 @@
     <!-- Status card -->
     <TransitionCollapse>
       <MissingModelStatusCard
-        v-if="selectedLibraryModel[modelKey]"
-        :model-name="selectedLibraryModel[modelKey]"
+        v-if="selectedLibraryModel[modelKey] || isDownloadActive"
+        :model-name="selectedLibraryModel[modelKey] || model.name"
         :is-download-active="isDownloadActive"
         :download-status="downloadStatus"
         :category-mismatch="importCategoryMismatch[modelKey]"
@@ -157,6 +157,7 @@
             size="md"
             class="flex w-full flex-1"
             :aria-label="`${t('g.download')} ${model.name}`"
+            :disabled="isDownloadActive"
             @click="handleDownload"
           >
             <i
@@ -211,6 +212,7 @@ import {
   toBrowsableUrl
 } from '@/platform/missingModel/missingModelDownload'
 import { formatSize } from '@/utils/formatUtil'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 const { model, directory, isAssetSupported } = defineProps<{
   model: MissingModelViewModel
@@ -224,6 +226,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const toastStore = useToastStore()
 const { copyToClipboard } = useCopyToClipboard()
 
 const modelKey = computed(() =>
@@ -284,13 +287,25 @@ const downloadLabel = computed(() => {
   return size ? `${base} (${formatSize(size)})` : base
 })
 
-function handleDownload() {
+async function handleDownload() {
   const rep = model.representative
   if (rep.url && rep.directory) {
-    downloadModel(
-      { name: rep.name, url: rep.url, directory: rep.directory },
-      store.folderPaths
-    )
+    try {
+      await downloadModel(
+        { name: rep.name, url: rep.url, directory: rep.directory },
+        store.folderPaths,
+        modelKey.value
+      )
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn('[MissingModelRow] Download failed:', error)
+      toastStore.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: message,
+        life: 8000
+      })
+    }
   } else {
     console.warn('[MissingModelRow] Cannot download: missing url or directory')
   }

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -271,11 +271,13 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { isCloud } from '@/platform/distribution/types'
 import {
+  downloadModel,
   isModelDownloadable,
   isTrustedHuggingFaceUrl,
   toBrowsableUrl
 } from '@/platform/missingModel/missingModelDownload'
 import { formatSize } from '@/utils/formatUtil'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 
 const {
   model,
@@ -297,6 +299,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const toastStore = useToastStore()
 const { copyToClipboard } = useCopyToClipboard()
 
 const modelKey = computed(() =>
@@ -337,7 +340,6 @@ const {
   fileSizeFor,
   gatedRepoUrlFor,
   prefetchModelMetadata,
-  downloadMissingModel,
   openModelAccessPage
 } = useMissingModelDownload()
 
@@ -438,14 +440,25 @@ onMounted(() => {
   }
 })
 
-function handleDownload() {
+async function handleDownload() {
   const rep = model.representative
   if (rep.url && rep.directory) {
-    downloadMissingModel({
-      name: rep.name,
-      url: rep.url,
-      directory: rep.directory
-    })
+    try {
+      await downloadModel(
+        { name: rep.name, url: rep.url, directory: rep.directory },
+        store.folderPaths,
+        modelKey.value
+      )
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn('[MissingModelRow] Download failed:', error)
+      toastStore.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: message,
+        life: 8000
+      })
+    }
   } else {
     console.warn('[MissingModelRow] Cannot download: missing url or directory')
   }

--- a/src/platform/missingModel/composables/useMissingModelInteractions.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.ts
@@ -281,6 +281,8 @@ export function useMissingModelInteractions() {
   }
 
   function getDownloadStatus(key: string) {
+    const direct = store.directDownloads[key]
+    if (direct) return direct
     const taskId = store.importTaskIds[key]
     if (!taskId) return null
     return (

--- a/src/platform/missingModel/composables/useMissingModelInteractions.ts
+++ b/src/platform/missingModel/composables/useMissingModelInteractions.ts
@@ -94,6 +94,8 @@ export function useMissingModelInteractions() {
   }
 
   function getDownloadStatus(key: string) {
+    const direct = store.directDownloads[key]
+    if (direct) return direct
     const taskId = store.importTaskIds[key]
     if (!taskId) return null
     return (

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -1,5 +1,8 @@
 import { downloadUrlToHfRepoUrl, isCivitaiModelUrl } from '@/utils/formatUtil'
 import { isDesktop } from '@/platform/distribution/types'
+import { api } from '@/scripts/api'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import type { AssetDownload } from '@/stores/assetDownloadStore'
 import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
@@ -25,9 +28,6 @@ const ALLOWED_SOURCES = [
   'http://localhost:'
 ] as const
 
-// Intentionally restrictive subset of model extensions permitted for download.
-// Does not include .bin, .onnx, .gguf — see MODEL_FILE_EXTENSIONS in
-// missingModelScan.ts for the broader scanning set.
 const ALLOWED_SUFFIXES = [
   '.safetensors',
   '.sft',
@@ -43,11 +43,150 @@ const WHITE_LISTED_URLS: ReadonlySet<string> = new Set([
 ])
 
 const MODEL_LIBRARY_TAB_ID = 'model-library'
+function isRemoteComfyUISession(): boolean {
+  if (typeof window === 'undefined') return false
+  if (window.__comfyDesktop2Remote) return true
+  const host = window.location.hostname.toLowerCase()
+  return host !== 'localhost' && host !== '127.0.0.1' && host !== '[::1]'
+}
+
+
 
 export interface ModelWithUrl {
   name: string
   url: string
   directory: string
+}
+
+function makeDownloadEntry(
+  key: string,
+  model: ModelWithUrl,
+  status: AssetDownload['status'],
+  progress = 0,
+  error?: string
+): AssetDownload {
+  const store = useMissingModelStore()
+  const bytesTotal = store.fileSizes[model.url] ?? 0
+  return {
+    taskId: key,
+    assetName: model.name,
+    bytesTotal,
+    bytesDownloaded: Math.round(bytesTotal * progress),
+    progress,
+    status,
+    lastUpdate: Date.now(),
+    modelType: model.directory,
+    error
+  }
+}
+
+async function pollServerDownloadProgress(
+  model: ModelWithUrl,
+  stateKey: string,
+  stop: { value: boolean }
+) {
+  const store = useMissingModelStore()
+  while (!stop.value) {
+    try {
+      const params = new URLSearchParams({
+        save_dir: model.directory,
+        filename: model.name
+      })
+      const response = await api.fetchApi(
+        `/download_model/progress?${params.toString()}`
+      )
+      if (response.ok) {
+        const data = await response.json()
+        const progress = Number(data.progress ?? 0)
+        const bytesTotal = Number(data.bytes_total ?? store.fileSizes[model.url] ?? 0)
+        const bytesDownloaded = Number(data.bytes_downloaded ?? 0)
+        const status =
+          data.status === 'completed'
+            ? 'completed'
+            : data.status === 'failed'
+              ? 'failed'
+              : 'running'
+        store.setDirectDownload(stateKey, {
+          taskId: stateKey,
+          assetName: model.name,
+          bytesTotal: bytesTotal || bytesDownloaded,
+          bytesDownloaded,
+          progress: status === 'completed' ? 1 : Math.max(progress, bytesTotal ? bytesDownloaded / bytesTotal : 0),
+          status,
+          lastUpdate: Date.now(),
+          modelType: model.directory,
+          error: data.error
+        })
+        if (status === 'completed' || status === 'failed') break
+      }
+    } catch {
+      // keep polling while main request runs
+    }
+    await new Promise((r) => setTimeout(r, 750))
+  }
+}
+
+async function downloadModelViaServer(
+  model: ModelWithUrl,
+  stateKey?: string
+): Promise<void> {
+  const store = useMissingModelStore()
+  if (stateKey) {
+    store.setDirectDownload(
+      stateKey,
+      makeDownloadEntry(stateKey, model, 'running', 0)
+    )
+  }
+
+  const stop = { value: false }
+  const pollPromise = stateKey
+    ? pollServerDownloadProgress(model, stateKey, stop)
+    : Promise.resolve()
+
+  try {
+    const response = await api.fetchApi('/download_model', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: model.url,
+        save_dir: model.directory,
+        filename: model.name
+      })
+    })
+    if (!response.ok) {
+      let message = `Download failed (${response.status})`
+      try {
+        const body = await response.json()
+        if (body?.error) message = body.error
+      } catch {
+        // ignore
+      }
+      throw new Error(message)
+    }
+    if (stateKey) {
+      store.setDirectDownload(
+        stateKey,
+        makeDownloadEntry(stateKey, model, 'completed', 1)
+      )
+    }
+  } catch (error) {
+    if (stateKey) {
+      store.setDirectDownload(
+        stateKey,
+        makeDownloadEntry(
+          stateKey,
+          model,
+          'failed',
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    throw error
+  } finally {
+    stop.value = true
+    await pollPromise
+  }
 }
 
 async function startDesktop2ModelDownload(
@@ -61,11 +200,6 @@ async function startDesktop2ModelDownload(
   }
 }
 
-/**
- * Converts a model download URL to a browsable page URL.
- * - HuggingFace: `/resolve/` → `/blob/` (file page with model info)
- * - Civitai: strips `/api/download` or `/api/v1` prefix (model page)
- */
 export function toBrowsableUrl(url: string): string {
   if (isCivitaiModelUrl(url)) {
     return url.replace('/api/download/', '/').replace('/api/v1/', '/')
@@ -85,30 +219,27 @@ export function isModelDownloadable(model: ModelWithUrl): boolean {
   return true
 }
 
-export function downloadModel(
+export async function downloadModel(
   model: ModelWithUrl,
-  paths: Record<string, string[]>
-): void {
-  const desktop2Bridge = window.__comfyDesktop2
-  if (desktop2Bridge?.downloadModel && !window.__comfyDesktop2Remote) {
-    void startDesktop2ModelDownload(desktop2Bridge, model)
+  paths: Record<string, string[]>,
+  stateKey?: string
+): Promise<void> {
+  // Remote browser/desktop sessions must never trigger a local file download.
+  if (isRemoteComfyUISession() || !isDesktop) {
+    await downloadModelViaServer(model, stateKey)
     return
   }
 
-  if (!isDesktop) {
-    const link = document.createElement('a')
-    link.href = model.url
-    link.download = model.name
-    link.target = '_blank'
-    link.rel = 'noopener noreferrer'
-    link.click()
+  const desktop2Bridge = window.__comfyDesktop2
+  if (desktop2Bridge?.downloadModel) {
+    await startDesktop2ModelDownload(desktop2Bridge, model)
     return
   }
 
   const modelPaths = paths[model.directory]
   if (modelPaths?.[0]) {
     useSidebarTabStore().activeSidebarTabId = MODEL_LIBRARY_TAB_ID
-    void useElectronDownloadStore().start({
+    await useElectronDownloadStore().start({
       url: model.url,
       savePath: modelPaths[0],
       filename: model.name
@@ -116,6 +247,7 @@ export function downloadModel(
   }
 }
 
+// metadata helpers below unchanged
 interface ModelMetadata {
   fileSize: number | null
   gatedRepoUrl: string | null

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -1,8 +1,18 @@
 import { downloadUrlToHfRepoUrl, isCivitaiModelUrl } from '@/utils/formatUtil'
 import { isDesktop } from '@/platform/distribution/types'
+import { api } from '@/scripts/api'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import type { AssetDownload } from '@/stores/assetDownloadStore'
 import { useElectronDownloadStore } from '@/stores/electronDownloadStore'
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import type { ComfyDesktop2Bridge } from '@/types'
+
+class ModelDownloadError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ModelDownloadError'
+  }
+}
 
 const ALLOWED_SOURCES = [
   'https://civitai.com/',
@@ -37,10 +47,156 @@ function isModelUrlAllowlisted(url: string): boolean {
 
 const MODEL_LIBRARY_TAB_ID = 'model-library'
 
+function isRemoteComfyUISession(): boolean {
+  if (typeof window === 'undefined') return false
+  if (window.__comfyDesktop2Remote) return true
+  const host = window.location.hostname.toLowerCase()
+  return host !== 'localhost' && host !== '127.0.0.1' && host !== '[::1]'
+}
+
 export interface ModelWithUrl {
   name: string
   url: string
   directory: string
+}
+
+function makeDownloadEntry(
+  key: string,
+  model: ModelWithUrl,
+  status: AssetDownload['status'],
+  progress = 0,
+  error?: string
+): AssetDownload {
+  const store = useMissingModelStore()
+  const bytesTotal = store.fileSizes[model.url] ?? 0
+  return {
+    taskId: key,
+    assetName: model.name,
+    bytesTotal,
+    bytesDownloaded: Math.round(bytesTotal * progress),
+    progress,
+    status,
+    lastUpdate: Date.now(),
+    modelType: model.directory,
+    error
+  }
+}
+
+async function pollServerDownloadProgress(
+  model: ModelWithUrl,
+  stateKey: string,
+  stop: { value: boolean }
+) {
+  const store = useMissingModelStore()
+  while (!stop.value) {
+    try {
+      const params = new URLSearchParams({
+        save_dir: model.directory,
+        filename: model.name
+      })
+      const response = await api.fetchApi(
+        `/download_model/progress?${params.toString()}`
+      )
+      if (response.ok) {
+        const data = await response.json()
+        const progress = Number(data.progress ?? 0)
+        const bytesTotal = Number(
+          data.bytes_total ?? store.fileSizes[model.url] ?? 0
+        )
+        const bytesDownloaded = Number(data.bytes_downloaded ?? 0)
+        const status: AssetDownload['status'] =
+          data.status === 'completed'
+            ? 'completed'
+            : data.status === 'failed'
+              ? 'failed'
+              : 'running'
+        store.setDirectDownload(stateKey, {
+          taskId: stateKey,
+          assetName: model.name,
+          bytesTotal: bytesTotal || bytesDownloaded,
+          bytesDownloaded,
+          progress:
+            status === 'completed'
+              ? 1
+              : Math.max(
+                  progress,
+                  bytesTotal ? bytesDownloaded / bytesTotal : 0
+                ),
+          status,
+          lastUpdate: Date.now(),
+          modelType: model.directory,
+          error: data.error
+        })
+        if (status === 'completed' || status === 'failed') break
+      }
+    } catch {
+      // Keep polling while the main request runs.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 750))
+  }
+}
+
+async function downloadModelViaServer(
+  model: ModelWithUrl,
+  stateKey?: string
+): Promise<void> {
+  const store = useMissingModelStore()
+  if (stateKey) {
+    store.setDirectDownload(
+      stateKey,
+      makeDownloadEntry(stateKey, model, 'running')
+    )
+  }
+
+  const stop = { value: false }
+  const pollPromise = stateKey
+    ? pollServerDownloadProgress(model, stateKey, stop)
+    : Promise.resolve()
+
+  try {
+    const response = await api.fetchApi('/download_model', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: model.url,
+        save_dir: model.directory,
+        filename: model.name
+      })
+    })
+    if (!response.ok) {
+      let message = `Download failed (${response.status})`
+      try {
+        const body = await response.json()
+        if (body?.error) message = body.error
+      } catch {
+        // Ignore malformed error responses.
+      }
+      throw new ModelDownloadError(message)
+    }
+    if (stateKey) {
+      store.setDirectDownload(
+        stateKey,
+        makeDownloadEntry(stateKey, model, 'completed', 1)
+      )
+    }
+  } catch (error) {
+    if (stateKey) {
+      store.setDirectDownload(
+        stateKey,
+        makeDownloadEntry(
+          stateKey,
+          model,
+          'failed',
+          0,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    throw error
+  } finally {
+    stop.value = true
+    await pollPromise
+  }
 }
 
 async function startDesktop2ModelDownload(
@@ -118,29 +274,28 @@ export function isModelDownloadable(model: ModelWithUrl): boolean {
   return true
 }
 
-export function downloadModel(
+export async function downloadModel(
   model: ModelWithUrl,
-  paths: Record<string, string[]>
-): void {
+  paths: Record<string, string[]>,
+  stateKey?: string
+): Promise<void> {
   if (!isModelDownloadable(model)) return
 
   const desktop2Bridge = window.__comfyDesktop2
-  const isRemote =
-    desktop2Bridge?.isRemote?.() ?? window.__comfyDesktop2Remote ?? false
-  if (desktop2Bridge?.downloadModel && !isRemote) {
-    void startDesktop2ModelDownload(desktop2Bridge, model)
+  if (isRemoteComfyUISession() || !isDesktop) {
+    await downloadModelViaServer(model, stateKey)
     return
   }
 
-  if (!isDesktop) {
-    openUrlInNewTab(model.url, model.name)
+  if (desktop2Bridge?.downloadModel) {
+    await startDesktop2ModelDownload(desktop2Bridge, model)
     return
   }
 
   const modelPaths = paths[model.directory]
   if (modelPaths?.[0]) {
     useSidebarTabStore().activeSidebarTabId = MODEL_LIBRARY_TAB_ID
-    void useElectronDownloadStore().start({
+    await useElectronDownloadStore().start({
       url: model.url,
       savePath: modelPaths[0],
       filename: model.name

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -90,6 +90,7 @@ export const useMissingModelStore = defineStore('missingModel', () => {
   const urlImporting = ref<Record<string, boolean>>({})
   const folderPaths = ref<Record<string, string[]>>({})
   const fileSizes = ref<Record<string, number>>({})
+  const directDownloads = ref<Record<string, import('@/stores/assetDownloadStore').AssetDownload>>({})
 
   const _urlDebounceTimers: Record<string, ReturnType<typeof setTimeout>> = {}
 
@@ -251,6 +252,20 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     folderPaths.value = paths
   }
 
+  function setDirectDownload(
+    key: string,
+    download: import('@/stores/assetDownloadStore').AssetDownload
+  ) {
+    directDownloads.value = { ...directDownloads.value, [key]: download }
+  }
+
+  function clearDirectDownload(key: string) {
+    if (!(key in directDownloads.value)) return
+    const next = { ...directDownloads.value }
+    delete next[key]
+    directDownloads.value = next
+  }
+
   function setFileSize(url: string, size: number) {
     fileSizes.value[url] = size
   }
@@ -271,6 +286,7 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     urlImporting.value = {}
     folderPaths.value = {}
     fileSizes.value = {}
+    directDownloads.value = {}
   }
 
   function isAbortError(error: unknown) {
@@ -331,8 +347,11 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     urlImporting,
     folderPaths,
     fileSizes,
+    directDownloads,
 
     setFolderPaths,
+    setDirectDownload,
+    clearDirectDownload,
     setFileSize,
 
     setDebounceTimer,

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -12,6 +12,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { getAncestorExecutionIds } from '@/types/nodeIdentification'
 import type { NodeExecutionId, NodeLocatorId } from '@/types/nodeIdentification'
 import { getActiveGraphNodeIds } from '@/utils/graphTraversalUtil'
+import type { AssetDownload } from '@/stores/assetDownloadStore'
 
 /**
  * Missing model error state and interaction state.
@@ -90,6 +91,7 @@ export const useMissingModelStore = defineStore('missingModel', () => {
   const folderPaths = ref<Record<string, string[]>>({})
   const fileSizes = ref<Record<string, number>>({})
   const gatedRepoUrls = ref<Record<string, string>>({})
+  const directDownloads = ref<Record<string, AssetDownload>>({})
 
   let _verificationAbortController: AbortController | null = null
 
@@ -246,6 +248,17 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     folderPaths.value = paths
   }
 
+  function setDirectDownload(key: string, download: AssetDownload) {
+    directDownloads.value = { ...directDownloads.value, [key]: download }
+  }
+
+  function clearDirectDownload(key: string) {
+    if (!(key in directDownloads.value)) return
+    const next = { ...directDownloads.value }
+    delete next[key]
+    directDownloads.value = next
+  }
+
   function setFileSize(url: string, size: number) {
     fileSizes.value[url] = size
   }
@@ -264,6 +277,7 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     folderPaths.value = {}
     fileSizes.value = {}
     gatedRepoUrls.value = {}
+    directDownloads.value = {}
   }
 
   function isAbortError(error: unknown) {
@@ -323,8 +337,11 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     folderPaths,
     fileSizes,
     gatedRepoUrls,
+    directDownloads,
 
     setFolderPaths,
+    setDirectDownload,
+    clearDirectDownload,
     setFileSize,
     setGatedRepoUrl
   }


### PR DESCRIPTION
## Summary

- Routes missing-model **Download** / **Download All** through `POST /download_model` when using the web UI against a remote host (non-localhost / `__comfyDesktop2Remote`).
- Polls `GET /download_model/progress` and shows per-model progress in the missing-models panel.
- Removes browser `<a download>` fallback on remote sessions; shows an error toast instead when server download fails.

Fixes Comfy-Org/ComfyUI#13282

Related: Comfy-Org/ComfyUI#8826 — checkpoint validation errors when the required model file is missing on the server because the client browser received the download instead.

Requires companion backend PR: Comfy-Org/ComfyUI#14472

## Test plan

- [ ] Hard-refresh ComfyUI web UI on a remote host.
- [ ] Trigger missing-model download; verify network calls go to `/download_model` (not direct HuggingFace/Civitai navigation).
- [ ] Verify progress UI updates during large downloads.
- [ ] Verify no file appears in the client Downloads folder on remote sessions.
- [ ] Verify failed downloads show an error toast (no silent browser fallback).
- [ ] Verify local Comfy Desktop (localhost) still uses desktop/electron download when not remote.