### PR TITLE
feat: add stable survey identity

### DIFF
--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/vue'
+import { cleanup, render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
@@ -42,7 +42,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
 }))
 
 vi.mock('@/platform/surveys/surveyIdentity', () => ({
-  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+  getSurveyIdentityTags: () => Promise.resolve({ anon_id: 'anon-1' })
 }))
 
 vi.mock('@/platform/telemetry', () => ({
@@ -135,10 +135,12 @@ describe('HelpCenterMenuContent feedback item', () => {
 
     await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=help-center&anon_id=anon-1',
-      '_blank',
-      'noopener,noreferrer'
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=help-center&anon_id=anon-1',
+        '_blank',
+        'noopener,noreferrer'
+      )
     )
     expect(commandStoreExecute).not.toHaveBeenCalled()
   })
@@ -149,10 +151,12 @@ describe('HelpCenterMenuContent feedback item', () => {
 
     await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=help-center&anon_id=anon-1',
-      '_blank',
-      'noopener,noreferrer'
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=help-center&anon_id=anon-1',
+        '_blank',
+        'noopener,noreferrer'
+      )
     )
     expect(commandStoreExecute).not.toHaveBeenCalled()
   })

--- a/src/components/helpcenter/HelpCenterMenuContent.test.ts
+++ b/src/components/helpcenter/HelpCenterMenuContent.test.ts
@@ -41,6 +41,10 @@ vi.mock('@/platform/settings/settingStore', () => ({
   })
 }))
 
+vi.mock('@/platform/surveys/surveyIdentity', () => ({
+  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+}))
+
 vi.mock('@/platform/telemetry', () => ({
   useTelemetry: () => ({
     trackHelpResourceClicked: vi.fn(),
@@ -132,7 +136,7 @@ describe('HelpCenterMenuContent feedback item', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).toHaveBeenCalledWith(
-      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=help-center',
+      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=help-center&anon_id=anon-1',
       '_blank',
       'noopener,noreferrer'
     )
@@ -146,7 +150,7 @@ describe('HelpCenterMenuContent feedback item', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Give Feedback' }))
 
     expect(openSpy).toHaveBeenCalledWith(
-      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=help-center',
+      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=help-center&anon_id=anon-1',
       '_blank',
       'noopener,noreferrer'
     )

--- a/src/components/helpcenter/HelpCenterMenuContent.vue
+++ b/src/components/helpcenter/HelpCenterMenuContent.vue
@@ -306,11 +306,11 @@ const menuItems = computed<MenuItem[]>(() => {
       action: () => {
         trackResourceClick('help_feedback', isCloud || isNightly)
         if (isCloud || isNightly) {
-          window.open(
-            buildFeedbackTypeformUrl('help-center'),
-            '_blank',
-            'noopener,noreferrer'
-          )
+          // Identity resolves synchronously on web and Desktop is Electron, so
+          // the popup survives the microtask before window.open.
+          void buildFeedbackTypeformUrl('help-center').then((url) => {
+            window.open(url, '_blank', 'noopener,noreferrer')
+          })
         } else {
           void commandStore.execute('Comfy.ContactSupport')
         }

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, reactive } from 'vue'
 import { createI18n } from 'vue-i18n'
 
@@ -36,7 +36,15 @@ vi.mock('@/platform/settings/settingStore', () => ({
 }))
 
 vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({ isLoggedIn: { value: false } })
+  useCurrentUser: () => ({
+    isLoggedIn: { value: false },
+    userEmail: { value: undefined }
+  })
+}))
+
+const openFeedbackDialog = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/support/feedbackDialog', () => ({
+  openFeedbackDialog
 }))
 
 vi.mock('@/composables/useFeatureFlags', () => ({
@@ -128,44 +136,30 @@ function renderComponent() {
 }
 
 describe('WorkflowTabs feedback button', () => {
-  let openSpy: ReturnType<typeof vi.spyOn>
-
   beforeEach(() => {
     distribution.isCloud = false
     distribution.isDesktop = false
     distribution.isNightly = false
     tabBarLayout.value = 'Default'
-    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    openFeedbackDialog.mockReset()
   })
 
-  afterEach(() => {
-    openSpy.mockRestore()
-  })
-
-  it('opens the Typeform survey tagged with topbar source on Cloud', async () => {
+  it('opens the feedback dialog tagged with topbar source on Cloud', async () => {
     distribution.isCloud = true
     const { user } = renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Feedback' }))
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=topbar',
-      '_blank',
-      'noopener,noreferrer'
-    )
+    expect(openFeedbackDialog).toHaveBeenCalledWith('topbar')
   })
 
-  it('opens the Typeform survey tagged with topbar source on Nightly', async () => {
+  it('opens the feedback dialog tagged with topbar source on Nightly', async () => {
     distribution.isNightly = true
     const { user } = renderComponent()
 
     await user.click(screen.getByRole('button', { name: 'Feedback' }))
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=topbar',
-      '_blank',
-      'noopener,noreferrer'
-    )
+    expect(openFeedbackDialog).toHaveBeenCalledWith('topbar')
   })
 
   it('does not render the feedback button on non-Cloud/non-Nightly builds', () => {

--- a/src/components/topbar/WorkflowTabs.test.ts
+++ b/src/components/topbar/WorkflowTabs.test.ts
@@ -144,7 +144,7 @@ describe('WorkflowTabs feedback button', () => {
     openFeedbackDialog.mockReset()
   })
 
-  it('opens the feedback dialog tagged with topbar source on Cloud', async () => {
+  it('opens the feedback dialog tagged with topbar source when clicked', async () => {
     distribution.isCloud = true
     const { user } = renderComponent()
 
@@ -153,13 +153,11 @@ describe('WorkflowTabs feedback button', () => {
     expect(openFeedbackDialog).toHaveBeenCalledWith('topbar')
   })
 
-  it('opens the feedback dialog tagged with topbar source on Nightly', async () => {
+  it('renders the feedback button on Nightly', () => {
     distribution.isNightly = true
-    const { user } = renderComponent()
+    renderComponent()
 
-    await user.click(screen.getByRole('button', { name: 'Feedback' }))
-
-    expect(openFeedbackDialog).toHaveBeenCalledWith('topbar')
+    expect(screen.getByRole('button', { name: 'Feedback' })).toBeInTheDocument()
   })
 
   it('does not render the feedback button on non-Cloud/non-Nightly builds', () => {

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -119,7 +119,7 @@ import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useOverflowObserver } from '@/composables/element/useOverflowObserver'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { buildFeedbackTypeformUrl } from '@/platform/support/config'
+import { openFeedbackDialog } from '@/platform/support/feedbackDialog'
 import { useWorkflowService } from '@/platform/workflow/core/services/workflowService'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
@@ -153,11 +153,7 @@ const isIntegratedTabBar = computed(
 const showCurrentUser = computed(() => isCloud || isLoggedIn.value)
 
 function openFeedback() {
-  window.open(
-    buildFeedbackTypeformUrl('topbar'),
-    '_blank',
-    'noopener,noreferrer'
-  )
+  openFeedbackDialog('topbar')
 }
 
 const containerRef = ref<HTMLElement | null>(null)

--- a/src/components/ui/TypeformPopoverButton.test.ts
+++ b/src/components/ui/TypeformPopoverButton.test.ts
@@ -15,6 +15,10 @@ vi.mock('@vueuse/core', async (importOriginal) => {
   }
 })
 
+vi.mock('@/platform/surveys/surveyIdentity', () => ({
+  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+}))
+
 const PopoverStub = defineComponent({
   name: 'Popover',
   setup(_, { slots }) {
@@ -67,7 +71,7 @@ describe('TypeformPopoverButton', () => {
     expect(screen.queryByTestId('embed')).not.toBeInTheDocument()
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
-      'https://form.typeform.com/to/abc123'
+      'https://form.typeform.com/to/abc123#anon_id=anon-1'
     )
   })
 })

--- a/src/components/ui/TypeformPopoverButton.test.ts
+++ b/src/components/ui/TypeformPopoverButton.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as VueUse from '@vueuse/core'
 import { computed, defineComponent, h } from 'vue'
@@ -16,7 +16,7 @@ vi.mock('@vueuse/core', async (importOriginal) => {
 })
 
 vi.mock('@/platform/surveys/surveyIdentity', () => ({
-  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+  getSurveyIdentityTags: () => Promise.resolve({ anon_id: 'anon-1' })
 }))
 
 const PopoverStub = defineComponent({
@@ -64,14 +64,16 @@ describe('TypeformPopoverButton', () => {
     expect(screen.queryByTestId('embed')).not.toBeInTheDocument()
   })
 
-  it('links directly to the form on mobile instead of embedding', () => {
+  it('links directly to the form on mobile instead of embedding', async () => {
     isMobile.value = true
     renderButton({ dataTfWidget: 'abc123' })
 
     expect(screen.queryByTestId('embed')).not.toBeInTheDocument()
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      'https://form.typeform.com/to/abc123#anon_id=anon-1'
+    await waitFor(() =>
+      expect(screen.getByRole('link')).toHaveAttribute(
+        'href',
+        'https://form.typeform.com/to/abc123#anon_id=anon-1'
+      )
     )
   })
 })

--- a/src/components/ui/TypeformPopoverButton.test.ts
+++ b/src/components/ui/TypeformPopoverButton.test.ts
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as VueUse from '@vueuse/core'
+import { computed, defineComponent, h } from 'vue'
+
+import TypeformPopoverButton from './TypeformPopoverButton.vue'
+
+const isMobile = vi.hoisted(() => ({ value: false }))
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueUse>()
+  return {
+    ...actual,
+    useBreakpoints: () => ({ smaller: () => computed(() => isMobile.value) })
+  }
+})
+
+const PopoverStub = defineComponent({
+  name: 'Popover',
+  setup(_, { slots }) {
+    return () => h('div', [slots.button?.(), slots.default?.()])
+  }
+})
+
+const TypeformEmbedStub = defineComponent({
+  name: 'TypeformEmbed',
+  props: { typeformId: { type: String, required: true } },
+  setup(props) {
+    return () =>
+      h('div', { 'data-testid': 'embed', 'data-typeform-id': props.typeformId })
+  }
+})
+
+function renderButton(props: { dataTfWidget: string; active?: boolean }) {
+  return render(TypeformPopoverButton, {
+    props,
+    global: {
+      stubs: { Popover: PopoverStub, TypeformEmbed: TypeformEmbedStub }
+    }
+  })
+}
+
+describe('TypeformPopoverButton', () => {
+  beforeEach(() => {
+    isMobile.value = false
+  })
+
+  it('embeds the active survey in a popover on desktop', () => {
+    renderButton({ dataTfWidget: 'abc123' })
+
+    expect(screen.getByTestId('embed')).toHaveAttribute(
+      'data-typeform-id',
+      'abc123'
+    )
+  })
+
+  it('omits the embed when inactive', () => {
+    renderButton({ dataTfWidget: 'abc123', active: false })
+
+    expect(screen.queryByTestId('embed')).not.toBeInTheDocument()
+  })
+
+  it('links directly to the form on mobile instead of embedding', () => {
+    isMobile.value = true
+    renderButton({ dataTfWidget: 'abc123' })
+
+    expect(screen.queryByTestId('embed')).not.toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      'https://form.typeform.com/to/abc123'
+    )
+  })
+})

--- a/src/components/ui/TypeformPopoverButton.vue
+++ b/src/components/ui/TypeformPopoverButton.vue
@@ -1,22 +1,30 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
+import { computed } from 'vue'
 
 import Popover from '@/components/ui/Popover.vue'
 import Button from '@/components/ui/button/Button.vue'
 import TypeformEmbed from '@/platform/surveys/TypeformEmbed.vue'
+import { getSurveyIdentityTags } from '@/platform/surveys/surveyIdentity'
 
-const { active = true } = defineProps<{
+const { dataTfWidget, active = true } = defineProps<{
   dataTfWidget: string
   active?: boolean
 }>()
 
 const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
+
+// Mobile opens the form externally, so identity rides in the URL fragment.
+const formUrl = computed(() => {
+  const params = new URLSearchParams(getSurveyIdentityTags())
+  return `https://form.typeform.com/to/${dataTfWidget}#${params.toString()}`
+})
 </script>
 <template>
   <Button
     v-if="isMobile"
     as="a"
-    :href="`https://form.typeform.com/to/${dataTfWidget}`"
+    :href="formUrl"
     target="_blank"
     variant="inverted"
     class="flex h-10 items-center justify-center gap-2.5 px-3 py-2"

--- a/src/components/ui/TypeformPopoverButton.vue
+++ b/src/components/ui/TypeformPopoverButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import { computed } from 'vue'
+import { ref, watchEffect } from 'vue'
 
 import Popover from '@/components/ui/Popover.vue'
 import Button from '@/components/ui/button/Button.vue'
@@ -15,9 +15,19 @@ const { dataTfWidget, active = true } = defineProps<{
 const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
 
 // Mobile opens the form externally, so identity rides in the URL fragment.
-const formUrl = computed(() => {
-  const params = new URLSearchParams(getSurveyIdentityTags())
-  return `https://form.typeform.com/to/${dataTfWidget}#${params.toString()}`
+const formUrl = ref<string>()
+
+watchEffect((onCleanup) => {
+  const widgetId = dataTfWidget
+  let cancelled = false
+  onCleanup(() => {
+    cancelled = true
+  })
+  void getSurveyIdentityTags().then((tags) => {
+    if (cancelled) return
+    const params = new URLSearchParams(tags)
+    formUrl.value = `https://form.typeform.com/to/${widgetId}#${params.toString()}`
+  })
 })
 </script>
 <template>

--- a/src/components/ui/TypeformPopoverButton.vue
+++ b/src/components/ui/TypeformPopoverButton.vue
@@ -1,23 +1,16 @@
 <script setup lang="ts">
-import { breakpointsTailwind, useBreakpoints, whenever } from '@vueuse/core'
-import { useTemplateRef } from 'vue'
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 
 import Popover from '@/components/ui/Popover.vue'
 import Button from '@/components/ui/button/Button.vue'
+import TypeformEmbed from '@/platform/surveys/TypeformEmbed.vue'
 
 const { active = true } = defineProps<{
   dataTfWidget: string
   active?: boolean
 }>()
 
-const feedbackRef = useTemplateRef('feedbackRef')
 const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
-
-whenever(feedbackRef, () => {
-  const scriptEl = document.createElement('script')
-  scriptEl.src = '//embed.typeform.com/next/embed.js'
-  feedbackRef.value?.appendChild(scriptEl)
-})
 </script>
 <template>
   <Button
@@ -41,6 +34,6 @@ whenever(feedbackRef, () => {
         <i class="icon-[lucide--circle-help] size-4" />
       </Button>
     </template>
-    <div v-if="active" ref="feedbackRef" data-tf-auto-resize :data-tf-widget />
+    <TypeformEmbed v-if="active" :typeform-id="dataTfWidget" auto-resize />
   </Popover>
 </template>

--- a/src/extensions/core/cloudFeedbackTopbarButton.test.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ActionBarButton } from '@/types/comfy'
 
-const distribution = vi.hoisted(() => ({ isCloud: false, isNightly: false }))
-
 const tabBarLayout = vi.hoisted(() => ({ value: 'Default' }))
 const registerExtension = vi.hoisted(() => vi.fn())
+const openFeedbackDialog = vi.hoisted(() => vi.fn())
 
 vi.mock('@/i18n', () => ({
   t: (key: string) => key
@@ -24,28 +23,15 @@ vi.mock('@/services/extensionService', () => ({
   })
 }))
 
-vi.mock('@/platform/distribution/types', () => ({
-  get isCloud() {
-    return distribution.isCloud
-  },
-  get isNightly() {
-    return distribution.isNightly
-  }
+vi.mock('@/platform/support/feedbackDialog', () => ({
+  openFeedbackDialog
 }))
 
 describe('cloudFeedbackTopbarButton', () => {
-  let openSpy: ReturnType<typeof vi.spyOn>
-
   beforeEach(() => {
     vi.resetModules()
     registerExtension.mockReset()
-    distribution.isCloud = false
-    distribution.isNightly = false
-    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
-  })
-
-  afterEach(() => {
-    openSpy.mockRestore()
+    openFeedbackDialog.mockReset()
   })
 
   function getRegisteredButtons(): ActionBarButton[] {
@@ -56,22 +42,15 @@ describe('cloudFeedbackTopbarButton', () => {
     return extension.actionBarButtons
   }
 
-  it('opens the Typeform survey tagged with action-bar source on Cloud', async () => {
+  it('opens the feedback survey tagged with the action-bar source', async () => {
     tabBarLayout.value = 'Legacy'
-    distribution.isCloud = true
     await import('./cloudFeedbackTopbarButton')
 
     const buttons = getRegisteredButtons()
     expect(buttons).toHaveLength(1)
     buttons[0].onClick?.()
 
-    expect(openSpy).toHaveBeenCalledTimes(1)
-    const [url, target, features] = openSpy.mock.calls[0]
-    expect(url).toBe(
-      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=action-bar'
-    )
-    expect(target).toBe('_blank')
-    expect(features).toBe('noopener,noreferrer')
+    expect(openFeedbackDialog).toHaveBeenCalledWith('action-bar')
   })
 
   it('only registers the action bar button when the tab bar is Legacy', async () => {

--- a/src/extensions/core/cloudFeedbackTopbarButton.ts
+++ b/src/extensions/core/cloudFeedbackTopbarButton.ts
@@ -1,6 +1,6 @@
 import { t } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
-import { buildFeedbackTypeformUrl } from '@/platform/support/config'
+import { openFeedbackDialog } from '@/platform/support/feedbackDialog'
 import { useExtensionService } from '@/services/extensionService'
 import type { ActionBarButton } from '@/types/comfy'
 
@@ -9,13 +9,7 @@ const buttons: ActionBarButton[] = [
     icon: 'icon-[lucide--message-square-text]',
     label: t('actionbar.feedback'),
     tooltip: t('actionbar.feedbackTooltip'),
-    onClick: () => {
-      window.open(
-        buildFeedbackTypeformUrl('action-bar'),
-        '_blank',
-        'noopener,noreferrer'
-      )
-    }
+    onClick: () => openFeedbackDialog('action-bar')
   }
 ]
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2900,12 +2900,17 @@
     "description": "You've been using this feature. Would you take a moment to share your feedback?",
     "accept": "Sure, I'll help!",
     "notNow": "Not Now",
-    "dontAskAgain": "Don't Ask Again",
-    "loadError": "Failed to load survey. Please try again later."
+    "dontAskAgain": "Don't Ask Again"
   },
   "errorPanelSurvey": {
     "ctaText": "How's the new error panel?",
     "ctaButton": "Give feedback"
+  },
+  "feedback": {
+    "title": "Share Feedback"
+  },
+  "typeform": {
+    "loadError": "Failed to load the form. Please try again later."
   },
   "cloudOnboarding": {
     "skipToCloudApp": "Skip to the cloud app",

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,12 @@ if (isCloud) {
 
   const { initTelemetry } = await import('@/platform/telemetry/initTelemetry')
   await initTelemetry()
+
+  const { setCurrentIdentityProvider } =
+    await import('@/platform/surveys/surveyIdentity')
+  const { cloudIdentityProvider } =
+    await import('@/platform/surveys/cloudSurveyIdentity')
+  setCurrentIdentityProvider(cloudIdentityProvider)
 }
 
 const ComfyUIPreset = definePreset(Aura, {

--- a/src/platform/support/config.test.ts
+++ b/src/platform/support/config.test.ts
@@ -50,3 +50,28 @@ describe('buildFeedbackTypeformUrl', () => {
     expect(url.hash).toBe('#distribution=ccloud&source=topbar')
   })
 })
+
+describe('buildFeedbackHiddenFields', () => {
+  beforeEach(() => {
+    distribution.isCloud = false
+    distribution.isNightly = false
+  })
+
+  async function build(source: 'topbar' | 'action-bar' | 'help-center') {
+    vi.resetModules()
+    const { buildFeedbackHiddenFields } = await import('./config')
+    return buildFeedbackHiddenFields(source)
+  }
+
+  it('formats tags comma-separated for the Typeform embed data-tf-hidden attribute', async () => {
+    distribution.isCloud = true
+    expect(await build('topbar')).toBe('distribution=ccloud,source=topbar')
+  })
+
+  it('reflects the build distribution', async () => {
+    distribution.isNightly = true
+    expect(await build('action-bar')).toBe(
+      'distribution=oss-nightly,source=action-bar'
+    )
+  })
+})

--- a/src/platform/support/config.test.ts
+++ b/src/platform/support/config.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as SurveyIdentityModule from '@/platform/surveys/surveyIdentity'
+
 const distribution = vi.hoisted(() => ({ isCloud: false, isNightly: false }))
 
 vi.mock('@/platform/distribution/types', () => ({
@@ -9,6 +11,11 @@ vi.mock('@/platform/distribution/types', () => ({
   get isNightly() {
     return distribution.isNightly
   }
+}))
+
+vi.mock('@/platform/surveys/surveyIdentity', async (importOriginal) => ({
+  ...(await importOriginal<typeof SurveyIdentityModule>()),
+  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
 }))
 
 describe('buildFeedbackTypeformUrl', () => {
@@ -26,28 +33,27 @@ describe('buildFeedbackTypeformUrl', () => {
   it('tags Cloud builds with distribution=ccloud', async () => {
     distribution.isCloud = true
     expect(await build('topbar')).toBe(
-      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=topbar'
+      'https://form.typeform.com/to/q7azbWPi#distribution=ccloud&source=topbar&anon_id=anon-1'
     )
   })
 
   it('tags Nightly builds with distribution=oss-nightly', async () => {
     distribution.isNightly = true
     expect(await build('action-bar')).toBe(
-      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=action-bar'
+      'https://form.typeform.com/to/q7azbWPi#distribution=oss-nightly&source=action-bar&anon_id=anon-1'
     )
   })
 
-  it('tags OSS builds with distribution=oss', async () => {
-    expect(await build('help-center')).toBe(
-      'https://form.typeform.com/to/q7azbWPi#distribution=oss&source=help-center'
-    )
+  it('includes the survey identity for analytics joins', async () => {
+    const url = new URL(await build('help-center'))
+    expect(url.hash).toContain('anon_id=anon-1')
   })
 
-  it('uses a URL fragment so distribution and source are not sent to the server', async () => {
+  it('uses a URL fragment so the tags are not sent to the server', async () => {
     distribution.isCloud = true
     const url = new URL(await build('topbar'))
     expect(url.search).toBe('')
-    expect(url.hash).toBe('#distribution=ccloud&source=topbar')
+    expect(url.hash).toBe('#distribution=ccloud&source=topbar&anon_id=anon-1')
   })
 })
 
@@ -57,16 +63,13 @@ describe('buildFeedbackHiddenFields', () => {
     distribution.isNightly = false
   })
 
-  async function build(
-    source: 'topbar' | 'action-bar' | 'help-center',
-    extraTags?: Record<string, string>
-  ) {
+  async function build(source: 'topbar' | 'action-bar' | 'help-center') {
     vi.resetModules()
     const { buildFeedbackHiddenFields } = await import('./config')
-    return buildFeedbackHiddenFields(source, extraTags)
+    return buildFeedbackHiddenFields(source)
   }
 
-  it('formats tags comma-separated for the Typeform embed data-tf-hidden attribute', async () => {
+  it('formats segmentation tags comma-separated for data-tf-hidden', async () => {
     distribution.isCloud = true
     expect(await build('topbar')).toBe('distribution=ccloud,source=topbar')
   })
@@ -75,13 +78,6 @@ describe('buildFeedbackHiddenFields', () => {
     distribution.isNightly = true
     expect(await build('action-bar')).toBe(
       'distribution=oss-nightly,source=action-bar'
-    )
-  })
-
-  it('appends extra tags after the base segmentation tags', async () => {
-    distribution.isCloud = true
-    expect(await build('topbar', { email: 'user@example.com' })).toBe(
-      'distribution=ccloud,source=topbar,email=user@example.com'
     )
   })
 })

--- a/src/platform/support/config.test.ts
+++ b/src/platform/support/config.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/platform/distribution/types', () => ({
 
 vi.mock('@/platform/surveys/surveyIdentity', async (importOriginal) => ({
   ...(await importOriginal<typeof SurveyIdentityModule>()),
-  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+  getSurveyIdentityTags: () => Promise.resolve({ anon_id: 'anon-1' })
 }))
 
 describe('buildFeedbackTypeformUrl', () => {

--- a/src/platform/support/config.test.ts
+++ b/src/platform/support/config.test.ts
@@ -57,10 +57,13 @@ describe('buildFeedbackHiddenFields', () => {
     distribution.isNightly = false
   })
 
-  async function build(source: 'topbar' | 'action-bar' | 'help-center') {
+  async function build(
+    source: 'topbar' | 'action-bar' | 'help-center',
+    extraTags?: Record<string, string>
+  ) {
     vi.resetModules()
     const { buildFeedbackHiddenFields } = await import('./config')
-    return buildFeedbackHiddenFields(source)
+    return buildFeedbackHiddenFields(source, extraTags)
   }
 
   it('formats tags comma-separated for the Typeform embed data-tf-hidden attribute', async () => {
@@ -72,6 +75,13 @@ describe('buildFeedbackHiddenFields', () => {
     distribution.isNightly = true
     expect(await build('action-bar')).toBe(
       'distribution=oss-nightly,source=action-bar'
+    )
+  })
+
+  it('appends extra tags after the base segmentation tags', async () => {
+    distribution.isCloud = true
+    expect(await build('topbar', { email: 'user@example.com' })).toBe(
+      'distribution=ccloud,source=topbar,email=user@example.com'
     )
   })
 })

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -25,7 +25,17 @@ function getDistribution(): 'ccloud' | 'oss-nightly' | 'oss' {
 }
 
 const SUPPORT_BASE_URL = 'https://support.comfy.org/hc/en-us/requests/new'
-const FEEDBACK_TYPEFORM_BASE_URL = 'https://form.typeform.com/to/q7azbWPi'
+
+export type FeedbackSource = 'topbar' | 'action-bar' | 'help-center'
+
+export const FEEDBACK_TYPEFORM_ID = 'q7azbWPi'
+
+const FEEDBACK_TYPEFORM_BASE_URL = `https://form.typeform.com/to/${FEEDBACK_TYPEFORM_ID}`
+
+/** Shared by the URL and embed builders so their segmentation tags can't drift. */
+function getFeedbackTags(source: FeedbackSource): Record<string, string> {
+  return { distribution: getDistribution(), source }
+}
 
 /**
  * Builds the feedback Typeform URL tagged with the current build distribution
@@ -33,14 +43,15 @@ const FEEDBACK_TYPEFORM_BASE_URL = 'https://form.typeform.com/to/q7azbWPi'
  * (Typeform's hidden-field convention) so survey responses can be segmented
  * by distribution (cloud / oss-nightly / oss) and entry point.
  */
-export function buildFeedbackTypeformUrl(
-  source: 'topbar' | 'action-bar' | 'help-center'
-): string {
-  const params = new URLSearchParams({
-    distribution: getDistribution(),
-    source
-  })
+export function buildFeedbackTypeformUrl(source: FeedbackSource): string {
+  const params = new URLSearchParams(getFeedbackTags(source))
   return `${FEEDBACK_TYPEFORM_BASE_URL}#${params.toString()}`
+}
+
+export function buildFeedbackHiddenFields(source: FeedbackSource): string {
+  return Object.entries(getFeedbackTags(source))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
 }
 
 /**

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -1,4 +1,8 @@
 import { isCloud, isNightly } from '@/platform/distribution/types'
+import {
+  formatTypeformHiddenFields,
+  getSurveyIdentityTags
+} from '@/platform/surveys/surveyIdentity'
 
 /**
  * Zendesk ticket form field IDs.
@@ -44,17 +48,15 @@ function getFeedbackTags(source: FeedbackSource): Record<string, string> {
  * by distribution (cloud / oss-nightly / oss) and entry point.
  */
 export function buildFeedbackTypeformUrl(source: FeedbackSource): string {
-  const params = new URLSearchParams(getFeedbackTags(source))
+  const params = new URLSearchParams({
+    ...getFeedbackTags(source),
+    ...getSurveyIdentityTags()
+  })
   return `${FEEDBACK_TYPEFORM_BASE_URL}#${params.toString()}`
 }
 
-export function buildFeedbackHiddenFields(
-  source: FeedbackSource,
-  extraTags: Record<string, string> = {}
-): string {
-  return Object.entries({ ...getFeedbackTags(source), ...extraTags })
-    .map(([key, value]) => `${key}=${value}`)
-    .join(',')
+export function buildFeedbackHiddenFields(source: FeedbackSource): string {
+  return formatTypeformHiddenFields(getFeedbackTags(source))
 }
 
 /**

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -47,10 +47,12 @@ function getFeedbackTags(source: FeedbackSource): Record<string, string> {
  * (Typeform's hidden-field convention) so survey responses can be segmented
  * by distribution (cloud / oss-nightly / oss) and entry point.
  */
-export function buildFeedbackTypeformUrl(source: FeedbackSource): string {
+export async function buildFeedbackTypeformUrl(
+  source: FeedbackSource
+): Promise<string> {
   const params = new URLSearchParams({
     ...getFeedbackTags(source),
-    ...getSurveyIdentityTags()
+    ...(await getSurveyIdentityTags())
   })
   return `${FEEDBACK_TYPEFORM_BASE_URL}#${params.toString()}`
 }

--- a/src/platform/support/config.ts
+++ b/src/platform/support/config.ts
@@ -48,8 +48,11 @@ export function buildFeedbackTypeformUrl(source: FeedbackSource): string {
   return `${FEEDBACK_TYPEFORM_BASE_URL}#${params.toString()}`
 }
 
-export function buildFeedbackHiddenFields(source: FeedbackSource): string {
-  return Object.entries(getFeedbackTags(source))
+export function buildFeedbackHiddenFields(
+  source: FeedbackSource,
+  extraTags: Record<string, string> = {}
+): string {
+  return Object.entries({ ...getFeedbackTags(source), ...extraTags })
     .map(([key, value]) => `${key}=${value}`)
     .join(',')
 }

--- a/src/platform/support/feedbackDialog.test.ts
+++ b/src/platform/support/feedbackDialog.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openTypeformDialog } from '@/platform/surveys/openTypeformDialog'
+import { useTelemetry } from '@/platform/telemetry'
+
+import { FEEDBACK_TYPEFORM_ID } from './config'
+import { openFeedbackDialog } from './feedbackDialog'
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/surveys/openTypeformDialog', () => ({
+  openTypeformDialog: vi.fn()
+}))
+
+const trackUiButtonClicked = vi.fn()
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: vi.fn(() => ({ trackUiButtonClicked }))
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: true,
+  isNightly: false
+}))
+
+describe('openFeedbackDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the feedback form tagged with distribution and source', () => {
+    openFeedbackDialog('action-bar')
+
+    expect(openTypeformDialog).toHaveBeenCalledWith({
+      key: 'global-feedback',
+      typeformId: FEEDBACK_TYPEFORM_ID,
+      title: 'feedback.title',
+      hiddenFields: 'distribution=ccloud,source=action-bar'
+    })
+  })
+
+  it('tracks the button click tagged with the opening source', () => {
+    openFeedbackDialog('topbar')
+
+    expect(trackUiButtonClicked).toHaveBeenCalledWith({
+      button_id: 'feedback_button_clicked',
+      element_group: 'topbar'
+    })
+  })
+
+  it('does not throw when telemetry is unavailable', () => {
+    vi.mocked(useTelemetry).mockReturnValueOnce(null)
+
+    expect(() => openFeedbackDialog('action-bar')).not.toThrow()
+    expect(openTypeformDialog).toHaveBeenCalled()
+  })
+})

--- a/src/platform/support/feedbackDialog.test.ts
+++ b/src/platform/support/feedbackDialog.test.ts
@@ -19,7 +19,9 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({ trackUiButtonClicked }))
 }))
 
-const userEmail = vi.hoisted(() => ({ value: undefined as string | undefined }))
+const userEmail = vi.hoisted((): { value: string | undefined } => ({
+  value: undefined
+}))
 vi.mock('@/composables/auth/useCurrentUser', () => ({
   useCurrentUser: () => ({ userEmail })
 }))

--- a/src/platform/support/feedbackDialog.test.ts
+++ b/src/platform/support/feedbackDialog.test.ts
@@ -19,13 +19,6 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({ trackUiButtonClicked }))
 }))
 
-const userEmail = vi.hoisted((): { value: string | undefined } => ({
-  value: undefined
-}))
-vi.mock('@/composables/auth/useCurrentUser', () => ({
-  useCurrentUser: () => ({ userEmail })
-}))
-
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: true,
   isNightly: false
@@ -34,7 +27,6 @@ vi.mock('@/platform/distribution/types', () => ({
 describe('openFeedbackDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    userEmail.value = undefined
   })
 
   it('opens the feedback form tagged with distribution and source', () => {
@@ -46,19 +38,6 @@ describe('openFeedbackDialog', () => {
       title: 'feedback.title',
       hiddenFields: 'distribution=ccloud,source=action-bar'
     })
-  })
-
-  it('includes the logged-in user email as a hidden field', () => {
-    userEmail.value = 'user@example.com'
-
-    openFeedbackDialog('action-bar')
-
-    expect(openTypeformDialog).toHaveBeenCalledWith(
-      expect.objectContaining({
-        hiddenFields:
-          'distribution=ccloud,source=action-bar,email=user@example.com'
-      })
-    )
   })
 
   it('tracks the button click tagged with the opening source', () => {

--- a/src/platform/support/feedbackDialog.test.ts
+++ b/src/platform/support/feedbackDialog.test.ts
@@ -19,6 +19,11 @@ vi.mock('@/platform/telemetry', () => ({
   useTelemetry: vi.fn(() => ({ trackUiButtonClicked }))
 }))
 
+const userEmail = vi.hoisted(() => ({ value: undefined as string | undefined }))
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({ userEmail })
+}))
+
 vi.mock('@/platform/distribution/types', () => ({
   isCloud: true,
   isNightly: false
@@ -27,6 +32,7 @@ vi.mock('@/platform/distribution/types', () => ({
 describe('openFeedbackDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    userEmail.value = undefined
   })
 
   it('opens the feedback form tagged with distribution and source', () => {
@@ -38,6 +44,19 @@ describe('openFeedbackDialog', () => {
       title: 'feedback.title',
       hiddenFields: 'distribution=ccloud,source=action-bar'
     })
+  })
+
+  it('includes the logged-in user email as a hidden field', () => {
+    userEmail.value = 'user@example.com'
+
+    openFeedbackDialog('action-bar')
+
+    expect(openTypeformDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hiddenFields:
+          'distribution=ccloud,source=action-bar,email=user@example.com'
+      })
+    )
   })
 
   it('tracks the button click tagged with the opening source', () => {

--- a/src/platform/support/feedbackDialog.ts
+++ b/src/platform/support/feedbackDialog.ts
@@ -1,0 +1,19 @@
+import { t } from '@/i18n'
+import { openTypeformDialog } from '@/platform/surveys/openTypeformDialog'
+import { useTelemetry } from '@/platform/telemetry'
+
+import { FEEDBACK_TYPEFORM_ID, buildFeedbackHiddenFields } from './config'
+import type { FeedbackSource } from './config'
+
+export function openFeedbackDialog(source: FeedbackSource) {
+  useTelemetry()?.trackUiButtonClicked({
+    button_id: 'feedback_button_clicked',
+    element_group: source
+  })
+  openTypeformDialog({
+    key: 'global-feedback',
+    typeformId: FEEDBACK_TYPEFORM_ID,
+    title: t('feedback.title'),
+    hiddenFields: buildFeedbackHiddenFields(source)
+  })
+}

--- a/src/platform/support/feedbackDialog.ts
+++ b/src/platform/support/feedbackDialog.ts
@@ -1,4 +1,3 @@
-import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { t } from '@/i18n'
 import { openTypeformDialog } from '@/platform/surveys/openTypeformDialog'
 import { useTelemetry } from '@/platform/telemetry'
@@ -7,8 +6,6 @@ import { FEEDBACK_TYPEFORM_ID, buildFeedbackHiddenFields } from './config'
 import type { FeedbackSource } from './config'
 
 export function openFeedbackDialog(source: FeedbackSource) {
-  const { userEmail } = useCurrentUser()
-
   useTelemetry()?.trackUiButtonClicked({
     button_id: 'feedback_button_clicked',
     element_group: source
@@ -17,9 +14,6 @@ export function openFeedbackDialog(source: FeedbackSource) {
     key: 'global-feedback',
     typeformId: FEEDBACK_TYPEFORM_ID,
     title: t('feedback.title'),
-    hiddenFields: buildFeedbackHiddenFields(
-      source,
-      userEmail.value ? { email: userEmail.value } : {}
-    )
+    hiddenFields: buildFeedbackHiddenFields(source)
   })
 }

--- a/src/platform/support/feedbackDialog.ts
+++ b/src/platform/support/feedbackDialog.ts
@@ -1,3 +1,4 @@
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { t } from '@/i18n'
 import { openTypeformDialog } from '@/platform/surveys/openTypeformDialog'
 import { useTelemetry } from '@/platform/telemetry'
@@ -6,6 +7,8 @@ import { FEEDBACK_TYPEFORM_ID, buildFeedbackHiddenFields } from './config'
 import type { FeedbackSource } from './config'
 
 export function openFeedbackDialog(source: FeedbackSource) {
+  const { userEmail } = useCurrentUser()
+
   useTelemetry()?.trackUiButtonClicked({
     button_id: 'feedback_button_clicked',
     element_group: source
@@ -14,6 +17,9 @@ export function openFeedbackDialog(source: FeedbackSource) {
     key: 'global-feedback',
     typeformId: FEEDBACK_TYPEFORM_ID,
     title: t('feedback.title'),
-    hiddenFields: buildFeedbackHiddenFields(source)
+    hiddenFields: buildFeedbackHiddenFields(
+      source,
+      userEmail.value ? { email: userEmail.value } : {}
+    )
   })
 }

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -2,8 +2,11 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
 
 const FEATURE_USAGE_KEY = 'Comfy.FeatureUsage'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
 
 const mockIsNightly = vi.hoisted(() => ({ value: true }))
 const mockIsCloud = vi.hoisted(() => ({ value: false }))
@@ -19,12 +22,6 @@ vi.mock('@/platform/distribution/types', () => ({
   get isDesktop() {
     return mockIsDesktop.value
   }
-}))
-
-vi.mock('vue-i18n', () => ({
-  useI18n: vi.fn(() => ({
-    t: (key: string) => key
-  }))
 }))
 
 describe('NightlySurveyPopover', () => {
@@ -74,6 +71,7 @@ describe('NightlySurveyPopover', () => {
         ...eventHandlers
       },
       global: {
+        plugins: [i18n],
         stubs: {
           Teleport: true
         }
@@ -195,6 +193,7 @@ describe('NightlySurveyPopover', () => {
           open
         },
         global: {
+          plugins: [i18n],
           stubs: {
             Teleport: true
           }

--- a/src/platform/surveys/NightlySurveyPopover.test.ts
+++ b/src/platform/surveys/NightlySurveyPopover.test.ts
@@ -111,6 +111,19 @@ describe('NightlySurveyPopover', () => {
       ).not.toBeInTheDocument()
     })
 
+    it('does not show when typeform id is invalid', async () => {
+      setFeatureUsage('test-feature', 5)
+
+      await renderComponent({ ...defaultConfig, typeformId: 'invalid id!' })
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(1000)
+      await nextTick()
+
+      expect(
+        screen.queryByTestId('nightly-survey-popover')
+      ).not.toBeInTheDocument()
+    })
+
     it('does not show on cloud', async () => {
       mockIsCloud.value = true
       setFeatureUsage('test-feature', 5)

--- a/src/platform/surveys/NightlySurveyPopover.vue
+++ b/src/platform/surveys/NightlySurveyPopover.vue
@@ -25,17 +25,9 @@
           </Button>
         </div>
 
-        <div v-if="typeformError" class="text-danger text-sm">
-          {{ t('nightlySurvey.loadError') }}
+        <div class="min-h-[300px]">
+          <TypeformEmbed :typeform-id="config.typeformId" auto-resize />
         </div>
-
-        <div
-          v-show="!typeformError && isValidTypeformId"
-          ref="typeformRef"
-          data-tf-auto-resize
-          :data-tf-widget="typeformId"
-          class="min-h-[300px]"
-        />
 
         <div
           class="mt-3 flex items-center gap-2"
@@ -59,14 +51,15 @@
 </template>
 
 <script setup lang="ts">
-import { onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
 
+import TypeformEmbed from './TypeformEmbed.vue'
 import type { FeatureSurveyConfig } from './useSurveyEligibility'
 import { useSurveyEligibility } from './useSurveyEligibility'
-import { useTypeformEmbed } from './useTypeformEmbed'
+import { isTypeformIdValid } from './useTypeformEmbed'
 
 const { config, mode = 'eligible' } = defineProps<{
   config: FeatureSurveyConfig
@@ -95,12 +88,6 @@ const { isEligible, delayMs, markSurveyShown, optOut } = useSurveyEligibility(
 )
 
 const hasOpenedOnce = ref(openModel.value)
-const typeformRef = useTemplateRef<HTMLDivElement>('typeformRef')
-
-const { typeformError, isValidTypeformId, typeformId } = useTypeformEmbed(
-  typeformRef,
-  () => config.typeformId
-)
 
 // Teleport stays mounted after the first open so the Typeform iframe
 // persists across consumer-side lifecycle changes.
@@ -126,7 +113,7 @@ watch(
 
     showTimeout = setTimeout(() => {
       showTimeout = null
-      if (!isValidTypeformId.value) return
+      if (!isTypeformIdValid(config.typeformId)) return
       if (openModel.value) return
       openModel.value = true
       markSurveyShown()

--- a/src/platform/surveys/TypeformDialogContent.vue
+++ b/src/platform/surveys/TypeformDialogContent.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import TypeformEmbed from './TypeformEmbed.vue'
+
+const { typeformId, hiddenFields } = defineProps<{
+  typeformId: string
+  hiddenFields?: string
+}>()
+</script>
+
+<template>
+  <div class="h-[70vh] min-h-96">
+    <TypeformEmbed :typeform-id :hidden-fields redirect-target="_self" />
+  </div>
+</template>

--- a/src/platform/surveys/TypeformEmbed.test.ts
+++ b/src/platform/surveys/TypeformEmbed.test.ts
@@ -21,7 +21,7 @@ vi.mock('./useTypeformEmbed', () => ({
 
 vi.mock('./surveyIdentity', async (importOriginal) => ({
   ...(await importOriginal<typeof SurveyIdentityModule>()),
-  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+  getSurveyIdentityTags: () => Promise.resolve({ anon_id: 'anon-1' })
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
@@ -36,10 +36,10 @@ describe('TypeformEmbed', () => {
     embedState.isValidTypeformId = true
   })
 
-  it('appends the survey identity to the caller hidden fields', () => {
+  it('appends the survey identity to the caller hidden fields', async () => {
     renderEmbed({ typeformId: 'abc123', hiddenFields: 'source=topbar' })
 
-    const embed = screen.getByTestId('typeform-embed')
+    const embed = await screen.findByTestId('typeform-embed')
     expect(embed).toHaveAttribute('data-tf-widget', 'abc123')
     expect(embed).toHaveAttribute(
       'data-tf-hidden',
@@ -49,28 +49,28 @@ describe('TypeformEmbed', () => {
     expect(embed).not.toHaveAttribute('data-tf-auto-resize')
   })
 
-  it('sends the survey identity even without caller hidden fields', () => {
+  it('sends the survey identity even without caller hidden fields', async () => {
     renderEmbed({ typeformId: 'abc123' })
 
-    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+    expect(await screen.findByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-hidden',
       'anon_id=anon-1'
     )
   })
 
-  it('keeps redirect-on-completion inside the iframe when requested', () => {
+  it('keeps redirect-on-completion inside the iframe when requested', async () => {
     renderEmbed({ typeformId: 'abc123', redirectTarget: '_self' })
 
-    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+    expect(await screen.findByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-redirect-target',
       '_self'
     )
   })
 
-  it('enables auto-resize when requested', () => {
+  it('enables auto-resize when requested', async () => {
     renderEmbed({ typeformId: 'abc123', autoResize: true })
 
-    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+    expect(await screen.findByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-auto-resize'
     )
   })

--- a/src/platform/surveys/TypeformEmbed.test.ts
+++ b/src/platform/surveys/TypeformEmbed.test.ts
@@ -1,12 +1,10 @@
 import { render, screen } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
+import { createI18n } from 'vue-i18n'
 
 import TypeformEmbed from './TypeformEmbed.vue'
-
-vi.mock('vue-i18n', () => ({
-  useI18n: vi.fn(() => ({ t: (key: string) => key }))
-}))
 
 const embedState = vi.hoisted(() => ({
   typeformError: false,
@@ -20,6 +18,12 @@ vi.mock('./useTypeformEmbed', () => ({
   }))
 }))
 
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+function renderEmbed(props: ComponentProps<typeof TypeformEmbed>) {
+  return render(TypeformEmbed, { props, global: { plugins: [i18n] } })
+}
+
 describe('TypeformEmbed', () => {
   beforeEach(() => {
     embedState.typeformError = false
@@ -27,9 +31,7 @@ describe('TypeformEmbed', () => {
   })
 
   it('forwards hidden fields and leaves redirect target to Typeform by default', () => {
-    render(TypeformEmbed, {
-      props: { typeformId: 'abc123', hiddenFields: 'source=topbar' }
-    })
+    renderEmbed({ typeformId: 'abc123', hiddenFields: 'source=topbar' })
 
     const embed = screen.getByTestId('typeform-embed')
     expect(embed).toHaveAttribute('data-tf-widget', 'abc123')
@@ -39,9 +41,7 @@ describe('TypeformEmbed', () => {
   })
 
   it('keeps redirect-on-completion inside the iframe when requested', () => {
-    render(TypeformEmbed, {
-      props: { typeformId: 'abc123', redirectTarget: '_self' }
-    })
+    renderEmbed({ typeformId: 'abc123', redirectTarget: '_self' })
 
     expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-redirect-target',
@@ -50,7 +50,7 @@ describe('TypeformEmbed', () => {
   })
 
   it('enables auto-resize when requested', () => {
-    render(TypeformEmbed, { props: { typeformId: 'abc123', autoResize: true } })
+    renderEmbed({ typeformId: 'abc123', autoResize: true })
 
     expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-auto-resize'
@@ -59,7 +59,7 @@ describe('TypeformEmbed', () => {
 
   it('shows the load-error message instead of the embed when the script fails', () => {
     embedState.typeformError = true
-    render(TypeformEmbed, { props: { typeformId: 'abc123' } })
+    renderEmbed({ typeformId: 'abc123' })
 
     expect(screen.getByText('typeform.loadError')).toBeInTheDocument()
     expect(screen.queryByTestId('typeform-embed')).toBeNull()
@@ -67,7 +67,7 @@ describe('TypeformEmbed', () => {
 
   it('shows the load-error message instead of the embed for an invalid form id', () => {
     embedState.isValidTypeformId = false
-    render(TypeformEmbed, { props: { typeformId: 'bad id!' } })
+    renderEmbed({ typeformId: 'bad id!' })
 
     expect(screen.getByText('typeform.loadError')).toBeInTheDocument()
     expect(screen.queryByTestId('typeform-embed')).toBeNull()

--- a/src/platform/surveys/TypeformEmbed.test.ts
+++ b/src/platform/surveys/TypeformEmbed.test.ts
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import TypeformEmbed from './TypeformEmbed.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: vi.fn(() => ({ t: (key: string) => key }))
+}))
+
+const embedState = vi.hoisted(() => ({
+  typeformError: false,
+  isValidTypeformId: true
+}))
+
+vi.mock('./useTypeformEmbed', () => ({
+  useTypeformEmbed: vi.fn(() => ({
+    typeformError: ref(embedState.typeformError),
+    isValidTypeformId: ref(embedState.isValidTypeformId)
+  }))
+}))
+
+describe('TypeformEmbed', () => {
+  beforeEach(() => {
+    embedState.typeformError = false
+    embedState.isValidTypeformId = true
+  })
+
+  it('forwards hidden fields and leaves redirect target to Typeform by default', () => {
+    render(TypeformEmbed, {
+      props: { typeformId: 'abc123', hiddenFields: 'source=topbar' }
+    })
+
+    const embed = screen.getByTestId('typeform-embed')
+    expect(embed).toHaveAttribute('data-tf-widget', 'abc123')
+    expect(embed).toHaveAttribute('data-tf-hidden', 'source=topbar')
+    expect(embed).not.toHaveAttribute('data-tf-redirect-target')
+    expect(embed).not.toHaveAttribute('data-tf-auto-resize')
+  })
+
+  it('keeps redirect-on-completion inside the iframe when requested', () => {
+    render(TypeformEmbed, {
+      props: { typeformId: 'abc123', redirectTarget: '_self' }
+    })
+
+    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+      'data-tf-redirect-target',
+      '_self'
+    )
+  })
+
+  it('enables auto-resize when requested', () => {
+    render(TypeformEmbed, { props: { typeformId: 'abc123', autoResize: true } })
+
+    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+      'data-tf-auto-resize'
+    )
+  })
+
+  it('shows the load-error message instead of the embed when the script fails', () => {
+    embedState.typeformError = true
+    render(TypeformEmbed, { props: { typeformId: 'abc123' } })
+
+    expect(screen.getByText('typeform.loadError')).toBeInTheDocument()
+    expect(screen.queryByTestId('typeform-embed')).toBeNull()
+  })
+
+  it('shows the load-error message instead of the embed for an invalid form id', () => {
+    embedState.isValidTypeformId = false
+    render(TypeformEmbed, { props: { typeformId: 'bad id!' } })
+
+    expect(screen.getByText('typeform.loadError')).toBeInTheDocument()
+    expect(screen.queryByTestId('typeform-embed')).toBeNull()
+  })
+})

--- a/src/platform/surveys/TypeformEmbed.test.ts
+++ b/src/platform/surveys/TypeformEmbed.test.ts
@@ -5,6 +5,7 @@ import type { ComponentProps } from 'vue-component-type-helpers'
 import { createI18n } from 'vue-i18n'
 
 import TypeformEmbed from './TypeformEmbed.vue'
+import type * as SurveyIdentityModule from './surveyIdentity'
 
 const embedState = vi.hoisted(() => ({
   typeformError: false,
@@ -16,6 +17,11 @@ vi.mock('./useTypeformEmbed', () => ({
     typeformError: ref(embedState.typeformError),
     isValidTypeformId: ref(embedState.isValidTypeformId)
   }))
+}))
+
+vi.mock('./surveyIdentity', async (importOriginal) => ({
+  ...(await importOriginal<typeof SurveyIdentityModule>()),
+  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
@@ -30,14 +36,26 @@ describe('TypeformEmbed', () => {
     embedState.isValidTypeformId = true
   })
 
-  it('forwards hidden fields and leaves redirect target to Typeform by default', () => {
+  it('appends the survey identity to the caller hidden fields', () => {
     renderEmbed({ typeformId: 'abc123', hiddenFields: 'source=topbar' })
 
     const embed = screen.getByTestId('typeform-embed')
     expect(embed).toHaveAttribute('data-tf-widget', 'abc123')
-    expect(embed).toHaveAttribute('data-tf-hidden', 'source=topbar')
+    expect(embed).toHaveAttribute(
+      'data-tf-hidden',
+      'source=topbar,anon_id=anon-1'
+    )
     expect(embed).not.toHaveAttribute('data-tf-redirect-target')
     expect(embed).not.toHaveAttribute('data-tf-auto-resize')
+  })
+
+  it('sends the survey identity even without caller hidden fields', () => {
+    renderEmbed({ typeformId: 'abc123' })
+
+    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+      'data-tf-hidden',
+      'anon_id=anon-1'
+    )
   })
 
   it('keeps redirect-on-completion inside the iframe when requested', () => {

--- a/src/platform/surveys/TypeformEmbed.vue
+++ b/src/platform/surveys/TypeformEmbed.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { useTypeformEmbed } from './useTypeformEmbed'
+
+const {
+  typeformId,
+  hiddenFields,
+  autoResize = false,
+  redirectTarget
+} = defineProps<{
+  typeformId: string
+  /** Comma-separated `key=value` tags passed to Typeform via `data-tf-hidden`. */
+  hiddenFields?: string
+  autoResize?: boolean
+  /** `_self` keeps a form's completion redirect inside the iframe, never navigating the host app. */
+  redirectTarget?: '_self' | '_blank'
+}>()
+
+const { t } = useI18n()
+
+const typeformRef = useTemplateRef<HTMLDivElement>('typeformRef')
+const { typeformError, isValidTypeformId } = useTypeformEmbed(
+  typeformRef,
+  () => typeformId
+)
+</script>
+
+<template>
+  <div
+    v-if="typeformError || !isValidTypeformId"
+    class="text-danger flex h-full items-center text-sm"
+  >
+    {{ t('typeform.loadError') }}
+  </div>
+  <!-- `data-tf-auto-resize` is read by presence, so it must be absent (not "false") when disabled -->
+  <div
+    v-else
+    ref="typeformRef"
+    data-testid="typeform-embed"
+    :data-tf-widget="typeformId"
+    :data-tf-hidden="hiddenFields"
+    :data-tf-redirect-target="redirectTarget"
+    :data-tf-auto-resize="autoResize || undefined"
+    :class="autoResize ? 'w-full' : 'size-full'"
+  />
+</template>

--- a/src/platform/surveys/TypeformEmbed.vue
+++ b/src/platform/surveys/TypeformEmbed.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
-import { useTemplateRef } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import {
+  formatTypeformHiddenFields,
+  getSurveyIdentityTags
+} from './surveyIdentity'
 import { useTypeformEmbed } from './useTypeformEmbed'
 
 const {
@@ -25,6 +29,11 @@ const { typeformError, isValidTypeformId } = useTypeformEmbed(
   typeformRef,
   () => typeformId
 )
+
+const dataTfHidden = computed(() => {
+  const identity = formatTypeformHiddenFields(getSurveyIdentityTags())
+  return [hiddenFields, identity].filter(Boolean).join(',')
+})
 </script>
 
 <template>
@@ -40,7 +49,7 @@ const { typeformError, isValidTypeformId } = useTypeformEmbed(
     ref="typeformRef"
     data-testid="typeform-embed"
     :data-tf-widget="typeformId"
-    :data-tf-hidden="hiddenFields"
+    :data-tf-hidden="dataTfHidden"
     :data-tf-redirect-target="redirectTarget"
     :data-tf-auto-resize="autoResize || undefined"
     :class="autoResize ? 'w-full' : 'size-full'"

--- a/src/platform/surveys/TypeformEmbed.vue
+++ b/src/platform/surveys/TypeformEmbed.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useTemplateRef } from 'vue'
+import { ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
@@ -30,10 +30,21 @@ const { typeformError, isValidTypeformId } = useTypeformEmbed(
   () => typeformId
 )
 
-const dataTfHidden = computed(() => {
-  const identity = formatTypeformHiddenFields(getSurveyIdentityTags())
-  return [hiddenFields, identity].filter(Boolean).join(',')
-})
+const dataTfHidden = ref<string>()
+
+watch(
+  () => hiddenFields,
+  async (_, __, onCleanup) => {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    const identity = formatTypeformHiddenFields(await getSurveyIdentityTags())
+    if (cancelled) return
+    dataTfHidden.value = [hiddenFields, identity].filter(Boolean).join(',')
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
@@ -45,7 +56,7 @@ const dataTfHidden = computed(() => {
   </div>
   <!-- `data-tf-auto-resize` is read by presence, so it must be absent (not "false") when disabled -->
   <div
-    v-else
+    v-else-if="dataTfHidden !== undefined"
     ref="typeformRef"
     data-testid="typeform-embed"
     :data-tf-widget="typeformId"

--- a/src/platform/surveys/cloudSurveyIdentity.test.ts
+++ b/src/platform/surveys/cloudSurveyIdentity.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { cloudIdentityProvider } from './cloudSurveyIdentity'
+
+const currentUser = vi.hoisted(
+  (): { resolvedUserInfo: { value: { id: string } | null } } => ({
+    resolvedUserInfo: { value: null }
+  })
+)
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => currentUser
+}))
+
+const distinctId = vi.hoisted((): { value: string | null } => ({ value: null }))
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ getDistinctId: () => distinctId.value })
+}))
+
+describe('cloudIdentityProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    currentUser.resolvedUserInfo.value = null
+    distinctId.value = null
+  })
+
+  it('uses the stable local id as anon_id regardless of PostHog', () => {
+    distinctId.value = 'ph-123'
+
+    const identity = cloudIdentityProvider.getIdentity()
+
+    expect(identity.anon_id).toBe(localStorage.getItem('Comfy.SurveyAnonId'))
+    expect(identity.anon_id).not.toBe('ph-123')
+  })
+
+  it('sends the PostHog distinct id as a separate field for stitching', () => {
+    distinctId.value = 'ph-123'
+
+    expect(cloudIdentityProvider.getIdentity().distinct_id).toBe('ph-123')
+  })
+
+  it('omits distinct_id when PostHog has none', () => {
+    expect(cloudIdentityProvider.getIdentity().distinct_id).toBeUndefined()
+  })
+
+  it('includes the authenticated id when signed in', () => {
+    currentUser.resolvedUserInfo.value = { id: 'uid-1' }
+
+    expect(cloudIdentityProvider.getIdentity().comfy_id).toBe('uid-1')
+  })
+
+  it('omits the authenticated id for an anonymous visitor', () => {
+    expect(cloudIdentityProvider.getIdentity().comfy_id).toBeUndefined()
+  })
+})

--- a/src/platform/surveys/cloudSurveyIdentity.ts
+++ b/src/platform/surveys/cloudSurveyIdentity.ts
@@ -4,7 +4,7 @@ import { useTelemetry } from '@/platform/telemetry'
 import { getOrCreateAnonId } from './surveyIdentity'
 import type { IdentityProvider } from './surveyIdentity'
 
-export const cloudIdentityProvider: IdentityProvider = {
+export const cloudIdentityProvider = {
   getIdentity() {
     const { resolvedUserInfo } = useCurrentUser()
     return {
@@ -13,4 +13,4 @@ export const cloudIdentityProvider: IdentityProvider = {
       comfy_id: resolvedUserInfo.value?.id
     }
   }
-}
+} satisfies IdentityProvider

--- a/src/platform/surveys/cloudSurveyIdentity.ts
+++ b/src/platform/surveys/cloudSurveyIdentity.ts
@@ -1,0 +1,16 @@
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { useTelemetry } from '@/platform/telemetry'
+
+import { getOrCreateAnonId } from './surveyIdentity'
+import type { IdentityProvider } from './surveyIdentity'
+
+export const cloudIdentityProvider: IdentityProvider = {
+  getIdentity() {
+    const { resolvedUserInfo } = useCurrentUser()
+    return {
+      anon_id: getOrCreateAnonId(),
+      distinct_id: useTelemetry()?.getDistinctId() ?? undefined,
+      comfy_id: resolvedUserInfo.value?.id
+    }
+  }
+}

--- a/src/platform/surveys/openTypeformDialog.test.ts
+++ b/src/platform/surveys/openTypeformDialog.test.ts
@@ -1,0 +1,43 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDialogStore } from '@/stores/dialogStore'
+
+import TypeformDialogContent from './TypeformDialogContent.vue'
+import { openTypeformDialog } from './openTypeformDialog'
+
+describe('openTypeformDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('opens the form embed in a Reka dialog with the given id and hidden fields', () => {
+    const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+    openTypeformDialog({
+      typeformId: 'abc123',
+      title: 'A Form',
+      hiddenFields: 'foo=bar'
+    })
+
+    expect(showDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'typeform-abc123',
+        title: 'A Form',
+        component: TypeformDialogContent,
+        props: { typeformId: 'abc123', hiddenFields: 'foo=bar' },
+        dialogComponentProps: expect.objectContaining({ renderer: 'reka' })
+      })
+    )
+  })
+
+  it('honors an explicit dialog key', () => {
+    const showDialog = vi.spyOn(useDialogStore(), 'showDialog')
+
+    openTypeformDialog({ typeformId: 'abc123', title: 'A Form', key: 'custom' })
+
+    expect(showDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'custom' })
+    )
+  })
+})

--- a/src/platform/surveys/openTypeformDialog.ts
+++ b/src/platform/surveys/openTypeformDialog.ts
@@ -1,0 +1,29 @@
+import { useDialogStore } from '@/stores/dialogStore'
+
+import TypeformDialogContent from './TypeformDialogContent.vue'
+
+export interface TypeformDialogOptions {
+  typeformId: string
+  title: string
+  /** Comma-separated `key=value` tags passed to Typeform via `data-tf-hidden`. */
+  hiddenFields?: string
+  key?: string
+}
+
+export function openTypeformDialog({
+  typeformId,
+  title,
+  hiddenFields,
+  key
+}: TypeformDialogOptions) {
+  useDialogStore().showDialog({
+    key: key ?? `typeform-${typeformId}`,
+    title,
+    component: TypeformDialogContent,
+    props: { typeformId, hiddenFields },
+    dialogComponentProps: {
+      renderer: 'reka',
+      size: 'lg'
+    }
+  })
+}

--- a/src/platform/surveys/surveyIdentity.test.ts
+++ b/src/platform/surveys/surveyIdentity.test.ts
@@ -16,21 +16,21 @@ describe('survey identity', () => {
     vi.restoreAllMocks()
   })
 
-  it('is anonymous by default', () => {
-    const tags = getSurveyIdentityTags()
+  it('is anonymous by default', async () => {
+    const tags = await getSurveyIdentityTags()
 
     expect(tags.anon_id).toBeTruthy()
     expect(tags.comfy_id).toBeUndefined()
   })
 
-  it('mints a stable anonymous id and reuses it across calls', () => {
-    const anonId = getSurveyIdentityTags().anon_id
+  it('mints a stable anonymous id and reuses it across calls', async () => {
+    const anonId = (await getSurveyIdentityTags()).anon_id
 
     expect(localStorage.getItem('Comfy.SurveyAnonId')).toBe(anonId)
-    expect(getSurveyIdentityTags().anon_id).toBe(anonId)
+    expect((await getSurveyIdentityTags()).anon_id).toBe(anonId)
   })
 
-  it('falls back to a stable in-memory id when storage is unavailable', () => {
+  it('falls back to a stable in-memory id when storage is unavailable', async () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('storage disabled')
     })
@@ -38,28 +38,39 @@ describe('survey identity', () => {
       throw new Error('storage disabled')
     })
 
-    const anonId = getSurveyIdentityTags().anon_id
+    const anonId = (await getSurveyIdentityTags()).anon_id
 
     expect(anonId).toBeTruthy()
-    expect(getSurveyIdentityTags().anon_id).toBe(anonId)
+    expect((await getSurveyIdentityTags()).anon_id).toBe(anonId)
   })
 
-  it('resolves tags through the registered provider, dropping absent fields', () => {
+  it('resolves tags through the registered provider, dropping absent fields', async () => {
     setCurrentIdentityProvider({ getIdentity: () => ({ anon_id: 'fixed' }) })
 
-    expect(getSurveyIdentityTags()).toEqual({ anon_id: 'fixed' })
+    expect(await getSurveyIdentityTags()).toEqual({ anon_id: 'fixed' })
   })
 
-  it('includes distinct_id and comfy_id when the provider supplies them', () => {
+  it('backfills the anon id when an async provider omits it', async () => {
     setCurrentIdentityProvider({
-      getIdentity: () => ({
-        anon_id: 'fixed',
-        distinct_id: 'ph-1',
-        comfy_id: 'uid-9'
-      })
+      getIdentity: () => Promise.resolve({ distinct_id: 'ph-1' })
     })
 
-    expect(getSurveyIdentityTags()).toEqual({
+    const tags = await getSurveyIdentityTags()
+    expect(tags.anon_id).toBeTruthy()
+    expect(tags.distinct_id).toBe('ph-1')
+  })
+
+  it('includes distinct_id and comfy_id when the provider supplies them', async () => {
+    setCurrentIdentityProvider({
+      getIdentity: () =>
+        Promise.resolve({
+          anon_id: 'fixed',
+          distinct_id: 'ph-1',
+          comfy_id: 'uid-9'
+        })
+    })
+
+    expect(await getSurveyIdentityTags()).toEqual({
       anon_id: 'fixed',
       distinct_id: 'ph-1',
       comfy_id: 'uid-9'

--- a/src/platform/surveys/surveyIdentity.test.ts
+++ b/src/platform/surveys/surveyIdentity.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  anonymousIdentityProvider,
+  getSurveyIdentityTags,
+  setCurrentIdentityProvider
+} from './surveyIdentity'
+
+describe('survey identity', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setCurrentIdentityProvider(anonymousIdentityProvider)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('is anonymous by default', () => {
+    const tags = getSurveyIdentityTags()
+
+    expect(tags.anon_id).toBeTruthy()
+    expect(tags.comfy_id).toBeUndefined()
+  })
+
+  it('mints a stable anonymous id and reuses it across calls', () => {
+    const anonId = getSurveyIdentityTags().anon_id
+
+    expect(localStorage.getItem('Comfy.SurveyAnonId')).toBe(anonId)
+    expect(getSurveyIdentityTags().anon_id).toBe(anonId)
+  })
+
+  it('falls back to a stable in-memory id when storage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+
+    const anonId = getSurveyIdentityTags().anon_id
+
+    expect(anonId).toBeTruthy()
+    expect(getSurveyIdentityTags().anon_id).toBe(anonId)
+  })
+
+  it('resolves tags through the registered provider, dropping absent fields', () => {
+    setCurrentIdentityProvider({ getIdentity: () => ({ anon_id: 'fixed' }) })
+
+    expect(getSurveyIdentityTags()).toEqual({ anon_id: 'fixed' })
+  })
+
+  it('includes distinct_id and comfy_id when the provider supplies them', () => {
+    setCurrentIdentityProvider({
+      getIdentity: () => ({
+        anon_id: 'fixed',
+        distinct_id: 'ph-1',
+        comfy_id: 'uid-9'
+      })
+    })
+
+    expect(getSurveyIdentityTags()).toEqual({
+      anon_id: 'fixed',
+      distinct_id: 'ph-1',
+      comfy_id: 'uid-9'
+    })
+  })
+})

--- a/src/platform/surveys/surveyIdentity.ts
+++ b/src/platform/surveys/surveyIdentity.ts
@@ -11,8 +11,10 @@ export interface SurveyIdentity {
   comfy_id?: string
 }
 
+type MaybePromise<T> = T | Promise<T>
+
 export interface IdentityProvider {
-  getIdentity(): SurveyIdentity
+  getIdentity(): MaybePromise<Partial<SurveyIdentity> | null | undefined>
 }
 
 let memoryAnonId: string | undefined
@@ -41,15 +43,14 @@ export function setCurrentIdentityProvider(provider: IdentityProvider): void {
   currentProvider = provider
 }
 
-function getSurveyIdentity(): SurveyIdentity {
-  return currentProvider.getIdentity()
-}
-
-/** Identity as Typeform hidden-field tags, dropping any absent field. */
-export function getSurveyIdentityTags(): Record<string, string> {
-  const { anon_id, distinct_id, comfy_id } = getSurveyIdentity()
+/**
+ * Identity as Typeform hidden-field tags, dropping any absent field.
+ */
+export async function getSurveyIdentityTags(): Promise<Record<string, string>> {
+  const identity = await currentProvider.getIdentity()
+  const { distinct_id, comfy_id } = identity ?? {}
   return {
-    anon_id,
+    anon_id: identity?.anon_id ?? getOrCreateAnonId(),
     ...(distinct_id ? { distinct_id } : {}),
     ...(comfy_id ? { comfy_id } : {})
   }

--- a/src/platform/surveys/surveyIdentity.ts
+++ b/src/platform/surveys/surveyIdentity.ts
@@ -1,0 +1,65 @@
+import { createUuidv4 } from '@/utils/uuid'
+
+const ANON_ID_KEY = 'Comfy.SurveyAnonId'
+
+export interface SurveyIdentity {
+  /** Stable local id, present for the user's whole journey across opt-in/login. */
+  anon_id: string
+  /** PostHog distinct id, bridging responses to product analytics when present. */
+  distinct_id?: string
+  /** Set only for an authenticated (consented) user. */
+  comfy_id?: string
+}
+
+export interface IdentityProvider {
+  getIdentity(): SurveyIdentity
+}
+
+let memoryAnonId: string | undefined
+
+export function getOrCreateAnonId(): string {
+  try {
+    const existing = localStorage.getItem(ANON_ID_KEY)
+    if (existing) return existing
+
+    const anonId = createUuidv4()
+    localStorage.setItem(ANON_ID_KEY, anonId)
+    return anonId
+  } catch {
+    // Storage disabled: degrade to an in-memory id so a feedback click never throws.
+    return (memoryAnonId ??= createUuidv4())
+  }
+}
+
+export const anonymousIdentityProvider: IdentityProvider = {
+  getIdentity: () => ({ anon_id: getOrCreateAnonId() })
+}
+
+let currentProvider: IdentityProvider = anonymousIdentityProvider
+
+export function setCurrentIdentityProvider(provider: IdentityProvider): void {
+  currentProvider = provider
+}
+
+function getSurveyIdentity(): SurveyIdentity {
+  return currentProvider.getIdentity()
+}
+
+/** Identity as Typeform hidden-field tags, dropping any absent field. */
+export function getSurveyIdentityTags(): Record<string, string> {
+  const { anon_id, distinct_id, comfy_id } = getSurveyIdentity()
+  return {
+    anon_id,
+    ...(distinct_id ? { distinct_id } : {}),
+    ...(comfy_id ? { comfy_id } : {})
+  }
+}
+
+/** Formats tags as Typeform's comma-separated `key=value` hidden-field string. */
+export function formatTypeformHiddenFields(
+  tags: Record<string, string>
+): string {
+  return Object.entries(tags)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
+}

--- a/src/platform/surveys/useTypeformEmbed.test.ts
+++ b/src/platform/surveys/useTypeformEmbed.test.ts
@@ -24,7 +24,6 @@ describe('useTypeformEmbed', () => {
     const result = runInScope(() => useTypeformEmbed(containerRef, 'goZLqjKL'))
 
     expect(result.isValidTypeformId.value).toBe(true)
-    expect(result.typeformId.value).toBe('goZLqjKL')
   })
 
   it('marks ids with non-alphanumeric characters as invalid', () => {
@@ -34,7 +33,6 @@ describe('useTypeformEmbed', () => {
     )
 
     expect(result.isValidTypeformId.value).toBe(false)
-    expect(result.typeformId.value).toBe('')
   })
 
   it('marks undefined id as invalid', () => {
@@ -42,7 +40,6 @@ describe('useTypeformEmbed', () => {
     const result = runInScope(() => useTypeformEmbed(containerRef, undefined))
 
     expect(result.isValidTypeformId.value).toBe(false)
-    expect(result.typeformId.value).toBe('')
   })
 
   it('marks empty string id as invalid', () => {
@@ -50,7 +47,6 @@ describe('useTypeformEmbed', () => {
     const result = runInScope(() => useTypeformEmbed(containerRef, ''))
 
     expect(result.isValidTypeformId.value).toBe(false)
-    expect(result.typeformId.value).toBe('')
   })
 
   it('exposes a reactive typeformError ref initialized to false', () => {

--- a/src/platform/surveys/useTypeformEmbed.ts
+++ b/src/platform/surveys/useTypeformEmbed.ts
@@ -99,10 +99,6 @@ export function useTypeformEmbed(
     isTypeformIdValid(toValue(typeformIdInput))
   )
 
-  const typeformId = computed(() =>
-    isValidTypeformId.value ? (toValue(typeformIdInput) ?? '') : ''
-  )
-
   whenever(typeformRef, async () => {
     try {
       await ensureScriptLoaded()
@@ -119,7 +115,6 @@ export function useTypeformEmbed(
 
   return {
     typeformError,
-    isValidTypeformId,
-    typeformId
+    isValidTypeformId
   }
 }

--- a/src/platform/telemetry/TelemetryRegistry.test.ts
+++ b/src/platform/telemetry/TelemetryRegistry.test.ts
@@ -45,4 +45,34 @@ describe('TelemetryRegistry', () => {
       })
     ).not.toThrow()
   })
+
+  it('getDistinctId returns the first provider id, skipping those without one', () => {
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({})
+    registry.registerProvider({ getDistinctId: () => 'ph-1' })
+    registry.registerProvider({ getDistinctId: () => 'ph-2' })
+
+    expect(registry.getDistinctId()).toBe('ph-1')
+  })
+
+  it('getDistinctId returns null when no provider has one', () => {
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({})
+    registry.registerProvider({ getDistinctId: () => null })
+
+    expect(registry.getDistinctId()).toBeNull()
+  })
+
+  it('getDistinctId skips a provider that throws and returns the next id', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const registry = new TelemetryRegistry()
+    registry.registerProvider({
+      getDistinctId: () => {
+        throw new Error('boom')
+      }
+    })
+    registry.registerProvider({ getDistinctId: () => 'ph-2' })
+
+    expect(registry.getDistinctId()).toBe('ph-2')
+  })
 })

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -75,6 +75,18 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackUserLoggedIn?.())
   }
 
+  getDistinctId(): string | null {
+    for (const provider of this.providers) {
+      try {
+        const distinctId = provider.getDistinctId?.()
+        if (distinctId) return distinctId
+      } catch (error) {
+        console.error('[Telemetry] getDistinctId failed', error)
+      }
+    }
+    return null
+  }
+
   trackSubscription(
     event: 'modal_opened' | 'subscribe_clicked',
     metadata?: SubscriptionMetadata

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -75,6 +75,11 @@ export class TelemetryRegistry implements TelemetryDispatcher {
     this.dispatch((provider) => provider.trackUserLoggedIn?.())
   }
 
+  /**
+   * Returns the distinct id of the first provider that exposes one, in
+   * registration order. Providers opt in by implementing `getDistinctId`;
+   * registration order decides the winner.
+   */
   getDistinctId(): string | null {
     for (const provider of this.providers) {
       try {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -10,6 +10,7 @@ const hoisted = vi.hoisted(() => {
   const mockPeopleSetOnce = vi.fn()
   const mockRegister = vi.fn()
   const mockReset = vi.fn()
+  const mockGetDistinctId = vi.fn(() => 'distinct-xyz')
   const mockOnUserResolved = vi.fn()
   const mockOnUserLogout = vi.fn()
 
@@ -21,6 +22,7 @@ const hoisted = vi.hoisted(() => {
     mockPeopleSetOnce,
     mockRegister,
     mockReset,
+    mockGetDistinctId,
     mockOnUserResolved,
     mockOnUserLogout,
     mockPosthog: {
@@ -30,7 +32,8 @@ const hoisted = vi.hoisted(() => {
         identify: mockIdentify,
         register: mockRegister,
         people: { set: mockPeopleSet, set_once: mockPeopleSetOnce },
-        reset: mockReset
+        reset: mockReset,
+        get_distinct_id: mockGetDistinctId
       }
     }
   }
@@ -86,6 +89,21 @@ describe('PostHogTelemetryProvider', () => {
     window.__CONFIG__ = {
       posthog_project_token: 'phc_test_token'
     } as typeof window.__CONFIG__
+  })
+
+  describe('getDistinctId', () => {
+    it('returns the PostHog distinct id once initialized', async () => {
+      const provider = createProvider()
+      await vi.dynamicImportSettled()
+
+      expect(provider.getDistinctId()).toBe('distinct-xyz')
+    })
+
+    it('returns null before initialization', () => {
+      const provider = createProvider()
+
+      expect(provider.getDistinctId()).toBeNull()
+    })
   })
 
   describe('initialization', () => {

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -338,6 +338,11 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
     this.trackEvent(TelemetryEvents.USER_LOGGED_IN)
   }
 
+  getDistinctId(): string | null {
+    if (!this.isEnabled || !this.isInitialized || !this.posthog) return null
+    return this.posthog.get_distinct_id()
+  }
+
   trackSubscription(
     event: 'modal_opened' | 'subscribe_clicked',
     metadata?: SubscriptionMetadata

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -473,6 +473,9 @@ export interface TelemetryProvider {
   trackAuth?(metadata: AuthMetadata): void
   trackUserLoggedIn?(): void
 
+  /** Anonymous/identified id used to stitch activity; null when unavailable. */
+  getDistinctId?(): string | null
+
   // Subscription flow events
   trackSubscription?(
     event: 'modal_opened' | 'subscribe_clicked',


### PR DESCRIPTION
## Summary

Adds distinct stable IDs to TypeForm surveys to allow linking responses together with per-distribution identity provider. 
- OSS: Anonymous UUID, not tied to any user/PII, purely randomly generated string
- Cloud: anon_id always, plus PostHog distinct_id and Comfy user ID when signed in
- Desktop2: Requires follow up implementation, falls back to anonymous ID
- Desktop1: Falls back to anonymous ID

## Changes

- **What**: 
- add IdentityProvider, defaulting to anonymous uuid upgraded to provider based on cloud
- persist anon uuid in localStorage (in memory fallback if no localStorage)
- feed through to typeform surveys, removing email
- add `getDistinctId` to PostHog telemetry provider 


## Review Focus
- [ ] Ensure that using an anonymous ID on OSS is acceptable
- [ ] Ensure distribution gating is correct
- [ ] Desktop2 provider not implemented, how should that set its own identity provider

