### PR TITLE
[backport cloud/1.45] feat(workspace): switcher popover left of profile menu + DES-246 copy (FE-769) (#12763)

### DIFF
--- a/browser_tests/tests/workspaceSwitcher.spec.ts
+++ b/browser_tests/tests/workspaceSwitcher.spec.ts
@@ -98,4 +98,43 @@ test.describe('Workspace switcher', { tag: '@cloud' }, () => {
     expect(box).not.toBeNull()
     expect(box!.height).toBeLessThan(SINGLE_LINE_MAX_HEIGHT_PX)
   })
+
+  test('opens the switcher to the left of the profile menu without overlap', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+
+    await comfyPage.toast.closeToasts()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+
+    const panel = page.getByTestId('workspace-switcher-panel')
+    await expect(panel).toBeVisible()
+
+    const profileMenu = page.locator('.current-user-popover')
+    const panelBox = await panel.boundingBox()
+    const profileBox = await profileMenu.boundingBox()
+    expect(panelBox).not.toBeNull()
+    expect(profileBox).not.toBeNull()
+    expect(panelBox!.x + panelBox!.width).toBeLessThanOrEqual(profileBox!.x)
+  })
+
+  test('opens the create-workspace dialog with DES-246 copy', async ({
+    comfyPage
+  }) => {
+    const page = comfyPage.page
+
+    await comfyPage.toast.closeToasts()
+    await page.getByRole('button', { name: 'Current user' }).click()
+    await page.getByTestId('workspace-switcher-trigger').click()
+
+    await page.getByText('Create a workspace').click()
+
+    await expect(
+      page.getByText(
+        'Workspaces keep your projects and files organized. Subscribe to a Team plan to invite members.'
+      )
+    ).toBeVisible()
+    await expect(page.getByPlaceholder('Ex: Comfy Org')).toBeVisible()
+  })
 })

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2684,9 +2684,9 @@
     },
     "createWorkspaceDialog": {
       "title": "Create a new workspace",
-      "message": "Workspaces create a new credit pool that can be shared among members. You'll become the owner after creating this.",
-      "nameLabel": "Workspace name*",
-      "namePlaceholder": "Enter workspace name",
+      "message": "Workspaces keep your projects and files organized. Subscribe to a Team plan to invite members.",
+      "nameLabel": "Workspace name",
+      "namePlaceholder": "Ex: Comfy Org",
       "create": "Create"
     },
     "toast": {
@@ -2732,7 +2732,7 @@
     "personal": "Personal",
     "roleOwner": "Owner",
     "roleMember": "Member",
-    "createWorkspace": "Create new workspace",
+    "createWorkspace": "Create a workspace",
     "maxWorkspacesReached": "You can only own 10 workspaces. Delete one to create a new one.",
     "failedToSwitch": "Failed to switch workspace"
   },

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.test.ts
@@ -1,0 +1,161 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { computed, defineComponent, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMessages from '@/locales/en/main.json'
+
+import CurrentUserPopoverWorkspace from './CurrentUserPopoverWorkspace.vue'
+
+const showCreateWorkspaceDialog = vi.fn()
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    userDisplayName: ref('Liz'),
+    userEmail: ref('liz@example.com'),
+    userPhotoUrl: ref(null),
+    handleSignOut: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: ref(true),
+    isFreeTier: ref(false),
+    subscription: ref(null),
+    balance: ref(null),
+    isLoading: ref(false),
+    fetchBalance: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: computed(() => ({
+      canTopUp: false,
+      canManageSubscription: false
+    }))
+  })
+}))
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({ showPricingTable: vi.fn() })
+  })
+)
+
+vi.mock('@/platform/settings/composables/useSettingsDialog', () => ({
+  useSettingsDialog: () => ({ show: vi.fn() })
+}))
+
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({
+    showCreateWorkspaceDialog,
+    showTopUpCreditsDialog: vi.fn()
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => undefined
+}))
+
+vi.mock('@/composables/useExternalLink', () => ({
+  useExternalLink: () => ({
+    buildDocsUrl: vi.fn(() => 'https://docs.comfy.org'),
+    docsPaths: { partnerNodesPricing: 'partner-nodes' }
+  })
+}))
+
+const WorkspaceSwitcherPopoverStub = defineComponent({
+  emits: ['select', 'create'],
+  template: `
+    <div>
+      <button data-testid="stub-select-workspace" @click="$emit('select')" />
+      <button data-testid="stub-create-workspace" @click="$emit('create')" />
+    </div>
+  `
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: enMessages }
+})
+
+function renderComponent() {
+  return render(CurrentUserPopoverWorkspace, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            teamWorkspace: {
+              initState: 'ready',
+              activeWorkspaceId: 'ws-personal'
+            }
+          }
+        }),
+        i18n
+      ],
+      directives: {
+        tooltip: {}
+      },
+      stubs: {
+        WorkspaceSwitcherPopover: WorkspaceSwitcherPopoverStub,
+        SubscribeButton: true,
+        UserAvatar: true,
+        WorkspaceProfilePic: true,
+        Skeleton: true,
+        Divider: true
+      }
+    }
+  })
+}
+
+describe('CurrentUserPopoverWorkspace', () => {
+  it('toggles the workspace switcher panel from the selector row', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    expect(
+      screen.queryByTestId('workspace-switcher-panel')
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('workspace-switcher-trigger'))
+    expect(screen.getByTestId('workspace-switcher-panel')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('workspace-switcher-trigger'))
+    expect(
+      screen.queryByTestId('workspace-switcher-panel')
+    ).not.toBeInTheDocument()
+  })
+
+  it('closes the switcher panel after selecting a workspace', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByTestId('workspace-switcher-trigger'))
+    await user.click(screen.getByTestId('stub-select-workspace'))
+
+    expect(
+      screen.queryByTestId('workspace-switcher-panel')
+    ).not.toBeInTheDocument()
+  })
+
+  it('opens the create-workspace dialog and closes the popover on create', async () => {
+    const user = userEvent.setup()
+    const { emitted } = renderComponent()
+
+    await user.click(screen.getByTestId('workspace-switcher-trigger'))
+    await user.click(screen.getByTestId('stub-create-workspace'))
+
+    expect(showCreateWorkspaceDialog).toHaveBeenCalled()
+    expect(emitted('close')).toHaveLength(1)
+    expect(
+      screen.queryByTestId('workspace-switcher-panel')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -24,36 +24,37 @@
     </div>
 
     <!-- Workspace Selector -->
-    <div
-      class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
-      @click="toggleWorkspaceSwitcher"
-    >
-      <div class="flex min-w-0 flex-1 items-center gap-2">
-        <WorkspaceProfilePic
-          class="size-6 shrink-0 text-xs"
-          :workspace-name="workspaceName"
-        />
-        <span class="truncate text-sm text-base-foreground">{{
-          workspaceName
-        }}</span>
+    <div class="relative">
+      <div
+        ref="workspaceSwitcherTrigger"
+        class="flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 hover:bg-secondary-background-hover"
+        data-testid="workspace-switcher-trigger"
+        @click="toggleWorkspaceSwitcher"
+      >
+        <div class="flex min-w-0 flex-1 items-center gap-2">
+          <WorkspaceProfilePic
+            class="size-6 shrink-0 text-xs"
+            :workspace-name="workspaceName"
+          />
+          <span class="truncate text-sm text-base-foreground">{{
+            workspaceName
+          }}</span>
+        </div>
+        <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
       </div>
-      <i class="pi pi-chevron-down shrink-0 text-sm text-muted-foreground" />
-    </div>
 
-    <Popover
-      ref="workspaceSwitcherPopover"
-      append-to="body"
-      :pt="{
-        content: {
-          class: 'p-0'
-        }
-      }"
-    >
-      <WorkspaceSwitcherPopover
-        @select="workspaceSwitcherPopover?.hide()"
-        @create="handleCreateWorkspace"
-      />
-    </Popover>
+      <div
+        v-if="isWorkspaceSwitcherOpen"
+        ref="workspaceSwitcherPanel"
+        class="absolute top-0 right-full z-10 mr-4 rounded-lg border border-border-default bg-base-background shadow-[1px_1px_8px_0_rgba(0,0,0,0.4)]"
+        data-testid="workspace-switcher-panel"
+      >
+        <WorkspaceSwitcherPopover
+          @select="isWorkspaceSwitcherOpen = false"
+          @create="handleCreateWorkspace"
+        />
+      </div>
+    </div>
 
     <!-- Credits Section -->
 
@@ -218,11 +219,11 @@
 </template>
 
 <script setup lang="ts">
+import { onClickOutside } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import Divider from 'primevue/divider'
-import Popover from 'primevue/popover'
 import Skeleton from 'primevue/skeleton'
-import { computed, ref } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { formatCreditsFromCents } from '@/base/credits/comfyCredits'
@@ -250,7 +251,17 @@ const {
   isInPersonalWorkspace: isPersonalWorkspace
 } = storeToRefs(workspaceStore)
 const { permissions } = useWorkspaceUI()
-const workspaceSwitcherPopover = ref<InstanceType<typeof Popover> | null>(null)
+const isWorkspaceSwitcherOpen = ref(false)
+const workspaceSwitcherTrigger = useTemplateRef('workspaceSwitcherTrigger')
+const workspaceSwitcherPanel = useTemplateRef('workspaceSwitcherPanel')
+
+onClickOutside(
+  workspaceSwitcherPanel,
+  () => {
+    isWorkspaceSwitcherOpen.value = false
+  },
+  { ignore: [workspaceSwitcherTrigger] }
+)
 
 const emit = defineEmits<{
   close: []
@@ -362,13 +373,13 @@ const handleLogout = async () => {
 }
 
 const handleCreateWorkspace = () => {
-  workspaceSwitcherPopover.value?.hide()
+  isWorkspaceSwitcherOpen.value = false
   dialogService.showCreateWorkspaceDialog()
   emit('close')
 }
 
-const toggleWorkspaceSwitcher = (event: MouseEvent) => {
-  workspaceSwitcherPopover.value?.toggle(event)
+const toggleWorkspaceSwitcher = () => {
+  isWorkspaceSwitcherOpen.value = !isWorkspaceSwitcherOpen.value
 }
 
 const refreshBalance = () => {

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.test.ts
@@ -1,7 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
 import WorkspaceSwitcherPopover from './WorkspaceSwitcherPopover.vue'
@@ -10,8 +9,14 @@ vi.mock('@/platform/workspace/composables/useWorkspaceSwitch', () => ({
   useWorkspaceSwitch: () => ({ switchWorkspace: vi.fn() })
 }))
 
+const billingMocks = vi.hoisted(() => ({
+  subscription: {
+    value: null as { tier: string; duration: string } | null
+  }
+}))
+
 vi.mock('@/composables/billing/useBillingContext', () => ({
-  useBillingContext: () => ({ subscription: ref(null) })
+  useBillingContext: () => ({ subscription: billingMocks.subscription })
 }))
 
 const LONG_WORKSPACE_NAME =
@@ -26,9 +31,14 @@ const i18n = createI18n({
         personal: 'Personal',
         roleOwner: 'Owner',
         roleMember: 'Member',
-        createWorkspace: 'Create new workspace',
+        createWorkspace: 'Create a team workspace',
         maxWorkspacesReached:
           'You can only own 10 workspaces. Delete one to create a new one.'
+      },
+      subscription: {
+        tiers: {
+          pro: { name: 'Pro' }
+        }
       }
     }
   }
@@ -47,7 +57,12 @@ function createWorkspaceState(overrides: Record<string, unknown>) {
   }
 }
 
-function renderComponent() {
+function renderComponent(
+  overrides: {
+    activeWorkspaceId?: string
+    workspaces?: Record<string, unknown>[]
+  } = {}
+) {
   return render(WorkspaceSwitcherPopover, {
     global: {
       plugins: [
@@ -55,9 +70,9 @@ function renderComponent() {
           createSpy: vi.fn,
           initialState: {
             teamWorkspace: {
-              activeWorkspaceId: 'ws-personal',
+              activeWorkspaceId: overrides.activeWorkspaceId ?? 'ws-personal',
               isFetchingWorkspaces: false,
-              workspaces: [
+              workspaces: overrides.workspaces ?? [
                 createWorkspaceState({
                   id: 'ws-personal',
                   name: 'Personal Workspace',
@@ -84,11 +99,66 @@ function renderComponent() {
 }
 
 describe('WorkspaceSwitcherPopover', () => {
+  beforeEach(() => {
+    billingMocks.subscription.value = null
+  })
+
   it('exposes the full team workspace name as a tooltip on the row', () => {
     renderComponent()
 
     const name = screen.getByText(LONG_WORKSPACE_NAME)
 
     expect(name).toHaveAttribute('title', LONG_WORKSPACE_NAME)
+  })
+
+  it('does not render a tier badge on team workspace rows', () => {
+    billingMocks.subscription.value = { tier: 'PRO', duration: 'MONTHLY' }
+
+    renderComponent({
+      activeWorkspaceId: 'ws-team',
+      workspaces: [
+        createWorkspaceState({
+          id: 'ws-personal',
+          name: 'Personal Workspace',
+          type: 'personal',
+          role: 'owner'
+        }),
+        createWorkspaceState({
+          id: 'ws-team',
+          name: 'Team Comfy',
+          type: 'team',
+          role: 'owner',
+          isSubscribed: true,
+          subscriptionTier: 'PRO'
+        })
+      ]
+    })
+
+    expect(screen.getByText('Team Comfy')).toBeInTheDocument()
+    expect(screen.queryByText('Pro')).not.toBeInTheDocument()
+  })
+
+  it('keeps the tier badge on a subscribed personal workspace row', () => {
+    renderComponent({
+      activeWorkspaceId: 'ws-team',
+      workspaces: [
+        createWorkspaceState({
+          id: 'ws-personal',
+          name: 'Personal Workspace',
+          type: 'personal',
+          role: 'owner',
+          isSubscribed: true,
+          subscriptionTier: 'PRO'
+        }),
+        createWorkspaceState({
+          id: 'ws-team',
+          name: 'Team Comfy',
+          type: 'team',
+          role: 'owner'
+        })
+      ]
+    })
+
+    expect(screen.getByText('Pro')).toBeInTheDocument()
   })
 })

--- a/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
+++ b/src/platform/workspace/components/WorkspaceSwitcherPopover.vue
@@ -183,6 +183,8 @@ function getRoleLabel(role: AvailableWorkspace['role']): string {
 }
 
 function resolveTierLabel(workspace: AvailableWorkspace): string | null {
+  if (workspace.type !== 'personal') return null
+
   if (isCurrentWorkspace(workspace)) {
     return currentSubscriptionTierName.value || null
   }

--- a/src/platform/workspace/components/dialogs/CreateWorkspaceDialogContent.vue
+++ b/src/platform/workspace/components/dialogs/CreateWorkspaceDialogContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex w-full max-w-[400px] flex-col rounded-2xl border border-border-default bg-base-background"
+    class="flex w-full max-w-lg flex-col rounded-2xl border border-border-default bg-base-background"
   >
     <!-- Header -->
     <div
@@ -24,13 +24,13 @@
         {{ $t('workspacePanel.createWorkspaceDialog.message') }}
       </p>
       <div class="flex flex-col gap-2">
-        <label class="text-sm text-base-foreground">
+        <label class="text-sm text-muted-foreground">
           {{ $t('workspacePanel.createWorkspaceDialog.nameLabel') }}
         </label>
         <input
           v-model="workspaceName"
           type="text"
-          class="focus:ring-secondary-foreground w-full rounded-lg border border-border-default bg-transparent px-3 py-2 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
+          class="focus:ring-secondary-foreground h-10 w-full rounded-lg border-none bg-secondary-background px-4 text-sm text-base-foreground placeholder:text-muted-foreground focus:ring-1 focus:outline-none"
           :placeholder="
             $t('workspacePanel.createWorkspaceDialog.namePlaceholder')
           "


### PR DESCRIPTION
Backport of #12763 to `cloud/1.45`.

Cherry-picked squash commit `700ff4644f6d1c0f2d6d0bacddbe28654474b5b0` cleanly (no conflicts). Original authorship preserved.

Independent backport off `cloud/1.45`; cherry-pick order #1 in the billing/auth series (earliest in main history, ahead of the facade stack).