### PR TITLE
test: stop flaky teardown error in AssetBrowserModal test

### DIFF
--- a/src/platform/assets/components/AssetBrowserModal.test.ts
+++ b/src/platform/assets/components/AssetBrowserModal.test.ts
@@ -39,6 +39,18 @@ vi.mock('@/stores/modelToNodeStore', () => ({
   })
 }))
 
+// Stub model-type fetching so mounting the modal does not fire a real
+// `api.getModelFolders()` network request. The unmocked call hit
+// http://localhost:3000/api/experiment/models, failed with ECONNREFUSED, and
+// logged via console.error asynchronously after the test had finished —
+// racing with vitest worker teardown and surfacing as a flaky
+// "EnvironmentTeardownError: Closing rpc while onUserConsoleLog was pending".
+vi.mock('@/platform/assets/composables/useModelTypes', () => ({
+  useModelTypes: () => ({
+    fetchModelTypes: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
 vi.mock('@/components/common/SearchBox.vue', () => ({
   default: {
     name: 'SearchBox',


### PR DESCRIPTION
## Summary

`src/platform/assets/components/AssetBrowserModal.test.ts` is the source of a nondeterministic unit-test failure where every test passes but the run still exits 1:

```
⎯⎯ Unhandled Errors ⎯⎯
Vitest caught 2 unhandled errors during the test run.
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
  → src/platform/assets/components/AssetBrowserModal.test.ts
```

## Root cause

`AssetBrowserModal.vue` runs `void useModelTypes().fetchModelTypes()` on setup, which calls `api.getModelFolders()`. The test mocks the asset store and the child components but **not** this composable, so every render fires a real `fetch('http://localhost:3000/api/experiment/models')`. The request fails with `ECONNREFUSED` and `useModelTypes` logs `console.error('Failed to fetch model types:', err)` **asynchronously, after the test has already finished**.

Under CI load that late console write races with the vitest worker teardown and surfaces as the `EnvironmentTeardownError` above. Vitest counts it as an unhandled error and fails the whole run even though all tests pass.

Reproduced locally — every render of the modal emits:
```
stderr | AssetBrowserModal.test.ts > ...
Failed to fetch model types: DOMException [NetworkError]: ... "http://localhost:3000/api/experiment/models": connect ECONNREFUSED 127.0.0.1:3000
```

## History

Surfaced on run [27791561006](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/27791561006/job/82241545973) (the `core/1.46` backport of #12804). The identical change passed the unit job on the sibling backport, confirming the failure was nondeterministic rather than caused by the change.

## Changes

Mock `useModelTypes` in the test so mounting performs no network I/O and emits no late logs. After the fix the `Failed to fetch model types` / `ECONNREFUSED` output is gone and all 14 tests pass.

---

## 🔀 Rebase & handoff status (2026-07-13)

**Status: APPROVED + green months ago → rotted on `main` (merge-skew) → now rebased onto current `main` → ready to merge.**

- Was **181 commits behind** `main`; now rebased.
- **Fully green / mergeState CLEAN** — the most merge-ready of the batch.

- [x] Rebased onto current `main`
- [x] Fully green, mergeState CLEAN
- [x] Ready to merge — assigned to @christian-byrne