### PR TITLE
fix: prefer text/uri-list resource over dataTransfer.files in extractFilesFromDragEvent

### DIFF
--- a/src/utils/__tests__/eventUtils.test.ts
+++ b/src/utils/__tests__/eventUtils.test.ts
@@ -159,6 +159,59 @@ describe('eventUtils', () => {
 
       expect(actual).toEqual([])
     })
+
+    it('should prefer the URI resource over a dataTransfer file when both are present', async () => {
+      // Regression test: dragging an in-page <img> (e.g. from the asset
+      // gallery) can make the browser synthesize a lossy re-encoded file
+      // into dataTransfer.files alongside the genuine resource URL. The URL
+      // must win so the original file (with its metadata intact) is used.
+      const uri =
+        'https://example.com/api/view?filename=original.png&type=output'
+      const originalBlob = new Blob(
+        [new Uint8Array([0x89, 0x50, 0x4e, 0x47])],
+        {
+          type: 'image/png'
+        }
+      )
+      fetchSpy.mockResolvedValue(new Response(originalBlob))
+
+      const synthesizedFile = new File(
+        [new Uint8Array([0xff, 0xd8])],
+        'original.png',
+        { type: 'image/jpeg' }
+      )
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(synthesizedFile)
+      dataTransfer.setData('text/uri-list', uri)
+
+      const actual = await extractFilesFromDragEvent(
+        new FakeDragEvent('drop', { dataTransfer })
+      )
+
+      expect(fetchSpy).toHaveBeenCalledOnce()
+      expect(actual).toHaveLength(1)
+      expect(actual[0].type).toBe('image/png')
+      expect(actual[0]).not.toBe(synthesizedFile)
+    })
+
+    it('should fall back to dataTransfer files when the URI fetch responds with a non-ok status', async () => {
+      const uri =
+        'https://example.com/api/view?filename=missing.png&type=output'
+      fetchSpy.mockResolvedValue(new Response(null, { status: 404 }))
+
+      const fallbackFile = new File([new Uint8Array()], 'fallback.json', {
+        type: 'application/json'
+      })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(fallbackFile)
+      dataTransfer.setData('text/uri-list', uri)
+
+      const actual = await extractFilesFromDragEvent(
+        new FakeDragEvent('drop', { dataTransfer })
+      )
+
+      expect(actual).toEqual([fallbackFile])
+    })
   })
 })
 

--- a/src/utils/__tests__/eventUtils.test.ts
+++ b/src/utils/__tests__/eventUtils.test.ts
@@ -191,6 +191,7 @@ describe('eventUtils', () => {
       expect(fetchSpy).toHaveBeenCalledOnce()
       expect(actual).toHaveLength(1)
       expect(actual[0].type).toBe('image/png')
+      expect(actual[0].name).toBe('original.png')
       expect(actual[0]).not.toBe(synthesizedFile)
     })
 
@@ -210,6 +211,79 @@ describe('eventUtils', () => {
         new FakeDragEvent('drop', { dataTransfer })
       )
 
+      expect(actual).toEqual([fallbackFile])
+    })
+
+    it('should extract the filename from the URI query parameter', async () => {
+      const uri =
+        'https://example.com/api/view?filename=original.png&type=output'
+      const imageBlob = new Blob([new Uint8Array([0x89, 0x50])], {
+        type: 'image/png'
+      })
+      fetchSpy.mockResolvedValue(new Response(imageBlob))
+
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData('text/uri-list', uri)
+
+      const actual = await extractFilesFromDragEvent(
+        new FakeDragEvent('drop', { dataTransfer })
+      )
+
+      expect(actual[0].name).toBe('original.png')
+    })
+
+    it('should fall back to the last path segment when the URI has no filename query parameter', async () => {
+      const uri = 'https://example.com/static/some-resource.png'
+      const imageBlob = new Blob([new Uint8Array([0x89, 0x50])], {
+        type: 'image/png'
+      })
+      fetchSpy.mockResolvedValue(new Response(imageBlob))
+
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData('text/uri-list', uri)
+
+      const actual = await extractFilesFromDragEvent(
+        new FakeDragEvent('drop', { dataTransfer })
+      )
+
+      expect(actual[0].name).toBe('some-resource.png')
+    })
+
+    it('should skip leading comment lines in a text/uri-list payload', async () => {
+      // Regression test: per RFC 2483, text/uri-list may contain comment
+      // lines starting with '#'. Naively taking the first line would treat
+      // the comment as the URI, which (resolving as a same-page fragment)
+      // can fetch successfully and wrongly shadow real dragged files.
+      const uri = 'https://example.com/api/view?filename=real.png&type=output'
+      const imageBlob = new Blob([new Uint8Array([0x89, 0x50])], {
+        type: 'image/png'
+      })
+      fetchSpy.mockResolvedValue(new Response(imageBlob))
+
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData('text/uri-list', `# a comment line\n${uri}`)
+
+      const actual = await extractFilesFromDragEvent(
+        new FakeDragEvent('drop', { dataTransfer })
+      )
+
+      expect(fetchSpy).toHaveBeenCalledWith(uri)
+      expect(actual).toHaveLength(1)
+    })
+
+    it('should fall back to dataTransfer files when text/uri-list contains only a comment', async () => {
+      const fallbackFile = new File([new Uint8Array()], 'fallback.json', {
+        type: 'application/json'
+      })
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(fallbackFile)
+      dataTransfer.setData('text/uri-list', '#just-a-comment')
+
+      const actual = await extractFilesFromDragEvent(
+        new FakeDragEvent('drop', { dataTransfer })
+      )
+
+      expect(fetchSpy).not.toHaveBeenCalled()
       expect(actual).toEqual([fallbackFile])
     })
   })

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -1,3 +1,21 @@
+/**
+ * Best-effort filename extraction from a dragged resource URL. Prefers
+ * ComfyUI's own `?filename=` query convention (used by /api/view and /view),
+ * falling back to the last path segment for other URLs.
+ */
+function extractFilenameFromUri(uri: string): string {
+  try {
+    const url = new URL(uri)
+    const queryFilename = url.searchParams.get('filename')
+    if (queryFilename) return queryFilename
+
+    const lastSegment = url.pathname.split('/').filter(Boolean).pop()
+    return lastSegment || 'file'
+  } catch {
+    return uri.split('/').pop() || 'file'
+  }
+}
+
 export async function extractFilesFromDragEvent(
   event: DragEvent
 ): Promise<File[]> {
@@ -14,13 +32,23 @@ export async function extractFilesFromDragEvent(
     validTypes.includes(t)
   )
   if (match) {
-    const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
+    // text/uri-list (RFC 2483) may contain multiple lines, where lines
+    // starting with '#' are comments and must be skipped - otherwise a
+    // leading comment line (e.g. one starting with '#') would resolve as a
+    // same-page fragment URL and be fetched instead of the real URI.
+    const uri = event.dataTransfer
+      .getData(match)
+      ?.split('\n')
+      .map((line) => line.trim())
+      .find((line) => line && !line.startsWith('#'))
     if (uri) {
       try {
         const response = await fetch(uri)
         if (response.ok) {
           const blob = await response.blob()
-          return [new File([blob], uri, { type: blob.type })]
+          return [
+            new File([blob], extractFilenameFromUri(uri), { type: blob.type })
+          ]
         }
       } catch {
         // Fall through to dataTransfer.files below

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -3,30 +3,37 @@ export async function extractFilesFromDragEvent(
 ): Promise<File[]> {
   if (!event.dataTransfer) return []
 
-  // Dragging from Chrome->Firefox there is a file but its a bmp, so ignore that
-  const files = Array.from(event.dataTransfer.files).filter(
-    (file) => file.type !== 'image/bmp'
-  )
-
-  if (files.length > 0) return files
-
-  // Try loading the first URI in the transfer list
+  // Prefer a same-page resource URL when one is present. Browsers can
+  // synthesize a lossy, re-encoded copy of an in-page <img> element (with no
+  // original metadata, and not necessarily a stable/filterable MIME type)
+  // into dataTransfer.files when dragging directly from e.g. the asset
+  // gallery, even though the genuine resource URL is also available via
+  // text/uri-list. Fetching that URL gets the real file.
   const validTypes = ['text/uri-list', 'text/x-moz-url']
   const match = [...event.dataTransfer.types].find((t) =>
     validTypes.includes(t)
   )
-  if (!match) return []
-
-  const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
-  if (!uri) return []
-
-  try {
-    const response = await fetch(uri)
-    const blob = await response.blob()
-    return [new File([blob], uri, { type: blob.type })]
-  } catch {
-    return []
+  if (match) {
+    const uri = event.dataTransfer.getData(match)?.split('\n')?.[0]
+    if (uri) {
+      try {
+        const response = await fetch(uri)
+        if (response.ok) {
+          const blob = await response.blob()
+          return [new File([blob], uri, { type: blob.type })]
+        }
+      } catch {
+        // Fall through to dataTransfer.files below
+      }
+    }
   }
+
+  // Genuine OS-level file drags don't populate a URI list at all, so this is
+  // also the fallback used when there's no URL, or fetching it failed.
+  // Dragging from Chrome->Firefox there is a file but its a bmp, so ignore that
+  return Array.from(event.dataTransfer.files).filter(
+    (file) => file.type !== 'image/bmp'
+  )
 }
 
 export function hasImageType({ type }: File): boolean {


### PR DESCRIPTION
## Summary
Fixes #13055.

Dragging an image directly from the Assets panel (an in-page `<img>`) onto the graph can restore the wrong, lossy image instead of the original — losing all embedded workflow/prompt metadata — even though the genuine file is correctly served and the original drag source has access to it.

Browsers can synthesize a re-encoded copy of the decoded `<img>` bitmap into `dataTransfer.files` when dragging an in-page image element, rather than handing over the original resource. The existing code only filtered out `image/bmp` synthesized files (added for a documented Chrome→Firefox case), so other synthesized formats (observed: a small re-encoded JPEG with no metadata) were accepted as-is — even though the genuine resource URL was simultaneously available via `text/uri-list`.

## Change
Reverses the priority in `extractFilesFromDragEvent`: try the `text/uri-list`/`text/x-moz-url` resource first when present (fetching the real file from its URL), and only fall back to `dataTransfer.files` if there's no URL, or fetching it fails/responds non-ok. Genuine OS-level file drags never populate a URI list, so that path is unaffected.

## Test plan
- [x] Added a regression test: `dataTransfer` contains both a synthesized non-bmp file and a valid `text/uri-list` — asserts the URL-fetched file (with correct type/content) is returned, not the synthesized one.
- [x] Added a test for falling back to `dataTransfer.files` when the URI fetch responds non-ok (e.g. 404).
- [x] All existing tests in `eventUtils.test.ts` pass unmodified (none previously exercised both a file and a URI simultaneously, so this is purely additive in coverage).
- [x] `vitest run src/utils/__tests__/eventUtils.test.ts` — 12/12 passing
- [x] `eslint` on changed files — clean
- [x] `vue-tsc --noEmit` (full project) — clean
- [x] Manually verified against a local instance: dragging an Assets-panel thumbnail with embedded workflow metadata now restores the full workflow instead of falling back to a `LoadImage` node, while plain OS file-explorer drag-and-drop (already working) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)