### PR TITLE
fix(test): import AppMode from utils/appMode in WorkflowHelper

### DIFF
--- a/browser_tests/fixtures/helpers/WorkflowHelper.ts
+++ b/browser_tests/fixtures/helpers/WorkflowHelper.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs'
 
 import { test } from '@playwright/test'
 
-import type { AppMode } from '@/composables/useAppMode'
+import type { AppMode } from '@/utils/appMode'
 import type {
   ComfyApiWorkflow,
   ComfyWorkflowJSON


### PR DESCRIPTION
## Summary

`pnpm typecheck:browser` (`vue-tsc --project browser_tests/tsconfig.json`) currently fails on `main`, turning `lint-and-format` red for every PR built on it:

```
browser_tests/fixtures/helpers/WorkflowHelper.ts(5,15): error TS2459:
Module '"@/composables/useAppMode"' declares 'AppMode' locally, but it is not exported.
```

## Cause

#12925 (`bc885f383c`, "Decouple run telemetry context from providers") moved the `AppMode` type from `@/composables/useAppMode` to `@/utils/appMode`. `useAppMode` now only `import type`s `AppMode` (it no longer re-exports it), so this fixture's `import type { AppMode } from '@/composables/useAppMode'` became invalid. The other `useAppMode` import sites are unaffected — they import the `useAppMode` composable (still exported), not the type.

## Fix

Import `AppMode` from its actual source, `@/utils/appMode`. One line, no behavior change.

Verified `vue-tsc --project browser_tests/tsconfig.json` no longer reports the `WorkflowHelper.ts` error.
