### PR TITLE
Track theme setting changes via telemetry

### DIFF
--- a/src/platform/settings/components/SettingItem.test.ts
+++ b/src/platform/settings/components/SettingItem.test.ts
@@ -9,15 +9,6 @@ import { i18n } from '@/i18n'
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-const { trackSettingChanged } = vi.hoisted(() => ({
-  trackSettingChanged: vi.fn()
-}))
-vi.mock('@/platform/telemetry', () => ({
-  useTelemetry: vi.fn(() => ({
-    trackSettingChanged
-  }))
-}))
-
 const mockGet = vi.fn()
 const mockSet = vi.fn()
 vi.mock('@/platform/settings/settingStore', () => ({
@@ -63,7 +54,7 @@ describe('SettingItem', () => {
     })
   }
 
-  it('tracks telemetry when value changes via UI (uses normalized value)', async () => {
+  it('persists setting updates through the setting store', async () => {
     const settingParams: SettingParams = {
       id: 'main.sub.setting.name',
       name: 'Visible Setting',
@@ -71,7 +62,7 @@ describe('SettingItem', () => {
       defaultValue: 'default'
     }
 
-    mockGet.mockReturnValueOnce('default').mockReturnValueOnce('normalized')
+    mockGet.mockReturnValue('default')
     mockSet.mockResolvedValue(undefined)
 
     renderComponent(settingParams)
@@ -81,33 +72,5 @@ describe('SettingItem', () => {
     await flushPromises()
 
     expect(mockSet).toHaveBeenCalledWith('main.sub.setting.name', 'newvalue')
-    expect(trackSettingChanged).toHaveBeenCalledTimes(1)
-    expect(trackSettingChanged).toHaveBeenCalledWith(
-      expect.objectContaining({
-        setting_id: 'main.sub.setting.name',
-        previous_value: 'default',
-        new_value: 'normalized'
-      })
-    )
-  })
-
-  it('does not track telemetry when normalized value does not change', async () => {
-    const settingParams: SettingParams = {
-      id: 'main.sub.setting.name',
-      name: 'Visible Setting',
-      type: 'text',
-      defaultValue: 'same'
-    }
-
-    mockGet.mockReturnValue('same')
-    mockSet.mockResolvedValue(undefined)
-
-    renderComponent(settingParams)
-
-    emitFormValue!('same')
-
-    await flushPromises()
-
-    expect(trackSettingChanged).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/settings/components/SettingItem.test.ts
+++ b/src/platform/settings/components/SettingItem.test.ts
@@ -9,6 +9,15 @@ import { i18n } from '@/i18n'
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
+const { trackSettingChanged } = vi.hoisted(() => ({
+  trackSettingChanged: vi.fn()
+}))
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: vi.fn(() => ({
+    trackSettingChanged
+  }))
+}))
+
 const mockGet = vi.fn()
 const mockSet = vi.fn()
 vi.mock('@/platform/settings/settingStore', () => ({
@@ -54,7 +63,7 @@ describe('SettingItem', () => {
     })
   }
 
-  it('persists form updates through the setting store', async () => {
+  it('tracks telemetry when value changes via UI (uses normalized value)', async () => {
     const settingParams: SettingParams = {
       id: 'main.sub.setting.name',
       name: 'Visible Setting',
@@ -62,7 +71,7 @@ describe('SettingItem', () => {
       defaultValue: 'default'
     }
 
-    mockGet.mockReturnValue('default')
+    mockGet.mockReturnValueOnce('default').mockReturnValueOnce('normalized')
     mockSet.mockResolvedValue(undefined)
 
     renderComponent(settingParams)
@@ -72,5 +81,33 @@ describe('SettingItem', () => {
     await flushPromises()
 
     expect(mockSet).toHaveBeenCalledWith('main.sub.setting.name', 'newvalue')
+    expect(trackSettingChanged).toHaveBeenCalledTimes(1)
+    expect(trackSettingChanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setting_id: 'main.sub.setting.name',
+        previous_value: 'default',
+        new_value: 'normalized'
+      })
+    )
+  })
+
+  it('does not track telemetry when normalized value does not change', async () => {
+    const settingParams: SettingParams = {
+      id: 'main.sub.setting.name',
+      name: 'Visible Setting',
+      type: 'text',
+      defaultValue: 'same'
+    }
+
+    mockGet.mockReturnValue('same')
+    mockSet.mockResolvedValue(undefined)
+
+    renderComponent(settingParams)
+
+    emitFormValue!('same')
+
+    await flushPromises()
+
+    expect(trackSettingChanged).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/settings/components/SettingItem.test.ts
+++ b/src/platform/settings/components/SettingItem.test.ts
@@ -9,13 +9,6 @@ import { i18n } from '@/i18n'
 const flushPromises = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-const trackSettingChanged = vi.fn()
-vi.mock('@/platform/telemetry', () => ({
-  useTelemetry: vi.fn(() => ({
-    trackSettingChanged
-  }))
-}))
-
 const mockGet = vi.fn()
 const mockSet = vi.fn()
 vi.mock('@/platform/settings/settingStore', () => ({
@@ -40,7 +33,7 @@ const FormItemUpdateStub = defineComponent({
   template: '<div data-testid="form-item-stub" />'
 })
 
-describe('SettingItem (telemetry UI tracking)', () => {
+describe('SettingItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     emitFormValue = null
@@ -61,15 +54,15 @@ describe('SettingItem (telemetry UI tracking)', () => {
     })
   }
 
-  it('tracks telemetry when value changes via UI (uses normalized value)', async () => {
+  it('persists form updates through the setting store', async () => {
     const settingParams: SettingParams = {
       id: 'main.sub.setting.name',
-      name: 'Telemetry Visible',
+      name: 'Visible Setting',
       type: 'text',
       defaultValue: 'default'
     }
 
-    mockGet.mockReturnValueOnce('default').mockReturnValueOnce('normalized')
+    mockGet.mockReturnValue('default')
     mockSet.mockResolvedValue(undefined)
 
     renderComponent(settingParams)
@@ -78,33 +71,6 @@ describe('SettingItem (telemetry UI tracking)', () => {
 
     await flushPromises()
 
-    expect(trackSettingChanged).toHaveBeenCalledTimes(1)
-    expect(trackSettingChanged).toHaveBeenCalledWith(
-      expect.objectContaining({
-        setting_id: 'main.sub.setting.name',
-        previous_value: 'default',
-        new_value: 'normalized'
-      })
-    )
-  })
-
-  it('does not track telemetry when normalized value does not change', async () => {
-    const settingParams: SettingParams = {
-      id: 'main.sub.setting.name',
-      name: 'Telemetry Visible',
-      type: 'text',
-      defaultValue: 'same'
-    }
-
-    mockGet.mockReturnValueOnce('same').mockReturnValueOnce('same')
-    mockSet.mockResolvedValue(undefined)
-
-    renderComponent(settingParams)
-
-    emitFormValue!('same')
-
-    await flushPromises()
-
-    expect(trackSettingChanged).not.toHaveBeenCalled()
+    expect(mockSet).toHaveBeenCalledWith('main.sub.setting.name', 'newvalue')
   })
 })

--- a/src/platform/settings/components/SettingItem.vue
+++ b/src/platform/settings/components/SettingItem.vue
@@ -31,7 +31,6 @@ import FormItem from '@/components/common/FormItem.vue'
 import { st } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingOption, SettingParams } from '@/platform/settings/types'
-import { useTelemetry } from '@/platform/telemetry'
 import type { Settings } from '@/schemas/apiSchema'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
@@ -81,19 +80,6 @@ const settingValue = computed(() => settingStore.get(props.setting.id))
 const updateSettingValue = async <K extends keyof Settings>(
   newValue: Settings[K]
 ) => {
-  const telemetry = useTelemetry()
-  const settingId = props.setting.id
-  const previousValue = settingValue.value
-
-  await settingStore.set(settingId, newValue)
-
-  const normalizedValue = settingStore.get(settingId)
-  if (previousValue !== normalizedValue) {
-    telemetry?.trackSettingChanged({
-      setting_id: settingId,
-      previous_value: previousValue,
-      new_value: normalizedValue
-    })
-  }
+  await settingStore.set(props.setting.id, newValue)
 }
 </script>

--- a/src/platform/settings/components/SettingItem.vue
+++ b/src/platform/settings/components/SettingItem.vue
@@ -31,6 +31,7 @@ import FormItem from '@/components/common/FormItem.vue'
 import { st } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingOption, SettingParams } from '@/platform/settings/types'
+import { useTelemetry } from '@/platform/telemetry'
 import type { Settings } from '@/schemas/apiSchema'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
@@ -80,6 +81,18 @@ const settingValue = computed(() => settingStore.get(props.setting.id))
 const updateSettingValue = async <K extends keyof Settings>(
   newValue: Settings[K]
 ) => {
-  await settingStore.set(props.setting.id, newValue)
+  const settingId = props.setting.id
+  const previousValue = settingValue.value
+
+  await settingStore.set(settingId, newValue)
+
+  const normalizedValue = settingStore.get(settingId)
+  if (previousValue !== normalizedValue) {
+    useTelemetry()?.trackSettingChanged({
+      setting_id: settingId,
+      previous_value: previousValue,
+      new_value: normalizedValue
+    })
+  }
 }
 </script>

--- a/src/platform/settings/components/SettingItem.vue
+++ b/src/platform/settings/components/SettingItem.vue
@@ -31,7 +31,6 @@ import FormItem from '@/components/common/FormItem.vue'
 import { st } from '@/i18n'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import type { SettingOption, SettingParams } from '@/platform/settings/types'
-import { useTelemetry } from '@/platform/telemetry'
 import type { Settings } from '@/schemas/apiSchema'
 import { normalizeI18nKey } from '@/utils/formatUtil'
 
@@ -81,18 +80,6 @@ const settingValue = computed(() => settingStore.get(props.setting.id))
 const updateSettingValue = async <K extends keyof Settings>(
   newValue: Settings[K]
 ) => {
-  const settingId = props.setting.id
-  const previousValue = settingValue.value
-
-  await settingStore.set(settingId, newValue)
-
-  const normalizedValue = settingStore.get(settingId)
-  if (previousValue !== normalizedValue) {
-    useTelemetry()?.trackSettingChanged({
-      setting_id: settingId,
-      previous_value: previousValue,
-      new_value: normalizedValue
-    })
-  }
+  await settingStore.set(props.setting.id, newValue)
 }
 </script>

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -945,6 +945,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     type: 'hidden',
     defaultValue: 'dark',
     versionModified: '1.6.7',
+    telemetry: { trackChanges: true, includeValues: true },
     migrateDeprecatedValue(val: unknown) {
       const value = val as string
       // Legacy custom palettes were prefixed with 'custom_'

--- a/src/platform/settings/settingStore.test.ts
+++ b/src/platform/settings/settingStore.test.ts
@@ -408,15 +408,6 @@ describe('useSettingStore', () => {
       expect(onChangeMock).toHaveBeenCalledTimes(2)
       expect(dispatchChangeMock).toHaveBeenCalledTimes(2)
       expect(api.storeSetting).toHaveBeenCalledWith('test.setting', 'newvalue')
-      expect(trackSettingChanged).toHaveBeenCalledWith({
-        setting_id: 'test.setting'
-      })
-
-      // Set the same value again, it should not trigger onChange
-      await store.set('test.setting', 'newvalue')
-      expect(onChangeMock).toHaveBeenCalledTimes(2)
-      expect(dispatchChangeMock).toHaveBeenCalledTimes(2)
-      expect(trackSettingChanged).toHaveBeenCalledTimes(1)
 
       // Set a different value, it should trigger onChange
       await store.set('test.setting', 'differentvalue')
@@ -427,18 +418,47 @@ describe('useSettingStore', () => {
         'test.setting',
         'differentvalue'
       )
+    })
+
+    it('does not track settings that have not opted in', async () => {
+      store.addSetting({
+        id: 'test.setting',
+        name: 'test.setting',
+        type: 'text',
+        defaultValue: 'default'
+      })
+
+      await store.set('test.setting', 'newvalue')
+
+      expect(trackSettingChanged).not.toHaveBeenCalled()
+    })
+
+    it('tracks settings that opt in, without shipping values by default', async () => {
+      store.addSetting({
+        id: 'test.setting',
+        name: 'test.setting',
+        type: 'text',
+        defaultValue: 'default',
+        telemetry: { trackChanges: true }
+      })
+
+      await store.set('test.setting', 'newvalue')
       expect(trackSettingChanged).toHaveBeenCalledWith({
         setting_id: 'test.setting'
       })
-      expect(trackSettingChanged).toHaveBeenCalledTimes(2)
+
+      // Setting the same value again is a no-op and should not re-emit
+      await store.set('test.setting', 'newvalue')
+      expect(trackSettingChanged).toHaveBeenCalledTimes(1)
     })
 
-    it('tracks hidden color palette setting changes', async () => {
+    it('ships previous/new values when the setting opts into includeValues', async () => {
       store.addSetting({
         id: 'Comfy.ColorPalette',
         name: 'The active color palette id',
         type: 'hidden',
-        defaultValue: 'dark'
+        defaultValue: 'dark',
+        telemetry: { trackChanges: true, includeValues: true }
       })
 
       await store.set('Comfy.ColorPalette', 'light')
@@ -455,7 +475,8 @@ describe('useSettingStore', () => {
         id: 'test.setting',
         name: 'test.setting',
         type: 'text',
-        defaultValue: 'default'
+        defaultValue: 'default',
+        telemetry: { trackChanges: true }
       })
       vi.mocked(api.storeSetting).mockRejectedValueOnce(new Error('failed'))
 
@@ -591,11 +612,33 @@ describe('useSettingStore', () => {
         'Comfy.Release.Status': 'changelog seen'
       })
       expect(api.storeSetting).not.toHaveBeenCalled()
-      expect(trackSettingChanged).toHaveBeenCalledWith({
-        setting_id: 'Comfy.Release.Version'
+    })
+
+    it('tracks only the settings in a batch that opt in', async () => {
+      store.addSetting({
+        id: 'Comfy.ColorPalette',
+        name: 'The active color palette id',
+        type: 'hidden',
+        defaultValue: 'dark',
+        telemetry: { trackChanges: true, includeValues: true }
       })
+      store.addSetting({
+        id: 'Comfy.Release.Version',
+        name: 'Release Version',
+        type: 'hidden',
+        defaultValue: ''
+      })
+
+      await store.setMany({
+        'Comfy.ColorPalette': 'light',
+        'Comfy.Release.Version': '1.0.0'
+      })
+
+      expect(trackSettingChanged).toHaveBeenCalledTimes(1)
       expect(trackSettingChanged).toHaveBeenCalledWith({
-        setting_id: 'Comfy.Release.Status'
+        setting_id: 'Comfy.ColorPalette',
+        previous_value: 'dark',
+        new_value: 'light'
       })
     })
 
@@ -623,10 +666,6 @@ describe('useSettingStore', () => {
       expect(api.storeSettings).toHaveBeenCalledWith({
         'Comfy.Release.Status': 'changelog seen'
       })
-      expect(trackSettingChanged).toHaveBeenCalledWith({
-        setting_id: 'Comfy.Release.Status'
-      })
-      expect(trackSettingChanged).toHaveBeenCalledTimes(1)
     })
 
     it('should not call API when all values are unchanged', async () => {

--- a/src/platform/settings/settingStore.test.ts
+++ b/src/platform/settings/settingStore.test.ts
@@ -420,7 +420,7 @@ describe('useSettingStore', () => {
       )
     })
 
-    it('tracks visible settings without values by default', async () => {
+    it('tracks visible settings with values by default', async () => {
       store.addSetting({
         id: 'test.setting',
         name: 'test.setting',
@@ -431,7 +431,9 @@ describe('useSettingStore', () => {
       await store.set('test.setting', 'newvalue')
 
       expect(trackSettingChanged).toHaveBeenCalledWith({
-        setting_id: 'test.setting'
+        setting_id: 'test.setting',
+        previous_value: 'default',
+        new_value: 'newvalue'
       })
     })
 
@@ -460,6 +462,22 @@ describe('useSettingStore', () => {
       await store.set('test.setting', 'newvalue')
 
       expect(trackSettingChanged).not.toHaveBeenCalled()
+    })
+
+    it('tracks visible settings without values when values opt out', async () => {
+      store.addSetting({
+        id: 'test.setting',
+        name: 'test.setting',
+        type: 'text',
+        defaultValue: 'default',
+        telemetry: { includeValues: false }
+      })
+
+      await store.set('test.setting', 'newvalue')
+
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'test.setting'
+      })
     })
 
     it('tracks hidden settings that opt in, without shipping values by default', async () => {

--- a/src/platform/settings/settingStore.test.ts
+++ b/src/platform/settings/settingStore.test.ts
@@ -11,6 +11,16 @@ import type { Settings } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
 
+const { trackSettingChanged } = vi.hoisted(() => ({
+  trackSettingChanged: vi.fn()
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: vi.fn(() => ({
+    trackSettingChanged
+  }))
+}))
+
 // Mock the api
 vi.mock('@/scripts/api', () => ({
   api: {
@@ -398,11 +408,15 @@ describe('useSettingStore', () => {
       expect(onChangeMock).toHaveBeenCalledTimes(2)
       expect(dispatchChangeMock).toHaveBeenCalledTimes(2)
       expect(api.storeSetting).toHaveBeenCalledWith('test.setting', 'newvalue')
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'test.setting'
+      })
 
       // Set the same value again, it should not trigger onChange
       await store.set('test.setting', 'newvalue')
       expect(onChangeMock).toHaveBeenCalledTimes(2)
       expect(dispatchChangeMock).toHaveBeenCalledTimes(2)
+      expect(trackSettingChanged).toHaveBeenCalledTimes(1)
 
       // Set a different value, it should trigger onChange
       await store.set('test.setting', 'differentvalue')
@@ -413,6 +427,43 @@ describe('useSettingStore', () => {
         'test.setting',
         'differentvalue'
       )
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'test.setting'
+      })
+      expect(trackSettingChanged).toHaveBeenCalledTimes(2)
+    })
+
+    it('tracks hidden color palette setting changes', async () => {
+      store.addSetting({
+        id: 'Comfy.ColorPalette',
+        name: 'The active color palette id',
+        type: 'hidden',
+        defaultValue: 'dark'
+      })
+
+      await store.set('Comfy.ColorPalette', 'light')
+
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'Comfy.ColorPalette',
+        previous_value: 'dark',
+        new_value: 'light'
+      })
+    })
+
+    it('does not track telemetry when persistence fails', async () => {
+      store.addSetting({
+        id: 'test.setting',
+        name: 'test.setting',
+        type: 'text',
+        defaultValue: 'default'
+      })
+      vi.mocked(api.storeSetting).mockRejectedValueOnce(new Error('failed'))
+
+      await expect(store.set('test.setting', 'newvalue')).rejects.toThrow(
+        'failed'
+      )
+
+      expect(trackSettingChanged).not.toHaveBeenCalled()
     })
 
     describe('object mutation prevention', () => {
@@ -540,6 +591,12 @@ describe('useSettingStore', () => {
         'Comfy.Release.Status': 'changelog seen'
       })
       expect(api.storeSetting).not.toHaveBeenCalled()
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'Comfy.Release.Version'
+      })
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'Comfy.Release.Status'
+      })
     })
 
     it('should skip unchanged values', async () => {
@@ -566,6 +623,10 @@ describe('useSettingStore', () => {
       expect(api.storeSettings).toHaveBeenCalledWith({
         'Comfy.Release.Status': 'changelog seen'
       })
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'Comfy.Release.Status'
+      })
+      expect(trackSettingChanged).toHaveBeenCalledTimes(1)
     })
 
     it('should not call API when all values are unchanged', async () => {
@@ -581,6 +642,7 @@ describe('useSettingStore', () => {
       await store.setMany({ 'Comfy.Release.Version': 'existing' })
 
       expect(api.storeSettings).not.toHaveBeenCalled()
+      expect(trackSettingChanged).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/platform/settings/settingStore.test.ts
+++ b/src/platform/settings/settingStore.test.ts
@@ -420,7 +420,7 @@ describe('useSettingStore', () => {
       )
     })
 
-    it('does not track settings that have not opted in', async () => {
+    it('tracks visible settings without values by default', async () => {
       store.addSetting({
         id: 'test.setting',
         name: 'test.setting',
@@ -430,14 +430,43 @@ describe('useSettingStore', () => {
 
       await store.set('test.setting', 'newvalue')
 
+      expect(trackSettingChanged).toHaveBeenCalledWith({
+        setting_id: 'test.setting'
+      })
+    })
+
+    it('does not track hidden settings by default', async () => {
+      store.addSetting({
+        id: 'test.setting',
+        name: 'test.setting',
+        type: 'hidden',
+        defaultValue: 'default'
+      })
+
+      await store.set('test.setting', 'newvalue')
+
       expect(trackSettingChanged).not.toHaveBeenCalled()
     })
 
-    it('tracks settings that opt in, without shipping values by default', async () => {
+    it('does not track visible settings that opt out', async () => {
       store.addSetting({
         id: 'test.setting',
         name: 'test.setting',
         type: 'text',
+        defaultValue: 'default',
+        telemetry: { trackChanges: false }
+      })
+
+      await store.set('test.setting', 'newvalue')
+
+      expect(trackSettingChanged).not.toHaveBeenCalled()
+    })
+
+    it('tracks hidden settings that opt in, without shipping values by default', async () => {
+      store.addSetting({
+        id: 'test.setting',
+        name: 'test.setting',
+        type: 'hidden',
         defaultValue: 'default',
         telemetry: { trackChanges: true }
       })

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -57,10 +57,13 @@ function settingChangedEvent<K extends keyof Settings>(
   key: K,
   applied: AppliedSetting<Settings[K]>
 ): SettingChangedMetadata | undefined {
-  const telemetry = setting?.telemetry
-  if (!telemetry?.trackChanges) return undefined
+  if (!setting) return undefined
 
-  return telemetry.includeValues
+  const telemetry = setting.telemetry
+  const trackChanges = telemetry?.trackChanges ?? setting.type !== 'hidden'
+  if (!trackChanges) return undefined
+
+  return telemetry?.includeValues
     ? {
         setting_id: key,
         previous_value: applied.previousValue,

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -6,6 +6,8 @@ import { compare, valid } from 'semver'
 import { ref } from 'vue'
 
 import type { SettingParams } from '@/platform/settings/types'
+import { useTelemetry } from '@/platform/telemetry'
+import type { SettingChangedMetadata } from '@/platform/telemetry/types'
 import type { Settings } from '@/schemas/apiSchema'
 import { api } from '@/scripts/api'
 import { app } from '@/scripts/app'
@@ -21,6 +23,11 @@ export const getSettingInfo = (setting: SettingParams) => {
 
 export interface SettingTreeNode extends TreeNode {
   data?: SettingParams
+}
+
+interface AppliedSetting<TValue> {
+  previousValue: TValue
+  newValue: TValue
 }
 
 function tryMigrateDeprecatedValue(
@@ -43,6 +50,20 @@ function onChange(
   if (setting) {
     app.ui.settings.dispatchChange(setting.id, newValue, oldValue)
   }
+}
+
+function createSettingChangedMetadata<K extends keyof Settings>(
+  key: K,
+  applied: AppliedSetting<Settings[K]>
+): SettingChangedMetadata {
+  const metadata: SettingChangedMetadata = { setting_id: key }
+
+  if (key === 'Comfy.ColorPalette') {
+    metadata.previous_value = applied.previousValue
+    metadata.new_value = applied.newValue
+  }
+
+  return metadata
 }
 
 export const useSettingStore = defineStore('setting', () => {
@@ -99,7 +120,7 @@ export const useSettingStore = defineStore('setting', () => {
   function applySettingLocally<K extends keyof Settings>(
     key: K,
     value: Settings[K]
-  ): Settings[K] | undefined {
+  ): AppliedSetting<Settings[K]> | undefined {
     const clonedValue = _.cloneDeep(value)
     const newValue = tryMigrateDeprecatedValue(
       settingsById.value[key],
@@ -109,8 +130,12 @@ export const useSettingStore = defineStore('setting', () => {
     if (newValue === oldValue) return undefined
 
     onChange(settingsById.value[key], newValue, oldValue)
-    settingValues.value[key] = newValue
-    return newValue as Settings[K]
+    const typedNewValue = newValue as Settings[K]
+    settingValues.value[key] = typedNewValue
+    return {
+      previousValue: oldValue,
+      newValue: typedNewValue
+    }
   }
 
   /**
@@ -121,7 +146,10 @@ export const useSettingStore = defineStore('setting', () => {
   async function set<K extends keyof Settings>(key: K, value: Settings[K]) {
     const applied = applySettingLocally(key, value)
     if (applied === undefined) return
-    await api.storeSetting(key, applied)
+    await api.storeSetting(key, applied.newValue)
+    useTelemetry()?.trackSettingChanged(
+      createSettingChangedMetadata(key, applied)
+    )
   }
 
   /**
@@ -130,6 +158,7 @@ export const useSettingStore = defineStore('setting', () => {
    */
   async function setMany(settings: Partial<Settings>) {
     const updatedSettings: Partial<Settings> = {}
+    const telemetryEvents: SettingChangedMetadata[] = []
 
     for (const key of Object.keys(settings) as (keyof Settings)[]) {
       const applied = applySettingLocally(
@@ -137,12 +166,17 @@ export const useSettingStore = defineStore('setting', () => {
         settings[key] as Settings[typeof key]
       )
       if (applied !== undefined) {
-        updatedSettings[key] = applied
+        updatedSettings[key] = applied.newValue
+        telemetryEvents.push(createSettingChangedMetadata(key, applied))
       }
     }
 
     if (Object.keys(updatedSettings).length > 0) {
       await api.storeSettings(updatedSettings)
+      const telemetry = useTelemetry()
+      for (const event of telemetryEvents) {
+        telemetry?.trackSettingChanged(event)
+      }
     }
   }
 

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -52,18 +52,21 @@ function onChange(
   }
 }
 
-function createSettingChangedMetadata<K extends keyof Settings>(
+function settingChangedEvent<K extends keyof Settings>(
+  setting: SettingParams | undefined,
   key: K,
   applied: AppliedSetting<Settings[K]>
-): SettingChangedMetadata {
-  const metadata: SettingChangedMetadata = { setting_id: key }
+): SettingChangedMetadata | undefined {
+  const telemetry = setting?.telemetry
+  if (!telemetry?.trackChanges) return undefined
 
-  if (key === 'Comfy.ColorPalette') {
-    metadata.previous_value = applied.previousValue
-    metadata.new_value = applied.newValue
-  }
-
-  return metadata
+  return telemetry.includeValues
+    ? {
+        setting_id: key,
+        previous_value: applied.previousValue,
+        new_value: applied.newValue
+      }
+    : { setting_id: key }
 }
 
 export const useSettingStore = defineStore('setting', () => {
@@ -147,9 +150,9 @@ export const useSettingStore = defineStore('setting', () => {
     const applied = applySettingLocally(key, value)
     if (applied === undefined) return
     await api.storeSetting(key, applied.newValue)
-    useTelemetry()?.trackSettingChanged(
-      createSettingChangedMetadata(key, applied)
-    )
+
+    const event = settingChangedEvent(settingsById.value[key], key, applied)
+    if (event) useTelemetry()?.trackSettingChanged(event)
   }
 
   /**
@@ -167,7 +170,8 @@ export const useSettingStore = defineStore('setting', () => {
       )
       if (applied !== undefined) {
         updatedSettings[key] = applied.newValue
-        telemetryEvents.push(createSettingChangedMetadata(key, applied))
+        const event = settingChangedEvent(settingsById.value[key], key, applied)
+        if (event) telemetryEvents.push(event)
       }
     }
 

--- a/src/platform/settings/settingStore.ts
+++ b/src/platform/settings/settingStore.ts
@@ -60,10 +60,12 @@ function settingChangedEvent<K extends keyof Settings>(
   if (!setting) return undefined
 
   const telemetry = setting.telemetry
-  const trackChanges = telemetry?.trackChanges ?? setting.type !== 'hidden'
+  const isVisible = setting.type !== 'hidden'
+  const trackChanges = telemetry?.trackChanges ?? isVisible
   if (!trackChanges) return undefined
 
-  return telemetry?.includeValues
+  const includeValues = telemetry?.includeValues ?? isVisible
+  return includeValues
     ? {
         setting_id: key,
         previous_value: applied.previousValue,

--- a/src/platform/settings/types.ts
+++ b/src/platform/settings/types.ts
@@ -27,7 +27,9 @@ export interface SettingOption {
 }
 
 interface SettingTelemetryOptions {
-  // Emit a `setting_changed` event when this setting changes.
+  // Emit a `setting_changed` event from the store whenever this setting is
+  // persisted. Use for settings changed outside the settings dialog (e.g. the
+  // hidden theme setting); dialog changes are already tracked by SettingItem.
   trackChanges?: boolean
   // Ship previous_value/new_value with the event. Leave unset for settings
   // whose values must not leave the client (hidden/server/secret values).

--- a/src/platform/settings/types.ts
+++ b/src/platform/settings/types.ts
@@ -26,15 +26,15 @@ export interface SettingOption {
   value?: string | number
 }
 
-interface SettingTelemetryOptions {
-  // Emit a `setting_changed` event from the store whenever this setting is
-  // persisted. Use for settings changed outside the settings dialog (e.g. the
-  // hidden theme setting); dialog changes are already tracked by SettingItem.
-  trackChanges?: boolean
-  // Ship previous_value/new_value with the event. Leave unset for settings
-  // whose values must not leave the client (hidden/server/secret values).
-  includeValues?: boolean
-}
+type SettingTelemetryOptions =
+  | {
+      trackChanges?: false
+      includeValues?: never
+    }
+  | {
+      trackChanges: true
+      includeValues?: boolean
+    }
 
 export interface SettingParams<TValue = unknown> extends FormItem {
   id: keyof Settings

--- a/src/platform/settings/types.ts
+++ b/src/platform/settings/types.ts
@@ -26,11 +26,20 @@ export interface SettingOption {
   value?: string | number
 }
 
+interface SettingTelemetryOptions {
+  // Emit a `setting_changed` event when this setting changes.
+  trackChanges?: boolean
+  // Ship previous_value/new_value with the event. Leave unset for settings
+  // whose values must not leave the client (hidden/server/secret values).
+  includeValues?: boolean
+}
+
 export interface SettingParams<TValue = unknown> extends FormItem {
   id: keyof Settings
   defaultValue: TValue | (() => TValue)
   defaultsByInstallVersion?: Record<`${number}.${number}.${number}`, TValue>
   onChange?(newValue: TValue, oldValue?: TValue): void
+  telemetry?: SettingTelemetryOptions
   // By default category is id.split('.'). However, changing id to assign
   // new category has poor backward compatibility. Use this field to overwrite
   // default category from id.

--- a/src/platform/settings/types.ts
+++ b/src/platform/settings/types.ts
@@ -26,10 +26,15 @@ export interface SettingOption {
   value?: string | number
 }
 
-interface SettingTelemetryOptions {
-  trackChanges?: boolean
-  includeValues?: boolean
-}
+type SettingTelemetryOptions =
+  | {
+      trackChanges: false
+      includeValues?: never
+    }
+  | {
+      trackChanges?: true
+      includeValues?: boolean
+    }
 
 export interface SettingParams<TValue = unknown> extends FormItem {
   id: keyof Settings

--- a/src/platform/settings/types.ts
+++ b/src/platform/settings/types.ts
@@ -26,15 +26,10 @@ export interface SettingOption {
   value?: string | number
 }
 
-type SettingTelemetryOptions =
-  | {
-      trackChanges?: false
-      includeValues?: never
-    }
-  | {
-      trackChanges: true
-      includeValues?: boolean
-    }
+interface SettingTelemetryOptions {
+  trackChanges?: boolean
+  includeValues?: boolean
+}
 
 export interface SettingParams<TValue = unknown> extends FormItem {
   id: keyof Settings


### PR DESCRIPTION
Fix Color Palette changes not getting tracked, requested by design team.

Capture theme changes as `app:setting_changed` telemetry. The only existing hook lived in `SettingItem.vue`, which renders *visible* settings; `Comfy.ColorPalette` is hidden and changed through bespoke theme UI, so it was never tracked.

Open to opinions here, we can also remove the hook in SettingItem.vue, and just make everything that was visible opt in.

Linear: https://linear.app/comfyorg/issue/GTM-158/track-theme-usage-with-posthog-events
