### PR TITLE
test: cover node pack install composable

### DIFF
--- a/src/workbench/extensions/manager/composables/nodePack/usePackInstall.test.ts
+++ b/src/workbench/extensions/manager/composables/nodePack/usePackInstall.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { components } from '@/types/comfyRegistryTypes'
+import { usePackInstall } from '@/workbench/extensions/manager/composables/nodePack/usePackInstall'
+
+type NodePack = components['schemas']['Node']
+
+const { managerStore, showDialog, checkNodeCompatibility } = vi.hoisted(() => ({
+  managerStore: {
+    installPack: { call: vi.fn(), clear: vi.fn() },
+    isPackInstalling: vi.fn((_id?: string) => false),
+    isPackInstalled: vi.fn((_id?: string) => false)
+  },
+  showDialog: vi.fn(),
+  checkNodeCompatibility: vi.fn(() => ({ hasConflict: false, conflicts: [] }))
+}))
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+vi.mock('@/workbench/extensions/manager/stores/comfyManagerStore', () => ({
+  useComfyManagerStore: () => managerStore
+}))
+
+vi.mock(
+  '@/workbench/extensions/manager/composables/useNodeConflictDialog',
+  () => ({
+    useNodeConflictDialog: () => ({ show: showDialog })
+  })
+)
+
+vi.mock(
+  '@/workbench/extensions/manager/composables/useConflictDetection',
+  () => ({
+    useConflictDetection: () => ({ checkNodeCompatibility })
+  })
+)
+
+function pack(over: Partial<NodePack> = {}): NodePack {
+  return { id: 'pack-a', name: 'Pack A', ...over } as NodePack
+}
+
+beforeEach(() => {
+  managerStore.installPack.call.mockReset().mockResolvedValue(undefined)
+  managerStore.installPack.clear.mockReset()
+  managerStore.isPackInstalling.mockReset().mockReturnValue(false)
+  managerStore.isPackInstalled.mockReset().mockReturnValue(false)
+  showDialog.mockReset()
+  checkNodeCompatibility.mockReset().mockReturnValue({
+    hasConflict: false,
+    conflicts: []
+  })
+})
+
+describe('usePackInstall', () => {
+  it('reports isInstalling when any pack is installing', () => {
+    managerStore.isPackInstalling.mockImplementation(
+      (id?: string) => id === 'pack-b'
+    )
+    const { isInstalling } = usePackInstall(() => [
+      pack(),
+      pack({ id: 'pack-b' })
+    ])
+    expect(isInstalling.value).toBe(true)
+  })
+
+  it('reports not installing for an empty or idle pack list', () => {
+    expect(usePackInstall(() => []).isInstalling.value).toBe(false)
+    expect(usePackInstall(() => [pack()]).isInstalling.value).toBe(false)
+  })
+
+  it('installs each pack and clears the command afterward', async () => {
+    const { performInstallation } = usePackInstall(() => [])
+    await performInstallation([
+      pack({
+        id: 'a',
+        latest_version: { version: '1.2.0' }
+      } as Partial<NodePack>),
+      pack({ id: 'b', publisher: { name: 'Unclaimed' } } as Partial<NodePack>)
+    ])
+
+    expect(managerStore.installPack.call).toHaveBeenCalledTimes(2)
+    expect(managerStore.installPack.call).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'a', selected_version: '1.2.0' })
+    )
+    expect(managerStore.installPack.call).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'b', selected_version: 'nightly' })
+    )
+    expect(managerStore.installPack.clear).toHaveBeenCalled()
+  })
+
+  it('installAllPacks installs only the not-yet-installed packs', async () => {
+    managerStore.isPackInstalled.mockImplementation(
+      (id?: string) => id === 'installed'
+    )
+    const { installAllPacks } = usePackInstall(() => [
+      pack({ id: 'installed' }),
+      pack({ id: 'fresh' })
+    ])
+
+    await installAllPacks()
+
+    expect(managerStore.installPack.call).toHaveBeenCalledTimes(1)
+    expect(managerStore.installPack.call).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'fresh' })
+    )
+  })
+
+  it('installAllPacks opens the conflict dialog instead of installing when conflicted', async () => {
+    checkNodeCompatibility.mockReturnValue({
+      hasConflict: true,
+      conflicts: [{ type: 'os' }]
+    } as never)
+    const { installAllPacks } = usePackInstall(
+      () => [pack({ id: 'x' })],
+      () => true,
+      () => [{ type: 'os' } as never]
+    )
+
+    await installAllPacks()
+
+    expect(showDialog).toHaveBeenCalledTimes(1)
+    expect(managerStore.installPack.call).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Stage 3–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `usePackInstall`, raising it from **0% → ~65% branch**. Extension-manager install flow — the plan's extension-compatibility area.

## Changes

- **What**: New `usePackInstall.test.ts` covering `isInstalling` (idle / installing / empty), `performInstallation` (builds install payloads — `latest_version` vs unclaimed→`nightly` — and clears the command in `finally`), `installAllPacks` installing only not-yet-installed packs, and the conflict path opening the node-conflict dialog instead of installing.
- **Dependencies**: none.

## Review Focus

- **Composable tested at its seams**: `comfyManagerStore` (with the `installPack` `{call, clear}` command object), the conflict dialog, conflict detection, and i18n are stubbed via `vi.hoisted`; assertions check the payloads sent to `installPack.call` and which path runs (install vs dialog), not mock plumbing.
- **`createPayload` version selection** is exercised through `performInstallation` (unclaimed publisher → `nightly`, otherwise `latest_version.version`).

## Validation

- `pnpm test:unit src/workbench/extensions/manager/composables/nodePack/usePackInstall.test.ts` → 5 passed.
- Coverage: `usePackInstall.ts` branches 0% → 65.4%, statements 79.2%.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior modified.
> 
> **Overview**
> Adds **`usePackInstall.test.ts`** with five Vitest cases for the extension manager node-pack install composable (previously untested).
> 
> Tests stub **`comfyManagerStore`**, conflict dialog, conflict detection, and i18n at the composable boundary. They assert **`isInstalling`** when any listed pack is installing vs idle/empty lists; **`performInstallation`** building install payloads (`latest_version` vs unclaimed publisher → **`nightly`**) and calling **`installPack.clear`** after runs; **`installAllPacks`** skipping already-installed packs; and the conflict path opening the node-conflict dialog instead of calling install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119b0d7f6a55da176205da5846f9e571534eaea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->