### PR TITLE
test: cover execution store error routing

### DIFF
--- a/src/stores/executionError.test.ts
+++ b/src/stores/executionError.test.ts
@@ -1,0 +1,183 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const {
+  handlers,
+  openSet,
+  errorStore,
+  dist,
+  resolvePrecondition,
+  classifyCloud
+} = vi.hoisted(() => ({
+  handlers: {} as Record<string, (e: { detail: unknown }) => void>,
+  openSet: new Set<unknown>(),
+  errorStore: {
+    clearExecutionStartErrors: () => {},
+    clearPromptError: () => {}
+  } as Record<string, unknown>,
+  dist: { isCloud: false },
+  resolvePrecondition: vi.fn(),
+  classifyCloud: vi.fn()
+}))
+
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: (name: string, fn: (e: { detail: unknown }) => void) => {
+      handlers[name] = fn
+    },
+    removeEventListener: () => {}
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    isOpen: (workflow: unknown) => openSet.has(workflow),
+    openWorkflows: [],
+    nodeLocatorIdToNodeExecutionId: () => null
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => errorStore
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ mode: ref('default'), isAppMode: ref(false) })
+}))
+
+vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+
+vi.mock('@/utils/appMode', () => ({
+  getWorkflowMode: () => 'workflow',
+  isAppModeValue: () => false
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return dist.isCloud
+  }
+}))
+
+vi.mock('@/platform/errorCatalog/accountPreconditionRouting', () => ({
+  resolveAccountPrecondition: resolvePrecondition
+}))
+
+vi.mock('@/utils/executionErrorUtil', () => ({
+  classifyCloudValidationError: classifyCloud
+}))
+
+function workflow(path: string): ComfyWorkflow {
+  return { path } as unknown as ComfyWorkflow
+}
+
+function setup() {
+  const store = useExecutionStore()
+  store.bindExecutionEvents()
+  return store
+}
+
+function fireError(detail: Record<string, unknown>) {
+  handlers['execution_error']?.({ detail })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  for (const key of Object.keys(handlers)) delete handlers[key]
+  openSet.clear()
+  dist.isCloud = false
+  resolvePrecondition.mockReturnValue(null)
+  classifyCloud.mockReturnValue(null)
+  for (const key of ['lastExecutionError', 'lastPromptError', 'lastNodeErrors'])
+    delete errorStore[key]
+})
+
+describe('executionStore error handling', () => {
+  it('marks an open workflow failed and records the raw execution error', () => {
+    const store = setup()
+    const wf = workflow('a.json')
+    openSet.add(wf)
+    store.storeJob({
+      nodes: [],
+      id: 'job-1',
+      promptOutput: {} as never,
+      workflow: wf
+    })
+
+    const detail = {
+      prompt_id: 'job-1',
+      node_id: '5',
+      exception_message: 'boom'
+    }
+    fireError(detail)
+
+    expect(store.getWorkflowStatus(wf)).toBe('failed')
+    expect(errorStore.lastExecutionError).toBe(detail)
+  })
+
+  it('routes account-precondition errors away from the failed badge', () => {
+    resolvePrecondition.mockReturnValue({ type: 'credits' })
+    const store = setup()
+    const wf = workflow('b.json')
+    openSet.add(wf)
+    store.storeJob({
+      nodes: [],
+      id: 'job-2',
+      promptOutput: {} as never,
+      workflow: wf
+    })
+
+    fireError({ prompt_id: 'job-2', exception_type: 'AccountError' })
+
+    expect(store.getWorkflowStatus(wf)).toBeUndefined()
+    expect(errorStore.lastExecutionError).toBeUndefined()
+  })
+
+  it('records a node-less service-level error as a prompt error', () => {
+    setup()
+
+    fireError({
+      prompt_id: 'job-3',
+      exception_type: 'StagnationError',
+      exception_message: 'stuck',
+      traceback: ['line1', 'line2']
+    })
+
+    expect(errorStore.lastPromptError).toEqual({
+      type: 'StagnationError',
+      message: 'StagnationError: stuck',
+      details: 'line1\nline2'
+    })
+  })
+
+  it('records classified cloud validation node errors without a failed badge', () => {
+    dist.isCloud = true
+    classifyCloud.mockReturnValue({
+      kind: 'nodeErrors',
+      nodeErrors: { '5': { errors: [] } }
+    })
+    const store = setup()
+    const wf = workflow('c.json')
+    openSet.add(wf)
+    store.storeJob({
+      nodes: [],
+      id: 'job-4',
+      promptOutput: {} as never,
+      workflow: wf
+    })
+
+    fireError({ prompt_id: 'job-4', exception_message: '{"nodeErrors":{}}' })
+
+    expect(store.getWorkflowStatus(wf)).toBeUndefined()
+    expect(errorStore.lastNodeErrors).toEqual({ '5': { errors: [] } })
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useExecutionStore`'s error routing — the execution-failure / paywall critical area. Adds ~19% branch to `executionStore.ts`, stacking with the status (#13225) and progress (#13226) slices.

## Changes

- **What**: New `executionError.test.ts` covering the `execution_error` dispatch: a node error marks the workflow `failed` and stores the raw error; account-precondition errors (sign-in/credits) route away from the failed badge; node-less service-level errors become formatted prompt errors (`type: message`, joined traceback); and cloud validation errors are classified into node errors without a failed badge.
- **Dependencies**: none.

## Review Focus

- **Same proven harness** (captured `api` handlers, exposed `storeJob`/`getWorkflowStatus`, plain-object workflows) plus three boundary predicates stubbed: `resolveAccountPrecondition`, `classifyCloudValidationError`, and a getter-backed `isCloud`. `executionErrorStore` is a shared object so the test reads back the fields the store assigns (`lastExecutionError`/`lastPromptError`/`lastNodeErrors`).
- **The dispatch order is the contract**: cloud-validation (cloud only) → account-precondition → service-level → default-failed. Each branch is exercised and asserted by its observable effect (status badge vs which error field is set), not by mock call-counts.

## Validation

- `pnpm test:unit src/stores/executionError.test.ts` → 4 passed.
- Coverage: `executionStore.ts` +19.1% branch from this test (stacks with #13225/#13226 toward ~40% of the 862-line file).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime behavior modified.
> 
> **Overview**
> Adds **`executionError.test.ts`**, unit tests for `useExecutionStore`'s `execution_error` handler without changing production code.
> 
> The suite reuses the same pattern as other execution-store slices: capture the mocked `api` listener, call `bindExecutionEvents` / `storeJob`, and assertive synthetic errors. **`resolveAccountPrecondition`**, **`classifyCloudValidationError`**, and **`isCloud`** are stubbed so each branch can be isolated.
> 
> Four cases lock in observable behavior: default node errors set workflow **`failed`** and **`lastExecutionError`**; account-precondition matches skip the failed badge and raw execution error; node-less service errors become formatted **`lastPromptError`**; on cloud, classified validation errors populate **`lastNodeErrors`** without a failed badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9f225746cbc5316013be574cde1a021ebbb3b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->