### PR TITLE
fix(workspace): guard sortWorkspaces against missing workspace dates

### DIFF
--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -2,6 +2,8 @@ import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+
 import { sortWorkspaces, useTeamWorkspaceStore } from './teamWorkspaceStore'
 
 // Mock workspaceAuthStore
@@ -974,5 +976,18 @@ describe('sortWorkspaces', () => {
       'w-team-member',
       'w-team-new-owner'
     ])
+  })
+
+  it('does not crash when a workspace is missing its date fields', () => {
+    // A malformed API response (dates are contractually required) must not throw
+    // and blank the entire account menu via a sort crash.
+    const input = [
+      { id: 'w-owner', name: 'Owner Team', role: 'owner', type: 'team' },
+      { id: 'w-member', name: 'Member Team', role: 'member', type: 'team' },
+      { id: 'w-personal', name: 'Personal', role: 'owner', type: 'personal' }
+    ] as unknown as WorkspaceWithRole[]
+
+    expect(() => sortWorkspaces(input)).not.toThrow()
+    expect(sortWorkspaces(input)[0].id).toBe('w-personal')
   })
 })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -80,8 +80,10 @@ export function sortWorkspaces<T extends WorkspaceWithRole>(list: T[]): T[] {
   return [...list].sort((a, b) => {
     if (a.type === 'personal') return -1
     if (b.type === 'personal') return 1
-    const dateA = a.role === 'owner' ? a.created_at : a.joined_at
-    const dateB = b.role === 'owner' ? b.created_at : b.joined_at
+    // Fall back to '' if a date is absent so one malformed workspace can't throw
+    // and blank the entire account menu (init aborts when sorting throws).
+    const dateA = (a.role === 'owner' ? a.created_at : a.joined_at) ?? ''
+    const dateB = (b.role === 'owner' ? b.created_at : b.joined_at) ?? ''
     return dateA.localeCompare(dateB)
   })
 }


### PR DESCRIPTION
## Summary
`sortWorkspaces` calls `.localeCompare` on `created_at`/`joined_at`. The `WorkspaceWithRole` type marks both required, but a malformed `/api/workspaces` response can omit one. With a **single** workspace the array comparator never runs, so the gap is invisible; with **2+ workspaces** the comparator runs and throws `TypeError: Cannot read properties of undefined (reading 'localeCompare')`.

That throw propagates out of `teamWorkspaceStore.initialize()` → retries exhaust → `initState = 'error'`. Since the account/profile popover only renders when `initState === 'ready'`, the **entire menu shows up blank** for the user.

## Fix
Fall back to `''` for an absent date so one malformed workspace can't crash the sort (and thus blank the whole menu). Ordering for valid data is unchanged.

## Test
Added a regression test in the existing `sortWorkspaces` block. Red→green verified locally:
- before: `× does not crash when a workspace is missing its date fields` (throws the exact TypeError)
- after: `✓` (47/47 pass)

## Context
Surfaced during manual Billing V1 verification (team workspaces) with the 2nd-workspace toggle on. Real production responses always include the dates, so this is defensive hardening at the consumer (schema stays strict).