### PR TITLE
fix(website): correct top-up credit rollover copy on cloud pricing

### DIFF
--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1385,9 +1385,9 @@ const translations = {
     'zh-CN': '随时加购积分'
   },
   'pricing.included.feature5.description': {
-    en: 'Purchase additional credits at any time. Unused top-ups roll over to the next month automatically for up to 1 year.',
+    en: 'Purchase additional credits at any time. Top-up credits are valid for 1 year from the date of purchase and do not roll over with your monthly plan.',
     'zh-CN':
-      '可随时购买额外积分。未使用的充值积分自动结转至下月，最长保留 1 年。'
+      '可随时购买额外积分。充值积分自购买之日起 1 年内有效，且不会随月度计划结转。'
   },
   'pricing.included.feature6.title': {
     en: 'Pre-installed models',


### PR DESCRIPTION
## Summary

The `/cloud/pricing` page's "Add more credits anytime" feature claims unused top-up credits **roll over** to the next month. Per product (Pablo, #cloud), top-up credits **do not** roll over. Fix the copy to match policy and the docs.

## Changes

- **What**: `pricing.included.feature5.description` (en + zh-CN) in `apps/website/src/i18n/translations.ts`.
  - Before: "Purchase additional credits at any time. Unused top-ups roll over to the next month automatically for up to 1 year."
  - After: "Purchase additional credits at any time. Top-up credits are valid for 1 year from the date of purchase and do not roll over with your monthly plan."
- Keeps the accurate 1-year validity window (matches `docs/interface/credits.mdx`).
- Scope: this is the **only** rollover claim on the page. The tier cards (lines 1224/1255/1286) only say "top-ups available" — no change needed.
- **Breaking**: none (copy only).

## Deliberately out of scope

The Slack thread surfaced an **unresolved** question: Pablo said top-ups don't roll over *"as opposed to subscription credits which do,"* but `docs/interface/credits.mdx` says monthly credits don't roll over either. This PR makes **no claim about subscription/monthly credit rollover** (the new copy is neutral: "do not roll over *with your monthly plan*"). Resolving that — and the optional FAQ entry / docs alignment Glary-Bot proposed — needs a product decision first. Flagging for follow-up.