### PR TITLE
test: cover graph selection operations

### DIFF
--- a/src/composables/graph/useSelectionOperations.test.ts
+++ b/src/composables/graph/useSelectionOperations.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSelectionOperations } from '@/composables/graph/useSelectionOperations'
+
+const {
+  canvas,
+  toastAdd,
+  captureCanvasState,
+  updateSelectedItems,
+  prompt,
+  titleEditor,
+  store
+} = vi.hoisted(() => ({
+  canvas: {
+    selectedItems: new Set<unknown>(),
+    copyToClipboard: vi.fn(),
+    pasteFromClipboard: vi.fn(),
+    deleteSelected: vi.fn(),
+    setDirty: vi.fn()
+  },
+  toastAdd: vi.fn(),
+  captureCanvasState: vi.fn(),
+  updateSelectedItems: vi.fn(),
+  prompt: vi.fn(),
+  titleEditor: { titleEditorTarget: null as unknown },
+  store: { selectedItems: [] as unknown[] }
+}))
+
+vi.mock('@/scripts/app', () => ({ app: { canvas } }))
+vi.mock('@/i18n', () => ({ t: (key: string) => key }))
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ add: toastAdd })
+}))
+vi.mock('@/platform/workflow/management/stores/workflowStore', () => ({
+  useWorkflowStore: () => ({
+    activeWorkflow: { changeTracker: { captureCanvasState } }
+  })
+}))
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    updateSelectedItems,
+    get selectedItems() {
+      return store.selectedItems
+    }
+  }),
+  useTitleEditorStore: () => titleEditor
+}))
+vi.mock('@/services/dialogService', () => ({
+  useDialogService: () => ({ prompt })
+}))
+
+beforeEach(() => {
+  canvas.selectedItems = new Set()
+  canvas.copyToClipboard.mockReset()
+  canvas.pasteFromClipboard.mockReset()
+  canvas.deleteSelected.mockReset()
+  canvas.setDirty.mockReset()
+  toastAdd.mockReset()
+  captureCanvasState.mockReset()
+  updateSelectedItems.mockReset()
+  prompt.mockReset()
+  titleEditor.titleEditorTarget = null
+  store.selectedItems = []
+})
+
+describe('useSelectionOperations', () => {
+  it('warns and does nothing when copying an empty selection', () => {
+    useSelectionOperations().copySelection()
+    expect(canvas.copyToClipboard).not.toHaveBeenCalled()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'warn' })
+    )
+  })
+
+  it('copies a non-empty selection and reports success', () => {
+    canvas.selectedItems = new Set(['a'])
+    useSelectionOperations().copySelection()
+    expect(canvas.copyToClipboard).toHaveBeenCalled()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'success' })
+    )
+  })
+
+  it('pastes from clipboard and captures canvas state', () => {
+    useSelectionOperations().pasteSelection()
+    expect(canvas.pasteFromClipboard).toHaveBeenCalledWith({
+      connectInputs: false
+    })
+    expect(captureCanvasState).toHaveBeenCalled()
+  })
+
+  it('duplicates by copy, clear, paste', () => {
+    canvas.selectedItems = new Set(['a'])
+    useSelectionOperations().duplicateSelection()
+    expect(canvas.copyToClipboard).toHaveBeenCalled()
+    expect(updateSelectedItems).toHaveBeenCalled()
+    expect(canvas.pasteFromClipboard).toHaveBeenCalled()
+  })
+
+  it('warns when duplicating nothing', () => {
+    useSelectionOperations().duplicateSelection()
+    expect(canvas.copyToClipboard).not.toHaveBeenCalled()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'warn' })
+    )
+  })
+
+  it('deletes a non-empty selection and marks the canvas dirty', () => {
+    canvas.selectedItems = new Set(['a'])
+    useSelectionOperations().deleteSelection()
+    expect(canvas.deleteSelected).toHaveBeenCalled()
+    expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
+  })
+
+  it('warns when deleting nothing', () => {
+    useSelectionOperations().deleteSelection()
+    expect(canvas.deleteSelected).not.toHaveBeenCalled()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'warn' })
+    )
+  })
+
+  it('renames a single non-node item via the prompt dialog', async () => {
+    const group = { title: 'Old' }
+    store.selectedItems = [group]
+    prompt.mockResolvedValue('New')
+
+    await useSelectionOperations().renameSelection()
+
+    expect(group.title).toBe('New')
+    expect(canvas.setDirty).toHaveBeenCalledWith(true, true)
+  })
+
+  it('batch-renames multiple items with an indexed base name', async () => {
+    const a = { title: 'a' }
+    const b = { title: 'b' }
+    store.selectedItems = [a, b]
+    prompt.mockResolvedValue('Item')
+
+    await useSelectionOperations().renameSelection()
+
+    expect(a.title).toBe('Item 1')
+    expect(b.title).toBe('Item 2')
+  })
+
+  it('warns when renaming an empty selection', async () => {
+    await useSelectionOperations().renameSelection()
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'warn' })
+    )
+  })
+})

--- a/src/composables/graph/useSelectionOperations.test.ts
+++ b/src/composables/graph/useSelectionOperations.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useSelectionOperations } from '@/composables/graph/useSelectionOperations'
 
 const {
@@ -118,6 +119,16 @@ describe('useSelectionOperations', () => {
     expect(toastAdd).toHaveBeenCalledWith(
       expect.objectContaining({ severity: 'warn' })
     )
+  })
+
+  it('routes a single node rename to the title editor', async () => {
+    const node = new LGraphNode('Test')
+    store.selectedItems = [node]
+
+    await useSelectionOperations().renameSelection()
+
+    expect(titleEditor.titleEditorTarget).toBe(node)
+    expect(prompt).not.toHaveBeenCalled()
   })
 
   it('renames a single non-node item via the prompt dialog', async () => {


### PR DESCRIPTION
## Summary

Stages 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useSelectionOperations` (graph canvas selection actions), raising it from **0% → ~80% branch** (no pre-existing test).

## Changes

- **What**: New `useSelectionOperations.test.ts` covering copy/duplicate/delete empty-selection warnings and their non-empty canvas actions (`copyToClipboard`, `deleteSelected`, `setDirty`, change capture), paste, single non-node rename via the prompt dialog, indexed batch rename, and the empty-selection rename warning.
- **Dependencies**: none.

## Review Focus

- **Mocks are first-party only** — `app.canvas`, toast/workflow/canvas stores, and the dialog service are all our own modules (this isn't third-party mocking). Assertions check the canvas methods invoked and the resulting titles/toasts, not mock internals.
- **Scope**: the uncovered ~20% is the single-node rename path (`item instanceof LGraphNode` → title editor), which needs a real `LGraphNode` instance and is left as a follow-up; the group/multi/empty rename paths and all copy/paste/duplicate/delete branches are covered.

## Validation

- `pnpm test:unit src/composables/graph/useSelectionOperations.test.ts` → 10 passed.
- Coverage: `useSelectionOperations.ts` 0% → 80.0% branch (no pre-existing test).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no production or runtime behavior changes.
> 
> **Overview**
> Adds **`useSelectionOperations.test.ts`**, the first unit tests for graph canvas selection actions (copy, paste, duplicate, delete, rename).
> 
> Tests use **hoisted Vitest mocks** for `app.canvas`, toast/workflow/canvas stores, and the dialog service. They assert **behavior**: empty-selection **warn** toasts, successful copy toasts, clipboard/delete/dirty calls, paste with `connectInputs: false` plus change capture, duplicate’s copy → clear selection → paste flow, and rename paths (single **`LGraphNode`** → title editor, single group via prompt, batch indexed titles, empty selection warn).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6bd51bc027a05a90360e57c56e9068bfd899254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->