### PR TITLE
ci: carry forward unit and e2e coverage flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,14 @@ comment:
   require_changes: false
   require_base: false
   require_head: true
+
+# Carry forward the last known coverage for a flag when its upload is missing or
+# late. The `e2e` flag is uploaded by a separate workflow_run job that can fail
+# or arrive after Codecov has already computed the patch status; without this,
+# E2E-only code paths show up as patch misses and the patch status fails. See
+# https://docs.codecov.com/docs/carryforward-flags
+flags:
+  unit:
+    carryforward: true
+  e2e:
+    carryforward: true


### PR DESCRIPTION
## Summary

Enable Codecov carryforward on the `unit` and `e2e` flags so a missing or late E2E coverage upload no longer produces a false `codecov/patch` failure.

## Changes

- **What**: Add a `flags` block to `codecov.yml` marking `unit` and `e2e` as `carryforward: true`. When a flag's upload is absent for a commit, Codecov reuses that flag's last known coverage for unchanged files instead of treating those lines as patch misses.

## Review Focus

The `e2e` flag is uploaded by the separate `ci-tests-e2e-coverage` `workflow_run` job, which runs after CI and currently fails or skips intermittently (uploaded with `fail_ci_if_error: false`). When that upload is missing, the head report holds only the `unit` session, so E2E-only code paths (canvas, vue-nodes, minimap, glsl, etc.) report as uncovered and the patch status fails against the full-coverage base. Carryforward fixes that symptom; the flaky coverage workflow remains a separate root-cause fix.

Validated with `curl --data-binary @codecov.yml https://codecov.io/validate` → `Valid!`. Carryforward takes effect after merge once a `main` build establishes a baseline for both flags.
