### PR TITLE
test: cover queue TaskItemImpl task model

### DIFF
--- a/src/stores/queueTaskItem.test.ts
+++ b/src/stores/queueTaskItem.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SerializedNodeId } from '@/types/nodeId'
+import { ResultItemImpl, TaskItemImpl } from '@/stores/queueStore'
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    apiURL: (path: string) => `http://localhost:8188${path}`,
+    addEventListener: () => {}
+  }
+}))
+
+vi.mock('@/scripts/app', () => ({ app: {} }))
+
+vi.mock('@/platform/distribution/cloudPreviewUtil', () => ({
+  appendCloudResParam: () => {}
+}))
+
+const { parseTaskOutput } = vi.hoisted(() => ({ parseTaskOutput: vi.fn() }))
+vi.mock('@/stores/resultItemParsing', () => ({ parseTaskOutput }))
+
+type JobStatus =
+  | 'in_progress'
+  | 'pending'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+interface JobOverrides {
+  id?: string
+  status?: JobStatus
+  outputs_count?: number
+  workflow_id?: string
+  create_time?: number
+  execution_start_time?: number
+  execution_end_time?: number
+  execution_error?: { exception_type?: string; exception_message?: string }
+  preview_output?: unknown
+}
+
+function job(over: JobOverrides = {}) {
+  return {
+    id: 'job-1',
+    status: 'completed',
+    create_time: 1000,
+    ...over
+  } as never
+}
+
+function result(filename: string, type = 'output') {
+  return new ResultItemImpl({
+    filename,
+    subfolder: '',
+    type: type as 'output' | 'input' | 'temp',
+    nodeId: '1' as SerializedNodeId,
+    mediaType: 'images'
+  })
+}
+
+describe('TaskItemImpl', () => {
+  it('maps job status to taskType and apiTaskType', () => {
+    expect(new TaskItemImpl(job({ status: 'in_progress' })).taskType).toBe(
+      'Running'
+    )
+    expect(new TaskItemImpl(job({ status: 'pending' })).taskType).toBe(
+      'Pending'
+    )
+    expect(new TaskItemImpl(job({ status: 'completed' })).taskType).toBe(
+      'History'
+    )
+
+    expect(new TaskItemImpl(job({ status: 'pending' })).apiTaskType).toBe(
+      'queue'
+    )
+    expect(new TaskItemImpl(job({ status: 'completed' })).apiTaskType).toBe(
+      'history'
+    )
+  })
+
+  it('exposes displayStatus for every backend status', () => {
+    const statuses: [JobStatus, string][] = [
+      ['in_progress', 'Running'],
+      ['pending', 'Pending'],
+      ['completed', 'Completed'],
+      ['failed', 'Failed'],
+      ['cancelled', 'Cancelled']
+    ]
+    for (const [status, display] of statuses) {
+      expect(new TaskItemImpl(job({ status })).displayStatus).toBe(display)
+    }
+  })
+
+  it('derives history/running flags and a status-qualified key', () => {
+    const running = new TaskItemImpl(job({ id: 'a', status: 'in_progress' }))
+    expect(running.isRunning).toBe(true)
+    expect(running.isHistory).toBe(false)
+    expect(running.key).toBe('aRunning')
+
+    expect(new TaskItemImpl(job({ status: 'completed' })).isHistory).toBe(true)
+  })
+
+  it('uses explicitly provided flat outputs', () => {
+    const outputs = [result('a.png')]
+    const task = new TaskItemImpl(job(), undefined, outputs)
+    expect(task.flatOutputs).toBe(outputs)
+  })
+
+  it('parses outputs lazily when flat outputs are not supplied', () => {
+    const parsed = [result('p.png')]
+    parseTaskOutput.mockReturnValueOnce(parsed)
+    const task = new TaskItemImpl(job(), { '1': { images: [] } } as never)
+    expect(parseTaskOutput).toHaveBeenCalled()
+    expect(task.flatOutputs).toBe(parsed)
+  })
+
+  it('synthesizes outputs from preview_output when none are provided', () => {
+    parseTaskOutput.mockReturnValueOnce([])
+    const preview = { nodeId: '5', mediaType: 'images', filename: 'prev.png' }
+    new TaskItemImpl(job({ preview_output: preview }))
+    expect(parseTaskOutput).toHaveBeenCalledWith({
+      '5': { images: [preview] }
+    })
+  })
+
+  it('prefers the last saved output over temp previews for previewOutput', () => {
+    const temp = result('temp.png', 'temp')
+    const saved = result('saved.png', 'output')
+    const task = new TaskItemImpl(job(), undefined, [temp, saved])
+    expect(task.previewOutput).toBe(saved)
+
+    const onlyTemp = new TaskItemImpl(job(), undefined, [temp])
+    expect(onlyTemp.previewOutput).toBe(temp)
+  })
+
+  it('reports interrupted only for an interrupt-typed failure', () => {
+    expect(
+      new TaskItemImpl(
+        job({
+          status: 'failed',
+          execution_error: { exception_type: 'InterruptProcessingException' }
+        })
+      ).interrupted
+    ).toBe(true)
+    expect(
+      new TaskItemImpl(
+        job({ status: 'failed', execution_error: { exception_type: 'Other' } })
+      ).interrupted
+    ).toBe(false)
+  })
+
+  it('surfaces error message and passthrough job fields', () => {
+    const task = new TaskItemImpl(
+      job({
+        status: 'failed',
+        outputs_count: 3,
+        workflow_id: 'wf-9',
+        execution_error: { exception_message: 'boom' }
+      })
+    )
+    expect(task.errorMessage).toBe('boom')
+    expect(task.outputsCount).toBe(3)
+    expect(task.workflowId).toBe('wf-9')
+  })
+
+  it('computes execution time only when both timestamps exist', () => {
+    expect(
+      new TaskItemImpl(
+        job({ execution_start_time: 1000, execution_end_time: 3000 })
+      ).executionTimeInSeconds
+    ).toBe(2)
+    expect(
+      new TaskItemImpl(job({ execution_start_time: 1000 })).executionTime
+    ).toBeUndefined()
+  })
+
+  it('flatten returns itself when not completed', () => {
+    const running = new TaskItemImpl(job({ status: 'in_progress' }))
+    expect(running.flatten()).toEqual([running])
+  })
+
+  it('flatten expands a completed task into one task per output', () => {
+    const outputs = [result('a.png'), result('b.png')]
+    const task = new TaskItemImpl(
+      job({ id: 'j', status: 'completed' }),
+      undefined,
+      outputs
+    )
+
+    const flattened = task.flatten()
+
+    expect(flattened).toHaveLength(2)
+    expect(flattened.map((t) => t.jobId)).toEqual(['j-0', 'j-1'])
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `TaskItemImpl`, the queue task data model. Adds ~27% branch to `queueStore.ts`, stacking with the `ResultItemImpl` coverage in #13217 toward the critical queue/results area.

## Changes

- **What**: New `queueTaskItem.test.ts` covering `TaskItemImpl`: status→`taskType`/`apiTaskType`/`displayStatus` mapping (all backend statuses), `isHistory`/`isRunning` and the status-qualified `key`, flat-output handling (explicit, lazy `parseTaskOutput`, and `preview_output` synthesis), `previewOutput` saved-over-temp preference, `interrupted` (interrupt-typed failure only), error/passthrough fields, execution-time math (both-timestamps guard), and `flatten` (non-completed passthrough vs one-task-per-output expansion).
- **Dependencies**: none.

## Review Focus

- **Construction-based, I/O methods excluded.** Covers the synchronous model logic; `loadFullOutputs`/`loadWorkflow` (which fetch job detail and touch app/output stores) are intentionally left for a follow-up rather than dragging in those mocks here.
- **`parseTaskOutput` is the one mocked seam** — stubbed via `vi.hoisted` so the lazy `calculateFlatOutputs` path and the `preview_output`→synthetic-outputs construction are asserted by what they pass to it. Same `@/scripts/app`/`api`/`appendCloudResParam` import stubs as #13217 (transitive `ComfyApp` singleton).
- Pairs with #13217 (`ResultItemImpl`); together they cover the two data-model classes in `queueStore.ts`.

## Validation

- `pnpm test:unit src/stores/queueTaskItem.test.ts` → 12 passed.
- Coverage: `queueStore.ts` whole-file branches 0% → 27.2% from this test (the `TaskItemImpl` portion; stacks with #13217).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or production code changes.
> 
> **Overview**
> Adds **`queueTaskItem.test.ts`** with 12 Vitest cases for **`TaskItemImpl`** in `queueStore.ts`—no production code changes.
> 
> Coverage targets synchronous model behavior: job status → **`taskType`**, **`apiTaskType`**, and **`displayStatus`**; **`isRunning`** / **`isHistory`** and the status-qualified **`key`**; flat outputs (explicit list, lazy **`parseTaskOutput`**, and **`preview_output`** synthesis); **`previewOutput`** preferring saved over temp; **`interrupted`** only for interrupt-typed failures; error and passthrough fields; execution time when both timestamps exist; and **`flatten`** (passthrough vs one task per output). **`parseTaskOutput`** is mocked via **`vi.hoisted`**; **`api`**, **`app`**, and cloud preview helpers are stubbed like sibling queue tests. Async **`loadFullOutputs`** / **`loadWorkflow`** are out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f4ddc14234d8d17a7283e8af115727074b6bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->