### PR TITLE
Add long widget values to tooltips

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/tooltips.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/tooltips.spec.ts
@@ -1,0 +1,26 @@
+import {
+  comfyExpect as expect,
+  comfyPageFixture as test
+} from '@e2e/fixtures/ComfyPage'
+
+test.describe('tooltips', { tag: '@vue-nodes' }, async () => {
+  test.beforeEach(async ({ comfyPage }) => {
+    await comfyPage.settings.setSetting('Comfy.EnableTooltips', true)
+    await comfyPage.settings.setSetting('LiteGraph.Node.TooltipDelay', 0)
+  })
+
+  test('widget value tooltips', async ({ comfyPage }) => {
+    const tooltip = comfyPage.page.locator('.p-tooltip-text')
+    await comfyPage.vueNodes.getWidgetByName('load check', 'ckpt_name').hover()
+    await expect(tooltip, 'displays for combos').toContainText('v1-5-pruned')
+
+    await comfyPage.vueNodes.getWidgetByName('ksampler', 'seed').hover()
+    await expect(tooltip, 'displays for numbers').toContainText('15668')
+
+    await comfyPage.vueNodes.getNodeLocator('6').getByLabel('text').hover()
+    await expect(tooltip).toBeVisible()
+    await expect(tooltip, "doesn't display for prompts").not.toContainText(
+      'purple galaxy bottle'
+    )
+  })
+})

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -46,12 +46,11 @@ import {
   getLocatorIdFromNodeData
 } from '@/utils/graphTraversalUtil'
 
-const TOOLTIP_VALUE_TYPES: Readonly<string[]> = [
-  'asset',
-  'combo',
-  'number',
-  'text'
-]
+const TOOLTIP_VALUE_TYPES = ['asset', 'combo', 'number', 'text'] as const
+type TooltipValueType = (typeof TOOLTIP_VALUE_TYPES)[number]
+function isTooltipValueType(val: unknown): val is TooltipValueType {
+  return TOOLTIP_VALUE_TYPES.includes(val as TooltipValueType)
+}
 
 interface ProcessedWidget {
   advanced: boolean
@@ -327,7 +326,7 @@ export function computeProcessedWidgets({
     )
 
     const valueTooltip =
-      TOOLTIP_VALUE_TYPES.includes(widget.type) && String(value).length > 10
+      isTooltipValueType(widget.type) && String(value).length > 10
         ? String(value)
         : undefined
     const tooltipConfig = ui.getTooltipConfig(widget, valueTooltip)

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -46,6 +46,13 @@ import {
   getLocatorIdFromNodeData
 } from '@/utils/graphTraversalUtil'
 
+const TOOLTIP_VALUE_TYPES: Readonly<string[]> = [
+  'asset',
+  'combo',
+  'number',
+  'text'
+]
+
 interface ProcessedWidget {
   advanced: boolean
   handleContextMenu: (e: PointerEvent) => void
@@ -67,7 +74,7 @@ interface ProcessedWidget {
 }
 
 interface WidgetUiCallbacks {
-  getTooltipConfig: (widget: SafeWidgetData) => TooltipOptions
+  getTooltipConfig: (widget: SafeWidgetData, fullVal?: string) => TooltipOptions
   handleNodeRightClick: (e: PointerEvent, nodeId: string) => void
 }
 
@@ -319,7 +326,11 @@ export function computeProcessedWidgets({
       executionErrorStore
     )
 
-    const tooltipConfig = ui.getTooltipConfig(widget)
+    const valueTooltip =
+      TOOLTIP_VALUE_TYPES.includes(widget.type) && String(value).length > 10
+        ? String(value)
+        : undefined
+    const tooltipConfig = ui.getTooltipConfig(widget, valueTooltip)
     const handleContextMenu = (e: PointerEvent) => {
       e.preventDefault()
       e.stopPropagation()
@@ -375,7 +386,10 @@ export function useProcessedWidgets(
   const { getWidgetTooltip, createTooltipConfig } = useNodeTooltips(nodeType)
 
   const ui: WidgetUiCallbacks = {
-    getTooltipConfig: (widget) => createTooltipConfig(getWidgetTooltip(widget)),
+    getTooltipConfig: (widget, fullValue = '') =>
+      createTooltipConfig(
+        [getWidgetTooltip(widget), fullValue].join('\n\n').trim()
+      ),
     handleNodeRightClick
   }
 


### PR DESCRIPTION
If a widget value is long (> 10 characters) and on a known single-line widget (`number`, `combo`, or `string), then the widget's full value will be added to the tooltip.

Additionally, margins on combo widgets are slightly tweaked so more of the text displays before truncation occurs.

| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/fefd76e9-6511-4e98-80f6-030a6dc34fb8" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/0cbc100d-066e-4272-afe9-795e56c12353" />|

