### PR TITLE
[backport cloud/1.45] Fix Cloud media input defaults (#12562)

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingMediaRuntime.spec.ts
@@ -23,6 +23,26 @@ const plainVideoFileName = 'plain_video.mp4'
 const graphDropPosition = { x: 500, y: 300 }
 const missingMediaUploadObservationMs = 1_000
 const missingMediaUploadPollMs = 100
+const emptyMediaLoaderNodes = [
+  {
+    nodeType: 'LoadImage',
+    widgetName: 'image',
+    serverOnlyOption: 'server-only-image.png',
+    position: { x: 150, y: 150 }
+  },
+  {
+    nodeType: 'LoadVideo',
+    widgetName: 'file',
+    serverOnlyOption: 'server-only-video.mp4',
+    position: { x: 450, y: 150 }
+  },
+  {
+    nodeType: 'LoadAudio',
+    widgetName: 'audio',
+    serverOnlyOption: 'server-only-audio.wav',
+    position: { x: 750, y: 150 }
+  }
+]
 
 const cloudOutputAsset: Asset & { hash?: string } = {
   id: 'test-output-hash-001',
@@ -66,12 +86,168 @@ interface CloudUploadAssetState {
   isUploadedAssetAvailable: boolean
 }
 
-const cloudOutputTest = createCloudAssetsFixture([cloudOutputAsset])
+type ObjectInfoResponse = Record<
+  string,
+  { input?: { required?: Record<string, unknown> } }
+>
+
+function setComboInputOptions(
+  objectInfo: ObjectInfoResponse,
+  nodeType: string,
+  inputName: string,
+  values: string[]
+) {
+  const nodeInfo = objectInfo[nodeType]
+  if (!nodeInfo) {
+    throw new Error(`Missing object_info entry for ${nodeType}`)
+  }
+
+  const requiredInputs = nodeInfo.input?.required
+  if (!requiredInputs) {
+    throw new Error(`Missing required inputs for ${nodeType}`)
+  }
+
+  const input = requiredInputs[inputName]
+  if (!Array.isArray(input)) {
+    throw new Error(`Expected ${nodeType}.${inputName} to be a combo input`)
+  }
+
+  const [valuesOrType, options] = input
+  const optionsObject =
+    options && typeof options === 'object' && !Array.isArray(options)
+  if (Array.isArray(valuesOrType)) {
+    input[0] = values
+  } else if (valuesOrType !== 'COMBO') {
+    throw new Error(`Expected ${nodeType}.${inputName} to have combo options`)
+  }
+
+  if (optionsObject) {
+    Object.assign(options, { options: values })
+  } else if (!Array.isArray(valuesOrType)) {
+    throw new Error(
+      `Expected ${nodeType}.${inputName} to have options metadata`
+    )
+  }
+}
+
+async function routeCloudBootstrapApis(page: Page) {
+  await page.route('**/api/settings**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({})
+    })
+  })
+  await page.route('**/api/userdata**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    })
+  })
+  await page.route('**/i18n', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({})
+    })
+  })
+  await page.route('**/customers/cloud-subscription-status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ is_active: true })
+    })
+  })
+}
+
+async function routeSetupObjectInfo(
+  page: Page,
+  customize?: (objectInfo: ObjectInfoResponse) => void
+) {
+  const setupApiUrl =
+    process.env.PLAYWRIGHT_SETUP_API_URL ?? 'http://127.0.0.1:8188'
+  const objectInfoUrl = new URL('/object_info', setupApiUrl).toString()
+
+  const objectInfoRouteHandler = async (route: Route) => {
+    try {
+      const response = await fetch(objectInfoUrl, {
+        signal: AbortSignal.timeout(5_000)
+      })
+      if (!response.ok) {
+        await route.fulfill({
+          status: response.status,
+          contentType: response.headers.get('content-type') ?? 'text/plain',
+          body: await response.text()
+        })
+        return
+      }
+
+      const objectInfo = (await response.json()) as ObjectInfoResponse
+      customize?.(objectInfo)
+
+      await route.fulfill({
+        status: response.status,
+        contentType: 'application/json',
+        body: JSON.stringify(objectInfo)
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: `Failed to fetch setup object_info from ${objectInfoUrl}: ${message}`
+        })
+      })
+    }
+  }
+
+  await page.route('**/object_info', objectInfoRouteHandler)
+  return async () =>
+    await page.unroute('**/object_info', objectInfoRouteHandler)
+}
+
+const cloudOutputTest = createCloudAssetsFixture([cloudOutputAsset]).extend({
+  page: async ({ page }, use) => {
+    await routeCloudBootstrapApis(page)
+    const unrouteObjectInfo = await routeSetupObjectInfo(page)
+
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
+
+const cloudEmptyMediaInputsTest = createCloudAssetsFixture([]).extend({
+  page: async ({ page }, use) => {
+    await routeCloudBootstrapApis(page)
+
+    const unrouteObjectInfo = await routeSetupObjectInfo(page, (objectInfo) => {
+      for (const node of emptyMediaLoaderNodes) {
+        setComboInputOptions(objectInfo, node.nodeType, node.widgetName, [
+          node.serverOnlyOption
+        ])
+      }
+    })
+
+    try {
+      await use(page)
+    } finally {
+      await unrouteObjectInfo()
+    }
+  }
+})
 const cloudUploadAssetStateByPage = new WeakMap<Page, CloudUploadAssetState>()
 const cloudUploadRaceTest = comfyPageFixture.extend<{
   markUploadedCloudAssetAvailable: () => void
 }>({
   page: async ({ page }, use) => {
+    await routeCloudBootstrapApis(page)
+    const unrouteObjectInfo = await routeSetupObjectInfo(page)
+
     const state: CloudUploadAssetState = {
       isUploadedAssetAvailable: false
     }
@@ -106,9 +282,13 @@ const cloudUploadRaceTest = comfyPageFixture.extend<{
     }
 
     await page.route(/\/api\/assets(?:\?.*)?$/, assetsRouteHandler)
-    await use(page)
-    await page.unroute(/\/api\/assets(?:\?.*)?$/, assetsRouteHandler)
-    cloudUploadAssetStateByPage.delete(page)
+    try {
+      await use(page)
+    } finally {
+      await page.unroute(/\/api\/assets(?:\?.*)?$/, assetsRouteHandler)
+      await unrouteObjectInfo()
+      cloudUploadAssetStateByPage.delete(page)
+    }
   },
   markUploadedCloudAssetAvailable: async ({ page }, use) => {
     await use(() => {
@@ -139,7 +319,41 @@ async function expectNoErrorsTab(comfyPage: ComfyPage) {
   ).toBeHidden()
 }
 
-async function delayNextUpload(comfyPage: ComfyPage) {
+async function closeTemplatesDialogIfOpen(comfyPage: ComfyPage) {
+  const templatesDialog = comfyPage.page.getByRole('dialog').filter({
+    has: comfyPage.templates.content
+  })
+  const closeButton = templatesDialog.getByRole('button', {
+    name: 'Close dialog'
+  })
+  await closeButton
+    .waitFor({ state: 'visible', timeout: 1_000 })
+    .catch(() => undefined)
+
+  if (await closeButton.isVisible()) {
+    await closeButton.click()
+    await expect(templatesDialog).toBeHidden()
+  }
+}
+
+async function getMediaLoaderWidgetValues(comfyPage: ComfyPage) {
+  return await comfyPage.page.evaluate((nodes) => {
+    return nodes.map(({ nodeType, widgetName }) => {
+      const node = window.app!.graph.nodes.find(
+        (graphNode) => graphNode.type === nodeType
+      )
+      const widget = node?.widgets?.find(
+        (candidate) => candidate.name === widgetName
+      )
+      return widget?.value ?? null
+    })
+  }, emptyMediaLoaderNodes)
+}
+
+async function delayNextUpload(
+  comfyPage: ComfyPage,
+  uploadResult?: { name: string; subfolder: string; type: 'input' }
+) {
   let releaseUpload!: () => void
   let resolveUploadStarted!: () => void
   const uploadStarted = new Promise<void>((resolve) => {
@@ -152,6 +366,14 @@ async function delayNextUpload(comfyPage: ComfyPage) {
   const uploadRouteHandler = async (route: Route) => {
     resolveUploadStarted()
     await release
+    if (uploadResult) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(uploadResult)
+      })
+      return
+    }
     await route.continue()
   }
 
@@ -295,12 +517,51 @@ ossTest.describe(
   }
 )
 
+cloudEmptyMediaInputsTest.describe(
+  'Errors tab - Cloud empty media loader inputs',
+  { tag: '@cloud' },
+  () => {
+    cloudEmptyMediaInputsTest.beforeEach(async ({ comfyPage }) => {
+      await enableErrorsTab(comfyPage)
+      await closeTemplatesDialogIfOpen(comfyPage)
+    })
+
+    cloudEmptyMediaInputsTest(
+      'does not surface missing inputs after adding LoadImage, LoadVideo, and LoadAudio nodes with no cloud input assets',
+      async ({ cloudAssetRequests, comfyPage }) => {
+        await comfyPage.nodeOps.clearGraph()
+
+        for (const node of emptyMediaLoaderNodes) {
+          await comfyPage.nodeOps.addNode(
+            node.nodeType,
+            undefined,
+            node.position
+          )
+        }
+
+        await expect
+          .poll(() =>
+            cloudAssetRequests.some((url) =>
+              assetRequestIncludesTag(url, 'input')
+            )
+          )
+          .toBe(true)
+        await expect
+          .poll(() => getMediaLoaderWidgetValues(comfyPage))
+          .toEqual(['', '', ''])
+        await expectNoErrorsTab(comfyPage)
+      }
+    )
+  }
+)
+
 cloudOutputTest.describe(
   'Errors tab - Cloud missing media runtime sources',
   { tag: '@cloud' },
   () => {
     cloudOutputTest.beforeEach(async ({ comfyPage }) => {
       await enableErrorsTab(comfyPage)
+      await closeTemplatesDialogIfOpen(comfyPage)
     })
 
     cloudOutputTest(
@@ -329,13 +590,18 @@ cloudUploadRaceTest.describe(
   () => {
     cloudUploadRaceTest.beforeEach(async ({ comfyPage }) => {
       await enableErrorsTab(comfyPage)
+      await closeTemplatesDialogIfOpen(comfyPage)
     })
 
     cloudUploadRaceTest(
       'does not surface missing media while dropped video upload is in progress',
       async ({ comfyFiles, comfyPage, markUploadedCloudAssetAvailable }) => {
         await comfyPage.nodeOps.clearGraph()
-        const delayedUpload = await delayNextUpload(comfyPage)
+        const delayedUpload = await delayNextUpload(comfyPage, {
+          name: plainVideoFileName,
+          subfolder: '',
+          type: 'input'
+        })
 
         await comfyPage.dragDrop.dragAndDropFile(plainVideoFileName, {
           dropPosition: graphDropPosition

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.test.ts
@@ -2,13 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
 import { assetService } from '@/platform/assets/services/assetService'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useComboWidget } from '@/renderer/extensions/vueNodes/widgets/composables/useComboWidget'
 import type { InputSpec } from '@/schemas/nodeDef/nodeDefSchemaV2'
+import { addValueControlWidgets } from '@/scripts/widgets'
 
-// Mock factory using actual type
 function createMockAssetItem(overrides: Partial<AssetItem> = {}): AssetItem {
   return {
     id: 'test-asset-id',
@@ -24,7 +23,6 @@ function createMockAssetItem(overrides: Partial<AssetItem> = {}): AssetItem {
   }
 }
 
-// Use vi.hoisted() to ensure mock state is initialized before mocks
 const mockDistributionState = vi.hoisted(() => ({ isCloud: false }))
 const mockUpdateInputs = vi.hoisted(() => vi.fn(() => Promise.resolve()))
 const mockGetInputName = vi.hoisted(() => vi.fn((hash: string) => hash))
@@ -90,7 +88,6 @@ vi.mock('@/platform/assets/composables/useAssetBrowserDialog', () => {
   }
 })
 
-// Test factory functions
 function createMockWidget(overrides: Partial<IBaseWidget> = {}): IBaseWidget {
   const mockCallback = vi.fn()
   const widget: IBaseWidget = {
@@ -109,7 +106,6 @@ function createMockNode(comfyClass = 'TestNode'): LGraphNode {
   const node = new LGraphNode('TestNode')
   node.comfyClass = comfyClass
 
-  // Spy on the addWidget method
   vi.spyOn(node, 'addWidget').mockImplementation(
     (type, name, value, callback, options = {}) => {
       const normalizedOptions =
@@ -144,13 +140,13 @@ describe('useComboWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSettingStoreGet.mockReturnValue(false)
+    mockGetInputName.mockImplementation((hash: string) => hash)
+    mockGetAssets.mockImplementation(() => [])
     vi.mocked(assetService.isAssetBrowserEligible).mockReturnValue(false)
     vi.mocked(assetService.shouldUseAssetBrowser).mockReturnValue(false)
-    vi.mocked(useAssetBrowserDialog).mockClear()
     mockDistributionState.isCloud = false
     mockAssetsStoreState.inputAssets = []
     mockAssetsStoreState.inputLoading = false
-    mockUpdateInputs.mockClear()
   })
 
   it('should handle undefined spec', () => {
@@ -344,60 +340,289 @@ describe('useComboWidget', () => {
   })
 
   describe('cloud input asset mapping', () => {
-    const HASH_FILENAME =
-      '72e786ff2a44d682c4294db0b7098e569832bc394efc6dad644e6ec85a78efb7.png'
-    const HASH_FILENAME_2 =
-      'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456.jpg'
+    const cloudInputScenarios = [
+      {
+        nodeClass: 'LoadImage',
+        inputName: 'image',
+        assetName: 'cloud-image.png',
+        assetHash: 'cloud-image-hash.png',
+        serverOption: 'server-only-image.png'
+      },
+      {
+        nodeClass: 'LoadVideo',
+        inputName: 'file',
+        assetName: 'cloud-video.mp4',
+        assetHash: 'cloud-video-hash.mp4',
+        serverOption: 'server-only-video.mp4'
+      },
+      {
+        nodeClass: 'LoadAudio',
+        inputName: 'audio',
+        assetName: 'cloud-audio.wav',
+        assetHash: 'cloud-audio-hash.wav',
+        serverOption: 'server-only-audio.wav'
+      }
+    ] as const
 
-    it.for([
-      { nodeClass: 'LoadImage', inputName: 'image' },
-      { nodeClass: 'LoadVideo', inputName: 'video' },
-      { nodeClass: 'LoadAudio', inputName: 'audio' }
-    ])(
-      'should create combo widget with getOptionLabel for $nodeClass in cloud',
-      ({ nodeClass, inputName }) => {
-        mockDistributionState.isCloud = true
+    function setupCloudInputMappingWidget(
+      scenario: (typeof cloudInputScenarios)[number],
+      inputSpecOverrides: Partial<InputSpec> = {},
+      inputAssets: AssetItem[] = []
+    ) {
+      mockDistributionState.isCloud = true
+      mockAssetsStoreState.inputAssets = inputAssets
 
-        const constructor = useComboWidget()
-        const mockWidget = createMockWidget({
-          type: 'combo',
-          name: inputName,
-          value: HASH_FILENAME
+      const constructor = useComboWidget()
+      const mockNode = createMockNode(scenario.nodeClass)
+      const inputSpec = createMockInputSpec({
+        name: scenario.inputName,
+        ...inputSpecOverrides
+      })
+
+      const widget = constructor(mockNode, inputSpec)
+      return { mockNode, widget }
+    }
+
+    function getInputWidgetDefault(
+      mockNode: ReturnType<typeof createMockNode>
+    ) {
+      return vi.mocked(mockNode.addWidget).mock.calls[0]?.[2]
+    }
+
+    function getInputWidgetOptions(
+      mockNode: ReturnType<typeof createMockNode>
+    ) {
+      const options = vi.mocked(mockNode.addWidget).mock.calls[0]?.[4]
+
+      if (typeof options !== 'object' || !options) {
+        throw new Error('Expected options to be an object')
+      }
+
+      return options
+    }
+
+    function getInputWidgetValues(mockNode: ReturnType<typeof createMockNode>) {
+      const options = getInputWidgetOptions(mockNode)
+
+      if (!('values' in options)) {
+        throw new Error('Expected options to have values property')
+      }
+
+      return options.values
+    }
+
+    it.for(cloudInputScenarios)(
+      'should use an empty default for $nodeClass when only server combo options exist',
+      (scenario) => {
+        const { mockNode, widget } = setupCloudInputMappingWidget(scenario, {
+          options: [scenario.serverOption]
         })
-        const mockNode = createMockNode(nodeClass)
-        vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
-        const inputSpec = createMockInputSpec({
-          name: inputName,
-          options: [HASH_FILENAME, HASH_FILENAME_2]
+
+        expect(getInputWidgetDefault(mockNode)).toBe('')
+        expect(widget.value).toBe('')
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should use first matching cloud input asset for $nodeClass instead of server combo options',
+      (scenario) => {
+        const { mockNode, widget } = setupCloudInputMappingWidget(
+          scenario,
+          { options: [scenario.serverOption] },
+          [
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+        )
+
+        expect(getInputWidgetDefault(mockNode)).toBe(scenario.assetHash)
+        expect(widget.value).toBe(scenario.assetHash)
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should use an empty default for $nodeClass when inputSpec.default is not in cloud input assets',
+      (scenario) => {
+        const { mockNode, widget } = setupCloudInputMappingWidget(scenario, {
+          default: scenario.serverOption
         })
 
-        const widget = constructor(mockNode, inputSpec)
+        expect(getInputWidgetDefault(mockNode)).toBe('')
+        expect(widget.value).toBe('')
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should fallback to first matching cloud input asset for $nodeClass when inputSpec.default is not in assets',
+      (scenario) => {
+        const { mockNode, widget } = setupCloudInputMappingWidget(
+          scenario,
+          { default: scenario.serverOption },
+          [
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+        )
+
+        expect(getInputWidgetDefault(mockNode)).toBe(scenario.assetHash)
+        expect(widget.value).toBe(scenario.assetHash)
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should prefer inputSpec.default for $nodeClass when it matches a cloud input asset hash',
+      (scenario) => {
+        const fallbackHash = `fallback-${scenario.assetHash}`
+        const { mockNode, widget } = setupCloudInputMappingWidget(
+          scenario,
+          { default: scenario.assetHash },
+          [
+            createMockAssetItem({
+              name: `fallback-${scenario.assetName}`,
+              hash: fallbackHash
+            }),
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+        )
+
+        expect(getInputWidgetDefault(mockNode)).toBe(scenario.assetHash)
+        expect(widget.value).toBe(scenario.assetHash)
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should prefer inputSpec.default for $nodeClass when it matches a cloud input asset name',
+      (scenario) => {
+        const fallbackHash = `fallback-${scenario.assetHash}`
+        const { mockNode, widget } = setupCloudInputMappingWidget(
+          scenario,
+          { default: scenario.assetName },
+          [
+            createMockAssetItem({
+              name: `fallback-${scenario.assetName}`,
+              hash: fallbackHash
+            }),
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+        )
+
+        expect(getInputWidgetDefault(mockNode)).toBe(scenario.assetHash)
+        expect(widget.value).toBe(scenario.assetHash)
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should prefer a hash match over an earlier name match for $nodeClass',
+      (scenario) => {
+        const nameMatchHash = `name-match-${scenario.assetHash}`
+        const { mockNode, widget } = setupCloudInputMappingWidget(
+          scenario,
+          { default: scenario.assetHash },
+          [
+            createMockAssetItem({
+              name: scenario.assetHash,
+              hash: nameMatchHash
+            }),
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            })
+          ]
+        )
+
+        expect(getInputWidgetDefault(mockNode)).toBe(scenario.assetHash)
+        expect(widget.value).toBe(scenario.assetHash)
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should create combo widget options for $nodeClass using cloud input values',
+      (scenario) => {
+        const { mockNode, widget } = setupCloudInputMappingWidget(scenario, {
+          options: [scenario.serverOption]
+        })
 
         expect(mockNode.addWidget).toHaveBeenCalledWith(
           'combo',
-          inputName,
-          HASH_FILENAME,
+          scenario.inputName,
+          '',
           expect.any(Function),
           expect.objectContaining({
-            values: [], // Empty initially, populated via dynamic getter
+            values: [],
             getOptionLabel: expect.any(Function)
           })
         )
-        expect(widget).toBe(mockWidget)
+        expect(widget.type).toBe('combo')
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should expose only matching cloud input asset values for $nodeClass',
+      (scenario) => {
+        const { mockNode } = setupCloudInputMappingWidget(
+          scenario,
+          { options: [scenario.serverOption] },
+          [
+            createMockAssetItem({
+              name: 'wrong-kind.txt',
+              hash: 'wrong-kind.txt'
+            }),
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: scenario.assetHash
+            }),
+            createMockAssetItem({
+              name: `second-${scenario.assetName}`,
+              hash: `second-${scenario.assetHash}`
+            })
+          ]
+        )
+
+        const values = getInputWidgetValues(mockNode)
+        expect(values).toEqual([
+          scenario.assetHash,
+          `second-${scenario.assetHash}`
+        ])
+        expect(values).toContain(getInputWidgetDefault(mockNode))
+      }
+    )
+
+    it.for(cloudInputScenarios)(
+      'should ignore cloud input assets without hashes for $nodeClass',
+      (scenario) => {
+        const { mockNode, widget } = setupCloudInputMappingWidget(
+          scenario,
+          { default: scenario.assetName },
+          [
+            createMockAssetItem({
+              name: scenario.assetName,
+              hash: ''
+            })
+          ]
+        )
+
+        expect(getInputWidgetDefault(mockNode)).toBe('')
+        expect(widget.value).toBe('')
+        expect(getInputWidgetValues(mockNode)).toEqual([])
       }
     )
 
     it('should keep the original options object for cloud input mappings', () => {
-      mockDistributionState.isCloud = true
+      const scenario = cloudInputScenarios[0]
 
-      const constructor = useComboWidget()
-      const mockNode = createMockNode('LoadImage')
-      const inputSpec = createMockInputSpec({
-        name: 'image',
-        options: [HASH_FILENAME]
+      const { mockNode, widget } = setupCloudInputMappingWidget(scenario, {
+        options: [scenario.serverOption]
       })
-
-      const widget = constructor(mockNode, inputSpec)
       const addWidgetCall = vi.mocked(mockNode.addWidget).mock.calls[0]
       const options = addWidgetCall[4]
 
@@ -405,31 +630,20 @@ describe('useComboWidget', () => {
     })
 
     it("should format option labels using store's getInputName function", () => {
-      mockDistributionState.isCloud = true
+      const scenario = cloudInputScenarios[0]
       mockGetInputName.mockReturnValue('Beautiful Sunset.png')
 
-      const constructor = useComboWidget()
-      const mockWidget = createMockWidget({
-        type: 'combo',
-        name: 'image',
-        value: HASH_FILENAME
-      })
-      const mockNode = createMockNode('LoadImage')
-      vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
-      const inputSpec = createMockInputSpec({
-        name: 'image',
-        options: [HASH_FILENAME]
-      })
-
-      constructor(mockNode, inputSpec)
-
-      // Extract the injected getOptionLabel function with type narrowing
-      const addWidgetCall = vi.mocked(mockNode.addWidget).mock.calls[0]
-      const options = addWidgetCall[4]
-
-      if (typeof options !== 'object' || !options) {
-        throw new Error('Expected options to be an object')
-      }
+      const { mockNode } = setupCloudInputMappingWidget(
+        scenario,
+        { options: [scenario.serverOption] },
+        [
+          createMockAssetItem({
+            name: scenario.assetName,
+            hash: scenario.assetHash
+          })
+        ]
+      )
+      const options = getInputWidgetOptions(mockNode)
 
       if (!('getOptionLabel' in options)) {
         throw new Error('Expected options to have getOptionLabel property')
@@ -439,13 +653,43 @@ describe('useComboWidget', () => {
         throw new Error('Expected getOptionLabel to be a function')
       }
 
-      // Test that the injected function calls getInputName
-      const result = options.getOptionLabel(HASH_FILENAME)
-      expect(mockGetInputName).toHaveBeenCalledWith(HASH_FILENAME)
+      const result = options.getOptionLabel(scenario.assetHash)
+      expect(mockGetInputName).toHaveBeenCalledWith(scenario.assetHash)
       expect(result).toBe('Beautiful Sunset.png')
     })
 
+    it('should add control widgets for cloud input mappings when requested', () => {
+      const scenario = cloudInputScenarios[0]
+
+      const { mockNode, widget } = setupCloudInputMappingWidget(
+        scenario,
+        { control_after_generate: true },
+        [
+          createMockAssetItem({
+            name: scenario.assetName,
+            hash: scenario.assetHash
+          })
+        ]
+      )
+
+      expect(addValueControlWidgets).toHaveBeenCalledWith(
+        mockNode,
+        widget,
+        'randomize',
+        undefined,
+        [
+          'COMBO',
+          {
+            control_after_generate: true,
+            name: scenario.inputName,
+            type: 'COMBO'
+          }
+        ]
+      )
+    })
+
     it('should create normal combo widget for non-input nodes in cloud', () => {
+      const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
 
       const constructor = useComboWidget()
@@ -454,7 +698,7 @@ describe('useComboWidget', () => {
       vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
       const inputSpec = createMockInputSpec({
         name: 'option',
-        options: [HASH_FILENAME, HASH_FILENAME_2]
+        options: [scenario.assetHash, 'other-option']
       })
 
       const widget = constructor(mockNode, inputSpec)
@@ -462,14 +706,15 @@ describe('useComboWidget', () => {
       expect(mockNode.addWidget).toHaveBeenCalledWith(
         'combo',
         'option',
-        HASH_FILENAME,
+        scenario.assetHash,
         expect.any(Function),
-        { values: [HASH_FILENAME, HASH_FILENAME_2] }
+        { values: [scenario.assetHash, 'other-option'] }
       )
       expect(widget).toBe(mockWidget)
     })
 
     it('should create normal combo widget for LoadImage in OSS', () => {
+      const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = false
 
       const constructor = useComboWidget()
@@ -478,7 +723,7 @@ describe('useComboWidget', () => {
       vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
       const inputSpec = createMockInputSpec({
         name: 'image',
-        options: [HASH_FILENAME, HASH_FILENAME_2]
+        options: [scenario.assetHash, 'other-option']
       })
 
       const widget = constructor(mockNode, inputSpec)
@@ -486,16 +731,17 @@ describe('useComboWidget', () => {
       expect(mockNode.addWidget).toHaveBeenCalledWith(
         'combo',
         'image',
-        HASH_FILENAME,
+        scenario.assetHash,
         expect.any(Function),
         {
-          values: [HASH_FILENAME, HASH_FILENAME_2]
+          values: [scenario.assetHash, 'other-option']
         }
       )
       expect(widget).toBe(mockWidget)
     })
 
     it('should trigger lazy load for cloud input nodes', () => {
+      const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
       mockAssetsStoreState.inputAssets = []
       mockAssetsStoreState.inputLoading = false
@@ -506,7 +752,7 @@ describe('useComboWidget', () => {
       vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
       const inputSpec = createMockInputSpec({
         name: 'image',
-        options: [HASH_FILENAME]
+        options: [scenario.assetHash]
       })
 
       constructor(mockNode, inputSpec)
@@ -514,7 +760,41 @@ describe('useComboWidget', () => {
       expect(mockUpdateInputs).toHaveBeenCalledTimes(1)
     })
 
+    it('should keep empty cloud input value after lazy-loaded inputs resolve a default', async () => {
+      const scenario = cloudInputScenarios[0]
+      mockDistributionState.isCloud = true
+      mockAssetsStoreState.inputAssets = []
+      mockAssetsStoreState.inputLoading = false
+      mockUpdateInputs.mockImplementationOnce(async () => {
+        mockAssetsStoreState.inputAssets = [
+          createMockAssetItem({
+            name: scenario.assetName,
+            hash: scenario.assetHash
+          })
+        ]
+      })
+
+      const constructor = useComboWidget()
+      const mockNode = createMockNode(scenario.nodeClass)
+      const inputSpec = createMockInputSpec({
+        name: scenario.inputName,
+        default: scenario.assetName
+      })
+
+      const widget = constructor(mockNode, inputSpec)
+
+      expect(mockUpdateInputs).toHaveBeenCalledTimes(1)
+      expect(getInputWidgetDefault(mockNode)).toBe('')
+      expect(widget.value).toBe('')
+
+      await mockUpdateInputs.mock.results[0]?.value
+
+      expect(getInputWidgetValues(mockNode)).toEqual([scenario.assetHash])
+      expect(widget.value).toBe('')
+    })
+
     it('should not trigger lazy load if assets already loading', () => {
+      const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
       mockAssetsStoreState.inputAssets = []
       mockAssetsStoreState.inputLoading = true
@@ -525,7 +805,7 @@ describe('useComboWidget', () => {
       vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
       const inputSpec = createMockInputSpec({
         name: 'image',
-        options: [HASH_FILENAME]
+        options: [scenario.assetHash]
       })
 
       constructor(mockNode, inputSpec)
@@ -534,12 +814,13 @@ describe('useComboWidget', () => {
     })
 
     it('should not trigger lazy load if assets already loaded', () => {
+      const scenario = cloudInputScenarios[0]
       mockDistributionState.isCloud = true
       mockAssetsStoreState.inputAssets = [
         createMockAssetItem({
           id: 'asset-123',
-          name: 'image1.png',
-          hash: HASH_FILENAME
+          name: scenario.assetName,
+          hash: scenario.assetHash
         })
       ]
       mockAssetsStoreState.inputLoading = false
@@ -550,7 +831,7 @@ describe('useComboWidget', () => {
       vi.mocked(mockNode.addWidget).mockReturnValue(mockWidget)
       const inputSpec = createMockInputSpec({
         name: 'image',
-        options: [HASH_FILENAME]
+        options: [scenario.assetHash]
       })
 
       constructor(mockNode, inputSpec)

--- a/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useComboWidget.ts
@@ -6,6 +6,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { isComboWidget } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { assetService } from '@/platform/assets/services/assetService'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { getAssetFilename } from '@/platform/assets/utils/assetMetadataUtils'
 import { createAssetWidget } from '@/platform/assets/utils/createAssetWidget'
 import { isCloud } from '@/platform/distribution/types'
@@ -124,6 +125,42 @@ function resolveCloudDefault(
   return filename || undefined
 }
 
+function getCloudInputAssets(nodeType: string | undefined): AssetItem[] {
+  const mediaType = NODE_MEDIA_TYPE_MAP[nodeType ?? '']
+  if (!mediaType) return []
+
+  return useAssetsStore().inputAssets.filter(
+    (asset) =>
+      getCloudInputAssetValue(asset) &&
+      getMediaTypeFromFilename(asset.name) === mediaType
+  )
+}
+
+function getCloudInputAssetValue(asset: AssetItem): string | undefined {
+  return asset.hash ?? undefined
+}
+
+function getCloudInputAssetValues(nodeType: string | undefined): string[] {
+  return getCloudInputAssets(nodeType)
+    .map(getCloudInputAssetValue)
+    .filter((value): value is string => !!value)
+}
+
+function resolveCloudInputDefault(
+  nodeType: string | undefined,
+  specDefault: string | undefined
+): string | undefined {
+  const assets = getCloudInputAssets(nodeType)
+  if (specDefault != null) {
+    const matchingAsset =
+      assets.find((asset) => getCloudInputAssetValue(asset) === specDefault) ??
+      assets.find((asset) => asset.name === specDefault)
+    if (matchingAsset) return getCloudInputAssetValue(matchingAsset)
+  }
+
+  return assets[0] ? getCloudInputAssetValue(assets[0]) : undefined
+}
+
 function createAssetBrowserWidget(
   node: LGraphNode,
   inputSpec: ComboInputSpec,
@@ -177,14 +214,7 @@ const createInputMappingWidget = (
   }
 
   bindDynamicValuesOption(widget, () =>
-    assetsStore.inputAssets
-      .filter(
-        (asset) =>
-          getMediaTypeFromFilename(asset.name) ===
-          NODE_MEDIA_TYPE_MAP[node.comfyClass ?? '']
-      )
-      .map((asset) => asset.hash)
-      .filter((hash): hash is string => !!hash)
+    getCloudInputAssetValues(node.comfyClass)
   )
 
   if (inputSpec.control_after_generate) {
@@ -226,7 +256,11 @@ const addComboWidget = (
     }
 
     if (NODE_MEDIA_TYPE_MAP[node.comfyClass ?? '']) {
-      return createInputMappingWidget(node, inputSpec, defaultValue)
+      return createInputMappingWidget(
+        node,
+        inputSpec,
+        resolveCloudInputDefault(node.comfyClass, inputSpec.default)
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

Backport #12562 to cloud/1.45 so Cloud media loader widgets resolve defaults from Cloud input assets instead of server object_info options.

## Changes

- **What**: Applies Cloud media input default resolution for LoadImage, LoadVideo, and LoadAudio.
- **What**: Keeps the cloud/1.45 canonical `AssetItem.hash` field during manual conflict resolution instead of reintroducing legacy `asset_hash`.
- **What**: Backports the related unit and browser regression coverage.
- **Breaking**: None.
- **Dependencies**: None.

## Review Focus

Manual conflicts were limited to `useComboWidget.ts` and `useComboWidget.test.ts`; the browser spec auto-merged. Please verify the conflict resolution around `getCloudInputAssetValue` and the test fixtures using `hash`.

Backport of #12562.