### PR TITLE
test: cover queue ResultItemImpl output model

### DIFF
--- a/src/stores/queueResultItem.test.ts
+++ b/src/stores/queueResultItem.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SerializedNodeId } from '@/types/nodeId'
+import { ResultItemImpl } from '@/stores/queueStore'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    apiURL: (path: string) => `http://localhost:8188${path}`,
+    addEventListener: () => {}
+  }
+}))
+
+// Importing ResultItemImpl transitively loads @/scripts/app, whose module-level
+// ComfyApp singleton wires real listeners. Stub it; ResultItemImpl needs none of it.
+vi.mock('@/scripts/app', () => ({ app: {} }))
+
+// Keep preview-url assertions deterministic: don't append cloud params.
+vi.mock('@/platform/distribution/cloudPreviewUtil', () => ({
+  appendCloudResParam: () => {}
+}))
+
+interface ItemOverrides {
+  filename?: string
+  mediaType?: string
+  format?: string
+  frame_rate?: number
+}
+
+function item(over: ItemOverrides = {}) {
+  return new ResultItemImpl({
+    filename: over.filename ?? 'out.png',
+    subfolder: 'sub',
+    type: 'output',
+    nodeId: '1' as SerializedNodeId,
+    mediaType: over.mediaType ?? 'images',
+    format: over.format,
+    frame_rate: over.frame_rate
+  })
+}
+
+describe('ResultItemImpl', () => {
+  it('builds view url params and omits absent vhs fields', () => {
+    const params = item({ filename: 'a.png' }).urlParams
+    expect(params.get('filename')).toBe('a.png')
+    expect(params.get('type')).toBe('output')
+    expect(params.get('subfolder')).toBe('sub')
+    expect(params.has('format')).toBe(false)
+    expect(params.has('frame_rate')).toBe(false)
+  })
+
+  it('includes vhs format and frame_rate params when present', () => {
+    const params = item({ format: 'video/h264-mp4', frame_rate: 24 }).urlParams
+    expect(params.get('format')).toBe('video/h264-mp4')
+    expect(params.get('frame_rate')).toBe('24')
+  })
+
+  it('returns an empty url for a nameless item and a view url otherwise', () => {
+    expect(item({ filename: '' }).url).toBe('')
+    expect(item({ filename: 'a.png' }).url).toContain('/view?')
+  })
+
+  it('routes image preview urls through /view', () => {
+    expect(
+      item({ filename: 'a.png', mediaType: 'images' }).previewUrl
+    ).toContain('/view?')
+  })
+
+  it('exposes the vhs advanced preview endpoint', () => {
+    expect(item().vhsAdvancedPreviewUrl).toContain('/viewvideo?')
+  })
+
+  it('maps html video mime types by suffix and vhs format', () => {
+    expect(item({ filename: 'a.webm' }).htmlVideoType).toBe('video/webm')
+    expect(item({ filename: 'a.mp4' }).htmlVideoType).toBe('video/mp4')
+    expect(item({ filename: 'a.mov' }).htmlVideoType).toBe('video/quicktime')
+    expect(
+      item({ filename: 'a.bin', format: 'video/mp4', frame_rate: 24 })
+        .htmlVideoType
+    ).toBe('video/mp4')
+    expect(item({ filename: 'a.txt' }).htmlVideoType).toBeUndefined()
+  })
+
+  it('maps html audio mime types by suffix', () => {
+    expect(item({ filename: 'a.mp3' }).htmlAudioType).toBe('audio/mpeg')
+    expect(item({ filename: 'a.wav' }).htmlAudioType).toBe('audio/wav')
+    expect(item({ filename: 'a.ogg' }).htmlAudioType).toBe('audio/ogg')
+    expect(item({ filename: 'a.flac' }).htmlAudioType).toBe('audio/flac')
+    expect(item({ filename: 'a.png' }).htmlAudioType).toBeUndefined()
+  })
+
+  it('treats vhs format as such only with both format and frame_rate', () => {
+    expect(item({ format: 'video/mp4', frame_rate: 24 }).isVhsFormat).toBe(true)
+    expect(item({ format: 'video/mp4' }).isVhsFormat).toBe(false)
+  })
+
+  it('classifies video by suffix and by media type', () => {
+    expect(item({ filename: 'a.webm' }).isVideo).toBe(true)
+    expect(item({ filename: 'a.bin', mediaType: 'video' }).isVideo).toBe(true)
+    expect(item({ filename: 'a.png', mediaType: 'video' }).isVideo).toBe(false)
+  })
+
+  it('classifies image only when not contradicted by a media suffix', () => {
+    expect(item({ filename: 'a.png', mediaType: 'images' }).isImage).toBe(true)
+    expect(item({ filename: 'a.webm', mediaType: 'images' }).isImage).toBe(
+      false
+    )
+  })
+
+  it('classifies audio by suffix and by media type', () => {
+    expect(item({ filename: 'a.mp3' }).isAudio).toBe(true)
+    expect(item({ filename: 'a.bin', mediaType: 'audio' }).isAudio).toBe(true)
+    expect(item({ filename: 'a.png', mediaType: 'audio' }).isAudio).toBe(false)
+  })
+
+  it('reports text and preview support', () => {
+    expect(item({ mediaType: 'text' }).isText).toBe(true)
+    expect(item({ filename: 'a.png' }).supportsPreview).toBe(true)
+    expect(
+      item({ filename: 'a.bin', mediaType: 'binary' }).supportsPreview
+    ).toBe(false)
+  })
+
+  it('filters previewable outputs and finds an item by url', () => {
+    const png = item({ filename: 'a.png' })
+    const bin = item({ filename: 'a.bin', mediaType: 'binary' })
+    expect(ResultItemImpl.filterPreviewable([png, bin])).toEqual([png])
+
+    expect(ResultItemImpl.findByUrl([png, bin], png.url)).toBe(0)
+    expect(ResultItemImpl.findByUrl([png, bin], 'no-match')).toBe(0)
+    expect(ResultItemImpl.findByUrl([png, bin])).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `ResultItemImpl`, the queue output-result data model, raising `queueStore.ts` from **0% → ~37% branch**. First step into the plan's critical queue/results area; `TaskItemImpl` and `useQueueStore` are follow-ups.

## Changes

- **What**: New `queueResultItem.test.ts` covering `ResultItemImpl`: `urlParams` (with/without vhs `format`/`frame_rate`), `url`/`previewUrl`/`vhsAdvancedPreviewUrl` construction and the nameless-item guard, `htmlVideoType`/`htmlAudioType` MIME mapping (by suffix and vhs format), media classification (`isVideo`/`isImage`/`isAudio` across suffix vs `mediaType` vs `format`), `isText`/`supportsPreview`, and the `filterPreviewable`/`findByUrl` statics.
- **Dependencies**: none.

## Review Focus

- **Tests the data model by construction**, not the store's websocket/api orchestration — `ResultItemImpl` owns the user-visible output-rendering logic (which URL to hit, whether a result is previewable and as what media type), so it's covered directly with constructed instances.
- **Import-time stubs are the notable bit**: importing `ResultItemImpl` from `queueStore` transitively loads `@/scripts/app`, whose module-level `ComfyApp` singleton wires real listeners — so `@/scripts/app` is stubbed to `{}` (ResultItemImpl uses only `api.apiURL`). `appendCloudResParam` is stubbed to keep preview-url assertions deterministic; `getMediaTypeFromFilename` runs unmocked (pure util).
- **Scope is deliberately one class.** `queueStore.ts` is a 692-line multi-unit file; this covers the `ResultItemImpl` third. `TaskItemImpl` and `useQueueStore` (api/ws-coupled) are separate follow-up PRs rather than one mega-test.

## Validation

- `pnpm test:unit src/stores/queueResultItem.test.ts` → 13 passed.
- Coverage: `queueStore.ts` whole-file branches 0% → 37.1% (the `ResultItemImpl` portion).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or production logic changes.
> 
> **Overview**
> Adds **`queueResultItem.test.ts`** with 13 Vitest cases for **`ResultItemImpl`** in `queueStore.ts`—URL/query construction (including optional VHS `format`/`frame_rate`), preview and VHS preview endpoints, HTML video/audio MIME mapping, media-type flags, and static helpers **`filterPreviewable`** / **`findByUrl`**.
> 
> Tests construct instances directly and mock **`@/scripts/api`**, **`@/scripts/app`**, and **`appendCloudResParam`** so imports stay isolated from the ComfyApp singleton and cloud preview query params. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d5e24db6b90047a39a9eedd568575058d7a7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->