### PR TITLE
fix: re-disable ultralytics asset-picker registration

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -223,8 +223,18 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   ['film', 'FILM VFI', 'ckpt_name'],
 
   // ---- Ultralytics YOLO detectors (ComfyUI-Impact-Pack) ----
-  ['ultralytics/bbox', 'UltralyticsDetectorProvider', 'model_name'],
-  ['ultralytics/segm', 'UltralyticsDetectorProvider', 'model_name'],
+  // Intentionally NOT mapped to the asset-picker. The cloud asset-ingestion
+  // metadata for nested model folders (`ultralytics/bbox`, `ultralytics/segm`)
+  // still has the two known half-bugs described in #12075:
+  //   1. Tag lookup mismatch (cloud stores combined tags, picker queries split).
+  //   2. Submitted value mismatch (picker returns basenames, ingest expects
+  //      subdirectory-prefixed `bbox/<file>` / `segm/<file>`).
+  // PR #12151 re-added the bbox/segm entries before either half was fixed,
+  // reintroducing the FaceDetailer breakage. Until BE-689 lands the cloud-side
+  // fixes, leave these disabled so the node falls back to the static combo
+  // populated from `/api/object_info`.
+  // ['ultralytics/bbox', 'UltralyticsDetectorProvider', 'model_name'],
+  // ['ultralytics/segm', 'UltralyticsDetectorProvider', 'model_name'],
 
   // ---- Mel-Band RoFormer audio separation (ComfyUI-MelBandRoFormer) ----
   ['diffusion_models', 'MelBandRoFormerModelLoader', 'model_name'],


### PR DESCRIPTION
## Summary

Re-comment the `ultralytics/bbox` and `ultralytics/segm` entries in `MODEL_NODE_MAPPINGS` so `UltralyticsDetectorProvider` falls back to the static combo from `/api/object_info`, restoring the working post-#12075 behavior. Companion to [Comfy-Org/cloud#4395](https://github.com/Comfy-Org/cloud/pull/4395) (ONNX dummy-placeholder fix).

## Why

PR #12151 (2026-05-12) re-added these entries before BE-689 (the cloud-side asset-ingestion fix) landed, reintroducing both halves of the regression that #12075 originally cited:

1. **Tag lookup mismatch.** Cloud stores model tags as combined values like `ultralytics/bbox`, but the asset query splits them into `(models, ultralytics)` with exact-match filtering, so the picker returns no results.
2. **Submitted value mismatch.** Picker returns basenames like `face_yolov8m.pt`, but the ingest service validates against the subdirectory-prefixed form (`bbox/face_yolov8m.pt`) that the static combo path produces. The combo rejects the basename with `Value not in list` (the exact error users hit in BE-1116).

Until BE-689 lands both halves of the cloud fix, the asset-picker registration cannot ship without breaking the node.

## Changes

- **What**: comment out the two ultralytics entries in `src/platform/assets/mappings/modelNodeMappings.ts` with an inline note pointing at BE-689 and PR #12075 / #12151 for context.
- **Breaking**: none. The node returns to the same static-combo behavior it had between #12075 and #12151.
- **Dependencies**: none.

## Review Focus

- The existing assertion in `src/stores/modelToNodeStore.test.ts:278` already expects `ultralytics`, `ultralytics/bbox`, and `ultralytics/segm` to NOT resolve to a default provider — that test was added with #12075 and was left in place when #12151 re-added the mappings. After this change the mappings file is consistent with the test again. 55/55 in `modelToNodeStore.test.ts` pass locally.
- This is a targeted revert of the ultralytics half of #12151. The other entries that PR added (`background_removal`, `frame_interpolation`, `film`) are unaffected.

## Companion PRs

- Comfy-Org/cloud#4395 — fixes the `ONNXDetectorProvider` half of the FaceDetailer-broken report (BE-1116) by repairing the dummy-placeholder mechanism so the static combo carries the right model list. ONNX uses the static-combo path (no `MODEL_NODE_MAPPINGS` entry), so the cloud-side fix is sufficient there.

<!-- Fixes BE-689 -->