### PR TITLE
fix(auth): provision customer on auth-resolved so Desktop doesn't race the server

### DIFF
--- a/src/extensions/core/cloudSessionCookie.ts
+++ b/src/extensions/core/cloudSessionCookie.ts
@@ -1,6 +1,8 @@
-import { clearOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
 import { useSessionCookie } from '@/platform/auth/session/useSessionCookie'
+import { clearOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
+import { isCloud } from '@/platform/distribution/types'
 import { useExtensionService } from '@/services/extensionService'
+import { useAuthStore } from '@/stores/authStore'
 
 /**
  * Cloud-only extension that manages session cookies for authentication.
@@ -10,6 +12,27 @@ useExtensionService().registerExtension({
   name: 'Comfy.Cloud.SessionCookie',
 
   onAuthUserResolved: async () => {
+    // Ensure the customer record (and its billing) exists before any other
+    // authenticated request fans out. The web login form provisions via
+    // executeAuthAction({ createCustomer: true }), but Desktop's native sign-in
+    // writes the Firebase credentials to IndexedDB and reloads, resolving the
+    // user without ever calling it. That left every Desktop user unprovisioned,
+    // so the server raced to provision on concurrent first reads (the
+    // customers_pkey duplicate-key / Stripe idempotency 500s). Provision once,
+    // up front, instead. Idempotent: a returning user's POST /customers is a
+    // no-op, and a failure here must never block session creation — the
+    // server-side provisioner stays as a safety net.
+    if (isCloud) {
+      try {
+        await useAuthStore().createCustomer()
+      } catch (error) {
+        console.warn(
+          '[Comfy.Cloud] failed to ensure customer is provisioned',
+          error
+        )
+      }
+    }
+
     const { createSession } = useSessionCookie()
     await createSession()
   },


### PR DESCRIPTION
## Summary

The web login form provisions the customer via `executeAuthAction({ createCustomer: true })`. Desktop 2.0's native sign-in, however, writes Firebase credentials to IndexedDB and `location.reload()`s — the user resolves on rehydrate **without ever calling `createCustomer`**. So every Desktop user arrived unprovisioned, and the comfy-api server had to provision them lazily on concurrent first reads (`/customers/me`, `/customers/balance`, `/customers/cloud-subscription-status`). That race produced the `customers_pkey` duplicate-key cascade (and, after the server-side upsert fix, Stripe `idempotency_key_in_use` 409s) — 500s on first launch.

This calls `createCustomer` once from the shared `onAuthUserResolved` hook (cloud only), **before** `createSession`, so the customer + billing exist up front instead of being race-provisioned on N concurrent server reads. The embedded view in Desktop *is* this frontend, so this single hook covers Desktop sign-in and web rehydration.

- **Idempotent:** a returning user's `POST /customers` is a no-op (server returns 200), and any failure here is caught and logged — it never blocks `createSession`. The comfy-api middleware provisioner remains a safety net.
- **Supersedes #12898** (closed), which hooked `onAuthStateChanged` and did not sequence provisioning ahead of the authenticated fan-out, effectively adding another concurrent writer.

## Companion PRs
- cloud **#4349** — atomic `UpsertCustomer` (ON CONFLICT) + idempotent, out-of-tx billing provisioning. That made the server tolerate the race; this PR removes the race at its source. The two are complementary: ship both, then the middleware provisioner can eventually be retired.

## How has this been tested?

- `eslint` clean on the changed file.
- Behaviorally: with this change Desktop issues exactly one `POST /customers` on sign-in before its authenticated requests fan out, instead of none. The server-side half was validated on staging (a raw `$1`/`$5` top-up before/after); this closes the client-side gap that created the concurrency.

> Note: draft — happy to add a unit test around the hook (mock `useAuthStore`/`useSessionCookie`/`isCloud`, assert createCustomer precedes createSession and that a createCustomer rejection still allows createSession) if reviewers want it.
