### PR TITLE
[backport cloud/1.46] feat(auth): Cloudflare Turnstile on email signup (origin-gated)

### DIFF
--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -133,3 +133,24 @@ jobs:
             exit 1
           fi
           echo '✅ No Customer.io references found'
+
+      - name: Scan dist for Cloudflare Turnstile sitekey references
+        run: |
+          set -euo pipefail
+          echo '🔍 Scanning for Cloudflare Turnstile sitekeys...'
+          if rg --no-ignore -n \
+            -g '*.html' \
+            -g '*.js' \
+            -e '0x4AAAAAADnYZPVOpFCL_zeo' \
+            -e '0x4AAAAAADnYY4_Q0qxHZ5a7' \
+            -e '1x00000000000000000000AA' \
+            dist; then
+            echo '❌ ERROR: Cloudflare Turnstile sitekey found in dist assets!'
+            echo 'The per-env Turnstile sitekeys are cloud-only and must be tree-shaken from OSS builds.'
+            echo ''
+            echo 'To fix this:'
+            echo '1. Gate sitekey selection on the __DISTRIBUTION__ build define, not the runtime isCloud const'
+            echo '2. See getTurnstileSiteKey() in src/config/turnstile.ts'
+            exit 1
+          fi
+          echo '✅ No Turnstile sitekey references found'

--- a/src/components/dialog/content/SignInContent.vue
+++ b/src/components/dialog/content/SignInContent.vue
@@ -37,7 +37,7 @@
         <Message v-if="userIsInChina" severity="warn" class="mb-4">
           {{ t('auth.signup.regionRestrictionChina') }}
         </Message>
-        <SignUpForm v-else @submit="signUpWithEmail" />
+        <SignUpForm v-else ref="signUpForm" @submit="signUpWithEmail" />
       </template>
 
       <!-- Divider -->
@@ -206,9 +206,21 @@ const signInWithEmail = async (values: SignInData) => {
   }
 }
 
-const signUpWithEmail = async (values: SignUpData) => {
-  if (await authActions.signUpWithEmail(values.email, values.password)) {
+const signUpForm = ref<InstanceType<typeof SignUpForm> | null>(null)
+
+const signUpWithEmail = async (values: SignUpData, turnstileToken?: string) => {
+  if (
+    await authActions.signUpWithEmail(
+      values.email,
+      values.password,
+      turnstileToken
+    )
+  ) {
     onSuccess()
+  } else {
+    // Signup failed while the form is still mounted: re-arm the single-use
+    // Turnstile token so the next attempt sends a fresh one.
+    signUpForm.value?.resetTurnstile()
   }
 }
 

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -1,12 +1,13 @@
 import { Form, FormField } from '@primevue/forms'
+import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 import Button from '@/components/ui/button/Button.vue'
-import PrimeVue from 'primevue/config'
 import InputText from 'primevue/inputtext'
 import Password from 'primevue/password'
+import PrimeVue from 'primevue/config'
 import ProgressSpinner from 'primevue/progressspinner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -36,34 +37,116 @@ vi.mock('@/stores/authStore', () => ({
   }))
 }))
 
+const mockTurnstileEnabled = ref(false)
+const mockTurnstileEnforced = ref(false)
+const mockReset = vi.fn()
+let emitTurnstileToken: ((token: string) => void) | undefined
+
+vi.mock('@/composables/auth/useTurnstile', () => ({
+  useTurnstile: () => ({
+    enabled: mockTurnstileEnabled,
+    enforced: mockTurnstileEnforced
+  })
+}))
+
+// Stub the real widget (which loads the external Turnstile script) with one that
+// exposes a spyable reset() and lets a test drive the v-model token the way a
+// solved challenge would.
+vi.mock('./TurnstileWidget.vue', async () => {
+  const { defineComponent: defineMock } = await import('vue')
+  return {
+    default: defineMock({
+      name: 'TurnstileWidget',
+      emits: ['update:token'],
+      setup(_, { expose, emit }) {
+        expose({ reset: mockReset })
+        emitTurnstileToken = (token: string) => emit('update:token', token)
+        return () => null
+      }
+    })
+  }
+})
+
+const signUpButton = enMessages.auth.signup.signUpButton
+
+function globalOptions() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
+  return {
+    plugins: [PrimeVue, i18n],
+    components: {
+      Form,
+      FormField,
+      Button,
+      InputText,
+      Password,
+      ProgressSpinner
+    }
+  }
+}
+
 describe('SignUpForm', () => {
   beforeEach(() => {
     mockLoadingRef.value = false
+    mockTurnstileEnabled.value = false
+    mockTurnstileEnforced.value = false
+    mockReset.mockClear()
+    emitTurnstileToken = undefined
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  function renderComponent() {
-    const i18n = createI18n({
-      legacy: false,
-      locale: 'en',
-      messages: { en: enMessages }
-    })
-    return render(SignUpForm, {
-      global: {
-        plugins: [PrimeVue, i18n],
-        components: {
-          Form,
-          FormField,
-          Button,
-          InputText,
-          Password,
-          ProgressSpinner
-        }
+  function renderComponent(props: Record<string, unknown> = {}) {
+    const user = userEvent.setup()
+    const utils = render(SignUpForm, { global: globalOptions(), props })
+    return { ...utils, user }
+  }
+
+  /** Render through a host that keeps a ref, so the parent-facing exposed
+   * `resetTurnstile()` can be invoked the way SignInContent would. */
+  function renderWithRef() {
+    const formRef = ref<{ resetTurnstile: () => void } | null>(null)
+    const Host = defineComponent({
+      setup() {
+        return () => h(SignUpForm, { ref: formRef })
       }
     })
+    const utils = render(Host, { global: globalOptions() })
+    return {
+      ...utils,
+      form: () => {
+        if (!formRef.value) throw new Error('form not mounted')
+        return formRef.value
+      }
+    }
+  }
+
+  const expectedValues = {
+    email: 'new@example.com',
+    password: 'Password1!',
+    confirmPassword: 'Password1!'
+  }
+
+  async function fillValidSignup(user: ReturnType<typeof userEvent.setup>) {
+    await user.type(
+      screen.getByPlaceholderText(enMessages.auth.signup.emailPlaceholder),
+      expectedValues.email
+    )
+    await user.type(
+      screen.getByPlaceholderText(enMessages.auth.signup.passwordPlaceholder),
+      expectedValues.password
+    )
+    await user.type(
+      screen.getByPlaceholderText(
+        enMessages.auth.login.confirmPasswordPlaceholder
+      ),
+      expectedValues.confirmPassword
+    )
   }
 
   describe('Password manager autofill attributes', () => {
@@ -105,6 +188,99 @@ describe('SignUpForm', () => {
         'autocomplete',
         'new-password'
       )
+    })
+  })
+
+  describe('Turnstile single-use token reset', () => {
+    it('exposes resetTurnstile() that resets the rendered widget', async () => {
+      mockTurnstileEnabled.value = true
+      const { form } = renderWithRef()
+      await nextTick()
+
+      form().resetTurnstile()
+
+      expect(mockReset).toHaveBeenCalledOnce()
+    })
+
+    it('does not reset the widget on the initial render', async () => {
+      mockTurnstileEnabled.value = true
+      renderWithRef()
+      await nextTick()
+
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Turnstile token hygiene', () => {
+    it('clears the stale token when Turnstile becomes disabled', async () => {
+      mockTurnstileEnabled.value = true
+      mockTurnstileEnforced.value = true
+      const { user } = renderComponent()
+      await fillValidSignup(user)
+
+      emitTurnstileToken!('stale-token')
+      await nextTick()
+      expect(
+        screen.getByRole('button', { name: signUpButton })
+      ).not.toBeDisabled()
+
+      mockTurnstileEnabled.value = false
+      await nextTick()
+
+      // re-enable: the stale token must have been cleared so submit is blocked again
+      mockTurnstileEnabled.value = true
+      await nextTick()
+
+      expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
+    })
+  })
+
+  describe('Turnstile submit gating', () => {
+    it('disables the submit button in enforce mode until a token is present', async () => {
+      mockTurnstileEnabled.value = true
+      mockTurnstileEnforced.value = true
+      renderComponent()
+      await nextTick()
+
+      expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
+    })
+
+    it('does not emit submit in enforce mode while the token is empty', async () => {
+      mockTurnstileEnabled.value = true
+      mockTurnstileEnforced.value = true
+      const onSubmit = vi.fn()
+      const { user } = renderComponent({ onSubmit })
+      await fillValidSignup(user)
+
+      await user.click(screen.getByRole('button', { name: signUpButton }))
+
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it('emits submit with the token in enforce mode once the challenge is solved', async () => {
+      mockTurnstileEnabled.value = true
+      mockTurnstileEnforced.value = true
+      const onSubmit = vi.fn()
+      const { user } = renderComponent({ onSubmit })
+      await fillValidSignup(user)
+
+      emitTurnstileToken!('token-xyz')
+      await nextTick()
+      await user.click(screen.getByRole('button', { name: signUpButton }))
+
+      expect(onSubmit).toHaveBeenCalledWith(expectedValues, 'token-xyz')
+    })
+
+    it('emits submit without a token in shadow mode (never blocks)', async () => {
+      mockTurnstileEnabled.value = true
+      mockTurnstileEnforced.value = false
+      const onSubmit = vi.fn()
+      const { user } = renderComponent({ onSubmit })
+      await fillValidSignup(user)
+
+      await user.click(screen.getByRole('button', { name: signUpButton }))
+
+      expect(onSubmit).toHaveBeenCalledWith(expectedValues, undefined)
     })
   })
 })

--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -29,13 +29,34 @@
 
     <PasswordFields />
 
+    <TurnstileWidget
+      v-if="turnstileEnabled"
+      ref="turnstileWidget"
+      v-model:token="turnstileToken"
+    />
+
+    <small
+      v-show="submitBlockedByTurnstile"
+      id="comfy-org-sign-up-turnstile-hint"
+      role="status"
+      aria-live="polite"
+      class="opacity-80"
+    >
+      {{ t('auth.turnstile.submitBlockedHint') }}
+    </small>
+
     <!-- Submit Button -->
     <ProgressSpinner v-if="loading" class="mx-auto size-8" />
     <Button
       v-else
       type="submit"
       class="mt-4 h-10 font-medium"
-      :disabled="!$form.valid"
+      :disabled="!$form.valid || submitBlockedByTurnstile"
+      :aria-describedby="
+        submitBlockedByTurnstile
+          ? 'comfy-org-sign-up-turnstile-hint'
+          : undefined
+      "
     >
       {{ t('auth.signup.signUpButton') }}
     </Button>
@@ -49,27 +70,58 @@ import { zodResolver } from '@primevue/forms/resolvers/zod'
 import { useThrottleFn } from '@vueuse/core'
 import InputText from 'primevue/inputtext'
 import ProgressSpinner from 'primevue/progressspinner'
-import { computed } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
+import { useTurnstile } from '@/composables/auth/useTurnstile'
 import { signUpSchema } from '@/schemas/signInSchema'
 import type { SignUpData } from '@/schemas/signInSchema'
 import { useAuthStore } from '@/stores/authStore'
 
 import PasswordFields from './PasswordFields.vue'
+import TurnstileWidget from './TurnstileWidget.vue'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
 const loading = computed(() => authStore.loading)
 
+const { enabled: turnstileEnabled, enforced: turnstileEnforced } =
+  useTurnstile()
+const turnstileToken = ref('')
+const turnstileWidget =
+  useTemplateRef<InstanceType<typeof TurnstileWidget>>('turnstileWidget')
+const submitBlockedByTurnstile = computed(
+  () => turnstileEnforced.value && !turnstileToken.value
+)
+
+watch(turnstileEnabled, (on) => {
+  if (!on) turnstileToken.value = ''
+})
+
 const emit = defineEmits<{
-  submit: [values: SignUpData]
+  submit: [values: SignUpData, turnstileToken?: string]
 }>()
 
 const onSubmit = useThrottleFn((event: FormSubmitEvent) => {
-  if (event.valid) {
-    emit('submit', event.values as SignUpData)
+  if (event.valid && !submitBlockedByTurnstile.value) {
+    emit(
+      'submit',
+      event.values as SignUpData,
+      turnstileToken.value || undefined
+    )
   }
 }, 1_500)
+
+// Turnstile tokens are single-use. The parent calls this after a FAILED signup
+// (the form can't observe the submit outcome itself) to discard the spent token
+// and request a fresh challenge. Driving it from the actual result — instead of
+// watching the store-global loading flag — keeps an unrelated auth action from
+// wiping a freshly-solved token, and avoids resetting a widget that is about to
+// unmount on success.
+function resetTurnstile() {
+  turnstileWidget.value?.reset()
+}
+
+defineExpose({ resetTurnstile })
 </script>

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import { render } from '@testing-library/vue'
+
+import type { TurnstileRenderOptions } from '@/composables/auth/turnstileScript'
+
+import TurnstileWidget from './TurnstileWidget.vue'
+
+const { mockLoadTurnstile, mockGetSiteKey, mockLightTheme } = vi.hoisted(
+  () => ({
+    mockLoadTurnstile: vi.fn(),
+    mockGetSiteKey: vi.fn(() => 'site-key'),
+    mockLightTheme: { value: true }
+  })
+)
+
+vi.mock('@/composables/auth/turnstileScript', () => ({
+  loadTurnstile: mockLoadTurnstile
+}))
+vi.mock('@/config/turnstile', () => ({
+  getTurnstileSiteKey: mockGetSiteKey
+}))
+vi.mock('@/stores/workspace/colorPaletteStore', () => ({
+  useColorPaletteStore: () => ({
+    completedActivePalette: {
+      get light_theme() {
+        return mockLightTheme.value
+      }
+    }
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      auth: {
+        turnstile: {
+          expired: 'Challenge expired',
+          failed: 'Verification failed'
+        }
+      }
+    }
+  }
+})
+
+/** A controllable Cloudflare Turnstile global whose render() captures options. */
+function fakeTurnstile() {
+  let captured: TurnstileRenderOptions | undefined
+  const api = {
+    render: vi.fn((_el: unknown, options: TurnstileRenderOptions) => {
+      captured = options
+      return 'widget-id'
+    }),
+    reset: vi.fn(),
+    remove: vi.fn()
+  }
+  return { api, options: () => captured }
+}
+
+/** Drain the onMounted async (loadTurnstile) plus any follow-up microtasks. */
+const flush = async () => {
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve))
+}
+
+const renderWidget = () =>
+  render(TurnstileWidget, { global: { plugins: [i18n] } })
+
+/**
+ * Render TurnstileWidget through a thin host that keeps a ref to it, so the
+ * exposed `reset()` method can be invoked the way a parent (SignUpForm) would.
+ */
+const renderWidgetWithExpose = () => {
+  const widgetRef = ref<{ reset: () => void } | null>(null)
+  const Host = defineComponent({
+    setup(_, { emit }) {
+      return () =>
+        h(TurnstileWidget, {
+          ref: widgetRef,
+          'onUpdate:token': (value: string) => emit('update:token', value)
+        })
+    }
+  })
+  const utils = render(Host, { global: { plugins: [i18n] } })
+  return {
+    ...utils,
+    getCurrentInstance: () => {
+      if (!widgetRef.value) throw new Error('widget not mounted')
+      return widgetRef.value
+    }
+  }
+}
+
+describe('TurnstileWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSiteKey.mockReturnValue('site-key')
+    mockLightTheme.value = true
+    delete window.turnstile
+  })
+
+  afterEach(() => {
+    delete window.turnstile
+  })
+
+  it('renders the widget with the configured sitekey and light theme', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+
+    renderWidget()
+    await flush()
+
+    expect(mockLoadTurnstile).toHaveBeenCalledOnce()
+    expect(api.render).toHaveBeenCalledOnce()
+    expect(options()?.sitekey).toBe('site-key')
+    expect(options()?.theme).toBe('light')
+  })
+
+  it('uses the dark theme when the active palette is not light', async () => {
+    mockLightTheme.value = false
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+
+    renderWidget()
+    await flush()
+
+    expect(options()?.theme).toBe('dark')
+  })
+
+  it('emits the solved token via v-model and shows no error', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+
+    const { emitted, container } = renderWidget()
+    await flush()
+
+    options()!.callback!('token-abc')
+    await flush()
+
+    expect(emitted()['update:token'].at(-1)).toEqual(['token-abc'])
+    expect(container.textContent).not.toContain('Challenge expired')
+    expect(container.textContent).not.toContain('Verification failed')
+  })
+
+  it('clears the token and surfaces the expired message on expiry', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+
+    const { emitted, container } = renderWidget()
+    await flush()
+
+    options()!.callback!('token-abc')
+    options()!['expired-callback']!()
+    await flush()
+
+    expect(emitted()['update:token'].at(-1)).toEqual([''])
+    expect(container.textContent).toContain('Challenge expired')
+  })
+
+  it('clears the token and surfaces the failure message on widget error', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+
+    const { emitted, container } = renderWidget()
+    await flush()
+
+    options()!.callback!('token-abc')
+    options()!['error-callback']!()
+    await flush()
+
+    expect(emitted()['update:token'].at(-1)).toEqual([''])
+    expect(container.textContent).toContain('Verification failed')
+  })
+
+  it('resets the widget on a challenge error to fetch a fresh challenge', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+
+    renderWidget()
+    await flush()
+
+    options()!['error-callback']!()
+    await flush()
+
+    expect(api.reset).toHaveBeenCalledWith('widget-id')
+  })
+
+  it('shows the failure message when the Turnstile script fails to load', async () => {
+    mockLoadTurnstile.mockRejectedValue(new Error('script failed'))
+
+    const { container } = renderWidget()
+    await flush()
+
+    expect(container.textContent).toContain('Verification failed')
+  })
+
+  it('reset() clears the token model and resets the rendered widget', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+
+    const { emitted, getCurrentInstance } = renderWidgetWithExpose()
+    await flush()
+
+    options()!.callback!('token-abc')
+    await flush()
+    expect(emitted()['update:token'].at(-1)).toEqual(['token-abc'])
+
+    getCurrentInstance().reset()
+    await flush()
+
+    expect(api.reset).toHaveBeenCalledWith('widget-id')
+    expect(emitted()['update:token'].at(-1)).toEqual([''])
+  })
+
+  it('reset() clears a stale error so it does not linger over a fresh challenge', async () => {
+    const { api, options } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+
+    const { container, getCurrentInstance } = renderWidgetWithExpose()
+    await flush()
+
+    options()!['error-callback']!()
+    await flush()
+    expect(container.textContent).toContain('Verification failed')
+
+    getCurrentInstance().reset()
+    await flush()
+    expect(container.textContent).not.toContain('Verification failed')
+  })
+
+  it('reset() clears the token even when the widget never rendered', async () => {
+    mockLoadTurnstile.mockRejectedValue(new Error('script failed'))
+
+    const { emitted, getCurrentInstance } = renderWidgetWithExpose()
+    await flush()
+
+    getCurrentInstance().reset()
+    await flush()
+
+    // No widget id was captured, so window.turnstile.reset is never called,
+    // but the token model is still cleared.
+    expect(emitted()['update:token']?.at(-1) ?? ['']).toEqual([''])
+  })
+
+  it('removes the widget on unmount when one was rendered', async () => {
+    const { api } = fakeTurnstile()
+    mockLoadTurnstile.mockResolvedValue(api)
+    window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+
+    const { unmount } = renderWidget()
+    await flush()
+
+    unmount()
+
+    expect(api.remove).toHaveBeenCalledWith('widget-id')
+  })
+})

--- a/src/components/dialog/content/signin/TurnstileWidget.vue
+++ b/src/components/dialog/content/signin/TurnstileWidget.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <div ref="containerRef"></div>
+    <small
+      v-if="errorMessage"
+      role="alert"
+      aria-live="assertive"
+      class="text-red-500"
+      >{{ errorMessage }}</small
+    >
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { loadTurnstile } from '@/composables/auth/turnstileScript'
+import { getTurnstileSiteKey } from '@/config/turnstile'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+
+const token = defineModel<string>('token', { default: '' })
+
+const { t } = useI18n()
+const colorPaletteStore = useColorPaletteStore()
+
+const containerRef = ref<HTMLDivElement>()
+const errorMessage = ref('')
+let widgetId: string | undefined
+
+const clearToken = () => {
+  token.value = ''
+}
+
+/**
+ * Fetch a fresh challenge and clear the current token.
+ *
+ * Turnstile tokens are single-use, so after a token is consumed by a submit
+ * attempt that did not succeed, the spent token must be discarded and a new
+ * challenge requested. Clearing the model re-blocks submission until the user
+ * solves the fresh challenge; clearing the error drops any stale failure text
+ * so it can't linger over the new challenge.
+ */
+const reset = () => {
+  clearToken()
+  errorMessage.value = ''
+  if (widgetId && window.turnstile) {
+    window.turnstile.reset(widgetId)
+  }
+}
+
+defineExpose({ reset })
+
+onMounted(async () => {
+  try {
+    const turnstile = await loadTurnstile()
+    if (!containerRef.value) return
+
+    const theme = colorPaletteStore.completedActivePalette.light_theme
+      ? 'light'
+      : 'dark'
+
+    widgetId = turnstile.render(containerRef.value, {
+      sitekey: getTurnstileSiteKey(),
+      theme,
+      callback: (newToken: string) => {
+        errorMessage.value = ''
+        token.value = newToken
+      },
+      'expired-callback': () => {
+        clearToken()
+        errorMessage.value = t('auth.turnstile.expired')
+      },
+      'error-callback': () => {
+        clearToken()
+        console.warn('Turnstile challenge failed')
+        errorMessage.value = t('auth.turnstile.failed')
+        if (widgetId && window.turnstile) window.turnstile.reset(widgetId)
+      }
+    })
+  } catch (error) {
+    console.warn('Turnstile failed to load', error)
+    errorMessage.value = t('auth.turnstile.failed')
+  }
+})
+
+onBeforeUnmount(() => {
+  if (widgetId && window.turnstile) {
+    window.turnstile.remove(widgetId)
+  }
+})
+</script>

--- a/src/composables/auth/turnstileScript.test.ts
+++ b/src/composables/auth/turnstileScript.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TurnstileApi } from '@/composables/auth/turnstileScript'
+
+const TURNSTILE_SRC =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+const fakeApi = (): TurnstileApi => ({
+  render: vi.fn(() => 'widget-id'),
+  reset: vi.fn(),
+  remove: vi.fn()
+})
+
+/**
+ * Controllable stand-in for the injected <script>. We never insert a real
+ * external script because jsdom would try (and fail) to fetch it and fire its
+ * own `error` event, making `load` impossible to simulate deterministically.
+ * Instead `createElement`/`querySelector`/`appendChild` are spied to route
+ * through this fake, so the test drives `load`/`error`/timeout itself.
+ */
+class FakeScript {
+  src = ''
+  async = false
+  private handlers: Record<string, Array<(e: Event) => void>> = {}
+
+  addEventListener(type: string, cb: (e: Event) => void) {
+    ;(this.handlers[type] ??= []).push(cb)
+  }
+
+  dispatchEvent(event: Event): boolean {
+    for (const cb of this.handlers[event.type] ?? []) cb(event)
+    return true
+  }
+
+  remove() {
+    const i = inserted.indexOf(this)
+    if (i >= 0) inserted.splice(i, 1)
+  }
+}
+
+let inserted: FakeScript[] = []
+
+const scriptEl = (): FakeScript | null =>
+  inserted.find((s) => s.src === TURNSTILE_SRC) ?? null
+
+const scriptCount = () => inserted.filter((s) => s.src === TURNSTILE_SRC).length
+
+/**
+ * The module keeps a private singleton promise, so each test imports a fresh
+ * copy after `vi.resetModules()`.
+ */
+async function freshLoadTurnstile() {
+  vi.resetModules()
+  const mod = await import('@/composables/auth/turnstileScript')
+  return mod.loadTurnstile
+}
+
+describe('loadTurnstile', () => {
+  beforeEach(() => {
+    inserted = []
+    delete window.turnstile
+
+    const realCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) =>
+      tag === 'script'
+        ? (new FakeScript() as unknown as HTMLElement)
+        : realCreateElement(tag)
+    )
+    vi.spyOn(document, 'querySelector').mockImplementation((sel: string) =>
+      typeof sel === 'string' && sel.includes('challenges.cloudflare.com')
+        ? (scriptEl() as unknown as Element | null)
+        : null
+    )
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node: Node) => {
+      inserted.push(node as unknown as FakeScript)
+      return node
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('resolves immediately with the existing global and appends no script', async () => {
+    const api = fakeApi()
+    window.turnstile = api
+
+    const loadTurnstile = await freshLoadTurnstile()
+
+    await expect(loadTurnstile()).resolves.toBe(api)
+    expect(scriptEl()).toBeNull()
+  })
+
+  it('appends the script and resolves once it loads and exposes the global', async () => {
+    const loadTurnstile = await freshLoadTurnstile()
+
+    const promise = loadTurnstile()
+    const el = scriptEl()
+    expect(el).not.toBeNull()
+    expect(el?.async).toBe(true)
+
+    const api = fakeApi()
+    window.turnstile = api
+    el!.dispatchEvent(new Event('load'))
+
+    await expect(promise).resolves.toBe(api)
+  })
+
+  it('caches the in-flight promise so concurrent callers share one load', async () => {
+    const loadTurnstile = await freshLoadTurnstile()
+
+    const p1 = loadTurnstile()
+    const p2 = loadTurnstile()
+
+    expect(p1).toBe(p2)
+    expect(scriptCount()).toBe(1)
+  })
+
+  it('polls for the global when it is published asynchronously after the load event', async () => {
+    vi.useFakeTimers()
+    const loadTurnstile = await freshLoadTurnstile()
+
+    const promise = loadTurnstile()
+    scriptEl()!.dispatchEvent(new Event('load'))
+    // global published shortly after load
+    const api = fakeApi()
+    window.turnstile = api
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(promise).resolves.toBe(api)
+    // tag stays in place on success
+    expect(scriptEl()).not.toBeNull()
+  })
+
+  it('rejects and clears the cache when the global never appears after load (poll timeout)', async () => {
+    vi.useFakeTimers()
+    const loadTurnstile = await freshLoadTurnstile()
+
+    const promise = loadTurnstile()
+    scriptEl()!.dispatchEvent(new Event('load'))
+    // global never published; deadline elapses
+    const assertion = expect(promise).rejects.toThrow(/timed out/i)
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await assertion
+    // dead tag is removed so a later retry starts clean
+    expect(scriptEl()).toBeNull()
+    // cache was reset → a later call starts a brand-new load
+    const retry = loadTurnstile()
+    expect(retry).not.toBe(promise)
+    // settle the throwaway retry so it doesn't leak a 10s timer
+    retry.catch(() => {})
+    scriptEl()!.dispatchEvent(new Event('error'))
+    await expect(retry).rejects.toThrow()
+  })
+
+  it('rejects, removes the self-appended script, and clears the cache on load error', async () => {
+    const loadTurnstile = await freshLoadTurnstile()
+
+    const promise = loadTurnstile()
+    scriptEl()!.dispatchEvent(new Event('error'))
+
+    await expect(promise).rejects.toThrow(/failed to load/i)
+    expect(scriptEl()).toBeNull()
+    // cache was reset → a later call starts a brand-new load
+    const retry = loadTurnstile()
+    expect(retry).not.toBe(promise)
+    // settle the throwaway retry so it doesn't leak a 10s timer
+    retry.catch(() => {})
+    scriptEl()!.dispatchEvent(new Event('error'))
+    await expect(retry).rejects.toThrow()
+  })
+
+  it('rejects, removes the script, and clears the cache on timeout', async () => {
+    vi.useFakeTimers()
+    const loadTurnstile = await freshLoadTurnstile()
+
+    const promise = loadTurnstile()
+    const assertion = expect(promise).rejects.toThrow(/timed out/i)
+    vi.advanceTimersByTime(10_000)
+
+    await assertion
+    expect(scriptEl()).toBeNull()
+  })
+
+  it('reuses a pre-existing script tag and resolves promptly once the global appears (no duplicate, tag left in place)', async () => {
+    vi.useFakeTimers()
+    const existing = new FakeScript()
+    existing.src = TURNSTILE_SRC
+    inserted.push(existing)
+
+    const loadTurnstile = await freshLoadTurnstile()
+    const promise = loadTurnstile()
+
+    // no duplicate appended
+    expect(scriptCount()).toBe(1)
+
+    // The pre-existing tag's load event may have already fired before we
+    // attached listeners, so resolution must come from polling for the global
+    // rather than from a (dead) load event.
+    const api = fakeApi()
+    window.turnstile = api
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(promise).resolves.toBe(api)
+    // a pre-existing tag is left alone (never removed by this loader)
+    expect(scriptEl()).not.toBeNull()
+  })
+
+  it('reuses a pre-existing script tag and times out (clearing the cache) if the global never appears, leaving the tag in place', async () => {
+    vi.useFakeTimers()
+    const existing = new FakeScript()
+    existing.src = TURNSTILE_SRC
+    inserted.push(existing)
+
+    const loadTurnstile = await freshLoadTurnstile()
+    const promise = loadTurnstile()
+    const assertion = expect(promise).rejects.toThrow(/timed out/i)
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await assertion
+    // pre-existing tag is never removed by the loader
+    expect(scriptEl()).not.toBeNull()
+    // cache was reset → a later call starts a brand-new load
+    const retry = loadTurnstile()
+    expect(retry).not.toBe(promise)
+    // drain the throwaway retry's timer/promise so nothing leaks
+    retry.catch(() => {})
+    await vi.advanceTimersByTimeAsync(10_000)
+  })
+})

--- a/src/composables/auth/turnstileScript.ts
+++ b/src/composables/auth/turnstileScript.ts
@@ -1,0 +1,36 @@
+import { createScriptLoader } from '@/utils/loadExternalScript'
+
+const TURNSTILE_SRC =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+export interface TurnstileRenderOptions {
+  sitekey: string
+  theme?: 'light' | 'dark' | 'auto'
+  callback?: (token: string) => void
+  'expired-callback'?: () => void
+  'error-callback'?: () => void
+}
+
+export interface TurnstileApi {
+  render: (
+    container: string | HTMLElement,
+    options: TurnstileRenderOptions
+  ) => string
+  reset: (widgetId?: string) => void
+  remove: (widgetId: string) => void
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi
+  }
+}
+
+const loadTurnstileScript = createScriptLoader(
+  TURNSTILE_SRC,
+  () => window.turnstile ?? null
+)
+
+export function loadTurnstile(): Promise<TurnstileApi> {
+  return loadTurnstileScript()
+}

--- a/src/composables/auth/useAuthActions.ts
+++ b/src/composables/auth/useAuthActions.ts
@@ -186,8 +186,8 @@ export const useAuthActions = () => {
   )
 
   const signUpWithEmail = wrapWithErrorHandlingAsync(
-    async (email: string, password: string) => {
-      return await authStore.register(email, password)
+    async (email: string, password: string, turnstileToken?: string) => {
+      return await authStore.register(email, password, turnstileToken)
     },
     reportError
   )

--- a/src/composables/auth/useTurnstile.test.ts
+++ b/src/composables/auth/useTurnstile.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isTurnstileEnabled,
+  normalizeTurnstileMode,
+  useTurnstile
+} from '@/composables/auth/useTurnstile'
+import { getTurnstileSiteKey } from '@/config/turnstile'
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { api } from '@/scripts/api'
+import { getDevOverride } from '@/utils/devFeatureFlagOverride'
+
+vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+  remoteConfig: { value: {} }
+}))
+vi.mock('@/scripts/api', () => ({
+  api: { getServerFeature: vi.fn() }
+}))
+vi.mock('@/utils/devFeatureFlagOverride', () => ({
+  getDevOverride: vi.fn()
+}))
+vi.mock('@/config/turnstile', () => ({
+  getTurnstileSiteKey: vi.fn()
+}))
+
+const mockedDevOverride = vi.mocked(getDevOverride)
+const mockedGetServerFeature = vi.mocked(api.getServerFeature)
+const mockedSiteKey = vi.mocked(getTurnstileSiteKey)
+
+describe('normalizeTurnstileMode', () => {
+  it('passes through known modes', () => {
+    expect(normalizeTurnstileMode('off')).toBe('off')
+    expect(normalizeTurnstileMode('shadow')).toBe('shadow')
+    expect(normalizeTurnstileMode('enforce')).toBe('enforce')
+  })
+
+  it('clamps unknown or missing values to off', () => {
+    expect(normalizeTurnstileMode('enfroce')).toBe('off')
+    expect(normalizeTurnstileMode('')).toBe('off')
+    expect(normalizeTurnstileMode(undefined)).toBe('off')
+  })
+})
+
+describe('isTurnstileEnabled', () => {
+  it('renders when the flag is active and a sitekey is configured', () => {
+    expect(isTurnstileEnabled('shadow', 'site-key')).toBe(true)
+    expect(isTurnstileEnabled('enforce', 'site-key')).toBe(true)
+  })
+
+  it('does not render when the flag is off', () => {
+    expect(isTurnstileEnabled('off', 'site-key')).toBe(false)
+  })
+
+  it('does not render without a sitekey (OSS / local builds)', () => {
+    expect(isTurnstileEnabled('shadow', '')).toBe(false)
+    expect(isTurnstileEnabled('enforce', '')).toBe(false)
+  })
+})
+
+describe('useTurnstile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    remoteConfig.value = {}
+    mockedDevOverride.mockReturnValue(undefined)
+    mockedGetServerFeature.mockReturnValue('off')
+    mockedSiteKey.mockReturnValue('site-key')
+  })
+
+  describe('mode precedence', () => {
+    it('prefers the dev override over remote config and the server feature', () => {
+      mockedDevOverride.mockReturnValue('enforce')
+      remoteConfig.value = { signup_turnstile: 'shadow' }
+      mockedGetServerFeature.mockReturnValue('off')
+
+      expect(useTurnstile().mode.value).toBe('enforce')
+    })
+
+    it('uses remote config when there is no dev override', () => {
+      remoteConfig.value = { signup_turnstile: 'shadow' }
+
+      expect(useTurnstile().mode.value).toBe('shadow')
+    })
+
+    it('falls back to the server feature flag (default off) when nothing else is set', () => {
+      mockedGetServerFeature.mockReturnValue('enforce')
+
+      expect(useTurnstile().mode.value).toBe('enforce')
+      expect(mockedGetServerFeature).toHaveBeenCalledWith(
+        'signup_turnstile',
+        'off'
+      )
+    })
+
+    it('clamps an unknown remote-config value to off', () => {
+      remoteConfig.value = {
+        signup_turnstile: 'bogus' as unknown as 'shadow'
+      }
+
+      expect(useTurnstile().mode.value).toBe('off')
+    })
+
+    it('resolves to off when every source is unset', () => {
+      expect(useTurnstile().mode.value).toBe('off')
+    })
+  })
+
+  describe('enabled / enforced', () => {
+    it('is enabled but not enforced in shadow with a sitekey', () => {
+      remoteConfig.value = { signup_turnstile: 'shadow' }
+
+      const { enabled, enforced } = useTurnstile()
+      expect(enabled.value).toBe(true)
+      expect(enforced.value).toBe(false)
+    })
+
+    it('is enabled and enforced in enforce with a sitekey', () => {
+      remoteConfig.value = { signup_turnstile: 'enforce' }
+
+      const { enabled, enforced } = useTurnstile()
+      expect(enabled.value).toBe(true)
+      expect(enforced.value).toBe(true)
+    })
+
+    it('is neither enabled nor enforced without a sitekey, even in enforce', () => {
+      remoteConfig.value = { signup_turnstile: 'enforce' }
+      mockedSiteKey.mockReturnValue('')
+
+      const { enabled, enforced } = useTurnstile()
+      expect(enabled.value).toBe(false)
+      expect(enforced.value).toBe(false)
+    })
+
+    it('is disabled when the mode is off', () => {
+      const { enabled, enforced } = useTurnstile()
+      expect(enabled.value).toBe(false)
+      expect(enforced.value).toBe(false)
+    })
+  })
+})

--- a/src/composables/auth/useTurnstile.ts
+++ b/src/composables/auth/useTurnstile.ts
@@ -1,0 +1,44 @@
+import { computed } from 'vue'
+
+import { getTurnstileSiteKey } from '@/config/turnstile'
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import type { TurnstileMode } from '@/platform/remoteConfig/types'
+
+/**
+ * Clamp an externally-sourced value to a known TurnstileMode. Unknown strings
+ * (typos, stale flag variants) resolve to 'off' so a bad value can never leave
+ * the widget rendered-but-unenforced — mirrors the server-side resolver.
+ */
+export function normalizeTurnstileMode(raw: string | undefined): TurnstileMode {
+  return raw === 'shadow' || raw === 'enforce' ? raw : 'off'
+}
+
+/**
+ * Whether the signup Turnstile widget should render. Purely config-driven: the
+ * flag must be shadow/enforce and a sitekey must be configured. OSS / local
+ * builds resolve no sitekey — the real per-env keys are tree-shaken out via the
+ * __DISTRIBUTION__ build define (see config/turnstile.ts) — so the widget never
+ * renders. The local-OSS exemption lives server-side (loopback-IP check in
+ * CreateCustomer).
+ */
+export function isTurnstileEnabled(
+  mode: TurnstileMode,
+  siteKey: string
+): boolean {
+  return mode !== 'off' && siteKey !== ''
+}
+
+/**
+ * Reactive Turnstile state for the signup form.
+ * - `enabled`: render the widget
+ * - `enforced`: block submit until the challenge is solved
+ */
+export function useTurnstile() {
+  const { flags } = useFeatureFlags()
+  const mode = computed(() => normalizeTurnstileMode(flags.signupTurnstileMode))
+  const siteKey = computed(getTurnstileSiteKey)
+  const enabled = computed(() => isTurnstileEnabled(mode.value, siteKey.value))
+  const enforced = computed(() => enabled.value && mode.value === 'enforce')
+
+  return { mode, siteKey, enabled, enforced }
+}

--- a/src/composables/useFeatureFlags.test.ts
+++ b/src/composables/useFeatureFlags.test.ts
@@ -221,6 +221,39 @@ describe('useFeatureFlags', () => {
     })
   })
 
+  describe('signupTurnstileMode', () => {
+    afterEach(() => {
+      localStorage.clear()
+    })
+
+    it('falls back to the server feature flag with default off', () => {
+      vi.mocked(api.getServerFeature).mockImplementation(
+        (path, defaultValue) => {
+          if (path === ServerFeatureFlag.SIGNUP_TURNSTILE) return 'enforce'
+          return defaultValue
+        }
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.signupTurnstileMode).toBe('enforce')
+      expect(api.getServerFeature).toHaveBeenCalledWith(
+        ServerFeatureFlag.SIGNUP_TURNSTILE,
+        'off'
+      )
+    })
+
+    it('lets a dev override beat the server value', () => {
+      vi.mocked(api.getServerFeature).mockReturnValue('off')
+      localStorage.setItem(
+        `ff:${ServerFeatureFlag.SIGNUP_TURNSTILE}`,
+        '"shadow"'
+      )
+
+      const { flags } = useFeatureFlags()
+      expect(flags.signupTurnstileMode).toBe('shadow')
+    })
+  })
+
   describe('unifiedCloudAuthEnabled', () => {
     afterEach(() => {
       localStorage.clear()

--- a/src/composables/useFeatureFlags.ts
+++ b/src/composables/useFeatureFlags.ts
@@ -29,7 +29,8 @@ export enum ServerFeatureFlag {
   COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
   COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
   SHOW_SIGNIN_BUTTON = 'show_signin_button',
-  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth'
+  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth',
+  SIGNUP_TURNSTILE = 'signup_turnstile'
 }
 
 /**
@@ -172,6 +173,13 @@ export function useFeatureFlags() {
         ServerFeatureFlag.UNIFIED_CLOUD_AUTH,
         remoteConfig.value.unified_cloud_auth,
         false
+      )
+    },
+    get signupTurnstileMode() {
+      return resolveFlag(
+        ServerFeatureFlag.SIGNUP_TURNSTILE,
+        remoteConfig.value.signup_turnstile,
+        'off'
       )
     }
   })

--- a/src/config/turnstile.test.ts
+++ b/src/config/turnstile.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getTurnstileSiteKey } from '@/config/turnstile'
+
+const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA'
+// __USE_PROD_CONFIG__ is false under vitest (see vitest.setup.ts), so the
+// build-time fallback resolves to the staging sitekey.
+const STAGING_TURNSTILE_SITE_KEY = '0x4AAAAAADnYY4_Q0qxHZ5a7'
+
+// Mutable containers go through vi.hoisted so the hoisted vi.mock factories can
+// reference them without a temporal-dead-zone crash (which surfaces under
+// coverage instrumentation, not a plain run).
+const { mockRemoteConfig } = vi.hoisted(() => ({
+  mockRemoteConfig: { value: {} as Record<string, unknown> }
+}))
+vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+  remoteConfig: mockRemoteConfig,
+  configValueOrDefault: (
+    cfg: Record<string, unknown>,
+    key: string,
+    fallback: unknown
+  ) => cfg[key] || fallback
+}))
+
+describe('getTurnstileSiteKey', () => {
+  beforeEach(() => {
+    mockRemoteConfig.value = {}
+    vi.stubGlobal('__DISTRIBUTION__', 'localhost')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  describe('OSS / non-cloud build', () => {
+    it('falls back to the always-pass test key in dev', () => {
+      vi.stubEnv('DEV', true)
+
+      expect(getTurnstileSiteKey()).toBe(TURNSTILE_TEST_SITE_KEY)
+    })
+
+    it('returns empty string outside dev so the widget never renders', () => {
+      vi.stubEnv('DEV', false)
+
+      expect(getTurnstileSiteKey()).toBe('')
+    })
+
+    it('ignores remote config (the widget is cloud-only)', () => {
+      vi.stubEnv('DEV', false)
+      mockRemoteConfig.value = { turnstile_sitekey: '0xshould-not-be-used' }
+
+      expect(getTurnstileSiteKey()).toBe('')
+    })
+  })
+
+  describe('cloud build', () => {
+    beforeEach(() => {
+      vi.stubGlobal('__DISTRIBUTION__', 'cloud')
+    })
+
+    it('returns the sitekey delivered via remote config', () => {
+      mockRemoteConfig.value = { turnstile_sitekey: '0x4AAAAAreal' }
+
+      expect(getTurnstileSiteKey()).toBe('0x4AAAAAreal')
+    })
+
+    it('falls back to the build-time per-env sitekey during a remote-config gap', () => {
+      expect(getTurnstileSiteKey()).toBe(STAGING_TURNSTILE_SITE_KEY)
+    })
+  })
+})

--- a/src/config/turnstile.ts
+++ b/src/config/turnstile.ts
@@ -1,0 +1,43 @@
+import {
+  configValueOrDefault,
+  remoteConfig
+} from '@/platform/remoteConfig/remoteConfig'
+
+/**
+ * Cloudflare Turnstile always-pass test sitekey, used only in local dev so the
+ * signup flow can be exercised without a real key.
+ * @see https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+ */
+const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA'
+
+// Public per-environment sitekeys, baked at build time so a cloud build renders
+// the widget even before (or without) remote config; remote config still
+// overrides them, so keys rotate live without a rebuild.
+const PROD_TURNSTILE_SITE_KEY = '0x4AAAAAADnYZPVOpFCL_zeo'
+const STAGING_TURNSTILE_SITE_KEY = '0x4AAAAAADnYY4_Q0qxHZ5a7'
+
+/**
+ * Returns the Cloudflare Turnstile sitekey for the current environment.
+ * - OSS / localhost never renders the cloud widget (server-side loopback
+ *   exemption covers local signup); in dev it falls back to the always-pass test
+ *   key so the flow is exercisable locally, otherwise ''.
+ * - Cloud builds prefer the per-env sitekey delivered via remote config
+ *   (`turnstile_sitekey`) and fall back to the build-time constant, so the widget
+ *   still renders during a remote-config gap rather than silently disappearing.
+ */
+export function getTurnstileSiteKey(): string {
+  // Gate on the __DISTRIBUTION__ build define rather than the cross-module
+  // `isCloud` const so dead-code elimination strips the real per-env sitekeys
+  // from OSS/desktop bundles — same idiom as initTelemetry.ts, enforced by the
+  // dist scan in ci-dist-telemetry-scan.yaml.
+  const isCloudBuild = __DISTRIBUTION__ === 'cloud'
+  if (!isCloudBuild) {
+    return import.meta.env.DEV ? TURNSTILE_TEST_SITE_KEY : ''
+  }
+
+  return configValueOrDefault(
+    remoteConfig.value,
+    'turnstile_sitekey',
+    __USE_PROD_CONFIG__ ? PROD_TURNSTILE_SITE_KEY : STAGING_TURNSTILE_SITE_KEY
+  )
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2280,6 +2280,11 @@
       "personalDataConsentLabel": "I agree to the processing of my personal data.",
       "emailNotEligibleForFreeTier": "Email sign-up is not eligible for Free Tier."
     },
+    "turnstile": {
+      "failed": "Verification failed. Please try again.",
+      "expired": "Verification expired. Please complete the challenge again.",
+      "submitBlockedHint": "Complete the verification challenge above to enable sign up."
+    },
     "signOut": {
       "signOut": "Log Out",
       "success": "Signed out successfully",

--- a/src/platform/cloud/onboarding/CloudSignupView.vue
+++ b/src/platform/cloud/onboarding/CloudSignupView.vue
@@ -69,6 +69,7 @@
           </Message>
           <SignUpForm
             v-else
+            ref="signUpForm"
             :auth-error="authError"
             @submit="signUpWithEmail"
           />
@@ -180,10 +181,22 @@ const signInWithGithub = async () => {
   }
 }
 
-const signUpWithEmail = async (values: SignUpData) => {
+const signUpForm = ref<InstanceType<typeof SignUpForm> | null>(null)
+
+const signUpWithEmail = async (values: SignUpData, turnstileToken?: string) => {
   authError.value = ''
-  if (await authActions.signUpWithEmail(values.email, values.password)) {
+  if (
+    await authActions.signUpWithEmail(
+      values.email,
+      values.password,
+      turnstileToken
+    )
+  ) {
     await onAuthSuccess()
+  } else {
+    // Signup failed while the form is still mounted: re-arm the single-use
+    // Turnstile token so the next attempt sends a fresh one.
+    signUpForm.value?.resetTurnstile()
   }
 }
 

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -110,4 +110,17 @@ export type RemoteConfig = {
   comfyhub_profile_gate_enabled?: boolean
   unified_cloud_auth?: boolean
   sentry_dsn?: string
+  turnstile_sitekey?: string
+  // Raw, unvalidated wire value (a server typo like 'enfroce' is possible).
+  // Always funnel it through normalizeTurnstileMode before trusting it as a
+  // TurnstileMode — that resolver is the single narrowing boundary.
+  signup_turnstile?: string
 }
+
+/**
+ * Gate mode for the signup Turnstile challenge.
+ * - 'off': do not render the widget
+ * - 'shadow': render the widget but never block submit (observe only)
+ * - 'enforce': block submit until the challenge is solved
+ */
+export type TurnstileMode = 'off' | 'shadow' | 'enforce'

--- a/src/platform/surveys/useTypeformEmbed.ts
+++ b/src/platform/surveys/useTypeformEmbed.ts
@@ -2,9 +2,10 @@ import { whenever } from '@vueuse/core'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { computed, ref, toValue } from 'vue'
 
+import { createScriptLoader } from '@/utils/loadExternalScript'
+
 const TYPEFORM_SRC = 'https://embed.typeform.com/next/embed.js'
 const VALID_ID_PATTERN = /^[A-Za-z0-9]+$/
-const SCRIPT_LOAD_TIMEOUT_MS = 10_000
 
 interface TypeformGlobal {
   load?: () => void
@@ -22,60 +23,12 @@ export function isTypeformIdValid(id: string | undefined | null): boolean {
   return !!id && VALID_ID_PATTERN.test(id)
 }
 
-/**
- * Module-level singleton so every consumer shares one script load.
- * Resets to `null` on failure so a later consumer can retry.
- */
-let scriptPromise: Promise<void> | null = null
+const loadTypeformScript = createScriptLoader(TYPEFORM_SRC, () =>
+  typeof window.tf?.load === 'function' ? (window.tf as TypeformGlobal) : null
+)
 
-function ensureScriptLoaded(): Promise<void> {
-  if (scriptPromise) return scriptPromise
-
-  scriptPromise = new Promise<void>((resolve, reject) => {
-    const existing = document.querySelector<HTMLScriptElement>(
-      `script[src="${TYPEFORM_SRC}"]`
-    )
-
-    if (existing && typeof window.tf?.load === 'function') {
-      resolve()
-      return
-    }
-
-    const scriptEl = existing ?? document.createElement('script')
-
-    const timeoutId = window.setTimeout(() => {
-      scriptEl.remove()
-      scriptPromise = null
-      reject(new Error('Typeform embed script load timed out'))
-    }, SCRIPT_LOAD_TIMEOUT_MS)
-
-    scriptEl.addEventListener(
-      'load',
-      () => {
-        window.clearTimeout(timeoutId)
-        resolve()
-      },
-      { once: true }
-    )
-    scriptEl.addEventListener(
-      'error',
-      () => {
-        window.clearTimeout(timeoutId)
-        scriptEl.remove()
-        scriptPromise = null
-        reject(new Error('Typeform embed script failed to load'))
-      },
-      { once: true }
-    )
-
-    if (!existing) {
-      scriptEl.src = TYPEFORM_SRC
-      scriptEl.async = true
-      document.head.appendChild(scriptEl)
-    }
-  })
-
-  return scriptPromise
+function ensureScriptLoaded(): Promise<TypeformGlobal> {
+  return loadTypeformScript()
 }
 
 /**

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -9,7 +9,7 @@ import * as vuefire from 'vuefire'
 import { clearPreservedQuery } from '@/platform/navigation/preservedQueryManager'
 import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
 import { useDialogService } from '@/services/dialogService'
-import { useAuthStore } from '@/stores/authStore'
+import { AuthStoreError, useAuthStore } from '@/stores/authStore'
 import { createTestingPinia } from '@pinia/testing'
 
 // Hoisted mocks for dynamic imports
@@ -27,8 +27,9 @@ const { mockFeatureFlags } = vi.hoisted(() => ({
   }
 }))
 
-type MockUser = Omit<User, 'getIdToken'> & {
+type MockUser = Omit<User, 'getIdToken' | 'delete'> & {
   getIdToken: Mock
+  delete: Mock
 }
 
 type MockAuth = Record<string, unknown>
@@ -148,7 +149,8 @@ describe('useAuthStore', () => {
   const mockUser: MockUser = {
     uid: 'test-user-id',
     email: 'test@example.com',
-    getIdToken: vi.fn().mockResolvedValue('mock-id-token')
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    delete: vi.fn().mockResolvedValue(undefined)
   } as Partial<User> as MockUser
 
   beforeEach(() => {
@@ -397,6 +399,90 @@ describe('useAuthStore', () => {
       )
       expect(store.loading).toBe(false)
     })
+
+    it('forwards the turnstile token to createCustomer as turnstile_token', async () => {
+      vi.mocked(firebaseAuth.createUserWithEmailAndPassword).mockResolvedValue({
+        user: mockUser
+      } as Partial<UserCredential> as UserCredential)
+
+      await store.register('new@example.com', 'password', 'turnstile-abc')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/customers'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ turnstile_token: 'turnstile-abc' })
+        })
+      )
+    })
+
+    it('omits the request body when no turnstile token is provided', async () => {
+      vi.mocked(firebaseAuth.createUserWithEmailAndPassword).mockResolvedValue({
+        user: mockUser
+      } as Partial<UserCredential> as UserCredential)
+
+      await store.register('new@example.com', 'password')
+
+      const customerCall = mockFetch.mock.calls.find(([url]) =>
+        String(url).endsWith('/customers')
+      )
+      expect(customerCall?.[1]).not.toHaveProperty('body')
+    })
+
+    it('rolls back the orphaned Firebase user when customer creation fails', async () => {
+      vi.mocked(firebaseAuth.createUserWithEmailAndPassword).mockResolvedValue({
+        user: mockUser
+      } as Partial<UserCredential> as UserCredential)
+      // The server-side customer creation (where Turnstile is validated) fails.
+      mockFetch.mockImplementation((url: string) =>
+        url.endsWith('/customers')
+          ? Promise.resolve({
+              ok: false,
+              statusText: 'Forbidden',
+              json: () => Promise.resolve({})
+            })
+          : Promise.reject(new Error('Unexpected API call'))
+      )
+
+      await expect(
+        store.register('new@example.com', 'password', 'turnstile-bad')
+      ).rejects.toThrow()
+
+      // The just-created user is deleted so the email is freed for retry.
+      expect(mockUser.delete).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not delete the user on a successful registration', async () => {
+      vi.mocked(firebaseAuth.createUserWithEmailAndPassword).mockResolvedValue({
+        user: mockUser
+      } as Partial<UserCredential> as UserCredential)
+
+      await store.register('new@example.com', 'password')
+
+      expect(mockUser.delete).not.toHaveBeenCalled()
+    })
+
+    it('does not delete an existing user when customer creation fails during login', async () => {
+      // Regression guard: the rollback must be scoped to register only — login
+      // signs in an EXISTING user, so a customer hiccup must never delete it.
+      vi.mocked(firebaseAuth.signInWithEmailAndPassword).mockResolvedValue({
+        user: mockUser
+      } as Partial<UserCredential> as UserCredential)
+      mockFetch.mockImplementation((url: string) =>
+        url.endsWith('/customers')
+          ? Promise.resolve({
+              ok: false,
+              statusText: 'Forbidden',
+              json: () => Promise.resolve({})
+            })
+          : Promise.reject(new Error('Unexpected API call'))
+      )
+
+      await expect(
+        store.login('test@example.com', 'password')
+      ).rejects.toThrow()
+      expect(mockUser.delete).not.toHaveBeenCalled()
+    })
   })
 
   describe('logout', () => {
@@ -550,6 +636,20 @@ describe('useAuthStore', () => {
         expect(store.loading).toBe(false)
       })
 
+      it('never sends a turnstile_token on the customer request (OAuth is exempt)', async () => {
+        vi.mocked(firebaseAuth.signInWithPopup).mockResolvedValue({
+          user: mockUser
+        } as Partial<UserCredential> as UserCredential)
+
+        await store.loginWithGoogle()
+
+        const customerCall = mockFetch.mock.calls.find(([url]) =>
+          String(url).endsWith('/customers')
+        )
+        expect(customerCall).toBeDefined()
+        expect(customerCall?.[1]).not.toHaveProperty('body')
+      })
+
       it('should handle Google sign in errors', async () => {
         const mockError = new Error('Google authentication failed')
         vi.mocked(firebaseAuth.signInWithPopup).mockRejectedValue(mockError)
@@ -581,6 +681,20 @@ describe('useAuthStore', () => {
         )
         expect(result).toEqual(mockUserCredential)
         expect(store.loading).toBe(false)
+      })
+
+      it('never sends a turnstile_token on the customer request (OAuth is exempt)', async () => {
+        vi.mocked(firebaseAuth.signInWithPopup).mockResolvedValue({
+          user: mockUser
+        } as Partial<UserCredential> as UserCredential)
+
+        await store.loginWithGithub()
+
+        const customerCall = mockFetch.mock.calls.find(([url]) =>
+          String(url).endsWith('/customers')
+        )
+        expect(customerCall).toBeDefined()
+        expect(customerCall?.[1]).not.toHaveProperty('body')
       })
 
       it('should handle Github sign in errors', async () => {
@@ -857,6 +971,18 @@ describe('useAuthStore', () => {
       mockApiKeyGetAuthHeader.mockReturnValue(null)
 
       await expect(store.createCustomer()).rejects.toThrow()
+    })
+
+    it('carries the HTTP status on a non-ok response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity'
+      })
+
+      const error = await store.createCustomer().catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(AuthStoreError)
+      expect((error as AuthStoreError).status).toBe(422)
     })
   })
 })

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -42,6 +42,20 @@ type CreditPurchasePayload =
   operations['InitiateCreditPurchase']['requestBody']['content']['application/json']
 type CreateCustomerResponse =
   operations['createCustomer']['responses']['201']['content']['application/json']
+
+/**
+ * Request body for createCustomer. The Cloudflare Turnstile token captured at
+ * signup is forwarded to the backend as `turnstile_token` (snake_case), which
+ * reads this field on the CreateCustomer request; it is omitted for non-signup
+ * flows and on OSS / localhost where Turnstile is not rendered.
+ *
+ * TODO: replace with the generated `operations['createCustomer']` request-body
+ * type once the backend OpenAPI spec includes `turnstile_token`, so the field
+ * name/optionality drift-checks against the backend at compile time.
+ */
+type CreateCustomerPayload = {
+  turnstile_token?: string
+}
 type GetCustomerBalanceResponse =
   operations['GetCustomerBalance']['responses']['200']['content']['application/json']
 type AccessBillingPortalResponse =
@@ -55,9 +69,12 @@ export type BillingPortalTargetTier = NonNullable<
 >['target_tier']
 
 export class AuthStoreError extends Error {
-  constructor(message: string) {
+  readonly status: number | undefined
+
+  constructor(message: string, status?: number) {
     super(message)
     this.name = 'AuthStoreError'
+    this.status = status
   }
 }
 
@@ -291,7 +308,9 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  const createCustomer = async (): Promise<CreateCustomerResponse> => {
+  const createCustomer = async (
+    payload?: CreateCustomerPayload
+  ): Promise<CreateCustomerResponse> => {
     const authHeader = await getAuthHeader()
     if (!authHeader) {
       throw new AuthStoreError(t('toastMessages.userNotAuthenticated'))
@@ -302,13 +321,16 @@ export const useAuthStore = defineStore('auth', () => {
       headers: {
         ...authHeader,
         'Content-Type': 'application/json'
-      }
+      },
+      ...(payload &&
+        Object.keys(payload).length > 0 && { body: JSON.stringify(payload) })
     })
     if (!createCustomerRes.ok) {
       throw new AuthStoreError(
         t('toastMessages.failedToCreateCustomer', {
           error: createCustomerRes.statusText
-        })
+        }),
+        createCustomerRes.status
       )
     }
 
@@ -329,6 +351,7 @@ export const useAuthStore = defineStore('auth', () => {
     action: (auth: Auth) => Promise<T>,
     options: {
       createCustomer?: boolean
+      customerPayload?: CreateCustomerPayload
     } = {}
   ): Promise<T> => {
     loading.value = true
@@ -342,7 +365,7 @@ export const useAuthStore = defineStore('auth', () => {
         if (!token) {
           throw new Error('Cannot create customer: User not authenticated')
         }
-        await createCustomer()
+        await createCustomer(options.customerPayload)
       }
 
       return result
@@ -376,13 +399,41 @@ export const useAuthStore = defineStore('auth', () => {
 
   const register = async (
     email: string,
-    password: string
+    password: string,
+    turnstileToken?: string
   ): Promise<UserCredential> => {
-    const result = await executeAuthAction(
-      (authInstance) =>
-        createUserWithEmailAndPassword(authInstance, email, password),
-      { createCustomer: true }
-    )
+    // Drive create + customer inside one action so a failed customer step can
+    // roll back the just-created Firebase user. createCustomer is where the
+    // Turnstile token is validated server-side; if it fails (rejection, 5xx,
+    // network) the Firebase user is already created and, without rollback, the
+    // account is orphaned — every retry then fails "email already in use",
+    // permanently bricking signup. Rollback is scoped to register only; login /
+    // social sign-in must never delete an existing user on a customer hiccup.
+    const result = await executeAuthAction(async (authInstance) => {
+      const credential = await createUserWithEmailAndPassword(
+        authInstance,
+        email,
+        password
+      )
+      try {
+        await createCustomer(
+          turnstileToken ? { turnstile_token: turnstileToken } : undefined
+        )
+      } catch (error) {
+        // Best-effort rollback of the user created in THIS call; never let a
+        // cleanup failure mask the original error.
+        try {
+          await credential.user.delete()
+        } catch (deleteError) {
+          console.warn(
+            'Failed to roll back orphaned Firebase user after customer creation failed',
+            deleteError
+          )
+        }
+        throw error
+      }
+      return credential
+    })
 
     if (isCloud) {
       useTelemetry()?.trackAuth({

--- a/src/utils/loadExternalScript.ts
+++ b/src/utils/loadExternalScript.ts
@@ -1,0 +1,110 @@
+const POLL_INTERVAL_MS = 50
+
+/**
+ * Returns a singleton loader for an external script. `getReady` should return
+ * the resolved value when the script's global is available, or `null` when not.
+ * The returned function caches the in-flight Promise so concurrent callers share
+ * one load, and resets on failure so a later caller can retry.
+ */
+export function createScriptLoader<T>(
+  src: string,
+  getReady: () => T | null,
+  timeoutMs = 10_000
+): () => Promise<T> {
+  let scriptPromise: Promise<T> | null = null
+
+  return function loadScript(): Promise<T> {
+    if (scriptPromise) return scriptPromise
+
+    scriptPromise = new Promise<T>((resolve, reject) => {
+      let settled = false
+      let cancelPoll: (() => void) | undefined
+
+      function trySettle(fn: () => void) {
+        if (settled) return
+        settled = true
+        fn()
+      }
+
+      const ready = getReady()
+      if (ready !== null) {
+        resolve(ready)
+        return
+      }
+
+      const existing = document.querySelector<HTMLScriptElement>(
+        `script[src="${src}"]`
+      )
+
+      function startPoll(onSuccess: () => void): () => void {
+        const pollId = window.setInterval(() => {
+          const value = getReady()
+          if (value !== null) {
+            window.clearInterval(pollId)
+            onSuccess()
+            trySettle(() => resolve(value))
+          }
+        }, POLL_INTERVAL_MS)
+        return () => window.clearInterval(pollId)
+      }
+
+      if (existing) {
+        // load/error may have already fired on the pre-existing tag; poll for readiness
+        const timeoutId = window.setTimeout(() => {
+          cancelPoll?.()
+          trySettle(() => {
+            scriptPromise = null
+            reject(new Error(`Script load timed out: ${src}`))
+          })
+        }, timeoutMs)
+        cancelPoll = startPoll(() => window.clearTimeout(timeoutId))
+        return
+      }
+
+      const scriptEl = document.createElement('script')
+
+      const timeoutId = window.setTimeout(() => {
+        cancelPoll?.()
+        scriptEl.remove()
+        trySettle(() => {
+          scriptPromise = null
+          reject(new Error(`Script load timed out: ${src}`))
+        })
+      }, timeoutMs)
+
+      scriptEl.addEventListener(
+        'load',
+        () => {
+          if (settled) return
+          const value = getReady()
+          if (value !== null) {
+            window.clearTimeout(timeoutId)
+            trySettle(() => resolve(value))
+          } else {
+            // global may arrive asynchronously after load; poll under the shared timeout
+            cancelPoll = startPoll(() => window.clearTimeout(timeoutId))
+          }
+        },
+        { once: true }
+      )
+      scriptEl.addEventListener(
+        'error',
+        () => {
+          window.clearTimeout(timeoutId)
+          scriptEl.remove()
+          trySettle(() => {
+            scriptPromise = null
+            reject(new Error(`Script failed to load: ${src}`))
+          })
+        },
+        { once: true }
+      )
+
+      scriptEl.src = src
+      scriptEl.async = true
+      document.head.appendChild(scriptEl)
+    })
+
+    return scriptPromise
+  }
+}


### PR DESCRIPTION
Backport of #12924 to `cloud/1.46`.

The automated backport hit a cherry-pick conflict in `src/stores/authStore.ts`: the squashed commit on `main` routed `createCustomer` through `fetchWithUnifiedRemint`, but that helper (`platform/auth/unified/remintRetry.ts`) does not exist on `cloud/1.46`. Resolved by keeping `cloud/1.46`'s plain `fetch` and adding only the Turnstile change — the optional `turnstile_token` request body. No other behavioral change; the unified-remint wrapper is intentionally not backported.

Validation (local, against the `cloud/1.46` baseline): 145 affected unit tests pass (authStore, useFeatureFlags, turnstile config, auth composables, loadExternalScript, signin components); `vue-tsc` typecheck clean.