### PR TITLE
Filter canvasOnly non-preview widgets in editor

### DIFF
--- a/browser_tests/tests/subgraphPromotedWidgetPanel.spec.ts
+++ b/browser_tests/tests/subgraphPromotedWidgetPanel.spec.ts
@@ -114,6 +114,25 @@ test.describe(
           .poll(() => collectWidgetLabels(shownSection))
           .not.toContain('text')
       })
+
+      test(
+        'control after generate does not display',
+        { tag: '@vue-nodes' },
+        async ({ comfyPage }) => {
+          await comfyPage.workflow.loadWorkflow('subgraphs/basic-subgraph')
+          const subgraphNode = comfyPage.vueNodes.getNodeByTitle('New Subgraph')
+          const { editor } = comfyPage.subgraph
+          await editor.ensureOpen(subgraphNode)
+
+          await expect(
+            editor.promotionItems.first(),
+            'some promotion item is visible'
+          ).toBeVisible()
+
+          const widgetName = 'control_after_generate'
+          await expect(editor.resolveItem({ widgetName })).toBeHidden()
+        }
+      )
     })
 
     test.describe('Parameters tab (WidgetActions menu)', () => {

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -5,6 +5,7 @@ import { computed, onMounted, shallowRef, watch } from 'vue'
 
 import DraggableList from '@/components/common/DraggableList.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import {
   demotePromotedInput,
   demoteWidget,
@@ -53,6 +54,7 @@ const canvasStore = useCanvasStore()
 const previewExposureStore = usePreviewExposureStore()
 const rightSidePanelStore = useRightSidePanelStore()
 const { searchQuery } = storeToRefs(rightSidePanelStore)
+const { shouldRenderVueNodes } = useVueFeatureFlags()
 
 const activeNode = computed(() => {
   const node = canvasStore.selectedItems[0]
@@ -175,9 +177,13 @@ const candidateWidgets = computed<WidgetItem[]>(() => {
   const node = activeNode.value
   if (!node) return []
   const promotedSourceKeys = new Set(activeRows.value.map(activeRowSourceKey))
-  return interiorWidgets.value.filter(
-    ([n, w]) => !promotedSourceKeys.has(`${n.id}:${w.name}`)
-  )
+  return interiorWidgets.value
+    .filter(([n, w]) => !promotedSourceKeys.has(`${n.id}:${w.name}`))
+    .filter(
+      ([, w]) =>
+        w.name.startsWith('$$') ||
+        !(w.options.canvasOnly && shouldRenderVueNodes.value)
+    )
 })
 const filteredCandidates = computed<WidgetItem[]>(() => {
   const query = searchQuery.value.toLowerCase()


### PR DESCRIPTION
Non preview, `canvasOnly` widgets like `control_after_generate` could be displayed in the subgraph editor even though promoting them would have no visual or functional effect when in vue mode.

In vue mode, these entries are now hidden from the list of candidate items for promotion to reduce confusion.