### PR TITLE
test: cover execution store progress lifecycle

### DIFF
--- a/src/stores/executionLifecycle.test.ts
+++ b/src/stores/executionLifecycle.test.ts
@@ -1,0 +1,114 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const { handlers } = vi.hoisted(() => ({
+  handlers: {} as Record<string, (e: { detail: unknown }) => void>
+}))
+
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: (name: string, fn: (e: { detail: unknown }) => void) => {
+      handlers[name] = fn
+    },
+    removeEventListener: () => {}
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    isOpen: () => false,
+    openWorkflows: [],
+    nodeLocatorIdToNodeExecutionId: () => null
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => ({
+    clearExecutionStartErrors: () => {},
+    clearPromptError: () => {}
+  })
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ mode: ref('default'), isAppMode: ref(false) })
+}))
+
+vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+
+vi.mock('@/utils/appMode', () => ({
+  getWorkflowMode: () => 'workflow',
+  isAppModeValue: () => false
+}))
+
+function setup() {
+  const store = useExecutionStore()
+  store.bindExecutionEvents()
+  return store
+}
+
+function startJob(
+  store: ReturnType<typeof useExecutionStore>,
+  id: string,
+  nodes: string[]
+) {
+  store.storeJob({
+    nodes,
+    id,
+    promptOutput: {} as never,
+    workflow: { path: `${id}.json` } as unknown as ComfyWorkflow
+  })
+  handlers['execution_start']?.({ detail: { prompt_id: id } })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  for (const key of Object.keys(handlers)) delete handlers[key]
+})
+
+describe('executionStore execution lifecycle', () => {
+  it('reports zero progress while idle', () => {
+    const store = setup()
+    expect(store.totalNodesToExecute).toBe(0)
+    expect(store.nodesExecuted).toBe(0)
+    expect(store.executionProgress).toBe(0)
+  })
+
+  it('counts the queued nodes once a job starts', () => {
+    const store = setup()
+    startJob(store, 'job-1', ['a', 'b', 'c'])
+
+    expect(store.totalNodesToExecute).toBe(3)
+    expect(store.nodesExecuted).toBe(0)
+    expect(store.executionProgress).toBe(0)
+  })
+
+  it('advances progress as executed events arrive', () => {
+    const store = setup()
+    startJob(store, 'job-1', ['a', 'b', 'c'])
+
+    handlers['executed']?.({ detail: { node: 'a' } })
+    expect(store.nodesExecuted).toBe(1)
+    expect(store.executionProgress).toBeCloseTo(1 / 3)
+
+    handlers['executed']?.({ detail: { node: 'b' } })
+    handlers['executed']?.({ detail: { node: 'c' } })
+    expect(store.nodesExecuted).toBe(3)
+    expect(store.executionProgress).toBe(1)
+  })
+
+  it('ignores executed events when there is no active job', () => {
+    const store = setup()
+    handlers['executed']?.({ detail: { node: 'a' } })
+    expect(store.nodesExecuted).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useExecutionStore`'s progress lifecycle — the execution progress-bar logic. Adds ~12% branch to `executionStore.ts`, the fourth stacked slice (status #13225 + progress #13226 + error #13227 + this), taking the 862-line file past ~50% combined.

## Changes

- **What**: New `executionLifecycle.test.ts` covering: zero progress while idle; `totalNodesToExecute` reflecting the queued node set once a job starts; `nodesExecuted`/`executionProgress` advancing as `executed` events arrive; and `executed` events ignored when there's no active job.
- **Dependencies**: none.

## Review Focus

- **Same proven harness, no new mocks** — `storeJob` seeds the queued nodes, `execution_start` activates the job, and `executed` events flip nodes done; the test asserts the derived progress computeds (`done/total`), not mock calls.
- Scoped to the progress counts; the executing-node-display and interrupted/notification handlers remain follow-ups.

## Validation

- `pnpm test:unit src/stores/executionLifecycle.test.ts` → 4 passed.
- Coverage: `executionStore.ts` +11.8% branch from this test (stacks with #13225/#13226/#13227).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior modified.
> 
> **Overview**
> Adds **`executionLifecycle.test.ts`** with unit tests for `useExecutionStore` progress behavior used by the execution progress bar.
> 
> Tests drive the same event flow as production: **`storeJob`** seeds queued nodes, **`execution_start`** activates the job, and **`executed`** marks nodes done. Assertions target derived state — **`totalNodesToExecute`**, **`nodesExecuted`**, and **`executionProgress`** — not mock call counts.
> 
> Coverage includes idle zero progress, totals after job start, incremental progress through completion, and ignoring **`executed`** when no active job. The harness reuses existing mocks (API event listeners, workflow/canvas/error stores) aligned with prior execution-store test slices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46918ebf99289ba768a1266b8f3dc14a3c36c276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->