### PR TITLE
fix(textarea): reserve scrollbar gutter on both edges for symmetric padding

### DIFF
--- a/src/components/ui/textarea/Textarea.vue
+++ b/src/components/ui/textarea/Textarea.vue
@@ -23,7 +23,7 @@ defineExpose({
     v-model="modelValue"
     :class="
       cn(
-        'flex min-h-16 w-full scrollbar-gutter-stable rounded-lg border-none bg-secondary-background px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-border-default focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+        'flex min-h-16 w-full scrollbar-gutter-both rounded-lg border-none bg-secondary-background px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-border-default focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
         className
       )
     "


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

The shared shadcn `Textarea` wrapper applied `scrollbar-gutter-stable`, which reserves scrollbar space only on the inline-end edge. Combined with symmetric `px-3` padding, content appeared left-shifted inside the textarea — visible in Vue Nodes 2.0 Note nodes as the dark text input looking pushed left within the node body, with a noticeable empty band on the right.

Switching to [`scrollbar-gutter-both`](https://tailwindcss.com/docs/scrollbar-gutter#reserving-space-on-both-sides) (CSS `scrollbar-gutter: stable both-edges`) reserves the gutter on both sides so the textarea content sits centered, while preserving the no-reflow guarantee from #12280. Propagates to all consumers of the wrapper (`WidgetTextarea`, `WidgetMarkdown`, `ComfyHubDescribeStep`, `ComfyHubCreateProfileForm`).

## Before / After (Vue Nodes 2.0 Note node)

| Before (`stable`) | After (`stable both-edges`) |
| --- | --- |
| Text starts flush against left padding, extra empty band on the right | Text symmetrically inset on both sides |

## Verification

- `pnpm typecheck` — clean
- `pnpm vitest run src/components/ui/textarea/Textarea.test.ts src/renderer/extensions/vueNodes/widgets/components/WidgetTextarea.test.ts` — 26 tests passing
- Manual: spawned a Note node in Vue Nodes 2.0 mode, confirmed `getComputedStyle(textarea).scrollbarGutter === 'stable both-edges'` and visual padding is symmetric (see screenshots).

## Screenshots

![Before: Note node textarea with asymmetric right padding (scrollbar-gutter-stable)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1c048cec127a8e45706528791956792335b655b46189c0e4e22daf974e404b99/pr-images/1781681518486-780d4ed6-5aae-43ae-b80c-52ac751bf2b3.png)

![After: Note node textarea with symmetric padding (scrollbar-gutter-both)](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/1c048cec127a8e45706528791956792335b655b46189c0e4e22daf974e404b99/pr-images/1781681519211-f6509123-cc42-4ef5-a980-b3b0756182a9.png)