### PR TITLE
[backport cloud/1.45] fix: show cloud models in IC-LoRA Loader Model Only node (FE-838)

### DIFF
--- a/src/platform/assets/mappings/modelNodeMappings.ts
+++ b/src/platform/assets/mappings/modelNodeMappings.ts
@@ -226,5 +226,8 @@ export const MODEL_NODE_MAPPINGS: ReadonlyArray<
   ['geometry_estimation', 'LoadMoGeModel', 'model_name'],
 
   // ---- ComfyUI core optical flow (RAFT) ----
-  ['optical_flow', 'OpticalFlowLoader', 'model_name']
+  ['optical_flow', 'OpticalFlowLoader', 'model_name'],
+
+  // ---- LTX-Video IC-LoRA (ComfyUI-LTXVideo) ----
+  ['loras', 'LTXICLoRALoaderModelOnly', 'lora_name']
 ] as const satisfies ReadonlyArray<readonly [string, string, string]>

--- a/src/stores/modelToNodeStore.test.ts
+++ b/src/stores/modelToNodeStore.test.ts
@@ -87,7 +87,8 @@ const MOCK_NODE_NAMES = [
   'IPAdapterModelLoader',
   'LS_LoadSegformerModel',
   'LoadNLFModel',
-  'FlashVSRNode'
+  'FlashVSRNode',
+  'LTXICLoRALoaderModelOnly'
 ] as const
 
 const mockNodeDefsByName = Object.fromEntries(
@@ -307,7 +308,22 @@ describe('useModelToNodeStore', () => {
       )
 
       const loraProviders = modelToNodeStore.getAllNodeProviders('loras')
-      expect(loraProviders).toHaveLength(2)
+      expect(loraProviders).toHaveLength(3)
+      expect(loraProviders).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            nodeDef: expect.objectContaining({ name: 'LoraLoader' })
+          }),
+          expect.objectContaining({
+            nodeDef: expect.objectContaining({ name: 'LoraLoaderModelOnly' })
+          }),
+          expect.objectContaining({
+            nodeDef: expect.objectContaining({
+              name: 'LTXICLoRALoaderModelOnly'
+            })
+          })
+        ])
+      )
     })
 
     it('should return single provider for model type with one node', () => {
@@ -559,6 +575,18 @@ describe('useModelToNodeStore', () => {
         modelToNodeStore.getCategoryForNodeType('NonExistentNode')
       ).toBeUndefined()
       expect(modelToNodeStore.getCategoryForNodeType('')).toBeUndefined()
+    })
+
+    it('maps the IC-LoRA Loader Model Only node to loras so its lora_name dropdown uses the cloud asset browser (FE-838)', () => {
+      const modelToNodeStore = useModelToNodeStore()
+      modelToNodeStore.registerDefaults()
+
+      expect(
+        modelToNodeStore.getCategoryForNodeType('LTXICLoRALoaderModelOnly')
+      ).toBe('loras')
+      expect(
+        modelToNodeStore.getRegisteredNodeTypes()['LTXICLoRALoaderModelOnly']
+      ).toBe('lora_name')
     })
 
     it('should return first category when node type exists in multiple categories', () => {


### PR DESCRIPTION
## Summary

Manual backport of #12488 to cloud/1.45.

The IC-LoRA Loader Model Only node (LTXICLoRALoaderModelOnly) was missing from MODEL_NODE_MAPPINGS, so its lora_name combo stayed on the legacy dropdown instead of using the cloud asset browser.

## Changes

- Add LTXICLoRALoaderModelOnly -> lora_name under the loras model mapping.
- Backport the FE-838 unit regression coverage from the original PR.
- Keep the backport intentionally small; no unrelated newer mappings from main are included.

## Validation

- PATH=/Users/jaeone/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm test:unit src/stores/modelToNodeStore.test.ts
- PATH=/Users/jaeone/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec oxfmt --check src/platform/assets/mappings/modelNodeMappings.ts src/stores/modelToNodeStore.test.ts
- git diff --check

Notes:
- The first local test attempt with shell Node v25 failed during Vitest environment setup before tests ran; rerunning with the repo-required Node 24 passed.
- Commit hook also ran staged oxfmt, oxlint, eslint, and pnpm typecheck successfully.