### PR TITLE
test: cover about panel store

### DIFF
--- a/src/stores/aboutPanelStore.test.ts
+++ b/src/stores/aboutPanelStore.test.ts
@@ -1,0 +1,125 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AboutPageBadge } from '@/types/comfy'
+import { useAboutPanelStore } from '@/stores/aboutPanelStore'
+
+interface SystemInfo {
+  comfyui_version?: string
+  installed_templates_version?: string
+  required_templates_version?: string
+}
+
+const { dist, stats, exts } = vi.hoisted(() => ({
+  dist: { isCloud: false, isDesktop: false },
+  stats: { system: {} as SystemInfo },
+  exts: { list: [] as { aboutPageBadges?: AboutPageBadge[] }[] }
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return dist.isCloud
+  },
+  get isDesktop() {
+    return dist.isDesktop
+  }
+}))
+
+vi.mock('@/composables/useExternalLink', () => ({
+  useExternalLink: () => ({
+    staticUrls: {
+      github: 'https://github.com/comfyanonymous/ComfyUI',
+      githubFrontend: 'https://github.com/Comfy-Org/ComfyUI_frontend',
+      comfyOrg: 'https://comfy.org',
+      discord: 'https://discord.com'
+    }
+  })
+}))
+
+vi.mock('@/utils/envUtil', () => ({
+  electronAPI: () => ({ getComfyUIVersion: () => '9.9.9' })
+}))
+
+vi.mock('@/stores/extensionStore', () => ({
+  useExtensionStore: () => ({ extensions: exts.list })
+}))
+
+vi.mock('@/stores/systemStatsStore', () => ({
+  useSystemStatsStore: () => ({ systemStats: stats })
+}))
+
+function label(badges: AboutPageBadge[], includes: string) {
+  return badges.find((b) => b.label.includes(includes))
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  dist.isCloud = false
+  dist.isDesktop = false
+  stats.system = {}
+  exts.list = []
+})
+
+describe('aboutPanelStore', () => {
+  it('builds the default desktop-less, non-cloud core badges', () => {
+    stats.system = { comfyui_version: 'abc1234' }
+    const store = useAboutPanelStore()
+
+    const core = label(store.badges, 'ComfyUI ')!
+    expect(core.icon).toBe('pi pi-github')
+    expect(core.url).toContain('github.com/comfyanonymous')
+    expect(label(store.badges, 'ComfyUI_frontend')).toBeDefined()
+    expect(label(store.badges, 'Discord')).toBeDefined()
+    expect(label(store.badges, 'Templates')).toBeUndefined()
+  })
+
+  it('uses cloud url and icon for the core badge when running on cloud', () => {
+    dist.isCloud = true
+    const store = useAboutPanelStore()
+
+    const core = label(store.badges, 'ComfyUI ')!
+    expect(core.icon).toBe('pi pi-cloud')
+    expect(core.url).toBe('https://comfy.org')
+  })
+
+  it('uses the electron-reported version label on desktop', () => {
+    dist.isDesktop = true
+    const store = useAboutPanelStore()
+
+    expect(label(store.badges, 'ComfyUI v9.9.9')).toBeDefined()
+  })
+
+  it('adds a danger templates badge when the installed version is outdated', () => {
+    stats.system = {
+      installed_templates_version: '1.0.0',
+      required_templates_version: '1.1.0'
+    }
+    const store = useAboutPanelStore()
+
+    const templates = label(store.badges, 'Templates v1.0.0')!
+    expect(templates.severity).toBe('danger')
+  })
+
+  it('adds a templates badge without severity when versions match', () => {
+    stats.system = {
+      installed_templates_version: '1.1.0',
+      required_templates_version: '1.1.0'
+    }
+    const store = useAboutPanelStore()
+
+    const templates = label(store.badges, 'Templates v1.1.0')!
+    expect(templates.severity).toBeUndefined()
+  })
+
+  it('appends extension badges and tolerates extensions without any', () => {
+    exts.list = [
+      {
+        aboutPageBadges: [{ label: 'My Ext', url: 'https://ext', icon: 'pi' }]
+      },
+      {} // extension without aboutPageBadges -> ?? [] branch
+    ]
+    const store = useAboutPanelStore()
+
+    expect(label(store.badges, 'My Ext')).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useAboutPanelStore`, raising it from **0% → ~95% branch** (100% statements, 100% functions).

## Changes

- **What**: New `aboutPanelStore.test.ts` covering badge assembly: core badge github-vs-cloud url/icon, desktop electron-version label vs commit-hash label, the templates-badge presence + outdated→`danger` severity branches, and extension `aboutPageBadges` flatMap including the missing-badges (`?? []`) fallback.
- **Dependencies**: none.

## Review Focus

- **Per-test `isCloud`/`isDesktop` come from getter-backed mocks.** Those are module constants from `@/platform/distribution/types`; the mock exposes them as getters over a `vi.hoisted` object so each test flips the distribution without `resetModules`, and the store's computeds read the current value lazily.
- **Asserts on the resulting badge list**, looked up by label substring, rather than on index positions — robust to badge reordering.
- `formatCommitHash` is left unmocked (pure util); only the boundary stores/services (`useExternalLink`, `electronAPI`, `extensionStore`, `systemStatsStore`) are stubbed.

## Validation

- `pnpm exec vitest run src/stores/aboutPanelStore.test.ts` → 6 passed.
- Coverage (file-scoped): branches 95.2%, statements 100%, functions 100%.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or production code modifications.
> 
> **Overview**
> Adds **`aboutPanelStore.test.ts`** with six Vitest cases that exercise `useAboutPanelStore` badge assembly without changing production code.
> 
> Tests stub distribution flags via **getter-backed hoisted mocks** (so `isCloud` / `isDesktop` can flip per test), plus `useExternalLink`, `electronAPI`, `extensionStore`, and `systemStatsStore`. Assertions look up badges by **label substring** rather than list index. Coverage includes default non-cloud badges (GitHub icon/URL, frontend + Discord, no templates when absent), cloud core badge (cloud icon + comfy.org URL), desktop ComfyUI label from Electron version, templates badge with **`danger`** when installed vs required versions differ vs no severity when they match, and extension **`aboutPageBadges`** flatMap including the **`?? []`** fallback for extensions without badges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7a33fd07a698f941e60b0b792377e2d5c377bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->