### PR TITLE
test: cover execution store node progress

### DIFF
--- a/src/stores/executionNodeProgress.test.ts
+++ b/src/stores/executionNodeProgress.test.ts
@@ -1,0 +1,131 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useExecutionStore } from '@/stores/executionStore'
+
+const { handlers } = vi.hoisted(() => ({
+  handlers: {} as Record<string, (e: { detail: unknown }) => void>
+}))
+
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: (name: string, fn: (e: { detail: unknown }) => void) => {
+      handlers[name] = fn
+    },
+    removeEventListener: () => {}
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    isOpen: () => false,
+    openWorkflows: [],
+    nodeLocatorIdToNodeExecutionId: () => null
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => ({
+    clearExecutionStartErrors: () => {},
+    clearPromptError: () => {}
+  })
+}))
+
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({ revokePreviewsByExecutionId: () => {} })
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ mode: ref('default'), isAppMode: ref(false) })
+}))
+
+vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+
+vi.mock('@/utils/appMode', () => ({
+  getWorkflowMode: () => 'workflow',
+  isAppModeValue: () => false
+}))
+
+interface NodeState {
+  state: string
+  value?: number
+  max?: number
+  node_id?: string
+}
+
+function progressState(jobId: string, nodes: Record<string, NodeState>) {
+  handlers['progress_state']?.({ detail: { prompt_id: jobId, nodes } })
+}
+
+function setup() {
+  const store = useExecutionStore()
+  store.bindExecutionEvents()
+  return store
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  for (const key of Object.keys(handlers)) delete handlers[key]
+})
+
+describe('executionStore node progress', () => {
+  it('is idle until an execution starts', () => {
+    const store = setup()
+    expect(store.isIdle).toBe(true)
+
+    handlers['execution_start']?.({ detail: { prompt_id: 'job-1' } })
+    expect(store.isIdle).toBe(false)
+  })
+
+  it('derives the running node ids from a progress_state event', () => {
+    const store = setup()
+
+    progressState('job-1', {
+      n1: { state: 'running', value: 1, max: 4 },
+      n2: { state: 'finished' },
+      n3: { state: 'pending' }
+    })
+
+    expect(store.executingNodeIds).toEqual(['n1'])
+    expect(store.executingNodeId).toBe('n1')
+  })
+
+  it('exposes fractional progress for the executing node', () => {
+    const store = setup()
+
+    progressState('job-1', {
+      n1: { state: 'running', value: 1, max: 4 }
+    })
+
+    expect(store.executingNodeProgress).toBe(0.25)
+  })
+
+  it('reports no executing node when none are running', () => {
+    const store = setup()
+
+    progressState('job-1', {
+      n1: { state: 'finished' },
+      n2: { state: 'pending' }
+    })
+
+    expect(store.executingNodeIds).toEqual([])
+    expect(store.executingNodeId).toBeNull()
+  })
+
+  it('replaces progress state on each progress_state event', () => {
+    const store = setup()
+
+    progressState('job-1', { n1: { state: 'running', value: 1, max: 4 } })
+    expect(store.executingNodeId).toBe('n1')
+
+    progressState('job-1', { n2: { state: 'running', value: 2, max: 2 } })
+    expect(store.executingNodeIds).toEqual(['n2'])
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useExecutionStore`'s node-progress tracking. Adds ~11% branch to `executionStore.ts`, stacking with the status-machine coverage in #13225 (workflow-execution critical area).

## Changes

- **What**: New `executionNodeProgress.test.ts` covering: `isIdle` until `execution_start`; `executingNodeIds`/`executingNodeId` derived from `progress_state` events (running vs finished/pending); fractional `executingNodeProgress` (value/max); the no-running-node case; and progress-state replacement across successive `progress_state` events.
- **Dependencies**: none.

## Review Focus

- **Same proven heavy-store harness as #13225** — capture the real `api` event handlers and fire `progress_state`/`execution_start`, then assert the exposed computed progress selectors. No internal reach-in.
- **One extra boundary mock vs #13225**: `useNodeOutputStore().revokePreviewsByExecutionId` (called when a node transitions to running). Everything asserted is the store's own derivation logic (which nodes are running, the progress fraction), not mock calls.
- Scoped to the progress selectors; the error-routing / cloud-precondition handlers remain separate follow-ups.

## Validation

- `pnpm test:unit src/stores/executionNodeProgress.test.ts` → 5 passed.
- Coverage: `executionStore.ts` +10.8% branch from this test (stacks with #13225's status coverage on the same 862-line file).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds **`executionNodeProgress.test.ts`**, unit tests for **`useExecutionStore`** node-progress behavior without changing production code.
> 
> Tests use the same pattern as related execution-store coverage: mock **`api`** listeners, call **`bindExecutionEvents()`**, then drive **`execution_start`** and **`progress_state`** payloads. Assertions target public selectors — **`isIdle`**, **`executingNodeIds`** / **`executingNodeId`**, **`executingNodeProgress`** (`value/max`), empty running-node cases, and full replacement when a new **`progress_state`** arrives. Mocks include **`useNodeOutputStore().revokePreviewsByExecutionId`** so running-node transitions don't throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f215a38e5d2225f537e2a83e7df16c9ecf1cfd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->