### PR TITLE
test: cover execution store workflow status state machine

### DIFF
--- a/src/stores/executionWorkflowStatus.test.ts
+++ b/src/stores/executionWorkflowStatus.test.ts
@@ -1,0 +1,152 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const { handlers, openSet } = vi.hoisted(() => ({
+  handlers: {} as Record<string, (e: { detail: unknown }) => void>,
+  openSet: new Set<unknown>()
+}))
+
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: (name: string, fn: (e: { detail: unknown }) => void) => {
+      handlers[name] = fn
+    },
+    removeEventListener: () => {}
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    isOpen: (workflow: unknown) => openSet.has(workflow),
+    openWorkflows: [],
+    nodeLocatorIdToNodeExecutionId: () => null
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => ({
+    clearExecutionStartErrors: () => {},
+    clearPromptError: () => {}
+  })
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ mode: ref('default'), isAppMode: ref(false) })
+}))
+
+vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+
+vi.mock('@/utils/appMode', () => ({
+  getWorkflowMode: () => 'workflow',
+  isAppModeValue: () => false
+}))
+
+function workflow(path: string): ComfyWorkflow {
+  return { path } as unknown as ComfyWorkflow
+}
+
+function storeJob(
+  store: ReturnType<typeof useExecutionStore>,
+  id: string,
+  wf: ComfyWorkflow
+) {
+  store.storeJob({ nodes: [], id, promptOutput: {} as never, workflow: wf })
+}
+
+function fire(event: string, jobId: string) {
+  handlers[event]?.({ detail: { prompt_id: jobId } })
+}
+
+function setup() {
+  const store = useExecutionStore()
+  store.bindExecutionEvents()
+  return store
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  for (const key of Object.keys(handlers)) delete handlers[key]
+  openSet.clear()
+})
+
+describe('executionStore workflow status', () => {
+  it('marks an open workflow running on execution_start and completed on success', () => {
+    const store = setup()
+    const wf = workflow('a.json')
+    openSet.add(wf)
+    storeJob(store, 'job-1', wf)
+
+    fire('execution_start', 'job-1')
+    expect(store.getWorkflowStatus(wf)).toBe('running')
+
+    fire('execution_success', 'job-1')
+    expect(store.getWorkflowStatus(wf)).toBe('completed')
+  })
+
+  it('buffers a status that arrives before the job is attached, then flushes on storeJob', () => {
+    const store = setup()
+    const wf = workflow('b.json')
+    openSet.add(wf)
+
+    // Status event arrives before storeJob maps the job to a workflow
+    fire('execution_start', 'job-2')
+    expect(store.getWorkflowStatus(wf)).toBeUndefined()
+
+    storeJob(store, 'job-2', wf)
+    expect(store.getWorkflowStatus(wf)).toBe('running')
+  })
+
+  it('does not apply status to a workflow that is not open', () => {
+    const store = setup()
+    const wf = workflow('c.json')
+    // not added to openSet
+    storeJob(store, 'job-3', wf)
+
+    fire('execution_start', 'job-3')
+    expect(store.getWorkflowStatus(wf)).toBeUndefined()
+  })
+
+  it('clears a workflow status', () => {
+    const store = setup()
+    const wf = workflow('d.json')
+    openSet.add(wf)
+    storeJob(store, 'job-4', wf)
+    fire('execution_start', 'job-4')
+    expect(store.getWorkflowStatus(wf)).toBe('running')
+
+    store.clearWorkflowStatus(wf)
+    expect(store.getWorkflowStatus(wf)).toBeUndefined()
+  })
+
+  it('does not let a late buffered running overwrite a terminal status', () => {
+    const store = setup()
+    const wf = workflow('e.json')
+    openSet.add(wf)
+
+    storeJob(store, 'job-5', wf)
+    fire('execution_success', 'job-5')
+    expect(store.getWorkflowStatus(wf)).toBe('completed')
+
+    // A second run of the same workflow: a stale 'running' is buffered before
+    // its storeJob, and must not resurrect over the existing terminal status.
+    fire('execution_start', 'job-6')
+    storeJob(store, 'job-6', wf)
+    expect(store.getWorkflowStatus(wf)).toBe('completed')
+  })
+
+  it('returns undefined for a null or unknown workflow', () => {
+    const store = setup()
+    expect(store.getWorkflowStatus(null)).toBeUndefined()
+    expect(store.getWorkflowStatus(workflow('unknown.json'))).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useExecutionStore`'s per-workflow status state machine — the workflow-execution critical area. First reviewed step into the heavy I/O-coupled stores; raises `executionStore.ts` from **0% → ~16% branch** (the status machine; progress/error handlers are follow-ups).

## Changes

- **What**: New `executionWorkflowStatus.test.ts` covering: an open workflow → `running` on `execution_start` and `completed` on `execution_success`; a status arriving before `storeJob` is buffered then flushed on attach; status is not applied to a workflow that isn't open; `clearWorkflowStatus` removes it; and a late buffered `running` cannot overwrite an existing terminal status (the stale-resurrection guard).
- **Dependencies**: none.

## Review Focus

- **Driven through real seams, asserting real state.** The test captures the actual `api` event handlers (`execution_start`/`execution_success`) and drives them plus the exposed `storeJob`/`getWorkflowStatus`/`clearWorkflowStatus` — so it exercises the genuine buffer→flush→apply logic and asserts the resulting status, not mock call-counts.
- **Workflows are plain objects** because the store keys status by `ComfyWorkflow` reference (`Map<ComfyWorkflow, status>`); `workflowStore.isOpen` is mocked off a `Set` so the apply-only-if-open and prune semantics are real.
- **Heavy-store mock surface, kept honest.** ~8 deps stubbed at the boundary (api, app, workflowStore, canvasStore, executionErrorStore, useAppMode, telemetry, appMode utils). This is the reviewed, one-at-a-time approach the plan prescribes for these stores; the progress/node-execution/error-routing handlers are deliberately left for separate follow-up PRs rather than one mega-test.

## Validation

- `pnpm test:unit src/stores/executionWorkflowStatus.test.ts` → 6 passed.
- Coverage: `executionStore.ts` whole-file branches 0% → 15.7% from this test (the status-machine portion of an 862-line file).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications; mocks isolate boundaries without altering runtime behavior.
> 
> **Overview**
> Adds **`executionWorkflowStatus.test.ts`**, the first targeted unit coverage for **`useExecutionStore`**’s per-workflow execution status logic (previously untested in this area).
> 
> Tests drive the real **`api`** handlers registered by **`bindExecutionEvents`** (`execution_start` / `execution_success`) plus **`storeJob`**, **`getWorkflowStatus`**, and **`clearWorkflowStatus`**. They assert open workflows move **`running` → `completed`**, statuses that arrive before **`storeJob`** are buffered and flushed on attach, closed workflows never get status, **`clearWorkflowStatus`** clears entries, and a late buffered **`running`** cannot overwrite an existing terminal status.
> 
> Dependencies are stubbed at the store boundary (api, workflow **`isOpen`**, canvas, errors, app mode, telemetry) so the status map and buffer behavior are exercised without full I/O.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb404ca158ea8050bce0457adcd36122da150d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->