### PR TITLE
fix: remove unused export from ExportFormatOption interface

### DIFF
--- a/src/extensions/core/load3d/constants.ts
+++ b/src/extensions/core/load3d/constants.ts
@@ -27,7 +27,7 @@ export const LOAD3D_NONE_MODEL = 'none'
 
 export const DIRECT_EXPORT_FORMATS = new Set(['ply', 'spz', 'splat', 'ksplat'])
 
-export interface ExportFormatOption {
+interface ExportFormatOption {
   label: string
   value: string
 }


### PR DESCRIPTION
## Summary

Remove unused `export` keyword from `ExportFormatOption` interface. The interface is only used internally in `constants.ts` and is not imported elsewhere.

Fixes knip "unused exported types" error.