### PR TITLE
test: add cloud-critical browser lane

### DIFF
--- a/browser_tests/tests/cloud.spec.ts
+++ b/browser_tests/tests/cloud.spec.ts
@@ -14,36 +14,44 @@ const SHARE_AUTH_STORAGE_KEY = 'Comfy.PreservedQuery.share_auth'
  * routes and elements.
  */
 test.describe('Cloud distribution UI', { tag: '@cloud' }, () => {
-  test('cloud build redirects unauthenticated users to login', async ({
-    page
-  }) => {
-    await page.goto(APP_URL)
-    // Cloud build has an auth guard that redirects to /cloud/login.
-    // This route only exists in the cloud distribution — it's tree-shaken
-    // in the OSS build. Its presence confirms the cloud build is active.
-    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
-  })
+  test(
+    'cloud build redirects unauthenticated users to login',
+    { tag: '@critical' },
+    async ({ page }) => {
+      await page.goto(APP_URL)
+      // Cloud build has an auth guard that redirects to /cloud/login.
+      // This route only exists in the cloud distribution — it's tree-shaken
+      // in the OSS build. Its presence confirms the cloud build is active.
+      await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+    }
+  )
 
-  test('preserves share auth attribution before redirecting logged-out users', async ({
-    page
-  }) => {
-    await page.goto(new URL('/?share=abc', APP_URL).toString())
+  test(
+    'preserves share auth attribution before redirecting logged-out users',
+    { tag: '@critical' },
+    async ({ page }) => {
+      await page.goto(new URL('/?share=abc', APP_URL).toString())
 
-    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
-    await expect
-      .poll(() =>
-        page.evaluate(
-          (key) => sessionStorage.getItem(key),
-          SHARE_AUTH_STORAGE_KEY
+      await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+      await expect
+        .poll(() =>
+          page.evaluate(
+            (key) => sessionStorage.getItem(key),
+            SHARE_AUTH_STORAGE_KEY
+          )
         )
-      )
-      .toBe(JSON.stringify({ share: 'abc' }))
-  })
+        .toBe(JSON.stringify({ share: 'abc' }))
+    }
+  )
 
-  test('cloud login page renders sign-in options', async ({ page }) => {
-    await page.goto(APP_URL)
-    await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
-    // Verify cloud-specific login UI is rendered
-    await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
-  })
+  test(
+    'cloud login page renders sign-in options',
+    { tag: '@critical' },
+    async ({ page }) => {
+      await page.goto(APP_URL)
+      await expect(page).toHaveURL(/\/cloud\/login/, { timeout: 10_000 })
+      // Verify cloud-specific login UI is rendered
+      await expect(page.getByRole('button', { name: /google/i })).toBeVisible()
+    }
+  )
 })

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "stylelint": "stylelint --cache '{apps,packages,src}/**/*.{css,vue}'",
     "test:browser": "pnpm exec playwright test",
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
+    "test:browser:cloud-critical": "pnpm exec playwright test --project=cloud --grep @critical",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run",


### PR DESCRIPTION
## Summary

Browser track PR 4 / Stage 6 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): add the cloud-critical browser lane — a separate `@critical` split for the `cloud` project so cloud/auth/billing risk is gated independently of the default Chromium lane.

## Changes

- **What**: Add `test:browser:cloud-critical` (`playwright test --project=cloud --grep @critical`) and tag three stable cloud auth journeys `@critical`: unauthenticated→login redirect, share-auth attribution preserved across redirect, and login page sign-in options.
- **Dependencies**: none.

## Review Focus

- **Separation is the point.** These run only in the `cloud` project (`DISTRIBUTION=cloud`); the `@cloud` tag already excludes them from the default Chromium lane, so OSS-only PRs don't pay cloud cost while cloud/auth/billing-impacting PRs get a dedicated required check.
- **No new behavior or flake** — already-passing `@cloud` tests; `@critical` is additive. They assert real cloud-build behavior (cloud-only `/cloud/login` route, sessionStorage share attribution, Google sign-in button), no screenshots.
- Per the plan, the cloud-critical lane is required only for cloud/auth/asset/billing changes, not every PR.

## Validation

- `playwright test --project=cloud --grep @critical --list` → resolves to exactly the 3 cloud journeys.
- Confirmed they stay out of the Chromium lane (the `cloud` project / `@cloud` tag scopes them).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`, `pnpm typecheck:browser`.

## Screenshots (if applicable)

N/A — tagging/tooling only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test tagging and an npm script only; no production or auth logic changes.
> 
> **Overview**
> Introduces a **dedicated cloud-critical browser check** so cloud/auth journeys can be required independently of the default Chromium lane.
> 
> Adds **`test:browser:cloud-critical`** (`playwright test --project=cloud --grep @critical`) and tags the three existing cloud auth E2E tests in `cloud.spec.ts` with **`@critical`**: login redirect for unauthenticated users, share attribution preserved in sessionStorage before redirect, and Google sign-in visible on the login page. Test logic is unchanged; only Playwright test metadata and the npm script are new.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c9e7470c533ddd1d372b171fd9b4305a8469c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->