### PR TITLE
Fix 'insert as node' in sidebar tab

### DIFF
--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -1105,3 +1105,46 @@ test.describe('Assets sidebar - drag and drop', () => {
     await expect.poll(() => fileComboWidget.getValue()).toBe('test.png [temp]')
   })
 })
+
+test('Insert as node', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
+  await comfyPage.assets.mockOutputHistory([
+    createMockJob({
+      id: 'job1',
+      preview_output: {
+        filename: `test.png`,
+        type: 'temp',
+        nodeId: '1',
+        mediaType: 'images'
+      }
+    }),
+    createMockJob({
+      id: 'job2',
+      preview_output: {
+        filename: `test.png`,
+        type: 'output',
+        nodeId: '1',
+        mediaType: 'images'
+      }
+    })
+  ])
+  const { assetsTab } = comfyPage.menu
+  await assetsTab.open()
+  await assetsTab.waitForAssets()
+  await expect(assetsTab.assetCards).toHaveCount(2)
+  for (const [index, type] of [
+    [0, 'temp'],
+    [1, 'output']
+  ] as const) {
+    await comfyPage.nodeOps.clearGraph()
+    await assetsTab.assetCards.nth(index).scrollIntoViewIfNeeded()
+    await assetsTab.assetCards.nth(index).click({ button: 'right' })
+
+    await expect(comfyPage.contextMenu.primeVueMenu).toBeVisible()
+    await comfyPage.contextMenu.primeVueMenu.getByText('Insert as node').click()
+
+    await expect.poll(() => comfyPage.vueNodes.getNodeCount()).toBe(1)
+    const nodes = await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
+    const fileWidget = await nodes[0].getWidget(0)
+    await expect.poll(() => fileWidget.getValue()).toBe(`test.png [${type}]`)
+  }
+})

--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -1111,7 +1111,7 @@ test('Insert as node', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
     createMockJob({
       id: 'job1',
       preview_output: {
-        filename: `test.png`,
+        filename: `1.png`,
         type: 'temp',
         nodeId: '1',
         mediaType: 'images'
@@ -1120,8 +1120,17 @@ test('Insert as node', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
     createMockJob({
       id: 'job2',
       preview_output: {
-        filename: `test.png`,
+        filename: `2.png`,
         type: 'output',
+        nodeId: '1',
+        mediaType: 'images'
+      }
+    }),
+    createMockJob({
+      id: 'job2',
+      preview_output: {
+        filename: `3.png`,
+        type: 'input',
         nodeId: '1',
         mediaType: 'images'
       }
@@ -1130,10 +1139,11 @@ test('Insert as node', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
   const { assetsTab } = comfyPage.menu
   await assetsTab.open()
   await assetsTab.waitForAssets()
-  await expect(assetsTab.assetCards).toHaveCount(2)
-  for (const [index, type] of [
-    [0, 'temp'],
-    [1, 'output']
+  await expect(assetsTab.assetCards).toHaveCount(3)
+  for (const [index, expectedName] of [
+    [0, '1.png [temp]'],
+    [1, '2.png [output]'],
+    [2, '3.png']
   ] as const) {
     await comfyPage.nodeOps.clearGraph()
     await assetsTab.assetCards.nth(index).scrollIntoViewIfNeeded()
@@ -1145,6 +1155,6 @@ test('Insert as node', { tag: '@vue-nodes' }, async ({ comfyPage }) => {
     await expect.poll(() => comfyPage.vueNodes.getNodeCount()).toBe(1)
     const nodes = await comfyPage.nodeOps.getNodeRefsByType('LoadImage')
     const fileWidget = await nodes[0].getWidget(0)
-    await expect.poll(() => fileWidget.getValue()).toBe(`test.png [${type}]`)
+    await expect.poll(() => fileWidget.getValue()).toBe(expectedName)
   }
 })

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -313,9 +313,7 @@ export function useMediaAssetActions() {
         subfolder: metadata?.subfolder || '',
         type: isResultItemType(assetType) ? assetType : undefined
       },
-      {
-        rootFolder: isResultItemType(assetType) ? assetType : undefined
-      }
+      { rootFolder: 'input' }
     )
 
     const widget = node.widgets?.find((w) => w.name === widgetName)

--- a/src/platform/assets/utils/assetTypeUtil.ts
+++ b/src/platform/assets/utils/assetTypeUtil.ts
@@ -20,5 +20,9 @@ export function getAssetType(
   asset: AssetItem,
   defaultType: 'input' | 'output' = 'output'
 ): string {
-  return asset.tags?.[0] || defaultType
+  const urlType = new URL(
+    asset.preview_url ?? '',
+    window.location.origin
+  ).searchParams.get('type')
+  return urlType || asset.tags?.[0] || defaultType
 }

--- a/src/platform/assets/utils/assetTypeUtil.ts
+++ b/src/platform/assets/utils/assetTypeUtil.ts
@@ -20,9 +20,8 @@ export function getAssetType(
   asset: AssetItem,
   defaultType: 'input' | 'output' = 'output'
 ): string {
-  const urlType = new URL(
-    asset.preview_url ?? '',
-    window.location.origin
-  ).searchParams.get('type')
+  const urlType = new URLSearchParams(
+    (asset.preview_url ?? '').split('?')[1] ?? ''
+  ).get('type')
   return urlType || asset.tags?.[0] || defaultType
 }


### PR DESCRIPTION
When right clicking an output asset from the assets sidebar panel, the 'insert as node in workflow' action was twice bugged
- The default type, as used for determining filename annotation, was set to the type of the file. This meant that annotations would never be applied to the filename
- `temp` outputs would incorrectly be assigned the `output` type.
  - My fix for this one gives me a slightly bad taste in my mouth. Parsing URLs isn't great, but it's cleaner than needing to scan the (potentially sparse) full outputs to try and find the corresponding output.