### PR TITLE
When dragging vue nodes, also drag reroutes

### DIFF
--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@e2e/fixtures/ComfyPage'
 import type { ComfyPage } from '@e2e/fixtures/ComfyPage'
 import type { Position } from '@e2e/fixtures/types'
+import { VueNodeFixture } from '@e2e/fixtures/utils/vueNodeFixtures'
 
 test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
   const getHeaderPos = async (
@@ -357,6 +358,55 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     await comfyPage.page.mouse.move(10, 10, { steps: 20 })
     await comfyPage.nextFrame()
     expect(await getOffset(), 'drag canceled').toEqual(secondaryOffset)
+  })
+
+  test('dragging a node moves all selected items', async ({
+    comfyPage,
+    comfyMouse
+  }) => {
+    const samplerLocator = comfyPage.vueNodes.getNodeByTitle('KSampler')
+    const ksampler = new VueNodeFixture(samplerLocator)
+    const loaderLocator = comfyPage.vueNodes.getNodeByTitle('Load Checkpoint')
+    const loader = new VueNodeFixture(loaderLocator)
+
+    await test.step('create graph with group and reroute', async () => {
+      await comfyPage.nodeOps.clearGraph()
+      await comfyPage.searchBoxV2.addNode('Load Checkpoint')
+      const samplerOptions = { position: { x: 800, y: 200 } }
+      await comfyPage.searchBoxV2.addNode('KSampler', samplerOptions)
+      await ksampler.getSlot('model').dragTo(loader.getSlot('MODEL'))
+
+      await test.step('add reroute', async () => {
+        const b1 = await ksampler.getSlot('model').boundingBox()
+        const b2 = await loader.getSlot('MODEL').boundingBox()
+        if (!b1 || !b2) throw new Error('Failed to get bounds')
+
+        const x = (b1.x + b2.x + (b1.width + b2.width) / 2) / 2
+        const y = (b1.y + b2.y + (b1.height + b2.height) / 2) / 2
+        await comfyPage.page.keyboard.down('Alt')
+        await comfyPage.page.mouse.click(x, y)
+        await comfyPage.page.keyboard.up('Alt')
+
+        const rerouteSize = () =>
+          comfyPage.page.evaluate(() => graph!.reroutes.size)
+        await expect.poll(rerouteSize).toBe(1)
+      })
+
+      await comfyPage.keyboard.selectAll()
+      await comfyPage.page.keyboard.press('Control+G')
+      await comfyPage.keyboard.selectAll()
+    })
+
+    const getReroutePos = () =>
+      comfyPage.page.evaluate(() => [...graph!.reroutes.values()][0])
+    const getGroupPos = () =>
+      comfyPage.page.evaluate(() => graph!.groups[0].pos)
+    const initialReroutePos = await getReroutePos()
+    const initialGroupPos = await getGroupPos()
+    await comfyMouse.dragElementBy(ksampler.root, { x: 100 })
+
+    await expect.poll(getReroutePos).not.toEqual(initialReroutePos)
+    await expect.poll(getGroupPos).not.toEqual(initialGroupPos)
   })
 
   test(

--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -387,9 +387,9 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
         await comfyPage.page.mouse.click(x, y)
         await comfyPage.page.keyboard.up('Alt')
 
-        const rerouteSize = () =>
+        const rerouteCount = () =>
           comfyPage.page.evaluate(() => graph!.reroutes.size)
-        await expect.poll(rerouteSize).toBe(1)
+        await expect.poll(rerouteCount).toBe(1)
       })
 
       await comfyPage.keyboard.selectAll()
@@ -403,7 +403,7 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
       comfyPage.page.evaluate(() => graph!.groups[0].pos)
     const initialReroutePos = await getReroutePos()
     const initialGroupPos = await getGroupPos()
-    await comfyMouse.dragElementBy(ksampler.root, { x: 100 })
+    await comfyMouse.dragElementBy(ksampler.title, { x: 100 })
 
     await expect.poll(getReroutePos).not.toEqual(initialReroutePos)
     await expect.poll(getGroupPos).not.toEqual(initialGroupPos)

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -2,7 +2,7 @@ import { createSharedComposable, whenever } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { toValue } from 'vue'
 
-import type { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
+import type { Positionable } from '@/lib/litegraph/src/interfaces'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
@@ -16,7 +16,7 @@ import type {
 import { useNodeSnap } from '@/renderer/extensions/vueNodes/composables/useNodeSnap'
 import { useShiftKeySync } from '@/renderer/extensions/vueNodes/composables/useShiftKeySync'
 import { useTransformState } from '@/renderer/core/layout/transform/useTransformState'
-import { isLGraphGroup } from '@/utils/litegraphUtil'
+import { isLGraphNode } from '@/utils/litegraphUtil'
 
 export const useNodeDrag = createSharedComposable(useNodeDragIndividual)
 
@@ -44,7 +44,7 @@ function useNodeDragIndividual() {
 
   // For groups: track the last applied canvas delta to compute frame delta
   let lastCanvasDelta: Point | null = null
-  let selectedGroups: LGraphGroup[] | null = null
+  let selectedOther: Positionable[] | null = null
 
   // Auto-pan state
   let autoPan: AutoPanController | null = null
@@ -90,10 +90,10 @@ function useNodeDragIndividual() {
     // Capture selected groups only if the dragged node is part of the selection
     // This prevents groups from moving when dragging an unrelated node
     if (isDraggedNodeInSelection) {
-      selectedGroups = toValue(selectedItems).filter(isLGraphGroup)
+      selectedOther = toValue(selectedItems).filter((i) => !isLGraphNode(i))
       lastCanvasDelta = { x: 0, y: 0 }
     } else {
-      selectedGroups = null
+      selectedOther = null
       lastCanvasDelta = null
     }
 
@@ -123,8 +123,8 @@ function useNodeDragIndividual() {
             pos.y += panY
           }
         }
-        if (selectedGroups) {
-          for (const group of selectedGroups) {
+        if (selectedOther) {
+          for (const group of selectedOther) {
             group.move(panX, panY, true)
           }
         }
@@ -182,13 +182,13 @@ function useNodeDragIndividual() {
 
     mutations.batchMoveNodes(updates)
 
-    if (selectedGroups && selectedGroups.length > 0 && lastCanvasDelta) {
+    if (selectedOther && selectedOther.length > 0 && lastCanvasDelta) {
       const frameDelta = {
         x: canvasDelta.x - lastCanvasDelta.x,
         y: canvasDelta.y - lastCanvasDelta.y
       }
 
-      for (const group of selectedGroups) {
+      for (const group of selectedOther) {
         group.move(frameDelta.x, frameDelta.y, true)
       }
     }
@@ -289,7 +289,7 @@ function useNodeDragIndividual() {
     dragStartPos = null
     dragStartMouse = null
     otherSelectedNodesStartPositions = null
-    selectedGroups = null
+    selectedOther = null
     lastCanvasDelta = null
 
     autoPan?.stop()

--- a/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
+++ b/src/renderer/extensions/vueNodes/layout/useNodeDrag.ts
@@ -44,7 +44,7 @@ function useNodeDragIndividual() {
 
   // For groups: track the last applied canvas delta to compute frame delta
   let lastCanvasDelta: Point | null = null
-  let selectedOther: Positionable[] | null = null
+  let selectedNonNode: Positionable[] | null = null
 
   // Auto-pan state
   let autoPan: AutoPanController | null = null
@@ -90,10 +90,10 @@ function useNodeDragIndividual() {
     // Capture selected groups only if the dragged node is part of the selection
     // This prevents groups from moving when dragging an unrelated node
     if (isDraggedNodeInSelection) {
-      selectedOther = toValue(selectedItems).filter((i) => !isLGraphNode(i))
+      selectedNonNode = toValue(selectedItems).filter((i) => !isLGraphNode(i))
       lastCanvasDelta = { x: 0, y: 0 }
     } else {
-      selectedOther = null
+      selectedNonNode = null
       lastCanvasDelta = null
     }
 
@@ -123,8 +123,8 @@ function useNodeDragIndividual() {
             pos.y += panY
           }
         }
-        if (selectedOther) {
-          for (const group of selectedOther) {
+        if (selectedNonNode) {
+          for (const group of selectedNonNode) {
             group.move(panX, panY, true)
           }
         }
@@ -182,13 +182,13 @@ function useNodeDragIndividual() {
 
     mutations.batchMoveNodes(updates)
 
-    if (selectedOther && selectedOther.length > 0 && lastCanvasDelta) {
+    if (selectedNonNode && selectedNonNode.length > 0 && lastCanvasDelta) {
       const frameDelta = {
         x: canvasDelta.x - lastCanvasDelta.x,
         y: canvasDelta.y - lastCanvasDelta.y
       }
 
-      for (const group of selectedOther) {
+      for (const group of selectedNonNode) {
         group.move(frameDelta.x, frameDelta.y, true)
       }
     }
@@ -289,7 +289,7 @@ function useNodeDragIndividual() {
     dragStartPos = null
     dragStartMouse = null
     otherSelectedNodesStartPositions = null
-    selectedOther = null
+    selectedNonNode = null
     lastCanvasDelta = null
 
     autoPan?.stop()


### PR DESCRIPTION
`selectedItems` was being filtered to nodes and groups. Since no special behaviour is being performed on groups, the 'move groups' code is relaxed to instead 'move all non-node selected items'.