### PR TITLE
test: cover workflow store tab management

### DIFF
--- a/src/platform/workflow/management/stores/workflowTabs.test.ts
+++ b/src/platform/workflow/management/stores/workflowTabs.test.ts
@@ -1,0 +1,99 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+vi.mock('@/scripts/app', () => ({ app: {} }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: () => {},
+    getUserData: async () => ({ status: 404 }),
+    storeUserData: async () => {}
+  }
+}))
+
+vi.mock('@/renderer/core/thumbnail/useWorkflowThumbnail', () => ({
+  useWorkflowThumbnail: () => ({
+    moveWorkflowThumbnail: () => {},
+    clearThumbnail: () => {}
+  })
+}))
+
+vi.mock('@/platform/workflow/persistence/stores/workflowDraftStoreV2', () => ({
+  useWorkflowDraftStoreV2: () => ({
+    getDraft: () => null,
+    saveDraft: () => {},
+    deleteDraft: () => {}
+  })
+}))
+
+function wf(path: string): ComfyWorkflow {
+  return { path } as unknown as ComfyWorkflow
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('workflowStore tab management', () => {
+  it('attaches workflows into the lookup and finds them by path', () => {
+    const store = useWorkflowStore()
+    const a = wf('a.json')
+    store.attachWorkflow(a)
+
+    // Pinia wraps stored objects in reactive proxies, so compare structurally.
+    expect(store.getWorkflowByPath('a.json')).toEqual(a)
+    expect(store.getWorkflowByPath('missing.json')).toBeNull()
+    expect(store.workflows).toContainEqual(a)
+  })
+
+  it('tracks which workflows are open', () => {
+    const store = useWorkflowStore()
+    const open = wf('open.json')
+    const closed = wf('closed.json')
+    store.attachWorkflow(open, 0)
+    store.attachWorkflow(closed)
+
+    expect(store.isOpen(open)).toBe(true)
+    expect(store.isOpen(closed)).toBe(false)
+    expect(store.openWorkflows).toEqual([open])
+  })
+
+  it('reorders open workflow tabs', () => {
+    const store = useWorkflowStore()
+    const a = wf('a.json')
+    const b = wf('b.json')
+    const c = wf('c.json')
+    store.attachWorkflow(a, 0)
+    store.attachWorkflow(b, 1)
+    store.attachWorkflow(c, 2)
+
+    store.reorderWorkflows(0, 2)
+
+    expect(store.openWorkflows).toEqual([b, c, a])
+  })
+
+  it('opens background workflows on the requested side, ignoring unknown paths', () => {
+    const store = useWorkflowStore()
+    const left = wf('left.json')
+    const mid = wf('mid.json')
+    const right = wf('right.json')
+    store.attachWorkflow(left)
+    store.attachWorkflow(mid, 0)
+    store.attachWorkflow(right)
+
+    store.openWorkflowsInBackground({
+      left: ['left.json', 'unknown.json'],
+      right: ['right.json']
+    })
+
+    expect(store.openWorkflows).toEqual([left, mid, right])
+  })
+
+  it('reports no active workflow before one is opened', () => {
+    const store = useWorkflowStore()
+    expect(store.isActive(wf('a.json'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useWorkflowStore`'s synchronous tab / open-list management — the workflow-persistence critical area. Raises `workflowStore.ts` from **0% → ~8% branch** (a clean sync slice of a 918-line, mostly-async-I/O store).

## Changes

- **What**: New `workflowTabs.test.ts` covering `attachWorkflow` + `getWorkflowByPath` lookup (and missing → null), `isOpen` (open vs attached-but-closed), `workflows` listing, `reorderWorkflows` tab reordering, `openWorkflowsInBackground` left/right placement with invalid-path filtering, and `isActive` with no active workflow.
- **Dependencies**: none.

## Review Focus

- **Sync slice only.** The store's open/load/save/rename actions are async and I/O-coupled (api, draft store, thumbnails) and belong in reviewed follow-ups; this PR covers the deterministic path-keyed tab state that drives the workflow tab bar.
- **Plain-object workflows** drive the `workflowLookup`/`openWorkflowPaths` state (the store keys by `.path`), so no `ComfyWorkflow`/`UserFile` construction is needed. Boundary deps (app, api, thumbnail, draft store) are stubbed.
- **Pinia proxy note** (called out in a comment): stored objects come back as reactive proxies, so lookups are compared with `toEqual`/`toContainEqual`, not reference equality.

## Validation

- `pnpm test:unit src/platform/workflow/management/stores/workflowTabs.test.ts` → 5 passed.
- Coverage: `workflowStore.ts` branches 0% → 7.9%.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds **`workflowTabs.test.ts`**, a focused Vitest suite for the synchronous tab/open-list slice of **`useWorkflowStore`** (path lookup, open vs attached-only, tab reorder, background open left/right with-file, and **`isActive`** when nothing is active).
> 
> **`app`**, **`api`**, thumbnail, and draft-store dependencies are mocked so tests use minimal `{ path }` workflow stubs and structural assertions (Pinia reactive proxies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b187a6a85e7e4192974d23bc241cd415aa028fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->