### PR TITLE
fix: keep Customer.io identity after reset

### DIFF
--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts
@@ -20,7 +20,11 @@ const hoisted = vi.hoisted(() => {
       logoutCb = cb
     }),
     resolveUser: (id: string) => resolvedCb?.({ id }),
-    logoutUser: () => logoutCb?.()
+    logoutUser: () => logoutCb?.(),
+    resetCallbacks: () => {
+      resolvedCb = undefined
+      logoutCb = undefined
+    }
   }
 })
 
@@ -57,6 +61,7 @@ function createProvider(
 describe('CustomerIoTelemetryProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hoisted.resetCallbacks()
     hoisted.load.mockReturnValue(hoisted.analytics)
     hoisted.analytics.register.mockResolvedValue(undefined)
     window.__CONFIG__ = {} as typeof window.__CONFIG__
@@ -109,7 +114,25 @@ describe('CustomerIoTelemetryProvider', () => {
     await vi.dynamicImportSettled()
 
     expect(hoisted.analytics.identify).toHaveBeenCalledWith('forced-uid')
-    expect(hoisted.onUserResolved).not.toHaveBeenCalled()
+    expect(hoisted.onUserResolved).toHaveBeenCalledOnce()
+  })
+
+  it('re-identifies with the configured user_id override after logout and re-login', async () => {
+    createProvider({
+      customer_io: {
+        write_key: WRITE_KEY,
+        site_id: SITE_ID,
+        user_id: 'forced-uid'
+      }
+    })
+    await vi.dynamicImportSettled()
+
+    hoisted.logoutUser()
+    hoisted.resolveUser('resolved-uid')
+
+    expect(hoisted.analytics.reset).toHaveBeenCalledOnce()
+    expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(1, 'forced-uid')
+    expect(hoisted.analytics.identify).toHaveBeenNthCalledWith(2, 'forced-uid')
   })
 
   it('identifies before flushing events buffered before the SDK loads', async () => {
@@ -189,6 +212,7 @@ describe('CustomerIoTelemetryProvider', () => {
       invoke: (p) =>
         p.trackShareFlow({
           step: 'dialog_opened',
+          share_id: 'share-1',
           view_mode: 'graph',
           is_app_mode: false
         }),
@@ -212,6 +236,29 @@ describe('CustomerIoTelemetryProvider', () => {
       expect(hoisted.analytics.track).toHaveBeenCalledWith(event, expected)
     }
   )
+
+  it('does not send raw auth email or share id to Customer.io', async () => {
+    const provider = createProvider()
+    await vi.dynamicImportSettled()
+
+    provider.trackAuth({
+      method: 'google',
+      is_new_user: true,
+      user_id: 'uid-1',
+      email: 'person@example.com',
+      share_id: 'share-1'
+    })
+
+    expect(hoisted.analytics.track).toHaveBeenCalledWith(
+      'app:user_auth_completed',
+      {
+        ...SOURCE,
+        method: 'google',
+        is_new_user: true,
+        user_id: 'uid-1'
+      }
+    )
+  })
 
   it('flushes events buffered before load once, in order', async () => {
     const provider = createProvider()

--- a/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser'
+import { omit } from 'es-toolkit'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 
@@ -59,13 +60,21 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
         )
         this.analytics = analytics
 
+        const configuredUserId = userIdOverride || undefined
+        let identifiedUserId = configuredUserId
+        if (identifiedUserId) void analytics.identify(identifiedUserId)
+
         const currentUser = useCurrentUser()
-        if (userIdOverride) {
-          void analytics.identify(userIdOverride)
-        } else {
-          currentUser.onUserResolved((user) => void analytics.identify(user.id))
-        }
-        currentUser.onUserLogout(() => void analytics.reset())
+        currentUser.onUserResolved((user) => {
+          const userId = configuredUserId ?? user.id
+          if (userId === identifiedUserId) return
+          identifiedUserId = userId
+          void analytics.identify(userId)
+        })
+        currentUser.onUserLogout(() => {
+          identifiedUserId = undefined
+          void analytics.reset()
+        })
 
         this.flushQueue()
       })
@@ -101,7 +110,10 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   }
 
   trackAuth(metadata: AuthMetadata): void {
-    this.track(TelemetryEvents.USER_AUTH_COMPLETED, metadata)
+    this.track(
+      TelemetryEvents.USER_AUTH_COMPLETED,
+      omit(metadata, ['email', 'share_id'])
+    )
   }
 
   trackSubscription(
@@ -137,6 +149,6 @@ export class CustomerIoTelemetryProvider implements TelemetryProvider {
   }
 
   trackShareFlow(metadata: ShareFlowMetadata): void {
-    this.track(TelemetryEvents.SHARE_FLOW, metadata)
+    this.track(TelemetryEvents.SHARE_FLOW, omit(metadata, ['share_id']))
   }
 }


### PR DESCRIPTION
## Summary

Keep Customer.io identified after logout/reset and avoid forwarding raw auth/share identifiers.

## Changes

- **What**: Continue listening for resolved users even when `customer_io.user_id` is configured, re-identify after reset, and omit raw `email` / `share_id` fields from Customer.io payloads.
- **Dependencies**: None

## Review Focus

Customer.io should use the backend-provided `customer_io.user_id` when configured, including after logout/re-login.

## Testing

- `pnpm test:unit src/platform/telemetry/providers/cloud/CustomerIoTelemetryProvider.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `DISTRIBUTION=localhost pnpm build`