### PR TITLE
test: extend @critical browser lane with queue and missing-dependency journeys

### DIFF
--- a/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
@@ -33,19 +33,21 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
     await cleanupFakeModel(comfyPage)
   })
 
-  test('Should show missing models group in errors tab', async ({
-    comfyPage
-  }) => {
-    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
+  test(
+    'Should show missing models group in errors tab',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
 
-    const missingModelsGroup = comfyPage.page.getByTestId(
-      TestIds.dialogs.missingModelsGroup
-    )
-    await expect(missingModelsGroup).toBeVisible()
-    await expect(
-      missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
-    ).toHaveText(/\S/)
-  })
+      const missingModelsGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingModelsGroup
+      )
+      await expect(missingModelsGroup).toBeVisible()
+      await expect(
+        missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
+    }
+  )
 
   test('Should display model name and metadata', async ({ comfyPage }) => {
     await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -12,23 +12,25 @@ test.describe('Errors tab - Missing nodes', { tag: ['@ui', '@canvas'] }, () => {
     )
   })
 
-  test('Should show missing node pack card with guidance', async ({
-    comfyPage
-  }) => {
-    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
+  test(
+    'Should show missing node pack card with guidance',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
 
-    const missingNodeGroup = comfyPage.page.getByTestId(
-      TestIds.dialogs.missingNodePacksGroup
-    )
+      const missingNodeGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingNodePacksGroup
+      )
 
-    await expect(
-      comfyPage.page.getByTestId(TestIds.dialogs.missingNodeCard)
-    ).toBeVisible()
-    await expect(missingNodeGroup).toBeVisible()
-    await expect(
-      missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
-    ).toHaveText(/\S/)
-  })
+      await expect(
+        comfyPage.page.getByTestId(TestIds.dialogs.missingNodeCard)
+      ).toBeVisible()
+      await expect(missingNodeGroup).toBeVisible()
+      await expect(
+        missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
+    }
+  )
 
   test('Should show unknown pack node rows by default', async ({
     comfyPage

--- a/browser_tests/tests/queue/queueOverlay.spec.ts
+++ b/browser_tests/tests/queue/queueOverlay.spec.ts
@@ -54,13 +54,19 @@ test.describe('Queue overlay', () => {
     await comfyPage.setup()
   })
 
-  test('Toggle button opens expanded queue overlay', async ({ comfyPage }) => {
-    const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
-    await toggle.click()
+  test(
+    'Toggle button opens expanded queue overlay',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
+      await toggle.click()
 
-    // Expanded overlay should show job items
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
-  })
+      // Expanded overlay should show job items
+      await expect(
+        comfyPage.page.locator('[data-job-id]').first()
+      ).toBeVisible()
+    }
+  )
 
   test('Overlay shows filter tabs (All, Completed)', async ({ comfyPage }) => {
     const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)


### PR DESCRIPTION
## Summary

Browser track PR 2 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): extend the `@critical` lane into the queue/progress and missing-dependency (data-loss-adjacent) critical areas by tagging three more stable, functional journeys. Builds on the lane established in #13211.

## Changes

- **What**: Tag `@critical` on three existing non-screenshot journeys:
  - `queue/queueOverlay.spec.ts` → *Toggle button opens expanded queue overlay* (user-visible queue/history status via typed mocked jobs)
  - `propertiesPanel/errorsTabMissingNodes.spec.ts` → *Should show missing node pack card with guidance*
  - `propertiesPanel/errorsTabMissingModels.spec.ts` → *Should show missing models group in errors tab*
- **Dependencies**: none.

## Review Focus

- **No new behavior or flake** — these are already-passing `@ui`/`@canvas` tests; `@critical` is additive and runs inside the existing `chromium` project. They assert real DOM/state (job rows visible, missing-pack card + non-empty guidance text, missing-models group visible), not screenshots — per the plan's critical-lane rules.
- **Coverage of the plan's curated journeys**: this adds Priority 4 (queue/progress status) and Priority 5 (missing node + missing model actionable-without-data-loss). Combined with #13211 (boot/graph/execution/search), the lane now spans 6 of the targeted 8–12 journeys.
- The queue journey uses `jobsRouteFixture` typed mocks, so it asserts user-visible status rather than mocked calls.

## Validation

- `playwright test --project=chromium --grep @critical --list` → resolves to exactly the 3 intended tests on this branch.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`, `pnpm typecheck:browser`.
- Full lane execution requires a ComfyUI backend and is left to CI.

## Screenshots (if applicable)

N/A — tagging only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test metadata only; no production code or test logic changes beyond Playwright tag configuration.
> 
> **Overview**
> Extends the browser **`@critical`** lane by tagging three existing Playwright journeys—no new assertions or app changes.
> 
> **Queue overlay:** *Toggle button opens expanded queue overlay* in `queueOverlay.spec.ts` now runs in the critical suite (queue/history visibility with mocked jobs).
> 
> **Errors tab — missing dependencies:** *Should show missing node pack card with guidance* and *Should show missing models group in errors tab* in the properties panel specs are tagged **`@critical`**, covering missing-node and missing-model guidance in the errors tab.
> 
> Each test keeps its prior **`@ui`** / **`@canvas`** describe tags; **`@critical`** is additive for `--grep @critical` / CI critical runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f84059a8dde0826b3951d270036572229f2eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->