### PR TITLE
test: extend @critical browser lane with subgraph and extension-compat journeys

### DIFF
--- a/browser_tests/tests/extensionAPI.spec.ts
+++ b/browser_tests/tests/extensionAPI.spec.ts
@@ -13,33 +13,37 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 type TestSettingId = keyof Settings
 
 test.describe('Topbar commands', () => {
-  test('Should allow registering topbar commands', async ({ comfyPage }) => {
-    await comfyPage.page.evaluate(() => {
-      window.app!.registerExtension({
-        name: 'TestExtension1',
-        commands: [
-          {
-            id: 'foo',
-            label: 'foo-command',
-            function: () => {
-              window.foo = true
+  test(
+    'Should allow registering topbar commands',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(() => {
+        window.app!.registerExtension({
+          name: 'TestExtension1',
+          commands: [
+            {
+              id: 'foo',
+              label: 'foo-command',
+              function: () => {
+                window.foo = true
+              }
             }
-          }
-        ],
-        menuCommands: [
-          {
-            path: ['ext'],
-            commands: ['foo']
-          }
-        ]
+          ],
+          menuCommands: [
+            {
+              path: ['ext'],
+              commands: ['foo']
+            }
+          ]
+        })
       })
-    })
 
-    await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
-    await expect
-      .poll(() => comfyPage.page.evaluate(() => window.foo))
-      .toBe(true)
-  })
+      await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
+      await expect
+        .poll(() => comfyPage.page.evaluate(() => window.foo))
+        .toBe(true)
+    }
+  )
 
   test('Should not allow register command defined in other extension', async ({
     comfyPage

--- a/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
@@ -129,7 +129,7 @@ async function expectPromotedWidgetsToResolveToInteriorNodes(
 test.describe('Subgraph Serialization', { tag: ['@subgraph'] }, () => {
   test(
     'Legacy primitive proxy widgets migrate to host inputs without proxyWidgets round-trip',
-    { tag: ['@vue-nodes'] },
+    { tag: ['@vue-nodes', '@critical'] },
     async ({ comfyPage }) => {
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-with-link-and-proxied-primitive'


### PR DESCRIPTION
## Summary

Browser track PR 3 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): extend the `@critical` lane into the high-churn subgraph and extension-compatibility areas. Builds on #13211 and #13222; brings the lane to ~8 journeys, hitting the plan's 8–12 target.

## Changes

- **What**: Tag `@critical` on two existing functional journeys:
  - `subgraph/subgraphSerialization.spec.ts` → the primitive-proxy migration **serialize-and-reload round-trip** (asserts widget values + link integrity survive reload — a data-loss-critical path)
  - `extensionAPI.spec.ts` → *Should allow registering topbar commands* (registers a command via the real extension API, triggers it, asserts the side effect)
- **Dependencies**: none.

## Review Focus

- **No new behavior or flake** — both are already-passing tests; `@critical` is additive (the subgraph test keeps its `@vue-nodes` tag). Both run in the default `chromium` project.
- **Plan Priority 6 + 7**: one subgraph round-trip (not the whole file, per the plan) and one representative extension-API path covering command registration through real browser wiring.
- The subgraph test asserts interior/host widget values and link counts are preserved across `serializeAndReload()` — exactly the "survives reload" contract the plan flags as high-risk.

## Validation

- `playwright test --project=chromium --grep @critical --list` → resolves to exactly the 2 intended tests on this branch.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`, `pnpm typecheck:browser`.
- Full lane execution requires a ComfyUI backend and is left to CI.

## Screenshots (if applicable)

N/A — tagging only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test metadata and formatting only; no application or test assertion changes.
> 
> **Overview**
> Extends the Playwright **`@critical`** browser lane with two existing journeys—no new tests or product changes.
> 
> **`extensionAPI.spec.ts`**: *Should allow registering topbar commands* is tagged **`@critical`** (test declaration reformatted to the multi-line `test(..., { tag }, async ...)` style). Same Side effect is unchanged: register an extension command, trigger it from the topbar, assert the handler ran.
> 
> **`subgraph/subgraphSerialization.spec.ts`**: The legacy primitive-proxy migration case keeps **`@vue-nodes`** and adds **`@critical`**. It still covers **`serializeAndReload()`** preserving host/interior widget values and link integrity without **`proxyWidgets`** round-trip.
> 
> CI can run the critical subset via **`--grep @critical`** alongside other tagged critical specs from earlier PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6885364ecd1700b893c3997efa4bc1f94747eae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->