### PR TITLE
[backport cloud/1.45] feat(billing): deep link to open the pricing table (FE-1104) (#13001)

### DIFF
--- a/browser_tests/fixtures/utils/cloudBillingMocks.ts
+++ b/browser_tests/fixtures/utils/cloudBillingMocks.ts
@@ -1,0 +1,34 @@
+import type { Page } from '@playwright/test'
+
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+/**
+ * Minimal valid billing shapes so the billing facade resolves while a
+ * subscription dialog mounts. Active personal sub with zero balance.
+ */
+export async function mockBilling(page: Page) {
+  await page.route('**/api/billing/status', (r) =>
+    r.fulfill(
+      jsonRoute({
+        is_active: true,
+        has_funds: true,
+        subscription_status: 'active',
+        subscription_tier: 'pro',
+        subscription_duration: 'MONTHLY',
+        billing_status: 'paid'
+      })
+    )
+  )
+  await page.route('**/api/billing/balance', (r) =>
+    r.fulfill(jsonRoute({ amount_micros: 0, currency: 'usd' }))
+  )
+  await page.route('**/api/billing/plans', (r) =>
+    r.fulfill(jsonRoute({ plans: [] }))
+  )
+  await page.route('**/customers/cloud-subscription-status', (r) =>
+    r.fulfill(jsonRoute({ is_active: false }))
+  )
+  await page.route('**/customers/balance', (r) =>
+    r.fulfill(jsonRoute({ amount_micros: 0, currency: 'usd' }))
+  )
+}

--- a/browser_tests/fixtures/utils/cloudBootMocks.ts
+++ b/browser_tests/fixtures/utils/cloudBootMocks.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+
+import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
+import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+interface CloudBootOptions {
+  /** Remote-config payload for `/api/features` (enables the flags under test). */
+  features: RemoteConfig
+  /** Body for `/api/settings` (defaults to `{}`). */
+  settings?: unknown
+}
+
+/**
+ * Stub the core endpoints the cloud app hits on boot so a raw `page` reaches the
+ * working app without falling through to the OSS devtools backend. Specs layer
+ * their own feature- or flow-specific routes on top.
+ */
+export async function mockCloudBoot(
+  page: Page,
+  { features, settings = {} }: CloudBootOptions
+) {
+  await page.route('**/api/features', (r) => r.fulfill(jsonRoute(features)))
+  await page.route('**/api/system_stats', (r) =>
+    r.fulfill(jsonRoute(mockSystemStats))
+  )
+  await page.route('**/api/users', (r) =>
+    r.fulfill(
+      jsonRoute({
+        storage: 'server',
+        migrated: true,
+        users: { 'test-user-e2e': 'E2E Test User' }
+      })
+    )
+  )
+  await page.route('**/api/user', (r) =>
+    r.fulfill(jsonRoute({ status: 'active' }))
+  )
+  await page.route('**/api/settings', (r) => r.fulfill(jsonRoute(settings)))
+  await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))
+  await page.route('**/api/extensions', (r) => r.fulfill(jsonRoute([])))
+  await page.route('**/api/object_info', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/global_subgraphs', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/i18n', (r) => r.fulfill(jsonRoute({})))
+  await page.route('**/api/auth/session', (r) =>
+    r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
+  )
+  await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
+}
+
+/**
+ * Mock Firebase auth and pre-select the e2e user so the cloud app boots
+ * signed-in. The signed-in email (`e2e@test.comfy.org`) is what the
+ * original-owner gate matches against the members self-row.
+ */
+export async function bootCloud(page: Page) {
+  const auth = new CloudAuthHelper(page)
+  await auth.mockAuth()
+  await page.addInitScript(() => {
+    localStorage.setItem('Comfy.userId', 'test-user-e2e')
+  })
+}

--- a/browser_tests/fixtures/utils/jsonRoute.ts
+++ b/browser_tests/fixtures/utils/jsonRoute.ts
@@ -1,0 +1,12 @@
+/**
+ * Build a 200 JSON body for `route.fulfill()`. Generic so callers can type the
+ * payload (e.g. `jsonRoute({ ... } satisfies RemoteConfig)`) and catch contract
+ * drift against the real API shape.
+ */
+export function jsonRoute<T>(body: T) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body)
+  }
+}

--- a/browser_tests/fixtures/utils/workspaceMocks.ts
+++ b/browser_tests/fixtures/utils/workspaceMocks.ts
@@ -1,0 +1,68 @@
+import type { Page } from '@playwright/test'
+
+import type {
+  Member,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
+
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+
+export function workspace(
+  type: 'personal' | 'team',
+  role: 'owner' | 'member'
+): WorkspaceWithRole {
+  return {
+    id: `ws-${type}`,
+    name: type === 'team' ? 'My Team' : 'Personal Workspace',
+    type,
+    role,
+    created_at: '2026-01-01T00:00:00Z',
+    joined_at: '2026-01-01T00:00:00Z'
+  }
+}
+
+export function member(
+  overrides: Partial<Member> & Pick<Member, 'email' | 'role'>
+): Member {
+  return {
+    id: `user-${overrides.email}`,
+    name: overrides.email,
+    joined_at: '2026-01-01T00:00:00Z',
+    is_original_owner: false,
+    ...overrides
+  }
+}
+
+/**
+ * Stub the workspace resolution + members list so the cloud app boots into the
+ * given workspace with the given roster (drives the original-owner gate).
+ */
+export async function mockWorkspace(
+  page: Page,
+  ws: WorkspaceWithRole,
+  members: Member[]
+) {
+  await page.route('**/api/workspaces', async (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    await route.fulfill(jsonRoute({ workspaces: [ws] }))
+  })
+  await page.route('**/api/auth/token', (r) =>
+    r.fulfill(
+      jsonRoute({
+        token: 'mock-workspace-token',
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        workspace: { id: ws.id, name: ws.name, type: ws.type },
+        role: ws.role,
+        permissions: []
+      })
+    )
+  )
+  await page.route('**/api/workspace/members**', (r) =>
+    r.fulfill(
+      jsonRoute({
+        members,
+        pagination: { offset: 0, limit: 50, total: members.length }
+      })
+    )
+  )
+}

--- a/browser_tests/tests/cloudSurveyGate.spec.ts
+++ b/browser_tests/tests/cloudSurveyGate.spec.ts
@@ -4,8 +4,7 @@ import type { Page } from '@playwright/test'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
-import { mockSystemStats } from '@e2e/fixtures/data/systemStats'
-import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
 
 /**
  * getSurveyCompletedStatus fails safe: a transient 401 on `/` must not bounce a
@@ -16,51 +15,12 @@ import { CloudAuthHelper } from '@e2e/fixtures/helpers/CloudAuthHelper'
  */
 const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
 
-function jsonRoute(body: unknown) {
-  return {
-    status: 200,
-    contentType: 'application/json',
-    body: JSON.stringify(body)
-  }
-}
-
-async function mockCloudBoot(page: Page) {
-  // `/api/features` is the remote-config source: production builds resolve
-  // `onboardingSurveyEnabled` from it (the `ff:` localStorage override is
-  // dev-only). Enable the survey so the gate is actually live.
-  await page.route('**/api/features', (r) =>
-    r.fulfill(
-      jsonRoute({ onboarding_survey_enabled: true } satisfies RemoteConfig)
-    )
-  )
-  await page.route('**/api/system_stats', (r) =>
-    r.fulfill(jsonRoute(mockSystemStats))
-  )
-  await page.route('**/api/users', (r) =>
-    r.fulfill(
-      jsonRoute({
-        storage: 'server',
-        migrated: true,
-        users: { 'test-user-e2e': 'E2E Test User' }
-      })
-    )
-  )
-  // Cloud user status (getUserCloudStatus) — an active account so the gate
-  // proceeds to the survey check instead of bouncing back to login.
-  await page.route('**/api/user', (r) =>
-    r.fulfill(jsonRoute({ status: 'active' }))
-  )
-  await page.route('**/api/settings', (r) => r.fulfill(jsonRoute({})))
-  await page.route('**/api/userdata**', (r) => r.fulfill(jsonRoute([])))
-  await page.route('**/api/extensions', (r) => r.fulfill(jsonRoute([])))
-  await page.route('**/api/object_info', (r) => r.fulfill(jsonRoute({})))
-  await page.route('**/api/global_subgraphs', (r) => r.fulfill(jsonRoute({})))
-  await page.route('**/api/i18n', (r) => r.fulfill(jsonRoute({})))
-  await page.route('**/api/auth/session', (r) =>
-    r.fulfill(jsonRoute({ token: 'mock-workspace-token' }))
-  )
-  await page.route('**/releases**', (r) => r.fulfill(jsonRoute([])))
-}
+// `/api/features` is the remote-config source: production builds resolve
+// `onboardingSurveyEnabled` from it (the `ff:` localStorage override is
+// dev-only). Enable the survey so the gate is actually live.
+const BOOT_FEATURES = {
+  onboarding_survey_enabled: true
+} satisfies RemoteConfig
 
 // Genuine "not completed": the cloud backend returns 404 for a survey key that
 // was never stored. This is the response that must still route to the survey.
@@ -89,22 +49,13 @@ async function mockSurveyTransient401(page: Page) {
   )
 }
 
-async function bootCloud(page: Page) {
-  const auth = new CloudAuthHelper(page)
-  await auth.mockAuth()
-  // Pre-select the mock user to skip the user-select screen.
-  await page.addInitScript(() => {
-    localStorage.setItem('Comfy.userId', 'test-user-e2e')
-  })
-}
-
 test.describe('Cloud onboarding survey gate', { tag: '@cloud' }, () => {
   test('a transient 401 on the survey check does not bounce a working user to the survey', async ({
     page
   }) => {
-    test.setTimeout(60_000)
+    test.slow()
 
-    await mockCloudBoot(page)
+    await mockCloudBoot(page, { features: BOOT_FEATURES })
     await mockSurveyTransient401(page)
     await bootCloud(page)
 
@@ -122,9 +73,9 @@ test.describe('Cloud onboarding survey gate', { tag: '@cloud' }, () => {
   test('a not-completed (404) user landing on / is routed to the survey', async ({
     page
   }) => {
-    test.setTimeout(60_000)
+    test.slow()
 
-    await mockCloudBoot(page)
+    await mockCloudBoot(page, { features: BOOT_FEATURES })
     await mockSurveyNotCompleted(page)
     await bootCloud(page)
 

--- a/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
+++ b/browser_tests/tests/dialogs/pricingTableDeepLink.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import type { RemoteConfig } from '@/platform/remoteConfig/types'
+import type {
+  Member,
+  WorkspaceWithRole
+} from '@/platform/workspace/api/workspaceApi'
+
+import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
+import { mockBilling } from '@e2e/fixtures/utils/cloudBillingMocks'
+import { bootCloud, mockCloudBoot } from '@e2e/fixtures/utils/cloudBootMocks'
+import { jsonRoute } from '@e2e/fixtures/utils/jsonRoute'
+import {
+  member,
+  mockWorkspace,
+  workspace
+} from '@e2e/fixtures/utils/workspaceMocks'
+
+/**
+ * The `?pricing=` deep link opens the pricing table on app load, gated to the
+ * original owner (canManageSubscriptionLifecycle). Drives a raw `page` so the
+ * cloud app boots against fully mocked endpoints, like the survey-gate spec.
+ */
+const APP_URL = process.env.PLAYWRIGHT_TEST_URL || 'http://localhost:8188'
+
+// CloudAuthHelper.mockAuth() signs in as this email; the original-owner gate
+// matches it against the members self-row.
+const SELF_EMAIL = 'e2e@test.comfy.org'
+
+const BOOT_FEATURES = { team_workspaces_enabled: true } satisfies RemoteConfig
+// Disable the experimental Asset API: with it on (cloud default) the unmocked
+// asset endpoints 403 and workflow restore throws uncaught, aborting the
+// GraphCanvas onMounted chain before the deep-link loader.
+const BOOT_SETTINGS = { 'Comfy.Assets.UseAssetAPI': false }
+
+// The deep-link loader runs at the tail of GraphCanvas onMounted, so the boot
+// chain must not throw before it: a missing settings subpath, prompt exec_info,
+// or queue status each abort that chain.
+async function mockGraphBootExtras(page: Page) {
+  // Boot only reads these; fall back on any write so an unexpected POST/PUT
+  // surfaces instead of being masked by a blanket 200.
+  await page.route('**/api/settings/**', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({}))
+  })
+  await page.route('**/api/prompt', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ exec_info: { queue_remaining: 0 } }))
+  })
+  await page.route('**/api/queue', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill(jsonRoute({ queue_running: [], queue_pending: [] }))
+  })
+}
+
+async function setupCloudApp(
+  page: Page,
+  ws: WorkspaceWithRole,
+  members: Member[]
+) {
+  await mockCloudBoot(page, {
+    features: BOOT_FEATURES,
+    settings: BOOT_SETTINGS
+  })
+  await mockGraphBootExtras(page)
+  await mockBilling(page)
+  await mockWorkspace(page, ws, members)
+  await bootCloud(page)
+}
+
+const pricingHeading = (page: Page) =>
+  page.getByRole('heading', { name: 'Choose a Plan' })
+
+test.describe('Pricing table deep link', { tag: '@cloud' }, () => {
+  test('opens the pricing table for a personal owner', async ({ page }) => {
+    test.slow()
+    await setupCloudApp(page, workspace('personal', 'owner'), [])
+
+    await page.goto(`${APP_URL}/?pricing=1`)
+
+    await expect(pricingHeading(page)).toBeVisible({ timeout: 45_000 })
+    await expect(page).not.toHaveURL(/[?&]pricing=/)
+  })
+
+  test('opens on the Team tab for ?pricing=team', async ({ page }) => {
+    test.slow()
+    await setupCloudApp(page, workspace('personal', 'owner'), [])
+
+    await page.goto(`${APP_URL}/?pricing=team`)
+
+    await expect(pricingHeading(page)).toBeVisible({ timeout: 45_000 })
+    await expect(
+      page.getByRole('button', { name: 'For Teams' })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('opens for a team original owner', async ({ page }) => {
+    test.slow()
+    await setupCloudApp(page, workspace('team', 'owner'), [
+      member({ email: SELF_EMAIL, role: 'owner', is_original_owner: true })
+    ])
+
+    await page.goto(`${APP_URL}/?pricing=1`)
+
+    await expect(pricingHeading(page)).toBeVisible({ timeout: 45_000 })
+  })
+
+  test('is a silent no-op for a team member', async ({ page }) => {
+    test.slow()
+    await setupCloudApp(page, workspace('team', 'member'), [
+      member({
+        email: 'creator@test.comfy.org',
+        role: 'owner',
+        is_original_owner: true
+      }),
+      member({ email: SELF_EMAIL, role: 'member' })
+    ])
+
+    await page.goto(`${APP_URL}/?pricing=1`)
+
+    await page.waitForFunction(() => !!window.app?.extensionManager, null, {
+      timeout: 45_000
+    })
+    await expect(page).not.toHaveURL(/[?&]pricing=/)
+    await expect(pricingHeading(page)).toBeHidden()
+  })
+})

--- a/src/components/graph/GraphCanvas.vue
+++ b/src/components/graph/GraphCanvas.vue
@@ -188,10 +188,7 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { forEachNode } from '@/utils/graphTraversalUtil'
 
 import SelectionRectangle from './SelectionRectangle.vue'
-import { isCloud } from '@/platform/distribution/types'
-import { useFeatureFlags } from '@/composables/useFeatureFlags'
-import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
-import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
+import { useUrlActionLoaders } from '@/composables/useUrlActionLoaders'
 
 const { t } = useI18n()
 const emit = defineEmits<{
@@ -450,10 +447,7 @@ useEventListener(
 
 const comfyAppReady = ref(false)
 const workflowPersistence = useWorkflowPersistence()
-const { flags } = useFeatureFlags()
-// Set up URL loaders during setup phase so useRoute/useRouter work correctly
-const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
-const createWorkspaceUrlLoader = isCloud ? useCreateWorkspaceUrlLoader() : null
+const { runUrlActionLoaders } = useUrlActionLoaders()
 useCanvasDrop(canvasRef)
 useLitegraphSettings()
 useNodeBadge()
@@ -561,23 +555,8 @@ onMounted(async () => {
     () => canvasStore.updateSelectedItems()
   )
 
-  // Accept workspace invite from URL if present (e.g., ?invite=TOKEN)
-  // WorkspaceAuthGate ensures flag state is resolved before GraphCanvas mounts
-  if (inviteUrlLoader && flags.teamWorkspacesEnabled) {
-    await inviteUrlLoader.loadInviteFromUrl()
-  }
-
-  // Open create workspace dialog from URL if present (e.g., ?create_workspace=1)
-  if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
-    try {
-      await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
-    } catch (error) {
-      console.error(
-        '[GraphCanvas] Failed to load create workspace from URL:',
-        error
-      )
-    }
-  }
+  // Run query-param deep-link loaders (?invite, ?create_workspace, ?pricing)
+  await runUrlActionLoaders()
 
   // Initialize release store to fetch releases from comfy-api (fire-and-forget)
   const { useReleaseStore } =

--- a/src/composables/useUrlActionLoaders.test.ts
+++ b/src/composables/useUrlActionLoaders.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUrlActionLoaders } from './useUrlActionLoaders'
+
+const mockIsCloud = vi.hoisted(() => ({ value: true }))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+
+const mockFlags = vi.hoisted(() => ({ value: { teamWorkspacesEnabled: true } }))
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFlags.value })
+}))
+
+const mocks = vi.hoisted(() => ({
+  loadInvite: vi.fn().mockResolvedValue(undefined),
+  loadCreateWorkspace: vi.fn().mockResolvedValue(undefined),
+  loadPricingTable: vi.fn().mockResolvedValue(undefined),
+  useInvite: vi.fn(),
+  useCreateWorkspace: vi.fn(),
+  usePricingTable: vi.fn()
+}))
+mocks.useInvite.mockImplementation(() => ({
+  loadInviteFromUrl: mocks.loadInvite
+}))
+mocks.useCreateWorkspace.mockImplementation(() => ({
+  loadCreateWorkspaceFromUrl: mocks.loadCreateWorkspace
+}))
+mocks.usePricingTable.mockImplementation(() => ({
+  loadPricingTableFromUrl: mocks.loadPricingTable
+}))
+
+vi.mock('@/platform/workspace/composables/useInviteUrlLoader', () => ({
+  useInviteUrlLoader: mocks.useInvite
+}))
+vi.mock('@/platform/workspace/composables/useCreateWorkspaceUrlLoader', () => ({
+  useCreateWorkspaceUrlLoader: mocks.useCreateWorkspace
+}))
+vi.mock(
+  '@/platform/cloud/subscription/composables/usePricingTableUrlLoader',
+  () => ({ usePricingTableUrlLoader: mocks.usePricingTable })
+)
+
+describe('useUrlActionLoaders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsCloud.value = true
+    mockFlags.value = { teamWorkspacesEnabled: true }
+  })
+
+  it('does not instantiate or run any loader off cloud', async () => {
+    mockIsCloud.value = false
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await runUrlActionLoaders()
+
+    expect(mocks.useInvite).not.toHaveBeenCalled()
+    expect(mocks.useCreateWorkspace).not.toHaveBeenCalled()
+    expect(mocks.usePricingTable).not.toHaveBeenCalled()
+    expect(mocks.loadInvite).not.toHaveBeenCalled()
+    expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
+    expect(mocks.loadPricingTable).not.toHaveBeenCalled()
+  })
+
+  it('runs all loaders on cloud when team workspaces are enabled', async () => {
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await runUrlActionLoaders()
+
+    expect(mocks.loadInvite).toHaveBeenCalledOnce()
+    expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
+    expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('runs the pricing loader but skips the flag-gated loaders when team workspaces are disabled', async () => {
+    mockFlags.value = { teamWorkspacesEnabled: false }
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await runUrlActionLoaders()
+
+    expect(mocks.loadInvite).not.toHaveBeenCalled()
+    expect(mocks.loadCreateWorkspace).not.toHaveBeenCalled()
+    expect(mocks.loadPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('isolates a pricing-loader failure so it does not abort the boot chain', async () => {
+    mocks.loadPricingTable.mockRejectedValueOnce(new Error('boom'))
+
+    const { runUrlActionLoaders } = useUrlActionLoaders()
+    await expect(runUrlActionLoaders()).resolves.toBeUndefined()
+
+    expect(mocks.loadInvite).toHaveBeenCalledOnce()
+    expect(mocks.loadCreateWorkspace).toHaveBeenCalledOnce()
+  })
+})

--- a/src/composables/useUrlActionLoaders.ts
+++ b/src/composables/useUrlActionLoaders.ts
@@ -1,0 +1,55 @@
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
+import { usePricingTableUrlLoader } from '@/platform/cloud/subscription/composables/usePricingTableUrlLoader'
+import { isCloud } from '@/platform/distribution/types'
+import { useCreateWorkspaceUrlLoader } from '@/platform/workspace/composables/useCreateWorkspaceUrlLoader'
+import { useInviteUrlLoader } from '@/platform/workspace/composables/useInviteUrlLoader'
+
+/**
+ * Aggregates the query-param "deep link" loaders the cloud app checks on mount
+ * (`?invite`, `?create_workspace`, `?pricing`). The loaders are instantiated in
+ * setup so their `useRoute`/`useRouter` resolve; call `runUrlActionLoaders()`
+ * from `onMounted` once the app is ready.
+ */
+export function useUrlActionLoaders() {
+  const { flags } = useFeatureFlags()
+  const inviteUrlLoader = isCloud ? useInviteUrlLoader() : null
+  const createWorkspaceUrlLoader = isCloud
+    ? useCreateWorkspaceUrlLoader()
+    : null
+  const pricingTableUrlLoader = isCloud ? usePricingTableUrlLoader() : null
+
+  async function runUrlActionLoaders() {
+    // Accept workspace invite from URL if present (e.g., ?invite=TOKEN).
+    // WorkspaceAuthGate ensures flag state is resolved before the app mounts.
+    if (inviteUrlLoader && flags.teamWorkspacesEnabled) {
+      await inviteUrlLoader.loadInviteFromUrl()
+    }
+
+    // Open create workspace dialog from URL if present (e.g., ?create_workspace=1).
+    if (createWorkspaceUrlLoader && flags.teamWorkspacesEnabled) {
+      try {
+        await createWorkspaceUrlLoader.loadCreateWorkspaceFromUrl()
+      } catch (error) {
+        console.error(
+          '[UrlActionLoaders] Failed to load create workspace from URL:',
+          error
+        )
+      }
+    }
+
+    // Open the pricing table from URL if present (e.g., ?pricing=1 / ?pricing=team).
+    // Not gated on the team-workspaces flag: it also drives personal/legacy users.
+    if (pricingTableUrlLoader) {
+      try {
+        await pricingTableUrlLoader.loadPricingTableFromUrl()
+      } catch (error) {
+        console.error(
+          '[UrlActionLoaders] Failed to load pricing table from URL:',
+          error
+        )
+      }
+    }
+  }
+
+  return { runUrlActionLoaders }
+}

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.test.ts
@@ -59,6 +59,15 @@ vi.mock('@/platform/cloud/subscription/utils/subscriptionCheckoutUtil', () => ({
     mockPerformSubscriptionCheckout(...args)
 }))
 
+const mockPerformTeamSubscriptionCheckout = vi.fn()
+vi.mock(
+  '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil',
+  () => ({
+    performTeamSubscriptionCheckout: (...args: unknown[]) =>
+      mockPerformTeamSubscriptionCheckout(...args)
+  })
+)
+
 const createI18nInstance = () =>
   createI18n({
     legacy: false,
@@ -73,6 +82,7 @@ const createI18nInstance = () =>
         },
         subscription: {
           subscribeTo: 'Subscribe to {plan}',
+          teamPlan: { name: 'Team Plan' },
           tiers: {
             standard: { name: 'Standard' },
             creator: { name: 'Creator' },
@@ -161,5 +171,25 @@ describe('CloudSubscriptionRedirectView', () => {
       'monthly',
       false
     )
+  })
+
+  test('checks out the team plan via the workspace path with the chosen stop and cycle', async () => {
+    await mountView({ tier: 'team', stop: 'team_700', cycle: 'yearly' })
+
+    expect(mockRouterPush).not.toHaveBeenCalledWith('/')
+    expect(screen.getByText('Subscribe to Team Plan')).toBeInTheDocument()
+    expect(mockPerformTeamSubscriptionCheckout).toHaveBeenCalledWith(
+      'team_700',
+      'yearly'
+    )
+    // Team never goes through the personal checkout path
+    expect(mockPerformSubscriptionCheckout).not.toHaveBeenCalled()
+  })
+
+  test('redirects to home for a team link with no stop', async () => {
+    await mountView({ tier: 'team', cycle: 'yearly' })
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/')
+    expect(mockPerformTeamSubscriptionCheckout).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
+++ b/src/platform/cloud/onboarding/CloudSubscriptionRedirectView.vue
@@ -10,8 +10,18 @@ import { useAuthActions } from '@/composables/auth/useAuthActions'
 import { useErrorHandling } from '@/composables/useErrorHandling'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { performSubscriptionCheckout } from '@/platform/cloud/subscription/utils/subscriptionCheckoutUtil'
+import { performTeamSubscriptionCheckout } from '@/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil'
 
 import type { BillingCycle } from '../subscription/utils/subscriptionTierRank'
+
+function isBillingCycle(value: string): value is BillingCycle {
+  return value === 'monthly' || value === 'yearly'
+}
+
+// Only paid personal tiers can be checked out via this redirect.
+function isCheckoutTierKey(value: string): value is TierKey {
+  return ['standard', 'creator', 'pro', 'founder'].includes(value)
+}
 
 const { t } = useI18n()
 const route = useRoute()
@@ -34,6 +44,12 @@ const tierDisplayName = computed(() => {
   }
   return names[selectedTierKey.value]
 })
+
+const isTeamCheckout = ref(false)
+
+const planLabel = computed(() =>
+  isTeamCheckout.value ? t('subscription.teamPlan.name') : tierDisplayName.value
+)
 
 const runRedirect = wrapWithErrorHandlingAsync(async () => {
   const rawType = route.query.tier
@@ -58,21 +74,36 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
     return
   }
 
-  // Only paid tiers can be checked out via redirect
-  const validTierKeys: TierKey[] = ['standard', 'creator', 'pro', 'founder']
-  if (!(validTierKeys as string[]).includes(tierKeyParam)) {
+  const billingCycle: BillingCycle = isBillingCycle(cycleParam)
+    ? cycleParam
+    : 'monthly'
+
+  // Team is a per-credit plan picked on a slider, so it carries a `stop` (the
+  // chosen credit commitment) instead of a tier and checks out through the
+  // workspace billing endpoint rather than the personal one.
+  if (tierKeyParam === 'team') {
+    const rawStop = route.query.stop
+    const stopId =
+      typeof rawStop === 'string'
+        ? rawStop
+        : Array.isArray(rawStop)
+          ? rawStop[0]
+          : null
+    if (!stopId) {
+      await router.push('/')
+      return
+    }
+    isTeamCheckout.value = true
+    await performTeamSubscriptionCheckout(stopId, billingCycle)
+    return
+  }
+
+  if (!isCheckoutTierKey(tierKeyParam)) {
     await router.push('/')
     return
   }
 
-  const tierKey = tierKeyParam as TierKey
-
-  selectedTierKey.value = tierKey
-
-  const validCycles: BillingCycle[] = ['monthly', 'yearly']
-  if (!cycleParam || !(validCycles as string[]).includes(cycleParam)) {
-    cycleParam = 'monthly'
-  }
+  selectedTierKey.value = tierKeyParam
 
   if (!isInitialized.value) {
     await initialize()
@@ -81,11 +112,7 @@ const runRedirect = wrapWithErrorHandlingAsync(async () => {
   if (isActiveSubscription.value) {
     await accessBillingPortal(undefined, false)
   } else {
-    await performSubscriptionCheckout(
-      tierKey,
-      cycleParam as BillingCycle,
-      false
-    )
+    await performSubscriptionCheckout(tierKeyParam, billingCycle, false)
   }
 }, reportError)
 
@@ -105,18 +132,18 @@ onMounted(() => {
         class="size-16"
       />
       <p
-        v-if="selectedTierKey"
+        v-if="planLabel"
         class="font-inter text-base/normal font-normal text-base-foreground"
       >
         {{
           t('subscription.subscribeTo', {
-            plan: tierDisplayName
+            plan: planLabel
           })
         }}
       </p>
-      <ProgressSpinner v-if="selectedTierKey" class="size-8" stroke-width="4" />
+      <ProgressSpinner v-if="planLabel" class="size-8" stroke-width="4" />
       <Button
-        v-if="selectedTierKey"
+        v-if="planLabel"
         as="a"
         href="/"
         link

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.test.ts
@@ -1,0 +1,239 @@
+import { fromAny } from '@total-typescript/shoehorn'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePricingTableUrlLoader } from './usePricingTableUrlLoader'
+
+const preservedQueryMocks = vi.hoisted(() => ({
+  clearPreservedQuery: vi.fn(),
+  hydratePreservedQuery: vi.fn(),
+  mergePreservedQueryIntoQuery: vi.fn()
+}))
+
+vi.mock(
+  '@/platform/navigation/preservedQueryManager',
+  () => preservedQueryMocks
+)
+
+const mockRouteQuery = vi.hoisted(() => ({
+  value: {} as Record<string, string>
+}))
+const mockRouterReplace = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: mockRouteQuery.value
+  }),
+  useRouter: () => ({
+    replace: mockRouterReplace
+  })
+}))
+
+const mockShowPricingTable = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  '@/platform/cloud/subscription/composables/useSubscriptionDialog',
+  () => ({
+    useSubscriptionDialog: () => ({
+      showPricingTable: mockShowPricingTable
+    })
+  })
+)
+
+const mockPermissions = vi.hoisted(() => ({
+  value: { canManageSubscriptionLifecycle: true }
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({ permissions: mockPermissions })
+}))
+
+const mockFetchMembers = vi.hoisted(() => vi.fn().mockResolvedValue([]))
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    fetchMembers: mockFetchMembers
+  })
+}))
+
+const mockTrackSubscription = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackSubscription: mockTrackSubscription })
+}))
+
+describe('usePricingTableUrlLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouteQuery.value = {}
+    mockPermissions.value = { canManageSubscriptionLifecycle: true }
+    // clearAllMocks resets calls, not implementations, so restore the default
+    // (a test overrides fetchMembers to flip the gate mid-await).
+    mockFetchMembers.mockResolvedValue([])
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when no pricing param present', async () => {
+    mockRouteQuery.value = {}
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+  })
+
+  it('opens the pricing table for an original owner', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: undefined
+    })
+    expect(mockTrackSubscription).toHaveBeenCalledWith('modal_opened', {
+      reason: 'deep_link'
+    })
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('reads the gate only after members finish loading', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    // The original owner becomes known only once the members list resolves;
+    // proves the loader awaits fetchMembers before reading the gate.
+    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+    mockFetchMembers.mockImplementation(async () => {
+      mockPermissions.value = { canManageSubscriptionLifecycle: true }
+      return []
+    })
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('opens on the team tab for ?pricing=team', async () => {
+    mockRouteQuery.value = { pricing: 'team' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'team'
+    })
+  })
+
+  it('opens on the personal tab for ?pricing=personal', async () => {
+    mockRouteQuery.value = { pricing: 'personal' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: 'personal'
+    })
+  })
+
+  it('is a silent no-op for a member or promoted owner', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockTrackSubscription).not.toHaveBeenCalled()
+  })
+
+  it('denies, strips, and clears together when the user is not eligible', async () => {
+    mockRouteQuery.value = { pricing: '1', other: 'param' }
+    mockPermissions.value = { canManageSubscriptionLifecycle: false }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockTrackSubscription).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({
+      query: { other: 'param' }
+    })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'pricing'
+    )
+  })
+
+  it('restores preserved query and opens the table', async () => {
+    mockRouteQuery.value = {}
+    preservedQueryMocks.mergePreservedQueryIntoQuery.mockReturnValue({
+      pricing: '1'
+    })
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(preservedQueryMocks.hydratePreservedQuery).toHaveBeenCalledWith(
+      'pricing'
+    )
+    expect(mockShowPricingTable).toHaveBeenCalledOnce()
+  })
+
+  it('strips but does not open for an empty param', async () => {
+    mockRouteQuery.value = { pricing: '' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'pricing'
+    )
+  })
+
+  it('strips but does not open for a non-string param', async () => {
+    mockRouteQuery.value = { pricing: fromAny<string, unknown>(['array']) }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('opens the default tab for an unrecognized pricing value', async () => {
+    mockRouteQuery.value = { pricing: 'garbage' }
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await loadPricingTableFromUrl()
+
+    expect(mockShowPricingTable).toHaveBeenCalledWith({
+      reason: 'deep_link',
+      planMode: undefined
+    })
+  })
+
+  it('strips and clears, then propagates a members-fetch failure', async () => {
+    mockRouteQuery.value = { pricing: '1' }
+    mockFetchMembers.mockRejectedValue(new Error('listMembers failed'))
+
+    const { loadPricingTableFromUrl } = usePricingTableUrlLoader()
+    await expect(loadPricingTableFromUrl()).rejects.toThrow(
+      'listMembers failed'
+    )
+
+    expect(mockShowPricingTable).not.toHaveBeenCalled()
+    expect(mockTrackSubscription).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith({ query: {} })
+    expect(preservedQueryMocks.clearPreservedQuery).toHaveBeenCalledWith(
+      'pricing'
+    )
+  })
+})

--- a/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
+++ b/src/platform/cloud/subscription/composables/usePricingTableUrlLoader.ts
@@ -1,0 +1,72 @@
+import { useRoute, useRouter } from 'vue-router'
+
+import { useSubscriptionDialog } from '@/platform/cloud/subscription/composables/useSubscriptionDialog'
+import {
+  clearPreservedQuery,
+  hydratePreservedQuery,
+  mergePreservedQueryIntoQuery
+} from '@/platform/navigation/preservedQueryManager'
+import { PRESERVED_QUERY_NAMESPACES } from '@/platform/navigation/preservedQueryNamespaces'
+import { useTelemetry } from '@/platform/telemetry'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+const NAMESPACE = PRESERVED_QUERY_NAMESPACES.PRICING
+
+/**
+ * Opens the pricing table from a `?pricing=` deep link, to send pilot users
+ * straight to subscribe. Values: `1` (default tab), `team`, `personal`.
+ *
+ * Gated to the original owner (`canManageSubscriptionLifecycle`); a member or
+ * promoted owner is a silent no-op with the param stripped. Survives the login
+ * redirect via the preserved-query system, like the invite URL loader.
+ */
+export function usePricingTableUrlLoader() {
+  const route = useRoute()
+  const router = useRouter()
+  const subscriptionDialog = useSubscriptionDialog()
+  const workspaceStore = useTeamWorkspaceStore()
+  const { permissions } = useWorkspaceUI()
+
+  /** Reads `?pricing=`, strips it, and opens the table when the gate allows. */
+  async function loadPricingTableFromUrl() {
+    hydratePreservedQuery(NAMESPACE)
+    const query =
+      mergePreservedQueryIntoQuery(NAMESPACE, route.query) ?? route.query
+    const param = query.pricing
+    if (param === undefined) return
+
+    // Strip any present pricing param (even ineligible or malformed values) and
+    // write the clean URL in a single replace before any await, so a clean URL
+    // is guaranteed even if the replace rejects or the gate later denies.
+    const cleanQuery = { ...query }
+    delete cleanQuery.pricing
+    router.replace({ query: cleanQuery }).catch((error) => {
+      console.warn(
+        '[usePricingTableUrlLoader] Failed to clean URL params:',
+        error
+      )
+    })
+    clearPreservedQuery(NAMESPACE)
+
+    // Only a non-empty string value opens the table; an empty/array param just
+    // gets stripped above.
+    if (typeof param !== 'string' || !param) return
+
+    // Load members before reading the gate so the original-owner self-row is
+    // present. fetchMembers always awaits the request; ensureMembersLoaded can
+    // early-return on a cached/in-flight load and let the gate read empty members.
+    await workspaceStore.fetchMembers()
+    if (!permissions.value.canManageSubscriptionLifecycle) return
+
+    const planMode =
+      param === 'team' || param === 'personal' ? param : undefined
+
+    useTelemetry()?.trackSubscription('modal_opened', { reason: 'deep_link' })
+    subscriptionDialog.showPricingTable({ reason: 'deep_link', planMode })
+  }
+
+  return {
+    loadPricingTableFromUrl
+  }
+}

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -15,6 +15,7 @@ export type SubscriptionDialogReason =
   | 'subscription_required'
   | 'out_of_credits'
   | 'top_up_blocked'
+  | 'deep_link'
 
 interface SubscriptionDialogOptions {
   reason?: SubscriptionDialogReason

--- a/src/platform/cloud/subscription/constants/teamPlanCreditStops.ts
+++ b/src/platform/cloud/subscription/constants/teamPlanCreditStops.ts
@@ -50,6 +50,17 @@ export const TEAM_PLAN_CREDIT_STOPS: readonly CreditStop[] = [
 export const DEFAULT_TEAM_PLAN_STOP_INDEX = 2
 
 /**
+ * Per-credit Team plan slug for a billing cadence (cloud catalog). The slug
+ * encodes the cadence; `POST /api/billing/subscribe` reads `plan_slug` +
+ * `team_credit_stop_id` and resolves all amounts server-side from the stop.
+ */
+export function getTeamPlanSlug(billingCycle: 'monthly' | 'yearly'): string {
+  return billingCycle === 'yearly'
+    ? 'team_per_credit_annual'
+    : 'team_per_credit_monthly'
+}
+
+/**
  * Discounted monthly price for a stop's list `usd`, applying the billing-cycle
  * discount (yearly = full `discountPercentYearly`; monthly halves it). Shared by
  * the slider display and the checkout confirm step so the two never drift.

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockIsCloud, mockSubscribe } = vi.hoisted(() => ({
+  mockIsCloud: { value: true },
+  mockSubscribe: vi.fn()
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return mockIsCloud.value
+  }
+}))
+vi.mock('@/config/comfyApi', () => ({
+  getComfyPlatformBaseUrl: () => 'https://app.test'
+}))
+vi.mock('@/platform/workspace/api/workspaceApi', () => ({
+  workspaceApi: { subscribe: mockSubscribe }
+}))
+
+import { performTeamSubscriptionCheckout } from './teamSubscriptionCheckoutUtil'
+
+describe('performTeamSubscriptionCheckout', () => {
+  let assignedHref: string | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsCloud.value = true
+    assignedHref = undefined
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: {
+        set href(value: string) {
+          assignedHref = value
+        }
+      }
+    })
+  })
+
+  it('subscribes at the stop with the yearly slug and redirects to the Stripe payment page', async () => {
+    mockSubscribe.mockResolvedValue({
+      status: 'needs_payment_method',
+      payment_method_url: 'https://stripe.test/pay',
+      billing_op_id: 'op_1'
+    })
+
+    await performTeamSubscriptionCheckout('team_700', 'yearly')
+
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'team_per_credit_annual',
+      'https://app.test/payment/success',
+      'https://app.test/payment/failed',
+      'team_700'
+    )
+    expect(assignedHref).toBe('https://stripe.test/pay')
+  })
+
+  it('uses the monthly slug and lands in the app when no Stripe step is needed', async () => {
+    mockSubscribe.mockResolvedValue({
+      status: 'subscribed',
+      billing_op_id: 'op_2'
+    })
+
+    await performTeamSubscriptionCheckout('team_1400', 'monthly')
+
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      'team_per_credit_monthly',
+      expect.any(String),
+      expect.any(String),
+      'team_1400'
+    )
+    expect(assignedHref).toBe('/')
+  })
+
+  it('throws when payment is needed but no payment URL is returned', async () => {
+    mockSubscribe.mockResolvedValue({
+      status: 'needs_payment_method',
+      billing_op_id: 'op_3'
+    })
+
+    await expect(
+      performTeamSubscriptionCheckout('team_700', 'yearly')
+    ).rejects.toThrow(/payment URL/)
+
+    expect(assignedHref).toBeUndefined()
+  })
+
+  it('does nothing off cloud', async () => {
+    mockIsCloud.value = false
+
+    await performTeamSubscriptionCheckout('team_700', 'yearly')
+
+    expect(mockSubscribe).not.toHaveBeenCalled()
+    expect(assignedHref).toBeUndefined()
+  })
+})

--- a/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/teamSubscriptionCheckoutUtil.ts
@@ -1,0 +1,51 @@
+import { getComfyPlatformBaseUrl } from '@/config/comfyApi'
+import { getTeamPlanSlug } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
+import { isCloud } from '@/platform/distribution/types'
+import { workspaceApi } from '@/platform/workspace/api/workspaceApi'
+
+import type { BillingCycle } from './subscriptionTierRank'
+
+/**
+ * Direct team-plan checkout for the marketing `/cloud/subscribe?tier=team` deep
+ * link: subscribes to the per-credit Team plan at the chosen slider stop and
+ * sends the user straight to the Stripe payment page.
+ *
+ * Mirrors `performSubscriptionCheckout` (personal) but routes through the
+ * workspace billing endpoint (`POST /api/billing/subscribe`), because the
+ * per-credit Team plan lives there and the backend lets any workspace — personal
+ * included — subscribe to it. The slug encodes the cadence; the stop id is
+ * validated and priced server-side.
+ *
+ * Caller guards on `isCloud`, owns loading state, and wraps error handling. A
+ * `needs_payment_method` response is a full-page redirect to Stripe; the other
+ * statuses land back in the app, which polls the billing op to completion.
+ */
+export async function performTeamSubscriptionCheckout(
+  teamCreditStopId: string,
+  billingCycle: BillingCycle
+): Promise<void> {
+  if (!isCloud) return
+
+  const planSlug = getTeamPlanSlug(billingCycle)
+  const response = await workspaceApi.subscribe(
+    planSlug,
+    `${getComfyPlatformBaseUrl()}/payment/success`,
+    `${getComfyPlatformBaseUrl()}/payment/failed`,
+    teamCreditStopId
+  )
+
+  if (response.status === 'needs_payment_method') {
+    // A needs_payment_method response without a URL is unusable: surface it to
+    // the caller's error handling rather than silently dropping the user home
+    // with a subscription stuck mid-payment.
+    if (!response.payment_method_url) {
+      throw new Error(
+        'Team subscription needs a payment method but no payment URL was returned'
+      )
+    }
+    globalThis.location.href = response.payment_method_url
+    return
+  }
+
+  globalThis.location.href = '/'
+}

--- a/src/platform/navigation/preservedQueryNamespaces.ts
+++ b/src/platform/navigation/preservedQueryNamespaces.ts
@@ -4,5 +4,6 @@ export const PRESERVED_QUERY_NAMESPACES = {
   SHARE: 'share',
   SHARE_AUTH: 'share_auth',
   CREATE_WORKSPACE: 'create_workspace',
-  OAUTH: 'oauth'
+  OAUTH: 'oauth',
+  PRICING: 'pricing'
 } as const

--- a/src/platform/workspace/api/workspaceApi.ts
+++ b/src/platform/workspace/api/workspaceApi.ts
@@ -157,6 +157,8 @@ interface SubscribeRequest {
   idempotency_key?: string
   return_url?: string
   cancel_url?: string
+  /** Required for the per-credit Team plan; selects the slider stop. */
+  team_credit_stop_id?: string
 }
 
 type SubscribeStatus = 'subscribed' | 'needs_payment_method' | 'pending_payment'
@@ -625,7 +627,8 @@ export const workspaceApi = {
   async subscribe(
     planSlug: string,
     returnUrl?: string,
-    cancelUrl?: string
+    cancelUrl?: string,
+    teamCreditStopId?: string
   ): Promise<SubscribeResponse> {
     const headers = await getAuthHeaderOrThrow()
     try {
@@ -634,7 +637,8 @@ export const workspaceApi = {
         {
           plan_slug: planSlug,
           return_url: returnUrl,
-          cancel_url: cancelUrl
+          cancel_url: cancelUrl,
+          team_credit_stop_id: teamCreditStopId
         } satisfies SubscribeRequest,
         { headers }
       )

--- a/src/router.ts
+++ b/src/router.ts
@@ -115,6 +115,10 @@ installPreservedQueryTracker(router, [
   {
     namespace: PRESERVED_QUERY_NAMESPACES.OAUTH,
     keys: ['oauth_request_id']
+  },
+  {
+    namespace: PRESERVED_QUERY_NAMESPACES.PRICING,
+    keys: ['pricing']
   }
 ])
 


### PR DESCRIPTION
Backport of #13001 to `cloud/1.45`.

Cherry-picked squash commit `f19597ce8120ee540e8a72fa96e380706d15d59a` cleanly (no conflicts). Original authorship preserved.

Carries stacked child **#13088** (team Stripe checkout deep link) — its `teamSubscriptionCheckoutUtil.ts` is folded into this squash.

**Stacked** on #13092 (base: `backport-13092-to-cloud-1.45`). Part of the cloud/1.45 billing facade stack; merge bottom-up.