### PR TITLE
Gate model library asset view behind a runtime setting, distinct from UseAssetAPI

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1227,6 +1227,15 @@ export const CORE_SETTINGS: SettingParams[] = [
     experimental: true
   },
   {
+    id: 'Comfy.Assets.ModelLibraryAssetView',
+    name: 'Asset-backed model library',
+    type: 'hidden',
+    tooltip:
+      'When enabled, the model library opens the asset browser. When disabled, it opens the sidebar.',
+    defaultValue: isCloud ? true : false,
+    experimental: true
+  },
+  {
     id: 'Comfy.VersionCompatibility.DisableWarnings',
     name: 'Disable version compatibility warnings',
     type: 'hidden',

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -429,6 +429,7 @@ const zSettings = z.object({
   'Comfy.AppBuilder.VueNodeSwitchDismissed': z.boolean(),
   'Comfy.VueNodes.AutoScaleLayout': z.boolean(),
   'Comfy.Assets.UseAssetAPI': z.boolean(),
+  'Comfy.Assets.ModelLibraryAssetView': z.boolean(),
   'Comfy.Queue.QPOV2': z.boolean(),
   'Comfy.Queue.ShowRunProgressBar': z.boolean(),
   'Comfy-Desktop.AutoUpdate': z.boolean(),

--- a/src/stores/workspace/sidebarTabStore.test.ts
+++ b/src/stores/workspace/sidebarTabStore.test.ts
@@ -5,12 +5,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useSidebarTabStore } from '@/stores/workspace/sidebarTabStore'
 
-const { mockGetSetting, mockRegisterCommand, mockRegisterCommands } =
-  vi.hoisted(() => ({
+const {
+  mockGetSetting,
+  mockRegisterCommand,
+  mockRegisterCommands,
+  mockBrowseModelAssets,
+  registeredCommands,
+  commandStoreCommands
+} = vi.hoisted(() => {
+  const registeredCommands: { id: string; function: () => unknown }[] = []
+  return {
     mockGetSetting: vi.fn(),
-    mockRegisterCommand: vi.fn(),
-    mockRegisterCommands: vi.fn()
-  }))
+    mockRegisterCommand: vi.fn((command) => registeredCommands.push(command)),
+    mockRegisterCommands: vi.fn(),
+    mockBrowseModelAssets: vi.fn(),
+    registeredCommands,
+    commandStoreCommands: [] as { id: string; function: () => unknown }[]
+  }
+})
 
 vi.mock('@/platform/settings/settingStore', () => ({
   useSettingStore: () => ({
@@ -21,7 +33,7 @@ vi.mock('@/platform/settings/settingStore', () => ({
 vi.mock('@/stores/commandStore', () => ({
   useCommandStore: () => ({
     registerCommand: mockRegisterCommand,
-    commands: []
+    commands: commandStoreCommands
   })
 }))
 
@@ -99,7 +111,17 @@ describe('useSidebarTabStore', () => {
     mockGetSetting.mockReset()
     mockRegisterCommand.mockClear()
     mockRegisterCommands.mockClear()
+    mockBrowseModelAssets.mockClear()
+    registeredCommands.length = 0
+    commandStoreCommands.length = 0
   })
+
+  const toggleModelLibrary = async () => {
+    const toggleCommand = registeredCommands.find(
+      (command) => command.id === 'Workspace.ToggleSidebarTab.model-library'
+    )
+    await toggleCommand?.function()
+  }
 
   it('registers the job history tab when QPO V2 is enabled', () => {
     mockGetSetting.mockImplementation((key: string) =>
@@ -159,5 +181,43 @@ describe('useSidebarTabStore', () => {
       'apps'
     ])
     expect(mockRegisterCommand).toHaveBeenCalledTimes(6)
+  })
+
+  describe('model library view selection', () => {
+    it('toggles the sidebar tab when the asset view is disabled', async () => {
+      mockGetSetting.mockImplementation((key: string) =>
+        key === 'Comfy.Assets.ModelLibraryAssetView' ? false : undefined
+      )
+      commandStoreCommands.push({
+        id: 'Comfy.BrowseModelAssets',
+        function: mockBrowseModelAssets
+      })
+
+      const store = useSidebarTabStore()
+      store.registerCoreSidebarTabs()
+
+      await toggleModelLibrary()
+
+      expect(store.activeSidebarTabId).toBe('model-library')
+      expect(mockBrowseModelAssets).not.toHaveBeenCalled()
+    })
+
+    it('opens the asset browser when the asset view is enabled', async () => {
+      mockGetSetting.mockImplementation((key: string) =>
+        key === 'Comfy.Assets.ModelLibraryAssetView' ? true : undefined
+      )
+      commandStoreCommands.push({
+        id: 'Comfy.BrowseModelAssets',
+        function: mockBrowseModelAssets
+      })
+
+      const store = useSidebarTabStore()
+      store.registerCoreSidebarTabs()
+
+      await toggleModelLibrary()
+
+      expect(mockBrowseModelAssets).toHaveBeenCalledOnce()
+      expect(store.activeSidebarTabId).toBeNull()
+    })
   })
 })

--- a/src/stores/workspace/sidebarTabStore.ts
+++ b/src/stores/workspace/sidebarTabStore.ts
@@ -78,7 +78,7 @@ export const useSidebarTabStore = defineStore('sidebarTab', () => {
 
         if (
           tab.id === 'model-library' &&
-          settingStore.get('Comfy.Assets.UseAssetAPI')
+          settingStore.get('Comfy.Assets.ModelLibraryAssetView')
         ) {
           await commandStore.commands
             .find((cmd) => cmd.id === 'Comfy.BrowseModelAssets')


### PR DESCRIPTION
## Summary

Keep the model library as the existing sidebar on Core by default, while leaving the asset-backed model browser reachable via a runtime setting (not a compile-time `isCloud` check), so it can be tested on Core without forcing the cutover.

## Changes

- **What**: Add a hidden, experimental setting `Comfy.Assets.ModelLibraryAssetView` (`defaultValue: isCloud ? true : false`). The model-library sidebar toggle now reads this setting to decide between the asset browser and the sidebar, instead of `Comfy.Assets.UseAssetAPI`. Default resolves to the sidebar on Core and the asset browser on Cloud; flipping the setting (dev console / Command Palette via "Browse Model Assets") renders the asset-backed view on Core for testing.
- This is **frontend-only**. The `/settings` store is a schemaless key/value blob, so neither backend needs to know the key; when absent the frontend substitutes the env-derived default, and a user flip persists per-user.

## Review Focus

- The view selection is now decoupled from Asset API enablement. `Comfy.Assets.UseAssetAPI`, the `modelStore` data source, and `isAssetAPIEnabled()` are intentionally left untouched: enabling the Asset API no longer cuts the model library over to the asset browser.
- **Blocks BE-786 / FE-729 (#12322)**: the assets-always-on work must not land before this, or Core users get the cloud model-library UX. FE-729 currently makes the model-library toggle *unconditionally* open the asset browser; it should instead preserve this `ModelLibraryAssetView` gate so the sidebar cutover stays deferred.

<!-- Fixes #ISSUE_NUMBER -->