### PR TITLE
[backport cloud/1.45] feat(billing): role-aware run-lock for cancelled/inactive team plans (FE-978) (#12786)

### DIFF
--- a/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
+++ b/src/components/actionbar/ComfyRunButton/CloudRunButtonWrapper.test.ts
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import CloudRunButtonWrapper from './CloudRunButtonWrapper.vue'
+
+const mockIsActiveSubscription = ref(true)
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: mockIsActiveSubscription
+  })
+}))
+
+vi.mock('@/components/actionbar/ComfyRunButton/ComfyQueueButton.vue', () => ({
+  default: {
+    name: 'ComfyQueueButton',
+    template: '<div data-testid="queue-button" />'
+  }
+}))
+
+vi.mock('@/platform/cloud/subscription/components/SubscribeToRun.vue', () => ({
+  default: {
+    name: 'SubscribeToRun',
+    template: '<div data-testid="subscribe-to-run-button" />'
+  }
+}))
+
+function renderWrapper() {
+  return render(CloudRunButtonWrapper)
+}
+
+describe('CloudRunButtonWrapper', () => {
+  beforeEach(() => {
+    mockIsActiveSubscription.value = true
+  })
+
+  it('renders the runnable queue button when the subscription is active', () => {
+    renderWrapper()
+
+    expect(screen.getByTestId('queue-button')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('subscribe-to-run-button')
+    ).not.toBeInTheDocument()
+  })
+
+  it('locks the run button when the subscription is inactive', () => {
+    mockIsActiveSubscription.value = false
+    renderWrapper()
+
+    expect(screen.getByTestId('subscribe-to-run-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('queue-button')).not.toBeInTheDocument()
+  })
+
+  it('unlocks the run button once the subscription becomes active again', async () => {
+    mockIsActiveSubscription.value = false
+    renderWrapper()
+
+    expect(screen.getByTestId('subscribe-to-run-button')).toBeInTheDocument()
+
+    mockIsActiveSubscription.value = true
+    await nextTick()
+
+    expect(screen.getByTestId('queue-button')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('subscribe-to-run-button')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2545,6 +2545,13 @@
       "pollingFailed": "Subscription activation failed",
       "pollingTimeout": "Timed out waiting for subscription. Please refresh and try again."
     },
+    "inactive": {
+      "memberTitle": "This workspace's subscription is inactive",
+      "memberDescription": "Ask your workspace owner to reactivate the workspace's subscription to run workflows.",
+      "memberCta": "Ok, got it",
+      "memberRunTooltip": "Contact your workspace owner to resubscribe",
+      "runLabel": "Run"
+    },
     "subscribeToRun": "Subscribe",
     "subscribeToRunFull": "Subscribe to Run",
     "subscribeForMore": "Upgrade",

--- a/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
@@ -1,0 +1,114 @@
+import type * as VueUseCore from '@vueuse/core'
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import SubscribeToRun from './SubscribeToRun.vue'
+
+const mockShowSubscriptionDialog = vi.fn()
+const mockCanManageSubscription = ref(true)
+const mockIsMdOrLarger = ref(true)
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    showSubscriptionDialog: mockShowSubscriptionDialog
+  })
+}))
+
+vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
+  useWorkspaceUI: () => ({
+    permissions: computed(() => ({
+      canManageSubscription: mockCanManageSubscription.value
+    }))
+  })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: true
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => null
+}))
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof VueUseCore>()
+  return {
+    ...actual,
+    useBreakpoints: () => ({
+      greaterOrEqual: () => mockIsMdOrLarger
+    })
+  }
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      subscription: {
+        subscribeToRun: 'Subscribe',
+        subscribeToRunFull: 'Subscribe to Run',
+        inactive: {
+          runLabel: 'Run',
+          memberRunTooltip: 'Contact your workspace owner to resubscribe'
+        }
+      }
+    }
+  }
+})
+
+function renderButton() {
+  const user = userEvent.setup()
+  const result = render(SubscribeToRun, {
+    global: {
+      plugins: [i18n],
+      directives: { tooltip: () => {} }
+    }
+  })
+  return { ...result, user }
+}
+
+describe('SubscribeToRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCanManageSubscription.value = true
+    mockIsMdOrLarger.value = true
+  })
+
+  it('shows the subscribe label for owners who can manage the subscription', () => {
+    renderButton()
+
+    expect(screen.getByTestId('subscribe-to-run-button')).toHaveTextContent(
+      'Subscribe to Run'
+    )
+  })
+
+  it('shows a neutral run label for members who cannot subscribe', () => {
+    mockCanManageSubscription.value = false
+    renderButton()
+
+    const button = screen.getByTestId('subscribe-to-run-button')
+    expect(button).toHaveTextContent('Run')
+    expect(button).not.toHaveTextContent('Subscribe')
+  })
+
+  it('opens the subscription dialog for owners on click', async () => {
+    const { user } = renderButton()
+
+    await user.click(screen.getByTestId('subscribe-to-run-button'))
+
+    expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
+  })
+
+  it('routes members to the same role-aware dialog on click', async () => {
+    mockCanManageSubscription.value = false
+    const { user } = renderButton()
+
+    await user.click(screen.getByTestId('subscribe-to-run-button'))
+
+    expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
+  })
+})

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -1,7 +1,7 @@
 <template>
   <Button
     v-tooltip.bottom="{
-      value: $t('subscription.subscribeToRunFull'),
+      value: buttonTooltip,
       showDelay: 600
     }"
     class="subscribe-to-run-button h-8 gap-1.5 rounded-lg px-4 whitespace-nowrap"
@@ -24,20 +24,31 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { isCloud } from '@/platform/distribution/types'
 import { useTelemetry } from '@/platform/telemetry'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 
 const { t } = useI18n()
 const breakpoints = useBreakpoints(breakpointsTailwind)
 const isMdOrLarger = breakpoints.greaterOrEqual('md')
 
-const buttonLabel = computed(() =>
-  isMdOrLarger.value
-    ? t('subscription.subscribeToRunFull')
-    : t('subscription.subscribeToRun')
-)
-
+const { permissions } = useWorkspaceUI()
 const { showSubscriptionDialog } = useBillingContext()
 
-const handleSubscribeToRun = () => {
+const canResubscribe = computed(() => permissions.value.canManageSubscription)
+
+const buttonLabel = computed(() => {
+  if (!canResubscribe.value) return t('subscription.inactive.runLabel')
+  return isMdOrLarger.value
+    ? t('subscription.subscribeToRunFull')
+    : t('subscription.subscribeToRun')
+})
+
+const buttonTooltip = computed(() =>
+  canResubscribe.value
+    ? t('subscription.subscribeToRunFull')
+    : t('subscription.inactive.memberRunTooltip')
+)
+
+function handleSubscribeToRun() {
   if (isCloud) {
     useTelemetry()?.trackRunButton({ subscribe_to_run: true })
   }

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -4,6 +4,7 @@ import { useDialogStore } from '@/stores/dialogStore'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
 import { isCloud } from '@/platform/distribution/types'
+import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
 import { useTeamWorkspaceStore } from '@/platform/workspace/stores/teamWorkspaceStore'
 
 const DIALOG_KEY = 'subscription-required'
@@ -31,6 +32,7 @@ export const useSubscriptionDialog = () => {
   const dialogService = useDialogService()
   const dialogStore = useDialogStore()
   const workspaceStore = useTeamWorkspaceStore()
+  const { permissions } = useWorkspaceUI()
 
   function hide() {
     dialogStore.closeDialog({ key: DIALOG_KEY })
@@ -39,6 +41,33 @@ export const useSubscriptionDialog = () => {
 
   function showPricingTable(options?: SubscriptionDialogOptions) {
     if (!isCloud) return
+
+    // Members can't manage the workspace subscription, so a blocked run shows a
+    // small read-only "ask your owner to reactivate" modal instead of the
+    // pricing table. Out-of-credits still routes everyone to the credits flow.
+    if (
+      flags.teamWorkspacesEnabled &&
+      !workspaceStore.isInPersonalWorkspace &&
+      !permissions.value.canManageSubscription &&
+      options?.reason !== 'out_of_credits'
+    ) {
+      dialogService.showLayoutDialog({
+        key: DIALOG_KEY,
+        component: defineAsyncComponent(
+          () =>
+            import('@/platform/workspace/components/SubscriptionInactiveMemberDialog.vue')
+        ),
+        props: { onClose: hide },
+        dialogComponentProps: {
+          style: 'width: min(360px, 95vw);',
+          pt: {
+            root: { class: 'bg-transparent' },
+            content: { class: '!p-0 bg-transparent border-none shadow-none' }
+          }
+        }
+      })
+      return
+    }
 
     // Shared dialog shell styling for both variants.
     const dialogComponentProps = {

--- a/src/platform/workspace/components/SubscriptionInactiveMemberDialog.test.ts
+++ b/src/platform/workspace/components/SubscriptionInactiveMemberDialog.test.ts
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import SubscriptionInactiveMemberDialog from './SubscriptionInactiveMemberDialog.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      g: { close: 'Close' },
+      subscription: {
+        inactive: {
+          memberTitle: "This workspace's subscription is inactive",
+          memberDescription:
+            "Ask your workspace owner to reactivate the workspace's subscription to run workflows.",
+          memberCta: 'Ok, got it'
+        }
+      }
+    }
+  }
+})
+
+function renderComponent(onClose = vi.fn()) {
+  render(SubscriptionInactiveMemberDialog, {
+    props: { onClose },
+    global: { plugins: [i18n] }
+  })
+  return onClose
+}
+
+describe('SubscriptionInactiveMemberDialog', () => {
+  it('renders the inactive title, description and CTA', () => {
+    renderComponent()
+    expect(
+      screen.getByText("This workspace's subscription is inactive")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Ask your workspace owner to reactivate the workspace's subscription to run workflows."
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Ok, got it' })
+    ).toBeInTheDocument()
+  })
+
+  it('exposes no subscribe affordance', () => {
+    renderComponent()
+    expect(screen.queryByText(/subscribe/i)).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when the CTA is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Ok, got it' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the header close button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = renderComponent()
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/platform/workspace/components/SubscriptionInactiveMemberDialog.vue
+++ b/src/platform/workspace/components/SubscriptionInactiveMemberDialog.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    class="flex flex-col overflow-hidden rounded-2xl border border-border-default bg-base-background"
+    data-testid="member-resubscribe-message"
+  >
+    <div
+      class="flex h-12 items-center gap-2 border-b border-border-default p-4"
+    >
+      <p class="m-0 min-w-0 flex-1 font-inter text-sm text-base-foreground">
+        {{ $t('subscription.inactive.memberTitle') }}
+      </p>
+      <button
+        type="button"
+        :aria-label="$t('g.close')"
+        class="flex size-4 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent text-base-foreground"
+        @click="onClose"
+      >
+        <i class="pi pi-times text-xs" />
+      </button>
+    </div>
+
+    <div class="p-4">
+      <p class="m-0 font-inter text-sm text-muted-foreground">
+        {{ $t('subscription.inactive.memberDescription') }}
+      </p>
+    </div>
+
+    <div class="flex items-center justify-end p-4">
+      <Button variant="secondary" size="lg" @click="onClose">
+        {{ $t('subscription.inactive.memberCta') }}
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+
+const { onClose } = defineProps<{
+  onClose: () => void
+}>()
+</script>


### PR DESCRIPTION
Backport of #12786 to `cloud/1.45` — the last billing backport (closes the FE-978 gap; was only on 1.46).

Cherry-picked squash commit `5a846db6cf`. Original authorship preserved.

**Conflict resolved** in `useSubscriptionDialog.ts`: #12786 predates the B1 (#12953) Jun-5 unified-pricing-table rework, so its old personal-vs-team fork structure conflicted. Adapted the member-inactive gating onto the current unified structure — kept the `SubscriptionInactiveMemberDialog` block (`!permissions.value.canManageSubscription` → read-only modal), discarded the obsolete fork code, kept the unified `dialogComponentProps`. Dropped the top-level `isFreeTier` (B1 resolves it lazily via `useBillingContext` in `show()`).

Brings the `RunButtonProperties` telemetry shape + `SubscriptionInactiveMemberDialog`.