### PR TITLE
fix(test): de-flake Canvas ctrl+shift+vertical-drag zoom e2e

### DIFF
--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -622,7 +622,10 @@ test.describe('Canvas Interaction', { tag: '@screenshot' }, () => {
     await expect(comfyPage.canvas).toHaveScreenshot('zoomed-in-ctrl-shift.png')
     await comfyPage.canvasOps.ctrlShiftDrag({ x: 10, y: 40 }, { x: 10, y: 160 })
     await expect(comfyPage.canvas).toHaveScreenshot('zoomed-out-ctrl-shift.png')
-    await comfyPage.canvasOps.ctrlShiftDrag({ x: 10, y: 280 }, { x: 10, y: 220 })
+    await comfyPage.canvasOps.ctrlShiftDrag(
+      { x: 10, y: 280 },
+      { x: 10, y: 220 }
+    )
     await expect(comfyPage.canvas).toHaveScreenshot(
       'zoomed-default-ctrl-shift.png'
     )

--- a/browser_tests/tests/interaction.spec.ts
+++ b/browser_tests/tests/interaction.spec.ts
@@ -612,18 +612,20 @@ test.describe('Canvas Interaction', { tag: '@screenshot' }, () => {
   test('Can zoom in/out with ctrl+shift+vertical-drag', async ({
     comfyPage
   }) => {
-    await comfyPage.page.keyboard.down('Control')
-    await comfyPage.page.keyboard.down('Shift')
-    await comfyPage.canvasOps.dragAndDrop({ x: 10, y: 100 }, { x: 10, y: 40 })
+    // Use ctrlShiftDrag so the Control+Shift modifiers are pressed and released
+    // around each individual gesture. Holding the modifiers down across all
+    // three drags plus the intervening screenshot assertions could saturate the
+    // main thread and stall a single mouse.move step past the test timeout, and
+    // a mid-test failure would leave the modifiers stuck down. Releasing per
+    // gesture matches the robust pattern used in canvasSettings.spec.ts.
+    await comfyPage.canvasOps.ctrlShiftDrag({ x: 10, y: 100 }, { x: 10, y: 40 })
     await expect(comfyPage.canvas).toHaveScreenshot('zoomed-in-ctrl-shift.png')
-    await comfyPage.canvasOps.dragAndDrop({ x: 10, y: 40 }, { x: 10, y: 160 })
+    await comfyPage.canvasOps.ctrlShiftDrag({ x: 10, y: 40 }, { x: 10, y: 160 })
     await expect(comfyPage.canvas).toHaveScreenshot('zoomed-out-ctrl-shift.png')
-    await comfyPage.canvasOps.dragAndDrop({ x: 10, y: 280 }, { x: 10, y: 220 })
+    await comfyPage.canvasOps.ctrlShiftDrag({ x: 10, y: 280 }, { x: 10, y: 220 })
     await expect(comfyPage.canvas).toHaveScreenshot(
       'zoomed-default-ctrl-shift.png'
     )
-    await comfyPage.page.keyboard.up('Control')
-    await comfyPage.page.keyboard.up('Shift')
   })
 
   test('Can zoom in/out after decreasing canvas zoom speed setting', async ({


### PR DESCRIPTION
## Observed flake

The e2e test `Canvas Interaction > Can zoom in/out with ctrl+shift+vertical-drag` (`browser_tests/tests/interaction.spec.ts`) intermittently failed in CI with:

```
Error: mouse.move: Test timeout of 15000ms exceeded
```

It failed all 3 retries on a single shard while 209 other tests on that shard passed, and passed on a later re-run — i.e. genuinely flaky, not a hard break.

## Root cause

The test pressed `Control` and `Shift` *down* once, then ran three `canvasOps.dragAndDrop` gestures (each performs a `mouse.move(target, { steps: 100 })`) with three `toHaveScreenshot` assertions interleaved, and only released the modifiers at the very end — with no `try/finally`.

Two problems:
1. Holding the modifiers across all three drags means every one of the ~300 step-wise `mousemove` events drives litegraph's ctrl+shift zoom handler (scale recompute + canvas redraw). Combined with the screenshot captures in between, the main thread can saturate, and a single `mouse.move` step can stall past the 15s test timeout. That is exactly the failing call in the signature.
2. Without `try/finally`, a mid-test failure leaves `Control`/`Shift` stuck down.

## Fix

Switch to the existing `canvasOps.ctrlShiftDrag(from, to)` helper, which presses and releases `Control`+`Shift` around each individual gesture. This is the robust pattern already used in `canvasSettings.spec.ts`. The modifiers are never held across the heavy multi-drag + screenshot sequence, and are always released.

Test intent, drag coordinates, and all three screenshot assertions are unchanged.

## Validation

- Verified by reasoning: `ctrlShiftDrag` wraps the same `dragAndDrop` with `keyboard.down/up` of the same modifiers, called with identical `Position` args, so behavior and types are preserved.
- Could not run the browser e2e locally (requires a running ComfyUI backend + Playwright browsers; `node_modules` not installed in this environment). Relying on CI for the full e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)