### PR TITLE
[backport cloud/1.45] fix(billing): DES review polish on workspace billing UI (#12917)

### DIFF
--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -4,9 +4,9 @@
       value: $t('subscription.subscribeToRunFull'),
       showDelay: 600
     }"
-    class="subscribe-to-run-button whitespace-nowrap"
+    class="subscribe-to-run-button h-8 gap-1.5 rounded-lg px-4 whitespace-nowrap"
     variant="gradient"
-    size="sm"
+    size="unset"
     data-testid="subscribe-to-run-button"
     @click="handleSubscribeToRun"
   >

--- a/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
+++ b/src/platform/workspace/components/CurrentUserPopoverWorkspace.vue
@@ -142,12 +142,6 @@
       <span class="flex-1 text-sm text-base-foreground">{{
         $t('subscription.plansAndPricing')
       }}</span>
-      <span
-        v-if="canUpgrade"
-        class="rounded-full bg-base-foreground px-1.5 py-0.5 text-xs font-bold text-base-background"
-      >
-        {{ $t('subscription.upgrade') }}
-      </span>
     </div>
 
     <!-- Manage Plan (PERSONAL and OWNER, only if subscribed) -->
@@ -291,12 +285,6 @@ const displayedCredits = computed(() => {
       maximumFractionDigits: 2
     }
   })
-})
-
-const canUpgrade = computed(() => {
-  // PRO is currently the only/highest tier, so no upgrades available
-  // This will need updating when additional tiers are added
-  return false
 })
 
 const showPlansAndPricing = computed(


### PR DESCRIPTION
Backport of #12917 to `cloud/1.45`.

Cherry-picked squash commit `543a39a6b05dd11cc10b1ac3adc2ab28a898dc31`. Original authorship preserved.

Applies 2 of the 3 polish items, which are independent of the facade/run-lock stack:
- **Remove dead 'Upgrade' badge** in `CurrentUserPopoverWorkspace.vue`
- **Subscribe-to-Run button height** (`SubscribeToRun.vue`, `size=unset` + `h-8`)

**Deferred (1 item):** the member 'subscription inactive' dialog border polish in `useSubscriptionDialog.ts` targets the `SubscriptionInactiveMemberDialog` block from **FE-978 (#12786)**, which is not yet on `cloud/1.45`. Resolved the conflict by keeping cloud/1.45's version (the block doesn't exist here yet). Re-apply that one-line `root` pt polish (`border-none rounded-none shadow-none`) when #12786's backport lands.