### PR TITLE
Decouple run telemetry context from providers

### DIFF
--- a/src/components/builder/BuilderFooterToolbar.test.ts
+++ b/src/components/builder/BuilderFooterToolbar.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
-import type { AppMode } from '@/composables/useAppMode'
+import type { AppMode } from '@/utils/appMode'
 
 import BuilderFooterToolbar from '@/components/builder/BuilderFooterToolbar.vue'
 

--- a/src/composables/useAppMode.ts
+++ b/src/composables/useAppMode.ts
@@ -4,9 +4,6 @@ import { useWorkflowStore } from '@/platform/workflow/management/stores/workflow
 import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
 import type { AppMode } from '@/utils/appMode'
 
-export { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
-export type { AppMode } from '@/utils/appMode'
-
 const enableAppBuilder = ref(true)
 
 export function useAppMode() {

--- a/src/composables/useAppMode.ts
+++ b/src/composables/useAppMode.ts
@@ -1,28 +1,11 @@
 import { computed, ref } from 'vue'
 
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
+import type { AppMode } from '@/utils/appMode'
 
-export type AppMode =
-  | 'graph'
-  | 'app'
-  | 'builder:inputs'
-  | 'builder:outputs'
-  | 'builder:arrange'
-
-type WorkflowModeSource = {
-  activeMode: AppMode | null
-  initialMode: AppMode | null | undefined
-}
-
-export function getWorkflowMode(
-  workflow: WorkflowModeSource | null | undefined
-): AppMode {
-  return workflow?.activeMode ?? workflow?.initialMode ?? 'graph'
-}
-
-export function isAppModeValue(mode: AppMode): boolean {
-  return mode === 'app' || mode === 'builder:arrange'
-}
+export { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
+export type { AppMode } from '@/utils/appMode'
 
 const enableAppBuilder = ref(true)
 

--- a/src/composables/useCoreCommands.ts
+++ b/src/composables/useCoreCommands.ts
@@ -4,6 +4,7 @@ import { useSelectedLiteGraphItems } from '@/composables/canvas/useSelectedLiteG
 import { useSubgraphOperations } from '@/composables/graph/useSubgraphOperations'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useModelSelectorDialog } from '@/composables/useModelSelectorDialog'
+import { useRunButtonTelemetry } from '@/composables/useRunButtonTelemetry'
 import {
   DEFAULT_DARK_COLOR_PALETTE,
   DEFAULT_LIGHT_COLOR_PALETTE
@@ -85,6 +86,7 @@ export function useCoreCommands(): ComfyCommand[] {
   const executionStore = useExecutionStore()
   const modelStore = useModelStore()
   const telemetry = useTelemetry()
+  const { trackRunButton } = useRunButtonTelemetry()
   const { staticUrls, buildDocsUrl } = useExternalLink()
   const settingStore = useSettingStore()
 
@@ -499,7 +501,7 @@ export function useCoreCommands(): ComfyCommand[] {
         subscribe_to_run?: boolean
         trigger_source?: ExecutionTriggerSource
       }) => {
-        useTelemetry()?.trackRunButton(metadata)
+        trackRunButton(metadata)
         if (!isActiveSubscription.value) {
           showSubscriptionDialog()
           return
@@ -522,7 +524,7 @@ export function useCoreCommands(): ComfyCommand[] {
         subscribe_to_run?: boolean
         trigger_source?: ExecutionTriggerSource
       }) => {
-        useTelemetry()?.trackRunButton(metadata)
+        trackRunButton(metadata)
         if (!isActiveSubscription.value) {
           showSubscriptionDialog()
           return
@@ -544,7 +546,7 @@ export function useCoreCommands(): ComfyCommand[] {
         subscribe_to_run?: boolean
         trigger_source?: ExecutionTriggerSource
       }) => {
-        useTelemetry()?.trackRunButton(metadata)
+        trackRunButton(metadata)
         if (!isActiveSubscription.value) {
           showSubscriptionDialog()
           return

--- a/src/composables/useRunButtonTelemetry.test.ts
+++ b/src/composables/useRunButtonTelemetry.test.ts
@@ -16,7 +16,8 @@ const state = vi.hoisted(() => ({
     api_node_names: ['LoadImage'],
     has_toolkit_nodes: false,
     toolkit_node_names: []
-  }
+  },
+  executionContextError: null as Error | null
 }))
 
 vi.mock('@/composables/useAppMode', () => ({
@@ -31,7 +32,10 @@ vi.mock('@/platform/telemetry', () => ({
 }))
 
 vi.mock('@/platform/telemetry/utils/getExecutionContext', () => ({
-  getExecutionContext: () => state.executionContext
+  getExecutionContext: () => {
+    if (state.executionContextError) throw state.executionContextError
+    return state.executionContext
+  }
 }))
 
 import {
@@ -45,6 +49,7 @@ describe('useRunButtonTelemetry', () => {
     state.telemetry.trackRunButton.mockClear()
     state.mode.value = 'graph'
     state.isAppMode.value = false
+    state.executionContextError = null
   })
 
   it('builds run button properties from workspace state', () => {
@@ -83,5 +88,25 @@ describe('useRunButtonTelemetry', () => {
         workflow_name: 'Desktop workflow'
       })
     )
+  })
+
+  it('does not throw when run button context collection fails', () => {
+    const error = new Error('Context unavailable')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    state.executionContextError = error
+
+    try {
+      expect(() =>
+        useRunButtonTelemetry().trackRunButton({ trigger_source: 'linear' })
+      ).not.toThrow()
+
+      expect(state.telemetry.trackRunButton).not.toHaveBeenCalled()
+      expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+        '[Telemetry] Run button tracking failed',
+        error
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })

--- a/src/composables/useRunButtonTelemetry.test.ts
+++ b/src/composables/useRunButtonTelemetry.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  mode: { value: 'graph' },
+  isAppMode: { value: false },
+  telemetry: {
+    trackRunButton: vi.fn()
+  },
+  executionContext: {
+    is_template: false,
+    workflow_name: 'Desktop workflow',
+    custom_node_count: 2,
+    total_node_count: 4,
+    subgraph_count: 1,
+    has_api_nodes: true,
+    api_node_names: ['LoadImage'],
+    has_toolkit_nodes: false,
+    toolkit_node_names: []
+  }
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({
+    mode: state.mode,
+    isAppMode: state.isAppMode
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => state.telemetry
+}))
+
+vi.mock('@/platform/telemetry/utils/getExecutionContext', () => ({
+  getExecutionContext: () => state.executionContext
+}))
+
+import {
+  getRunButtonTelemetryProperties,
+  useRunButtonTelemetry
+} from './useRunButtonTelemetry'
+
+describe('useRunButtonTelemetry', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    state.telemetry.trackRunButton.mockClear()
+    state.mode.value = 'graph'
+    state.isAppMode.value = false
+  })
+
+  it('builds run button properties from workspace state', () => {
+    localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
+
+    expect(
+      getRunButtonTelemetryProperties({
+        subscribe_to_run: true,
+        trigger_source: 'button'
+      })
+    ).toEqual({
+      subscribe_to_run: true,
+      workflow_type: 'custom',
+      workflow_name: 'Desktop workflow',
+      custom_node_count: 2,
+      total_node_count: 4,
+      subgraph_count: 1,
+      has_api_nodes: true,
+      api_node_names: ['LoadImage'],
+      has_toolkit_nodes: false,
+      toolkit_node_names: [],
+      trigger_source: 'button',
+      view_mode: 'graph',
+      is_app_mode: false,
+      dock_state: 'floating'
+    })
+  })
+
+  it('tracks the completed run button payload', () => {
+    useRunButtonTelemetry().trackRunButton({ trigger_source: 'linear' })
+
+    expect(state.telemetry.trackRunButton).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        subscribe_to_run: false,
+        trigger_source: 'linear',
+        workflow_name: 'Desktop workflow'
+      })
+    )
+  })
+})

--- a/src/composables/useRunButtonTelemetry.ts
+++ b/src/composables/useRunButtonTelemetry.ts
@@ -38,7 +38,14 @@ export function getRunButtonTelemetryProperties(
 
 export function useRunButtonTelemetry() {
   function trackRunButton(options?: RunButtonTelemetryOptions): void {
-    useTelemetry()?.trackRunButton(getRunButtonTelemetryProperties(options))
+    const telemetry = useTelemetry()
+    if (!telemetry) return
+
+    try {
+      telemetry.trackRunButton(getRunButtonTelemetryProperties(options))
+    } catch (error) {
+      console.error('[Telemetry] Run button tracking failed', error)
+    }
   }
 
   return { trackRunButton }

--- a/src/composables/useRunButtonTelemetry.ts
+++ b/src/composables/useRunButtonTelemetry.ts
@@ -1,0 +1,45 @@
+import { useAppMode } from '@/composables/useAppMode'
+import { useTelemetry } from '@/platform/telemetry'
+import type {
+  ExecutionTriggerSource,
+  RunButtonProperties
+} from '@/platform/telemetry/types'
+import { getActionbarDockState } from '@/platform/telemetry/utils/getActionbarDockState'
+import { getExecutionContext } from '@/platform/telemetry/utils/getExecutionContext'
+
+export type RunButtonTelemetryOptions = {
+  subscribe_to_run?: boolean
+  trigger_source?: ExecutionTriggerSource
+}
+
+export function getRunButtonTelemetryProperties(
+  options?: RunButtonTelemetryOptions
+): RunButtonProperties {
+  const executionContext = getExecutionContext()
+  const { mode, isAppMode } = useAppMode()
+
+  return {
+    subscribe_to_run: options?.subscribe_to_run ?? false,
+    workflow_type: executionContext.is_template ? 'template' : 'custom',
+    workflow_name: executionContext.workflow_name ?? 'untitled',
+    custom_node_count: executionContext.custom_node_count,
+    total_node_count: executionContext.total_node_count,
+    subgraph_count: executionContext.subgraph_count,
+    has_api_nodes: executionContext.has_api_nodes,
+    api_node_names: executionContext.api_node_names,
+    has_toolkit_nodes: executionContext.has_toolkit_nodes,
+    toolkit_node_names: executionContext.toolkit_node_names,
+    trigger_source: options?.trigger_source,
+    view_mode: mode.value,
+    is_app_mode: isAppMode.value,
+    dock_state: getActionbarDockState()
+  }
+}
+
+export function useRunButtonTelemetry() {
+  function trackRunButton(options?: RunButtonTelemetryOptions): void {
+    useTelemetry()?.trackRunButton(getRunButtonTelemetryProperties(options))
+  }
+
+  return { trackRunButton }
+}

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -22,8 +22,8 @@ import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useRunButtonTelemetry } from '@/composables/useRunButtonTelemetry'
 import { isCloud } from '@/platform/distribution/types'
-import { useTelemetry } from '@/platform/telemetry'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 const { t } = useI18n()
@@ -32,6 +32,7 @@ const isMdOrLarger = breakpoints.greaterOrEqual('md')
 
 const { permissions } = useWorkspaceUI()
 const { showSubscriptionDialog } = useBillingContext()
+const { trackRunButton } = useRunButtonTelemetry()
 
 const canResubscribe = computed(() => permissions.value.canManageSubscription)
 
@@ -50,7 +51,7 @@ const buttonTooltip = computed(() =>
 
 function handleSubscribeToRun() {
   if (isCloud) {
-    useTelemetry()?.trackRunButton({ subscribe_to_run: true })
+    trackRunButton({ subscribe_to_run: true })
   }
 
   showSubscriptionDialog()

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -9,7 +9,6 @@ import type {
   ShareLinkOpenedMetadata,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
-  ExecutionTriggerSource,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -19,6 +18,7 @@ import type {
   SearchQueryMetadata,
   PageViewMetadata,
   PageVisibilityMetadata,
+  RunButtonProperties,
   SettingChangedMetadata,
   SharedWorkflowRunMetadata,
   ShellLayoutMetadata,
@@ -112,11 +112,8 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackApiCreditTopupSucceeded?.())
   }
 
-  trackRunButton(options?: {
-    subscribe_to_run?: boolean
-    trigger_source?: ExecutionTriggerSource
-  }): void {
-    this.dispatch((provider) => provider.trackRunButton?.(options))
+  trackRunButton(properties: RunButtonProperties): void {
+    this.dispatch((provider) => provider.trackRunButton?.(properties))
   }
 
   startTopupTracking(): void {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.test.ts
@@ -1,11 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-vi.mock('@/composables/useAppMode', () => ({
-  useAppMode: () => ({
-    mode: { value: 'app' },
-    isAppMode: { value: true }
-  })
-}))
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { GtmTelemetryProvider } from './GtmTelemetryProvider'
 
@@ -192,8 +185,22 @@ describe('GtmTelemetryProvider', () => {
 
     it('pushes run_workflow with trigger_source', () => {
       const provider = createInitializedProvider()
-      localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
-      provider.trackRunButton({ trigger_source: 'button' })
+      provider.trackRunButton({
+        subscribe_to_run: false,
+        workflow_type: 'custom',
+        workflow_name: 'untitled',
+        custom_node_count: 0,
+        total_node_count: 0,
+        subgraph_count: 0,
+        has_api_nodes: false,
+        api_node_names: [],
+        has_toolkit_nodes: false,
+        toolkit_node_names: [],
+        trigger_source: 'button',
+        view_mode: 'app',
+        is_app_mode: true,
+        dock_state: 'floating'
+      })
       expect(lastDataLayerEntry()).toMatchObject({
         event: 'run_workflow',
         trigger_source: 'button',

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -5,7 +5,6 @@ import type {
   EnterLinearMetadata,
   ExecutionErrorMetadata,
   ExecutionSuccessMetadata,
-  ExecutionTriggerSource,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -13,6 +12,7 @@ import type {
   NodeSearchResultMetadata,
   PageViewMetadata,
   PageVisibilityMetadata,
+  RunButtonProperties,
   SettingChangedMetadata,
   ShareFlowMetadata,
   SubscriptionMetadata,
@@ -29,8 +29,6 @@ import type {
   WorkflowImportMetadata,
   WorkflowSavedMetadata
 } from '../../types'
-import { useAppMode } from '@/composables/useAppMode'
-import { getActionbarDockState } from '../../utils/getActionbarDockState'
 
 /**
  * Google Tag Manager telemetry provider.
@@ -183,18 +181,13 @@ export class GtmTelemetryProvider implements TelemetryProvider {
     )
   }
 
-  trackRunButton(options?: {
-    subscribe_to_run?: boolean
-    trigger_source?: ExecutionTriggerSource
-  }): void {
-    const { mode, isAppMode } = useAppMode()
-
+  trackRunButton(properties: RunButtonProperties): void {
     this.pushEvent('run_workflow', {
-      subscribe_to_run: options?.subscribe_to_run ?? false,
-      trigger_source: options?.trigger_source ?? 'unknown',
-      view_mode: mode.value,
-      is_app_mode: isAppMode.value,
-      dock_state: getActionbarDockState()
+      subscribe_to_run: properties.subscribe_to_run,
+      trigger_source: properties.trigger_source ?? 'unknown',
+      view_mode: properties.view_mode,
+      is_app_mode: properties.is_app_mode,
+      dock_state: properties.dock_state
     })
   }
 

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.test.ts
@@ -17,33 +17,12 @@ vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({ onUserResolved: mockOnUserResolved })
 }))
 
-vi.mock('@/composables/useAppMode', () => ({
-  useAppMode: () => ({
-    mode: { value: 'graph' },
-    isAppMode: { value: false }
-  })
-}))
-
 const topupMocks = vi.hoisted(() => ({
   startTopupTracking: vi.fn(),
   clearTopupTracking: vi.fn(),
   checkForCompletedTopup: vi.fn().mockReturnValue(true)
 }))
 vi.mock('@/platform/telemetry/topupTracker', () => topupMocks)
-
-vi.mock('@/platform/telemetry/utils/getExecutionContext', () => ({
-  getExecutionContext: () => ({
-    is_template: false,
-    workflow_name: 'untitled',
-    custom_node_count: 0,
-    total_node_count: 0,
-    subgraph_count: 0,
-    has_api_nodes: false,
-    api_node_names: [],
-    has_toolkit_nodes: false,
-    toolkit_node_names: []
-  })
-}))
 
 const mockNormalizeSurveyResponses = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/telemetry/utils/surveyNormalization', () => ({
@@ -59,6 +38,7 @@ import type {
   AuthMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
+  RunButtonProperties,
   ShareFlowMetadata,
   ShellLayoutMetadata,
   SurveyResponses,
@@ -450,27 +430,33 @@ describe('MixpanelTelemetryProvider — direct event tracking methods', () => {
     )
   })
 
-  it('trackRunButton populates RunButtonProperties from the execution context', async () => {
+  it('trackRunButton forwards RunButtonProperties', async () => {
     const provider = new MixpanelTelemetryProvider()
     await waitForMixpanelInit()
     mockMixpanel.track.mockClear()
-    localStorage.setItem('Comfy.MenuPosition.Docked', 'false')
 
-    provider.trackRunButton({
+    const properties: RunButtonProperties = {
       subscribe_to_run: true,
-      trigger_source: 'button'
-    })
+      workflow_type: 'custom',
+      workflow_name: 'untitled',
+      custom_node_count: 0,
+      total_node_count: 0,
+      subgraph_count: 0,
+      has_api_nodes: false,
+      api_node_names: [],
+      has_toolkit_nodes: false,
+      toolkit_node_names: [],
+      trigger_source: 'button',
+      view_mode: 'graph',
+      is_app_mode: false,
+      dock_state: 'floating'
+    }
+
+    provider.trackRunButton(properties)
 
     expect(mockMixpanel.track).toHaveBeenCalledWith(
       TelemetryEvents.RUN_BUTTON_CLICKED,
-      expect.objectContaining({
-        subscribe_to_run: true,
-        workflow_type: 'custom',
-        trigger_source: 'button',
-        view_mode: 'graph',
-        is_app_mode: false,
-        dock_state: 'floating'
-      })
+      properties
     )
   })
 

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -2,7 +2,6 @@ import type { OverridedMixpanel } from 'mixpanel-browser'
 import { omit } from 'es-toolkit'
 import { watch } from 'vue'
 
-import { useAppMode } from '@/composables/useAppMode'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import {
   checkForCompletedTopup as checkTopupUtil,
@@ -11,14 +10,11 @@ import {
 } from '@/platform/telemetry/topupTracker'
 import type { AuditLog } from '@/services/customerEventsService'
 
-import { getExecutionContext } from '../../utils/getExecutionContext'
-
 import type {
   AuthMetadata,
   CreditTopupMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
-  ExecutionTriggerSource,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -48,7 +44,6 @@ import type {
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import { TelemetryEvents } from '../../types'
-import { getActionbarDockState } from '../../utils/getActionbarDockState'
 import { normalizeSurveyResponses } from '../../utils/surveyNormalization'
 
 const DEFAULT_DISABLED_EVENTS = [
@@ -276,31 +271,8 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
     clearTopupUtil()
   }
 
-  trackRunButton(options?: {
-    subscribe_to_run?: boolean
-    trigger_source?: ExecutionTriggerSource
-  }): void {
-    const executionContext = getExecutionContext()
-    const { mode, isAppMode } = useAppMode()
-
-    const runButtonProperties: RunButtonProperties = {
-      subscribe_to_run: options?.subscribe_to_run || false,
-      workflow_type: executionContext.is_template ? 'template' : 'custom',
-      workflow_name: executionContext.workflow_name ?? 'untitled',
-      custom_node_count: executionContext.custom_node_count,
-      total_node_count: executionContext.total_node_count,
-      subgraph_count: executionContext.subgraph_count,
-      has_api_nodes: executionContext.has_api_nodes,
-      api_node_names: executionContext.api_node_names,
-      has_toolkit_nodes: executionContext.has_toolkit_nodes,
-      toolkit_node_names: executionContext.toolkit_node_names,
-      trigger_source: options?.trigger_source,
-      view_mode: mode.value,
-      is_app_mode: isAppMode.value,
-      dock_state: getActionbarDockState()
-    }
-
-    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
+  trackRunButton(properties: RunButtonProperties): void {
+    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, properties)
   }
 
   trackSurvey(

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -3,7 +3,6 @@ import { watch } from 'vue'
 
 import { createPostHogBeforeSend } from '@comfyorg/shared-frontend-utils/piiUtil'
 
-import { useAppMode } from '@/composables/useAppMode'
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useSubscription } from '@/platform/cloud/subscription/composables/useSubscription'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
@@ -15,7 +14,6 @@ import type {
   EnterLinearMetadata,
   ShareFlowMetadata,
   ShareLinkOpenedMetadata,
-  ExecutionTriggerSource,
   HelpCenterClosedMetadata,
   HelpCenterOpenedMetadata,
   HelpResourceClickedMetadata,
@@ -46,8 +44,6 @@ import type {
   WorkflowSavedMetadata
 } from '../../types'
 import { TelemetryEvents } from '../../types'
-import { getActionbarDockState } from '../../utils/getActionbarDockState'
-import { getExecutionContext } from '../../utils/getExecutionContext'
 import { normalizeSurveyResponses } from '../../utils/surveyNormalization'
 
 const DEFAULT_DISABLED_EVENTS = [
@@ -374,31 +370,8 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED)
   }
 
-  trackRunButton(options?: {
-    subscribe_to_run?: boolean
-    trigger_source?: ExecutionTriggerSource
-  }): void {
-    const executionContext = getExecutionContext()
-    const { mode, isAppMode } = useAppMode()
-
-    const runButtonProperties: RunButtonProperties = {
-      subscribe_to_run: options?.subscribe_to_run || false,
-      workflow_type: executionContext.is_template ? 'template' : 'custom',
-      workflow_name: executionContext.workflow_name ?? 'untitled',
-      custom_node_count: executionContext.custom_node_count,
-      total_node_count: executionContext.total_node_count,
-      subgraph_count: executionContext.subgraph_count,
-      has_api_nodes: executionContext.has_api_nodes,
-      api_node_names: executionContext.api_node_names,
-      has_toolkit_nodes: executionContext.has_toolkit_nodes,
-      toolkit_node_names: executionContext.toolkit_node_names,
-      trigger_source: options?.trigger_source,
-      view_mode: mode.value,
-      is_app_mode: isAppMode.value,
-      dock_state: getActionbarDockState()
-    }
-
-    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, runButtonProperties)
+  trackRunButton(properties: RunButtonProperties): void {
+    this.trackEvent(TelemetryEvents.RUN_BUTTON_CLICKED, properties)
   }
 
   trackSurvey(

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -12,11 +12,11 @@
  * 3. Check dist/assets/*.js files contain no tracking code
  */
 
-import type { AppMode } from '@/composables/useAppMode'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { AuditLog } from '@/services/customerEventsService'
+import type { AppMode } from '@/utils/appMode'
 
 /**
  * Authentication metadata for sign-up tracking
@@ -486,10 +486,7 @@ export interface TelemetryProvider {
   trackAddApiCreditButtonClicked?(): void
   trackApiCreditTopupButtonPurchaseClicked?(amount: number): void
   trackApiCreditTopupSucceeded?(): void
-  trackRunButton?(options?: {
-    subscribe_to_run?: boolean
-    trigger_source?: ExecutionTriggerSource
-  }): void
+  trackRunButton?(properties: RunButtonProperties): void
 
   // Credit top-up tracking (composition with internal utilities)
   startTopupTracking?(): void

--- a/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
+++ b/src/platform/telemetry/utils/getShellLayoutSnapshot.test.ts
@@ -5,13 +5,7 @@ const state = vi.hoisted(() => ({
   activeSidebarTabId: null as string | null,
   rightSidePanelOpen: false,
   bottomPanelVisible: false,
-  openWorkflows: [] as unknown[],
-  mode: { value: 'graph' },
-  isAppMode: { value: false }
-}))
-
-vi.mock('@/composables/useAppMode', () => ({
-  useAppMode: () => ({ mode: state.mode, isAppMode: state.isAppMode })
+  openWorkflows: [] as unknown[]
 }))
 
 vi.mock('@/platform/settings/settingStore', () => ({
@@ -48,12 +42,12 @@ describe('getShellLayoutSnapshot', () => {
     state.rightSidePanelOpen = false
     state.bottomPanelVisible = false
     state.openWorkflows = []
-    state.mode.value = 'graph'
-    state.isAppMode.value = false
   })
 
   it('captures the default layout', () => {
-    expect(getShellLayoutSnapshot()).toEqual({
+    expect(
+      getShellLayoutSnapshot({ view_mode: 'graph', is_app_mode: false })
+    ).toEqual({
       view_mode: 'graph',
       is_app_mode: false,
       dock_state: 'docked',
@@ -71,10 +65,10 @@ describe('getShellLayoutSnapshot', () => {
     state.rightSidePanelOpen = true
     state.bottomPanelVisible = true
     state.openWorkflows = [{}, {}, {}]
-    state.mode.value = 'app'
-    state.isAppMode.value = true
 
-    expect(getShellLayoutSnapshot()).toEqual({
+    expect(
+      getShellLayoutSnapshot({ view_mode: 'app', is_app_mode: true })
+    ).toEqual({
       view_mode: 'app',
       is_app_mode: true,
       dock_state: 'floating',

--- a/src/platform/telemetry/utils/getShellLayoutSnapshot.ts
+++ b/src/platform/telemetry/utils/getShellLayoutSnapshot.ts
@@ -1,4 +1,3 @@
-import { useAppMode } from '@/composables/useAppMode'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
 import { useBottomPanelStore } from '@/stores/workspace/bottomPanelStore'
@@ -8,11 +7,15 @@ import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 import type { ShellLayoutMetadata } from '../types'
 import { getActionbarDockState } from './getActionbarDockState'
 
-export function getShellLayoutSnapshot(): ShellLayoutMetadata {
-  const { mode, isAppMode } = useAppMode()
+type ShellLayoutMode = Pick<ShellLayoutMetadata, 'view_mode' | 'is_app_mode'>
+
+export function getShellLayoutSnapshot({
+  view_mode,
+  is_app_mode
+}: ShellLayoutMode): ShellLayoutMetadata {
   return {
-    view_mode: mode.value,
-    is_app_mode: isAppMode.value,
+    view_mode,
+    is_app_mode,
     dock_state: getActionbarDockState(),
     actionbar_position: useSettingStore().get('Comfy.UseNewMenu'),
     active_sidebar_tab: useSidebarTabStore().activeSidebarTabId,

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -18,9 +18,9 @@ import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useMissingMediaStore } from '@/platform/missingMedia/missingMediaStore'
 import { app } from '@/scripts/app'
 import { useAppMode } from '@/composables/useAppMode'
-import type { AppMode } from '@/composables/useAppMode'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import { createMockChangeTracker } from '@/utils/__tests__/litegraphTestUtils'
+import type { AppMode } from '@/utils/appMode'
 import { t } from '@/i18n'
 
 function createModeTestWorkflow(

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -23,7 +23,6 @@ import { app } from '@/scripts/app'
 import { blankGraph, defaultGraph } from '@/scripts/defaultGraph'
 import { useDialogService } from '@/services/dialogService'
 import { useAppMode } from '@/composables/useAppMode'
-import type { AppMode } from '@/composables/useAppMode'
 import { useDomWidgetStore } from '@/stores/domWidgetStore'
 import { useAppModeStore } from '@/stores/appModeStore'
 import { useExecutionErrorStore } from '@/stores/executionErrorStore'
@@ -37,6 +36,7 @@ import {
   appendWorkflowJsonExt,
   generateUUID
 } from '@/utils/formatUtil'
+import type { AppMode } from '@/utils/appMode'
 
 function linearModeToAppMode(linearMode: unknown): AppMode | null {
   if (typeof linearMode !== 'boolean') return null

--- a/src/platform/workflow/management/stores/comfyWorkflow.ts
+++ b/src/platform/workflow/management/stores/comfyWorkflow.ts
@@ -2,13 +2,13 @@ import { markRaw } from 'vue'
 
 import { t } from '@/i18n'
 import type { ChangeTracker } from '@/scripts/changeTracker'
-import type { AppMode } from '@/composables/useAppMode'
 import type { NodeId } from '@/lib/litegraph/src/LGraphNode'
 import { UserFile } from '@/stores/userFileStore'
 import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/workflowSchema'
 import type { MissingModelCandidate } from '@/platform/missingModel/types'
 import type { MissingMediaCandidate } from '@/platform/missingMedia/types'
 import type { MissingNodeType } from '@/types/comfy'
+import type { AppMode } from '@/utils/appMode'
 
 export interface InputWidgetConfig {
   height?: number

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -1,11 +1,12 @@
-import { useSettingStore } from '@/platform/settings/settingStore'
-import { WORKFLOW_ACCEPT_STRING } from '@/platform/workflow/core/types/formats'
-import { type StatusWsMessageStatus } from '@/schemas/apiSchema'
-import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { useRunButtonTelemetry } from '@/composables/useRunButtonTelemetry'
 import { isCloud } from '@/platform/distribution/types'
 import { extractWorkflow } from '@/platform/remote/comfyui/jobs/fetchJobs'
 import type { JobListItem } from '@/platform/remote/comfyui/jobs/jobTypes'
+import { useSettingsDialog } from '@/platform/settings/composables/useSettingsDialog'
+import { useSettingStore } from '@/platform/settings/settingStore'
 import { useTelemetry } from '@/platform/telemetry'
+import { WORKFLOW_ACCEPT_STRING } from '@/platform/workflow/core/types/formats'
+import { type StatusWsMessageStatus } from '@/schemas/apiSchema'
 import { useLitegraphService } from '@/services/litegraphService'
 import { useCommandStore } from '@/stores/commandStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
@@ -488,7 +489,9 @@ export class ComfyUI {
           textContent: 'Queue Prompt',
           onclick: () => {
             if (isCloud) {
-              useTelemetry()?.trackRunButton({ trigger_source: 'legacy_ui' })
+              useRunButtonTelemetry().trackRunButton({
+                trigger_source: 'legacy_ui'
+              })
               useTelemetry()?.trackWorkflowExecution()
             }
             app.queuePrompt(0, this.batchCount)
@@ -596,7 +599,9 @@ export class ComfyUI {
             textContent: 'Queue Front',
             onclick: () => {
               if (isCloud) {
-                useTelemetry()?.trackRunButton({ trigger_source: 'legacy_ui' })
+                useRunButtonTelemetry().trackRunButton({
+                  trigger_source: 'legacy_ui'
+                })
                 useTelemetry()?.trackWorkflowExecution()
               }
               app.queuePrompt(-1, this.batchCount)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -2,12 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
 import { useNodeProgressText } from '@/composables/node/useNodeProgressText'
-import type { AppMode } from '@/composables/useAppMode'
-import {
-  getWorkflowMode,
-  isAppModeValue,
-  useAppMode
-} from '@/composables/useAppMode'
+import { useAppMode } from '@/composables/useAppMode'
 import { isCloud } from '@/platform/distribution/types'
 import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useTelemetry } from '@/platform/telemetry'
@@ -41,6 +36,8 @@ import { useExecutionErrorStore } from '@/stores/executionErrorStore'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 import { classifyCloudValidationError } from '@/utils/executionErrorUtil'
 import { executionIdToNodeLocatorId } from '@/utils/graphTraversalUtil'
+import type { AppMode } from '@/utils/appMode'
+import { getWorkflowMode, isAppModeValue } from '@/utils/appMode'
 
 interface ExecutionNodeInfo {
   title?: string | null

--- a/src/utils/appMode.ts
+++ b/src/utils/appMode.ts
@@ -1,0 +1,21 @@
+export type AppMode =
+  | 'graph'
+  | 'app'
+  | 'builder:inputs'
+  | 'builder:outputs'
+  | 'builder:arrange'
+
+type WorkflowModeSource = {
+  activeMode: AppMode | null
+  initialMode: AppMode | null | undefined
+}
+
+export function getWorkflowMode(
+  workflow: WorkflowModeSource | null | undefined
+): AppMode {
+  return workflow?.activeMode ?? workflow?.initialMode ?? 'graph'
+}
+
+export function isAppModeValue(mode: AppMode): boolean {
+  return mode === 'app' || mode === 'builder:arrange'
+}

--- a/src/views/GraphView.vue
+++ b/src/views/GraphView.vue
@@ -111,7 +111,7 @@ const queueStore = useQueueStore()
 const assetsStore = useAssetsStore()
 const versionCompatibilityStore = useVersionCompatibilityStore()
 const graphCanvasContainerRef = ref<HTMLDivElement | null>(null)
-const { isBuilderMode } = useAppMode()
+const { isBuilderMode, mode, isAppMode } = useAppMode()
 const { linearMode } = storeToRefs(useCanvasStore())
 
 watch(linearMode, (isLinear) => {
@@ -354,7 +354,12 @@ const onGraphReady = () => {
 
     // Shell layout snapshot, once per session (cloud only)
     if (isCloud && telemetry) {
-      telemetry.trackShellLayout(getShellLayoutSnapshot())
+      telemetry.trackShellLayout(
+        getShellLayoutSnapshot({
+          view_mode: mode.value,
+          is_app_mode: isAppMode.value
+        })
+      )
     }
 
     // Setting values now available after comfyApp.setup.


### PR DESCRIPTION
## Summary

Move run-button context assembly out of telemetry providers so telemetry can initialize without importing app-mode/workspace state.

## Changes

- **What**: Providers now accept completed `RunButtonProperties`; run-button call sites use a workspace composable to build that payload.
- **Dependencies**: None.