### PR TITLE
feat: Add server-side model downloads + HuggingFace OAuth UI (POC)

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -8,6 +8,7 @@
     "noWorkflowsFound": "No workflows found.",
     "comingSoon": "Coming Soon",
     "download": "Download",
+    "downloaded": "Downloaded",
     "downloadImage": "Download image",
     "downloadVideo": "Download video",
     "downloadAudio": "Download audio",
@@ -1943,6 +1944,17 @@
     "customModelsInstruction": "You'll need to find and download them manually. Search for them online (try Civitai or HuggingFace) or contact the original workflow provider.",
     "acceptTerms": "Accept terms"
   },
+  "hfAuthSettings": {
+    "title": "HuggingFace",
+    "description": "Sign in with HuggingFace to let ComfyUI download gated model files (license-protected weights) on your behalf.",
+    "loggedIn": "Logged in",
+    "notLoggedIn": "Not logged in",
+    "logIn": "Log in with HuggingFace",
+    "logOut": "Log out",
+    "loginFailed": "Login failed.",
+    "logoutFailed": "Logout failed.",
+    "tokenStorageNote": "Tokens are stored locally and never leave this machine. Logging out removes the cached token from disk."
+  },
   "versionMismatchWarning": {
     "title": "Version Compatibility Warning",
     "frontendOutdated": "Frontend version {frontendVersion} is outdated. Backend requires version {requiredVersion} or higher.",
@@ -3776,9 +3788,18 @@
       "unknownCategory": "Unknown",
       "missingModelsTitle": "Missing Models",
       "downloadAll": "Download all",
+      "downloadAllAvailable": "Download All Available",
       "refresh": "Refresh",
       "refreshing": "Refreshing missing models.",
-      "refreshFailed": "Failed to refresh missing models. Please try again."
+      "refreshFailed": "Failed to refresh missing models. Please try again.",
+      "hfLoginRequired": "HuggingFace login required",
+      "hfLoginPrompt": "Some required models are gated. Sign in to let ComfyUI download them on your behalf.",
+      "logInWithHf": "Log in with HuggingFace",
+      "repositoryPage": "repository page",
+      "gatedManual": "This model is gated. Open the {repositoryPage} to accept the license, then place the file in {modelPath} manually.",
+      "gatedNeedLogin": "Gated — log in with HuggingFace above to enable the download.",
+      "gatedAccept": "Gated — visit the {repositoryPage} to accept the license, then come back to download.",
+      "cancelFailed": "Failed to cancel the download. Please try again."
     },
     "missingMedia": {
       "missingMediaTitle": "Missing Inputs"

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="px-3">
+  <!-- Server-side download flow when the server advertises support -->
+  <MissingModelCardServerSide
+    v-if="useServerSideFlow"
+    :missing-model-groups="missingModelGroups"
+  />
+  <div v-else class="px-3">
     <div
       v-if="importableModelRows.length > 0"
       data-testid="missing-model-importable-rows"
@@ -65,6 +70,8 @@ import { useI18n } from 'vue-i18n'
 import type { MissingModelGroup } from '@/platform/missingModel/types'
 import { isCloud } from '@/platform/distribution/types'
 import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.vue'
+import MissingModelCardServerSide from '@/platform/missingModel/serverDownloads/MissingModelCardServerSide.vue'
+import { isServerSideDownloadsAvailable } from '@/platform/missingModel/serverDownloads/useServerSideDownloads'
 import Button from '@/components/ui/button/Button.vue'
 import { downloadModel } from '@/platform/missingModel/missingModelDownload'
 import { getDownloadableModels } from '@/platform/missingModel/missingModelViewUtils'
@@ -116,6 +123,10 @@ const importableModelRows = computed(() =>
 
 const unsupportedModelRows = computed(() =>
   isCloud ? sortedModelRows.value.filter((row) => !canCloudImport(row)) : []
+)
+
+const useServerSideFlow = computed(
+  () => !isCloud && isServerSideDownloadsAvailable()
 )
 
 const downloadableModels = computed(() => {

--- a/src/platform/missingModel/serverDownloads/HfAuthSettingsPanel.vue
+++ b/src/platform/missingModel/serverDownloads/HfAuthSettingsPanel.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="flex flex-col gap-4 p-4">
+    <div>
+      <h2 class="text-base font-semibold">{{ t('hfAuthSettings.title') }}</h2>
+      <p class="mt-1 text-sm text-muted-foreground">
+        {{ t('hfAuthSettings.description') }}
+      </p>
+    </div>
+
+    <div
+      class="flex flex-col gap-2 rounded-lg border border-interface-stroke p-3"
+    >
+      <div class="flex items-center gap-2">
+        <i
+          aria-hidden="true"
+          :class="
+            status.token_available
+              ? 'icon-[lucide--check-circle-2] size-4 shrink-0 text-success-background'
+              : 'icon-[lucide--circle] size-4 shrink-0 text-muted-foreground'
+          "
+        />
+        <span class="text-sm font-medium">
+          {{
+            status.token_available
+              ? t('hfAuthSettings.loggedIn')
+              : t('hfAuthSettings.notLoggedIn')
+          }}
+        </span>
+        <span
+          v-if="status.token_available && status.username"
+          class="text-xs text-muted-foreground"
+        >
+          ({{ status.username }})
+        </span>
+      </div>
+
+      <div class="flex gap-2 pt-1">
+        <Button
+          v-if="!status.token_available"
+          variant="primary"
+          size="sm"
+          :disabled="busy"
+          @click="onLogin"
+        >
+          <i aria-hidden="true" class="icon-[lucide--log-in] size-4 shrink-0" />
+          {{ t('hfAuthSettings.logIn') }}
+        </Button>
+        <Button
+          v-else
+          variant="secondary"
+          size="sm"
+          :disabled="busy"
+          @click="onLogout"
+        >
+          <i
+            aria-hidden="true"
+            class="icon-[lucide--log-out] size-4 shrink-0"
+          />
+          {{ t('hfAuthSettings.logOut') }}
+        </Button>
+      </div>
+
+      <p v-if="errorMessage" class="text-xs text-destructive-background-hover">
+        {{ errorMessage }}
+      </p>
+    </div>
+
+    <p class="text-xs text-muted-foreground">
+      {{ t('hfAuthSettings.tokenStorageNote') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import {
+  fetchHfAuthTokenStatus,
+  logoutHfAuth,
+  startHfAuthLogin
+} from '@/platform/missingModel/serverDownloads/serverDownloadsApi'
+import type { HfAuthTokenStatusResponse } from '@/platform/missingModel/serverDownloads/serverDownloadsApi'
+
+const { t } = useI18n()
+
+const status = ref<HfAuthTokenStatusResponse>({
+  token_available: false,
+  username: null
+})
+const busy = ref(false)
+const errorMessage = ref<string | null>(null)
+
+// Re-poll after login so the panel reflects the new state. We don't
+// know exactly when the user finishes the OAuth tab so we poll a few
+// times after starting; once the token shows up, we stop.
+let shouldPoll = false
+// Bound the post-login poll so an abandoned/failed login can't poll forever.
+const MAX_POLL_ATTEMPTS = 150 // ~2.5 min at 1s
+const POLL_INTERVAL_MS = 1000
+
+function stopPolling() {
+  shouldPoll = false
+}
+
+async function refresh() {
+  try {
+    status.value = await fetchHfAuthTokenStatus()
+  } catch (err) {
+    console.warn('[HfAuthSettings] status fetch failed:', err)
+  }
+}
+
+// Recursive timeout (not setInterval) so the next poll is only scheduled
+// after the previous refresh resolves — never overlapping requests. The
+// `shouldPoll` flag prevents concurrent loops and lets stopPolling() halt the
+// chain; any already-scheduled tick no-ops on the guard.
+async function pollForToken(attempts = 0) {
+  if (!shouldPoll) return
+  await refresh()
+  if (!shouldPoll) return
+  if (status.value.token_available || attempts + 1 >= MAX_POLL_ATTEMPTS) {
+    stopPolling()
+    return
+  }
+  setTimeout(() => void pollForToken(attempts + 1), POLL_INTERVAL_MS)
+}
+
+onMounted(() => {
+  void refresh()
+})
+
+// Never leave polling running once this panel is gone.
+onUnmounted(stopPolling)
+
+async function onLogin() {
+  errorMessage.value = null
+  busy.value = true
+  try {
+    const { authorize_url } = await startHfAuthLogin()
+    window.open(authorize_url, '_blank', 'noopener,noreferrer')
+    if (!shouldPoll) {
+      shouldPoll = true
+      void pollForToken()
+    }
+  } catch (err) {
+    errorMessage.value =
+      err instanceof Error ? err.message : t('hfAuthSettings.loginFailed')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onLogout() {
+  errorMessage.value = null
+  busy.value = true
+  try {
+    await logoutHfAuth()
+    await refresh()
+  } catch (err) {
+    errorMessage.value =
+      err instanceof Error ? err.message : t('hfAuthSettings.logoutFailed')
+  } finally {
+    busy.value = false
+  }
+}
+</script>

--- a/src/platform/missingModel/serverDownloads/MissingModelCardServerSide.vue
+++ b/src/platform/missingModel/serverDownloads/MissingModelCardServerSide.vue
@@ -1,0 +1,417 @@
+<template>
+  <div class="px-4 pb-2" data-testid="missing-model-card-server-side">
+    <!-- HF login banner: shown when there's at least one gated row and
+         the deployment is eligible but not yet logged in. -->
+    <div
+      v-if="showLoginBanner"
+      data-testid="missing-model-hf-login-banner"
+      class="my-2 flex items-start gap-2 rounded-lg border border-primary-background/40 bg-primary-background/10 p-3"
+    >
+      <div class="flex size-5 shrink-0 items-center justify-center">
+        <i
+          aria-hidden="true"
+          class="icon-[lucide--log-in] size-5 text-primary-background"
+        />
+      </div>
+      <div class="flex min-w-0 flex-1 flex-col gap-2">
+        <div class="flex flex-col gap-0.5">
+          <p class="text-foreground text-sm font-semibold">
+            {{ t('rightSidePanel.missingModels.hfLoginRequired') }}
+          </p>
+          <p class="text-xs/tight text-muted-foreground">
+            {{ t('rightSidePanel.missingModels.hfLoginPrompt') }}
+          </p>
+        </div>
+        <Button
+          data-testid="missing-model-hf-login"
+          variant="primary"
+          size="sm"
+          class="self-start rounded-lg text-sm"
+          @click="handleLogin"
+        >
+          <i aria-hidden="true" class="icon-[lucide--log-in] size-4 shrink-0" />
+          {{ t('rightSidePanel.missingModels.logInWithHf') }}
+        </Button>
+      </div>
+    </div>
+
+    <div
+      v-if="hasAnyDownloadableMissing"
+      data-testid="missing-model-actions"
+      class="flex items-center gap-2 border-b border-interface-stroke py-2"
+    >
+      <Button
+        data-testid="missing-model-download-all"
+        variant="secondary"
+        size="sm"
+        class="h-8 min-w-0 flex-1 rounded-lg text-sm"
+        @click="handleDownloadAll"
+      >
+        <i aria-hidden="true" class="icon-[lucide--download] size-4 shrink-0" />
+        <span class="truncate">{{ downloadAllLabel }}</span>
+      </Button>
+    </div>
+
+    <div
+      v-for="{ group, rows } in groupViews"
+      :key="`server-side::${group.directory ?? '__unknown__'}`"
+      class="flex w-full flex-col border-t border-interface-stroke py-2 first:border-t-0 first:pt-0"
+    >
+      <div class="flex h-8 w-full items-center">
+        <p
+          class="min-w-0 flex-1 truncate text-sm font-medium text-destructive-background-hover"
+        >
+          {{
+            group.directory ?? t('rightSidePanel.missingModels.unknownCategory')
+          }}
+          ({{ group.models.length }})
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-1 overflow-hidden pl-2">
+        <div
+          v-for="row in rows"
+          :key="row.model.name"
+          class="flex w-full flex-col py-1"
+        >
+          <div class="flex h-8 w-full items-center gap-2">
+            <i
+              aria-hidden="true"
+              class="text-foreground icon-[lucide--file-check] size-4 shrink-0"
+            />
+            <p
+              class="text-foreground min-w-0 flex-1 truncate text-sm font-medium"
+              :title="row.model.name"
+            >
+              {{ row.model.name }}
+            </p>
+          </div>
+
+          <p v-if="row.id === null" class="px-1 text-xs text-muted-foreground">
+            {{ t('rightSidePanel.missingModels.unknownCategory') }}
+          </p>
+
+          <p
+            v-else-if="row.status === 'gated'"
+            class="flex items-start gap-1.5 p-1 text-xs text-warning-background"
+            data-testid="missing-model-gated-notice"
+          >
+            <i
+              aria-hidden="true"
+              class="mt-0.5 icon-[lucide--lock] size-3.5 shrink-0"
+            />
+            <!-- Three sub-states, by (eligible, logged-in):
+                 - not eligible: manual-download instructions (legacy text)
+                 - eligible, not logged in: pointer to the login banner above
+                 - eligible, logged in: accept-license-and-come-back -->
+            <i18n-t
+              v-if="gatedMode === 'manual'"
+              keypath="rightSidePanel.missingModels.gatedManual"
+              tag="span"
+            >
+              <template #repositoryPage>
+                <a
+                  :href="row.browseUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="underline"
+                >
+                  {{ t('rightSidePanel.missingModels.repositoryPage') }}
+                </a>
+              </template>
+              <template #modelPath>
+                <code class="font-mono">models/{{ group.directory }}/</code>
+              </template>
+            </i18n-t>
+            <span v-else-if="gatedMode === 'need-login'">
+              {{ t('rightSidePanel.missingModels.gatedNeedLogin') }}
+            </span>
+            <i18n-t
+              v-else
+              keypath="rightSidePanel.missingModels.gatedAccept"
+              tag="span"
+            >
+              <template #repositoryPage>
+                <a
+                  :href="row.browseUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="underline"
+                >
+                  {{ t('rightSidePanel.missingModels.repositoryPage') }}
+                </a>
+              </template>
+            </i18n-t>
+          </p>
+
+          <div
+            v-else-if="row.status === 'downloading'"
+            class="flex items-center gap-2 py-1"
+            data-testid="missing-model-downloading"
+          >
+            <div
+              class="h-2 flex-1 overflow-hidden rounded-full bg-secondary-background"
+            >
+              <div
+                class="h-full bg-primary transition-all"
+                :style="{
+                  width: `${Math.round((row.progress ?? 0) * 100)}%`
+                }"
+              />
+            </div>
+            <span class="w-16 text-right text-xs text-muted-foreground">
+              {{ row.progressLabel }}
+            </span>
+            <Button
+              data-testid="missing-model-cancel"
+              variant="textonly"
+              size="icon-sm"
+              class="size-7 shrink-0"
+              :aria-label="t('g.cancel')"
+              @click="handleCancel(row)"
+            >
+              <i
+                aria-hidden="true"
+                class="icon-[lucide--x] size-4 text-muted-foreground"
+              />
+            </Button>
+          </div>
+
+          <p
+            v-else-if="row.status === 'available'"
+            class="flex items-center gap-1.5 p-1 text-xs text-success-background"
+          >
+            <i
+              aria-hidden="true"
+              class="icon-[lucide--check] size-3.5 shrink-0"
+            />
+            <span>{{ t('g.downloaded') }}</span>
+          </p>
+
+          <Button
+            v-else
+            data-testid="missing-model-download"
+            variant="secondary"
+            size="md"
+            class="flex w-full flex-1"
+            :aria-label="`${t('g.download')} ${row.model.name}`"
+            @click="handleSingleDownload(row)"
+          >
+            <i
+              aria-hidden="true"
+              class="text-foreground mr-1 icon-[lucide--download] size-4 shrink-0"
+            />
+            <span class="text-foreground min-w-0 truncate text-sm">
+              {{ row.downloadLabel }}
+            </span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import type {
+  MissingModelGroup,
+  MissingModelViewModel
+} from '@/platform/missingModel/types'
+import { toBrowsableUrl } from '@/platform/missingModel/missingModelDownload'
+import { useServerSideDownloadsStore } from '@/platform/missingModel/serverDownloads/useServerSideDownloads'
+import { useToastStore } from '@/platform/updates/common/toastStore'
+import { modelIdFor } from '@/platform/missingModel/serverDownloads/serverDownloadsApi'
+import type { ServerDownloadStatus } from '@/platform/missingModel/serverDownloads/serverDownloadsApi'
+import { formatSize } from '@/utils/formatUtil'
+
+/** ``huggingface.co/<org>/<repo>/resolve/<rev>/<path>``
+ *      → ``huggingface.co/<org>/<repo>``.
+ *
+ * The license-accept page lives at the repo root, not at the file
+ * blob URL. For non-HF URLs we fall back to ``toBrowsableUrl`` which
+ * is fine for Civitai (its public model page) and a no-op otherwise. */
+function repoHomeUrl(url: string): string {
+  try {
+    const u = new URL(url)
+    if (u.hostname !== 'huggingface.co') return toBrowsableUrl(url)
+    const parts = u.pathname.split('/').filter(Boolean)
+    if (parts.length < 2) return toBrowsableUrl(url)
+    return `https://huggingface.co/${parts[0]}/${parts[1]}`
+  } catch {
+    return toBrowsableUrl(url)
+  }
+}
+
+const props = defineProps<{
+  missingModelGroups: MissingModelGroup[]
+}>()
+
+const { t } = useI18n()
+const store = useServerSideDownloadsStore()
+
+function flattenRegistrations(
+  groups: MissingModelGroup[]
+): { modelId: string; url: string }[] {
+  const out: { modelId: string; url: string }[] = []
+  for (const group of groups) {
+    if (!group.directory) continue
+    for (const model of group.models) {
+      const rep = model.representative
+      if (!rep.url) continue
+      out.push({
+        modelId: modelIdFor(group.directory, rep.name),
+        url: rep.url
+      })
+    }
+  }
+  return out
+}
+
+watch(
+  () => props.missingModelGroups,
+  (next) => store.setRegistered(flattenRegistrations(next)),
+  { deep: true, immediate: true }
+)
+onBeforeUnmount(() => store.clear())
+
+/** Per-row state computed once and used everywhere — saves re-deriving
+ *  the same fields 4-7× per render from the template. */
+interface RowView {
+  model: MissingModelViewModel
+  /** Null when the row has no usable url+directory and can't be driven. */
+  id: string | null
+  status: ServerDownloadStatus
+  progress: number | null
+  progressLabel: string
+  downloadLabel: string
+  browseUrl: string
+}
+
+interface GroupView {
+  group: MissingModelGroup
+  rows: RowView[]
+}
+
+function buildRow(
+  model: MissingModelViewModel,
+  group: MissingModelGroup
+): RowView {
+  const rep = model.representative
+  const id =
+    rep.url && group.directory ? modelIdFor(group.directory, rep.name) : null
+
+  const entry = id ? store.entryOf(id) : undefined
+
+  let status: ServerDownloadStatus = 'missing'
+  if (entry) {
+    if (entry.state === 'available') status = 'available'
+    else if (entry.state === 'downloading') status = 'downloading'
+    else if (entry.is_hf_downloadable === false) status = 'gated'
+  }
+
+  const dp = entry?.progress ?? null
+  const progress = dp?.progress ?? null
+  const progressLabel = dp
+    ? dp.progress !== null
+      ? `${Math.round(dp.progress * 100)}%`
+      : formatSize(dp.bytes_downloaded)
+    : ''
+
+  const baseDownload = t('g.download')
+  const size = entry?.file_size ?? null
+  const downloadLabel = size
+    ? `${baseDownload} (${formatSize(size)})`
+    : baseDownload
+
+  return {
+    model,
+    id,
+    status,
+    progress,
+    progressLabel,
+    downloadLabel,
+    browseUrl: rep.url ? repoHomeUrl(rep.url) : '#'
+  }
+}
+
+const groupViews = computed<GroupView[]>(() =>
+  props.missingModelGroups.map((g) => ({
+    group: g,
+    rows: g.models.map((m) => buildRow(m, g))
+  }))
+)
+
+const hasAnyDownloadableMissing = computed(
+  () => store.downloadableMissingIds.length > 0
+)
+
+/** Show the HF login banner iff:
+ *   - there's at least one row gated to us, AND
+ *   - the deployment is eligible for interactive login, AND
+ *   - we don't already have a stored token.
+ *
+ * Once the user logs in (token_available flips true), the store
+ * re-probes metadata and gated rows that the token unlocks flip
+ * to ``downloadable`` automatically. */
+const showLoginBanner = computed(
+  () =>
+    store.hasAnyGated && store.hfAuth.eligible && !store.hfAuth.token_available
+)
+
+/** Which message variant to show on a gated row.
+ *
+ * - ``manual``     — multi-tenant / public-IP deployment; user must
+ *                    acquire the file out-of-band.
+ * - ``need-login`` — eligible deployment but not logged in yet.
+ * - ``accept``     — logged in but token doesn't grant access; user
+ *                    must accept the license on huggingface.co. */
+const gatedMode = computed<'manual' | 'need-login' | 'accept'>(() => {
+  if (!store.hfAuth.eligible) return 'manual'
+  if (!store.hfAuth.token_available) return 'need-login'
+  return 'accept'
+})
+
+async function handleLogin() {
+  try {
+    await store.beginHfLogin()
+  } catch {
+    // Errors are logged inside the store; nothing else to surface here.
+  }
+}
+
+const downloadAllLabel = computed(() => {
+  const base = store.hasAnyGated
+    ? t('rightSidePanel.missingModels.downloadAllAvailable')
+    : t('rightSidePanel.missingModels.downloadAll')
+  const total = store.downloadableMissingIds.reduce(
+    (sum: number, id: string) => sum + (store.entryOf(id)?.file_size ?? 0),
+    0
+  )
+  return total > 0 ? `${base} (${formatSize(total)})` : base
+})
+
+async function handleDownloadAll() {
+  await store.startDownload(store.downloadableMissingIds.slice())
+}
+
+async function handleSingleDownload(row: RowView) {
+  if (!row.id) return
+  await store.startSingleDownload(row.id)
+}
+
+async function handleCancel(row: RowView) {
+  if (!row.id) return
+  try {
+    await store.cancelDownload(row.id)
+  } catch (err) {
+    console.warn('[serverSideDownloads] cancel failed:', err)
+    useToastStore().add({
+      severity: 'error',
+      summary: t('rightSidePanel.missingModels.cancelFailed')
+    })
+  }
+}
+</script>

--- a/src/platform/missingModel/serverDownloads/serverDownloadsApi.ts
+++ b/src/platform/missingModel/serverDownloads/serverDownloadsApi.ts
@@ -1,0 +1,201 @@
+/**
+ * Typed wrappers around the server-side model download endpoints.
+ *
+ * One polling endpoint (``models-availability-status``) returns
+ * per-id state + metadata + HF auth snapshot. There's no separate
+ * metadata cache to maintain on the client.
+ */
+
+import { api } from '@/scripts/api'
+
+// --- per-model status ----------------------------------------------------- //
+
+type ModelState = 'available' | 'missing' | 'downloading'
+
+interface DownloadProgress {
+  bytes_downloaded: number
+  total_bytes: number | null
+  /** Fraction in [0,1]; null until total_bytes is known. */
+  progress: number | null
+}
+
+export interface ModelStatusEntry {
+  state: ModelState
+  progress: DownloadProgress | null
+  file_size: number | null
+  /** HF-only signal: true if server can fetch with current auth state,
+   *  false if gated and lacking access, null for non-HF / probe failure. */
+  is_hf_downloadable: boolean | null
+}
+
+export interface HfAuthStatus {
+  token_available: boolean
+  eligible: boolean
+}
+
+export interface AvailabilityStatusResponse {
+  models: Record<string, ModelStatusEntry>
+  hf_auth: HfAuthStatus
+}
+
+// --- response envelopes for the other endpoints --------------------------- //
+
+export interface DownloadModelsResponse {
+  accepted: boolean
+  scheduled: string[]
+}
+
+interface ApiErrorBody {
+  error: {
+    code: string
+    message: string
+    details?: Record<string, unknown>
+  }
+}
+
+/**
+ * Error thrown by every endpoint wrapper in this module. Carries the
+ * backend error `code`, the HTTP `status`, and any structured `details`
+ * so callers can branch on the failure or surface it to the user.
+ */
+export class ServerDownloadError extends Error {
+  readonly code: string
+  readonly status: number
+  readonly details: Record<string, unknown>
+
+  constructor(
+    code: string,
+    message: string,
+    status: number,
+    details: Record<string, unknown> = {}
+  ) {
+    super(message)
+    this.code = code
+    this.status = status
+    this.details = details
+  }
+}
+
+/** POST `body` as JSON, returning the parsed response or throwing a
+ * {@link ServerDownloadError} for any non-2xx status. */
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await api.fetchApi(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+  if (!res.ok) {
+    let parsed: ApiErrorBody | null = null
+    try {
+      parsed = (await res.json()) as ApiErrorBody
+    } catch {
+      // Body wasn't JSON; surface a generic error.
+    }
+    const code = parsed?.error?.code ?? `HTTP_${res.status}`
+    const message = parsed?.error?.message ?? res.statusText
+    const details = parsed?.error?.details ?? {}
+    throw new ServerDownloadError(code, message, res.status, details)
+  }
+  return (await res.json()) as T
+}
+
+// --- model_id helper ------------------------------------------------------ //
+
+/** ``model_id`` = ``"<directory>/<filename>"``, matching the backend's contract. */
+export function modelIdFor(directory: string, name: string): string {
+  return `${directory}/${name}`
+}
+
+/** Per-row state derived for the UI. Pure function of a ModelStatusEntry. */
+export type ServerDownloadStatus =
+  | 'available'
+  | 'missing'
+  | 'downloading'
+  | 'gated'
+
+// --- endpoints ------------------------------------------------------------ //
+
+/** Poll per-model availability/state plus the current HF auth snapshot.
+ * Short-circuits with an empty result when no models are requested. */
+export async function fetchAvailabilityStatus(
+  models: Record<string, string>
+): Promise<AvailabilityStatusResponse> {
+  if (Object.keys(models).length === 0) {
+    return {
+      models: {},
+      hf_auth: { token_available: false, eligible: false }
+    }
+  }
+  return postJson<AvailabilityStatusResponse>('/models-availability-status', {
+    models
+  })
+}
+
+/** Schedule server-side downloads for the given `model_id` → URL map. */
+export async function startModelDownloads(
+  models: Record<string, string>
+): Promise<DownloadModelsResponse> {
+  return postJson<DownloadModelsResponse>('/download-models', { models })
+}
+
+/** Cancel an in-flight download. Throws if the server does not confirm
+ * the cancellation (`{ cancelled: false }`) so callers don't assume success. */
+export async function cancelModelDownload(modelId: string): Promise<void> {
+  const { cancelled } = await postJson<{ cancelled: boolean }>(
+    '/cancel-model-download-session',
+    { model_id: modelId }
+  )
+  if (!cancelled) {
+    throw new ServerDownloadError(
+      'CANCEL_NOT_CONFIRMED',
+      'Server did not confirm cancellation',
+      200,
+      { model_id: modelId }
+    )
+  }
+}
+
+// --- HF auth -------------------------------------------------------------- //
+
+export interface HfAuthTokenStatusResponse {
+  token_available: boolean
+  username: string | null
+}
+
+export interface HfAuthLoginStartResponse {
+  authorize_url: string
+}
+
+/** Read whether a HuggingFace token is stored server-side and, if so, the username. */
+export async function fetchHfAuthTokenStatus(): Promise<HfAuthTokenStatusResponse> {
+  const res = await api.fetchApi('/hf-auth-token-status')
+  if (!res.ok) {
+    throw new ServerDownloadError(
+      `HTTP_${res.status}`,
+      res.statusText,
+      res.status
+    )
+  }
+  return (await res.json()) as HfAuthTokenStatusResponse
+}
+
+/** Begin the HuggingFace OAuth flow, returning the URL to open for authorization. */
+export async function startHfAuthLogin(): Promise<HfAuthLoginStartResponse> {
+  return postJson<HfAuthLoginStartResponse>('/hf-auth-login-start', {})
+}
+
+/** Clear the stored HuggingFace token. Throws if the server does not confirm
+ * the logout (`{ logged_out: false }`) so callers don't assume success. */
+export async function logoutHfAuth(): Promise<void> {
+  const { logged_out } = await postJson<{ logged_out: boolean }>(
+    '/hf-auth-logout',
+    {}
+  )
+  if (!logged_out) {
+    throw new ServerDownloadError(
+      'LOGOUT_NOT_CONFIRMED',
+      'Server did not confirm logout',
+      200
+    )
+  }
+}

--- a/src/platform/missingModel/serverDownloads/useServerSideDownloads.ts
+++ b/src/platform/missingModel/serverDownloads/useServerSideDownloads.ts
@@ -1,0 +1,294 @@
+/**
+ * Orchestration store for the server-side missing-models flow.
+ *
+ * Responsibilities:
+ *   - Track the set of (model_id, url) pairs declared by the workflow.
+ *   - Poll the unified ``/api/models-availability-status`` every 1s while
+ *     anything is still missing-and-not-gated or downloading.
+ *   - Expose start / cancel / login actions.
+ *
+ * Per-model metadata (file_size, is_hf_downloadable) is part of the
+ * polling response — the server caches what it can and re-evaluates
+ * the rest per call. The client maintains no separate metadata cache.
+ */
+
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+
+import { api } from '@/scripts/api'
+import {
+  cancelModelDownload,
+  fetchAvailabilityStatus,
+  ServerDownloadError,
+  startHfAuthLogin,
+  startModelDownloads
+} from '@/platform/missingModel/serverDownloads/serverDownloadsApi'
+import type {
+  HfAuthStatus,
+  ModelStatusEntry
+} from '@/platform/missingModel/serverDownloads/serverDownloadsApi'
+
+const POLL_INTERVAL_MS = 1000
+
+/** True iff the server registered itself as supporting this flow.
+ *  Old servers will not have this key — fall back to the legacy
+ *  in-browser download path. */
+export function isServerSideDownloadsAvailable(): boolean {
+  const flags = api.serverFeatureFlags.value as Record<string, unknown>
+  return flags['server_side_model_downloads'] === true
+}
+
+interface RegisteredModel {
+  modelId: string
+  url: string
+}
+
+export const useServerSideDownloadsStore = defineStore(
+  'serverSideDownloads',
+  () => {
+    /** model_id → URL the workflow declared for it. */
+    const registered = ref<Record<string, RegisteredModel>>({})
+
+    /** model_id → server's per-poll snapshot. Replaced wholesale on each
+     *  poll that observes any difference. */
+    const models = ref<Record<string, ModelStatusEntry>>({})
+
+    const hfAuth = ref<HfAuthStatus>({
+      token_available: false,
+      eligible: false
+    })
+
+    let pollHandle: ReturnType<typeof setInterval> | null = null
+
+    /** Guards against overlapping polls when a refresh outlives the
+     *  poll interval — prevents request pile-up and out-of-order writes. */
+    let refreshInFlight = false
+
+    /** Keep polling alive after starting OAuth so the panel auto-flips
+     *  once the token lands, even when every row is currently gated. */
+    let awaitingHfLogin = false
+
+    // ----- derived views -----
+
+    /** Missing rows we can attempt to download (excludes gated-to-us). */
+    const downloadableMissingIds = computed<string[]>(() => {
+      const ids: string[] = []
+      const m = models.value
+      for (const id of Object.keys(m)) {
+        const entry = m[id]
+        if (entry.state !== 'missing') continue
+        if (entry.is_hf_downloadable === false) continue
+        ids.push(id)
+      }
+      return ids
+    })
+
+    /** Missing rows that we can't currently fetch (gated, no access). */
+    const gatedMissingIds = computed<string[]>(() => {
+      const ids: string[] = []
+      const m = models.value
+      for (const id of Object.keys(m)) {
+        const entry = m[id]
+        if (entry.state === 'missing' && entry.is_hf_downloadable === false) {
+          ids.push(id)
+        }
+      }
+      return ids
+    })
+
+    const hasAnyGated = computed(() => gatedMissingIds.value.length > 0)
+
+    function entryOf(modelId: string): ModelStatusEntry | undefined {
+      return models.value[modelId]
+    }
+
+    // ----- registration: who's in this workflow -----
+
+    function setRegistered(items: RegisteredModel[]) {
+      registered.value = Object.fromEntries(items.map((it) => [it.modelId, it]))
+      models.value = {}
+      void refresh()
+      ensurePolling()
+    }
+
+    function clear() {
+      registered.value = {}
+      models.value = {}
+      awaitingHfLogin = false
+      stopPolling()
+    }
+
+    // ----- backend calls -----
+
+    function registeredModelsMap(): Record<string, string> {
+      const map: Record<string, string> = {}
+      const r = registered.value
+      for (const id of Object.keys(r)) {
+        map[id] = r[id].url
+      }
+      return map
+    }
+
+    async function refresh(): Promise<void> {
+      if (refreshInFlight) return
+      const map = registeredModelsMap()
+      if (Object.keys(map).length === 0) return
+      refreshInFlight = true
+      try {
+        const data = await fetchAvailabilityStatus(map)
+        if (!modelsEqual(models.value, data.models)) {
+          models.value = data.models
+        }
+        hfAuth.value = data.hf_auth
+        if (hfAuth.value.token_available) {
+          awaitingHfLogin = false
+        }
+        maybeStopPolling()
+      } catch (err) {
+        console.warn('[serverSideDownloads] poll failed:', err)
+      } finally {
+        refreshInFlight = false
+      }
+    }
+
+    /** Stop the timer when nothing more can change without a user action.
+     *  Gated-to-us entries stay in ``missing`` until login or license
+     *  acceptance; both of those trigger an explicit refresh elsewhere. */
+    function maybeStopPolling() {
+      if (awaitingHfLogin && !hfAuth.value.token_available) return
+      const m = models.value
+      for (const id of Object.keys(m)) {
+        const entry = m[id]
+        if (entry.state === 'downloading') return
+        if (entry.state === 'missing' && entry.is_hf_downloadable !== false) {
+          return
+        }
+      }
+      stopPolling()
+    }
+
+    async function startDownload(modelIds: string[]): Promise<void> {
+      const map: Record<string, string> = {}
+      for (const id of modelIds) {
+        const reg = registered.value[id]
+        if (!reg) continue
+        map[id] = reg.url
+      }
+      if (Object.keys(map).length === 0) return
+
+      try {
+        await startModelDownloads(map)
+      } catch (err) {
+        if (err instanceof ServerDownloadError) {
+          console.warn(
+            `[serverSideDownloads] download rejected (${err.code}): ${err.message}`,
+            err.details
+          )
+        } else {
+          console.warn('[serverSideDownloads] download failed:', err)
+        }
+        // Re-poll so the UI reflects whatever state actually obtains
+        // server-side (race: someone else may have already taken the
+        // file we tried to start).
+        void refresh()
+        throw err
+      }
+
+      ensurePolling()
+      // Eagerly poll so the user sees the progress bar appear immediately.
+      void refresh()
+    }
+
+    async function startSingleDownload(modelId: string): Promise<void> {
+      await startDownload([modelId])
+    }
+
+    async function cancelDownload(modelId: string): Promise<void> {
+      try {
+        await cancelModelDownload(modelId)
+      } finally {
+        void refresh()
+      }
+    }
+
+    /** Trigger the OAuth flow and open the authorize URL in a new tab. */
+    async function beginHfLogin(): Promise<void> {
+      try {
+        const { authorize_url } = await startHfAuthLogin()
+        awaitingHfLogin = true
+        window.open(authorize_url, '_blank', 'noopener,noreferrer')
+        ensurePolling()
+      } catch (err) {
+        console.warn('[serverSideDownloads] HF login start failed:', err)
+        throw err
+      }
+    }
+
+    // ----- polling lifecycle -----
+
+    function ensurePolling() {
+      if (pollHandle !== null) return
+      pollHandle = setInterval(() => {
+        void refresh()
+      }, POLL_INTERVAL_MS)
+    }
+
+    function stopPolling() {
+      if (pollHandle !== null) {
+        clearInterval(pollHandle)
+        pollHandle = null
+      }
+    }
+
+    return {
+      // state
+      models,
+      hfAuth,
+      // derived
+      downloadableMissingIds,
+      gatedMissingIds,
+      hasAnyGated,
+      entryOf,
+      // actions
+      setRegistered,
+      clear,
+      refresh,
+      startDownload,
+      startSingleDownload,
+      cancelDownload,
+      beginHfLogin
+    }
+  }
+)
+
+/** Cheap structural diff that lets us skip reactive writes when the
+ *  poll returns identical data — saves needless re-renders during
+ *  long-running downloads where nothing actually changed yet. */
+function modelsEqual(
+  a: Record<string, ModelStatusEntry>,
+  b: Record<string, ModelStatusEntry>
+): boolean {
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  for (const id of ak) {
+    const x = a[id]
+    const y = b[id]
+    if (!y) return false
+    if (x.state !== y.state) return false
+    if (x.file_size !== y.file_size) return false
+    if (x.is_hf_downloadable !== y.is_hf_downloadable) return false
+    const xp = x.progress
+    const yp = y.progress
+    if ((xp === null) !== (yp === null)) return false
+    if (xp && yp) {
+      if (
+        xp.bytes_downloaded !== yp.bytes_downloaded ||
+        xp.total_bytes !== yp.total_bytes
+      ) {
+        return false
+      }
+    }
+  }
+  return true
+}

--- a/src/platform/settings/composables/useSettingUI.ts
+++ b/src/platform/settings/composables/useSettingUI.ts
@@ -7,6 +7,7 @@ import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import { isCloud, isDesktop } from '@/platform/distribution/types'
+import { api } from '@/scripts/api'
 import {
   getSettingInfo,
   useSettingStore
@@ -233,6 +234,28 @@ export function useSettingUI(
     )
   }
 
+  const hfAuthPanel: SettingPanelItem = {
+    node: {
+      key: 'hf-auth',
+      label: 'HuggingFace',
+      children: []
+    },
+    component: defineAsyncComponent(
+      () =>
+        import(
+          '@/platform/missingModel/serverDownloads/HfAuthSettingsPanel.vue'
+        )
+    )
+  }
+
+  // The HF auth panel is opt-in based on a server feature flag the
+  // backend computes from ``is_loopback(--listen) AND not --multi-user``.
+  // Anywhere else the surface is hidden so users don't see an option
+  // that wouldn't work for them.
+  const shouldShowHfAuthPanel = computed(
+    () => api.serverFeatureFlags.value['hf_auth_eligible'] === true
+  )
+
   const panels = computed<SettingPanelItem[]>(() =>
     [
       aboutPanel,
@@ -242,6 +265,7 @@ export function useSettingUI(
       keybindingPanel,
       extensionPanel,
       ...(isDesktop ? [serverConfigPanel] : []),
+      ...(shouldShowHfAuthPanel.value ? [hfAuthPanel] : []),
       ...(shouldShowPlanCreditsPanel.value && subscriptionPanel
         ? [subscriptionPanel]
         : []),
@@ -309,7 +333,10 @@ export function useSettingUI(
         translateCategory(keybindingPanel.node),
         translateCategory(extensionPanel.node),
         translateCategory(aboutPanel.node),
-        ...(isDesktop ? [translateCategory(serverConfigPanel.node)] : [])
+        ...(isDesktop ? [translateCategory(serverConfigPanel.node)] : []),
+        ...(shouldShowHfAuthPanel.value
+          ? [translateCategory(hfAuthPanel.node)]
+          : [])
       ]
     }),
     // Custom node settings (only shown if custom nodes have registered settings)
@@ -358,7 +385,8 @@ export function useSettingUI(
         keybindingPanel.node,
         extensionPanel.node,
         aboutPanel.node,
-        ...(isDesktop ? [serverConfigPanel.node] : [])
+        ...(isDesktop ? [serverConfigPanel.node] : []),
+        ...(shouldShowHfAuthPanel.value ? [hfAuthPanel.node] : [])
       ].map(translateCategory)
     }
   ])


### PR DESCRIPTION
## Summary

**Companion backend PR:** Comfy-Org/ComfyUI#14586 — the server-side subsystem that exposes the endpoints + feature flags this UI consumes.

The frontend counterpart to the server-side model download backend subsystem. When a workflow references a missing model, this lets the user download it server-side — straight into the correct model folder, with live progress and cancellation — and log in to HuggingFace (one click) so gated models can be fetched on their behalf.

It replaces, for capable servers, the legacy behavior where the browser downloads the file to the user's Downloads folder and they have to move it into `models/<dir>/` by hand (and gated models couldn't be fetched at all).

## Changes

- **What**: New `serverDownloads` module — typed API wrappers, a polling store, and the missing-model card + HuggingFace auth panel UI.
- **Dependencies**: The backend PR adding the `/api/models-availability-status`, `/api/download-models`, `/api/cancel-model-download-session`, and `/api/hf-auth-*` endpoints plus the `server_side_model_downloads` / `hf_auth_eligible` feature flags. This PR is inert without it.