### PR TITLE
fix: rename user-facing 'API Nodes' to 'Partner Nodes'

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1506,7 +1506,7 @@
     "Light": "Light",
     "User": "User",
     "Credits": "Credits",
-    "API Nodes": "API Nodes",
+    "API Nodes": "Partner Nodes",
     "Notification Preferences": "Notification Preferences",
     "3DViewer": "3DViewer",
     "Canvas Navigation": "Canvas Navigation",
@@ -1966,11 +1966,11 @@
     "accessRestrictedMessage": "Your account is not authorized for this feature."
   },
   "apiNodesSignInDialog": {
-    "title": "Sign In Required to Use API Nodes",
-    "message": "This workflow contains API Nodes, which require you to be signed in to your account in order to run."
+    "title": "Sign In Required to Use Partner Nodes",
+    "message": "This workflow contains Partner Nodes, which require you to be signed in to your account in order to run."
   },
   "apiNodesCostBreakdown": {
-    "title": "API Node(s)",
+    "title": "Partner Node(s)",
     "costPerRun": "Cost per run",
     "totalCost": "Total Cost"
   },
@@ -2229,7 +2229,7 @@
     "apiKey": {
       "title": "API Key",
       "label": "API Key",
-      "description": "Use your Comfy API key to enable API Nodes",
+      "description": "Use your Comfy API key to enable Partner Nodes",
       "placeholder": "Enter your API Key",
       "error": "Invalid API Key",
       "storageFailed": "Failed to store API Key",
@@ -2340,7 +2340,7 @@
       "cancel": "Cancel"
     },
     "loginButton": {
-      "tooltipHelp": "Login to be able to use \"API Nodes\"",
+      "tooltipHelp": "Login to be able to use \"Partner Nodes\"",
       "tooltipLearnMore": "Learn more..."
     }
   },


### PR DESCRIPTION
Rename the user-facing label "API Nodes" to "Partner Nodes" across UI strings in src/locales/en/main.json (sign-in dialog, cost breakdown, settings category, API key description, login tooltip). Only display values changed; i18n lookup keys and "API Key" references are left intact.