### PR TITLE
fix(auth): show a clear message when sign-up is rejected by the backend

### DIFF
--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -245,6 +245,20 @@ describe('useAuthActions.reportError', () => {
     expect(mockToastErrorHandler).not.toHaveBeenCalled()
   })
 
+  it('matches the signup_blocked token case-insensitively', () => {
+    const { reportError } = useAuthActions()
+
+    reportError(
+      new FirebaseError('auth/internal-error', 'rejected: SIGNUP_BLOCKED')
+    )
+
+    expect(mockToastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'auth.errors.signupBlocked'
+    })
+  })
+
   it('shows the generic fallback for an unknown Firebase auth code', () => {
     const { reportError } = useAuthActions()
 

--- a/src/composables/auth/useAuthActions.test.ts
+++ b/src/composables/auth/useAuthActions.test.ts
@@ -225,6 +225,26 @@ describe('useAuthActions.reportError', () => {
     expect(mockToastErrorHandler).not.toHaveBeenCalled()
   })
 
+  it('shows the signupBlocked message when the error carries the signup_blocked token', () => {
+    const { reportError } = useAuthActions()
+
+    // The backend wraps the rejection in a generic code; we match the token in
+    // the message, so it must win over the auth.errors.${code} fallback.
+    reportError(
+      new FirebaseError(
+        'auth/internal-error',
+        'Account creation is temporarily unavailable. (ref: signup_blocked)'
+      )
+    )
+
+    expect(mockToastStore.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'g.error',
+      detail: 'auth.errors.signupBlocked'
+    })
+    expect(mockToastErrorHandler).not.toHaveBeenCalled()
+  })
+
   it('shows the generic fallback for an unknown Firebase auth code', () => {
     const { reportError } = useAuthActions()
 

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -51,17 +51,10 @@ export const useAuthActions = () => {
       error instanceof FirebaseError &&
       error.message.toLowerCase().includes('signup_blocked')
     ) {
-      // We match on `error.message` rather than `error.code` because a Firebase
-      // `beforeUserCreated` blocking-function rejection does not surface the
-      // thrown code to the client — the SDK collapses it into a generic,
-      // version-dependent code (typically `auth/internal-error`). Matching on
-      // `error.code` would therefore be either too broad (catching unrelated
-      // internal errors) or too brittle (a pinned specific code drifts across
-      // SDK versions). The message is the only channel that carries our intent
-      // through the SDK wrapping. `signup_blocked` is a stable, cross-repo
-      // contract token (a matching comment lives on the backend throw) that is
-      // distinctive enough to avoid false positives; we match it
-      // case-insensitively to tolerate any future backend recasing.
+      // Match on `error.message`, not `error.code`: Firebase `beforeUserCreated`
+      // rejections collapse the thrown code into a generic `auth/internal-error`,
+      // so the message is the only reliable channel. `signup_blocked` is a
+      // cross-repo contract token; matched case-insensitively.
       toastStore.add({
         severity: 'error',
         summary: t('g.error'),

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -49,12 +49,12 @@ export const useAuthActions = () => {
       })
     } else if (
       error instanceof FirebaseError &&
-      typeof error.message === 'string' &&
-      error.message.includes('signup_blocked')
+      error.message.toLowerCase().includes('signup_blocked')
     ) {
       // `signup_blocked` is a stable token from the auth backend's sign-up
-      // rejection response. Matched on the message (not error.code, which the
-      // Firebase SDK wraps inconsistently across versions).
+      // rejection response. Matched case-insensitively on the message (not
+      // error.code, which the Firebase SDK wraps inconsistently across
+      // versions).
       toastStore.add({
         severity: 'error',
         summary: t('g.error'),

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -47,6 +47,19 @@ export const useAuthActions = () => {
           email: 'support@comfy.org'
         })
       })
+    } else if (
+      error instanceof FirebaseError &&
+      typeof error.message === 'string' &&
+      error.message.includes('signup_blocked')
+    ) {
+      // `signup_blocked` is a stable token from the auth backend's sign-up
+      // rejection response. Matched on the message (not error.code, which the
+      // Firebase SDK wraps inconsistently across versions).
+      toastStore.add({
+        severity: 'error',
+        summary: t('g.error'),
+        detail: t('auth.errors.signupBlocked')
+      })
     } else if (error instanceof FirebaseError) {
       toastStore.add({
         severity: 'error',

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -51,10 +51,17 @@ export const useAuthActions = () => {
       error instanceof FirebaseError &&
       error.message.toLowerCase().includes('signup_blocked')
     ) {
-      // `signup_blocked` is a stable token from the auth backend's sign-up
-      // rejection response. Matched case-insensitively on the message (not
-      // error.code, which the Firebase SDK wraps inconsistently across
-      // versions).
+      // We match on `error.message` rather than `error.code` because a Firebase
+      // `beforeUserCreated` blocking-function rejection does not surface the
+      // thrown code to the client — the SDK collapses it into a generic,
+      // version-dependent code (typically `auth/internal-error`). Matching on
+      // `error.code` would therefore be either too broad (catching unrelated
+      // internal errors) or too brittle (a pinned specific code drifts across
+      // SDK versions). The message is the only channel that carries our intent
+      // through the SDK wrapping. `signup_blocked` is a stable, cross-repo
+      // contract token (a matching comment lives on the backend throw) that is
+      // distinctive enough to avoid false positives; we match it
+      // case-insensitively to tolerate any future backend recasing.
       toastStore.add({
         severity: 'error',
         summary: t('g.error'),

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2328,7 +2328,8 @@
       "auth/network-request-failed": "Network error. Please check your connection and try again.",
       "auth/popup-closed-by-user": "Sign-in was cancelled. Please try again.",
       "auth/cancelled-popup-request": "Sign-in was cancelled. Please try again.",
-      "generic": "Something went wrong while signing you in. Please try again."
+      "generic": "Something went wrong while signing you in. Please try again.",
+      "signupBlocked": "We couldn't create your account right now. Please try again later. If this keeps happening, contact support."
     },
     "deleteAccount": {
       "contactSupport": "To delete your account, please contact {email}"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2329,7 +2329,7 @@
       "auth/popup-closed-by-user": "Sign-in was cancelled. Please try again.",
       "auth/cancelled-popup-request": "Sign-in was cancelled. Please try again.",
       "generic": "Something went wrong while signing you in. Please try again.",
-      "signupBlocked": "We couldn't create your account right now. Please try again later. If this keeps happening, contact support."
+      "signupBlocked": "We couldn't create your account right now. Please try again later. If this keeps happening, email support@comfy.org."
     },
     "deleteAccount": {
       "contactSupport": "To delete your account, please contact {email}"


### PR DESCRIPTION
## Problem

When the auth backend rejects a sign-up, the Firebase client SDK surfaces the rejection wrapped in a generic error code (e.g. `auth/internal-error`). `reportError` maps only by `error.code` → `auth.errors.${code}`, so this case falls through to the generic *"Something went wrong while signing you in. Please try again."* toast — giving the user no actionable guidance.

## Change

- `useAuthActions.ts` — add a branch in `reportError` that matches a stable `signup_blocked` token in `error.message` (matched **case-insensitively** on the message, not `error.code`, which the SDK wraps inconsistently across versions) and shows a dedicated message.
- `locales/en/main.json` — new `auth.errors.signupBlocked` string. Other locales inherit it via `fallbackLocale: 'en'`.
- `useAuthActions.test.ts` — unit tests asserting the token path wins over the generic fallback, and that the match is case-insensitive.

## Validation

- `vitest run src/composables/auth` — 12/12 pass (incl. token + case-insensitive tests)
- `vue-tsc --noEmit` — clean

## Why no E2E (Playwright) test

This branch is reachable only when the **auth backend actively rejects a Google-Workspace-SSO sign-up** (a server-side blocking decision) and the Firebase SDK returns an error whose message carries the `signup_blocked` token. Reproducing that in the browser E2E harness would require driving a real federated-SSO sign-up against a backend configured to reject the specific account — state the FE test environment cannot set up deterministically. The logic under test is pure error-mapping with no UI/navigation surface beyond the existing toast, so it is fully covered by the unit tests above. The end-to-end path will instead be confirmed via a one-time staging repro (see below).

## Draft — pending confirmation

Kept as **draft** until we confirm, via a staging repro, the exact error shape the client receives for this rejection (the message-token match is the robust hedge regardless of `error.code`, but a live repro makes it deterministic). The backend that emits the `signup_blocked` token is a separate change.