### PR TITLE
feat: show model destination folder in missing-models panel

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3900,7 +3900,13 @@
       "downloadAll": "Download all",
       "refresh": "Refresh",
       "refreshing": "Refreshing missing models.",
-      "refreshFailed": "Failed to refresh missing models. Please try again."
+      "refreshFailed": "Failed to refresh missing models. Please try again.",
+      "placeFileIn": "Place this file in:",
+      "remoteServerNotice": "This ComfyUI is running on a remote server. Transfer the file there (for example with scp or your cloud provider's upload), then place it in:",
+      "copyPath": "Copy path",
+      "moreFolders": "+{count} more folder | +{count} more folders",
+      "hideExtraFolders": "Hide extra folders",
+      "afterDownloadInstruction": "When the download finishes, move the file to the folder above, then click Refresh at the top of this panel."
     },
     "missingMedia": {
       "missingMediaTitle": "Missing Inputs"

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3906,7 +3906,7 @@
       "copyPath": "Copy path",
       "moreFolders": "+{count} more folder | +{count} more folders",
       "hideExtraFolders": "Hide extra folders",
-      "afterDownloadInstruction": "When the download finishes, move the file to the folder above, then click Refresh at the top of this panel."
+      "afterDownloadInstruction": "Once downloaded, move it here and Refresh."
     },
     "missingMedia": {
       "missingMediaTitle": "Missing Inputs"

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import type * as MissingModelDownload from '@/platform/missingModel/missingModelDownload'
 import type {
   MissingModelGroup,
   MissingModelViewModel
@@ -42,6 +43,14 @@ vi.mock('@/platform/distribution/types', () => ({
     return mockIsCloud.value
   }
 }))
+
+const mockDownloadModel = vi.hoisted(() => vi.fn())
+vi.mock('@/platform/missingModel/missingModelDownload', async () => {
+  const actual = await vi.importActual<typeof MissingModelDownload>(
+    '@/platform/missingModel/missingModelDownload'
+  )
+  return { ...actual, downloadModel: mockDownloadModel }
+})
 
 import MissingModelCard from './MissingModelCard.vue'
 
@@ -257,10 +266,39 @@ describe('MissingModelCard', () => {
 describe('MissingModelCard (OSS)', () => {
   beforeEach(() => {
     mockIsCloud.value = false
+    mockDownloadModel.mockClear()
   })
 
   afterEach(() => {
     mockIsCloud.value = true
+  })
+
+  it('staggers Download all so every model downloads, not just the first', async () => {
+    vi.useFakeTimers()
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      mountCard({
+        missingModelGroups: [
+          makeGroup({
+            withDownloadUrls: true,
+            modelNames: ['a.safetensors', 'b.safetensors', 'c.safetensors']
+          })
+        ]
+      })
+
+      await user.click(screen.getByRole('button', { name: /Download all/ }))
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mockDownloadModel).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(700)
+      expect(mockDownloadModel).toHaveBeenCalledTimes(2)
+
+      await vi.advanceTimersByTimeAsync(700)
+      expect(mockDownloadModel).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('shows directory name instead of "Import Not Supported" for unsupported groups', () => {

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -133,10 +133,16 @@ const downloadAllLabel = computed(() => {
   return total > 0 ? `${base} (${formatSize(total)})` : base
 })
 
+// Browsers drop rapid back-to-back programmatic downloads, so a single
+// "Download all" click only ever started one file. Stagger them instead.
+const DOWNLOAD_ALL_STAGGER_MS = 700
+
 function downloadAllModels() {
-  for (const model of downloadableModels.value) {
-    downloadModel(model, missingModelStore.folderPaths)
-  }
+  downloadableModels.value.forEach((model, index) => {
+    window.setTimeout(() => {
+      downloadModel(model, missingModelStore.folderPaths)
+    }, index * DOWNLOAD_ALL_STAGGER_MS)
+  })
 }
 
 function getModelRowKey(

--- a/src/platform/missingModel/components/MissingModelDestination.test.ts
+++ b/src/platform/missingModel/components/MissingModelDestination.test.ts
@@ -103,8 +103,6 @@ describe('MissingModelDestination', () => {
 
     renderDestination({ directory: 'loras', downloadTriggered: true })
 
-    expect(
-      screen.getByText(/move the file to the folder above/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/move it here and refresh/i)).toBeInTheDocument()
   })
 })

--- a/src/platform/missingModel/components/MissingModelDestination.test.ts
+++ b/src/platform/missingModel/components/MissingModelDestination.test.ts
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json' with { type: 'json' }
+import MissingModelDestination from '@/platform/missingModel/components/MissingModelDestination.vue'
+
+const mockIsLocal = vi.hoisted(() => ({ value: true }))
+const mockFolderPaths = vi.hoisted(() => ({
+  value: {} as Record<string, string[]>
+}))
+const mockCopyToClipboard = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copyToClipboard: mockCopyToClipboard })
+}))
+
+vi.mock('@/platform/missingModel/missingModelDownload', () => ({
+  isLocalHost: () => mockIsLocal.value
+}))
+
+vi.mock('@/platform/missingModel/missingModelStore', () => ({
+  useMissingModelStore: () => ({ folderPaths: mockFolderPaths.value })
+}))
+
+function renderDestination(props: {
+  directory: string
+  downloadTriggered?: boolean
+}) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMessages }
+  })
+  return render(MissingModelDestination, {
+    props,
+    global: { plugins: [i18n] }
+  })
+}
+
+beforeEach(() => {
+  mockIsLocal.value = true
+  mockFolderPaths.value = {}
+  mockCopyToClipboard.mockClear()
+})
+
+describe('MissingModelDestination', () => {
+  it('shows the destination path and copies the full path on a local install', async () => {
+    mockFolderPaths.value = { loras: ['/home/user/ComfyUI/models/loras'] }
+
+    renderDestination({ directory: 'loras' })
+
+    expect(screen.getByText('Place this file in:')).toBeInTheDocument()
+    expect(screen.getByText('…/models/loras/')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('missing-model-copy-path'))
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      '/home/user/ComfyUI/models/loras'
+    )
+  })
+
+  it('shows the remote-server transfer notice when not served from localhost', () => {
+    mockIsLocal.value = false
+    mockFolderPaths.value = { loras: ['/srv/ComfyUI/models/loras'] }
+
+    renderDestination({ directory: 'loras' })
+
+    expect(screen.getByText(/running on a remote server/i)).toBeInTheDocument()
+    expect(screen.queryByText('Place this file in:')).not.toBeInTheDocument()
+  })
+
+  it('falls back to a default relative path with no copy button when the folder is unknown', () => {
+    mockFolderPaths.value = {}
+
+    renderDestination({ directory: 'diffusion_models' })
+
+    expect(screen.getByText('models/diffusion_models/')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('missing-model-copy-path')
+    ).not.toBeInTheDocument()
+  })
+
+  it('reveals additional configured folders behind a toggle', async () => {
+    mockFolderPaths.value = {
+      text_encoders: [
+        '/home/user/ComfyUI/models/text_encoders',
+        '/mnt/extra/models/clip'
+      ]
+    }
+
+    renderDestination({ directory: 'text_encoders' })
+
+    const toggle = screen.getByTestId('missing-model-more-folders')
+    expect(toggle).toHaveTextContent('+1 more folder')
+
+    await userEvent.click(toggle)
+    expect(toggle).toHaveTextContent('Hide extra folders')
+  })
+
+  it('shows the post-download move instruction once a download has been triggered', () => {
+    mockFolderPaths.value = { loras: ['/home/user/ComfyUI/models/loras'] }
+
+    renderDestination({ directory: 'loras', downloadTriggered: true })
+
+    expect(
+      screen.getByText(/move the file to the folder above/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/src/platform/missingModel/components/MissingModelDestination.vue
+++ b/src/platform/missingModel/components/MissingModelDestination.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="flex min-w-0 flex-col gap-0.5 text-2xs/tight">
+    <span v-if="!local" class="text-muted-foreground">
+      {{ t('rightSidePanel.missingModels.remoteServerNotice') }}
+    </span>
+
+    <span class="flex min-w-0 items-center gap-1">
+      <span v-if="local" class="shrink-0 text-muted-foreground">
+        {{ t('rightSidePanel.missingModels.placeFileIn') }}
+      </span>
+      <span
+        class="min-w-0 flex-1 truncate font-mono text-base-foreground"
+        :title="fullPath ?? undefined"
+      >
+        {{ shortPath }}
+      </span>
+      <Button
+        v-if="fullPath"
+        data-testid="missing-model-copy-path"
+        variant="textonly"
+        size="unset"
+        class="flex shrink-0 items-center gap-0.5 p-0.5 text-muted-foreground hover:bg-transparent hover:text-base-foreground focus-visible:ring-inset"
+        @click="copyPath"
+      >
+        <i aria-hidden="true" class="icon-[lucide--copy] size-3" />
+        {{ t('rightSidePanel.missingModels.copyPath') }}
+      </Button>
+    </span>
+
+    <template v-if="extraPaths.length">
+      <Button
+        data-testid="missing-model-more-folders"
+        variant="textonly"
+        size="unset"
+        class="self-start p-0.5 text-muted-foreground hover:bg-transparent hover:text-base-foreground focus-visible:ring-inset"
+        :aria-expanded="showExtras"
+        @click="showExtras = !showExtras"
+      >
+        {{
+          showExtras
+            ? t('rightSidePanel.missingModels.hideExtraFolders')
+            : t('rightSidePanel.missingModels.moreFolders', extraPaths.length)
+        }}
+      </Button>
+      <span
+        v-for="path in extraPaths"
+        v-show="showExtras"
+        :key="path"
+        class="truncate pl-1 font-mono text-muted-foreground"
+        :title="path"
+      >
+        {{ shorten(path) }}
+      </span>
+    </template>
+
+    <span v-if="downloadTriggered" class="text-muted-foreground">
+      {{ t('rightSidePanel.missingModels.afterDownloadInstruction') }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import Button from '@/components/ui/button/Button.vue'
+import { useI18n } from 'vue-i18n'
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
+import { isLocalHost } from '@/platform/missingModel/missingModelDownload'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+
+const { directory, downloadTriggered = false } = defineProps<{
+  directory: string
+  downloadTriggered?: boolean
+}>()
+
+const { t } = useI18n()
+const { copyToClipboard } = useCopyToClipboard()
+const store = useMissingModelStore()
+
+const local = isLocalHost()
+const showExtras = ref(false)
+
+const configuredPaths = computed(() => store.folderPaths[directory] ?? [])
+const fullPath = computed<string | null>(() => configuredPaths.value[0] ?? null)
+const extraPaths = computed(() => configuredPaths.value.slice(1))
+
+function shorten(path: string): string {
+  const segments = path
+    .replace(/[/\\]+$/, '')
+    .split(/[/\\]/)
+    .filter(Boolean)
+  if (segments.length <= 2) return path
+  return `…/${segments.slice(-2).join('/')}/`
+}
+
+const shortPath = computed(() =>
+  fullPath.value ? shorten(fullPath.value) : `models/${directory}/`
+)
+
+function copyPath() {
+  if (fullPath.value) copyToClipboard(fullPath.value)
+}
+</script>

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -16,6 +16,7 @@ import type * as GraphTraversalUtil from '@/utils/graphTraversalUtil'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
+const mockIsDesktop = vi.hoisted(() => ({ value: false }))
 const mockShowUploadDialog = vi.hoisted(() => vi.fn())
 const mockCopyToClipboard = vi.hoisted(() => vi.fn())
 const mockDownloadModel = vi.hoisted(() => vi.fn())
@@ -70,6 +71,9 @@ vi.mock('@/utils/graphTraversalUtil', async () => {
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
     return mockIsCloud.value
+  },
+  get isDesktop() {
+    return mockIsDesktop.value
   }
 }))
 

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -144,6 +144,13 @@
       </Button>
     </div>
 
+    <MissingModelDestination
+      v-if="showDestination && directory"
+      :directory="directory"
+      :download-triggered="downloadTriggered"
+      :class="cn('mt-0.5', hasMultipleReferences && 'pl-5')"
+    />
+
     <TransitionCollapse>
       <ul
         v-if="showReferenceList"
@@ -187,7 +194,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -209,8 +216,10 @@ import {
   downloadModel,
   fetchModelMetadata,
   isModelDownloadable,
-  toBrowsableUrl
+  toBrowsableUrl,
+  usesBrowserDownload
 } from '@/platform/missingModel/missingModelDownload'
+import MissingModelDestination from '@/platform/missingModel/components/MissingModelDestination.vue'
 import { formatSize } from '@/utils/formatUtil'
 
 const {
@@ -303,6 +312,14 @@ const downloadable = computed(() => {
 
 const showDownloadAction = computed(() => !isCloud && downloadable.value)
 
+const downloadTriggered = ref(false)
+const showDestination = computed(
+  () =>
+    showDownloadAction.value &&
+    !isUnknownCategory.value &&
+    usesBrowserDownload()
+)
+
 const downloadSizeLabel = computed(() => {
   if (!showDownloadAction.value) return undefined
 
@@ -368,6 +385,7 @@ onMounted(() => {
 function handleDownload() {
   const rep = model.representative
   if (rep.url && rep.directory) {
+    downloadTriggered.value = true
     downloadModel(
       { name: rep.name, url: rep.url, directory: rep.directory },
       store.folderPaths

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -62,6 +62,33 @@ export function toBrowsableUrl(url: string): string {
   return url
 }
 
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1'
+])
+
+/**
+ * Whether the Download action results in a plain browser download (file lands
+ * in the user's downloads, not auto-placed). True only for the web build with
+ * no auto-placing desktop bridge — in that case the user must move the file
+ * into the model folder themselves, so we surface the destination path.
+ */
+export function usesBrowserDownload(): boolean {
+  const bridge = window.__comfyDesktop2
+  if (bridge?.downloadModel && !bridge.isRemote()) return false
+  return !isDesktop
+}
+
+/**
+ * Whether ComfyUI is being served from the same machine as the browser. When
+ * false, the model folder path is on a remote server the user can't reach by
+ * moving a local download, so the destination guidance changes accordingly.
+ */
+export function isLocalHost(): boolean {
+  return LOOPBACK_HOSTS.has(window.location.hostname)
+}
+
 export function isModelDownloadable(model: ModelWithUrl): boolean {
   if (WHITE_LISTED_URLS.has(model.url)) return true
   if (!ALLOWED_SOURCES.some((source) => model.url.startsWith(source)))


### PR DESCRIPTION
## Summary

On the web build, tell the user which `ComfyUI/models/<subfolder>` a missing model belongs in, instead of leaving them to guess after a browser download.

## Changes

- **What**: In the missing-models panel, each downloadable row now shows the destination folder (web build only — desktop already auto-places). It displays `Place this file in: <path>` with a Copy-path button, resolved from the folder paths the backend already provides. After Download is clicked, a move-then-Refresh instruction appears. When ComfyUI is served from a remote host, a transfer-to-server notice is shown instead, since the model folder lives on the server. Additional configured folders (`extra_model_paths.yaml`) collapse behind a toggle, and a default relative path is shown when none is configured.

## Review Focus

- The browser download is fire-and-forget — there is no download-completion or save-location signal available to JS. The post-click text is therefore an instruction, never an asserted status, and resolution is driven only by the existing Refresh re-scan.
- Gating: shown only when the row uses a plain browser download (`usesBrowserDownload()` — not desktop, no auto-placing desktop bridge); localhost detection (`localhost`/`127.0.0.1`/`::1`) selects the local vs remote-server copy.
- `folderPaths[directory]` can be empty/undefined or hold multiple paths; both are handled (default fallback, "+N more folders" expander).