### PR TITLE
test: cover registry-to-frontend node def mapper

### DIFF
--- a/src/utils/mapperUtil.test.ts
+++ b/src/utils/mapperUtil.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import type { components } from '@/types/comfyRegistryTypes'
+import { registryToFrontendV2NodeDef } from '@/utils/mapperUtil'
+
+type RegistryNode = components['schemas']['ComfyNode']
+type RegistryPack = components['schemas']['Node']
+
+function nodeDef(over: Partial<RegistryNode> = {}): RegistryNode {
+  return over as RegistryNode
+}
+
+function pack(over: Partial<RegistryPack> = {}): RegistryPack {
+  return over as RegistryPack
+}
+
+describe('registryToFrontendV2NodeDef', () => {
+  it('maps outputs, defaulting names to types and is_list to false', () => {
+    const def = registryToFrontendV2NodeDef(
+      nodeDef({
+        return_types: '["INT","IMAGE"]',
+        return_names: '["count",""]',
+        output_is_list: [true]
+      }),
+      pack()
+    )
+
+    expect(def.outputs).toEqual([
+      { type: 'INT', name: 'count', is_list: true, index: 0 },
+      { type: 'IMAGE', name: 'IMAGE', is_list: false, index: 1 }
+    ])
+  })
+
+  it('returns no outputs when return_types is empty or absent', () => {
+    expect(
+      registryToFrontendV2NodeDef(nodeDef({ return_types: '[]' }), pack())
+        .outputs
+    ).toEqual([])
+    expect(registryToFrontendV2NodeDef(nodeDef(), pack()).outputs).toEqual([])
+  })
+
+  it('maps required and optional inputs into keyed specs', () => {
+    const def = registryToFrontendV2NodeDef(
+      nodeDef({
+        input_types: JSON.stringify({
+          required: { seed: ['INT', { default: 0 }] },
+          optional: { label: ['STRING', {}] }
+        })
+      }),
+      pack()
+    )
+
+    expect(Object.keys(def.inputs)).toEqual(['seed', 'label'])
+  })
+
+  it('returns no inputs when input_types is empty or absent', () => {
+    expect(registryToFrontendV2NodeDef(nodeDef(), pack()).inputs).toEqual({})
+    expect(
+      registryToFrontendV2NodeDef(nodeDef({ input_types: '{}' }), pack()).inputs
+    ).toEqual({})
+  })
+
+  it('applies field fallbacks for name, category, and python_module', () => {
+    const def = registryToFrontendV2NodeDef(nodeDef(), pack({ id: 'pack-id' }))
+
+    expect(def.name).toBe('Node Name')
+    expect(def.display_name).toBe('Node Name')
+    expect(def.category).toBe('unknown')
+    expect(def.python_module).toBe('pack-id') // name absent -> falls back to id
+  })
+
+  it('prefers explicit values over fallbacks', () => {
+    const def = registryToFrontendV2NodeDef(
+      nodeDef({ comfy_node_name: 'KSampler', category: 'sampling' }),
+      pack({ name: 'comfy-core' })
+    )
+
+    expect(def.name).toBe('KSampler')
+    expect(def.category).toBe('sampling')
+    expect(def.python_module).toBe('comfy-core')
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `registryToFrontendV2NodeDef`, raising `mapperUtil.ts` from **0% → ~87% branch** (100% statements, 100% functions). This mapper feeds registry node definitions into the frontend node system, so a regression here corrupts node discovery/installation.

## Changes

- **What**: New `mapperUtil.test.ts` covering output mapping (name→type and `is_list` defaults, index assignment), empty/absent `return_types`, required + optional input transformation into keyed specs, empty/absent `input_types`, and the `name`/`category`/`python_module` fallbacks (and explicit values overriding them).
- **Dependencies**: none.

## Review Focus

- **`transformInputSpecV1ToV2` is left unmocked** — it's our own pure migration util, so the inputs path exercises the real V1→V2 transform; the test asserts on the resulting keys rather than re-checking migration internals.
- **The parse-driven branches are the point**: `return_types`/`return_names`/`input_types` arrive as JSON strings with `?? '{}'` defaults, and outputs fall back name→type and `is_list ?? false` — both empty-and-populated cases are covered.

## Validation

- `pnpm test:unit src/utils/mapperUtil.test.ts` → 6 passed.
- Coverage: `mapperUtil.ts` branches 0% → 87.1%, statements/functions 100%.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds **`mapperUtil.test.ts`** with six Vitest cases for **`registryToFrontendV2NodeDef`**, the mapper that turns registry node/pack payloads into frontend V2 node definitions (used for node discovery/installation).
> 
> Coverage targets **JSON-string parsing branches**: outputs from `return_types` / `return_names` / `output_is_list` (empty name → type, missing `is_list` → false, indices), empty or missing `return_types`; inputs from `input_types` required/optional keys via the real **`transformInputSpecV1ToV2`** path, plus empty/missing `input_types`; and **metadata fallbacks** (`name`/`display_name`, `category`, `python_module` from pack `name` or `id`) versus explicit registry/pack fields.
> 
> No production code changes—tests only, aimed at raising **`mapperUtil.ts`** branch coverage from 0% to ~87%.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d471c9845f6d032babfdfc0c3779648c47dba69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->