### PR TITLE
fix: use error colour for runtime execution error node outline

### DIFF
--- a/src/services/litegraphService.ts
+++ b/src/services/litegraphService.ts
@@ -251,7 +251,7 @@ export const useLitegraphService = () => {
     }
     node.strokeStyles['executionError'] = function (this: LGraphNode) {
       if (app.lastExecutionError?.node_id == this.id) {
-        return { color: '#f0f', lineWidth: 3 }
+        return { color: LiteGraph.NODE_ERROR_COLOUR, lineWidth: 3 }
       }
     }
   }


### PR DESCRIPTION
## Summary

A node that fails at runtime is now outlined in the same red as a node that fails validation, instead of magenta.

## Changes

- **What**: The `executionError` stroke in `litegraphService.ts` was hardcoded to magenta (`#f0f`); validation errors use `LiteGraph.NODE_ERROR_COLOUR` (red). Reuse that constant so both error states render consistently. One-line change; `LiteGraph` is already imported.

## Review Focus

No test added: asserting a hardcoded stroke colour would be a change-detector test. The two error paths (validation via `has_errors` / `NODE_ERROR_COLOUR`, runtime via `lastExecutionError`) now share the same colour source.