### PR TITLE
test: cover workflow store list selectors

### DIFF
--- a/src/platform/workflow/management/stores/workflowLists.test.ts
+++ b/src/platform/workflow/management/stores/workflowLists.test.ts
@@ -1,0 +1,81 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+vi.mock('@/scripts/app', () => ({ app: {} }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: () => {},
+    getUserData: async () => ({ status: 404 }),
+    storeUserData: async () => {}
+  }
+}))
+
+vi.mock('@/renderer/core/thumbnail/useWorkflowThumbnail', () => ({
+  useWorkflowThumbnail: () => ({
+    moveWorkflowThumbnail: () => {},
+    clearThumbnail: () => {}
+  })
+}))
+
+vi.mock('@/platform/workflow/persistence/stores/workflowDraftStoreV2', () => ({
+  useWorkflowDraftStoreV2: () => ({
+    getDraft: () => null,
+    saveDraft: () => {},
+    deleteDraft: () => {}
+  })
+}))
+
+interface WorkflowFlags {
+  path: string
+  isPersisted?: boolean
+  isModified?: boolean
+}
+
+function wf(flags: WorkflowFlags): ComfyWorkflow {
+  return flags as unknown as ComfyWorkflow
+}
+
+function paths(workflows: ComfyWorkflow[]) {
+  return workflows.map((w) => w.path)
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('workflowStore workflow lists', () => {
+  it('persistedWorkflows excludes unpersisted and subgraph entries', () => {
+    const store = useWorkflowStore()
+    store.attachWorkflow(wf({ path: 'a.json', isPersisted: true }))
+    store.attachWorkflow(wf({ path: 'b.json', isPersisted: false }))
+    store.attachWorkflow(wf({ path: 'subgraphs/c.json', isPersisted: true }))
+
+    expect(paths(store.persistedWorkflows)).toEqual(['a.json'])
+  })
+
+  it('modifiedWorkflows includes only modified workflows', () => {
+    const store = useWorkflowStore()
+    store.attachWorkflow(wf({ path: 'a.json', isModified: true }))
+    store.attachWorkflow(wf({ path: 'b.json', isModified: false }))
+
+    expect(paths(store.modifiedWorkflows)).toEqual(['a.json'])
+  })
+
+  it('bookmarkedWorkflows is empty when nothing is bookmarked', () => {
+    const store = useWorkflowStore()
+    store.attachWorkflow(wf({ path: 'a.json' }))
+
+    expect(store.bookmarkedWorkflows).toEqual([])
+  })
+
+  it('openedWorkflowIndexShift returns null when no workflow is active', () => {
+    const store = useWorkflowStore()
+    store.attachWorkflow(wf({ path: 'a.json' }), 0)
+
+    expect(store.openedWorkflowIndexShift(1)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useWorkflowStore`'s list selectors, stacking with the tab-management coverage in #13229 (workflow-persistence critical area).

## Changes

- **What**: New `workflowLists.test.ts` covering `persistedWorkflows` (excludes unpersisted and `subgraphs/` entries), `modifiedWorkflows` (only `isModified`), `bookmarkedWorkflows` (empty when nothing bookmarked), and `openedWorkflowIndexShift` returning null with no active workflow.
- **Dependencies**: none.

## Review Focus

- **Sync selectors only**, driven by flagged plain-object workflows attached via `attachWorkflow` (the store keys/filters by `.path`/`.isPersisted`/`.isModified`). Same boundary mocks as #13229; async open/save/sync actions remain reviewed follow-ups.
- Each computed is asserted by the resulting path list (the real filter predicate), not mock calls.

## Validation

- `pnpm test:unit src/platform/workflow/management/stores/workflowLists.test.ts` → 4 passed.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modified.
> 
> **Overview**
> Adds **`workflowLists.test.ts`** with unit tests for `useWorkflowStore` list/tab helpers, using the same Pinia + boundary mocks pattern as related workflow store tests.
> 
> Coverage asserts **`persistedWorkflows`** drops unpersisted workflows and anything under `subgraphs/`, **`modifiedWorkflows`** only includes `isModified` entries, **`bookmarkedWorkflows`** is empty with no bookmarks, and **`openedWorkflowIndexShift`** returns `null` when there is no active workflow. Workflows are attached via **`attachWorkflow`** with minimal flag objects; expectations use resulting paths, not mock internals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f983bf608791e4c63a99c97debc226a0a17cdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->