### PR TITLE
feat(billing): team-plan Stripe checkout deep link

### DIFF
--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -59,6 +59,15 @@ vi.mock('@/platform/cloud/subscription/utils/subscriptionCheckoutUtil', () => ({
     mockPerformSubscriptionCheckout(...args)
 }))
 
+const mockPerformTeamSubscriptionCheckout = vi.fn()
+vi.mock(
+  '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil',
+  () => ({
+    performTeamSubscriptionCheckout: (...args: unknown[]) =>
+      mockPerformTeamSubscriptionCheckout(...args)
+  })
+)
+
 const createI18nInstance = () =>
   createI18n({
     legacy: false,
@@ -73,6 +82,7 @@ const createI18nInstance = () =>
         },
         subscription: {
           subscribeTo: 'Subscribe to {plan}',
+          teamPlan: { name: 'Team Plan' },
           tiers: {
             standard: { name: 'Standard' },
             creator: { name: 'Creator' },
@@ -161,5 +171,25 @@ describe('CloudSubscriptionRedirectView', () => {
       'monthly',
       false
     )
+  })
+
+  test('checks out the team plan via the workspace path with the chosen stop and cycle', async () => {
+    await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
+
+    expect(mockRouterPush).not.toHaveBeenCalledWith('/')
+    expect(screen.getByText('Subscribe to Team Plan')).toBeInTheDocument()
+    expect(mockPerformTeamSubscriptionCheckout).toHaveBeenCalledWith(
+      'team_700',
+      'yearly'
+    )
+    // Team never goes through the personal checkout path
+    expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+  })
+
+  test('redirects to home for a team link with no stop', async () => {
+    await mountView({ tier: 'team', cycle: 'yearly' })
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/')
+    expect(mockPerformTeamSubscriptionCheckout).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -10,6 +10,7 @@ import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { performSubscriptionCheckout } from '@/platform/cloud/subscription/utils/subscriptionCheckoutUtil'
+import { performTeamSubscriptionCheckout } from '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil'
 
 import type { BillingCycle } from '../subscription/utils/subscriptionTierRank'
 
@@ -35,6 +36,12 @@ const tierDisplayName = computed(() => {
   return names[selectedTierKey.value]
 })
 
+const isTeamCheckout = ref(false)
+
+const planLabel = computed(() =>
+  isTeamCheckout.value ? t('subscription.teamPlan.name') : tierDisplayName.value
+)
+
 const runRedirect = wrapWithErrorHandlingAsync(async () => {
   const rawType = route.query.tier
   const rawCycle = route.query.cycle
@@ -58,7 +65,34 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     return
   }
 
-  // Only paid tiers can be checked out via redirect
+  const validCycles: BillingCycle[] = ['monthly', 'yearly']
+  const billingCycle: BillingCycle = (validCycles as string[]).includes(
+    cycleParam
+  )
+    ? (cycleParam as BillingCycle)
+    : 'monthly'
+
+  // Team is a per-credit plan picked on a slider, so it carries a `stop` (the
+  // chosen credit commitment) instead of a tier and checks out through the
+  // workspace billing endpoint rather than the personal one.
+  if (tierKeyParam === 'team') {
+    const rawStop = route.query.stop
+    const stopId =
+      typeof rawStop === 'string'
+        ? rawStop
+        : Array.isArray(rawStop)
+          ? rawStop[0]
+          : null
+    if (!stopId) {
+      await router.push('/')
+      return
+    }
+    isTeamCheckout.value = true
+    await performTeamSubscriptionCheckout(stopId, billingCycle)
+    return
+  }
+
+  // Only paid personal tiers can be checked out via redirect
   const validTierKeys: TierKey[] = ['standard', 'creator', 'pro', 'founder']
   if (!(validTierKeys as string[]).includes(tierKeyParam)) {
     await router.push('/')
@@ -69,11 +103,6 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
 
   selectedTierKey.value = tierKey
 
-  const validCycles: BillingCycle[] = ['monthly', 'yearly']
-  if (!cycleParam || !(validCycles as string[]).includes(cycleParam)) {
-    cycleParam = 'monthly'
-  }
-
   if (!isInitialized.value) {
     await initialize()
   }
@@ -81,11 +110,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
   if (isActiveSubscription.value) {
     await accessBillingPortal(undefined, false)
   } else {
-    await performSubscriptionCheckout(
-      tierKey,
-      cycleParam as BillingCycle,
-      false
-    )
+    await performSubscriptionCheckout(tierKey, billingCycle, false)
   }
 }, reportError)
 
@@ -105,18 +130,18 @@ onMounted(() => {
         class="size-16"
       />
       <p
-        v-if="selectedTierKey"
+        v-if="planLabel"
         class="font-inter text-base/normal font-normal text-base-foreground"
       >
         {{
           t('subscription.subscribeTo', {
-            plan: tierDisplayName
+            plan: planLabel
           })
         }}
       </p>
-      <ProgressSpinner v-if="selectedTierKey" class="size-8" stroke-width="4" />
+      <ProgressSpinner v-if="planLabel" class="size-8" stroke-width="4" />
       <Button
-        v-if="selectedTierKey"
+        v-if="planLabel"
         as="a"
         href="/"
         link

--- a/src/platform/cloud/subscription/constants/teamPlanCreditStops.ts
+++ b/src/platform/cloud/subscription/constants/teamPlanCreditStops.ts
@@ -50,6 +50,17 @@ export const TEAM_PLAN_CREDIT_STOPS: readonly CreditStop[] = [
 export const DEFAULT_TEAM_PLAN_STOP_INDEX = 2
 
 /**
+ * Per-credit Team plan slug for a billing cadence (cloud catalog). The slug
+ * encodes the cadence; `POST /api/billing/subscribe` reads `plan_slug` +
+ * `team_credit_stop_id` and resolves all amounts server-side from the stop.
+ */
+export function getTeamPlanSlug(billingCycle: 'monthly' | 'yearly'): string {
+  return billingCycle === 'yearly'
+    ? 'team_per_credit_annual'
+    : 'team_per_credit_monthly'
+}
+
+/**
  * Discounted monthly price for a stop's list `usd`, applying the billing-cycle
  * discount (yearly = full `discountPercentYearly`; monthly halves it). Shared by
  * the slider display and the checkout confirm step so the two never drift.

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockIsCloud, mockSubscribe } = vi.hoisted(() => ({
+  mockIsCloud: { value: true },
+  mockSubscribe: vi.fn()
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+vi.mock('@/config/comfyApi', () => ({
+  getComfyPlatformBaseUrl: () => 'https://app.test'
+}))
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: { subscribe: mockSubscribe }
+}))
+
+import { performTeamSubscriptionCheckout } from './teamSubscriptionCheckoutUtil'
+
+describe('performTeamSubscriptionCheckout', () => {
+  let assignedHref: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsCloud.value = true
+    assignedHref = undefined
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: {
+        set href(value: string) {
+          assignedHref = value
+        }
+      }
+    })
+  })
+
+  it('subscribes at the stop with the yearly slug and redirects to the Stripe payment page', async () => {
+    mockSubscribe.mockResolvedValue({
+      status: 'needs_payment_method',
+      payment_method_url: 'https://stripe.test/pay',
+      billing_op_id: 'op_1'
+    })
+
+    await performTeamSubscriptionCheckout('team_700', 'yearly')
+
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'team_per_credit_annual',
+      'https://app.test/payment/success',
+      'https://app.test/payment/failed',
+      'team_700'
+    )
+    expect(assignedHref).toBe('https://stripe.test/pay')
+  })
+
+  it('uses the monthly slug and lands in the app when no Stripe step is needed', async () => {
+    mockSubscribe.mockResolvedValue({
+      status: 'subscribed',
+      billing_op_id: 'op_2'
+    })
+
+    await performTeamSubscriptionCheckout('team_1400', 'monthly')
+
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'team_per_credit_monthly',
+      expect.any(String),
+      expect.any(String),
+      'team_1400'
+    )
+    expect(assignedHref).toBe('/')
+  })
+
+  it('does nothing off cloud', async () => {
+    mockIsCloud.value = false
+
+    await performTeamSubscriptionCheckout('team_700', 'yearly')
+
+    expect(mockSubscribe).not.toHaveBeenCalled()
+    expect(assignedHref).toBeUndefined()
+  })
+})

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
@@ -1,0 +1,46 @@
+import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
+import { getTeamPlanSlug } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
+import { isCloud } from '@/platform/distribution/types'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+
+import type { BillingCycle } from './subscriptionTierRank'
+
+/**
+ * Direct team-plan checkout for the marketing `/cloud/subscribe?tier=team` deep
+ * link: subscribes to the per-credit Team plan at the chosen slider stop and
+ * sends the user straight to the Stripe payment page.
+ *
+ * Mirrors `performSubscriptionCheckout` (personal) but routes through the
+ * workspace billing endpoint (`POST /api/billing/subscribe`), because the
+ * per-credit Team plan lives there and the backend lets any workspace — personal
+ * included — subscribe to it. The slug encodes the cadence; the stop id is
+ * validated and priced server-side.
+ *
+ * Caller guards on `isCloud`, owns loading state, and wraps error handling. A
+ * `needs_payment_method` response is a full-page redirect to Stripe; the other
+ * statuses land back in the app, which polls the billing op to completion.
+ */
+export async function performTeamSubscriptionCheckout(
+  teamCreditStopId: string,
+  billingCycle: BillingCycle
+): Promise<void> {
+  if (!isCloud) return
+
+  const planSlug = getTeamPlanSlug(billingCycle)
+  const response = await workspaceApi.subscribe(
+    planSlug,
+    `${getComfyPlatformBaseUrl()}/payment/success`,
+    `${getComfyPlatformBaseUrl()}/payment/failed`,
+    teamCreditStopId
+  )
+
+  if (
+    response.status === 'needs_payment_method' &&
+    response.payment_method_url
+  ) {
+    globalThis.location.href = response.payment_method_url
+    return
+  }
+
+  globalThis.location.href = '/'
+}

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -156,6 +156,8 @@ interface SubscribeRequest {
   idempotency_key?: string
   return_url?: string
   cancel_url?: string
+  /** Required for the per-credit Team plan; selects the slider stop. */
+  team_credit_stop_id?: string
 }
 
 type SubscribeStatus = 'subscribed' | 'needs_payment_method' | 'pending_payment'
@@ -603,7 +605,8 @@ export const workspaceApi = {
   async subscribe(
     planSlug: string,
     returnUrl?: string,
-    cancelUrl?: string
+    cancelUrl?: string,
+    teamCreditStopId?: string
   ): Promise<SubscribeResponse> {
     const headers = await getAuthHeaderOrThrow()
     try {
@@ -612,7 +615,8 @@ export const workspaceApi = {
         {
           plan_slug: planSlug,
           return_url: returnUrl,
-          cancel_url: cancelUrl
+          cancel_url: cancelUrl,
+          team_credit_stop_id: teamCreditStopId
         } satisfies SubscribeRequest,
         { headers }
       )


### PR DESCRIPTION
create deep link for new team credit stops like cloud.comfy.org/cloud/subscribe?tier=standard&cycle=monthly&_gl=1*1ilhegx*_gcl_au*MjY0MTE1NzA0LjE3ODE4NTc5MTQ.*_ga*MTcxNjgzOTExOC4xNzgxODU4NTUy*_ga_C8GM67L51P*czE3ODIyODY3NTckbzEyJGcxJHQxNzgyMjg5MzgyJGo2MCRsMCRoMA.. 
## Summary

Adds a **Stripe-direct deep link for the Team plan** so the marketing pricing page (`comfy.org/cloud/pricing`) can send users straight to Stripe checkout, exactly like the personal tiers do today.

```
cloud.comfy.org/cloud/subscribe?tier=team&stop=<stopId>&cycle=<monthly|yearly>
```

This is the Stripe-direct counterpart to the pricing-table deep link (`?pricing=team`, #13001) — same initiative, separate entry point.

## What changed (cloud app only)

- **`CloudSubscriptionRedirectView`**: branches on `tier=team`, reads the slider `stop` + `cycle`, and routes to the workspace billing checkout. `tier=team` without a `stop` falls back to `/`. Personal tiers are unchanged.
- **`performTeamSubscriptionCheckout`** (new util): mirrors `performSubscriptionCheckout` (personal) but calls `POST /api/billing/subscribe` with the per-credit plan slug + `team_credit_stop_id`. A `needs_payment_method` response is a full-page redirect to the Stripe `payment_method_url`; `subscribed` / `pending_payment` land back in the app, which polls the billing op.
- **`workspaceApi.subscribe`**: additive optional `team_credit_stop_id` param.
- **`getTeamPlanSlug(cycle)`**: maps the cycle to the catalog slug (`team_per_credit_monthly` / `team_per_credit_annual`).

Routes through the **workspace billing** endpoint (not the personal `/customers` one) because the per-credit Team plan lives there, and the backend explicitly lets **any** workspace — personal included — subscribe to it, so a marketing visitor does not need a pre-existing team workspace.

## No new BE work

The contract is already on `Comfy-Org/cloud` main: `handleSubscribe` accepts `{ plan_slug: team_per_credit_*, team_credit_stop_id }`, a fresh subscribe (no active sub) returns `needs_payment_method` + `payment_method_url`, and `GET /api/billing/plans` returns `team_credit_stops`. Only a team *change* (existing sub → new stop) is unsupported, which is irrelevant for the marketing button (new subscribers).

## Out of scope

- **Website button** — emitting the slider `stop` id + the monthly/yearly toggle into the URL belongs in the website pricing page (PR #13065, Michael). This PR is the cloud-app capability the button targets.

## Merge gating

Soft-gated on the cloud team contract being **deployed to prod** (it is on cloud main). Until then the link 422s against prod; no impact on existing flows.

## Stack

Stacked on `jaewon/fe-1104-pricing-table-deep-link` (#13001). Not for `main` until that lands. **Draft** until the prod-deploy confirm.

## Tests

- `teamSubscriptionCheckoutUtil.test.ts`: slug-by-cycle, redirect to `payment_method_url`, lands in-app when no Stripe step, off-cloud no-op.
- `CloudSubscriptionRedirectView.test.ts`: team link checks out via the workspace path with the chosen stop/cycle and never the personal path; missing `stop` → home.

`pnpm typecheck`, oxlint, oxfmt green; affected unit suites green.
