### PR TITLE
fix: commit promoted asset modal selections

### DIFF
--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -112,6 +112,10 @@ export const TestIds = {
     root: 'properties-panel',
     errorsTab: 'panel-tab-errors'
   },
+  assets: {
+    browserModal: 'asset-browser-modal',
+    card: 'asset-card'
+  },
   subgraphEditor: {
     hiddenSection: 'subgraph-editor-hidden-section',
     iconEye: 'icon-eye',

--- a/browser_tests/tests/cloud-asset-promoted-widget.spec.ts
+++ b/browser_tests/tests/cloud-asset-promoted-widget.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import {
+  assetRequestIncludesTag,
+  createCloudAssetsFixture
+} from '@e2e/fixtures/assetApiFixture'
+import {
+  STABLE_CHECKPOINT,
+  STABLE_CHECKPOINT_2
+} from '@e2e/fixtures/data/assetFixtures'
+
+const WORKFLOW = 'missing/missing_model_promoted_widget'
+const HOST_NODE_ID = 2
+const WIDGET_NAME = 'ckpt_name'
+const SELECTED_MODEL = STABLE_CHECKPOINT_2.name
+
+const test = createCloudAssetsFixture([STABLE_CHECKPOINT, STABLE_CHECKPOINT_2])
+
+interface WidgetSnapshot {
+  type: string
+  value: string
+  hasLayout: boolean
+}
+
+async function getHostWidgetSnapshot(page: Page): Promise<WidgetSnapshot> {
+  return await page.evaluate(
+    ({ nodeId, widgetName }) => {
+      const node = window.app!.graph.getNodeById(nodeId)
+      const widget = node?.widgets?.find((widget) => widget.name === widgetName)
+
+      return {
+        type: widget?.type ?? '',
+        value: String(widget?.value ?? ''),
+        hasLayout: widget?.last_y != null
+      }
+    },
+    { nodeId: HOST_NODE_ID, widgetName: WIDGET_NAME }
+  )
+}
+
+test.describe(
+  'Promoted subgraph asset widgets',
+  { tag: ['@cloud', '@canvas', '@widget'] },
+  () => {
+    test.afterEach(async ({ comfyPage }) => {
+      await comfyPage.nodeOps.clearGraph()
+    })
+
+    test('legacy asset browser selection updates the promoted host widget value', async ({
+      cloudAssetRequests,
+      comfyPage
+    }) => {
+      await comfyPage.settings.setSetting('Comfy.Assets.UseAssetAPI', true)
+      await comfyPage.workflow.loadWorkflow(WORKFLOW)
+
+      await expect
+        .poll(
+          () =>
+            cloudAssetRequests.some((url) =>
+              assetRequestIncludesTag(url, 'checkpoints')
+            ),
+          { timeout: 10_000 }
+        )
+        .toBe(true)
+      await expect
+        .poll(() => getHostWidgetSnapshot(comfyPage.page))
+        .toMatchObject({
+          type: 'asset',
+          hasLayout: true
+        })
+
+      const hostNode = await comfyPage.nodeOps.getNodeRefById(HOST_NODE_ID)
+      await hostNode.centerOnNode()
+      const promotedWidget = await hostNode.getWidgetByName(WIDGET_NAME)
+      await promotedWidget.click()
+
+      const modal = comfyPage.page.locator(
+        '[data-component-id="AssetBrowserModal"]'
+      )
+      await expect(modal).toBeVisible()
+
+      const assetCard = modal
+        .locator('[data-component-id="AssetCard"]')
+        .filter({ hasText: SELECTED_MODEL })
+        .first()
+      await expect(assetCard).toBeVisible()
+      await assetCard.getByRole('button', { name: 'Use' }).click()
+
+      await expect(modal).toBeHidden()
+      await expect
+        .poll(() =>
+          getHostWidgetSnapshot(comfyPage.page).then((widget) => widget.value)
+        )
+        .toBe(SELECTED_MODEL)
+    })
+  }
+)

--- a/browser_tests/tests/cloud-asset-promoted-widget.spec.ts
+++ b/browser_tests/tests/cloud-asset-promoted-widget.spec.ts
@@ -9,6 +9,7 @@ import {
   STABLE_CHECKPOINT,
   STABLE_CHECKPOINT_2
 } from '@e2e/fixtures/data/assetFixtures'
+import { TestIds } from '@e2e/fixtures/selectors'
 
 const WORKFLOW = 'missing/missing_model_promoted_widget'
 const HOST_NODE_ID = 2
@@ -75,13 +76,11 @@ test.describe(
       const promotedWidget = await hostNode.getWidgetByName(WIDGET_NAME)
       await promotedWidget.click()
 
-      const modal = comfyPage.page.locator(
-        '[data-component-id="AssetBrowserModal"]'
-      )
+      const modal = comfyPage.page.getByTestId(TestIds.assets.browserModal)
       await expect(modal).toBeVisible()
 
       const assetCard = modal
-        .locator('[data-component-id="AssetCard"]')
+        .getByTestId(TestIds.assets.card)
         .filter({ hasText: SELECTED_MODEL })
         .first()
       await expect(assetCard).toBeVisible()

--- a/browser_tests/tests/cloud-asset-promoted-widget.spec.ts
+++ b/browser_tests/tests/cloud-asset-promoted-widget.spec.ts
@@ -70,6 +70,8 @@ test.describe(
           type: 'asset',
           hasLayout: true
         })
+      const initialWidget = await getHostWidgetSnapshot(comfyPage.page)
+      expect(initialWidget.value).not.toBe(SELECTED_MODEL)
 
       const hostNode = await comfyPage.nodeOps.getNodeRefById(HOST_NODE_ID)
       await hostNode.centerOnNode()

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -7,7 +7,6 @@ import type {
   LLink
 } from '@/lib/litegraph/src/litegraph'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
-import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type {
   IBaseWidget,
   TWidgetValue
@@ -275,13 +274,6 @@ export class PrimitiveNode extends LGraphNode {
       inputNameForBrowser: targetInputName,
       defaultValue,
       onValueChange: (widget, newValue, oldValue) => {
-        widget.callback?.(
-          widget.value,
-          app.canvas,
-          this,
-          app.canvas.graph_mouse,
-          {} as CanvasPointerEvent
-        )
         this.onWidgetChanged?.(widget.name, newValue, oldValue, widget)
       }
     })

--- a/src/platform/assets/components/AssetBrowserModal.vue
+++ b/src/platform/assets/components/AssetBrowserModal.vue
@@ -1,6 +1,7 @@
 <template>
   <BaseModalLayout
     v-model:right-panel-open="isRightPanelOpen"
+    data-testid="asset-browser-modal"
     data-component-id="AssetBrowserModal"
     class="size-full max-h-full max-w-full min-w-0"
     :content-title="displayTitle"

--- a/src/platform/assets/components/AssetCard.vue
+++ b/src/platform/assets/components/AssetCard.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    data-testid="asset-card"
     data-component-id="AssetCard"
     :data-asset-id="asset.id"
     :aria-labelledby="titleId"

--- a/src/platform/assets/utils/createAssetWidget.test.ts
+++ b/src/platform/assets/utils/createAssetWidget.test.ts
@@ -1,0 +1,104 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type {
+  IAssetWidget,
+  IBaseWidget
+} from '@/lib/litegraph/src/types/widgets'
+import { useAssetBrowserDialog } from '@/platform/assets/composables/useAssetBrowserDialog'
+import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
+
+import { createAssetWidget } from './createAssetWidget'
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/assets/composables/useAssetBrowserDialog', () => {
+  const show = vi.fn()
+  const browse = vi.fn()
+  const dialog = { show, browse }
+  return {
+    useAssetBrowserDialog: () => dialog
+  }
+})
+
+function checkpointAsset(name: string): AssetItem {
+  return {
+    id: `asset-${name}`,
+    name,
+    hash: 'checkpoint-hash',
+    mime_type: 'application/octet-stream',
+    tags: []
+  }
+}
+
+function expectAssetWidget(
+  widget: IBaseWidget
+): asserts widget is IAssetWidget {
+  if (widget.type !== 'asset') {
+    throw new Error('Expected createAssetWidget to create an asset widget')
+  }
+}
+
+describe('createAssetWidget', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('notifies the widget callback when the asset browser commits a selected filename', async () => {
+    const node: Pick<LGraphNode, 'addWidget'> = {
+      addWidget(type, name, value, callback, options): IBaseWidget {
+        return {
+          type,
+          name,
+          value,
+          callback: typeof callback === 'function' ? callback : undefined,
+          options:
+            typeof options === 'string'
+              ? { property: options }
+              : (options ?? {}),
+          y: 0
+        }
+      }
+    }
+    const callback = vi.fn<NonNullable<IBaseWidget['callback']>>()
+    const onValueChange =
+      vi.fn<
+        (widget: IBaseWidget, newValue: string, oldValue: unknown) => void
+      >()
+    const widget = createAssetWidget({
+      node,
+      widgetName: 'ckpt_name',
+      nodeTypeForBrowser: 'CheckpointLoaderSimple',
+      defaultValue: 'fake_model.safetensors',
+      onValueChange
+    })
+
+    expectAssetWidget(widget)
+
+    widget.callback = callback
+    await widget.options.openModal(widget)
+
+    const showOptions = vi.mocked(useAssetBrowserDialog().show).mock
+      .calls[0]?.[0]
+    if (!showOptions) {
+      throw new Error('Expected the asset browser dialog to open')
+    }
+
+    showOptions.onAssetSelected?.(checkpointAsset('real_model.safetensors'))
+
+    expect(widget.value).toBe('real_model.safetensors')
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('real_model.safetensors')
+    expect(onValueChange).toHaveBeenCalledTimes(1)
+    expect(onValueChange).toHaveBeenCalledWith(
+      widget,
+      'real_model.safetensors',
+      'fake_model.safetensors'
+    )
+  })
+})

--- a/src/platform/assets/utils/createAssetWidget.ts
+++ b/src/platform/assets/utils/createAssetWidget.ts
@@ -14,9 +14,11 @@ import {
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import { getAssetFilename } from '@/platform/assets/utils/assetMetadataUtils'
 
+type AssetWidgetNode = Pick<LGraphNode, 'addWidget'>
+
 interface CreateAssetWidgetParams {
   /** The node to add the widget to */
-  node: LGraphNode
+  node: AssetWidgetNode
   /** The widget name */
   widgetName: string
   /** The node type to show in asset browser (may differ from node.comfyClass for PrimitiveNode) */

--- a/src/platform/assets/utils/createAssetWidget.ts
+++ b/src/platform/assets/utils/createAssetWidget.ts
@@ -98,6 +98,7 @@ export function createAssetWidget(
 
         const oldValue = widget.value
         widget.value = validatedFilename.data
+        widget.callback?.(widget.value)
         onValueChange?.(widget, validatedFilename.data, oldValue)
       }
     })


### PR DESCRIPTION
## Summary

Fix promoted subgraph asset widgets so selecting a model from the Asset Browser modal commits the selected value back through the widget callback bridge instead of updating only the transient canvas widget wrapper.

## Changes

- **What**: Move the asset modal selection callback notification into the shared `createAssetWidget` commit path. After the selected asset is validated and converted into the canonical filename, `createAssetWidget` now sets `widget.value` and invokes `widget.callback?.(widget.value)` before running the caller-specific `onValueChange` hook.
- **What**: Remove the older PrimitiveNode-only callback call from `widgetInputs.ts`. PrimitiveNode still receives its `onWidgetChanged` notification, and its `applyToGraph()` behavior remains covered by the existing callback chain. Moving the callback into `createAssetWidget` avoids duplicate callback execution while making the behavior available to regular asset widgets, PrimitiveNode asset widgets, and promoted subgraph asset widgets.
- **What**: Add stable `data-testid` selectors for `AssetBrowserModal` and `AssetCard`, and route the new E2E through `TestIds.assets` instead of relying on `data-component-id`.
- **What**: Add a cloud E2E regression test for the legacy canvas promoted-subgraph asset widget flow.
- **What**: Add a focused Vitest regression test for `createAssetWidget` to pin the callback bridge at the shared asset modal commit point.
- **Breaking**: None.
- **Dependencies**: None.

## Why this is needed

Promoted subgraph widgets are store-backed projections of an internal widget. In the legacy canvas path, clicking a promoted asset widget wraps the projected POJO widget with a transient concrete `AssetWidget` via `toConcreteWidget(...)`. The Asset Browser modal receives that transient wrapper.

Before this PR, the async modal selection path in `createAssetWidget` wrote the selected filename to `widget.value`, then called `onValueChange`. That was enough for ordinary asset widgets and PrimitiveNode's local path, but it was not enough for promoted subgraph widgets: the value write landed on the transient wrapper, while the actual promoted host widget value lives behind the promoted widget callback/store bridge. As a result, the modal closed successfully but the promoted host widget stayed on the old value.

This was especially visible for cloud asset widgets because the Asset Browser modal is the main edit surface. Selecting a valid model from the modal did not update the promoted host widget value, which also prevented follow-up behavior such as missing-model error clearing from observing the selected model.

The fix restores the same conceptual contract used by normal widget edits: once a widget value changes, the widget callback is notified so consumers can run their own propagation logic. Placing the callback in `createAssetWidget` is intentionally generic. The asset modal selection path is shared by regular nodes, PrimitiveNode, and promoted subgraph widgets, so the callback bridge belongs at the shared commit point rather than in a PrimitiveNode-specific `onValueChange` hook.

## Review Focus

- Confirm that `createAssetWidget` is the right shared commit boundary for Asset Browser selections.
- Confirm that invoking `widget.callback?.(widget.value)` before `onValueChange` matches the existing LiteGraph edit ordering closely enough for this async modal path.
- Confirm that removing the PrimitiveNode-specific callback call does not change built-in behavior. PrimitiveNode still chains `applyToGraph()` into the widget callback, and downstream target widgets still receive their normal propagation context through the existing `applyFirstWidgetValueToGraph` path.
- Confirm that the new E2E asserts the promoted host widget's projected/store-backed value, not the transient modal wrapper value.
- Confirm that the added unit test is scoped to the shared asset modal commit behavior and does not over-mock the widget implementation.

## Red-Green Verification

- Red E2E commit: `1b29ec46d test: cover promoted asset widget selection`
  - Verified locally against the pre-fix implementation.
  - The test failed after selecting the second checkpoint from the Asset Browser modal because the promoted host widget value remained `fake_model.safetensors`.
  - Failure assertion: expected `v1-5-pruned-emaonly.safetensors`, received `fake_model.safetensors`.
- Green production commit: `777ef4a4e fix: commit promoted asset modal selections`
  - The same E2E passed after the shared callback bridge was restored in `createAssetWidget`.
- Unit regression commit: `2f7e86efa test: cover asset widget modal callback`
  - The unit test was also checked against the broken runtime by temporarily removing only `widget.callback?.(widget.value)` from `createAssetWidget`; it failed with `expected "vi.fn()" to be called 1 times, but got 0 times`.
  - With the fix restored, the unit test passes.

## Test Plan

- `pnpm exec vitest run src/platform/assets/utils/createAssetWidget.test.ts --reporter verbose`
- `pnpm typecheck`
- `pnpm typecheck:browser`
- `pnpm exec eslint src/platform/assets/utils/createAssetWidget.test.ts src/platform/assets/utils/createAssetWidget.ts`
- `pnpm exec oxlint --type-aware src/platform/assets/utils/createAssetWidget.test.ts src/platform/assets/utils/createAssetWidget.ts`
- `pnpm exec oxfmt --check src/platform/assets/utils/createAssetWidget.test.ts src/platform/assets/utils/createAssetWidget.ts`
- `pnpm build:cloud`
- `PLAYWRIGHT_TEST_URL=http://localhost:8188 PLAYWRIGHT_SETUP_API_URL=http://localhost:8188 pnpm exec playwright test browser_tests/tests/cloud-asset-promoted-widget.spec.ts --project=cloud --reporter=line`
- pre-commit hooks on the fix and unit-test commits
- push hook: `knip --cache`

## Screenshots (if applicable)

Not applicable. This is a widget value propagation fix covered by automated regression tests.
