### PR TITLE
feat(telemetry): instrument cloud funnel gaps + enable cloud web analytics

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -544,6 +544,13 @@ const allTemplates = computed(() => {
 // Navigation
 const selectedNavItem = ref<string | null>(initialCategory)
 
+// Track category/tab switches (e.g. "Getting Started" vs "All") so we can see
+// which curated entry points users browse before opening a template.
+watch(selectedNavItem, (to, from) => {
+  if (!to || to === from) return
+  useTelemetry()?.trackTemplateCategorySelected({ category_id: to })
+})
+
 // Filter templates based on selected navigation item
 const navigationFilteredTemplates = computed(() => {
   if (!selectedNavItem.value) {

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -31,6 +31,7 @@ const mockAccessBillingPortal = vi.fn()
 const mockReportError = vi.fn()
 const mockTrackBeginCheckout = vi.fn()
 const mockTrackSubscription = vi.fn()
+const mockTrackBillingCycleToggled = vi.fn()
 const mockUserId = ref<string | undefined>('user-123')
 const mockGetAuthHeader = vi.fn(() =>
   Promise.resolve({ Authorization: 'Bearer test-token' })
@@ -113,7 +114,8 @@ vi.mock('@/stores/authStore', () => ({
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackBeginCheckout: mockTrackBeginCheckout,
-    trackSubscription: mockTrackSubscription
+    trackSubscription: mockTrackSubscription,
+    trackBillingCycleToggled: mockTrackBillingCycleToggled
   })
 }))
 
@@ -225,6 +227,7 @@ describe('PricingTable', () => {
     mockAccessBillingPortal.mockResolvedValue(true)
     mockTrackBeginCheckout.mockReset()
     mockTrackSubscription.mockReset()
+    mockTrackBillingCycleToggled.mockReset()
     mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -508,6 +511,29 @@ describe('PricingTable', () => {
       await flushPromises()
 
       expect(mockTrackSubscription).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('billing cycle toggle telemetry', () => {
+    it('fires billing_cycle_toggled with from/to when switching to monthly', async () => {
+      renderComponent()
+      await flushPromises()
+
+      const monthlyToggle = screen.getByRole('button', { name: 'Monthly' })
+      await userEvent.click(monthlyToggle)
+      await flushPromises()
+
+      expect(mockTrackBillingCycleToggled).toHaveBeenCalledWith({
+        from: 'yearly',
+        to: 'monthly'
+      })
+    })
+
+    it('does not fire on initial render when the cycle has not changed', async () => {
+      renderComponent()
+      await flushPromises()
+
+      expect(mockTrackBillingCycleToggled).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/cloud/subscription/components/PricingTable.test.ts
+++ b/src/platform/cloud/subscription/components/PricingTable.test.ts
@@ -30,6 +30,7 @@ const mockIsYearlySubscription = ref(false)
 const mockAccessBillingPortal = vi.fn()
 const mockReportError = vi.fn()
 const mockTrackBeginCheckout = vi.fn()
+const mockTrackSubscription = vi.fn()
 const mockUserId = ref<string | undefined>('user-123')
 const mockGetAuthHeader = vi.fn(() =>
   Promise.resolve({ Authorization: 'Bearer test-token' })
@@ -111,7 +112,8 @@ vi.mock('@/stores/authStore', () => ({
 
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
-    trackBeginCheckout: mockTrackBeginCheckout
+    trackBeginCheckout: mockTrackBeginCheckout,
+    trackSubscription: mockTrackSubscription
   })
 }))
 
@@ -222,6 +224,7 @@ describe('PricingTable', () => {
     mockAccessBillingPortal.mockReset()
     mockAccessBillingPortal.mockResolvedValue(true)
     mockTrackBeginCheckout.mockReset()
+    mockTrackSubscription.mockReset()
     mockLocalStorage.__reset()
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -437,6 +440,74 @@ describe('PricingTable', () => {
       await userEvent.click(teamLink!)
 
       expect(onChooseTeamWorkspace).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('subscribe-now click telemetry', () => {
+    it('fires subscribe_clicked with tier/cycle/source on the new-subscriber path', async () => {
+      mockIsActiveSubscription.value = false
+
+      const windowOpenSpy = vi
+        .spyOn(window, 'open')
+        .mockImplementation(() => null)
+
+      renderComponent()
+      await flushPromises()
+
+      const creatorButton = screen
+        .getAllByRole('button')
+        .find((b) => b.textContent?.includes('Creator'))
+
+      await userEvent.click(creatorButton!)
+      await flushPromises()
+
+      expect(mockTrackSubscription).toHaveBeenCalledWith('subscribe_clicked', {
+        current_tier: undefined,
+        tier: 'creator',
+        cycle: 'yearly',
+        source: 'pricing_table'
+      })
+
+      windowOpenSpy.mockRestore()
+    })
+
+    it('fires subscribe_clicked on the change path for an existing subscriber', async () => {
+      mockIsActiveSubscription.value = true
+      mockSubscriptionTier.value = 'STANDARD'
+
+      renderComponent()
+      await flushPromises()
+
+      const proButton = screen
+        .getAllByRole('button')
+        .find((b) => b.textContent?.includes('Pro'))
+
+      await userEvent.click(proButton!)
+      await flushPromises()
+
+      expect(mockTrackSubscription).toHaveBeenCalledWith('subscribe_clicked', {
+        current_tier: 'standard',
+        tier: 'pro',
+        cycle: 'yearly',
+        source: 'pricing_table'
+      })
+    })
+
+    it('does not fire subscribe_clicked when clicking the current plan', async () => {
+      mockIsActiveSubscription.value = true
+      mockSubscriptionTier.value = 'CREATOR'
+
+      renderComponent()
+      await flushPromises()
+
+      const currentPlanButton = screen
+        .getAllByRole('button')
+        .find((b) => b.textContent?.includes('Current Plan'))
+
+      await userEvent.click(currentPlanButton!)
+      await flushPromises()
+
+      expect(mockTrackSubscription).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -258,7 +258,7 @@ import { storeToRefs } from 'pinia'
 import Popover from 'primevue/popover'
 import SelectButton from 'primevue/selectbutton'
 import type { ToggleButtonPassThroughMethodOptions } from 'primevue/togglebutton'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
@@ -373,6 +373,13 @@ const isLoading = ref(false)
 const loadingTier = ref<CheckoutTierKey | null>(null)
 const popover = ref()
 const currentBillingCycle = ref<BillingCycle>('yearly')
+
+// Track monthly/yearly toggles so we can see whether the annual-discount
+// nudge actually moves the cycle selection before checkout.
+watch(currentBillingCycle, (to, from) => {
+  if (!isCloud || to === from) return
+  telemetry?.trackBillingCycleToggled({ from, to })
+})
 
 const hasPaidSubscription = computed(
   () => isActiveSubscription.value && !isFreeTier.value

--- a/src/platform/cloud/subscription/components/PricingTable.vue
+++ b/src/platform/cloud/subscription/components/PricingTable.vue
@@ -448,6 +448,16 @@ const handleSubscribe = wrapWithErrorHandlingAsync(
     isLoading.value = true
     loadingTier.value = tierKey
 
+    // Fire the subscribe-now click before opening checkout so the funnel
+    // captures intent even if the checkout window is blocked or abandoned.
+    // Covers both the 'change' (existing paid subscriber) and 'new' paths.
+    telemetry?.trackSubscription('subscribe_clicked', {
+      current_tier: subscriptionTier.value?.toLowerCase(),
+      tier: tierKey,
+      cycle: currentBillingCycle.value,
+      source: 'pricing_table'
+    })
+
     try {
       if (hasPaidSubscription.value) {
         const targetPlan = {

--- a/src/platform/cloud/subscription/components/SubscribeButton.vue
+++ b/src/platform/cloud/subscription/components/SubscribeButton.vue
@@ -55,7 +55,8 @@ watch(
 const handleSubscribe = () => {
   if (isCloud) {
     useTelemetry()?.trackSubscription('subscribe_clicked', {
-      current_tier: subscriptionTier.value?.toLowerCase()
+      current_tier: subscriptionTier.value?.toLowerCase(),
+      source: 'subscribe_button'
     })
   }
   isAwaitingStripeSubscription.value = true

--- a/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
@@ -10,6 +10,8 @@ import SubscribeToRun from './SubscribeToRun.vue'
 const mockShowSubscriptionDialog = vi.fn()
 const mockCanManageSubscription = ref(true)
 const mockIsMdOrLarger = ref(true)
+const mockTrackRunButton = vi.fn()
+const mockTrackSubscription = vi.fn()
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
   useBillingContext: () => ({
@@ -30,7 +32,10 @@ vi.mock('@/platform/distribution/types', () => ({
 }))
 
 vi.mock('@/platform/telemetry', () => ({
-  useTelemetry: () => null
+  useTelemetry: () => ({
+    trackRunButton: mockTrackRunButton,
+    trackSubscription: mockTrackSubscription
+  })
 }))
 
 vi.mock('@vueuse/core', async (importOriginal) => {
@@ -110,5 +115,16 @@ describe('SubscribeToRun', () => {
     await user.click(screen.getByTestId('subscribe-to-run-button'))
 
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
+  })
+
+  it('tracks both the run button and a subscribe-now click on click', async () => {
+    const { user } = renderButton()
+
+    await user.click(screen.getByTestId('subscribe-to-run-button'))
+
+    expect(mockTrackRunButton).toHaveBeenCalledWith({ subscribe_to_run: true })
+    expect(mockTrackSubscription).toHaveBeenCalledWith('subscribe_clicked', {
+      source: 'subscribe_to_run'
+    })
   })
 })

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -50,7 +50,14 @@ const buttonTooltip = computed(() =>
 
 function handleSubscribeToRun() {
   if (isCloud) {
-    useTelemetry()?.trackRunButton({ subscribe_to_run: true })
+    const telemetry = useTelemetry()
+    telemetry?.trackRunButton({ subscribe_to_run: true })
+    // Also count this as a subscribe-now click so the lock-button CTA shows up
+    // in the subscribe-click funnel alongside the pricing table and the
+    // legacy SubscribeButton (previously the only fired surface).
+    telemetry?.trackSubscription('subscribe_clicked', {
+      source: 'subscribe_to_run'
+    })
   }
 
   showSubscriptionDialog()

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -3,6 +3,7 @@ import type { AuditLog } from '@/services/customerEventsService'
 import type {
   AuthMetadata,
   BeginCheckoutMetadata,
+  BillingCycleToggledMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
   ShareFlowMetadata,
@@ -84,6 +85,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackBeginCheckout(metadata: BeginCheckoutMetadata): void {
     this.dispatch((provider) => provider.trackBeginCheckout?.(metadata))
+  }
+
+  trackBillingCycleToggled(metadata: BillingCycleToggledMetadata): void {
+    this.dispatch((provider) => provider.trackBillingCycleToggled?.(metadata))
   }
 
   trackMonthlySubscriptionSucceeded(

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -4,6 +4,8 @@ import type {
   AuthMetadata,
   BeginCheckoutMetadata,
   BillingCycleToggledMetadata,
+  AuthErrorMetadata,
+  TemplateCategorySelectedMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
   ShareFlowMetadata,
@@ -89,6 +91,18 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackBillingCycleToggled(metadata: BillingCycleToggledMetadata): void {
     this.dispatch((provider) => provider.trackBillingCycleToggled?.(metadata))
+  }
+
+  trackAuthError(metadata: AuthErrorMetadata): void {
+    this.dispatch((provider) => provider.trackAuthError?.(metadata))
+  }
+
+  trackTemplateCategorySelected(
+    metadata: TemplateCategorySelectedMetadata
+  ): void {
+    this.dispatch((provider) =>
+      provider.trackTemplateCategorySelected?.(metadata)
+    )
   }
 
   trackMonthlySubscriptionSucceeded(

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -324,6 +324,18 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
+    it('captures billing cycle toggles with from/to', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      provider.trackBillingCycleToggled({ from: 'yearly', to: 'monthly' })
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.BILLING_CYCLE_TOGGLED,
+        { from: 'yearly', to: 'monthly' }
+      )
+    })
+
     it('captures search queries with surface, query, length, and result count', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -11,6 +11,7 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 import type {
   AuthMetadata,
+  BillingCycleToggledMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
   ShareFlowMetadata,
@@ -348,6 +349,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
         : TelemetryEvents.SUBSCRIBE_NOW_BUTTON_CLICKED
 
     this.trackEvent(eventName, metadata)
+  }
+
+  trackBillingCycleToggled(metadata: BillingCycleToggledMetadata): void {
+    this.trackEvent(TelemetryEvents.BILLING_CYCLE_TOGGLED, metadata)
   }
 
   trackAddApiCreditButtonClicked(): void {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -12,6 +12,8 @@ import type { RemoteConfig } from '@/platform/remoteConfig/types'
 import type {
   AuthMetadata,
   BillingCycleToggledMetadata,
+  AuthErrorMetadata,
+  TemplateCategorySelectedMetadata,
   DefaultViewSetMetadata,
   EnterLinearMetadata,
   ShareFlowMetadata,
@@ -127,9 +129,14 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
               api_host:
                 window.__CONFIG__?.posthog_api_host || 'https://t.comfy.org',
               ui_host: 'https://us.posthog.com',
-              autocapture: false,
-              capture_pageview: false,
-              capture_pageleave: false,
+              // Web analytics enabled so cloud.comfy.org gets heatmaps + $pageview
+              // (the login/onboarding pages previously had zero coverage). autocapture
+              // does NOT record input *values* (posthog masks them), and these defaults
+              // remain overridable per-environment via `serverConfig` (spread below).
+              autocapture: true,
+              capture_pageview: true,
+              capture_pageleave: true,
+              heatmaps: true,
               persistence: 'localStorage+cookie',
               debug: import.meta.env.VITE_POSTHOG_DEBUG === 'true',
               ...serverConfig,
@@ -353,6 +360,16 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackBillingCycleToggled(metadata: BillingCycleToggledMetadata): void {
     this.trackEvent(TelemetryEvents.BILLING_CYCLE_TOGGLED, metadata)
+  }
+
+  trackAuthError(metadata: AuthErrorMetadata): void {
+    this.trackEvent(TelemetryEvents.AUTH_ERROR, metadata)
+  }
+
+  trackTemplateCategorySelected(
+    metadata: TemplateCategorySelectedMetadata
+  ): void {
+    this.trackEvent(TelemetryEvents.TEMPLATE_CATEGORY_SELECTED, metadata)
   }
 
   trackAddApiCreditButtonClicked(): void {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -423,9 +423,24 @@ export interface CheckoutAttributionMetadata {
   wbraid?: string
 }
 
+/**
+ * Surface that triggered a subscribe-now click. Lets us attribute the
+ * `app:subscribe_now_button_clicked` event to the specific CTA the user
+ * actually clicked, rather than only the legacy SubscribeButton.
+ */
+export type SubscribeClickSource =
+  | 'pricing_table'
+  | 'subscribe_to_run'
+  | 'subscribe_button'
+
 export interface SubscriptionMetadata {
   current_tier?: string
   reason?: SubscriptionDialogReason
+  // Populated on subscribe-now clicks so the funnel can split intent by the
+  // tier/cycle selected and the CTA surface that fired the event.
+  tier?: TierKey
+  cycle?: BillingCycle
+  source?: SubscribeClickSource
 }
 
 export interface BeginCheckoutMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -443,6 +443,16 @@ export interface SubscriptionMetadata {
   source?: SubscribeClickSource
 }
 
+/**
+ * Fired when the user toggles the monthly/yearly billing cycle on the
+ * pricing table. Lets us see whether the annual-discount nudge actually
+ * moves the cycle selection before checkout.
+ */
+export interface BillingCycleToggledMetadata {
+  from: BillingCycle
+  to: BillingCycle
+}
+
 export interface BeginCheckoutMetadata
   extends Record<string, unknown>, CheckoutAttributionMetadata {
   user_id: string
@@ -494,6 +504,7 @@ export interface TelemetryProvider {
     metadata?: SubscriptionMetadata
   ): void
   trackBeginCheckout?(metadata: BeginCheckoutMetadata): void
+  trackBillingCycleToggled?(metadata: BillingCycleToggledMetadata): void
   trackMonthlySubscriptionSucceeded?(
     metadata?: SubscriptionSuccessMetadata
   ): void
@@ -601,6 +612,7 @@ export const TelemetryEvents = {
   RUN_BUTTON_CLICKED: 'app:run_button_click',
   SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'app:subscription_required_modal_opened',
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
+  BILLING_CYCLE_TOGGLED: 'app:billing_cycle_toggled',
   MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
   MONTHLY_SUBSCRIPTION_CANCELLED: 'app:monthly_subscription_cancelled',
   ADD_API_CREDIT_BUTTON_CLICKED: 'app:add_api_credit_button_clicked',
@@ -718,3 +730,4 @@ export type TelemetryEventProperties =
   | DefaultViewSetMetadata
   | SubscriptionMetadata
   | SubscriptionSuccessMetadata
+  | BillingCycleToggledMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -453,6 +453,28 @@ export interface BillingCycleToggledMetadata {
   to: BillingCycle
 }
 
+/**
+ * Fired when an authentication attempt fails (sign-in or sign-up). Lets the
+ * signup funnel see the error/bounce leak that `app:user_auth_completed`
+ * (success-only) cannot.
+ */
+export interface AuthErrorMetadata {
+  method: 'email' | 'google' | 'github'
+  is_sign_up: boolean
+  error_code?: string
+  error_message?: string
+}
+
+/**
+ * Fired when the user switches category/tab in the template selector (e.g.
+ * "Getting Started" vs "All"), so we can see which curated entry points get
+ * used before a template is opened.
+ */
+export interface TemplateCategorySelectedMetadata {
+  category_id: string
+  category_label?: string
+}
+
 export interface BeginCheckoutMetadata
   extends Record<string, unknown>, CheckoutAttributionMetadata {
   user_id: string
@@ -505,6 +527,10 @@ export interface TelemetryProvider {
   ): void
   trackBeginCheckout?(metadata: BeginCheckoutMetadata): void
   trackBillingCycleToggled?(metadata: BillingCycleToggledMetadata): void
+  trackAuthError?(metadata: AuthErrorMetadata): void
+  trackTemplateCategorySelected?(
+    metadata: TemplateCategorySelectedMetadata
+  ): void
   trackMonthlySubscriptionSucceeded?(
     metadata?: SubscriptionSuccessMetadata
   ): void
@@ -613,6 +639,8 @@ export const TelemetryEvents = {
   SUBSCRIPTION_REQUIRED_MODAL_OPENED: 'app:subscription_required_modal_opened',
   SUBSCRIBE_NOW_BUTTON_CLICKED: 'app:subscribe_now_button_clicked',
   BILLING_CYCLE_TOGGLED: 'app:billing_cycle_toggled',
+  AUTH_ERROR: 'app:auth_error',
+  TEMPLATE_CATEGORY_SELECTED: 'app:template_category_selected',
   MONTHLY_SUBSCRIPTION_SUCCEEDED: 'app:monthly_subscription_succeeded',
   MONTHLY_SUBSCRIPTION_CANCELLED: 'app:monthly_subscription_cancelled',
   ADD_API_CREDIT_BUTTON_CLICKED: 'app:add_api_credit_button_clicked',
@@ -731,3 +759,5 @@ export type TelemetryEventProperties =
   | SubscriptionMetadata
   | SubscriptionSuccessMetadata
   | BillingCycleToggledMetadata
+  | AuthErrorMetadata
+  | TemplateCategorySelectedMetadata

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -329,6 +329,10 @@ export const useAuthStore = defineStore('auth', () => {
     action: (auth: Auth) => Promise<T>,
     options: {
       createCustomer?: boolean
+      authError?: {
+        method: 'email' | 'google' | 'github'
+        isSignUp: boolean
+      }
     } = {}
   ): Promise<T> => {
     loading.value = true
@@ -346,6 +350,18 @@ export const useAuthStore = defineStore('auth', () => {
       }
 
       return result
+    } catch (error) {
+      // Surface the auth failure leak that trackAuth (success-only) misses.
+      if (isCloud && options?.authError) {
+        useTelemetry()?.trackAuthError({
+          method: options.authError.method,
+          is_sign_up: options.authError.isSignUp,
+          error_code: (error as { code?: string })?.code,
+          error_message:
+            error instanceof Error ? error.message : String(error)
+        })
+      }
+      throw error
     } finally {
       loading.value = false
     }
@@ -358,7 +374,10 @@ export const useAuthStore = defineStore('auth', () => {
     const result = await executeAuthAction(
       (authInstance) =>
         signInWithEmailAndPassword(authInstance, email, password),
-      { createCustomer: true }
+      {
+        createCustomer: true,
+        authError: { method: 'email', isSignUp: false }
+      }
     )
 
     if (isCloud) {
@@ -381,7 +400,10 @@ export const useAuthStore = defineStore('auth', () => {
     const result = await executeAuthAction(
       (authInstance) =>
         createUserWithEmailAndPassword(authInstance, email, password),
-      { createCustomer: true }
+      {
+        createCustomer: true,
+        authError: { method: 'email', isSignUp: true }
+      }
     )
 
     if (isCloud) {
@@ -402,7 +424,10 @@ export const useAuthStore = defineStore('auth', () => {
   }): Promise<UserCredential> => {
     const result = await executeAuthAction(
       (authInstance) => signInWithPopup(authInstance, googleProvider),
-      { createCustomer: true }
+      {
+        createCustomer: true,
+        authError: { method: 'google', isSignUp: options?.isNewUser ?? false }
+      }
     )
 
     if (isCloud) {
@@ -425,7 +450,10 @@ export const useAuthStore = defineStore('auth', () => {
   }): Promise<UserCredential> => {
     const result = await executeAuthAction(
       (authInstance) => signInWithPopup(authInstance, githubProvider),
-      { createCustomer: true }
+      {
+        createCustomer: true,
+        authError: { method: 'github', isSignUp: options?.isNewUser ?? false }
+      }
     )
 
     if (isCloud) {


### PR DESCRIPTION
## Summary

Closes the cloud funnel-telemetry gaps from the funnel audit: subscribe-click coverage, billing-cycle toggle, auth errors, template-category selection, and enabling web analytics (heatmaps / `$pageview`) on cloud.comfy.org.

## Changes

- **What**:
  - **Subscribe-click coverage** — `app:subscribe_now_button_clicked` now fires from the real tier CTAs in `PricingTable.vue` (`handleSubscribe`, new + change) and `SubscribeToRun.vue`, not only `SubscribeButton.vue`. Previously the event undercounted vs actual conversions because the forced post-signup pricing modal's tier buttons never fired it.
  - **Billing-cycle toggle** — new `app:billing_cycle_toggled {from,to}` on the monthly/yearly switch (today ~96% pick monthly, ~4% annual, yearly is default — we had no visibility into the toggle).
  - **Auth errors** — new `app:auth_error {method,is_sign_up,error_code,error_message}` on the sign-in/up failure path (the signup leak that success-only `app:user_auth_completed` can't see).
  - **Template category** — new `app:template_category_selected {category_id}` when the user switches tab/category (e.g. Getting Started vs All) in the template selector.
  - **Cloud web analytics** — enable `autocapture`, `capture_pageview`, `capture_pageleave`, and `heatmaps` in the cloud app's posthog-js init. cloud.comfy.org currently emits zero `$pageview`/autocapture, so the login/onboarding pages have no heatmaps and there is no on-site sourcing.
- **Breaking**: none.

## Review Focus

- **Web-analytics enablement (volume + consent):** this turns on autocapture + pageviews + heatmaps for the cloud app for the first time. It stays consent-gated like the rest of telemetry, and autocapture does not record input *values* (posthog masks them). Please sanity-check the data-volume implications and that nothing sensitive is captured. The hardcoded defaults remain overridable per-environment via the server `posthog_config` (spread after them), so this can be tuned or disabled remotely without a deploy.
- **SPA pageviews:** relying on posthog-js history-based `$pageview` capture — worth confirming route-change pageviews actually fire on the Vue SPA (add a router `afterEach` hook if not).
- **Not included (scoped follow-up):** populating the paywall `reason` on `app:subscription_required_modal_opened` (it arrives empty in prod). `useSubscriptionDialog` already threads a `reason` into the dialog, but the `modal_opened` event and the ~10 `showSubscriptionDialog` call-sites don't pass it, and the reason taxonomy (`subscription_required` / `out_of_credits` / `top_up_blocked`) needs a product decision on what to track — left out deliberately.

## Companion PRs

- Comfy-Org/ComfyUI_frontend#12934 — homepage CTA telemetry (`website:cta_clicked`) on the comfy.org marketing site.
- Pairs with the Desktop telemetry work in `Comfy-Org/Comfy-Desktop`.
