### PR TITLE
Fix share auth attribution gap

### DIFF
--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -1,6 +1,9 @@
 import { expect } from '@playwright/test'
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+const SHARE_AUTH_STORAGE_KEY = 'Comfy.PreservedQuery.share_auth'
+
 /**
  * Cloud distribution E2E tests.
  *
@@ -14,15 +17,31 @@ test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
   test('cloud build redirects unauthenticated users to login', async ({
     page
   }) => {
-    await page.goto('http://localhost:8188')
+    await page.goto(APP_URL)
     // Cloud build has an auth guard that redirects to /cloud/login.
     // This route only exists in the cloud distribution — it's tree-shaken
     // in the OSS build. Its presence confirms the cloud build is active.
     await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
   })
 
+  test('preserves share auth attribution before redirecting logged-out users', async ({
+    page
+  }) => {
+    await page.goto(new URL('/?share=abc', APP_URL).toString())
+
+    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+    await expect
+      .poll(() =>
+        page.evaluate(
+          (key) => sessionStorage.getItem(key),
+          SHARE_AUTH_STORAGE_KEY
+        )
+      )
+      .toBe(JSON.stringify({ share: 'abc' }))
+  })
+
   test('cloud login page renders sign-in options', async ({ page }) => {
-    await page.goto('http://localhost:8188')
+    await page.goto(APP_URL)
     await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
     // Verify cloud-specific login UI is rendered
     await expect(page.getByRole('button', { name: /google/i })).toBeVisible()

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -258,15 +258,15 @@ describe('PostHogTelemetryProvider', () => {
       )
     })
 
-    it('captures events with metadata', async () => {
+    it('captures auth events with metadata', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()
 
-      provider.trackAuth({ method: 'google' })
+      provider.trackAuth({ method: 'google', share_id: 'share-1' })
 
       expect(hoisted.mockCapture).toHaveBeenCalledWith(
         TelemetryEvents.USER_AUTH_COMPLETED,
-        { method: 'google' }
+        { method: 'google', share_id: 'share-1' }
       )
     })
 

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.test.ts
@@ -266,11 +266,7 @@ describe('useSharedWorkflowUrlLoader', () => {
       view_mode: 'graph',
       is_app_mode: false
     })
-    expect(preservedQueryMocks.capturePreservedQuery).toHaveBeenCalledWith(
-      'share_auth',
-      { share: 'share-id-1' },
-      ['share']
-    )
+    expect(preservedQueryMocks.capturePreservedQuery).not.toHaveBeenCalled()
     expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
     expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
       'share'

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -9,13 +9,13 @@ import { useTelemetry } from '@/platform/telemetry'
 import OpenSharedWorkflowDialogContent from '@/platform/workflow/sharing/components/OpenSharedWorkflowDialogContent.vue'
 import type { SharedWorkflowPayload } from '@/platform/workflow/sharing/types/shareTypes'
 import {
-  capturePreservedQuery,
   clearPreservedQuery,
   hydratePreservedQuery,
   mergePreservedQueryIntoQuery
 } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useWorkflowShareService } from '@/platform/workflow/sharing/services/workflowShareService'
+import { isValidShareId } from '@/platform/workflow/sharing/utils/shareAuthAttribution'
 import { app } from '@/scripts/app'
 import { useDialogService } from '@/services/dialogService'
 import { useDialogStore } from '@/stores/dialogStore'
@@ -48,10 +48,6 @@ export function useSharedWorkflowUrlLoader() {
   const { isLoggedIn } = useCurrentUser()
   const { mode, isAppMode } = useAppMode()
   const SHARE_NAMESPACE = PRESERVED_QUERY_NAMESPACES.SHARE
-
-  function isValidParameter(param: string): boolean {
-    return /^[a-zA-Z0-9_.-]+$/.test(param)
-  }
 
   async function ensureShareQueryFromIntent() {
     hydratePreservedQuery(SHARE_NAMESPACE)
@@ -129,7 +125,7 @@ export function useSharedWorkflowUrlLoader() {
       return 'not-present'
     }
 
-    if (!isValidParameter(shareParam)) {
+    if (!isValidShareId(shareParam)) {
       console.warn(
         `[useSharedWorkflowUrlLoader] Invalid share parameter format: ${shareParam}`
       )
@@ -148,13 +144,6 @@ export function useSharedWorkflowUrlLoader() {
       view_mode: mode.value,
       is_app_mode: isAppMode.value
     })
-    if (!isLoggedIn.value) {
-      capturePreservedQuery(
-        PRESERVED_QUERY_NAMESPACES.SHARE_AUTH,
-        { share: shareParam },
-        ['share']
-      )
-    }
 
     const result = await showOpenSharedWorkflowDialog(shareParam)
 

--- a/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
+++ b/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
@@ -16,7 +16,8 @@ const SHARE_AUTH_NAMESPACE = PRESERVED_QUERY_NAMESPACES.SHARE_AUTH
 const invalidShareQueries: Array<{ name: string; query: LocationQuery }> = [
   { name: 'missing', query: {} },
   { name: 'array value', query: { share: ['share-id-1'] } },
-  { name: 'invalid characters', query: { share: '../share-id-1' } }
+  { name: 'invalid characters', query: { share: '../share-id-1' } },
+  { name: 'too long', query: { share: 'a'.repeat(129) } }
 ]
 
 describe('shareAuthAttribution', () => {
@@ -62,7 +63,14 @@ describe('shareAuthAttribution', () => {
   it.for([
     { shareId: 'abc123', expected: true },
     { shareId: 'share-id_1.2', expected: true },
+    { shareId: 'a'.repeat(128), expected: true },
     { shareId: '../share-id-1', expected: false },
+    { shareId: '.', expected: false },
+    { shareId: '..', expected: false },
+    { shareId: '-share-id', expected: false },
+    { shareId: 'share id', expected: false },
+    { shareId: '\u5171\u4eab', expected: false },
+    { shareId: 'a'.repeat(129), expected: false },
     { shareId: '', expected: false }
   ])('validates "$shareId" as $expected', ({ shareId, expected }) => {
     expect(isValidShareId(shareId)).toBe(expected)

--- a/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
+++ b/src/platform/workflow/sharing/utils/shareAuthAttribution.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { LocationQuery } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  getPreservedQueryParam
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+
+import {
+  isValidShareId,
+  preserveLoggedOutShareAuthAttribution
+} from './shareAuthAttribution'
+
+const SHARE_AUTH_NAMESPACE = PRESERVED_QUERY_NAMESPACES.SHARE_AUTH
+const invalidShareQueries: Array<{ name: string; query: LocationQuery }> = [
+  { name: 'missing', query: {} },
+  { name: 'array value', query: { share: ['share-id-1'] } },
+  { name: 'invalid characters', query: { share: '../share-id-1' } }
+]
+
+describe('shareAuthAttribution', () => {
+  beforeEach(() => {
+    clearPreservedQuery(SHARE_AUTH_NAMESPACE)
+    sessionStorage.clear()
+  })
+
+  it('preserves a valid share id for logged-out users', () => {
+    preserveLoggedOutShareAuthAttribution({ share: 'share-id_1.2' }, false)
+
+    expect(getPreservedQueryParam(SHARE_AUTH_NAMESPACE, 'share')).toBe(
+      'share-id_1.2'
+    )
+    expect(sessionStorage.getItem('Comfy.PreservedQuery.share_auth')).toContain(
+      'share-id_1.2'
+    )
+  })
+
+  it('does not preserve share attribution for logged-in users', () => {
+    preserveLoggedOutShareAuthAttribution({ share: 'share-id-1' }, true)
+
+    expect(
+      getPreservedQueryParam(SHARE_AUTH_NAMESPACE, 'share')
+    ).toBeUndefined()
+    expect(sessionStorage.getItem('Comfy.PreservedQuery.share_auth')).toBeNull()
+  })
+
+  it.for(invalidShareQueries)(
+    'does not preserve $name share params',
+    ({ query }) => {
+      preserveLoggedOutShareAuthAttribution(query, false)
+
+      expect(
+        getPreservedQueryParam(SHARE_AUTH_NAMESPACE, 'share')
+      ).toBeUndefined()
+      expect(
+        sessionStorage.getItem('Comfy.PreservedQuery.share_auth')
+      ).toBeNull()
+    }
+  )
+
+  it.for([
+    { shareId: 'abc123', expected: true },
+    { shareId: 'share-id_1.2', expected: true },
+    { shareId: '../share-id-1', expected: false },
+    { shareId: '', expected: false }
+  ])('validates "$shareId" as $expected', ({ shareId, expected }) => {
+    expect(isValidShareId(shareId)).toBe(expected)
+  })
+})

--- a/src/platform/workflow/sharing/utils/shareAuthAttribution.ts
+++ b/src/platform/workflow/sharing/utils/shareAuthAttribution.ts
@@ -4,9 +4,11 @@ import { capturePreservedQuery } from '@/platform/navigation/preservedQueryManag
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 
 const SHARE_QUERY_KEY = 'share'
+const MAX_SHARE_ID_LENGTH = 128
+const SHARE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/
 
 export function isValidShareId(shareId: string): boolean {
-  return /^[a-zA-Z0-9_.-]+$/.test(shareId)
+  return shareId.length <= MAX_SHARE_ID_LENGTH && SHARE_ID_PATTERN.test(shareId)
 }
 
 export function preserveLoggedOutShareAuthAttribution(

--- a/src/platform/workflow/sharing/utils/shareAuthAttribution.ts
+++ b/src/platform/workflow/sharing/utils/shareAuthAttribution.ts
@@ -1,0 +1,26 @@
+import type { LocationQuery } from 'vue-router'
+
+import { capturePreservedQuery } from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+
+const SHARE_QUERY_KEY = 'share'
+
+export function isValidShareId(shareId: string): boolean {
+  return /^[a-zA-Z0-9_.-]+$/.test(shareId)
+}
+
+export function preserveLoggedOutShareAuthAttribution(
+  query: LocationQuery,
+  isLoggedIn: boolean
+): void {
+  if (isLoggedIn) return
+
+  const shareId = query[SHARE_QUERY_KEY]
+  if (typeof shareId !== 'string' || !isValidShareId(shareId)) return
+
+  capturePreservedQuery(
+    PRESERVED_QUERY_NAMESPACES.SHARE_AUTH,
+    { [SHARE_QUERY_KEY]: shareId },
+    [SHARE_QUERY_KEY]
+  )
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,6 +18,7 @@ import LayoutDefault from '@/views/layouts/LayoutDefault.vue'
 import { captureOAuthRequestId } from '@/platform/cloud/oauth/oauthState'
 import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { preserveLoggedOutShareAuthAttribution } from '@/platform/workflow/sharing/utils/shareAuthAttribution'
 
 const cloudOnboardingRoutes = isCloud
   ? (await import('./platform/cloud/onboarding/onboardingCloudRoutes'))
@@ -169,6 +170,7 @@ if (isCloud) {
     // Pass authenticated users
     const authHeader = await authStore.getAuthHeader()
     const isLoggedIn = !!authHeader
+    preserveLoggedOutShareAuthAttribution(to.query, isLoggedIn)
 
     // Allow public routes
     if (isPublicRoute(to)) {

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -6,7 +6,10 @@ import type { Mock } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vuefire from 'vuefire'
 
-import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
+import {
+  capturePreservedQuery,
+  clearPreservedQuery
+} from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useDialogService } from '@/services/dialogService'
 import { useAuthStore } from '@/stores/authStore'
@@ -687,30 +690,103 @@ describe('useAuthStore', () => {
           )
         }
       )
+    })
+  })
 
-      it('includes preserved share id on new-user social auth', async () => {
-        sessionStorage.setItem(
-          'Comfy.PreservedQuery.share_auth',
-          JSON.stringify({ share: 'share-1' })
-        )
-        vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
-          isNewUser: true,
-          providerId: 'google.com',
-          profile: null
-        })
+  describe('share auth attribution', () => {
+    const mockUserCredential = {
+      user: mockUser
+    } as Partial<UserCredential> as UserCredential
 
-        await store.loginWithGoogle()
+    const preserveShareAuth = () => {
+      capturePreservedQuery(
+        PRESERVED_QUERY_NAMESPACES.SHARE_AUTH,
+        { share: 'share-1' },
+        ['share']
+      )
+    }
 
-        expect(mockTrackAuth).toHaveBeenCalledWith(
-          expect.objectContaining({
-            is_new_user: true,
-            share_id: 'share-1'
-          })
-        )
-        expect(
-          sessionStorage.getItem('Comfy.PreservedQuery.share_auth')
-        ).toBeNull()
+    const expectShareAuthConsumed = () => {
+      expect(
+        sessionStorage.getItem('Comfy.PreservedQuery.share_auth')
+      ).toBeNull()
+    }
+
+    beforeEach(() => {
+      vi.mocked(firebaseAuth.signInWithEmailAndPassword).mockResolvedValue(
+        mockUserCredential
+      )
+      vi.mocked(firebaseAuth.createUserWithEmailAndPassword).mockResolvedValue(
+        mockUserCredential
+      )
+      vi.mocked(firebaseAuth.signInWithPopup).mockResolvedValue(
+        mockUserCredential
+      )
+      vi.mocked(firebaseAuth.getAdditionalUserInfo).mockReturnValue({
+        isNewUser: true,
+        providerId: 'google.com',
+        profile: null
       })
+    })
+
+    it('includes share_id on email signup auth completion', async () => {
+      preserveShareAuth()
+
+      await store.register('new@example.com', 'password')
+
+      expect(mockTrackAuth).toHaveBeenCalledWith({
+        method: 'email',
+        is_new_user: true,
+        user_id: 'test-user-id',
+        email: 'test@example.com',
+        share_id: 'share-1'
+      })
+      expectShareAuthConsumed()
+    })
+
+    it('includes share_id on email login auth completion', async () => {
+      preserveShareAuth()
+
+      await store.login('test@example.com', 'password')
+
+      expect(mockTrackAuth).toHaveBeenCalledWith({
+        method: 'email',
+        is_new_user: false,
+        user_id: 'test-user-id',
+        email: 'test@example.com',
+        share_id: 'share-1'
+      })
+      expectShareAuthConsumed()
+    })
+
+    it('includes share_id on Google auth completion', async () => {
+      preserveShareAuth()
+
+      await store.loginWithGoogle()
+
+      expect(mockTrackAuth).toHaveBeenCalledWith({
+        method: 'google',
+        is_new_user: true,
+        user_id: 'test-user-id',
+        email: 'test@example.com',
+        share_id: 'share-1'
+      })
+      expectShareAuthConsumed()
+    })
+
+    it('includes share_id on GitHub auth completion', async () => {
+      preserveShareAuth()
+
+      await store.loginWithGithub()
+
+      expect(mockTrackAuth).toHaveBeenCalledWith({
+        method: 'github',
+        is_new_user: true,
+        user_id: 'test-user-id',
+        email: 'test@example.com',
+        share_id: 'share-1'
+      })
+      expectShareAuthConsumed()
     })
   })
 

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -695,8 +695,10 @@ describe('useAuthStore', () => {
 
   describe('share auth attribution', () => {
     const mockUserCredential = {
-      user: mockUser
-    } as Partial<UserCredential> as UserCredential
+      user: mockUser,
+      providerId: null,
+      operationType: 'signIn'
+    } satisfies UserCredential
 
     const preserveShareAuth = () => {
       capturePreservedQuery(


### PR DESCRIPTION
## Summary

Logged-out users who open a share link and then sign up/in were not attributed to the share. The `share_id` capture lived in `useSharedWorkflowUrlLoader`, which only runs after `GraphView` mounts — i.e. after the cloud auth guard has already redirected the logged-out user to login. The capture never happened, so `trackAuth` fired without a `share_id`.

This moves the capture into the cloud auth guard (`router.beforeEach`), so it runs on the initial navigation before any login redirect. The `share_id` is preserved across the auth round-trip and consumed on auth completion as before.

## Changes

- Capture logged-out share attribution in the router guard instead of the share loader, via a new `preserveLoggedOutShareAuthAttribution` util
- Extract `isValidShareId` into the shared util and reuse it in the loader (removes the duplicated regex)
- Gate capture on `isCloud` (matching the cloud-only consumption); drop the now-dead capture branch from the loader
- Make the accepted share-id shape explicit: ASCII alphanumeric start, ASCII alphanumeric/`_.-` after that, max 128 chars

## Notes

- Capture no-ops when `share` is absent, so param-less redirects do not clear attribution
- If another valid share link is visited before auth completes, the latest valid share replaces the previous attribution
- `SHARE` and `SHARE_AUTH` stay separate intentionally: `SHARE` preserves the workflow-loading query, while `SHARE_AUTH` is consumed once by auth telemetry attribution
- No behavior change for logged-in users or for share-dialog open/cancel

## Testing

- New unit tests for `isValidShareId` and `preserveLoggedOutShareAuthAttribution` (valid/invalid/array/logged-in/boundary cases)
- Auth store tests cover `share_id` propagation + consumption across email signup/login, Google, and GitHub
- Updated loader and telemetry tests for the relocated capture and `share_id` passthrough
- Cloud E2E regression covers logged-out `/?share=abc` redirecting to login after capturing share auth attribution
