### PR TITLE
Support opus format in assets panel

### DIFF
--- a/packages/shared-frontend-utils/src/formatUtil.test.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.test.ts
@@ -102,6 +102,7 @@ describe('formatUtil', () => {
         expect(getMediaTypeFromFilename('sound.wav')).toBe('audio')
         expect(getMediaTypeFromFilename('music.ogg')).toBe('audio')
         expect(getMediaTypeFromFilename('audio.flac')).toBe('audio')
+        expect(getMediaTypeFromFilename('music.opus')).toBe('audio')
       })
     })
 

--- a/packages/shared-frontend-utils/src/formatUtil.ts
+++ b/packages/shared-frontend-utils/src/formatUtil.ts
@@ -590,7 +590,7 @@ const IMAGE_EXTENSIONS = [
   'svg'
 ] as const
 const VIDEO_EXTENSIONS = ['mp4', 'm4v', 'webm', 'mov', 'avi', 'mkv'] as const
-const AUDIO_EXTENSIONS = ['mp3', 'wav', 'ogg', 'flac'] as const
+const AUDIO_EXTENSIONS = ['mp3', 'wav', 'ogg', 'flac', 'opus'] as const
 const THREE_D_EXTENSIONS = [
   'obj',
   'fbx',


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/aa6ff824-ee90-49db-a059-0da408ba10bf" /> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/98717dfd-4fee-474a-bd5c-03e7b7e23a05"  />|
