### PR TITLE
test: cover workflow templates store loading and grouping

### DIFF
--- a/src/platform/workflow/templates/repositories/workflowTemplatesStore.test.ts
+++ b/src/platform/workflow/templates/repositories/workflowTemplatesStore.test.ts
@@ -1,0 +1,99 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useWorkflowTemplatesStore } from '@/platform/workflow/templates/repositories/workflowTemplatesStore'
+
+const { coreResult, customResult } = vi.hoisted(() => ({
+  coreResult: {
+    value: [] as unknown[]
+  },
+  customResult: { value: {} as Record<string, string[]> }
+}))
+
+vi.mock('@/scripts/api', () => ({
+  api: {
+    getWorkflowTemplates: async () => customResult.value,
+    getCoreWorkflowTemplates: async () => coreResult.value,
+    fileURL: (p: string) => p
+  }
+}))
+
+vi.mock('@/i18n', () => ({
+  i18n: { global: { locale: { value: 'en' } } },
+  st: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  get isCloud() {
+    return false
+  }
+}))
+
+function coreCategory() {
+  return {
+    moduleName: 'comfy_core',
+    title: 'Basics',
+    type: 'image',
+    templates: [
+      {
+        name: 'default',
+        title: 'Default',
+        description: 'A basic template',
+        mediaType: 'image',
+        mediaSubtype: 'webp'
+      }
+    ]
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  coreResult.value = [coreCategory()]
+  customResult.value = {}
+  vi.stubGlobal(
+    'fetch',
+    async () => ({ headers: { get: () => 'text/html' } }) as never
+  )
+})
+
+describe('workflowTemplatesStore', () => {
+  it('loads core templates and indexes their names', async () => {
+    const store = useWorkflowTemplatesStore()
+    expect(store.isLoaded).toBe(false)
+
+    await store.loadWorkflowTemplates()
+
+    expect(store.isLoaded).toBe(true)
+    expect(store.knownTemplateNames.has('default')).toBe(true)
+    expect(store.getTemplateByName('default')).toBeDefined()
+    expect(store.getTemplateByName('missing')).toBeUndefined()
+  })
+
+  it('exposes grouped templates with localized titles', async () => {
+    const store = useWorkflowTemplatesStore()
+    await store.loadWorkflowTemplates()
+
+    expect(store.groupedTemplates.length).toBeGreaterThan(0)
+    const allNames = store.groupedTemplates.flatMap((g) =>
+      (g.modules ?? []).flatMap((m) => (m.templates ?? []).map((t) => t.name))
+    )
+    expect(allNames).toContain('default')
+  })
+
+  it('does not refetch once loaded', async () => {
+    const store = useWorkflowTemplatesStore()
+    await store.loadWorkflowTemplates()
+
+    coreResult.value = [] // would empty the store if refetched
+    await store.loadWorkflowTemplates()
+
+    expect(store.knownTemplateNames.has('default')).toBe(true)
+  })
+
+  it('returns null english metadata when no english templates are loaded', async () => {
+    const store = useWorkflowTemplatesStore()
+    await store.loadWorkflowTemplates()
+
+    expect(store.getEnglishMetadata('default')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Stages 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useWorkflowTemplatesStore`, raising it from **0% → ~18% branch** (no pre-existing test). Workflow-templates is part of the plan's workflow/onboarding surface.

## Changes

- **What**: New `workflowTemplatesStore.test.ts` covering `loadWorkflowTemplates` (populates core templates + `knownTemplateNames`), `getTemplateByName` (hit/miss), `groupedTemplates` (loaded templates surface through the grouped structure), the `isLoaded` guard preventing refetch, and `getEnglishMetadata` returning null when no english templates are loaded.
- **Dependencies**: none.

## Review Focus

- **Drives the real load + grouping** with mocked `api.getCoreWorkflowTemplates`/`getWorkflowTemplates` returning template fixtures; `fetchLogoIndex`'s `fetch` is stubbed to a non-JSON response so it returns `{}`. `categoryUtil` (id/icon) runs unmocked.
- **Scope**: the load + `groupedTemplates` path. The nav-group construction, category filters, logo-url resolution, and locale-reload watch are larger follow-ups — this is the first genuinely-additive slice on a 590-line, previously-untested store.

## Validation

- `pnpm test:unit src/platform/workflow/templates/repositories/workflowTemplatesStore.test.ts` → 4 passed.
- Coverage: `workflowTemplatesStore.ts` 0% → 18.0% branch (no pre-existing test).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with mocked API; no production or runtime behavior changes.
> 
> **Overview**
> Adds **`workflowTemplatesStore.test.ts`**, the first behavioral tests for `useWorkflowTemplatesStore` (previously untested).
> 
> Tests drive **`loadWorkflowTemplates`** with mocked **`api.getCoreWorkflowTemplates`** / **`getWorkflowTemplates`** and a stubbed **`fetch`** (non-JSON logo index). They assert core load sets **`isLoaded`**, **`knownTemplateNames`**, and **`getTemplateByName`**; **`groupedTemplates`** includes loaded template names; a second load does **not** refetch when already loaded; and **`getEnglishMetadata`** returns **null** when no English templates are loaded. **`categoryUtil`** runs unmocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31200b43a336e70b2be2fa97119fd2635c2effa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->