### PR TITLE
test: cover more-options menu orchestration

### DIFF
--- a/src/composables/graph/useMoreOptionsMenu.test.ts
+++ b/src/composables/graph/useMoreOptionsMenu.test.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LGraphGroup } from '@/lib/litegraph/src/litegraph'
 import {
   isNodeOptionsOpen,
   registerNodeOptionsInstance,
@@ -50,7 +51,7 @@ vi.mock('@/composables/graph/useGroupMenuOptions', () => ({
   useGroupMenuOptions: () => ({
     getFitGroupToNodesOption: () => ({ label: 'Fit' }),
     getGroupColorOptions: () => ({ label: 'Group Color' }),
-    getGroupModeOptions: () => []
+    getGroupModeOptions: () => [{ label: 'Group Mode' }]
   })
 }))
 vi.mock('@/composables/graph/useSelectionMenuOptions', () => ({
@@ -128,5 +129,16 @@ describe('useMoreOptionsMenu', () => {
       bump()
       void menuOptions.value
     }).not.toThrow()
+  })
+
+  it('assembles group-context options for a single selected group', () => {
+    const group = new LGraphGroup('Group')
+    selectionState.selectedItems.value = [group]
+    selectionState.selectedNodes.value = []
+
+    const labels = useMoreOptionsMenu().menuOptions.value.map((o) => o.label)
+    expect(labels).toContain('Group Mode')
+    expect(labels).toContain('Fit')
+    expect(labels).toContain('Group Color')
   })
 })

--- a/src/composables/graph/useMoreOptionsMenu.test.ts
+++ b/src/composables/graph/useMoreOptionsMenu.test.ts
@@ -1,0 +1,132 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isNodeOptionsOpen,
+  registerNodeOptionsInstance,
+  showNodeOptions,
+  toggleNodeOptions,
+  useMoreOptionsMenu
+} from '@/composables/graph/useMoreOptionsMenu'
+
+// Plain { value } objects stand in for refs — vi.hoisted runs before imports,
+// so vue's ref isn't available here; the composable only reads `.value`.
+const { selectionState } = vi.hoisted(() => ({
+  selectionState: {
+    selectedItems: { value: [] as unknown[] },
+    selectedNodes: { value: [] as unknown[] },
+    canOpenNodeInfo: { value: false },
+    openNodeInfo: vi.fn(),
+    hasSubgraphs: { value: false },
+    hasImageNode: { value: false },
+    hasOutputNodesSelected: { value: false },
+    hasMultipleSelection: { value: false },
+    computeSelectionFlags: vi.fn(() => ({}))
+  }
+}))
+
+vi.mock('@/composables/graph/useSelectionState', () => ({
+  useSelectionState: () => selectionState
+}))
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({ canvas: undefined })
+}))
+vi.mock('@/services/litegraphService', () => ({
+  getExtraOptionsForWidget: () => []
+}))
+vi.mock('@/composables/graph/useImageMenuOptions', () => ({
+  useImageMenuOptions: () => ({ getImageMenuOptions: () => [] })
+}))
+vi.mock('@/composables/graph/useNodeMenuOptions', () => ({
+  useNodeMenuOptions: () => ({
+    getNodeInfoOption: () => ({ label: 'Info' }),
+    getNodeVisualOptions: () => [],
+    getPinOption: () => ({ label: 'Pin' }),
+    getBypassOption: () => ({ label: 'Bypass' }),
+    getRunBranchOption: () => ({ label: 'Run Branch' })
+  })
+}))
+vi.mock('@/composables/graph/useGroupMenuOptions', () => ({
+  useGroupMenuOptions: () => ({
+    getFitGroupToNodesOption: () => ({ label: 'Fit' }),
+    getGroupColorOptions: () => ({ label: 'Group Color' }),
+    getGroupModeOptions: () => []
+  })
+}))
+vi.mock('@/composables/graph/useSelectionMenuOptions', () => ({
+  useSelectionMenuOptions: () => ({
+    getBasicSelectionOptions: () => [{ label: 'Copy' }],
+    getMultipleNodesOptions: () => [{ label: 'Align' }],
+    getSubgraphOptions: () => []
+  })
+}))
+
+beforeEach(() => {
+  registerNodeOptionsInstance(null)
+  selectionState.selectedItems.value = []
+  selectionState.selectedNodes.value = []
+  selectionState.hasOutputNodesSelected.value = false
+  selectionState.hasMultipleSelection.value = false
+})
+
+describe('node options popover instance', () => {
+  it('reports closed when no instance is registered', () => {
+    expect(isNodeOptionsOpen()).toBe(false)
+  })
+
+  it('reflects the registered instance open state and forwards toggle/show', () => {
+    const toggle = vi.fn()
+    const show = vi.fn()
+    registerNodeOptionsInstance({
+      toggle,
+      show,
+      hide: vi.fn(),
+      isOpen: ref(true)
+    })
+
+    expect(isNodeOptionsOpen()).toBe(true)
+    toggleNodeOptions(new Event('click'))
+    showNodeOptions(new MouseEvent('contextmenu'))
+    expect(toggle).toHaveBeenCalled()
+    expect(show).toHaveBeenCalled()
+  })
+
+  it('no-ops toggle/show when no instance is registered', () => {
+    expect(() => toggleNodeOptions(new Event('click'))).not.toThrow()
+    expect(() => showNodeOptions(new MouseEvent('contextmenu'))).not.toThrow()
+  })
+})
+
+describe('useMoreOptionsMenu', () => {
+  it('assembles a non-empty menu for a single selected node', () => {
+    const node = { id: 1, widgets: [] }
+    selectionState.selectedItems.value = [node]
+    selectionState.selectedNodes.value = [node]
+
+    const { menuOptions } = useMoreOptionsMenu()
+    const labels = menuOptions.value.map((o) => o.label)
+    expect(labels).toContain('Copy')
+    expect(labels).toContain('Pin')
+  })
+
+  it('includes multiple-node options when several nodes are selected', () => {
+    const nodes = [
+      { id: 1, widgets: [] },
+      { id: 2, widgets: [] }
+    ]
+    selectionState.selectedItems.value = nodes
+    selectionState.selectedNodes.value = nodes
+    selectionState.hasMultipleSelection.value = true
+
+    const { menuOptions } = useMoreOptionsMenu()
+    expect(menuOptions.value.map((o) => o.label)).toContain('Align')
+  })
+
+  it('bumps the options version to force recompute', () => {
+    const { bump, menuOptions } = useMoreOptionsMenu()
+    expect(() => {
+      bump()
+      void menuOptions.value
+    }).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Stages 1–4 of the [Test Coverage Implementation Plan](https://app.notion.com/p/38c6d73d36508193b95ee13f05ed8b4a): behavioral coverage for `useMoreOptionsMenu` (the graph context-menu orchestrator), raising it from **0% → ~62% branch** (no pre-existing test).

## Changes

- **What**: New `useMoreOptionsMenu.test.ts` covering the node-options popover singleton (`registerNodeOptionsInstance`/`isNodeOptionsOpen`/`toggleNodeOptions`/`showNodeOptions` forwarding, and no-op when unregistered) and the `menuOptions` assembly for single-node and multi-node selections (basic ops + pin present, multiple-node options present), plus the `bump` version recompute.
- **Dependencies**: none.

## Review Focus

- **Sub-composables and selection state are mocked** (all first-party); the menu builders return marker options and the test asserts those markers survive into the assembled menu via the real `buildStructuredMenu`. Selection-state stand-ins are plain `{ value }` objects (vi.hoisted runs before vue's `ref` import).
- **Scope**: the single-node / multi-node assembly + the popover singleton. The group-context (`isLGraphGroup`), image-node, widget-extra, and LiteGraph-merge branches are follow-ups requiring real group/widget instances.

## Validation

- `pnpm test:unit src/composables/graph/useMoreOptionsMenu.test.ts` → 6 passed.
- Coverage: `useMoreOptionsMenu.ts` 0% → 61.8% branch (no pre-existing test).
- Pre-commit: oxfmt, oxlint, eslint, `pnpm typecheck`.

## Screenshots (if applicable)

N/A — unit tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with mocked dependencies; no production behavior or runtime paths are modified.
> 
> **Overview**
> Adds **`useMoreOptionsMenu.test.ts`** to exercise the graph “more options” context menu composable, which previously had no unit tests.
> 
> Coverage targets the **node-options popover singleton** (`registerNodeOptionsInstance`, `isNodeOptionsOpen`, `toggleNodeOptions` / `showNodeOptions` forwarding, and safe no-ops when nothing is registered) and **`menuOptions` assembly** via the real `buildStructuredMenu` path: single-node menus include mocked basic selection + pin options, multi-select adds align-style options when `hasMultipleSelection` is set, a single **`LGraphGroup`** selection surfaces group fit/color/mode markers, and **`bump`** is smoke-tested for recompute.
> 
> Sub-composables and selection state are **fully mocked** with marker labels; image-node, widget extras, and LiteGraph-merge branches are left for follow-up work per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b956a91f97cd02072d7c99a23e96c97d517728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->