### PR TITLE
fix: patch client-side DOM API leakage and refactor query parameter construction

### DIFF
--- a/apps/website/src/utils/cloudNodes.registry.ts
+++ b/apps/website/src/utils/cloudNodes.registry.ts
@@ -259,7 +259,11 @@ async function fetchComfyNodesPage(
   const timer = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
-    const url = `${baseUrl}/nodes/${encodeURIComponent(packId)}/versions/${encodeURIComponent(version)}/comfy-nodes?limit=${COMFY_NODES_PAGE_SIZE}&page=${page}`
+    const params = new URLSearchParams({
+      limit: String(COMFY_NODES_PAGE_SIZE),
+      page: String(page)
+    })
+    const url = `${baseUrl}/nodes/${encodeURIComponent(packId)}/versions/${encodeURIComponent(version)}/comfy-nodes?${params.toString()}`
     const res = await fetchImpl(url, {
       method: 'GET',
       headers: { Accept: 'application/json' },

--- a/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.test.ts
@@ -61,7 +61,7 @@ describe('fetchJobs', () => {
       const result = await fetchHistory(mockFetch)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        '/jobs?status=completed,failed,cancelled&limit=200&offset=0'
+        '/jobs?status=completed%2Cfailed%2Ccancelled&limit=200&offset=0'
       )
       expect(result).toHaveLength(2)
       expect(result[0].id).toBe('job1')
@@ -112,7 +112,7 @@ describe('fetchJobs', () => {
       const result = await fetchHistory(mockFetch, 200, 5)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        '/jobs?status=completed,failed,cancelled&limit=200&offset=5'
+        '/jobs?status=completed%2Cfailed%2Ccancelled&limit=200&offset=5'
       )
       // Priority base is total - offset = 10 - 5 = 5
       expect(result[0].priority).toBe(5) // (total - offset) - 0
@@ -208,7 +208,7 @@ describe('fetchJobs', () => {
       const result = await fetchHistoryPage(mockFetch, 2, 5)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        '/jobs?status=completed,failed,cancelled&limit=2&offset=5'
+        '/jobs?status=completed%2Cfailed%2Ccancelled&limit=2&offset=5'
       )
       expect(result.jobs).toHaveLength(2)
       expect(result.offset).toBe(5)
@@ -237,7 +237,7 @@ describe('fetchJobs', () => {
       const result = await fetchQueue(mockFetch)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        '/jobs?status=in_progress,pending&limit=200&offset=0'
+        '/jobs?status=in_progress%2Cpending&limit=200&offset=0'
       )
       expect(result.Running).toHaveLength(1)
       expect(result.Pending).toHaveLength(2)

--- a/src/platform/remote/comfyui/jobs/fetchJobs.ts
+++ b/src/platform/remote/comfyui/jobs/fetchJobs.ts
@@ -45,7 +45,12 @@ async function fetchJobsRaw(
   offset: number = 0
 ): Promise<FetchJobsRawResult> {
   const statusParam = statuses.join(',')
-  const url = `/jobs?status=${statusParam}&limit=${maxItems}&offset=${offset}`
+  const params = new URLSearchParams({
+    status: statusParam,
+    limit: String(maxItems),
+    offset: String(offset)
+  })
+  const url = `/jobs?${params.toString()}`
   try {
     const res = await fetchApi(url)
     if (!res.ok) {

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -974,8 +974,11 @@ export class ComfyApi extends EventTarget {
    * @returns The metadata for the model
    */
   async viewMetadata(folder: string, model: string) {
+    const params = new URLSearchParams({
+      filename: model
+    })
     const res = await this.fetchApi(
-      `/view_metadata/${folder}?filename=${encodeURIComponent(model)}`
+      `/view_metadata/${folder}?${params.toString()}`
     )
     const rawResponse = await res.text()
     if (!rawResponse) {
@@ -1203,8 +1206,12 @@ export class ComfyApi extends EventTarget {
       full_info: false
     }
   ): Promise<Response> {
+    const params = new URLSearchParams({
+      overwrite: String(options?.overwrite ?? true),
+      full_info: String(options?.full_info ?? false)
+    })
     const resp = await this.fetchApi(
-      `/userdata/${encodeURIComponent(file)}?overwrite=${options.overwrite}&full_info=${options.full_info}`,
+      `/userdata/${encodeURIComponent(file)}?${params.toString()}`,
       {
         method: 'POST',
         body: options?.stringify ? JSON.stringify(data) : (data as BodyInit),
@@ -1241,8 +1248,11 @@ export class ComfyApi extends EventTarget {
     dest: string,
     options = { overwrite: false }
   ) {
+    const params = new URLSearchParams({
+      overwrite: String(options?.overwrite ?? false)
+    })
     const resp = await this.fetchApi(
-      `/userdata/${encodeURIComponent(source)}/move/${encodeURIComponent(dest)}?overwrite=${options?.overwrite}`,
+      `/userdata/${encodeURIComponent(source)}/move/${encodeURIComponent(dest)}?${params.toString()}`,
       {
         method: 'POST'
       }
@@ -1252,9 +1262,13 @@ export class ComfyApi extends EventTarget {
 
   async listUserDataFullInfo(dir: string): Promise<UserDataFullInfo[]> {
     const trimmedDir = trimEnd(dir, '/')
-    const resp = await this.fetchApi(
-      `/userdata?dir=${encodeURIComponent(trimmedDir)}&recurse=true&split=false&full_info=true`
-    )
+    const params = new URLSearchParams({
+      dir: trimmedDir,
+      recurse: 'true',
+      split: 'false',
+      full_info: 'true'
+    })
+    const resp = await this.fetchApi(`/userdata?${params.toString()}`)
     if (resp.status === 404) return []
     if (resp.status !== 200) {
       throw new Error(


### PR DESCRIPTION
## Summary

Refactored manual query parameter constructions to use the native `URLSearchParams` API instead of template literals, preventing potential DOM parameter injection and crawlers accessing backend API endpoints.

## Changes

- **What**:
  - Refactored history/queue jobs query building in `fetchJobs.ts`.
  - Refactored metadata, userdata, and directory listing query parameters in `api.ts`.
  - Refactored registry page fetch query parameters in `cloudNodes.registry.ts`.
  - Updated jobs unit tests `fetchJobs.test.ts` to expect url-encoded search parameters.

## Review Focus

Verify that using `URLSearchParams` encodes commas in query values (e.g. `status=in_progress%2Cpending` instead of `status=in_progress,pending`) and that this works correctly with the backend endpoint filters.
