### PR TITLE
fix(billing): keep successful team subscribe when post-write refresh fails

### DIFF
--- a/src/platform/workspace/composables/useWorkspaceBilling.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.test.ts
@@ -274,6 +274,27 @@ describe('useWorkspaceBilling', () => {
       expect(billing.balance.value?.amountMicros).toBe(5_000_000)
     })
 
+    it('returns the successful response when the post-subscribe refresh fails', async () => {
+      mockWorkspaceApi.subscribe.mockResolvedValue({
+        billing_op_id: 'op-1',
+        status: 'subscribed'
+      })
+      mockWorkspaceApi.getBillingStatus.mockRejectedValue(
+        new Error('refresh down')
+      )
+      mockWorkspaceApi.getBillingBalance.mockResolvedValue(positiveBalance)
+
+      const billing = setupBilling()
+
+      await expect(billing.subscribe('pro')).resolves.toStrictEqual({
+        billing_op_id: 'op-1',
+        status: 'subscribed'
+      })
+      expect(billing.error.value).toBe(
+        'Subscription succeeded, but billing state refresh failed'
+      )
+    })
+
     it('propagates error and records message when subscribe fails', async () => {
       mockWorkspaceApi.subscribe.mockRejectedValue(new Error('denied'))
 

--- a/src/platform/workspace/composables/useWorkspaceBilling.ts
+++ b/src/platform/workspace/composables/useWorkspaceBilling.ts
@@ -146,8 +146,18 @@ export function useWorkspaceBilling(): BillingState & BillingActions {
         cancelUrl
       )
 
-      // Refresh status and balance after subscription
-      await Promise.all([fetchStatus(), fetchBalance()])
+      // Refresh is non-fatal: the subscribe write already succeeded, so a failed
+      // refresh must not reject and prompt a retry of an active subscription.
+      const [statusResult, balanceResult] = await Promise.allSettled([
+        fetchStatus(),
+        fetchBalance()
+      ])
+      if (
+        statusResult.status === 'rejected' ||
+        balanceResult.status === 'rejected'
+      ) {
+        error.value = 'Subscription succeeded, but billing state refresh failed'
+      }
 
       return response
     } catch (err) {


### PR DESCRIPTION
## What

Mirrors the personal/legacy adapter fix (`useLegacyBilling.subscribe` in #12945, FE-967) on the **team** workspace adapter.

`useWorkspaceBilling.subscribe` performed the write (`workspaceApi.subscribe`) and then refreshed status + balance with `Promise.all([fetchStatus(), fetchBalance()])`. A post-write **refresh** failure rejected the whole call, so the caller saw "subscribe failed" and could prompt a retry of an **already-active** subscription.

## Fix

The refresh is now non-fatal: `Promise.allSettled` runs the refresh and, on a rejected refresh, surfaces a soft signal via the existing `error` ref (`Subscription succeeded, but billing state refresh failed`) and returns the successful `SubscribeResponse`. Write semantics and the success / needs-payment / pending branches are unchanged; a failed **write** still rejects as before.

## Test

Added a regression test: `subscribe` resolves but the post-write refresh rejects -> still returns the response (no false failure) and records the soft error.

## Verification

- `pnpm typecheck` clean
- `pnpm test:unit src/platform/workspace/composables/useWorkspaceBilling.test.ts` -> 41 passed
- eslint / oxlint / oxfmt clean on changed files