### PR TITLE
fix(billing): DES review polish on workspace billing UI

### DIFF
--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -4,9 +4,9 @@
       value: buttonTooltip,
       showDelay: 600
     }"
-    class="subscribe-to-run-button whitespace-nowrap"
+    class="subscribe-to-run-button h-8 gap-1.5 rounded-lg px-4 whitespace-nowrap"
     variant="gradient"
-    size="sm"
+    size="unset"
     data-testid="subscribe-to-run-button"
     @click="handleSubscribeToRun"
   >

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -51,7 +51,7 @@ export const useSubscriptionDialog = () => {
         dialogComponentProps: {
           style: 'width: min(360px, 95vw);',
           pt: {
-            root: { class: 'bg-transparent' },
+            root: { class: 'bg-transparent border-none rounded-none shadow-none' },
             content: { class: '!p-0 bg-transparent border-none shadow-none' }
           }
         }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -51,7 +51,9 @@ export const useSubscriptionDialog = () => {
         dialogComponentProps: {
           style: 'width: min(360px, 95vw);',
           pt: {
-            root: { class: 'bg-transparent border-none rounded-none shadow-none' },
+            root: {
+              class: 'bg-transparent border-none rounded-none shadow-none'
+            },
             content: { class: '!p-0 bg-transparent border-none shadow-none' }
           }
         }

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -139,12 +139,6 @@
       <span class="flex-1 text-sm text-base-foreground">{{
         $t('subscription.plansAndPricing')
       }}</span>
-      <span
-        v-if="canUpgrade"
-        class="rounded-full bg-base-foreground px-1.5 py-0.5 text-xs font-bold text-base-background"
-      >
-        {{ $t('subscription.upgrade') }}
-      </span>
     </div>
 
     <!-- Manage Plan (PERSONAL and OWNER, only if subscribed) -->
@@ -298,12 +292,6 @@ const displayedCredits = computed(() => {
       maximumFractionDigits: 2
     }
   })
-})
-
-const canUpgrade = computed(() => {
-  // PRO is currently the only/highest tier, so no upgrades available
-  // This will need updating when additional tiers are added
-  return false
 })
 
 const showPlansAndPricing = computed(


### PR DESCRIPTION
### before
https://www.figma.com/board/R9eN9DHmDgX3qEJXsRKiRr?node-id=410-297#1803836299 
<img width="539" height="475" alt="Screenshot 2026-06-17 at 9 52 50 PM" src="https://github.com/user-attachments/assets/dd562cb4-870c-43de-aca4-81e0118735e9" />

### after 
<img width="529" height="592" alt="Screenshot 2026-06-17 at 9 53 40 PM" src="https://github.com/user-attachments/assets/ba8ed01e-ac91-4654-bfaa-d8f73923f378" />


Design-review polish on the team-workspace billing UI (3 of the items from the Figma 'Team Plan - Workspaces' review). All three components are on main.

### 1. Remove dead 'Upgrade' badge in account popover
`CurrentUserPopoverWorkspace.vue` — the white badge beside 'Plans & pricing' was gated on `canUpgrade`, which is hardcoded `false` (PRO is the only tier), so it never rendered. Removed the badge markup and the dead computed. (Figma node 2797-724189.)

### 2. Subscribe-to-Run button height
`SubscribeToRun.vue` — used `size="sm"`, which didn't match the sibling run/queue button (an `h-8` button group it swaps with in the same slot via `CloudRunButtonWrapper`). Switched to `size="unset"` + `h-8 rounded-lg gap-1.5 px-4` to match.

### 3. Duplicate border/radius on member 'subscription inactive' dialog
`useSubscriptionDialog.ts` — the layout dialog already zeroes the *content* border (`border-none shadow-none`), but the *root* pt kept only `bg-transparent`, so the dialog frame's default border+radius doubled with the card's own `rounded-2xl border`. Added `border-none rounded-none shadow-none` to root so only the card's single border/radius shows. (Figma node 3253-19473.)

Surfaced during Billing V1 design review (team workspaces).