### PR TITLE
[backport cloud/1.45] feat(workspace): redesign Members invite UI to DES-186 (FE-768) (#12759)

### DIFF
--- a/src/components/common/DropdownItem.vue
+++ b/src/components/common/DropdownItem.vue
@@ -11,6 +11,8 @@ import {
 import { useI18n } from 'vue-i18n'
 import { toValue } from 'vue'
 
+import { cn } from '@comfyorg/tailwind-utils'
+
 const { t } = useI18n()
 
 defineOptions({
@@ -50,7 +52,16 @@ defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
   </DropdownMenuSub>
   <DropdownMenuItem
     v-else
-    :class="itemClass"
+    v-tooltip="
+      item.tooltip ? { value: String(item.tooltip), showDelay: 0 } : undefined
+    "
+    :class="
+      cn(
+        itemClass,
+        String(item.class ?? ''),
+        Boolean(item.tooltip) && toValue(item.disabled) && 'pointer-events-auto'
+      )
+    "
     :disabled="toValue(item.disabled) ?? !item.command"
     @select="item.command?.({ originalEvent: $event, item })"
   >

--- a/src/components/common/DropdownMenu.vue
+++ b/src/components/common/DropdownMenu.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ZIndex } from '@primeuix/utils/zindex'
 import type { MenuItem } from 'primevue/menuitem'
 import {
   DropdownMenuArrow,
@@ -7,12 +8,15 @@ import {
   DropdownMenuRoot,
   DropdownMenuTrigger
 } from 'reka-ui'
-import { computed, toValue } from 'vue'
+import { computed, ref, toValue } from 'vue'
 
 import DropdownItem from '@/components/common/DropdownItem.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { cn } from '@comfyorg/tailwind-utils'
 import type { ButtonVariants } from '../ui/button/button.variants'
+
+// Shared base for @primeuix's auto-incrementing 'modal' z-index counter.
+const MODAL_BASE_Z_INDEX = 1700
 
 defineOptions({
   inheritAttrs: false
@@ -41,10 +45,20 @@ const contentClass = computed(() =>
     contentProp
   )
 )
+
+// Body-portaled content keeps its static z-1700 unless a dialog that joined
+// @primeuix's auto-incrementing 'modal' counter is open above it; then lift
+// past that dialog so the menu isn't hidden behind it.
+const open = ref(false)
+const contentStyle = computed(() => {
+  if (!open.value) return undefined
+  const topZIndex = ZIndex.getCurrent('modal')
+  return topZIndex >= MODAL_BASE_Z_INDEX ? { zIndex: topZIndex + 1 } : undefined
+})
 </script>
 
 <template>
-  <DropdownMenuRoot>
+  <DropdownMenuRoot v-model:open="open">
     <DropdownMenuTrigger as-child>
       <slot name="button">
         <Button :size="buttonSize ?? 'icon'" :class="buttonClass">
@@ -60,6 +74,7 @@ const contentClass = computed(() =>
         :collision-padding="10"
         v-bind="$attrs"
         :class="contentClass"
+        :style="contentStyle"
       >
         <slot :item-class>
           <DropdownItem

--- a/src/components/common/DropdownMenu.zindex.test.ts
+++ b/src/components/common/DropdownMenu.zindex.test.ts
@@ -1,0 +1,56 @@
+import { ZIndex } from '@primeuix/utils/zindex'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import DropdownMenu from './DropdownMenu.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+function renderMenu() {
+  return render(DropdownMenu, {
+    props: { entries: [{ label: 'Item A' }] },
+    global: { plugins: [i18n], directives: { tooltip: {} } }
+  })
+}
+
+let openModal: HTMLElement | undefined
+
+afterEach(() => {
+  if (openModal) {
+    ZIndex.clear(openModal)
+    openModal = undefined
+  }
+})
+
+describe('DropdownMenu z-index', () => {
+  it('opens above a dialog registered with the modal z-index counter', async () => {
+    openModal = document.createElement('div')
+    ZIndex.set('modal', openModal, 1700)
+    const dialogZ = Number(openModal.style.zIndex)
+
+    const user = userEvent.setup()
+    renderMenu()
+    await user.click(screen.getByRole('button'))
+
+    const menu = await screen.findByRole('menu')
+    expect(Number(menu.style.zIndex)).toBeGreaterThan(dialogZ)
+  })
+
+  it('leaves the static z-index untouched when no dialog is open', async () => {
+    const user = userEvent.setup()
+    renderMenu()
+    await user.click(screen.getByRole('button'))
+
+    const menu = await screen.findByRole('menu')
+    expect(menu.style.zIndex).toBe('')
+    expect(menu.className).toContain('z-1700')
+  })
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2666,7 +2666,7 @@
   "workspacePanel": {
     "invite": "Invite",
     "inviteMember": "Invite member",
-    "inviteLimitReached": "You've reached the maximum of 50 members",
+    "inviteLimitReached": "You've reached the maximum of {count} members",
     "tabs": {
       "dashboard": "Dashboard",
       "planCredits": "Plan & Credits",
@@ -2676,7 +2676,8 @@
       "placeholder": "Dashboard workspace settings"
     },
     "members": {
-      "membersCount": "{count}/{maxSeats} Members",
+      "header": "Members",
+      "membersCount": "{count} of {maxSeats} members",
       "pendingInvitesCount": "{count} pending invite | {count} pending invites",
       "tabs": {
         "active": "Active",
@@ -2685,26 +2686,29 @@
       "columns": {
         "inviteDate": "Invite date",
         "expiryDate": "Expiry date",
-        "joinDate": "Join date"
+        "role": "Role"
       },
       "actions": {
-        "copyLink": "Copy invite link",
-        "revokeInvite": "Revoke invite",
+        "resendInvite": "Resend invite",
+        "cancelInvite": "Cancel invite",
         "removeMember": "Remove member"
       },
-      "upsellBannerSubscribe": "Subscribe to the Creator plan or above to invite team members to this workspace.",
-      "upsellBannerUpgrade": "Upgrade to the Creator plan or above to invite additional team members.",
-      "viewPlans": "View plans",
+      "upsellBanner": "To add teammates, upgrade your plan.",
+      "upsellBannerReactivate": "To add more teammates, reactivate your plan.",
+      "upgradeToTeam": "Upgrade to Team",
+      "reactivateTeam": "Reactivate Team",
+      "needMoreMembers": "Need more members?",
+      "contactUs": "Contact us",
       "noInvites": "No pending invites",
       "noMembers": "No members",
-      "personalWorkspaceMessage": "You can't invite other members to your personal workspace right now. To add members to a workspace,",
-      "createNewWorkspace": "create a new one."
+      "searchPlaceholder": "Search..."
     },
     "menu": {
       "editWorkspace": "Edit workspace details",
       "leaveWorkspace": "Leave Workspace",
       "deleteWorkspace": "Delete Workspace",
-      "deleteWorkspaceDisabledTooltip": "Cancel your workspace's active subscription first"
+      "deleteWorkspaceDisabledTooltip": "Cancel your workspace's active subscription first",
+      "creatorCannotLeave": "The workspace creator can't leave the workspace they created"
     },
     "editWorkspaceDialog": {
       "title": "Edit workspace details",
@@ -2734,26 +2738,18 @@
       "revoke": "Uninvite"
     },
     "inviteUpsellDialog": {
-      "titleNotSubscribed": "A subscription is required to invite members",
+      "titleNotSubscribed": "A Team plan is required to invite members",
       "titleSingleSeat": "Your current plan supports a single seat",
-      "messageNotSubscribed": "To add team members to this workspace, you need a Creator plan or above. The Standard plan supports only a single seat (the owner).",
-      "messageSingleSeat": "The Standard plan includes one seat for the workspace owner. To invite additional members, upgrade to the Creator plan or above to unlock multiple seats.",
-      "viewPlans": "View Plans",
-      "upgradeToCreator": "Upgrade to Creator"
+      "messageNotSubscribed": "To add teammates to this workspace, upgrade to a Team plan.",
+      "messageSingleSeat": "Your current plan includes one seat for the workspace owner. To add teammates, upgrade to a Team plan.",
+      "upgradeToTeam": "Upgrade to Team"
     },
     "inviteMemberDialog": {
-      "title": "Invite a person to this workspace",
-      "message": "Create a shareable invite link to send to someone",
-      "placeholder": "Enter the person's email",
-      "createLink": "Create link",
-      "linkStep": {
-        "title": "Send this link to the person",
-        "message": "Make sure their account uses this email.",
-        "copyLink": "Copy Link",
-        "done": "Done"
-      },
-      "linkCopied": "Copied",
-      "linkCopyFailed": "Failed to copy link"
+      "title": "Invite members to this workspace",
+      "placeholder": "Enter emails separated by commas",
+      "invalidEmailCount": "{count} invalid email address | {count} invalid email addresses",
+      "failedCount": "Couldn't send {count} invite. Try again. | Couldn't send {count} invites. Try again.",
+      "invitedMessage": "An invite was sent to {emails} | Invites were sent to {emails}"
     },
     "createWorkspaceDialog": {
       "title": "Create a new workspace",
@@ -2780,6 +2776,8 @@
         "title": "Left workspace",
         "message": "You have left the workspace."
       },
+      "inviteResent": "Invite resent",
+      "inviteResendFailed": "Failed to resend invite",
       "failedToUpdateWorkspace": "Failed to update workspace",
       "failedToCreateWorkspace": "Failed to create workspace",
       "failedToDeleteWorkspace": "Failed to delete workspace",

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.test.ts
@@ -1,0 +1,186 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import InviteMemberDialogContent from './InviteMemberDialogContent.vue'
+
+import type { PendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+const { mockCreateInvite, mockCloseDialog, mockToastAdd } = vi.hoisted(() => ({
+  mockCreateInvite: vi.fn(),
+  mockCloseDialog: vi.fn(),
+  mockToastAdd: vi.fn()
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    createInvite: mockCreateInvite
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: mockCloseDialog
+  })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: mockToastAdd
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function pendingInviteFor(email: string): PendingInvite {
+  return {
+    id: `inv-${email}`,
+    email,
+    inviteDate: new Date(0),
+    expiryDate: new Date(0)
+  }
+}
+
+function renderDialog() {
+  const user = userEvent.setup()
+  const result = render(InviteMemberDialogContent, {
+    global: { plugins: [i18n] }
+  })
+  return { ...result, user }
+}
+
+function emailInput() {
+  return screen.getByRole('textbox')
+}
+
+function inviteButton() {
+  return screen.getByRole('button', { name: 'workspacePanel.invite' })
+}
+
+describe('InviteMemberDialogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateInvite.mockImplementation(async (email: string) =>
+      pendingInviteFor(email)
+    )
+  })
+
+  it('turns comma- and enter-delimited input into chips', async () => {
+    const { user } = renderDialog()
+
+    await user.type(emailInput(), 'a@b.com,')
+    await user.type(emailInput(), 'c@d.com{Enter}')
+
+    expect(screen.getByText('a@b.com')).toBeInTheDocument()
+    expect(screen.getByText('c@d.com')).toBeInTheDocument()
+  })
+
+  it('splits a pasted comma-separated list into chips', async () => {
+    const { user } = renderDialog()
+
+    await user.click(emailInput())
+    await user.paste('a@b.com, c@d.com')
+
+    expect(screen.getByText('a@b.com')).toBeInTheDocument()
+    expect(screen.getByText('c@d.com')).toBeInTheDocument()
+  })
+
+  it('disables Invite while there are no chips', () => {
+    renderDialog()
+
+    expect(inviteButton()).toBeDisabled()
+  })
+
+  it('flags invalid emails and keeps Invite disabled', async () => {
+    const { user } = renderDialog()
+
+    await user.type(emailInput(), 'not-an-email{Enter}')
+
+    expect(screen.getByText('not-an-email')).toBeInTheDocument()
+    expect(
+      screen.getByText('workspacePanel.inviteMemberDialog.invalidEmailCount')
+    ).toBeInTheDocument()
+    expect(inviteButton()).toBeDisabled()
+
+    await user.type(emailInput(), 'a@b.com{Enter}')
+
+    expect(inviteButton()).toBeDisabled()
+  })
+
+  it('creates an invite per email and shows the success state', async () => {
+    const { user } = renderDialog()
+
+    await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
+    await user.click(inviteButton())
+
+    expect(
+      await screen.findByText(
+        'workspacePanel.inviteMemberDialog.invitedMessage'
+      )
+    ).toBeInTheDocument()
+    expect(mockCreateInvite).toHaveBeenCalledTimes(2)
+    expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
+    expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+
+    const closeButton = screen
+      .getAllByRole('button', { name: 'g.close' })
+      .find((button) => button.textContent?.includes('g.close'))
+    await user.click(closeButton!)
+
+    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'invite-member' })
+  })
+
+  it('keeps only failed emails as chips and toasts on partial failure', async () => {
+    mockCreateInvite.mockImplementation(async (email: string) => {
+      if (email === 'fail@x.com') throw new Error('nope')
+      return pendingInviteFor(email)
+    })
+    const { user } = renderDialog()
+
+    await user.type(emailInput(), 'ok@x.com,fail@x.com{Enter}')
+    await user.click(inviteButton())
+
+    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('fail@x.com')).toBeInTheDocument()
+    expect(screen.queryByText('ok@x.com')).not.toBeInTheDocument()
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+    expect(inviteButton()).toBeEnabled()
+  })
+
+  it('stays on the form and keeps every chip when all invites fail', async () => {
+    mockCreateInvite.mockRejectedValue(new Error('nope'))
+    const { user } = renderDialog()
+
+    await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
+    await user.click(inviteButton())
+
+    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    expect(
+      screen.queryByText('workspacePanel.inviteMemberDialog.invitedMessage')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('a@b.com')).toBeInTheDocument()
+    expect(screen.getByText('c@d.com')).toBeInTheDocument()
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+    expect(inviteButton()).toBeEnabled()
+  })
+
+  it('closes without inviting on Cancel', async () => {
+    const { user } = renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'g.cancel' }))
+
+    expect(mockCreateInvite).not.toHaveBeenCalled()
+    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'invite-member' })
+  })
+})

--- a/src/platform/workspace/components/dialogs/InviteMemberDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/InviteMemberDialogContent.vue
@@ -1,97 +1,100 @@
 <template>
   <div
-    class="flex w-full max-w-[512px] flex-col rounded-2xl border border-border-default bg-base-background"
+    class="flex w-full max-w-lg flex-col rounded-2xl border border-border-default bg-base-background"
   >
-    <!-- Header -->
     <div
       class="flex h-12 items-center justify-between border-b border-border-default px-4"
     >
       <h2 class="m-0 text-sm font-normal text-base-foreground">
-        {{
-          step === 'email'
-            ? $t('workspacePanel.inviteMemberDialog.title')
-            : $t('workspacePanel.inviteMemberDialog.linkStep.title')
-        }}
+        {{ $t('workspacePanel.inviteMemberDialog.title') }}
       </h2>
       <button
         class="focus-visible:ring-secondary-foreground cursor-pointer rounded-sm border-none bg-transparent p-0 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
         :aria-label="$t('g.close')"
-        @click="onCancel"
+        @click="onClose"
       >
         <i class="pi pi-times size-4" />
       </button>
     </div>
 
-    <!-- Body: Email Step -->
-    <template v-if="step === 'email'">
-      <div class="flex flex-col gap-4 p-4">
-        <p class="m-0 text-sm text-muted-foreground">
-          {{ $t('workspacePanel.inviteMemberDialog.message') }}
+    <template v-if="step === 'form'">
+      <div class="flex flex-col gap-2 p-4">
+        <TagsInput
+          always-editing
+          add-on-paste
+          add-on-blur
+          :delimiter="EMAIL_DELIMITER"
+          :convert-value="trimEmail"
+          :model-value="emails"
+          class="min-h-10 w-full bg-secondary-background"
+          @update:model-value="onEmailsUpdate"
+        >
+          <TagsInputItem
+            v-for="email in emails"
+            :key="email"
+            :value="email"
+            :class="
+              cn(
+                'rounded-full',
+                !EMAIL_REGEX.test(email) && 'bg-danger/20 text-danger'
+              )
+            "
+          >
+            <TagsInputItemText />
+            <TagsInputItemDelete />
+          </TagsInputItem>
+          <TagsInputInput
+            auto-focus
+            class="text-sm"
+            :placeholder="
+              emails.length === 0
+                ? $t('workspacePanel.inviteMemberDialog.placeholder')
+                : undefined
+            "
+          />
+        </TagsInput>
+        <p v-if="invalidEmails.length > 0" class="text-danger m-0 text-xs">
+          {{
+            $t(
+              'workspacePanel.inviteMemberDialog.invalidEmailCount',
+              invalidEmails.length
+            )
+          }}
         </p>
-        <input
-          v-model="email"
-          type="email"
-          class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
-          :placeholder="$t('workspacePanel.inviteMemberDialog.placeholder')"
-        />
       </div>
 
-      <!-- Footer: Email Step -->
       <div class="flex items-center justify-end gap-4 p-4">
-        <Button variant="muted-textonly" @click="onCancel">
+        <Button variant="muted-textonly" @click="onClose">
           {{ $t('g.cancel') }}
         </Button>
         <Button
-          variant="primary"
+          variant="secondary"
           size="lg"
           :loading
-          :disabled="!isValidEmail"
-          @click="onCreateLink"
+          :disabled="!canSubmit"
+          @click="onInvite"
         >
-          {{ $t('workspacePanel.inviteMemberDialog.createLink') }}
+          {{ $t('workspacePanel.invite') }}
         </Button>
       </div>
     </template>
 
-    <!-- Body: Link Step -->
     <template v-else>
-      <div class="flex flex-col gap-4 p-4">
-        <p class="m-0 text-sm text-muted-foreground">
-          {{ $t('workspacePanel.inviteMemberDialog.linkStep.message') }}
+      <div class="p-4">
+        <p class="m-0 text-sm/5 text-muted-foreground">
+          {{
+            $t(
+              'workspacePanel.inviteMemberDialog.invitedMessage',
+              { emails: invitedEmails.join(', ') },
+              invitedEmails.length
+            )
+          }}
         </p>
-        <p class="m-0 text-sm font-medium text-base-foreground">
-          {{ email }}
-        </p>
-        <div class="relative">
-          <input
-            :value="generatedLink"
-            readonly
-            class="w-full cursor-pointer rounded-lg border border-border-default bg-transparent px-3 py-2 pr-10 text-sm text-base-foreground focus:outline-none"
-            @click="onSelectLink"
-          />
-          <div
-            class="absolute top-2.5 right-3 cursor-pointer"
-            @click="onCopyLink"
-          >
-            <i
-              :class="
-                cn(
-                  'pi size-4',
-                  justCopied ? 'pi-check text-green-500' : 'pi-copy'
-                )
-              "
-            />
-          </div>
-        </div>
       </div>
 
-      <!-- Footer: Link Step -->
-      <div class="flex items-center justify-end gap-4 p-4">
-        <Button variant="muted-textonly" @click="onCancel">
-          {{ $t('g.cancel') }}
-        </Button>
-        <Button variant="primary" size="lg" @click="onCopyLink">
-          {{ $t('workspacePanel.inviteMemberDialog.linkStep.copyLink') }}
+      <div class="flex items-center justify-end p-4">
+        <Button variant="secondary" size="lg" @click="onClose">
+          {{ $t('g.close') }}
         </Button>
       </div>
     </template>
@@ -104,69 +107,73 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import { cn } from '@comfyorg/tailwind-utils'
+import TagsInput from '@/components/ui/tags-input/TagsInput.vue'
+import TagsInputInput from '@/components/ui/tags-input/TagsInputInput.vue'
+import TagsInputItem from '@/components/ui/tags-input/TagsInputItem.vue'
+import TagsInputItemDelete from '@/components/ui/tags-input/TagsInputItemDelete.vue'
+import TagsInputItemText from '@/components/ui/tags-input/TagsInputItemText.vue'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogStore } from '@/stores/dialogStore'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const EMAIL_DELIMITER = /[,\s]+/
 
 const dialogStore = useDialogStore()
 const toast = useToast()
 const { t } = useI18n()
 const workspaceStore = useTeamWorkspaceStore()
 
+const step = ref<'form' | 'invited'>('form')
+const emails = ref<string[]>([])
+const invitedEmails = ref<string[]>([])
 const loading = ref(false)
-const email = ref('')
-const step = ref<'email' | 'link'>('email')
-const generatedLink = ref('')
-const justCopied = ref(false)
 
-const isValidEmail = computed(() => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-  return emailRegex.test(email.value)
-})
+const invalidEmails = computed(() =>
+  emails.value.filter((email) => !EMAIL_REGEX.test(email))
+)
+const canSubmit = computed(
+  () => emails.value.length > 0 && invalidEmails.value.length === 0
+)
 
-function onCancel() {
+function trimEmail(value: string) {
+  return value.trim()
+}
+
+function onEmailsUpdate(value: string[]) {
+  emails.value = value.filter((email) => email.length > 0)
+}
+
+function onClose() {
   dialogStore.closeDialog({ key: 'invite-member' })
 }
 
-async function onCreateLink() {
-  if (!isValidEmail.value) return
+async function onInvite() {
+  if (!canSubmit.value || loading.value) return
   loading.value = true
   try {
-    generatedLink.value = await workspaceStore.createInviteLink(email.value)
-    step.value = 'link'
-  } catch (error) {
+    const submitted = [...emails.value]
+    const results = await Promise.allSettled(
+      submitted.map((email) => workspaceStore.createInvite(email))
+    )
+    const failedEmails = submitted.filter(
+      (_, index) => results[index].status === 'rejected'
+    )
+    if (failedEmails.length === 0) {
+      invitedEmails.value = submitted
+      step.value = 'invited'
+      return
+    }
+    emails.value = failedEmails
     toast.add({
       severity: 'error',
-      summary: t('workspacePanel.inviteMemberDialog.linkCopyFailed'),
-      detail: error instanceof Error ? error.message : undefined
+      summary: t(
+        'workspacePanel.inviteMemberDialog.failedCount',
+        failedEmails.length
+      )
     })
   } finally {
     loading.value = false
   }
-}
-
-async function onCopyLink() {
-  try {
-    await navigator.clipboard.writeText(generatedLink.value)
-    justCopied.value = true
-    setTimeout(() => {
-      justCopied.value = false
-    }, 759)
-    toast.add({
-      severity: 'success',
-      summary: t('workspacePanel.inviteMemberDialog.linkCopied'),
-      life: 2000
-    })
-  } catch {
-    toast.add({
-      severity: 'error',
-      summary: t('workspacePanel.inviteMemberDialog.linkCopyFailed')
-    })
-  }
-}
-
-function onSelectLink(event: Event) {
-  const input = event.target as HTMLInputElement
-  input.select()
 }
 </script>

--- a/src/platform/workspace/components/dialogs/InviteMemberUpsellDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/InviteMemberUpsellDialogContent.vue
@@ -39,11 +39,7 @@
         {{ $t('g.cancel') }}
       </Button>
       <Button variant="primary" size="lg" @click="onUpgrade">
-        {{
-          isActiveSubscription
-            ? $t('workspacePanel.inviteUpsellDialog.upgradeToCreator')
-            : $t('workspacePanel.inviteUpsellDialog.viewPlans')
-        }}
+        {{ $t('workspacePanel.inviteUpsellDialog.upgradeToTeam') }}
       </Button>
     </div>
   </div>

--- a/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
@@ -15,25 +15,26 @@
         :pt:icon:class="{ 'text-xl!': !isCurrentUser || !photoUrl }"
       />
       <div class="flex min-w-0 flex-1 flex-col gap-1">
-        <div class="flex items-center gap-2">
-          <span class="text-sm text-base-foreground">
-            {{ member.name }}
-            <span v-if="isCurrentUser" class="text-muted-foreground">
-              ({{ $t('g.you') }})
-            </span>
+        <span class="text-sm text-base-foreground">
+          {{ member.name }}
+          <span v-if="isCurrentUser" class="text-muted-foreground">
+            ({{ $t('g.you') }})
           </span>
-          <RoleBadge v-if="showRoleBadge" :role="member.role" />
-        </div>
+        </span>
         <span class="text-sm text-muted-foreground">
           {{ member.email }}
         </span>
       </div>
     </div>
     <span
-      v-if="showDateColumn && !isSingleSeatPlan"
+      v-if="showRoleColumn && !isSingleSeatPlan"
       class="text-right text-sm text-muted-foreground"
     >
-      {{ formatDate(member.joinDate) }}
+      {{
+        member.role === 'owner'
+          ? $t('workspaceSwitcher.roleOwner')
+          : $t('workspaceSwitcher.roleMember')
+      }}
     </span>
     <div
       v-if="canRemoveMembers && !isSingleSeatPlan"
@@ -54,17 +55,13 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
-
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import Button from '@/components/ui/button/Button.vue'
-import RoleBadge from '@/platform/workspace/components/RoleBadge.vue'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const {
-  showRoleBadge = false,
-  showDateColumn = false,
+  showRoleColumn = false,
   canRemoveMembers = false,
   isSingleSeatPlan = false,
   striped = false
@@ -73,8 +70,7 @@ const {
   isCurrentUser: boolean
   photoUrl?: string
   gridCols: string
-  showRoleBadge?: boolean
-  showDateColumn?: boolean
+  showRoleColumn?: boolean
   canRemoveMembers?: boolean
   isSingleSeatPlan?: boolean
   striped?: boolean
@@ -83,10 +79,4 @@ const {
 defineEmits<{
   showMenu: [event: Event]
 }>()
-
-const { d } = useI18n()
-
-function formatDate(date: Date): string {
-  return d(date, { dateStyle: 'medium' })
-}
 </script>

--- a/src/platform/workspace/components/dialogs/settings/MemberUpsellBanner.stories.ts
+++ b/src/platform/workspace/components/dialogs/settings/MemberUpsellBanner.stories.ts
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import MemberUpsellBanner from './MemberUpsellBanner.vue'
+
+const meta: Meta<typeof MemberUpsellBanner> = {
+  title: 'Platform/Workspace/MemberUpsellBanner',
+  component: MemberUpsellBanner,
+  tags: ['autodocs'],
+  argTypes: {
+    reactivate: { control: 'boolean' },
+    onShowPlans: { action: 'showPlans' }
+  },
+  args: {
+    reactivate: false
+  },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template: '<div class="w-[720px] bg-base-background p-6"><story /></div>'
+    })
+  ]
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Workspace that never subscribed to a team plan: acquisition copy.
+export const Upgrade: Story = {
+  args: { reactivate: false }
+}
+
+// Team plan that was subscribed and has since been cancelled or ended: win-back
+// copy (driven by hasLapsedTeamPlan → subscriptionStatus 'canceled' | 'ended').
+export const Reactivate: Story = {
+  args: { reactivate: true }
+}
+
+export const BothStates: Story = {
+  render: () => ({
+    components: { MemberUpsellBanner },
+    template: `
+      <div class="flex flex-col gap-4">
+        <MemberUpsellBanner :reactivate="false" />
+        <MemberUpsellBanner :reactivate="true" />
+      </div>
+    `
+  })
+}

--- a/src/platform/workspace/components/dialogs/settings/MemberUpsellBanner.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MemberUpsellBanner.test.ts
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import MemberUpsellBanner from './MemberUpsellBanner.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+function renderBanner(props: { reactivate?: boolean } = {}) {
+  return render(MemberUpsellBanner, {
+    props,
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('MemberUpsellBanner', () => {
+  it('shows upgrade copy when the workspace never subscribed', () => {
+    renderBanner()
+
+    expect(
+      screen.getByText('To add teammates, upgrade your plan.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Upgrade to Team' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows reactivate copy when the team plan has lapsed', () => {
+    renderBanner({ reactivate: true })
+
+    expect(
+      screen.getByText('To add more teammates, reactivate your plan.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Reactivate Team' })
+    ).toBeInTheDocument()
+  })
+
+  it('emits showPlans when the CTA is clicked', async () => {
+    const user = userEvent.setup()
+    const { emitted } = renderBanner({ reactivate: true })
+
+    await user.click(screen.getByRole('button', { name: 'Reactivate Team' }))
+
+    expect(emitted()).toHaveProperty('showPlans')
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue
@@ -1,20 +1,28 @@
 <template>
   <div
-    class="mt-4 flex items-center justify-center gap-2 rounded-xl border border-border-default bg-secondary-background px-4 py-3"
+    class="mt-4 flex w-full items-center justify-between gap-4 rounded-2xl border border-interface-stroke bg-secondary-background p-6 max-sm:flex-col max-sm:items-stretch"
   >
-    <p class="text-foreground m-0 text-sm">
-      {{
-        isActiveSubscription
-          ? $t('workspacePanel.members.upsellBannerUpgrade')
-          : $t('workspacePanel.members.upsellBannerSubscribe')
-      }}
-    </p>
+    <div class="flex items-center gap-2">
+      <i class="icon-[lucide--info] size-4 shrink-0 text-muted-foreground" />
+      <p class="m-0 text-sm text-muted-foreground">
+        {{
+          reactivate
+            ? $t('workspacePanel.members.upsellBannerReactivate')
+            : $t('workspacePanel.members.upsellBanner')
+        }}
+      </p>
+    </div>
     <Button
-      variant="muted-textonly"
-      class="cursor-pointer text-sm underline"
+      variant="inverted"
+      size="lg"
+      class="max-sm:w-full"
       @click="$emit('showPlans')"
     >
-      {{ $t('workspacePanel.members.viewPlans') }}
+      {{
+        reactivate
+          ? $t('workspacePanel.members.reactivateTeam')
+          : $t('workspacePanel.members.upgradeToTeam')
+      }}
     </Button>
   </div>
 </template>
@@ -22,8 +30,8 @@
 <script setup lang="ts">
 import Button from '@/components/ui/button/Button.vue'
 
-defineProps<{
-  isActiveSubscription: boolean
+const { reactivate = false } = defineProps<{
+  reactivate?: boolean
 }>()
 
 defineEmits<{

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
+import type { Slots } from 'vue'
+import { computed, h, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import MembersPanelContent from './MembersPanelContent.vue'
@@ -11,12 +12,12 @@ import type {
   WorkspaceMember
 } from '../../../stores/teamWorkspaceStore'
 
-const mockHandleCopyInviteLink = vi.fn()
+const mockHandleResendInvite = vi.fn()
 const mockHandleRevokeInvite = vi.fn()
-const mockHandleCreateWorkspace = vi.fn()
 const mockShowTeamPlans = vi.fn()
 const mockSelectMember = vi.fn()
 const mockToggleSort = vi.fn()
+const mockHandleInviteMember = vi.fn()
 
 const {
   mockMembers,
@@ -24,8 +25,12 @@ const {
   mockFilteredMembers,
   mockFilteredPendingInvites,
   mockIsPersonalWorkspace,
-  mockIsSingleSeatPlan,
-  mockIsActiveSubscription,
+  mockIsOnTeamPlan,
+  mockHasMultipleMembers,
+  mockShowSearch,
+  mockShowViewTabs,
+  mockShowInviteButton,
+  mockIsInviteDisabled,
   mockActiveView,
   mockSearchQuery,
   mockPermissions,
@@ -37,11 +42,15 @@ const {
   return {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
+    mockHasMultipleMembers: ref(true),
+    mockShowSearch: ref(true),
+    mockShowViewTabs: ref(true),
+    mockShowInviteButton: ref(true),
+    mockIsInviteDisabled: ref(false),
     mockFilteredMembers: ref<WorkspaceMember[]>([]),
     mockFilteredPendingInvites: ref<PendingInvite[]>([]),
     mockIsPersonalWorkspace: ref(false),
-    mockIsSingleSeatPlan: ref(false),
-    mockIsActiveSubscription: ref(true),
+    mockIsOnTeamPlan: ref(true),
     mockActiveView: ref<'active' | 'pending'>('active'),
     mockSearchQuery: ref(''),
     mockPermissions: ref({
@@ -59,8 +68,7 @@ const {
       showMembersList: true,
       showPendingTab: true,
       showSearch: true,
-      showDateColumn: true,
-      showRoleBadge: true,
+      showRoleColumn: true,
       membersGridCols: 'grid-cols-[50%_40%_10%]',
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
@@ -76,7 +84,14 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
     searchQuery: mockSearchQuery,
     activeView: mockActiveView,
     maxSeats: computed(() => 20),
-    isSingleSeatPlan: mockIsSingleSeatPlan,
+    isOnTeamPlan: mockIsOnTeamPlan,
+    hasMultipleMembers: mockHasMultipleMembers,
+    showSearch: mockShowSearch,
+    showViewTabs: mockShowViewTabs,
+    showInviteButton: mockShowInviteButton,
+    isInviteDisabled: mockIsInviteDisabled,
+    inviteTooltip: computed(() => null),
+    handleInviteMember: mockHandleInviteMember,
     personalWorkspaceMember: computed(() => ({
       id: 'self',
       name: 'Owner User',
@@ -93,18 +108,21 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
     pendingInvites: mockPendingInvites,
     permissions: mockPermissions,
     uiConfig: mockUiConfig,
-    isActiveSubscription: mockIsActiveSubscription,
     userPhotoUrl: ref(null),
     isCurrentUser: (m: WorkspaceMember) =>
       m.email.toLowerCase() === 'owner@example.com',
     selectMember: mockSelectMember,
     toggleSort: mockToggleSort,
     showTeamPlans: mockShowTeamPlans,
-    handleCopyInviteLink: mockHandleCopyInviteLink,
+    handleResendInvite: mockHandleResendInvite,
     handleRevokeInvite: mockHandleRevokeInvite,
-    handleCreateWorkspace: mockHandleCreateWorkspace,
     handleRemoveMember: vi.fn()
   })
+}))
+
+vi.mock('@/components/button/MoreButton.vue', () => ({
+  default: (_: unknown, { slots }: { slots: Slots }) =>
+    h('div', slots.default?.({ close: () => {} }))
 }))
 
 const i18n = createI18n({
@@ -138,6 +156,7 @@ function renderComponent() {
         Button: ButtonStub,
         SearchInput: SearchInputStub,
         UserAvatar: true,
+        WorkspaceMenuButton: true,
         Menu: { template: '<div />', props: ['model', 'popup'] }
       },
       directives: { tooltip: () => {} }
@@ -163,7 +182,6 @@ function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
   return {
     id: 'invite-1',
     email: 'invitee@example.com',
-    token: 'token-abc',
     inviteDate: new Date('2025-03-01'),
     expiryDate: new Date('2025-04-01'),
     ...overrides
@@ -178,8 +196,12 @@ describe('MembersPanelContent', () => {
     mockFilteredMembers.value = []
     mockFilteredPendingInvites.value = []
     mockIsPersonalWorkspace.value = false
-    mockIsSingleSeatPlan.value = false
-    mockIsActiveSubscription.value = true
+    mockIsOnTeamPlan.value = true
+    mockHasMultipleMembers.value = true
+    mockShowSearch.value = true
+    mockShowViewTabs.value = true
+    mockShowInviteButton.value = true
+    mockIsInviteDisabled.value = false
     mockActiveView.value = 'active'
     mockSearchQuery.value = ''
     mockPermissions.value = {
@@ -197,8 +219,7 @@ describe('MembersPanelContent', () => {
       showMembersList: true,
       showPendingTab: true,
       showSearch: true,
-      showDateColumn: true,
-      showRoleBadge: true,
+      showRoleColumn: true,
       membersGridCols: 'grid-cols-[50%_40%_10%]',
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
@@ -211,27 +232,31 @@ describe('MembersPanelContent', () => {
   describe('personal workspace', () => {
     beforeEach(() => {
       mockIsPersonalWorkspace.value = true
+      mockIsOnTeamPlan.value = false
+      mockHasMultipleMembers.value = false
+      mockShowSearch.value = false
+      mockShowViewTabs.value = false
+      mockIsInviteDisabled.value = true
       mockUiConfig.value.showMembersList = false
       mockUiConfig.value.showSearch = false
       mockUiConfig.value.showPendingTab = false
     })
 
-    it('shows personal workspace message and create workspace button', () => {
+    it('shows the upsell banner below the members card', () => {
       renderComponent()
       expect(
-        screen.getByText('workspacePanel.members.personalWorkspaceMessage')
-      ).toBeTruthy()
-      expect(
-        screen.getByText('workspacePanel.members.createNewWorkspace')
+        screen.getByText('workspacePanel.members.upsellBanner')
       ).toBeTruthy()
     })
 
-    it('calls handleCreateWorkspace when create button is clicked', async () => {
+    it('opens team plans on upgrade click', async () => {
       renderComponent()
       await userEvent.click(
-        screen.getByText('workspacePanel.members.createNewWorkspace')
+        screen.getByRole('button', {
+          name: /workspacePanel\.members\.upgradeToTeam/
+        })
       )
-      expect(mockHandleCreateWorkspace).toHaveBeenCalled()
+      expect(mockShowTeamPlans).toHaveBeenCalled()
     })
 
     it('does not show search input', () => {
@@ -241,6 +266,19 @@ describe('MembersPanelContent', () => {
   })
 
   describe('team workspace - member list', () => {
+    it('shows the Role column header and member roles', () => {
+      mockFilteredMembers.value = [
+        createMember({ role: 'owner', email: 'boss@test.com' }),
+        createMember({ id: '2', role: 'member', email: 'peer@test.com' })
+      ]
+      renderComponent()
+      expect(
+        screen.getByText('workspacePanel.members.columns.role')
+      ).toBeTruthy()
+      expect(screen.getByText('workspaceSwitcher.roleOwner')).toBeTruthy()
+      expect(screen.getByText('workspaceSwitcher.roleMember')).toBeTruthy()
+    })
+
     it('renders filtered members', () => {
       mockFilteredMembers.value = [
         createMember({ name: 'Alice', email: 'alice@test.com' }),
@@ -285,53 +323,143 @@ describe('MembersPanelContent', () => {
       ).toBeTruthy()
     })
 
-    it('triggers handleRevokeInvite on revoke click', async () => {
+    it('triggers handleRevokeInvite from the row menu cancel item', async () => {
       mockActiveView.value = 'pending'
       mockFilteredPendingInvites.value = [createInvite({ id: 'inv-42' })]
       renderComponent()
-      const revokeBtn = screen.getByRole('button', {
-        name: 'workspacePanel.members.actions.revokeInvite'
-      })
-      await userEvent.click(revokeBtn)
-      expect(mockHandleRevokeInvite).toHaveBeenCalled()
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'workspacePanel.members.actions.cancelInvite'
+        })
+      )
+      expect(mockHandleRevokeInvite).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'inv-42' })
+      )
     })
 
-    it('triggers handleCopyInviteLink on copy click', async () => {
+    it('triggers handleResendInvite from the row menu resend item', async () => {
       mockActiveView.value = 'pending'
       mockFilteredPendingInvites.value = [createInvite({ id: 'inv-42' })]
       renderComponent()
-      const copyBtn = screen.getByRole('button', {
-        name: 'workspacePanel.members.actions.copyLink'
-      })
-      await userEvent.click(copyBtn)
-      expect(mockHandleCopyInviteLink).toHaveBeenCalled()
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'workspacePanel.members.actions.resendInvite'
+        })
+      )
+      expect(mockHandleResendInvite).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'inv-42' })
+      )
     })
   })
 
-  describe('single seat plan', () => {
+  describe('member role', () => {
     beforeEach(() => {
-      mockIsSingleSeatPlan.value = true
+      mockPermissions.value = {
+        canViewOtherMembers: true,
+        canViewPendingInvites: false,
+        canInviteMembers: false,
+        canManageInvites: false,
+        canRemoveMembers: false,
+        canLeaveWorkspace: true,
+        canAccessWorkspaceMenu: true,
+        canManageSubscription: false,
+        canTopUp: false
+      }
+      mockUiConfig.value.showPendingTab = false
+    })
+
+    it('hides the pending tab button', () => {
+      mockPendingInvites.value = [createInvite()]
+      renderComponent()
+      expect(
+        screen.queryByText(/workspacePanel\.members\.tabs\.pendingCount/)
+      ).toBeNull()
+    })
+
+    it('does not show the pending invites header', () => {
+      mockActiveView.value = 'pending'
+      mockPendingInvites.value = [createInvite()]
+      renderComponent()
+      expect(
+        screen.queryByText(/workspacePanel\.members\.pendingInvitesCount/)
+      ).toBeNull()
+    })
+
+    it('shows no action menus on member rows', () => {
+      mockFilteredMembers.value = [
+        createMember({ name: 'Other', email: 'other@test.com' })
+      ]
+      renderComponent()
+      expect(
+        screen.queryAllByRole('button', { name: 'g.moreOptions' })
+      ).toHaveLength(0)
+    })
+  })
+
+  describe('not on team plan', () => {
+    beforeEach(() => {
+      mockIsOnTeamPlan.value = false
+      mockShowSearch.value = false
+      mockShowViewTabs.value = false
     })
 
     it('shows upsell banner', () => {
       renderComponent()
       expect(
-        screen.getByText('workspacePanel.members.upsellBannerUpgrade')
+        screen.getByText('workspacePanel.members.upsellBanner')
       ).toBeTruthy()
     })
 
-    it('opens team plans on view plans click', async () => {
+    it('hides the upsell banner when on a team plan', () => {
+      mockIsOnTeamPlan.value = true
       renderComponent()
-      const viewPlansBtn = screen.getByRole('button', {
-        name: /workspacePanel\.members\.viewPlans/
+      expect(
+        screen.queryByText('workspacePanel.members.upsellBanner')
+      ).toBeNull()
+    })
+
+    it('opens subscription dialog on upgrade click', async () => {
+      renderComponent()
+      const upgradeBtn = screen.getByRole('button', {
+        name: /workspacePanel\.members\.upgradeToTeam/
       })
-      await userEvent.click(viewPlansBtn)
+      await userEvent.click(upgradeBtn)
       expect(mockShowTeamPlans).toHaveBeenCalled()
     })
 
     it('hides search input', () => {
       renderComponent()
       expect(screen.queryByRole('textbox')).toBeNull()
+    })
+
+    it('hides the contact us footer', () => {
+      renderComponent()
+      expect(screen.queryByText('workspacePanel.members.contactUs')).toBeNull()
+    })
+  })
+
+  describe('contact us footer', () => {
+    it('opens discord in a new tab for team workspaces on a team plan', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+      renderComponent()
+      expect(
+        screen.getByText('workspacePanel.members.needMoreMembers')
+      ).toBeTruthy()
+      await userEvent.click(
+        screen.getByText('workspacePanel.members.contactUs')
+      )
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://www.comfy.org/discord',
+        '_blank',
+        'noopener,noreferrer'
+      )
+      openSpy.mockRestore()
+    })
+
+    it('is hidden in personal workspaces', () => {
+      mockIsPersonalWorkspace.value = true
+      renderComponent()
+      expect(screen.queryByText('workspacePanel.members.contactUs')).toBeNull()
     })
   })
 
@@ -346,6 +474,44 @@ describe('MembersPanelContent', () => {
       expect(
         screen.getByText(/workspacePanel\.members\.membersCount/)
       ).toBeTruthy()
+    })
+  })
+
+  describe('card header actions', () => {
+    it('invokes the invite flow from the header invite button', async () => {
+      renderComponent()
+      await userEvent.click(
+        screen.getByRole('button', { name: 'workspacePanel.invite' })
+      )
+      expect(mockHandleInviteMember).toHaveBeenCalled()
+    })
+
+    it('hides the invite button without invite access', () => {
+      mockShowInviteButton.value = false
+      renderComponent()
+      expect(
+        screen.queryByRole('button', { name: 'workspacePanel.invite' })
+      ).toBeNull()
+    })
+
+    it('disables the invite button when gated', () => {
+      mockIsInviteDisabled.value = true
+      renderComponent()
+      const button = screen.getByRole('button', {
+        name: 'workspacePanel.invite'
+      })
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    })
+
+    it('hides the view tabs for a lone owner', () => {
+      mockShowViewTabs.value = false
+      renderComponent()
+      expect(
+        screen.queryByText('workspacePanel.members.tabs.active')
+      ).toBeNull()
+      expect(
+        screen.queryByText('workspacePanel.members.columns.role')
+      ).toBeNull()
     })
   })
 })

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -8,15 +8,17 @@
         <div class="flex min-w-0 flex-1 items-baseline gap-2">
           <span class="text-base font-semibold text-base-foreground">
             <template v-if="activeView === 'active'">
-              {{
-                $t('workspacePanel.members.membersCount', {
-                  count:
-                    isSingleSeatPlan || isPersonalWorkspace
-                      ? 1
-                      : members.length,
-                  maxSeats: maxSeats
-                })
-              }}
+              <template v-if="isOnTeamPlan && !isPersonalWorkspace">
+                {{
+                  $t('workspacePanel.members.membersCount', {
+                    count: members.length,
+                    maxSeats: maxSeats
+                  })
+                }}
+              </template>
+              <template v-else>
+                {{ $t('workspacePanel.members.header') }}
+              </template>
             </template>
             <template v-else-if="permissions.canViewPendingInvites">
               {{
@@ -28,16 +30,30 @@
             </template>
           </span>
         </div>
-        <div
-          v-if="uiConfig.showSearch && !isSingleSeatPlan"
-          class="flex items-start gap-2"
-        >
+        <div class="flex items-center gap-2">
           <SearchInput
+            v-if="showSearch"
             v-model="searchQuery"
-            :placeholder="$t('g.search')"
+            :placeholder="$t('workspacePanel.members.searchPlaceholder')"
             size="lg"
             class="w-64"
           />
+          <Button
+            v-if="showInviteButton"
+            v-tooltip="
+              inviteTooltip
+                ? { value: inviteTooltip, showDelay: 0 }
+                : { value: $t('workspacePanel.inviteMember'), showDelay: 300 }
+            "
+            variant="secondary"
+            size="lg"
+            :disabled="isInviteDisabled"
+            @click="handleInviteMember"
+          >
+            {{ $t('workspacePanel.invite') }}
+            <i class="pi pi-plus text-sm" />
+          </Button>
+          <WorkspaceMenuButton v-if="permissions.canAccessWorkspaceMenu" />
         </div>
       </div>
 
@@ -45,20 +61,18 @@
       <div class="flex min-h-0 flex-1 flex-col">
         <!-- Table Header with Tab Buttons and Column Headers -->
         <div
-          v-if="uiConfig.showMembersList"
+          v-if="uiConfig.showMembersList && showViewTabs"
           :class="
             cn(
               'grid w-full items-center py-2',
-              isSingleSeatPlan
-                ? 'grid-cols-1 py-0'
-                : activeView === 'pending'
-                  ? uiConfig.pendingGridCols
-                  : uiConfig.headerGridCols
+              activeView === 'pending'
+                ? uiConfig.pendingGridCols
+                : uiConfig.headerGridCols
             )
           "
         >
           <!-- Tab buttons in first column -->
-          <div v-if="!isSingleSeatPlan" class="flex items-center gap-2">
+          <div class="flex items-center gap-2">
             <Button
               :variant="
                 activeView === 'active' ? 'secondary' : 'muted-textonly'
@@ -107,19 +121,17 @@
             <div />
           </template>
           <template v-else>
-            <template v-if="!isSingleSeatPlan">
-              <Button
-                variant="muted-textonly"
-                size="sm"
-                class="justify-end"
-                @click="toggleSort('joinDate')"
-              >
-                {{ $t('workspacePanel.members.columns.joinDate') }}
-                <i class="icon-[lucide--chevrons-up-down] size-4" />
-              </Button>
-              <!-- Empty cell for action column header (OWNER only) -->
-              <div v-if="permissions.canRemoveMembers" />
-            </template>
+            <Button
+              variant="muted-textonly"
+              size="sm"
+              class="justify-end"
+              @click="toggleSort('role')"
+            >
+              {{ $t('workspacePanel.members.columns.role') }}
+              <i class="icon-[lucide--chevrons-up-down] size-4" />
+            </Button>
+            <!-- Empty cell for action column header (OWNER only) -->
+            <div v-if="permissions.canRemoveMembers" />
           </template>
         </div>
 
@@ -134,7 +146,6 @@
                 :is-current-user="true"
                 :photo-url="userPhotoUrl ?? undefined"
                 :grid-cols="uiConfig.membersGridCols"
-                :show-role-badge="uiConfig.showRoleBadge"
               />
             </template>
 
@@ -151,10 +162,11 @@
                     : undefined
                 "
                 :grid-cols="uiConfig.membersGridCols"
-                :show-role-badge="uiConfig.showRoleBadge"
-                :show-date-column="uiConfig.showDateColumn"
+                :show-role-column="
+                  uiConfig.showRoleColumn && hasMultipleMembers
+                "
                 :can-remove-members="permissions.canRemoveMembers"
-                :is-single-seat-plan="isSingleSeatPlan"
+                :is-single-seat-plan="!isOnTeamPlan"
                 :striped="index % 2 === 1"
                 @show-menu="showMemberMenu($event, member)"
               />
@@ -164,35 +176,39 @@
             </template>
           </template>
 
-          <!-- Upsell Banner -->
-          <MemberUpsellBanner
-            v-if="isSingleSeatPlan"
-            :is-active-subscription="isActiveSubscription"
-            @show-plans="showTeamPlans()"
-          />
-
           <!-- Pending Invites -->
           <PendingInvitesList
             v-if="activeView === 'pending'"
             :invites="filteredPendingInvites"
             :grid-cols="uiConfig.pendingGridCols"
-            @copy-link="handleCopyInviteLink"
+            @resend="handleResendInvite"
             @revoke="handleRevokeInvite"
           />
         </div>
       </div>
     </div>
-    <!-- Personal Workspace Message -->
-    <div v-if="isPersonalWorkspace" class="flex items-center">
+    <!-- Upsell Banner -->
+    <MemberUpsellBanner
+      v-if="!isOnTeamPlan"
+      :reactivate="hasLapsedTeamPlan"
+      @show-plans="showTeamPlans()"
+    />
+    <!-- Need More Members Footer -->
+    <div
+      v-if="isOnTeamPlan && !isPersonalWorkspace"
+      class="flex items-center pt-2"
+    >
       <p class="text-sm text-muted-foreground">
-        {{ $t('workspacePanel.members.personalWorkspaceMessage') }}
+        {{ $t('workspacePanel.members.needMoreMembers') }}
       </p>
-      <button
-        class="cursor-pointer border-none bg-transparent underline"
-        @click="handleCreateWorkspace"
+      <Button
+        variant="muted-textonly"
+        size="sm"
+        class="text-base-foreground"
+        @click="handleContactUs"
       >
-        {{ $t('workspacePanel.members.createNewWorkspace') }}
-      </button>
+        {{ $t('workspacePanel.members.contactUs') }}
+      </Button>
     </div>
   </div>
 </template>
@@ -203,9 +219,11 @@ import { ref } from 'vue'
 
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
+import { useExternalLink } from '@/composables/useExternalLink'
 import MemberListItem from '@/platform/workspace/components/dialogs/settings/MemberListItem.vue'
 import MemberUpsellBanner from '@/platform/workspace/components/dialogs/settings/MemberUpsellBanner.vue'
 import PendingInvitesList from '@/platform/workspace/components/dialogs/settings/PendingInvitesList.vue'
+import WorkspaceMenuButton from '@/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue'
 import { useMembersPanel } from '@/platform/workspace/composables/useMembersPanel'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
@@ -214,7 +232,15 @@ const {
   searchQuery,
   activeView,
   maxSeats,
-  isSingleSeatPlan,
+  isOnTeamPlan,
+  hasLapsedTeamPlan,
+  hasMultipleMembers,
+  showSearch,
+  showViewTabs,
+  showInviteButton,
+  isInviteDisabled,
+  inviteTooltip,
+  handleInviteMember,
   personalWorkspaceMember,
   filteredMembers,
   filteredPendingInvites,
@@ -224,21 +250,25 @@ const {
   pendingInvites,
   permissions,
   uiConfig,
-  isActiveSubscription,
   userPhotoUrl,
   isCurrentUser,
   selectMember,
   toggleSort,
   showTeamPlans,
-  handleCopyInviteLink,
-  handleRevokeInvite,
-  handleCreateWorkspace
+  handleResendInvite,
+  handleRevokeInvite
 } = useMembersPanel()
+
+const { staticUrls } = useExternalLink()
 
 const memberMenu = ref<InstanceType<typeof Menu> | null>(null)
 
 function showMemberMenu(event: Event, member: WorkspaceMember) {
   selectMember(member)
   memberMenu.value?.toggle(event)
+}
+
+function handleContactUs() {
+  window.open(staticUrls.discord, '_blank', 'noopener,noreferrer')
 }
 </script>

--- a/src/platform/workspace/components/dialogs/settings/PendingInvitesList.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/PendingInvitesList.test.ts
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Slots } from 'vue'
+import { h } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import PendingInvitesList from './PendingInvitesList.vue'
+
+import type { PendingInvite } from '../../../stores/teamWorkspaceStore'
+
+const mockMenuClose = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/button/MoreButton.vue', () => ({
+  default: (_: unknown, { slots }: { slots: Slots }) =>
+    h('div', slots.default?.({ close: mockMenuClose }))
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
+  return {
+    id: 'invite-1',
+    email: 'invitee@example.com',
+    inviteDate: new Date('2025-03-01'),
+    expiryDate: new Date('2025-04-01'),
+    ...overrides
+  }
+}
+
+function renderComponent(invites: PendingInvite[]) {
+  return render(PendingInvitesList, {
+    props: {
+      invites,
+      gridCols: 'grid-cols-[50%_20%_20%_10%]'
+    },
+    global: { plugins: [i18n] }
+  })
+}
+
+describe('PendingInvitesList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the empty state without action buttons when there are no invites', () => {
+    renderComponent([])
+
+    expect(screen.getByText('workspacePanel.members.noInvites')).toBeTruthy()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('emits resend with the invite and closes the menu', async () => {
+    const invite = createInvite({ id: 'inv-7' })
+    const { emitted } = renderComponent([invite])
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'workspacePanel.members.actions.resendInvite'
+      })
+    )
+
+    expect(emitted('resend')).toEqual([[invite]])
+    expect(mockMenuClose).toHaveBeenCalled()
+  })
+
+  it('emits revoke with the invite from the cancel item', async () => {
+    const invite = createInvite({ id: 'inv-8' })
+    const { emitted } = renderComponent([invite])
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'workspacePanel.members.actions.cancelInvite'
+      })
+    )
+
+    expect(emitted('revoke')).toEqual([[invite]])
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/PendingInvitesList.vue
+++ b/src/platform/workspace/components/dialogs/settings/PendingInvitesList.vue
@@ -34,31 +34,37 @@
       <span class="text-sm text-muted-foreground">
         {{ formatDate(invite.expiryDate) }}
       </span>
-      <div class="flex items-center justify-end gap-2">
-        <Button
-          v-tooltip="{
-            value: $t('workspacePanel.members.actions.copyLink'),
-            showDelay: 300
-          }"
-          variant="secondary"
-          size="md"
-          :aria-label="$t('workspacePanel.members.actions.copyLink')"
-          @click="$emit('copyLink', invite)"
-        >
-          <i class="icon-[lucide--link] size-4" />
-        </Button>
-        <Button
-          v-tooltip="{
-            value: $t('workspacePanel.members.actions.revokeInvite'),
-            showDelay: 300
-          }"
-          variant="secondary"
-          size="md"
-          :aria-label="$t('workspacePanel.members.actions.revokeInvite')"
-          @click="$emit('revoke', invite)"
-        >
-          <i class="icon-[lucide--mail-x] size-4" />
-        </Button>
+      <div class="flex items-center justify-end">
+        <MoreButton v-slot="{ close }" :aria-label="$t('g.moreOptions')">
+          <Button
+            variant="textonly"
+            size="unset"
+            :class="menuItemClass"
+            @click="
+              () => {
+                close()
+                $emit('resend', invite)
+              }
+            "
+          >
+            <i class="icon-[lucide--mail-plus] size-4" />
+            <span>{{ $t('workspacePanel.members.actions.resendInvite') }}</span>
+          </Button>
+          <Button
+            variant="textonly"
+            size="unset"
+            :class="menuItemClass"
+            @click="
+              () => {
+                close()
+                $emit('revoke', invite)
+              }
+            "
+          >
+            <i class="icon-[lucide--mail-x] size-4" />
+            <span>{{ $t('workspacePanel.members.actions.cancelInvite') }}</span>
+          </Button>
+        </MoreButton>
       </div>
     </div>
     <div
@@ -73,9 +79,12 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
+import MoreButton from '@/components/button/MoreButton.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { PendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
+
+const menuItemClass = 'w-full justify-start rounded-sm px-3 py-2'
 
 defineProps<{
   invites: PendingInvite[]
@@ -83,7 +92,7 @@ defineProps<{
 }>()
 
 defineEmits<{
-  copyLink: [invite: PendingInvite]
+  resend: [invite: PendingInvite]
   revoke: [invite: PendingInvite]
 }>()
 

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.test.ts
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import WorkspaceMenuButton from './WorkspaceMenuButton.vue'
+
+const ownerConfig = {
+  showEditWorkspaceMenuItem: true,
+  workspaceMenuAction: 'delete' as const,
+  workspaceMenuDisabledTooltip:
+    'workspacePanel.menu.deleteWorkspaceDisabledTooltip'
+}
+const memberConfig = {
+  showEditWorkspaceMenuItem: false,
+  workspaceMenuAction: 'leave' as const,
+  workspaceMenuDisabledTooltip: null
+}
+
+const mockUiConfig = ref<Record<string, unknown>>(ownerConfig)
+const mockIsCurrentUserOriginalOwner = ref(false)
+const mockIsWorkspaceSubscribed = ref(false)
+
+const mockShowLeaveWorkspaceDialog = vi.fn()
+const mockShowDeleteWorkspaceDialog = vi.fn()
+const mockShowEditWorkspaceDialog = vi.fn()
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({ uiConfig: mockUiConfig })
+}))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
+    isCurrentUserOriginalOwner: mockIsCurrentUserOriginalOwner
+  })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showLeaveWorkspaceDialog: mockShowLeaveWorkspaceDialog,
+    showDeleteWorkspaceDialog: mockShowDeleteWorkspaceDialog,
+    showEditWorkspaceDialog: mockShowEditWorkspaceDialog
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+const DropdownMenuStub = {
+  props: ['entries'],
+  template:
+    '<div data-testid="menu"><button v-for="entry in entries" :key="entry.label" type="button" :disabled="entry.disabled" @click="entry.command?.()">{{ entry.label }}</button></div>'
+}
+
+function renderComponent() {
+  return render(WorkspaceMenuButton, {
+    global: {
+      plugins: [i18n],
+      directives: { tooltip: {} },
+      stubs: { DropdownMenu: DropdownMenuStub, Button: true }
+    }
+  })
+}
+
+describe('WorkspaceMenuButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUiConfig.value = ownerConfig
+    mockIsCurrentUserOriginalOwner.value = false
+    mockIsWorkspaceSubscribed.value = false
+  })
+
+  it('lets a member leave and offers no destructive workspace actions', () => {
+    mockUiConfig.value = memberConfig
+    renderComponent()
+
+    const leave = screen.getByRole('button', { name: 'Leave Workspace' })
+    expect(leave).toBeEnabled()
+    expect(
+      screen.queryByRole('button', { name: 'Delete Workspace' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('lets a non-creator owner leave', () => {
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Leave Workspace' })
+    ).toBeEnabled()
+    expect(
+      screen.getByRole('button', { name: 'Delete Workspace' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows the creator a disabled Leave option', () => {
+    mockIsCurrentUserOriginalOwner.value = true
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', { name: 'Leave Workspace' })
+    ).toBeDisabled()
+  })
+
+  it('opens the leave dialog when a non-creator owner clicks Leave', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Leave Workspace' }))
+    expect(mockShowLeaveWorkspaceDialog).toHaveBeenCalledOnce()
+  })
+
+  it('does not open the leave dialog for the creator', async () => {
+    const user = userEvent.setup()
+    mockIsCurrentUserOriginalOwner.value = true
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Leave Workspace' }))
+    expect(mockShowLeaveWorkspaceDialog).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue
@@ -1,0 +1,99 @@
+<template>
+  <DropdownMenu :entries="menuItems">
+    <template #button>
+      <Button
+        v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
+        variant="muted-textonly"
+        size="icon-lg"
+        :aria-label="$t('g.moreOptions')"
+      >
+        <i class="pi pi-ellipsis-h" />
+      </Button>
+    </template>
+  </DropdownMenu>
+</template>
+
+<script setup lang="ts">
+import type { MenuItem } from 'primevue/menuitem'
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import DropdownMenu from '@/components/common/DropdownMenu.vue'
+import Button from '@/components/ui/button/Button.vue'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogService } from '@/services/dialogService'
+
+const { t } = useI18n()
+const {
+  showLeaveWorkspaceDialog,
+  showDeleteWorkspaceDialog,
+  showEditWorkspaceDialog
+} = useDialogService()
+const { isWorkspaceSubscribed, isCurrentUserOriginalOwner } = storeToRefs(
+  useTeamWorkspaceStore()
+)
+const { uiConfig } = useWorkspaceUI()
+
+// Disable delete when the workspace has an active subscription (prevents
+// accidental deletion); uses the workspace's own status, not the global one.
+const isDeleteDisabled = computed(
+  () =>
+    uiConfig.value.workspaceMenuAction === 'delete' &&
+    isWorkspaceSubscribed.value
+)
+
+const deleteTooltip = computed(() => {
+  if (!isDeleteDisabled.value) return undefined
+  const tooltipKey = uiConfig.value.workspaceMenuDisabledTooltip
+  return tooltipKey ? t(tooltipKey) : undefined
+})
+
+const menuItems = computed<MenuItem[]>(() => {
+  const items: MenuItem[] = []
+
+  if (uiConfig.value.showEditWorkspaceMenuItem) {
+    items.push({
+      label: t('workspacePanel.menu.editWorkspace'),
+      icon: 'pi pi-pencil',
+      command: () => showEditWorkspaceDialog()
+    })
+  }
+
+  const action = uiConfig.value.workspaceMenuAction
+  if (action === 'delete') {
+    items.push({
+      label: t('workspacePanel.menu.deleteWorkspace'),
+      icon: 'pi pi-trash',
+      class: isDeleteDisabled.value ? 'text-danger/50' : 'text-danger',
+      disabled: isDeleteDisabled.value,
+      tooltip: deleteTooltip.value,
+      command: isDeleteDisabled.value
+        ? undefined
+        : () => showDeleteWorkspaceDialog()
+    })
+  }
+
+  // Members and non-creator owners can leave; the creator sees it disabled.
+  if (action === 'leave' || action === 'delete') {
+    items.push(
+      isCurrentUserOriginalOwner.value
+        ? {
+            label: t('workspacePanel.menu.leaveWorkspace'),
+            icon: 'pi pi-sign-out',
+            class: 'opacity-50',
+            disabled: true,
+            tooltip: t('workspacePanel.menu.creatorCannotLeave')
+          }
+        : {
+            label: t('workspacePanel.menu.leaveWorkspace'),
+            icon: 'pi pi-sign-out',
+            command: () => showLeaveWorkspaceDialog()
+          }
+    )
+  }
+
+  return items
+})
+</script>

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.test.ts
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+import WorkspacePanelContent from './WorkspacePanelContent.vue'
+
+const mockFetchMembers = vi.fn()
+const mockFetchPendingInvites = vi.fn()
+
+const { mockMembers, mockWorkspaceType } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+
+  return {
+    mockMembers: ref<WorkspaceMember[]>([]),
+    mockWorkspaceType: ref<'personal' | 'team'>('team')
+  }
+})
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+  return {
+    useTeamWorkspaceStore: () => ({
+      workspaceName: ref('Acme Team'),
+      members: mockMembers,
+      fetchMembers: mockFetchMembers,
+      fetchPendingInvites: mockFetchPendingInvites
+    })
+  }
+})
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+  return {
+    useWorkspaceUI: () => ({
+      workspaceType: mockWorkspaceType,
+      workspaceRole: ref('owner')
+    })
+  }
+})
+
+vi.mock(
+  '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue',
+  () => ({
+    default: { name: 'SubscriptionPanelContentWorkspace', template: '<div />' }
+  })
+)
+
+vi.mock(
+  '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue',
+  () => ({
+    default: { name: 'MembersPanelContent', template: '<div />' }
+  })
+)
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function createMember(id: string): WorkspaceMember {
+  return {
+    id,
+    name: `Member ${id}`,
+    email: `member${id}@example.com`,
+    joinDate: new Date('2025-01-15'),
+    role: 'member',
+    isOriginalOwner: false
+  }
+}
+
+function renderComponent() {
+  return render(WorkspacePanelContent, {
+    global: {
+      plugins: [i18n],
+      stubs: { WorkspaceProfilePic: true }
+    }
+  })
+}
+
+describe('WorkspacePanelContent members tab label', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMembers.value = []
+    mockWorkspaceType.value = 'team'
+  })
+
+  it('shows the counted label for team workspaces with multiple members', () => {
+    mockMembers.value = [createMember('1'), createMember('2')]
+    renderComponent()
+    expect(screen.getByText(/workspacePanel\.tabs\.membersCount/)).toBeTruthy()
+  })
+
+  it('drops the count when the owner is the only member', () => {
+    mockMembers.value = [createMember('1')]
+    renderComponent()
+    expect(screen.getByText('workspacePanel.members.header')).toBeTruthy()
+    expect(screen.queryByText(/workspacePanel\.tabs\.membersCount/)).toBeNull()
+  })
+
+  it('shows the plain Members label for personal workspaces', () => {
+    mockWorkspaceType.value = 'personal'
+    mockMembers.value = [createMember('1'), createMember('2')]
+    renderComponent()
+    expect(screen.getByText('workspacePanel.members.header')).toBeTruthy()
+    expect(screen.queryByText(/workspacePanel\.tabs\.membersCount/)).toBeNull()
+  })
+
+  it('fetches members and pending invites on mount', () => {
+    renderComponent()
+    expect(mockFetchMembers).toHaveBeenCalled()
+    expect(mockFetchPendingInvites).toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/WorkspacePanelContent.vue
@@ -10,98 +10,36 @@
       </h1>
     </header>
     <TabsRoot v-model="activeTab">
-      <div class="flex w-full items-center justify-between">
-        <TabsList class="flex items-center gap-2 pb-1">
-          <TabsTrigger
-            value="plan"
-            :class="
-              cn(
-                tabTriggerBase,
-                activeTab === 'plan' ? tabTriggerActive : tabTriggerInactive
-              )
-            "
-          >
-            {{ $t('workspacePanel.tabs.planCredits') }}
-          </TabsTrigger>
-          <TabsTrigger
-            value="members"
-            :class="
-              cn(
-                tabTriggerBase,
-                activeTab === 'members' ? tabTriggerActive : tabTriggerInactive
-              )
-            "
-          >
-            {{
-              $t('workspacePanel.tabs.membersCount', {
-                count: members.length
-              })
-            }}
-          </TabsTrigger>
-        </TabsList>
-        <div class="flex items-center gap-1">
-          <Button
-            v-if="permissions.canInviteMembers"
-            v-tooltip="
-              inviteTooltip
-                ? { value: inviteTooltip, showDelay: 0 }
-                : { value: $t('workspacePanel.inviteMember'), showDelay: 300 }
-            "
-            variant="secondary"
-            size="lg"
-            :disabled="!isSingleSeatPlan && isInviteLimitReached"
-            :class="
-              !isSingleSeatPlan &&
-              isInviteLimitReached &&
-              'cursor-not-allowed opacity-50'
-            "
-            :aria-label="$t('workspacePanel.inviteMember')"
-            @click="handleInviteMember"
-          >
-            <i class="pi pi-plus text-sm" />
-          </Button>
-          <template v-if="permissions.canAccessWorkspaceMenu">
-            <Button
-              v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
-              variant="muted-textonly"
-              size="icon"
-              :aria-label="$t('g.moreOptions')"
-              @click="menu?.toggle($event)"
-            >
-              <i class="pi pi-ellipsis-h" />
-            </Button>
-            <Menu ref="menu" :model="menuItems" :popup="true">
-              <template #item="{ item }">
-                <button
-                  v-tooltip="
-                    item.disabled && deleteTooltip
-                      ? { value: deleteTooltip, showDelay: 0 }
-                      : null
-                  "
-                  type="button"
-                  :disabled="!!item.disabled"
-                  :class="
-                    cn(
-                      'flex w-full cursor-pointer items-center gap-2 border-none bg-transparent px-3 py-2',
-                      item.class,
-                      item.disabled && 'pointer-events-auto cursor-not-allowed'
-                    )
-                  "
-                  @click="
-                    item.command?.({
-                      originalEvent: $event,
-                      item
-                    })
-                  "
-                >
-                  <i :class="item.icon" />
-                  <span>{{ item.label }}</span>
-                </button>
-              </template>
-            </Menu>
-          </template>
-        </div>
-      </div>
+      <TabsList class="flex items-center gap-2 pb-1">
+        <TabsTrigger
+          value="plan"
+          :class="
+            cn(
+              tabTriggerBase,
+              activeTab === 'plan' ? tabTriggerActive : tabTriggerInactive
+            )
+          "
+        >
+          {{ $t('workspacePanel.tabs.planCredits') }}
+        </TabsTrigger>
+        <TabsTrigger
+          value="members"
+          :class="
+            cn(
+              tabTriggerBase,
+              activeTab === 'members' ? tabTriggerActive : tabTriggerInactive
+            )
+          "
+        >
+          {{
+            showMembersTabCount
+              ? $t('workspacePanel.tabs.membersCount', {
+                  count: members.length
+                })
+              : $t('workspacePanel.members.header')
+          }}
+        </TabsTrigger>
+      </TabsList>
 
       <TabsContent value="plan" class="mt-4">
         <SubscriptionPanelContentWorkspace />
@@ -115,21 +53,15 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import Menu from 'primevue/menu'
 import { computed, onMounted, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from 'reka-ui'
 
 import WorkspaceProfilePic from '@/platform/workspace/components/WorkspaceProfilePic.vue'
 import MembersPanelContent from '@/platform/workspace/components/dialogs/settings/MembersPanelContent.vue'
-import Button from '@/components/ui/button/Button.vue'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
-import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
 import SubscriptionPanelContentWorkspace from '@/platform/workspace/components/SubscriptionPanelContentWorkspace.vue'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
-import { useDialogService } from '@/services/dialogService'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const tabTriggerBase =
@@ -143,108 +75,18 @@ const { defaultTab = 'plan' } = defineProps<{
   defaultTab?: string
 }>()
 
-const { t } = useI18n()
-const {
-  showLeaveWorkspaceDialog,
-  showDeleteWorkspaceDialog,
-  showInviteMemberDialog,
-  showInviteMemberUpsellDialog,
-  showEditWorkspaceDialog
-} = useDialogService()
-const { isActiveSubscription, subscription, getMaxSeats } = useBillingContext()
-
-const isSingleSeatPlan = computed(() => {
-  if (!isActiveSubscription.value) return true
-  const tier = subscription.value?.tier
-  if (!tier) return true
-  const tierKey = TIER_TO_KEY[tier]
-  if (!tierKey) return true
-  return getMaxSeats(tierKey) <= 1
-})
 const workspaceStore = useTeamWorkspaceStore()
-const { workspaceName, members, isInviteLimitReached, isWorkspaceSubscribed } =
-  storeToRefs(workspaceStore)
+const { workspaceName, members } = storeToRefs(workspaceStore)
 const { fetchMembers, fetchPendingInvites } = workspaceStore
 
-const { workspaceRole, permissions, uiConfig } = useWorkspaceUI()
+const { workspaceType, workspaceRole } = useWorkspaceUI()
+const isPersonalWorkspace = computed(() => workspaceType.value === 'personal')
 const activeTab = ref(defaultTab)
 
-const menu = ref<InstanceType<typeof Menu> | null>(null)
-
-function handleLeaveWorkspace() {
-  showLeaveWorkspaceDialog()
-}
-
-function handleDeleteWorkspace() {
-  showDeleteWorkspaceDialog()
-}
-
-function handleEditWorkspace() {
-  showEditWorkspaceDialog()
-}
-
-// Disable delete when workspace has an active subscription (to prevent accidental deletion)
-// Use workspace's own subscription status, not the global isActiveSubscription
-const isDeleteDisabled = computed(
-  () =>
-    uiConfig.value.workspaceMenuAction === 'delete' &&
-    isWorkspaceSubscribed.value
+// Per design, the tab counts members only when there is more than the owner
+const showMembersTabCount = computed(
+  () => !isPersonalWorkspace.value && members.value.length > 1
 )
-
-const deleteTooltip = computed(() => {
-  if (!isDeleteDisabled.value) return null
-  const tooltipKey = uiConfig.value.workspaceMenuDisabledTooltip
-  return tooltipKey ? t(tooltipKey) : null
-})
-
-const inviteTooltip = computed(() => {
-  if (isSingleSeatPlan.value) return null
-  if (!isInviteLimitReached.value) return null
-  return t('workspacePanel.inviteLimitReached')
-})
-
-function handleInviteMember() {
-  if (isSingleSeatPlan.value) {
-    showInviteMemberUpsellDialog()
-    return
-  }
-  if (isInviteLimitReached.value) return
-  showInviteMemberDialog()
-}
-
-const menuItems = computed(() => {
-  const items = []
-
-  // Add edit option for owners
-  if (uiConfig.value.showEditWorkspaceMenuItem) {
-    items.push({
-      label: t('workspacePanel.menu.editWorkspace'),
-      icon: 'pi pi-pencil',
-      command: handleEditWorkspace
-    })
-  }
-
-  const action = uiConfig.value.workspaceMenuAction
-  if (action === 'delete') {
-    items.push({
-      label: t('workspacePanel.menu.deleteWorkspace'),
-      icon: 'pi pi-trash',
-      class: isDeleteDisabled.value
-        ? 'text-danger/50 cursor-not-allowed'
-        : 'text-danger',
-      disabled: isDeleteDisabled.value,
-      command: isDeleteDisabled.value ? undefined : handleDeleteWorkspace
-    })
-  } else if (action === 'leave') {
-    items.push({
-      label: t('workspacePanel.menu.leaveWorkspace'),
-      icon: 'pi pi-sign-out',
-      command: handleLeaveWorkspace
-    })
-  }
-
-  return items
-})
 
 onMounted(() => {
   fetchMembers()

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -30,7 +30,6 @@ function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
   return {
     id: 'invite-1',
     email: 'invitee@example.com',
-    token: 'token-abc',
     inviteDate: new Date('2025-03-01'),
     expiryDate: new Date('2025-04-01'),
     ...overrides
@@ -38,12 +37,20 @@ function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
 }
 
 describe('sortMembers', () => {
-  it('places owners before members', () => {
+  it('places owners before members when sorting descending', () => {
     const owner = createMember({ id: 'o', role: 'owner', name: 'Owner' })
     const member = createMember({ id: 'm', role: 'member', name: 'Member' })
     const result = sortMembers([member, owner], null, 'desc')
     expect(result[0].id).toBe('o')
     expect(result[1].id).toBe('m')
+  })
+
+  it('places members before owners when sorting ascending', () => {
+    const owner = createMember({ id: 'o', role: 'owner', name: 'Owner' })
+    const member = createMember({ id: 'm', role: 'member', name: 'Member' })
+    const result = sortMembers([member, owner], null, 'asc')
+    expect(result[0].id).toBe('m')
+    expect(result[1].id).toBe('o')
   })
 
   it('places current user after owners but before others', () => {
@@ -172,7 +179,7 @@ describe('sortPendingInvites', () => {
     expect(result[1].id).toBe('l')
   })
 
-  it('falls back to inviteDate when sortField is joinDate', () => {
+  it('falls back to inviteDate when sortField is role', () => {
     const early = createInvite({
       id: 'e',
       inviteDate: new Date('2025-01-01')
@@ -181,7 +188,7 @@ describe('sortPendingInvites', () => {
       id: 'l',
       inviteDate: new Date('2025-06-01')
     })
-    const result = sortPendingInvites([early, late], 'joinDate', 'desc')
+    const result = sortPendingInvites([early, late], 'role', 'desc')
     expect(result[0].id).toBe('l')
   })
 
@@ -203,16 +210,20 @@ describe('sortPendingInvites', () => {
 })
 
 const mockToastAdd = vi.fn()
-const mockCopyInviteLink = vi.fn()
+const mockResendInvite = vi.fn()
 const mockShowRemoveMemberDialog = vi.fn()
 const mockShowRevokeInviteDialog = vi.fn()
-const mockShowCreateWorkspaceDialog = vi.fn()
 const mockShowSubscriptionDialog = vi.fn()
+const mockShowInviteMemberDialog = vi.fn()
+const mockShowInviteMemberUpsellDialog = vi.fn()
 
 const {
   mockMembers,
   mockPendingInvites,
   mockIsInPersonalWorkspace,
+  mockIsWorkspaceSubscribed,
+  mockTotalMemberSlots,
+  mockIsInviteLimitReached,
   mockPermissions,
   mockUiConfig,
   mockIsActiveSubscription,
@@ -225,6 +236,9 @@ const {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
     mockIsInPersonalWorkspace: ref(false),
+    mockIsWorkspaceSubscribed: ref(true),
+    mockTotalMemberSlots: ref(0),
+    mockIsInviteLimitReached: ref(false),
     mockPermissions: ref({
       canViewOtherMembers: true,
       canViewPendingInvites: true,
@@ -240,8 +254,7 @@ const {
       showMembersList: true,
       showPendingTab: true,
       showSearch: true,
-      showDateColumn: true,
-      showRoleBadge: true,
+      showRoleColumn: true,
       membersGridCols: 'grid-cols-[50%_40%_10%]',
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
@@ -250,7 +263,10 @@ const {
       workspaceMenuDisabledTooltip: null as string | null
     }),
     mockIsActiveSubscription: ref(true),
-    mockSubscription: ref<{ tier: string } | null>({ tier: 'PRO' })
+    mockSubscription: ref<{ tier: string; isCancelled?: boolean } | null>({
+      tier: 'PRO',
+      isCancelled: false
+    })
   }
 })
 
@@ -271,11 +287,15 @@ vi.mock('pinia', async (importOriginal) => {
 })
 
 vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  MAX_WORKSPACE_MEMBERS: 30,
   useTeamWorkspaceStore: () => ({
     members: mockMembers,
     pendingInvites: mockPendingInvites,
+    totalMemberSlots: mockTotalMemberSlots,
+    isInviteLimitReached: mockIsInviteLimitReached,
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
-    copyInviteLink: mockCopyInviteLink
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed,
+    resendInvite: mockResendInvite
   })
 }))
 
@@ -311,16 +331,6 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
-vi.mock('@/platform/cloud/subscription/constants/tierPricing', () => ({
-  TIER_TO_KEY: {
-    FREE: 'free',
-    STANDARD: 'standard',
-    CREATOR: 'creator',
-    PRO: 'pro',
-    FOUNDERS_EDITION: 'founder'
-  }
-}))
-
 vi.mock(
   '@/platform/cloud/subscription/composables/useSubscriptionDialog',
   () => ({
@@ -332,7 +342,8 @@ vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
     showRemoveMemberDialog: mockShowRemoveMemberDialog,
     showRevokeInviteDialog: mockShowRevokeInviteDialog,
-    showCreateWorkspaceDialog: mockShowCreateWorkspaceDialog
+    showInviteMemberDialog: mockShowInviteMemberDialog,
+    showInviteMemberUpsellDialog: mockShowInviteMemberUpsellDialog
   })
 }))
 
@@ -342,8 +353,11 @@ describe('useMembersPanel', () => {
     mockMembers.value = []
     mockPendingInvites.value = []
     mockIsInPersonalWorkspace.value = false
+    mockIsWorkspaceSubscribed.value = true
+    mockTotalMemberSlots.value = 0
+    mockIsInviteLimitReached.value = false
     mockIsActiveSubscription.value = true
-    mockSubscription.value = { tier: 'PRO' }
+    mockSubscription.value = { tier: 'PRO', isCancelled: false }
   })
 
   // Lazy import so mocks are in place
@@ -352,49 +366,28 @@ describe('useMembersPanel', () => {
     return useMembersPanel()
   }
 
-  describe('isSingleSeatPlan', () => {
-    it('is false for personal workspace', async () => {
+  describe('team plan detection', () => {
+    it('is on the team plan for a subscribed team workspace', async () => {
+      const panel = await setup()
+      expect(panel.isOnTeamPlan.value).toBe(true)
+    })
+
+    it('is off the team plan in a personal workspace', async () => {
       mockIsInPersonalWorkspace.value = true
       const panel = await setup()
-      expect(panel.isSingleSeatPlan.value).toBe(false)
+      expect(panel.isOnTeamPlan.value).toBe(false)
     })
 
-    it('is true when no active subscription', async () => {
-      mockIsActiveSubscription.value = false
+    it('is off the team plan when the team workspace is not subscribed', async () => {
+      mockIsWorkspaceSubscribed.value = false
       const panel = await setup()
-      expect(panel.isSingleSeatPlan.value).toBe(true)
+      expect(panel.isOnTeamPlan.value).toBe(false)
     })
 
-    it('is true for standard tier (1 seat)', async () => {
-      mockSubscription.value = { tier: 'STANDARD' }
+    it('caps members at the flat team maximum regardless of tier', async () => {
+      mockSubscription.value = { tier: 'CREATOR', isCancelled: false }
       const panel = await setup()
-      expect(panel.isSingleSeatPlan.value).toBe(true)
-    })
-
-    it('is false for pro tier (20 seats)', async () => {
-      mockSubscription.value = { tier: 'PRO' }
-      const panel = await setup()
-      expect(panel.isSingleSeatPlan.value).toBe(false)
-    })
-  })
-
-  describe('maxSeats', () => {
-    it('returns 1 for personal workspace', async () => {
-      mockIsInPersonalWorkspace.value = true
-      const panel = await setup()
-      expect(panel.maxSeats.value).toBe(1)
-    })
-
-    it('returns tier-appropriate seats', async () => {
-      mockSubscription.value = { tier: 'CREATOR' }
-      const panel = await setup()
-      expect(panel.maxSeats.value).toBe(5)
-    })
-
-    it('returns 1 when no subscription', async () => {
-      mockSubscription.value = null
-      const panel = await setup()
-      expect(panel.maxSeats.value).toBe(1)
+      expect(panel.maxSeats.value).toBe(30)
     })
   })
 
@@ -462,23 +455,29 @@ describe('useMembersPanel', () => {
     })
   })
 
-  describe('handleCopyInviteLink', () => {
-    it('shows success toast on success', async () => {
-      mockCopyInviteLink.mockResolvedValue(undefined)
+  describe('handleResendInvite', () => {
+    it('resends the invite and shows a success toast', async () => {
+      mockResendInvite.mockResolvedValue(undefined)
       const panel = await setup()
-      await panel.handleCopyInviteLink(createInvite({ id: 'inv-1' }))
-      expect(mockCopyInviteLink).toHaveBeenCalledWith('inv-1')
+      await panel.handleResendInvite(createInvite({ id: 'inv-1' }))
+      expect(mockResendInvite).toHaveBeenCalledWith('inv-1')
       expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({ severity: 'success' })
+        expect.objectContaining({
+          severity: 'success',
+          summary: 'workspacePanel.toast.inviteResent'
+        })
       )
     })
 
     it('shows error toast on failure', async () => {
-      mockCopyInviteLink.mockRejectedValue(new Error('fail'))
+      mockResendInvite.mockRejectedValue(new Error('fail'))
       const panel = await setup()
-      await panel.handleCopyInviteLink(createInvite({ id: 'inv-1' }))
+      await panel.handleResendInvite(createInvite({ id: 'inv-1' }))
       expect(mockToastAdd).toHaveBeenCalledWith(
-        expect.objectContaining({ severity: 'error' })
+        expect.objectContaining({
+          severity: 'error',
+          summary: 'workspacePanel.toast.inviteResendFailed'
+        })
       )
     })
   })
@@ -491,19 +490,130 @@ describe('useMembersPanel', () => {
     })
   })
 
-  describe('handleCreateWorkspace', () => {
-    it('calls showCreateWorkspaceDialog', async () => {
-      const panel = await setup()
-      panel.handleCreateWorkspace()
-      expect(mockShowCreateWorkspaceDialog).toHaveBeenCalled()
-    })
-  })
-
   describe('handleRemoveMember', () => {
     it('calls showRemoveMemberDialog', async () => {
       const panel = await setup()
       panel.handleRemoveMember(createMember({ id: 'mem-7' }))
       expect(mockShowRemoveMemberDialog).toHaveBeenCalledWith('mem-7')
+    })
+  })
+
+  describe('single-member visibility gating', () => {
+    it('hides search and view tabs when the owner is alone', async () => {
+      mockMembers.value = [
+        createMember({ role: 'owner', email: 'owner@example.com' })
+      ]
+      const panel = await setup()
+      expect(panel.showSearch.value).toBe(false)
+      expect(panel.showViewTabs.value).toBe(false)
+    })
+
+    it('shows search and view tabs with more than one member', async () => {
+      mockMembers.value = [createMember(), createMember({ id: '2' })]
+      const panel = await setup()
+      expect(panel.showSearch.value).toBe(true)
+      expect(panel.showViewTabs.value).toBe(true)
+    })
+
+    it('shows view tabs for a lone owner with pending invites', async () => {
+      mockMembers.value = [
+        createMember({ role: 'owner', email: 'owner@example.com' })
+      ]
+      mockPendingInvites.value = [createInvite()]
+      const panel = await setup()
+      expect(panel.showViewTabs.value).toBe(true)
+      expect(panel.showSearch.value).toBe(false)
+    })
+
+    it('shows search for >1 member regardless of tier', async () => {
+      mockSubscription.value = { tier: 'STANDARD', isCancelled: false }
+      mockMembers.value = [createMember(), createMember({ id: '2' })]
+      const panel = await setup()
+      expect(panel.showSearch.value).toBe(true)
+      expect(panel.showViewTabs.value).toBe(true)
+    })
+
+    it('hides view tabs when the team workspace is not subscribed', async () => {
+      mockIsWorkspaceSubscribed.value = false
+      mockMembers.value = [createMember(), createMember({ id: '2' })]
+      const panel = await setup()
+      expect(panel.showViewTabs.value).toBe(false)
+      expect(panel.showSearch.value).toBe(true)
+    })
+  })
+
+  describe('invite gating', () => {
+    it('opens the invite dialog on an active team plan', async () => {
+      const panel = await setup()
+      panel.handleInviteMember()
+      expect(mockShowInviteMemberDialog).toHaveBeenCalled()
+      expect(mockShowInviteMemberUpsellDialog).not.toHaveBeenCalled()
+    })
+
+    it('opens the upsell dialog when not on a team plan', async () => {
+      mockIsWorkspaceSubscribed.value = false
+      const panel = await setup()
+      panel.handleInviteMember()
+      expect(mockShowInviteMemberUpsellDialog).toHaveBeenCalled()
+      expect(mockShowInviteMemberDialog).not.toHaveBeenCalled()
+    })
+
+    it('disables the invite button at the member cap (30)', async () => {
+      mockTotalMemberSlots.value = 30
+      const panel = await setup()
+      expect(panel.isInviteDisabled.value).toBe(true)
+      expect(panel.inviteTooltip.value).toBe(
+        'workspacePanel.inviteLimitReached'
+      )
+      panel.handleInviteMember()
+      expect(mockShowInviteMemberDialog).not.toHaveBeenCalled()
+    })
+
+    it('keeps the invite button enabled below the member cap', async () => {
+      mockTotalMemberSlots.value = 29
+      const panel = await setup()
+      expect(panel.isInviteDisabled.value).toBe(false)
+      expect(panel.inviteTooltip.value).toBeNull()
+    })
+
+    it('disables the invite button at the flat backend member cap', async () => {
+      mockIsInviteLimitReached.value = true
+      const panel = await setup()
+      expect(panel.isInviteDisabled.value).toBe(true)
+    })
+
+    it('disables the invite button when not on a team plan', async () => {
+      mockIsWorkspaceSubscribed.value = false
+      const panel = await setup()
+      expect(panel.isInviteDisabled.value).toBe(true)
+    })
+
+    it('disables the invite button when the team plan is cancelled', async () => {
+      mockSubscription.value = { tier: 'PRO', isCancelled: true }
+      const panel = await setup()
+      expect(panel.isInviteDisabled.value).toBe(true)
+      panel.handleInviteMember()
+      expect(mockShowInviteMemberDialog).not.toHaveBeenCalled()
+    })
+
+    it('shows a disabled invite button in a personal workspace', async () => {
+      mockIsInPersonalWorkspace.value = true
+      mockPermissions.value = {
+        ...mockPermissions.value,
+        canInviteMembers: false
+      }
+      const panel = await setup()
+      expect(panel.showInviteButton.value).toBe(true)
+      expect(panel.isInviteDisabled.value).toBe(true)
+    })
+
+    it('hides the invite button for members without invite permission', async () => {
+      mockPermissions.value = {
+        ...mockPermissions.value,
+        canInviteMembers: false
+      }
+      const panel = await setup()
+      expect(panel.showInviteButton.value).toBe(false)
     })
   })
 })

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -4,19 +4,21 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
-import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
-import { TIER_TO_KEY } from '@/platform/cloud/subscription/constants/tierPricing'
+import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import type {
   PendingInvite,
   WorkspaceMember
 } from '@/platform/workspace/stores/teamWorkspaceStore'
-import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import {
+  MAX_WORKSPACE_MEMBERS,
+  useTeamWorkspaceStore
+} from '@/platform/workspace/stores/teamWorkspaceStore'
 import { useDialogService } from '@/services/dialogService'
 
 type ActiveView = 'active' | 'pending'
-type SortField = 'inviteDate' | 'expiryDate' | 'joinDate'
+type SortField = 'inviteDate' | 'expiryDate' | 'role'
 type SortDirection = 'asc' | 'desc'
 
 export function sortMembers(
@@ -25,8 +27,10 @@ export function sortMembers(
   sortDirection: SortDirection
 ): WorkspaceMember[] {
   return [...members].sort((a, b) => {
-    if (a.role === 'owner' && b.role !== 'owner') return -1
-    if (a.role !== 'owner' && b.role === 'owner') return 1
+    if (a.role !== b.role) {
+      const ownerFirst = a.role === 'owner' ? -1 : 1
+      return sortDirection === 'desc' ? ownerFirst : -ownerFirst
+    }
 
     const aIsCurrent = a.email.toLowerCase() === currentUserEmail?.toLowerCase()
     const bIsCurrent = b.email.toLowerCase() === currentUserEmail?.toLowerCase()
@@ -52,12 +56,20 @@ export function filterBySearch<T extends { email: string; name?: string }>(
   )
 }
 
+type InviteSortField = 'inviteDate' | 'expiryDate'
+
+// Pending invites carry no role, so the members' 'role' sort has no equivalent
+// here and falls back to the invite date.
+function toInviteSortField(sortField: SortField): InviteSortField {
+  return sortField === 'expiryDate' ? 'expiryDate' : 'inviteDate'
+}
+
 export function sortPendingInvites(
   invites: PendingInvite[],
   sortField: SortField,
   sortDirection: SortDirection
 ): PendingInvite[] {
-  const field = sortField === 'joinDate' ? 'inviteDate' : sortField
+  const field = toInviteSortField(sortField)
   return [...invites].sort((a, b) => {
     const aDate = a[field]
     const bDate = b[field]
@@ -75,34 +87,67 @@ export function useMembersPanel() {
   const {
     showRemoveMemberDialog,
     showRevokeInviteDialog,
-    showCreateWorkspaceDialog
+    showInviteMemberDialog,
+    showInviteMemberUpsellDialog
   } = useDialogService()
   const workspaceStore = useTeamWorkspaceStore()
   const {
     members,
     pendingInvites,
+    totalMemberSlots,
+    isInviteLimitReached,
     isInPersonalWorkspace: isPersonalWorkspace
   } = storeToRefs(workspaceStore)
-  const { copyInviteLink } = workspaceStore
+  const { resendInvite } = workspaceStore
   const { permissions, uiConfig } = useWorkspaceUI()
-  const { isActiveSubscription, subscription, getMaxSeats } =
-    useBillingContext()
+  const { isOnTeamPlan, isCancelled, hasLapsedTeamPlan } = useTeamPlan()
   const subscriptionDialog = useSubscriptionDialog()
 
-  const maxSeats = computed(() => {
-    if (isPersonalWorkspace.value) return 1
-    const tier = subscription.value?.tier
-    if (!tier) return 1
-    const tierKey = TIER_TO_KEY[tier]
-    if (!tierKey) return 1
-    return getMaxSeats(tierKey)
+  // The team plan caps members at a flat MAX_WORKSPACE_MEMBERS, independent of
+  // the subscription tier.
+  const maxSeats = computed(() => MAX_WORKSPACE_MEMBERS)
+
+  const hasMultipleMembers = computed(() => members.value.length > 1)
+
+  const showSearch = computed(
+    () => uiConfig.value.showSearch && hasMultipleMembers.value
+  )
+
+  const showViewTabs = computed(
+    () =>
+      isOnTeamPlan.value &&
+      (hasMultipleMembers.value || pendingInvites.value.length > 0)
+  )
+
+  const showInviteButton = computed(
+    () => permissions.value.canInviteMembers || isPersonalWorkspace.value
+  )
+
+  // Plan seat limit, with the flat backend cap (isInviteLimitReached) as backstop
+  const isMemberLimitReached = computed(
+    () => isInviteLimitReached.value || totalMemberSlots.value >= maxSeats.value
+  )
+
+  // Invite is allowed only on an active (non-cancelled) team plan that is under
+  // the member cap.
+  const isInviteDisabled = computed(
+    () => !isOnTeamPlan.value || isCancelled.value || isMemberLimitReached.value
+  )
+
+  const inviteTooltip = computed(() => {
+    if (!isOnTeamPlan.value) return null
+    if (!isMemberLimitReached.value) return null
+    return t('workspacePanel.inviteLimitReached', { count: maxSeats.value })
   })
 
-  const isSingleSeatPlan = computed(() => {
-    if (isPersonalWorkspace.value) return false
-    if (!isActiveSubscription.value) return true
-    return maxSeats.value <= 1
-  })
+  function handleInviteMember() {
+    if (!isOnTeamPlan.value) {
+      void showInviteMemberUpsellDialog()
+      return
+    }
+    if (isCancelled.value || isMemberLimitReached.value) return
+    void showInviteMemberDialog()
+  }
 
   const personalWorkspaceMember = computed<WorkspaceMember>(() => ({
     id: 'self',
@@ -159,28 +204,24 @@ export function useMembersPanel() {
     }
   }
 
-  async function handleCopyInviteLink(invite: PendingInvite) {
+  async function handleResendInvite(invite: PendingInvite) {
     try {
-      await copyInviteLink(invite.id)
+      await resendInvite(invite.id)
       toast.add({
         severity: 'success',
-        summary: t('g.copied'),
+        summary: t('workspacePanel.toast.inviteResent'),
         life: 2000
       })
     } catch {
       toast.add({
         severity: 'error',
-        summary: t('g.error')
+        summary: t('workspacePanel.toast.inviteResendFailed')
       })
     }
   }
 
   function handleRevokeInvite(invite: PendingInvite) {
     void showRevokeInviteDialog(invite.id)
-  }
-
-  function handleCreateWorkspace() {
-    void showCreateWorkspaceDialog()
   }
 
   function handleRemoveMember(member: WorkspaceMember) {
@@ -198,7 +239,15 @@ export function useMembersPanel() {
     sortDirection,
     selectedMember,
     maxSeats,
-    isSingleSeatPlan,
+    isOnTeamPlan,
+    hasLapsedTeamPlan,
+    hasMultipleMembers,
+    showSearch,
+    showViewTabs,
+    showInviteButton,
+    isInviteDisabled,
+    inviteTooltip,
+    handleInviteMember,
     personalWorkspaceMember,
     filteredMembers,
     filteredPendingInvites,
@@ -208,15 +257,13 @@ export function useMembersPanel() {
     pendingInvites,
     permissions,
     uiConfig,
-    isActiveSubscription,
     userPhotoUrl,
     isCurrentUser,
     selectMember,
     toggleSort,
     showTeamPlans,
-    handleCopyInviteLink,
+    handleResendInvite,
     handleRevokeInvite,
-    handleCreateWorkspace,
     handleRemoveMember
   }
 }

--- a/src/platform/workspace/composables/useTeamPlan.test.ts
+++ b/src/platform/workspace/composables/useTeamPlan.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockIsInPersonalWorkspace,
+  mockIsWorkspaceSubscribed,
+  mockSubscription,
+  mockSubscriptionStatus
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+  const { ref } = require('vue') as typeof import('vue')
+
+  return {
+    mockIsInPersonalWorkspace: ref(false),
+    mockIsWorkspaceSubscribed: ref(true),
+    mockSubscription: ref<{ isCancelled?: boolean } | null>({
+      isCancelled: false
+    }),
+    mockSubscriptionStatus: ref<string | null>('active')
+  }
+})
+
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    storeToRefs: (store: Record<string, unknown>) => store
+  }
+})
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    isInPersonalWorkspace: mockIsInPersonalWorkspace,
+    isWorkspaceSubscribed: mockIsWorkspaceSubscribed
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    subscription: mockSubscription,
+    subscriptionStatus: mockSubscriptionStatus
+  })
+}))
+
+async function setup() {
+  const { useTeamPlan } = await import('./useTeamPlan')
+  return useTeamPlan()
+}
+
+describe('useTeamPlan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsInPersonalWorkspace.value = false
+    mockIsWorkspaceSubscribed.value = true
+    mockSubscription.value = { isCancelled: false }
+    mockSubscriptionStatus.value = 'active'
+  })
+
+  it('is on the team plan for a subscribed team workspace', async () => {
+    const plan = await setup()
+    expect(plan.isOnTeamPlan.value).toBe(true)
+  })
+
+  it('is off the team plan in a personal workspace', async () => {
+    mockIsInPersonalWorkspace.value = true
+    const plan = await setup()
+    expect(plan.isOnTeamPlan.value).toBe(false)
+  })
+
+  it('is off the team plan when the team workspace is not subscribed', async () => {
+    mockIsWorkspaceSubscribed.value = false
+    const plan = await setup()
+    expect(plan.isOnTeamPlan.value).toBe(false)
+  })
+
+  it('reflects the cancelled state of the subscription', async () => {
+    const plan = await setup()
+    expect(plan.isCancelled.value).toBe(false)
+    mockSubscription.value = { isCancelled: true }
+    expect(plan.isCancelled.value).toBe(true)
+  })
+
+  it('treats a missing subscription as not cancelled', async () => {
+    mockSubscription.value = null
+    const plan = await setup()
+    expect(plan.isCancelled.value).toBe(false)
+  })
+
+  it('does not flag a lapsed plan while the team subscription is active', async () => {
+    const plan = await setup()
+    expect(plan.hasLapsedTeamPlan.value).toBe(false)
+  })
+
+  it('flags a lapsed plan when the team subscription is cancelled or ended', async () => {
+    const plan = await setup()
+    mockSubscriptionStatus.value = 'canceled'
+    expect(plan.hasLapsedTeamPlan.value).toBe(true)
+    mockSubscriptionStatus.value = 'ended'
+    expect(plan.hasLapsedTeamPlan.value).toBe(true)
+  })
+
+  it('does not flag a lapsed plan in a personal workspace', async () => {
+    mockIsInPersonalWorkspace.value = true
+    mockSubscriptionStatus.value = 'canceled'
+    const plan = await setup()
+    expect(plan.hasLapsedTeamPlan.value).toBe(false)
+  })
+})

--- a/src/platform/workspace/composables/useTeamPlan.ts
+++ b/src/platform/workspace/composables/useTeamPlan.ts
@@ -1,0 +1,35 @@
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+
+import { useBillingContext } from '@/composables/billing/useBillingContext'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+/**
+ * Team-plan state for the active workspace. The team plan is tier-independent
+ * (no standard/creator/pro): "on the team plan" simply means a team workspace
+ * that is subscribed to it.
+ */
+export function useTeamPlan() {
+  const { subscription, subscriptionStatus } = useBillingContext()
+  const { isInPersonalWorkspace, isWorkspaceSubscribed } = storeToRefs(
+    useTeamWorkspaceStore()
+  )
+
+  const isTeamWorkspace = computed(() => !isInPersonalWorkspace.value)
+
+  const isOnTeamPlan = computed(
+    () => isTeamWorkspace.value && isWorkspaceSubscribed.value
+  )
+  const isCancelled = computed(() => subscription.value?.isCancelled ?? false)
+
+  const isSubscriptionLapsed = computed(
+    () =>
+      subscriptionStatus.value === 'canceled' ||
+      subscriptionStatus.value === 'ended'
+  )
+  const hasLapsedTeamPlan = computed(
+    () => isTeamWorkspace.value && isSubscriptionLapsed.value
+  )
+
+  return { isOnTeamPlan, isCancelled, hasLapsedTeamPlan }
+}

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -110,8 +110,7 @@ describe('useWorkspaceUI', () => {
         showMembersList: false,
         showPendingTab: false,
         showSearch: false,
-        showDateColumn: false,
-        showRoleBadge: false,
+        showRoleColumn: false,
         showEditWorkspaceMenuItem: false,
         workspaceMenuAction: null,
         workspaceMenuDisabledTooltip: null

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -26,8 +26,7 @@ interface WorkspaceUIConfig {
   showMembersList: boolean
   showPendingTab: boolean
   showSearch: boolean
-  showDateColumn: boolean
-  showRoleBadge: boolean
+  showRoleColumn: boolean
   membersGridCols: string
   pendingGridCols: string
   headerGridCols: string
@@ -96,8 +95,7 @@ function getUIConfig(
       showMembersList: false,
       showPendingTab: false,
       showSearch: false,
-      showDateColumn: false,
-      showRoleBadge: false,
+      showRoleColumn: false,
       membersGridCols: 'grid-cols-1',
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-1',
@@ -112,8 +110,7 @@ function getUIConfig(
       showMembersList: true,
       showPendingTab: true,
       showSearch: true,
-      showDateColumn: true,
-      showRoleBadge: true,
+      showRoleColumn: true,
       membersGridCols: 'grid-cols-[50%_40%_10%]',
       pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
       headerGridCols: 'grid-cols-[50%_40%_10%]',
@@ -129,8 +126,7 @@ function getUIConfig(
     showMembersList: true,
     showPendingTab: false,
     showSearch: true,
-    showDateColumn: true,
-    showRoleBadge: true,
+    showRoleColumn: true,
     membersGridCols: 'grid-cols-[1fr_auto]',
     pendingGridCols: 'grid-cols-[50%_20%_20%_10%]',
     headerGridCols: 'grid-cols-[1fr_auto]',

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -960,6 +960,157 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.pendingInvites[0].id).toBe('inv-2')
     })
 
+    it('resendInvite creates a fresh invite before revoking the old one', async () => {
+      mockWorkspaceApi.listInvites.mockResolvedValue({
+        invites: [
+          {
+            id: 'inv-1',
+            email: 'one@test.com',
+            token: 'token-1',
+            invited_at: '2024-01-01T00:00:00Z',
+            expires_at: '2024-01-08T00:00:00Z'
+          }
+        ]
+      })
+      mockWorkspaceApi.createInvite.mockResolvedValue({
+        id: 'inv-2',
+        email: 'one@test.com',
+        token: 'token-2',
+        invited_at: '2024-02-01T00:00:00Z',
+        expires_at: '2024-02-08T00:00:00Z'
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchPendingInvites()
+
+      const result = await store.resendInvite('inv-1')
+
+      expect(mockWorkspaceApi.revokeInvite).toHaveBeenCalledWith('inv-1')
+      expect(mockWorkspaceApi.createInvite).toHaveBeenCalledWith({
+        email: 'one@test.com'
+      })
+      expect(
+        mockWorkspaceApi.createInvite.mock.invocationCallOrder[0]
+      ).toBeLessThan(mockWorkspaceApi.revokeInvite.mock.invocationCallOrder[0])
+      expect(result.id).toBe('inv-2')
+      expect(store.pendingInvites).toHaveLength(1)
+      expect(store.pendingInvites[0].id).toBe('inv-2')
+    })
+
+    it('resendInvite keeps the original invite and rethrows when creation fails', async () => {
+      mockWorkspaceApi.listInvites.mockResolvedValue({
+        invites: [
+          {
+            id: 'inv-1',
+            email: 'one@test.com',
+            token: 'token-1',
+            invited_at: '2024-01-01T00:00:00Z',
+            expires_at: '2024-01-08T00:00:00Z'
+          }
+        ]
+      })
+      mockWorkspaceApi.createInvite.mockRejectedValue(
+        new Error('create failed')
+      )
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchPendingInvites()
+
+      await expect(store.resendInvite('inv-1')).rejects.toThrow('create failed')
+
+      expect(mockWorkspaceApi.revokeInvite).not.toHaveBeenCalled()
+      expect(store.pendingInvites).toHaveLength(1)
+      expect(store.pendingInvites[0].id).toBe('inv-1')
+    })
+
+    it('resendInvite resyncs invites and rethrows when revoking the old fails', async () => {
+      const inviteOne = {
+        id: 'inv-1',
+        email: 'one@test.com',
+        token: 'token-1',
+        invited_at: '2024-01-01T00:00:00Z',
+        expires_at: '2024-01-08T00:00:00Z'
+      }
+      const inviteTwo = {
+        id: 'inv-2',
+        email: 'one@test.com',
+        token: 'token-2',
+        invited_at: '2024-02-01T00:00:00Z',
+        expires_at: '2024-02-08T00:00:00Z'
+      }
+      mockWorkspaceApi.listInvites
+        .mockResolvedValueOnce({ invites: [inviteOne] })
+        .mockResolvedValue({ invites: [inviteOne, inviteTwo] })
+      mockWorkspaceApi.createInvite.mockResolvedValue(inviteTwo)
+      mockWorkspaceApi.revokeInvite.mockRejectedValue(
+        new Error('revoke failed')
+      )
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchPendingInvites()
+
+      await expect(store.resendInvite('inv-1')).rejects.toThrow('revoke failed')
+
+      expect(mockWorkspaceApi.listInvites).toHaveBeenCalledTimes(2)
+      expect(store.pendingInvites.map((i) => i.id)).toEqual(['inv-1', 'inv-2'])
+    })
+
+    it('resendInvite rejects a concurrent resend for the same invite', async () => {
+      const inviteOne = {
+        id: 'inv-1',
+        email: 'one@test.com',
+        token: 'token-1',
+        invited_at: '2024-01-01T00:00:00Z',
+        expires_at: '2024-01-08T00:00:00Z'
+      }
+      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: [inviteOne] })
+      mockWorkspaceApi.createInvite.mockResolvedValue({
+        id: 'inv-2',
+        email: 'one@test.com',
+        token: 'token-2',
+        invited_at: '2024-02-01T00:00:00Z',
+        expires_at: '2024-02-08T00:00:00Z'
+      })
+      mockWorkspaceApi.revokeInvite.mockResolvedValue(undefined)
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchPendingInvites()
+
+      const first = store.resendInvite('inv-1')
+      await expect(store.resendInvite('inv-1')).rejects.toThrow(
+        'already in progress'
+      )
+      await first
+
+      expect(mockWorkspaceApi.createInvite).toHaveBeenCalledTimes(1)
+    })
+
+    it('resendInvite throws for an unknown invite id', async () => {
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      await expect(store.resendInvite('missing')).rejects.toThrow(
+        'Invite not found'
+      )
+      expect(mockWorkspaceApi.revokeInvite).not.toHaveBeenCalled()
+      expect(mockWorkspaceApi.createInvite).not.toHaveBeenCalled()
+    })
+
     it('acceptInvite refreshes workspace list', async () => {
       mockWorkspaceApi.acceptInvite.mockResolvedValue({
         workspace_id: 'ws-joined',
@@ -975,60 +1126,6 @@ describe('useTeamWorkspaceStore', () => {
       expect(result.workspaceId).toBe('ws-joined')
       expect(result.workspaceName).toBe('Joined Workspace')
       expect(mockWorkspaceApi.list).toHaveBeenCalledTimes(2)
-    })
-  })
-
-  describe('invite link helpers', () => {
-    it('getInviteLink returns link for existing invite', async () => {
-      const mockInvites = [
-        {
-          id: 'inv-1',
-          email: 'test@test.com',
-          token: 'secret-token',
-          invited_at: '2024-01-01T00:00:00Z',
-          expires_at: '2024-01-08T00:00:00Z'
-        }
-      ]
-      mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
-
-      const store = useTeamWorkspaceStore()
-      await store.initialize()
-      await store.fetchPendingInvites()
-
-      const link = store.getInviteLink('inv-1')
-
-      expect(link).toContain('?invite=secret-token')
-    })
-
-    it('getInviteLink returns null for non-existent invite', async () => {
-      const store = useTeamWorkspaceStore()
-      await store.initialize()
-
-      const link = store.getInviteLink('non-existent')
-
-      expect(link).toBeNull()
-    })
-
-    it('createInviteLink creates invite and returns link', async () => {
-      const newInvite = {
-        id: 'inv-new',
-        email: 'new@test.com',
-        token: 'new-token',
-        invited_at: '2024-01-01T00:00:00Z',
-        expires_at: '2024-01-08T00:00:00Z'
-      }
-      mockWorkspaceApi.createInvite.mockResolvedValue(newInvite)
-      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
-      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
-
-      const store = useTeamWorkspaceStore()
-      await store.initialize()
-
-      const link = await store.createInviteLink('new@test.com')
-
-      expect(link).toContain('?invite=new-token')
     })
   })
 
@@ -1086,8 +1183,8 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.isInviteLimitReached).toBe(false)
     })
 
-    it('isInviteLimitReached returns true at 50 slots', async () => {
-      const mockMembers = Array.from({ length: 48 }, (_, i) => ({
+    it('isInviteLimitReached enforces the flat 30-member backend cap, independent of plan seats', async () => {
+      const mockMembers = Array.from({ length: 28 }, (_, i) => ({
         id: `user-${i}`,
         name: `User ${i}`,
         email: `user${i}@test.com`,
@@ -1111,7 +1208,7 @@ describe('useTeamWorkspaceStore', () => {
       ]
       mockWorkspaceApi.listMembers.mockResolvedValue({
         members: mockMembers,
-        pagination: { offset: 0, limit: 50, total: 48 }
+        pagination: { offset: 0, limit: 50, total: 28 }
       })
       mockWorkspaceApi.listInvites.mockResolvedValue({ invites: mockInvites })
       mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
@@ -1122,7 +1219,7 @@ describe('useTeamWorkspaceStore', () => {
       await store.fetchMembers()
       await store.fetchPendingInvites()
 
-      expect(store.totalMemberSlots).toBe(50)
+      expect(store.totalMemberSlots).toBe(30)
       expect(store.isInviteLimitReached).toBe(true)
     })
   })

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -28,7 +28,6 @@ export interface WorkspaceMember {
 export interface PendingInvite {
   id: string
   email: string
-  token: string
   inviteDate: Date
   expiryDate: Date
 }
@@ -60,7 +59,6 @@ function mapApiInviteToPendingInvite(invite: ApiPendingInvite): PendingInvite {
   return {
     id: invite.id,
     email: invite.email,
-    token: invite.token,
     inviteDate: new Date(invite.invited_at),
     expiryDate: new Date(invite.expires_at)
   }
@@ -106,7 +104,7 @@ function setLastWorkspaceId(workspaceId: string): void {
 }
 
 const MAX_OWNED_WORKSPACES = 10
-const MAX_WORKSPACE_MEMBERS = 50
+export const MAX_WORKSPACE_MEMBERS = 30
 const MAX_INIT_RETRIES = 3
 const BASE_RETRY_DELAY_MS = 1000
 
@@ -608,6 +606,40 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     }
   }
 
+  const resendingInviteIds = new Set<string>()
+
+  /**
+   * Resend a pending invite by issuing a fresh one before revoking the old.
+   * Create-first so a failed resend never destroys the original invite. If the
+   * revoke fails, the store is resynced (so the leftover original surfaces) and
+   * the error is rethrown so the caller can report the partial failure rather
+   * than show success over two live invites for the same email.
+   */
+  async function resendInvite(inviteId: string): Promise<PendingInvite> {
+    if (resendingInviteIds.has(inviteId)) {
+      throw new Error('Invite resend already in progress')
+    }
+    const invite = activeWorkspace.value?.pendingInvites.find(
+      (i) => i.id === inviteId
+    )
+    if (!invite) {
+      throw new Error('Invite not found')
+    }
+    resendingInviteIds.add(inviteId)
+    try {
+      const newInvite = await createInvite(invite.email)
+      try {
+        await revokeInvite(inviteId)
+      } catch (error) {
+        await fetchPendingInvites()
+        throw error
+      }
+      return newInvite
+    } finally {
+      resendingInviteIds.delete(inviteId)
+    }
+  }
+
   /**
    * Accept a workspace invite.
    * Returns workspace info so UI can offer "View Workspace" button.
@@ -624,44 +656,6 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
       workspaceId: response.workspace_id,
       workspaceName: response.workspace_name
     }
-  }
-
-  function buildInviteLink(token: string): string {
-    const baseUrl = window.location.origin
-    return `${baseUrl}?invite=${encodeURIComponent(token)}`
-  }
-
-  /**
-   * Get the invite link for a pending invite.
-   */
-  function getInviteLink(inviteId: string): string | null {
-    const invite = activeWorkspace.value?.pendingInvites.find(
-      (i) => i.id === inviteId
-    )
-    return invite ? buildInviteLink(invite.token) : null
-  }
-
-  /**
-   * Create an invite link for a given email.
-   */
-  async function createInviteLink(email: string): Promise<string> {
-    const invite = await createInvite(email)
-    return buildInviteLink(invite.token)
-  }
-
-  /**
-   * Copy an invite link to clipboard.
-   */
-  async function copyInviteLink(inviteId: string): Promise<string> {
-    const invite = activeWorkspace.value?.pendingInvites.find(
-      (i) => i.id === inviteId
-    )
-    if (!invite) {
-      throw new Error('Invite not found')
-    }
-    const inviteLink = buildInviteLink(invite.token)
-    await navigator.clipboard.writeText(inviteLink)
-    return inviteLink
   }
 
   //TODO: when billing lands update this
@@ -728,10 +722,8 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     fetchPendingInvites,
     createInvite,
     revokeInvite,
+    resendInvite,
     acceptInvite,
-    getInviteLink,
-    createInviteLink,
-    copyInviteLink,
 
     // Subscription
     subscribeWorkspace,


### PR DESCRIPTION
Backport of #12759 to `cloud/1.45`.

Part of an ordered, **stacked** backport series for cloud/1.45, merged **bottom-up**.

**Stacked on:** #13188 (backport of #12734). Base branch = `backport-12734-to-cloud-1.45`.

Cherry-picked squash commit `988dc719552a27efcf4ebfde25cab705686914b6` — applied cleanly with no conflicts. Original authorship preserved.