### PR TITLE
FE-1150 feat(rightSidePanel): hide 3D viewport widgets from panel

### DIFF
--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -39,7 +39,11 @@ const advancedWidgetsSectionDataList = computed((): NodeWidgetsListList => {
       const advancedWidgets = widgets
         .filter(
           (w) =>
-            !(w.options?.canvasOnly || w.options?.hidden) && w.options?.advanced
+            !(
+              w.options?.canvasOnly ||
+              w.options?.hidden ||
+              w.options?.hideInPanel
+            ) && w.options?.advanced
         )
         .map((widget) => ({ node, widget }))
       return { widgets: advancedWidgets, node }

--- a/src/components/rightSidePanel/shared.test.ts
+++ b/src/components/rightSidePanel/shared.test.ts
@@ -1,10 +1,16 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
 import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { Positionable } from '@/lib/litegraph/src/interfaces'
-import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
+import type {
+  IBaseWidget,
+  IWidgetOptions
+} from '@/lib/litegraph/src/types/widgets'
 import { toNodeId } from '@/types/nodeId'
 import { describe, expect, it, beforeEach } from 'vitest'
 import {
+  computedSectionDataList,
   flatAndCategorizeSelectedItems,
   searchWidgets,
   searchWidgetsAndNodes
@@ -126,6 +132,51 @@ describe('searchWidgetsAndNodes', () => {
         widgets: [matchingWidget.widgets[1]]
       }
     ])
+  })
+})
+
+describe('computedSectionDataList', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia())
+  })
+
+  function createWidget(
+    name: string,
+    options: IWidgetOptions = {}
+  ): IBaseWidget {
+    return { name, type: 'number', options, y: 0 } as IBaseWidget
+  }
+
+  it('omits hideInPanel widgets while keeping the rest on the node', () => {
+    const node = new LGraphNode('Load3D')
+    node.widgets = [
+      createWidget('seed'),
+      createWidget('viewport', { hideInPanel: true })
+    ]
+
+    const { widgetsSectionDataList } = computedSectionDataList([node])
+    const shownNames = widgetsSectionDataList.value[0].widgets.map(
+      ({ widget }) => widget.name
+    )
+
+    expect(shownNames).toEqual(['seed'])
+  })
+
+  it('hides canvasOnly, hidden, and hideInPanel widgets from the panel', () => {
+    const node = new LGraphNode('Load3D')
+    node.widgets = [
+      createWidget('seed'),
+      createWidget('preview', { canvasOnly: true }),
+      createWidget('internal', { hidden: true }),
+      createWidget('viewport', { hideInPanel: true })
+    ]
+
+    const { widgetsSectionDataList } = computedSectionDataList([node])
+    const shownNames = widgetsSectionDataList.value[0].widgets.map(
+      ({ widget }) => widget.name
+    )
+
+    expect(shownNames).toEqual(['seed'])
   })
 })
 

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -263,6 +263,7 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
             !(
               w.options?.canvasOnly ||
               w.options?.hidden ||
+              w.options?.hideInPanel ||
               (w.options?.advanced && !includesAdvanced.value)
             )
         )

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -343,7 +343,7 @@ useExtensionService().registerExtension({
           name: inputName,
           component: Load3D,
           inputSpec: { ...inputSpecLoad3D, name: inputName },
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3D'
@@ -566,7 +566,7 @@ useExtensionService().registerExtension({
           name: inputSpecPreview3D.name,
           component: Load3D,
           inputSpec: inputSpecPreview3D,
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3D'

--- a/src/extensions/core/load3dAdvanced.ts
+++ b/src/extensions/core/load3dAdvanced.ts
@@ -45,7 +45,7 @@ useExtensionService().registerExtension({
           name: 'viewport_state',
           component: Load3DAdvanced,
           inputSpec: inputSpecLoad3DAdvanced,
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3DAdvanced'

--- a/src/extensions/core/saveMesh.ts
+++ b/src/extensions/core/saveMesh.ts
@@ -107,7 +107,7 @@ useExtensionService().registerExtension({
           name: inputSpec.name,
           component: Load3D,
           inputSpec,
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3D'

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -43,6 +43,14 @@ export interface IWidgetOptions<TValues = unknown> {
   socketless?: boolean
   /** If `true`, the widget will not be rendered by the Vue renderer. */
   canvasOnly?: boolean
+  /**
+   * If `true`, the widget still renders on the node but is omitted from the
+   * right side panel. Unlike {@link IWidgetOptions.canvasOnly}, the node body
+   * keeps rendering it via the Vue renderer. Used for widgets that hold
+   * non-syncable state (e.g. a Three.js viewport) where a second instance in
+   * the panel would diverge from the one on the node.
+   */
+  hideInPanel?: boolean
   /** Used as a temporary override for determining the asset type in vue mode*/
   nodeType?: string
 


### PR DESCRIPTION
## Summary
Add a hideInPanel widget option so a widget still renders on the node body but is omitted from the right side panel. Apply it to the Three.js viewport widgets (Load3D, Preview3D, Load3DAdvanced, SaveGLB), whose non-syncable scene state would diverge if a second instance rendered in the panel. 

App mode and the subgraph editor are unaffected (they filter on canvasOnly independently).

Discussed with @alexisrolland and @PabloWiedemann 

## Screenshots
before
<img width="2206" height="1181" alt="image" src="https://github.com/user-attachments/assets/e536871f-65e6-4d6e-aa61-dc981362214f" />

after
<img width="2743" height="1295" alt="image" src="https://github.com/user-attachments/assets/6cc6d252-57ac-464a-a2b7-1ada5ab9e705" />
