### PR TITLE
fix(ci): strip served bundle scripts from e2e coverage before genhtml

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -85,6 +85,16 @@ jobs:
             fi
           done
 
+      - name: Strip non-source entries from coverage
+        if: steps.coverage-shards.outputs.has-coverage == 'true'
+        run: |
+          # Drop served bundle scripts (localhost-8188/assets/*.js) that V8 records but have no source file on disk, which would abort genhtml.
+          lcov --remove coverage/playwright/coverage.lcov \
+            '*localhost-8188*' \
+            -o coverage/playwright/coverage.lcov \
+            --ignore-errors unused
+          wc -l coverage/playwright/coverage.lcov
+
       - name: Upload merged coverage data
         if: steps.coverage-shards.outputs.has-coverage == 'true'
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Problem

The **CI: E2E Coverage** `merge` job fails in the *Generate HTML coverage report* step ([example run](https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/28051468752)):

```
genhtml: ERROR: localhost-8188/assets/nodeDefs-BNhq_6cm.js is not readable or doesn't exist.
##[error]Process completed with exit code 1.
```

V8/Playwright coverage records scripts the test server serves at `localhost-8188/assets/*.js` (built bundles), which are not source files on disk. `genhtml` aborts on the missing source even with `--ignore-errors source`, so the whole job fails.

## Change

Add a *Strip non-source entries from coverage* step that runs `lcov --remove '*localhost-8188*'` on the merged lcov. It is placed **after** the data-loss validation (so the merged-vs-shard integrity check stays consistent) and **before** the Codecov upload and genhtml — which also makes the Codecov report more accurate, since those served bundles aren't repo source.

## Validation

- YAML parses cleanly; pre-commit lint/format/typecheck pass.
- The removed paths are non-source served assets only; real `src/**` entries (absolute paths under the repo workspace) are untouched by the `*localhost-8188*` pattern.
- `--ignore-errors unused` guards against runs where no such entries exist.