### PR TITLE
fix: e2e coverage html report asset failures

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -88,9 +88,9 @@ jobs:
       - name: Strip non-source entries from coverage
         if: steps.coverage-shards.outputs.has-coverage == 'true'
         run: |
-          # Drop served bundle scripts (localhost-8188/assets/*.js) that V8 records but have no source file on disk, which would abort genhtml.
           lcov --remove coverage/playwright/coverage.lcov \
             '*localhost-8188*' \
+            'assets/images/*' \
             -o coverage/playwright/coverage.lcov \
             --ignore-errors unused
           wc -l coverage/playwright/coverage.lcov
@@ -121,7 +121,8 @@ jobs:
             --title "ComfyUI E2E Coverage" \
             --no-function-coverage \
             --precision 1 \
-            --ignore-errors source,unmapped
+            --ignore-errors source,unmapped,range \
+            --synthesize-missing
 
       - name: Upload HTML report artifact
         if: steps.coverage-shards.outputs.has-coverage == 'true'


### PR DESCRIPTION
## Summary

Harden E2E coverage HTML generation against non-renderable LCOV source entries so public assets and stale sourcemap paths no longer abort the report.

## Changes

- **What**: Removes `assets/images/*` entries from merged E2E LCOV before upload/report generation.
- **What**: Lets `genhtml` ignore range warnings and synthesize missing source files when LCOV references stale paths.
- **Dependencies**: None.

## Review Focus

Root cause: Playwright/Monocart can emit LCOV `SF:` records that `genhtml` cannot read from the checkout. The failed run stopped first on public assets like `assets/images/hf-logo.svg`; replaying the same artifact also exposed stale source paths after those assets were removed.

The filter is intentionally `assets/images/*`, not `assets/*`, because real `lcov` matching would also remove legitimate source coverage under `src/platform/assets/...`.

## Validation

- `yamllint --config-file .yamllint .github/workflows/ci-tests-e2e-coverage.yaml`
- Replayed failed run `28138018468` merged LCOV:
  - `assets/images/*` strip leaves `0` `SF:assets/...` entries
  - preserves `68` `SF:src/platform/assets/...` entries
  - `genhtml` exits `0` with `--ignore-errors source,unmapped,range --synthesize-missing`
- Commit hook: `oxfmt`, `oxlint`, `eslint`, `pnpm typecheck`
- Push hook: `knip --cache`

## Screenshots (if applicable)

N/A, CI workflow-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the E2E coverage GitHub Actions workflow; no application runtime or security paths are touched.
> 
> **Overview**
> Fixes E2E coverage HTML generation failing when merged LCOV references paths **genhtml** cannot read (public static assets and stale sourcemap paths from Playwright/Monocart).
> 
> The **Strip non-source entries** step now also drops `assets/images/*` via `lcov --remove`, scoped narrowly so real source under `src/platform/assets/...` stays in the report. **Generate HTML coverage report** passes `--ignore-errors source,unmapped,range` and `--synthesize-missing` so remaining unmapped or missing sources do not abort the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede555664436874bcaa7af8a3dfde22c0b357ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->