### PR TITLE
test: harden assets media-type filter spec against VirtualGrid flake

### DIFF
--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -15,6 +15,13 @@ import { createMixedMediaJobs } from '@e2e/fixtures/helpers/AssetsHelper'
 // fixtures — Playwright runs auto fixtures before the `comfyPage` fixture's
 // internal `setup()`, so the page first-loads with mocks already in place.
 // See cloud-asset-default.spec.ts for the same pattern.
+//
+// Readiness waits use `waitForAssets()` (first card visible) rather than
+// `waitForAssets(MIXED_JOBS.length)`. VirtualGrid sizes its render window from
+// a single uniform item height; the taller audio card pushes the 3D card out
+// of the initial window, so it is intermittently virtualized out of the DOM
+// (same cause as #11635). Filtering reads the full asset store regardless of
+// what is mounted, so the per-filter count assertions still provide coverage.
 
 const MIXED_JOBS = createMixedMediaJobs(['images', 'video', 'audio', '3D'])
 
@@ -113,7 +120,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
 
@@ -136,7 +143,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
     await tab.toggleMediaTypeFilter('image')
@@ -153,7 +160,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
     await tab.toggleMediaTypeFilter('video')
@@ -167,7 +174,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
     await tab.toggleMediaTypeFilter('audio')
@@ -179,7 +186,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   test('Selecting only "3D" hides non-3D assets', async ({ comfyPage }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
     await tab.toggleMediaTypeFilter('3d')
@@ -193,7 +200,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
     await tab.toggleMediaTypeFilter('image')
@@ -211,7 +218,7 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
   }) => {
     const tab = comfyPage.menu.assetsTab
     await tab.open()
-    await tab.waitForAssets(MIXED_JOBS.length)
+    await tab.waitForAssets()
 
     await tab.openFilterMenu()
     await tab.toggleMediaTypeFilter('image')

--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -16,12 +16,9 @@ import { createMixedMediaJobs } from '@e2e/fixtures/helpers/AssetsHelper'
 // internal `setup()`, so the page first-loads with mocks already in place.
 // See cloud-asset-default.spec.ts for the same pattern.
 //
-// Readiness waits use `waitForAssets()` (first card visible) rather than
-// `waitForAssets(MIXED_JOBS.length)`. VirtualGrid sizes its render window from
-// a single uniform item height; the taller audio card pushes the 3D card out
-// of the initial window, so it is intermittently virtualized out of the DOM
-// (same cause as #11635). Filtering reads the full asset store regardless of
-// what is mounted, so the per-filter count assertions still provide coverage.
+// Use `waitForAssets()` not `waitForAssets(MIXED_JOBS.length)`: VirtualGrid can
+// virtualize the 3D card out of the initial render (#11635). Filtering reads the
+// full store, so the per-filter count assertions still cover the behavior.
 
 const MIXED_JOBS = createMixedMediaJobs(['images', 'video', 'audio', '3D'])
 


### PR DESCRIPTION
## Summary

Harden the cloud assets media-type filter spec against a VirtualGrid virtualization flake that intermittently failed CI at the `waitForAssets(4)` precondition.

## Changes

- **What**: Replace the 7 `waitForAssets(MIXED_JOBS.length)` preconditions in `assets-filter.spec.ts` with `waitForAssets()` (first card visible = data loaded), and document why.

## Review Focus

CI artifact (`playwright-report-cloud`) from the failing run showed only 3 of 4 cards in the DOM — the 3D card was missing and the audio card rendered taller (inline player). `VirtualGrid.vue` sizes its render window from a single uniform `itemHeight` measured off the first card, so the taller audio card pushes the 3D card out of the initial window and it is virtualized out of the DOM until a re-measure (same cause as #11635).

Requiring all 4 cards to be mounted simultaneously fights virtualization. `tab.open()` already waits for the first card (data loaded), and filtering reads the full asset store regardless of what is mounted, so the per-filter count assertions still provide the real coverage. No behavioral change to the tests — only the readiness/precondition strategy.

Verified `pnpm exec eslint` and `pnpm typecheck:browser` pass. Cloud E2E could not be run locally (needs a running frontend + backend); relies on the cloud CI job for confirmation.

Related to #11635
