### PR TITLE
chore: disable CodeRabbit docstring coverage pre-merge check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,6 +15,11 @@ reviews:
       - github-actions[bot]
   pre_merge_checks:
     override_requested_reviewers_only: true
+    # Explicitly disable the built-in docstring coverage check, which is
+    # enabled via organization-level settings. This repo opts out at the
+    # repo level without affecting other org repos.
+    docstrings:
+      mode: 'off'
     custom_checks:
       - name: End-to-end regression coverage for fixes
         mode: error


### PR DESCRIPTION
## Summary

The **Docstring Coverage** pre-merge check is currently blocking merges. It is not defined in our `.coderabbit.yaml` — it is enabled via CodeRabbit **organization-level settings** (this repo has "use organization settings" toggled on, but the repo config file overrides specific keys).

This PR explicitly opts the repo out of that check by setting `reviews.pre_merge_checks.docstrings.mode: 'off'`. A repo-level `.coderabbit.yaml` takes precedence over org settings, so this disables the check **only for this repo** — other org repos that want it keep it.

```yaml
reviews:
  pre_merge_checks:
    docstrings:
      mode: 'off'
```

## Why

- Docstring coverage is a poor fit for this TS/Vue frontend codebase and was added at the org level, not chosen here.
- It's a blocking gate with no repo-level config, so it can't currently be tuned from the dashboard without affecting other repos.

## References

- [Built-in pre-merge checks](https://docs.coderabbit.ai/pr-reviews/pre-merge-checks)
- [Configuration reference](https://docs.coderabbit.ai/reference/configuration)
- Prior art: [crossplane/.coderabbit.yaml](https://github.com/crossplane/crossplane/blob/main/.coderabbit.yaml) disables docstrings the same way