### PR TITLE
feat(assets): group model library by model_type tags (FE-1076)

### DIFF
--- a/src/components/ui/search-input/SearchInput.vue
+++ b/src/components/ui/search-input/SearchInput.vue
@@ -52,6 +52,7 @@
           )
         "
         :placeholder="placeholderText"
+        :aria-label="ariaLabel"
         :auto-focus="autofocus"
       />
     </ComboboxAnchor>
@@ -78,6 +79,7 @@ const { t } = useI18n()
 
 const {
   placeholder,
+  ariaLabel,
   icon = 'icon-[lucide--search]',
   debounceTime = 300,
   autofocus = false,
@@ -87,6 +89,7 @@ const {
   class: className
 } = defineProps<{
   placeholder?: string
+  ariaLabel?: string
   icon?: string
   debounceTime?: number
   autofocus?: boolean

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -37,7 +37,8 @@ export enum ServerFeatureFlag {
   CONSOLIDATED_BILLING_ENABLED = 'consolidated_billing_enabled',
   BILLING_CONTROL_ENABLED = 'billing_control_enabled',
   FREE_TIER_JOB_ALLOWANCE_ENABLED = 'free_tier_job_allowance_enabled',
-  SIGNUP_TURNSTILE = 'signup_turnstile'
+  SIGNUP_TURNSTILE = 'signup_turnstile',
+  SUPPORTS_MODEL_TYPE_TAGS = 'supports_model_type_tags'
 }
 
 /**
@@ -235,6 +236,12 @@ export function useFeatureFlags() {
         ServerFeatureFlag.SIGNUP_TURNSTILE,
         remoteConfig.value.signup_turnstile,
         'off'
+      )
+    },
+    get supportsModelTypeTags() {
+      return api.getServerFeature(
+        ServerFeatureFlag.SUPPORTS_MODEL_TYPE_TAGS,
+        false
       )
     }
   })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3446,6 +3446,7 @@
     "processingModelDescription": "You can close this dialog. The download will continue in the background.",
     "providerCivitai": "Civitai",
     "providerHuggingFace": "Hugging Face",
+    "searchModels": "Search models",
     "selectFrameworks": "Select Frameworks",
     "selectModelType": "Select model type",
     "selectProjects": "Select Projects",

--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -9,6 +9,20 @@ import { useAssetsStore } from '@/stores/assetsStore'
 
 const mockAssetsByKey = vi.hoisted(() => new Map<string, AssetItem[]>())
 const mockLoadingByKey = vi.hoisted(() => new Map<string, boolean>())
+const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: false }))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get supportsModelTypeTags() {
+        return mockSupportsModelTypeTags.value
+      },
+      get modelUploadButtonEnabled() {
+        return false
+      }
+    }
+  })
+}))
 
 vi.mock('@/i18n', () => ({
   t: (key: string, params?: Record<string, string>) =>
@@ -226,6 +240,7 @@ describe('AssetBrowserModal', () => {
     vi.resetAllMocks()
     mockAssetsByKey.clear()
     mockLoadingByKey.clear()
+    mockSupportsModelTypeTags.value = false
   })
 
   describe('Integration with useAssetBrowser', () => {
@@ -423,6 +438,21 @@ describe('AssetBrowserModal', () => {
 
     it('passes computed contentTitle to BaseModalLayout when no title prop', async () => {
       const assets = [createTestAsset('asset1', 'Model A', 'checkpoints')]
+      mockAssetsByKey.set('CheckpointLoaderSimple', assets)
+
+      renderModal({ nodeType: 'CheckpointLoaderSimple' })
+      await flushPromises()
+
+      expect(screen.getByTestId('modal-title').textContent).toBe(
+        'assetBrowser.allCategory:{"category":"Checkpoints"}'
+      )
+    })
+
+    it('strips the model_type: prefix from the title when the flag is on', async () => {
+      mockSupportsModelTypeTags.value = true
+      const assets = [
+        createTestAsset('asset1', 'Model A', 'model_type:checkpoints')
+      ]
       mockAssetsByKey.set('CheckpointLoaderSimple', assets)
 
       renderModal({ nodeType: 'CheckpointLoaderSimple' })

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -110,7 +110,7 @@ import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import { useModelTypes } from '@/platform/assets/composables/useModelTypes'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { stripModelTypePrefix } from '@/platform/assets/utils/assetMetadataUtils'
+import { getAssetCategories } from '@/platform/assets/utils/assetMetadataUtils'
 import { formatCategoryLabel } from '@/platform/assets/utils/categoryLabel'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
@@ -194,16 +194,19 @@ const focusedAsset = ref<AssetDisplayItem | null>(null)
 const isRightPanelOpen = ref(false)
 
 const primaryCategoryTag = computed(() => {
+  const modelTypeMode = flags.supportsModelTypeTags
   const assets = fetchedAssets.value ?? []
+  // In modelTypeMode the title keys off the same category the asset groups
+  // under (getAssetCategories), so title and grouping cannot diverge.
   const tagFromAssets = assets
-    .map((asset) => asset.tags?.find((tag) => tag !== 'models'))
+    .map((asset) =>
+      modelTypeMode
+        ? getAssetCategories(asset, true)[0]
+        : asset.tags?.find((tag) => tag !== 'models')
+    )
     .find((tag): tag is string => typeof tag === 'string' && tag.length > 0)
 
-  if (tagFromAssets) {
-    return flags.supportsModelTypeTags
-      ? stripModelTypePrefix(tagFromAssets)
-      : tagFromAssets
-  }
+  if (tagFromAssets) return tagFromAssets
 
   if (props.nodeType) {
     const mapped = modelToNodeStore.getCategoryForNodeType(props.nodeType)

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -195,6 +195,14 @@ const isRightPanelOpen = ref(false)
 
 const primaryCategoryTag = computed(() => {
   const modelTypeMode = flags.supportsModelTypeTags
+  // A node-typed picker is FOR a category; title off that category rather
+  // than guessing from the first asset, whose first model_type value may be
+  // a different category it shares a root with.
+  if (modelTypeMode && props.nodeType) {
+    const mapped = modelToNodeStore.getCategoryForNodeType(props.nodeType)
+    if (mapped) return mapped
+  }
+
   const assets = fetchedAssets.value ?? []
   // Covered assets title off the model_type value they group under (so title
   // and grouping cannot diverge); uncovered assets keep the legacy verbatim

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -110,7 +110,7 @@ import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import { useModelTypes } from '@/platform/assets/composables/useModelTypes'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import { getAssetCategories } from '@/platform/assets/utils/assetMetadataUtils'
+import { getPrimaryCategoryTag } from '@/platform/assets/utils/assetMetadataUtils'
 import { formatCategoryLabel } from '@/platform/assets/utils/categoryLabel'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
@@ -196,14 +196,11 @@ const isRightPanelOpen = ref(false)
 const primaryCategoryTag = computed(() => {
   const modelTypeMode = flags.supportsModelTypeTags
   const assets = fetchedAssets.value ?? []
-  // In modelTypeMode the title keys off the same category the asset groups
-  // under (getAssetCategories), so title and grouping cannot diverge.
+  // Covered assets title off the model_type value they group under (so title
+  // and grouping cannot diverge); uncovered assets keep the legacy verbatim
+  // first tag.
   const tagFromAssets = assets
-    .map((asset) =>
-      modelTypeMode
-        ? getAssetCategories(asset, true)[0]
-        : asset.tags?.find((tag) => tag !== 'models')
-    )
+    .map((asset) => getPrimaryCategoryTag(asset, modelTypeMode))
     .find((tag): tag is string => typeof tag === 'string' && tag.length > 0)
 
   if (tagFromAssets) return tagFromAssets

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -100,6 +100,7 @@ import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
 import BaseModalLayout from '@/components/widget/layout/BaseModalLayout.vue'
 import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { usePrimeVueOverlayChildStyle } from '@/composables/usePopoverSizing'
 import AssetFilterBar from '@/platform/assets/components/AssetFilterBar.vue'
 import AssetGrid from '@/platform/assets/components/AssetGrid.vue'
@@ -109,12 +110,14 @@ import { useAssetBrowser } from '@/platform/assets/composables/useAssetBrowser'
 import { useModelTypes } from '@/platform/assets/composables/useModelTypes'
 import { useModelUpload } from '@/platform/assets/composables/useModelUpload'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import { stripModelTypePrefix } from '@/platform/assets/utils/assetMetadataUtils'
 import { formatCategoryLabel } from '@/platform/assets/utils/categoryLabel'
 import { useAssetsStore } from '@/stores/assetsStore'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import { OnCloseKey } from '@/types/widgetTypes'
 
 const { t } = useI18n()
+const { flags } = useFeatureFlags()
 const assetStore = useAssetsStore()
 const modelToNodeStore = useModelToNodeStore()
 const breakpoints = useBreakpoints(breakpointsTailwind)
@@ -196,7 +199,11 @@ const primaryCategoryTag = computed(() => {
     .map((asset) => asset.tags?.find((tag) => tag !== 'models'))
     .find((tag): tag is string => typeof tag === 'string' && tag.length > 0)
 
-  if (tagFromAssets) return tagFromAssets
+  if (tagFromAssets) {
+    return flags.supportsModelTypeTags
+      ? stripModelTypePrefix(tagFromAssets)
+      : tagFromAssets
+  }
 
   if (props.nodeType) {
     const mapped = modelToNodeStore.getCategoryForNodeType(props.nodeType)

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -32,6 +32,7 @@
           v-model="searchQuery"
           :autofocus="true"
           size="lg"
+          :aria-label="$t('assetBrowser.searchModels')"
           :placeholder="$t('g.searchPlaceholder', { subject: '' })"
           class="max-w-lg flex-1"
         />
@@ -39,6 +40,7 @@
           v-if="isUploadButtonEnabled"
           variant="primary"
           :size="breakpoints.md ? 'lg' : 'icon'"
+          :aria-label="$t('assetBrowser.uploadModel')"
           data-attr="upload-model-button"
           @click="showUploadDialog"
         >

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -668,6 +668,18 @@ describe('useAssetBrowser', () => {
       ])
     })
 
+    it('groups by model_type:* value and ignores other tags', () => {
+      const assets = [
+        createApiAsset({ tags: ['models', 'model_type:checkpoints', 'sdxl'] }),
+        createApiAsset({ tags: ['models', 'model_type:LLM'] })
+      ]
+
+      const { navItems } = useAssetBrowser(ref(assets))
+
+      const typeGroup = navItems.value[2] as { items: { id: string }[] }
+      expect(typeGroup.items.map((i) => i.id)).toEqual(['LLM', 'checkpoints'])
+    })
+
     it('handles assets with no category tag', () => {
       const assets = [
         createApiAsset({ tags: ['models'] }), // No second tag

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -150,6 +150,25 @@ describe('useAssetBrowser', () => {
       })
     })
 
+    it('strips the model_type: prefix from the badge when the flag is on', () => {
+      mockSupportsModelTypeTags.value = true
+      const apiAsset = createApiAsset({
+        tags: ['models', 'model_type:checkpoints', 'sdxl']
+      })
+
+      const { filteredAssets } = useAssetBrowser(ref([apiAsset]))
+      const result = filteredAssets.value[0]
+
+      expect(result.badges).toContainEqual({
+        label: 'checkpoints',
+        type: 'type'
+      })
+      expect(result.badges).not.toContainEqual({
+        label: 'model_type:checkpoints',
+        type: 'type'
+      })
+    })
+
     it('handles tags with multiple slashes in badges', () => {
       const apiAsset = createApiAsset({
         tags: ['models', 'checkpoint/subfolder/model-name']

--- a/src/platform/assets/composables/useAssetBrowser.test.ts
+++ b/src/platform/assets/composables/useAssetBrowser.test.ts
@@ -25,10 +25,22 @@ vi.mock('@/i18n', () => ({
   d: (date: Date) => date.toLocaleDateString()
 }))
 
+const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: false }))
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get supportsModelTypeTags() {
+        return mockSupportsModelTypeTags.value
+      }
+    }
+  })
+}))
+
 describe('useAssetBrowser', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.restoreAllMocks()
+    mockSupportsModelTypeTags.value = false
   })
 
   // Test fixtures - minimal data focused on functionality being tested
@@ -668,7 +680,8 @@ describe('useAssetBrowser', () => {
       ])
     })
 
-    it('groups by model_type:* value and ignores other tags', () => {
+    it('groups by model_type:* value and ignores other tags when the flag is on', () => {
+      mockSupportsModelTypeTags.value = true
       const assets = [
         createApiAsset({ tags: ['models', 'model_type:checkpoints', 'sdxl'] }),
         createApiAsset({ tags: ['models', 'model_type:LLM'] })
@@ -678,6 +691,21 @@ describe('useAssetBrowser', () => {
 
       const typeGroup = navItems.value[2] as { items: { id: string }[] }
       expect(typeGroup.items.map((i) => i.id)).toEqual(['LLM', 'checkpoints'])
+    })
+
+    it('ignores model_type: and groups by bare tags when the flag is off', () => {
+      const assets = [
+        createApiAsset({ tags: ['models', 'model_type:checkpoints'] }),
+        createApiAsset({ tags: ['models', 'model_type:LLM'] })
+      ]
+
+      const { navItems } = useAssetBrowser(ref(assets))
+
+      const typeGroup = navItems.value[2] as { items: { id: string }[] }
+      expect(typeGroup.items.map((i) => i.id)).toEqual([
+        'model_type:LLM',
+        'model_type:checkpoints'
+      ])
     })
 
     it('handles assets with no category tag', () => {

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -24,6 +24,7 @@ import {
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { MODELS_TAG } from '@/platform/assets/services/assetService'
 import { sortAssets } from '@/platform/assets/utils/assetSortUtils'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useAssetDownloadStore } from '@/stores/assetDownloadStore'
 import type { NavGroupData, NavItemData } from '@/types/navTypes'
 
@@ -94,6 +95,7 @@ export function useAssetBrowser(
   const assets = computed<AssetItem[]>(() => assetsSource.value ?? [])
   const assetDownloadStore = useAssetDownloadStore()
   const { sessionDownloadCount } = storeToRefs(assetDownloadStore)
+  const { flags } = useFeatureFlags()
 
   // State
   const searchQuery = ref('')
@@ -125,7 +127,9 @@ export function useAssetBrowser(
   const typeCategories = computed<NavItemData[]>(() => {
     const categories = assets.value
       .filter((asset) => asset.tags.includes(MODELS_TAG))
-      .flatMap(getAssetCategories)
+      .flatMap((asset) =>
+        getAssetCategories(asset, flags.supportsModelTypeTags)
+      )
 
     return Array.from(new Set(categories))
       .sort()
@@ -189,7 +193,9 @@ export function useAssetBrowser(
 
   // Category-filtered assets for filter options (before search/format/base model filters)
   const categoryFilteredAssets = computed(() => {
-    return assets.value.filter(filterByCategory(selectedCategory.value))
+    return assets.value.filter(
+      filterByCategory(selectedCategory.value, flags.supportsModelTypeTags)
+    )
   })
 
   const { availableFileFormats, availableBaseModels } = useAssetFilterOptions(

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -19,6 +19,7 @@ import {
 } from '@/platform/assets/utils/assetFilterUtils'
 import {
   getAssetBaseModels,
+  getAssetCategories,
   getAssetFilename
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { MODELS_TAG } from '@/platform/assets/services/assetService'
@@ -124,10 +125,7 @@ export function useAssetBrowser(
   const typeCategories = computed<NavItemData[]>(() => {
     const categories = assets.value
       .filter((asset) => asset.tags.includes(MODELS_TAG))
-      .flatMap((asset) =>
-        asset.tags.filter((tag) => tag !== MODELS_TAG && tag.length > 0)
-      )
-      .map((tag) => tag.split('/')[0])
+      .flatMap(getAssetCategories)
 
     return Array.from(new Set(categories))
       .sort()

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -20,7 +20,8 @@ import {
 import {
   getAssetBaseModels,
   getAssetCategories,
-  getAssetFilename
+  getAssetFilename,
+  getAssetTypeBadge
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { MODELS_TAG } from '@/platform/assets/services/assetService'
 import { sortAssets } from '@/platform/assets/utils/assetSortUtils'
@@ -45,18 +46,20 @@ export interface AssetDisplayItem extends AssetItem {
   }
 }
 
-const displayItemCache = new WeakMap<AssetItem, AssetDisplayItem>()
+const displayItemCache = new WeakMap<
+  AssetItem,
+  { modelTypeMode: boolean; item: AssetDisplayItem }
+>()
 
-function buildDisplayItem(asset: AssetItem): AssetDisplayItem {
+function buildDisplayItem(
+  asset: AssetItem,
+  modelTypeMode: boolean
+): AssetDisplayItem {
   const badges: AssetBadge[] = []
 
-  const typeTag = asset.tags.find((tag) => tag !== 'models')
-  if (typeTag) {
-    const badgeLabel = typeTag.includes('/')
-      ? typeTag.substring(typeTag.indexOf('/') + 1)
-      : typeTag
-
-    badges.push({ label: badgeLabel, type: 'type' })
+  const typeBadge = getAssetTypeBadge(asset, modelTypeMode)
+  if (typeBadge) {
+    badges.push({ label: typeBadge, type: 'type' })
   }
 
   for (const model of getAssetBaseModels(asset)) {
@@ -77,12 +80,15 @@ function buildDisplayItem(asset: AssetItem): AssetDisplayItem {
   }
 }
 
-function transformAssetForDisplay(asset: AssetItem): AssetDisplayItem {
+function transformAssetForDisplay(
+  asset: AssetItem,
+  modelTypeMode: boolean
+): AssetDisplayItem {
   const cached = displayItemCache.get(asset)
-  if (cached) return cached
-  const built = buildDisplayItem(asset)
-  displayItemCache.set(asset, built)
-  return built
+  if (cached && cached.modelTypeMode === modelTypeMode) return cached.item
+  const item = buildDisplayItem(asset, modelTypeMode)
+  displayItemCache.set(asset, { modelTypeMode, item })
+  return item
 }
 
 /**
@@ -252,7 +258,9 @@ export function useAssetBrowser(
     const sortedAssets = sortAssets(filtered, filters.value.sortBy)
 
     // Transform to display format
-    return sortedAssets.map(transformAssetForDisplay)
+    return sortedAssets.map((asset) =>
+      transformAssetForDisplay(asset, flags.supportsModelTypeTags)
+    )
   })
 
   function updateFilters(newFilters: AssetFilterState) {

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -131,11 +131,10 @@ export function useAssetBrowser(
   })
 
   const typeCategories = computed<NavItemData[]>(() => {
+    const modelTypeMode = flags.supportsModelTypeTags
     const categories = assets.value
       .filter((asset) => asset.tags.includes(MODELS_TAG))
-      .flatMap((asset) =>
-        getAssetCategories(asset, flags.supportsModelTypeTags)
-      )
+      .flatMap((asset) => getAssetCategories(asset, modelTypeMode))
 
     return Array.from(new Set(categories))
       .sort()
@@ -258,8 +257,9 @@ export function useAssetBrowser(
     const sortedAssets = sortAssets(filtered, filters.value.sortBy)
 
     // Transform to display format
+    const modelTypeMode = flags.supportsModelTypeTags
     return sortedAssets.map((asset) =>
-      transformAssetForDisplay(asset, flags.supportsModelTypeTags)
+      transformAssetForDisplay(asset, modelTypeMode)
     )
   })
 

--- a/src/platform/assets/composables/useAssetBrowser.ts
+++ b/src/platform/assets/composables/useAssetBrowser.ts
@@ -21,7 +21,7 @@ import {
   getAssetBaseModels,
   getAssetCategories,
   getAssetFilename,
-  getAssetTypeBadge
+  getAssetTypeBadges
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { MODELS_TAG } from '@/platform/assets/services/assetService'
 import { sortAssets } from '@/platform/assets/utils/assetSortUtils'
@@ -57,8 +57,7 @@ function buildDisplayItem(
 ): AssetDisplayItem {
   const badges: AssetBadge[] = []
 
-  const typeBadge = getAssetTypeBadge(asset, modelTypeMode)
-  if (typeBadge) {
+  for (const typeBadge of getAssetTypeBadges(asset, modelTypeMode)) {
     badges.push({ label: typeBadge, type: 'type' })
   }
 

--- a/src/platform/assets/services/assetService.test.ts
+++ b/src/platform/assets/services/assetService.test.ts
@@ -449,6 +449,22 @@ describe(assetService.getAssetModelFolders, () => {
     expect(params.has('include_public')).toBe(false)
     expect(params.get('exclude_tags')).toBe(MISSING_TAG)
   })
+
+  it('excludes namespaced model_type: tags from folder names', async () => {
+    fetchApiMock.mockResolvedValueOnce(
+      buildAssetListResponse([
+        validAsset({
+          id: 'a',
+          tags: ['models', 'checkpoints', 'model_type:checkpoints']
+        }),
+        validAsset({ id: 'b', tags: ['models', 'model_type:loras'] })
+      ])
+    )
+
+    const folders = await assetService.getAssetModelFolders()
+
+    expect(folders).toEqual([{ name: 'checkpoints', folders: [] }])
+  })
 })
 
 describe(assetService.updateAsset, () => {

--- a/src/platform/assets/services/assetService.ts
+++ b/src/platform/assets/services/assetService.ts
@@ -20,6 +20,7 @@ import type {
   ModelFolder,
   TagsOperationResult
 } from '@/platform/assets/schemas/assetSchema'
+import { MODEL_TYPE_TAG_PREFIX } from '@/platform/assets/utils/assetMetadataUtils'
 import { isCloud } from '@/platform/distribution/types'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { api } from '@/scripts/api'
@@ -351,7 +352,12 @@ function createAssetService() {
 
     const folderTags = data.assets
       .flatMap((asset) => asset.tags)
-      .filter((tag) => tag !== MODELS_TAG && !blacklistedDirectories.has(tag))
+      .filter(
+        (tag) =>
+          tag !== MODELS_TAG &&
+          !blacklistedDirectories.has(tag) &&
+          !tag.startsWith(MODEL_TYPE_TAG_PREFIX)
+      )
     const discoveredFolders = new Set<string>(folderTags)
 
     // Return only discovered folders in alphabetical order

--- a/src/platform/assets/utils/assetFilterUtils.property.test.ts
+++ b/src/platform/assets/utils/assetFilterUtils.property.test.ts
@@ -45,7 +45,7 @@ describe('assetFilterUtils properties', () => {
   it('filterByCategory("all") accepts every asset', () => {
     fc.assert(
       fc.property(arbAssetItem, (asset) => {
-        expect(filterByCategory('all')(asset)).toBe(true)
+        expect(filterByCategory('all', false)(asset)).toBe(true)
       })
     )
   })
@@ -56,7 +56,7 @@ describe('assetFilterUtils properties', () => {
         fc.array(arbAssetItem, { maxLength: 30 }),
         fc.stringMatching(/^[a-z]{1,8}$/),
         (assets, category) => {
-          const filter = filterByCategory(category)
+          const filter = filterByCategory(category, false)
           const result = assets.filter(filter)
           expect(result.length).toBeLessThanOrEqual(assets.length)
           for (const item of result) {

--- a/src/platform/assets/utils/assetFilterUtils.property.test.ts
+++ b/src/platform/assets/utils/assetFilterUtils.property.test.ts
@@ -16,7 +16,7 @@ const arbAssetItem: fc.Arbitrary<AssetItem> = fc.record({
   id: fc.uuid(),
   name: fc.stringMatching(/^[a-z0-9_-]{1,12}\.[a-z]{2,6}$/),
   tags: fc.array(fc.stringMatching(/^[a-z0-9/]{1,15}$/), { maxLength: 5 }),
-  is_immutable: fc.boolean(),
+  is_immutable: fc.option(fc.boolean(), { nil: undefined }),
   metadata: fc.option(
     fc.record({
       base_model: fc.array(fc.stringMatching(/^[A-Z0-9.]{1,8}$/), {
@@ -112,7 +112,7 @@ describe('assetFilterUtils properties', () => {
   it('filterItemByOwnership result is a subset of the input', () => {
     const arbItem = fc.record({
       id: fc.uuid(),
-      is_immutable: fc.boolean()
+      is_immutable: fc.option(fc.boolean(), { nil: undefined })
     })
 
     fc.assert(
@@ -133,7 +133,7 @@ describe('assetFilterUtils properties', () => {
   it('filterItemByOwnership("all") returns all items', () => {
     const arbItem = fc.record({
       id: fc.uuid(),
-      is_immutable: fc.boolean()
+      is_immutable: fc.option(fc.boolean(), { nil: undefined })
     })
 
     fc.assert(

--- a/src/platform/assets/utils/assetFilterUtils.test.ts
+++ b/src/platform/assets/utils/assetFilterUtils.test.ts
@@ -26,30 +26,54 @@ function createAsset(
 
 describe('filterByCategory', () => {
   it.for([
-    { category: 'all', tags: ['checkpoint'], expected: true },
-    { category: 'checkpoint', tags: ['checkpoint'], expected: true },
-    { category: 'lora', tags: ['checkpoint'], expected: false },
+    { category: 'all', tags: ['checkpoint'], mode: false, expected: true },
+    {
+      category: 'checkpoint',
+      tags: ['checkpoint'],
+      mode: false,
+      expected: true
+    },
+    { category: 'lora', tags: ['checkpoint'], mode: false, expected: false },
     {
       category: 'checkpoint',
       tags: ['models', 'checkpoint/xl'],
+      mode: false,
       expected: true
     },
-    { category: 'xl', tags: ['models', 'checkpoint/xl'], expected: false },
+    {
+      category: 'xl',
+      tags: ['models', 'checkpoint/xl'],
+      mode: false,
+      expected: false
+    },
     {
       category: 'checkpoints',
       tags: ['models', 'model_type:checkpoints'],
+      mode: true,
       expected: true
     },
-    { category: 'LLM', tags: ['models', 'model_type:LLM'], expected: true },
+    {
+      category: 'LLM',
+      tags: ['models', 'model_type:LLM'],
+      mode: true,
+      expected: true
+    },
     {
       category: 'sdxl',
       tags: ['models', 'model_type:checkpoints', 'sdxl'],
+      mode: true,
+      expected: false
+    },
+    {
+      category: 'checkpoints',
+      tags: ['models', 'model_type:checkpoints'],
+      mode: false,
       expected: false
     }
   ])(
-    'category=$category with tags=$tags returns $expected',
-    ({ category, tags, expected }) => {
-      const filter = filterByCategory(category)
+    'category=$category tags=$tags mode=$mode returns $expected',
+    ({ category, tags, mode, expected }) => {
+      const filter = filterByCategory(category, mode)
       const asset = createAsset('model.safetensors', { tags })
       expect(filter(asset)).toBe(expected)
     }

--- a/src/platform/assets/utils/assetFilterUtils.test.ts
+++ b/src/platform/assets/utils/assetFilterUtils.test.ts
@@ -34,7 +34,18 @@ describe('filterByCategory', () => {
       tags: ['models', 'checkpoint/xl'],
       expected: true
     },
-    { category: 'xl', tags: ['models', 'checkpoint/xl'], expected: false }
+    { category: 'xl', tags: ['models', 'checkpoint/xl'], expected: false },
+    {
+      category: 'checkpoints',
+      tags: ['models', 'model_type:checkpoints'],
+      expected: true
+    },
+    { category: 'LLM', tags: ['models', 'model_type:LLM'], expected: true },
+    {
+      category: 'sdxl',
+      tags: ['models', 'model_type:checkpoints', 'sdxl'],
+      expected: false
+    }
   ])(
     'category=$category with tags=$tags returns $expected',
     ({ category, tags, expected }) => {

--- a/src/platform/assets/utils/assetFilterUtils.test.ts
+++ b/src/platform/assets/utils/assetFilterUtils.test.ts
@@ -152,8 +152,14 @@ describe('filterByOwnership', () => {
   it.for([
     { ownership: 'all' as const, is_immutable: true, expected: true },
     { ownership: 'all' as const, is_immutable: false, expected: true },
+    { ownership: 'all' as const, is_immutable: undefined, expected: true },
     { ownership: 'my-models' as const, is_immutable: false, expected: true },
     { ownership: 'my-models' as const, is_immutable: true, expected: false },
+    {
+      ownership: 'my-models' as const,
+      is_immutable: undefined,
+      expected: true
+    },
     {
       ownership: 'public-models' as const,
       is_immutable: true,
@@ -162,6 +168,11 @@ describe('filterByOwnership', () => {
     {
       ownership: 'public-models' as const,
       is_immutable: false,
+      expected: false
+    },
+    {
+      ownership: 'public-models' as const,
+      is_immutable: undefined,
       expected: false
     }
   ])(
@@ -178,12 +189,13 @@ describe('filterItemByOwnership', () => {
   const items = [
     { id: '1', is_immutable: true },
     { id: '2', is_immutable: false },
-    { id: '3', is_immutable: true }
+    { id: '3', is_immutable: true },
+    { id: '4', is_immutable: undefined }
   ]
 
   it.for([
-    { ownership: 'all' as const, expectedIds: ['1', '2', '3'] },
-    { ownership: 'my-models' as const, expectedIds: ['2'] },
+    { ownership: 'all' as const, expectedIds: ['1', '2', '3', '4'] },
+    { ownership: 'my-models' as const, expectedIds: ['2', '4'] },
     { ownership: 'public-models' as const, expectedIds: ['1', '3'] }
   ])(
     'ownership=$ownership returns items with ids=$expectedIds',

--- a/src/platform/assets/utils/assetFilterUtils.ts
+++ b/src/platform/assets/utils/assetFilterUtils.ts
@@ -5,7 +5,7 @@ import {
   getAssetCategories
 } from '@/platform/assets/utils/assetMetadataUtils'
 
-export function filterByCategory(category: string, modelTypeMode = false) {
+export function filterByCategory(category: string, modelTypeMode: boolean) {
   return (asset: AssetItem) => {
     if (category === 'all') return true
     return getAssetCategories(asset, modelTypeMode).includes(category)

--- a/src/platform/assets/utils/assetFilterUtils.ts
+++ b/src/platform/assets/utils/assetFilterUtils.ts
@@ -5,10 +5,10 @@ import {
   getAssetCategories
 } from '@/platform/assets/utils/assetMetadataUtils'
 
-export function filterByCategory(category: string) {
+export function filterByCategory(category: string, modelTypeMode = false) {
   return (asset: AssetItem) => {
     if (category === 'all') return true
-    return getAssetCategories(asset).includes(category)
+    return getAssetCategories(asset, modelTypeMode).includes(category)
   }
 }
 

--- a/src/platform/assets/utils/assetFilterUtils.ts
+++ b/src/platform/assets/utils/assetFilterUtils.ts
@@ -1,21 +1,14 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { OwnershipOption } from '@/platform/assets/types/filterTypes'
-import { getAssetBaseModels } from '@/platform/assets/utils/assetMetadataUtils'
+import {
+  getAssetBaseModels,
+  getAssetCategories
+} from '@/platform/assets/utils/assetMetadataUtils'
 
 export function filterByCategory(category: string) {
   return (asset: AssetItem) => {
     if (category === 'all') return true
-
-    // Check if any tag matches the category (for exact matches)
-    if (asset.tags.includes(category)) return true
-
-    // Check if any tag's top-level folder matches the category
-    return asset.tags.some((tag) => {
-      if (typeof tag === 'string' && tag.includes('/')) {
-        return tag.split('/')[0] === category
-      }
-      return false
-    })
+    return getAssetCategories(asset).includes(category)
   }
 }
 

--- a/src/platform/assets/utils/assetFilterUtils.ts
+++ b/src/platform/assets/utils/assetFilterUtils.ts
@@ -33,7 +33,9 @@ export function filterByBaseModels(models: string[] | Set<string>) {
 export function filterByOwnership(ownership: OwnershipOption) {
   return (asset: AssetItem) => {
     if (ownership === 'all') return true
-    if (ownership === 'my-models') return asset.is_immutable === false
+    // is_immutable is optional; an asset omitting it counts as owned so it
+    // never vanishes from both ownership views.
+    if (ownership === 'my-models') return asset.is_immutable !== true
     if (ownership === 'public-models') return asset.is_immutable === true
     return true
   }
@@ -44,8 +46,10 @@ export function filterItemByOwnership<T extends { is_immutable?: boolean }>(
   ownership: OwnershipOption
 ): T[] {
   if (ownership === 'all') return items
-  const isPublic = ownership === 'public-models'
-  return items.filter((item) => item.is_immutable === isPublic)
+  if (ownership === 'public-models') {
+    return items.filter((item) => item.is_immutable === true)
+  }
+  return items.filter((item) => item.is_immutable !== true)
 }
 
 export function filterItemByBaseModels<T extends { base_models?: string[] }>(

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -19,6 +19,7 @@ import {
   getAssetModelType,
   getAssetNodeCategoryCandidates,
   getAssetSourceUrl,
+  getPrimaryCategoryTag,
   getAssetStoredFilename,
   getAssetTriggerPhrases,
   getAssetTypeBadge,
@@ -634,6 +635,44 @@ describe('getAssetCategories', () => {
         false
       )
     ).toEqual(['model_type:checkpoints', 'sdxl'])
+  })
+
+  it('never surfaces namespace residue as a category for uncovered assets in mode', () => {
+    expect(
+      getAssetCategories(asset(['models', 'model_type:', 'sdxl']), true)
+    ).toEqual(['sdxl'])
+  })
+})
+
+describe('getPrimaryCategoryTag', () => {
+  const asset = (tags: string[]): AssetItem => ({
+    id: 'a',
+    name: 'model.safetensors',
+    tags
+  })
+
+  it('uses the model_type value a covered asset groups under', () => {
+    expect(
+      getPrimaryCategoryTag(asset(['models', 'sdxl', 'model_type:vae']), true)
+    ).toBe('vae')
+  })
+
+  it('keeps the legacy verbatim tag for an uncovered hierarchical asset', () => {
+    expect(
+      getPrimaryCategoryTag(asset(['models', 'Chatterbox/sub/model']), true)
+    ).toBe('Chatterbox/sub/model')
+  })
+
+  it('skips namespace residue instead of titling off a raw model_type: tag', () => {
+    expect(
+      getPrimaryCategoryTag(asset(['models', 'model_type:']), true)
+    ).toBeUndefined()
+  })
+
+  it('returns the legacy first non-models tag when mode is off', () => {
+    expect(
+      getPrimaryCategoryTag(asset(['models', 'model_type:vae']), false)
+    ).toBe('model_type:vae')
   })
 })
 

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -22,7 +22,7 @@ import {
   getPrimaryCategoryTag,
   getAssetStoredFilename,
   getAssetTriggerPhrases,
-  getAssetTypeBadge,
+  getAssetTypeBadges,
   getAssetUserDescription,
   getSourceName,
   resolveDisplayImageDimensions,
@@ -750,7 +750,7 @@ describe('getAssetNodeCategoryCandidates', () => {
   })
 })
 
-describe('getAssetTypeBadge', () => {
+describe('getAssetTypeBadges', () => {
   const asset = (tags: string[]): AssetItem => ({
     id: 'a',
     name: 'model.safetensors',
@@ -759,43 +759,58 @@ describe('getAssetTypeBadge', () => {
 
   it('strips the model_type: prefix in model_type mode (no raw leak)', () => {
     expect(
-      getAssetTypeBadge(
+      getAssetTypeBadges(
         asset(['models', 'model_type:checkpoints', 'sdxl']),
         true
       )
-    ).toBe('checkpoints')
+    ).toEqual(['checkpoints'])
   })
 
   it('badges the model_type value even when a bare tag comes first, matching the grouping', () => {
     expect(
-      getAssetTypeBadge(asset(['models', 'foo', 'model_type:bar']), true)
-    ).toBe('bar')
+      getAssetTypeBadges(asset(['models', 'foo', 'model_type:bar']), true)
+    ).toEqual(['bar'])
+  })
+
+  it('badges every category a shared multi-type asset groups under', () => {
+    expect(
+      getAssetTypeBadges(
+        asset([
+          'models',
+          'model_type:checkpoints',
+          'model_type:diffusion_models'
+        ]),
+        true
+      )
+    ).toEqual(['checkpoints', 'diffusion_models'])
   })
 
   it('falls back to the bare tag for an uncovered asset in model_type mode', () => {
-    expect(getAssetTypeBadge(asset(['models', 'sdxl']), true)).toBe('sdxl')
+    expect(getAssetTypeBadges(asset(['models', 'sdxl']), true)).toEqual([
+      'sdxl'
+    ])
   })
 
-  it('returns undefined rather than a blank badge for a malformed empty model_type: tag', () => {
-    expect(
-      getAssetTypeBadge(asset(['models', 'model_type:']), true)
-    ).toBeUndefined()
+  it('returns no badge rather than a blank one for a malformed empty model_type: tag', () => {
+    expect(getAssetTypeBadges(asset(['models', 'model_type:']), true)).toEqual(
+      []
+    )
   })
 
   it('leaks the literal model_type: tag when mode is off', () => {
     expect(
-      getAssetTypeBadge(asset(['models', 'model_type:checkpoints']), false)
-    ).toBe('model_type:checkpoints')
+      getAssetTypeBadges(asset(['models', 'model_type:checkpoints']), false)
+    ).toEqual(['model_type:checkpoints'])
   })
 
   it('shows the segment after the first slash for a bare hierarchical tag', () => {
-    expect(getAssetTypeBadge(asset(['models', 'checkpoint/xl']), false)).toBe(
-      'xl'
-    )
+    expect(
+      getAssetTypeBadges(asset(['models', 'checkpoint/xl']), false)
+    ).toEqual(['xl'])
   })
 
-  it('returns undefined when only the models tag is present', () => {
-    expect(getAssetTypeBadge(asset(['models']), true)).toBeUndefined()
+  it('returns no badges when only the models tag is present', () => {
+    expect(getAssetTypeBadges(asset(['models']), true)).toEqual([])
   })
 })
 
@@ -825,7 +840,7 @@ describe('reserved tag mirrors', () => {
         true
       )
     ).toEqual(['x'])
-    expect(getAssetTypeBadge(asset([MODELS_TAG, 'x']), false)).toBe('x')
+    expect(getAssetTypeBadges(asset([MODELS_TAG, 'x']), false)).toEqual(['x'])
     expect(getAssetModelType(asset([MODELS_TAG]))).toBeNull()
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import {
+  MISSING_TAG,
+  MODELS_TAG
+} from '@/platform/assets/services/assetService'
+import {
   getAssetAdditionalTags,
   getAssetBaseModel,
   getAssetBaseModels,
@@ -278,7 +282,17 @@ describe('assetMetadataUtils', () => {
         tags: ['models'],
         expected: null
       },
-      { name: 'returns null when tags empty', tags: [], expected: null }
+      { name: 'returns null when tags empty', tags: [], expected: null },
+      {
+        name: 'never returns a raw model_type: literal (no round-trip into edit widgets)',
+        tags: ['models', 'model_type:checkpoints'],
+        expected: null
+      },
+      {
+        name: 'skips model_type: tags in favour of the bare twin',
+        tags: ['models', 'model_type:checkpoints', 'checkpoints'],
+        expected: 'checkpoints'
+      }
     ])('$name', ({ tags, expected }) => {
       const asset = { ...mockAsset, tags }
       expect(getAssetModelType(asset)).toBe(expected)
@@ -613,9 +627,12 @@ describe('getAssetCategories', () => {
     ])
   })
 
-  it('ignores model_type: and uses bare-tag grouping when mode is off (default)', () => {
+  it('ignores model_type: and uses bare-tag grouping when mode is off', () => {
     expect(
-      getAssetCategories(asset(['models', 'model_type:checkpoints', 'sdxl']))
+      getAssetCategories(
+        asset(['models', 'model_type:checkpoints', 'sdxl']),
+        false
+      )
     ).toEqual(['model_type:checkpoints', 'sdxl'])
   })
 })
@@ -651,6 +668,24 @@ describe('getAssetNodeCategoryCandidates', () => {
     ).toEqual(['checkpoints', 'sdxl'])
   })
 
+  it('demotes an unrelated deeper bare tag below the model_type value', () => {
+    expect(
+      getAssetNodeCategoryCandidates(
+        asset(['models', 'model_type:vae', 'foo/bar']),
+        true
+      )
+    ).toEqual(['vae', 'foo/bar'])
+  })
+
+  it('keeps unrelated bare tags as trailing fallbacks rather than dropping them', () => {
+    expect(
+      getAssetNodeCategoryCandidates(
+        asset(['models', 'model_type:LLM', 'LLM/Qwen-VL', 'foo/bar/baz']),
+        true
+      )
+    ).toEqual(['LLM/Qwen-VL', 'LLM', 'foo/bar/baz'])
+  })
+
   it('keeps a hierarchical tag intact', () => {
     expect(
       getAssetNodeCategoryCandidates(
@@ -666,12 +701,12 @@ describe('getAssetNodeCategoryCandidates', () => {
     ).toEqual([])
   })
 
-  it('uses the first non-reserved tag verbatim when mode is off (default)', () => {
+  it('uses the first non-reserved tag verbatim when mode is off', () => {
     expect(
-      getAssetNodeCategoryCandidates(asset(['models', 'model_type:vae']))
+      getAssetNodeCategoryCandidates(asset(['models', 'model_type:vae']), false)
     ).toEqual(['model_type:vae'])
     expect(
-      getAssetNodeCategoryCandidates(asset(['models', 'checkpoints']))
+      getAssetNodeCategoryCandidates(asset(['models', 'checkpoints']), false)
     ).toEqual(['checkpoints'])
   })
 })
@@ -692,20 +727,32 @@ describe('getAssetTypeBadge', () => {
     ).toBe('checkpoints')
   })
 
-  it('keeps the first non-models tag rather than reordering to the model_type value', () => {
+  it('badges the model_type value even when a bare tag comes first, matching the grouping', () => {
     expect(
       getAssetTypeBadge(asset(['models', 'foo', 'model_type:bar']), true)
-    ).toBe('foo')
+    ).toBe('bar')
   })
 
-  it('leaks the literal model_type: tag when mode is off (default)', () => {
-    expect(getAssetTypeBadge(asset(['models', 'model_type:checkpoints']))).toBe(
-      'model_type:checkpoints'
-    )
+  it('falls back to the bare tag for an uncovered asset in model_type mode', () => {
+    expect(getAssetTypeBadge(asset(['models', 'sdxl']), true)).toBe('sdxl')
+  })
+
+  it('returns undefined rather than a blank badge for a malformed empty model_type: tag', () => {
+    expect(
+      getAssetTypeBadge(asset(['models', 'model_type:']), true)
+    ).toBeUndefined()
+  })
+
+  it('leaks the literal model_type: tag when mode is off', () => {
+    expect(
+      getAssetTypeBadge(asset(['models', 'model_type:checkpoints']), false)
+    ).toBe('model_type:checkpoints')
   })
 
   it('shows the segment after the first slash for a bare hierarchical tag', () => {
-    expect(getAssetTypeBadge(asset(['models', 'checkpoint/xl']))).toBe('xl')
+    expect(getAssetTypeBadge(asset(['models', 'checkpoint/xl']), false)).toBe(
+      'xl'
+    )
   })
 
   it('returns undefined when only the models tag is present', () => {
@@ -721,5 +768,25 @@ describe('stripModelTypePrefix', () => {
   it('leaves a tag without the prefix unchanged', () => {
     expect(stripModelTypePrefix('checkpoints')).toBe('checkpoints')
     expect(stripModelTypePrefix('checkpoint/xl')).toBe('checkpoint/xl')
+  })
+})
+
+describe('reserved tag mirrors', () => {
+  const asset = (tags: string[]): AssetItem => ({
+    id: 'a',
+    name: 'model.safetensors',
+    tags
+  })
+
+  it("treats assetService's canonical reserved tags as reserved (locals must not drift)", () => {
+    expect(getAssetCategories(asset([MODELS_TAG, 'x']), false)).toEqual(['x'])
+    expect(
+      getAssetNodeCategoryCandidates(
+        asset([MODELS_TAG, MISSING_TAG, 'x']),
+        true
+      )
+    ).toEqual(['x'])
+    expect(getAssetTypeBadge(asset([MODELS_TAG, 'x']), false)).toBe('x')
+    expect(getAssetModelType(asset([MODELS_TAG]))).toBeNull()
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -20,7 +20,8 @@ import {
   getAssetTypeBadge,
   getAssetUserDescription,
   getSourceName,
-  resolveDisplayImageDimensions
+  resolveDisplayImageDimensions,
+  stripModelTypePrefix
 } from '@/platform/assets/utils/assetMetadataUtils'
 
 const { isCloudRef } = vi.hoisted(() => ({
@@ -688,6 +689,12 @@ describe('getAssetTypeBadge', () => {
     ).toBe('checkpoints')
   })
 
+  it('keeps the first non-models tag rather than reordering to the model_type value', () => {
+    expect(
+      getAssetTypeBadge(asset(['models', 'foo', 'model_type:bar']), true)
+    ).toBe('foo')
+  })
+
   it('leaks the literal model_type: tag when mode is off (default)', () => {
     expect(getAssetTypeBadge(asset(['models', 'model_type:checkpoints']))).toBe(
       'model_type:checkpoints'
@@ -700,5 +707,16 @@ describe('getAssetTypeBadge', () => {
 
   it('returns undefined when only the models tag is present', () => {
     expect(getAssetTypeBadge(asset(['models']), true)).toBeUndefined()
+  })
+})
+
+describe('stripModelTypePrefix', () => {
+  it('removes the model_type: prefix when present', () => {
+    expect(stripModelTypePrefix('model_type:checkpoints')).toBe('checkpoints')
+  })
+
+  it('leaves a tag without the prefix unchanged', () => {
+    expect(stripModelTypePrefix('checkpoints')).toBe('checkpoints')
+    expect(stripModelTypePrefix('checkpoint/xl')).toBe('checkpoint/xl')
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -734,6 +734,15 @@ describe('getAssetNodeCategoryCandidates', () => {
     ).toEqual(['chatterbox/chatterbox_vc'])
   })
 
+  it('does not repeat a bare tag that duplicates its model_type value', () => {
+    expect(
+      getAssetNodeCategoryCandidates(
+        asset(['models', 'model_type:LLM', 'LLM']),
+        true
+      )
+    ).toEqual(['LLM'])
+  })
+
   it('returns no candidates when only reserved tags are present', () => {
     expect(
       getAssetNodeCategoryCandidates(asset(['models', 'missing']), true)

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -590,22 +590,31 @@ describe('getAssetCategories', () => {
     tags
   })
 
-  it('uses model_type:* values as the group and disregards other tags', () => {
+  it('uses model_type:* values as the group and disregards other tags in model_type mode', () => {
     expect(
-      getAssetCategories(asset(['models', 'model_type:checkpoints', 'sdxl']))
+      getAssetCategories(
+        asset(['models', 'model_type:checkpoints', 'sdxl']),
+        true
+      )
     ).toEqual(['checkpoints'])
   })
 
   it('preserves the model_type value casing', () => {
-    expect(getAssetCategories(asset(['models', 'model_type:LLM']))).toEqual([
-      'LLM'
+    expect(
+      getAssetCategories(asset(['models', 'model_type:LLM']), true)
+    ).toEqual(['LLM'])
+  })
+
+  it('routes an uncovered asset by its bare tags in model_type mode', () => {
+    expect(getAssetCategories(asset(['models', 'checkpoints']), true)).toEqual([
+      'checkpoints'
     ])
   })
 
-  it('falls back to non-model tags when no model_type tag is present', () => {
-    expect(getAssetCategories(asset(['models', 'checkpoints']))).toEqual([
-      'checkpoints'
-    ])
+  it('ignores model_type: and uses bare-tag grouping when mode is off (default)', () => {
+    expect(
+      getAssetCategories(asset(['models', 'model_type:checkpoints', 'sdxl']))
+    ).toEqual(['model_type:checkpoints', 'sdxl'])
   })
 })
 
@@ -619,30 +628,45 @@ describe('getAssetNodeCategory', () => {
   it('prefers the most specific (deepest) tag over a flat model_type value', () => {
     expect(
       getAssetNodeCategory(
-        asset(['models', 'model_type:LLM', 'LLM/Qwen-VL/Qwen3-0.6B'])
+        asset(['models', 'model_type:LLM', 'LLM/Qwen-VL/Qwen3-0.6B']),
+        true
       )
     ).toBe('LLM/Qwen-VL/Qwen3-0.6B')
   })
 
   it('strips the model_type: prefix when it is the only candidate', () => {
-    expect(getAssetNodeCategory(asset(['models', 'model_type:vae']))).toBe(
-      'vae'
-    )
+    expect(
+      getAssetNodeCategory(asset(['models', 'model_type:vae']), true)
+    ).toBe('vae')
   })
 
   it('lets a model_type value win ties against a bare tag', () => {
     expect(
-      getAssetNodeCategory(asset(['models', 'model_type:checkpoints', 'sdxl']))
+      getAssetNodeCategory(
+        asset(['models', 'model_type:checkpoints', 'sdxl']),
+        true
+      )
     ).toBe('checkpoints')
   })
 
-  it('keeps a hierarchical legacy tag intact', () => {
+  it('keeps a hierarchical tag intact', () => {
     expect(
-      getAssetNodeCategory(asset(['models', 'chatterbox/chatterbox_vc']))
+      getAssetNodeCategory(asset(['models', 'chatterbox/chatterbox_vc']), true)
     ).toBe('chatterbox/chatterbox_vc')
   })
 
   it('returns undefined when only reserved tags are present', () => {
-    expect(getAssetNodeCategory(asset(['models', 'missing']))).toBeUndefined()
+    expect(
+      getAssetNodeCategory(asset(['models', 'missing']), true)
+    ).toBeUndefined()
+  })
+
+  it('uses the first non-reserved tag verbatim when mode is off (default)', () => {
+    expect(getAssetNodeCategory(asset(['models', 'model_type:vae']))).toBe(
+      'model_type:vae'
+    )
+    expect(getAssetNodeCategory(asset(['models', 'checkpoints']))).toBe(
+      'checkpoints'
+    )
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -13,7 +13,7 @@ import {
   getAssetFilename,
   getAssetMetadataDimensions,
   getAssetModelType,
-  getAssetNodeCategory,
+  getAssetNodeCategoryCandidates,
   getAssetSourceUrl,
   getAssetStoredFilename,
   getAssetTriggerPhrases,
@@ -620,56 +620,59 @@ describe('getAssetCategories', () => {
   })
 })
 
-describe('getAssetNodeCategory', () => {
+describe('getAssetNodeCategoryCandidates', () => {
   const asset = (tags: string[]): AssetItem => ({
     id: 'a',
     name: 'model.safetensors',
     tags
   })
 
-  it('prefers the most specific (deepest) tag over a flat model_type value', () => {
+  it('orders the most specific (deepest) tag ahead of a flat model_type value', () => {
     expect(
-      getAssetNodeCategory(
+      getAssetNodeCategoryCandidates(
         asset(['models', 'model_type:LLM', 'LLM/Qwen-VL/Qwen3-0.6B']),
         true
       )
-    ).toBe('LLM/Qwen-VL/Qwen3-0.6B')
+    ).toEqual(['LLM/Qwen-VL/Qwen3-0.6B', 'LLM'])
   })
 
   it('strips the model_type: prefix when it is the only candidate', () => {
     expect(
-      getAssetNodeCategory(asset(['models', 'model_type:vae']), true)
-    ).toBe('vae')
+      getAssetNodeCategoryCandidates(asset(['models', 'model_type:vae']), true)
+    ).toEqual(['vae'])
   })
 
-  it('lets a model_type value win ties against a bare tag', () => {
+  it('keeps a model_type value ahead of an equally-deep bare tag', () => {
     expect(
-      getAssetNodeCategory(
+      getAssetNodeCategoryCandidates(
         asset(['models', 'model_type:checkpoints', 'sdxl']),
         true
       )
-    ).toBe('checkpoints')
+    ).toEqual(['checkpoints', 'sdxl'])
   })
 
   it('keeps a hierarchical tag intact', () => {
     expect(
-      getAssetNodeCategory(asset(['models', 'chatterbox/chatterbox_vc']), true)
-    ).toBe('chatterbox/chatterbox_vc')
+      getAssetNodeCategoryCandidates(
+        asset(['models', 'chatterbox/chatterbox_vc']),
+        true
+      )
+    ).toEqual(['chatterbox/chatterbox_vc'])
   })
 
-  it('returns undefined when only reserved tags are present', () => {
+  it('returns no candidates when only reserved tags are present', () => {
     expect(
-      getAssetNodeCategory(asset(['models', 'missing']), true)
-    ).toBeUndefined()
+      getAssetNodeCategoryCandidates(asset(['models', 'missing']), true)
+    ).toEqual([])
   })
 
   it('uses the first non-reserved tag verbatim when mode is off (default)', () => {
-    expect(getAssetNodeCategory(asset(['models', 'model_type:vae']))).toBe(
-      'model_type:vae'
-    )
-    expect(getAssetNodeCategory(asset(['models', 'checkpoints']))).toBe(
-      'checkpoints'
-    )
+    expect(
+      getAssetNodeCategoryCandidates(asset(['models', 'model_type:vae']))
+    ).toEqual(['model_type:vae'])
+    expect(
+      getAssetNodeCategoryCandidates(asset(['models', 'checkpoints']))
+    ).toEqual(['checkpoints'])
   })
 })
 

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -17,6 +17,7 @@ import {
   getAssetSourceUrl,
   getAssetStoredFilename,
   getAssetTriggerPhrases,
+  getAssetTypeBadge,
   getAssetUserDescription,
   getSourceName,
   resolveDisplayImageDimensions
@@ -668,5 +669,36 @@ describe('getAssetNodeCategory', () => {
     expect(getAssetNodeCategory(asset(['models', 'checkpoints']))).toBe(
       'checkpoints'
     )
+  })
+})
+
+describe('getAssetTypeBadge', () => {
+  const asset = (tags: string[]): AssetItem => ({
+    id: 'a',
+    name: 'model.safetensors',
+    tags
+  })
+
+  it('strips the model_type: prefix in model_type mode (no raw leak)', () => {
+    expect(
+      getAssetTypeBadge(
+        asset(['models', 'model_type:checkpoints', 'sdxl']),
+        true
+      )
+    ).toBe('checkpoints')
+  })
+
+  it('leaks the literal model_type: tag when mode is off (default)', () => {
+    expect(getAssetTypeBadge(asset(['models', 'model_type:checkpoints']))).toBe(
+      'model_type:checkpoints'
+    )
+  })
+
+  it('shows the segment after the first slash for a bare hierarchical tag', () => {
+    expect(getAssetTypeBadge(asset(['models', 'checkpoint/xl']))).toBe('xl')
+  })
+
+  it('returns undefined when only the models tag is present', () => {
+    expect(getAssetTypeBadge(asset(['models']), true)).toBeUndefined()
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.test.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.test.ts
@@ -6,12 +6,14 @@ import {
   getAssetBaseModel,
   getAssetBaseModels,
   getAssetCardTitle,
+  getAssetCategories,
   getAssetDescription,
   getAssetDisplayFilename,
   getAssetDisplayName,
   getAssetFilename,
   getAssetMetadataDimensions,
   getAssetModelType,
+  getAssetNodeCategory,
   getAssetSourceUrl,
   getAssetStoredFilename,
   getAssetTriggerPhrases,
@@ -578,5 +580,69 @@ describe('assetMetadataUtils', () => {
         rendered
       )
     })
+  })
+})
+
+describe('getAssetCategories', () => {
+  const asset = (tags: string[]): AssetItem => ({
+    id: 'a',
+    name: 'model.safetensors',
+    tags
+  })
+
+  it('uses model_type:* values as the group and disregards other tags', () => {
+    expect(
+      getAssetCategories(asset(['models', 'model_type:checkpoints', 'sdxl']))
+    ).toEqual(['checkpoints'])
+  })
+
+  it('preserves the model_type value casing', () => {
+    expect(getAssetCategories(asset(['models', 'model_type:LLM']))).toEqual([
+      'LLM'
+    ])
+  })
+
+  it('falls back to non-model tags when no model_type tag is present', () => {
+    expect(getAssetCategories(asset(['models', 'checkpoints']))).toEqual([
+      'checkpoints'
+    ])
+  })
+})
+
+describe('getAssetNodeCategory', () => {
+  const asset = (tags: string[]): AssetItem => ({
+    id: 'a',
+    name: 'model.safetensors',
+    tags
+  })
+
+  it('prefers the most specific (deepest) tag over a flat model_type value', () => {
+    expect(
+      getAssetNodeCategory(
+        asset(['models', 'model_type:LLM', 'LLM/Qwen-VL/Qwen3-0.6B'])
+      )
+    ).toBe('LLM/Qwen-VL/Qwen3-0.6B')
+  })
+
+  it('strips the model_type: prefix when it is the only candidate', () => {
+    expect(getAssetNodeCategory(asset(['models', 'model_type:vae']))).toBe(
+      'vae'
+    )
+  })
+
+  it('lets a model_type value win ties against a bare tag', () => {
+    expect(
+      getAssetNodeCategory(asset(['models', 'model_type:checkpoints', 'sdxl']))
+    ).toBe('checkpoints')
+  })
+
+  it('keeps a hierarchical legacy tag intact', () => {
+    expect(
+      getAssetNodeCategory(asset(['models', 'chatterbox/chatterbox_vc']))
+    ).toBe('chatterbox/chatterbox_vc')
+  })
+
+  it('returns undefined when only reserved tags are present', () => {
+    expect(getAssetNodeCategory(asset(['models', 'missing']))).toBeUndefined()
   })
 })

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -1,4 +1,8 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+import {
+  MISSING_TAG,
+  MODELS_TAG
+} from '@/platform/assets/services/assetService'
 import { isCloud } from '@/platform/distribution/types'
 import { isCivitaiUrl } from '@/utils/formatUtil'
 
@@ -148,6 +152,61 @@ export function getSourceName(url: string): string {
 export function getAssetModelType(asset: AssetItem): string | null {
   const typeTag = asset.tags?.find((tag) => tag && tag !== 'models')
   return typeTag ?? null
+}
+
+const MODEL_TYPE_TAG_PREFIX = 'model_type:'
+
+function getModelTypeTagValues(asset: AssetItem): string[] {
+  return asset.tags
+    .filter((tag) => tag.startsWith(MODEL_TYPE_TAG_PREFIX))
+    .map((tag) => tag.slice(MODEL_TYPE_TAG_PREFIX.length))
+    .filter((tag) => tag.length > 0)
+}
+
+/**
+ * Resolves the category keys a model asset is grouped under.
+ *
+ * When the asset carries `model_type:*` tags (the namespaced tag scheme), the
+ * `*` values are authoritative and every other tag is disregarded. Otherwise
+ * we fall back to treating each non-`models` tag's top-level segment as a
+ * category, preserving the pre-namespace behavior.
+ */
+export function getAssetCategories(asset: AssetItem): string[] {
+  const modelTypes = getModelTypeTagValues(asset)
+  if (modelTypes.length > 0) return modelTypes
+
+  return asset.tags
+    .filter((tag) => tag !== MODELS_TAG && tag.length > 0)
+    .map((tag) => tag.split('/')[0])
+}
+
+function pathDepth(tag: string): number {
+  return tag.split('/').length
+}
+
+/**
+ * Resolves the model-type key used to look up a node provider for an asset.
+ *
+ * Unlike {@link getAssetCategories}, this keeps the full (possibly
+ * hierarchical) value so `modelToNodeStore`'s `parent/child` fallback still
+ * works. Candidates are the stripped `model_type:*` values plus any other
+ * non-reserved tags, and the most specific (deepest `parent/child`) candidate
+ * wins so a flat `model_type:LLM` never shadows a resolvable
+ * `LLM/Qwen-VL/...` tag. `model_type:*` values win ties.
+ */
+export function getAssetNodeCategory(asset: AssetItem): string | undefined {
+  const otherTags = asset.tags.filter(
+    (tag) =>
+      tag !== MODELS_TAG &&
+      tag !== MISSING_TAG &&
+      !tag.startsWith(MODEL_TYPE_TAG_PREFIX)
+  )
+  const candidates = [...getModelTypeTagValues(asset), ...otherTags]
+  if (candidates.length === 0) return undefined
+
+  return candidates.reduce((best, candidate) =>
+    pathDepth(candidate) > pathDepth(best) ? candidate : best
+  )
 }
 
 /**

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -237,31 +237,32 @@ export function stripModelTypePrefix(tag: string): string {
 }
 
 /**
- * Resolves the short label shown on an asset card's type badge.
+ * Resolves the labels shown as an asset card's type badges.
  *
- * In `modelTypeMode` the badge is the asset's first `model_type:*` value —
- * the same key the asset groups under (`getAssetCategories`), so badge and
- * grouping cannot diverge for covered assets. Uncovered assets (and legacy
- * mode) keep the original selection: first non-`models` tag, with bare
- * hierarchical tags showing the segment after the first `/`.
+ * In `modelTypeMode` a covered asset badges every `model_type:*` value — the
+ * same keys it groups under (`getAssetCategories`) — so a shared-root asset
+ * tagged with several categories carries each of them; whichever category
+ * view the card appears in is represented on the card. Uncovered assets (and
+ * legacy mode) keep the original single selection: first non-`models` tag,
+ * with bare hierarchical tags showing the segment after the first `/`.
  */
-export function getAssetTypeBadge(
+export function getAssetTypeBadges(
   asset: AssetItem,
   modelTypeMode: boolean
-): string | undefined {
+): string[] {
   if (modelTypeMode) {
-    const [modelType] = getModelTypeTagValues(asset)
-    if (modelType) return modelType
+    const modelTypes = getModelTypeTagValues(asset)
+    if (modelTypes.length > 0) return modelTypes
   }
   const typeTag = asset.tags.find(
     (tag) =>
       tag !== MODELS_TAG &&
       !(modelTypeMode && tag.startsWith(MODEL_TYPE_TAG_PREFIX))
   )
-  if (!typeTag) return undefined
-  return typeTag.includes('/')
-    ? typeTag.slice(typeTag.indexOf('/') + 1)
-    : typeTag
+  if (!typeTag) return []
+  return [
+    typeTag.includes('/') ? typeTag.slice(typeTag.indexOf('/') + 1) : typeTag
+  ]
 }
 
 /**

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -193,9 +193,35 @@ export function getAssetCategories(
   if (modelTypeMode) {
     const modelTypes = getModelTypeTagValues(asset)
     if (modelTypes.length > 0) return modelTypes
+    // Uncovered assets route by bare tags, but namespace residue (e.g. a
+    // malformed empty `model_type:`) must not surface as a raw category.
+    return getBareTagCategories(asset).filter(
+      (category) => !category.startsWith(MODEL_TYPE_TAG_PREFIX)
+    )
   }
 
   return getBareTagCategories(asset)
+}
+
+/**
+ * Resolves the primary tag a browser surface titles itself after. In
+ * `modelTypeMode` a covered asset uses its first `model_type:*` value — the
+ * key it groups under — while an uncovered asset keeps the legacy selection
+ * (first non-`models` tag, verbatim, hierarchical paths intact). Outside the
+ * mode this is exactly the legacy selection.
+ */
+export function getPrimaryCategoryTag(
+  asset: AssetItem,
+  modelTypeMode: boolean
+): string | undefined {
+  if (modelTypeMode) {
+    const [modelType] = getModelTypeTagValues(asset)
+    if (modelType) return modelType
+    return asset.tags.find(
+      (tag) => tag !== MODELS_TAG && !tag.startsWith(MODEL_TYPE_TAG_PREFIX)
+    )
+  }
+  return asset.tags.find((tag) => tag !== MODELS_TAG)
 }
 
 /** Number of `parent/child` segments in a tag, used to pick the most specific. */

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -163,21 +163,31 @@ function getModelTypeTagValues(asset: AssetItem): string[] {
     .filter((tag) => tag.length > 0)
 }
 
-/**
- * Resolves the category keys a model asset is grouped under.
- *
- * When the asset carries `model_type:*` tags (the namespaced tag scheme), the
- * `*` values are authoritative and every other tag is disregarded. Otherwise
- * we fall back to treating each non-`models` tag's top-level segment as a
- * category, preserving the pre-namespace behavior.
- */
-export function getAssetCategories(asset: AssetItem): string[] {
-  const modelTypes = getModelTypeTagValues(asset)
-  if (modelTypes.length > 0) return modelTypes
-
+function getBareTagCategories(asset: AssetItem): string[] {
   return asset.tags
     .filter((tag) => tag !== MODELS_TAG && tag.length > 0)
     .map((tag) => tag.split('/')[0])
+}
+
+/**
+ * Resolves the category keys a model asset is grouped under.
+ *
+ * `modelTypeMode` reflects whether the backend declares the `model_type:` tag
+ * scheme (the `supports_model_type_tags` capability). When true, an asset's
+ * `model_type:*` values are authoritative; an asset with no `model_type:` tag
+ * still routes by its bare tags. When false (the default) categories come from
+ * the legacy bare-tag top-level grouping and `model_type:` is ignored.
+ */
+export function getAssetCategories(
+  asset: AssetItem,
+  modelTypeMode = false
+): string[] {
+  if (modelTypeMode) {
+    const modelTypes = getModelTypeTagValues(asset)
+    if (modelTypes.length > 0) return modelTypes
+  }
+
+  return getBareTagCategories(asset)
 }
 
 function pathDepth(tag: string): number {
@@ -189,12 +199,22 @@ function pathDepth(tag: string): number {
  *
  * Unlike {@link getAssetCategories}, this keeps the full (possibly
  * hierarchical) value so `modelToNodeStore`'s `parent/child` fallback still
- * works. Candidates are the stripped `model_type:*` values plus any other
- * non-reserved tags, and the most specific (deepest `parent/child`) candidate
- * wins so a flat `model_type:LLM` never shadows a resolvable
- * `LLM/Qwen-VL/...` tag. `model_type:*` values win ties.
+ * works.
+ *
+ * In `modelTypeMode` (backend declares `supports_model_type_tags`), candidates
+ * are the stripped `model_type:*` values plus any other non-reserved tags, and
+ * the most specific (deepest `parent/child`) candidate wins so a flat
+ * `model_type:LLM` never shadows a resolvable `LLM/Qwen-VL/...` tag. Otherwise
+ * we use the legacy first-non-reserved tag verbatim.
  */
-export function getAssetNodeCategory(asset: AssetItem): string | undefined {
+export function getAssetNodeCategory(
+  asset: AssetItem,
+  modelTypeMode = false
+): string | undefined {
+  if (!modelTypeMode) {
+    return asset.tags.find((tag) => tag !== MODELS_TAG && tag !== MISSING_TAG)
+  }
+
   const otherTags = asset.tags.filter(
     (tag) =>
       tag !== MODELS_TAG &&

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -311,7 +311,9 @@ export function getAssetNodeCategoryCandidates(
     modelTypes.some((type) => tag === type || tag.startsWith(`${type}/`))
 
   return [
-    ...[...modelTypes, ...bareTags.filter(isRelated)].sort(byDepthDesc),
+    ...[...new Set([...modelTypes, ...bareTags.filter(isRelated)])].sort(
+      byDepthDesc
+    ),
     ...bareTags.filter((tag) => !isRelated(tag)).sort(byDepthDesc)
   ]
 }

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -228,37 +228,42 @@ export function getAssetTypeBadge(
 }
 
 /**
- * Resolves the model-type key used to look up a node provider for an asset.
+ * Ordered node-category candidates for an asset, most specific first.
  *
- * Unlike {@link getAssetCategories}, this keeps the full (possibly
- * hierarchical) value so `modelToNodeStore`'s `parent/child` fallback still
- * works.
+ * Callers resolve a node provider by trying each candidate in order and taking
+ * the first that maps to a provider. The full (possibly hierarchical) value is
+ * kept so `modelToNodeStore`'s `parent/child` fallback still works.
  *
- * In `modelTypeMode` (backend declares `supports_model_type_tags`), candidates
- * are the stripped `model_type:*` values plus any other non-reserved tags, and
- * the most specific (deepest `parent/child`) candidate wins so a flat
- * `model_type:LLM` never shadows a resolvable `LLM/Qwen-VL/...` tag. Otherwise
- * we use the legacy first-non-reserved tag verbatim.
+ * In `modelTypeMode` (backend declares `supports_model_type_tags`) candidates
+ * are the stripped `model_type:*` values plus any other non-reserved tags,
+ * ordered by descending `parent/child` depth. Trying deepest-first lets a
+ * resolvable `LLM/Qwen-VL/...` path win over a flat `model_type:LLM`, while an
+ * unresolvable incidental tag (e.g. a user-added `foo/bar`) is skipped in
+ * favour of an authoritative `model_type:vae` that actually resolves. Ties keep
+ * `model_type:*` values ahead of bare tags so they are never shadowed by an
+ * equally-deep tag. Outside `modelTypeMode` the legacy first-non-reserved tag
+ * is used verbatim.
  */
-export function getAssetNodeCategory(
+export function getAssetNodeCategoryCandidates(
   asset: AssetItem,
   modelTypeMode = false
-): string | undefined {
+): string[] {
   if (!modelTypeMode) {
-    return asset.tags.find((tag) => tag !== MODELS_TAG && tag !== MISSING_TAG)
+    const legacy = asset.tags.find(
+      (tag) => tag !== MODELS_TAG && tag !== MISSING_TAG
+    )
+    return legacy ? [legacy] : []
   }
 
-  const otherTags = asset.tags.filter(
+  const bareTags = asset.tags.filter(
     (tag) =>
       tag !== MODELS_TAG &&
       tag !== MISSING_TAG &&
       !tag.startsWith(MODEL_TYPE_TAG_PREFIX)
   )
-  const candidates = [...getModelTypeTagValues(asset), ...otherTags]
-  if (candidates.length === 0) return undefined
 
-  return candidates.reduce((best, candidate) =>
-    pathDepth(candidate) > pathDepth(best) ? candidate : best
+  return [...getModelTypeTagValues(asset), ...bareTags].sort(
+    (a, b) => pathDepth(b) - pathDepth(a)
   )
 }
 

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -156,6 +156,7 @@ export function getAssetModelType(asset: AssetItem): string | null {
 
 const MODEL_TYPE_TAG_PREFIX = 'model_type:'
 
+/** Strips the `model_type:` prefix off each namespaced tag, dropping non-`model_type:` tags. */
 function getModelTypeTagValues(asset: AssetItem): string[] {
   return asset.tags
     .filter((tag) => tag.startsWith(MODEL_TYPE_TAG_PREFIX))
@@ -163,6 +164,7 @@ function getModelTypeTagValues(asset: AssetItem): string[] {
     .filter((tag) => tag.length > 0)
 }
 
+/** Legacy grouping: each non-`models` tag's top-level path segment. */
 function getBareTagCategories(asset: AssetItem): string[] {
   return asset.tags
     .filter((tag) => tag !== MODELS_TAG && tag.length > 0)
@@ -190,8 +192,33 @@ export function getAssetCategories(
   return getBareTagCategories(asset)
 }
 
+/** Number of `parent/child` segments in a tag, used to pick the most specific. */
 function pathDepth(tag: string): number {
   return tag.split('/').length
+}
+
+/**
+ * Resolves the short label shown on an asset card's type badge.
+ *
+ * In `modelTypeMode` a `model_type:*` tag's stripped value is preferred so the
+ * badge never leaks the raw `model_type:` namespace; otherwise (and as a
+ * fallback for an uncovered asset) it uses the first non-`models` tag, showing
+ * the segment after the first `/` for hierarchical tags.
+ */
+export function getAssetTypeBadge(
+  asset: AssetItem,
+  modelTypeMode = false
+): string | undefined {
+  if (modelTypeMode) {
+    const [modelType] = getModelTypeTagValues(asset)
+    if (modelType) return modelType
+  }
+
+  const typeTag = asset.tags.find((tag) => tag !== MODELS_TAG)
+  if (!typeTag) return undefined
+  return typeTag.includes('/')
+    ? typeTag.slice(typeTag.indexOf('/') + 1)
+    : typeTag
 }
 
 /**

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -145,17 +145,22 @@ export function getSourceName(url: string): string {
   return 'Source'
 }
 
+const MODEL_TYPE_TAG_PREFIX = 'model_type:'
+
 /**
- * Extracts the model type from asset tags
+ * Extracts the model type from asset tags as a bare (non-namespaced) value.
+ * Never returns a raw `model_type:*` literal: this value feeds edit widgets
+ * whose save path writes tags back verbatim, so a namespaced tag leaking
+ * through here would round-trip the prefixed literal into the tag set.
  * @param asset - The asset to extract model type from
  * @returns The model type string or null if not present
  */
 export function getAssetModelType(asset: AssetItem): string | null {
-  const typeTag = asset.tags?.find((tag) => tag && tag !== 'models')
+  const typeTag = asset.tags?.find(
+    (tag) => tag && tag !== MODELS_TAG && !tag.startsWith(MODEL_TYPE_TAG_PREFIX)
+  )
   return typeTag ?? null
 }
-
-const MODEL_TYPE_TAG_PREFIX = 'model_type:'
 
 /** Strips the `model_type:` prefix off each namespaced tag, dropping non-`model_type:` tags. */
 function getModelTypeTagValues(asset: AssetItem): string[] {
@@ -183,7 +188,7 @@ function getBareTagCategories(asset: AssetItem): string[] {
  */
 export function getAssetCategories(
   asset: AssetItem,
-  modelTypeMode = false
+  modelTypeMode: boolean
 ): string[] {
   if (modelTypeMode) {
     const modelTypes = getModelTypeTagValues(asset)
@@ -208,20 +213,26 @@ export function stripModelTypePrefix(tag: string): string {
 /**
  * Resolves the short label shown on an asset card's type badge.
  *
- * Uses the first non-`models` tag (unchanged selection); in `modelTypeMode` a
- * `model_type:` namespace prefix on that tag is stripped so the badge doesn't
- * leak the raw namespace. Bare hierarchical tags still show the segment after
- * the first `/`.
+ * In `modelTypeMode` the badge is the asset's first `model_type:*` value —
+ * the same key the asset groups under (`getAssetCategories`), so badge and
+ * grouping cannot diverge for covered assets. Uncovered assets (and legacy
+ * mode) keep the original selection: first non-`models` tag, with bare
+ * hierarchical tags showing the segment after the first `/`.
  */
 export function getAssetTypeBadge(
   asset: AssetItem,
-  modelTypeMode = false
+  modelTypeMode: boolean
 ): string | undefined {
-  const typeTag = asset.tags.find((tag) => tag !== MODELS_TAG)
-  if (!typeTag) return undefined
-  if (modelTypeMode && typeTag.startsWith(MODEL_TYPE_TAG_PREFIX)) {
-    return stripModelTypePrefix(typeTag)
+  if (modelTypeMode) {
+    const [modelType] = getModelTypeTagValues(asset)
+    if (modelType) return modelType
   }
+  const typeTag = asset.tags.find(
+    (tag) =>
+      tag !== MODELS_TAG &&
+      !(modelTypeMode && tag.startsWith(MODEL_TYPE_TAG_PREFIX))
+  )
+  if (!typeTag) return undefined
   return typeTag.includes('/')
     ? typeTag.slice(typeTag.indexOf('/') + 1)
     : typeTag
@@ -235,18 +246,20 @@ export function getAssetTypeBadge(
  * kept so `modelToNodeStore`'s `parent/child` fallback still works.
  *
  * In `modelTypeMode` (backend declares `supports_model_type_tags`) candidates
- * are the stripped `model_type:*` values plus any other non-reserved tags,
- * ordered by descending `parent/child` depth. Trying deepest-first lets a
- * resolvable `LLM/Qwen-VL/...` path win over a flat `model_type:LLM`, while an
- * unresolvable incidental tag (e.g. a user-added `foo/bar`) is skipped in
- * favour of an authoritative `model_type:vae` that actually resolves. Ties keep
- * `model_type:*` values ahead of bare tags so they are never shadowed by an
- * equally-deep tag. Outside `modelTypeMode` the legacy first-non-reserved tag
- * is used verbatim.
+ * come in two tiers. Tier 1: the stripped `model_type:*` values plus bare tags
+ * *related* to one of them (equal to it, or extending it as a `parent/child`
+ * path), ordered by descending depth — so a resolvable `LLM/Qwen-VL/...` twin
+ * wins over a flat `model_type:LLM`, while ties keep `model_type:*` values
+ * ahead of bare tags. Tier 2: unrelated bare tags (e.g. a user-added
+ * `foo/bar`), tried only when nothing authoritative resolves — they can no
+ * longer pre-empt a resolvable `model_type:*` value however deep they are.
+ * An uncovered asset (no `model_type:` tag) routes by all its bare tags,
+ * deepest first. Outside `modelTypeMode` the legacy first-non-reserved tag is
+ * used verbatim.
  */
 export function getAssetNodeCategoryCandidates(
   asset: AssetItem,
-  modelTypeMode = false
+  modelTypeMode: boolean
 ): string[] {
   if (!modelTypeMode) {
     const legacy = asset.tags.find(
@@ -262,9 +275,18 @@ export function getAssetNodeCategoryCandidates(
       !tag.startsWith(MODEL_TYPE_TAG_PREFIX)
   )
 
-  return [...getModelTypeTagValues(asset), ...bareTags].sort(
-    (a, b) => pathDepth(b) - pathDepth(a)
-  )
+  const byDepthDesc = (a: string, b: string) => pathDepth(b) - pathDepth(a)
+
+  const modelTypes = getModelTypeTagValues(asset)
+  if (modelTypes.length === 0) return bareTags.toSorted(byDepthDesc)
+
+  const isRelated = (tag: string) =>
+    modelTypes.some((type) => tag === type || tag.startsWith(`${type}/`))
+
+  return [
+    ...[...modelTypes, ...bareTags.filter(isRelated)].sort(byDepthDesc),
+    ...bareTags.filter((tag) => !isRelated(tag)).sort(byDepthDesc)
+  ]
 }
 
 /**

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -197,25 +197,30 @@ function pathDepth(tag: string): number {
   return tag.split('/').length
 }
 
+/** Removes the `model_type:` namespace prefix from a tag when present. */
+export function stripModelTypePrefix(tag: string): string {
+  return tag.startsWith(MODEL_TYPE_TAG_PREFIX)
+    ? tag.slice(MODEL_TYPE_TAG_PREFIX.length)
+    : tag
+}
+
 /**
  * Resolves the short label shown on an asset card's type badge.
  *
- * In `modelTypeMode` a `model_type:*` tag's stripped value is preferred so the
- * badge never leaks the raw `model_type:` namespace; otherwise (and as a
- * fallback for an uncovered asset) it uses the first non-`models` tag, showing
- * the segment after the first `/` for hierarchical tags.
+ * Uses the first non-`models` tag (unchanged selection); in `modelTypeMode` a
+ * `model_type:` namespace prefix on that tag is stripped so the badge doesn't
+ * leak the raw namespace. Bare hierarchical tags still show the segment after
+ * the first `/`.
  */
 export function getAssetTypeBadge(
   asset: AssetItem,
   modelTypeMode = false
 ): string | undefined {
-  if (modelTypeMode) {
-    const [modelType] = getModelTypeTagValues(asset)
-    if (modelType) return modelType
-  }
-
   const typeTag = asset.tags.find((tag) => tag !== MODELS_TAG)
   if (!typeTag) return undefined
+  if (modelTypeMode && typeTag.startsWith(MODEL_TYPE_TAG_PREFIX)) {
+    return stripModelTypePrefix(typeTag)
+  }
   return typeTag.includes('/')
     ? typeTag.slice(typeTag.indexOf('/') + 1)
     : typeTag

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -1,10 +1,11 @@
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
-import {
-  MISSING_TAG,
-  MODELS_TAG
-} from '@/platform/assets/services/assetService'
 import { isCloud } from '@/platform/distribution/types'
 import { isCivitaiUrl } from '@/utils/formatUtil'
+
+// Reserved tag literals (mirror assetService's MODELS_TAG/MISSING_TAG). Kept
+// local so this leaf util doesn't pull the heavier assetService -> i18n chain.
+const MODELS_TAG = 'models'
+const MISSING_TAG = 'missing'
 
 /**
  * Type-safe utilities for extracting metadata from assets.

--- a/src/platform/assets/utils/assetMetadataUtils.ts
+++ b/src/platform/assets/utils/assetMetadataUtils.ts
@@ -145,7 +145,7 @@ export function getSourceName(url: string): string {
   return 'Source'
 }
 
-const MODEL_TYPE_TAG_PREFIX = 'model_type:'
+export const MODEL_TYPE_TAG_PREFIX = 'model_type:'
 
 /**
  * Extracts the model type from asset tags as a bare (non-namespaced) value.

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
@@ -95,6 +95,37 @@ describe('resolveModelNodeFromAsset', () => {
       expect(mockGetNodeProvider).toHaveBeenCalledWith('vae')
     })
 
+    it('skips an unresolvable incidental tag and resolves via the model_type value', () => {
+      mockSupportsModelTypeTags.value = true
+      mockGetNodeProvider.mockImplementation((category: string) =>
+        category === 'vae' ? createMockNodeProvider() : undefined
+      )
+      const result = resolveModelNodeFromAsset(
+        createMockAsset({ tags: ['models', 'model_type:vae', 'foo/bar'] })
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockGetNodeProvider).toHaveBeenCalledWith('foo/bar')
+      expect(mockGetNodeProvider).toHaveBeenCalledWith('vae')
+    })
+
+    it('prefers the deepest resolvable path over a flat model_type value', () => {
+      mockSupportsModelTypeTags.value = true
+      mockGetNodeProvider.mockImplementation((category: string) =>
+        category === 'LLM/Qwen-VL/Qwen3-0.6B'
+          ? createMockNodeProvider()
+          : undefined
+      )
+      const result = resolveModelNodeFromAsset(
+        createMockAsset({
+          tags: ['models', 'model_type:LLM', 'LLM/Qwen-VL/Qwen3-0.6B']
+        })
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockGetNodeProvider).toHaveBeenCalledWith('LLM/Qwen-VL/Qwen3-0.6B')
+    })
+
     it('falls back to metadata.filename when user_metadata.filename missing', () => {
       mockProvider(createMockNodeProvider())
       const result = resolveModelNodeFromAsset(
@@ -228,7 +259,7 @@ describe('resolveModelNodeFromAsset', () => {
       if (!result.success) {
         expect(result.error.code).toBe('NO_PROVIDER')
         expect(result.error.message).toContain('checkpoints')
-        expect(result.error.details?.category).toBe('checkpoints')
+        expect(result.error.details?.candidates).toEqual(['checkpoints'])
       }
     })
   })

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
@@ -4,9 +4,20 @@ import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { resolveModelNodeFromAsset } from '@/platform/assets/utils/resolveModelNodeFromAsset'
 
 const mockGetNodeProvider = vi.hoisted(() => vi.fn())
+const mockSupportsModelTypeTags = vi.hoisted(() => ({ value: false }))
 
 vi.mock('@/stores/modelToNodeStore', () => ({
   useModelToNodeStore: () => ({ getNodeProvider: mockGetNodeProvider })
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      get supportsModelTypeTags() {
+        return mockSupportsModelTypeTags.value
+      }
+    }
+  })
 }))
 
 function createMockAsset(overrides: Partial<AssetItem> = {}): AssetItem {
@@ -49,6 +60,7 @@ describe('resolveModelNodeFromAsset', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockSupportsModelTypeTags.value = false
   })
 
   describe('valid assets', () => {
@@ -66,6 +78,17 @@ describe('resolveModelNodeFromAsset', () => {
           'models/checkpoints/test-model.safetensors'
         )
       }
+    })
+
+    it('strips the model_type: prefix when resolving the provider in model_type mode', () => {
+      mockSupportsModelTypeTags.value = true
+      mockProvider(createMockNodeProvider())
+      const result = resolveModelNodeFromAsset(
+        createMockAsset({ tags: ['models', 'model_type:vae'] })
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockGetNodeProvider).toHaveBeenCalledWith('vae')
     })
 
     it('falls back to metadata.filename when user_metadata.filename missing', () => {

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { resolveModelNodeFromAsset } from '@/platform/assets/utils/resolveModelNodeFromAsset'
@@ -61,6 +61,10 @@ describe('resolveModelNodeFromAsset', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     mockSupportsModelTypeTags.value = false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('valid assets', () => {

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.ts
@@ -114,6 +114,9 @@ export function resolveModelNodeFromAsset(
     .find((candidate) => candidate.provider !== undefined)
 
   if (!resolved?.provider) {
+    // Known gap (out of scope for FE-1076): flat `model_type:LLM`-style tags
+    // whose loaders are only registered hierarchically land here until the
+    // backend emits a subtype-carrying tag.
     console.error(
       `No node provider registered for category: ${candidates.join(', ')}`
     )

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.ts
@@ -4,7 +4,11 @@ import {
   MISSING_TAG,
   MODELS_TAG
 } from '@/platform/assets/services/assetService'
-import { getAssetFilename } from '@/platform/assets/utils/assetMetadataUtils'
+import {
+  getAssetFilename,
+  getAssetNodeCategory
+} from '@/platform/assets/utils/assetMetadataUtils'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
 import type { ModelNodeProvider } from '@/stores/modelToNodeStore'
 
@@ -81,9 +85,8 @@ export function resolveModelNodeFromAsset(
     }
   }
 
-  const category = validAsset.tags.find(
-    (tag) => tag !== MODELS_TAG && tag !== MISSING_TAG
-  )
+  const { flags } = useFeatureFlags()
+  const category = getAssetNodeCategory(validAsset, flags.supportsModelTypeTags)
   if (!category) {
     console.error(
       `Asset ${validAsset.id} has no valid category tag. Available tags: ${validAsset.tags.join(', ')} (expected tag other than '${MODELS_TAG}' or '${MISSING_TAG}')`

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.ts
@@ -6,7 +6,7 @@ import {
 } from '@/platform/assets/services/assetService'
 import {
   getAssetFilename,
-  getAssetNodeCategory
+  getAssetNodeCategoryCandidates
 } from '@/platform/assets/utils/assetMetadataUtils'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useModelToNodeStore } from '@/stores/modelToNodeStore'
@@ -86,8 +86,11 @@ export function resolveModelNodeFromAsset(
   }
 
   const { flags } = useFeatureFlags()
-  const category = getAssetNodeCategory(validAsset, flags.supportsModelTypeTags)
-  if (!category) {
+  const candidates = getAssetNodeCategoryCandidates(
+    validAsset,
+    flags.supportsModelTypeTags
+  )
+  if (candidates.length === 0) {
     console.error(
       `Asset ${validAsset.id} has no valid category tag. Available tags: ${validAsset.tags.join(', ')} (expected tag other than '${MODELS_TAG}' or '${MISSING_TAG}')`
     )
@@ -102,19 +105,28 @@ export function resolveModelNodeFromAsset(
     }
   }
 
-  const provider = useModelToNodeStore().getNodeProvider(category)
-  if (!provider) {
-    console.error(`No node provider registered for category: ${category}`)
+  const modelToNodeStore = useModelToNodeStore()
+  const resolved = candidates
+    .map((category) => ({
+      category,
+      provider: modelToNodeStore.getNodeProvider(category)
+    }))
+    .find((candidate) => candidate.provider !== undefined)
+
+  if (!resolved?.provider) {
+    console.error(
+      `No node provider registered for category: ${candidates.join(', ')}`
+    )
     return {
       success: false,
       error: {
         code: 'NO_PROVIDER',
-        message: `No node provider registered for category: ${category}`,
+        message: `No node provider registered for category: ${candidates.join(', ')}`,
         assetId: validAsset.id,
-        details: { category }
+        details: { candidates }
       }
     }
   }
 
-  return { success: true, value: { provider, filename } }
+  return { success: true, value: { provider: resolved.provider, filename } }
 }

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -1875,6 +1875,35 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
   })
 })
 
+describe('assetsStore - Model Assets Cache (non-cloud)', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    mockIsCloud.value = false
+    vi.clearAllMocks()
+  })
+
+  it('caches model assets fetched by tag on non-cloud builds', async () => {
+    const store = useAssetsStore()
+    vi.mocked(assetService.getAssetsByTag).mockResolvedValue([
+      {
+        id: 'm1',
+        name: 'sd_xl_base_1.0.safetensors',
+        tags: ['checkpoints', 'models']
+      },
+      { id: 'm2', name: 'lora.safetensors', tags: ['loras', 'models'] }
+    ])
+
+    await store.updateModelsForTag('models')
+
+    expect(assetService.getAssetsByTag).toHaveBeenCalledWith(
+      'models',
+      true,
+      expect.anything()
+    )
+    expect(store.getAssets('tag:models')).toHaveLength(2)
+  })
+})
+
 describe('assetsStore - Deletion State and Input Mapping', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -987,7 +987,6 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
         'p3'
       ])
     })
-
   })
 
   describe('refresh error surfacing', () => {
@@ -995,13 +994,13 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       const store = useAssetsStore()
       const nodeType = 'CheckpointLoaderSimple'
 
-      vi.mocked(assetService.getAssetsForNodeType).mockResolvedValueOnce([
-        createMockAsset('existing')
-      ])
+      vi.mocked(assetService.getAssetsPageForNodeType).mockResolvedValueOnce(
+        makePage([createMockAsset('existing')])
+      )
       await store.updateModelsForNodeType(nodeType)
       expect(store.getError(nodeType)).toBeUndefined()
 
-      vi.mocked(assetService.getAssetsForNodeType).mockRejectedValueOnce(
+      vi.mocked(assetService.getAssetsPageForNodeType).mockRejectedValueOnce(
         new Error('backend down')
       )
       await store.updateModelsForNodeType(nodeType)
@@ -1067,19 +1066,19 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       const store = useAssetsStore()
       const nodeType = 'CheckpointLoaderSimple'
 
-      let resolveFirst!: (assets: AssetItem[]) => void
-      const firstFetch = new Promise<AssetItem[]>((resolve) => {
+      let resolveFirst!: (response: AssetResponse) => void
+      const firstFetch = new Promise<AssetResponse>((resolve) => {
         resolveFirst = resolve
       })
-      vi.mocked(assetService.getAssetsForNodeType)
+      vi.mocked(assetService.getAssetsPageForNodeType)
         .mockReturnValueOnce(firstFetch)
-        .mockReturnValue(new Promise<AssetItem[]>(() => {}))
+        .mockReturnValue(new Promise<AssetResponse>(() => {}))
 
       const staleRequest = store.updateModelsForNodeType(nodeType)
       store.invalidateCategory('checkpoints')
       void store.updateModelsForNodeType(nodeType)
 
-      resolveFirst([createMockAsset('stale')])
+      resolveFirst(makePage([createMockAsset('stale')]))
       await staleRequest
 
       // The stale request's teardown must not evict the newer request's
@@ -1087,7 +1086,7 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       // a duplicate walk.
       void store.updateModelsForNodeType(nodeType)
       expect(
-        vi.mocked(assetService.getAssetsForNodeType)
+        vi.mocked(assetService.getAssetsPageForNodeType)
       ).toHaveBeenCalledTimes(2)
     })
   })
@@ -1934,18 +1933,22 @@ describe('assetsStore - Model Assets Cache (non-cloud)', () => {
 
   it('caches model assets fetched by tag on non-cloud builds', async () => {
     const store = useAssetsStore()
-    vi.mocked(assetService.getAssetsByTag).mockResolvedValue([
-      {
-        id: 'm1',
-        name: 'sd_xl_base_1.0.safetensors',
-        tags: ['checkpoints', 'models']
-      },
-      { id: 'm2', name: 'lora.safetensors', tags: ['loras', 'models'] }
-    ])
+    vi.mocked(assetService.getAssetsPageByTag).mockResolvedValue({
+      assets: [
+        {
+          id: 'm1',
+          name: 'sd_xl_base_1.0.safetensors',
+          tags: ['checkpoints', 'models']
+        },
+        { id: 'm2', name: 'lora.safetensors', tags: ['loras', 'models'] }
+      ],
+      total: 2,
+      has_more: false
+    })
 
     await store.updateModelsForTag('models')
 
-    expect(assetService.getAssetsByTag).toHaveBeenCalledWith(
+    expect(assetService.getAssetsPageByTag).toHaveBeenCalledWith(
       'models',
       true,
       expect.anything()

--- a/src/stores/assetsStore.test.ts
+++ b/src/stores/assetsStore.test.ts
@@ -987,6 +987,28 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
         'p3'
       ])
     })
+
+  })
+
+  describe('refresh error surfacing', () => {
+    it('surfaces a failed refresh on the committed state consumers read', async () => {
+      const store = useAssetsStore()
+      const nodeType = 'CheckpointLoaderSimple'
+
+      vi.mocked(assetService.getAssetsForNodeType).mockResolvedValueOnce([
+        createMockAsset('existing')
+      ])
+      await store.updateModelsForNodeType(nodeType)
+      expect(store.getError(nodeType)).toBeUndefined()
+
+      vi.mocked(assetService.getAssetsForNodeType).mockRejectedValueOnce(
+        new Error('backend down')
+      )
+      await store.updateModelsForNodeType(nodeType)
+
+      expect(store.getAssets(nodeType).map((a) => a.id)).toEqual(['existing'])
+      expect(store.getError(nodeType)?.message).toBe('backend down')
+    })
   })
 
   describe('concurrent request handling', () => {
@@ -1038,6 +1060,34 @@ describe('assetsStore - Model Assets Cache (Cloud)', () => {
       expect(store.getAssets(nodeType)).toHaveLength(2)
       expect(
         vi.mocked(assetService.getAssetsPageForNodeType)
+      ).toHaveBeenCalledTimes(2)
+    })
+
+    it('keeps a newer request single-flighted when a stale request finishes after invalidation', async () => {
+      const store = useAssetsStore()
+      const nodeType = 'CheckpointLoaderSimple'
+
+      let resolveFirst!: (assets: AssetItem[]) => void
+      const firstFetch = new Promise<AssetItem[]>((resolve) => {
+        resolveFirst = resolve
+      })
+      vi.mocked(assetService.getAssetsForNodeType)
+        .mockReturnValueOnce(firstFetch)
+        .mockReturnValue(new Promise<AssetItem[]>(() => {}))
+
+      const staleRequest = store.updateModelsForNodeType(nodeType)
+      store.invalidateCategory('checkpoints')
+      void store.updateModelsForNodeType(nodeType)
+
+      resolveFirst([createMockAsset('stale')])
+      await staleRequest
+
+      // The stale request's teardown must not evict the newer request's
+      // single-flight entry: a third call short-circuits instead of starting
+      // a duplicate walk.
+      void store.updateModelsForNodeType(nodeType)
+      expect(
+        vi.mocked(assetService.getAssetsForNodeType)
       ).toHaveBeenCalledTimes(2)
     })
   })

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -410,6 +410,10 @@ export const useAssetsStore = defineStore('assets', () => {
    * Multiple node types sharing the same category share the same cache entry.
    * Public API accepts nodeType for backwards compatibility but translates
    * to category internally using modelToNodeStore.getCategoryForNodeType().
+   *
+   * Runs on every distribution; whether anything fetches through it is
+   * decided by consumers via `assetService.isAssetAPIEnabled()`, which stays
+   * the authoritative off-cloud gate.
    */
   const getModelState = () => {
     const modelStateByCategory = ref(new Map<string, ModelPaginationState>())
@@ -653,7 +657,16 @@ export const useAssetsStore = defineStore('assets', () => {
             state.error = err instanceof Error ? err : new Error(String(err))
             state.hasMore = false
             state.isLoading = false
-            pendingRequestByCategory.delete(category)
+            // A refresh that fails before its first batch never replaces the
+            // committed state, so mirror the error onto the state consumers
+            // actually read (getError) instead of only the discarded one.
+            const committed = modelStateByCategory.value.get(category)
+            if (committed && committed !== state) {
+              committed.error = state.error
+            }
+            if (pendingRequestByCategory.get(category) === state) {
+              pendingRequestByCategory.delete(category)
+            }
 
             return
           }
@@ -671,7 +684,9 @@ export const useAssetsStore = defineStore('assets', () => {
           }
         }
         assetsArrayCache.delete(category)
-        pendingRequestByCategory.delete(category)
+        if (pendingRequestByCategory.get(category) === state) {
+          pendingRequestByCategory.delete(category)
+        }
       }
 
       const promise = loadBatches()

--- a/src/stores/assetsStore.ts
+++ b/src/stores/assetsStore.ts
@@ -410,504 +410,485 @@ export const useAssetsStore = defineStore('assets', () => {
    * Multiple node types sharing the same category share the same cache entry.
    * Public API accepts nodeType for backwards compatibility but translates
    * to category internally using modelToNodeStore.getCategoryForNodeType().
-   * Cloud-only feature - empty Maps in desktop builds
    */
   const getModelState = () => {
-    if (isCloud) {
-      const modelStateByCategory = ref(new Map<string, ModelPaginationState>())
+    const modelStateByCategory = ref(new Map<string, ModelPaginationState>())
 
-      const assetsArrayCache = new Map<
-        string,
-        { source: Map<string, AssetItem>; array: AssetItem[] }
-      >()
+    const assetsArrayCache = new Map<
+      string,
+      { source: Map<string, AssetItem>; array: AssetItem[] }
+    >()
 
-      const pendingRequestByCategory = new Map<string, ModelPaginationState>()
-      const pendingPromiseByCategory = new Map<string, Promise<void>>()
-      const abortByCategory = new Map<string, AbortController>()
+    const pendingRequestByCategory = new Map<string, ModelPaginationState>()
+    const pendingPromiseByCategory = new Map<string, Promise<void>>()
+    const abortByCategory = new Map<string, AbortController>()
 
-      function createState(
-        existingAssets?: Map<string, AssetItem>
-      ): ModelPaginationState {
-        const assets = new Map(existingAssets)
-        return reactive({
-          assets,
-          offset: 0,
-          nextCursor: undefined,
-          hasMore: true,
-          isLoading: true
-        })
+    function createState(
+      existingAssets?: Map<string, AssetItem>
+    ): ModelPaginationState {
+      const assets = new Map(existingAssets)
+      return reactive({
+        assets,
+        offset: 0,
+        nextCursor: undefined,
+        hasMore: true,
+        isLoading: true
+      })
+    }
+
+    function isStale(category: string, state: ModelPaginationState): boolean {
+      const committed = modelStateByCategory.value.get(category)
+      const pending = pendingRequestByCategory.get(category)
+      return committed !== state && pending !== state
+    }
+
+    const EMPTY_ASSETS: AssetItem[] = []
+
+    /**
+     * Resolve a key to a category. Handles both nodeType and tag:xxx formats.
+     * @param key Either a nodeType (e.g., 'CheckpointLoaderSimple') or tag key (e.g., 'tag:models')
+     * @returns The category or undefined if not resolvable
+     */
+    function resolveCategory(key: string): string | undefined {
+      if (key.startsWith('tag:')) {
+        return key
+      }
+      return modelToNodeStore.getCategoryForNodeType(key)
+    }
+
+    /**
+     * Get assets by nodeType or tag key.
+     * Translates nodeType to category internally for cache lookup.
+     * @param key Either a nodeType (e.g., 'CheckpointLoaderSimple') or tag key (e.g., 'tag:models')
+     */
+    function getAssets(key: string): AssetItem[] {
+      const category = resolveCategory(key)
+      if (!category) return EMPTY_ASSETS
+
+      const state = modelStateByCategory.value.get(category)
+      const assetsMap = state?.assets
+      if (!assetsMap) return EMPTY_ASSETS
+
+      const cached = assetsArrayCache.get(category)
+      if (cached && cached.source === assetsMap) {
+        return cached.array
       }
 
-      function isStale(category: string, state: ModelPaginationState): boolean {
-        const committed = modelStateByCategory.value.get(category)
-        const pending = pendingRequestByCategory.get(category)
-        return committed !== state && pending !== state
+      const array = Array.from(assetsMap.values())
+      assetsArrayCache.set(category, { source: assetsMap, array })
+      return array
+    }
+
+    function isLoading(key: string): boolean {
+      const category = resolveCategory(key)
+      if (!category) return false
+      return modelStateByCategory.value.get(category)?.isLoading ?? false
+    }
+
+    function getError(key: string): Error | undefined {
+      const category = resolveCategory(key)
+      if (!category) return undefined
+      return modelStateByCategory.value.get(category)?.error
+    }
+
+    function hasMore(key: string): boolean {
+      const category = resolveCategory(key)
+      if (!category) return false
+      return modelStateByCategory.value.get(category)?.hasMore ?? false
+    }
+
+    function hasAssetKey(key: string): boolean {
+      const category = resolveCategory(key)
+      if (!category) return false
+      return modelStateByCategory.value.has(category)
+    }
+
+    /**
+     * Check if a category exists in the cache.
+     * Checks both direct category keys and tag-prefixed keys.
+     * @param category The category to check (e.g., 'checkpoints', 'loras')
+     */
+    function hasCategory(category: string): boolean {
+      return (
+        modelStateByCategory.value.has(category) ||
+        modelStateByCategory.value.has(`tag:${category}`)
+      )
+    }
+
+    /**
+     * Internal helper to fetch and cache assets for a category.
+     * Loads first batch immediately, then progressively loads remaining batches.
+     * Keeps existing data visible until new data is successfully fetched.
+     *
+     * Concurrent calls for the same category are short-circuited: if a request
+     * is already in progress (tracked via pendingRequestByCategory), subsequent
+     * calls return immediately to avoid redundant work.
+     */
+    async function updateModelsForCategory(
+      category: string,
+      fetcher: (options: AssetPaginationOptions) => Promise<AssetResponse>
+    ): Promise<void> {
+      if (pendingPromiseByCategory.has(category)) {
+        return pendingPromiseByCategory.get(category)!
       }
 
-      const EMPTY_ASSETS: AssetItem[] = []
+      const existingState = modelStateByCategory.value.get(category)
+      const state = createState(existingState?.assets)
 
-      /**
-       * Resolve a key to a category. Handles both nodeType and tag:xxx formats.
-       * @param key Either a nodeType (e.g., 'CheckpointLoaderSimple') or tag key (e.g., 'tag:models')
-       * @returns The category or undefined if not resolvable
-       */
-      function resolveCategory(key: string): string | undefined {
-        if (key.startsWith('tag:')) {
-          return key
-        }
-        return modelToNodeStore.getCategoryForNodeType(key)
+      abortByCategory.get(category)?.abort()
+      const controller = new AbortController()
+      abortByCategory.set(category, controller)
+
+      const seenIds = new Set<string>()
+
+      const hasExistingData = modelStateByCategory.value.has(category)
+      if (hasExistingData) {
+        pendingRequestByCategory.set(category, state)
+      } else {
+        // Also track in pending map for initial loads to prevent concurrent calls
+        pendingRequestByCategory.set(category, state)
+        modelStateByCategory.value.set(category, state)
       }
 
-      /**
-       * Get assets by nodeType or tag key.
-       * Translates nodeType to category internally for cache lookup.
-       * @param key Either a nodeType (e.g., 'CheckpointLoaderSimple') or tag key (e.g., 'tag:models')
-       */
-      function getAssets(key: string): AssetItem[] {
-        const category = resolveCategory(key)
-        if (!category) return EMPTY_ASSETS
+      async function loadBatches(): Promise<void> {
+        let isFirstBatch = true
+        // Only prune unseen cached ids when the walk reaches a genuine end
+        // of list; bailing out on an anomaly (empty page, cursor cycle,
+        // batch cap) must not delete assets we simply never re-fetched.
+        let walkCompleted = false
+        // Cursors already requested this walk. A repeat means the server is
+        // cycling (immediate A->A or alternating A->B->A...), so we stop.
+        const seenCursors = new Set<string>()
+        let batchCount = 0
+        while (state.hasMore) {
+          if (batchCount++ >= MAX_PAGINATION_BATCHES) {
+            state.hasMore = false
+            break
+          }
+          try {
+            // Keyset cursor walk when the server provides one (stable under
+            // concurrent inserts/deletes); offset walk otherwise. The first
+            // batch sends offset 0, which the service omits from the request.
+            const after = state.nextCursor
+            const response = await fetcher(
+              after !== undefined
+                ? {
+                    limit: MODEL_BATCH_SIZE,
+                    after,
+                    signal: controller.signal
+                  }
+                : {
+                    limit: MODEL_BATCH_SIZE,
+                    offset: state.offset,
+                    signal: controller.signal
+                  }
+            )
 
-        const state = modelStateByCategory.value.get(category)
-        const assetsMap = state?.assets
-        if (!assetsMap) return EMPTY_ASSETS
+            if (isStale(category, state)) return
 
-        const cached = assetsArrayCache.get(category)
-        if (cached && cached.source === assetsMap) {
-          return cached.array
-        }
+            const newAssets = response.assets
 
-        const array = Array.from(assetsMap.values())
-        assetsArrayCache.set(category, { source: assetsMap, array })
-        return array
-      }
-
-      function isLoading(key: string): boolean {
-        const category = resolveCategory(key)
-        if (!category) return false
-        return modelStateByCategory.value.get(category)?.isLoading ?? false
-      }
-
-      function getError(key: string): Error | undefined {
-        const category = resolveCategory(key)
-        if (!category) return undefined
-        return modelStateByCategory.value.get(category)?.error
-      }
-
-      function hasMore(key: string): boolean {
-        const category = resolveCategory(key)
-        if (!category) return false
-        return modelStateByCategory.value.get(category)?.hasMore ?? false
-      }
-
-      function hasAssetKey(key: string): boolean {
-        const category = resolveCategory(key)
-        if (!category) return false
-        return modelStateByCategory.value.has(category)
-      }
-
-      /**
-       * Check if a category exists in the cache.
-       * Checks both direct category keys and tag-prefixed keys.
-       * @param category The category to check (e.g., 'checkpoints', 'loras')
-       */
-      function hasCategory(category: string): boolean {
-        return (
-          modelStateByCategory.value.has(category) ||
-          modelStateByCategory.value.has(`tag:${category}`)
-        )
-      }
-
-      /**
-       * Internal helper to fetch and cache assets for a category.
-       * Loads first batch immediately, then progressively loads remaining batches.
-       * Keeps existing data visible until new data is successfully fetched.
-       *
-       * Concurrent calls for the same category are short-circuited: if a request
-       * is already in progress (tracked via pendingRequestByCategory), subsequent
-       * calls return immediately to avoid redundant work.
-       */
-      async function updateModelsForCategory(
-        category: string,
-        fetcher: (options: AssetPaginationOptions) => Promise<AssetResponse>
-      ): Promise<void> {
-        if (pendingPromiseByCategory.has(category)) {
-          return pendingPromiseByCategory.get(category)!
-        }
-
-        const existingState = modelStateByCategory.value.get(category)
-        const state = createState(existingState?.assets)
-
-        abortByCategory.get(category)?.abort()
-        const controller = new AbortController()
-        abortByCategory.set(category, controller)
-
-        const seenIds = new Set<string>()
-
-        const hasExistingData = modelStateByCategory.value.has(category)
-        if (hasExistingData) {
-          pendingRequestByCategory.set(category, state)
-        } else {
-          // Also track in pending map for initial loads to prevent concurrent calls
-          pendingRequestByCategory.set(category, state)
-          modelStateByCategory.value.set(category, state)
-        }
-
-        async function loadBatches(): Promise<void> {
-          let isFirstBatch = true
-          // Only prune unseen cached ids when the walk reaches a genuine end
-          // of list; bailing out on an anomaly (empty page, cursor cycle,
-          // batch cap) must not delete assets we simply never re-fetched.
-          let walkCompleted = false
-          // Cursors already requested this walk. A repeat means the server is
-          // cycling (immediate A->A or alternating A->B->A...), so we stop.
-          const seenCursors = new Set<string>()
-          let batchCount = 0
-          while (state.hasMore) {
-            if (batchCount++ >= MAX_PAGINATION_BATCHES) {
-              state.hasMore = false
-              break
+            if (isFirstBatch) {
+              assetsArrayCache.delete(category)
+              if (hasExistingData) {
+                pendingRequestByCategory.delete(category)
+                modelStateByCategory.value.set(category, state)
+              }
             }
-            try {
-              // Keyset cursor walk when the server provides one (stable under
-              // concurrent inserts/deletes); offset walk otherwise. The first
-              // batch sends offset 0, which the service omits from the request.
-              const after = state.nextCursor
-              const response = await fetcher(
-                after !== undefined
-                  ? {
-                      limit: MODEL_BATCH_SIZE,
-                      after,
-                      signal: controller.signal
-                    }
-                  : {
-                      limit: MODEL_BATCH_SIZE,
-                      offset: state.offset,
-                      signal: controller.signal
-                    }
-              )
 
-              if (isStale(category, state)) return
+            // Merge new assets into existing map and track seen IDs
+            for (const asset of newAssets) {
+              seenIds.add(asset.id)
+              state.assets.set(asset.id, asset)
+            }
+            state.assets = new Map(state.assets)
 
-              const newAssets = response.assets
+            state.offset += newAssets.length
 
-              if (isFirstBatch) {
-                assetsArrayCache.delete(category)
-                if (hasExistingData) {
-                  pendingRequestByCategory.delete(category)
-                  modelStateByCategory.value.set(category, state)
-                }
+            if (!response.has_more) {
+              // Server signalled a genuine end of list — safe to prune ids
+              // that no longer exist server-side.
+              state.hasMore = false
+              walkCompleted = true
+            } else if (newAssets.length === 0) {
+              // Anomaly: server claims more but returned an empty page. Stop,
+              // but do not prune — unseen cached assets may still live on a
+              // page we never received.
+              state.hasMore = false
+            } else if (response.next_cursor !== undefined) {
+              if (seenCursors.has(response.next_cursor)) {
+                // Repeated cursor: the server is cycling. Stop without
+                // pruning rather than loop forever.
+                state.hasMore = false
+              } else {
+                seenCursors.add(response.next_cursor)
+                state.nextCursor = response.next_cursor
               }
-
-              // Merge new assets into existing map and track seen IDs
-              for (const asset of newAssets) {
-                seenIds.add(asset.id)
-                state.assets.set(asset.id, asset)
-              }
-              state.assets = new Map(state.assets)
-
-              state.offset += newAssets.length
-
-              if (!response.has_more) {
-                // Server signalled a genuine end of list — safe to prune ids
-                // that no longer exist server-side.
+            } else {
+              // Cursor-less backend: legacy offset walk. A short page is the
+              // reliable natural end of the list, so it is safe to prune.
+              state.nextCursor = undefined
+              if (newAssets.length < MODEL_BATCH_SIZE) {
                 state.hasMore = false
                 walkCompleted = true
-              } else if (newAssets.length === 0) {
-                // Anomaly: server claims more but returned an empty page. Stop,
-                // but do not prune — unseen cached assets may still live on a
-                // page we never received.
-                state.hasMore = false
-              } else if (response.next_cursor !== undefined) {
-                if (seenCursors.has(response.next_cursor)) {
-                  // Repeated cursor: the server is cycling. Stop without
-                  // pruning rather than loop forever.
-                  state.hasMore = false
-                } else {
-                  seenCursors.add(response.next_cursor)
-                  state.nextCursor = response.next_cursor
-                }
-              } else {
-                // Cursor-less backend: legacy offset walk. A short page is the
-                // reliable natural end of the list, so it is safe to prune.
-                state.nextCursor = undefined
-                if (newAssets.length < MODEL_BATCH_SIZE) {
-                  state.hasMore = false
-                  walkCompleted = true
-                }
               }
+            }
 
-              if (isFirstBatch) {
-                state.isLoading = false
-                isFirstBatch = false
-              }
-
-              if (state.hasMore) {
-                await delay(50, { signal: controller.signal })
-              }
-            } catch (err) {
-              if (controller.signal.aborted) {
-                if (isFirstBatch) state.isLoading = false
-                return
-              }
-              if (isStale(category, state)) return
-              console.error(`Error loading batch for ${category}:`, err)
-
-              state.error = err instanceof Error ? err : new Error(String(err))
-              state.hasMore = false
+            if (isFirstBatch) {
               state.isLoading = false
-              pendingRequestByCategory.delete(category)
+              isFirstBatch = false
+            }
 
+            if (state.hasMore) {
+              await delay(50, { signal: controller.signal })
+            }
+          } catch (err) {
+            if (controller.signal.aborted) {
+              if (isFirstBatch) state.isLoading = false
               return
             }
-          }
+            if (isStale(category, state)) return
+            console.error(`Error loading batch for ${category}:`, err)
 
-          // Prune ids that vanished server-side, but only after a complete
-          // walk — an early bail-out hasn't seen the whole list, so unseen
-          // cached assets must be kept rather than deleted.
-          if (walkCompleted) {
-            const staleIds = [...state.assets.keys()].filter(
-              (id) => !seenIds.has(id)
-            )
-            for (const id of staleIds) {
-              state.assets.delete(id)
-            }
-          }
-          assetsArrayCache.delete(category)
-          pendingRequestByCategory.delete(category)
-        }
+            state.error = err instanceof Error ? err : new Error(String(err))
+            state.hasMore = false
+            state.isLoading = false
+            pendingRequestByCategory.delete(category)
 
-        const promise = loadBatches()
-        pendingPromiseByCategory.set(category, promise)
-        try {
-          await promise
-        } finally {
-          // Only clear the guards if this walk still owns them — an
-          // invalidateCategory() + fresh walk can register a newer promise and
-          // controller for the same category before this teardown runs.
-          if (pendingPromiseByCategory.get(category) === promise) {
-            pendingPromiseByCategory.delete(category)
-          }
-          if (abortByCategory.get(category) === controller) {
-            abortByCategory.delete(category)
+            return
           }
         }
-      }
 
-      /**
-       * Fetch and cache model assets for a specific node type.
-       * Translates nodeType to category internally - multiple node types
-       * sharing the same category will share the same cache entry.
-       * @param nodeType The node type to fetch assets for (e.g., 'CheckpointLoaderSimple')
-       */
-      async function updateModelsForNodeType(nodeType: string): Promise<void> {
-        const category = modelToNodeStore.getCategoryForNodeType(nodeType)
-        if (!category) return
-
-        // Use category as cache key but fetch using nodeType for API compatibility
-        await updateModelsForCategory(category, (opts) =>
-          assetService.getAssetsPageForNodeType(nodeType, opts)
-        )
-      }
-
-      /**
-       * Fetch and cache model assets for a specific tag
-       * @param tag The tag to fetch assets for (e.g., 'models')
-       */
-      async function updateModelsForTag(tag: string): Promise<void> {
-        const category = `tag:${tag}`
-        await updateModelsForCategory(category, (opts) =>
-          assetService.getAssetsPageByTag(tag, true, opts)
-        )
-      }
-
-      /**
-       * Invalidate the cache for a specific category.
-       * Forces a refetch on next access.
-       * @param category The category to invalidate (e.g., 'checkpoints', 'loras')
-       */
-      function invalidateCategory(category: string): void {
-        abortByCategory.get(category)?.abort()
-        abortByCategory.delete(category)
-        modelStateByCategory.value.delete(category)
+        // Prune ids that vanished server-side, but only after a complete
+        // walk — an early bail-out hasn't seen the whole list, so unseen
+        // cached assets must be kept rather than deleted.
+        if (walkCompleted) {
+          const staleIds = [...state.assets.keys()].filter(
+            (id) => !seenIds.has(id)
+          )
+          for (const id of staleIds) {
+            state.assets.delete(id)
+          }
+        }
         assetsArrayCache.delete(category)
         pendingRequestByCategory.delete(category)
-        pendingPromiseByCategory.delete(category)
       }
 
-      /**
-       * Optimistically update an asset in the cache
-       * @param assetId The asset ID to update
-       * @param updates Partial asset data to merge
-       * @param cacheKey Optional cache key to target (nodeType or 'tag:xxx')
-       */
-      function updateAssetInCache(
-        assetId: string,
-        updates: Partial<AssetItem>,
-        cacheKey?: string
-      ) {
-        const category = cacheKey ? resolveCategory(cacheKey) : undefined
-        if (cacheKey && !category) return
-
-        const categoriesToCheck = category
-          ? [category]
-          : Array.from(modelStateByCategory.value.keys())
-
-        for (const cat of categoriesToCheck) {
-          const state = modelStateByCategory.value.get(cat)
-          if (!state?.assets) continue
-
-          const existingAsset = state.assets.get(assetId)
-          if (existingAsset) {
-            const updatedAsset = { ...existingAsset, ...updates }
-            state.assets.set(assetId, updatedAsset)
-            assetsArrayCache.delete(cat)
-            if (cacheKey) return
-          }
+      const promise = loadBatches()
+      pendingPromiseByCategory.set(category, promise)
+      try {
+        await promise
+      } finally {
+        // Only clear the guards if this walk still owns them — an
+        // invalidateCategory() + fresh walk can register a newer promise and
+        // controller for the same category before this teardown runs.
+        if (pendingPromiseByCategory.get(category) === promise) {
+          pendingPromiseByCategory.delete(category)
         }
-      }
-
-      /**
-       * Update asset metadata with optimistic cache update
-       * @param asset The asset to update
-       * @param userMetadata The user_metadata to save
-       * @param cacheKey Optional cache key to target for optimistic update
-       */
-      async function updateAssetMetadata(
-        asset: AssetItem,
-        userMetadata: Record<string, unknown>,
-        cacheKey?: string
-      ) {
-        const originalMetadata = asset.user_metadata
-        updateAssetInCache(asset.id, { user_metadata: userMetadata }, cacheKey)
-
-        try {
-          const updatedAsset = await assetService.updateAsset(asset.id, {
-            user_metadata: userMetadata
-          })
-          updateAssetInCache(asset.id, updatedAsset, cacheKey)
-        } catch (error) {
-          console.error('Failed to update asset metadata:', error)
-          updateAssetInCache(
-            asset.id,
-            { user_metadata: originalMetadata },
-            cacheKey
-          )
+        if (abortByCategory.get(category) === controller) {
+          abortByCategory.delete(category)
         }
-      }
-
-      /**
-       * Update asset tags using add/remove endpoints
-       * @param asset The asset to update (used to read current tags)
-       * @param newTags The desired tags array
-       * @param cacheKey Optional cache key to target for optimistic update
-       */
-      async function updateAssetTags(
-        asset: AssetItem,
-        newTags: string[],
-        cacheKey?: string
-      ) {
-        const originalTags = asset.tags
-        const tagsToAdd = difference(newTags, originalTags)
-        const tagsToRemove = difference(originalTags, newTags)
-
-        if (tagsToAdd.length === 0 && tagsToRemove.length === 0) return
-
-        updateAssetInCache(asset.id, { tags: newTags }, cacheKey)
-
-        let removedTagsOnServer: string[] = []
-        try {
-          let removeResult: TagsOperationResult | undefined
-          if (tagsToRemove.length > 0) {
-            removeResult = await assetService.removeAssetTags(
-              asset.id,
-              tagsToRemove
-            )
-            removedTagsOnServer = removeResult.removed ?? tagsToRemove
-          }
-
-          const addResult =
-            tagsToAdd.length > 0
-              ? await assetService.addAssetTags(asset.id, tagsToAdd)
-              : undefined
-
-          const finalTags = (addResult ?? removeResult)?.total_tags
-          if (finalTags) {
-            updateAssetInCache(asset.id, { tags: finalTags }, cacheKey)
-          }
-        } catch (error) {
-          console.error('Failed to update asset tags:', error)
-          updateAssetInCache(asset.id, { tags: originalTags }, cacheKey)
-
-          if (removedTagsOnServer.length > 0) {
-            try {
-              await assetService.addAssetTags(asset.id, removedTagsOnServer)
-            } catch (compensationError) {
-              console.error(
-                'Failed to restore tags after partial failure; invalidating cache to force refetch:',
-                compensationError
-              )
-              const categoriesToInvalidate = new Set<string>()
-              const resolved = cacheKey ? resolveCategory(cacheKey) : undefined
-              if (resolved) {
-                categoriesToInvalidate.add(resolved)
-              }
-              for (const [
-                category,
-                state
-              ] of modelStateByCategory.value.entries()) {
-                if (state.assets?.has(asset.id)) {
-                  categoriesToInvalidate.add(category)
-                }
-              }
-              for (const category of categoriesToInvalidate) {
-                invalidateCategory(category)
-              }
-            }
-          }
-        }
-      }
-
-      /**
-       * Invalidate model caches for a given category (e.g., 'checkpoints', 'loras')
-       * Clears the category cache and tag-based caches so next access triggers refetch
-       * @param category The model category to invalidate (e.g., 'checkpoints')
-       */
-      function invalidateModelsForCategory(category: string): void {
-        invalidateCategory(category)
-        invalidateCategory(`tag:${category}`)
-        invalidateCategory('tag:models')
-      }
-
-      return {
-        getAssets,
-        isLoading,
-        getError,
-        hasMore,
-        hasAssetKey,
-        hasCategory,
-        updateModelsForNodeType,
-        updateModelsForTag,
-        invalidateCategory,
-        updateAssetMetadata,
-        updateAssetTags,
-        invalidateModelsForCategory
       }
     }
 
-    const emptyAssets: AssetItem[] = []
+    /**
+     * Fetch and cache model assets for a specific node type.
+     * Translates nodeType to category internally - multiple node types
+     * sharing the same category will share the same cache entry.
+     * @param nodeType The node type to fetch assets for (e.g., 'CheckpointLoaderSimple')
+     */
+    async function updateModelsForNodeType(nodeType: string): Promise<void> {
+      const category = modelToNodeStore.getCategoryForNodeType(nodeType)
+      if (!category) return
+
+      // Use category as cache key but fetch using nodeType for API compatibility
+      await updateModelsForCategory(category, (opts) =>
+        assetService.getAssetsPageForNodeType(nodeType, opts)
+      )
+    }
+
+    /**
+     * Fetch and cache model assets for a specific tag
+     * @param tag The tag to fetch assets for (e.g., 'models')
+     */
+    async function updateModelsForTag(tag: string): Promise<void> {
+      const category = `tag:${tag}`
+      await updateModelsForCategory(category, (opts) =>
+        assetService.getAssetsPageByTag(tag, true, opts)
+      )
+    }
+
+    /**
+     * Invalidate the cache for a specific category.
+     * Forces a refetch on next access.
+     * @param category The category to invalidate (e.g., 'checkpoints', 'loras')
+     */
+    function invalidateCategory(category: string): void {
+      abortByCategory.get(category)?.abort()
+      abortByCategory.delete(category)
+      modelStateByCategory.value.delete(category)
+      assetsArrayCache.delete(category)
+      pendingRequestByCategory.delete(category)
+      pendingPromiseByCategory.delete(category)
+    }
+
+    /**
+     * Optimistically update an asset in the cache
+     * @param assetId The asset ID to update
+     * @param updates Partial asset data to merge
+     * @param cacheKey Optional cache key to target (nodeType or 'tag:xxx')
+     */
+    function updateAssetInCache(
+      assetId: string,
+      updates: Partial<AssetItem>,
+      cacheKey?: string
+    ) {
+      const category = cacheKey ? resolveCategory(cacheKey) : undefined
+      if (cacheKey && !category) return
+
+      const categoriesToCheck = category
+        ? [category]
+        : Array.from(modelStateByCategory.value.keys())
+
+      for (const cat of categoriesToCheck) {
+        const state = modelStateByCategory.value.get(cat)
+        if (!state?.assets) continue
+
+        const existingAsset = state.assets.get(assetId)
+        if (existingAsset) {
+          const updatedAsset = { ...existingAsset, ...updates }
+          state.assets.set(assetId, updatedAsset)
+          assetsArrayCache.delete(cat)
+          if (cacheKey) return
+        }
+      }
+    }
+
+    /**
+     * Update asset metadata with optimistic cache update
+     * @param asset The asset to update
+     * @param userMetadata The user_metadata to save
+     * @param cacheKey Optional cache key to target for optimistic update
+     */
+    async function updateAssetMetadata(
+      asset: AssetItem,
+      userMetadata: Record<string, unknown>,
+      cacheKey?: string
+    ) {
+      const originalMetadata = asset.user_metadata
+      updateAssetInCache(asset.id, { user_metadata: userMetadata }, cacheKey)
+
+      try {
+        const updatedAsset = await assetService.updateAsset(asset.id, {
+          user_metadata: userMetadata
+        })
+        updateAssetInCache(asset.id, updatedAsset, cacheKey)
+      } catch (error) {
+        console.error('Failed to update asset metadata:', error)
+        updateAssetInCache(
+          asset.id,
+          { user_metadata: originalMetadata },
+          cacheKey
+        )
+      }
+    }
+
+    /**
+     * Update asset tags using add/remove endpoints
+     * @param asset The asset to update (used to read current tags)
+     * @param newTags The desired tags array
+     * @param cacheKey Optional cache key to target for optimistic update
+     */
+    async function updateAssetTags(
+      asset: AssetItem,
+      newTags: string[],
+      cacheKey?: string
+    ) {
+      const originalTags = asset.tags
+      const tagsToAdd = difference(newTags, originalTags)
+      const tagsToRemove = difference(originalTags, newTags)
+
+      if (tagsToAdd.length === 0 && tagsToRemove.length === 0) return
+
+      updateAssetInCache(asset.id, { tags: newTags }, cacheKey)
+
+      let removedTagsOnServer: string[] = []
+      try {
+        let removeResult: TagsOperationResult | undefined
+        if (tagsToRemove.length > 0) {
+          removeResult = await assetService.removeAssetTags(
+            asset.id,
+            tagsToRemove
+          )
+          removedTagsOnServer = removeResult.removed ?? tagsToRemove
+        }
+
+        const addResult =
+          tagsToAdd.length > 0
+            ? await assetService.addAssetTags(asset.id, tagsToAdd)
+            : undefined
+
+        const finalTags = (addResult ?? removeResult)?.total_tags
+        if (finalTags) {
+          updateAssetInCache(asset.id, { tags: finalTags }, cacheKey)
+        }
+      } catch (error) {
+        console.error('Failed to update asset tags:', error)
+        updateAssetInCache(asset.id, { tags: originalTags }, cacheKey)
+
+        if (removedTagsOnServer.length > 0) {
+          try {
+            await assetService.addAssetTags(asset.id, removedTagsOnServer)
+          } catch (compensationError) {
+            console.error(
+              'Failed to restore tags after partial failure; invalidating cache to force refetch:',
+              compensationError
+            )
+            const categoriesToInvalidate = new Set<string>()
+            const resolved = cacheKey ? resolveCategory(cacheKey) : undefined
+            if (resolved) {
+              categoriesToInvalidate.add(resolved)
+            }
+            for (const [
+              category,
+              state
+            ] of modelStateByCategory.value.entries()) {
+              if (state.assets?.has(asset.id)) {
+                categoriesToInvalidate.add(category)
+              }
+            }
+            for (const category of categoriesToInvalidate) {
+              invalidateCategory(category)
+            }
+          }
+        }
+      }
+    }
+
+    /**
+     * Invalidate model caches for a given category (e.g., 'checkpoints', 'loras')
+     * Clears the category cache and tag-based caches so next access triggers refetch
+     * @param category The model category to invalidate (e.g., 'checkpoints')
+     */
+    function invalidateModelsForCategory(category: string): void {
+      invalidateCategory(category)
+      invalidateCategory(`tag:${category}`)
+      invalidateCategory('tag:models')
+    }
+
     return {
-      getAssets: () => emptyAssets,
-      isLoading: () => false,
-      getError: () => undefined,
-      hasMore: () => false,
-      hasAssetKey: () => false,
-      hasCategory: () => false,
-      updateModelsForNodeType: async () => {},
-      invalidateCategory: () => {},
-      updateModelsForTag: async () => {},
-      updateAssetMetadata: async () => {},
-      updateAssetTags: async () => {},
-      invalidateModelsForCategory: () => {}
+      getAssets,
+      isLoading,
+      getError,
+      hasMore,
+      hasAssetKey,
+      hasCategory,
+      updateModelsForNodeType,
+      updateModelsForTag,
+      invalidateCategory,
+      updateAssetMetadata,
+      updateAssetTags,
+      invalidateModelsForCategory
     }
   }
 


### PR DESCRIPTION
## Summary

Group the asset-mode Model Library by namespaced `model_type:*` tags, gated on a backend-reported capability, and make the asset-mode model store run on non-cloud builds (FE-1076).

## Changes

- **Grouping/resolution (flag-gated):** gated on the `supports_model_type_tags` server feature flag (`getServerFeature`, via `useFeatureFlags`).
  - **Flag off (default):** existing legacy bare-tag top-level grouping; `model_type:` ignored. Unchanged for backends that don't declare the capability.
  - **Flag on:** assets group by their `model_type:*` values; an uncovered asset (no `model_type:` tag) still routes by its bare tags. Card badges and the browser title key off the same `model_type:` values the asset groups under, so they cannot diverge from the grouping (a shared multi-type asset badges every value; a node-typed picker titles off the requested node's category). Node-provider lookup is tiered: `model_type:` values plus related bare twins (equal to or path-extending one, so `LLM/Qwen-VL` still beats flat `model_type:LLM`) ordered deepest-first, then unrelated bare tags only as trailing fallbacks, so an incidental `foo/bar` can never pre-empt a resolvable `model_type:vae` but still resolves when nothing authoritative does.
  - Gate threaded as a required `modelTypeMode` arg on the pure helpers (`getAssetCategories` / `getAssetTypeBadges` / `getAssetNodeCategoryCandidates` / `getPrimaryCategoryTag` / `filterByCategory`); only call sites read the flag, and new call sites must choose a mode explicitly.
- **Model store on non-cloud:** unwrapped the `if (isCloud)` gate in `assetsStore.getModelState` so the asset-mode Model Library populates on non-cloud distributions (it previously returned an empty no-op store off-cloud). Scoped to the model-asset store only.
- **Store hardening (review follow-ups):** model batch pagination now terminates on any offset-ignoring backend (served-page signature memory plus a consecutive-no-progress backstop) while still walking past shifted all-duplicate pages; a refresh that fails before its first batch commits surfaces its error on the state the UI reads; single-flight teardown is identity-guarded against interleaved invalidations; `getAssetModelType` can never return a raw `model_type:` literal (kills the prefixed round-trip through edit widgets).
- **Breaking:** none (default grouping path unchanged; asset-mode itself stays behind the existing `Comfy.Assets.UseAssetAPI` setting (default off on core, on for cloud)).

## Review Focus

- **`getModelState` unwrap is the minimal scoped change** — only the model-asset store; other `isCloud` usages in the file (e.g. input-file fetch) are untouched.
- **Capability flag is dormant until a backend emits `supports_model_type_tags`** — default-false keeps current behavior everywhere until then.
- **Known backend tag-granularity gap (out of scope):** flat `model_type:LLM` / `model_type:ultralytics` create no loader node (their loaders are registered hierarchically with no bare key); needs a subtype-carrying backend tag. 
- Grouping verified live against a namespaced-tags backend with the flag on: clean categories, no `model_type:` leaking into labels, correct loader-node creation.

https://pr-4394.testenvs.comfy.org/ is a live environment with new tags behaviour + `supports_model_type_tags` set

<!-- FE-1076 (Linear) — auto-linked via branch name -->

