### PR TITLE
fix(website): remove series-entertainment "Read more on this topic" CTA

### DIFF
--- a/apps/website/src/config/customerStories.ts
+++ b/apps/website/src/config/customerStories.ts
@@ -18,9 +18,7 @@ export const customerStories: CustomerStory[] = [
     category: 'customers.story.series-entertainment.category',
     title: 'customers.story.series-entertainment.title',
     body: 'customers.story.series-entertainment.body',
-    detailPrefix: 'customers.detail.series-entertainment',
-    readMoreHref:
-      'https://comfy.org/cloud/enterprise-case-studies/how-series-entertainment-rebuilt-game-and-video-production-with-comfyui'
+    detailPrefix: 'customers.detail.series-entertainment'
   },
   {
     slug: 'open-story-movement',


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Removes the "Read more on this topic" CTA at the bottom of the [Series Entertainment customer story page](https://comfy.org/customers/series-entertainment). The linking destination was incorrect; per product decision, we drop the CTA rather than fix the URL.

## Change

Removed the `readMoreHref` field from the `series-entertainment` entry in `customerStories.ts`. `ContentSection.vue` already gates the CTA with `v-if="readMoreHref"`, so no component changes are needed — the `groove-jones` entry already relies on this same fallback.

```diff
   {
     slug: 'series-entertainment',
     ...
-    detailPrefix: 'customers.detail.series-entertainment',
-    readMoreHref:
-      'https://comfy.org/cloud/enterprise-case-studies/how-series-entertainment-rebuilt-game-and-video-production-with-comfyui'
+    detailPrefix: 'customers.detail.series-entertainment'
   },
```

## Verification

- `pnpm --filter @comfyorg/website typecheck` → 0 errors (warnings/hints all pre-existing, unrelated).
- `eslint` + `oxfmt --check` on the modified file → clean.
- Loaded `/customers/series-entertainment` in `astro dev` and confirmed the CTA no longer renders (see screenshot).
- Loaded `/customers/open-story-movement` as a control — its CTA still renders with the correct href, confirming no regression to the other stories.
- Code review (Oracle): 0 findings.

## Screenshots

![Bottom of /customers/series-entertainment showing the Read more CTA is gone; the page goes straight from the body into the Whats Next section.](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/de785b642b33aa12de3dea293e50f3eb0d0c6920a1ee1cab248607e91702da2e/pr-images/1781580269807-fe2345ec-a567-49e0-bd7c-10e6ea344a9d.png)