### PR TITLE
fix: remove unused export from Load3dSerializedBase type

### DIFF
--- a/src/extensions/core/load3d/load3dSerialize.ts
+++ b/src/extensions/core/load3d/load3dSerialize.ts
@@ -6,7 +6,7 @@ import type {
 } from '@/extensions/core/load3d/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 
-export type Load3dSerializedBase = {
+type Load3dSerializedBase = {
   camera_info: CameraState | null
   model_3d_info: Model3DInfo
 }


### PR DESCRIPTION
## Summary

Remove unused `export` keyword from `Load3dSerializedBase` type. The type is only used internally as the return type of `snapshotLoad3dState` and is not imported elsewhere.

Fixes knip "unused exported types" error.