### PR TITLE
test(litegraph): add litegraphInstance seam characterization test

### DIFF
--- a/src/lib/litegraph/src/litegraphInstance.test.ts
+++ b/src/lib/litegraph/src/litegraphInstance.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('litegraphInstance', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('throws a named error when read before registration', async () => {
+    const { litegraph } = await import('./litegraphInstance')
+    expect(() => litegraph()).toThrowError(
+      'LiteGraph singleton accessed before initialisation'
+    )
+  })
+
+  it('returns the registered LiteGraph singleton after the barrel loads', async () => {
+    const { LiteGraph } = await import('./litegraph')
+    const { litegraph } = await import('./litegraphInstance')
+    expect(litegraph()).toBe(LiteGraph)
+  })
+})


### PR DESCRIPTION
## Purpose

Demonstrate that the review's contribution over `drjkl/no-promotions` is **purely additive test coverage** — it changes none of the branch's behavior.

Built directly on top of `drjkl/no-promotions`, so the diff against it is the evidence.

## What changes

One file: `src/lib/litegraph/src/litegraphInstance.test.ts` (+20 lines).

GitHub compare (`drjkl/no-promotions...this`): `status: ahead`, `ahead_by: 1`, `behind_by: 0`, `1 file changed` — i.e. the branch adds a commit and removes/modifies nothing.

## The test

The late-bound `litegraph()` seam (`litegraphInstance.ts`) already exists on the branch but its throw-before-registration path had no coverage. This characterization test pins the contract:

- `litegraph()` throws `'LiteGraph singleton accessed before initialisation'` before `registerLiteGraphInstance`
- returns the registered singleton after the barrel loads (`litegraph() === LiteGraph`)

## Note on the full stacked analysis

The broader review decomposed `drjkl/no-promotions` into the maximal cleanly-stackable sequence and found only two concerns separate cleanly (the litegraph init seam; the branded `WidgetId` type); the `PromotedWidgetView` → store-backed projection swap is structurally atomic (~15 consumers read the removed object model). That analysis lives in the working notes, not this branch — this branch is scoped to the additive test evidence.
