### PR TITLE
test: 1/x fix coverage run

### DIFF
--- a/src/composables/useWorkflowStatusDismissal.ts
+++ b/src/composables/useWorkflowStatusDismissal.ts
@@ -8,12 +8,12 @@ export function useWorkflowStatusDismissal() {
   const executionStore = useExecutionStore()
 
   watch(
-    () => workflowStore.activeWorkflow,
-    (workflow) => {
-      if (
-        workflow &&
-        executionStore.getWorkflowStatus(workflow) !== 'running'
-      ) {
+    () => {
+      const workflow = workflowStore.activeWorkflow
+      return [workflow, executionStore.getWorkflowStatus(workflow)] as const
+    },
+    ([workflow, status]) => {
+      if (workflow && status !== undefined && status !== 'running') {
         executionStore.clearWorkflowStatus(workflow)
       }
     },

--- a/src/extensions/core/load3dLazy.test.ts
+++ b/src/extensions/core/load3dLazy.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/scripts/app', () => ({
 }))
 
 vi.mock('@/extensions/core/load3d', () => ({}))
+vi.mock('@/extensions/core/load3dAdvanced', () => ({}))
 vi.mock('@/extensions/core/load3dPreviewExtensions', () => ({}))
 vi.mock('@/extensions/core/saveMesh', () => ({}))
 


### PR DESCRIPTION
## Summary

Fix the two current blockers that prevented `pnpm test:coverage` from completing on `main`.

Stack order: 1/x

## Changes

- Mock `load3dAdvanced` in the lazy-loader test so coverage does not import the real Load3DAdvanced UI graph.
- Track the active workflow status in `useWorkflowStatusDismissal` so terminal statuses arriving after activation are cleared.

## Test Results

| | before | after |
| -- | -- | -- |
| `pnpm test:coverage` | ❌ failed, so the stack had no usable coverage baseline | ✅ passed with 877 test files passed; 11,772 passed / 8 skipped |
| focused tests | `load3dLazy` timed out; `useWorkflowStatusDismissal` failed its active-workflow status case | ✅ `load3dLazy`: 13 passed; `useWorkflowStatusDismissal`: 4 passed |

## Coverage

| | before | after |
| -- | -- | -- |
| statements | unavailable | 62.84% |
| branches | unavailable | 53.03% |
| functions | unavailable | 56.94% |
| lines | unavailable | 64.05% |

Screenshots: N/A, no UI change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 94c4c9bac16cab9d55a5a8343e2f9908b08e12bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->