### PR TITLE
feat: add HDR/EXR image viewer for SaveImageAdvanced outputs

### DIFF
--- a/src/components/hdr/HdrViewerContent.test.ts
+++ b/src/components/hdr/HdrViewerContent.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import HdrViewerContent from './HdrViewerContent.vue'
+
+vi.mock('@/base/common/downloadUtil', () => ({ downloadFile: vi.fn() }))
+
+const holder = vi.hoisted(() => ({ viewer: undefined as unknown }))
+vi.mock('@/composables/useHdrViewer', () => ({
+  useHdrViewer: () => holder.viewer,
+  CHANNEL_MODES: ['rgb', 'r', 'g', 'b', 'a', 'luminance']
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { loading: 'Loading', downloadImage: 'Download' },
+      hdrViewer: {
+        failedToLoad: 'Failed',
+        exposure: 'Exposure',
+        normalizeExposure: 'Auto exposure',
+        channel: 'Channel',
+        channels: {
+          rgb: 'RGB',
+          r: 'R',
+          g: 'G',
+          b: 'B',
+          a: 'Alpha',
+          luminance: 'Luminance'
+        },
+        sourceGamut: 'Source gamut',
+        dither: 'Dither',
+        clipWarnings: 'Clip warnings',
+        fitView: 'Fit',
+        histogram: 'Histogram',
+        resolution: 'Resolution',
+        min: 'Min',
+        max: 'Max',
+        mean: 'Mean',
+        stdDev: 'Std dev',
+        nan: 'NaN',
+        inf: 'Inf'
+      }
+    }
+  }
+})
+
+function makeViewer(overrides: Record<string, unknown> = {}) {
+  return {
+    exposureStops: ref(0),
+    dither: ref(true),
+    clipWarnings: ref(false),
+    gamut: ref('sRGB'),
+    channel: ref('r'),
+    loading: ref(false),
+    error: ref(null),
+    dimensions: ref('512 x 512'),
+    stats: ref({
+      min: 0,
+      max: 4,
+      mean: 0.5,
+      stdDev: 0.2,
+      nanCount: 2,
+      infCount: 1
+    }),
+    histogram: ref(new Uint32Array([1, 2, 3, 4])),
+    pixel: ref({ x: 1, y: 2, r: 0.1, g: 0.2, b: 0.3, a: 1 }),
+    mount: vi.fn(),
+    dispose: vi.fn(),
+    fitView: vi.fn(),
+    normalizeExposure: vi.fn(),
+    ...overrides
+  }
+}
+
+function renderViewer() {
+  return render(HdrViewerContent, {
+    props: { imageUrl: '/api/view?filename=out.exr' },
+    global: { plugins: [i18n], stubs: { Button: true } }
+  })
+}
+
+describe('HdrViewerContent', () => {
+  beforeEach(() => {
+    holder.viewer = makeViewer()
+  })
+
+  it('renders the full statistics set including NaN/Inf', () => {
+    renderViewer()
+    for (const label of [
+      'Resolution',
+      'Min',
+      'Max',
+      'Mean',
+      'Std dev',
+      'NaN',
+      'Inf'
+    ]) {
+      screen.getByText(label)
+    }
+  })
+
+  it('shows the pixel readout when a pixel is hovered', () => {
+    renderViewer()
+    expect(screen.getByTestId('hdr-pixel-readout')).toBeInTheDocument()
+  })
+
+  it('colors the histogram according to the selected channel', () => {
+    holder.viewer = makeViewer({ channel: ref('g') })
+    const { container } = renderViewer()
+    const path = container.querySelector('svg path')
+    expect(path?.getAttribute('class')).toContain('text-green-500')
+  })
+
+  it('renders an option for each channel mode', () => {
+    renderViewer()
+    expect(
+      screen.getByRole('option', { name: 'Luminance' })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/hdr/HdrViewerContent.vue
+++ b/src/components/hdr/HdrViewerContent.vue
@@ -1,0 +1,258 @@
+<template>
+  <div class="flex size-full bg-base-background">
+    <div class="relative flex-1">
+      <div
+        ref="containerRef"
+        class="absolute size-full"
+        data-testid="hdr-viewer-canvas"
+      />
+
+      <div
+        v-if="viewer.loading.value"
+        class="absolute inset-0 flex items-center justify-center text-base-foreground"
+      >
+        {{ $t('g.loading') }}...
+      </div>
+      <div
+        v-else-if="viewer.error.value"
+        role="alert"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-2 text-base-foreground"
+      >
+        <i class="icon-[lucide--image-off] size-12" />
+        <p class="text-sm">{{ $t('hdrViewer.failedToLoad') }}</p>
+      </div>
+
+      <div
+        v-if="viewer.pixel.value"
+        class="absolute top-2 left-2 rounded-sm bg-base-background/80 px-2 py-1 font-mono text-xs text-base-foreground"
+        data-testid="hdr-pixel-readout"
+      >
+        <div>{{ viewer.pixel.value.x }}, {{ viewer.pixel.value.y }}</div>
+        <div>
+          {{ formatNum(viewer.pixel.value.r) }}
+          {{ formatNum(viewer.pixel.value.g) }}
+          {{ formatNum(viewer.pixel.value.b) }}
+          <template v-if="viewer.pixel.value.a !== null">
+            {{ formatNum(viewer.pixel.value.a) }}
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex w-72 flex-col" data-testid="hdr-viewer-sidebar">
+      <div class="flex-1 overflow-y-auto p-4">
+        <div class="space-y-2">
+          <div class="space-y-4 p-2">
+            <div class="flex flex-col gap-2">
+              <label>{{ $t('hdrViewer.exposure') }}: {{ exposureLabel }}</label>
+              <input
+                v-model.number="viewer.exposureStops.value"
+                type="range"
+                min="-10"
+                max="10"
+                step="0.1"
+                class="w-full"
+                :aria-label="$t('hdrViewer.exposure')"
+              />
+            </div>
+            <Button
+              variant="secondary"
+              class="w-full"
+              @click="viewer.normalizeExposure"
+            >
+              {{ $t('hdrViewer.normalizeExposure') }}
+            </Button>
+          </div>
+
+          <div class="space-y-4 p-2">
+            <div class="flex flex-col gap-2">
+              <label>{{ $t('hdrViewer.channel') }}</label>
+              <select
+                v-model="viewer.channel.value"
+                class="bg-base-component-surface w-full rounded-sm px-2 py-1"
+                :aria-label="$t('hdrViewer.channel')"
+              >
+                <option v-for="mode in channelModes" :key="mode" :value="mode">
+                  {{ channelLabels[mode] }}
+                </option>
+              </select>
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <label>{{ $t('hdrViewer.sourceGamut') }}</label>
+              <select
+                v-model="viewer.gamut.value"
+                class="bg-base-component-surface w-full rounded-sm px-2 py-1"
+                :aria-label="$t('hdrViewer.sourceGamut')"
+              >
+                <option v-for="name in gamutNames" :key="name" :value="name">
+                  {{ name }}
+                </option>
+              </select>
+            </div>
+          </div>
+
+          <div class="space-y-4 p-2">
+            <div class="flex items-center gap-2">
+              <input
+                id="hdr-dither"
+                v-model="viewer.dither.value"
+                type="checkbox"
+                class="size-4 cursor-pointer accent-node-component-surface-highlight"
+              />
+              <label for="hdr-dither" class="cursor-pointer">
+                {{ $t('hdrViewer.dither') }}
+              </label>
+            </div>
+            <div class="flex items-center gap-2">
+              <input
+                id="hdr-clip"
+                v-model="viewer.clipWarnings.value"
+                type="checkbox"
+                class="size-4 cursor-pointer accent-node-component-surface-highlight"
+              />
+              <label for="hdr-clip" class="cursor-pointer">
+                {{ $t('hdrViewer.clipWarnings') }}
+              </label>
+            </div>
+          </div>
+
+          <div v-if="histogramPath" class="space-y-2 p-2">
+            <label>{{ $t('hdrViewer.histogram') }}</label>
+            <svg
+              viewBox="0 0 1 1"
+              preserveAspectRatio="none"
+              class="bg-base-component-surface aspect-3/2 w-full rounded-sm"
+            >
+              <path
+                :d="histogramPath"
+                :class="histogramColorClass"
+                fill="currentColor"
+                fill-opacity="0.5"
+                stroke="none"
+              />
+            </svg>
+          </div>
+
+          <div
+            v-if="viewer.stats.value"
+            class="space-y-1 p-2 text-xs tabular-nums"
+          >
+            <div v-if="viewer.dimensions.value" class="flex justify-between">
+              <span>{{ $t('hdrViewer.resolution') }}</span>
+              <span>{{ viewer.dimensions.value }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span>{{ $t('hdrViewer.min') }}</span>
+              <span>{{ formatNum(viewer.stats.value.min) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span>{{ $t('hdrViewer.max') }}</span>
+              <span>{{ formatNum(viewer.stats.value.max) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span>{{ $t('hdrViewer.mean') }}</span>
+              <span>{{ formatNum(viewer.stats.value.mean) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span>{{ $t('hdrViewer.stdDev') }}</span>
+              <span>{{ formatNum(viewer.stats.value.stdDev) }}</span>
+            </div>
+            <div
+              v-if="viewer.stats.value.nanCount"
+              class="flex justify-between text-error"
+            >
+              <span>{{ $t('hdrViewer.nan') }}</span>
+              <span>{{ viewer.stats.value.nanCount }}</span>
+            </div>
+            <div
+              v-if="viewer.stats.value.infCount"
+              class="flex justify-between text-error"
+            >
+              <span>{{ $t('hdrViewer.inf') }}</span>
+              <span>{{ viewer.stats.value.infCount }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-4">
+        <div class="flex gap-2">
+          <Button variant="secondary" class="flex-1" @click="viewer.fitView">
+            {{ $t('hdrViewer.fitView') }}
+          </Button>
+          <Button variant="secondary" class="flex-1" @click="handleDownload">
+            {{ $t('g.downloadImage') }}
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { downloadFile } from '@/base/common/downloadUtil'
+import Button from '@/components/ui/button/Button.vue'
+import type { ChannelMode } from '@/composables/useHdrViewer'
+import { CHANNEL_MODES, useHdrViewer } from '@/composables/useHdrViewer'
+import { GAMUT_NAMES } from '@/renderer/hdr/colorGamut'
+import { toFullResolutionUrl } from '@/utils/hdrFormatUtil'
+import { histogramToPath } from '@/utils/histogramUtil'
+
+const { imageUrl } = defineProps<{ imageUrl: string }>()
+
+const { t } = useI18n()
+const viewer = useHdrViewer()
+const gamutNames = GAMUT_NAMES
+const channelModes = CHANNEL_MODES
+const containerRef = useTemplateRef<HTMLDivElement>('containerRef')
+
+const exposureLabel = computed(() => {
+  const value = viewer.exposureStops.value
+  return `${value > 0 ? '+' : ''}${value.toFixed(1)}`
+})
+
+const histogramPath = computed(() =>
+  viewer.histogram.value ? histogramToPath(viewer.histogram.value) : ''
+)
+
+const histogramColorClass = computed(() => {
+  switch (viewer.channel.value) {
+    case 'r':
+      return 'text-red-500'
+    case 'g':
+      return 'text-green-500'
+    case 'b':
+      return 'text-blue-500'
+    default:
+      return 'text-base-foreground'
+  }
+})
+
+const channelLabels = computed<Record<ChannelMode, string>>(() => ({
+  rgb: t('hdrViewer.channels.rgb'),
+  r: t('hdrViewer.channels.r'),
+  g: t('hdrViewer.channels.g'),
+  b: t('hdrViewer.channels.b'),
+  a: t('hdrViewer.channels.a'),
+  luminance: t('hdrViewer.channels.luminance')
+}))
+
+function formatNum(value: number): string {
+  if (!Number.isFinite(value)) return String(value)
+  return Math.abs(value) >= 1000 || (value !== 0 && Math.abs(value) < 0.001)
+    ? value.toExponential(3)
+    : value.toFixed(4)
+}
+
+function handleDownload() {
+  downloadFile(toFullResolutionUrl(imageUrl))
+}
+
+onMounted(() => {
+  if (containerRef.value) void viewer.mount(containerRef.value, imageUrl)
+})
+</script>

--- a/src/composables/useHdrViewer.ts
+++ b/src/composables/useHdrViewer.ts
@@ -1,4 +1,3 @@
-import { useResizeObserver } from '@vueuse/core'
 import * as THREE from 'three'
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
@@ -18,6 +17,7 @@ import {
   computeChannelHistograms,
   computeImageStats
 } from '@/renderer/hdr/hdrStats'
+import { WebGLViewport } from '@/renderer/three/WebGLViewport'
 import { getImageFilenameFromUrl } from '@/utils/hdrFormatUtil'
 
 const MIN_ZOOM = 0.05
@@ -126,6 +126,7 @@ export function useHdrViewer() {
   const containerRef = shallowRef<HTMLElement | null>(null)
 
   let renderer: THREE.WebGLRenderer | null = null
+  let viewport: WebGLViewport | null = null
   let scene: THREE.Scene | null = null
   let camera: THREE.OrthographicCamera | null = null
   let material: THREE.ShaderMaterial | null = null
@@ -204,6 +205,7 @@ export function useHdrViewer() {
 
   function buildScene() {
     renderer = new THREE.WebGLRenderer({ antialias: false, alpha: false })
+    viewport = new WebGLViewport(renderer)
     renderer.outputColorSpace = THREE.LinearSRGBColorSpace
     renderer.setPixelRatio(window.devicePixelRatio)
     renderer.setClearColor(0x0a0a0a, 1)
@@ -278,6 +280,7 @@ export function useHdrViewer() {
       resize()
       applyUniforms()
       attachInteractions(renderer!.domElement)
+      viewport!.observeResize(container, resize)
 
       const { texture: loaded, gamut: detectedGamut } =
         await loadHdrTexture(url)
@@ -400,18 +403,14 @@ export function useHdrViewer() {
       renderer.domElement.removeEventListener('pointerdown', onPointerDown)
       renderer.domElement.removeEventListener('pointermove', onHoverMove)
       renderer.domElement.removeEventListener('pointerleave', onHoverLeave)
-      renderer.forceContextLoss()
-      renderer.domElement.dispatchEvent(
-        new Event('webglcontextlost', { bubbles: true, cancelable: true })
-      )
-      renderer.dispose()
-      renderer.domElement.remove()
     }
+    viewport?.disposeRenderer()
     texture?.dispose()
     material?.dispose()
     mesh?.geometry.dispose()
 
     renderer = null
+    viewport = null
     scene = null
     camera = null
     material = null
@@ -419,8 +418,6 @@ export function useHdrViewer() {
     texture = null
     readSample = null
   }
-
-  useResizeObserver(containerRef, resize)
 
   watch([exposureStops, dither, clipWarnings, gamut, channel], applyUniforms)
 

--- a/src/composables/useHdrViewer.ts
+++ b/src/composables/useHdrViewer.ts
@@ -1,0 +1,446 @@
+import { useResizeObserver } from '@vueuse/core'
+import * as THREE from 'three'
+import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader'
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+import { computed, onUnmounted, ref, shallowRef, watch } from 'vue'
+
+import type { ChromaticityCoords, GamutName } from '@/renderer/hdr/colorGamut'
+import {
+  detectGamutFromChromaticities,
+  gamutToSrgbMatrix
+} from '@/renderer/hdr/colorGamut'
+import {
+  HDR_VIEWER_FRAGMENT_SHADER,
+  HDR_VIEWER_VERTEX_SHADER
+} from '@/renderer/hdr/hdrViewerShader'
+import type { ChannelHistograms, ImageStats } from '@/renderer/hdr/hdrStats'
+import {
+  computeChannelHistograms,
+  computeImageStats
+} from '@/renderer/hdr/hdrStats'
+import { getImageFilenameFromUrl } from '@/utils/hdrFormatUtil'
+
+const MIN_ZOOM = 0.05
+const MAX_ZOOM = 64
+
+export type ChannelMode = 'rgb' | 'r' | 'g' | 'b' | 'a' | 'luminance'
+
+export const CHANNEL_MODES: ChannelMode[] = [
+  'rgb',
+  'r',
+  'g',
+  'b',
+  'a',
+  'luminance'
+]
+
+const CHANNEL_INDEX: Record<ChannelMode, number> = {
+  rgb: 0,
+  r: 1,
+  g: 2,
+  b: 3,
+  a: 4,
+  luminance: 5
+}
+
+export interface PixelReadout {
+  x: number
+  y: number
+  r: number
+  g: number
+  b: number
+  a: number | null
+}
+
+interface ExrTexData {
+  header?: { chromaticities?: ChromaticityCoords }
+}
+
+function createLoader(url: string) {
+  const filename = getImageFilenameFromUrl(url)
+  if (filename?.toLowerCase().endsWith('.hdr')) return new RGBELoader()
+  const loader = new EXRLoader()
+  loader.setDataType(THREE.FloatType)
+  return loader
+}
+
+function makeReader(
+  data: ArrayLike<number>,
+  type: THREE.TextureDataType
+): (index: number) => number {
+  if (type === THREE.HalfFloatType) {
+    return (index) => THREE.DataUtils.fromHalfFloat(data[index])
+  }
+  return (index) => data[index]
+}
+
+function loadHdrTexture(
+  url: string
+): Promise<{ texture: THREE.DataTexture; gamut: GamutName }> {
+  return new Promise((resolve, reject) => {
+    createLoader(url).load(
+      url,
+      (texture, texData) => {
+        const chromaticities = (texData as ExrTexData)?.header?.chromaticities
+        resolve({
+          texture,
+          gamut: detectGamutFromChromaticities(chromaticities)
+        })
+      },
+      undefined,
+      reject
+    )
+  })
+}
+
+export function useHdrViewer() {
+  const exposureStops = ref(0)
+  const dither = ref(true)
+  const clipWarnings = ref(false)
+  const gamut = ref<GamutName>('sRGB')
+  const channel = ref<ChannelMode>('rgb')
+  const loading = ref(true)
+  const error = ref<string | null>(null)
+  const dimensions = ref<string | null>(null)
+  const stats = ref<ImageStats | null>(null)
+  const histograms = shallowRef<ChannelHistograms | null>(null)
+  const pixel = ref<PixelReadout | null>(null)
+
+  const histogram = computed<Uint32Array | null>(() => {
+    const channelHistograms = histograms.value
+    if (!channelHistograms) return null
+    switch (channel.value) {
+      case 'r':
+        return channelHistograms.r
+      case 'g':
+        return channelHistograms.g
+      case 'b':
+        return channelHistograms.b
+      case 'a':
+        return channelHistograms.a
+      default:
+        return channelHistograms.luminance
+    }
+  })
+
+  const containerRef = shallowRef<HTMLElement | null>(null)
+
+  let renderer: THREE.WebGLRenderer | null = null
+  let scene: THREE.Scene | null = null
+  let camera: THREE.OrthographicCamera | null = null
+  let material: THREE.ShaderMaterial | null = null
+  let mesh: THREE.Mesh | null = null
+  let texture: THREE.Texture | null = null
+  let imageAspect = 1
+  let frameRequested = false
+
+  let readSample: ((index: number) => number) | null = null
+  let imageWidth = 0
+  let imageHeight = 0
+  let imageChannels = 4
+
+  const raycaster = new THREE.Raycaster()
+  const pointerNdc = new THREE.Vector2()
+
+  function requestRender() {
+    if (!renderer || frameRequested) return
+    frameRequested = true
+    requestAnimationFrame(() => {
+      frameRequested = false
+      if (renderer && scene && camera) renderer.render(scene, camera)
+    })
+  }
+
+  function containerSize() {
+    const el = containerRef.value
+    return {
+      width: el?.clientWidth || 1,
+      height: el?.clientHeight || 1
+    }
+  }
+
+  function updateProjection() {
+    if (!camera) return
+    const { width, height } = containerSize()
+    const halfH = 0.5
+    const halfW = (0.5 * width) / height
+    camera.left = -halfW
+    camera.right = halfW
+    camera.top = halfH
+    camera.bottom = -halfH
+    camera.updateProjectionMatrix()
+  }
+
+  function fitView() {
+    if (!camera) return
+    const { width, height } = containerSize()
+    const containerAspect = width / height
+    camera.zoom = Math.min(1, containerAspect / imageAspect)
+    camera.position.set(0, 0, 1)
+    camera.updateProjectionMatrix()
+    requestRender()
+  }
+
+  function applyUniforms() {
+    if (!material) return
+    material.uniforms.uGain.value = Math.pow(2, exposureStops.value)
+    material.uniforms.uDither.value = dither.value
+    material.uniforms.uClipWarnings.value = clipWarnings.value
+    material.uniforms.uChannel.value = CHANNEL_INDEX[channel.value]
+    const m = gamutToSrgbMatrix(gamut.value)
+    ;(material.uniforms.uGamutToSRGB.value as THREE.Matrix3).set(
+      m[0],
+      m[1],
+      m[2],
+      m[3],
+      m[4],
+      m[5],
+      m[6],
+      m[7],
+      m[8]
+    )
+    requestRender()
+  }
+
+  function buildScene() {
+    renderer = new THREE.WebGLRenderer({ antialias: false, alpha: false })
+    renderer.outputColorSpace = THREE.LinearSRGBColorSpace
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.setClearColor(0x0a0a0a, 1)
+
+    scene = new THREE.Scene()
+    camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10)
+    camera.position.set(0, 0, 1)
+
+    material = new THREE.ShaderMaterial({
+      glslVersion: THREE.GLSL3,
+      vertexShader: HDR_VIEWER_VERTEX_SHADER,
+      fragmentShader: HDR_VIEWER_FRAGMENT_SHADER,
+      uniforms: {
+        uImage: { value: null },
+        uGamutToSRGB: { value: new THREE.Matrix3() },
+        uGain: { value: 1 },
+        uChannel: { value: 0 },
+        uDither: { value: true },
+        uClipWarnings: { value: false },
+        uClipRange: { value: new THREE.Vector2(0, 1) }
+      }
+    })
+
+    mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material)
+    scene.add(mesh)
+  }
+
+  function resize() {
+    if (!renderer) return
+    const { width, height } = containerSize()
+    renderer.setSize(width, height, false)
+    updateProjection()
+    requestRender()
+  }
+
+  function setTexture(loaded: THREE.DataTexture) {
+    if (!material || !mesh) return
+    loaded.colorSpace = THREE.LinearSRGBColorSpace
+    loaded.minFilter = THREE.LinearFilter
+    loaded.magFilter = THREE.LinearFilter
+    loaded.needsUpdate = true
+
+    const { width, height, data } = loaded.image
+    texture = loaded
+    imageAspect = width / height
+    mesh.scale.set(imageAspect, 1, 1)
+    material.uniforms.uImage.value = loaded
+    dimensions.value = `${width} x ${height}`
+
+    if (!data) return
+    imageWidth = width
+    imageHeight = height
+    imageChannels = data.length / (width * height)
+    readSample = makeReader(data, loaded.type)
+    stats.value = computeImageStats(readSample, data.length, imageChannels)
+    histograms.value = computeChannelHistograms(
+      readSample,
+      data.length,
+      imageChannels
+    )
+  }
+
+  async function mount(container: HTMLElement, url: string) {
+    containerRef.value = container
+    loading.value = true
+    error.value = null
+
+    try {
+      buildScene()
+      container.appendChild(renderer!.domElement)
+      renderer!.domElement.classList.add('block', 'size-full')
+      resize()
+      applyUniforms()
+      attachInteractions(renderer!.domElement)
+
+      const { texture: loaded, gamut: detectedGamut } =
+        await loadHdrTexture(url)
+      if (!material || !mesh) {
+        loaded.dispose()
+        return
+      }
+      gamut.value = detectedGamut
+      setTexture(loaded)
+      applyUniforms()
+      fitView()
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e)
+      dispose()
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function normalizeExposure() {
+    const max = stats.value?.max ?? 0
+    exposureStops.value = max > 0 ? -Math.log2(max) : 0
+  }
+
+  function attachInteractions(canvas: HTMLCanvasElement) {
+    canvas.addEventListener('wheel', onWheel, { passive: false })
+    canvas.addEventListener('pointerdown', onPointerDown)
+    canvas.addEventListener('pointermove', onHoverMove)
+    canvas.addEventListener('pointerleave', onHoverLeave)
+  }
+
+  function onWheel(event: WheelEvent) {
+    if (!camera) return
+    event.preventDefault()
+    const factor = Math.exp(-event.deltaY * 0.001)
+    const nextZoom = THREE.MathUtils.clamp(
+      camera.zoom * factor,
+      MIN_ZOOM,
+      MAX_ZOOM
+    )
+    camera.zoom = nextZoom
+    camera.updateProjectionMatrix()
+    requestRender()
+  }
+
+  let dragStart: { x: number; y: number; camX: number; camY: number } | null =
+    null
+
+  function onPointerDown(event: PointerEvent) {
+    if (!camera) return
+    dragStart = {
+      x: event.clientX,
+      y: event.clientY,
+      camX: camera.position.x,
+      camY: camera.position.y
+    }
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (!camera || !dragStart) return
+    const { height } = containerSize()
+    const worldPerPixel = 1 / (height * camera.zoom)
+    camera.position.x =
+      dragStart.camX - (event.clientX - dragStart.x) * worldPerPixel
+    camera.position.y =
+      dragStart.camY + (event.clientY - dragStart.y) * worldPerPixel
+    requestRender()
+  }
+
+  function onPointerUp() {
+    dragStart = null
+    window.removeEventListener('pointermove', onPointerMove)
+    window.removeEventListener('pointerup', onPointerUp)
+  }
+
+  function onHoverMove(event: PointerEvent) {
+    if (!camera || !mesh || !renderer || dragStart || !readSample) return
+    const rect = renderer.domElement.getBoundingClientRect()
+    pointerNdc.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+    pointerNdc.y = -(((event.clientY - rect.top) / rect.height) * 2 - 1)
+    raycaster.setFromCamera(pointerNdc, camera)
+    const hit = raycaster.intersectObject(mesh)[0]
+    if (!hit?.uv) {
+      pixel.value = null
+      return
+    }
+    const col = THREE.MathUtils.clamp(
+      Math.floor(hit.uv.x * imageWidth),
+      0,
+      imageWidth - 1
+    )
+    const row = THREE.MathUtils.clamp(
+      Math.floor(hit.uv.y * imageHeight),
+      0,
+      imageHeight - 1
+    )
+    const base = (row * imageWidth + col) * imageChannels
+    pixel.value = {
+      x: col,
+      y: imageHeight - 1 - row,
+      r: readSample(base),
+      g: readSample(base + 1),
+      b: readSample(base + 2),
+      a: imageChannels === 4 ? readSample(base + 3) : null
+    }
+  }
+
+  function onHoverLeave() {
+    pixel.value = null
+  }
+
+  function dispose() {
+    window.removeEventListener('pointermove', onPointerMove)
+    window.removeEventListener('pointerup', onPointerUp)
+
+    if (renderer) {
+      renderer.domElement.removeEventListener('wheel', onWheel)
+      renderer.domElement.removeEventListener('pointerdown', onPointerDown)
+      renderer.domElement.removeEventListener('pointermove', onHoverMove)
+      renderer.domElement.removeEventListener('pointerleave', onHoverLeave)
+      renderer.forceContextLoss()
+      renderer.domElement.dispatchEvent(
+        new Event('webglcontextlost', { bubbles: true, cancelable: true })
+      )
+      renderer.dispose()
+      renderer.domElement.remove()
+    }
+    texture?.dispose()
+    material?.dispose()
+    mesh?.geometry.dispose()
+
+    renderer = null
+    scene = null
+    camera = null
+    material = null
+    mesh = null
+    texture = null
+    readSample = null
+  }
+
+  useResizeObserver(containerRef, resize)
+
+  watch([exposureStops, dither, clipWarnings, gamut, channel], applyUniforms)
+
+  onUnmounted(dispose)
+
+  return {
+    exposureStops,
+    dither,
+    clipWarnings,
+    gamut,
+    channel,
+    loading,
+    error,
+    dimensions,
+    stats,
+    histogram,
+    pixel,
+    mount,
+    dispose,
+    fitView,
+    normalizeExposure
+  }
+}

--- a/src/extensions/core/load3d/Viewport3d.ts
+++ b/src/extensions/core/load3d/Viewport3d.ts
@@ -1,5 +1,7 @@
 import * as THREE from 'three'
 
+import { WebGLViewport } from '@/renderer/three/WebGLViewport'
+
 import type { CameraManager } from './CameraManager'
 import type { ControlsManager } from './ControlsManager'
 import type { EventManager } from './EventManager'
@@ -27,8 +29,7 @@ export type Viewport3dDeps = {
   viewHelperManager: ViewHelperManager
 }
 
-export class Viewport3d {
-  renderer: THREE.WebGLRenderer
+export class Viewport3d extends WebGLViewport {
   protected clock: THREE.Clock
   private renderLoop: RenderLoopHandle | null = null
   private onContextMenuCallback?: (event: MouseEvent) => void
@@ -52,7 +53,6 @@ export class Viewport3d {
   isViewerMode: boolean = false
 
   private disposeContextMenuGuard: (() => void) | null = null
-  private resizeObserver: ResizeObserver | null = null
   private getZoomScaleCallback: (() => number) | undefined
   private externalActiveCamera: THREE.Camera | null = null
   private overlay: SceneOverlay | null = null
@@ -63,6 +63,7 @@ export class Viewport3d {
     deps: Viewport3dDeps,
     options: Load3DOptions = {}
   ) {
+    super(deps.renderer)
     this.clock = new THREE.Clock()
     this.isViewerMode = options.isViewerMode || false
     this.onContextMenuCallback = options.onContextMenu
@@ -73,7 +74,6 @@ export class Viewport3d {
       this.applyTargetSize(options.width, options.height)
     }
 
-    this.renderer = deps.renderer
     this.eventManager = deps.eventManager
     this.sceneManager = deps.sceneManager
     this.cameraManager = deps.cameraManager
@@ -94,7 +94,7 @@ export class Viewport3d {
     this.STATUS_MOUSE_ON_VIEWER = false
 
     this.initContextMenu()
-    this.initResizeObserver(container)
+    this.observeResize(container, () => this.handleResize())
   }
 
   start(): void {
@@ -116,16 +116,6 @@ export class Viewport3d {
     this.targetWidth = width
     this.targetHeight = height
     this.targetAspectRatio = width / height
-  }
-
-  private initResizeObserver(container: Element | HTMLElement): void {
-    if (typeof ResizeObserver === 'undefined') return
-
-    this.resizeObserver?.disconnect()
-    this.resizeObserver = new ResizeObserver(() => {
-      this.handleResize()
-    })
-    this.resizeObserver.observe(container)
   }
 
   private initContextMenu(): void {
@@ -400,29 +390,15 @@ export class Viewport3d {
       this.initialRenderTimer = null
     }
 
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect()
-      this.resizeObserver = null
-    }
-
     this.disposeContextMenuGuard?.()
     this.disposeContextMenuGuard = null
-
-    this.renderer.forceContextLoss()
-    const canvas = this.renderer.domElement
-    const event = new Event('webglcontextlost', {
-      bubbles: true,
-      cancelable: true
-    })
-    canvas.dispatchEvent(event)
 
     this.renderLoop?.stop()
     this.renderLoop = null
 
     this.disposeManagers()
 
-    this.renderer.dispose()
-    this.renderer.domElement.remove()
+    this.disposeRenderer()
   }
 
   protected disposeManagers(): void {

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -387,6 +387,35 @@
     "collapseAll": "Collapse all",
     "expandAll": "Expand all"
   },
+  "hdrViewer": {
+    "title": "HDR Viewer",
+    "openInHdrViewer": "Open in HDR Viewer",
+    "hdrImage": "HDR image",
+    "failedToLoad": "Failed to load HDR image",
+    "exposure": "Exposure",
+    "normalizeExposure": "Auto exposure",
+    "channel": "Channel",
+    "channels": {
+      "rgb": "RGB",
+      "r": "R",
+      "g": "G",
+      "b": "B",
+      "a": "Alpha",
+      "luminance": "Luminance"
+    },
+    "sourceGamut": "Source gamut",
+    "dither": "Dither",
+    "clipWarnings": "Clip warnings",
+    "fitView": "Fit",
+    "histogram": "Histogram",
+    "resolution": "Resolution",
+    "min": "Min",
+    "max": "Max",
+    "mean": "Mean",
+    "stdDev": "Std dev",
+    "nan": "NaN",
+    "inf": "Inf"
+  },
   "manager": {
     "title": "Nodes Manager",
     "nodePackInfo": "Node Pack Info",

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -15,6 +15,10 @@ vi.mock('@/base/common/downloadUtil', () => ({
   downloadFile: vi.fn()
 }))
 
+vi.mock('@/services/hdrViewerService', () => ({
+  openHdrViewer: vi.fn()
+}))
+
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
@@ -36,6 +40,10 @@ const i18n = createI18n({
         loading: 'Loading',
         viewGrid: 'Grid view',
         galleryThumbnail: 'Gallery thumbnail'
+      },
+      hdrViewer: {
+        hdrImage: 'HDR image',
+        openInHdrViewer: 'Open in HDR Viewer'
       }
     }
   }
@@ -84,6 +92,15 @@ describe('ImagePreview', () => {
     const { container } = renderImagePreview({ imageUrls: [] })
 
     expect(container.querySelector('.image-preview')).not.toBeInTheDocument()
+  })
+
+  it('offers the HDR viewer instead of an <img> for exr outputs', () => {
+    renderImagePreview({
+      imageUrls: ['/api/view?filename=out.exr&type=output']
+    })
+
+    expect(screen.getByTestId('hdr-open-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('main-image')).not.toBeInTheDocument()
   })
 
   it('displays calculating dimensions text in gallery mode', async () => {

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -89,7 +89,6 @@
         >
           {{ $t('hdrViewer.openInHdrViewer') }}
         </span>
-        <span class="text-xs">{{ getImageFilename(currentImageUrl) }}</span>
       </button>
       <!-- Main Image -->
       <img

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -23,15 +23,23 @@
             total: imageUrls.length
           })
         "
-        @click="openImageInGallery(index)"
+        @click="handleGridClick(index)"
       >
         <img
+          v-if="!isHdrImageUrl(imageUrls[index])"
           :src="url"
           :alt="`${$t('g.galleryThumbnail')} ${index + 1}`"
           draggable="false"
           class="pointer-events-none size-full object-contain"
           @load="updateAspectRatio($event, index)"
         />
+        <div
+          v-else
+          class="flex size-full flex-col items-center justify-center gap-1 text-base-foreground"
+        >
+          <i class="icon-[lucide--sun] size-6" />
+          <span class="text-xs">{{ $t('hdrViewer.hdrImage') }}</span>
+        </div>
       </Button>
     </div>
 
@@ -61,12 +69,31 @@
         </p>
       </div>
       <!-- Loading State -->
-      <div v-if="showLoader && !imageError" class="size-full">
+      <div
+        v-if="showLoader && !imageError && !currentImageIsHdr"
+        class="size-full"
+      >
         <Skeleton class="size-full rounded-sm" />
       </div>
+      <button
+        v-if="!imageError && currentImageIsHdr"
+        type="button"
+        data-testid="hdr-open-button"
+        class="absolute inset-0 flex cursor-pointer flex-col items-center justify-center gap-3 border-0 bg-transparent text-base-foreground"
+        @click="openHdrViewer(currentImageUrl)"
+      >
+        <i class="icon-[lucide--sun] size-12" />
+        <span class="text-sm">{{ $t('hdrViewer.hdrImage') }}</span>
+        <span
+          class="rounded-md bg-base-foreground px-3 py-1.5 text-sm text-base-background"
+        >
+          {{ $t('hdrViewer.openInHdrViewer') }}
+        </span>
+        <span class="text-xs">{{ getImageFilename(currentImageUrl) }}</span>
+      </button>
       <!-- Main Image -->
       <img
-        v-if="!imageError"
+        v-if="!imageError && !currentImageIsHdr"
         data-testid="main-image"
         :src="currentImageUrl"
         :alt="imageAltText"
@@ -82,7 +109,7 @@
       >
         <!-- Mask/Edit Button -->
         <button
-          v-if="!hasMultipleImages && !imageError"
+          v-if="!hasMultipleImages && !imageError && !currentImageIsHdr"
           :class="actionButtonClass"
           :title="$t('g.editOrMaskImage')"
           :aria-label="$t('g.editOrMaskImage')"
@@ -117,7 +144,7 @@
 
     <!-- Image Dimensions (gallery mode only) -->
     <div
-      v-if="viewMode === 'gallery'"
+      v-if="viewMode === 'gallery' && !currentImageIsHdr"
       class="pt-2 text-center text-xs text-base-foreground"
     >
       <span
@@ -178,7 +205,9 @@ import Button from '@/components/ui/button/Button.vue'
 import Skeleton from '@/components/ui/skeleton/Skeleton.vue'
 import { useMaskEditor } from '@/composables/maskeditor/useMaskEditor'
 import { useToastStore } from '@/platform/updates/common/toastStore'
+import { openHdrViewer } from '@/services/hdrViewerService'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
+import { isHdrImageUrl } from '@/utils/hdrFormatUtil'
 import { getGridThumbnailUrl } from '@/utils/imageUtil'
 import { resolveNode } from '@/utils/litegraphUtil'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -228,6 +257,7 @@ const { start: startDelayedLoader, stop: stopDelayedLoader } = useTimeoutFn(
 )
 
 const currentImageUrl = computed(() => imageUrls[currentIndex.value] ?? '')
+const currentImageIsHdr = computed(() => isHdrImageUrl(currentImageUrl.value))
 const gridImageUrls = computed(() => imageUrls.map(getGridThumbnailUrl))
 const hasMultipleImages = computed(() => imageUrls.length > 1)
 const imageAltText = computed(() =>
@@ -331,6 +361,15 @@ async function openImageInGallery(index: number) {
   viewMode.value = 'gallery'
   await nextTick()
   galleryPanelEl.value?.focus()
+}
+
+function handleGridClick(index: number) {
+  const url = imageUrls[index]
+  if (isHdrImageUrl(url)) {
+    openHdrViewer(url)
+    return
+  }
+  void openImageInGallery(index)
 }
 
 function getNavigationDotClass(index: number) {

--- a/src/renderer/hdr/colorGamut.test.ts
+++ b/src/renderer/hdr/colorGamut.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GAMUT_NAMES,
+  detectGamutFromChromaticities,
+  gamutToSrgbMatrix
+} from './colorGamut'
+
+const IDENTITY = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+
+describe('gamutToSrgbMatrix', () => {
+  it('returns identity for sRGB source', () => {
+    expect(gamutToSrgbMatrix('sRGB')).toEqual(IDENTITY)
+  })
+
+  it('matches the published linear Rec.2020 to sRGB matrix', () => {
+    const expected = [
+      1.6605, -0.5876, -0.0728, -0.1246, 1.1329, -0.0083, -0.0182, -0.1006,
+      1.1187
+    ]
+    const actual = gamutToSrgbMatrix('Rec.2020')
+    for (let i = 0; i < 9; i++) {
+      expect(actual[i]).toBeCloseTo(expected[i], 3)
+    }
+  })
+
+  it('maps the Rec.2020 white point to equal-energy sRGB (rows sum to ~1)', () => {
+    const m = gamutToSrgbMatrix('Rec.2020')
+    for (let row = 0; row < 3; row++) {
+      const sum = m[row * 3] + m[row * 3 + 1] + m[row * 3 + 2]
+      expect(sum).toBeCloseTo(1, 3)
+    }
+  })
+
+  it('exposes the supported gamut names', () => {
+    expect(GAMUT_NAMES).toContain('sRGB')
+    expect(GAMUT_NAMES).toContain('Rec.2020')
+  })
+})
+
+describe('detectGamutFromChromaticities', () => {
+  it('falls back to sRGB when the attribute is absent', () => {
+    expect(detectGamutFromChromaticities(undefined)).toBe('sRGB')
+  })
+
+  it('detects Rec.2020 primaries from the EXR header', () => {
+    expect(
+      detectGamutFromChromaticities({
+        redX: 0.708,
+        redY: 0.292,
+        greenX: 0.17,
+        greenY: 0.797,
+        blueX: 0.131,
+        blueY: 0.046,
+        whiteX: 0.3127,
+        whiteY: 0.329
+      })
+    ).toBe('Rec.2020')
+  })
+
+  it('does not match Rec.2020 when the white point differs', () => {
+    expect(
+      detectGamutFromChromaticities({
+        redX: 0.708,
+        redY: 0.292,
+        greenX: 0.17,
+        greenY: 0.797,
+        blueX: 0.131,
+        blueY: 0.046,
+        whiteX: 0.314,
+        whiteY: 0.351
+      })
+    ).toBe('sRGB')
+  })
+
+  it('detects Rec.709/sRGB primaries from the EXR header', () => {
+    expect(
+      detectGamutFromChromaticities({
+        redX: 0.64,
+        redY: 0.33,
+        greenX: 0.3,
+        greenY: 0.6,
+        blueX: 0.15,
+        blueY: 0.06,
+        whiteX: 0.3127,
+        whiteY: 0.329
+      })
+    ).toBe('sRGB')
+  })
+})

--- a/src/renderer/hdr/colorGamut.ts
+++ b/src/renderer/hdr/colorGamut.ts
@@ -1,0 +1,144 @@
+interface Chromaticities {
+  red: readonly [number, number]
+  green: readonly [number, number]
+  blue: readonly [number, number]
+  white: readonly [number, number]
+}
+
+const D65: readonly [number, number] = [0.3127, 0.329]
+
+const CHROMATICITIES = {
+  sRGB: {
+    red: [0.64, 0.33],
+    green: [0.3, 0.6],
+    blue: [0.15, 0.06],
+    white: D65
+  },
+  'Rec.2020': {
+    red: [0.708, 0.292],
+    green: [0.17, 0.797],
+    blue: [0.131, 0.046],
+    white: D65
+  }
+} satisfies Record<string, Chromaticities>
+
+export type GamutName = keyof typeof CHROMATICITIES
+
+export const GAMUT_NAMES = Object.keys(CHROMATICITIES) as GamutName[]
+
+type Mat3 = readonly number[]
+
+const IDENTITY: Mat3 = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+
+function rgbToXyz(c: Chromaticities): Mat3 {
+  const [rx, ry] = c.red
+  const [gx, gy] = c.green
+  const [bx, by] = c.blue
+  const [wx, wy] = c.white
+
+  const xWhite = wx / wy
+  const zWhite = (1 - wx - wy) / wy
+
+  const d = rx * (by - gy) + bx * (gy - ry) + gx * (ry - by)
+
+  const srN =
+    xWhite * (by - gy) -
+    gx * (by - 1 + by * (xWhite + zWhite)) +
+    bx * (gy - 1 + gy * (xWhite + zWhite))
+  const sgN =
+    xWhite * (ry - by) +
+    rx * (by - 1 + by * (xWhite + zWhite)) -
+    bx * (ry - 1 + ry * (xWhite + zWhite))
+  const sbN =
+    xWhite * (gy - ry) -
+    rx * (gy - 1 + gy * (xWhite + zWhite)) +
+    gx * (ry - 1 + ry * (xWhite + zWhite))
+
+  const sr = srN / d
+  const sg = sgN / d
+  const sb = sbN / d
+
+  return [
+    sr * rx,
+    sg * gx,
+    sb * bx,
+    sr * ry,
+    sg * gy,
+    sb * by,
+    sr * (1 - rx - ry),
+    sg * (1 - gx - gy),
+    sb * (1 - bx - by)
+  ]
+}
+
+function multiply(a: Mat3, b: Mat3): Mat3 {
+  const result = new Array<number>(9).fill(0)
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 3; col++) {
+      let sum = 0
+      for (let k = 0; k < 3; k++) sum += a[row * 3 + k] * b[k * 3 + col]
+      result[row * 3 + col] = sum
+    }
+  }
+  return result
+}
+
+function invert(m: Mat3): Mat3 {
+  const [a, b, c, d, e, f, g, h, i] = m
+  const det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+  if (det === 0) return IDENTITY
+
+  const invDet = 1 / det
+  return [
+    (e * i - f * h) * invDet,
+    (c * h - b * i) * invDet,
+    (b * f - c * e) * invDet,
+    (f * g - d * i) * invDet,
+    (a * i - c * g) * invDet,
+    (c * d - a * f) * invDet,
+    (d * h - e * g) * invDet,
+    (b * g - a * h) * invDet,
+    (a * e - b * d) * invDet
+  ]
+}
+
+const SRGB_TO_XYZ = rgbToXyz(CHROMATICITIES.sRGB)
+const XYZ_TO_SRGB = invert(SRGB_TO_XYZ)
+
+export function gamutToSrgbMatrix(gamut: GamutName): Mat3 {
+  if (gamut === 'sRGB') return IDENTITY
+  return multiply(XYZ_TO_SRGB, rgbToXyz(CHROMATICITIES[gamut]))
+}
+
+export interface ChromaticityCoords {
+  redX: number
+  redY: number
+  greenX: number
+  greenY: number
+  blueX: number
+  blueY: number
+  whiteX: number
+  whiteY: number
+}
+
+function matchesGamut(c: ChromaticityCoords, gamut: GamutName): boolean {
+  const ref = CHROMATICITIES[gamut]
+  const tol = 0.01
+  return (
+    Math.abs(c.redX - ref.red[0]) < tol &&
+    Math.abs(c.redY - ref.red[1]) < tol &&
+    Math.abs(c.greenX - ref.green[0]) < tol &&
+    Math.abs(c.greenY - ref.green[1]) < tol &&
+    Math.abs(c.blueX - ref.blue[0]) < tol &&
+    Math.abs(c.blueY - ref.blue[1]) < tol &&
+    Math.abs(c.whiteX - ref.white[0]) < tol &&
+    Math.abs(c.whiteY - ref.white[1]) < tol
+  )
+}
+
+export function detectGamutFromChromaticities(
+  c: ChromaticityCoords | undefined
+): GamutName {
+  if (!c) return 'sRGB'
+  return GAMUT_NAMES.find((name) => matchesGamut(c, name)) ?? 'sRGB'
+}

--- a/src/renderer/hdr/hdrStats.test.ts
+++ b/src/renderer/hdr/hdrStats.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeChannelHistograms, computeImageStats } from './hdrStats'
+
+function reader(values: number[]) {
+  return (i: number) => values[i]
+}
+
+describe('computeImageStats', () => {
+  it('computes min/max/mean over RGB, skipping alpha', () => {
+    const data = [0, 0.5, 1, 1, 0.2, 0.4, 0.6, 1]
+    const stats = computeImageStats(reader(data), data.length, 4)
+    expect(stats.min).toBe(0)
+    expect(stats.max).toBe(1)
+    expect(stats.mean).toBeCloseTo((0 + 0.5 + 1 + 0.2 + 0.4 + 0.6) / 6, 6)
+  })
+
+  it('counts NaN and Inf and excludes them from min/max/mean', () => {
+    const data = [0.5, NaN, Infinity, -Infinity, 0.25]
+    const stats = computeImageStats(reader(data), data.length, 3)
+    expect(stats.nanCount).toBe(1)
+    expect(stats.infCount).toBe(2)
+    expect(stats.min).toBe(0.25)
+    expect(stats.max).toBe(0.5)
+    expect(stats.mean).toBeCloseTo(0.375, 6)
+  })
+
+  it('counts NaN/Inf in alpha but keeps alpha out of min/max/mean', () => {
+    const data = [0.1, 0.2, 0.3, NaN, 0.4, 0.5, 0.6, Infinity]
+    const stats = computeImageStats(reader(data), data.length, 4)
+    expect(stats.nanCount).toBe(1)
+    expect(stats.infCount).toBe(1)
+    expect(stats.min).toBe(0.1)
+    expect(stats.max).toBe(0.6)
+    expect(stats.mean).toBeCloseTo((0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 0.6) / 6, 6)
+  })
+
+  it('reports HDR values above one', () => {
+    const data = [2, 4, 8]
+    const stats = computeImageStats(reader(data), data.length, 3)
+    expect(stats.max).toBe(8)
+    expect(stats.mean).toBeCloseTo(14 / 3, 6)
+  })
+
+  it('returns zeros when there are no finite samples', () => {
+    const data = [NaN, Infinity]
+    const stats = computeImageStats(reader(data), data.length, 3)
+    expect(stats).toEqual({
+      min: 0,
+      max: 0,
+      mean: 0,
+      stdDev: 0,
+      nanCount: 1,
+      infCount: 1
+    })
+  })
+})
+
+describe('computeChannelHistograms', () => {
+  it('bins each channel independently', () => {
+    const data = [0, 0.5, 1, 0.5, 0.5, 0.5]
+    const hist = computeChannelHistograms(reader(data), data.length, 3, 4)
+    expect(hist.r[0]).toBe(1)
+    expect(hist.r[2]).toBe(1)
+    expect(hist.g[2]).toBe(2)
+    expect(hist.b[3]).toBe(1)
+    expect(hist.a).toBeNull()
+  })
+
+  it('builds an alpha histogram for RGBA data', () => {
+    const data = [0, 0, 0, 1, 1, 1, 1, 0]
+    const hist = computeChannelHistograms(reader(data), data.length, 4, 4)
+    expect(hist.a).not.toBeNull()
+    expect(hist.a![3]).toBe(1)
+    expect(hist.a![0]).toBe(1)
+  })
+
+  it('clamps HDR values above one into the last bin', () => {
+    const data = [8, 8, 8]
+    const hist = computeChannelHistograms(reader(data), data.length, 3, 4)
+    expect(hist.luminance[3]).toBe(1)
+    expect(hist.r[3]).toBe(1)
+  })
+
+  it('skips NaN samples per channel', () => {
+    const data = [NaN, 0.5, 0.5]
+    const hist = computeChannelHistograms(reader(data), data.length, 3, 4)
+    expect(hist.r.reduce((a, b) => a + b, 0)).toBe(0)
+    expect(hist.g.reduce((a, b) => a + b, 0)).toBe(1)
+  })
+})

--- a/src/renderer/hdr/hdrStats.ts
+++ b/src/renderer/hdr/hdrStats.ts
@@ -1,0 +1,92 @@
+export interface ImageStats {
+  min: number
+  max: number
+  mean: number
+  stdDev: number
+  nanCount: number
+  infCount: number
+}
+
+export function computeImageStats(
+  read: (index: number) => number,
+  length: number,
+  channels: number
+): ImageStats {
+  let min = Infinity
+  let max = -Infinity
+  let sum = 0
+  let sumSq = 0
+  let count = 0
+  let nanCount = 0
+  let infCount = 0
+
+  for (let i = 0; i < length; i++) {
+    const value = read(i)
+    if (Number.isNaN(value)) {
+      nanCount++
+      continue
+    }
+    if (!Number.isFinite(value)) {
+      infCount++
+      continue
+    }
+    if (channels === 4 && i % channels === 3) continue
+    if (value < min) min = value
+    if (value > max) max = value
+    sum += value
+    sumSq += value * value
+    count++
+  }
+
+  if (count === 0) {
+    return { min: 0, max: 0, mean: 0, stdDev: 0, nanCount, infCount }
+  }
+
+  const mean = sum / count
+  const variance = Math.max(0, sumSq / count - mean * mean)
+  return { min, max, mean, stdDev: Math.sqrt(variance), nanCount, infCount }
+}
+
+export interface ChannelHistograms {
+  r: Uint32Array
+  g: Uint32Array
+  b: Uint32Array
+  a: Uint32Array | null
+  luminance: Uint32Array
+}
+
+export function computeChannelHistograms(
+  read: (index: number) => number,
+  length: number,
+  channels: number,
+  bins = 256
+): ChannelHistograms {
+  const last = bins - 1
+  const r = new Uint32Array(bins)
+  const g = new Uint32Array(bins)
+  const b = new Uint32Array(bins)
+  const luminance = new Uint32Array(bins)
+  const a = channels === 4 ? new Uint32Array(bins) : null
+
+  const accumulate = (target: Uint32Array, value: number) => {
+    if (Number.isNaN(value)) return
+    const bin = Math.floor(Math.max(0, value) * bins)
+    target[bin > last ? last : bin]++
+  }
+
+  for (let i = 0; i + channels - 1 < length; i += channels) {
+    const rv = read(i)
+    const gv = channels >= 3 ? read(i + 1) : rv
+    const bv = channels >= 3 ? read(i + 2) : rv
+    accumulate(r, rv)
+    accumulate(g, gv)
+    accumulate(b, bv)
+    if (a) accumulate(a, read(i + 3))
+    accumulate(
+      luminance,
+      channels >= 3 ? 0.2126 * rv + 0.7152 * gv + 0.0722 * bv : rv
+    )
+  }
+
+  return { r, g, b, a, luminance }
+}

--- a/src/renderer/hdr/hdrViewerShader.ts
+++ b/src/renderer/hdr/hdrViewerShader.ts
@@ -1,0 +1,79 @@
+export const HDR_VIEWER_VERTEX_SHADER = `
+out vec2 vUv;
+
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`
+
+export const HDR_VIEWER_FRAGMENT_SHADER = `
+in vec2 vUv;
+out vec4 frag_color;
+
+uniform sampler2D uImage;
+uniform mat3 uGamutToSRGB;
+uniform float uGain;
+uniform int uChannel;
+uniform bool uDither;
+uniform bool uClipWarnings;
+uniform vec2 uClipRange;
+
+float linearToS(float a) {
+  float s = sign(a);
+  a = abs(a);
+  return s * (a < 0.0031308 ? 12.92 * a : 1.055 * pow(a, 1.0 / 2.4) - 0.055);
+}
+
+vec3 linearToSRGB(vec3 c) {
+  return vec3(linearToS(c.r), linearToS(c.g), linearToS(c.b));
+}
+
+float ign(vec2 p) {
+  return fract(52.9829189 * fract(0.06711056 * p.x + 0.00583715 * p.y));
+}
+
+float tent(float r) {
+  float rp = sqrt(2.0 * r);
+  float rn = sqrt(2.0 * r + 1.0) - 1.0;
+  return (r < 0.0) ? 0.5 * rn : 0.5 * rp;
+}
+
+void main() {
+  vec4 texel = texture(uImage, vUv);
+  vec3 mapped = uGamutToSRGB * texel.rgb;
+
+  vec3 selected;
+  if (uChannel == 1) selected = vec3(mapped.r);
+  else if (uChannel == 2) selected = vec3(mapped.g);
+  else if (uChannel == 3) selected = vec3(mapped.b);
+  else if (uChannel == 4) selected = vec3(texel.a);
+  else if (uChannel == 5)
+    selected = vec3(dot(mapped, vec3(0.2126, 0.7152, 0.0722)));
+  else selected = mapped;
+
+  vec3 exposed = selected * uGain;
+
+  vec3 display = linearToSRGB(exposed);
+
+  if (uDither) {
+    float r = ign(gl_FragCoord.xy) - 0.5;
+    display += vec3(tent(r) / 255.0);
+  }
+
+  display = clamp(display, 0.0, 1.0);
+
+  if (uClipWarnings) {
+    float zebra1 =
+      mod(floor((gl_FragCoord.x + gl_FragCoord.y) / 8.0), 2.0) == 0.0 ? 0.0 : 1.0;
+    float zebra2 =
+      mod(floor((gl_FragCoord.x - gl_FragCoord.y) / 8.0), 2.0) == 0.0 ? 0.0 : 1.0;
+    bvec3 over = greaterThan(exposed, vec3(uClipRange.y));
+    bvec3 under = lessThan(exposed, vec3(uClipRange.x));
+    display = mix(display, vec3(zebra1), vec3(over));
+    display = mix(display, vec3(zebra2), vec3(under));
+  }
+
+  frag_color = vec4(display, 1.0);
+}
+`

--- a/src/renderer/three/WebGLViewport.test.ts
+++ b/src/renderer/three/WebGLViewport.test.ts
@@ -1,0 +1,52 @@
+import type * as THREE from 'three'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { WebGLViewport } from './WebGLViewport'
+
+function fakeRenderer() {
+  const domElement = document.createElement('canvas')
+  return {
+    forceContextLoss: vi.fn(),
+    dispose: vi.fn(),
+    domElement
+  } as unknown as THREE.WebGLRenderer
+}
+
+describe('WebGLViewport', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('releases the context via forceContextLoss before disposing', () => {
+    const renderer = fakeRenderer()
+    const dispatchSpy = vi.spyOn(renderer.domElement, 'dispatchEvent')
+    const removeSpy = vi.spyOn(renderer.domElement, 'remove')
+
+    new WebGLViewport(renderer).disposeRenderer()
+
+    expect(renderer.forceContextLoss).toHaveBeenCalledOnce()
+    expect(renderer.dispose).toHaveBeenCalledOnce()
+    expect(removeSpy).toHaveBeenCalledOnce()
+    expect(dispatchSpy.mock.calls[0][0].type).toBe('webglcontextlost')
+  })
+
+  it('observes the resize target and disconnects on dispose', () => {
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = observe
+        disconnect = disconnect
+        unobserve = vi.fn()
+      }
+    )
+    const target = document.createElement('div')
+    const onResize = vi.fn()
+    const viewport = new WebGLViewport(fakeRenderer())
+
+    viewport.observeResize(target, onResize)
+    expect(observe).toHaveBeenCalledWith(target)
+
+    viewport.disposeRenderer()
+    expect(disconnect).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/three/WebGLViewport.ts
+++ b/src/renderer/three/WebGLViewport.ts
@@ -1,0 +1,29 @@
+import type * as THREE from 'three'
+
+export class WebGLViewport {
+  renderer: THREE.WebGLRenderer
+  private resizeObserver: ResizeObserver | null = null
+
+  constructor(renderer: THREE.WebGLRenderer) {
+    this.renderer = renderer
+  }
+
+  observeResize(target: Element, onResize: () => void): void {
+    if (typeof ResizeObserver === 'undefined') return
+    this.resizeObserver?.disconnect()
+    this.resizeObserver = new ResizeObserver(() => onResize())
+    this.resizeObserver.observe(target)
+  }
+
+  disposeRenderer(): void {
+    this.resizeObserver?.disconnect()
+    this.resizeObserver = null
+
+    this.renderer.forceContextLoss()
+    this.renderer.domElement.dispatchEvent(
+      new Event('webglcontextlost', { bubbles: true, cancelable: true })
+    )
+    this.renderer.dispose()
+    this.renderer.domElement.remove()
+  }
+}

--- a/src/services/hdrViewerService.test.ts
+++ b/src/services/hdrViewerService.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { showDialog } = vi.hoisted(() => ({ showDialog: vi.fn() }))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ showDialog })
+}))
+vi.mock('@/i18n', () => ({ t: (key: string) => key }))
+
+import { openHdrViewer } from './hdrViewerService'
+
+describe('openHdrViewer', () => {
+  it('opens a full-screen dialog with the full-resolution url and filename title', () => {
+    openHdrViewer('/api/view?filename=out.exr&preview=webp;75&rand=1')
+
+    expect(showDialog).toHaveBeenCalledOnce()
+    const options = showDialog.mock.calls[0][0]
+    expect(options.key).toBe('hdr-viewer')
+    expect(options.title).toBe('out.exr')
+    expect(options.props.imageUrl).toBe('/api/view?filename=out.exr&rand=1')
+    expect(options.dialogComponentProps.size).toBe('full')
+  })
+})

--- a/src/services/hdrViewerService.ts
+++ b/src/services/hdrViewerService.ts
@@ -1,0 +1,28 @@
+import { defineAsyncComponent } from 'vue'
+
+import { t } from '@/i18n'
+import { useDialogStore } from '@/stores/dialogStore'
+import {
+  getImageFilenameFromUrl,
+  toFullResolutionUrl
+} from '@/utils/hdrFormatUtil'
+
+const HdrViewerContent = defineAsyncComponent(
+  () => import('@/components/hdr/HdrViewerContent.vue')
+)
+
+export function openHdrViewer(url: string) {
+  const fullResUrl = toFullResolutionUrl(url)
+  useDialogStore().showDialog({
+    key: 'hdr-viewer',
+    title: getImageFilenameFromUrl(fullResUrl) ?? t('hdrViewer.title'),
+    component: HdrViewerContent,
+    props: { imageUrl: fullResUrl },
+    dialogComponentProps: {
+      renderer: 'reka',
+      size: 'full',
+      contentClass: 'w-[80vw] h-[80vh] max-h-[80vh]',
+      maximizable: true
+    }
+  })
+}

--- a/src/utils/hdrFormatUtil.test.ts
+++ b/src/utils/hdrFormatUtil.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getImageFilenameFromUrl,
+  isHdrImageFilename,
+  isHdrImageUrl,
+  toFullResolutionUrl
+} from './hdrFormatUtil'
+
+describe('isHdrImageFilename', () => {
+  it('detects exr and hdr regardless of case', () => {
+    expect(isHdrImageFilename('render.exr')).toBe(true)
+    expect(isHdrImageFilename('RENDER.EXR')).toBe(true)
+    expect(isHdrImageFilename('env.hdr')).toBe(true)
+  })
+
+  it('rejects non-hdr formats and empty input', () => {
+    expect(isHdrImageFilename('image.png')).toBe(false)
+    expect(isHdrImageFilename('image.webp')).toBe(false)
+    expect(isHdrImageFilename(undefined)).toBe(false)
+    expect(isHdrImageFilename('')).toBe(false)
+  })
+})
+
+describe('getImageFilenameFromUrl', () => {
+  it('reads the filename query parameter from a view url', () => {
+    expect(
+      getImageFilenameFromUrl('/api/view?filename=out.exr&type=output')
+    ).toBe('out.exr')
+  })
+
+  it('falls back to the last path segment', () => {
+    expect(getImageFilenameFromUrl('https://x.test/files/out.hdr')).toBe(
+      'out.hdr'
+    )
+  })
+})
+
+describe('isHdrImageUrl', () => {
+  it('detects hdr outputs from view urls', () => {
+    expect(isHdrImageUrl('/api/view?filename=scene.exr&type=output')).toBe(true)
+    expect(isHdrImageUrl('/api/view?filename=scene.png&type=output')).toBe(
+      false
+    )
+  })
+})
+
+describe('toFullResolutionUrl', () => {
+  it('strips the preview parameter', () => {
+    expect(
+      toFullResolutionUrl('/api/view?filename=out.exr&preview=webp;75&rand=1')
+    ).toBe('/api/view?filename=out.exr&rand=1')
+  })
+
+  it('leaves urls without a preview parameter untouched', () => {
+    expect(toFullResolutionUrl('/api/view?filename=out.exr')).toBe(
+      '/api/view?filename=out.exr'
+    )
+  })
+})

--- a/src/utils/hdrFormatUtil.test.ts
+++ b/src/utils/hdrFormatUtil.test.ts
@@ -34,6 +34,16 @@ describe('getImageFilenameFromUrl', () => {
       'out.hdr'
     )
   })
+
+  it('returns undefined for empty input', () => {
+    expect(getImageFilenameFromUrl('')).toBeUndefined()
+  })
+})
+
+describe('isHdrImageUrl edge cases', () => {
+  it('returns false for undefined', () => {
+    expect(isHdrImageUrl(undefined)).toBe(false)
+  })
 })
 
 describe('isHdrImageUrl', () => {
@@ -56,5 +66,11 @@ describe('toFullResolutionUrl', () => {
     expect(toFullResolutionUrl('/api/view?filename=out.exr')).toBe(
       '/api/view?filename=out.exr'
     )
+  })
+
+  it('preserves absolute http urls while stripping preview', () => {
+    expect(
+      toFullResolutionUrl('https://x.test/api/view?filename=out.exr&preview=w')
+    ).toBe('https://x.test/api/view?filename=out.exr')
   })
 })

--- a/src/utils/hdrFormatUtil.ts
+++ b/src/utils/hdrFormatUtil.ts
@@ -1,0 +1,38 @@
+const HDR_EXTENSIONS = ['.exr', '.hdr'] as const
+
+export function isHdrImageFilename(filename: string | undefined): boolean {
+  if (!filename) return false
+  const lower = filename.toLowerCase()
+  return HDR_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function getImageFilenameFromUrl(url: string): string | undefined {
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url, window.location.origin)
+    return (
+      parsed.searchParams.get('filename') ??
+      parsed.pathname.split('/').pop() ??
+      undefined
+    )
+  } catch {
+    return url.split('/').pop()
+  }
+}
+
+export function isHdrImageUrl(url: string | undefined): boolean {
+  if (!url) return false
+  return isHdrImageFilename(getImageFilenameFromUrl(url))
+}
+
+export function toFullResolutionUrl(url: string): string {
+  try {
+    const parsed = new URL(url, window.location.origin)
+    parsed.searchParams.delete('preview')
+    return url.startsWith('http')
+      ? parsed.toString()
+      : `${parsed.pathname}${parsed.search}`
+  } catch {
+    return url
+  }
+}


### PR DESCRIPTION
## Summary
Browsers cannot render EXR/HDR in <img>, so these outputs showed as broken images. Add a full-screen three.js viewer holding a single WebGL context created on open and released on close, opened via an 'Open in HDR Viewer' action on EXR/HDR outputs in ImagePreview. The layout mirrors the 3D viewer: canvas on the left, grouped controls in a right-hand sidebar.

The display pipeline (gamut -> exposure -> linear-to-sRGB -> dither -> clamp, plus clip warnings) is adapted from [HDRView](https://github.com/wkjarosz/hdrview). Source gamut is auto-detected from the EXR chromaticities attribute (Rec.709/Rec.2020) with a manual override.

Inspection tools operate on the EXR float data kept on the CPU by EXRLoader:
- pixel inspector: hover to read raw RGBA values and coordinates
- statistics: min/max/mean/std-dev plus NaN and Inf counts
- auto-exposure: set exposure so the max value maps to 1
- channel isolation: view R/G/B/A or luminance individually

## Screenshots (if applicable)


https://github.com/user-attachments/assets/22b80718-4b15-41ee-86b5-8fe38a6a82e2

