### PR TITLE
Fix undated failed runs in job history grouping

### DIFF
--- a/src/composables/queue/useJobList.test.ts
+++ b/src/composables/queue/useJobList.test.ts
@@ -2,6 +2,7 @@ import { render } from '@testing-library/vue'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { nextTick, reactive, ref } from 'vue'
 import type { Ref } from 'vue'
+import { createI18n } from 'vue-i18n'
 
 import { useJobList } from '@/composables/queue/useJobList'
 import type { JobState } from '@/types/queue'
@@ -19,32 +20,24 @@ type TestTask = {
   workflowId?: string
 }
 
-const translations: Record<string, string> = {
-  'queue.jobList.undated': 'Undated',
-  'g.emDash': '--',
-  'g.untitled': 'Untitled'
-}
-let localeRef: Ref<string>
-let tMock: ReturnType<typeof vi.fn>
-const ensureLocaleMocks = () => {
-  if (!localeRef) {
-    localeRef = ref('en-US') as Ref<string>
-  }
-  if (!tMock) {
-    tMock = vi.fn((key: string) => translations[key] ?? key)
-  }
-  return { localeRef, tMock }
-}
-
-vi.mock('vue-i18n', () => ({
-  useI18n: () => {
-    ensureLocaleMocks()
-    return {
-      t: tMock,
-      locale: localeRef
+const createTestI18n = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        queue: {
+          jobList: {
+            undated: 'Undated'
+          }
+        },
+        g: {
+          emDash: '--',
+          untitled: 'Untitled'
+        }
+      }
     }
-  }
-}))
+  })
 
 vi.mock('@/i18n', () => ({
   st: vi.fn((key: string, fallback?: string) => `i18n(${key})-${fallback}`)
@@ -184,13 +177,20 @@ const createTask = (
 
 const mountUseJobList = () => {
   let composable: ReturnType<typeof useJobList>
-  const result = render({
-    template: '<div />',
-    setup() {
-      composable = useJobList()
-      return {}
+  const result = render(
+    {
+      template: '<div />',
+      setup() {
+        composable = useJobList()
+        return {}
+      }
+    },
+    {
+      global: {
+        plugins: [createTestI18n()]
+      }
     }
-  })
+  )
   return { ...result, composable: composable! }
 }
 
@@ -214,10 +214,6 @@ const resetStores = () => {
   ensureProgressRefs()
   totalPercent.value = 0
   currentNodePercent.value = 0
-
-  ensureLocaleMocks()
-  localeRef.value = 'en-US'
-  tMock.mockClear()
 
   if (isJobInitializingMock) {
     vi.mocked(isJobInitializingMock).mockReset()
@@ -559,6 +555,35 @@ describe('useJobList', () => {
     expect(instance.currentNodeName.value).toBe(
       'i18n(nodeDefs.My Node Type.display_name)-My Node Type'
     )
+  })
+
+  it('groups terminal jobs without an execution end timestamp by create time', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-10T12:00:00Z'))
+    queueStoreMock.historyTasks = [
+      createTask({
+        jobId: 'failed-before-execution',
+        job: { priority: 1 },
+        mockState: 'failed',
+        createTime: Date.now()
+      }),
+      createTask({
+        jobId: 'completed-without-end-time',
+        job: { priority: 1 },
+        mockState: 'completed',
+        createTime: Date.now() - 1_000
+      })
+    ]
+
+    const instance = initComposable()
+    await flush()
+
+    const groups = instance.groupedJobItems.value
+    expect(groups.map((g) => g.label)).toEqual(['Today'])
+    expect(groups[0].items.map((item) => item.id)).toEqual([
+      'failed-before-execution',
+      'completed-without-end-time'
+    ])
   })
 
   it('groups job items by date label and sorts by total generation time when requested', async () => {

--- a/src/composables/queue/useJobList.ts
+++ b/src/composables/queue/useJobList.ts
@@ -341,7 +341,7 @@ export function useJobList() {
     for (const { task, state } of searchableTaskEntries.value) {
       let ts: number | undefined
       if (state === 'completed' || state === 'failed') {
-        ts = task.executionEndTimestamp
+        ts = task.executionEndTimestamp ?? task.createTime
       } else {
         ts = task.createTime
       }


### PR DESCRIPTION
## Summary

Fixes FE-874 by preventing terminal jobs that do not have an `execution_end_time` from being grouped under the `Undated` section in the expanded job history / queue UI.

The production change is intentionally small: when grouping completed or failed jobs by date, the UI now falls back from `executionEndTimestamp` to `createTime`.

```ts
ts = task.executionEndTimestamp ?? task.createTime
```

This keeps the existing preference for execution completion time when it is available, while still giving pre-execution terminal jobs a meaningful date bucket based on when the job was created.

## Root Cause

Some terminal jobs, especially failures that happen before execution actually starts, can legitimately arrive without `execution_end_time`. This matches the backend semantics: if there is no execution start, there may be no execution end timestamp either.

Before this change, the frontend grouping logic treated missing `executionEndTimestamp` as if there were no usable date at all for terminal jobs. That caused failed jobs with a valid `create_time` to appear in the `Undated` group.

At the same time, the list sorting logic already used `createTime`, so those jobs could appear near the top of the list while still being labeled as `Undated`. That mismatch made recent failed jobs look like they had no date, even though the job creation timestamp was present.

## What Changed

- Updated `useJobList` date grouping for terminal jobs:
  - `completed` and `failed` jobs still use `executionEndTimestamp` when available.
  - If `executionEndTimestamp` is missing, they now fall back to `createTime`.
- Added regression coverage for terminal jobs without an execution end timestamp:
  - A failed job without `executionEndTimestamp` is grouped by `createTime`.
  - A completed job without `executionEndTimestamp` is also covered because the production fallback applies to both terminal states in the same code path.
- Cleaned up the `useJobList` test harness by replacing the mocked `vue-i18n` module with a real `createI18n` instance per mount.
  - This follows the repo testing guidance to avoid mocking `vue-i18n`.
  - Each composable mount now receives a fresh i18n instance, avoiding shared mutable i18n state between tests.

## User Impact

Failed jobs that never reached execution will no longer show up under `Undated` when they still have a valid creation timestamp. They will instead appear under the correct date group, such as `Today`, `Yesterday`, or a localized month/day label.

This should make the expanded job history easier to scan and avoid the confusing case where recent failed runs appear at the top while also being labeled as undated.

## E2E Regression Coverage Rationale

I did not add a Playwright regression test under `browser_tests/` for this fix because the regression is isolated to the timestamp selection used by `useJobList` when it builds date groups. There is no changed user interaction, navigation flow, API request shape, route handling, or browser-only behavior.

The existing browser coverage already verifies that the Job History sidebar opens, renders active and terminal jobs, and filters completed/failed jobs using the mocked jobs route fixture. Adding an E2E for this specific case would require creating another mocked `/api/jobs` response with a terminal job that has `create_time` but no `execution_end_time`, opening the sidebar, and asserting the rendered date header. That would mostly duplicate the composable-level assertion through the DOM while adding extra moving parts around relative date labels, locale/timezone formatting, and the virtualized job list.

The regression is therefore covered more directly and deterministically at the unit level in `src/composables/queue/useJobList.test.ts`. The new test drives the same grouping pipeline that the UI consumes and asserts that terminal jobs without `executionEndTimestamp` are grouped by `createTime` instead of falling into `Undated`. I also verified the test fails against the pre-fix implementation with `['Undated']` and passes with the fallback.

## Notes

This PR does not attempt to synthesize an execution end time. The backend can validly omit `execution_end_time` for jobs that never started execution. The frontend fix is limited to display grouping: if there is no execution end timestamp, use the already-present creation timestamp as the grouping date.

If product requirements later need the exact terminal failure timestamp for pre-execution failures, that would require a separate backend/API timestamp such as a terminal-state or update timestamp. This PR only fixes the current display fallback.

## Validation

Local validation run before publishing:

```bash
pnpm test:unit src/composables/queue/useJobList.test.ts
pnpm exec eslint src/composables/queue/useJobList.ts src/composables/queue/useJobList.test.ts
pnpm exec oxlint src/composables/queue/useJobList.ts src/composables/queue/useJobList.test.ts --type-aware
git diff --check -- src/composables/queue/useJobList.ts src/composables/queue/useJobList.test.ts
```

The commit hook also ran successfully during the final amend and passed:

```bash
pnpm exec oxfmt --write ...
pnpm exec oxlint --type-aware --fix ...
pnpm exec eslint --cache --fix ...
pnpm typecheck
```

## Screenshots

Before
<img width="346" height="624" alt="Screenshot 2026-06-17 1:35:06 AM" src="https://github.com/user-attachments/assets/02269f57-038a-4f06-9892-0758ad84d2c7" />

After
<img width="352" height="632" alt="Screenshot 2026-06-17 1:35:37 AM" src="https://github.com/user-attachments/assets/251cd762-2c88-4af6-8218-4af1915727b6" />
