### PR TITLE
test: cover graph node customization

### DIFF
--- a/src/composables/graph/useNodeCustomization.test.ts
+++ b/src/composables/graph/useNodeCustomization.test.ts
@@ -1,0 +1,104 @@
+import type * as VueI18n from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useNodeCustomization } from '@/composables/graph/useNodeCustomization'
+
+const { selection, refreshCanvas, palette } = vi.hoisted(() => ({
+  selection: { items: [] as unknown[] },
+  refreshCanvas: vi.fn(),
+  palette: { light_theme: false }
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof VueI18n>()),
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    get selectedItems() {
+      return selection.items
+    }
+  })
+}))
+
+vi.mock('@/stores/workspace/colorPaletteStore', () => ({
+  useColorPaletteStore: () => ({
+    get completedActivePalette() {
+      return { light_theme: palette.light_theme }
+    }
+  })
+}))
+
+vi.mock('@/composables/graph/useCanvasRefresh', () => ({
+  useCanvasRefresh: () => ({ refreshCanvas })
+}))
+
+function colorable(bgcolor?: string) {
+  return {
+    setColorOption: vi.fn(),
+    getColorOption: () => (bgcolor ? { bgcolor } : null)
+  }
+}
+
+beforeEach(() => {
+  selection.items = []
+  refreshCanvas.mockReset()
+  palette.light_theme = false
+})
+
+describe('useNodeCustomization', () => {
+  it('exposes color and shape option lists', () => {
+    const { colorOptions, shapeOptions } = useNodeCustomization()
+    expect(colorOptions.length).toBeGreaterThan(1)
+    expect(shapeOptions.length).toBeGreaterThan(0)
+  })
+
+  it('reflects the active palette light-theme flag', () => {
+    palette.light_theme = true
+    expect(useNodeCustomization().isLightTheme.value).toBe(true)
+  })
+
+  it('clears color on all colorable items for the no-color option', () => {
+    const item = colorable()
+    selection.items = [item]
+    useNodeCustomization().applyColor(null)
+
+    expect(item.setColorOption).toHaveBeenCalledWith(null)
+    expect(refreshCanvas).toHaveBeenCalled()
+  })
+
+  it('applies a named color option to colorable items', () => {
+    const item = colorable()
+    selection.items = [item]
+    const { colorOptions, applyColor } = useNodeCustomization()
+    // Options are built from LGraphCanvas.node_colors, so the last one is a
+    // real named color that resolves to a non-null canvas color option.
+    const named = colorOptions.at(-1)!
+
+    applyColor(named)
+
+    expect(item.setColorOption).toHaveBeenCalledTimes(1)
+    expect(item.setColorOption.mock.calls[0][0]).not.toBeNull()
+  })
+
+  it('returns null current color for an empty selection', () => {
+    expect(useNodeCustomization().getCurrentColor()).toBeNull()
+  })
+
+  it('falls back to the no-color option for an unrecognized current color', () => {
+    selection.items = [colorable('#not-a-known-color')]
+    const result = useNodeCustomization().getCurrentColor()
+    expect(result?.name).toBeDefined()
+  })
+
+  it('no-ops shape changes when no graph nodes are selected', () => {
+    selection.items = [colorable()] // colorable but not an LGraphNode
+    useNodeCustomization().applyShape({ name: 'box', value: 'box' } as never)
+    expect(refreshCanvas).not.toHaveBeenCalled()
+  })
+
+  it('returns null current shape with no nodes selected', () => {
+    expect(useNodeCustomization().getCurrentShape()).toBeNull()
+  })
+})

--- a/src/composables/graph/useNodeCustomization.test.ts
+++ b/src/composables/graph/useNodeCustomization.test.ts
@@ -1,6 +1,8 @@
 import type * as VueI18n from 'vue-i18n'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+
 import { useNodeCustomization } from '@/composables/graph/useNodeCustomization'
 
 const { selection, refreshCanvas, palette } = vi.hoisted(() => ({
@@ -100,5 +102,26 @@ describe('useNodeCustomization', () => {
 
   it('returns null current shape with no nodes selected', () => {
     expect(useNodeCustomization().getCurrentShape()).toBeNull()
+  })
+
+  it('applies a shape to selected graph nodes and refreshes', () => {
+    const node = new LGraphNode('Test')
+    selection.items = [node]
+    const { applyShape, shapeOptions } = useNodeCustomization()
+    const target = shapeOptions[0]
+
+    applyShape(target)
+
+    expect(node.shape).toBe(target.value)
+    expect(refreshCanvas).toHaveBeenCalled()
+  })
+
+  it('reports the current shape of a selected node', () => {
+    const node = new LGraphNode('Test')
+    const { shapeOptions, getCurrentShape } = useNodeCustomization()
+    node.shape = shapeOptions[0].value
+    selection.items = [node]
+
+    expect(getCurrentShape()?.value).toBe(shapeOptions[0].value)
   })
 })


### PR DESCRIPTION
## Summary

Stages 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useNodeCustomization` (node color/shape), raising it from **0% → ~69% branch** (no pre-existing test).

## Changes

- **What**: New `useNodeCustomization.test.ts` covering the color/shape option lists, the light-theme flag, `applyColor` (no-color clear and named-color apply with canvas refresh), `getCurrentColor` (empty selection and unrecognized-color fallback), and the no-node-selected guards for `applyShape`/`getCurrentShape`.
- **Dependencies**: none.

## Review Focus

- **Colorable items are duck-typed** via the real `isColorable` (`setColorOption`/`getColorOption`), so the color paths are covered with plain fakes — no `LGraphNode` needed. The `instanceof LGraphNode` shape-apply path is a deliberate follow-up.
- First-party deps only (canvas store, color-palette store, canvas refresh) are mocked; `vue-i18n` is partial-mocked (real `createI18n` preserved for the transitive `@/i18n`).

## Validation

- `pnpm test:unit src/composables/graph/useNodeCustomization.test.ts` → 8 passed.
- Coverage: `useNodeCustomization.ts` 0% → 69.2% branch (no pre-existing test).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no production code changes; mocks isolate stores and refresh behavior.
> 
> **Overview**
> Adds **`useNodeCustomization.test.ts`**, the first behavioral tests for the graph node color/shape composable.
> 
> Tests mock canvas selection, palette theme, i18n, and canvas refresh, then cover option lists, light-theme reflection, **`applyColor`** (clear vs named color + refresh), **`getCurrentColor`** (empty / unknown fallback), and **`applyShape`** / **`getCurrentShape`** (including no-op when selection isn’t **`LGraphNode`** and real-node shape apply + refresh). Color paths use duck-typed **`colorable`** fakes; shape paths use **`LGraphNode`** where **`instanceof`** matters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0510fd28ee3980aa835710293ef17adf85476bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->