### PR TITLE
fix: add explicit type parameters to useTemplateRef in LinearView

### DIFF
--- a/src/views/LinearView.vue
+++ b/src/views/LinearView.vue
@@ -88,9 +88,10 @@ const { onResizeEnd } = useStablePrimeVueSplitterSizer(
 
 const TYPEFORM_WIDGET_ID = 'jmmzmlKw'
 
-const bottomLeftRef = useTemplateRef('bottomLeftRef')
-const bottomRightRef = useTemplateRef('bottomRightRef')
-const linearWorkflowRef = useTemplateRef('linearWorkflowRef')
+const bottomLeftRef = useTemplateRef<HTMLDivElement>('bottomLeftRef')
+const bottomRightRef = useTemplateRef<HTMLDivElement>('bottomRightRef')
+const linearWorkflowRef =
+  useTemplateRef<InstanceType<typeof LinearControls>>('linearWorkflowRef')
 
 function dragDrop(e: DragEvent) {
   const { dataTransfer } = e


### PR DESCRIPTION
## Summary
- Add explicit type parameters to `useTemplateRef` calls to fix TS7022 errors during declaration file generation
- Refs were implicitly typed as 'any' due to circular reference in type inference

## Changes
- `bottomLeftRef` and `bottomRightRef` typed as `HTMLDivElement`
- `linearWorkflowRef` typed as `InstanceType<typeof LinearControls>`

## Test plan
- [ ] Types build succeeds: `pnpm build:types`
- [ ] Typecheck passes: `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)