### PR TITLE
Add Desktop2 frontend distribution

### DIFF
--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -120,7 +120,7 @@ jobs:
             -e 'DesktopTelemetry' \
             -e 'initDesktopTelemetry' \
             -e '__comfyDesktop2\??\.Telemetry' \
-            -e 'Telemetry\\??\\.capture' \
+            -e 'Telemetry\??\.capture' \
             dist; then
             echo '❌ ERROR: Desktop telemetry references found in OSS dist assets!'
             echo 'Desktop telemetry must only ship in the desktop2 distribution.'

--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -119,7 +119,7 @@ jobs:
             -g '*.js' \
             -e 'DesktopTelemetry' \
             -e 'initDesktopTelemetry' \
-            -e '__comfyDesktop2\\??\\.Telemetry' \
+            -e '__comfyDesktop2\??\.Telemetry' \
             -e 'Telemetry\\??\\.capture' \
             dist; then
             echo '❌ ERROR: Desktop telemetry references found in OSS dist assets!'

--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -109,3 +109,21 @@ jobs:
             exit 1
           fi
           echo '✅ No PostHog references found'
+
+      - name: Scan dist for Desktop telemetry references
+        run: |
+          set -euo pipefail
+          echo '🔍 Scanning for Desktop telemetry references...'
+          if rg --no-ignore -n \
+            -g '*.html' \
+            -g '*.js' \
+            -e 'DesktopTelemetry' \
+            -e 'initDesktopTelemetry' \
+            -e '__comfyDesktop2\\??\\.Telemetry' \
+            -e 'Telemetry\\??\\.capture' \
+            dist; then
+            echo '❌ ERROR: Desktop telemetry references found in OSS dist assets!'
+            echo 'Desktop telemetry must only ship in the desktop2 distribution.'
+            exit 1
+          fi
+          echo '✅ No Desktop telemetry references found'

--- a/.github/workflows/release-biweekly-comfyui.yaml
+++ b/.github/workflows/release-biweekly-comfyui.yaml
@@ -231,6 +231,7 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+          pnpm build:desktop2
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -244,7 +245,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p comfyui_frontend_package/comfyui_frontend_package/static/
+          mkdir -p comfyui_frontend_package/comfyui_frontend_package/static-desktop2/
           cp -r dist/* comfyui_frontend_package/comfyui_frontend_package/static/
+          cp -r dist-desktop2/* comfyui_frontend_package/comfyui_frontend_package/static-desktop2/
 
       - name: Build pypi package
         run: python -m build

--- a/.github/workflows/release-pypi-dev.yaml
+++ b/.github/workflows/release-pypi-dev.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+          pnpm build:desktop2
           pnpm zipdist
       - name: Upload dist artifact
         uses: actions/upload-artifact@v6
@@ -45,6 +46,7 @@ jobs:
           name: dist-files
           path: |
             dist/
+            dist-desktop2/
             dist.zip
 
   publish_pypi:
@@ -66,7 +68,9 @@ jobs:
       - name: Setup pypi package
         run: |
           mkdir -p comfyui_frontend_package/comfyui_frontend_package/static/
+          mkdir -p comfyui_frontend_package/comfyui_frontend_package/static-desktop2/
           cp -r dist/* comfyui_frontend_package/comfyui_frontend_package/static/
+          cp -r dist-desktop2/* comfyui_frontend_package/comfyui_frontend_package/static-desktop2/
       - name: Build pypi package
         run: python -m build
         working-directory: comfyui_frontend_package

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules
 .pnpm-store
 .nx
 dist
+dist-desktop2
 dist-ssr
 *.local
 # Claude configuration

--- a/comfyui_frontend_package/MANIFEST.in
+++ b/comfyui_frontend_package/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include comfyui_frontend_package/static *
+recursive-include comfyui_frontend_package/static-desktop2 *

--- a/comfyui_frontend_package/README.md
+++ b/comfyui_frontend_package/README.md
@@ -2,7 +2,7 @@
 
 This is the pypi package structure for the comfyui frontend.
 
-During build process, the compiled assets are copied into the `${PROJECT_ROOT}/comfyui_frontend_package/comfyui_frontend_package/static` directory.
+During build process, the compiled OSS assets are copied into the `${PROJECT_ROOT}/comfyui_frontend_package/comfyui_frontend_package/static` directory. Desktop2 assets are copied into `${PROJECT_ROOT}/comfyui_frontend_package/comfyui_frontend_package/static-desktop2`.
 
 The package can be installed with the following command:
 

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "scripts": {
     "build:cloud": "cross-env DISTRIBUTION=cloud vite build --config vite.config.mts",
     "build:desktop": "pnpm --filter @comfyorg/desktop-ui run build",
+    "build:desktop2": "cross-env DISTRIBUTION=desktop2 vite build --config vite.config.mts --outDir dist-desktop2",
     "build-storybook": "storybook build",
     "build:types": "vite build --config vite.types.config.mts && node scripts/prepare-types.js",
     "build:analyze": "cross-env ANALYZE_BUNDLE=true pnpm build",
     "build": "pnpm typecheck && vite build --config vite.config.mts",
-    "clean": "pnpm dlx rimraf dist dist-ssr coverage playwright-report blob-report test-results node_modules/.vite apps/desktop-ui/dist apps/website/dist",
+    "clean": "pnpm dlx rimraf dist dist-desktop2 dist-ssr coverage playwright-report blob-report test-results node_modules/.vite apps/desktop-ui/dist apps/website/dist",
     "clean:all": "pnpm clean && pnpm dlx rimraf node_modules",
     "size:collect": "node scripts/size-collect.js",
     "size:report": "node scripts/size-report.js",

--- a/scripts/vite-define-shim.ts
+++ b/scripts/vite-define-shim.ts
@@ -11,7 +11,7 @@ declare global {
   const __ALGOLIA_APP_ID__: string
   const __ALGOLIA_API_KEY__: string
   const __USE_PROD_CONFIG__: boolean
-  const __DISTRIBUTION__: 'desktop' | 'localhost' | 'cloud'
+  const __DISTRIBUTION__: 'desktop' | 'desktop2' | 'localhost' | 'cloud'
   const __IS_NIGHTLY__: boolean
 }
 
@@ -22,7 +22,7 @@ type GlobalWithDefines = typeof globalThis & {
   __ALGOLIA_APP_ID__: string
   __ALGOLIA_API_KEY__: string
   __USE_PROD_CONFIG__: boolean
-  __DISTRIBUTION__: 'desktop' | 'localhost' | 'cloud'
+  __DISTRIBUTION__: 'desktop' | 'desktop2' | 'localhost' | 'cloud'
   __IS_NIGHTLY__: boolean
   window?: Record<string, unknown>
 }

--- a/scripts/vite-define-shim.ts
+++ b/scripts/vite-define-shim.ts
@@ -3,6 +3,8 @@
  * This file should be imported before any code that uses Vite define variables
  */
 
+import type { Distribution } from '../src/platform/distribution/types'
+
 // Define global constants that Vite would normally replace at build time
 declare global {
   const __COMFYUI_FRONTEND_VERSION__: string
@@ -11,7 +13,7 @@ declare global {
   const __ALGOLIA_APP_ID__: string
   const __ALGOLIA_API_KEY__: string
   const __USE_PROD_CONFIG__: boolean
-  const __DISTRIBUTION__: 'desktop' | 'desktop2' | 'localhost' | 'cloud'
+  const __DISTRIBUTION__: Distribution
   const __IS_NIGHTLY__: boolean
 }
 
@@ -22,7 +24,7 @@ type GlobalWithDefines = typeof globalThis & {
   __ALGOLIA_APP_ID__: string
   __ALGOLIA_API_KEY__: string
   __USE_PROD_CONFIG__: boolean
-  __DISTRIBUTION__: 'desktop' | 'desktop2' | 'localhost' | 'cloud'
+  __DISTRIBUTION__: Distribution
   __IS_NIGHTLY__: boolean
   window?: Record<string, unknown>
 }

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import type { IFuseOptions } from 'fuse.js'
 
+import type { Distribution } from '@/platform/distribution/types'
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
 import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
@@ -436,9 +437,8 @@ describe('useTemplateFiltering', () => {
   })
 
   describe('Distribution filtering', () => {
-    const setDistribution = (
-      distribution: 'desktop' | 'desktop2' | 'localhost' | 'cloud'
-    ) => vi.stubGlobal('__DISTRIBUTION__', distribution)
+    const setDistribution = (distribution: Distribution) =>
+      vi.stubGlobal('__DISTRIBUTION__', distribution)
 
     const cloudTemplate: TemplateInfo = {
       name: 'cloud-only',

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -458,6 +458,14 @@ describe('useTemplateFiltering', () => {
       includeOnDistributions: [TemplateIncludeOnDistributionEnum.Desktop]
     }
 
+    const localTemplate: TemplateInfo = {
+      name: 'local-only',
+      description: 'Local template',
+      mediaType: 'image',
+      mediaSubtype: 'png',
+      includeOnDistributions: [TemplateIncludeOnDistributionEnum.Local]
+    }
+
     const universalTemplate: TemplateInfo = {
       name: 'universal',
       description: 'Universal template',
@@ -541,14 +549,6 @@ describe('useTemplateFiltering', () => {
 
     it('shows local templates on localhost distribution', () => {
       setDistribution('localhost')
-      const localTemplate: TemplateInfo = {
-        name: 'local-only',
-        description: 'Local template',
-        mediaType: 'image',
-        mediaSubtype: 'png',
-        includeOnDistributions: [TemplateIncludeOnDistributionEnum.Local]
-      }
-
       const templates = ref([localTemplate, cloudTemplate, desktopTemplate])
 
       const { filteredTemplates, filteredCount, totalCount } =
@@ -559,16 +559,16 @@ describe('useTemplateFiltering', () => {
       expect(filteredTemplates.value[0].name).toBe('local-only')
     })
 
-    it('shows desktop templates on desktop2 distribution', () => {
+    it('shows local templates on desktop2 distribution', () => {
       setDistribution('desktop2')
-      const templates = ref([desktopTemplate, cloudTemplate])
+      const templates = ref([localTemplate, desktopTemplate, cloudTemplate])
 
       const { filteredTemplates, filteredCount, totalCount } =
         useTemplateFiltering(templates)
 
       expect(filteredCount.value).toBe(1)
       expect(totalCount.value).toBe(1)
-      expect(filteredTemplates.value[0].name).toBe('desktop-only')
+      expect(filteredTemplates.value[0].name).toBe('local-only')
     })
 
     it('includes templates with multiple distributions when any match', () => {

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -436,8 +436,9 @@ describe('useTemplateFiltering', () => {
   })
 
   describe('Distribution filtering', () => {
-    const setDistribution = (distribution: 'desktop' | 'localhost' | 'cloud') =>
-      vi.stubGlobal('__DISTRIBUTION__', distribution)
+    const setDistribution = (
+      distribution: 'desktop' | 'desktop2' | 'localhost' | 'cloud'
+    ) => vi.stubGlobal('__DISTRIBUTION__', distribution)
 
     const cloudTemplate: TemplateInfo = {
       name: 'cloud-only',
@@ -556,6 +557,18 @@ describe('useTemplateFiltering', () => {
       expect(filteredCount.value).toBe(1)
       expect(totalCount.value).toBe(1)
       expect(filteredTemplates.value[0].name).toBe('local-only')
+    })
+
+    it('shows desktop templates on desktop2 distribution', () => {
+      setDistribution('desktop2')
+      const templates = ref([desktopTemplate, cloudTemplate])
+
+      const { filteredTemplates, filteredCount, totalCount } =
+        useTemplateFiltering(templates)
+
+      expect(filteredCount.value).toBe(1)
+      expect(totalCount.value).toBe(1)
+      expect(filteredTemplates.value[0].name).toBe('desktop-only')
     })
 
     it('includes templates with multiple distributions when any match', () => {

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -81,6 +81,7 @@ export function useTemplateFiltering(
       case 'localhost':
         return [TemplateIncludeOnDistributionEnum.Local]
       case 'desktop':
+      case 'desktop2':
       default:
         if (systemStatsStore.systemStats?.system.os === 'darwin') {
           return [

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -79,7 +79,6 @@ export function useTemplateFiltering(
       case 'cloud':
         return [TemplateIncludeOnDistributionEnum.Cloud]
       case 'localhost':
-        return [TemplateIncludeOnDistributionEnum.Local]
       case 'desktop2':
         return [TemplateIncludeOnDistributionEnum.Local]
       case 'desktop':

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -80,9 +80,9 @@ export function useTemplateFiltering(
         return [TemplateIncludeOnDistributionEnum.Cloud]
       case 'localhost':
         return [TemplateIncludeOnDistributionEnum.Local]
-      case 'desktop':
       case 'desktop2':
-      default:
+        return [TemplateIncludeOnDistributionEnum.Local]
+      case 'desktop':
         if (systemStatsStore.systemStats?.system.os === 'darwin') {
           return [
             TemplateIncludeOnDistributionEnum.Desktop,

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
+import type { Distribution } from '@/platform/distribution/types'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 
@@ -58,7 +59,6 @@ const {
 }))
 
 let scope: ReturnType<typeof effectScope> | undefined
-type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 const setDistribution = (distribution: Distribution) => {
   ;(

--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -58,7 +58,7 @@ const {
 }))
 
 let scope: ReturnType<typeof effectScope> | undefined
-type Distribution = 'desktop' | 'localhost' | 'cloud'
+type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 const setDistribution = (distribution: Distribution) => {
   ;(

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, reactive } from 'vue'
 
+import type { Distribution } from '@/platform/distribution/types'
 import { PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { performSubscriptionCheckout } from './subscriptionCheckoutUtil'
 
@@ -88,8 +89,6 @@ vi.mock('@/platform/telemetry/utils/checkoutAttribution', () => ({
 }))
 
 global.fetch = vi.fn()
-
-type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 const setDistribution = (distribution: Distribution) => {
   ;(

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -89,7 +89,7 @@ vi.mock('@/platform/telemetry/utils/checkoutAttribution', () => ({
 
 global.fetch = vi.fn()
 
-type Distribution = 'desktop' | 'localhost' | 'cloud'
+type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 const setDistribution = (distribution: Distribution) => {
   ;(

--- a/src/platform/distribution/types.ts
+++ b/src/platform/distribution/types.ts
@@ -3,7 +3,7 @@
  * multi-distribution builds (Desktop, Desktop2, Localhost, Cloud)
  */
 
-type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
+export type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 declare global {
   const __DISTRIBUTION__: Distribution

--- a/src/platform/distribution/types.ts
+++ b/src/platform/distribution/types.ts
@@ -1,9 +1,9 @@
 /**
  * Distribution types and compile-time constants for managing
- * multi-distribution builds (Desktop, Localhost, Cloud)
+ * multi-distribution builds (Desktop, Desktop2, Localhost, Cloud)
  */
 
-type Distribution = 'desktop' | 'localhost' | 'cloud'
+type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 declare global {
   const __DISTRIBUTION__: Distribution

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -18,6 +18,7 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 import { comfyAPIPlugin } from './build/plugins'
+import type { Distribution } from './src/platform/distribution/types'
 
 dotenvConfig()
 
@@ -42,8 +43,6 @@ const VITE_OG_KEYWORDS = 'ComfyUI, Comfy Cloud, ComfyUI online'
 // Auto-detect cloud mode from DEV_SERVER_COMFYUI_URL
 const DEV_SERVER_COMFYUI_ENV_URL = process.env.DEV_SERVER_COMFYUI_URL
 const IS_CLOUD_URL = DEV_SERVER_COMFYUI_ENV_URL?.includes('.comfy.org')
-
-type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
 
 function parseDistribution(
   value: string | undefined

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -43,14 +43,23 @@ const VITE_OG_KEYWORDS = 'ComfyUI, Comfy Cloud, ComfyUI online'
 const DEV_SERVER_COMFYUI_ENV_URL = process.env.DEV_SERVER_COMFYUI_URL
 const IS_CLOUD_URL = DEV_SERVER_COMFYUI_ENV_URL?.includes('.comfy.org')
 
-const DISTRIBUTION: 'desktop' | 'localhost' | 'cloud' =
-  process.env.DISTRIBUTION === 'desktop' ||
-  process.env.DISTRIBUTION === 'localhost' ||
-  process.env.DISTRIBUTION === 'cloud'
-    ? process.env.DISTRIBUTION
-    : IS_CLOUD_URL
-      ? 'cloud'
-      : 'localhost'
+type Distribution = 'desktop' | 'desktop2' | 'localhost' | 'cloud'
+
+function parseDistribution(
+  value: string | undefined
+): Distribution | undefined {
+  switch (value) {
+    case 'desktop':
+    case 'desktop2':
+    case 'localhost':
+    case 'cloud':
+      return value
+  }
+}
+
+const DISTRIBUTION: Distribution =
+  parseDistribution(process.env.DISTRIBUTION) ??
+  (IS_CLOUD_URL ? 'cloud' : 'localhost')
 
 // Nightly builds are from main branch; RC/stable builds are from core/* branches
 // Can be overridden via IS_NIGHTLY env var for testing


### PR DESCRIPTION
## Summary
- add a `desktop2` frontend distribution build
- package OSS assets under `static` and Desktop2 assets under `static-desktop2`
- extend CI scanning so OSS `dist` cannot contain Desktop telemetry references

## Tests
- `pnpm exec vitest run src/composables/useTemplateFiltering.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:desktop2`
- `pnpm lint`
- manual telemetry reference scan against `dist`