### PR TITLE
feat: set default Tab keybinding for Toggle Search Box

### DIFF
--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -40,7 +40,8 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
     combo: {
       key: 'Tab'
     },
-    commandId: 'Workspace.SearchBox.Toggle'
+    commandId: 'Workspace.SearchBox.Toggle',
+    targetElementId: 'graph-canvas-container'
   },
   {
     combo: {

--- a/src/platform/keybindings/defaults.ts
+++ b/src/platform/keybindings/defaults.ts
@@ -38,6 +38,12 @@ export const CORE_KEYBINDINGS: Keybinding[] = [
   },
   {
     combo: {
+      key: 'Tab'
+    },
+    commandId: 'Workspace.SearchBox.Toggle'
+  },
+  {
+    combo: {
       key: 'n'
     },
     commandId: 'Workspace.ToggleSidebarTab.node-library'


### PR DESCRIPTION
## Summary

Set the default keybinding for the Toggle Search Box command (the node-search modal) to `Tab`, scoped to the graph canvas.

## Changes

- **What**: Added a default `Tab` binding for `Workspace.SearchBox.Toggle` in `src/platform/keybindings/defaults.ts`, scoped with `targetElementId: 'graph-canvas-container'`. `Tab` matches the node-search/add-node convention of Houdini, Nuke, and TouchDesigner — the tools ComfyUI's users come from.

## Review Focus

- **Accessibility (WCAG 2.1.1)**: the binding is scoped to `graph-canvas-container` (the same pattern used by `Delete`, `Fit View`, and other canvas commands), so `Tab` only opens the search box when focus is on the canvas — where `Tab` has no meaningful sequential-navigation role. Everywhere else (toolbar, sidebars, dialogs, settings) `Tab` continues to navigate focus normally. Verified live: `Tab` from the canvas opens search; `Tab` from outside the canvas container does not.
- **Text inputs**: additionally, the keybinding handler skips bare keys while focus is in an `INPUT`/`TEXTAREA`/`contenteditable`, so typing is never affected.
- **No conflict**: `Tab` was not previously bound to any command.
- **No unit test added**: asserting a default-value entry would be a change-detector test, which the repo testing guidelines disallow. Verified behaviorally instead.

## Follow-up

Pairs with the stacked PR that makes `Tab` close the modal (instead of cycling focus inside it).