### PR TITLE
feat: implement customer.io SDK & telemetry provider

### DIFF
--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -109,3 +109,27 @@ jobs:
             exit 1
           fi
           echo '✅ No PostHog references found'
+
+      - name: Scan dist for Customer.io telemetry references
+        run: |
+          set -euo pipefail
+          echo '🔍 Scanning for Customer.io references...'
+          if rg --no-ignore -n \
+            -g '*.html' \
+            -g '*.js' \
+            -e 'CustomerIoTelemetryProvider' \
+            -e '@customerio/cdp-analytics-browser' \
+            -e 'customerio-gist-web' \
+            -e '(?i)cdp\.customer\.io' \
+            -e 'Comfy\.CustomerIo' \
+            dist; then
+            echo '❌ ERROR: Customer.io references found in dist assets!'
+            echo 'Customer.io must be properly tree-shaken from OSS builds.'
+            echo ''
+            echo 'To fix this:'
+            echo '1. Use the TelemetryProvider pattern (see src/platform/telemetry/)'
+            echo '2. Call telemetry via useTelemetry() hook'
+            echo '3. Use conditional dynamic imports behind isCloud checks'
+            exit 1
+          fi
+          echo '✅ No Customer.io references found'

--- a/global.d.ts
+++ b/global.d.ts
@@ -49,6 +49,11 @@ interface Window {
     posthog_project_token?: string
     posthog_api_host?: string
     posthog_config?: Record<string, unknown>
+    customer_io?: {
+      write_key?: string
+      site_id?: string
+      user_id?: string
+    }
     require_whitelist?: boolean
     subscription_required?: boolean
     max_upload_size?: number

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@comfyorg/registry-types": "workspace:*",
     "@comfyorg/shared-frontend-utils": "workspace:*",
     "@comfyorg/tailwind-utils": "workspace:*",
+    "@customerio/cdp-analytics-browser": "catalog:",
     "@formkit/auto-animate": "catalog:",
     "@iconify/json": "catalog:",
     "@primeuix/forms": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@comfyorg/comfyui-electron-types':
       specifier: 0.6.2
       version: 0.6.2
+    '@customerio/cdp-analytics-browser':
+      specifier: ^0.5.3
+      version: 0.5.3
     '@eslint/js':
       specifier: ^10.0.1
       version: 10.0.1
@@ -447,6 +450,9 @@ importers:
       '@comfyorg/tailwind-utils':
         specifier: workspace:*
         version: link:packages/tailwind-utils
+      '@customerio/cdp-analytics-browser':
+        specifier: 'catalog:'
+        version: 0.5.3
       '@formkit/auto-animate':
         specifier: 'catalog:'
         version: 0.9.0
@@ -1441,6 +1447,15 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.0.0
 
+  '@customerio/cdp-analytics-browser@0.5.3':
+    resolution: {integrity: sha512-P4lBz+P2iCekq+DOETiAtSfdMyNVQd7OjXhocjffjPtyBJ0ADhpvYuNZAT9R+q2AFrDTx0m8cuyJAtEG+qiXPQ==}
+
+  '@customerio/cdp-analytics-core@0.5.3':
+    resolution: {integrity: sha512-mjR0dyzsX8UjMAh22bT5ByiIEYwtpnNhc9TlHTk2nGPhFnMctSsn9KuMXD9BmfSFcjdmTPg+iABOq68yyPBPHg==}
+
+  '@customerio/jist@0.1.8':
+    resolution: {integrity: sha512-MPiAm5rxu6+wQiEPwY+nV/5i7y67vJ0TvQpeQrOuATzWC45kgpu4YAJm+RlrpDOq35CK1C3utlPG/wI1F6ycXg==}
+
   '@cyberalien/svg-utils@1.2.15':
     resolution: {integrity: sha512-ZbKU6npzW5PNocdoLVJYfKzaP+c/RpT6JUkoaKrW1DOcw6lyXub8XtcNpI3xok6FnyNjS6ZbsrrtjTnS9yeZAQ==}
 
@@ -2382,6 +2397,14 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
+  '@lukeed/uuid@2.0.1':
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
@@ -3274,6 +3297,18 @@ packages:
 
   '@rushstack/ts-command-line@5.3.1':
     resolution: {integrity: sha512-mid/JIZSJafwy3x9e4v0wVLuAqSSYYErEHV0HXPALYLSBN13YNkR5caOk0hf97lSRKrxhtvQjGaDKSEelR3sMg==}
+
+  '@segment/analytics.js-video-plugins@0.2.1':
+    resolution: {integrity: sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==}
+
+  '@segment/facade@3.4.10':
+    resolution: {integrity: sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==}
+
+  '@segment/isodate-traverse@1.1.1':
+    resolution: {integrity: sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==}
+
+  '@segment/isodate@1.0.3':
+    resolution: {integrity: sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==}
 
   '@sentry-internal/browser-utils@10.32.1':
     resolution: {integrity: sha512-sjLLep1es3rTkbtAdTtdpc/a6g7v7bK5YJiZJsUigoJ4NTiFeMI5uIDCxbH/tjJ1q23YE1LzVn7T96I+qBRjHA==}
@@ -5037,6 +5072,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  customerio-gist-web@3.23.2:
+    resolution: {integrity: sha512-oCM7WNEx/3cmEG1qQCKWrMwOtU+h41TTKJICNEb7Wj/1jR6+RJsj3b+3N+5u9TxgvUMusmLFvnVvqshU017eHA==}
+
   cva@1.0.0-beta.4:
     resolution: {integrity: sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==}
     peerDependencies:
@@ -6255,6 +6293,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  js-cookie@3.0.1:
+    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
+    engines: {node: '>=12'}
+
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
@@ -6887,6 +6929,9 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  new-date@1.0.3:
+    resolution: {integrity: sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==}
+
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
@@ -6935,6 +6980,9 @@ packages:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  obj-case@0.2.1:
+    resolution: {integrity: sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7776,6 +7824,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spark-md5@3.0.2:
+    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
+
   speakingurl@14.0.1:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
@@ -8175,6 +8226,12 @@ packages:
   unescape-js@1.1.4:
     resolution: {integrity: sha512-42SD8NOQEhdYntEiUQdYq/1V/YHwr1HLwlHuTJB5InVVdOSbgI6xu8jK5q65yIzuFCfczzyDF/7hbGzVbyCw0g==}
 
+  unfetch@3.1.2:
+    resolution: {integrity: sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==}
+
+  unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -8358,6 +8415,10 @@ packages:
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   valibot@1.2.0:
@@ -8640,8 +8701,8 @@ packages:
   vue-component-type-helpers@3.3.2:
     resolution: {integrity: sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==}
 
-  vue-component-type-helpers@3.3.4:
-    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -9489,6 +9550,30 @@ snapshots:
   '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.1)':
     dependencies:
       postcss-selector-parser: 7.1.1
+
+  '@customerio/cdp-analytics-browser@0.5.3':
+    dependencies:
+      '@customerio/cdp-analytics-core': 0.5.3
+      '@lukeed/uuid': 2.0.1
+      '@segment/analytics.js-video-plugins': 0.2.1
+      '@segment/facade': 3.4.10
+      customerio-gist-web: 3.23.2
+      dset: 3.1.4
+      js-cookie: 3.0.1
+      node-fetch: 2.7.0
+      spark-md5: 3.0.2
+      tslib: 2.8.1
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@customerio/cdp-analytics-core@0.5.3':
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      dset: 3.1.4
+      tslib: 2.8.1
+
+  '@customerio/jist@0.1.8': {}
 
   '@cyberalien/svg-utils@1.2.15':
     dependencies:
@@ -10450,6 +10535,12 @@ snapshots:
       - ws
       - zod
 
+  '@lukeed/csprng@1.1.0': {}
+
+  '@lukeed/uuid@2.0.1':
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
   '@mdx-js/react@3.1.1(@types/react@19.1.9)(react@19.2.4)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -11079,6 +11170,23 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@segment/analytics.js-video-plugins@0.2.1':
+    dependencies:
+      unfetch: 3.1.2
+
+  '@segment/facade@3.4.10':
+    dependencies:
+      '@segment/isodate-traverse': 1.1.1
+      inherits: 2.0.4
+      new-date: 1.0.3
+      obj-case: 0.2.1
+
+  '@segment/isodate-traverse@1.1.1':
+    dependencies:
+      '@segment/isodate': 1.0.3
+
+  '@segment/isodate@1.0.3': {}
+
   '@sentry-internal/browser-utils@10.32.1':
     dependencies:
       '@sentry/core': 10.32.1
@@ -11323,7 +11431,7 @@ snapshots:
       storybook: 10.2.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.4
+      vue-component-type-helpers: 3.3.5
 
   '@swc/helpers@0.5.21':
     dependencies:
@@ -13103,6 +13211,11 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  customerio-gist-web@3.23.2:
+    dependencies:
+      '@customerio/jist': 0.1.8
+      uuid: 14.0.0
+
   cva@1.0.0-beta.4(typescript@5.9.3):
     dependencies:
       clsx: 2.1.1
@@ -14475,6 +14588,8 @@ snapshots:
       js-cookie: 3.0.7
       nopt: 7.2.1
 
+  js-cookie@3.0.1: {}
+
   js-cookie@3.0.7: {}
 
   js-stringify@1.0.2: {}
@@ -15281,6 +15396,10 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
+  new-date@1.0.3:
+    dependencies:
+      '@segment/isodate': 1.0.3
+
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -15322,6 +15441,8 @@ snapshots:
       citty: 0.2.1
       pathe: 2.0.3
       tinyexec: 1.0.4
+
+  obj-case@0.2.1: {}
 
   object-assign@4.1.1: {}
 
@@ -16440,6 +16561,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  spark-md5@3.0.2: {}
+
   speakingurl@14.0.1: {}
 
   sprintf-js@1.0.3: {}
@@ -16854,6 +16977,10 @@ snapshots:
     dependencies:
       string.fromcodepoint: 0.2.1
 
+  unfetch@3.1.2: {}
+
+  unfetch@4.2.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -17043,6 +17170,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
+
+  uuid@14.0.0: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
@@ -17469,7 +17598,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.2: {}
 
-  vue-component-type-helpers@3.3.4: {}
+  vue-component-type-helpers@3.3.5: {}
 
   vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ catalog:
   '@astrojs/sitemap': ^3.7.3
   '@astrojs/vue': ^6.0.1
   '@comfyorg/comfyui-electron-types': 0.6.2
+  '@customerio/cdp-analytics-browser': ^0.5.3
   '@eslint/js': ^10.0.1
   '@formkit/auto-animate': ^0.9.0
   '@iconify-json/lucide': ^1.1.178

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -82,6 +82,11 @@ export type RemoteConfig = {
   posthog_project_token?: string
   posthog_api_host?: string
   posthog_config?: Partial<PostHogConfig>
+  customer_io?: {
+    write_key?: string
+    site_id?: string
+    user_id?: string
+  }
   subscription_required?: boolean
   server_health_alert?: ServerHealthAlert
   max_upload_size?: number

--- a/src/platform/telemetry/initTelemetry.ts
+++ b/src/platform/telemetry/initTelemetry.ts
@@ -26,14 +26,16 @@ export async function initTelemetry(): Promise<void> {
       { GtmTelemetryProvider },
       { ImpactTelemetryProvider },
       { PostHogTelemetryProvider },
-      { ClickHouseTelemetryProvider }
+      { ClickHouseTelemetryProvider },
+      { CustomerIoTelemetryProvider }
     ] = await Promise.all([
       import('./TelemetryRegistry'),
       import('./providers/cloud/MixpanelTelemetryProvider'),
       import('./providers/cloud/GtmTelemetryProvider'),
       import('./providers/cloud/ImpactTelemetryProvider'),
       import('./providers/cloud/PostHogTelemetryProvider'),
-      import('./providers/cloud/ClickHouseTelemetryProvider')
+      import('./providers/cloud/ClickHouseTelemetryProvider'),
+      import('./providers/cloud/CustomerIoTelemetryProvider')
     ])
 
     const registry = new TelemetryRegistry()
@@ -42,6 +44,7 @@ export async function initTelemetry(): Promise<void> {
     registry.registerProvider(new ImpactTelemetryProvider())
     registry.registerProvider(new PostHogTelemetryProvider())
     registry.registerProvider(new ClickHouseTelemetryProvider())
+    registry.registerProvider(new CustomerIoTelemetryProvider())
 
     setTelemetryRegistry(registry)
   })()

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => {
+  const analytics = {
+    identify: vi.fn(),
+    track: vi.fn(),
+    reset: vi.fn(),
+    register: vi.fn().mockResolvedValue(undefined)
+  }
+  let resolvedCb: ((user: { id: string }) => void) | undefined
+  let logoutCb: (() => void) | undefined
+  return {
+    analytics,
+    load: vi.fn(() => analytics),
+    inAppPlugin: vi.fn(() => ({ name: 'Customer.io In-App Plugin' })),
+    onUserResolved: vi.fn((cb: (user: { id: string }) => void) => {
+      resolvedCb = cb
+    }),
+    onUserLogout: vi.fn((cb: () => void) => {
+      logoutCb = cb
+    }),
+    resolveUser: (id: string) => resolvedCb?.({ id }),
+    logoutUser: () => logoutCb?.()
+  }
+})
+
+vi.mock('@customerio/cdp-analytics-browser', () => ({
+  AnalyticsBrowser: { load: hoisted.load },
+  InAppPlugin: hoisted.inAppPlugin
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    onUserResolved: hoisted.onUserResolved,
+    onUserLogout: hoisted.onUserLogout
+  })
+}))
+
+import {
+  CustomerIoTelemetryProvider,
+  EVENT_SOURCE
+} from './CustomerIoTelemetryProvider'
+
+const WRITE_KEY = 'cdp_test_write_key'
+const SITE_ID = 'f87746f8c188c8ddcf41'
+const SOURCE = { event_source: EVENT_SOURCE }
+
+function createProvider(
+  config: Partial<typeof window.__CONFIG__> = {
+    customer_io: { write_key: WRITE_KEY, site_id: SITE_ID }
+  }
+): CustomerIoTelemetryProvider {
+  window.__CONFIG__ = config as typeof window.__CONFIG__
+  return new CustomerIoTelemetryProvider()
+}
+
+describe('CustomerIoTelemetryProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.load.mockReturnValue(hoisted.analytics)
+    hoisted.analytics.register.mockResolvedValue(undefined)
+    window.__CONFIG__ = {} as typeof window.__CONFIG__
+  })
+
+  it('loads the client and registers the in-app plugin with the site id', async () => {
+    createProvider()
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.load).toHaveBeenCalledWith({ writeKey: WRITE_KEY })
+    expect(hoisted.inAppPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({ siteId: SITE_ID })
+    )
+    expect(hoisted.analytics.register).toHaveBeenCalled()
+  })
+
+  it('does not initialize without a write key', async () => {
+    const provider = createProvider({ customer_io: { site_id: SITE_ID } })
+    await vi.dynamicImportSettled()
+
+    provider.trackWorkflowExecution()
+    expect(hoisted.load).not.toHaveBeenCalled()
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+  })
+
+  it('does not initialize without a site id', async () => {
+    createProvider({ customer_io: { write_key: WRITE_KEY } })
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.load).not.toHaveBeenCalled()
+  })
+
+  it('identifies the person by uid only on auth resolve', async () => {
+    createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.resolveUser('test-uid-7f3a9c')
+
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('test-uid-7f3a9c')
+  })
+
+  it('identifies with the configured user_id override without waiting for auth', async () => {
+    createProvider({
+      customer_io: {
+        write_key: WRITE_KEY,
+        site_id: SITE_ID,
+        user_id: 'forced-uid'
+      }
+    })
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.analytics.identify).toHaveBeenCalledWith('forced-uid')
+    expect(hoisted.onUserResolved).not.toHaveBeenCalled()
+  })
+
+  it('identifies before flushing events buffered before the SDK loads', async () => {
+    const provider = createProvider({
+      customer_io: {
+        write_key: WRITE_KEY,
+        site_id: SITE_ID,
+        user_id: 'forced-uid'
+      }
+    })
+    provider.trackWorkflowExecution()
+
+    await vi.dynamicImportSettled()
+
+    const identifyOrder = hoisted.analytics.identify.mock.invocationCallOrder[0]
+    const trackOrder = hoisted.analytics.track.mock.invocationCallOrder[0]
+    expect(identifyOrder).toBeLessThan(trackOrder)
+  })
+
+  it('resets on logout', async () => {
+    createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.logoutUser()
+
+    expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
+  })
+
+  const DIRECT_EVENTS: Array<{
+    event: string
+    invoke: (p: CustomerIoTelemetryProvider) => void
+    expected: Record<string, unknown>
+  }> = [
+    {
+      event: 'app:user_auth_completed',
+      invoke: (p) => p.trackAuth({ method: 'google', is_new_user: true }),
+      expected: { ...SOURCE, method: 'google', is_new_user: true }
+    },
+    {
+      event: 'app:subscription_required_modal_opened',
+      invoke: (p) =>
+        p.trackSubscription('modal_opened', { current_tier: 'pro' }),
+      expected: { ...SOURCE, current_tier: 'pro' }
+    },
+    {
+      event: 'app:subscribe_now_button_clicked',
+      invoke: (p) => p.trackSubscription('subscribe_clicked'),
+      expected: SOURCE
+    },
+    {
+      event: 'app:add_api_credit_button_clicked',
+      invoke: (p) => p.trackAddApiCreditButtonClicked(),
+      expected: SOURCE
+    },
+    {
+      event: 'execution_start',
+      invoke: (p) => p.trackWorkflowExecution(),
+      expected: SOURCE
+    },
+    {
+      event: 'execution_success',
+      invoke: (p) => p.trackExecutionSuccess({ jobId: 'job-abc' }),
+      expected: { ...SOURCE, jobId: 'job-abc' }
+    },
+    {
+      event: 'app:template_workflow_opened',
+      invoke: (p) => p.trackTemplate({ workflow_name: 'flux-dev' }),
+      expected: { ...SOURCE, workflow_name: 'flux-dev' }
+    },
+    {
+      event: 'app:template_library_opened',
+      invoke: (p) => p.trackTemplateLibraryOpened({ source: 'sidebar' }),
+      expected: { ...SOURCE, source: 'sidebar' }
+    },
+    {
+      event: 'app:share_flow',
+      invoke: (p) =>
+        p.trackShareFlow({
+          step: 'dialog_opened',
+          view_mode: 'graph',
+          is_app_mode: false
+        }),
+      expected: {
+        ...SOURCE,
+        step: 'dialog_opened',
+        view_mode: 'graph',
+        is_app_mode: false
+      }
+    }
+  ]
+
+  it.for(DIRECT_EVENTS)(
+    'sends $event with its metadata merged under the event_source tag',
+    async ({ event, invoke, expected }) => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      invoke(provider)
+
+      expect(hoisted.analytics.track).toHaveBeenCalledWith(event, expected)
+    }
+  )
+
+  it('flushes events buffered before load once, in order', async () => {
+    const provider = createProvider()
+    provider.trackWorkflowExecution()
+    provider.trackAddApiCreditButtonClicked()
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+
+    await vi.dynamicImportSettled()
+
+    expect(hoisted.analytics.track.mock.calls).toEqual([
+      ['execution_start', SOURCE],
+      ['app:add_api_credit_button_clicked', SOURCE]
+    ])
+  })
+
+  it('disables tracking when the SDK fails to load', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    hoisted.load.mockImplementation(() => {
+      throw new Error('network down')
+    })
+
+    const provider = createProvider()
+    provider.trackWorkflowExecution()
+    await vi.dynamicImportSettled()
+
+    provider.trackWorkflowExecution()
+
+    expect(hoisted.analytics.track).not.toHaveBeenCalled()
+  })
+
+  it('keeps tracking after an individual event fails to send', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    hoisted.analytics.track.mockImplementationOnce(() =>
+      Promise.reject(new Error('network blip'))
+    )
+    provider.trackWorkflowExecution()
+    provider.trackAddApiCreditButtonClicked()
+
+    expect(hoisted.analytics.track).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() =>
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to track Customer.io event:',
+        expect.any(Error)
+      )
+    )
+  })
+})

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -1,0 +1,142 @@
+import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser'
+
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+
+import { TelemetryEvents } from '../../types'
+import type {
+  AuthMetadata,
+  ExecutionSuccessMetadata,
+  ShareFlowMetadata,
+  SubscriptionMetadata,
+  TelemetryEventProperties,
+  TelemetryProvider,
+  TemplateLibraryMetadata,
+  TemplateMetadata
+} from '../../types'
+
+export const EVENT_SOURCE = 'web-sdk'
+
+interface QueuedEvent {
+  event: string
+  properties: Record<string, unknown>
+}
+
+/**
+ * Customer.io (Data Pipelines) Telemetry Provider - Cloud Build Implementation
+ *
+ * CRITICAL: OSS Build Safety
+ * Only registered from the cloud-only initTelemetry, so the file and its SDK
+ * import are tree-shaken away in OSS/desktop builds.
+ */
+export class CustomerIoTelemetryProvider implements TelemetryProvider {
+  private analytics: AnalyticsBrowser | null = null
+  private isEnabled = true
+  private eventQueue: QueuedEvent[] = []
+
+  constructor() {
+    const {
+      write_key: writeKey,
+      site_id: siteId,
+      user_id: userIdOverride
+    } = window.__CONFIG__?.customer_io ?? {}
+    if (!writeKey || !siteId) {
+      this.isEnabled = false
+      return
+    }
+
+    void import('@customerio/cdp-analytics-browser')
+      .then(({ AnalyticsBrowser, InAppPlugin }) => {
+        const analytics = AnalyticsBrowser.load({ writeKey })
+        void analytics.register(
+          InAppPlugin({
+            siteId,
+            events: null,
+            anonymousInApp: false,
+            _env: undefined,
+            _logging: undefined,
+            colorScheme: 'system'
+          })
+        )
+        this.analytics = analytics
+
+        const currentUser = useCurrentUser()
+        if (userIdOverride) {
+          void analytics.identify(userIdOverride)
+        } else {
+          currentUser.onUserResolved((user) => void analytics.identify(user.id))
+        }
+        currentUser.onUserLogout(() => void analytics.reset())
+
+        this.flushQueue()
+      })
+      .catch((error) => {
+        console.error('Failed to load Customer.io:', error)
+        this.isEnabled = false
+        this.eventQueue = []
+      })
+  }
+
+  private send(event: string, properties: Record<string, unknown>): void {
+    void this.analytics?.track(event, properties)?.catch((error) => {
+      console.error('Failed to track Customer.io event:', error)
+    })
+  }
+
+  private track(event: string, metadata?: TelemetryEventProperties): void {
+    if (!this.isEnabled) return
+    const properties = { ...metadata, event_source: EVENT_SOURCE }
+    if (this.analytics) {
+      this.send(event, properties)
+    } else {
+      this.eventQueue.push({ event, properties })
+    }
+  }
+
+  private flushQueue(): void {
+    if (!this.analytics) return
+    for (const { event, properties } of this.eventQueue) {
+      this.send(event, properties)
+    }
+    this.eventQueue = []
+  }
+
+  trackAuth(metadata: AuthMetadata): void {
+    this.track(TelemetryEvents.USER_AUTH_COMPLETED, metadata)
+  }
+
+  trackSubscription(
+    event: 'modal_opened' | 'subscribe_clicked',
+    metadata?: SubscriptionMetadata
+  ): void {
+    this.track(
+      event === 'modal_opened'
+        ? TelemetryEvents.SUBSCRIPTION_REQUIRED_MODAL_OPENED
+        : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED,
+      metadata
+    )
+  }
+
+  trackAddApiCreditButtonClicked(): void {
+    this.track(TelemetryEvents.ADD_API_CREDIT_BUTTON_CLICKED)
+  }
+
+  trackWorkflowExecution(): void {
+    this.track(TelemetryEvents.EXECUTION_START)
+  }
+
+  trackExecutionSuccess(metadata: ExecutionSuccessMetadata): void {
+    this.track(TelemetryEvents.EXECUTION_SUCCESS, metadata)
+  }
+
+  trackTemplate(metadata: TemplateMetadata): void {
+    this.track(TelemetryEvents.TEMPLATE_WORKFLOW_OPENED, metadata)
+  }
+
+  trackTemplateLibraryOpened(metadata: TemplateLibraryMetadata): void {
+    this.track(TelemetryEvents.TEMPLATE_LIBRARY_OPENED, metadata)
+  }
+
+  trackShareFlow(metadata: ShareFlowMetadata): void {
+    this.track(TelemetryEvents.SHARE_FLOW, metadata)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a cloud-only Customer.io telemetry provider that forwards key frontend lifecycle events and registers the in-app messaging plugin, enabling low-latency intent-moment campaigns.

## Changes

- **What**: 
- new `CustomerIoTelemetryProvider` (matching impl. and registration of other telemetry, dynamic import, tree shaken)
- Triggered from 9 initial sources
- Update telemetry scanner
- **Dependencies**: `@customerio/cdp-analytics-browser`

## Review Focus

- Matches other telemetry providers & is correctly removed from OSS builds

## Screenshots (if applicable)


