### PR TITLE
[codex] Add Desktop2 survey identity provider

### DIFF
--- a/src/components/ui/TypeformPopoverButton.test.ts
+++ b/src/components/ui/TypeformPopoverButton.test.ts
@@ -16,7 +16,8 @@ vi.mock('@vueuse/core', async (importOriginal) => {
 })
 
 vi.mock('@/platform/surveys/surveyIdentity', () => ({
-  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' }),
+  getSurveyIdentityTagsAsync: () => Promise.resolve({ anon_id: 'anon-1' })
 }))
 
 const PopoverStub = defineComponent({

--- a/src/components/ui/TypeformPopoverButton.vue
+++ b/src/components/ui/TypeformPopoverButton.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
-import { computed } from 'vue'
+import { ref, watchEffect } from 'vue'
 
 import Popover from '@/components/ui/Popover.vue'
 import Button from '@/components/ui/button/Button.vue'
 import TypeformEmbed from '@/platform/surveys/TypeformEmbed.vue'
-import { getSurveyIdentityTags } from '@/platform/surveys/surveyIdentity'
+import {
+  getSurveyIdentityTags,
+  getSurveyIdentityTagsAsync
+} from '@/platform/surveys/surveyIdentity'
 
 const { dataTfWidget, active = true } = defineProps<{
   dataTfWidget: string
@@ -15,9 +18,22 @@ const { dataTfWidget, active = true } = defineProps<{
 const isMobile = useBreakpoints(breakpointsTailwind).smaller('md')
 
 // Mobile opens the form externally, so identity rides in the URL fragment.
-const formUrl = computed(() => {
-  const params = new URLSearchParams(getSurveyIdentityTags())
-  return `https://form.typeform.com/to/${dataTfWidget}#${params.toString()}`
+function buildFormUrl(widgetId: string, tags: Record<string, string>): string {
+  const params = new URLSearchParams(tags)
+  return `https://form.typeform.com/to/${widgetId}#${params.toString()}`
+}
+
+const formUrl = ref(buildFormUrl(dataTfWidget, getSurveyIdentityTags()))
+
+watchEffect((onCleanup) => {
+  const widgetId = dataTfWidget
+  let cancelled = false
+  void getSurveyIdentityTagsAsync().then((tags) => {
+    if (!cancelled) formUrl.value = buildFormUrl(widgetId, tags)
+  })
+  onCleanup(() => {
+    cancelled = true
+  })
 })
 </script>
 <template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,14 @@ if (isCloud) {
   setCurrentIdentityProvider(cloudIdentityProvider)
 }
 
+if (isDesktop) {
+  const { setCurrentIdentityProvider } =
+    await import('@/platform/surveys/surveyIdentity')
+  const { desktopSurveyIdentityProvider } =
+    await import('@/platform/surveys/desktopSurveyIdentity')
+  setCurrentIdentityProvider(desktopSurveyIdentityProvider)
+}
+
 const ComfyUIPreset = definePreset(Aura, {
   semantic: {
     // @ts-expect-error fixme ts strict error

--- a/src/platform/surveys/TypeformEmbed.test.ts
+++ b/src/platform/surveys/TypeformEmbed.test.ts
@@ -21,7 +21,7 @@ vi.mock('./useTypeformEmbed', () => ({
 
 vi.mock('./surveyIdentity', async (importOriginal) => ({
   ...(await importOriginal<typeof SurveyIdentityModule>()),
-  getSurveyIdentityTags: () => ({ anon_id: 'anon-1' })
+  getSurveyIdentityTagsAsync: () => Promise.resolve({ anon_id: 'anon-1' })
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
@@ -36,10 +36,10 @@ describe('TypeformEmbed', () => {
     embedState.isValidTypeformId = true
   })
 
-  it('appends the survey identity to the caller hidden fields', () => {
+  it('appends the survey identity to the caller hidden fields', async () => {
     renderEmbed({ typeformId: 'abc123', hiddenFields: 'source=topbar' })
 
-    const embed = screen.getByTestId('typeform-embed')
+    const embed = await screen.findByTestId('typeform-embed')
     expect(embed).toHaveAttribute('data-tf-widget', 'abc123')
     expect(embed).toHaveAttribute(
       'data-tf-hidden',
@@ -49,28 +49,28 @@ describe('TypeformEmbed', () => {
     expect(embed).not.toHaveAttribute('data-tf-auto-resize')
   })
 
-  it('sends the survey identity even without caller hidden fields', () => {
+  it('sends the survey identity even without caller hidden fields', async () => {
     renderEmbed({ typeformId: 'abc123' })
 
-    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+    expect(await screen.findByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-hidden',
       'anon_id=anon-1'
     )
   })
 
-  it('keeps redirect-on-completion inside the iframe when requested', () => {
+  it('keeps redirect-on-completion inside the iframe when requested', async () => {
     renderEmbed({ typeformId: 'abc123', redirectTarget: '_self' })
 
-    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+    expect(await screen.findByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-redirect-target',
       '_self'
     )
   })
 
-  it('enables auto-resize when requested', () => {
+  it('enables auto-resize when requested', async () => {
     renderEmbed({ typeformId: 'abc123', autoResize: true })
 
-    expect(screen.getByTestId('typeform-embed')).toHaveAttribute(
+    expect(await screen.findByTestId('typeform-embed')).toHaveAttribute(
       'data-tf-auto-resize'
     )
   })

--- a/src/platform/surveys/TypeformEmbed.vue
+++ b/src/platform/surveys/TypeformEmbed.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { computed, useTemplateRef } from 'vue'
+import { ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
   formatTypeformHiddenFields,
-  getSurveyIdentityTags
+  getSurveyIdentityTagsAsync
 } from './surveyIdentity'
 import { useTypeformEmbed } from './useTypeformEmbed'
 
@@ -30,10 +30,23 @@ const { typeformError, isValidTypeformId } = useTypeformEmbed(
   () => typeformId
 )
 
-const dataTfHidden = computed(() => {
-  const identity = formatTypeformHiddenFields(getSurveyIdentityTags())
-  return [hiddenFields, identity].filter(Boolean).join(',')
-})
+const dataTfHidden = ref<string>()
+
+watch(
+  () => hiddenFields,
+  async (_, __, onCleanup) => {
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
+    const identity = formatTypeformHiddenFields(
+      await getSurveyIdentityTagsAsync()
+    )
+    if (cancelled) return
+    dataTfHidden.value = [hiddenFields, identity].filter(Boolean).join(',')
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
@@ -45,7 +58,7 @@ const dataTfHidden = computed(() => {
   </div>
   <!-- `data-tf-auto-resize` is read by presence, so it must be absent (not "false") when disabled -->
   <div
-    v-else
+    v-else-if="dataTfHidden !== undefined"
     ref="typeformRef"
     data-testid="typeform-embed"
     :data-tf-widget="typeformId"

--- a/src/platform/surveys/cloudSurveyIdentity.ts
+++ b/src/platform/surveys/cloudSurveyIdentity.ts
@@ -4,7 +4,7 @@ import { useTelemetry } from '@/platform/telemetry'
 import { getOrCreateAnonId } from './surveyIdentity'
 import type { IdentityProvider } from './surveyIdentity'
 
-export const cloudIdentityProvider: IdentityProvider = {
+export const cloudIdentityProvider = {
   getIdentity() {
     const { resolvedUserInfo } = useCurrentUser()
     return {
@@ -13,4 +13,4 @@ export const cloudIdentityProvider: IdentityProvider = {
       comfy_id: resolvedUserInfo.value?.id
     }
   }
-}
+} satisfies IdentityProvider

--- a/src/platform/surveys/desktopSurveyIdentity.test.ts
+++ b/src/platform/surveys/desktopSurveyIdentity.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { desktopSurveyIdentityProvider } from './desktopSurveyIdentity'
+
+function setDesktopBridge(
+  bridge:
+    | {
+        Surveys?: {
+          getIdentity?: () => Promise<Record<string, string> | null>
+        }
+      }
+    | undefined
+) {
+  ;(window as unknown as { __comfyDesktop2?: typeof bridge }).__comfyDesktop2 =
+    bridge
+}
+
+describe('desktopSurveyIdentityProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    setDesktopBridge(undefined)
+    vi.restoreAllMocks()
+  })
+
+  it('uses the Desktop-owned survey identity when available', async () => {
+    setDesktopBridge({
+      Surveys: {
+        getIdentity: vi.fn().mockResolvedValue({
+          anon_id: 'install-1',
+          distinct_id: 'user-1',
+          comfy_id: 'user-1'
+        })
+      }
+    })
+
+    await expect(desktopSurveyIdentityProvider.getIdentity()).resolves.toEqual({
+      anon_id: 'install-1',
+      distinct_id: 'user-1',
+      comfy_id: 'user-1'
+    })
+  })
+
+  it('falls back to a local anonymous id when the bridge returns null', async () => {
+    setDesktopBridge({
+      Surveys: {
+        getIdentity: vi.fn().mockResolvedValue(null)
+      }
+    })
+
+    const identity = await desktopSurveyIdentityProvider.getIdentity()
+
+    expect(identity?.anon_id).toBeTruthy()
+    expect(identity?.distinct_id).toBeUndefined()
+    expect(identity?.comfy_id).toBeUndefined()
+  })
+
+  it('falls back to a local anonymous id when the bridge is unavailable', async () => {
+    setDesktopBridge(undefined)
+
+    const identity = await desktopSurveyIdentityProvider.getIdentity()
+
+    expect(identity?.anon_id).toBe(localStorage.getItem('Comfy.SurveyAnonId'))
+  })
+})

--- a/src/platform/surveys/desktopSurveyIdentity.ts
+++ b/src/platform/surveys/desktopSurveyIdentity.ts
@@ -1,0 +1,27 @@
+import { getOrCreateAnonId } from './surveyIdentity'
+import type { IdentityProvider, SurveyIdentity } from './surveyIdentity'
+
+interface DesktopSurveyIdentityBridge {
+  Surveys?: {
+    getIdentity?: () => Promise<Partial<SurveyIdentity> | null>
+  }
+}
+
+function getDesktopBridge(): DesktopSurveyIdentityBridge | undefined {
+  return (window as Window & { __comfyDesktop2?: DesktopSurveyIdentityBridge })
+    .__comfyDesktop2
+}
+
+export const desktopSurveyIdentityProvider: IdentityProvider = {
+  async getIdentity() {
+    try {
+      const identity = await getDesktopBridge()?.Surveys?.getIdentity?.()
+      return {
+        ...identity,
+        anon_id: identity?.anon_id ?? getOrCreateAnonId()
+      }
+    } catch {
+      return { anon_id: getOrCreateAnonId() }
+    }
+  }
+}

--- a/src/platform/surveys/surveyIdentity.test.ts
+++ b/src/platform/surveys/surveyIdentity.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   anonymousIdentityProvider,
   getSurveyIdentityTags,
+  getSurveyIdentityTagsAsync,
   setCurrentIdentityProvider
 } from './surveyIdentity'
 
@@ -64,5 +65,31 @@ describe('survey identity', () => {
       distinct_id: 'ph-1',
       comfy_id: 'uid-9'
     })
+  })
+
+  it('resolves async providers for bridge-backed identities', async () => {
+    setCurrentIdentityProvider({
+      getIdentity: () =>
+        Promise.resolve({
+          anon_id: 'desktop-install',
+          distinct_id: 'desktop-user',
+          comfy_id: 'desktop-user'
+        })
+    })
+
+    await expect(getSurveyIdentityTagsAsync()).resolves.toEqual({
+      anon_id: 'desktop-install',
+      distinct_id: 'desktop-user',
+      comfy_id: 'desktop-user'
+    })
+  })
+
+  it('keeps the sync accessor on an anonymous fallback for async providers', () => {
+    setCurrentIdentityProvider({
+      getIdentity: () => Promise.resolve({ anon_id: 'desktop-install' })
+    })
+
+    expect(getSurveyIdentityTags().anon_id).toBeTruthy()
+    expect(getSurveyIdentityTags().anon_id).not.toBe('desktop-install')
   })
 })

--- a/src/platform/surveys/surveyIdentity.ts
+++ b/src/platform/surveys/surveyIdentity.ts
@@ -11,8 +11,11 @@ export interface SurveyIdentity {
   comfy_id?: string
 }
 
+type MaybePromise<T> = T | Promise<T>
+type SurveyIdentityResult = Partial<SurveyIdentity> | null | undefined
+
 export interface IdentityProvider {
-  getIdentity(): SurveyIdentity
+  getIdentity(): MaybePromise<SurveyIdentityResult>
 }
 
 let memoryAnonId: string | undefined
@@ -41,18 +44,42 @@ export function setCurrentIdentityProvider(provider: IdentityProvider): void {
   currentProvider = provider
 }
 
-function getSurveyIdentity(): SurveyIdentity {
-  return currentProvider.getIdentity()
+function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>)?.then === 'function'
 }
 
-/** Identity as Typeform hidden-field tags, dropping any absent field. */
-export function getSurveyIdentityTags(): Record<string, string> {
-  const { anon_id, distinct_id, comfy_id } = getSurveyIdentity()
+function normalizeSurveyIdentity(
+  identity: SurveyIdentityResult
+): SurveyIdentity {
+  return {
+    ...(identity ?? {}),
+    anon_id: identity?.anon_id ?? getOrCreateAnonId()
+  }
+}
+
+function tagsFromIdentity(
+  identity: SurveyIdentityResult
+): Record<string, string> {
+  const { anon_id, distinct_id, comfy_id } = normalizeSurveyIdentity(identity)
   return {
     anon_id,
     ...(distinct_id ? { distinct_id } : {}),
     ...(comfy_id ? { comfy_id } : {})
   }
+}
+
+/** Identity as Typeform hidden-field tags, dropping any absent field. */
+export function getSurveyIdentityTags(): Record<string, string> {
+  const identity = currentProvider.getIdentity()
+  return isPromiseLike(identity)
+    ? tagsFromIdentity(null)
+    : tagsFromIdentity(identity)
+}
+
+export async function getSurveyIdentityTagsAsync(): Promise<
+  Record<string, string>
+> {
+  return tagsFromIdentity(await currentProvider.getIdentity())
 }
 
 /** Formats tags as Typeform's comma-separated `key=value` hidden-field string. */


### PR DESCRIPTION
## Summary

Stacks on #13010 and adds the Desktop2 consumer side of survey identity.

- allows survey identity providers to resolve asynchronously
- adds a Desktop2 provider that reads `window.__comfyDesktop2.Surveys.getIdentity()`
- registers the Desktop2 provider only for desktop builds
- waits for async identity before mounting Typeform embeds so `data-tf-hidden` is present when Typeform scans the DOM
- refreshes mobile Typeform links with the async identity while preserving the existing anonymous fallback
- keeps Cloud/local anonymous behavior intact

## Dependency

Runtime Desktop2 identity comes from Comfy-Desktop #1151. Older Desktop builds or missing bridges fall back to the existing anonymous survey id, so the frontend remains backward-compatible.

## Why

Typeform submissions go directly to Typeform, so the existing Desktop telemetry capture relay cannot attach identity to survey responses. The frontend needs hidden fields before opening/rendering the form, but Desktop must own the actual consent-gated identity values.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint src/main.ts src/components/ui/TypeformPopoverButton.vue src/components/ui/TypeformPopoverButton.test.ts src/platform/surveys/surveyIdentity.ts src/platform/surveys/surveyIdentity.test.ts src/platform/surveys/cloudSurveyIdentity.ts src/platform/surveys/desktopSurveyIdentity.ts src/platform/surveys/desktopSurveyIdentity.test.ts src/platform/surveys/TypeformEmbed.vue src/platform/surveys/TypeformEmbed.test.ts`
- `pnpm exec vitest run src/platform/surveys/surveyIdentity.test.ts src/platform/surveys/cloudSurveyIdentity.test.ts src/platform/surveys/desktopSurveyIdentity.test.ts src/platform/surveys/TypeformEmbed.test.ts src/components/ui/TypeformPopoverButton.test.ts src/platform/support/config.test.ts src/components/helpcenter/HelpCenterMenuContent.test.ts`