### PR TITLE
Restrict Node.js engine version to <26

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "zod-to-json-schema": "catalog:"
   },
   "engines": {
-    "node": ">=25",
+    "node": ">=25 <26",
     "pnpm": ">=11.3"
   },
   "packageManager": "pnpm@11.3.0"


### PR DESCRIPTION
## Summary

We have a few dependencies that have conflicts with Node 26 still.