### PR TITLE
fix(auth): provision customer row on Desktop native sign-in

### DIFF
--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -859,4 +859,129 @@ describe('useAuthStore', () => {
       await expect(store.createCustomer()).rejects.toThrow()
     })
   })
+
+  describe('Desktop customer provisioning on auth-state change', () => {
+    beforeEach(async () => {
+      vi.resetModules()
+
+      // Switch to Desktop distribution so the onAuthStateChanged handler
+      // reaches the isDesktop branch instead of the isCloud branch
+      mockDistributionTypes.isCloud = false
+      mockDistributionTypes.isDesktop = true
+
+      // Capture the callback without firing it so each test controls timing
+      vi.mocked(firebaseAuth.onAuthStateChanged).mockImplementation(
+        (_, callback) => {
+          authStateCallback = callback as (user: User | null) => void
+          return vi.fn()
+        }
+      )
+
+      vi.mocked(vuefire.useFirebaseAuth).mockReturnValue(
+        mockAuth as Partial<
+          ReturnType<typeof vuefire.useFirebaseAuth>
+        > as ReturnType<typeof vuefire.useFirebaseAuth>
+      )
+
+      setActivePinia(createTestingPinia({ stubActions: false }))
+      const storeModule = await import('@/stores/authStore')
+      store = storeModule.useAuthStore()
+
+      // Clear fetch call history accumulated during store initialization
+      mockFetch.mockClear()
+    })
+
+    afterEach(() => {
+      // Restore defaults so tests outside this describe are unaffected
+      mockDistributionTypes.isCloud = true
+      mockDistributionTypes.isDesktop = true
+    })
+
+    it('calls POST /customers when user signs in via Desktop native auth', async () => {
+      authStateCallback(mockUser)
+
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/customers'),
+          expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+              Authorization: 'Bearer mock-id-token'
+            })
+          })
+        )
+      })
+    })
+
+    it('silently swallows 409 when customer row already exists', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 409 })
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
+
+      authStateCallback(mockUser)
+
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/customers'),
+          expect.objectContaining({ method: 'POST' })
+        )
+      })
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('[Desktop]')
+      )
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('logs a warning but does not throw on 5xx server error', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
+
+      authStateCallback(mockUser)
+
+      await vi.waitFor(() => {
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            '[Desktop] Failed to provision customer (HTTP 500)'
+          )
+        )
+      })
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('logs a warning but does not throw on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network offline'))
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
+
+      authStateCallback(mockUser)
+
+      await vi.waitFor(() => {
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[Desktop] Failed to provision customer'),
+          expect.any(Error)
+        )
+      })
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('does not call POST /customers when auth state changes to signed-out', async () => {
+      authStateCallback(null)
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 50))
+
+      const provisionCalls = mockFetch.mock.calls.filter((args) => {
+        const [url, opts] = args as [string, RequestInit]
+        return (
+          typeof url === 'string' &&
+          url.endsWith('/customers') &&
+          opts?.method === 'POST'
+        )
+      })
+      expect(provisionCalls).toHaveLength(0)
+    })
+  })
 })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -22,7 +22,7 @@ import { useFirebaseAuth } from 'vuefire'
 
 import { getComfyApiBaseUrl } from '@/config/comfyApi'
 import { t } from '@/i18n'
-import { isCloud } from '@/platform/distribution/types'
+import { isCloud, isDesktop } from '@/platform/distribution/types'
 import {
   clearPreservedQuery,
   getPreservedQueryParam
@@ -129,6 +129,15 @@ export const useAuthStore = defineStore('auth', () => {
       // Mint the single Cloud JWT at login (flag-guarded inside the store; a
       // no-op when unified_cloud_auth is off).
       void useWorkspaceAuthStore().mintAtLogin()
+    } else if (isDesktop) {
+      // Desktop native auth (inject.ts) writes Firebase credentials directly to
+      // IndexedDB and calls location.reload(), bypassing the web sign-in form's
+      // executeAuthAction which is the only other call site of createCustomer.
+      // Provision the customer row here so the user is never locked out on their
+      // first API call. The call is idempotent — a 409 means the row already
+      // exists (e.g. sign-in via the in-app web form on Desktop 1, or a second
+      // app launch after the row was created) and is silently swallowed.
+      void provisionDesktopCustomer()
     }
 
     // Reset balance when auth state changes
@@ -288,6 +297,35 @@ export const useAuthStore = defineStore('auth', () => {
       return balanceData
     } finally {
       isFetchingBalance.value = false
+    }
+  }
+
+  /**
+   * Called from onAuthStateChanged for Desktop builds.
+   *
+   * Desktop native auth (inject.ts) injects Firebase credentials into IndexedDB
+   * and reloads the page, so POST /customers is never called by the sign-in form.
+   * This function provisions the customer row idempotently: a 409 (row already
+   * exists) is silently swallowed; any other failure is logged as a warning and
+   * does not surface to the user — the server-side fallback provisioner catches
+   * it on the first authenticated API request.
+   */
+  const provisionDesktopCustomer = async (): Promise<void> => {
+    const authHeader = await getAuthHeader()
+    if (!authHeader) return
+
+    try {
+      const res = await fetch(buildApiUrl('/customers'), {
+        method: 'POST',
+        headers: { ...authHeader, 'Content-Type': 'application/json' }
+      })
+      if (!res.ok && res.status !== 409) {
+        console.warn(
+          `[Desktop] Failed to provision customer (HTTP ${res.status})`
+        )
+      }
+    } catch (err) {
+      console.warn('[Desktop] Failed to provision customer', err)
     }
   }
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -130,13 +130,8 @@ export const useAuthStore = defineStore('auth', () => {
       // no-op when unified_cloud_auth is off).
       void useWorkspaceAuthStore().mintAtLogin()
     } else if (isDesktop) {
-      // Desktop native auth (inject.ts) writes Firebase credentials directly to
-      // IndexedDB and calls location.reload(), bypassing the web sign-in form's
-      // executeAuthAction which is the only other call site of createCustomer.
-      // Provision the customer row here so the user is never locked out on their
-      // first API call. The call is idempotent — a 409 means the row already
-      // exists (e.g. sign-in via the in-app web form on Desktop 1, or a second
-      // app launch after the row was created) and is silently swallowed.
+      // inject.ts bypasses executeAuthAction, so POST /customers is never called
+      // via the sign-in form on Desktop. Provision idempotently here; 409 = already exists.
       void provisionDesktopCustomer()
     }
 
@@ -300,16 +295,6 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  /**
-   * Called from onAuthStateChanged for Desktop builds.
-   *
-   * Desktop native auth (inject.ts) injects Firebase credentials into IndexedDB
-   * and reloads the page, so POST /customers is never called by the sign-in form.
-   * This function provisions the customer row idempotently: a 409 (row already
-   * exists) is silently swallowed; any other failure is logged as a warning and
-   * does not surface to the user — the server-side fallback provisioner catches
-   * it on the first authenticated API request.
-   */
   const provisionDesktopCustomer = async (): Promise<void> => {
     const authHeader = await getAuthHeader()
     if (!authHeader) return


### PR DESCRIPTION
## Summary

Desktop 2's native auth path (`inject.ts`) writes Firebase credentials directly to IndexedDB and calls `location.reload()`, bypassing `executeAuthAction` which was the only call site for `POST /customers`. This left Desktop-only users without a customer row, causing a 500 on their first authenticated API call.

## Changes

- **What**: Add `provisionDesktopCustomer` called from `onAuthStateChanged` when `isDesktop` is true. Posts to `/customers` idempotently on every sign-in event. A 409 (row already exists) is silently swallowed. Other errors are logged as `console.warn` and don't surface UX noise -- the server-side provisioner in comfy-api acts as a secondary safety net.
- **Why now**: Desktop 2 users who sign in via the native injected credential are locked out. The web sign-in form path on Desktop 1 already called `createCustomer` so those users are fine.

## Review Focus

**Belt-and-suspenders design:** This PR is the client-side half. The server-side half (cloud PR #4323) handles existing locked-out users and older Desktop clients that haven't received this update. Both are intentional -- not redundant.

**`else if (isCloud) ... else if (isDesktop)`:** The branches are mutually exclusive. On cloud builds `isCloud` is true and `isDesktop` is false, so `provisionDesktopCustomer` is never reached. On Desktop builds the reverse applies.

**Why not reuse `createCustomer`?** `createCustomer` throws on failure, which would bubble out of `onAuthStateChanged` and crash the auth flow. The provisioning call here is fire-and-forget with silent 409 swallowing; a separate function keeps the error contract clear.

**Tests:** 5 new cases in `authStore.test.ts` using `vi.resetModules()` + distribution flag mutation to isolate the Desktop branch:
- POST `/customers` called on sign-in
- 409 silently swallowed (no `console.warn`)
- 5xx logs warning but does not throw
- Network failure logs warning but does not throw
- Sign-out (`null` user) does not trigger a provision call

## Companion PRs

- cloud #4323 -- server-side `CustomerProvisioner` middleware (belt-and-suspenders safety net + existing user recovery)

## Screenshots (if applicable)

<!-- Add screenshots or video recording to help explain your changes -->