### PR TITLE
[backport cloud/1.45] feat(workspace): promote/demote members via Change role menu (FE-770) (#12782)

### DIFF
--- a/browser_tests/fixtures/data/cloudWorkspace.ts
+++ b/browser_tests/fixtures/data/cloudWorkspace.ts
@@ -1,0 +1,96 @@
+import type {
+  BillingStatusResponse,
+  Member,
+  Plan,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+// `/api/features` is the remote-config source: production builds resolve the
+// workspaces flag from it (the `ff:` localStorage override is dev-only).
+export const WORKSPACE_FEATURE_FLAG: RemoteConfig = {
+  team_workspaces_enabled: true
+}
+
+export const TEAM_WORKSPACE: WorkspaceWithRole = {
+  id: 'ws-team',
+  name: 'Team Comfy',
+  type: 'team',
+  created_at: '2025-01-01T00:00:00Z',
+  joined_at: '2025-01-02T00:00:00Z',
+  role: 'owner',
+  subscription_tier: 'PRO'
+}
+
+export const CREATOR: Member = {
+  id: 'u-liz',
+  name: 'Liz',
+  email: 'liz@test.comfy.org',
+  joined_at: '2025-01-01T00:00:00Z',
+  role: 'owner',
+  is_original_owner: true
+}
+
+// Identity must match the CloudAuthHelper mock user so this row counts as
+// "(You)".
+export const VIEWER: Member = {
+  id: 'u-me',
+  name: 'E2E Test User',
+  email: 'e2e@test.comfy.org',
+  joined_at: '2025-01-02T00:00:00Z',
+  role: 'owner',
+  is_original_owner: false
+}
+
+export const MEMBER_JANE: Member = {
+  id: 'u-jane',
+  name: 'Jane',
+  email: 'jane@test.comfy.org',
+  joined_at: '2025-01-03T00:00:00Z',
+  role: 'member',
+  is_original_owner: false
+}
+
+export const MEMBER_JOHN: Member = {
+  id: 'u-john',
+  name: 'John',
+  email: 'john@test.comfy.org',
+  joined_at: '2025-01-04T00:00:00Z',
+  role: 'member',
+  is_original_owner: false
+}
+
+export const DEFAULT_TEAM_MEMBERS: Member[] = [
+  CREATOR,
+  VIEWER,
+  MEMBER_JANE,
+  MEMBER_JOHN
+]
+
+export const TEAM_BILLING_STATUS: BillingStatusResponse = {
+  is_active: true,
+  subscription_status: 'active',
+  subscription_tier: 'PRO',
+  subscription_duration: 'MONTHLY',
+  plan_slug: 'pro-monthly',
+  billing_status: 'paid',
+  has_funds: true,
+  renewal_date: '2099-02-20T00:00:00Z'
+}
+
+// `max_seats > 1` on the current plan is what flips `isOnTeamPlan`, which gates
+// the whole role-management UI.
+export const TEAM_PRO_PLAN: Plan = {
+  slug: 'pro-monthly',
+  tier: 'PRO',
+  duration: 'MONTHLY',
+  price_cents: 10000,
+  credits_cents: 21100,
+  max_seats: 30,
+  availability: { available: true },
+  seat_summary: {
+    seat_count: 4,
+    total_cost_cents: 40000,
+    total_credits_cents: 0
+  }
+}

--- a/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
+++ b/browser_tests/fixtures/helpers/CloudWorkspaceMockHelper.ts
@@ -1,0 +1,150 @@
+import type { Page, Route } from '@playwright/test'
+
+import type { Member } from '@/platform/workspace/api/workspaceApi'
+
+import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
+import {
+  DEFAULT_TEAM_MEMBERS,
+  TEAM_BILLING_STATUS,
+  TEAM_PRO_PLAN,
+  TEAM_WORKSPACE,
+  WORKSPACE_FEATURE_FLAG
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
+
+interface RoleChangeRequest {
+  url: string
+  role: string
+}
+
+interface MemberMockState {
+  members: Member[]
+  patches: RoleChangeRequest[]
+}
+
+const jsonRoute = (body: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body)
+})
+
+/**
+ * Boots the cloud app against fully mocked workspace + billing endpoints so
+ * member/role specs can drive a raw `page` (the `comfyPage` fixture would try
+ * to reach the OSS devtools backend during setup).
+ *
+ * Returns the mutable mock state: `members` reflects PATCH-applied roles and
+ * `patches` records every role-change request for assertion.
+ */
+export class CloudWorkspaceMockHelper {
+  constructor(private readonly page: Page) {}
+
+  async setup(
+    members: Member[] = DEFAULT_TEAM_MEMBERS
+  ): Promise<MemberMockState> {
+    const state = await this.mockBoot(members)
+    await new CloudAuthHelper(this.page).mockAuth()
+    await this.page.addInitScript(() => {
+      localStorage.setItem('Comfy.userId', 'test-user-e2e')
+      localStorage.setItem('Comfy.Workspace.LastWorkspaceId', 'ws-team')
+    })
+    return state
+  }
+
+  private async mockBoot(members: Member[]): Promise<MemberMockState> {
+    const state: MemberMockState = {
+      members: members.map((m) => ({ ...m })),
+      patches: []
+    }
+    const { page } = this
+
+    await page.route('**/api/features', (r) =>
+      r.fulfill(jsonRoute(WORKSPACE_FEATURE_FLAG))
+    )
+    await page.route('**/api/system_stats', (r) =>
+      r.fulfill(jsonRoute(mockSystemStats))
+    )
+    await page.route('**/api/users', (r) =>
+      r.fulfill(
+        jsonRoute({
+          storage: 'server',
+          migrated: true,
+          users: { 'test-user-e2e': 'E2E Test User' }
+        })
+      )
+    )
+    // A non-empty settings payload with TutorialCompleted marks the user as
+    // returning, so the new-user Templates dialog never auto-opens to block the
+    // Settings button. Errors tab off suppresses the model-folder 401 toast.
+    await page.route('**/api/settings', (r) =>
+      r.fulfill(
+        jsonRoute({
+          'Comfy.TutorialCompleted': true,
+          'Comfy.RightSidePanel.ShowErrorsTab': false
+        })
+      )
+    )
+    await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))
+    await page.route('**/api/extensions', (r) => r.fulfill(jsonRoute([])))
+    await page.route('**/api/object_info', (r) => r.fulfill(jsonRoute({})))
+    await page.route('**/api/global_subgraphs', (r) => r.fulfill(jsonRoute({})))
+    await page.route('**/api/i18n', (r) => r.fulfill(jsonRoute({})))
+    await page.route('**/api/auth/session', (r) =>
+      r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
+    )
+    await page.route('**/api/auth/token', (r) =>
+      r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
+    )
+    await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
+
+    await page.route('**/api/workspaces', (r) =>
+      r.fulfill(jsonRoute({ workspaces: [TEAM_WORKSPACE] }))
+    )
+
+    await page.route('**/api/workspace/members**', (route: Route) => {
+      const request = route.request()
+      if (request.method() === 'PATCH') {
+        const url = request.url()
+        const id = url.match(/\/api\/workspace\/members\/([^/?]+)/)?.[1]
+        const { role } = request.postDataJSON() as { role: Member['role'] }
+        state.patches.push({ url, role })
+        const member = state.members.find((m) => m.id === id)
+        if (member) member.role = role
+        // Echo the updated row like the real BE; the store merges only the role
+        // locally, so the response body shape is not load-bearing.
+        return route.fulfill(jsonRoute(member))
+      }
+      return route.fulfill(
+        jsonRoute({
+          members: state.members,
+          pagination: { offset: 0, limit: 50, total: state.members.length }
+        })
+      )
+    })
+    await page.route('**/api/workspace/invites', (r) =>
+      r.fulfill(jsonRoute({ invites: [] }))
+    )
+
+    await page.route('**/api/billing/status', (r) =>
+      r.fulfill(jsonRoute(TEAM_BILLING_STATUS))
+    )
+    await page.route('**/api/billing/balance', (r) =>
+      r.fulfill(
+        jsonRoute({
+          amount_micros: 6000,
+          currency: 'usd',
+          effective_balance_micros: 6000,
+          cloud_credit_balance_micros: 5000,
+          prepaid_balance_micros: 1000
+        })
+      )
+    )
+    await page.route('**/api/billing/plans', (r) =>
+      r.fulfill(
+        jsonRoute({ current_plan_slug: 'pro-monthly', plans: [TEAM_PRO_PLAN] })
+      )
+    )
+
+    return state
+  }
+}

--- a/browser_tests/tests/dialogs/memberRoleChange.spec.ts
+++ b/browser_tests/tests/dialogs/memberRoleChange.spec.ts
@@ -1,0 +1,264 @@
+import { expect } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+
+import type { Member } from '@/platform/workspace/api/workspaceApi'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import {
+  CREATOR,
+  MEMBER_JANE,
+  MEMBER_JOHN,
+  VIEWER
+} from '@e2e/fixtures/data/cloudWorkspace'
+import { CloudWorkspaceMockHelper } from '@e2e/fixtures/helpers/CloudWorkspaceMockHelper'
+
+// Drives a raw `page` (not the `comfyPage` fixture) so the cloud app boots
+// against fully mocked endpoints; `comfyPage` would try to reach the OSS
+// devtools backend during setup.
+
+/**
+ * Member role change (Settings ▸ Workspace ▸ Members) — Figma 2993-15512.
+ *
+ * The viewer is a promoted owner (not the workspace creator), so the spec can
+ * distinguish the creator guard from the self guard: the creator row and the
+ * viewer's own row hide the row menu, every other row exposes
+ * "Change role ›" (Owner / Member) plus "Remove member". Promoting a member
+ * sends PATCH /api/workspace/members/:id {role}, flips the Role column,
+ * re-sorts the row under the creator, and the promoted owner stays demotable.
+ */
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+async function openMembersTab(page: Page): Promise<Locator> {
+  await page.goto(APP_URL)
+  await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+    timeout: 45_000
+  })
+
+  await page
+    .getByRole('button', { name: /^Settings/ })
+    .first()
+    .click()
+  const dialog = page.getByTestId('settings-dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.locator('nav').getByRole('button', { name: 'Workspace' }).click()
+
+  const content = dialog.getByRole('main')
+  await content.getByRole('tab', { name: /Members/ }).click()
+  await expect(content.getByText('4 of 30 members')).toBeVisible()
+  return content
+}
+
+function memberRow(content: Locator, email: string): Locator {
+  return content
+    .locator('div.grid')
+    .filter({ has: content.page().getByText(email, { exact: true }) })
+}
+
+function menuButton(row: Locator): Locator {
+  return row.getByRole('button', { name: 'More Options' })
+}
+
+// Reka submenus open on real pointer travel or keyboard; Playwright's
+// synthetic hover doesn't trigger the pointermove handler, so drive the
+// subtrigger with ArrowRight instead.
+async function openChangeRoleSubmenu(page: Page) {
+  const trigger = page.getByRole('menuitem', { name: 'Change role' })
+  await expect(trigger).toBeVisible()
+  await trigger.press('ArrowRight')
+  await expect(
+    page.getByRole('menuitemradio', { name: 'Owner', exact: true })
+  ).toBeVisible()
+}
+
+test.describe('Member role change (Members tab)', { tag: '@cloud' }, () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('row menus respect creator and self guards', async ({ page }) => {
+    await new CloudWorkspaceMockHelper(page).setup()
+    const content = await openMembersTab(page)
+
+    // US8/US9 — no row actions on the creator row (Liz) nor on the viewer's
+    // own row; the two plain members each expose a menu.
+    await expect(
+      menuButton(memberRow(content, MEMBER_JOHN.email))
+    ).toBeVisible()
+    await expect(
+      menuButton(memberRow(content, MEMBER_JANE.email))
+    ).toBeVisible()
+    await expect(menuButton(memberRow(content, CREATOR.email))).toHaveCount(0)
+    await expect(menuButton(memberRow(content, VIEWER.email))).toHaveCount(0)
+
+    // US1/US12 — the row menu exposes Change role and the FE-768 remove flow.
+    await menuButton(memberRow(content, MEMBER_JANE.email)).click()
+    await expect(
+      page.getByRole('menuitem', { name: 'Change role' })
+    ).toBeVisible()
+    await page.getByRole('menuitem', { name: 'Remove member' }).click()
+    await expect(page.getByText('Remove this member?')).toBeVisible()
+  })
+
+  test('selecting the current role is a no-op', async ({ page }) => {
+    const state = await new CloudWorkspaceMockHelper(page).setup()
+    const content = await openMembersTab(page)
+
+    const janeRow = memberRow(content, MEMBER_JANE.email)
+    await menuButton(janeRow).click()
+    await openChangeRoleSubmenu(page)
+
+    // The current role is a checked radio item so assistive tech can announce
+    // which role is active.
+    await expect(
+      page.getByRole('menuitemradio', { name: 'Member', exact: true })
+    ).toHaveAttribute('aria-checked', 'true')
+    await expect(
+      page.getByRole('menuitemradio', { name: 'Owner', exact: true })
+    ).toHaveAttribute('aria-checked', 'false')
+
+    await page
+      .getByRole('menuitemradio', { name: 'Member', exact: true })
+      .click()
+
+    await expect(page.getByRole('heading', { name: /an owner\?/ })).toHaveCount(
+      0
+    )
+    expect(state.patches).toHaveLength(0)
+  })
+
+  test('promote dialog shows the Figma copy and cancelling keeps the role', async ({
+    page
+  }) => {
+    const state = await new CloudWorkspaceMockHelper(page).setup()
+    const content = await openMembersTab(page)
+
+    const janeRow = memberRow(content, MEMBER_JANE.email)
+    await menuButton(janeRow).click()
+    await openChangeRoleSubmenu(page)
+    await page
+      .getByRole('menuitemradio', { name: 'Owner', exact: true })
+      .click()
+
+    await expect(
+      page.getByRole('heading', { name: 'Make Jane an owner?' })
+    ).toBeVisible()
+    await expect(page.getByText("They'll be able to:")).toBeVisible()
+    await expect(page.getByText('Add additional credits')).toBeVisible()
+    await expect(
+      page.getByText('Manage members, payment methods, and workspace settings')
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        'Promote and demote other owners (except the workspace creator).'
+      )
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click()
+    await expect(
+      page.getByRole('heading', { name: 'Make Jane an owner?' })
+    ).toHaveCount(0)
+    await expect(janeRow.getByText('Member', { exact: true })).toBeVisible()
+    expect(state.patches).toHaveLength(0)
+  })
+
+  test('promoting a member re-sorts the row under the creator and stays demotable', async ({
+    page
+  }) => {
+    const state = await new CloudWorkspaceMockHelper(page).setup()
+    const content = await openMembersTab(page)
+
+    const emails = content.getByText(/@test\.comfy\.org/)
+    await expect(emails).toHaveText([
+      CREATOR.email,
+      VIEWER.email,
+      MEMBER_JOHN.email,
+      MEMBER_JANE.email
+    ])
+
+    const janeRow = memberRow(content, MEMBER_JANE.email)
+    await menuButton(janeRow).click()
+    await openChangeRoleSubmenu(page)
+    await page
+      .getByRole('menuitemradio', { name: 'Owner', exact: true })
+      .click()
+    await page.getByRole('button', { name: 'Make owner' }).click()
+
+    await expect(page.getByText('Role updated')).toBeVisible()
+    await expect(janeRow.getByText('Owner', { exact: true })).toBeVisible()
+    await expect(emails).toHaveText([
+      CREATOR.email,
+      VIEWER.email,
+      MEMBER_JANE.email,
+      MEMBER_JOHN.email
+    ])
+    expect(state.patches).toEqual([
+      {
+        url: expect.stringContaining('/api/workspace/members/u-jane'),
+        role: 'owner'
+      }
+    ])
+
+    // The promoted owner keeps its row menu (still demotable).
+    await expect(menuButton(janeRow)).toBeVisible()
+  })
+
+  test('demoting an owner returns them to member', async ({ page }) => {
+    const ownerJane: Member = { ...MEMBER_JANE, role: 'owner' }
+    const state = await new CloudWorkspaceMockHelper(page).setup([
+      CREATOR,
+      VIEWER,
+      ownerJane,
+      MEMBER_JOHN
+    ])
+    const content = await openMembersTab(page)
+
+    const janeRow = memberRow(content, MEMBER_JANE.email)
+    await expect(janeRow.getByText('Owner', { exact: true })).toBeVisible()
+
+    await menuButton(janeRow).click()
+    await openChangeRoleSubmenu(page)
+    await page
+      .getByRole('menuitemradio', { name: 'Member', exact: true })
+      .click()
+    await expect(
+      page.getByRole('heading', { name: 'Demote Jane to member?' })
+    ).toBeVisible()
+    await expect(page.getByText("They'll lose admin access.")).toBeVisible()
+    await page.getByRole('button', { name: 'Demote to member' }).click()
+
+    await expect(janeRow.getByText('Member', { exact: true })).toBeVisible()
+    expect(state.patches).toEqual([
+      {
+        url: expect.stringContaining('/api/workspace/members/u-jane'),
+        role: 'member'
+      }
+    ])
+  })
+
+  test('failed role change keeps the dialog open with an error toast', async ({
+    page
+  }) => {
+    await new CloudWorkspaceMockHelper(page).setup()
+    // Override the member route so PATCH fails after boot succeeds.
+    await page.route('**/api/workspace/members/**', (route) =>
+      route.request().method() === 'PATCH'
+        ? route.fulfill({ status: 500, body: '{}' })
+        : route.fallback()
+    )
+    const content = await openMembersTab(page)
+
+    const janeRow = memberRow(content, MEMBER_JANE.email)
+    await menuButton(janeRow).click()
+    await openChangeRoleSubmenu(page)
+    await page
+      .getByRole('menuitemradio', { name: 'Owner', exact: true })
+      .click()
+    await page.getByRole('button', { name: 'Make owner' }).click()
+
+    // US10 — error toast, dialog stays open, role unchanged.
+    await expect(page.getByText('Failed to update role')).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Make Jane an owner?' })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click()
+    await expect(janeRow.getByText('Member', { exact: true })).toBeVisible()
+  })
+})

--- a/src/components/common/DropdownItem.vue
+++ b/src/components/common/DropdownItem.vue
@@ -62,10 +62,17 @@ defineProps<{ itemClass: string; contentClass: string; item: MenuItem }>()
         Boolean(item.tooltip) && toValue(item.disabled) && 'pointer-events-auto'
       )
     "
+    v-bind="
+      'checked' in item
+        ? { role: 'menuitemradio', 'aria-checked': Boolean(item.checked) }
+        : {}
+    "
     :disabled="toValue(item.disabled) ?? !item.command"
     @select="item.command?.({ originalEvent: $event, item })"
   >
-    <i class="size-5 shrink-0" :class="item.icon" />
+    <!-- Items declaring an icon key (even empty) keep the slot so labels align
+         within icon-bearing menus; icon-less menus render labels flush-left. -->
+    <i v-if="'icon' in item" class="size-5 shrink-0" :class="item.icon" />
     <div class="mr-auto truncate" v-text="item.label" />
     <i v-if="item.checked" class="icon-[lucide--check] shrink-0" />
     <div

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2709,6 +2709,7 @@
       "actions": {
         "resendInvite": "Resend invite",
         "cancelInvite": "Cancel invite",
+        "changeRole": "Change role",
         "removeMember": "Remove member"
       },
       "upsellBanner": "To add teammates, upgrade your plan.",
@@ -2749,6 +2750,19 @@
       "remove": "Remove member",
       "success": "Member removed",
       "error": "Failed to remove member"
+    },
+    "changeRoleDialog": {
+      "promoteTitle": "Make {name} an owner?",
+      "promoteIntro": "They'll be able to:",
+      "promotePermissionCredits": "Add additional credits",
+      "promotePermissionManage": "Manage members, payment methods, and workspace settings",
+      "promotePermissionRoles": "Promote and demote other owners (except the workspace creator).",
+      "promoteConfirm": "Make owner",
+      "demoteTitle": "Demote {name} to member?",
+      "demoteMessage": "They'll lose admin access.",
+      "demoteConfirm": "Demote to member",
+      "success": "Role updated",
+      "error": "Failed to update role"
     },
     "revokeInviteDialog": {
       "title": "Uninvite this person?",

--- a/src/platform/workspace/api/workspaceApi.test.ts
+++ b/src/platform/workspace/api/workspaceApi.test.ts
@@ -212,6 +212,27 @@ describe('workspaceApi', () => {
         { headers: AUTH_HEADER }
       )
     })
+
+    it('updateMemberRole() sends PATCH /workspace/members/:userId with the role', async () => {
+      const updated = {
+        id: 'user-42',
+        name: 'Jane',
+        email: 'jane@test.comfy.org',
+        joined_at: '2025-01-03T00:00:00Z',
+        role: 'owner',
+        is_original_owner: false
+      }
+      mockAxiosInstance.patch.mockResolvedValue({ data: updated })
+
+      const result = await workspaceApi.updateMemberRole('user-42', 'owner')
+
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
+        '/api/workspace/members/user-42',
+        { role: 'owner' },
+        { headers: AUTH_HEADER }
+      )
+      expect(result).toEqual(updated)
+    })
   })
 
   describe('invite management', () => {

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -462,6 +462,24 @@ export const workspaceApi = {
   },
 
   /**
+   * Change a member's role (member ↔ owner).
+   * PATCH /api/workspace/members/:userId
+   */
+  async updateMemberRole(userId: UserId, role: WorkspaceRole): Promise<Member> {
+    const headers = await getAuthHeaderOrThrow()
+    try {
+      const response = await workspaceApiClient.patch<Member>(
+        api.apiURL(`/workspace/members/${userId}`),
+        { role },
+        { headers }
+      )
+      return response.data
+    } catch (err) {
+      handleAxiosError(err)
+    }
+  },
+
+  /**
    * List pending invites for the workspace.
    * GET /api/workspace/invites
    */

--- a/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.test.ts
+++ b/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.test.ts
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import ChangeMemberRoleDialogContent from './ChangeMemberRoleDialogContent.vue'
+
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
+
+const { mockChangeMemberRole, mockCloseDialog, mockToastAdd } = vi.hoisted(
+  () => ({
+    mockChangeMemberRole: vi.fn(),
+    mockCloseDialog: vi.fn(),
+    mockToastAdd: vi.fn()
+  })
+)
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    changeMemberRole: mockChangeMemberRole
+  })
+}))
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({
+    closeDialog: mockCloseDialog
+  })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: mockToastAdd
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function renderDialog(targetRole: WorkspaceRole) {
+  const user = userEvent.setup()
+  const result = render(ChangeMemberRoleDialogContent, {
+    props: { memberId: 'mem-1', memberName: 'Jane', targetRole },
+    global: { plugins: [i18n] }
+  })
+  return { ...result, user }
+}
+
+describe('ChangeMemberRoleDialogContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockChangeMemberRole.mockResolvedValue(undefined)
+  })
+
+  it('shows promote copy and confirms with Make owner', async () => {
+    const { user } = renderDialog('owner')
+
+    expect(
+      screen.getByText('workspacePanel.changeRoleDialog.promoteTitle')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('workspacePanel.changeRoleDialog.promoteIntro')
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'workspacePanel.changeRoleDialog.promoteConfirm'
+      })
+    )
+
+    expect(mockChangeMemberRole).toHaveBeenCalledWith('mem-1', 'owner')
+    await waitFor(() =>
+      expect(mockCloseDialog).toHaveBeenCalledWith({
+        key: 'change-member-role'
+      })
+    )
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' })
+    )
+  })
+
+  it('shows demote copy and confirms with Demote to member', async () => {
+    const { user } = renderDialog('member')
+
+    expect(
+      screen.getByText('workspacePanel.changeRoleDialog.demoteTitle')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('workspacePanel.changeRoleDialog.demoteMessage')
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'workspacePanel.changeRoleDialog.demoteConfirm'
+      })
+    )
+
+    expect(mockChangeMemberRole).toHaveBeenCalledWith('mem-1', 'member')
+  })
+
+  it('keeps the dialog open and toasts on failure', async () => {
+    mockChangeMemberRole.mockRejectedValue(new Error('boom'))
+    const { user } = renderDialog('owner')
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'workspacePanel.changeRoleDialog.promoteConfirm'
+      })
+    )
+
+    await waitFor(() =>
+      expect(mockToastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: 'error' })
+      )
+    )
+    expect(mockCloseDialog).not.toHaveBeenCalled()
+  })
+
+  it('closes without changing the role on cancel', async () => {
+    const { user } = renderDialog('owner')
+
+    await user.click(screen.getByRole('button', { name: 'g.cancel' }))
+
+    expect(mockCloseDialog).toHaveBeenCalledWith({ key: 'change-member-role' })
+    expect(mockChangeMemberRole).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.vue
@@ -1,0 +1,115 @@
+<template>
+  <div
+    class="flex w-full max-w-90 flex-col rounded-2xl border border-border-default bg-base-background"
+  >
+    <!-- Header -->
+    <div
+      class="flex h-12 items-center justify-between border-b border-border-default px-4"
+    >
+      <h2 class="m-0 text-sm font-normal text-base-foreground">
+        {{
+          isPromotion
+            ? $t('workspacePanel.changeRoleDialog.promoteTitle', {
+                name: memberName
+              })
+            : $t('workspacePanel.changeRoleDialog.demoteTitle', {
+                name: memberName
+              })
+        }}
+      </h2>
+      <button
+        class="focus-visible:ring-secondary-foreground -m-1 cursor-pointer rounded-sm border-none bg-transparent p-1 text-muted-foreground transition-colors hover:text-base-foreground focus-visible:ring-1 focus-visible:outline-none"
+        :aria-label="$t('g.close')"
+        @click="onCancel"
+      >
+        <i class="pi pi-times size-4" />
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="p-4">
+      <template v-if="isPromotion">
+        <p class="m-0 text-sm text-muted-foreground">
+          {{ $t('workspacePanel.changeRoleDialog.promoteIntro') }}
+        </p>
+        <ul class="m-0 mt-1 list-disc ps-5 text-sm text-muted-foreground">
+          <li v-for="permission in promotePermissions" :key="permission">
+            {{ permission }}
+          </li>
+        </ul>
+      </template>
+      <p v-else class="m-0 text-sm text-muted-foreground">
+        {{ $t('workspacePanel.changeRoleDialog.demoteMessage') }}
+      </p>
+    </div>
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-4 p-4">
+      <Button variant="muted-textonly" @click="onCancel">
+        {{ $t('g.cancel') }}
+      </Button>
+      <Button variant="secondary" size="lg" :loading @click="onConfirm">
+        {{
+          isPromotion
+            ? $t('workspacePanel.changeRoleDialog.promoteConfirm')
+            : $t('workspacePanel.changeRoleDialog.demoteConfirm')
+        }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useToast } from 'primevue/usetoast'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import { useDialogStore } from '@/stores/dialogStore'
+
+const { memberId, targetRole } = defineProps<{
+  memberId: string
+  memberName: string
+  targetRole: WorkspaceRole
+}>()
+
+const dialogStore = useDialogStore()
+const workspaceStore = useTeamWorkspaceStore()
+const toast = useToast()
+const { t } = useI18n()
+const loading = ref(false)
+
+const isPromotion = computed(() => targetRole === 'owner')
+
+const promotePermissions = computed(() => [
+  t('workspacePanel.changeRoleDialog.promotePermissionCredits'),
+  t('workspacePanel.changeRoleDialog.promotePermissionManage'),
+  t('workspacePanel.changeRoleDialog.promotePermissionRoles')
+])
+
+function onCancel() {
+  dialogStore.closeDialog({ key: 'change-member-role' })
+}
+
+async function onConfirm() {
+  loading.value = true
+  try {
+    await workspaceStore.changeMemberRole(memberId, targetRole)
+    toast.add({
+      severity: 'success',
+      summary: t('workspacePanel.changeRoleDialog.success'),
+      life: 2000
+    })
+    dialogStore.closeDialog({ key: 'change-member-role' })
+  } catch {
+    toast.add({
+      severity: 'error',
+      summary: t('workspacePanel.changeRoleDialog.error')
+    })
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
+++ b/src/platform/workspace/components/dialogs/settings/MemberListItem.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    :data-testid="`member-row-${member.id}`"
     :class="
       cn(
         'grid w-full items-center rounded-lg p-2',
@@ -37,24 +38,32 @@
       }}
     </span>
     <div
-      v-if="canRemoveMembers && !isSingleSeatPlan"
+      v-if="canManageMembers && !isSingleSeatPlan"
       class="flex items-center justify-end"
     >
-      <Button
-        v-if="!isCurrentUser"
-        v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
-        variant="muted-textonly"
-        size="icon"
-        :aria-label="$t('g.moreOptions')"
-        @click="$emit('showMenu', $event)"
+      <DropdownMenu
+        v-if="!isCurrentUser && !isOriginalOwner"
+        :entries="menuItems"
       >
-        <i class="pi pi-ellipsis-h" />
-      </Button>
+        <template #button>
+          <Button
+            v-tooltip="{ value: $t('g.moreOptions'), showDelay: 300 }"
+            variant="muted-textonly"
+            size="icon"
+            :aria-label="$t('g.moreOptions')"
+          >
+            <i class="pi pi-ellipsis-h" />
+          </Button>
+        </template>
+      </DropdownMenu>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import type { MenuItem } from 'primevue/menuitem'
+
+import DropdownMenu from '@/components/common/DropdownMenu.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import Button from '@/components/ui/button/Button.vue'
 import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
@@ -62,21 +71,21 @@ import { cn } from '@comfyorg/tailwind-utils'
 
 const {
   showRoleColumn = false,
-  canRemoveMembers = false,
+  canManageMembers = false,
   isSingleSeatPlan = false,
-  striped = false
+  isOriginalOwner = false,
+  striped = false,
+  menuItems = []
 } = defineProps<{
   member: WorkspaceMember
   isCurrentUser: boolean
   photoUrl?: string
   gridCols: string
   showRoleColumn?: boolean
-  canRemoveMembers?: boolean
+  canManageMembers?: boolean
   isSingleSeatPlan?: boolean
+  isOriginalOwner?: boolean
   striped?: boolean
-}>()
-
-defineEmits<{
-  showMenu: [event: Event]
+  menuItems?: MenuItem[]
 }>()
 </script>

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue'
+import { render, screen, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Slots } from 'vue'
@@ -14,14 +14,15 @@ import type {
 
 const mockHandleResendInvite = vi.fn()
 const mockHandleRevokeInvite = vi.fn()
+const mockMemberMenuItems = vi.fn(() => [])
 const mockShowTeamPlans = vi.fn()
-const mockSelectMember = vi.fn()
 const mockToggleSort = vi.fn()
 const mockHandleInviteMember = vi.fn()
 
 const {
   mockMembers,
   mockPendingInvites,
+  mockOriginalOwnerId,
   mockFilteredMembers,
   mockFilteredPendingInvites,
   mockIsPersonalWorkspace,
@@ -42,6 +43,7 @@ const {
   return {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
+    mockOriginalOwnerId: ref<string | null>(null),
     mockHasMultipleMembers: ref(true),
     mockShowSearch: ref(true),
     mockShowViewTabs: ref(true),
@@ -58,7 +60,7 @@ const {
       canViewPendingInvites: true,
       canInviteMembers: true,
       canManageInvites: true,
-      canRemoveMembers: true,
+      canManageMembers: true,
       canLeaveWorkspace: true,
       canAccessWorkspaceMenu: true,
       canManageSubscription: true,
@@ -102,7 +104,13 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
     })),
     filteredMembers: mockFilteredMembers,
     filteredPendingInvites: mockFilteredPendingInvites,
-    memberMenuItems: computed(() => []),
+    memberMenuItems: mockMemberMenuItems,
+    memberMenus: computed(
+      () =>
+        new Map(
+          mockFilteredMembers.value.map((m) => [m.id, mockMemberMenuItems()])
+        )
+    ),
     isPersonalWorkspace: mockIsPersonalWorkspace,
     members: mockMembers,
     pendingInvites: mockPendingInvites,
@@ -111,12 +119,13 @@ vi.mock('@/platform/workspace/composables/useMembersPanel', () => ({
     userPhotoUrl: ref(null),
     isCurrentUser: (m: WorkspaceMember) =>
       m.email.toLowerCase() === 'owner@example.com',
-    selectMember: mockSelectMember,
+    isOriginalOwner: (m: WorkspaceMember) => m.id === mockOriginalOwnerId.value,
     toggleSort: mockToggleSort,
     showTeamPlans: mockShowTeamPlans,
     handleResendInvite: mockHandleResendInvite,
     handleRevokeInvite: mockHandleRevokeInvite,
-    handleRemoveMember: vi.fn()
+    handleRemoveMember: vi.fn(),
+    handleChangeRole: vi.fn()
   })
 }))
 
@@ -156,8 +165,7 @@ function renderComponent() {
         Button: ButtonStub,
         SearchInput: SearchInputStub,
         UserAvatar: true,
-        WorkspaceMenuButton: true,
-        Menu: { template: '<div />', props: ['model', 'popup'] }
+        WorkspaceMenuButton: true
       },
       directives: { tooltip: () => {} }
     }
@@ -191,8 +199,10 @@ function createInvite(overrides: Partial<PendingInvite> = {}): PendingInvite {
 describe('MembersPanelContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockMemberMenuItems.mockReturnValue([])
     mockMembers.value = []
     mockPendingInvites.value = []
+    mockOriginalOwnerId.value = null
     mockFilteredMembers.value = []
     mockFilteredPendingInvites.value = []
     mockIsPersonalWorkspace.value = false
@@ -209,7 +219,7 @@ describe('MembersPanelContent', () => {
       canViewPendingInvites: true,
       canInviteMembers: true,
       canManageInvites: true,
-      canRemoveMembers: true,
+      canManageMembers: true,
       canLeaveWorkspace: true,
       canAccessWorkspaceMenu: true,
       canManageSubscription: true,
@@ -312,6 +322,29 @@ describe('MembersPanelContent', () => {
         screen.queryAllByRole('button', { name: 'g.moreOptions' })
       ).toHaveLength(0)
     })
+
+    it('does not show more options on the original owner row', () => {
+      mockOriginalOwnerId.value = 'creator-1'
+      mockFilteredMembers.value = [
+        createMember({
+          id: 'creator-1',
+          name: 'Creator',
+          email: 'creator@test.com',
+          role: 'owner'
+        }),
+        createMember({ id: '2', name: 'Other', email: 'other@test.com' })
+      ]
+      renderComponent()
+
+      const creatorRow = screen.getByTestId('member-row-creator-1')
+      const otherRow = screen.getByTestId('member-row-2')
+      expect(
+        within(creatorRow).queryByRole('button', { name: 'g.moreOptions' })
+      ).toBeNull()
+      expect(
+        within(otherRow).getByRole('button', { name: 'g.moreOptions' })
+      ).toBeInTheDocument()
+    })
   })
 
   describe('pending invites tab', () => {
@@ -359,7 +392,7 @@ describe('MembersPanelContent', () => {
         canViewPendingInvites: false,
         canInviteMembers: false,
         canManageInvites: false,
-        canRemoveMembers: false,
+        canManageMembers: false,
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: false,
@@ -481,7 +514,7 @@ describe('MembersPanelContent', () => {
     it('invokes the invite flow from the header invite button', async () => {
       renderComponent()
       await userEvent.click(
-        screen.getByRole('button', { name: 'workspacePanel.invite' })
+        screen.getByRole('button', { name: 'workspacePanel.inviteMember' })
       )
       expect(mockHandleInviteMember).toHaveBeenCalled()
     })
@@ -490,7 +523,7 @@ describe('MembersPanelContent', () => {
       mockShowInviteButton.value = false
       renderComponent()
       expect(
-        screen.queryByRole('button', { name: 'workspacePanel.invite' })
+        screen.queryByRole('button', { name: 'workspacePanel.inviteMember' })
       ).toBeNull()
     })
 
@@ -498,7 +531,7 @@ describe('MembersPanelContent', () => {
       mockIsInviteDisabled.value = true
       renderComponent()
       const button = screen.getByRole('button', {
-        name: 'workspacePanel.invite'
+        name: 'workspacePanel.inviteMember'
       })
       expect((button as HTMLButtonElement).disabled).toBe(true)
     })

--- a/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
+++ b/src/platform/workspace/components/dialogs/settings/MembersPanelContent.vue
@@ -48,6 +48,7 @@
             variant="secondary"
             size="lg"
             :disabled="isInviteDisabled"
+            :aria-label="$t('workspacePanel.inviteMember')"
             @click="handleInviteMember"
           >
             {{ $t('workspacePanel.invite') }}
@@ -131,7 +132,7 @@
               <i class="icon-[lucide--chevrons-up-down] size-4" />
             </Button>
             <!-- Empty cell for action column header (OWNER only) -->
-            <div v-if="permissions.canRemoveMembers" />
+            <div v-if="permissions.canManageMembers" />
           </template>
         </div>
 
@@ -165,14 +166,12 @@
                 :show-role-column="
                   uiConfig.showRoleColumn && hasMultipleMembers
                 "
-                :can-remove-members="permissions.canRemoveMembers"
+                :can-manage-members="permissions.canManageMembers"
                 :is-single-seat-plan="!isOnTeamPlan"
+                :is-original-owner="isOriginalOwner(member)"
                 :striped="index % 2 === 1"
-                @show-menu="showMemberMenu($event, member)"
+                :menu-items="memberMenus.get(member.id)"
               />
-
-              <!-- Member actions menu (shared for all members) -->
-              <Menu ref="memberMenu" :model="memberMenuItems" :popup="true" />
             </template>
           </template>
 
@@ -214,9 +213,6 @@
 </template>
 
 <script setup lang="ts">
-import Menu from 'primevue/menu'
-import { ref } from 'vue'
-
 import SearchInput from '@/components/ui/search-input/SearchInput.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -225,7 +221,6 @@ import MemberUpsellBanner from '@/platform/workspace/components/dialogs/settings
 import PendingInvitesList from '@/platform/workspace/components/dialogs/settings/PendingInvitesList.vue'
 import WorkspaceMenuButton from '@/platform/workspace/components/dialogs/settings/WorkspaceMenuButton.vue'
 import { useMembersPanel } from '@/platform/workspace/composables/useMembersPanel'
-import type { WorkspaceMember } from '@/platform/workspace/stores/teamWorkspaceStore'
 import { cn } from '@comfyorg/tailwind-utils'
 
 const {
@@ -244,7 +239,7 @@ const {
   personalWorkspaceMember,
   filteredMembers,
   filteredPendingInvites,
-  memberMenuItems,
+  memberMenus,
   isPersonalWorkspace,
   members,
   pendingInvites,
@@ -252,7 +247,7 @@ const {
   uiConfig,
   userPhotoUrl,
   isCurrentUser,
-  selectMember,
+  isOriginalOwner,
   toggleSort,
   showTeamPlans,
   handleResendInvite,
@@ -260,13 +255,6 @@ const {
 } = useMembersPanel()
 
 const { staticUrls } = useExternalLink()
-
-const memberMenu = ref<InstanceType<typeof Menu> | null>(null)
-
-function showMemberMenu(event: Event, member: WorkspaceMember) {
-  selectMember(member)
-  memberMenu.value?.toggle(event)
-}
 
 function handleContactUs() {
   window.open(staticUrls.discord, '_blank', 'noopener,noreferrer')

--- a/src/platform/workspace/composables/useMembersPanel.test.ts
+++ b/src/platform/workspace/composables/useMembersPanel.test.ts
@@ -114,6 +114,43 @@ describe('sortMembers', () => {
     sortMembers(members, null, 'desc')
     expect(members).toEqual(original)
   })
+
+  it('pins the original owner first regardless of sort direction', () => {
+    const creator = createMember({
+      id: 'creator',
+      role: 'owner',
+      email: 'creator@test.com',
+      joinDate: new Date('2025-01-01')
+    })
+    const promoted = createMember({
+      id: 'promoted',
+      role: 'owner',
+      email: 'me@test.com',
+      joinDate: new Date('2025-02-01')
+    })
+    const member = createMember({
+      id: 'm',
+      role: 'member',
+      email: 'other@test.com',
+      joinDate: new Date('2025-03-01')
+    })
+
+    const desc = sortMembers(
+      [member, promoted, creator],
+      'me@test.com',
+      'desc',
+      'creator'
+    )
+    expect(desc.map((m) => m.id)).toEqual(['creator', 'promoted', 'm'])
+
+    const asc = sortMembers(
+      [member, promoted, creator],
+      'me@test.com',
+      'asc',
+      'creator'
+    )
+    expect(asc[0].id).toBe('creator')
+  })
 })
 
 describe('filterBySearch', () => {
@@ -213,6 +250,7 @@ const mockToastAdd = vi.fn()
 const mockResendInvite = vi.fn()
 const mockShowRemoveMemberDialog = vi.fn()
 const mockShowRevokeInviteDialog = vi.fn()
+const mockShowChangeMemberRoleDialog = vi.fn()
 const mockShowSubscriptionDialog = vi.fn()
 const mockShowInviteMemberDialog = vi.fn()
 const mockShowInviteMemberUpsellDialog = vi.fn()
@@ -220,6 +258,7 @@ const mockShowInviteMemberUpsellDialog = vi.fn()
 const {
   mockMembers,
   mockPendingInvites,
+  mockOriginalOwnerId,
   mockIsInPersonalWorkspace,
   mockIsWorkspaceSubscribed,
   mockTotalMemberSlots,
@@ -235,6 +274,7 @@ const {
   return {
     mockMembers: ref<WorkspaceMember[]>([]),
     mockPendingInvites: ref<PendingInvite[]>([]),
+    mockOriginalOwnerId: ref<string | null>(null),
     mockIsInPersonalWorkspace: ref(false),
     mockIsWorkspaceSubscribed: ref(true),
     mockTotalMemberSlots: ref(0),
@@ -244,7 +284,7 @@ const {
       canViewPendingInvites: true,
       canInviteMembers: true,
       canManageInvites: true,
-      canRemoveMembers: true,
+      canManageMembers: true,
       canLeaveWorkspace: true,
       canAccessWorkspaceMenu: true,
       canManageSubscription: true,
@@ -291,6 +331,7 @@ vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
   useTeamWorkspaceStore: () => ({
     members: mockMembers,
     pendingInvites: mockPendingInvites,
+    originalOwnerId: mockOriginalOwnerId,
     totalMemberSlots: mockTotalMemberSlots,
     isInviteLimitReached: mockIsInviteLimitReached,
     isInPersonalWorkspace: mockIsInPersonalWorkspace,
@@ -342,6 +383,7 @@ vi.mock('@/services/dialogService', () => ({
   useDialogService: () => ({
     showRemoveMemberDialog: mockShowRemoveMemberDialog,
     showRevokeInviteDialog: mockShowRevokeInviteDialog,
+    showChangeMemberRoleDialog: mockShowChangeMemberRoleDialog,
     showInviteMemberDialog: mockShowInviteMemberDialog,
     showInviteMemberUpsellDialog: mockShowInviteMemberUpsellDialog
   })
@@ -352,6 +394,7 @@ describe('useMembersPanel', () => {
     vi.clearAllMocks()
     mockMembers.value = []
     mockPendingInvites.value = []
+    mockOriginalOwnerId.value = null
     mockIsInPersonalWorkspace.value = false
     mockIsWorkspaceSubscribed.value = true
     mockTotalMemberSlots.value = 0
@@ -495,6 +538,105 @@ describe('useMembersPanel', () => {
       const panel = await setup()
       panel.handleRemoveMember(createMember({ id: 'mem-7' }))
       expect(mockShowRemoveMemberDialog).toHaveBeenCalledWith('mem-7')
+    })
+  })
+
+  describe('handleChangeRole', () => {
+    it('opens the change-role dialog when promoting a member', async () => {
+      const panel = await setup()
+      panel.handleChangeRole(
+        createMember({ id: 'mem-7', name: 'Jane', role: 'member' }),
+        'owner'
+      )
+      expect(mockShowChangeMemberRoleDialog).toHaveBeenCalledWith({
+        memberId: 'mem-7',
+        memberName: 'Jane',
+        targetRole: 'owner'
+      })
+    })
+
+    it('opens the change-role dialog when demoting an owner', async () => {
+      const panel = await setup()
+      panel.handleChangeRole(
+        createMember({ id: 'own-2', name: 'Jane', role: 'owner' }),
+        'member'
+      )
+      expect(mockShowChangeMemberRoleDialog).toHaveBeenCalledWith({
+        memberId: 'own-2',
+        memberName: 'Jane',
+        targetRole: 'member'
+      })
+    })
+
+    it('is a no-op when the member already has the target role', async () => {
+      const panel = await setup()
+      panel.handleChangeRole(createMember({ role: 'member' }), 'member')
+      expect(mockShowChangeMemberRoleDialog).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('memberMenuItems', () => {
+    it('builds a Change role submenu with the current role checked', async () => {
+      const panel = await setup()
+      const items = panel.memberMenuItems(createMember({ role: 'member' }))
+
+      expect(items.map((i) => i.label)).toEqual([
+        'workspacePanel.members.actions.changeRole',
+        'workspacePanel.members.actions.removeMember'
+      ])
+
+      const roleItems = items[0].items ?? []
+      expect(roleItems.map((i) => i.label)).toEqual([
+        'workspaceSwitcher.roleOwner',
+        'workspaceSwitcher.roleMember'
+      ])
+      expect(roleItems.map((i) => i.checked)).toEqual([false, true])
+    })
+
+    it('checks Owner for owner rows', async () => {
+      const panel = await setup()
+      const items = panel.memberMenuItems(createMember({ role: 'owner' }))
+      const roleItems = items[0].items ?? []
+      expect(roleItems.map((i) => i.checked)).toEqual([true, false])
+    })
+
+    it('routes submenu selection to the change-role dialog', async () => {
+      const panel = await setup()
+      const member = createMember({ id: 'mem-9', role: 'member' })
+      const ownerItem = (panel.memberMenuItems(member)[0].items ?? [])[0]
+
+      ownerItem.command?.({
+        originalEvent: new Event('click'),
+        item: ownerItem
+      })
+
+      expect(mockShowChangeMemberRoleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ memberId: 'mem-9', targetRole: 'owner' })
+      )
+    })
+
+    it('routes Remove member to the remove dialog', async () => {
+      const panel = await setup()
+      const member = createMember({ id: 'mem-9' })
+      const removeItem = panel.memberMenuItems(member)[1]
+
+      removeItem.command?.({
+        originalEvent: new Event('click'),
+        item: removeItem
+      })
+
+      expect(mockShowRemoveMemberDialog).toHaveBeenCalledWith('mem-9')
+    })
+  })
+
+  describe('isOriginalOwner', () => {
+    it('matches against the store originalOwnerId', async () => {
+      mockOriginalOwnerId.value = 'creator-1'
+      const panel = await setup()
+      expect(panel.isOriginalOwner(createMember({ id: 'creator-1' }))).toBe(
+        true
+      )
+      expect(panel.isOriginalOwner(createMember({ id: 'other' }))).toBe(false)
     })
   })
 

--- a/src/platform/workspace/composables/useMembersPanel.ts
+++ b/src/platform/workspace/composables/useMembersPanel.ts
@@ -1,3 +1,4 @@
+import type { MenuItem } from 'primevue/menuitem'
 import { storeToRefs } from 'pinia'
 import { useToast } from 'primevue/usetoast'
 import { computed, ref } from 'vue'
@@ -5,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 
 import { useCurrentUser } from '@/composables/auth/useCurrentUser'
 import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
 import { useTeamPlan } from '@/platform/workspace/composables/useTeamPlan'
 import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import type {
@@ -24,9 +26,15 @@ type SortDirection = 'asc' | 'desc'
 export function sortMembers(
   members: WorkspaceMember[],
   currentUserEmail: string | null,
-  sortDirection: SortDirection
+  sortDirection: SortDirection,
+  originalOwnerId: string | null = null
 ): WorkspaceMember[] {
   return [...members].sort((a, b) => {
+    const aIsOriginalOwner = a.id === originalOwnerId
+    const bIsOriginalOwner = b.id === originalOwnerId
+    if (aIsOriginalOwner && !bIsOriginalOwner) return -1
+    if (!aIsOriginalOwner && bIsOriginalOwner) return 1
+
     if (a.role !== b.role) {
       const ownerFirst = a.role === 'owner' ? -1 : 1
       return sortDirection === 'desc' ? ownerFirst : -ownerFirst
@@ -87,6 +95,7 @@ export function useMembersPanel() {
   const {
     showRemoveMemberDialog,
     showRevokeInviteDialog,
+    showChangeMemberRoleDialog,
     showInviteMemberDialog,
     showInviteMemberUpsellDialog
   } = useDialogService()
@@ -94,6 +103,7 @@ export function useMembersPanel() {
   const {
     members,
     pendingInvites,
+    originalOwnerId,
     totalMemberSlots,
     isInviteLimitReached,
     isInPersonalWorkspace: isPersonalWorkspace
@@ -163,32 +173,58 @@ export function useMembersPanel() {
   const sortField = ref<SortField>('inviteDate')
   const sortDirection = ref<SortDirection>('desc')
 
-  const selectedMember = ref<WorkspaceMember | null>(null)
-
-  const memberMenuItems = computed(() => [
-    {
-      label: t('workspacePanel.members.actions.removeMember'),
-      icon: 'pi pi-user-minus',
-      command: () => {
-        if (selectedMember.value) {
-          handleRemoveMember(selectedMember.value)
-        }
-      }
+  function roleMenuItem(
+    member: WorkspaceMember,
+    role: WorkspaceRole,
+    label: string
+  ): MenuItem {
+    return {
+      label,
+      checked: member.role === role,
+      command: () => handleChangeRole(member, role)
     }
-  ])
+  }
 
-  function selectMember(member: WorkspaceMember) {
-    selectedMember.value = member
+  function memberMenuItems(member: WorkspaceMember): MenuItem[] {
+    return [
+      {
+        label: t('workspacePanel.members.actions.changeRole'),
+        items: [
+          roleMenuItem(member, 'owner', t('workspaceSwitcher.roleOwner')),
+          roleMenuItem(member, 'member', t('workspaceSwitcher.roleMember'))
+        ]
+      },
+      {
+        label: t('workspacePanel.members.actions.removeMember'),
+        command: () => handleRemoveMember(member)
+      }
+    ]
   }
 
   function isCurrentUser(member: WorkspaceMember): boolean {
     return member.email.toLowerCase() === userEmail.value?.toLowerCase()
   }
 
+  function isOriginalOwner(member: WorkspaceMember): boolean {
+    return member.id === originalOwnerId.value
+  }
+
   const filteredMembers = computed(() => {
     const searched = filterBySearch(members.value, searchQuery.value)
-    return sortMembers(searched, userEmail.value ?? null, sortDirection.value)
+    return sortMembers(
+      searched,
+      userEmail.value ?? null,
+      sortDirection.value,
+      originalOwnerId.value
+    )
   })
+
+  // Built once per member list rather than per row on every render, so an
+  // unrelated re-render (e.g. typing in the search box) doesn't rebuild every
+  // row's menu and churn MemberListItem's props.
+  const memberMenus = computed(
+    () => new Map(filteredMembers.value.map((m) => [m.id, memberMenuItems(m)]))
+  )
 
   const filteredPendingInvites = computed(() => {
     const searched = filterBySearch(pendingInvites.value, searchQuery.value)
@@ -228,6 +264,18 @@ export function useMembersPanel() {
     void showRemoveMemberDialog(member.id)
   }
 
+  function handleChangeRole(
+    member: WorkspaceMember,
+    targetRole: WorkspaceRole
+  ) {
+    if (member.role === targetRole) return
+    void showChangeMemberRoleDialog({
+      memberId: member.id,
+      memberName: member.name,
+      targetRole
+    })
+  }
+
   function showTeamPlans() {
     subscriptionDialog.show({ planMode: 'team' })
   }
@@ -237,7 +285,6 @@ export function useMembersPanel() {
     activeView,
     sortField,
     sortDirection,
-    selectedMember,
     maxSeats,
     isOnTeamPlan,
     hasLapsedTeamPlan,
@@ -252,6 +299,7 @@ export function useMembersPanel() {
     filteredMembers,
     filteredPendingInvites,
     memberMenuItems,
+    memberMenus,
     isPersonalWorkspace,
     members,
     pendingInvites,
@@ -259,11 +307,12 @@ export function useMembersPanel() {
     uiConfig,
     userPhotoUrl,
     isCurrentUser,
-    selectMember,
+    isOriginalOwner,
     toggleSort,
     showTeamPlans,
     handleResendInvite,
     handleRevokeInvite,
-    handleRemoveMember
+    handleRemoveMember,
+    handleChangeRole
   }
 }

--- a/src/platform/workspace/composables/useWorkspaceUI.test.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.test.ts
@@ -127,7 +127,7 @@ describe('useWorkspaceUI', () => {
         canViewPendingInvites: false,
         canInviteMembers: false,
         canManageInvites: false,
-        canRemoveMembers: false,
+        canManageMembers: false,
         canLeaveWorkspace: false,
         canAccessWorkspaceMenu: false
       })
@@ -173,7 +173,7 @@ describe('useWorkspaceUI', () => {
         canViewPendingInvites: true,
         canInviteMembers: true,
         canManageInvites: true,
-        canRemoveMembers: true,
+        canManageMembers: true,
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: true,
@@ -212,7 +212,7 @@ describe('useWorkspaceUI', () => {
         canViewPendingInvites: false,
         canInviteMembers: false,
         canManageInvites: false,
-        canRemoveMembers: false,
+        canManageMembers: false,
         canLeaveWorkspace: true,
         canAccessWorkspaceMenu: true,
         canManageSubscription: false,

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -14,7 +14,7 @@ interface WorkspacePermissions {
   canViewPendingInvites: boolean
   canInviteMembers: boolean
   canManageInvites: boolean
-  canRemoveMembers: boolean
+  canManageMembers: boolean
   canLeaveWorkspace: boolean
   canAccessWorkspaceMenu: boolean
   canManageSubscription: boolean
@@ -50,7 +50,7 @@ function getPermissions(
       canViewPendingInvites: false,
       canInviteMembers: false,
       canManageInvites: false,
-      canRemoveMembers: false,
+      canManageMembers: false,
       canLeaveWorkspace: false,
       canAccessWorkspaceMenu: false,
       canManageSubscription: true,
@@ -66,7 +66,7 @@ function getPermissions(
       canViewPendingInvites: true,
       canInviteMembers: true,
       canManageInvites: true,
-      canRemoveMembers: true,
+      canManageMembers: true,
       canLeaveWorkspace: true,
       canAccessWorkspaceMenu: true,
       canManageSubscription: true,
@@ -81,7 +81,7 @@ function getPermissions(
     canViewPendingInvites: false,
     canInviteMembers: false,
     canManageInvites: false,
-    canRemoveMembers: false,
+    canManageMembers: false,
     canLeaveWorkspace: true,
     canAccessWorkspaceMenu: true,
     canManageSubscription: false,

--- a/src/platform/workspace/stores/teamWorkspaceStore.test.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.test.ts
@@ -47,6 +47,7 @@ const mockWorkspaceApi = vi.hoisted(() => ({
   leave: vi.fn(),
   listMembers: vi.fn(),
   removeMember: vi.fn(),
+  updateMemberRole: vi.fn(),
   listInvites: vi.fn(),
   createInvite: vi.fn(),
   revokeInvite: vi.fn(),
@@ -688,6 +689,235 @@ describe('useTeamWorkspaceStore', () => {
       expect(store.members).toHaveLength(1)
       expect(store.members[0].id).toBe('user-2')
     })
+
+    it('changeMemberRole flips the role locally without trusting the response body', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'user-1',
+            name: 'User One',
+            email: 'one@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'owner',
+            is_original_owner: true
+          },
+          {
+            id: 'user-2',
+            name: 'User Two',
+            email: 'two@test.com',
+            joined_at: '2024-01-02T00:00:00Z',
+            role: 'member',
+            is_original_owner: false
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      // A divergent body (renamed, re-flagged) the store must NOT apply: only
+      // the role is merged onto the existing row.
+      mockWorkspaceApi.updateMemberRole.mockResolvedValue({
+        id: 'user-2',
+        name: 'Renamed By Server',
+        email: 'two@test.com',
+        joined_at: '2099-01-02T00:00:00Z',
+        role: 'owner',
+        is_original_owner: true
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      await store.changeMemberRole('user-2', 'owner')
+
+      expect(mockWorkspaceApi.updateMemberRole).toHaveBeenCalledWith(
+        'user-2',
+        'owner'
+      )
+      const updated = store.members.find((m) => m.id === 'user-2')
+      expect(updated?.role).toBe('owner')
+      expect(updated?.name).toBe('User Two')
+      expect(updated?.isOriginalOwner).toBe(false)
+    })
+
+    it('changeMemberRole leaves the list untouched when the API rejects', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'user-2',
+            name: 'User Two',
+            email: 'two@test.com',
+            joined_at: '2024-01-02T00:00:00Z',
+            role: 'member',
+            is_original_owner: false
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 1 }
+      })
+      mockWorkspaceApi.updateMemberRole.mockRejectedValue(new Error('boom'))
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      await expect(store.changeMemberRole('user-2', 'owner')).rejects.toThrow()
+      expect(store.members[0].role).toBe('member')
+    })
+
+    it('changeMemberRole refuses to change the flagged creator and never calls the API', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'user-2',
+            name: 'User Two',
+            email: 'two@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'member',
+            is_original_owner: false
+          },
+          {
+            id: 'creator',
+            name: 'Creator',
+            email: 'creator@test.com',
+            joined_at: '2024-01-02T00:00:00Z',
+            role: 'owner',
+            is_original_owner: true
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      await expect(store.changeMemberRole('creator', 'member')).rejects.toThrow(
+        "Cannot change the workspace creator's role"
+      )
+      expect(mockWorkspaceApi.updateMemberRole).not.toHaveBeenCalled()
+      expect(store.members.find((m) => m.id === 'creator')?.role).toBe('owner')
+    })
+
+    it('originalOwnerId is the member flagged is_original_owner, even when not earliest-joined', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'early-joiner',
+            name: 'Early Joiner',
+            email: 'early@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'owner',
+            is_original_owner: false
+          },
+          {
+            id: 'creator',
+            name: 'Creator',
+            email: 'creator@test.com',
+            joined_at: '2024-02-01T00:00:00Z',
+            role: 'owner',
+            is_original_owner: true
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+
+      expect(store.originalOwnerId).toBeNull()
+
+      await store.fetchMembers()
+
+      expect(store.originalOwnerId).toBe('creator')
+    })
+
+    it('originalOwnerId falls back to the earliest-joined member when no flag is present', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'later-joiner',
+            name: 'Later Joiner',
+            email: 'later@test.com',
+            joined_at: '2024-03-01T00:00:00Z',
+            role: 'owner'
+          },
+          {
+            id: 'founder',
+            name: 'Founder',
+            email: 'founder@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'owner'
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      expect(store.originalOwnerId).toBe('founder')
+
+      await expect(store.changeMemberRole('founder', 'member')).rejects.toThrow(
+        "Cannot change the workspace creator's role"
+      )
+      expect(mockWorkspaceApi.updateMemberRole).not.toHaveBeenCalled()
+    })
+
+    it('originalOwnerId fallback skips a non-owner earliest joiner, keeping them changeable', async () => {
+      mockWorkspaceApi.listMembers.mockResolvedValue({
+        members: [
+          {
+            id: 'early-member',
+            name: 'Early Member',
+            email: 'early@test.com',
+            joined_at: '2024-01-01T00:00:00Z',
+            role: 'member'
+          },
+          {
+            id: 'late-owner',
+            name: 'Late Owner',
+            email: 'late@test.com',
+            joined_at: '2024-02-01T00:00:00Z',
+            role: 'owner'
+          }
+        ],
+        pagination: { offset: 0, limit: 50, total: 2 }
+      })
+      mockWorkspaceApi.updateMemberRole.mockResolvedValue({
+        id: 'early-member',
+        name: 'Early Member',
+        email: 'early@test.com',
+        joined_at: '2024-01-01T00:00:00Z',
+        role: 'owner',
+        is_original_owner: false
+      })
+      mockWorkspaceAuthStore.initializeFromSession.mockReturnValue(true)
+      mockWorkspaceAuthStore.currentWorkspace = mockTeamWorkspace
+
+      const store = useTeamWorkspaceStore()
+      await store.initialize()
+      await store.fetchMembers()
+
+      // The earliest joiner is a plain member, so the creator falls back to the
+      // earliest owner instead of mis-pinning the member.
+      expect(store.originalOwnerId).toBe('late-owner')
+
+      await store.changeMemberRole('early-member', 'owner')
+      expect(mockWorkspaceApi.updateMemberRole).toHaveBeenCalledWith(
+        'early-member',
+        'owner'
+      )
+    })
   })
 
   describe('ensureMembersLoaded', () => {
@@ -823,14 +1053,35 @@ describe('useTeamWorkspaceStore', () => {
 
     it('is false when the self-row is a promoted (non-creator) owner', async () => {
       mockCurrentUser.userEmail.value = 'owner@test.com'
-      const store = await loadTeamWithMembers([promotedSelf])
+      const creator = {
+        id: 'creator',
+        name: 'Creator',
+        email: 'creator@test.com',
+        joined_at: '2023-01-01T00:00:00Z',
+        role: 'owner' as const,
+        is_original_owner: true
+      }
+      const store = await loadTeamWithMembers([creator, promotedSelf])
       expect(store.isCurrentUserOriginalOwner).toBe(false)
     })
 
-    it('fails closed when the self-row omits is_original_owner', async () => {
+    it('infers the earliest owner as the original owner when no member is flagged', async () => {
       mockCurrentUser.userEmail.value = 'owner@test.com'
-      const { is_original_owner: _omitted, ...selfWithoutFlag } = ownerSelf
-      const store = await loadTeamWithMembers([selfWithoutFlag])
+      const { is_original_owner: _omitted, ...ownerWithoutFlag } = ownerSelf
+      const store = await loadTeamWithMembers([ownerWithoutFlag])
+      expect(store.isCurrentUserOriginalOwner).toBe(true)
+    })
+
+    it('is false when the self-row is a plain member', async () => {
+      mockCurrentUser.userEmail.value = 'member@test.com'
+      const plainMember = {
+        id: 'plain-member',
+        name: 'Plain Member',
+        email: 'member@test.com',
+        joined_at: '2023-01-01T00:00:00Z',
+        role: 'member' as const
+      }
+      const store = await loadTeamWithMembers([ownerSelf, plainMember])
       expect(store.isCurrentUserOriginalOwner).toBe(false)
     })
 

--- a/src/platform/workspace/stores/teamWorkspaceStore.ts
+++ b/src/platform/workspace/stores/teamWorkspaceStore.ts
@@ -147,16 +147,28 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     () => activeWorkspace.value?.members ?? []
   )
 
-  // True when the current user is the active workspace's original owner,
-  // resolved from the self-row of the loaded members list. Matches by email
-  // (the stable current-user join key; member.id is a cloud user id, not the
-  // Firebase uid). Fails closed when members are not loaded or no self-row
-  // matches, so lifecycle gating stays hidden until the real signal arrives.
+  // The active workspace's original owner (creator). Prefers the
+  // `is_original_owner` flag; without it, falls back to the earliest-joined
+  // owner — never a plain member, who must stay role-changeable.
+  const originalOwnerId = computed<string | null>(() => {
+    const flagged = members.value.find((m) => m.isOriginalOwner)
+    if (flagged) return flagged.id
+    const owners = members.value.filter((m) => m.role === 'owner')
+    if (owners.length === 0) return null
+    return owners.reduce((earliest, m) =>
+      m.joinDate < earliest.joinDate ? m : earliest
+    ).id
+  })
+
+  // True when the current user is that original owner. Single-sourced from
+  // `originalOwnerId` so the two creator signals can never disagree. Matches the
+  // self-row by email (the stable current-user join key; member.id is a cloud
+  // user id, not the Firebase uid) and fails closed until members load.
   const isCurrentUserOriginalOwner = computed(() => {
     const email = useCurrentUser().userEmail.value?.toLowerCase()
     if (!email) return false
     const selfRow = members.value.find((m) => m.email.toLowerCase() === email)
-    return selfRow?.isOriginalOwner ?? false
+    return !!selfRow && selfRow.id === originalOwnerId.value
   })
 
   const pendingInvites = computed<PendingInvite[]>(
@@ -564,6 +576,30 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
   }
 
   /**
+   * Change a member's role in the current workspace.
+   */
+  async function changeMemberRole(
+    userId: string,
+    role: WorkspaceMember['role']
+  ): Promise<void> {
+    if (userId === originalOwnerId.value) {
+      throw new Error("Cannot change the workspace creator's role")
+    }
+    // Only the role changes; merge it onto the existing row rather than trusting
+    // the PATCH response to echo a full Member (a 204/partial body would
+    // otherwise drop joined_at / is_original_owner).
+    await workspaceApi.updateMemberRole(userId, role)
+    const current = activeWorkspace.value
+    if (current) {
+      updateActiveWorkspace({
+        members: current.members.map((m) =>
+          m.id === userId ? { ...m, role } : m
+        )
+      })
+    }
+  }
+
+  /**
    * Fetch pending invites for the current workspace.
    */
   async function fetchPendingInvites(): Promise<PendingInvite[]> {
@@ -693,6 +729,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     members,
     isCurrentUserOriginalOwner,
     pendingInvites,
+    originalOwnerId,
     totalMemberSlots,
     isInviteLimitReached,
     workspaceId,
@@ -717,6 +754,7 @@ export const useTeamWorkspaceStore = defineStore('teamWorkspace', () => {
     fetchMembers,
     ensureMembersLoaded,
     removeMember,
+    changeMemberRole,
 
     // Invite Actions
     fetchPendingInvites,

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -18,6 +18,7 @@ import type {
 
 import type { ComponentAttrs } from 'vue-component-type-helpers'
 import type { SubscriptionDialogReason } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import type { WorkspaceRole } from '@/platform/workspace/api/workspaceApi'
 
 // Lazy loaders for dialogs - components are loaded on first use
 const lazyApiNodesSignInContent = () =>
@@ -536,6 +537,21 @@ export const useDialogService = () => {
     })
   }
 
+  async function showChangeMemberRoleDialog(props: {
+    memberId: string
+    memberName: string
+    targetRole: WorkspaceRole
+  }) {
+    const { default: component } =
+      await import('@/platform/workspace/components/dialogs/ChangeMemberRoleDialogContent.vue')
+    return dialogStore.showDialog({
+      key: 'change-member-role',
+      component,
+      props,
+      dialogComponentProps: workspaceDialogPt
+    })
+  }
+
   async function showInviteMemberDialog() {
     const { default: component } =
       await import('@/platform/workspace/components/dialogs/InviteMemberDialogContent.vue')
@@ -659,6 +675,7 @@ export const useDialogService = () => {
     showLeaveWorkspaceDialog,
     showEditWorkspaceDialog,
     showRemoveMemberDialog,
+    showChangeMemberRoleDialog,
     showRevokeInviteDialog,
     showInviteMemberDialog,
     showInviteMemberUpsellDialog,


### PR DESCRIPTION
Backport of #12782 to `cloud/1.45`.

Part of an ordered, **stacked** backport series for cloud/1.45, merged **bottom-up**.

**Stacked on:** #13190 (backport of #12761). Base branch = `backport-12761-to-cloud-1.45`.

Cherry-picked squash commit `67009dcda244515d97170447bcd3357a7e5d3393` (clean textual merge). One semantic fixup: the new `showChangeMemberRoleDialog` referenced `workspaceDialogProps`, a main-only const not present on cloud/1.45 (where the equivalent is `workspaceDialogPt`, used by all sibling member dialogs). Repointed the new dialog to `workspaceDialogPt` to match local convention. Original authorship preserved.

Note: backport PR #13156 (of #12789) is stacked on top of this branch.