### PR TITLE
style(minimap): rework header/canvas layout and sizing

### DIFF
--- a/browser_tests/tests/minimap.spec.ts
+++ b/browser_tests/tests/minimap.spec.ts
@@ -74,6 +74,43 @@ test.describe('Minimap', { tag: '@canvas' }, () => {
     await expect(minimapMainContainer).toHaveCSS('z-index', '1000')
   })
 
+  test('Minimap canvas buffer matches its rendered container size', async ({
+    comfyPage
+  }) => {
+    const { container, canvas } = getMinimapLocators(comfyPage)
+    await expect(container).toBeVisible()
+    await expect(canvas).toBeVisible()
+
+    const readDims = async () => {
+      const buffer = await canvas.evaluate((el: HTMLCanvasElement) => ({
+        w: el.width,
+        h: el.height
+      }))
+      const box = await container.evaluate((el: HTMLElement) => ({
+        w: el.clientWidth,
+        h: el.clientHeight
+      }))
+      return {
+        bufferW: buffer.w,
+        bufferH: buffer.h,
+        clientW: box.w,
+        clientH: box.h
+      }
+    }
+
+    // The canvas bitmap resolution must equal its rendered content box (within
+    // sub-pixel rounding); otherwise the drawing is CSS-stretched and the
+    // viewport cone drifts off the nodes.
+    await expect
+      .poll(async () => {
+        const { bufferW, bufferH, clientW, clientH } = await readDims()
+        return (
+          Math.abs(bufferW - clientW) <= 1 && Math.abs(bufferH - clientH) <= 1
+        )
+      })
+      .toBe(true)
+  })
+
   test('Validate minimap toggle button state', async ({ comfyPage }) => {
     const { container, toggleButton } = getMinimapLocators(comfyPage)
 

--- a/src/components/graph/CanvasModeSelector.vue
+++ b/src/components/graph/CanvasModeSelector.vue
@@ -3,7 +3,6 @@
     ref="buttonRef"
     variant="secondary"
     class="group h-8 rounded-none! bg-comfy-menu-bg p-0 transition-none! hover:rounded-lg! hover:bg-interface-button-hover-surface!"
-    :style="buttonStyles"
     :aria-label="$t('graphCanvasMenu.canvasMode')"
     aria-haspopup="menu"
     :aria-expanded="isOpen"
@@ -97,11 +96,6 @@ import Button from '@/components/ui/button/Button.vue'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCommandStore } from '@/stores/commandStore'
 
-interface Props {
-  buttonStyles?: Record<string, string>
-}
-
-defineProps<Props>()
 const buttonRef = ref<ComponentPublicInstance | null>(null)
 const popover = ref<InstanceType<typeof Popover>>()
 const menuRef = ref<HTMLElement | null>(null)

--- a/src/components/graph/GraphCanvasMenu.vue
+++ b/src/components/graph/GraphCanvasMenu.vue
@@ -12,15 +12,10 @@
     <ButtonGroup
       role="toolbar"
       :aria-label="t('graphCanvasMenu.canvasToolbar')"
-      class="absolute right-0 bottom-0 z-1200 flex-row gap-1 border border-interface-stroke bg-comfy-menu-bg p-2"
-      :style="{
-        ...stringifiedMinimapStyles.buttonGroupStyles
-      }"
+      class="absolute right-0 bottom-0 z-1200 flex-row gap-1 rounded-lg border border-interface-stroke bg-comfy-menu-bg p-2"
       @wheel="canvasInteractions.handleWheel"
     >
-      <CanvasModeSelector
-        :button-styles="stringifiedMinimapStyles.buttonStyles"
-      />
+      <CanvasModeSelector />
 
       <div class="h-[27px] w-px self-center bg-node-divider" />
 
@@ -28,7 +23,6 @@
         v-tooltip.top="fitViewTooltip"
         variant="secondary"
         :aria-label="fitViewTooltip"
-        :style="stringifiedMinimapStyles.buttonStyles"
         class="size-8 bg-comfy-menu-bg p-0 hover:bg-interface-button-hover-surface!"
         @click="() => commandStore.execute('Comfy.Canvas.FitView')"
       >
@@ -41,7 +35,6 @@
         :class="zoomButtonClass"
         :aria-label="t('zoomControls.label')"
         data-testid="zoom-controls-button"
-        :style="stringifiedMinimapStyles.buttonStyles"
         @click="toggleModal"
       >
         <span class="inline-flex items-center gap-1 px-2 text-xs">
@@ -57,7 +50,6 @@
         variant="secondary"
         :aria-label="minimapTooltip"
         data-testid="toggle-minimap-button"
-        :style="stringifiedMinimapStyles.buttonStyles"
         :class="minimapButtonClass"
         @click="onMinimapToggleClick"
       >
@@ -77,7 +69,6 @@
         :class="linkVisibleClass"
         :aria-label="linkVisibilityAriaLabel"
         data-testid="toggle-link-visibility-button"
-        :style="stringifiedMinimapStyles.buttonStyles"
         @click="onLinkVisibilityToggleClick"
       >
         <i class="icon-[lucide--route-off] size-4" aria-hidden="true" />
@@ -98,7 +89,6 @@ import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useCanvasInteractions } from '@/renderer/core/canvas/useCanvasInteractions'
-import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
 import { useCommandStore } from '@/stores/commandStore'
 
 import CanvasModeSelector from './CanvasModeSelector.vue'
@@ -110,34 +100,9 @@ const { formatKeySequence } = useCommandStore()
 const canvasStore = useCanvasStore()
 const settingStore = useSettingStore()
 const canvasInteractions = useCanvasInteractions()
-const minimap = useMinimap()
 
 const { isModalVisible, toggleModal, hideModal, hasActivePopup } =
   useZoomControls()
-
-const stringifiedMinimapStyles = computed(() => {
-  const buttonGroupKeys = ['borderRadius']
-  const buttonKeys = ['borderRadius']
-  const additionalButtonStyles = {
-    border: 'none'
-  }
-
-  const containerStyles = minimap.containerStyles.value
-
-  const buttonStyles = {
-    ...Object.fromEntries(
-      Object.entries(containerStyles).filter(([key]) =>
-        buttonKeys.includes(key)
-      )
-    ),
-    ...additionalButtonStyles
-  }
-  const buttonGroupStyles = Object.entries(containerStyles)
-    .filter(([key]) => buttonGroupKeys.includes(key))
-    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
-
-  return { buttonStyles, buttonGroupStyles }
-})
 
 // Computed properties for reactive states
 const linkHidden = computed(

--- a/src/components/graph/modals/ZoomControlsModal.test.ts
+++ b/src/components/graph/modals/ZoomControlsModal.test.ts
@@ -41,14 +41,6 @@ const i18n = createI18n({
   messages: { en: {} }
 })
 
-vi.mock('@/renderer/extensions/minimap/composables/useMinimap', () => ({
-  useMinimap: () => ({
-    containerStyles: {
-      value: { backgroundColor: '#fff', borderRadius: '8px' }
-    }
-  })
-}))
-
 vi.mock('@/stores/commandStore', () => ({
   useCommandStore: () => ({
     execute: mockExecute,

--- a/src/components/graph/modals/ZoomControlsModal.vue
+++ b/src/components/graph/modals/ZoomControlsModal.vue
@@ -5,7 +5,6 @@
   >
     <div
       class="w-4/5 rounded-lg border border-interface-stroke bg-interface-panel-surface p-2 text-text-primary shadow-lg select-none"
-      :style="filteredMinimapStyles"
       @click.stop
     >
       <div class="flex flex-col gap-1">
@@ -76,10 +75,8 @@ import { InputNumber } from 'primevue'
 import { computed, nextTick, ref, watch } from 'vue'
 
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { useMinimap } from '@/renderer/extensions/minimap/composables/useMinimap'
 import { useCommandStore } from '@/stores/commandStore'
 
-const minimap = useMinimap()
 const commandStore = useCommandStore()
 const canvasStore = useCanvasStore()
 const { formatKeySequence } = useCommandStore()
@@ -117,13 +114,6 @@ const stopRepeat = () => {
     interval.value = null
   }
 }
-const filteredMinimapStyles = computed(() => {
-  return {
-    ...minimap.containerStyles.value,
-    height: undefined,
-    width: undefined
-  }
-})
 const zoomInCommandText = computed(() =>
   formatKeySequence(commandStore.getCommand('Comfy.Canvas.ZoomIn'))
 )

--- a/src/renderer/extensions/minimap/MiniMap.vue
+++ b/src/renderer/extensions/minimap/MiniMap.vue
@@ -22,62 +22,59 @@
     />
 
     <div
-      ref="containerRef"
-      class="litegraph-minimap relative border border-interface-stroke bg-comfy-menu-bg shadow-interface"
-      data-testid="minimap-container"
-      :style="containerStyles"
+      class="flex flex-col overflow-hidden rounded-lg border border-interface-stroke bg-comfy-menu-bg shadow-interface"
+      :style="{ width: containerStyles.width, height: containerStyles.height }"
     >
-      <Button
-        class="absolute top-0 left-0 z-10"
-        size="icon"
-        variant="muted-textonly"
-        :aria-label="$t('g.settings')"
-        @click.stop="toggleOptionsPanel"
-      >
-        <i class="icon-[lucide--settings-2]" />
-      </Button>
-      <Button
-        class="absolute top-0 right-0 z-10"
-        size="icon"
-        variant="muted-textonly"
-        :aria-label="$t('g.close')"
-        data-testid="close-minimap-button"
-        @click.stop="() => commandStore.execute('Comfy.Canvas.ToggleMinimap')"
-      >
-        <i class="icon-[lucide--x]" />
-      </Button>
-
-      <hr
-        class="absolute top-6 h-px border-0 bg-node-component-border"
-        :style="{
-          width: containerStyles.width
-        }"
-      />
-
-      <canvas
-        ref="canvasRef"
-        :width="width"
-        :height="height"
-        class="minimap-canvas"
-        data-testid="minimap-canvas"
-      />
+      <div class="flex shrink-0 items-center justify-between">
+        <Button
+          size="icon"
+          variant="muted-textonly"
+          :aria-label="$t('g.settings')"
+          @click.stop="toggleOptionsPanel"
+        >
+          <i class="icon-[lucide--settings-2]" />
+        </Button>
+        <Button
+          size="icon"
+          variant="muted-textonly"
+          :aria-label="$t('g.close')"
+          data-testid="close-minimap-button"
+          @click.stop="() => commandStore.execute('Comfy.Canvas.ToggleMinimap')"
+        >
+          <i class="icon-[lucide--x]" />
+        </Button>
+      </div>
 
       <div
-        class="minimap-viewport"
-        :style="viewportStyles"
-        data-testid="minimap-viewport"
-      />
+        ref="containerRef"
+        class="litegraph-minimap relative min-h-0 flex-1 overflow-hidden rounded-t-lg border-t border-node-component-border"
+        data-testid="minimap-container"
+      >
+        <canvas
+          ref="canvasRef"
+          :width="width"
+          :height="height"
+          class="minimap-canvas"
+          data-testid="minimap-canvas"
+        />
 
-      <div
-        class="absolute inset-0 touch-none"
-        data-testid="minimap-interaction-overlay"
-        @pointerdown="handlePointerDown"
-        @pointermove="handlePointerMove"
-        @pointerup="handlePointerUp"
-        @pointerleave="handlePointerUp"
-        @pointercancel="handlePointerCancel"
-        @wheel="handleWheel"
-      />
+        <div
+          class="minimap-viewport rounded-lg"
+          :style="viewportStyles"
+          data-testid="minimap-viewport"
+        />
+
+        <div
+          class="absolute inset-0 touch-none"
+          data-testid="minimap-interaction-overlay"
+          @pointerdown="handlePointerDown"
+          @pointermove="handlePointerMove"
+          @pointerup="handlePointerUp"
+          @pointerleave="handlePointerUp"
+          @pointercancel="handlePointerCancel"
+          @wheel="handleWheel"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -144,10 +141,6 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.litegraph-minimap {
-  overflow: hidden;
-}
-
 .minimap-canvas {
   display: block;
   width: 100%;

--- a/src/renderer/extensions/minimap/MiniMap.vue
+++ b/src/renderer/extensions/minimap/MiniMap.vue
@@ -22,7 +22,7 @@
     />
 
     <div
-      class="flex flex-col overflow-hidden bg-comfy-menu-bg shadow-interface"
+      class="flex flex-col overflow-hidden rounded-lg border border-interface-stroke bg-comfy-menu-bg shadow-interface"
       :style="containerStyles"
     >
       <div class="flex shrink-0 items-center justify-between">

--- a/src/renderer/extensions/minimap/MiniMap.vue
+++ b/src/renderer/extensions/minimap/MiniMap.vue
@@ -22,8 +22,8 @@
     />
 
     <div
-      class="flex flex-col overflow-hidden rounded-lg border border-interface-stroke bg-comfy-menu-bg shadow-interface"
-      :style="{ width: containerStyles.width, height: containerStyles.height }"
+      class="flex flex-col overflow-hidden bg-comfy-menu-bg shadow-interface"
+      :style="containerStyles"
     >
       <div class="flex shrink-0 items-center justify-between">
         <Button

--- a/src/renderer/extensions/minimap/MiniMapPanel.vue
+++ b/src/renderer/extensions/minimap/MiniMapPanel.vue
@@ -2,7 +2,7 @@
   <div
     :class="
       cn(
-        'minimap-panel flex flex-col gap-2 bg-comfy-menu-bg p-3 text-sm shadow-interface',
+        'minimap-panel flex flex-col gap-2 rounded-lg border border-interface-stroke bg-comfy-menu-bg p-3 text-sm shadow-interface',
         isMobile ? 'mb-1' : 'mr-1'
       )
     "

--- a/src/renderer/extensions/minimap/MiniMapPanel.vue
+++ b/src/renderer/extensions/minimap/MiniMapPanel.vue
@@ -3,7 +3,7 @@
     :class="
       cn(
         'minimap-panel flex flex-col gap-2 bg-comfy-menu-bg p-3 text-sm shadow-interface',
-        isMobile ? 'mb-2' : 'mr-2'
+        isMobile ? 'mb-1' : 'mr-1'
       )
     "
     :style="panelStyles"

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -86,7 +86,11 @@ vi.mock('@vueuse/core', () => {
       return (...args: unknown[]) => {
         return callback(...args)
       }
-    })
+    }),
+    useElementSize: vi.fn(() => ({
+      width: { value: 252 },
+      height: { value: 165 }
+    }))
   }
 })
 
@@ -332,8 +336,6 @@ describe('useMinimap', () => {
 
       const minimap = useMinimap()
 
-      expect(minimap.width).toBe(252)
-      expect(minimap.height).toBe(165)
       expect(minimap.visible.value).toBe(true)
       expect(minimap.initialized.value).toBe(false)
 

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -332,8 +332,8 @@ describe('useMinimap', () => {
 
       const minimap = useMinimap()
 
-      expect(minimap.width).toBe(250)
-      expect(minimap.height).toBe(200)
+      expect(minimap.width).toBe(252)
+      expect(minimap.height).toBe(165)
       expect(minimap.visible.value).toBe(true)
       expect(minimap.initialized.value).toBe(false)
 
@@ -920,7 +920,7 @@ describe('useMinimap', () => {
       const minimap = useMinimap()
       const styles = minimap.containerStyles.value
 
-      expect(styles.width).toBe('253px')
+      expect(styles.width).toBe('254px')
       expect(styles.height).toBe('200px')
       expect(styles.border).toBe('1px solid var(--interface-stroke)')
       expect(styles.borderRadius).toBe('8px')

--- a/src/renderer/extensions/minimap/composables/useMinimap.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.test.ts
@@ -924,8 +924,6 @@ describe('useMinimap', () => {
 
       expect(styles.width).toBe('254px')
       expect(styles.height).toBe('200px')
-      expect(styles.border).toBe('1px solid var(--interface-stroke)')
-      expect(styles.borderRadius).toBe('8px')
     })
   })
 

--- a/src/renderer/extensions/minimap/composables/useMinimap.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.ts
@@ -12,7 +12,11 @@ import type { MinimapCanvas, MinimapSettingsKey } from '../types'
 import { useMinimapGraph } from './useMinimapGraph'
 import { useMinimapInteraction } from './useMinimapInteraction'
 import { useMinimapRenderer } from './useMinimapRenderer'
-import { useMinimapSettings } from './useMinimapSettings'
+import {
+  CANVAS_HEIGHT as height,
+  CANVAS_WIDTH as width,
+  useMinimapSettings
+} from './useMinimapSettings'
 import { useMinimapViewport } from './useMinimapViewport'
 
 export function useMinimap({
@@ -32,9 +36,6 @@ export function useMinimap({
 
   const visible = ref(true)
   const initialized = ref(false)
-
-  const width = 252
-  const height = 165
 
   const canvas = computed(() => canvasStore.canvas as MinimapCanvas | null)
   const graph = computed(() => {

--- a/src/renderer/extensions/minimap/composables/useMinimap.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.ts
@@ -33,8 +33,8 @@ export function useMinimap({
   const visible = ref(true)
   const initialized = ref(false)
 
-  const width = 250
-  const height = 200
+  const width = 252
+  const height = 165
 
   const canvas = computed(() => canvasStore.canvas as MinimapCanvas | null)
   const graph = computed(() => {
@@ -232,9 +232,6 @@ export function useMinimap({
       height: `${transform.height}px`,
       border: `2px solid ${settings.isLightTheme.value ? '#E0E0E0' : '#FFF'}`,
       backgroundColor: `rgba(255, 255, 255, 0.2)`,
-      willChange: 'transform',
-      backfaceVisibility: 'hidden' as const,
-      perspective: '1000px',
       pointerEvents: 'none' as const
     }
   })

--- a/src/renderer/extensions/minimap/composables/useMinimap.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimap.ts
@@ -1,4 +1,4 @@
-import { useRafFn } from '@vueuse/core'
+import { useElementSize, useRafFn } from '@vueuse/core'
 import { computed, nextTick, ref, shallowRef, watch } from 'vue'
 import type { ShallowRef } from 'vue'
 
@@ -12,11 +12,7 @@ import type { MinimapCanvas, MinimapSettingsKey } from '../types'
 import { useMinimapGraph } from './useMinimapGraph'
 import { useMinimapInteraction } from './useMinimapInteraction'
 import { useMinimapRenderer } from './useMinimapRenderer'
-import {
-  CANVAS_HEIGHT as height,
-  CANVAS_WIDTH as width,
-  useMinimapSettings
-} from './useMinimapSettings'
+import { useMinimapSettings } from './useMinimapSettings'
 import { useMinimapViewport } from './useMinimapViewport'
 
 export function useMinimap({
@@ -36,6 +32,11 @@ export function useMinimap({
 
   const visible = ref(true)
   const initialized = ref(false)
+
+  const { width: measuredWidth, height: measuredHeight } =
+    useElementSize(containerRef)
+  const width = computed(() => Math.round(measuredWidth.value))
+  const height = computed(() => Math.round(measuredHeight.value))
 
   const canvas = computed(() => canvasStore.canvas as MinimapCanvas | null)
   const graph = computed(() => {
@@ -202,6 +203,17 @@ export function useMinimap({
       viewport.stopViewportSync()
     }
   })
+
+  watch(
+    [width, height],
+    ([w, h]) => {
+      if (!w || !h || !initialized.value || !visible.value) return
+      renderer.forceFullRedraw()
+      renderer.updateMinimap(viewport.updateBounds, viewport.updateViewport)
+      viewport.updateViewport()
+    },
+    { flush: 'post' }
+  )
 
   const executionStore = useExecutionStore()
   watch(

--- a/src/renderer/extensions/minimap/composables/useMinimapInteraction.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapInteraction.ts
@@ -1,5 +1,5 @@
-import { ref } from 'vue'
-import type { Ref, ShallowRef } from 'vue'
+import { ref, toValue } from 'vue'
+import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 
 import type { MinimapCanvas } from '../types'
 
@@ -7,8 +7,8 @@ export function useMinimapInteraction(
   containerRef: Readonly<ShallowRef<HTMLDivElement | null>>,
   bounds: Ref<{ minX: number; minY: number; width: number; height: number }>,
   scale: Ref<number>,
-  width: number,
-  height: number,
+  width: MaybeRefOrGetter<number>,
+  height: MaybeRefOrGetter<number>,
   centerViewOn: (worldX: number, worldY: number) => void,
   canvas: Ref<MinimapCanvas | null>
 ) {
@@ -16,8 +16,8 @@ export function useMinimapInteraction(
   const containerRect = ref({
     left: 0,
     top: 0,
-    width: width,
-    height: height
+    width: toValue(width),
+    height: toValue(height)
   })
 
   const updateContainerRect = () => {
@@ -48,8 +48,8 @@ export function useMinimapInteraction(
     const x = e.clientX - containerRect.value.left
     const y = e.clientY - containerRect.value.top
 
-    const offsetX = (width - bounds.value.width * scale.value) / 2
-    const offsetY = (height - bounds.value.height * scale.value) / 2
+    const offsetX = (toValue(width) - bounds.value.width * scale.value) / 2
+    const offsetY = (toValue(height) - bounds.value.height * scale.value) / 2
 
     const worldX = (x - offsetX) / scale.value + bounds.value.minX
     const worldY = (y - offsetY) / scale.value + bounds.value.minY
@@ -101,8 +101,8 @@ export function useMinimapInteraction(
     const x = e.clientX - containerRect.value.left
     const y = e.clientY - containerRect.value.top
 
-    const offsetX = (width - bounds.value.width * scale.value) / 2
-    const offsetY = (height - bounds.value.height * scale.value) / 2
+    const offsetX = (toValue(width) - bounds.value.width * scale.value) / 2
+    const offsetY = (toValue(height) - bounds.value.height * scale.value) / 2
 
     const worldX = (x - offsetX) / scale.value + bounds.value.minX
     const worldY = (y - offsetY) / scale.value + bounds.value.minY

--- a/src/renderer/extensions/minimap/composables/useMinimapRenderer.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapRenderer.ts
@@ -1,5 +1,5 @@
-import { ref } from 'vue'
-import type { Ref, ShallowRef } from 'vue'
+import { ref, toValue } from 'vue'
+import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 
@@ -19,8 +19,8 @@ export function useMinimapRenderer(
     renderBypass: Ref<boolean>
     renderError: Ref<boolean>
   },
-  width: number,
-  height: number
+  width: MaybeRefOrGetter<number>,
+  height: MaybeRefOrGetter<number>
 ) {
   const needsFullRedraw = ref(true)
   const needsBoundsUpdate = ref(true)
@@ -32,9 +32,13 @@ export function useMinimapRenderer(
     const ctx = canvasRef.value.getContext('2d')
     if (!ctx) return
 
+    const w = toValue(width)
+    const h = toValue(height)
+    if (!w || !h) return
+
     // Fast path for 0 nodes - just show background
     if (!g._nodes || g._nodes.length === 0) {
-      ctx.clearRect(0, 0, width, height)
+      ctx.clearRect(0, 0, w, h)
       return
     }
 
@@ -54,8 +58,8 @@ export function useMinimapRenderer(
           renderBypass: settings.renderBypass.value,
           renderError: settings.renderError.value
         },
-        width,
-        height
+        width: w,
+        height: h
       })
 
       needsFullRedraw.value = false

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
@@ -75,8 +75,6 @@ describe('useMinimapSettings', () => {
 
     expect(styles.width).toBe('254px')
     expect(styles.height).toBe('200px')
-    expect(styles.border).toBe('1px solid var(--interface-stroke)')
-    expect(styles.borderRadius).toBe('8px')
   })
 
   it('should generate light theme container styles', () => {
@@ -99,8 +97,6 @@ describe('useMinimapSettings', () => {
 
     expect(styles.width).toBe('254px')
     expect(styles.height).toBe('200px')
-    expect(styles.border).toBe('1px solid var(--interface-stroke)')
-    expect(styles.borderRadius).toBe('8px')
   })
 
   it('should generate panel styles based on theme', () => {
@@ -123,8 +119,6 @@ describe('useMinimapSettings', () => {
 
     expect(styles.width).toBe('210px')
     expect(styles.height).toBe('200px')
-    expect(styles.border).toBe('1px solid var(--interface-stroke)')
-    expect(styles.borderRadius).toBe('8px')
   })
 
   it('should create computed properties that call the store getter', () => {

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.test.ts
@@ -73,7 +73,7 @@ describe('useMinimapSettings', () => {
     const settings = useMinimapSettings()
     const styles = settings.containerStyles.value
 
-    expect(styles.width).toBe('253px')
+    expect(styles.width).toBe('254px')
     expect(styles.height).toBe('200px')
     expect(styles.border).toBe('1px solid var(--interface-stroke)')
     expect(styles.borderRadius).toBe('8px')
@@ -97,7 +97,7 @@ describe('useMinimapSettings', () => {
     const settings = useMinimapSettings()
     const styles = settings.containerStyles.value
 
-    expect(styles.width).toBe('253px')
+    expect(styles.width).toBe('254px')
     expect(styles.height).toBe('200px')
     expect(styles.border).toBe('1px solid var(--interface-stroke)')
     expect(styles.borderRadius).toBe('8px')

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
@@ -35,16 +35,12 @@ export function useMinimapSettings() {
 
   const containerStyles = computed(() => ({
     width: `${CARD_WIDTH}px`,
-    height: `${CARD_HEIGHT}px`,
-    border: '1px solid var(--interface-stroke)',
-    borderRadius: '8px'
+    height: `${CARD_HEIGHT}px`
   }))
 
   const panelStyles = computed(() => ({
     width: `210px`,
-    height: `${CARD_HEIGHT}px`,
-    border: '1px solid var(--interface-stroke)',
-    borderRadius: '8px'
+    height: `${CARD_HEIGHT}px`
   }))
 
   return {

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
@@ -3,14 +3,8 @@ import { computed } from 'vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
-const BORDER = 1
-const HEADER_HEIGHT = 32
-
 const CARD_WIDTH = 254
 const CARD_HEIGHT = 200
-
-export const CANVAS_WIDTH = CARD_WIDTH - 2 * BORDER
-export const CANVAS_HEIGHT = CARD_HEIGHT - HEADER_HEIGHT - 3 * BORDER
 
 /**
  * Composable for minimap configuration options that are set by the user in the

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
@@ -25,7 +25,7 @@ export function useMinimapSettings() {
     settingStore.get('Comfy.Minimap.RenderErrorState')
   )
 
-  const width = 253
+  const width = 254
   const height = 200
 
   // Theme-aware colors

--- a/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapSettings.ts
@@ -3,6 +3,15 @@ import { computed } from 'vue'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
+const BORDER = 1
+const HEADER_HEIGHT = 32
+
+const CARD_WIDTH = 254
+const CARD_HEIGHT = 200
+
+export const CANVAS_WIDTH = CARD_WIDTH - 2 * BORDER
+export const CANVAS_HEIGHT = CARD_HEIGHT - HEADER_HEIGHT - 3 * BORDER
+
 /**
  * Composable for minimap configuration options that are set by the user in the
  * settings. Provides reactive computed properties for the settings.
@@ -25,24 +34,21 @@ export function useMinimapSettings() {
     settingStore.get('Comfy.Minimap.RenderErrorState')
   )
 
-  const width = 254
-  const height = 200
-
   // Theme-aware colors
   const isLightTheme = computed(
     () => colorPaletteStore.completedActivePalette.light_theme
   )
 
   const containerStyles = computed(() => ({
-    width: `${width}px`,
-    height: `${height}px`,
+    width: `${CARD_WIDTH}px`,
+    height: `${CARD_HEIGHT}px`,
     border: '1px solid var(--interface-stroke)',
     borderRadius: '8px'
   }))
 
   const panelStyles = computed(() => ({
     width: `210px`,
-    height: `${height}px`,
+    height: `${CARD_HEIGHT}px`,
     border: '1px solid var(--interface-stroke)',
     borderRadius: '8px'
   }))

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.test.ts
@@ -9,7 +9,10 @@ import {
   calculateNodeBounds,
   enforceMinimumBounds
 } from '@/renderer/core/spatial/boundsCalculator'
-import { useMinimapViewport } from '@/renderer/extensions/minimap/composables/useMinimapViewport'
+import {
+  clampViewportSpan,
+  useMinimapViewport
+} from '@/renderer/extensions/minimap/composables/useMinimapViewport'
 import type { MinimapCanvas } from '@/renderer/extensions/minimap/types'
 
 vi.mock('@vueuse/core')
@@ -187,6 +190,38 @@ describe('useMinimapViewport', () => {
     expect(transform.height).toBeCloseTo(viewportHeight * 0.5) // 300 * 0.5 = 150
   })
 
+  it('rounds the viewport transform to whole pixels to avoid sub-pixel cone jitter', () => {
+    vi.mocked(calculateNodeBounds).mockReturnValue({
+      minX: 0,
+      minY: 0,
+      maxX: 500,
+      maxY: 400,
+      width: 500,
+      height: 400
+    })
+    vi.mocked(enforceMinimumBounds).mockImplementation((bounds) => bounds)
+    vi.mocked(calculateMinimapScale).mockReturnValue(0.5)
+
+    const canvasRef = ref(mockCanvas) as Ref<MinimapCanvas | null>
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+
+    const viewport = useMinimapViewport(canvasRef, graphRef, 250, 200)
+
+    mockCanvas.ds.scale = 2
+    mockCanvas.ds.offset = [-100.5, -50.5]
+
+    viewport.updateBounds()
+    viewport.updateCanvasDimensions()
+    viewport.updateViewport()
+
+    const transform = viewport.viewportTransform.value
+
+    expect(Number.isInteger(transform.x)).toBe(true)
+    expect(Number.isInteger(transform.y)).toBe(true)
+    expect(Number.isInteger(transform.width)).toBe(true)
+    expect(Number.isInteger(transform.height)).toBe(true)
+  })
+
   it('should maintain strict reference equality for viewportTransform when canvas state is unchanged', () => {
     vi.mocked(calculateNodeBounds).mockReturnValue({
       minX: 0,
@@ -225,6 +260,39 @@ describe('useMinimapViewport', () => {
 
     expect(transformAfterPan).not.toBe(initialTransform)
     expect(transformAfterPan.x).not.toBe(initialTransform.x)
+  })
+
+  it('short-circuits the re-render guard on sub-pixel pans that round to the same pixel', () => {
+    vi.mocked(calculateNodeBounds).mockReturnValue({
+      minX: 0,
+      minY: 0,
+      maxX: 500,
+      maxY: 400,
+      width: 500,
+      height: 400
+    })
+    vi.mocked(enforceMinimumBounds).mockImplementation((bounds) => bounds)
+    vi.mocked(calculateMinimapScale).mockReturnValue(0.5)
+
+    const canvasRef = ref(mockCanvas) as Ref<MinimapCanvas | null>
+    const graphRef = ref(mockGraph) as Ref<LGraph | null>
+
+    const viewport = useMinimapViewport(canvasRef, graphRef, 250, 200)
+
+    mockCanvas.ds.scale = 2
+    mockCanvas.ds.offset = [-100, -50]
+
+    viewport.updateBounds()
+    viewport.updateCanvasDimensions()
+    viewport.updateViewport()
+
+    const initialTransform = viewport.viewportTransform.value
+
+    // worldX shifts 0.5 -> rawX moves 0.25px -> rounds to the same pixel
+    mockCanvas.ds.offset = [-100.5, -50]
+    viewport.updateViewport()
+
+    expect(viewport.viewportTransform.value).toBe(initialTransform)
   })
 
   it('should center view on world coordinates', () => {
@@ -327,5 +395,28 @@ describe('useMinimapViewport', () => {
       value: originalDPR,
       configurable: true
     })
+  })
+})
+
+describe('clampViewportSpan', () => {
+  it('clamps a negative start to 0', () => {
+    expect(clampViewportSpan(-20, 30, 100)).toEqual({ offset: 0, span: 10 })
+  })
+
+  it('clamps the offset so the cone stays visible at the far edge', () => {
+    expect(clampViewportSpan(98, 30, 100)).toEqual({ offset: 96, span: 4 })
+  })
+
+  it('caps the span at the canvas when the cone is larger than it', () => {
+    expect(clampViewportSpan(0, 200, 100)).toEqual({ offset: 0, span: 100 })
+  })
+
+  it('caps the span at the right edge when start + size overflows', () => {
+    expect(clampViewportSpan(80, 40, 100)).toEqual({ offset: 80, span: 20 })
+  })
+
+  it('never returns a span below the minimum visible size', () => {
+    expect(clampViewportSpan(50, 0, 100).span).toBe(4)
+    expect(clampViewportSpan(-50, 20, 100).span).toBe(4)
   })
 })

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.ts
@@ -13,14 +13,14 @@ import type { MinimapBounds, MinimapCanvas, ViewportTransform } from '../types'
 
 const VIEWPORT_MIN_VISIBLE = 4
 
-function clampViewportSpan(
+export function clampViewportSpan(
   start: number,
   size: number,
   max: number
-): [number, number] {
-  const lo = Math.max(0, Math.min(start, max - VIEWPORT_MIN_VISIBLE))
-  const hi = Math.min(max, Math.max(start + size, VIEWPORT_MIN_VISIBLE))
-  return [lo, Math.max(VIEWPORT_MIN_VISIBLE, hi - lo)]
+): { offset: number; span: number } {
+  const offset = Math.max(0, Math.min(start, max - VIEWPORT_MIN_VISIBLE))
+  const end = Math.min(max, start + size)
+  return { offset, span: Math.max(VIEWPORT_MIN_VISIBLE, end - offset) }
 }
 
 export function useMinimapViewport(
@@ -69,7 +69,14 @@ export function useMinimapViewport(
     const dataSource = MinimapDataSourceFactory.create(graph.value)
 
     if (!dataSource.hasData()) {
-      return { minX: 0, minY: 0, maxX: 100, maxY: 100, width: 100, height: 100 }
+      return {
+        minX: 0,
+        minY: 0,
+        maxX: 100,
+        maxY: 100,
+        width: 100,
+        height: 100
+      }
     }
 
     const sourceBounds = dataSource.getBounds()
@@ -107,8 +114,13 @@ export function useMinimapViewport(
     const rawW = viewportWidth * scale.value
     const rawH = viewportHeight * scale.value
 
-    const [x, w] = clampViewportSpan(rawX, rawW, width)
-    const [y, h] = clampViewportSpan(rawY, rawH, height)
+    const horizontal = clampViewportSpan(rawX, rawW, width)
+    const vertical = clampViewportSpan(rawY, rawH, height)
+
+    const x = Math.round(horizontal.offset)
+    const y = Math.round(vertical.offset)
+    const w = Math.round(horizontal.span)
+    const h = Math.round(vertical.span)
 
     const curr = viewportTransform.value
     if (curr.x === x && curr.y === y && curr.width === w && curr.height === h)

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.ts
@@ -1,6 +1,6 @@
 import { useRafFn } from '@vueuse/core'
-import { computed, ref } from 'vue'
-import type { Ref } from 'vue'
+import { computed, ref, toValue } from 'vue'
+import type { MaybeRefOrGetter, Ref } from 'vue'
 
 import type { LGraph } from '@/lib/litegraph/src/litegraph'
 import {
@@ -26,8 +26,8 @@ export function clampViewportSpan(
 export function useMinimapViewport(
   canvas: Ref<MinimapCanvas | null>,
   graph: Ref<LGraph | null>,
-  width: number,
-  height: number
+  width: MaybeRefOrGetter<number>,
+  height: MaybeRefOrGetter<number>
 ) {
   const bounds = ref<MinimapBounds>({
     minX: 0,
@@ -84,7 +84,7 @@ export function useMinimapViewport(
   }
 
   const calculateScale = () => {
-    return calculateMinimapScale(bounds.value, width, height)
+    return calculateMinimapScale(bounds.value, toValue(width), toValue(height))
   }
 
   const updateViewport = () => {
@@ -106,16 +106,20 @@ export function useMinimapViewport(
     const worldX = -ds.offset[0]
     const worldY = -ds.offset[1]
 
-    const centerOffsetX = (width - bounds.value.width * scale.value) / 2
-    const centerOffsetY = (height - bounds.value.height * scale.value) / 2
+    const vw = toValue(width)
+    const vh = toValue(height)
+    if (!vw || !vh) return
+
+    const centerOffsetX = (vw - bounds.value.width * scale.value) / 2
+    const centerOffsetY = (vh - bounds.value.height * scale.value) / 2
 
     const rawX = (worldX - bounds.value.minX) * scale.value + centerOffsetX
     const rawY = (worldY - bounds.value.minY) * scale.value + centerOffsetY
     const rawW = viewportWidth * scale.value
     const rawH = viewportHeight * scale.value
 
-    const horizontal = clampViewportSpan(rawX, rawW, width)
-    const vertical = clampViewportSpan(rawY, rawH, height)
+    const horizontal = clampViewportSpan(rawX, rawW, vw)
+    const vertical = clampViewportSpan(rawY, rawH, vh)
 
     const x = Math.round(horizontal.offset)
     const y = Math.round(vertical.offset)

--- a/src/renderer/extensions/minimap/composables/useMinimapViewport.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapViewport.ts
@@ -11,6 +11,18 @@ import { MinimapDataSourceFactory } from '@/renderer/extensions/minimap/data/Min
 
 import type { MinimapBounds, MinimapCanvas, ViewportTransform } from '../types'
 
+const VIEWPORT_MIN_VISIBLE = 4
+
+function clampViewportSpan(
+  start: number,
+  size: number,
+  max: number
+): [number, number] {
+  const lo = Math.max(0, Math.min(start, max - VIEWPORT_MIN_VISIBLE))
+  const hi = Math.min(max, Math.max(start + size, VIEWPORT_MIN_VISIBLE))
+  return [lo, Math.max(VIEWPORT_MIN_VISIBLE, hi - lo)]
+}
+
 export function useMinimapViewport(
   canvas: Ref<MinimapCanvas | null>,
   graph: Ref<LGraph | null>,
@@ -90,10 +102,13 @@ export function useMinimapViewport(
     const centerOffsetX = (width - bounds.value.width * scale.value) / 2
     const centerOffsetY = (height - bounds.value.height * scale.value) / 2
 
-    const x = (worldX - bounds.value.minX) * scale.value + centerOffsetX
-    const y = (worldY - bounds.value.minY) * scale.value + centerOffsetY
-    const w = viewportWidth * scale.value
-    const h = viewportHeight * scale.value
+    const rawX = (worldX - bounds.value.minX) * scale.value + centerOffsetX
+    const rawY = (worldY - bounds.value.minY) * scale.value + centerOffsetY
+    const rawW = viewportWidth * scale.value
+    const rawH = viewportHeight * scale.value
+
+    const [x, w] = clampViewportSpan(rawX, rawW, width)
+    const [y, h] = clampViewportSpan(rawY, rawH, height)
 
     const curr = viewportTransform.value
     if (curr.x === x && curr.y === y && curr.width === w && curr.height === h)


### PR DESCRIPTION
## Summary

Rework the minimap into a header bar above a rounded, clipped canvas, and fix the viewport cone alignment, the card width, and the panel spacing so the minimap + controls cluster reads as one consistent unit.

## Changes

- **What**:
  - Split the settings/close controls into a flex header bar above a rounded, clipped canvas container (replaces the absolutely-positioned buttons and `<hr>` divider).
  - **Viewport cone alignment**: the canvas bitmap was rendered at a fixed resolution but CSS-stretched to fill the wider container, while the cone overlay was positioned in the *unstretched* coordinate space — so the cone drifted left of the graph and left a ~2px gap at the right edge. Set the canvas resolution to the card's inner width (card width − 2px border = 252) so it renders 1:1; the cone now tracks content and reaches the edge.
  - **Width match with the canvas controls**: the minimap card (253px) and the canvas controls toolbar (254px) are both right-anchored, so the 1px difference left their left edges misaligned. Card is now 254px so the edges line up.
  - **Consistent spacing**: the filters panel sat 8px from the minimap while the minimap sat 4px from the controls bar. Tighten the panel gap (`mr-2` → `mr-1`) so both gaps in the cluster are 4px.
  - Clamp the viewport cone to the canvas bounds with a minimum visible span so it can't collapse or drift off-screen at extreme zoom/pan.
- **Breaking**: none

## Review Focus

- Sizing invariant: canvas resolution must equal the card's inner width (card − 2px border). Height already follows this (200 − 2 border − 32 header − 1 divider = 165). Change the card width and the canvas resolution must change with it, or the cone stretch returns.
- `containerRef` moved from the old all-in-one container to the inner canvas container so click/scroll mapping (`clientX - rect.left`) stays aligned with the canvas now that the header is a separate bar.




## Screenshots & Video
| Before  | After |
| ------------- | ------------- |
| <img width="479" height="260" alt="2026-06-17-003807_hyprshot" src="https://github.com/user-attachments/assets/7f469039-c6d7-43b1-b38e-0fad7f1bb56d" /> | <img width="477" height="265" alt="2026-06-17-003754_hyprshot" src="https://github.com/user-attachments/assets/1c58f707-8125-4a66-b559-836561dc0556" />  |
| <img width="479" height="260" alt="2026-06-17-003833_hyprshot" src="https://github.com/user-attachments/assets/a333a50a-94c2-4eb8-b36b-8b74407981fc" />  | <img width="475" height="260" alt="2026-06-17-003840_hyprshot" src="https://github.com/user-attachments/assets/8512b866-eddd-45b7-b656-278d21bbee79" /> |

**Before**

https://github.com/user-attachments/assets/0e8291fc-91a1-46ea-b9e1-59e08d725f32

**After**

https://github.com/user-attachments/assets/ddf91088-249f-4302-ac68-535b3e31cf5b

