### PR TITLE
Long workflow name cleanup

### DIFF
--- a/browser_tests/tests/sidebar/assets.spec.ts
+++ b/browser_tests/tests/sidebar/assets.spec.ts
@@ -1095,6 +1095,33 @@ test.describe('Assets sidebar - drag and drop', () => {
     const fileComboWidget = await nodes[0].getWidget(0)
     await expect.poll(() => fileComboWidget.getValue()).toBe('test.png [temp]')
   })
+
+  test('Loading as workflow reuses asset name', async ({ comfyPage }) => {
+    await comfyPage.assets.mockOutputHistory([
+      createMockJob({
+        id: 'job',
+        preview_output: {
+          filename: `testimage.png`,
+          type: 'temp',
+          nodeId: '1',
+          mediaType: 'images'
+        }
+      })
+    ])
+    const path = comfyPage.assetPath('workflowInMedia/workflow.webp')
+    await comfyPage.page.route('**/view?**', (route) => route.fulfill({ path }))
+
+    const { assetsTab } = comfyPage.menu
+    await assetsTab.open()
+    await assetsTab.waitForAssets()
+    await expect(assetsTab.assetCards).toHaveCount(1)
+
+    const targetPosition = { x: 400, y: 100 }
+    await assetsTab.assetCards.dragTo(comfyPage.canvas, { targetPosition })
+
+    const getTabName = () => comfyPage.menu.topbar.getActiveTabName()
+    await expect.poll(getTabName).toContain('testimage')
+  })
 })
 
 test('Insert as node', { tag: '@vue-nodes' }, async ({ comfyPage }) => {

--- a/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
+++ b/src/components/breadcrumb/SubgraphBreadcrumbItem.vue
@@ -22,7 +22,7 @@
       data-testid="subgraph-breadcrumb-missing-nodes-icon"
       class="icon-[lucide--triangle-alert] text-warning-background"
     />
-    <span class="p-breadcrumb-item-label px-2">{{ item.label }}</span>
+    <span class="p-breadcrumb-item-label max-w-72 px-2">{{ item.label }}</span>
     <Tag
       v-if="item.isBlueprint"
       data-testid="subgraph-breadcrumb-blueprint-tag"

--- a/src/composables/node/useNodeDragAndDrop.ts
+++ b/src/composables/node/useNodeDragAndDrop.ts
@@ -1,7 +1,6 @@
 import { useChainCallback } from '@/composables/functional/useChainCallback'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
-import { MIME_ASSET_INFO } from '@/platform/assets/schemas/mediaAssetSchema'
-import { zResultItem } from '@/schemas/apiSchema'
+import { parseAssetInfo } from '@/platform/assets/schemas/mediaAssetSchema'
 import type { ResultItem } from '@/schemas/apiSchema'
 
 type DragHandler = (e: DragEvent) => boolean
@@ -12,14 +11,6 @@ interface DragAndDropOptions<T> {
   onDrop: DropHandler<T>
   onResultItemDrop?: (item: ResultItem) => void
   fileFilter?: (file: File) => boolean
-}
-
-function parseAssetInfo(assetString?: string) {
-  try {
-    return zResultItem.safeParse(JSON.parse(assetString ?? '')).data
-  } catch {
-    // output was not parsable, allow fallthrough and return undefined
-  }
 }
 
 /**
@@ -67,7 +58,7 @@ export const useNodeDragAndDrop = <T>(
       await onDrop(files)
       return true
     }
-    const asset = parseAssetInfo(e?.dataTransfer?.getData(MIME_ASSET_INFO))
+    const asset = parseAssetInfo(e.dataTransfer!)
     if (asset?.filename && options.onResultItemDrop) {
       await options.onResultItemDrop(asset)
       return true

--- a/src/platform/assets/components/MediaAssetCard.vue
+++ b/src/platform/assets/components/MediaAssetCard.vue
@@ -321,10 +321,15 @@ function dragStart(e: DragEvent) {
   const { dataTransfer } = e
   if (!dataTransfer) return
 
-  const { filename, subfolder, type } =
+  const { filename, subfolder, type, display_name } =
     getOutputAssetMetadata(asset.user_metadata)?.allOutputs?.[0] ?? {}
   if (filename) {
-    const outputString = JSON.stringify({ filename, subfolder, type })
+    const outputString = JSON.stringify({
+      filename,
+      subfolder,
+      type,
+      display_name
+    })
     dataTransfer.items.add(outputString, MIME_ASSET_INFO)
   }
 

--- a/src/platform/assets/schemas/mediaAssetSchema.ts
+++ b/src/platform/assets/schemas/mediaAssetSchema.ts
@@ -1,6 +1,8 @@
 import type { InjectionKey, Ref } from 'vue'
 import { z } from 'zod'
 
+import { zResultItem } from '@/schemas/apiSchema'
+
 import { assetItemSchema } from './assetSchema'
 
 const zMediaKindSchema = z.enum([
@@ -51,3 +53,12 @@ export const MediaAssetKey: InjectionKey<MediaAssetProviderValue> =
   Symbol('mediaAsset')
 
 export const MIME_ASSET_INFO = 'application/x-comfy-asset-info'
+
+export function parseAssetInfo(dataTransfer: DataTransfer) {
+  const assetString = dataTransfer?.getData(MIME_ASSET_INFO)
+  try {
+    return zResultItem.safeParse(JSON.parse(assetString ?? '')).data
+  } catch {
+    // output was not parsable, allow fallthrough and return undefined
+  }
+}

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -1,3 +1,5 @@
+import { parseAssetInfo } from '@/platform/assets/schemas/mediaAssetSchema'
+
 export async function extractFilesFromDragEvent(
   event: DragEvent
 ): Promise<File[]> {
@@ -9,6 +11,9 @@ export async function extractFilesFromDragEvent(
   )
 
   if (files.length > 0) return files
+
+  const asset = parseAssetInfo(event.dataTransfer)
+  const assetName = asset?.display_name ?? asset?.filename
 
   // Try loading the first URI in the transfer list
   const validTypes = ['text/uri-list', 'text/x-moz-url']
@@ -23,7 +28,7 @@ export async function extractFilesFromDragEvent(
   try {
     const response = await fetch(uri)
     const blob = await response.blob()
-    return [new File([blob], uri, { type: blob.type })]
+    return [new File([blob], assetName ?? uri, { type: blob.type })]
   } catch {
     return []
   }


### PR DESCRIPTION
When loading a workflow by dragging and dropping an output from the assets sidebar, the very long and unhelpful url would be used as the workflow name. This is fixed by instead using the asset display name
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/5c68ae48-1fa6-40e1-b2fb-6188ccd60391"/> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/29770c35-da48-4be9-943e-8ee69eb25e6a"  />|


Additionally, a max width is added to the breadcrumb items to avoid extremely long names.
| Before | After |
| ------ | ----- |
| <img width="360" alt="before" src="https://github.com/user-attachments/assets/508155ec-81d7-4ca5-8910-f42a70c9cb4b"/> | <img width="360" alt="after" src="https://github.com/user-attachments/assets/d335ceb7-bfeb-481f-a132-c700e017ee0c"  />|

