### PR TITLE
fix: update share dialog acknowledgement copy

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3340,7 +3340,7 @@
     "mediaLabel": "{count} Media File | {count} Media Files",
     "modelsLabel": "{count} Model | {count} Models",
     "checkingAssets": "Checking media visibility…",
-    "acknowledgeCheckbox": "I understand these media items will be published and made public",
+    "acknowledgeCheckbox": "I understand anyone with the link can view these files",
     "inLibrary": "In library",
     "comfyHubTitle": "Upload to ComfyHub",
     "comfyHubDescription": "ComfyHub is ComfyUI's official community hub.\nYour workflow will have a public page viewable by all.",


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Update the English copy on the share dialog acknowledgement checkbox to better reflect the link-based visibility model.

**Before:** "I understand these media items will be published and made public"
**After:** "I understand anyone with the link can view these files"

Only the `en` locale string was changed (`shareWorkflow.acknowledgeCheckbox` in `src/locales/en/main.json`), per the request. Other locale files are intentionally left to the standard translation sync process.

The component (`ShareAssetWarningBox.vue`) reads this string via `$t('shareWorkflow.acknowledgeCheckbox')`, so no component change is needed.

## Verification
- `ShareAssetWarningBox.test.ts` — 12 passed (tests use their own mock string and are unaffected).
- `ShareWorkflowDialogContent.test.ts` — 19 passed.
- Lint-staged hooks (oxfmt, oxlint, eslint, typecheck) ran on commit and passed.
- Visual verification: rendered the new copy in a representative checkbox layout via Playwright and confirmed the user-facing text matches (screenshot attached).

## Screenshots

![Share dialog acknowledgement checkbox showing new copy: 'I understand anyone with the link can view these files'](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/2c2cd89e57ce203d296953b0c02b0d05e0d065a22629e974bc336f890fa85d2e/pr-images/1781924023274-711d37d8-f31f-4c42-bd00-bc37ae83b3ed.png)