### PR TITLE
refactor(litegraph): remove vestigial use_uuids node-id mode

### DIFF
--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -973,7 +973,7 @@ export class LGraph
       console.warn(
         'LiteGraph: there is already a node with this ID, changing it'
       )
-      node.id = LiteGraph.use_uuids ? LiteGraph.uuidv4() : ++state.lastNodeId
+      node.id = ++state.lastNodeId
     }
 
     if (this._nodes.length >= LiteGraph.MAX_NUMBER_OF_NODES) {
@@ -981,14 +981,10 @@ export class LGraph
     }
 
     // give him an id
-    if (LiteGraph.use_uuids) {
-      if (node.id == null || node.id == -1) node.id = LiteGraph.uuidv4()
-    } else {
-      if (node.id == null || node.id == -1) {
-        node.id = ++state.lastNodeId
-      } else if (typeof node.id === 'number' && state.lastNodeId < node.id) {
-        state.lastNodeId = node.id
-      }
+    if (node.id == null || node.id == -1) {
+      node.id = ++state.lastNodeId
+    } else if (typeof node.id === 'number' && state.lastNodeId < node.id) {
+      state.lastNodeId = node.id
     }
 
     // Set ghost flag before registration so VueNodeData picks it up
@@ -2359,11 +2355,9 @@ export class LGraph
     Required<Pick<SerialisableGraph, 'nodes' | 'groups' | 'extra'>> {
     const { id, revision, config, state } = this
 
-    const nodeList =
-      !LiteGraph.use_uuids && options?.sortNodes
-        ? // @ts-expect-error If LiteGraph.use_uuids is false, ids are numbers.
-          [...this._nodes].sort((a, b) => a.id - b.id)
-        : this._nodes
+    const nodeList = options?.sortNodes
+      ? [...this._nodes].sort((a, b) => Number(a.id) - Number(b.id))
+      : this._nodes
 
     const nodes = nodeList.map((node) => node.serialize())
     const groups = this._groups.map((x) => x.serialize())

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -810,7 +810,7 @@ export class LGraphNode
   }
 
   constructor(title: string, type?: string) {
-    this.id = LiteGraph.use_uuids ? LiteGraph.uuidv4() : -1
+    this.id = -1
     this.title = title || 'Unnamed'
     this.type = type ?? ''
     this.size = [LiteGraph.NODE_WIDTH, 60]
@@ -1024,7 +1024,6 @@ export class LGraphNode
 
     node.id = this.id
     node.configure(data)
-    if (LiteGraph.use_uuids) node.id = LiteGraph.uuidv4()
 
     return node
   }

--- a/src/lib/litegraph/src/LiteGraphGlobal.ts
+++ b/src/lib/litegraph/src/LiteGraphGlobal.ts
@@ -266,10 +266,6 @@ export class LiteGraphGlobal {
    */
   ctrl_shift_v_paste_connect_unselected_outputs = true
 
-  // if true, all newly created nodes/links will use string UUIDs for their id fields instead of integers.
-  // use this if you must have node IDs that are unique across all graphs and subgraphs.
-  use_uuids = false
-
   // Whether to highlight the bounding box of selected groups
   highlight_selected_group = true
 

--- a/src/lib/litegraph/src/__snapshots__/litegraph.test.ts.snap
+++ b/src/lib/litegraph/src/__snapshots__/litegraph.test.ts.snap
@@ -193,7 +193,6 @@ LiteGraphGlobal {
   "throw_errors": true,
   "truncateWidgetTextEvenly": false,
   "truncateWidgetValuesFirst": false,
-  "use_uuids": false,
   "uuidv4": [Function],
   "vueNodesMode": false,
 }


### PR DESCRIPTION
## Summary

Removes LiteGraph's vestigial `use_uuids` node-id mode, which was never enabled anywhere in the codebase.

## Changes

- **What**: Deletes the `LiteGraph.use_uuids` flag and the node-id branches that read it. Newly created/added/cloned nodes now always receive integer ids. The `asSerialisable` sort guard drops its `@ts-expect-error` in favor of an explicit `Number(a.id) - Number(b.id)` comparison.
- **Breaking**: `LiteGraph.use_uuids` is removed from the public `LiteGraph` global. It defaulted to `false` and nothing ever set it to `true`, so behavior is unchanged for all real usage — but the property no longer exists on the global surface. Litegraph changes can affect downstream custom-node repos.

`createUuidv4` / `LiteGraph.uuidv4` are intentionally kept — still used for subgraph ids, slot ids, and clipboard remapping.

## Review Focus

- Confirm hard removal (vs. deprecate-then-remove no-op getter) is acceptable for the public `LiteGraph` surface.
- `asSerialisable` sort now coerces ids via `Number()`; all serialised node ids are numeric, so ordering is unchanged.

## Notes

- 2 litegraph test suites (`LGraphCanvas.clipboard.test.ts`, `SubgraphWidgetPromotion.test.ts`) fail at import with a pre-existing asset-URL error unrelated to this change (confirmed they fail with these changes stashed). All 909 tests that ran pass.
