### PR TITLE
fix: attempt each backport target branch independently

### DIFF
--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -273,32 +273,49 @@ jobs:
               continue
             fi
 
-            # Create backport branch
-            git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
+            # Create backport branch. A failure here (e.g. dirty state left
+            # by a prior target) must not abort the loop and skip remaining
+            # targets, so fall back to a clean checkout and record the error.
+            if ! git checkout -B "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"; then
+              echo "::error::Failed to create branch ${BACKPORT_BRANCH} for ${TARGET_BRANCH}"
+              FAILED="${FAILED}${TARGET_BRANCH}:branch-create-failed "
+              git checkout main || git checkout -f main
+              echo "::endgroup::"
+              continue
+            fi
 
             # Try cherry-pick
             if git cherry-pick "${MERGE_COMMIT}"; then
               if [ "$REMOTE_BACKPORT_EXISTS" = true ]; then
-                git push --force-with-lease origin "${BACKPORT_BRANCH}"
+                PUSH_CMD=(git push --force-with-lease origin "${BACKPORT_BRANCH}")
               else
-                git push origin "${BACKPORT_BRANCH}"
+                PUSH_CMD=(git push origin "${BACKPORT_BRANCH}")
               fi
-              echo "${BACKPORT_BRANCH}" >> "$CREATED_BRANCHES_FILE"
-              SUCCESS="${SUCCESS}${TARGET_BRANCH}:${BACKPORT_BRANCH} "
-              echo "Successfully created backport branch: ${BACKPORT_BRANCH}"
+
+              # A push failure for one target must not abort the loop and
+              # prevent remaining targets from being attempted.
+              if "${PUSH_CMD[@]}"; then
+                echo "${BACKPORT_BRANCH}" >> "$CREATED_BRANCHES_FILE"
+                SUCCESS="${SUCCESS}${TARGET_BRANCH}:${BACKPORT_BRANCH} "
+                echo "Successfully created backport branch: ${BACKPORT_BRANCH}"
+              else
+                echo "::error::Failed to push ${BACKPORT_BRANCH} for ${TARGET_BRANCH}"
+                FAILED="${FAILED}${TARGET_BRANCH}:push-failed "
+              fi
+
               # Return to main (keep the branch, we need it for PR)
-              git checkout main
+              git checkout main || git checkout -f main
             else
               # Get conflict info
               CONFLICTS=$(git diff --name-only --diff-filter=U | tr '\n' ',')
-              git cherry-pick --abort
+              git cherry-pick --abort || true
 
               echo "::error::Cherry-pick failed due to conflicts"
               FAILED="${FAILED}${TARGET_BRANCH}:conflicts:${CONFLICTS} "
 
               # Clean up the failed branch
-              git checkout main
-              git branch -D "${BACKPORT_BRANCH}"
+              git checkout main || git checkout -f main
+              git branch -D "${BACKPORT_BRANCH}" || true
             fi
 
             echo "::endgroup::"
@@ -419,6 +436,12 @@ jobs:
 
             elif [ "${reason}" = "already-exists" ]; then
               gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Commit \`${MERGE_COMMIT}\` already exists on branch \`${target}\`. No backport needed."
+
+            elif [ "${reason}" = "branch-create-failed" ]; then
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`${target}\` failed: could not create the backport branch. Please retry or backport manually."
+
+            elif [ "${reason}" = "push-failed" ]; then
+              gh pr comment "${PR_NUMBER}" --body "@${PR_AUTHOR} Backport to \`${target}\` cherry-picked cleanly but the push failed. Please retry or push the backport branch manually."
 
             elif [ "${reason}" = "conflicts" ]; then
               CONFLICTS_INLINE=$(echo "${conflicts}" | tr ',' ' ')


### PR DESCRIPTION
## Bug

The backport workflow targets multiple release branches per backport (e.g. `cloud/1.45`, `cloud/1.46`, `core/1.45`, `core/1.46`). When the cherry-pick/push to the **first** target branch failed, the remaining target branches were **never attempted**. This is why a backport could land on one branch (e.g. `cloud/1.46`) yet never be attempted on another (e.g. `cloud/1.45`) when an earlier target failed.

## Root cause

The `Backport commits` step processes every target in a single bash `for` loop. GitHub Actions runs `run:` blocks with an implicit `set -eo pipefail` (default shell `bash --noprofile --norc -eo pipefail {0}`), so **any unguarded command that returns non-zero aborts the entire step**, ending the loop before later targets are reached.

Several per-iteration git commands inside the loop were unguarded:

```bash
git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"   # line 277
...
git push --force-with-lease origin "${BACKPORT_BRANCH}"          # line 282
git push origin "${BACKPORT_BRANCH}"                             # line 284
...
git cherry-pick --abort                                          # line 294
git checkout main                                                # lines 290/300
git branch -D "${BACKPORT_BRANCH}"                               # line 301
```

If, for the first target, the `git checkout -b` failed (e.g. a pre-existing local branch) or a `git push` failed (transient/race/protected-branch), `set -e` killed the step immediately and the remaining targets were silently skipped. The cherry-pick itself was already guarded by `if`, but the surrounding git operations were not.

## Fix

Make each target's git operations resilient so one target's failure is recorded and the loop continues to the next target:

- Guard branch creation (`git checkout -B`, which also tolerates a pre-existing local branch) and record a `branch-create-failed` reason on failure.
- Guard the push and record a `push-failed` reason on failure (cherry-pick was clean but push failed).
- Make recovery commands non-fatal: `git cherry-pick --abort || true`, `git checkout main || git checkout -f main`, `git branch -D ... || true`.
- Surface the two new failure reasons in the `Comment on failures` step so the original PR author gets a clear message.

Each target now gets its own independent attempt and its own resulting PR or failure comment, regardless of whether earlier targets succeeded or failed.

## Validation

- `python3 -c 'import yaml; yaml.safe_load(...)'` — passes.
- `actionlint` — no new warnings introduced; pre-existing informational lints in unrelated steps unchanged.
- Pre-commit hooks (format, lint, typecheck) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)