### PR TITLE
fix: open Vue context menu when right-clicking a group

### DIFF
--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -280,3 +280,37 @@ test.describe('Vue Node Groups', { tag: ['@screenshot', '@vue-nodes'] }, () => {
     await expect.poll(bypassCount, "won't toggle double selected node").toBe(7)
   })
 })
+
+test.describe(
+  'Vue Node Group Context Menu',
+  { tag: ['@vue-nodes', '@canvas'] },
+  () => {
+    test('right-clicking a group opens the Vue context menu instead of the legacy menu', async ({
+      comfyPage
+    }) => {
+      // Group the nodes, then deselect so the right-click selects the group itself.
+      await comfyPage.keyboard.selectAll()
+      await comfyPage.page.keyboard.press(CREATE_GROUP_HOTKEY)
+      await expect
+        .poll(() => comfyPage.page.evaluate(() => graph!.groups.length))
+        .toBe(1)
+      await comfyPage.page.mouse.click(100, 100)
+      await comfyPage.nextFrame()
+
+      const groupPos = await getGroupTitlePosition(comfyPage, 'Group')
+      await comfyPage.page.mouse.click(groupPos.x, groupPos.y, {
+        button: 'right'
+      })
+
+      // The new Vue context menu opens; the legacy litegraph menu does not.
+      await expect(comfyPage.contextMenu.primeVueMenu).toBeVisible()
+      await expect(comfyPage.contextMenu.litegraphContextMenu).toBeHidden()
+      await expect(comfyPage.contextMenu.litegraphMenu).toBeHidden()
+
+      // Group-only action confirms it is the group menu.
+      await expect(
+        comfyPage.contextMenu.primeVueMenu.getByText('Fit Group To Nodes')
+      ).toBeVisible()
+    })
+  }
+)

--- a/browser_tests/tests/vueNodes/groups/groups.spec.ts
+++ b/browser_tests/tests/vueNodes/groups/groups.spec.ts
@@ -288,7 +288,7 @@ test.describe(
     test('right-clicking a group opens the Vue context menu instead of the legacy menu', async ({
       comfyPage
     }) => {
-      // Group the nodes, then deselect so the right-click selects the group itself.
+      // Deselect so the right-click selects the group itself.
       await comfyPage.keyboard.selectAll()
       await comfyPage.page.keyboard.press(CREATE_GROUP_HOTKEY)
       await expect
@@ -302,7 +302,6 @@ test.describe(
         button: 'right'
       })
 
-      // The new Vue context menu opens; the legacy litegraph menu does not.
       await expect(comfyPage.contextMenu.primeVueMenu).toBeVisible()
       await expect(comfyPage.contextMenu.litegraphContextMenu).toBeHidden()
       await expect(comfyPage.contextMenu.litegraphMenu).toBeHidden()

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -145,6 +145,7 @@ import TopbarBadges from '@/components/topbar/TopbarBadges.vue'
 import TopbarSubscribeButton from '@/components/topbar/TopbarSubscribeButton.vue'
 import WorkflowTabs from '@/components/topbar/WorkflowTabs.vue'
 import { useChainCallback } from '@/composables/functional/useChainCallback'
+import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
 import { installErrorClearingHooks } from '@/composables/graph/useErrorClearingHooks'
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
 import { useVueNodeLifecycle } from '@/composables/graph/useVueNodeLifecycle'
@@ -464,6 +465,7 @@ useNodeBadge()
 
 useGlobalLitegraph()
 useContextMenuTranslation()
+useGroupContextMenu()
 useCopy()
 usePaste()
 useWorkflowAutoSave()

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
+import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+
+const {
+  mockShowNodeOptions,
+  mockUpdateSelectedItems,
+  mockQueryRerouteAtPoint
+} = vi.hoisted(() => ({
+  mockShowNodeOptions: vi.fn(),
+  mockUpdateSelectedItems: vi.fn(),
+  mockQueryRerouteAtPoint: vi.fn<() => unknown>(() => null)
+}))
+
+vi.mock('@/composables/graph/useMoreOptionsMenu', () => ({
+  showNodeOptions: mockShowNodeOptions
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ updateSelectedItems: mockUpdateSelectedItems })
+}))
+
+vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
+  layoutStore: { queryRerouteAtPoint: mockQueryRerouteAtPoint }
+}))
+
+interface StubCanvas {
+  graph: { getGroupOnPos: ReturnType<typeof vi.fn> }
+  deselectAll: ReturnType<typeof vi.fn>
+  select: ReturnType<typeof vi.fn>
+}
+
+describe('useGroupContextMenu', () => {
+  const group = { id: 1 }
+  const event = { canvasX: 10, canvasY: 20 }
+  let realProcessContextMenu: typeof LGraphCanvas.prototype.processContextMenu
+  let originalSpy: ReturnType<typeof vi.fn>
+  let stubCanvas: StubCanvas
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockQueryRerouteAtPoint.mockReturnValue(null)
+    LiteGraph.vueNodesMode = true
+
+    realProcessContextMenu = LGraphCanvas.prototype.processContextMenu
+    originalSpy = vi.fn()
+    LGraphCanvas.prototype.processContextMenu = originalSpy as never
+
+    useGroupContextMenu()
+
+    stubCanvas = {
+      graph: { getGroupOnPos: vi.fn(() => group) },
+      deselectAll: vi.fn(),
+      select: vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    LGraphCanvas.prototype.processContextMenu = realProcessContextMenu
+    LiteGraph.vueNodesMode = false
+  })
+
+  function invoke(node: unknown) {
+    LGraphCanvas.prototype.processContextMenu.call(
+      stubCanvas as never,
+      node as never,
+      event as never
+    )
+  }
+
+  it('opens the Vue menu for a group right-click in Nodes 2.0 mode', () => {
+    invoke(undefined)
+
+    expect(stubCanvas.deselectAll).toHaveBeenCalledOnce()
+    expect(stubCanvas.select).toHaveBeenCalledWith(group)
+    expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
+    expect(originalSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the legacy menu when a node is under the cursor', () => {
+    invoke({ id: 'n1' })
+
+    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+    expect(stubCanvas.select).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the legacy menu in legacy (non-Nodes 2.0) mode', () => {
+    LiteGraph.vueNodesMode = false
+
+    invoke(undefined)
+
+    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+    expect(stubCanvas.select).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the legacy menu when no group is under the cursor', () => {
+    stubCanvas.graph.getGroupOnPos.mockReturnValue(undefined)
+
+    invoke(undefined)
+
+    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy menu when a reroute is under the cursor inside a group', () => {
+    mockQueryRerouteAtPoint.mockReturnValue({ id: 5 })
+
+    invoke(undefined)
+
+    expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
+    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+  })
+
+  it('preserves selection but still opens the menu when the group is already selected', () => {
+    stubCanvas.graph.getGroupOnPos.mockReturnValue({ id: 1, selected: true })
+
+    invoke(undefined)
+
+    expect(stubCanvas.deselectAll).not.toHaveBeenCalled()
+    expect(stubCanvas.select).not.toHaveBeenCalled()
+    expect(mockUpdateSelectedItems).not.toHaveBeenCalled()
+    expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
+    expect(originalSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the legacy menu when the canvas has no graph', () => {
+    const graphlessCanvas = { deselectAll: vi.fn(), select: vi.fn() }
+
+    LGraphCanvas.prototype.processContextMenu.call(
+      graphlessCanvas as never,
+      undefined as never,
+      event as never
+    )
+
+    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
 
 const {
   mockShowNodeOptions,
@@ -26,14 +27,20 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
 }))
 
 interface StubCanvas {
-  graph: { getGroupOnPos: ReturnType<typeof vi.fn> }
+  graph: {
+    getGroupOnPos: ReturnType<typeof vi.fn>
+    getRerouteOnPos: ReturnType<typeof vi.fn>
+  }
   deselectAll: ReturnType<typeof vi.fn>
   select: ReturnType<typeof vi.fn>
+  links_render_mode: number
 }
+
+type ProcessArgs = Parameters<typeof LGraphCanvas.prototype.processContextMenu>
 
 describe('useGroupContextMenu', () => {
   const group = { id: 1 }
-  const event = { canvasX: 10, canvasY: 20 }
+  const event = { canvasX: 10, canvasY: 20 } as unknown as ProcessArgs[1]
   let realProcessContextMenu: typeof LGraphCanvas.prototype.processContextMenu
   let originalSpy: ReturnType<typeof vi.fn>
   let stubCanvas: StubCanvas
@@ -45,14 +52,19 @@ describe('useGroupContextMenu', () => {
 
     realProcessContextMenu = LGraphCanvas.prototype.processContextMenu
     originalSpy = vi.fn()
-    LGraphCanvas.prototype.processContextMenu = originalSpy as never
+    LGraphCanvas.prototype.processContextMenu =
+      originalSpy as unknown as typeof LGraphCanvas.prototype.processContextMenu
 
     useGroupContextMenu()
 
     stubCanvas = {
-      graph: { getGroupOnPos: vi.fn(() => group) },
+      graph: {
+        getGroupOnPos: vi.fn(() => group),
+        getRerouteOnPos: vi.fn(() => undefined)
+      },
       deselectAll: vi.fn(),
-      select: vi.fn()
+      select: vi.fn(),
+      links_render_mode: LinkRenderType.SPLINE_LINK
     }
   })
 
@@ -61,11 +73,11 @@ describe('useGroupContextMenu', () => {
     LiteGraph.vueNodesMode = false
   })
 
-  function invoke(node: unknown) {
+  function invoke(node: ProcessArgs[0]) {
     LGraphCanvas.prototype.processContextMenu.call(
-      stubCanvas as never,
-      node as never,
-      event as never
+      stubCanvas as unknown as LGraphCanvas,
+      node,
+      event
     )
   }
 
@@ -80,7 +92,7 @@ describe('useGroupContextMenu', () => {
   })
 
   it('falls through to the legacy menu when a node is under the cursor', () => {
-    invoke({ id: 'n1' })
+    invoke({ id: 'n1' } as unknown as ProcessArgs[0])
 
     expect(originalSpy).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
@@ -106,14 +118,37 @@ describe('useGroupContextMenu', () => {
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
   })
 
-  it('keeps the legacy menu when a reroute is under the cursor inside a group', () => {
+  it('keeps the legacy menu when the layout store reports a reroute', () => {
     mockQueryRerouteAtPoint.mockReturnValue({ id: 5 })
+
+    invoke(undefined)
+
+    expect(stubCanvas.graph.getRerouteOnPos).not.toHaveBeenCalled()
+    expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
+    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy menu when getRerouteOnPos finds a reroute the layout store missed', () => {
+    stubCanvas.graph.getRerouteOnPos.mockReturnValue({ id: 5 })
 
     invoke(undefined)
 
     expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
     expect(originalSpy).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
+  })
+
+  it('skips the reroute check and opens the group menu when links are hidden', () => {
+    stubCanvas.links_render_mode = LinkRenderType.HIDDEN_LINK
+
+    invoke(undefined)
+
+    expect(mockQueryRerouteAtPoint).not.toHaveBeenCalled()
+    expect(stubCanvas.graph.getRerouteOnPos).not.toHaveBeenCalled()
+    expect(stubCanvas.select).toHaveBeenCalledWith(group)
+    expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
+    expect(originalSpy).not.toHaveBeenCalled()
   })
 
   it('preserves selection but still opens the menu when the group is already selected', () => {
@@ -132,9 +167,9 @@ describe('useGroupContextMenu', () => {
     const graphlessCanvas = { deselectAll: vi.fn(), select: vi.fn() }
 
     LGraphCanvas.prototype.processContextMenu.call(
-      graphlessCanvas as never,
-      undefined as never,
-      event as never
+      graphlessCanvas as unknown as LGraphCanvas,
+      undefined,
+      event
     )
 
     expect(originalSpy).toHaveBeenCalledOnce()

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -1,6 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useGroupContextMenu } from '@/composables/graph/useGroupContextMenu'
+import type {
+  CanvasPointerEvent,
+  LGraphNode
+} from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
 
@@ -36,12 +41,9 @@ interface StubCanvas {
   links_render_mode: number
 }
 
-type ProcessArgs = Parameters<typeof LGraphCanvas.prototype.processContextMenu>
-
 describe('useGroupContextMenu', () => {
   const group = { id: 1 }
-  const event = { canvasX: 10, canvasY: 20 } as unknown as ProcessArgs[1]
-  let realProcessContextMenu: typeof LGraphCanvas.prototype.processContextMenu
+  const event = fromPartial<CanvasPointerEvent>({ canvasX: 10, canvasY: 20 })
   let originalSpy: ReturnType<typeof vi.fn>
   let stubCanvas: StubCanvas
 
@@ -50,10 +52,8 @@ describe('useGroupContextMenu', () => {
     mockQueryRerouteAtPoint.mockReturnValue(null)
     LiteGraph.vueNodesMode = true
 
-    realProcessContextMenu = LGraphCanvas.prototype.processContextMenu
     originalSpy = vi.fn()
-    LGraphCanvas.prototype.processContextMenu =
-      originalSpy as unknown as typeof LGraphCanvas.prototype.processContextMenu
+    LGraphCanvas.prototype.processContextMenu = fromAny(originalSpy)
 
     useGroupContextMenu()
 
@@ -68,17 +68,8 @@ describe('useGroupContextMenu', () => {
     }
   })
 
-  afterEach(() => {
-    LGraphCanvas.prototype.processContextMenu = realProcessContextMenu
-    LiteGraph.vueNodesMode = false
-  })
-
-  function invoke(node: ProcessArgs[0]) {
-    LGraphCanvas.prototype.processContextMenu.call(
-      stubCanvas as unknown as LGraphCanvas,
-      node,
-      event
-    )
+  function invoke(node: LGraphNode | undefined) {
+    LGraphCanvas.prototype.processContextMenu.call(fromAny(stubCanvas), node, event)
   }
 
   it('opens the Vue menu for a group right-click in Nodes 2.0 mode', () => {
@@ -92,7 +83,7 @@ describe('useGroupContextMenu', () => {
   })
 
   it('falls through to the legacy menu when a node is under the cursor', () => {
-    invoke({ id: 'n1' } as unknown as ProcessArgs[0])
+    invoke(fromPartial<LGraphNode>({}))
 
     expect(originalSpy).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
@@ -164,10 +155,8 @@ describe('useGroupContextMenu', () => {
   })
 
   it('falls through to the legacy menu when the canvas has no graph', () => {
-    const graphlessCanvas = { deselectAll: vi.fn(), select: vi.fn() }
-
     LGraphCanvas.prototype.processContextMenu.call(
-      graphlessCanvas as unknown as LGraphCanvas,
+      fromAny({ deselectAll: vi.fn(), select: vi.fn() }),
       undefined,
       event
     )

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -37,23 +37,24 @@ interface StubCanvas {
     getRerouteOnPos: ReturnType<typeof vi.fn>
   }
   deselectAll: ReturnType<typeof vi.fn>
-  select: ReturnType<typeof vi.fn>
+  selectedItems: Set<unknown>
   links_render_mode: number
 }
 
 describe('useGroupContextMenu', () => {
-  const group = { id: 1 }
   const event = fromPartial<CanvasPointerEvent>({ canvasX: 10, canvasY: 20 })
-  let originalSpy: ReturnType<typeof vi.fn>
+  let group: { id: number; selected?: boolean }
+  let legacyMenuMock: ReturnType<typeof vi.fn>
   let stubCanvas: StubCanvas
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockQueryRerouteAtPoint.mockReturnValue(null)
     LiteGraph.vueNodesMode = true
+    group = { id: 1 }
 
-    originalSpy = vi.fn()
-    LGraphCanvas.prototype.processContextMenu = fromAny(originalSpy)
+    legacyMenuMock = vi.fn()
+    LGraphCanvas.prototype.processContextMenu = fromAny(legacyMenuMock)
 
     useGroupContextMenu()
 
@@ -63,7 +64,7 @@ describe('useGroupContextMenu', () => {
         getRerouteOnPos: vi.fn(() => undefined)
       },
       deselectAll: vi.fn(),
-      select: vi.fn(),
+      selectedItems: new Set(),
       links_render_mode: LinkRenderType.SPLINE_LINK
     }
   })
@@ -76,22 +77,23 @@ describe('useGroupContextMenu', () => {
     )
   }
 
-  it('opens the Vue menu for a group right-click in Nodes 2.0 mode', () => {
+  it('opens the Vue menu and selects only the group in Nodes 2.0 mode', () => {
     invoke(undefined)
 
     expect(stubCanvas.deselectAll).toHaveBeenCalledOnce()
-    expect(stubCanvas.select).toHaveBeenCalledWith(group)
+    expect(group.selected).toBe(true)
+    expect(stubCanvas.selectedItems.has(group)).toBe(true)
     expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
-    expect(originalSpy).not.toHaveBeenCalled()
+    expect(legacyMenuMock).not.toHaveBeenCalled()
   })
 
   it('falls through to the legacy menu when a node is under the cursor', () => {
     invoke(fromPartial<LGraphNode>({}))
 
-    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
-    expect(stubCanvas.select).not.toHaveBeenCalled()
+    expect(stubCanvas.selectedItems.size).toBe(0)
   })
 
   it('falls through to the legacy menu in legacy (non-Nodes 2.0) mode', () => {
@@ -99,9 +101,9 @@ describe('useGroupContextMenu', () => {
 
     invoke(undefined)
 
-    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
-    expect(stubCanvas.select).not.toHaveBeenCalled()
+    expect(stubCanvas.selectedItems.size).toBe(0)
   })
 
   it('falls through to the legacy menu when no group is under the cursor', () => {
@@ -109,7 +111,7 @@ describe('useGroupContextMenu', () => {
 
     invoke(undefined)
 
-    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
   })
 
@@ -120,7 +122,7 @@ describe('useGroupContextMenu', () => {
 
     expect(stubCanvas.graph.getRerouteOnPos).not.toHaveBeenCalled()
     expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
-    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
   })
 
@@ -130,7 +132,7 @@ describe('useGroupContextMenu', () => {
     invoke(undefined)
 
     expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
-    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
   })
 
@@ -141,31 +143,32 @@ describe('useGroupContextMenu', () => {
 
     expect(mockQueryRerouteAtPoint).not.toHaveBeenCalled()
     expect(stubCanvas.graph.getRerouteOnPos).not.toHaveBeenCalled()
-    expect(stubCanvas.select).toHaveBeenCalledWith(group)
+    expect(stubCanvas.selectedItems.has(group)).toBe(true)
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
-    expect(originalSpy).not.toHaveBeenCalled()
+    expect(legacyMenuMock).not.toHaveBeenCalled()
   })
 
-  it('preserves selection but still opens the menu when the group is already selected', () => {
-    stubCanvas.graph.getGroupOnPos.mockReturnValue({ id: 1, selected: true })
+  it('keeps the menu open without re-selecting when the group is already selected', () => {
+    const selectedGroup = { id: 1, selected: true }
+    stubCanvas.graph.getGroupOnPos.mockReturnValue(selectedGroup)
 
     invoke(undefined)
 
     expect(stubCanvas.deselectAll).not.toHaveBeenCalled()
-    expect(stubCanvas.select).not.toHaveBeenCalled()
-    expect(mockUpdateSelectedItems).not.toHaveBeenCalled()
+    expect(stubCanvas.selectedItems.size).toBe(0)
+    expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
-    expect(originalSpy).not.toHaveBeenCalled()
+    expect(legacyMenuMock).not.toHaveBeenCalled()
   })
 
   it('falls through to the legacy menu when the canvas has no graph', () => {
     LGraphCanvas.prototype.processContextMenu.call(
-      fromAny({ deselectAll: vi.fn(), select: vi.fn() }),
+      fromAny({ deselectAll: vi.fn() }),
       undefined,
       event
     )
 
-    expect(originalSpy).toHaveBeenCalledOnce()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
   })
 })

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -41,14 +41,18 @@ interface StubCanvas {
 
 describe('useGroupContextMenu', () => {
   const event = fromPartial<CanvasPointerEvent>({ canvasX: 10, canvasY: 20 })
-  let group: { id: number; selected?: boolean }
+  let group: {
+    id: number
+    selected?: boolean
+    recomputeInsideNodes: ReturnType<typeof vi.fn>
+  }
   let legacyMenuMock: ReturnType<typeof vi.fn>
   let stubCanvas: StubCanvas
 
   beforeEach(() => {
     vi.clearAllMocks()
     LiteGraph.vueNodesMode = true
-    group = { id: 1 }
+    group = { id: 1, recomputeInsideNodes: vi.fn() }
     mockGetCanvasContextMenuTarget.mockReturnValue({ group })
 
     legacyMenuMock = vi.fn()
@@ -79,6 +83,7 @@ describe('useGroupContextMenu', () => {
     expect(group.selected).toBe(true)
     expect(stubCanvas.selectedItems.has(group)).toBe(true)
     expect(stubCanvas.state.selectionChanged).toBe(true)
+    expect(group.recomputeInsideNodes).toHaveBeenCalledOnce()
     expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
     expect(legacyMenuMock).not.toHaveBeenCalled()

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -66,6 +66,9 @@ describe('useGroupContextMenu', () => {
       selectedItems: new Set(),
       state: { selectionChanged: false }
     }
+    stubCanvas.deselectAll.mockImplementation(() => {
+      stubCanvas.selectedItems.clear()
+    })
   })
 
   function invoke(node: LGraphNode | undefined) {
@@ -86,6 +89,9 @@ describe('useGroupContextMenu', () => {
     expect(group.recomputeInsideNodes).toHaveBeenCalledOnce()
     expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
+    expect(mockUpdateSelectedItems.mock.invocationCallOrder[0]).toBeLessThan(
+      mockShowNodeOptions.mock.invocationCallOrder[0]
+    )
     expect(legacyMenuMock).not.toHaveBeenCalled()
   })
 
@@ -130,16 +136,35 @@ describe('useGroupContextMenu', () => {
     expect(stubCanvas.selectedItems.size).toBe(0)
   })
 
-  it('keeps the menu open without re-selecting when the group is already selected', () => {
-    mockGetCanvasContextMenuTarget.mockReturnValue({
-      group: { id: 1, selected: true }
-    })
+  it('keeps the menu open without re-selecting when only the group is selected', () => {
+    group.selected = true
+    stubCanvas.selectedItems.add(group)
 
     invoke(undefined)
 
     expect(stubCanvas.deselectAll).not.toHaveBeenCalled()
-    expect(stubCanvas.selectedItems.size).toBe(0)
+    expect(stubCanvas.selectedItems.size).toBe(1)
+    expect(stubCanvas.selectedItems.has(group)).toBe(true)
     expect(stubCanvas.state.selectionChanged).toBe(false)
+    expect(group.recomputeInsideNodes).not.toHaveBeenCalled()
+    expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
+    expect(legacyMenuMock).not.toHaveBeenCalled()
+  })
+
+  it('reselects the group when selected child nodes would hide group actions', () => {
+    const childNode = { selected: true }
+    group.selected = true
+    stubCanvas.selectedItems.add(group)
+    stubCanvas.selectedItems.add(childNode)
+
+    invoke(undefined)
+
+    expect(stubCanvas.deselectAll).toHaveBeenCalledOnce()
+    expect(stubCanvas.selectedItems.size).toBe(1)
+    expect(stubCanvas.selectedItems.has(group)).toBe(true)
+    expect(stubCanvas.state.selectionChanged).toBe(true)
+    expect(group.recomputeInsideNodes).toHaveBeenCalledOnce()
     expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
     expect(legacyMenuMock).not.toHaveBeenCalled()

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -69,7 +69,11 @@ describe('useGroupContextMenu', () => {
   })
 
   function invoke(node: LGraphNode | undefined) {
-    LGraphCanvas.prototype.processContextMenu.call(fromAny(stubCanvas), node, event)
+    LGraphCanvas.prototype.processContextMenu.call(
+      fromAny(stubCanvas),
+      node,
+      event
+    )
   }
 
   it('opens the Vue menu for a group right-click in Nodes 2.0 mode', () => {

--- a/src/composables/graph/useGroupContextMenu.test.ts
+++ b/src/composables/graph/useGroupContextMenu.test.ts
@@ -7,16 +7,17 @@ import type {
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
 
 const {
   mockShowNodeOptions,
   mockUpdateSelectedItems,
-  mockQueryRerouteAtPoint
+  mockGetCanvasContextMenuTarget
 } = vi.hoisted(() => ({
   mockShowNodeOptions: vi.fn(),
   mockUpdateSelectedItems: vi.fn(),
-  mockQueryRerouteAtPoint: vi.fn<() => unknown>(() => null)
+  mockGetCanvasContextMenuTarget: vi.fn<
+    () => { reroute?: unknown; group?: unknown }
+  >(() => ({}))
 }))
 
 vi.mock('@/composables/graph/useMoreOptionsMenu', () => ({
@@ -27,18 +28,15 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
   useCanvasStore: () => ({ updateSelectedItems: mockUpdateSelectedItems })
 }))
 
-vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
-  layoutStore: { queryRerouteAtPoint: mockQueryRerouteAtPoint }
+vi.mock('@/lib/litegraph/src/canvas/getCanvasContextMenuTarget', () => ({
+  getCanvasContextMenuTarget: mockGetCanvasContextMenuTarget
 }))
 
 interface StubCanvas {
-  graph: {
-    getGroupOnPos: ReturnType<typeof vi.fn>
-    getRerouteOnPos: ReturnType<typeof vi.fn>
-  }
+  graph: object
   deselectAll: ReturnType<typeof vi.fn>
   selectedItems: Set<unknown>
-  links_render_mode: number
+  state: { selectionChanged: boolean }
 }
 
 describe('useGroupContextMenu', () => {
@@ -49,9 +47,9 @@ describe('useGroupContextMenu', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockQueryRerouteAtPoint.mockReturnValue(null)
     LiteGraph.vueNodesMode = true
     group = { id: 1 }
+    mockGetCanvasContextMenuTarget.mockReturnValue({ group })
 
     legacyMenuMock = vi.fn()
     LGraphCanvas.prototype.processContextMenu = fromAny(legacyMenuMock)
@@ -59,13 +57,10 @@ describe('useGroupContextMenu', () => {
     useGroupContextMenu()
 
     stubCanvas = {
-      graph: {
-        getGroupOnPos: vi.fn(() => group),
-        getRerouteOnPos: vi.fn(() => undefined)
-      },
+      graph: {},
       deselectAll: vi.fn(),
       selectedItems: new Set(),
-      links_render_mode: LinkRenderType.SPLINE_LINK
+      state: { selectionChanged: false }
     }
   })
 
@@ -83,6 +78,7 @@ describe('useGroupContextMenu', () => {
     expect(stubCanvas.deselectAll).toHaveBeenCalledOnce()
     expect(group.selected).toBe(true)
     expect(stubCanvas.selectedItems.has(group)).toBe(true)
+    expect(stubCanvas.state.selectionChanged).toBe(true)
     expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
     expect(legacyMenuMock).not.toHaveBeenCalled()
@@ -91,9 +87,9 @@ describe('useGroupContextMenu', () => {
   it('falls through to the legacy menu when a node is under the cursor', () => {
     invoke(fromPartial<LGraphNode>({}))
 
+    expect(mockGetCanvasContextMenuTarget).not.toHaveBeenCalled()
     expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
-    expect(stubCanvas.selectedItems.size).toBe(0)
   })
 
   it('falls through to the legacy menu in legacy (non-Nodes 2.0) mode', () => {
@@ -101,61 +97,44 @@ describe('useGroupContextMenu', () => {
 
     invoke(undefined)
 
+    expect(mockGetCanvasContextMenuTarget).not.toHaveBeenCalled()
+    expect(legacyMenuMock).toHaveBeenCalledOnce()
+    expect(mockShowNodeOptions).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the legacy menu when no group is under the cursor', () => {
+    mockGetCanvasContextMenuTarget.mockReturnValue({})
+
+    invoke(undefined)
+
     expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
     expect(stubCanvas.selectedItems.size).toBe(0)
   })
 
-  it('falls through to the legacy menu when no group is under the cursor', () => {
-    stubCanvas.graph.getGroupOnPos.mockReturnValue(undefined)
+  it('falls through to the legacy menu when the cursor is on a reroute', () => {
+    mockGetCanvasContextMenuTarget.mockReturnValue({
+      reroute: { id: 5 },
+      group
+    })
 
     invoke(undefined)
 
     expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
-  })
-
-  it('keeps the legacy menu when the layout store reports a reroute', () => {
-    mockQueryRerouteAtPoint.mockReturnValue({ id: 5 })
-
-    invoke(undefined)
-
-    expect(stubCanvas.graph.getRerouteOnPos).not.toHaveBeenCalled()
-    expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
-    expect(legacyMenuMock).toHaveBeenCalledOnce()
-    expect(mockShowNodeOptions).not.toHaveBeenCalled()
-  })
-
-  it('keeps the legacy menu when getRerouteOnPos finds a reroute the layout store missed', () => {
-    stubCanvas.graph.getRerouteOnPos.mockReturnValue({ id: 5 })
-
-    invoke(undefined)
-
-    expect(stubCanvas.graph.getGroupOnPos).not.toHaveBeenCalled()
-    expect(legacyMenuMock).toHaveBeenCalledOnce()
-    expect(mockShowNodeOptions).not.toHaveBeenCalled()
-  })
-
-  it('skips the reroute check and opens the group menu when links are hidden', () => {
-    stubCanvas.links_render_mode = LinkRenderType.HIDDEN_LINK
-
-    invoke(undefined)
-
-    expect(mockQueryRerouteAtPoint).not.toHaveBeenCalled()
-    expect(stubCanvas.graph.getRerouteOnPos).not.toHaveBeenCalled()
-    expect(stubCanvas.selectedItems.has(group)).toBe(true)
-    expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
-    expect(legacyMenuMock).not.toHaveBeenCalled()
+    expect(stubCanvas.selectedItems.size).toBe(0)
   })
 
   it('keeps the menu open without re-selecting when the group is already selected', () => {
-    const selectedGroup = { id: 1, selected: true }
-    stubCanvas.graph.getGroupOnPos.mockReturnValue(selectedGroup)
+    mockGetCanvasContextMenuTarget.mockReturnValue({
+      group: { id: 1, selected: true }
+    })
 
     invoke(undefined)
 
     expect(stubCanvas.deselectAll).not.toHaveBeenCalled()
     expect(stubCanvas.selectedItems.size).toBe(0)
+    expect(stubCanvas.state.selectionChanged).toBe(false)
     expect(mockUpdateSelectedItems).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).toHaveBeenCalledWith(event)
     expect(legacyMenuMock).not.toHaveBeenCalled()
@@ -168,6 +147,7 @@ describe('useGroupContextMenu', () => {
       event
     )
 
+    expect(mockGetCanvasContextMenuTarget).not.toHaveBeenCalled()
     expect(legacyMenuMock).toHaveBeenCalledOnce()
     expect(mockShowNodeOptions).not.toHaveBeenCalled()
   })

--- a/src/composables/graph/useGroupContextMenu.ts
+++ b/src/composables/graph/useGroupContextMenu.ts
@@ -1,5 +1,6 @@
 import { showNodeOptions } from '@/composables/graph/useMoreOptionsMenu'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 
@@ -27,11 +28,16 @@ export function useGroupContextMenu() {
       return
     }
 
-    // Reroutes can sit inside a group; keep their legacy right-click menu.
-    const onReroute = layoutStore.queryRerouteAtPoint({
-      x: event.canvasX,
-      y: event.canvasY
-    })
+    // A reroute can sit inside a group; defer it to the legacy "Delete Reroute"
+    // menu. Mirror processContextMenu's hit-test (layout store first, litegraph
+    // fallback) so we never miss one and wrongly open the group menu over it.
+    const onReroute =
+      this.links_render_mode !== LinkRenderType.HIDDEN_LINK &&
+      (!!layoutStore.queryRerouteAtPoint({
+        x: event.canvasX,
+        y: event.canvasY
+      }) ||
+        !!this.graph.getRerouteOnPos(event.canvasX, event.canvasY))
     const group = onReroute
       ? undefined
       : this.graph.getGroupOnPos(event.canvasX, event.canvasY)

--- a/src/composables/graph/useGroupContextMenu.ts
+++ b/src/composables/graph/useGroupContextMenu.ts
@@ -1,0 +1,53 @@
+import { showNodeOptions } from '@/composables/graph/useMoreOptionsMenu'
+import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
+import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+
+/**
+ * Routes a right-click on a group (frame) to the Vue context menu instead of
+ * the legacy litegraph menu, mirroring how a Vue node right-click opens the
+ * same menu via {@link showNodeOptions}.
+ *
+ * Only active in Nodes 2.0 mode ({@link LiteGraph.vueNodesMode}); in legacy
+ * rendering, groups keep the old menu so they stay consistent with legacy
+ * nodes. Nodes, the canvas background, and reroutes are left untouched.
+ */
+export function useGroupContextMenu() {
+  const canvasStore = useCanvasStore()
+  const original = LGraphCanvas.prototype.processContextMenu
+
+  function processContextMenuWithVueGroupMenu(
+    this: LGraphCanvas,
+    ...args: Parameters<typeof original>
+  ): void {
+    const [node, event] = args
+
+    if (node || !LiteGraph.vueNodesMode || !this.graph) {
+      original.apply(this, args)
+      return
+    }
+
+    // Reroutes can sit inside a group; keep their legacy right-click menu.
+    const onReroute = layoutStore.queryRerouteAtPoint({
+      x: event.canvasX,
+      y: event.canvasY
+    })
+    const group = onReroute
+      ? undefined
+      : this.graph.getGroupOnPos(event.canvasX, event.canvasY)
+
+    if (!group) {
+      original.apply(this, args)
+      return
+    }
+
+    if (!group.selected) {
+      this.deselectAll()
+      this.select(group)
+      canvasStore.updateSelectedItems()
+    }
+    showNodeOptions(event)
+  }
+
+  LGraphCanvas.prototype.processContextMenu = processContextMenuWithVueGroupMenu
+}

--- a/src/composables/graph/useGroupContextMenu.ts
+++ b/src/composables/graph/useGroupContextMenu.ts
@@ -1,4 +1,5 @@
 import { showNodeOptions } from '@/composables/graph/useMoreOptionsMenu'
+import type { Reroute } from '@/lib/litegraph/src/litegraph'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -14,7 +15,6 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
  * nodes. Nodes, the canvas background, and reroutes are left untouched.
  */
 export function useGroupContextMenu() {
-  const canvasStore = useCanvasStore()
   const original = LGraphCanvas.prototype.processContextMenu
 
   function processContextMenuWithVueGroupMenu(
@@ -28,16 +28,20 @@ export function useGroupContextMenu() {
       return
     }
 
-    // A reroute can sit inside a group; defer it to the legacy "Delete Reroute"
-    // menu. Mirror processContextMenu's hit-test (layout store first, litegraph
-    // fallback) so we never miss one and wrongly open the group menu over it.
+    const reroutesVisible =
+      this.links_render_mode !== LinkRenderType.HIDDEN_LINK
     const onReroute =
-      this.links_render_mode !== LinkRenderType.HIDDEN_LINK &&
+      reroutesVisible &&
       (!!layoutStore.queryRerouteAtPoint({
         x: event.canvasX,
         y: event.canvasY
       }) ||
-        !!this.graph.getRerouteOnPos(event.canvasX, event.canvasY))
+        !!this.graph.getRerouteOnPos(
+          event.canvasX,
+          event.canvasY,
+          (this as unknown as { _visibleReroutes: Set<Reroute> })
+            ._visibleReroutes
+        ))
     const group = onReroute
       ? undefined
       : this.graph.getGroupOnPos(event.canvasX, event.canvasY)
@@ -49,9 +53,10 @@ export function useGroupContextMenu() {
 
     if (!group.selected) {
       this.deselectAll()
-      this.select(group)
-      canvasStore.updateSelectedItems()
+      group.selected = true
+      this.selectedItems.add(group)
     }
+    useCanvasStore().updateSelectedItems()
     showNodeOptions(event)
   }
 

--- a/src/composables/graph/useGroupContextMenu.ts
+++ b/src/composables/graph/useGroupContextMenu.ts
@@ -1,9 +1,7 @@
 import { showNodeOptions } from '@/composables/graph/useMoreOptionsMenu'
-import type { Reroute } from '@/lib/litegraph/src/litegraph'
+import { getCanvasContextMenuTarget } from '@/lib/litegraph/src/canvas/getCanvasContextMenuTarget'
 import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
-import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 
 /**
  * Routes a right-click on a group (frame) to the Vue context menu instead of
@@ -28,25 +26,12 @@ export function useGroupContextMenu() {
       return
     }
 
-    const reroutesVisible =
-      this.links_render_mode !== LinkRenderType.HIDDEN_LINK
-    const onReroute =
-      reroutesVisible &&
-      (!!layoutStore.queryRerouteAtPoint({
-        x: event.canvasX,
-        y: event.canvasY
-      }) ||
-        !!this.graph.getRerouteOnPos(
-          event.canvasX,
-          event.canvasY,
-          (this as unknown as { _visibleReroutes: Set<Reroute> })
-            ._visibleReroutes
-        ))
-    const group = onReroute
-      ? undefined
-      : this.graph.getGroupOnPos(event.canvasX, event.canvasY)
-
-    if (!group) {
+    const { reroute, group } = getCanvasContextMenuTarget(
+      this,
+      event.canvasX,
+      event.canvasY
+    )
+    if (reroute || !group) {
       original.apply(this, args)
       return
     }
@@ -55,6 +40,7 @@ export function useGroupContextMenu() {
       this.deselectAll()
       group.selected = true
       this.selectedItems.add(group)
+      this.state.selectionChanged = true
     }
     useCanvasStore().updateSelectedItems()
     showNodeOptions(event)

--- a/src/composables/graph/useGroupContextMenu.ts
+++ b/src/composables/graph/useGroupContextMenu.ts
@@ -4,13 +4,8 @@ import { LGraphCanvas, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 
 /**
- * Routes a right-click on a group (frame) to the Vue context menu instead of
- * the legacy litegraph menu, mirroring how a Vue node right-click opens the
- * same menu via {@link showNodeOptions}.
- *
- * Only active in Nodes 2.0 mode ({@link LiteGraph.vueNodesMode}); in legacy
- * rendering, groups keep the old menu so they stay consistent with legacy
- * nodes. Nodes, the canvas background, and reroutes are left untouched.
+ * Routes Nodes 2.0 group right-clicks to Vue while nodes, reroutes,
+ * background, and legacy mode stay on litegraph.
  */
 export function useGroupContextMenu() {
   const original = LGraphCanvas.prototype.processContextMenu
@@ -39,6 +34,7 @@ export function useGroupContextMenu() {
     if (!group.selected) {
       this.deselectAll()
       group.selected = true
+      group.recomputeInsideNodes()
       this.selectedItems.add(group)
       this.state.selectionChanged = true
     }

--- a/src/composables/graph/useGroupContextMenu.ts
+++ b/src/composables/graph/useGroupContextMenu.ts
@@ -31,7 +31,10 @@ export function useGroupContextMenu() {
       return
     }
 
-    if (!group.selected) {
+    const groupIsOnlySelection =
+      this.selectedItems.size === 1 && this.selectedItems.has(group)
+
+    if (!groupIsOnlySelection) {
       this.deselectAll()
       group.selected = true
       group.recomputeInsideNodes()

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -27,6 +27,7 @@ import type { LinkId } from './LLink'
 import { Reroute } from './Reroute'
 import type { RerouteId } from './Reroute'
 import { LinkConnector } from './canvas/LinkConnector'
+import { getCanvasContextMenuTarget } from './canvas/getCanvasContextMenuTarget'
 import { isOverNodeInput, isOverNodeOutput } from './canvas/measureSlots'
 import { strokeShape } from './draw'
 import {
@@ -8719,42 +8720,25 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       menu_info = this.getCanvasMenuOptions()
       if (!this.graph) throw new NullGraphError()
 
-      // Check for reroutes
-      if (this.links_render_mode !== LinkRenderType.HIDDEN_LINK) {
-        // Try layout store first, fallback to old method
-        const rerouteLayout = layoutStore.queryRerouteAtPoint({
-          x: event.canvasX,
-          y: event.canvasY
-        })
+      const { reroute, group } = getCanvasContextMenuTarget(
+        this,
+        event.canvasX,
+        event.canvasY
+      )
+      if (reroute) {
+        menu_info.unshift(
+          {
+            content: 'Delete Reroute',
+            callback: () => {
+              if (!this.graph) throw new NullGraphError()
 
-        let reroute: Reroute | undefined
-        if (rerouteLayout) {
-          reroute = this.graph.getReroute(rerouteLayout.id)
-        } else {
-          reroute = this.graph.getRerouteOnPos(
-            event.canvasX,
-            event.canvasY,
-            this._visibleReroutes
-          )
-        }
-        if (reroute) {
-          menu_info.unshift(
-            {
-              content: 'Delete Reroute',
-              callback: () => {
-                if (!this.graph) throw new NullGraphError()
-
-                this.graph.removeReroute(reroute.id)
-              }
-            },
-            null
-          )
-        }
+              this.graph.removeReroute(reroute.id)
+            }
+          },
+          null
+        )
       }
-
-      const group = this.graph.getGroupOnPos(event.canvasX, event.canvasY)
       if (group) {
-        // on group
         menu_info.push(null, {
           content: 'Edit Group',
           has_submenu: true,

--- a/src/lib/litegraph/src/canvas/getCanvasContextMenuTarget.test.ts
+++ b/src/lib/litegraph/src/canvas/getCanvasContextMenuTarget.test.ts
@@ -1,0 +1,97 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCanvasContextMenuTarget } from '@/lib/litegraph/src/canvas/getCanvasContextMenuTarget'
+import { LinkRenderType } from '@/lib/litegraph/src/types/globalEnums'
+
+const { mockQueryRerouteAtPoint } = vi.hoisted(() => ({
+  mockQueryRerouteAtPoint: vi.fn<() => unknown>(() => null)
+}))
+
+vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
+  layoutStore: { queryRerouteAtPoint: mockQueryRerouteAtPoint }
+}))
+
+interface StubGraph {
+  getReroute: ReturnType<typeof vi.fn>
+  getRerouteOnPos: ReturnType<typeof vi.fn>
+  getGroupOnPos: ReturnType<typeof vi.fn>
+}
+
+interface StubCanvas {
+  graph: StubGraph | null
+  links_render_mode: number
+  _visibleReroutes: Set<unknown>
+}
+
+describe('getCanvasContextMenuTarget', () => {
+  let graph: StubGraph
+  let canvas: StubCanvas
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockQueryRerouteAtPoint.mockReturnValue(null)
+    graph = {
+      getReroute: vi.fn(() => ({ id: 9 })),
+      getRerouteOnPos: vi.fn(() => undefined),
+      getGroupOnPos: vi.fn(() => ({ id: 1 }))
+    }
+    canvas = {
+      graph,
+      links_render_mode: LinkRenderType.SPLINE_LINK,
+      _visibleReroutes: new Set()
+    }
+  })
+
+  function resolve() {
+    return getCanvasContextMenuTarget(fromAny(canvas), 10, 20)
+  }
+
+  it('returns the group under the point', () => {
+    const target = resolve()
+
+    expect(graph.getGroupOnPos).toHaveBeenCalledWith(10, 20)
+    expect(target.group).toEqual({ id: 1 })
+    expect(target.reroute).toBeUndefined()
+  })
+
+  it('resolves a reroute from the layout store without the positional fallback', () => {
+    mockQueryRerouteAtPoint.mockReturnValue({ id: 9 })
+
+    const target = resolve()
+
+    expect(graph.getReroute).toHaveBeenCalledWith(9)
+    expect(graph.getRerouteOnPos).not.toHaveBeenCalled()
+    expect(target.reroute).toEqual({ id: 9 })
+  })
+
+  it('falls back to the visible-scoped positional hit-test when the layout store misses', () => {
+    graph.getRerouteOnPos.mockReturnValue({ id: 7 })
+
+    const target = resolve()
+
+    expect(graph.getRerouteOnPos).toHaveBeenCalledWith(
+      10,
+      20,
+      canvas._visibleReroutes
+    )
+    expect(target.reroute).toEqual({ id: 7 })
+  })
+
+  it('skips reroute detection when links are hidden', () => {
+    canvas.links_render_mode = LinkRenderType.HIDDEN_LINK
+
+    const target = resolve()
+
+    expect(mockQueryRerouteAtPoint).not.toHaveBeenCalled()
+    expect(graph.getRerouteOnPos).not.toHaveBeenCalled()
+    expect(target.reroute).toBeUndefined()
+    expect(target.group).toEqual({ id: 1 })
+  })
+
+  it('returns an empty target when the canvas has no graph', () => {
+    canvas.graph = null
+
+    expect(resolve()).toEqual({})
+  })
+})

--- a/src/lib/litegraph/src/canvas/getCanvasContextMenuTarget.ts
+++ b/src/lib/litegraph/src/canvas/getCanvasContextMenuTarget.ts
@@ -1,0 +1,36 @@
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+
+import type { LGraphCanvas } from '../LGraphCanvas'
+import type { LGraphGroup } from '../LGraphGroup'
+import type { Reroute } from '../Reroute'
+import { LinkRenderType } from '../types/globalEnums'
+
+interface CanvasContextMenuTarget {
+  reroute?: Reroute
+  group?: LGraphGroup
+}
+
+/** Resolves the reroute and group under a canvas-space point for a right-click. */
+export function getCanvasContextMenuTarget(
+  canvas: LGraphCanvas,
+  x: number,
+  y: number
+): CanvasContextMenuTarget {
+  const { graph } = canvas
+  if (!graph) return {}
+
+  let reroute: Reroute | undefined
+  if (canvas.links_render_mode !== LinkRenderType.HIDDEN_LINK) {
+    const layoutHit = layoutStore.queryRerouteAtPoint({ x, y })
+    reroute = layoutHit
+      ? graph.getReroute(layoutHit.id)
+      : graph.getRerouteOnPos(
+          x,
+          y,
+          (canvas as unknown as { _visibleReroutes: Iterable<Reroute> })
+            ._visibleReroutes
+        )
+  }
+
+  return { reroute, group: graph.getGroupOnPos(x, y) }
+}


### PR DESCRIPTION
## Summary

Right-clicking a frame (group) now opens the new Vue context menu instead of
the legacy litegraph menu, matching the three-dot menu and node right-click.

## Changes

- **What**: In Nodes 2.0 mode, a group right-click is routed to the existing
  `showNodeOptions` flow (the same menu the three-dot button and node
  right-click use) instead of litegraph's `processContextMenu`. The group is
  selected (unless already in the selection) so the menu targets it. Nodes, the
  canvas background, reroutes, and legacy rendering are unchanged.

## Review Focus

- App-layer wrap of `LGraphCanvas.prototype.processContextMenu`, mirroring the
  existing `useContextMenuTranslation` pattern: no new methods on
  `LGraphCanvas` (ADR 0008).
- Gated on `LiteGraph.vueNodesMode`; legacy rendering keeps the old menu,
  consistent with legacy node right-click.
- Reroute guard: right-clicking a reroute inside a group still gets the legacy
  "Delete Reroute" menu, not the group menu.

Fixes FE-1090

## Screenshots (if applicable)

<img width="719" height="788" alt="image" src="https://github.com/user-attachments/assets/8d514c6d-b7d0-4ec1-841e-677793daf3c7" />
