### PR TITLE
feat(logging): add debug activity logger for execution pipeline

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -3,6 +3,16 @@ import axios from 'axios'
 import { storeToRefs } from 'pinia'
 import { get } from 'es-toolkit/compat'
 import { trimEnd } from 'es-toolkit'
+import {
+  logHttpRequest,
+  logHttpResponse,
+  logWebSocketOpen,
+  logWebSocketClose,
+  logWebSocketMessage,
+  startTiming,
+  endTiming,
+  logQueuePromptApiCall
+} from './debugLogger'
 import { ref } from 'vue'
 
 import defaultClientFeatureFlags from '@/config/clientFeatureFlags.json' with { type: 'json' }
@@ -437,6 +447,10 @@ export class ComfyApi extends EventTarget {
 
   async fetchApi(route: string, options?: RequestInit) {
     const headers: HeadersInit = options?.headers ?? {}
+    const method = options?.method || 'GET'
+    const reqBody = options?.body ? JSON.parse(options.body as string) : undefined
+    logHttpRequest(method, route, reqBody)
+    const reqStart = performance.now()
 
     if (isCloud) {
       await this.waitForAuthInitialization()
@@ -462,11 +476,13 @@ export class ComfyApi extends EventTarget {
     }
 
     addHeaderEntry(headers, 'Comfy-User', this.user)
-    return fetch(this.apiURL(route), {
+    const res = await fetch(this.apiURL(route), {
       cache: 'no-cache',
       ...options,
       headers
     })
+    logHttpResponse(method, route, res.status, performance.now() - reqStart)
+    return res
   }
 
   override addEventListener<TEvent extends keyof ApiEvents>(
@@ -593,6 +609,7 @@ export class ComfyApi extends EventTarget {
 
     this.socket.addEventListener('open', () => {
       opened = true
+      logWebSocketOpen(wsUrl)
 
       // Send feature flags as the first message
       this.socket!.send(
@@ -614,7 +631,8 @@ export class ComfyApi extends EventTarget {
       }
     })
 
-    this.socket.addEventListener('close', () => {
+    this.socket.addEventListener('close', (event) => {
+      logWebSocketClose(event.code, event.reason)
       setTimeout(async () => {
         this.socket = null
         await this.createSocket(true)
@@ -722,6 +740,7 @@ export class ComfyApi extends EventTarget {
           }
         } else {
           const msg = JSON.parse(event.data) as ApiMessageUnion
+          logWebSocketMessage(msg.type, msg.data)
           switch (msg.type) {
             case 'status':
               if (msg.data.sid) {
@@ -912,7 +931,9 @@ export class ComfyApi extends EventTarget {
       throw new PromptExecutionError(errorResponse, res.status)
     }
 
-    return await res.json()
+    const result = await res.json()
+    logQueuePromptApiCall(result.prompt_id)
+    return result
   }
 
   /**

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -449,9 +449,14 @@ export class ComfyApi extends EventTarget {
   async fetchApi(route: string, options?: RequestInit) {
     const headers: HeadersInit = options?.headers ?? {}
     const method = options?.method || 'GET'
-    const reqBody = options?.body
-      ? JSON.parse(options.body as string)
-      : undefined
+    let reqBody: unknown
+    if (options?.body && typeof options.body === 'string') {
+      try {
+        reqBody = JSON.parse(options.body)
+      } catch {
+        reqBody = options.body
+      }
+    }
     logHttpRequest(method, route, reqBody)
     const reqStart = performance.now()
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -9,7 +9,10 @@ import {
   logWebSocketOpen,
   logWebSocketClose,
   logWebSocketMessage,
-  logQueuePromptApiCall
+  logWebSocketSend,
+  logQueuePromptStart,
+  logQueuePromptApiCall,
+  logStatus
 } from './debugLogger'
 import { ref } from 'vue'
 
@@ -612,12 +615,12 @@ export class ComfyApi extends EventTarget {
       logWebSocketOpen(wsUrl)
 
       // Send feature flags as the first message
-      this.socket!.send(
-        JSON.stringify({
-          type: 'feature_flags',
-          data: this.getClientFeatureFlags()
-        })
-      )
+      const featureFlagsMsg = JSON.stringify({
+        type: 'feature_flags',
+        data: this.getClientFeatureFlags()
+      })
+      logWebSocketSend('feature_flags', this.getClientFeatureFlags())
+      this.socket!.send(featureFlagsMsg)
 
       if (isReconnect) {
         this.dispatchCustomEvent('reconnected')
@@ -743,6 +746,10 @@ export class ComfyApi extends EventTarget {
           logWebSocketMessage(msg.type, msg.data)
           switch (msg.type) {
             case 'status':
+              logStatus(
+                msg.data.status?.exec_info?.queue_remaining ?? -1,
+                msg.data.sid ?? ''
+              )
               if (msg.data.sid) {
                 const clientId = msg.data.sid
                 this.clientId = clientId
@@ -881,6 +888,7 @@ export class ComfyApi extends EventTarget {
     options?: QueuePromptOptions
   ): Promise<PromptResponse> {
     const { output: prompt, workflow } = data
+    logQueuePromptStart(this.clientId ?? 'unknown', Object.keys(prompt).length)
 
     const body: QueuePromptRequestBody = {
       client_id: this.clientId ?? '', // TODO: Unify clientId access

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -9,8 +9,6 @@ import {
   logWebSocketOpen,
   logWebSocketClose,
   logWebSocketMessage,
-  startTiming,
-  endTiming,
   logQueuePromptApiCall
 } from './debugLogger'
 import { ref } from 'vue'
@@ -448,7 +446,9 @@ export class ComfyApi extends EventTarget {
   async fetchApi(route: string, options?: RequestInit) {
     const headers: HeadersInit = options?.headers ?? {}
     const method = options?.method || 'GET'
-    const reqBody = options?.body ? JSON.parse(options.body as string) : undefined
+    const reqBody = options?.body
+      ? JSON.parse(options.body as string)
+      : undefined
     logHttpRequest(method, route, reqBody)
     const reqStart = performance.now()
 

--- a/src/scripts/debugLogger.ts
+++ b/src/scripts/debugLogger.ts
@@ -8,11 +8,17 @@
  * Or set URL param: ?debug=1
  */
 
+declare global {
+  interface Window {
+    __COMFY_DEBUG?: boolean
+  }
+}
+
 const urlParams = new URLSearchParams(window.location.search)
 const DEBUG_ENABLED =
   urlParams.get('debug') === '1' ||
   urlParams.get('debug') === 'true' ||
-  (window as any).__COMFY_DEBUG === true
+  window.__COMFY_DEBUG === true
 
 const START_TIME = performance.now()
 
@@ -28,7 +34,7 @@ function elapsed(): string {
   return ((performance.now() - START_TIME) / 1000).toFixed(3) + 's'
 }
 
-function log(category: string, icon: string, message: string, data?: any) {
+function log(category: string, icon: string, message: string, data?: unknown) {
   if (!DEBUG_ENABLED) return
   const ts = elapsed()
   const prefix = `${icon} [${ts}] [${category}]`
@@ -59,7 +65,7 @@ export function endTiming(label: string): number | undefined {
 
 // ─── HTTP API Calls ───────────────────────────────────────────────────────────
 
-export function logHttpRequest(method: string, url: string, body?: any) {
+export function logHttpRequest(method: string, url: string, body?: unknown) {
   log(
     'HTTP',
     '🌐',
@@ -73,7 +79,7 @@ export function logHttpResponse(
   url: string,
   status: number,
   duration: number,
-  body?: any
+  body?: unknown
 ) {
   const icon = status >= 400 ? '❌' : '✅'
   log(
@@ -94,12 +100,12 @@ export function logWebSocketClose(code: number, reason: string) {
   log('WS', '🔴', `Disconnected: code=${code} reason=${reason}`)
 }
 
-export function logWebSocketMessage(type: string, data: any) {
+export function logWebSocketMessage(type: string, data: unknown) {
   const icon = getWsIcon(type)
   log('WS', icon, `← ${type}`, truncate(data, 300))
 }
 
-export function logWebSocketSend(type: string, data?: any) {
+export function logWebSocketSend(type: string, data?: unknown) {
   log('WS', '📤', `→ ${type}`, data ? truncate(data, 300) : undefined)
 }
 
@@ -135,7 +141,7 @@ export function logExecutingNode(nodeId: string | null, promptId: string) {
   }
 }
 
-export function logNodeExecuted(nodeId: string, output?: any) {
+export function logNodeExecuted(nodeId: string, output?: unknown) {
   log(
     'EXEC',
     '✅',
@@ -152,7 +158,7 @@ export function logExecutionSuccess(promptId: string) {
   log('EXEC', '🎉', `Execution SUCCESS: prompt_id=${promptId}`)
 }
 
-export function logExecutionError(promptId: string, error: any) {
+export function logExecutionError(promptId: string, error: unknown) {
   log('EXEC', '❌', `Execution ERROR: prompt_id=${promptId}`, error)
 }
 
@@ -167,9 +173,12 @@ export function logProgress(nodeId: string, value: number, max: number) {
   log('PROG', '📊', `Node ${nodeId}: ${value}/${max} (${pct}%)`)
 }
 
-export function logProgressState(nodes: Record<string, any>) {
+export function logProgressState(nodes: Record<string, unknown>) {
   const summary = Object.entries(nodes)
-    .map(([id, n]: [string, any]) => `${id}:${n.state || 'unknown'}`)
+    .map(([id, n]) => {
+      const node = n as Record<string, unknown>
+      return `${id}:${String(node.state ?? 'unknown')}`
+    })
     .join(', ')
   log('PROG', '📊', `Progress state: ${summary}`)
 }
@@ -218,7 +227,7 @@ function getWsIcon(type: string): string {
   }
 }
 
-function truncate(obj: any, maxLen: number): any {
+function truncate(obj: unknown, maxLen: number): unknown {
   if (obj === null || obj === undefined) return obj
   const str = typeof obj === 'string' ? obj : JSON.stringify(obj)
   if (str.length <= maxLen) return obj

--- a/src/scripts/debugLogger.ts
+++ b/src/scripts/debugLogger.ts
@@ -1,0 +1,201 @@
+/**
+ * ComfyUI Desktop — Debug Activity Logger
+ *
+ * Centralized logging for execution pipeline tracking.
+ * Logs: HTTP calls, WebSocket messages, node execution, model loading, timing.
+ *
+ * Enable via: window.__COMFY_DEBUG = true
+ * Or set URL param: ?debug=1
+ */
+
+const urlParams = new URLSearchParams(window.location.search)
+const DEBUG_ENABLED =
+  urlParams.get('debug') === '1' ||
+  urlParams.get('debug') === 'true' ||
+  (window as any).__COMFY_DEBUG === true
+
+const START_TIME = performance.now()
+
+interface TimingEntry {
+  label: string
+  start: number
+  end?: number
+}
+
+const timings: Map<string, TimingEntry> = new Map()
+
+function elapsed(): string {
+  return ((performance.now() - START_TIME) / 1000).toFixed(3) + 's'
+}
+
+function log(category: string, icon: string, message: string, data?: any) {
+  if (!DEBUG_ENABLED) return
+  const ts = elapsed()
+  const prefix = `${icon} [${ts}] [${category}]`
+  if (data !== undefined) {
+    console.log(`${prefix} ${message}`, data)
+  } else {
+    console.log(`${prefix} ${message}`)
+  }
+}
+
+// ─── Timing ───────────────────────────────────────────────────────────────────
+
+export function startTiming(label: string) {
+  if (!DEBUG_ENABLED) return
+  timings.set(label, { label, start: performance.now() })
+  log('TIMING', '⏱️', `START: ${label}`)
+}
+
+export function endTiming(label: string): number | undefined {
+  if (!DEBUG_ENABLED) return undefined
+  const entry = timings.get(label)
+  if (!entry) return undefined
+  entry.end = performance.now()
+  const duration = entry.end - entry.start
+  log('TIMING', '⏱️', `END: ${label} (${duration.toFixed(1)}ms)`)
+  return duration
+}
+
+// ─── HTTP API Calls ───────────────────────────────────────────────────────────
+
+export function logHttpRequest(method: string, url: string, body?: any) {
+  log('HTTP', '🌐', `${method} ${url}`, body ? truncate(JSON.parse(JSON.stringify(body)), 500) : undefined)
+}
+
+export function logHttpResponse(method: string, url: string, status: number, duration: number, body?: any) {
+  const icon = status >= 400 ? '❌' : '✅'
+  log('HTTP', icon, `${method} ${url} → ${status} (${duration.toFixed(0)}ms)`, body ? truncate(body, 500) : undefined)
+}
+
+// ─── WebSocket Messages ───────────────────────────────────────────────────────
+
+export function logWebSocketOpen(url: string) {
+  log('WS', '🔌', `Connected: ${url}`)
+}
+
+export function logWebSocketClose(code: number, reason: string) {
+  log('WS', '🔴', `Disconnected: code=${code} reason=${reason}`)
+}
+
+export function logWebSocketMessage(type: string, data: any) {
+  const icon = getWsIcon(type)
+  log('WS', icon, `← ${type}`, truncate(data, 300))
+}
+
+export function logWebSocketSend(type: string, data?: any) {
+  log('WS', '📤', `→ ${type}`, data ? truncate(data, 300) : undefined)
+}
+
+// ─── Queue Prompt Flow ────────────────────────────────────────────────────────
+
+export function logQueuePromptStart(requestId: string, nodeCount: number) {
+  log('QUEUE', '🚀', `Queue Prompt START (requestId=${requestId}, nodes=${nodeCount})`)
+}
+
+export function logQueuePromptApiCall(promptId: string) {
+  log('QUEUE', '📡', `POST /api/prompt → prompt_id=${promptId}`)
+}
+
+export function logQueuePromptStored(jobId: string, nodeCount: number) {
+  log('QUEUE', '📋', `Job stored: id=${jobId}, nodes=${nodeCount}`)
+}
+
+// ─── Execution Pipeline ───────────────────────────────────────────────────────
+
+export function logExecutionStart(promptId: string) {
+  log('EXEC', '🎬', `Execution START: prompt_id=${promptId}`)
+}
+
+export function logExecutingNode(nodeId: string | null, promptId: string) {
+  if (nodeId === null) {
+    log('EXEC', '🏁', `Execution COMPLETE: prompt_id=${promptId}`)
+  } else {
+    log('EXEC', '⚙️', `Executing node: ${nodeId}`)
+  }
+}
+
+export function logNodeExecuted(nodeId: string, output?: any) {
+  log('EXEC', '✅', `Node executed: ${nodeId}`, output ? truncate(output, 200) : undefined)
+}
+
+export function logNodeCached(nodeIds: string[]) {
+  log('EXEC', '💾', `Cached nodes: ${nodeIds.join(', ')}`)
+}
+
+export function logExecutionSuccess(promptId: string) {
+  log('EXEC', '🎉', `Execution SUCCESS: prompt_id=${promptId}`)
+}
+
+export function logExecutionError(promptId: string, error: any) {
+  log('EXEC', '❌', `Execution ERROR: prompt_id=${promptId}`, error)
+}
+
+export function logExecutionInterrupted(promptId: string) {
+  log('EXEC', '🛑', `Execution INTERRUPTED: prompt_id=${promptId}`)
+}
+
+// ─── Progress ─────────────────────────────────────────────────────────────────
+
+export function logProgress(nodeId: string, value: number, max: number) {
+  const pct = ((value / max) * 100).toFixed(1)
+  log('PROG', '📊', `Node ${nodeId}: ${value}/${max} (${pct}%)`)
+}
+
+export function logProgressState(nodes: Record<string, any>) {
+  const summary = Object.entries(nodes)
+    .map(([id, n]: [string, any]) => `${id}:${n.state || 'unknown'}`)
+    .join(', ')
+  log('PROG', '📊', `Progress state: ${summary}`)
+}
+
+export function logProgressText(nodeId: string, text: string) {
+  log('PROG', '💬', `Node ${nodeId} text: ${text}`)
+}
+
+// ─── Status ───────────────────────────────────────────────────────────────────
+
+export function logStatus(queueRemaining: number, sessionId: string) {
+  log('STATUS', '📌', `Status: queue_remaining=${queueRemaining}, session=${sessionId}`)
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getWsIcon(type: string): string {
+  switch (type) {
+    case 'execution_start':
+      return '🎬'
+    case 'executing':
+      return '⚙️'
+    case 'progress':
+    case 'progress_state':
+      return '📊'
+    case 'executed':
+      return '✅'
+    case 'execution_cached':
+      return '💾'
+    case 'execution_success':
+      return '🎉'
+    case 'execution_error':
+      return '❌'
+    case 'execution_interrupted':
+      return '🛑'
+    case 'status':
+      return '📌'
+    case 'progress_text':
+      return '💬'
+    default:
+      return '📨'
+  }
+}
+
+function truncate(obj: any, maxLen: number): any {
+  if (obj === null || obj === undefined) return obj
+  const str = typeof obj === 'string' ? obj : JSON.stringify(obj)
+  if (str.length <= maxLen) return obj
+  return str.slice(0, maxLen) + `... (${str.length} chars total)`
+}
+
+export function isDebugEnabled(): boolean {
+  return DEBUG_ENABLED
+}

--- a/src/scripts/debugLogger.ts
+++ b/src/scripts/debugLogger.ts
@@ -60,12 +60,28 @@ export function endTiming(label: string): number | undefined {
 // ─── HTTP API Calls ───────────────────────────────────────────────────────────
 
 export function logHttpRequest(method: string, url: string, body?: any) {
-  log('HTTP', '🌐', `${method} ${url}`, body ? truncate(JSON.parse(JSON.stringify(body)), 500) : undefined)
+  log(
+    'HTTP',
+    '🌐',
+    `${method} ${url}`,
+    body ? truncate(JSON.parse(JSON.stringify(body)), 500) : undefined
+  )
 }
 
-export function logHttpResponse(method: string, url: string, status: number, duration: number, body?: any) {
+export function logHttpResponse(
+  method: string,
+  url: string,
+  status: number,
+  duration: number,
+  body?: any
+) {
   const icon = status >= 400 ? '❌' : '✅'
-  log('HTTP', icon, `${method} ${url} → ${status} (${duration.toFixed(0)}ms)`, body ? truncate(body, 500) : undefined)
+  log(
+    'HTTP',
+    icon,
+    `${method} ${url} → ${status} (${duration.toFixed(0)}ms)`,
+    body ? truncate(body, 500) : undefined
+  )
 }
 
 // ─── WebSocket Messages ───────────────────────────────────────────────────────
@@ -90,7 +106,11 @@ export function logWebSocketSend(type: string, data?: any) {
 // ─── Queue Prompt Flow ────────────────────────────────────────────────────────
 
 export function logQueuePromptStart(requestId: string, nodeCount: number) {
-  log('QUEUE', '🚀', `Queue Prompt START (requestId=${requestId}, nodes=${nodeCount})`)
+  log(
+    'QUEUE',
+    '🚀',
+    `Queue Prompt START (requestId=${requestId}, nodes=${nodeCount})`
+  )
 }
 
 export function logQueuePromptApiCall(promptId: string) {
@@ -116,7 +136,12 @@ export function logExecutingNode(nodeId: string | null, promptId: string) {
 }
 
 export function logNodeExecuted(nodeId: string, output?: any) {
-  log('EXEC', '✅', `Node executed: ${nodeId}`, output ? truncate(output, 200) : undefined)
+  log(
+    'EXEC',
+    '✅',
+    `Node executed: ${nodeId}`,
+    output ? truncate(output, 200) : undefined
+  )
 }
 
 export function logNodeCached(nodeIds: string[]) {
@@ -156,7 +181,11 @@ export function logProgressText(nodeId: string, text: string) {
 // ─── Status ───────────────────────────────────────────────────────────────────
 
 export function logStatus(queueRemaining: number, sessionId: string) {
-  log('STATUS', '📌', `Status: queue_remaining=${queueRemaining}, session=${sessionId}`)
+  log(
+    'STATUS',
+    '📌',
+    `Status: queue_remaining=${queueRemaining}, session=${sessionId}`
+  )
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -194,8 +223,4 @@ function truncate(obj: any, maxLen: number): any {
   const str = typeof obj === 'string' ? obj : JSON.stringify(obj)
   if (str.length <= maxLen) return obj
   return str.slice(0, maxLen) + `... (${str.length} chars total)`
-}
-
-export function isDebugEnabled(): boolean {
-  return DEBUG_ENABLED
 }

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -307,6 +307,7 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionCached(e: CustomEvent<ExecutionCachedWsMessage>) {
+    logNodeCached(e.detail.nodes.map(String))
     if (!activeJob.value) return
     for (const n of e.detail.nodes) {
       activeJob.value.nodes[n] = true
@@ -317,12 +318,13 @@ export const useExecutionStore = defineStore('execution', () => {
     e: CustomEvent<ExecutionInterruptedWsMessage>
   ) {
     const jobId = e.detail.prompt_id
+    logExecutionInterrupted(jobId)
     if (activeJobId.value) clearInitializationByJobId(activeJobId.value)
     resetExecutionState(jobId)
   }
 
   function handleExecuted(e: CustomEvent<ExecutedWsMessage>) {
-    logNodeExecuted(e.detail.node)
+    logNodeExecuted(String(e.detail.node))
     if (!activeJob.value) return
     activeJob.value.nodes[e.detail.node] = true
   }
@@ -350,7 +352,10 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecuting(e: CustomEvent<NodeId | null>): void {
-    logExecutingNode(e.detail, activeJobId.value || 'unknown')
+    logExecutingNode(
+      e.detail !== null ? String(e.detail) : null,
+      activeJobId.value || 'unknown'
+    )
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
 
@@ -432,6 +437,7 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleProgress(e: CustomEvent<ProgressWsMessage>) {
+    logProgress(String(e.detail.node), e.detail.value, e.detail.max)
     _executingNodeProgress.value = e.detail
   }
 
@@ -611,6 +617,8 @@ export const useExecutionStore = defineStore('execution', () => {
   function handleProgressText(e: CustomEvent<ProgressTextWsMessage>) {
     const { nodeId, text, prompt_id } = e.detail
     if (!text || !nodeId) return
+
+    logProgressText(String(nodeId), text)
 
     // Filter: only accept progress for the active prompt
     if (prompt_id && activeJobId.value && prompt_id !== activeJobId.value)

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -8,6 +8,20 @@ import { resolveAccountPrecondition } from '@/platform/errorCatalog/accountPreco
 import { useTelemetry } from '@/platform/telemetry'
 import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
 import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+import {
+  logExecutionStart,
+  logExecutingNode,
+  logNodeExecuted,
+  logNodeCached,
+  logExecutionSuccess,
+  logExecutionError,
+  logExecutionInterrupted,
+  logProgressState,
+  logProgress,
+  logProgressText,
+  startTiming,
+  endTiming
+} from '@/scripts/debugLogger'
 import type {
   ComfyApiWorkflow,
   NodeId,
@@ -276,6 +290,8 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionStart(e: CustomEvent<ExecutionStartWsMessage>) {
+    logExecutionStart(e.detail.prompt_id)
+    startTiming(`exec:${e.detail.prompt_id}`)
     executionIdToLocatorCache.clear()
     executionErrorStore.clearExecutionStartErrors()
     activeJobId.value = e.detail.prompt_id
@@ -306,11 +322,14 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecuted(e: CustomEvent<ExecutedWsMessage>) {
+    logNodeExecuted(e.detail.node)
     if (!activeJob.value) return
     activeJob.value.nodes[e.detail.node] = true
   }
 
   function handleExecutionSuccess(e: CustomEvent<ExecutionSuccessWsMessage>) {
+    endTiming(`exec:${e.detail.prompt_id}`)
+    logExecutionSuccess(e.detail.prompt_id)
     const jobId = e.detail.prompt_id
     const queuedJob = queuedJobs.value[jobId]
     const telemetry = useTelemetry()
@@ -331,6 +350,7 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecuting(e: CustomEvent<NodeId | null>): void {
+    logExecutingNode(e.detail, activeJobId.value || 'unknown')
     // Clear the current node progress when a new node starts executing
     _executingNodeProgress.value = null
 
@@ -375,6 +395,7 @@ export const useExecutionStore = defineStore('execution', () => {
 
   function handleProgressState(e: CustomEvent<ProgressStateWsMessage>) {
     const { nodes, prompt_id: jobId } = e.detail
+    logProgressState(nodes)
 
     // Revoke previews for nodes that are starting to execute
     const previousForJob = nodeProgressStatesByJob.value[jobId] || {}
@@ -424,6 +445,8 @@ export const useExecutionStore = defineStore('execution', () => {
   }
 
   function handleExecutionError(e: CustomEvent<ExecutionErrorWsMessage>) {
+    endTiming(`exec:${e.detail.prompt_id}`)
+    logExecutionError(e.detail.prompt_id, e.detail)
     useTelemetry()?.trackExecutionError({
       jobId: e.detail.prompt_id,
       nodeId: String(e.detail.node_id),

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -19,6 +19,7 @@ import {
   logProgressState,
   logProgress,
   logProgressText,
+  logQueuePromptStored,
   startTiming,
   endTiming
 } from '@/scripts/debugLogger'
@@ -644,6 +645,7 @@ export const useExecutionStore = defineStore('execution', () => {
     promptOutput: ComfyApiWorkflow
     workflow: ComfyWorkflow
   }) {
+    logQueuePromptStored(String(id), nodes.length)
     queuedJobs.value[id] ??= { nodes: {} }
     const queuedJob = queuedJobs.value[id]
     queuedJob.nodes = {

--- a/src/stores/executionStore.ts
+++ b/src/stores/executionStore.ts
@@ -320,7 +320,8 @@ export const useExecutionStore = defineStore('execution', () => {
   ) {
     const jobId = e.detail.prompt_id
     logExecutionInterrupted(jobId)
-    if (activeJobId.value) clearInitializationByJobId(activeJobId.value)
+    endTiming(`exec:${jobId}`)
+    clearInitializationByJobId(jobId)
     resetExecutionState(jobId)
   }
 


### PR DESCRIPTION
## Summary

Adds a centralized debug activity logger (`debugLogger.ts`) for tracking the full execution pipeline in browser console.

## Changes

- **`src/scripts/debugLogger.ts`** — New module: timing, HTTP, WebSocket, queue, execution, and progress logging. Enable via `?debug=1` URL param or `window.__COMFY_DEBUG = true`
- **`src/scripts/api.ts`** — Wire up: HTTP request/response, WebSocket open/close/message/send, queue prompt start/api call, status
- **`src/stores/executionStore.ts`** — Wire up: execution start/success/error/interrupted, node executed/cached, progress/progress text, timing

## Usage

Append `?debug=1` to ComfyUI URL or run in browser console:
```js
window.__COMFY_DEBUG = true
```

Logs appear in browser DevTools Console (F12) with timestamped, categorized entries:
```
[1.234s] [TIMING] START: exec:abc-123
[1.235s] [HTTP] POST /prompt → 200 (45ms)
[1.240s] [EXEC] Executing node: 5
[1.300s] [EXEC] Node executed: 5
[1.350s] [EXEC] Execution SUCCESS: prompt_id=abc-123
```

## Testing

- `pnpm typecheck` — clean
- `pnpm build` — successful
- `pnpm format:check` — all files correct
- `pnpm exec oxlint` — 0 warnings, 0 errors on changed files
- `pnpm test:unit` — 11493/11536 passed (35 failures are pre-existing locale bug in `useNodePricing.test.ts`, unrelated to this change)