### PR TITLE
fix: prevent Vitest createRequire crash on Windows public-asset URLs

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -156,6 +156,13 @@ const gcsRedirectProxyConfig: ProxyOptions = {
   }
 }
 
+// Disabling absolute asset-URL transforms under Vitest keeps `/assets/...` as
+// string literals, avoiding rootless `file:///assets/...` imports that crash
+// Vitest's `createRequire` on Windows.
+const vuePluginOptions = process.env.VITEST
+  ? { template: { transformAssetUrls: { includeAbsolute: false } } }
+  : undefined
+
 export default defineConfig({
   base: DISTRIBUTION === 'cloud' ? '/' : '',
   server: {
@@ -259,8 +266,8 @@ export default defineConfig({
 
   plugins: [
     ...(!DISABLE_VUE_PLUGINS
-      ? [vueDevTools(), vue(), createHtmlPlugin({})]
-      : [vue()]),
+      ? [vueDevTools(), vue(vuePluginOptions), createHtmlPlugin({})]
+      : [vue(vuePluginOptions)]),
     tailwindcss(),
     typegpuPlugin({}),
     comfyAPIPlugin(IS_DEV),


### PR DESCRIPTION
## Summary

Stop Vitest from crashing on Windows when a unit test imports a Vue component whose template references an absolute public-asset URL (e.g. `<img src="/assets/images/default-template.png">`).

## Changes

- **What**: Pass `template.transformAssetUrls.includeAbsolute: false` to `@vitejs/plugin-vue` under Vitest only. With no dev server, the plugin forces `includeAbsolute: true`, compiling absolute public-asset URLs into module imports. Vite's module runner then derives a rootless `import.meta.url` of `file:///assets/...`, which has no drive letter on Windows, so Vitest's `createRequire(import.meta.url)` throws `ERR_INVALID_ARG_VALUE` and aborts collection of any test transitively importing such a component. Disabling the absolute transform under tests keeps these as plain string literals (identical rendered output).
- **Breaking**: None — change is scoped to `process.env.VITEST`; dev and production builds are unchanged.

## Review Focus

`vite.config.mts` — the `vuePluginOptions` const is `undefined` outside Vitest, so only the test runner is affected.
