### PR TITLE
fix: empty-space click guard

### DIFF
--- a/src/components/sidebar/tabs/AssetsSidebarTab.vue
+++ b/src/components/sidebar/tabs/AssetsSidebarTab.vue
@@ -575,7 +575,7 @@ const handleDeselectAll = () => {
 }
 
 const handleEmptySpaceClick = () => {
-  if (hasSelection) {
+  if (hasSelection.value) {
     clearSelection()
   }
 }


### PR DESCRIPTION
## Summary

Fix condition

## Changes

- **What**: changed `if (hasSelection)` to `if (hasSelection.value)` in `AssetsSidebarTab.vue` so the guard actually gates on whether a selection exists instead of being unconditionally true.

## Review Focus

- This is a correctness fix
- Pre-existing since #6729
