### PR TITLE
Update CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,7 +41,7 @@ jobs:
 
           # Allowlist bots so they don't need to sign (optional, comma-separated).
           # *[bot] is a catch-all for any GitHub App bot account.
-          allowlist: actions-user,ampagent,claude,coderabbitai[bot],comfy-pr-bot,dependabot[bot],github-actions[bot],copilot-swe-agent[bot],devin-ai-integration[bot],*[bot]
+          allowlist: actions-user,ampagent,claude,comfy-pr-bot,github-actions,*[bot]
 
           # Custom PR comment messages
           custom-notsigned-prcomment: |


### PR DESCRIPTION
It's `github-actions` without the `[bot]`.  This was blocking every PR that contained updated browser test expectations.

Additionally, the action already included an allow list for every account ending in `[bot]`. This made half the entries redundant.