### PR TITLE
chore: shrink-wrap asset browser dialog chrome

### DIFF
--- a/src/platform/assets/composables/useAssetBrowserDialog.ts
+++ b/src/platform/assets/composables/useAssetBrowserDialog.ts
@@ -1,6 +1,7 @@
 import AssetBrowserModal from '@/platform/assets/components/AssetBrowserModal.vue'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import { useDialogService } from '@/services/dialogService'
+import type { DialogComponentProps } from '@/stores/dialogStore'
 import { useDialogStore } from '@/stores/dialogStore'
 
 interface ShowOptions {
@@ -23,6 +24,10 @@ interface BrowseOptions {
 }
 
 const DIALOG_KEY = 'global-asset-browser'
+const ASSET_BROWSER_DIALOG_PROPS = {
+  contentClass:
+    'w-fit max-w-[calc(100vw-1rem)] sm:max-w-[calc(100vw-1rem)] border-none bg-transparent shadow-none'
+} satisfies DialogComponentProps
 
 export const useAssetBrowserDialog = () => {
   const dialogService = useDialogService()
@@ -47,7 +52,8 @@ export const useAssetBrowserDialog = () => {
         currentValue: props.currentValue,
         onSelect: handleAssetSelected,
         onClose: hide
-      }
+      },
+      dialogComponentProps: ASSET_BROWSER_DIALOG_PROPS
     })
   }
 
@@ -66,7 +72,8 @@ export const useAssetBrowserDialog = () => {
         title: options.title,
         onSelect: handleAssetSelected,
         onClose: hide
-      }
+      },
+      dialogComponentProps: ASSET_BROWSER_DIALOG_PROPS
     })
   }
 


### PR DESCRIPTION
## Summary

- Shrink-wraps the asset browser dialog chrome around its self-sized BaseModalLayout content.
- Applies the same Reka dialog props to model-widget selection and direct asset browsing entry points.

## Cause

The Reka dialog cutover moved showLayoutDialog callers onto the shared Reka DialogContent wrapper. AssetBrowserModal already renders a large BaseModalLayout with its own modal sizing, but the outer wrapper still used the default md dialog width. That left the large modal content anchored from a narrow centered wrapper, pushing the right edge beyond the viewport.

This change keeps BaseModalLayout as the owner of the asset browser dimensions. The Reka wrapper now only shrink-wraps the content and removes its own border, background, and shadow.

## Validation

- pnpm exec oxfmt --write src/platform/assets/composables/useAssetBrowserDialog.ts
- pnpm exec eslint src/platform/assets/composables/useAssetBrowserDialog.ts
- pnpm typecheck
- pre-commit hook completed oxfmt, oxlint, eslint, and typecheck

## Screenshot
Before 
<img width="1920" height="1028" alt="스크린샷 2026-06-22 오후 9 30 15" src="https://github.com/user-attachments/assets/1534a0a8-a239-419e-b05f-9c5e43cedeb1" />

After
<img width="1918" height="1024" alt="스크린샷 2026-06-22 오후 9 29 39" src="https://github.com/user-attachments/assets/14ad751e-54c9-4f9e-87f5-805f6ca456d1" />
