### PR TITLE
test: cover asset export store

### DIFF
--- a/src/stores/assetExportStore.test.ts
+++ b/src/stores/assetExportStore.test.ts
@@ -1,0 +1,245 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as VueUse from '@vueuse/core'
+
+import type { AssetExportWsMessage } from '@/schemas/apiSchema'
+import { api } from '@/scripts/api'
+import type { TaskId } from '@/platform/tasks/services/taskService'
+import { useAssetExportStore } from '@/stores/assetExportStore'
+
+const { getExportDownloadUrl, getTask, toastAdd, intervalState } = vi.hoisted(
+  () => ({
+    getExportDownloadUrl: vi.fn(),
+    getTask: vi.fn(),
+    toastAdd: vi.fn(),
+    intervalState: { cb: null as null | (() => void) }
+  })
+)
+
+vi.mock('@vueuse/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof VueUse>()),
+  useIntervalFn: (cb: () => void) => {
+    intervalState.cb = cb
+    return { pause: vi.fn(), resume: vi.fn() }
+  }
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: { addEventListener: vi.fn() }
+}))
+
+vi.mock('@/platform/assets/services/assetService', () => ({
+  assetService: { getExportDownloadUrl }
+}))
+
+vi.mock('@/platform/tasks/services/taskService', () => ({
+  taskService: { getTask }
+}))
+
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: toastAdd })
+}))
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+function wsMessage(
+  over: Partial<AssetExportWsMessage> = {}
+): AssetExportWsMessage {
+  return {
+    task_id: 'task-1',
+    export_name: 'export.zip',
+    assets_total: 10,
+    assets_attempted: 5,
+    assets_failed: 0,
+    bytes_total: 1000,
+    bytes_processed: 500,
+    progress: 0.5,
+    status: 'running',
+    ...over
+  }
+}
+
+const taskId = (id: string) => id as TaskId
+
+/**
+ * Build a store and an `emit` bound to the real `asset_export` listener the
+ * store registers on `api`, so tests drive the state machine through its
+ * actual entry point rather than a private method.
+ */
+function setup() {
+  const store = useAssetExportStore()
+  const entry = vi
+    .mocked(api.addEventListener)
+    .mock.calls.find((c) => c[0] === 'asset_export')
+  const handler = entry![1] as (e: { detail: AssetExportWsMessage }) => void
+  const emit = (msg: AssetExportWsMessage) => handler({ detail: msg })
+  // Run the polling tick that `useIntervalFn` would normally fire, and let its
+  // async work settle.
+  const runPoll = async () => {
+    intervalState.cb?.()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  return { store, emit, runPoll }
+}
+
+const STALE_AGO_MS = 20_000
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.mocked(api.addEventListener).mockClear()
+  getExportDownloadUrl
+    .mockReset()
+    .mockResolvedValue({ url: 'https://example.com/export.zip' })
+  getTask.mockReset()
+  toastAdd.mockReset()
+})
+
+describe('assetExportStore', () => {
+  it('tracks a new export as created and is idempotent', () => {
+    const { store } = setup()
+
+    store.trackExport(taskId('t1'))
+    store.trackExport(taskId('t1'))
+
+    expect(store.exportList).toHaveLength(1)
+    expect(store.exportList[0].status).toBe('created')
+    expect(store.hasExports).toBe(true)
+    expect(store.hasActiveExports).toBe(true)
+  })
+
+  it('separates active from finished exports by status', () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ task_id: 'running', status: 'running' }))
+    emit(
+      wsMessage({ task_id: 'failed', status: 'failed', export_name: 'f.zip' })
+    )
+
+    expect(store.activeExports.map((e) => e.taskId)).toEqual(['running'])
+    expect(store.finishedExports.map((e) => e.taskId)).toEqual(['failed'])
+  })
+
+  it('updates an export from successive websocket messages', () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ progress: 0.5, status: 'running' }))
+    emit(wsMessage({ progress: 0.9, status: 'running' }))
+
+    expect(store.exportList).toHaveLength(1)
+    expect(store.exportList[0].progress).toBe(0.9)
+  })
+
+  it('ignores updates for an export already completed and downloaded', async () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ status: 'completed' }))
+    await Promise.resolve()
+    const triggeredCalls = getExportDownloadUrl.mock.calls.length
+
+    // A late 'running' message must not revive a completed+downloaded export
+    emit(wsMessage({ status: 'running', progress: 0.1 }))
+
+    expect(store.exportList[0].status).toBe('completed')
+    expect(getExportDownloadUrl).toHaveBeenCalledTimes(triggeredCalls)
+  })
+
+  it('falls back to the prior export name when a message omits it', async () => {
+    const { store, emit } = setup()
+
+    emit(wsMessage({ status: 'running', progress: 0.4 }))
+    emit(
+      wsMessage({ status: 'running', export_name: undefined, progress: 0.6 })
+    )
+
+    expect(store.exportList[0].exportName).toBe('export.zip')
+  })
+
+  it('triggers a download for a named export and clears prior errors', async () => {
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+
+    await store.triggerDownload(exp)
+
+    expect(getExportDownloadUrl).toHaveBeenCalledWith('export.zip')
+    expect(exp.downloadTriggered).toBe(true)
+    expect(exp.downloadError).toBeUndefined()
+  })
+
+  it('does not re-trigger a download unless forced', async () => {
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+    exp.downloadTriggered = true
+
+    await store.triggerDownload(exp)
+    expect(getExportDownloadUrl).not.toHaveBeenCalled()
+
+    await store.triggerDownload(exp, true)
+    expect(getExportDownloadUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('records a download error and surfaces a toast on failure', async () => {
+    getExportDownloadUrl.mockRejectedValueOnce(new Error('network down'))
+    const { store, emit } = setup()
+    emit(wsMessage({ status: 'running' }))
+    const [exp] = store.exportList
+
+    await store.triggerDownload(exp)
+
+    expect(exp.downloadError).toBe('network down')
+    expect(exp.downloadTriggered).toBe(false)
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    )
+  })
+
+  it('clears finished exports while keeping active ones', () => {
+    const { store, emit } = setup()
+    emit(wsMessage({ task_id: 'a', status: 'running' }))
+    emit(wsMessage({ task_id: 'b', status: 'failed', export_name: 'b.zip' }))
+
+    store.clearFinishedExports()
+
+    expect(store.exportList.map((e) => e.taskId)).toEqual(['a'])
+  })
+
+  it('does not poll when no active export is stale', async () => {
+    const { emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+
+    await runPoll()
+
+    expect(getTask).not.toHaveBeenCalled()
+  })
+
+  it('reconciles a stale export from the task service result', async () => {
+    const { store, emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+    store.exportList[0].lastUpdate = Date.now() - STALE_AGO_MS
+    getTask.mockResolvedValue({
+      status: 'completed',
+      result: { export_name: 'reconciled.zip', assets_total: 10 }
+    })
+
+    await runPoll()
+
+    expect(getTask).toHaveBeenCalledWith('task-1')
+    expect(store.exportList[0].status).toBe('completed')
+    expect(store.exportList[0].exportName).toBe('reconciled.zip')
+  })
+
+  it('leaves a stale export untouched when the task lookup fails', async () => {
+    const { store, emit, runPoll } = setup()
+    emit(wsMessage({ status: 'running' }))
+    store.exportList[0].lastUpdate = Date.now() - STALE_AGO_MS
+    getTask.mockRejectedValue(new Error('task not found'))
+
+    await runPoll()
+
+    expect(store.exportList[0].status).toBe('running')
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useAssetExportStore`, raising it from **0% → ~85% branch** (100% statements, 100% functions). Sits in the plan's asset-management / progress-reconnect critical area.

## Changes

- **What**: New `assetExportStore.test.ts` covering: `trackExport` idempotency; active/finished partitioning by status; the websocket-driven state machine (`handleAssetExport`: update, completed+downloaded short-circuit, export-name fallback); `triggerDownload` success / already-triggered guard / error-with-toast; `clearFinishedExports`; and the stale-export reconnect poll (`pollStaleExports`: no-op when fresh, task-service reconcile to completed, error-swallow).
- **Dependencies**: none.

## Review Focus

- **Driven through real entry points, not private methods.** `handleAssetExport` and `pollStaleExports` aren't exposed — the test captures the actual `api.addEventListener('asset_export', …)` handler and the `useIntervalFn` tick callback from the (mocked) dependencies and invokes those, so it exercises the genuine wiring rather than reaching into internals.
- **Staleness is simulated by mutating `lastUpdate`** on the live export object (the `exportList` computed returns the stored references), then firing the captured poll tick — the cleanest way to hit the `>= STALE_THRESHOLD_MS` branch deterministically without fake timers.
- Mocks (`api`, `assetService`, `taskService`, toast, i18n, partial `@vueuse/core`) are `vi.hoisted`; assertions check store state transitions and the download/toast side effects.

## Validation

- `pnpm exec vitest run src/stores/assetExportStore.test.ts` → 12 passed.
- Coverage (file-scoped): branches 84.8%, statements 100%, functions 100%.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition; no production code or runtime behavior changes.
> 
> **Overview**
> Adds **`assetExportStore.test.ts`** with 12 Vitest cases for `useAssetExportStore`, targeting the asset-export progress/reconnect area (plan stage: ~0% → ~85% branch coverage on the store).
> 
> Tests exercise **public wiring** instead of private helpers: websocket updates go through the captured `api.addEventListener('asset_export', …)` handler, and stale reconnect goes through the mocked `useIntervalFn` tick. **`lastUpdate`** is shifted past the stale threshold to drive poll branches without fake timers.
> 
> Coverage spans **`trackExport`** idempotency, active vs finished lists, websocket progress and export-name fallback, ignoring late messages after completed+downloaded, **`triggerDownload`** (success, no double-fetch unless forced, errors + error toast), **`clearFinishedExports`**, and **`pollStaleExports`** (skip when fresh, reconcile via **`taskService.getTask`**, leave state on lookup failure). Dependencies are hoisted mocks for API, asset/task services, toast, i18n, and partial `@vueuse/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42972d1c88bd6e75816159565dab5c758a1a2dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->