### PR TITLE
test: cover workflow metadata file dispatcher

### DIFF
--- a/src/scripts/metadata/parser.test.ts
+++ b/src/scripts/metadata/parser.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getFromWebmFile } from '@/scripts/metadata/ebml'
+import { getGltfBinaryMetadata } from '@/scripts/metadata/gltf'
+import { getFromIsobmffFile } from '@/scripts/metadata/isobmff'
+import { getDataFromJSON } from '@/scripts/metadata/json'
+import { getMp3Metadata } from '@/scripts/metadata/mp3'
+import { getOggMetadata } from '@/scripts/metadata/ogg'
+import { getWorkflowDataFromFile } from '@/scripts/metadata/parser'
+import { getSvgMetadata } from '@/scripts/metadata/svg'
+import {
+  getAvifMetadata,
+  getFlacMetadata,
+  getLatentMetadata,
+  getPngMetadata,
+  getWebpMetadata
+} from '@/scripts/pnginfo'
+
+vi.mock('@/scripts/metadata/ebml', () => ({ getFromWebmFile: vi.fn() }))
+vi.mock('@/scripts/metadata/gltf', () => ({ getGltfBinaryMetadata: vi.fn() }))
+vi.mock('@/scripts/metadata/isobmff', () => ({ getFromIsobmffFile: vi.fn() }))
+vi.mock('@/scripts/metadata/json', () => ({ getDataFromJSON: vi.fn() }))
+vi.mock('@/scripts/metadata/mp3', () => ({ getMp3Metadata: vi.fn() }))
+vi.mock('@/scripts/metadata/ogg', () => ({ getOggMetadata: vi.fn() }))
+vi.mock('@/scripts/metadata/svg', () => ({ getSvgMetadata: vi.fn() }))
+vi.mock('@/scripts/pnginfo', () => ({
+  getAvifMetadata: vi.fn(),
+  getFlacMetadata: vi.fn(),
+  getLatentMetadata: vi.fn(),
+  getPngMetadata: vi.fn(),
+  getWebpMetadata: vi.fn()
+}))
+
+function file(type: string, name = 'file') {
+  return new File(['data'], name, { type })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getWorkflowDataFromFile', () => {
+  it('routes png/avif/mp3/ogg/webm to their parsers and returns the result', async () => {
+    vi.mocked(getPngMetadata).mockResolvedValue({ a: 1 } as never)
+    expect(await getWorkflowDataFromFile(file('image/png'))).toEqual({ a: 1 })
+    expect(getPngMetadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('image/avif'))
+    expect(getAvifMetadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('audio/mpeg'))
+    expect(getMp3Metadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('audio/ogg'))
+    expect(getOggMetadata).toHaveBeenCalled()
+
+    await getWorkflowDataFromFile(file('video/webm'))
+    expect(getFromWebmFile).toHaveBeenCalled()
+  })
+
+  it('extracts workflow/prompt from webp, preferring lowercase keys', async () => {
+    vi.mocked(getWebpMetadata).mockResolvedValue({
+      workflow: 'wf',
+      prompt: 'pr'
+    } as never)
+    expect(await getWorkflowDataFromFile(file('image/webp'))).toEqual({
+      workflow: 'wf',
+      prompt: 'pr'
+    })
+  })
+
+  it('falls back to capitalized webp keys when lowercase are absent', async () => {
+    vi.mocked(getWebpMetadata).mockResolvedValue({
+      Workflow: 'WF',
+      Prompt: 'PR'
+    } as never)
+    expect(await getWorkflowDataFromFile(file('image/webp'))).toEqual({
+      workflow: 'WF',
+      prompt: 'PR'
+    })
+  })
+
+  it('handles both flac mime types and extracts workflow/prompt', async () => {
+    vi.mocked(getFlacMetadata).mockResolvedValue({ workflow: 'w' } as never)
+    expect(await getWorkflowDataFromFile(file('audio/flac'))).toEqual({
+      workflow: 'w',
+      prompt: undefined
+    })
+    expect(await getWorkflowDataFromFile(file('audio/x-flac'))).toEqual({
+      workflow: 'w',
+      prompt: undefined
+    })
+  })
+
+  it('routes isobmff by mime type and by file extension', async () => {
+    await getWorkflowDataFromFile(file('video/mp4'))
+    await getWorkflowDataFromFile(file('', 'clip.mov'))
+    await getWorkflowDataFromFile(file('', 'clip.m4v'))
+    expect(getFromIsobmffFile).toHaveBeenCalledTimes(3)
+  })
+
+  it('routes svg and gltf by mime type or extension', async () => {
+    await getWorkflowDataFromFile(file('image/svg+xml'))
+    await getWorkflowDataFromFile(file('', 'icon.svg'))
+    expect(getSvgMetadata).toHaveBeenCalledTimes(2)
+
+    await getWorkflowDataFromFile(file('model/gltf-binary'))
+    await getWorkflowDataFromFile(file('', 'model.glb'))
+    expect(getGltfBinaryMetadata).toHaveBeenCalledTimes(2)
+  })
+
+  it('routes latent/safetensors and json by extension or mime type', async () => {
+    await getWorkflowDataFromFile(file('', 'x.latent'))
+    await getWorkflowDataFromFile(file('', 'x.safetensors'))
+    expect(getLatentMetadata).toHaveBeenCalledTimes(2)
+
+    await getWorkflowDataFromFile(file('application/json'))
+    await getWorkflowDataFromFile(file('', 'x.json'))
+    expect(getDataFromJSON).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns undefined for an unrecognized file', async () => {
+    expect(
+      await getWorkflowDataFromFile(file('application/zip', 'a.zip'))
+    ).toBe(undefined)
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `getWorkflowDataFromFile`, the workflow-metadata import dispatcher, raising `metadata/parser.ts` from **0% → ~98% branch**. This is a data-loss-critical path (embedded workflow extraction on file import), squarely in the plan's parser/persistence focus.

## Changes

- **What**: New `metadata/parser.test.ts` covering the format dispatch by mime type and file extension to every parser (png/avif/webp/mp3/ogg/flac/webm/isobmff/svg/gltf/latent/json), the webp + flac `workflow`/`prompt` extraction with capitalized-key fallback, both flac mime types (`audio/flac`, `audio/x-flac`), the extension-based routes (`.mov`/`.m4v`/`.svg`/`.glb`/`.latent`/`.safetensors`/`.json`), and the unrecognized-file `undefined` path.
- **Dependencies**: none.

## Review Focus

- **Pure dispatch tested at the boundary.** All 8 format sub-parsers are stubbed with `vi.fn()`; the assertions verify *which* parser each file type routes to and that the result is returned — the parser internals are out of scope (their own units).
- **The two extraction branches matter most**: webp and flac don't just forward — they normalize to `{ workflow, prompt }` with a lowercase-then-Capitalized fallback (custom-node compatibility). Both key casings are covered.
- Real `File` objects (`new File([...], name, { type })`) drive the `file.type` vs `file.name`-extension branches.

## Validation

- `pnpm test:unit src/scripts/metadata/parser.test.ts` → 8 passed.
- Coverage: `metadata/parser.ts` branches 0% → 97.9%, statements/functions 100%.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds **`metadata/parser.test.ts`** with Vitest coverage for **`getWorkflowDataFromFile`**, the import-time dispatcher that picks format-specific metadata parsers.
> 
> Tests stub all downstream parsers and assert **routing** by MIME type and file extension (PNG/AVIF/WebP, MP3/OGG/FLAC, WebM, ISO BMFF, SVG, GLB, latent/safetensors, JSON), plus **`undefined`** for unrecognized types. **WebP and FLAC** paths also verify normalization to `{ workflow, prompt }` with **lowercase-first, capitalized-key fallback** (including both FLAC MIME types).
> 
> No production code changes—tests only, aimed at high branch coverage on a data-loss-sensitive import path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5c4aad4812e4fb5bdd9f32449326f890f6f820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->