### PR TITLE
fix(billing): restore unified pricing dialog width (Reka renderer regression)

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.test.ts
@@ -129,6 +129,21 @@ describe('useSubscriptionDialog', () => {
       expect(props).not.toHaveProperty('onChooseTeam')
     })
 
+    it('sizes the unified pricing dialog via the Reka contentClass, not the ignored PrimeVue style', () => {
+      mockTeamWorkspacesEnabled.value = true
+      mockIsInPersonalWorkspace.value = true
+      const { showPricingTable } = useSubscriptionDialog()
+
+      showPricingTable()
+
+      const { dialogComponentProps } = mockShowLayoutDialog.mock.calls[0][0]
+      // Reka (the default renderer) sizes via size/contentClass; a PrimeVue
+      // `style` width is silently ignored and collapses the wide table to the
+      // default md (576px) frame.
+      expect(dialogComponentProps).toHaveProperty('contentClass')
+      expect(dialogComponentProps).not.toHaveProperty('style')
+    })
+
     it('defaults to the personal tab in a personal workspace', () => {
       mockTeamWorkspacesEnabled.value = true
       mockIsInPersonalWorkspace.value = true

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -129,18 +129,15 @@ export const useSubscriptionDialog = () => {
             (workspaceStore.isInPersonalWorkspace ? 'personal' : 'team')
         },
         dialogComponentProps: {
-          // The dialog hugs its content so each step sizes itself: the pricing
-          // table stays wide/fixed (cards fill it, DES QA 2026-06-13) while the
-          // compact confirm/success steps shrink instead of floating in the big
-          // pricing modal. Sizes are set on the content root per checkoutStep.
-          style: 'max-width: 95vw; max-height: 90vh;',
-          pt: {
-            root: { class: 'rounded-2xl bg-transparent' },
-            content: {
-              class:
-                '!p-0 rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
-            }
-          }
+          // Reka (the default renderer) sizes via size/contentClass; a PrimeVue
+          // `style` width is ignored here and collapses the table to the default
+          // `md` frame. `w-fit` lets each step hug its content — the pricing
+          // table fills its 1280px content while the compact confirm/success
+          // steps shrink (the content root sets its own width per checkoutStep).
+          renderer: 'reka',
+          size: 'full',
+          contentClass:
+            'w-fit max-w-[min(1280px,95vw)] sm:max-w-[min(1280px,95vw)] max-h-[90vh] rounded-2xl border border-border-default bg-secondary-background shadow-[0_25px_80px_rgba(5,6,12,0.45)]'
         }
       })
       return


### PR DESCRIPTION
## Summary

Restore the unified "Choose a Plan" pricing dialog width — it was collapsing to the default `md` (576px) frame, so the 1280px table overflowed and rendered off-center with the right card clipped.

## Changes

- **What**: `showPricingTable` opens the unified dialog (`SubscriptionRequiredDialogContentUnified`) with PrimeVue-path props for sizing (`style: 'max-width: 95vw'` + `pt`). Since #12593 (FE-578 Phase 6a) made **Reka the default dialog renderer**, those props are ignored — Reka sizes via `size`/`contentClass`, so the dialog fell back to `size: 'md'` (`max-w-xl` = 576px). The content root's `xl:w-[min(1280px,95vw)]` then overflowed the 576px box and shifted off-center. Moved the width onto a Reka `contentClass` (`w-fit max-w-[min(1280px,95vw)]`), matching the sibling subscription dialogs in the same file.

## Review Focus

- **Regression origin**: the broken config landed when #12666 (FE-934, UnifiedPricingTable) merged on top of #12593's reka-default flip while still using the PrimeVue config. No merge conflict — the `style` line is valid but dead, so it broke silently. FE-991 (#12792) predates #12593, so it still rendered via PrimeVue and looked correct (matching the report that it was fine there).
- **`w-fit` vs fixed width**: `w-fit` preserves the original "dialog hugs its content per step" intent — the content root only sets the 1280px width on the pricing step, so confirm/success steps still shrink instead of floating in a 1280px box.
- Out of scope: the legacy-team / flag-off paths share a PrimeVue `style` shell and are likely affected the same way under Reka; left for a follow-up (flag-off is the lower-priority OSS path).

## Verification

- Unit test `useSubscriptionDialog.test.ts` — red without the fix (dialog has no `contentClass`), green with it.
- Verified live (cloud dev, viewport 1301px): box centered at 1236px (95vw), no overflow, all three personal cards visible.

## Screenshots

Personal tab, viewport 1301px:

| Before | After |
| --- | --- |
| <img width="480" alt="before" src="https://github.com/user-attachments/assets/e233fe00-f754-4e34-837f-cf6630ccbfb9" /> | <img width="480" alt="after" src="https://github.com/user-attachments/assets/dedd92b7-8707-4865-b7f3-289919043b48" /> |
