### PR TITLE
test: add @critical browser lane and tag stable journeys

### DIFF
--- a/browser_tests/tests/execution.spec.ts
+++ b/browser_tests/tests/execution.spec.ts
@@ -97,34 +97,38 @@ test.describe(
   'Execute to selected output nodes',
   { tag: ['@smoke', '@workflow'] },
   () => {
-    test('Execute to selected output nodes', async ({ comfyPage }) => {
-      await comfyPage.workflow.loadWorkflow('execution/partial_execution')
-      const input = await comfyPage.nodeOps.getNodeRefById(3)
-      const output1 = await comfyPage.nodeOps.getNodeRefById(1)
-      const output2 = await comfyPage.nodeOps.getNodeRefById(4)
-      await expect
-        .poll(async () => (await input.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output1.getWidget(0)).getValue())
-        .toBe('')
-      await expect
-        .poll(async () => (await output2.getWidget(0)).getValue())
-        .toBe('')
+    test(
+      'Execute to selected output nodes',
+      { tag: '@critical' },
+      async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('execution/partial_execution')
+        const input = await comfyPage.nodeOps.getNodeRefById(3)
+        const output1 = await comfyPage.nodeOps.getNodeRefById(1)
+        const output2 = await comfyPage.nodeOps.getNodeRefById(4)
+        await expect
+          .poll(async () => (await input.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output1.getWidget(0)).getValue())
+          .toBe('')
+        await expect
+          .poll(async () => (await output2.getWidget(0)).getValue())
+          .toBe('')
 
-      await output1.click('title')
+        await output1.click('title')
 
-      await comfyPage.command.executeCommand('Comfy.QueueSelectedOutputNodes')
-      await expect
-        .poll(async () => (await input.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output1.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output2.getWidget(0)).getValue())
-        .toBe('')
-    })
+        await comfyPage.command.executeCommand('Comfy.QueueSelectedOutputNodes')
+        await expect
+          .poll(async () => (await input.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output1.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output2.getWidget(0)).getValue())
+          .toBe('')
+      }
+    )
   }
 )
 

--- a/browser_tests/tests/graph.spec.ts
+++ b/browser_tests/tests/graph.spec.ts
@@ -22,11 +22,15 @@ test.describe('Graph', { tag: ['@smoke', '@canvas'] }, () => {
       .toBe(1)
   })
 
-  test('Validate workflow links', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Validation.Workflows', true)
-    await comfyPage.workflow.loadWorkflow('links/bad_link')
-    await expect(comfyPage.toast.visibleToasts).toHaveCount(2)
-  })
+  test(
+    'Validate workflow links',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Validation.Workflows', true)
+      await comfyPage.workflow.loadWorkflow('links/bad_link')
+      await expect(comfyPage.toast.visibleToasts).toHaveCount(2)
+    }
+  )
 
   // Regression: duplicate links with shifted target_slot (widget-to-input
   // conversion) caused the wrong link to survive during deduplication.

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -8,20 +8,24 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     await comfyPage.searchBoxV2.setup()
   })
 
-  test('Can open search and add node', async ({ comfyPage }) => {
-    const { searchBoxV2 } = comfyPage
-    const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+  test(
+    'Can open search and add node',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+      const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    await searchBoxV2.open()
-    await searchBoxV2.input.fill('KSampler')
-    await expect(searchBoxV2.results.first()).toBeVisible()
+      await searchBoxV2.open()
+      await searchBoxV2.input.fill('KSampler')
+      await expect(searchBoxV2.results.first()).toBeVisible()
 
-    await comfyPage.page.keyboard.press('Enter')
-    await expect(searchBoxV2.input).toBeHidden()
-    await expect
-      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
-      .toBe(initialCount + 1)
-  })
+      await comfyPage.page.keyboard.press('Enter')
+      await expect(searchBoxV2.input).toBeHidden()
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+        .toBe(initialCount + 1)
+    }
+  )
 
   test('Can add first default result with Enter', async ({ comfyPage }) => {
     const { searchBoxV2 } = comfyPage

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "stylelint": "stylelint --cache '{apps,packages,src}/**/*.{css,vue}'",
     "test:browser": "pnpm exec playwright test",
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
+    "test:browser:critical": "pnpm exec playwright test --project=chromium --grep @critical",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run",


### PR DESCRIPTION
## Summary

Establish the PR-blocking browser critical lane (Browser E2E track, "Do First PR 1" of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a)): add the `@critical` tag + `test:browser:critical` script and tag a small set of existing stable Chromium journeys — creating the contract without adding new flake or behavior.

## Changes

- **What**: Add `test:browser:critical` (`playwright test --project=chromium --grep @critical`). Tag three existing stable, functional (non-screenshot) journeys `@critical`:
  - `graph.spec.ts` → *Validate workflow links* (graph links validate, toast assertion)
  - `execution.spec.ts` → *Execute to selected output nodes* (partial execution; widget-value assertions)
  - `nodeSearchBoxV2.spec.ts` → *Can open search and add node* (node-count assertion)
- **Dependencies**: none.

## Review Focus

- **No new behavior or flake.** These are already-passing `@smoke`/`@node` tests; the added `@critical` tag is additive and changes nothing about how they run. `@critical` runs inside the existing `chromium` project (its `grepInvert` only excludes `@mobile|@perf|@audit|@cloud`).
- **Functional, not visual.** All three assert real state (toast count, widget values, graph node count) — no screenshot-only blockers, per the plan's critical-lane rules.
- **CI required-check wiring is deferred on purpose.** Per the plan, the first browser PR establishes the tag + script + tagged journeys; promoting the lane to a required check belongs in a follow-up once it's shown to stay green and under the 5-minute budget. This avoids making every PR slower before the lane is proven.

## Validation

- `pnpm exec playwright test --project=chromium --grep @critical --list` → resolves to exactly the 3 intended tests.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`, `pnpm typecheck:browser`.
- Full lane execution requires a ComfyUI backend and is left to CI.

## Screenshots (if applicable)

N/A — tagging/tooling only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test tagging and an npm script only; no application or test assertion changes.
> 
> **Overview**
> Introduces a **PR-blocking browser critical lane** by adding `test:browser:critical` (`playwright test --project=chromium --grep @critical`) and marking three existing stable journeys with `@critical`.
> 
> The tagged tests are unchanged in behavior: **Validate workflow links** (toast count), **Execute to selected output nodes** (partial execution widget values), and **Can open search and add node** (graph node count). Only Playwright `{ tag: '@critical' }` metadata and minor formatting were added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dead526968b5c0fe7e078e2bb6485be2d31e713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->