### PR TITLE
[backport core/1.45] FE-1150 feat(rightSidePanel): hide 3D viewport widgets from panel (#13206)

### DIFF
--- a/src/components/rightSidePanel/parameters/TabNormalInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabNormalInputs.vue
@@ -38,7 +38,11 @@ const advancedWidgetsSectionDataList = computed((): NodeWidgetsListList => {
       const advancedWidgets = widgets
         .filter(
           (w) =>
-            !(w.options?.canvasOnly || w.options?.hidden) && w.options?.advanced
+            !(
+              w.options?.canvasOnly ||
+              w.options?.hidden ||
+              w.options?.hideInPanel
+            ) && w.options?.advanced
         )
         .map((widget) => ({ node, widget }))
       return { widgets: advancedWidgets, node }

--- a/src/components/rightSidePanel/shared.ts
+++ b/src/components/rightSidePanel/shared.ts
@@ -266,6 +266,7 @@ export function computedSectionDataList(nodes: MaybeRefOrGetter<LGraphNode[]>) {
             !(
               w.options?.canvasOnly ||
               w.options?.hidden ||
+              w.options?.hideInPanel ||
               (w.options?.advanced && !includesAdvanced.value)
             )
         )

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -340,7 +340,7 @@ useExtensionService().registerExtension({
           name: inputName,
           component: Load3D,
           inputSpec: { ...inputSpecLoad3D, name: inputName },
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3D'
@@ -563,7 +563,7 @@ useExtensionService().registerExtension({
           name: inputSpecPreview3D.name,
           component: Load3D,
           inputSpec: inputSpecPreview3D,
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3D'

--- a/src/extensions/core/load3dAdvanced.ts
+++ b/src/extensions/core/load3dAdvanced.ts
@@ -45,7 +45,7 @@ useExtensionService().registerExtension({
           name: 'viewport_state',
           component: Load3DAdvanced,
           inputSpec: inputSpecLoad3DAdvanced,
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3DAdvanced'

--- a/src/extensions/core/saveMesh.ts
+++ b/src/extensions/core/saveMesh.ts
@@ -107,7 +107,7 @@ useExtensionService().registerExtension({
           name: inputSpec.name,
           component: Load3D,
           inputSpec,
-          options: {}
+          options: { hideInPanel: true }
         })
 
         widget.type = 'load3D'

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -46,6 +46,14 @@ export interface IWidgetOptions<TValues = unknown> {
   socketless?: boolean
   /** If `true`, the widget will not be rendered by the Vue renderer. */
   canvasOnly?: boolean
+  /**
+   * If `true`, the widget still renders on the node but is omitted from the
+   * right side panel. Unlike {@link IWidgetOptions.canvasOnly}, the node body
+   * keeps rendering it via the Vue renderer. Used for widgets that hold
+   * non-syncable state (e.g. a Three.js viewport) where a second instance in
+   * the panel would diverge from the one on the node.
+   */
+  hideInPanel?: boolean
   /** Used as a temporary override for determining the asset type in vue mode*/
   nodeType?: string
 


### PR DESCRIPTION
Backport of https://github.com/Comfy-Org/ComfyUI_frontend/pull/13206 to core/1.45