### PR TITLE
fix(billing): truncate long workspace names in the switcher

### DIFF
--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -30,7 +30,7 @@
               "
             >
               <button
-                class="flex flex-1 cursor-pointer items-center gap-2 border-none bg-transparent p-0"
+                class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 border-none bg-transparent p-0"
                 @click="handleSelectWorkspace(workspace)"
               >
                 <WorkspaceProfilePic
@@ -38,10 +38,10 @@
                   :workspace-name="workspace.name"
                 />
                 <div class="flex min-w-0 flex-1 flex-col items-start gap-1">
-                  <div class="flex max-w-full items-center gap-1.5">
+                  <div class="flex max-w-full min-w-0 items-center gap-1.5">
                     <span
                       :title="getDisplayName(workspace)"
-                      class="truncate text-sm text-base-foreground"
+                      class="min-w-0 truncate text-sm text-base-foreground"
                     >
                       {{ getDisplayName(workspace) }}
                     </span>


### PR DESCRIPTION
The workspace name was hard-clipped by the switcher panel's `overflow-hidden` instead of truncating with an ellipsis. The name span had `min-w-0` but its parent row `<button>` (`flex flex-1`) did not, so the button kept its content width and the long name overflowed.

Add `min-w-0` to the row button (and the name span) so the flex chain can shrink and the name truncates.

Follow-up to FE-769 (#12763, merged) — the component shipped without this.

## Before / After
<img width="1370" height="538" alt="fe769-before-after" src="https://github.com/user-attachments/assets/b05d6faf-9dfe-4c93-9941-3c0a9bbfcc2d" />

Verified live in the team-workspaces mock (long-named "Acme Studio Workspace").

### after
<img width="703" height="302" alt="Screenshot 2026-06-17 at 9 54 34 PM" src="https://github.com/user-attachments/assets/725c3175-b65f-4224-aca9-3de777c95e85" />
