### PR TITLE
chore: drop unnecessary exports on file-local types to satisfy knip

### DIFF
--- a/apps/website/src/utils/video.ts
+++ b/apps/website/src/utils/video.ts
@@ -1,7 +1,7 @@
 /** @knipIgnoreUsedByStackedPR */
 export type VideoFormat = 'webm' | 'mp4'
 
-export type VideoSource = {
+type VideoSource = {
   src: string
   type: `video/${VideoFormat}`
   format: VideoFormat

--- a/browser_tests/fixtures/utils/objectInfo.ts
+++ b/browser_tests/fixtures/utils/objectInfo.ts
@@ -12,7 +12,7 @@ import type {
   InputSpec
 } from '@/schemas/nodeDefSchema'
 
-export type ObjectInfoResponse = Record<string, ComfyNodeDef>
+type ObjectInfoResponse = Record<string, ComfyNodeDef>
 
 type ComboInput = ComboInputSpec | ComboInputSpecV2
 

--- a/browser_tests/fixtures/utils/promotedMissingModel.ts
+++ b/browser_tests/fixtures/utils/promotedMissingModel.ts
@@ -13,7 +13,7 @@ import type { ComfyWorkflowJSON } from '@/platform/workflow/validation/schemas/w
 
 const PROMOTED_MODEL_WIDGET_NAME = 'ckpt_name'
 
-export interface PromotedMissingModelWorkflow {
+interface PromotedMissingModelWorkflow {
   workflowName: string
   hostNodeId: number
   hostNodeTitle: string

--- a/src/composables/useHdrViewer.ts
+++ b/src/composables/useHdrViewer.ts
@@ -43,7 +43,7 @@ const CHANNEL_INDEX: Record<ChannelMode, number> = {
   luminance: 5
 }
 
-export interface PixelReadout {
+interface PixelReadout {
   x: number
   y: number
   r: number

--- a/src/composables/useImageCrop.ts
+++ b/src/composables/useImageCrop.ts
@@ -7,7 +7,7 @@ import type { Bounds } from '@/renderer/core/layout/types'
 import { useNodeOutputStore } from '@/stores/nodeOutputStore'
 import { resolveNode } from '@/utils/litegraphUtil'
 
-export type ResizeDirection =
+type ResizeDirection =
   | 'top'
   | 'bottom'
   | 'left'
@@ -17,7 +17,7 @@ export type ResizeDirection =
   | 'sw'
   | 'se'
 
-export interface ResizeHandle {
+interface ResizeHandle {
   direction: ResizeDirection
   class: string
   style: {

--- a/src/composables/useRunButtonTelemetry.ts
+++ b/src/composables/useRunButtonTelemetry.ts
@@ -7,7 +7,7 @@ import type {
 import { getActionbarDockState } from '@/platform/telemetry/utils/getActionbarDockState'
 import { getExecutionContext } from '@/platform/telemetry/utils/getExecutionContext'
 
-export type RunButtonTelemetryOptions = {
+type RunButtonTelemetryOptions = {
   subscribe_to_run?: boolean
   trigger_source?: ExecutionTriggerSource
 }

--- a/src/platform/assets/utils/resolveModelNodeFromAsset.ts
+++ b/src/platform/assets/utils/resolveModelNodeFromAsset.ts
@@ -17,7 +17,7 @@ export interface ResolveModelNodeError {
   details?: Record<string, unknown>
 }
 
-export interface ResolvedModelNode {
+interface ResolvedModelNode {
   provider: ModelNodeProvider
   filename: string
 }

--- a/src/platform/cloud/subscription/composables/useAccountPreconditionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useAccountPreconditionDialog.ts
@@ -1,7 +1,7 @@
 import type { AccountPrecondition } from '@/platform/errorCatalog/accountPreconditionRouting'
 import { useDialogService } from '@/services/dialogService'
 
-export interface AccountPreconditionContext {
+interface AccountPreconditionContext {
   /** Node type that triggered the precondition, used as modal context. */
   nodeType?: string
 }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -17,7 +17,7 @@ export type SubscriptionDialogReason =
   | 'top_up_blocked'
   | 'deep_link'
 
-export interface SubscriptionDialogOptions {
+interface SubscriptionDialogOptions {
   reason?: SubscriptionDialogReason
   /**
    * Forces the unified pricing dialog to open on a specific plan tab,

--- a/src/platform/cloud/subscription/utils/creditsProgress.ts
+++ b/src/platform/cloud/subscription/utils/creditsProgress.ts
@@ -1,4 +1,4 @@
-export interface MonthlyCreditsUsage {
+interface MonthlyCreditsUsage {
   /** Credits consumed from the monthly allowance (never negative). */
   used: number
   /** Fraction (0–1) of the monthly allowance consumed — drives the bar fill. */

--- a/src/platform/missingMedia/missingMediaGrouping.ts
+++ b/src/platform/missingMedia/missingMediaGrouping.ts
@@ -2,7 +2,7 @@ import { sumBy } from 'es-toolkit'
 
 import type { MissingMediaGroup, MissingMediaViewModel } from './types'
 
-export interface MissingMediaReference {
+interface MissingMediaReference {
   mediaItem: MissingMediaViewModel
   nodeRef: MissingMediaViewModel['referencingNodes'][number]
 }

--- a/src/renderer/extensions/vueNodes/widgets/utils/resolvePromotedWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/utils/resolvePromotedWidget.ts
@@ -1,7 +1,7 @@
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
-export interface ResolvedHostWidget {
+interface ResolvedHostWidget {
   node: LGraphNode
   widget: IBaseWidget
 }


### PR DESCRIPTION
Current `main` **fails a fresh `knip` run** with 13 unused exported types (exit 1). They're invisible on main because lint/knip only runs on `pull_request`/`merge_group`, never on push to main — so merge skew (one PR adds an export used by file X; a later PR removes X's usage) accumulates latent failures that ambush backport branches (e.g. #13163, #13162).

Each of the 13 is `export`ed but referenced only within its own file (verified 0 importers; ≥2 in-file uses, so not dead code). Fix: drop the redundant `export`.

Types cleaned: `VideoSource`, `ObjectInfoResponse`, `PromotedMissingModelWorkflow`, `PixelReadout`, `ResizeDirection`, `ResizeHandle`, `RunButtonTelemetryOptions`, `ResolvedModelNode`, `AccountPreconditionContext`, `SubscriptionDialogOptions`, `MonthlyCreditsUsage`, `MissingMediaReference`, `ResolvedHostWidget`.

Reviewer note: `ResolvedHostWidget` and `ResolvedModelNode` sit under `renderer/extensions`/`platform/assets`; no in-repo importers, but if either is intended as published/extension-facing API, prefer a knip `entry`/`ignore` over un-exporting — flag in review and I'll adjust.

After fresh `knip`: **0 unused exported types**.

Supersedes #13179 (fixed only `AccountPreconditionContext`). Pairs with the push-gate workflow #13203 — merge this first so that gate is green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)