### PR TITLE
GTM-93: add desktop login attribution callback

### DIFF
--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -95,7 +95,6 @@
 </template>
 
 <script setup lang="ts">
-import { until } from '@vueuse/core'
 import Message from 'primevue/message'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -103,18 +102,16 @@ import { useRoute, useRouter } from 'vue-router'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
-import { hasDesktopLoginRequest } from '@/platform/cloud/onboarding/desktopLoginBridge'
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
+import { completeDesktopLoginForExistingSession } from '@/platform/cloud/onboarding/composables/useDesktopLoginCompletion'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
 import type { SignInData } from '@/schemas/signInSchema'
 import { getGoogleSsoBlockedReason } from '@/base/webviewDetection'
-import { useAuthStore } from '@/stores/authStore'
 
 const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const authActions = useAuthActions()
-const authStore = useAuthStore()
 const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
 const showEmailForm = ref(false)
@@ -125,19 +122,7 @@ const { onAuthSuccess } = usePostAuthRedirect({
   defaultRedirect: () => ({ name: 'cloud-user-check' })
 })
 
-void completeDesktopLoginForExistingSession()
-
-async function completeDesktopLoginForExistingSession() {
-  if (!hasDesktopLoginRequest(route.query)) return
-
-  if (!authStore.isInitialized) {
-    await until(() => authStore.isInitialized).toBe(true)
-  }
-
-  if (!authStore.currentUser) return
-
-  await onAuthSuccess()
-}
+void completeDesktopLoginForExistingSession(route.query, onAuthSuccess)
 
 function switchToEmailForm() {
   showEmailForm.value = true

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -122,7 +122,11 @@ const { onAuthSuccess } = usePostAuthRedirect({
   defaultRedirect: () => ({ name: 'cloud-user-check' })
 })
 
-void completeDesktopLoginForExistingSession(route.query, onAuthSuccess)
+void completeDesktopLoginForExistingSession(route.query, onAuthSuccess).catch(
+  (error) => {
+    authError.value = error instanceof Error ? error.message : t('g.error')
+  }
+)
 
 function switchToEmailForm() {
   showEmailForm.value = true

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -103,7 +103,7 @@ import { useRoute, useRouter } from 'vue-router'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
-import { completeDesktopLoginForExistingSession } from '@/platform/cloud/onboarding/composables/useDesktopLoginCompletion'
+import { useDesktopLoginCompletion } from '@/platform/cloud/onboarding/composables/useDesktopLoginCompletion'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
 import type { SignInData } from '@/schemas/signInSchema'
 import { getGoogleSsoBlockedReason } from '@/base/webviewDetection'
@@ -121,6 +121,7 @@ const { onAuthSuccess } = usePostAuthRedirect({
   successSummary: 'Login Completed',
   defaultRedirect: () => ({ name: 'cloud-user-check' })
 })
+const { completeDesktopLoginForExistingSession } = useDesktopLoginCompletion()
 
 void completeDesktopLoginForExistingSession(route.query, onAuthSuccess).catch(
   (error) => {

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -95,8 +95,9 @@
 </template>
 
 <script setup lang="ts">
+import { until } from '@vueuse/core'
 import Message from 'primevue/message'
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -118,24 +119,25 @@ const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
 const showEmailForm = ref(false)
 const googleSsoBlockedReason = getGoogleSsoBlockedReason()
-let desktopLoginCompletionStarted = false
 const { onAuthSuccess } = usePostAuthRedirect({
   authError,
   successSummary: 'Login Completed',
   defaultRedirect: () => ({ name: 'cloud-user-check' })
 })
 
-watch(
-  () => [authStore.isInitialized, authStore.currentUser] as const,
-  ([isInitialized, user]) => {
-    if (!isInitialized || !user) return
-    if (!hasDesktopLoginRequest(route.query)) return
-    if (desktopLoginCompletionStarted) return
-    desktopLoginCompletionStarted = true
-    void onAuthSuccess()
-  },
-  { immediate: true }
-)
+void completeDesktopLoginForExistingSession()
+
+async function completeDesktopLoginForExistingSession() {
+  if (!hasDesktopLoginRequest(route.query)) return
+
+  if (!authStore.isInitialized) {
+    await until(() => authStore.isInitialized).toBe(true)
+  }
+
+  if (!authStore.currentUser) return
+
+  await onAuthSuccess()
+}
 
 function switchToEmailForm() {
   showEmailForm.value = true

--- a/src/platform/cloud/onboarding/CloudLoginView.vue
+++ b/src/platform/cloud/onboarding/CloudLoginView.vue
@@ -96,30 +96,46 @@
 
 <script setup lang="ts">
 import Message from 'primevue/message'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
+import { hasDesktopLoginRequest } from '@/platform/cloud/onboarding/desktopLoginBridge'
 import CloudSignInForm from '@/platform/cloud/onboarding/components/CloudSignInForm.vue'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
 import type { SignInData } from '@/schemas/signInSchema'
 import { getGoogleSsoBlockedReason } from '@/base/webviewDetection'
+import { useAuthStore } from '@/stores/authStore'
 
 const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const authActions = useAuthActions()
+const authStore = useAuthStore()
 const isSecureContext = globalThis.isSecureContext
 const authError = ref('')
 const showEmailForm = ref(false)
 const googleSsoBlockedReason = getGoogleSsoBlockedReason()
+let desktopLoginCompletionStarted = false
 const { onAuthSuccess } = usePostAuthRedirect({
   authError,
   successSummary: 'Login Completed',
   defaultRedirect: () => ({ name: 'cloud-user-check' })
 })
+
+watch(
+  () => [authStore.isInitialized, authStore.currentUser] as const,
+  ([isInitialized, user]) => {
+    if (!isInitialized || !user) return
+    if (!hasDesktopLoginRequest(route.query)) return
+    if (desktopLoginCompletionStarted) return
+    desktopLoginCompletionStarted = true
+    void onAuthSuccess()
+  },
+  { immediate: true }
+)
 
 function switchToEmailForm() {
   showEmailForm.value = true

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -133,7 +133,7 @@ import { useRoute, useRouter } from 'vue-router'
 import SignUpForm from '@/components/dialog/content/signin/SignUpForm.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
-import { completeDesktopLoginForExistingSession } from '@/platform/cloud/onboarding/composables/useDesktopLoginCompletion'
+import { useDesktopLoginCompletion } from '@/platform/cloud/onboarding/composables/useDesktopLoginCompletion'
 import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
 import { isCloud } from '@/platform/distribution/types'
@@ -162,6 +162,7 @@ const { onAuthSuccess } = usePostAuthRedirect({
   successSummary: 'Sign up Completed',
   defaultRedirect: () => ({ path: '/', query: route.query })
 })
+const { completeDesktopLoginForExistingSession } = useDesktopLoginCompletion()
 
 void completeDesktopLoginForExistingSession(route.query, onAuthSuccess).catch(
   (error) => {

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -163,7 +163,11 @@ const { onAuthSuccess } = usePostAuthRedirect({
   defaultRedirect: () => ({ path: '/', query: route.query })
 })
 
-void completeDesktopLoginForExistingSession(route.query, onAuthSuccess)
+void completeDesktopLoginForExistingSession(route.query, onAuthSuccess).catch(
+  (error) => {
+    authError.value = error instanceof Error ? error.message : t('g.error')
+  }
+)
 
 const navigateToLogin = async () => {
   await router.push({ name: 'cloud-login', query: route.query })

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -133,6 +133,7 @@ import { useRoute, useRouter } from 'vue-router'
 import SignUpForm from '@/components/dialog/content/signin/SignUpForm.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useAuthActions } from '@/composables/auth/useAuthActions'
+import { completeDesktopLoginForExistingSession } from '@/platform/cloud/onboarding/composables/useDesktopLoginCompletion'
 import { useFreeTierOnboarding } from '@/platform/cloud/onboarding/composables/useFreeTierOnboarding'
 import { usePostAuthRedirect } from '@/platform/cloud/onboarding/composables/usePostAuthRedirect'
 import { isCloud } from '@/platform/distribution/types'
@@ -161,6 +162,8 @@ const { onAuthSuccess } = usePostAuthRedirect({
   successSummary: 'Sign up Completed',
   defaultRedirect: () => ({ path: '/', query: route.query })
 })
+
+void completeDesktopLoginForExistingSession(route.query, onAuthSuccess)
 
 const navigateToLogin = async () => {
   await router.push({ name: 'cloud-login', query: route.query })

--- a/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.test.ts
+++ b/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { completeDesktopLoginForExistingSession } from './useDesktopLoginCompletion'
+
+const hoisted = vi.hoisted(() => ({
+  authStore: {
+    isInitialized: true,
+    currentUser: null as unknown
+  }
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => hoisted.authStore
+}))
+
+describe('completeDesktopLoginForExistingSession', () => {
+  beforeEach(() => {
+    hoisted.authStore.isInitialized = true
+    hoisted.authStore.currentUser = null
+  })
+
+  it('does nothing without a desktop login request', async () => {
+    const onAuthSuccess = vi.fn()
+
+    await completeDesktopLoginForExistingSession({}, onAuthSuccess)
+
+    expect(onAuthSuccess).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the desktop login request has no existing user', async () => {
+    const onAuthSuccess = vi.fn()
+
+    await completeDesktopLoginForExistingSession(
+      {
+        desktop_login_callback: 'http://localhost:9876/callback',
+        desktop_login_state: 'state-123'
+      },
+      onAuthSuccess
+    )
+
+    expect(onAuthSuccess).not.toHaveBeenCalled()
+  })
+
+  it('completes the desktop login request for an existing user', async () => {
+    hoisted.authStore.currentUser = { uid: 'user-123' }
+    const onAuthSuccess = vi.fn().mockResolvedValue(undefined)
+
+    await completeDesktopLoginForExistingSession(
+      {
+        desktop_login_callback: 'http://localhost:9876/callback',
+        desktop_login_state: 'state-123'
+      },
+      onAuthSuccess
+    )
+
+    expect(onAuthSuccess).toHaveBeenCalledOnce()
+  })
+})

--- a/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.test.ts
+++ b/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { completeDesktopLoginForExistingSession } from './useDesktopLoginCompletion'
+import { useDesktopLoginCompletion } from './useDesktopLoginCompletion'
 
 const hoisted = vi.hoisted(() => ({
   authStore: {
@@ -21,6 +21,8 @@ describe('completeDesktopLoginForExistingSession', () => {
 
   it('does nothing without a desktop login request', async () => {
     const onAuthSuccess = vi.fn()
+    const { completeDesktopLoginForExistingSession } =
+      useDesktopLoginCompletion()
 
     await completeDesktopLoginForExistingSession({}, onAuthSuccess)
 
@@ -29,6 +31,8 @@ describe('completeDesktopLoginForExistingSession', () => {
 
   it('does nothing when the desktop login request has no existing user', async () => {
     const onAuthSuccess = vi.fn()
+    const { completeDesktopLoginForExistingSession } =
+      useDesktopLoginCompletion()
 
     await completeDesktopLoginForExistingSession(
       {
@@ -44,6 +48,8 @@ describe('completeDesktopLoginForExistingSession', () => {
   it('completes the desktop login request for an existing user', async () => {
     hoisted.authStore.currentUser = { uid: 'user-123' }
     const onAuthSuccess = vi.fn().mockResolvedValue(undefined)
+    const { completeDesktopLoginForExistingSession } =
+      useDesktopLoginCompletion()
 
     await completeDesktopLoginForExistingSession(
       {
@@ -54,5 +60,25 @@ describe('completeDesktopLoginForExistingSession', () => {
     )
 
     expect(onAuthSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('dedupes concurrent completions for the same desktop login request', async () => {
+    hoisted.authStore.currentUser = { uid: 'user-123' }
+    const firstOnAuthSuccess = vi.fn().mockResolvedValue(undefined)
+    const latestOnAuthSuccess = vi.fn().mockResolvedValue(undefined)
+    const { completeDesktopLoginForExistingSession } =
+      useDesktopLoginCompletion()
+    const query = {
+      desktop_login_callback: 'http://localhost:9876/callback',
+      desktop_login_state: 'state-123'
+    }
+
+    await Promise.all([
+      completeDesktopLoginForExistingSession(query, firstOnAuthSuccess),
+      completeDesktopLoginForExistingSession(query, latestOnAuthSuccess)
+    ])
+
+    expect(firstOnAuthSuccess).not.toHaveBeenCalled()
+    expect(latestOnAuthSuccess).toHaveBeenCalledOnce()
   })
 })

--- a/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.test.ts
+++ b/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.test.ts
@@ -1,3 +1,4 @@
+import type * as VueUseCore from '@vueuse/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useDesktopLoginCompletion } from './useDesktopLoginCompletion'
@@ -6,8 +7,19 @@ const hoisted = vi.hoisted(() => ({
   authStore: {
     isInitialized: true,
     currentUser: null as unknown
-  }
+  },
+  untilToBe: vi.fn()
 }))
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof VueUseCore>('@vueuse/core')
+  return {
+    ...actual,
+    until: vi.fn(() => ({
+      toBe: hoisted.untilToBe
+    }))
+  }
+})
 
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => hoisted.authStore
@@ -17,6 +29,7 @@ describe('completeDesktopLoginForExistingSession', () => {
   beforeEach(() => {
     hoisted.authStore.isInitialized = true
     hoisted.authStore.currentUser = null
+    hoisted.untilToBe.mockResolvedValue(true)
   })
 
   it('does nothing without a desktop login request', async () => {
@@ -59,6 +72,26 @@ describe('completeDesktopLoginForExistingSession', () => {
       onAuthSuccess
     )
 
+    expect(onAuthSuccess).toHaveBeenCalledOnce()
+  })
+
+  it('waits for auth initialization before completing an existing session', async () => {
+    hoisted.authStore.isInitialized = false
+    hoisted.authStore.currentUser = { uid: 'user-123' }
+    const onAuthSuccess = vi.fn().mockResolvedValue(undefined)
+    const { completeDesktopLoginForExistingSession } =
+      useDesktopLoginCompletion()
+
+    const completion = completeDesktopLoginForExistingSession(
+      {
+        desktop_login_callback: 'http://localhost:9876/callback',
+        desktop_login_state: 'state-123'
+      },
+      onAuthSuccess
+    )
+    await completion
+
+    expect(hoisted.untilToBe).toHaveBeenCalledWith(true)
     expect(onAuthSuccess).toHaveBeenCalledOnce()
   })
 

--- a/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.ts
+++ b/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.ts
@@ -1,21 +1,70 @@
-import { until } from '@vueuse/core'
+import { createSharedComposable, until } from '@vueuse/core'
 import type { LocationQuery } from 'vue-router'
 
-import { hasDesktopLoginRequest } from '@/platform/cloud/onboarding/desktopLoginBridge'
+import { getDesktopLoginRequest } from '@/platform/cloud/onboarding/desktopLoginBridge'
 import { useAuthStore } from '@/stores/authStore'
 
-export async function completeDesktopLoginForExistingSession(
-  query: LocationQuery,
-  onAuthSuccess: () => Promise<void>
-): Promise<void> {
-  if (!hasDesktopLoginRequest(query)) return
+type OnAuthSuccess = () => Promise<void>
+type PendingCompletion = {
+  onAuthSuccess: OnAuthSuccess
+  promise: Promise<void>
+}
 
+function useDesktopLoginCompletionInternal() {
   const authStore = useAuthStore()
-  if (!authStore.isInitialized) {
-    await until(() => authStore.isInitialized).toBe(true)
+  let authInitializedPromise: Promise<void> | null = null
+  const pendingCompletions = new Map<string, PendingCompletion>()
+
+  async function waitForAuthInitialized(): Promise<void> {
+    if (authStore.isInitialized) return
+
+    authInitializedPromise ??= until(() => authStore.isInitialized)
+      .toBe(true)
+      .then(() => undefined)
+      .finally(() => {
+        authInitializedPromise = null
+      })
+
+    await authInitializedPromise
   }
 
-  if (!authStore.currentUser) return
+  async function completeDesktopLoginForExistingSession(
+    query: LocationQuery,
+    onAuthSuccess: OnAuthSuccess
+  ): Promise<void> {
+    const request = getDesktopLoginRequest(query)
+    if (!request) return
 
-  await onAuthSuccess()
+    const requestKey = `${request.callbackUrl.href}:${request.state}`
+    const pendingCompletion = pendingCompletions.get(requestKey)
+    if (pendingCompletion) {
+      pendingCompletion.onAuthSuccess = onAuthSuccess
+      return pendingCompletion.promise
+    }
+
+    const completion: PendingCompletion = {
+      onAuthSuccess,
+      promise: Promise.resolve()
+    }
+
+    completion.promise = (async () => {
+      await waitForAuthInitialized()
+      if (!authStore.currentUser) return
+
+      await completion.onAuthSuccess()
+    })().finally(() => {
+      if (pendingCompletions.get(requestKey) === completion) {
+        pendingCompletions.delete(requestKey)
+      }
+    })
+
+    pendingCompletions.set(requestKey, completion)
+    return completion.promise
+  }
+
+  return { completeDesktopLoginForExistingSession }
 }
+
+export const useDesktopLoginCompletion = createSharedComposable(
+  useDesktopLoginCompletionInternal
+)

--- a/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.ts
+++ b/src/platform/cloud/onboarding/composables/useDesktopLoginCompletion.ts
@@ -1,0 +1,21 @@
+import { until } from '@vueuse/core'
+import type { LocationQuery } from 'vue-router'
+
+import { hasDesktopLoginRequest } from '@/platform/cloud/onboarding/desktopLoginBridge'
+import { useAuthStore } from '@/stores/authStore'
+
+export async function completeDesktopLoginForExistingSession(
+  query: LocationQuery,
+  onAuthSuccess: () => Promise<void>
+): Promise<void> {
+  if (!hasDesktopLoginRequest(query)) return
+
+  const authStore = useAuthStore()
+  if (!authStore.isInitialized) {
+    await until(() => authStore.isInitialized).toBe(true)
+  }
+
+  if (!authStore.currentUser) return
+
+  await onAuthSuccess()
+}

--- a/src/platform/cloud/onboarding/composables/usePostAuthRedirect.test.ts
+++ b/src/platform/cloud/onboarding/composables/usePostAuthRedirect.test.ts
@@ -1,0 +1,185 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePostAuthRedirect } from './usePostAuthRedirect'
+
+const hoisted = vi.hoisted(() => ({
+  authStore: {
+    currentUser: { uid: 'user-123' }
+  },
+  completeDesktopLoginIfNeeded: vi.fn(),
+  getSafePreviousFullPath: vi.fn(),
+  resumeOAuthIfNeeded: vi.fn(),
+  route: {
+    query: {
+      desktop_login_callback: 'http://localhost:9876/callback',
+      desktop_login_state: 'state-123'
+    }
+  },
+  router: {
+    push: vi.fn(),
+    replace: vi.fn()
+  },
+  toastStore: {
+    add: vi.fn()
+  }
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => hoisted.route,
+  useRouter: () => hoisted.router
+}))
+
+vi.mock('@/platform/cloud/oauth/useOAuthPostLoginRedirect', () => ({
+  useOAuthPostLoginRedirect: () => ({
+    resumeOAuthIfNeeded: hoisted.resumeOAuthIfNeeded
+  })
+}))
+
+vi.mock('@/platform/cloud/onboarding/desktopLoginBridge', () => ({
+  completeDesktopLoginIfNeeded: hoisted.completeDesktopLoginIfNeeded
+}))
+
+vi.mock('@/platform/cloud/onboarding/utils/previousFullPath', () => ({
+  getSafePreviousFullPath: hoisted.getSafePreviousFullPath
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => hoisted.toastStore
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => hoisted.authStore
+}))
+
+function createRedirect() {
+  const authError = ref('')
+  const defaultRedirect = vi.fn(() => ({ name: 'cloud-user-check' }))
+  const { onAuthSuccess } = usePostAuthRedirect({
+    authError,
+    successSummary: 'Login Completed',
+    defaultRedirect
+  })
+
+  return { authError, defaultRedirect, onAuthSuccess }
+}
+
+describe('usePostAuthRedirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.authStore.currentUser = { uid: 'user-123' }
+    hoisted.route.query = {
+      desktop_login_callback: 'http://localhost:9876/callback',
+      desktop_login_state: 'state-123'
+    }
+    hoisted.completeDesktopLoginIfNeeded.mockResolvedValue(false)
+    hoisted.getSafePreviousFullPath.mockReturnValue(null)
+    hoisted.resumeOAuthIfNeeded.mockResolvedValue({ kind: 'no-oauth' })
+    hoisted.router.push.mockResolvedValue(undefined)
+    hoisted.router.replace.mockResolvedValue(undefined)
+  })
+
+  it('stops redirect handling after completing the desktop login callback', async () => {
+    hoisted.completeDesktopLoginIfNeeded.mockResolvedValue(true)
+    const { defaultRedirect, onAuthSuccess } = createRedirect()
+
+    await onAuthSuccess()
+
+    expect(hoisted.completeDesktopLoginIfNeeded).toHaveBeenCalledWith(
+      hoisted.route.query,
+      hoisted.authStore.currentUser
+    )
+    expect(hoisted.toastStore.add).not.toHaveBeenCalled()
+    expect(hoisted.resumeOAuthIfNeeded).not.toHaveBeenCalled()
+    expect(hoisted.router.push).not.toHaveBeenCalled()
+    expect(hoisted.router.replace).not.toHaveBeenCalled()
+    expect(defaultRedirect).not.toHaveBeenCalled()
+  })
+
+  it('surfaces desktop login callback failures without continuing redirects', async () => {
+    hoisted.completeDesktopLoginIfNeeded.mockRejectedValue(
+      new Error('Desktop login callback returned 500')
+    )
+    const { authError, onAuthSuccess } = createRedirect()
+
+    await onAuthSuccess()
+
+    expect(authError.value).toBe('Desktop login callback returned 500')
+    expect(hoisted.toastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'Desktop login callback returned 500',
+      life: 4000
+    })
+    expect(hoisted.resumeOAuthIfNeeded).not.toHaveBeenCalled()
+    expect(hoisted.router.push).not.toHaveBeenCalled()
+    expect(hoisted.router.replace).not.toHaveBeenCalled()
+  })
+
+  it('surfaces OAuth resume failures after normal sign-in success', async () => {
+    hoisted.resumeOAuthIfNeeded.mockResolvedValue({
+      kind: 'error',
+      message: 'OAuth session expired'
+    })
+    const { authError, onAuthSuccess } = createRedirect()
+
+    await onAuthSuccess()
+
+    expect(authError.value).toBe('OAuth session expired')
+    expect(hoisted.toastStore.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Login Completed',
+      life: 2000
+    })
+    expect(hoisted.toastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'oauth.consent.sessionErrorToastSummary',
+      detail: 'OAuth session expired',
+      life: 4000
+    })
+    expect(hoisted.router.push).not.toHaveBeenCalled()
+    expect(hoisted.router.replace).not.toHaveBeenCalled()
+  })
+
+  it('stops after OAuth resume handles the redirect', async () => {
+    hoisted.resumeOAuthIfNeeded.mockResolvedValue({ kind: 'resumed' })
+    const { defaultRedirect, onAuthSuccess } = createRedirect()
+
+    await onAuthSuccess()
+
+    expect(hoisted.resumeOAuthIfNeeded).toHaveBeenCalledWith(
+      hoisted.route.query
+    )
+    expect(hoisted.router.push).not.toHaveBeenCalled()
+    expect(hoisted.router.replace).not.toHaveBeenCalled()
+    expect(defaultRedirect).not.toHaveBeenCalled()
+  })
+
+  it('redirects to the preserved previous path when there is no OAuth redirect', async () => {
+    hoisted.getSafePreviousFullPath.mockReturnValue('/previous?from=login')
+    const { defaultRedirect, onAuthSuccess } = createRedirect()
+
+    await onAuthSuccess()
+
+    expect(hoisted.router.replace).toHaveBeenCalledWith('/previous?from=login')
+    expect(hoisted.router.push).not.toHaveBeenCalled()
+    expect(defaultRedirect).not.toHaveBeenCalled()
+  })
+
+  it('uses the default redirect when no desktop, OAuth, or previous-path redirect applies', async () => {
+    const { defaultRedirect, onAuthSuccess } = createRedirect()
+
+    await onAuthSuccess()
+
+    expect(defaultRedirect).toHaveBeenCalledOnce()
+    expect(hoisted.router.push).toHaveBeenCalledWith({
+      name: 'cloud-user-check'
+    })
+  })
+})

--- a/src/platform/cloud/onboarding/composables/usePostAuthRedirect.ts
+++ b/src/platform/cloud/onboarding/composables/usePostAuthRedirect.ts
@@ -4,8 +4,10 @@ import type { RouteLocationRaw } from 'vue-router'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useOAuthPostLoginRedirect } from '@/platform/cloud/oauth/useOAuthPostLoginRedirect'
+import { completeDesktopLoginIfNeeded } from '@/platform/cloud/onboarding/desktopLoginBridge'
 import { getSafePreviousFullPath } from '@/platform/cloud/onboarding/utils/previousFullPath'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { useAuthStore } from '@/stores/authStore'
 
 /**
  * Shared post-authentication redirect logic used by both CloudLoginView and
@@ -22,8 +24,28 @@ export function usePostAuthRedirect(options: {
   const route = useRoute()
   const toastStore = useToastStore()
   const { resumeOAuthIfNeeded } = useOAuthPostLoginRedirect()
+  const authStore = useAuthStore()
 
   async function onAuthSuccess() {
+    try {
+      const desktopLoginCompleted = await completeDesktopLoginIfNeeded(
+        route.query,
+        authStore.currentUser
+      )
+      if (desktopLoginCompleted) return
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Desktop login callback failed'
+      options.authError.value = message
+      toastStore.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: message,
+        life: 4000
+      })
+      return
+    }
+
     toastStore.add({
       severity: 'success',
       summary: options.successSummary,

--- a/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   completeDesktopLoginIfNeeded,
@@ -33,6 +33,10 @@ describe('desktopLoginBridge', () => {
     hoisted.firebaseConfig.apiKey = 'firebase-api-key'
     hoisted.identifyPostHogUser.mockClear()
     vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('accepts localhost callback requests with state', () => {
@@ -92,6 +96,7 @@ describe('desktopLoginBridge', () => {
         method: 'POST',
         mode: 'cors',
         credentials: 'omit',
+        signal: expect.any(AbortSignal),
         body: JSON.stringify({
           state: 'state-123',
           apiKey: 'firebase-api-key',
@@ -135,6 +140,57 @@ describe('desktopLoginBridge', () => {
         createFirebaseUser()
       )
     ).rejects.toThrow('Desktop login callback returned 500')
+
+    expect(hoisted.identifyPostHogUser).toHaveBeenCalledWith('user-123')
+  })
+
+  it('aborts the callback request when Desktop does not respond', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn<typeof fetch>(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          })
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const completion = completeDesktopLoginIfNeeded(
+      {
+        desktop_login_callback: 'http://localhost:9876/callback',
+        desktop_login_state: 'state-123'
+      },
+      createFirebaseUser()
+    )
+    const completionResult = completion.catch((error: unknown) => error)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    const completionError = await completionResult
+    expect(completionError).toBeInstanceOf(Error)
+    if (!(completionError instanceof Error)) {
+      throw new Error('Expected Desktop login completion to fail')
+    }
+    expect(completionError.message).toBe('Desktop login callback timed out')
+    expect(completionError.cause).toBeInstanceOf(DOMException)
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true)
+    expect(hoisted.identifyPostHogUser).toHaveBeenCalledWith('user-123')
+  })
+
+  it('rethrows callback request failures before the timeout elapses', async () => {
+    const requestError = new TypeError('Failed to fetch')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(requestError))
+
+    await expect(
+      completeDesktopLoginIfNeeded(
+        {
+          desktop_login_callback: 'http://localhost:9876/callback',
+          desktop_login_state: 'state-123'
+        },
+        createFirebaseUser()
+      )
+    ).rejects.toBe(requestError)
 
     expect(hoisted.identifyPostHogUser).toHaveBeenCalledWith('user-123')
   })

--- a/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
@@ -7,6 +7,9 @@ import {
 } from './desktopLoginBridge'
 
 const hoisted = vi.hoisted(() => ({
+  firebaseConfig: {
+    apiKey: 'firebase-api-key'
+  } as { apiKey?: string },
   identifyPostHogUser: vi.fn()
 }))
 
@@ -15,11 +18,19 @@ vi.mock('@/platform/telemetry/providers/cloud/posthogIdentity', () => ({
 }))
 
 vi.mock('@/config/firebase', () => ({
-  getFirebaseConfig: () => ({ apiKey: 'firebase-api-key' })
+  getFirebaseConfig: () => hoisted.firebaseConfig
 }))
+
+function createFirebaseUser() {
+  return {
+    uid: 'user-123',
+    toJSON: () => ({ uid: 'user-123', email: 'person@example.com' })
+  } as NonNullable<Parameters<typeof completeDesktopLoginIfNeeded>[1]>
+}
 
 describe('desktopLoginBridge', () => {
   beforeEach(() => {
+    hoisted.firebaseConfig.apiKey = 'firebase-api-key'
     hoisted.identifyPostHogUser.mockClear()
     vi.unstubAllGlobals()
   })
@@ -70,10 +81,7 @@ describe('desktopLoginBridge', () => {
         desktop_login_callback: 'http://localhost:9876/callback',
         desktop_login_state: 'state-123'
       },
-      {
-        uid: 'user-123',
-        toJSON: () => ({ uid: 'user-123', email: 'person@example.com' })
-      } as never
+      createFirebaseUser()
     )
 
     expect(completed).toBe(true)
@@ -91,5 +99,43 @@ describe('desktopLoginBridge', () => {
         })
       })
     )
+  })
+
+  it('throws before identifying when the Firebase API key is missing', async () => {
+    hoisted.firebaseConfig.apiKey = undefined
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      completeDesktopLoginIfNeeded(
+        {
+          desktop_login_callback: 'http://localhost:9876/callback',
+          desktop_login_state: 'state-123'
+        },
+        createFirebaseUser()
+      )
+    ).rejects.toThrow('Firebase API key missing')
+
+    expect(hoisted.identifyPostHogUser).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('throws when Desktop rejects the login callback', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    )
+
+    await expect(
+      completeDesktopLoginIfNeeded(
+        {
+          desktop_login_callback: 'http://localhost:9876/callback',
+          desktop_login_state: 'state-123'
+        },
+        createFirebaseUser()
+      )
+    ).rejects.toThrow('Desktop login callback returned 500')
+
+    expect(hoisted.identifyPostHogUser).toHaveBeenCalledWith('user-123')
   })
 })

--- a/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  completeDesktopLoginIfNeeded,
+  getDesktopLoginRequest,
+  hasDesktopLoginRequest
+} from './desktopLoginBridge'
+
+const hoisted = vi.hoisted(() => ({
+  identifyPostHogUser: vi.fn()
+}))
+
+vi.mock('@/platform/telemetry/providers/cloud/posthogIdentity', () => ({
+  identifyPostHogUser: hoisted.identifyPostHogUser
+}))
+
+vi.mock('@/config/firebase', () => ({
+  getFirebaseConfig: () => ({ apiKey: 'firebase-api-key' })
+}))
+
+describe('desktopLoginBridge', () => {
+  beforeEach(() => {
+    hoisted.identifyPostHogUser.mockClear()
+    vi.unstubAllGlobals()
+  })
+
+  it('accepts localhost callback requests with state', () => {
+    const query = {
+      desktop_login_callback: 'http://localhost:9876/callback',
+      desktop_login_state: 'state-123'
+    }
+
+    expect(hasDesktopLoginRequest(query)).toBe(true)
+    expect(getDesktopLoginRequest(query)).toMatchObject({
+      callbackUrl: new URL('http://localhost:9876/callback'),
+      state: 'state-123'
+    })
+  })
+
+  it('rejects non-loopback callback requests', () => {
+    expect(
+      hasDesktopLoginRequest({
+        desktop_login_callback: 'https://evil.example/callback',
+        desktop_login_state: 'state-123'
+      })
+    ).toBe(false)
+  })
+
+  it('identifies the browser PostHog user and posts Firebase user payload to Desktop', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const completed = await completeDesktopLoginIfNeeded(
+      {
+        desktop_login_callback: 'http://localhost:9876/callback',
+        desktop_login_state: 'state-123'
+      },
+      {
+        uid: 'user-123',
+        toJSON: () => ({ uid: 'user-123', email: 'person@example.com' })
+      } as never
+    )
+
+    expect(completed).toBe(true)
+    expect(hoisted.identifyPostHogUser).toHaveBeenCalledWith('user-123')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:9876/callback',
+      expect.objectContaining({
+        method: 'POST',
+        mode: 'cors',
+        credentials: 'omit',
+        body: JSON.stringify({
+          state: 'state-123',
+          apiKey: 'firebase-api-key',
+          user: { uid: 'user-123', email: 'person@example.com' }
+        })
+      })
+    )
+  })
+})

--- a/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.test.ts
@@ -46,6 +46,21 @@ describe('desktopLoginBridge', () => {
     ).toBe(false)
   })
 
+  it('rejects callback requests without the Desktop callback port', () => {
+    expect(
+      hasDesktopLoginRequest({
+        desktop_login_callback: 'http://localhost:1234/callback',
+        desktop_login_state: 'state-123'
+      })
+    ).toBe(false)
+    expect(
+      hasDesktopLoginRequest({
+        desktop_login_callback: 'http://localhost/callback',
+        desktop_login_state: 'state-123'
+      })
+    ).toBe(false)
+  })
+
   it('identifies the browser PostHog user and posts Firebase user payload to Desktop', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 })
     vi.stubGlobal('fetch', fetchMock)

--- a/src/platform/cloud/onboarding/desktopLoginBridge.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.ts
@@ -8,6 +8,7 @@ const CALLBACK_PARAM = 'desktop_login_callback'
 const STATE_PARAM = 'desktop_login_state'
 const MAX_STATE_LENGTH = 256
 const DESKTOP_LOGIN_CALLBACK_PORT = '9876'
+const DESKTOP_LOGIN_CALLBACK_TIMEOUT_MS = 10_000
 
 function firstQueryValue(value: LocationQuery[string]): string | null {
   if (Array.isArray(value)) return value[0] ?? null
@@ -64,19 +65,36 @@ export async function completeDesktopLoginIfNeeded(
   // provider flushes this identify call once the browser cookie store is ready.
   identifyPostHogUser(user.uid)
 
-  const response = await fetch(request.callbackUrl.href, {
-    method: 'POST',
-    mode: 'cors',
-    credentials: 'omit',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      state: request.state,
-      apiKey: firebaseConfig.apiKey,
-      user: user.toJSON()
+  const controller = new AbortController()
+  const timeoutId = globalThis.setTimeout(
+    () => controller.abort(),
+    DESKTOP_LOGIN_CALLBACK_TIMEOUT_MS
+  )
+
+  let response: Response
+  try {
+    response = await fetch(request.callbackUrl.href, {
+      method: 'POST',
+      mode: 'cors',
+      credentials: 'omit',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        state: request.state,
+        apiKey: firebaseConfig.apiKey,
+        user: user.toJSON()
+      })
     })
-  })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error('Desktop login callback timed out', { cause: error })
+    }
+    throw error
+  } finally {
+    globalThis.clearTimeout(timeoutId)
+  }
 
   if (!response.ok) {
     throw new Error(`Desktop login callback returned ${response.status}`)

--- a/src/platform/cloud/onboarding/desktopLoginBridge.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.ts
@@ -1,0 +1,84 @@
+import type { User } from 'firebase/auth'
+import type { LocationQuery } from 'vue-router'
+
+import { getFirebaseConfig } from '@/config/firebase'
+import { identifyPostHogUser } from '@/platform/telemetry/providers/cloud/posthogIdentity'
+
+const CALLBACK_PARAM = 'desktop_login_callback'
+const STATE_PARAM = 'desktop_login_state'
+const MAX_STATE_LENGTH = 256
+
+function firstQueryValue(value: LocationQuery[string]): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+function parseLoopbackCallback(rawUrl: string): URL | null {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'http:') return null
+  if (!['localhost', '127.0.0.1'].includes(url.hostname)) return null
+  if (url.pathname !== '/callback') return null
+
+  return url
+}
+
+export function hasDesktopLoginRequest(query: LocationQuery): boolean {
+  return Boolean(getDesktopLoginRequest(query))
+}
+
+export function getDesktopLoginRequest(query: LocationQuery): {
+  callbackUrl: URL
+  state: string
+} | null {
+  const callback = firstQueryValue(query[CALLBACK_PARAM])
+  const state = firstQueryValue(query[STATE_PARAM])
+  if (!callback || !state || state.length > MAX_STATE_LENGTH) return null
+
+  const callbackUrl = parseLoopbackCallback(callback)
+  if (!callbackUrl) return null
+
+  return { callbackUrl, state }
+}
+
+export async function completeDesktopLoginIfNeeded(
+  query: LocationQuery,
+  user: User | null | undefined
+): Promise<boolean> {
+  const request = getDesktopLoginRequest(query)
+  if (!request || !user) return false
+
+  // Queue-safe: if PostHog has not finished initializing yet, the cloud
+  // provider flushes this identify call once the browser cookie store is ready.
+  identifyPostHogUser(user.uid)
+
+  const firebaseConfig = getFirebaseConfig()
+  if (!firebaseConfig.apiKey) {
+    throw new Error('Firebase API key missing')
+  }
+
+  const response = await fetch(request.callbackUrl.href, {
+    method: 'POST',
+    mode: 'cors',
+    credentials: 'omit',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      state: request.state,
+      apiKey: firebaseConfig.apiKey,
+      user: user.toJSON()
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Desktop login callback returned ${response.status}`)
+  }
+
+  return true
+}

--- a/src/platform/cloud/onboarding/desktopLoginBridge.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.ts
@@ -7,6 +7,7 @@ import { identifyPostHogUser } from '@/platform/telemetry/providers/cloud/postho
 const CALLBACK_PARAM = 'desktop_login_callback'
 const STATE_PARAM = 'desktop_login_state'
 const MAX_STATE_LENGTH = 256
+const DESKTOP_LOGIN_CALLBACK_PORT = '9876'
 
 function firstQueryValue(value: LocationQuery[string]): string | null {
   if (Array.isArray(value)) return value[0] ?? null
@@ -23,6 +24,7 @@ function parseLoopbackCallback(rawUrl: string): URL | null {
 
   if (url.protocol !== 'http:') return null
   if (!['localhost', '127.0.0.1'].includes(url.hostname)) return null
+  if (url.port !== DESKTOP_LOGIN_CALLBACK_PORT) return null
   if (url.pathname !== '/callback') return null
 
   return url

--- a/src/platform/cloud/onboarding/desktopLoginBridge.ts
+++ b/src/platform/cloud/onboarding/desktopLoginBridge.ts
@@ -55,14 +55,14 @@ export async function completeDesktopLoginIfNeeded(
   const request = getDesktopLoginRequest(query)
   if (!request || !user) return false
 
-  // Queue-safe: if PostHog has not finished initializing yet, the cloud
-  // provider flushes this identify call once the browser cookie store is ready.
-  identifyPostHogUser(user.uid)
-
   const firebaseConfig = getFirebaseConfig()
   if (!firebaseConfig.apiKey) {
     throw new Error('Firebase API key missing')
   }
+
+  // Queue-safe: if PostHog has not finished initializing yet, the cloud
+  // provider flushes this identify call once the browser cookie store is ready.
+  identifyPostHogUser(user.uid)
 
   const response = await fetch(request.callbackUrl.href, {
     method: 'POST',

--- a/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
+++ b/src/platform/cloud/onboarding/onboardingCloudRoutes.ts
@@ -1,5 +1,6 @@
 import type { RouteRecordRaw } from 'vue-router'
 
+import { hasDesktopLoginRequest } from '@/platform/cloud/onboarding/desktopLoginBridge'
 import { getOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
 
 // `oauth_request_id` capture lives in the global router.beforeEach guard
@@ -53,7 +54,7 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
           import('@/platform/cloud/onboarding/CloudLoginView.vue'),
         beforeEnter: async (to, _from, next) => {
           // Only redirect if not explicitly switching accounts
-          if (!to.query.switchAccount) {
+          if (!to.query.switchAccount && !hasDesktopLoginRequest(to.query)) {
             const { useCurrentUser } =
               await import('@/composables/auth/useCurrentUser')
             const { isLoggedIn } = useCurrentUser()
@@ -71,7 +72,7 @@ export const cloudOnboardingRoutes: RouteRecordRaw[] = [
         component: () =>
           import('@/platform/cloud/onboarding/CloudSignupView.vue'),
         beforeEnter: async (to, _from, next) => {
-          if (!to.query.switchAccount) {
+          if (!to.query.switchAccount && !hasDesktopLoginRequest(to.query)) {
             const { useCurrentUser } =
               await import('@/composables/auth/useCurrentUser')
             const { isLoggedIn } = useCurrentUser()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -9,6 +9,10 @@ import { useSubscription } from '@/platform/cloud/subscription/composables/useSu
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
+import {
+  identifyPostHogUser,
+  setPostHogIdentityClient
+} from './posthogIdentity'
 import type {
   AuthMetadata,
   DefaultViewSetMetadata,
@@ -139,6 +143,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
               // to clear localStorage on other subdomains, causing identity bleed on logout.
               before_send: createPostHogBeforeSend()
             })
+            setPostHogIdentityClient(this.posthog)
             this.isInitialized = true
             this.flushEventQueue()
             this.registerDesktopEntryProps()
@@ -146,7 +151,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
             const currentUser = useCurrentUser()
             currentUser.onUserResolved((user) => {
               if (this.posthog && user.id) {
-                this.posthog.identify(user.id)
+                identifyPostHogUser(user.id)
                 this.setDesktopEntryPersonProperties()
                 this.setSubscriptionProperties()
               }
@@ -166,14 +171,17 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
           })
           .catch((error) => {
             console.error('Failed to load PostHog:', error)
+            setPostHogIdentityClient(null)
             this.isEnabled = false
           })
       } catch (error) {
         console.error('Failed to initialize PostHog:', error)
+        setPostHogIdentityClient(null)
         this.isEnabled = false
       }
     } else {
       console.warn('PostHog API key not provided in runtime config')
+      setPostHogIdentityClient(null)
       this.isEnabled = false
     }
   }

--- a/src/platform/telemetry/providers/cloud/posthogIdentity.test.ts
+++ b/src/platform/telemetry/providers/cloud/posthogIdentity.test.ts
@@ -1,0 +1,39 @@
+import type { PostHog } from 'posthog-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  identifyPostHogUser,
+  setPostHogIdentityClient
+} from './posthogIdentity'
+
+describe('posthogIdentity', () => {
+  beforeEach(() => {
+    setPostHogIdentityClient(null)
+  })
+
+  afterEach(() => {
+    setPostHogIdentityClient(null)
+  })
+
+  it('queues identify calls until the PostHog client is ready', () => {
+    identifyPostHogUser('user-123')
+
+    const posthog = {
+      identify: vi.fn()
+    } as unknown as PostHog
+    setPostHogIdentityClient(posthog)
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-123')
+  })
+
+  it('identifies immediately when the PostHog client is ready', () => {
+    const posthog = {
+      identify: vi.fn()
+    } as unknown as PostHog
+    setPostHogIdentityClient(posthog)
+
+    identifyPostHogUser('user-123')
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-123')
+  })
+})

--- a/src/platform/telemetry/providers/cloud/posthogIdentity.ts
+++ b/src/platform/telemetry/providers/cloud/posthogIdentity.ts
@@ -1,0 +1,36 @@
+import type { PostHog } from 'posthog-js'
+
+let posthogClient: PostHog | null = null
+const pendingUserIds = new Set<string>()
+
+function tryIdentify(userId: string): void {
+  if (!posthogClient) {
+    pendingUserIds.add(userId)
+    return
+  }
+
+  try {
+    posthogClient.identify(userId)
+  } catch (error) {
+    console.error('Failed to identify PostHog user:', error)
+  }
+}
+
+export function setPostHogIdentityClient(client: PostHog | null): void {
+  posthogClient = client
+  if (!client) {
+    pendingUserIds.clear()
+    return
+  }
+
+  const queuedUserIds = Array.from(pendingUserIds)
+  pendingUserIds.clear()
+  for (const userId of queuedUserIds) {
+    tryIdentify(userId)
+  }
+}
+
+export function identifyPostHogUser(userId: string | null | undefined): void {
+  if (!userId) return
+  tryIdentify(userId)
+}


### PR DESCRIPTION
## Summary
- Add Cloud login callback query handling for Desktop sign-in handoff.
- Queue PostHog identify until the Cloud PostHog provider is initialized, so the browser-side comfy.org cookie can be stitched to the Firebase user.
- Keep already-authenticated browser sessions on the login route long enough to complete the Desktop callback.

## Links
- Linear: https://linear.app/comfyorg/issue/GTM-93/fix-posthog-identify-call-unblock-funnel-attribution-desktop-funnel
- Desktop companion PR: https://github.com/Comfy-Org/Comfy-Desktop/pull/1150

## Test plan
- pnpm exec vitest run src/platform/cloud/onboarding/desktopLoginBridge.test.ts src/platform/telemetry/providers/cloud/posthogIdentity.test.ts src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
- pnpm typecheck
- pnpm format:check
- pnpm lint -- src/platform/cloud/onboarding/desktopLoginBridge.ts src/platform/cloud/onboarding/desktopLoginBridge.test.ts src/platform/telemetry/providers/cloud/posthogIdentity.ts src/platform/telemetry/providers/cloud/posthogIdentity.test.ts src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts src/platform/cloud/onboarding/composables/usePostAuthRedirect.ts src/platform/cloud/onboarding/onboardingCloudRoutes.ts src/platform/cloud/onboarding/CloudLoginView.vue
