### PR TITLE
test: cover workflow store node locator translation

### DIFF
--- a/src/platform/workflow/management/stores/workflowNodeLocator.test.ts
+++ b/src/platform/workflow/management/stores/workflowNodeLocator.test.ts
@@ -1,0 +1,78 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Subgraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { toNodeId } from '@/types/nodeId'
+import { useWorkflowStore } from '@/platform/workflow/management/stores/workflowStore'
+
+vi.mock('@/scripts/app', () => ({ app: {} }))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: () => {},
+    getUserData: async () => ({ status: 404 }),
+    storeUserData: async () => {}
+  }
+}))
+
+vi.mock('@/renderer/core/thumbnail/useWorkflowThumbnail', () => ({
+  useWorkflowThumbnail: () => ({
+    moveWorkflowThumbnail: () => {},
+    clearThumbnail: () => {}
+  })
+}))
+
+vi.mock('@/platform/workflow/persistence/stores/workflowDraftStoreV2', () => ({
+  useWorkflowDraftStoreV2: () => ({
+    getDraft: () => null,
+    saveDraft: () => {},
+    deleteDraft: () => {}
+  })
+}))
+
+const SUBGRAPH_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('workflowStore node locator translation', () => {
+  it('treats a node as a root-graph node when no subgraph is active', () => {
+    const store = useWorkflowStore()
+    expect(store.nodeIdToNodeLocatorId(toNodeId(5))).toBe('5')
+  })
+
+  it('prefixes the locator with an explicit subgraph uuid', () => {
+    const store = useWorkflowStore()
+    const subgraph = { id: SUBGRAPH_UUID } as unknown as Subgraph
+
+    expect(store.nodeIdToNodeLocatorId(toNodeId(5), subgraph)).toBe(
+      `${SUBGRAPH_UUID}:5`
+    )
+  })
+
+  it('derives a locator from a node based on whether its graph is a subgraph', () => {
+    const store = useWorkflowStore()
+    const rootNode = { id: toNodeId(7), graph: {} } as unknown as LGraphNode
+    expect(store.nodeToNodeLocatorId(rootNode)).toBe('7')
+  })
+
+  it('extracts the local node id from a locator', () => {
+    const store = useWorkflowStore()
+    expect(store.nodeLocatorIdToNodeId(`${SUBGRAPH_UUID}:5` as never)).toBe(
+      toNodeId(5)
+    )
+    expect(store.nodeLocatorIdToNodeId('9' as never)).toBe(toNodeId(9))
+  })
+
+  it('round-trips a root node id through locator translation', () => {
+    const store = useWorkflowStore()
+    const locator = store.nodeIdToNodeLocatorId(toNodeId(42))
+    expect(store.nodeLocatorIdToNodeId(locator)).toBe(toNodeId(42))
+  })
+
+  it('maps a root locator to a single-segment execution id', () => {
+    const store = useWorkflowStore()
+    expect(store.nodeLocatorIdToNodeExecutionId('5' as never)).toBe('5')
+  })
+})


### PR DESCRIPTION
## Summary

Stage 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useWorkflowStore`'s node-locator translation — the cross-app node-identification logic. Third stacked `workflowStore` slice (with #13229 tabs and #13230 lists).

## Changes

- **What**: New `workflowNodeLocator.test.ts` covering `nodeIdToNodeLocatorId` (root-graph bare id vs explicit-subgraph uuid prefix), `nodeToNodeLocatorId` (root path via the node's graph), `nodeLocatorIdToNodeId` extraction, a root round-trip, and `nodeLocatorIdToNodeExecutionId` for a root locator.
- **Dependencies**: none.

## Review Focus

- **Real translation utils, no mocking of what we own's logic** — `createNodeLocatorId`/`parseNodeLocatorId` run unmocked; the test asserts the actual locator strings (`'5'` for root, `uuid:5` for subgraph) and round-trips. Only the store's boundary deps (app, api, thumbnail, draft store) are stubbed.
- `activeSubgraph` defaults undefined without a canvas, so the root-graph branch is exercised by default and the subgraph branch via an explicit argument.

## Validation

- `pnpm test:unit src/platform/workflow/management/stores/workflowNodeLocator.test.ts` → 6 passed.
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior modified.
> 
> **Overview**
> Adds **`workflowNodeLocator.test.ts`**, a focused Vitest suite for **`useWorkflowStore`** node-locator helpers used across the app to identify nodes in the root graph vs inside subgraphs.
> 
> Six cases exercise real **`createNodeLocatorId` / `parseNodeLocatorId`** behavior (not mocked): bare ids when no subgraph is active, **`uuid:nodeId`** when a subgraph is passed explicitly, locators derived from a node’s graph, parsing locators back to local node ids, a root round-trip, and mapping a root locator to a single-segment execution id. Store boundary deps (**`app`**, **`api`**, thumbnail, draft store) are stubbed so the store can initialize under Pinia.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d598fa352b70492c5b4e63e9ba3aa47f0d8e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->