### PR TITLE
test: cover execution store running-state and error edges

### DIFF
--- a/src/stores/executionRunningState.test.ts
+++ b/src/stores/executionRunningState.test.ts
@@ -1,0 +1,149 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { ComfyWorkflow } from '@/platform/workflow/management/stores/workflowStore'
+import { useExecutionStore } from '@/stores/executionStore'
+
+const { handlers, errorStore, activeWorkflow, dist, classifyCloud } =
+  vi.hoisted(() => ({
+    handlers: {} as Record<string, (e: { detail: unknown }) => void>,
+    errorStore: {
+      clearExecutionStartErrors: () => {},
+      clearPromptError: () => {}
+    } as Record<string, unknown>,
+    activeWorkflow: { value: null as { path: string } | null },
+    dist: { isCloud: false },
+    classifyCloud: vi.fn(() => null)
+  }))
+
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+vi.mock('@/scripts/api', () => ({
+  api: {
+    addEventListener: (name: string, fn: (e: { detail: unknown }) => void) => {
+      handlers[name] = fn
+    },
+    removeEventListener: () => {}
+  }
+}))
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    isOpen: () => true,
+    openWorkflows: [],
+    nodeLocatorIdToNodeExecutionId: () => null,
+    get activeWorkflow() {
+      return activeWorkflow.value
+    }
+  })
+}))
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+vi.mock('@/stores/executionErrorStore', () => ({
+  useExecutionErrorStore: () => errorStore
+}))
+vi.mock('@/stores/nodeOutputStore', () => ({
+  useNodeOutputStore: () => ({ revokePreviewsByExecutionId: () => {} })
+}))
+vi.mock('@/composables/useAppMode', () => ({
+  useAppMode: () => ({ mode: ref('default'), isAppMode: ref(false) })
+}))
+vi.mock('@/platform/telemetry', () => ({ useTelemetry: () => undefined }))
+vi.mock('@/utils/appMode', () => ({
+  getWorkflowMode: () => 'workflow',
+  isAppModeValue: () => false
+}))
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return dist.isCloud
+  }
+}))
+vi.mock('@/platform/errorCatalog/accountPreconditionRouting', () => ({
+  resolveAccountPrecondition: () => null
+}))
+vi.mock('@/utils/executionErrorUtil', () => ({
+  classifyCloudValidationError: classifyCloud
+}))
+
+function setup() {
+  const store = useExecutionStore()
+  store.bindExecutionEvents()
+  return store
+}
+
+function workflow(path: string): ComfyWorkflow {
+  return { path } as unknown as ComfyWorkflow
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  for (const key of Object.keys(handlers)) delete handlers[key]
+  activeWorkflow.value = null
+  dist.isCloud = false
+  classifyCloud.mockReturnValue(null)
+  for (const k of ['lastPromptError', 'lastNodeErrors', 'lastExecutionError'])
+    delete errorStore[k]
+})
+
+describe('executionStore running state and error edges', () => {
+  it('lists jobs with a running node and counts running workflows', () => {
+    const store = setup()
+    handlers['progress_state']?.({
+      detail: {
+        prompt_id: 'job-1',
+        nodes: { n1: { state: 'running', value: 1, max: 2 } }
+      }
+    })
+
+    expect(store.runningJobIds).toEqual(['job-1'])
+    expect(store.runningWorkflowCount).toBe(1)
+  })
+
+  it('reports the active workflow as running only when job, path and session agree', () => {
+    const store = setup()
+    expect(store.isActiveWorkflowRunning).toBe(false)
+
+    const wf = workflow('w.json')
+    activeWorkflow.value = { path: 'w.json' }
+    store.storeJob({
+      nodes: [],
+      id: 'job-2',
+      promptOutput: {} as never,
+      workflow: wf
+    })
+    handlers['execution_start']?.({ detail: { prompt_id: 'job-2' } })
+
+    expect(store.isActiveWorkflowRunning).toBe(true)
+  })
+
+  it('formats a service-level error message from the exception message alone', () => {
+    setup()
+    handlers['execution_error']?.({
+      detail: { prompt_id: 'job-3', exception_message: 'Job has stagnated' }
+    })
+
+    expect(errorStore.lastPromptError).toEqual({
+      type: 'error',
+      message: 'Job has stagnated',
+      details: ''
+    })
+  })
+
+  it('stores a classified cloud prompt error on the prompt-error branch', () => {
+    dist.isCloud = true
+    classifyCloud.mockReturnValue({
+      kind: 'promptError',
+      promptError: { type: 'validation', message: 'bad input' }
+    } as never)
+    setup()
+
+    handlers['execution_error']?.({
+      detail: { prompt_id: 'job-4', exception_message: '{}' }
+    })
+
+    expect(errorStore.lastPromptError).toEqual({
+      type: 'validation',
+      message: 'bad input'
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Stages 2–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): close previously-uncovered branches in `useExecutionStore`. Verified **marginal** gain over the existing `executionStore.test.ts`: **67.6% → 74.5% branch** (+6.9pt), by targeting branches the existing suite doesn't reach.

## Changes

- **What**: New `executionRunningState.test.ts` covering: `runningJobIds`/`runningWorkflowCount` derived from `progress_state` events; `isActiveWorkflowRunning` (true only when active job, active-workflow path, and session path agree); the service-level error message formed from `exception_message` alone (no `exception_type`); and the cloud `promptError` classification branch.
- **Dependencies**: none.

## Review Focus

- **Targets uncovered branches, measured marginally.** I selected branches that `executionStore.test.ts` leaves uncovered (lines 587, 602/605, 804, 816–818) and confirmed the delta by running *existing + this* (74.5%) vs *existing alone* (67.6%) — not an isolated run. So this adds real coverage, not overlap.
- Reuses the established executionStore harness (captured `api` handlers, exposed actions, plain-object workflows, boundary-mocked deps); assertions check derived state and the error fields written, not mock calls.

## Validation

- `pnpm test:unit src/stores/executionRunningState.test.ts` → 4 passed.
- Marginal coverage: `executionStore.ts` 67.6% → 74.5% branch (existing test + this).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds **`executionRunningState.test.ts`**, a focused Vitest suite that exercises branches in `useExecutionStore` the main execution store tests reportedly miss (~**+6.9pt** branch coverage on `executionStore.ts`).
> 
> Tests drive the store through captured **`api`** WebSocket handlers after **`bindExecutionEvents()`**, using the same mock harness pattern (Pinia, workflow store, execution error store, cloud **`classifyCloudValidationError`**, etc.). Coverage targets: **`runningJobIds`** / **`runningWorkflowCount`** from **`progress_state`** with a running node; **`isActiveWorkflowRunning`** when active job, workflow path, and session mapping align; **`execution_error`** prompt errors built from **`exception_message`** alone (no **`exception_type`**); and the cloud path that writes **`lastPromptError`** from a **`promptError`** classification result.
> 
> **No production code changes**—tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f0e1dcf935d161f81275a37005e3561d00d6232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->