### PR TITLE
fix: close node-search modal on Tab instead of cycling focus

### DIFF
--- a/src/components/searchbox/NodeSearchBoxPopover.vue
+++ b/src/components/searchbox/NodeSearchBoxPopover.vue
@@ -31,6 +31,7 @@
             @remove-filter="removeFilter"
             @add-node="addNode"
             @hover-node="hoveredNodeDef = $event"
+            @close="closeDialog"
           />
           <NodePreviewCard
             v-if="hoveredNodeDef && enableNodePreview"

--- a/src/components/searchbox/v2/NodeSearchContent.test.ts
+++ b/src/components/searchbox/v2/NodeSearchContent.test.ts
@@ -37,6 +37,7 @@ describe('NodeSearchContent', () => {
     const onRemoveFilter =
       vi.fn<(f: FuseFilterWithValue<ComfyNodeDefImpl, string>) => void>()
     const onAddFilter = vi.fn()
+    const onClose = vi.fn()
     render(NodeSearchContent, {
       props: {
         filters: [],
@@ -44,6 +45,7 @@ describe('NodeSearchContent', () => {
         onHoverNode,
         onRemoveFilter,
         onAddFilter,
+        onClose,
         ...props
       },
       global: {
@@ -63,7 +65,14 @@ describe('NodeSearchContent', () => {
         }
       }
     })
-    return { user, onAddNode, onHoverNode, onRemoveFilter, onAddFilter }
+    return {
+      user,
+      onAddNode,
+      onHoverNode,
+      onRemoveFilter,
+      onAddFilter,
+      onClose
+    }
   }
 
   function mockBookmarks(
@@ -524,6 +533,30 @@ describe('NodeSearchContent', () => {
       expect(onAddNode).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'TestNode' })
       )
+    })
+  })
+
+  describe('close on Tab', () => {
+    it('should emit close when Tab is pressed from the search input', async () => {
+      const { user, onClose } = await setupFavorites([
+        { name: 'TestNode', display_name: 'Test Node' }
+      ])
+
+      await user.click(screen.getByRole('combobox'))
+      await user.keyboard('{Tab}')
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not emit close for Ctrl+Tab', async () => {
+      const { user, onClose } = await setupFavorites([
+        { name: 'TestNode', display_name: 'Test Node' }
+      ])
+
+      await user.click(screen.getByRole('combobox'))
+      await user.keyboard('{Control>}{Tab}{/Control}')
+
+      expect(onClose).not.toHaveBeenCalled()
     })
   })
 

--- a/src/components/searchbox/v2/NodeSearchContent.vue
+++ b/src/components/searchbox/v2/NodeSearchContent.vue
@@ -3,6 +3,7 @@
     <div
       ref="dialogRef"
       class="flex h-[min(80vh,750px)] w-full flex-col overflow-hidden rounded-lg border border-interface-stroke bg-base-background"
+      @keydown.capture="closeOnTab"
     >
       <!-- Search input row -->
       <NodeSearchInput
@@ -151,7 +152,21 @@ const emit = defineEmits<{
   addFilter: [filter: FuseFilterWithValue<ComfyNodeDefImpl, string>]
   removeFilter: [filter: FuseFilterWithValue<ComfyNodeDefImpl, string>]
   hoverNode: [nodeDef: ComfyNodeDefImpl | null]
+  close: []
 }>()
+
+function closeOnTab(event: KeyboardEvent) {
+  if (
+    event.key === 'Tab' &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey
+  ) {
+    event.preventDefault()
+    event.stopPropagation()
+    emit('close')
+  }
+}
 
 const { t } = useI18n()
 const { flags } = useFeatureFlags()


### PR DESCRIPTION
## Summary

Make `Tab` close the node-search modal instead of cycling focus through its controls, so it works consistently with the new Tab-toggles-search keybinding.

> Stacked on #12982 (base = `feat/default-search-box-tab-keybinding`). Retarget to `main` once that merges.

## Changes

- **What**: The v2 search modal wraps its content in a Reka UI `FocusScope`, so `Tab` cycled focus through the chips/input/results. Combined with #12982's `Tab` binding, behavior was inconsistent: while the auto-focused search input held focus, the global binding is skipped (`Tab` is reserved by text inputs), so the modal didn't close until focus had already moved off the input. Now a capture-phase `keydown` handler on the modal root intercepts `Tab` (before `FocusScope`) and closes the modal. `Ctrl`/`Cmd`/`Alt`+`Tab` are left to the browser.

## Review Focus

- **Auto-focus preserved**: this change is additive — the search input's `onMounted` auto-focus is untouched. Verified live: `Tab` opens the modal *and* focuses the input, then `Tab` closes it.
- **Why capture phase**: `FocusScope` listens on bubble; a capture-phase handler on the modal root reliably runs first regardless of listener registration order, without removing `FocusScope` (which still handles focus trapping/restoration).
- **Scope**: applies to the v2 search box (the default impl). The legacy v1 (`Comfy.NodeSearchBoxImpl` non-default) is out of scope.
- **Tests**: added behavioral tests — `Tab` emits `close`, `Ctrl+Tab` does not. Existing arrow/Enter navigation tests still pass (32/32).