### PR TITLE
fix(billing): widen user popover so the credits row keeps both buttons inside

### DIFF
--- a/browser_tests/tests/currentUserPopoverCredits.spec.ts
+++ b/browser_tests/tests/currentUserPopoverCredits.spec.ts
@@ -1,0 +1,138 @@
+import { expect } from '@playwright/test'
+
+import type { CloudSubscriptionStatusResponse } from '@/platform/cloud/subscription/composables/useSubscription'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type { WorkspaceWithRole } from '@/platform/workspace/api/workspaceApi'
+import type { WorkspaceTokenResponse } from '@/platform/workspace/stores/workspaceAuthStore'
+import type { operations } from '@/types/comfyRegistryTypes'
+import { comfyPageFixture } from '@e2e/fixtures/ComfyPage'
+
+type CustomerBalanceResponse = NonNullable<
+  operations['GetCustomerBalance']['responses']['200']['content']['application/json']
+>
+
+const PERSONAL_WORKSPACE_NAME = 'Personal Workspace'
+const FUTURE_DATE = '2099-01-01T00:00:00Z'
+
+const mockRemoteConfig: RemoteConfig = { team_workspaces_enabled: true }
+
+const mockListWorkspacesResponse: { workspaces: WorkspaceWithRole[] } = {
+  workspaces: [
+    {
+      id: 'ws-personal',
+      name: PERSONAL_WORKSPACE_NAME,
+      type: 'personal',
+      created_at: '2026-01-01T00:00:00Z',
+      joined_at: '2026-01-01T00:00:00Z',
+      role: 'owner'
+    }
+  ]
+}
+
+const mockTokenResponse: WorkspaceTokenResponse = {
+  token: 'mock-workspace-token',
+  expires_at: FUTURE_DATE,
+  workspace: {
+    id: 'ws-personal',
+    name: PERSONAL_WORKSPACE_NAME,
+    type: 'personal'
+  },
+  role: 'owner',
+  permissions: []
+}
+
+// Cancelled but still active: `end_date` set (cancelled) while `is_active` is
+// true. A personal owner in this state sees BOTH "Add credits" and "Resubscribe"
+// in the credits row.
+const mockSubscriptionStatus: CloudSubscriptionStatusResponse = {
+  is_active: true,
+  subscription_id: 'sub_e2e',
+  renewal_date: FUTURE_DATE,
+  end_date: FUTURE_DATE
+}
+
+// ~6.3M credits — a 7-digit balance is what pushes the second action button out
+// of the popover before the fix.
+const mockBalance: CustomerBalanceResponse = {
+  amount_micros: 3_000_000,
+  effective_balance_micros: 3_000_000,
+  currency: 'usd'
+}
+
+const test = comfyPageFixture.extend({
+  page: async ({ page }, use) => {
+    await page.route('**/api/features', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockRemoteConfig)
+      })
+    )
+
+    await page.route('**/api/workspaces', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.fallback()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockListWorkspacesResponse)
+      })
+    })
+
+    await page.route('**/api/auth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockTokenResponse)
+      })
+    )
+
+    await page.route('**/customers/cloud-subscription-status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockSubscriptionStatus)
+      })
+    )
+
+    await page.route('**/customers/balance', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockBalance)
+      })
+    )
+
+    await use(page)
+  }
+})
+
+test.describe('Current user popover credits row', { tag: '@cloud' }, () => {
+  test('keeps both action buttons inside the popover when cancelled but active', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+
+    await comfyPage.toast.closeToasts()
+    await page.getByRole('button', { name: 'Current user' }).click()
+
+    const popover = page.locator('.current-user-popover')
+    await expect(popover).toBeVisible()
+
+    const addCredits = page.getByTestId('add-credits-button')
+    const resubscribe = page.getByRole('button', { name: 'Resubscribe' })
+    await expect(addCredits).toBeVisible()
+    await expect(resubscribe).toBeVisible()
+
+    const popoverBox = await popover.boundingBox()
+    const resubscribeBox = await resubscribe.boundingBox()
+    expect(popoverBox).not.toBeNull()
+    expect(resubscribeBox).not.toBeNull()
+
+    const popoverRight = popoverBox!.x + popoverBox!.width
+    const resubscribeRight = resubscribeBox!.x + resubscribeBox!.width
+    expect(resubscribeRight).toBeLessThanOrEqual(popoverRight)
+  })
+})

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -1,7 +1,7 @@
 <!-- A popover that shows current user information and actions -->
 <template>
   <div
-    class="current-user-popover -m-3 w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+    class="current-user-popover -m-3 w-fit min-w-80 max-w-96 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
   >
     <!-- User Info Section -->
     <div class="mb-4 flex flex-col items-center px-0 py-3">

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -1,7 +1,7 @@
 <!-- A popover that shows current user information and actions -->
 <template>
   <div
-    class="current-user-popover -m-3 w-fit min-w-80 max-w-96 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+    class="current-user-popover -m-3 w-fit max-w-96 min-w-80 rounded-lg border border-border-default bg-base-background p-2 shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
   >
     <!-- User Info Section -->
     <div class="mb-4 flex flex-col items-center px-0 py-3">


### PR DESCRIPTION
## Issue

In the top-right user popover, a **cancelled-but-still-active** personal subscription renders **both** "Add credits" and "Resubscribe" in the credits row (the user can still top up *and* re-subscribe during the grace period). With a wide (7-digit) credit balance, balance + help icon + both buttons exceeded the fixed `w-80` (320px) popover and the trailing "Resubscribe" button spilled past the right edge.

Surfaced during FE-991 (Billing Rework V1) testing. Pre-existing on `main` — reproducible for any personal owner whose subscription is cancelled but not yet expired.

## Fix

Make the popover width **fluid** instead of fixed: `w-fit` clamped to `min-w-80 max-w-96`. It stays **320px** in the common single-action case (unchanged) and only grows — to **~370px** — when the credits row actually needs the room for a second button.

## Before / After

**Before (`w-80`)** — "Resubscribe" clipped past the popover edge:

<img width="320" alt="before" src="https://github.com/user-attachments/assets/439baae8-9e04-4cdf-b43f-098fb5e3853f" />

**After — single action (stays 320px):**

<img width="320" alt="after-single" src="https://github.com/user-attachments/assets/e96f784e-6afd-4286-80c3-1cf0ecec7aa8" />

**After — both actions (grows to ~370px, fits):**

<img width="370" alt="after-both" src="https://github.com/user-attachments/assets/578c1528-24ad-4717-a2b5-33e1af78f048" />

## Test

Adds a `@cloud` e2e that opens the popover in the cancelled-but-active state (mocked `/customers/cloud-subscription-status` with `end_date` + a 7-digit balance) and asserts the "Resubscribe" button's right edge stays within the popover bounds — same bounding-box pattern as `workspaceSwitcher.spec.ts`. Validated red→green locally (fails on fixed `w-80`, passes with the fluid width); single-action width measured at 320px, both-action at ~370px.
