### PR TITLE
test: add critical unit coverage gate (1/7)

### DIFF
--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Setup frontend
         uses: ./.github/actions/setup-frontend
 
-      - name: Run Vitest tests with coverage
-        run: pnpm test:coverage
+      - name: Run Vitest critical coverage gate
+        run: pnpm test:coverage:critical
 
       - name: Upload unit coverage artifact
         if: always() && github.event_name == 'push'

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:critical": "cross-env COVERAGE_CRITICAL=true vitest run --coverage",
     "test:unit": "vitest run",
     "typecheck": "vue-tsc --noEmit",
     "typecheck:browser": "vue-tsc --project browser_tests/tsconfig.json",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -29,6 +29,26 @@ const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
 const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
+const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
+
+// Directories carved out of the critical unit coverage gate: data/static
+// modules and shell views verified by E2E, Storybook, i18n, or static checks
+// rather than unit tests.
+const CRITICAL_COVERAGE_EXCLUDE = [
+  'src/config/**',
+  'src/constants/**',
+  'src/storybook/**',
+  'src/views/**'
+]
+
+// Stage 0 critical coverage floor (PR-blocking). Plan-documented baseline;
+// ratchet upward only after measured gains land on main.
+const CRITICAL_COVERAGE_THRESHOLDS = {
+  statements: 62.76,
+  branches: 53.38,
+  functions: 57.3,
+  lines: 63.98
+}
 
 // Open Graph / Twitter Meta Tags Constants
 const VITE_OG_URL = 'https://cloud.comfy.org'
@@ -667,7 +687,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
       include: ['src/**/*.{ts,vue}'],
       exclude: [
         'src/**/*.test.ts',
@@ -676,8 +696,10 @@ export default defineConfig({
         'src/**/*.d.ts',
         'src/locales/**',
         'src/lib/litegraph/**',
-        'src/assets/**'
-      ]
+        'src/assets/**',
+        ...(COVERAGE_CRITICAL ? CRITICAL_COVERAGE_EXCLUDE : [])
+      ],
+      ...(COVERAGE_CRITICAL ? { thresholds: CRITICAL_COVERAGE_THRESHOLDS } : {})
     },
     exclude: [
       '**/node_modules/**',


### PR DESCRIPTION
## Summary

Land the critical unit coverage gate (Stage 0 / **Stack order: 1/7** of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a)): a PR-blocking `test:coverage:critical` run that locks the current critical-coverage floor so future PRs cannot regress it.

## Changes

- **What**: Add `test:coverage:critical` (`cross-env COVERAGE_CRITICAL=true vitest run --coverage`). When the flag is set, the v8 coverage run additionally excludes `src/config/`, `src/constants/`, `src/storybook/`, and `src/views/` (on top of the existing `assets/`, `locales/`, `lib/litegraph/` excludes) and enforces baseline thresholds. The CI unit job now runs this gate instead of the plain coverage run; the same run still emits `lcov.info` for the existing Codecov upload, plus `json-summary` for machine-readable reporting.
- **Thresholds** (plan-documented baseline): statements 62.76 / branches 53.38 / functions 57.30 / lines 63.98.
- **Dependencies**: none.

## Review Focus

- **Scope is the contract.** The thresholds were measured against the *critical scope* (the four extra excludes), not the default coverage scope — bolting them onto the broader scope would mismatch the plan. The exclude list mirrors the plan's scope rule: those dirs are gated by E2E / Storybook / i18n / static checks, not unit tests.
- **Floor with headroom.** Measured today (critical scope): **statements 64.59% · branches 55.27% · functions 59.31% · lines 65.83%** — ~1.8–2 pts above the thresholds, so the gate passes now and unrelated refactors won't false-fail it. Per the plan, ratchet upward only after measured gains land on `main`.
- **The gate bites.** Verified both directions: full suite green at exit 0, and an inflated-threshold run exits non-zero with `Coverage for branches (X%) does not meet global threshold (Y%)` — naming the regressed metric, per the plan's "make wrong things look wrong" principle.

## Validation

- `pnpm test:coverage:critical` → 923 files / 12,240 tests pass, exit 0, thresholds enforced.
- Negative check: `--coverage.thresholds.branches=99` → exit 1 with a metric-naming error.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`. Pre-push: `knip --cache`.

## Screenshots (if applicable)

N/A — tooling/CI only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI only; no production code paths change, though misaligned excludes or thresholds could cause false CI failures.
> 
> **Overview**
> Introduces a **Stage 0 critical coverage gate** so CI can fail PRs that drop unit coverage below a fixed floor, without changing application runtime behavior.
> 
> Adds `pnpm test:coverage:critical` (`COVERAGE_CRITICAL=true` + Vitest coverage). When that flag is on, coverage **narrows scope** by also excluding `src/config`, `src/constants`, `src/storybook`, and `src/views`, and **enforces global thresholds** (~62–64% statements/lines, ~53% branches, ~57% functions). Reporters gain `json-summary`; thresholds apply only in critical mode.
> 
> The **CI unit workflow** now runs `test:coverage:critical` instead of plain `test:coverage`, while still uploading `lcov.info` to Codecov and artifacts on push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca894e87ebcf01def3feefbd4e6e47dff288fcdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->