### PR TITLE
test: cover execution store interrupt and cached events

### DIFF
--- a/src/stores/executionInterrupt.test.ts
+++ b/src/stores/executionInterrupt.test.ts
@@ -1,0 +1,115 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const { handlers, openSet } = vi.hoisted(() => ({
+  handlers: {} as Record<string, (e: { detail: unknown }) => void>,
+  openSet: new Set<unknown>()
+}))
+
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: (name: string, fn: (e: { detail: unknown }) => void) => {
+      handlers[name] = fn
+    },
+    removeEventListener: () => {}
+  }
+}))
+
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    isOpen: (workflow: unknown) => openSet.has(workflow),
+    openWorkflows: [],
+    nodeLocatorIdToNodeExecutionId: () => null
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => ({
+    clearExecutionStartErrors: () => {},
+    clearPromptError: () => {}
+  })
+}))
+
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ mode: ref('default'), isAppMode: ref(false) })
+}))
+
+vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+
+vi.mock('@/utils/appMode', () => ({
+  getWorkflowMode: () => 'workflow',
+  isAppModeValue: () => false
+}))
+
+function workflow(path: string): ComfyWorkflow {
+  return { path } as unknown as ComfyWorkflow
+}
+
+function setup() {
+  const store = useExecutionStore()
+  store.bindExecutionEvents()
+  return store
+}
+
+function startJob(
+  store: ReturnType<typeof useExecutionStore>,
+  id: string,
+  wf: ComfyWorkflow,
+  nodes: string[] = []
+) {
+  openSet.add(wf)
+  store.storeJob({ nodes, id, promptOutput: {} as never, workflow: wf })
+  handlers['execution_start']?.({ detail: { prompt_id: id } })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  for (const key of Object.keys(handlers)) delete handlers[key]
+  openSet.clear()
+})
+
+describe('executionStore interrupt and cached', () => {
+  it('drops the workflow badge and goes idle on interruption', () => {
+    const store = setup()
+    const wf = workflow('a.json')
+    startJob(store, 'job-1', wf)
+    expect(store.getWorkflowStatus(wf)).toBe('running')
+
+    handlers['execution_interrupted']?.({ detail: { prompt_id: 'job-1' } })
+
+    expect(store.getWorkflowStatus(wf)).toBeUndefined()
+    expect(store.isIdle).toBe(true)
+  })
+
+  it('ends the active job when executing resolves to null', () => {
+    const store = setup()
+    startJob(store, 'job-2', workflow('b.json'))
+    expect(store.isIdle).toBe(false)
+
+    handlers['executing']?.({ detail: null })
+
+    expect(store.isIdle).toBe(true)
+  })
+
+  it('marks cached nodes as executed', () => {
+    const store = setup()
+    startJob(store, 'job-3', workflow('c.json'), ['a', 'b', 'c'])
+    expect(store.nodesExecuted).toBe(0)
+
+    handlers['execution_cached']?.({
+      detail: { prompt_id: 'job-3', nodes: ['a', 'b'] }
+    })
+
+    expect(store.nodesExecuted).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useExecutionStore`'s interrupt/cached lifecycle events — the fifth stacked slice of the execution-status critical area (with #13225–28).

## Changes

- **What**: New `executionInterrupt.test.ts` covering: an interruption drops the workflow badge and returns to idle (user stop is not a failure); an `executing` event resolving to `null` ends the active job; and `execution_cached` marks the cached nodes as executed.
- **Dependencies**: none.

## Review Focus

- **Same proven harness** — captured `api` handlers, exposed `storeJob`/`getWorkflowStatus`, plain-object open workflows; assertions are on the resulting status badge / idle state / executed count, not mock calls.
- Completes the execution lifecycle (start → progress → cached → success/error/interrupt) coverage alongside the prior four slices.

## Validation

- `pnpm test:unit src/stores/executionInterrupt.test.ts` → 3 passed.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds **`executionInterrupt.test.ts`** with three behavioral unit tests for `useExecutionStore` lifecycle edges that were not covered by earlier execution-status slices.
> 
> The suite reuses the same harness as sibling tests (captured `api` event handlers, `storeJob` / `getWorkflowStatus`, mocked workflow/canvas/error stores). It asserts **`execution_interrupted`** clears the workflow running badge and returns **`isIdle`**, an **`executing`** payload of **`null`** ends the active job, and **`execution_cached`** increments **`nodesExecuted`** for the reported cached nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc48862e0a974fb7be27258a8f653ee19aff77ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->