### PR TITLE
[backport cloud/1.45] feat(billing): inline Invite-your-team block on team-upgrade success (FE-965 / DES-394) (#12954)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -84,6 +84,16 @@ const config: StorybookConfig = {
               process.cwd() + '/src/storybook/mocks/useBillingContext.ts'
           },
           {
+            find: '@/composables/useFeatureFlags',
+            replacement:
+              process.cwd() + '/src/storybook/mocks/useFeatureFlags.ts'
+          },
+          {
+            find: '@/platform/workspace/stores/teamWorkspaceStore',
+            replacement:
+              process.cwd() + '/src/storybook/mocks/teamWorkspaceStore.ts'
+          },
+          {
             find: '@/utils/formatUtil',
             replacement:
               process.cwd() +

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2700,8 +2700,12 @@
     },
     "success": {
       "allSet": "You're all set",
+      "inviteEmailsPlaceholder": "Enter emails separated by commas",
+      "inviteSubtext": "You can also invite people later from Settings",
+      "inviteTitle": "Invite your team",
       "planUpdated": "Your plan has been successfully updated.",
-      "receiptEmailed": "A receipt has been emailed to you."
+      "receiptEmailed": "A receipt has been emailed to you.",
+      "sendInvites": "Send invites"
     }
   },
   "userSettings": {
@@ -2814,7 +2818,8 @@
       "placeholder": "Enter emails separated by commas",
       "invalidEmailCount": "{count} invalid email address | {count} invalid email addresses",
       "failedCount": "Couldn't send {count} invite. Try again. | Couldn't send {count} invites. Try again.",
-      "invitedMessage": "An invite was sent to {emails} | Invites were sent to {emails}"
+      "invitedMessage": "An invite was sent to {emails} | Invites were sent to {emails}",
+      "seatLimitReached": "You can invite up to {count} teammate. | You can invite up to {count} teammates."
     },
     "createWorkspaceDialog": {
       "title": "Create a new workspace",

--- a/src/platform/telemetry/TelemetryRegistry.ts
+++ b/src/platform/telemetry/TelemetryRegistry.ts
@@ -35,7 +35,8 @@ import type {
   UiButtonClickMetadata,
   WorkflowCreatedMetadata,
   WorkflowImportMetadata,
-  WorkflowSavedMetadata
+  WorkflowSavedMetadata,
+  WorkspaceInviteMetadata
 } from './types'
 
 /**
@@ -110,6 +111,10 @@ export class TelemetryRegistry implements TelemetryDispatcher {
 
   trackApiCreditTopupSucceeded(): void {
     this.dispatch((provider) => provider.trackApiCreditTopupSucceeded?.())
+  }
+
+  trackWorkspaceInviteSent(metadata: WorkspaceInviteMetadata): void {
+    this.dispatch((provider) => provider.trackWorkspaceInviteSent?.(metadata))
   }
 
   trackRunButton(options?: {

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -27,7 +27,8 @@ import type {
   UiButtonClickMetadata,
   WorkflowCreatedMetadata,
   WorkflowImportMetadata,
-  WorkflowSavedMetadata
+  WorkflowSavedMetadata,
+  WorkspaceInviteMetadata
 } from '../../types'
 import { useAppMode } from '@/composables/useAppMode'
 import { getActionbarDockState } from '../../utils/getActionbarDockState'
@@ -181,6 +182,12 @@ export class GtmTelemetryProvider implements TelemetryProvider {
       'subscription_success',
       metadata ? { ...metadata } : undefined
     )
+  }
+
+  trackWorkspaceInviteSent(metadata: WorkspaceInviteMetadata): void {
+    // GA4 names must be bare snake_case; the TelemetryEvents enum carries an
+    // `app:` prefix for Mixpanel/PostHog that dataLayer would forward verbatim.
+    this.pushEvent('workspace_invite_sent', metadata)
   }
 
   trackRunButton(options?: {

--- a/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/MixpanelTelemetryProvider.ts
@@ -46,7 +46,8 @@ import type {
   UiButtonClickMetadata,
   WorkflowCreatedMetadata,
   WorkflowImportMetadata,
-  WorkflowSavedMetadata
+  WorkflowSavedMetadata,
+  WorkspaceInviteMetadata
 } from '../../types'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
 import type { RemoteConfig } from '@/platform/remoteConfig/types'
@@ -265,6 +266,10 @@ export class MixpanelTelemetryProvider implements TelemetryProvider {
 
   trackApiCreditTopupSucceeded(): void {
     this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED)
+  }
+
+  trackWorkspaceInviteSent(metadata: WorkspaceInviteMetadata): void {
+    this.trackEvent(TelemetryEvents.WORKSPACE_INVITE_SENT, metadata)
   }
 
   // Credit top-up tracking methods (composition with utility functions)

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -47,7 +47,8 @@ import type {
   UiButtonClickMetadata,
   WorkflowCreatedMetadata,
   WorkflowImportMetadata,
-  WorkflowSavedMetadata
+  WorkflowSavedMetadata,
+  WorkspaceInviteMetadata
 } from '../../types'
 import { TelemetryEvents } from '../../types'
 import { getActionbarDockState } from '../../utils/getActionbarDockState'
@@ -379,6 +380,10 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
 
   trackApiCreditTopupSucceeded(): void {
     this.trackEvent(TelemetryEvents.API_CREDIT_TOPUP_SUCCEEDED)
+  }
+
+  trackWorkspaceInviteSent(metadata: WorkspaceInviteMetadata): void {
+    this.trackEvent(TelemetryEvents.WORKSPACE_INVITE_SENT, metadata)
   }
 
   trackRunButton(options?: {

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -463,6 +463,11 @@ export interface SubscriptionSuccessMetadata extends Record<string, unknown> {
   ecommerce: EcommerceMetadata
 }
 
+export interface WorkspaceInviteMetadata extends Record<string, unknown> {
+  source: 'post_upgrade_success' | 'settings_members'
+  count: number
+}
+
 /**
  * Telemetry provider interface for individual providers.
  * All methods are optional - providers only implement what they need.
@@ -486,6 +491,7 @@ export interface TelemetryProvider {
   trackAddApiCreditButtonClicked?(): void
   trackApiCreditTopupButtonPurchaseClicked?(amount: number): void
   trackApiCreditTopupSucceeded?(): void
+  trackWorkspaceInviteSent?(metadata: WorkspaceInviteMetadata): void
   trackRunButton?(options?: {
     subscribe_to_run?: boolean
     trigger_source?: ExecutionTriggerSource
@@ -592,6 +598,7 @@ export const TelemetryEvents = {
   API_CREDIT_TOPUP_BUTTON_PURCHASE_CLICKED:
     'app:api_credit_topup_button_purchase_clicked',
   API_CREDIT_TOPUP_SUCCEEDED: 'app:api_credit_topup_succeeded',
+  WORKSPACE_INVITE_SENT: 'app:workspace_invite_sent',
 
   // Onboarding Survey
   USER_SURVEY_OPENED: 'app:user_survey_opened',

--- a/src/platform/workspace/components/InviteMembersForm.test.ts
+++ b/src/platform/workspace/components/InviteMembersForm.test.ts
@@ -1,0 +1,192 @@
+import { render, screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import InviteMembersForm from './InviteMembersForm.vue'
+
+import type { PendingInvite } from '@/platform/workspace/stores/teamWorkspaceStore'
+
+const { mockCreateInvite, mockToastAdd, mockTrackInviteSent } = vi.hoisted(
+  () => ({
+    mockCreateInvite: vi.fn(),
+    mockToastAdd: vi.fn(),
+    mockTrackInviteSent: vi.fn()
+  })
+)
+
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  useTeamWorkspaceStore: () => ({
+    createInvite: mockCreateInvite as (email: string) => Promise<PendingInvite>
+  })
+}))
+
+vi.mock('primevue/usetoast', () => ({
+  useToast: () => ({
+    add: mockToastAdd
+  })
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({
+    trackWorkspaceInviteSent: mockTrackInviteSent
+  })
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false
+})
+
+function pendingInviteFor(email: string): PendingInvite {
+  return {
+    id: `inv-${email}`,
+    email,
+    inviteDate: new Date(0),
+    expiryDate: new Date(0)
+  }
+}
+
+function renderForm(props: Record<string, unknown> = {}) {
+  const user = userEvent.setup()
+  const result = render(InviteMembersForm, {
+    props: {
+      submitLabel: 'Send invites',
+      placeholder: 'Enter emails',
+      source: 'post_upgrade_success',
+      ...props
+    },
+    global: { plugins: [i18n] }
+  })
+  return { ...result, user }
+}
+
+function emailInput() {
+  return screen.getByRole('textbox')
+}
+
+function submitButton() {
+  return screen.getByRole('button', { name: 'Send invites' })
+}
+
+describe('InviteMembersForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateInvite.mockImplementation(async (email: string) =>
+      pendingInviteFor(email)
+    )
+  })
+
+  it('turns comma- and enter-delimited input into chips', async () => {
+    const { user } = renderForm()
+
+    await user.type(emailInput(), 'a@b.com,')
+    await user.type(emailInput(), 'c@d.com{Enter}')
+
+    expect(screen.getByText('a@b.com')).toBeInTheDocument()
+    expect(screen.getByText('c@d.com')).toBeInTheDocument()
+  })
+
+  it('disables submit with no chips and flags invalid emails', async () => {
+    const { user } = renderForm()
+
+    expect(submitButton()).toBeDisabled()
+
+    await user.type(emailInput(), 'not-an-email{Enter}')
+
+    expect(screen.getByText('not-an-email')).toBeInTheDocument()
+    expect(
+      screen.getByText('workspacePanel.inviteMemberDialog.invalidEmailCount')
+    ).toBeInTheDocument()
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it('creates an invite per email, tracks telemetry, and emits submitted', async () => {
+    const { user, emitted } = renderForm()
+
+    await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
+    await user.click(submitButton())
+
+    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    expect(mockCreateInvite).toHaveBeenCalledWith('a@b.com')
+    expect(mockCreateInvite).toHaveBeenCalledWith('c@d.com')
+    expect(mockTrackInviteSent).toHaveBeenCalledWith({
+      source: 'post_upgrade_success',
+      count: 2
+    })
+    expect(emitted().submitted).toEqual([[['a@b.com', 'c@d.com']]])
+  })
+
+  it('keeps failed emails as chips, toasts, and emits the invited subset on partial failure', async () => {
+    mockCreateInvite.mockImplementation(async (email: string) => {
+      if (email === 'fail@x.com') throw new Error('nope')
+      return pendingInviteFor(email)
+    })
+    const { user, emitted } = renderForm()
+
+    await user.type(emailInput(), 'ok@x.com,fail@x.com{Enter}')
+    await user.click(submitButton())
+
+    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('fail@x.com')).toBeInTheDocument()
+    expect(screen.queryByText('ok@x.com')).not.toBeInTheDocument()
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+    expect(emitted().submitted).toEqual([[['ok@x.com']]])
+    expect(mockTrackInviteSent).toHaveBeenCalledWith({
+      source: 'post_upgrade_success',
+      count: 1
+    })
+  })
+
+  it('keeps all chips, toasts, and emits nothing when every invite fails', async () => {
+    mockCreateInvite.mockRejectedValue(new Error('nope'))
+    const { user, emitted } = renderForm()
+
+    await user.type(emailInput(), 'a@b.com,c@d.com{Enter}')
+    await user.click(submitButton())
+
+    await waitFor(() => expect(mockCreateInvite).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('a@b.com')).toBeInTheDocument()
+    expect(screen.getByText('c@d.com')).toBeInTheDocument()
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+    expect(emitted().submitted).toBeUndefined()
+    expect(mockTrackInviteSent).not.toHaveBeenCalled()
+  })
+
+  it('caps the number of chips at maxSeats', async () => {
+    const { user } = renderForm({ maxSeats: 2 })
+
+    await user.type(emailInput(), 'a@b.com,b@b.com,c@b.com{Enter}')
+
+    expect(screen.getByText('a@b.com')).toBeInTheDocument()
+    expect(screen.getByText('b@b.com')).toBeInTheDocument()
+    expect(screen.queryByText('c@b.com')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('workspacePanel.inviteMemberDialog.seatLimitReached')
+    ).toBeInTheDocument()
+  })
+
+  it('emits cancel when a cancel label is provided', async () => {
+    const { user, emitted } = renderForm({ cancelLabel: 'Cancel' })
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(emitted().cancel).toBeTruthy()
+    expect(mockCreateInvite).not.toHaveBeenCalled()
+  })
+
+  it('hides the built-in submit row when showSubmit is false', () => {
+    renderForm({ showSubmit: false })
+
+    expect(
+      screen.queryByRole('button', { name: 'Send invites' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/platform/workspace/components/InviteMembersForm.vue
+++ b/src/platform/workspace/components/InviteMembersForm.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <TagsInput
+      always-editing
+      add-on-paste
+      add-on-blur
+      :delimiter="EMAIL_DELIMITER"
+      :convert-value="normalizeEmail"
+      :model-value="emails"
+      class="min-h-10 w-full bg-tertiary-background px-3 focus-within:bg-tertiary-background hover:bg-tertiary-background-hover"
+      @update:model-value="onEmailsUpdate"
+    >
+      <TagsInputItem
+        v-for="email in emails"
+        :key="email"
+        :value="email"
+        :class="
+          cn('rounded-full', !isValidEmail(email) && 'bg-danger/20 text-danger')
+        "
+      >
+        <TagsInputItemText />
+        <TagsInputItemDelete />
+      </TagsInputItem>
+      <TagsInputInput
+        :auto-focus="autoFocus"
+        class="min-w-0 text-sm"
+        :aria-label="placeholder"
+        :aria-describedby="describedBy"
+        :placeholder="emails.length === 0 ? placeholder : undefined"
+      />
+    </TagsInput>
+
+    <p
+      v-if="invalidEmails.length > 0"
+      :id="invalidEmailsHintId"
+      role="alert"
+      class="text-danger m-0 text-xs"
+    >
+      {{
+        $t(
+          'workspacePanel.inviteMemberDialog.invalidEmailCount',
+          invalidEmails.length
+        )
+      }}
+    </p>
+    <p
+      v-if="isAtSeatLimit"
+      :id="seatLimitHintId"
+      aria-live="polite"
+      class="m-0 text-xs text-muted-foreground"
+    >
+      {{ $t('workspacePanel.inviteMemberDialog.seatLimitReached', maxSeats) }}
+    </p>
+
+    <div
+      v-if="showSubmit"
+      :class="
+        cn('flex', cancelLabel ? 'items-center justify-end gap-4' : 'flex-col')
+      "
+    >
+      <Button
+        v-if="cancelLabel"
+        variant="muted-textonly"
+        size="lg"
+        @click="$emit('cancel')"
+      >
+        {{ cancelLabel }}
+      </Button>
+      <Button
+        variant="secondary"
+        size="lg"
+        :class="cn(!cancelLabel && 'w-full rounded-lg')"
+        :loading
+        :disabled="!canSubmit"
+        :aria-busy="loading"
+        :aria-label="loading ? $t('g.loading') : submitLabel"
+        @click="onSubmit"
+      >
+        {{ submitLabel }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useToast } from 'primevue/usetoast'
+import { computed, ref, useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import Button from '@/components/ui/button/Button.vue'
+import TagsInput from '@/components/ui/tags-input/TagsInput.vue'
+import TagsInputInput from '@/components/ui/tags-input/TagsInputInput.vue'
+import TagsInputItem from '@/components/ui/tags-input/TagsInputItem.vue'
+import TagsInputItemDelete from '@/components/ui/tags-input/TagsInputItemDelete.vue'
+import TagsInputItemText from '@/components/ui/tags-input/TagsInputItemText.vue'
+import { useTelemetry } from '@/platform/telemetry'
+import type { WorkspaceInviteMetadata } from '@/platform/telemetry/types'
+import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
+import {
+  EMAIL_DELIMITER,
+  isValidEmail,
+  normalizeEmail,
+  sanitizeInviteEmails
+} from '@/platform/workspace/utils/inviteEmails'
+import { cn } from '@comfyorg/tailwind-utils'
+
+const {
+  submitLabel,
+  placeholder,
+  source,
+  cancelLabel,
+  maxSeats = Number.POSITIVE_INFINITY,
+  showSubmit = true,
+  autoFocus = false
+} = defineProps<{
+  submitLabel: string
+  placeholder: string
+  source: WorkspaceInviteMetadata['source']
+  cancelLabel?: string
+  maxSeats?: number
+  /** Hide the built-in submit row so a parent can place the action elsewhere
+   *  (e.g. the team-upgrade success footer); drive it via the exposed submit. */
+  showSubmit?: boolean
+  /** Focus the email input on mount. Off by default so an embedding dialog
+   *  keeps control of its own focus order. */
+  autoFocus?: boolean
+}>()
+
+const emit = defineEmits<{
+  submitted: [emails: string[]]
+  cancel: []
+}>()
+
+const { t } = useI18n()
+const toast = useToast()
+const telemetry = useTelemetry()
+const workspaceStore = useTeamWorkspaceStore()
+
+const emails = ref<string[]>([])
+const loading = ref(false)
+
+const invalidEmailsHintId = useId()
+const seatLimitHintId = useId()
+
+const invalidEmails = computed(() =>
+  emails.value.filter((email) => !isValidEmail(email))
+)
+const isAtSeatLimit = computed(() => emails.value.length >= maxSeats)
+const canSubmit = computed(
+  () =>
+    emails.value.length > 0 &&
+    emails.value.length <= maxSeats &&
+    invalidEmails.value.length === 0
+)
+
+const describedBy = computed(
+  () =>
+    [
+      invalidEmails.value.length > 0 ? invalidEmailsHintId : undefined,
+      isAtSeatLimit.value ? seatLimitHintId : undefined
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined
+)
+
+function onEmailsUpdate(value: string[]) {
+  emails.value = sanitizeInviteEmails(value, maxSeats)
+}
+
+async function onSubmit() {
+  if (loading.value) return
+  loading.value = true
+  if (!canSubmit.value) {
+    loading.value = false
+    return
+  }
+  try {
+    const emailSnapshot = [...emails.value]
+    const results = await Promise.allSettled(
+      emailSnapshot.map((email) => workspaceStore.createInvite(email))
+    )
+    const failedEmails = emailSnapshot.filter(
+      (_, index) => results[index].status === 'rejected'
+    )
+    const invitedCount = emailSnapshot.length - failedEmails.length
+
+    if (invitedCount > 0) {
+      telemetry?.trackWorkspaceInviteSent({ source, count: invitedCount })
+      emit(
+        'submitted',
+        emailSnapshot.filter((email) => !failedEmails.includes(email))
+      )
+    }
+
+    if (failedEmails.length === 0) return
+
+    emails.value = failedEmails
+    toast.add({
+      severity: 'error',
+      summary: t(
+        'workspacePanel.inviteMemberDialog.failedCount',
+        failedEmails.length
+      ),
+      life: 5000
+    })
+  } finally {
+    loading.value = false
+  }
+}
+
+defineExpose({
+  submit: onSubmit,
+  get canSubmit() {
+    return canSubmit.value
+  },
+  get loading() {
+    return loading.value
+  }
+})
+</script>

--- a/src/platform/workspace/components/SubscriptionCheckoutSteps.stories.ts
+++ b/src/platform/workspace/components/SubscriptionCheckoutSteps.stories.ts
@@ -205,3 +205,17 @@ export const SuccessAllSet: Story = {
     template: `${shell}<SubscriptionSuccessWorkspace tier-key="creator" :preview-data="previewData" /></div>`
   })
 }
+
+/**
+ * Team success — "You're all set" with the inline "Invite your team" block
+ * (FE-965 / DES-394). Team-only: gated on a team plan + teamWorkspacesEnabled.
+ */
+export const TeamSuccessWithInvite: Story = {
+  render: () => ({
+    components: { SubscriptionSuccessWorkspace },
+    data: () => ({
+      teamPlan: { usd: 700, credits: 147_700, discountedUsd: 630 }
+    }),
+    template: `${shell}<SubscriptionSuccessWorkspace :team-plan="teamPlan" is-team /></div>`
+  })
+}

--- a/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
+++ b/src/platform/workspace/components/SubscriptionRequiredDialogContentUnified.vue
@@ -102,6 +102,7 @@
       :tier-key="selectedTierKey"
       :team-plan="selectedTeamStop"
       :preview-data="previewData"
+      :is-team="isTeamCheckout"
       @close="handleSuccessClose"
     />
   </div>

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.test.ts
@@ -1,8 +1,9 @@
 import userEvent from '@testing-library/user-event'
-import { render, screen } from '@testing-library/vue'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+import { MAX_WORKSPACE_MEMBERS } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 import SubscriptionSuccessWorkspace from './SubscriptionSuccessWorkspace.vue'
 
@@ -11,6 +12,39 @@ vi.mock('vue-i18n', () => ({
     t: (key: string) => key,
     n: (value: number) => String(value)
   })
+}))
+
+const { mockMembers, mockPendingInvites } = vi.hoisted(() => ({
+  mockMembers: [] as unknown[],
+  mockPendingInvites: [] as unknown[]
+}))
+
+// Provide just the seat cap + member/invite slots so the component import doesn't
+// drag the team store's i18n/app chain into this unit test.
+vi.mock('@/platform/workspace/stores/teamWorkspaceStore', () => ({
+  MAX_WORKSPACE_MEMBERS: 30,
+  useTeamWorkspaceStore: () => ({
+    members: mockMembers,
+    pendingInvites: mockPendingInvites
+  })
+}))
+
+const { mockFlags } = vi.hoisted(() => ({
+  mockFlags: { teamWorkspacesEnabled: true }
+}))
+
+vi.mock('@/composables/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ flags: mockFlags })
+}))
+
+vi.mock('./InviteMembersForm.vue', () => ({
+  default: {
+    name: 'InviteMembersForm',
+    props: ['maxSeats', 'source', 'submitLabel', 'placeholder'],
+    emits: ['submitted'],
+    template:
+      '<div data-testid="invite-form">seats:{{ maxSeats }}<button data-testid="stub-submit" @click="$emit(\'submitted\', [\'a@b.com\'])">submit</button></div>'
+  }
 }))
 
 function makePreviewData(
@@ -41,11 +75,21 @@ function makePreviewData(
   }
 }
 
-function renderCard() {
+const TEAM_STOP = {
+  id: 'team_700',
+  usd: 700,
+  credits: 147_700,
+  discountedUsd: 630
+}
+
+function renderCard(props: Record<string, unknown> = {}) {
   return render(SubscriptionSuccessWorkspace, {
     props: {
-      tierKey: 'standard',
-      previewData: makePreviewData(1600)
+      tierKey: 'creator',
+      previewData: {
+        new_plan: { price_cents: 1600 }
+      } as unknown as PreviewSubscribeResponse,
+      ...props
     },
     global: {
       mocks: { $t: (key: string) => key },
@@ -58,28 +102,27 @@ function renderCard() {
   })
 }
 
-function renderTeamCard() {
-  return render(SubscriptionSuccessWorkspace, {
-    props: {
-      teamPlan: {
-        id: 'team_700',
-        usd: 700,
-        credits: 147_700,
-        discountedUsd: 630
-      }
-    },
-    global: {
-      mocks: { $t: (key: string) => key },
-      stubs: {
-        Button: {
-          template: '<button @click="$emit(\'click\')"><slot /></button>'
-        }
-      }
-    }
+function renderTeamCard(props: Record<string, unknown> = {}) {
+  return renderCard({
+    tierKey: null,
+    teamPlan: TEAM_STOP,
+    isTeam: true,
+    ...props
   })
 }
 
 describe('SubscriptionSuccessWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFlags.teamWorkspacesEnabled = true
+    mockMembers.length = 0
+    mockPendingInvites.length = 0
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
   it('renders the all-set heading and plan price', () => {
     renderCard()
     expect(screen.getByText('subscription.success.allSet')).toBeTruthy()
@@ -113,8 +156,61 @@ describe('SubscriptionSuccessWorkspace', () => {
   })
 
   it('emits close when the close button is clicked', async () => {
-    const { emitted } = renderCard()
+    const { emitted } = renderCard({ isTeam: false })
     await userEvent.click(screen.getByRole('button'))
     expect(emitted().close).toBeTruthy()
+  })
+
+  it('renders the invite block capped at the workspace member limit', () => {
+    renderTeamCard()
+    expect(screen.getByText('subscription.success.inviteTitle')).toBeTruthy()
+    // The buyer holds one of the flat team-member seats, so the rest are invitable.
+    expect(screen.getByTestId('invite-form')).toHaveTextContent(
+      `seats:${MAX_WORKSPACE_MEMBERS - 1}`
+    )
+  })
+
+  it('places the Send invites action in the footer for a team upgrade', () => {
+    renderTeamCard()
+    expect(screen.getByText('subscription.success.sendInvites')).toBeTruthy()
+  })
+
+  it('shows no Send invites action for a personal upgrade', () => {
+    renderCard({ isTeam: false })
+    expect(screen.queryByText('subscription.success.sendInvites')).toBeNull()
+  })
+
+  it('does not render the invite block for a personal upgrade', () => {
+    renderCard({ isTeam: false })
+    expect(screen.queryByText('subscription.success.inviteTitle')).toBeNull()
+    expect(screen.queryByTestId('invite-form')).toBeNull()
+  })
+
+  it('hides the invite block when team workspaces are disabled', () => {
+    mockFlags.teamWorkspacesEnabled = false
+    renderTeamCard()
+    expect(screen.queryByTestId('invite-form')).toBeNull()
+  })
+
+  it('subtracts existing members and pending invites from invitable seats', () => {
+    mockMembers.push({}, {})
+    mockPendingInvites.push({})
+    renderTeamCard()
+    expect(screen.getByTestId('invite-form')).toHaveTextContent(
+      `seats:${MAX_WORKSPACE_MEMBERS - 3}`
+    )
+  })
+
+  it('swaps the form for the success message once invites are submitted', async () => {
+    renderTeamCard()
+    expect(screen.getByTestId('invite-form')).toBeTruthy()
+
+    await userEvent.click(screen.getByTestId('stub-submit'))
+
+    expect(screen.queryByTestId('invite-form')).toBeNull()
+    expect(
+      screen.getByText('workspacePanel.inviteMemberDialog.invitedMessage')
+    ).toBeTruthy()
+    expect(screen.queryByText('subscription.success.sendInvites')).toBeNull()
   })
 })

--- a/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
+++ b/src/platform/workspace/components/SubscriptionSuccessWorkspace.vue
@@ -33,10 +33,54 @@
         </div>
       </div>
 
-      <!-- Team success "Invite your team" block renders here (FE-965 / DES-394). -->
+      <div v-if="showInviteBlock" class="mt-4 flex w-full flex-col gap-2">
+        <h3 class="m-0 text-base font-semibold text-base-foreground">
+          {{ $t('subscription.success.inviteTitle') }}
+        </h3>
+        <p class="m-0 text-sm text-muted-foreground">
+          {{ $t('subscription.success.inviteSubtext') }}
+        </p>
+        <div aria-live="polite">
+          <p
+            v-if="invitedEmails.length > 0"
+            ref="invitedMessage"
+            tabindex="-1"
+            class="text-success-foreground m-0 text-sm"
+          >
+            {{
+              $t(
+                'workspacePanel.inviteMemberDialog.invitedMessage',
+                { emails: invitedEmails.join(', ') },
+                invitedEmails.length
+              )
+            }}
+          </p>
+          <InviteMembersForm
+            v-else
+            ref="inviteForm"
+            :show-submit="false"
+            source="post_upgrade_success"
+            :submit-label="$t('subscription.success.sendInvites')"
+            :placeholder="$t('subscription.success.inviteEmailsPlaceholder')"
+            :max-seats="invitableSeats"
+            @submitted="onInvited"
+          />
+        </div>
+      </div>
     </div>
 
     <div class="flex flex-col gap-2 pt-8">
+      <Button
+        v-if="showInviteBlock && invitedEmails.length === 0"
+        variant="tertiary"
+        size="lg"
+        class="w-full rounded-lg"
+        :disabled="!canSendInvites"
+        :loading="isSendingInvites"
+        @click="handleSendInvites"
+      >
+        {{ $t('subscription.success.sendInvites') }}
+      </Button>
       <Button
         variant="secondary"
         size="lg"
@@ -50,24 +94,33 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import Button from '@/components/ui/button/Button.vue'
 import type { TeamPlanSelection } from '@/platform/cloud/subscription/constants/teamPlanCreditStops'
 import { getTierCredits } from '@/platform/cloud/subscription/constants/tierPricing'
 import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricing'
 import { isAnnualDuration } from '@/platform/cloud/subscription/utils/planDuration'
 import type { PreviewSubscribeResponse } from '@/platform/workspace/api/workspaceApi'
+import {
+  MAX_WORKSPACE_MEMBERS,
+  useTeamWorkspaceStore
+} from '@/platform/workspace/stores/teamWorkspaceStore'
+
+import InviteMembersForm from './InviteMembersForm.vue'
 
 const {
   tierKey,
   previewData = null,
-  teamPlan = null
+  teamPlan = null,
+  isTeam = false
 } = defineProps<{
   tierKey?: Exclude<TierKey, 'free' | 'founder'> | null
   previewData?: PreviewSubscribeResponse | null
   teamPlan?: TeamPlanSelection | null
+  isTeam?: boolean
 }>()
 
 defineEmits<{
@@ -75,6 +128,8 @@ defineEmits<{
 }>()
 
 const { t, n } = useI18n()
+const { flags } = useFeatureFlags()
+const workspaceStore = useTeamWorkspaceStore()
 
 const tierName = computed(() =>
   teamPlan
@@ -95,4 +150,33 @@ const displayPrice = computed(() => {
 const displayCredits = computed(() =>
   n(teamPlan ? teamPlan.credits : tierKey ? (getTierCredits(tierKey) ?? 0) : 0)
 )
+
+const occupiedSeats = computed(() =>
+  Math.max(
+    1,
+    workspaceStore.members.length + workspaceStore.pendingInvites.length
+  )
+)
+const invitableSeats = computed(() =>
+  Math.max(0, MAX_WORKSPACE_MEMBERS - occupiedSeats.value)
+)
+
+const showInviteBlock = computed(() => isTeam && flags.teamWorkspacesEnabled)
+
+const invitedEmails = ref<string[]>([])
+const invitedMessage = ref<HTMLElement>()
+
+const inviteForm = ref<InstanceType<typeof InviteMembersForm>>()
+const canSendInvites = computed(() => inviteForm.value?.canSubmit ?? false)
+const isSendingInvites = computed(() => inviteForm.value?.loading ?? false)
+
+function handleSendInvites() {
+  void inviteForm.value?.submit()?.catch(console.error)
+}
+
+async function onInvited(emails: string[]) {
+  invitedEmails.value = emails
+  await nextTick()
+  invitedMessage.value?.focus()
+}
 </script>

--- a/src/platform/workspace/utils/inviteEmails.test.ts
+++ b/src/platform/workspace/utils/inviteEmails.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isValidEmail,
+  normalizeEmail,
+  sanitizeInviteEmails
+} from './inviteEmails'
+
+describe('isValidEmail', () => {
+  it('accepts a well-formed address and rejects malformed ones', () => {
+    expect(isValidEmail('a@b.com')).toBe(true)
+    expect(isValidEmail('no-at-sign')).toBe(false)
+    expect(isValidEmail('missing@domain')).toBe(false)
+    expect(isValidEmail('two @spaces.com')).toBe(false)
+  })
+})
+
+describe('normalizeEmail', () => {
+  it('trims surrounding whitespace and lowercases', () => {
+    expect(normalizeEmail('  Alice@Example.COM ')).toBe('alice@example.com')
+  })
+})
+
+describe('sanitizeInviteEmails', () => {
+  it('dedupes case-insensitively after normalizing', () => {
+    expect(
+      sanitizeInviteEmails(['A@B.com', 'a@b.com ', 'c@d.com'], 50)
+    ).toEqual(['a@b.com', 'c@d.com'])
+  })
+
+  it('drops blank entries', () => {
+    expect(sanitizeInviteEmails(['a@b.com', '', '   '], 50)).toEqual([
+      'a@b.com'
+    ])
+  })
+
+  it('clamps to maxSeats, keeping the first entries', () => {
+    expect(sanitizeInviteEmails(['a@b.com', 'c@d.com', 'e@f.com'], 2)).toEqual([
+      'a@b.com',
+      'c@d.com'
+    ])
+  })
+})

--- a/src/platform/workspace/utils/inviteEmails.ts
+++ b/src/platform/workspace/utils/inviteEmails.ts
@@ -1,0 +1,22 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** Split pasted/typed input on commas and newlines only, so addresses with
+ *  surrounding whitespace (e.g. Outlook `"Alice B" <a@b.com>`) stay intact. */
+export const EMAIL_DELIMITER = /[,\n]+/
+
+export function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email)
+}
+
+/** Normalize, drop blanks, dedupe (case-insensitive), then clamp to `maxSeats`. */
+export function sanitizeInviteEmails(
+  values: string[],
+  maxSeats: number
+): string[] {
+  const unique = [...new Set(values.map(normalizeEmail).filter(Boolean))]
+  return unique.length > maxSeats ? unique.slice(0, maxSeats) : unique
+}

--- a/src/storybook/mocks/teamWorkspaceStore.ts
+++ b/src/storybook/mocks/teamWorkspaceStore.ts
@@ -1,0 +1,26 @@
+import type {
+  PendingInvite,
+  WorkspaceMember
+} from '../../platform/workspace/stores/teamWorkspaceStore'
+
+/**
+ * Storybook mock for `useTeamWorkspaceStore`.
+ *
+ * The real store pulls in workspace auth/network state that is unavailable in
+ * Storybook. This stub resolves invites locally so the post-upgrade invite
+ * block can be exercised without a backend.
+ */
+export const MAX_WORKSPACE_MEMBERS = 30
+
+export function useTeamWorkspaceStore() {
+  return {
+    members: [] as WorkspaceMember[],
+    pendingInvites: [] as PendingInvite[],
+    createInvite: async (email: string): Promise<PendingInvite> => ({
+      id: `inv-${email}`,
+      email,
+      inviteDate: new Date(0),
+      expiryDate: new Date(0)
+    })
+  }
+}

--- a/src/storybook/mocks/useBillingContext.ts
+++ b/src/storybook/mocks/useBillingContext.ts
@@ -33,7 +33,7 @@ export function useBillingContext(): BillingContext {
     subscriptionStatus: computed(() => null),
     tier: computed(() => null),
     renewalDate: computed(() => null),
-    getMaxSeats: () => 1,
+    getMaxSeats: (tierKey: string) => ({ creator: 5, pro: 20 })[tierKey] ?? 1,
     initialize: async () => {},
     fetchStatus: async () => {},
     fetchBalance: async () => {},

--- a/src/storybook/mocks/useFeatureFlags.ts
+++ b/src/storybook/mocks/useFeatureFlags.ts
@@ -1,0 +1,37 @@
+/**
+ * Storybook mock for `useFeatureFlags`.
+ *
+ * The real composable resolves flags from authenticated remote config, which is
+ * unavailable in Storybook. This stub enables the workspace-facing flags so
+ * team-plan billing components (e.g. the post-upgrade invite block) render.
+ */
+// Inlined from `@/composables/useFeatureFlags` (the alias points here) so the
+// enum, consumed by modules like nodeReplacementStore, resolves without dragging
+// the real composable's auth/remote-config dependency graph into the bundle.
+export enum ServerFeatureFlag {
+  SUPPORTS_PREVIEW_METADATA = 'supports_preview_metadata',
+  MAX_UPLOAD_SIZE = 'max_upload_size',
+  MANAGER_SUPPORTS_V4 = 'extension.manager.supports_v4',
+  MODEL_UPLOAD_BUTTON_ENABLED = 'model_upload_button_enabled',
+  ASSET_RENAME_ENABLED = 'asset_rename_enabled',
+  PRIVATE_MODELS_ENABLED = 'private_models_enabled',
+  ONBOARDING_SURVEY_ENABLED = 'onboarding_survey_enabled',
+  LINEAR_TOGGLE_ENABLED = 'linear_toggle_enabled',
+  TEAM_WORKSPACES_ENABLED = 'team_workspaces_enabled',
+  USER_SECRETS_ENABLED = 'user_secrets_enabled',
+  NODE_REPLACEMENTS = 'node_replacements',
+  NODE_LIBRARY_ESSENTIALS_ENABLED = 'node_library_essentials_enabled',
+  WORKFLOW_SHARING_ENABLED = 'workflow_sharing_enabled',
+  COMFYHUB_UPLOAD_ENABLED = 'comfyhub_upload_enabled',
+  COMFYHUB_PROFILE_GATE_ENABLED = 'comfyhub_profile_gate_enabled',
+  SHOW_SIGNIN_BUTTON = 'show_signin_button',
+  UNIFIED_CLOUD_AUTH = 'unified_cloud_auth'
+}
+
+export function useFeatureFlags() {
+  return {
+    flags: {
+      teamWorkspacesEnabled: true
+    }
+  }
+}


### PR DESCRIPTION
Backport of #12954 to `cloud/1.45`.

Cherry-picked squash commit `87e84e728038ddbe947587fda19c686ed727cf14`. Original authorship preserved.

**Telemetry conflict resolved** in 4 files (TelemetryRegistry, Gtm/PostHog providers, types). Kept only #12954's own additions — `WorkspaceInviteMetadata`, `trackWorkspaceInviteSent`, `WORKSPACE_INVITE_SENT` — and preserved cloud/1.45's existing `trackRunButton(options)` signature. The `trackRunButton(properties: RunButtonProperties)` refactor and `BEGIN_CHECKOUT` event seen in the conflict context belong to other not-yet-backported PRs (#12786 etc.) and were deliberately NOT pulled in.

**Stacked** on #12975 (base: `backport-12975-to-cloud-1.45`). Merge bottom-up.