### PR TITLE
fix: hide advanced inputs toggle on collapsed nodes

### DIFF
--- a/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.test.ts
@@ -121,7 +121,8 @@ const i18n = createI18n({
       },
       rightSidePanel: {
         showAdvancedShort: 'Show Advanced',
-        showAdvancedInputsButton: 'Show Advanced Inputs'
+        showAdvancedInputsButton: 'Show Advanced Inputs',
+        hideAdvancedInputsButton: 'Hide Advanced Inputs'
       },
       'Node Render Error': 'Node Render Error'
     }
@@ -176,6 +177,7 @@ describe('LGraphNode', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     mockData.mockExecuting = false
+    mockData.mockLgraphNode = null
 
     setActivePinia(pinia)
     const canvasStore = useCanvasStore()
@@ -310,6 +312,31 @@ describe('LGraphNode', () => {
     expect(screen.getByRole('button', { name: 'Error' })).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /show advanced/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should hide the "hide advanced inputs" footer button while the node is collapsed', () => {
+    mockData.mockLgraphNode = {
+      showAdvanced: true,
+      isSubgraphNode: () => false
+    }
+
+    renderLGraphNode({
+      nodeData: {
+        ...mockNodeData,
+        flags: { collapsed: true },
+        widgets: [
+          {
+            name: 'advancedWidget',
+            type: 'number',
+            options: { advanced: true }
+          }
+        ]
+      }
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /hide advanced/i })
     ).not.toBeInTheDocument()
   })
 

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -193,7 +193,7 @@
       :has-any-error="hasAnyError"
       :show-errors-tab-enabled="showErrorsTabEnabled"
       :show-advanced-inputs-button="showAdvancedInputsButton"
-      :show-advanced-state="showAdvancedState"
+      :show-advanced-state="!isCollapsed && showAdvancedState"
       :header-color="applyLightThemeColor(nodeData?.color)"
       :shape="nodeData.shape"
       @enter-subgraph="handleEnterSubgraph"


### PR DESCRIPTION
## Summary

Hide the advanced inputs footer toggle when a node is collapsed, so it no longer lingers after collapsing a node whose advanced inputs were shown.

## Changes

- **What**: The footer's advanced toggle stayed visible after collapsing a node whose advanced inputs were shown, because `showAdvancedState` tracks `node.showAdvanced` independent of collapse state. Gate the `show-advanced-state` prop on `!isCollapsed`, mirroring how `showAdvancedInputsButton` already handles collapse. The error footer still shows when a collapsed node has errors.

## Review Focus

- The fix intentionally leaves `node.showAdvanced` untouched, so expanding the node restores the previous advanced-inputs view — only the footer affordance is hidden while collapsed.
- The error-only footer is preserved for collapsed nodes with errors (existing behavior, still covered by `should show error-only footer for collapsed nodes with advanced widgets`).
- New regression test was verified red→green: it asserts the "Hide advanced inputs" button is gone when a node with `showAdvanced: true` is collapsed.

## Screenshots
| Before  | After  |
| ------------- | ------------- |
| <img width="885" height="265" alt="2026-06-18-214945_hyprshot" src="https://github.com/user-attachments/assets/cd75a9ff-2aa4-4cc3-8c5f-57848db337f4" /> | <img width="892" height="270" alt="2026-06-18-214941_hyprshot" src="https://github.com/user-attachments/assets/24487d46-f04e-4d58-9186-5680e4dcdf8c" /> |




