### PR TITLE
Allow Glary Bot through CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,7 +41,7 @@ jobs:
 
           # Allowlist bots so they don't need to sign (optional, comma-separated).
           # *[bot] is a catch-all for any GitHub App bot account.
-          allowlist: actions-user,ampagent,claude,comfy-pr-bot,github-actions,*[bot]
+          allowlist: actions-user,ampagent,claude,comfy-pr-bot,github-actions,*[bot],Glary Bot
 
           # Custom PR comment messages
           custom-notsigned-prcomment: |


### PR DESCRIPTION
## Summary

- Add `Glary Bot` to the CLA Assistant allowlist.

## Context

PR #13146 is blocked because its commit author is `Glary Bot <bot@glary.dev>`, which GitHub does not resolve to a GitHub user. The CLA action checks the unresolved commit author name after failing to find a linked GitHub account, so the existing `*[bot]` GitHub App allowlist does not apply.

## Validation

- Ran `git diff --check`.