### PR TITLE
fix(billing): add panel fallback + robust matching to precondition modal routing (FE-878)

### DIFF
--- a/browser_tests/tests/subscriptionPaywallError.spec.ts
+++ b/browser_tests/tests/subscriptionPaywallError.spec.ts
@@ -8,9 +8,10 @@ import { TestIds } from '@e2e/fixtures/selectors'
 
 // Regression for #12840: a free-tier paywall on queue (`POST /prompt` 402 with
 // `{ error: { type: 'PAYMENT_REQUIRED', message: 'Subscription required to
-// queue workflows' } }`) is an account precondition. It must open its own modal
-// and stay out of the error panel, instead of surfacing the raw backend string
-// with non-actionable Find-on-GitHub / Copy actions.
+// queue workflows' } }`) is an account precondition. When the subscription modal
+// can open it takes over the panel; when it cannot (non-cloud / subscription mode
+// off, as in this OSS test build) the paywall must fall back to the error panel
+// instead of being dropped from every surface.
 test.describe('Subscription paywall on queue', { tag: '@ui' }, () => {
   test.beforeEach(async ({ comfyPage }) => {
     await comfyPage.settings.setSetting(
@@ -30,7 +31,7 @@ test.describe('Subscription paywall on queue', { tag: '@ui' }, () => {
     })
   }
 
-  test('keeps the subscription paywall out of the error panel', async ({
+  test('falls back to the error panel when the subscription modal cannot open', async ({
     comfyPage
   }) => {
     await mockQueueError(comfyPage.page, {
@@ -45,7 +46,7 @@ test.describe('Subscription paywall on queue', { tag: '@ui' }, () => {
 
     await expect(
       comfyPage.page.getByTestId(TestIds.dialogs.errorOverlay)
-    ).toBeHidden()
+    ).toBeVisible()
   })
 
   test('still surfaces ordinary queue errors in the error panel', async ({

--- a/src/platform/cloud/subscription/composables/useAccountPreconditionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useAccountPreconditionDialog.test.ts
@@ -8,13 +8,21 @@ const mockDialogService = {
   showTopUpCreditsDialog: vi.fn()
 }
 
+const mockCanRoute = vi.fn((_precondition: string) => true)
+
 vi.mock('@/services/dialogService', () => ({
   useDialogService: vi.fn(() => mockDialogService)
+}))
+
+vi.mock('@/platform/errorCatalog/accountPreconditionRouting', () => ({
+  canRoutePreconditionToModal: (precondition: string) =>
+    mockCanRoute(precondition)
 }))
 
 describe('useAccountPreconditionDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanRoute.mockReturnValue(true)
   })
 
   it('routes a sign-in precondition to the API sign-in dialog with the node type', () => {
@@ -54,5 +62,22 @@ describe('useAccountPreconditionDialog', () => {
     expect(
       mockDialogService.showSubscriptionRequiredDialog
     ).not.toHaveBeenCalled()
+  })
+
+  it('does not open a dialog and returns false when the precondition cannot be routed', () => {
+    mockCanRoute.mockReturnValue(false)
+
+    const shown = useAccountPreconditionDialog().open('subscription')
+
+    expect(shown).toBe(false)
+    expect(
+      mockDialogService.showSubscriptionRequiredDialog
+    ).not.toHaveBeenCalled()
+  })
+
+  it('returns true when a modal is shown', () => {
+    expect(useAccountPreconditionDialog().open('subscription')).toBe(true)
+    expect(useAccountPreconditionDialog().open('sign_in')).toBe(true)
+    expect(useAccountPreconditionDialog().open('credits')).toBe(true)
   })
 })

--- a/src/platform/cloud/subscription/composables/useAccountPreconditionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useAccountPreconditionDialog.ts
@@ -1,4 +1,5 @@
 import type { AccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
+import { canRoutePreconditionToModal } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useDialogService } from '@/services/dialogService'
 
 export interface AccountPreconditionContext {
@@ -13,24 +14,27 @@ export interface AccountPreconditionContext {
 export function useAccountPreconditionDialog() {
   const dialogService = useDialogService()
 
+  // Opens the precondition modal and returns whether one was shown, so callers
+  // suppress the error panel only when the modal actually took over.
   function open(
     precondition: AccountPrecondition,
     context: AccountPreconditionContext = {}
-  ): void {
+  ): boolean {
+    if (!canRoutePreconditionToModal(precondition)) return false
     switch (precondition) {
       case 'sign_in':
         void dialogService.showApiNodesSignInDialog(
           context.nodeType ? [context.nodeType] : []
         )
-        return
+        return true
       case 'subscription':
         void dialogService.showSubscriptionRequiredDialog()
-        return
+        return true
       case 'credits':
         void dialogService.showTopUpCreditsDialog({
           isInsufficientCredits: true
         })
-        return
+        return true
     }
   }
 

--- a/src/platform/errorCatalog/accountPreconditionRouting.test.ts
+++ b/src/platform/errorCatalog/accountPreconditionRouting.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { PromptResponse } from '@/schemas/apiSchema'
+
 import {
   canRoutePreconditionToModal,
   isAccountPreconditionCatalogId,
@@ -138,6 +140,13 @@ describe('resolvePromptResponsePrecondition', () => {
   it('returns undefined for an ordinary string error', () => {
     expect(
       resolvePromptResponsePrecondition('The server exploded')
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when the response has no error field', () => {
+    expect(resolvePromptResponsePrecondition(undefined)).toBeUndefined()
+    expect(
+      resolvePromptResponsePrecondition({} as PromptResponse['error'])
     ).toBeUndefined()
   })
 })

--- a/src/platform/errorCatalog/accountPreconditionRouting.test.ts
+++ b/src/platform/errorCatalog/accountPreconditionRouting.test.ts
@@ -44,6 +44,15 @@ describe('resolveAccountPrecondition', () => {
     ).toBe('subscription')
   })
 
+  it('classifies a PAYMENT_REQUIRED error by type even when the message changes', () => {
+    expect(
+      resolveAccountPrecondition({
+        exceptionType: 'PAYMENT_REQUIRED',
+        exceptionMessage: 'Some other paywall wording'
+      })
+    ).toBe('subscription')
+  })
+
   it('classifies a subscription-upgrade error as a subscription precondition', () => {
     expect(
       resolveAccountPrecondition({

--- a/src/platform/errorCatalog/accountPreconditionRouting.test.ts
+++ b/src/platform/errorCatalog/accountPreconditionRouting.test.ts
@@ -1,11 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  canRoutePreconditionToModal,
   isAccountPreconditionCatalogId,
   preconditionForCatalogId,
   resolveAccountPrecondition,
+  resolvePromptResponsePrecondition,
   selectHighestPrecedencePrecondition
 } from './accountPreconditionRouting'
+
+vi.mock('@/platform/distribution/types', () => ({ isCloud: true }))
 import {
   EXECUTION_FAILED_CATALOG_ID,
   INSUFFICIENT_CREDITS_CATALOG_ID,
@@ -89,6 +93,51 @@ describe('resolveAccountPrecondition', () => {
         exceptionType: 'RuntimeError',
         exceptionMessage: 'CUDA out of memory'
       })
+    ).toBeUndefined()
+  })
+})
+
+describe('canRoutePreconditionToModal', () => {
+  afterEach(() => {
+    window.__CONFIG__ = {}
+  })
+
+  it('routes a subscription precondition only when subscription mode is enabled', () => {
+    window.__CONFIG__ = { subscription_required: true }
+    expect(canRoutePreconditionToModal('subscription')).toBe(true)
+
+    window.__CONFIG__ = { subscription_required: false }
+    expect(canRoutePreconditionToModal('subscription')).toBe(false)
+  })
+
+  it('always routes sign-in and credit preconditions', () => {
+    expect(canRoutePreconditionToModal('sign_in')).toBe(true)
+    expect(canRoutePreconditionToModal('credits')).toBe(true)
+  })
+})
+
+describe('resolvePromptResponsePrecondition', () => {
+  it('classifies a structured prompt-response paywall error', () => {
+    expect(
+      resolvePromptResponsePrecondition({
+        type: 'PAYMENT_REQUIRED',
+        message: 'Subscription required to queue workflows',
+        details: ''
+      })
+    ).toBe('subscription')
+  })
+
+  it('classifies a string-shaped prompt-response error', () => {
+    expect(
+      resolvePromptResponsePrecondition(
+        'Unauthorized: Please login first to use this node.'
+      )
+    ).toBe('sign_in')
+  })
+
+  it('returns undefined for an ordinary string error', () => {
+    expect(
+      resolvePromptResponsePrecondition('The server exploded')
     ).toBeUndefined()
   })
 })

--- a/src/platform/errorCatalog/accountPreconditionRouting.ts
+++ b/src/platform/errorCatalog/accountPreconditionRouting.ts
@@ -69,10 +69,10 @@ export function canRoutePreconditionToModal(
     : true
 }
 
-// Normalizes a /prompt response error, which can be a bare string or a
-// structured payload, into the account precondition it represents.
+// The /prompt body is unvalidated JSON, so the error field may be a string, a
+// structured payload, or absent (e.g. the 403 `{ message }` shape).
 export function resolvePromptResponsePrecondition(
-  responseError: PromptResponse['error']
+  responseError: PromptResponse['error'] | undefined
 ): AccountPrecondition | undefined {
   if (typeof responseError === 'string') {
     return resolveAccountPrecondition({
@@ -80,9 +80,10 @@ export function resolvePromptResponsePrecondition(
       exceptionMessage: responseError
     })
   }
+  if (!responseError || typeof responseError !== 'object') return undefined
   return resolveAccountPrecondition({
-    exceptionType: responseError.type,
-    exceptionMessage: responseError.message
+    exceptionType: responseError.type ?? '',
+    exceptionMessage: responseError.message ?? ''
   })
 }
 

--- a/src/platform/errorCatalog/accountPreconditionRouting.ts
+++ b/src/platform/errorCatalog/accountPreconditionRouting.ts
@@ -1,3 +1,6 @@
+import { isCloud } from '@/platform/distribution/types'
+import type { PromptResponse } from '@/schemas/apiSchema'
+
 import {
   INSUFFICIENT_CREDITS_CATALOG_ID,
   SIGN_IN_REQUIRED_CATALOG_ID,
@@ -53,6 +56,34 @@ export function resolveAccountPrecondition(
 ): AccountPrecondition | undefined {
   const match = resolveRuntimeCatalogMatch(info)
   return preconditionForCatalogId(match?.catalogId)
+}
+
+// The subscription modal no-ops unless cloud subscription mode is enabled, so a
+// subscription precondition can only be routed to a modal in that case. Sign-in
+// and credit modals always render, so they can always be routed.
+export function canRoutePreconditionToModal(
+  precondition: AccountPrecondition
+): boolean {
+  return precondition === 'subscription'
+    ? Boolean(isCloud && window.__CONFIG__?.subscription_required)
+    : true
+}
+
+// Normalizes a /prompt response error, which can be a bare string or a
+// structured payload, into the account precondition it represents.
+export function resolvePromptResponsePrecondition(
+  responseError: PromptResponse['error']
+): AccountPrecondition | undefined {
+  if (typeof responseError === 'string') {
+    return resolveAccountPrecondition({
+      exceptionType: '',
+      exceptionMessage: responseError
+    })
+  }
+  return resolveAccountPrecondition({
+    exceptionType: responseError.type,
+    exceptionMessage: responseError.message
+  })
 }
 
 // Resolves the winning precondition when several could co-occur. Ordering

--- a/src/platform/errorCatalog/runtimeErrorMatcher.ts
+++ b/src/platform/errorCatalog/runtimeErrorMatcher.ts
@@ -251,6 +251,7 @@ const RUNTIME_MATCH_RULES: RuntimeMatchRule[] = [
   {
     matches: (info, message) =>
       info.exceptionType === 'InactiveSubscriptionError' ||
+      info.exceptionType === 'PAYMENT_REQUIRED' ||
       SUBSCRIPTION_REQUIRED_MESSAGES.has(message),
     resolve: () => catalogMatch(SUBSCRIPTION_REQUIRED_CATALOG_ID)
   },

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -61,7 +61,10 @@ import {
   DOMWidgetImpl
 } from '@/scripts/domWidget'
 import { useAccountPreconditionDialog } from '@/platform/cloud/subscription/composables/useAccountPreconditionDialog'
-import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
+import {
+  resolveAccountPrecondition,
+  resolvePromptResponsePrecondition
+} from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useDialogService } from '@/services/dialogService'
 import { useExtensionService } from '@/services/extensionService'
 import { useLitegraphService } from '@/services/litegraphService'
@@ -776,11 +779,15 @@ export class ComfyApp {
         exceptionType: detail.exception_type ?? '',
         exceptionMessage: detail.exception_message ?? ''
       })
-      if (precondition) {
+      if (
+        precondition &&
         useAccountPreconditionDialog().open(precondition, {
           nodeType: detail.node_type
         })
-      } else if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
+      ) {
+        return
+      }
+      if (useSettingStore().get('Comfy.RightSidePanel.ShowErrorsTab')) {
         useExecutionErrorStore().showErrorOverlay()
       } else {
         useDialogService().showExecutionErrorDialog(detail)
@@ -1672,21 +1679,18 @@ export class ComfyApp {
               this.canvas.draw(true, true)
             }
           } catch (error: unknown) {
-            const preconditionResponseError =
-              error instanceof PromptExecutionError &&
-              typeof error.response.error === 'object'
-                ? error.response.error
+            const promptPrecondition =
+              error instanceof PromptExecutionError
+                ? resolvePromptResponsePrecondition(error.response.error)
                 : undefined
-            const promptPrecondition = preconditionResponseError
-              ? resolveAccountPrecondition({
-                  exceptionType: preconditionResponseError.type,
-                  exceptionMessage: preconditionResponseError.message
-                })
-              : undefined
             // Account preconditions (sign-in, subscription, credits) open their
-            // own modal and must stay out of the error panel and error count.
-            if (promptPrecondition) {
+            // own modal and stay out of the error panel. When the modal cannot
+            // open (subscription mode disabled), fall through so the error still
+            // surfaces in the panel instead of showing nothing.
+            if (
+              promptPrecondition &&
               useAccountPreconditionDialog().open(promptPrecondition)
+            ) {
               console.error(error)
               break
             }

--- a/src/stores/executionStore.test.ts
+++ b/src/stores/executionStore.test.ts
@@ -6,6 +6,7 @@ import { MAX_PROGRESS_JOBS, useExecutionStore } from '@/stores/executionStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import { useMissingNodesErrorStore } from '@/platform/nodeReplacement/missingNodesErrorStore'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
+import type * as AccountPreconditionRouting from '@/platform/errorCatalog/accountPreconditionRouting'
 import type * as DistributionTypes from '@/platform/distribution/types'
 import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
 import type * as WorkflowStoreModule from '@/platform/workflow/management/stores/workflowStore'
@@ -79,6 +80,16 @@ vi.mock('@/platform/telemetry', () => ({
     trackExecutionSuccess: mockTrackExecutionSuccess,
     trackSharedWorkflowRun: mockTrackSharedWorkflowRun
   })
+}))
+
+const mockCanRoutePrecondition = vi.hoisted(() =>
+  vi.fn((_precondition: string) => true)
+)
+
+vi.mock('@/platform/errorCatalog/accountPreconditionRouting', async (orig) => ({
+  ...(await orig<typeof AccountPreconditionRouting>()),
+  canRoutePreconditionToModal: (precondition: string) =>
+    mockCanRoutePrecondition(precondition)
 }))
 
 // Remove any previous global types
@@ -975,6 +986,7 @@ describe('useExecutionStore - WebSocket event handlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanRoutePrecondition.mockReturnValue(true)
     apiEventHandlers.clear()
     setActivePinia(createTestingPinia({ stubActions: false }))
     store = useExecutionStore()
@@ -1351,6 +1363,24 @@ describe('useExecutionStore - WebSocket event handlers', () => {
       expect(errorStore.lastExecutionError).toBeNull()
       expect(errorStore.lastPromptError).toBeNull()
       expect(errorStore.totalErrorCount).toBe(0)
+    })
+
+    it('keeps a subscription precondition in the error panel when its modal cannot open', () => {
+      mockCanRoutePrecondition.mockReturnValue(false)
+      const errorStore = useExecutionErrorStore()
+
+      fire('execution_error', {
+        prompt_id: 'job-1',
+        node_id: 'n1',
+        node_type: 'KSampler',
+        exception_type: 'InactiveSubscriptionError',
+        exception_message:
+          'User has no active subscription. Please subscribe to a plan to continue.',
+        traceback: []
+      })
+
+      expect(errorStore.lastExecutionError).not.toBeNull()
+      expect(errorStore.totalErrorCount).toBe(1)
     })
 
     it('still routes an ordinary node runtime error to the error panel', () => {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -9,7 +9,10 @@ import {
   useAppMode
 } from '@/composables/useAppMode'
 import { isCloud } from '@/platform/distribution/types'
-import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
+import {
+  canRoutePreconditionToModal,
+  resolveAccountPrecondition
+} from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useTelemetry } from '@/platform/telemetry'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -460,7 +463,11 @@ export const useExecutionStore = defineStore('execution', () => {
       exceptionType: detail.exception_type ?? '',
       exceptionMessage: detail.exception_message ?? ''
     })
-    if (!precondition) return false
+    // Keep the error in the panel when no modal can take over, otherwise it would
+    // be dropped from both surfaces and the user would see nothing.
+    if (!precondition || !canRoutePreconditionToModal(precondition)) {
+      return false
+    }
 
     clearInitializationByJobId(detail.prompt_id)
     resetExecutionState(detail.prompt_id)


### PR DESCRIPTION
## Summary

Builds on top of #12785  precondition→modal routing: adds an error-panel fallback so a gated-off modal never leaves the user with a blank screen, plus more robust paywall matching.

## Changes

- **What**:
  - Panel fallback — `canRoutePreconditionToModal` gate (shared by the dialog opener, queue catch, and execution store) suppresses the error panel only when a modal can actually open; otherwise the error stays in the panel. Fixes the blank-screen case when the subscription modal no-ops (non-cloud or `__CONFIG__.subscription_required` off).
  - Match `PAYMENT_REQUIRED` by exception type, not just the message string, so classification survives backend wording changes.
  - Normalize string-shaped `/prompt` response errors (`resolvePromptResponsePrecondition`) so the queue paywall routes regardless of payload shape.
  - Refactor: single pure routing predicate removes the duplicated subscription-mode check and the `executionStore → dialog → auth` coupling.

## Review Focus

- The fallback rule: matched precondition + modal opens → panel suppressed; matched + modal can't open → panel kept (never blank); unmatched → panel as before.
- `canRoutePreconditionToModal` is pure (reads `isCloud` + `__CONFIG__`, no auth/dialog imports) and is the single source of truth used by `useAccountPreconditionDialog.open`, the queue catch, and `executionStore`.
- `subscriptionPaywallError.spec.ts` updated: in the OSS test build (non-cloud) the paywall correctly falls back to the panel.

- Fixes #12840
