### PR TITLE
feat: decode canonical agent wire envelope in parseAgentEvent

### DIFF
--- a/src/platform/agent/common/agentProtocol.test.ts
+++ b/src/platform/agent/common/agentProtocol.test.ts
@@ -1,73 +1,188 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseAgentEvent } from './agentProtocol'
+import type { AgentTurnRequest } from './agentProtocol'
+import { parseAgentEvent, serializeAgentTurnRequest } from './agentProtocol'
 
-const base = { threadId: 't1', messageId: 'm1' }
+const data = { thread_id: 't1', message_id: 'm1' }
 
 describe('parseAgentEvent', () => {
-  it('decodes a draft_patch', () => {
+  it('decodes a draft_patch from the snake_case envelope', () => {
     const event = parseAgentEvent({
-      ...base,
       type: 'draft_patch',
+      data: {
+        ...data,
+        workflow_id: 'wf1',
+        content: { nodes: [] },
+        version: 8,
+        base_version: 7
+      }
+    })
+    expect(event).toEqual({
+      type: 'draft_patch',
+      threadId: 't1',
+      messageId: 'm1',
       workflowId: 'wf1',
       content: { nodes: [] },
       version: 8,
       baseVersion: 7
     })
-    expect(event).toMatchObject({
-      type: 'draft_patch',
-      workflowId: 'wf1',
-      version: 8
+  })
+
+  it('decodes a message delta', () => {
+    const event = parseAgentEvent({
+      type: 'agent_message_delta',
+      data: { ...data, delta: 'hi' }
+    })
+    expect(event).toEqual({
+      type: 'agent_message_delta',
+      threadId: 't1',
+      messageId: 'm1',
+      delta: 'hi'
     })
   })
 
   it('decodes a tool call and drops absent optional fields', () => {
     const event = parseAgentEvent({
-      ...base,
       type: 'agent_tool_call',
+      data: {
+        ...data,
+        tool_call_id: 'tc1',
+        tool_name: 'workflow set-slot',
+        status: 'success'
+      }
+    })
+    expect(event).toEqual({
+      type: 'agent_tool_call',
+      threadId: 't1',
+      messageId: 'm1',
       toolCallId: 'tc1',
       toolName: 'workflow set-slot',
       status: 'success'
     })
-    expect(event).toEqual({
-      ...base,
+  })
+
+  it('maps tool call duration and error code from snake_case', () => {
+    const event = parseAgentEvent({
       type: 'agent_tool_call',
-      toolCallId: 'tc1',
-      toolName: 'workflow set-slot',
-      status: 'success'
+      data: {
+        ...data,
+        tool_call_id: 'tc1',
+        tool_name: 'run',
+        status: 'error',
+        duration_ms: 1200,
+        error_code: 'OOM'
+      }
+    })
+    expect(event).toMatchObject({ durationMs: 1200, errorCode: 'OOM' })
+  })
+
+  it('maps message done usage to tokenUsage', () => {
+    const event = parseAgentEvent({
+      type: 'agent_message_done',
+      data: { ...data, usage: { input: 12, output: 34 } }
+    })
+    expect(event).toEqual({
+      type: 'agent_message_done',
+      threadId: 't1',
+      messageId: 'm1',
+      tokenUsage: { input: 12, output: 34 }
+    })
+  })
+
+  it('omits tokenUsage when usage is absent', () => {
+    const event = parseAgentEvent({
+      type: 'agent_message_done',
+      data: { ...data }
+    })
+    expect(event).toEqual({
+      type: 'agent_message_done',
+      threadId: 't1',
+      messageId: 'm1'
     })
   })
 
   it('rejects an unknown event type', () => {
-    expect(parseAgentEvent({ ...base, type: 'nope' })).toBeNull()
+    expect(parseAgentEvent({ type: 'nope', data })).toBeNull()
   })
 
-  it('rejects a payload missing the base identifiers', () => {
+  it('rejects a payload with no envelope body', () => {
     expect(
       parseAgentEvent({ type: 'agent_message_delta', delta: 'hi' })
     ).toBeNull()
   })
 
+  it('rejects a payload missing the base identifiers', () => {
+    expect(
+      parseAgentEvent({
+        type: 'agent_message_delta',
+        data: { delta: 'hi' }
+      })
+    ).toBeNull()
+  })
+
   it('rejects a draft_patch with a malformed version', () => {
     const event = parseAgentEvent({
-      ...base,
       type: 'draft_patch',
-      workflowId: 'wf1',
-      content: {},
-      version: '8',
-      baseVersion: 7
+      data: {
+        ...data,
+        workflow_id: 'wf1',
+        content: {},
+        version: '8',
+        base_version: 7
+      }
+    })
+    expect(event).toBeNull()
+  })
+
+  it('rejects a draft_patch missing base_version', () => {
+    const event = parseAgentEvent({
+      type: 'draft_patch',
+      data: { ...data, workflow_id: 'wf1', content: {}, version: 8 }
     })
     expect(event).toBeNull()
   })
 
   it('rejects a tool call with an invalid status', () => {
     const event = parseAgentEvent({
-      ...base,
       type: 'agent_tool_call',
-      toolCallId: 'tc1',
-      toolName: 'run',
-      status: 'pending'
+      data: {
+        ...data,
+        tool_call_id: 'tc1',
+        tool_name: 'run',
+        status: 'pending'
+      }
     })
     expect(event).toBeNull()
+  })
+})
+
+describe('serializeAgentTurnRequest', () => {
+  it('serializes baseVersion to the snake_case body', () => {
+    const request: AgentTurnRequest = {
+      content: 'add a sampler',
+      selection: ['1', '2'],
+      attachments: ['asset-1'],
+      target: 'active',
+      baseVersion: 7
+    }
+    expect(serializeAgentTurnRequest(request)).toEqual({
+      content: 'add a sampler',
+      selection: ['1', '2'],
+      attachments: ['asset-1'],
+      target: 'active',
+      base_version: 7
+    })
+  })
+
+  it('omits absent optional fields', () => {
+    expect(serializeAgentTurnRequest({ content: 'hi' })).toEqual({
+      content: 'hi'
+    })
+  })
+
+  it('keeps base_version 0 rather than dropping it', () => {
+    expect(
+      serializeAgentTurnRequest({ content: 'hi', baseVersion: 0 })
+    ).toEqual({ content: 'hi', base_version: 0 })
   })
 })

--- a/src/platform/agent/common/agentProtocol.test.ts
+++ b/src/platform/agent/common/agentProtocol.test.ts
@@ -186,6 +186,22 @@ describe('parseAgentEvent', () => {
     }
   })
 
+  it('rejects a draft_patch whose version is not a non-negative safe integer', () => {
+    for (const version of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      const event = parseAgentEvent({
+        type: 'draft_patch',
+        data: {
+          ...data,
+          workflow_id: 'wf1',
+          content: {},
+          version,
+          base_version: 7
+        }
+      })
+      expect(event).toBeNull()
+    }
+  })
+
   it('rejects a draft_patch whose content is an array', () => {
     const event = parseAgentEvent({
       type: 'draft_patch',
@@ -269,5 +285,11 @@ describe('parseDraftSnapshot', () => {
     expect(parseDraftSnapshot({ content: [], version: 3 })).toBeNull()
     expect(parseDraftSnapshot({ content: {}, version: '3' })).toBeNull()
     expect(parseDraftSnapshot({ content: {}, version: Number.NaN })).toBeNull()
+  })
+
+  it('rejects a version that is not a non-negative safe integer', () => {
+    for (const version of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(parseDraftSnapshot({ content: {}, version })).toBeNull()
+    }
   })
 })

--- a/src/platform/agent/common/agentProtocol.test.ts
+++ b/src/platform/agent/common/agentProtocol.test.ts
@@ -80,6 +80,22 @@ describe('parseAgentEvent', () => {
     expect(event).toMatchObject({ durationMs: 1200, errorCode: 'OOM' })
   })
 
+  it('omits a non-finite tool call duration', () => {
+    for (const durationMs of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      const event = parseAgentEvent({
+        type: 'agent_tool_call',
+        data: {
+          ...data,
+          tool_call_id: 'tc1',
+          tool_name: 'run',
+          status: 'success',
+          duration_ms: durationMs
+        }
+      })
+      expect(event).not.toHaveProperty('durationMs')
+    }
+  })
+
   it('maps message done usage to tokenUsage', () => {
     const event = parseAgentEvent({
       type: 'agent_message_done',
@@ -91,6 +107,14 @@ describe('parseAgentEvent', () => {
       messageId: 'm1',
       tokenUsage: { input: 12, output: 34 }
     })
+  })
+
+  it('omits tokenUsage when a usage field is non-finite', () => {
+    const event = parseAgentEvent({
+      type: 'agent_message_done',
+      data: { ...data, usage: { input: 12, output: Number.NaN } }
+    })
+    expect(event).not.toHaveProperty('tokenUsage')
   })
 
   it('omits tokenUsage when usage is absent', () => {

--- a/src/platform/agent/common/agentProtocol.test.ts
+++ b/src/platform/agent/common/agentProtocol.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AgentTurnRequest } from './agentProtocol'
-import { parseAgentEvent, serializeAgentTurnRequest } from './agentProtocol'
+import {
+  parseAgentEvent,
+  parseDraftSnapshot,
+  serializeAgentTurnRequest
+} from './agentProtocol'
 
 const data = { thread_id: 't1', message_id: 'm1' }
 
@@ -184,5 +188,30 @@ describe('serializeAgentTurnRequest', () => {
     expect(
       serializeAgentTurnRequest({ content: 'hi', baseVersion: 0 })
     ).toEqual({ content: 'hi', base_version: 0 })
+  })
+})
+
+describe('parseDraftSnapshot', () => {
+  it('decodes a well-formed snapshot body', () => {
+    const snapshot = parseDraftSnapshot({
+      content: { nodes: ['ksampler'] },
+      version: 12
+    })
+    expect(snapshot).toEqual({ content: { nodes: ['ksampler'] }, version: 12 })
+  })
+
+  it('accepts version 0', () => {
+    expect(parseDraftSnapshot({ content: {}, version: 0 })).toEqual({
+      content: {},
+      version: 0
+    })
+  })
+
+  it('rejects a malformed or partial body', () => {
+    expect(parseDraftSnapshot(null)).toBeNull()
+    expect(parseDraftSnapshot({ content: { nodes: [] } })).toBeNull()
+    expect(parseDraftSnapshot({ version: 3 })).toBeNull()
+    expect(parseDraftSnapshot({ content: 'nope', version: 3 })).toBeNull()
+    expect(parseDraftSnapshot({ content: {}, version: '3' })).toBeNull()
   })
 })

--- a/src/platform/agent/common/agentProtocol.test.ts
+++ b/src/platform/agent/common/agentProtocol.test.ts
@@ -146,6 +146,36 @@ describe('parseAgentEvent', () => {
     expect(event).toBeNull()
   })
 
+  it('rejects a draft_patch with a non-finite version', () => {
+    for (const version of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      const event = parseAgentEvent({
+        type: 'draft_patch',
+        data: {
+          ...data,
+          workflow_id: 'wf1',
+          content: {},
+          version,
+          base_version: 7
+        }
+      })
+      expect(event).toBeNull()
+    }
+  })
+
+  it('rejects a draft_patch whose content is an array', () => {
+    const event = parseAgentEvent({
+      type: 'draft_patch',
+      data: {
+        ...data,
+        workflow_id: 'wf1',
+        content: [],
+        version: 8,
+        base_version: 7
+      }
+    })
+    expect(event).toBeNull()
+  })
+
   it('rejects a tool call with an invalid status', () => {
     const event = parseAgentEvent({
       type: 'agent_tool_call',
@@ -212,6 +242,8 @@ describe('parseDraftSnapshot', () => {
     expect(parseDraftSnapshot({ content: { nodes: [] } })).toBeNull()
     expect(parseDraftSnapshot({ version: 3 })).toBeNull()
     expect(parseDraftSnapshot({ content: 'nope', version: 3 })).toBeNull()
+    expect(parseDraftSnapshot({ content: [], version: 3 })).toBeNull()
     expect(parseDraftSnapshot({ content: {}, version: '3' })).toBeNull()
+    expect(parseDraftSnapshot({ content: {}, version: Number.NaN })).toBeNull()
   })
 })

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -145,7 +145,7 @@ function parseToolCall(
     toolCallId: data.tool_call_id,
     toolName: data.tool_name,
     status: data.status,
-    ...(typeof data.duration_ms === 'number'
+    ...(isFiniteNumber(data.duration_ms)
       ? { durationMs: data.duration_ms }
       : {}),
     ...(typeof data.error_code === 'string'
@@ -180,8 +180,8 @@ function parseTokenUsage(
   usage: unknown
 ): { input: number; output: number } | undefined {
   return isRecord(usage) &&
-    typeof usage.input === 'number' &&
-    typeof usage.output === 'number'
+    isFiniteNumber(usage.input) &&
+    isFiniteNumber(usage.output)
     ? { input: usage.input, output: usage.output }
     : undefined
 }

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -120,6 +120,16 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value)
 }
 
+/**
+ * A `version` watermark: a non-negative safe integer. Rejects negative,
+ * fractional, and unsafe (>2^53) values at the untrusted boundary — an unsafe
+ * integer can collapse two distinct server versions onto the same JS number and
+ * mask a real patch as `stale`.
+ */
+function isVersion(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
 /** The base identifiers, read from the snake_case envelope body. */
 function parseBase(data: Record<string, unknown>): AgentEventBase | null {
   return typeof data.thread_id === 'string' &&
@@ -165,8 +175,8 @@ function parseDraftPatch(
   if (
     typeof data.workflow_id !== 'string' ||
     !isRecord(data.content) ||
-    !isFiniteNumber(data.version) ||
-    !isFiniteNumber(data.base_version)
+    !isVersion(data.version) ||
+    !isVersion(data.base_version)
   ) {
     return null
   }
@@ -241,11 +251,7 @@ export interface DraftSnapshot {
 
 /** Decode an untrusted `GET /api/agent/draft` body, or `null` if malformed. */
 export function parseDraftSnapshot(raw: unknown): DraftSnapshot | null {
-  if (
-    !isRecord(raw) ||
-    !isRecord(raw.content) ||
-    !isFiniteNumber(raw.version)
-  ) {
+  if (!isRecord(raw) || !isRecord(raw.content) || !isVersion(raw.version)) {
     return null
   }
   return { content: raw.content, version: raw.version }

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -36,6 +36,30 @@ export interface AgentTurnRequest {
   baseVersion?: number
 }
 
+/** Wire body the backend `/api/agent/*` endpoints accept (snake_case). */
+export interface AgentTurnRequestBody {
+  content: string
+  selection?: NodeId[]
+  attachments?: string[]
+  target?: AgentWriteTarget
+  base_version?: number
+}
+
+/** Serialize a turn request to the snake_case body the backend expects. */
+export function serializeAgentTurnRequest(
+  request: AgentTurnRequest
+): AgentTurnRequestBody {
+  return {
+    content: request.content,
+    ...(request.selection ? { selection: request.selection } : {}),
+    ...(request.attachments ? { attachments: request.attachments } : {}),
+    ...(request.target ? { target: request.target } : {}),
+    ...(request.baseVersion !== undefined
+      ? { base_version: request.baseVersion }
+      : {})
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Outbound: agent -> browser
 // ---------------------------------------------------------------------------
@@ -87,90 +111,106 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 
-type WithBase = Record<string, unknown> & {
-  threadId: string
-  messageId: string
-}
-
-function hasBase(value: Record<string, unknown>): value is WithBase {
-  return (
-    typeof value.threadId === 'string' && typeof value.messageId === 'string'
-  )
+/** The base identifiers, read from the snake_case envelope body. */
+function parseBase(data: Record<string, unknown>): AgentEventBase | null {
+  return typeof data.thread_id === 'string' &&
+    typeof data.message_id === 'string'
+    ? { threadId: data.thread_id, messageId: data.message_id }
+    : null
 }
 
 function isToolCallStatus(value: unknown): value is AgentToolCallStatus {
   return value === 'running' || value === 'success' || value === 'error'
 }
 
-function parseToolCall(raw: WithBase): AgentToolCallEvent | null {
+function parseToolCall(
+  data: Record<string, unknown>,
+  base: AgentEventBase
+): AgentToolCallEvent | null {
   if (
-    typeof raw.toolCallId !== 'string' ||
-    typeof raw.toolName !== 'string' ||
-    !isToolCallStatus(raw.status)
+    typeof data.tool_call_id !== 'string' ||
+    typeof data.tool_name !== 'string' ||
+    !isToolCallStatus(data.status)
   ) {
     return null
   }
   return {
     type: 'agent_tool_call',
-    threadId: raw.threadId,
-    messageId: raw.messageId,
-    toolCallId: raw.toolCallId,
-    toolName: raw.toolName,
-    status: raw.status,
-    ...(typeof raw.durationMs === 'number'
-      ? { durationMs: raw.durationMs }
+    ...base,
+    toolCallId: data.tool_call_id,
+    toolName: data.tool_name,
+    status: data.status,
+    ...(typeof data.duration_ms === 'number'
+      ? { durationMs: data.duration_ms }
       : {}),
-    ...(typeof raw.errorCode === 'string' ? { errorCode: raw.errorCode } : {})
+    ...(typeof data.error_code === 'string'
+      ? { errorCode: data.error_code }
+      : {})
   }
 }
 
-function parseDraftPatch(raw: WithBase): DraftPatchEvent | null {
+function parseDraftPatch(
+  data: Record<string, unknown>,
+  base: AgentEventBase
+): DraftPatchEvent | null {
   if (
-    typeof raw.workflowId !== 'string' ||
-    !isRecord(raw.content) ||
-    typeof raw.version !== 'number' ||
-    typeof raw.baseVersion !== 'number'
+    typeof data.workflow_id !== 'string' ||
+    !isRecord(data.content) ||
+    typeof data.version !== 'number' ||
+    typeof data.base_version !== 'number'
   ) {
     return null
   }
   return {
     type: 'draft_patch',
-    threadId: raw.threadId,
-    messageId: raw.messageId,
-    workflowId: raw.workflowId,
-    content: raw.content,
-    version: raw.version,
-    baseVersion: raw.baseVersion
+    ...base,
+    workflowId: data.workflow_id,
+    content: data.content,
+    version: data.version,
+    baseVersion: data.base_version
   }
+}
+
+function parseTokenUsage(
+  usage: unknown
+): { input: number; output: number } | undefined {
+  return isRecord(usage) &&
+    typeof usage.input === 'number' &&
+    typeof usage.output === 'number'
+    ? { input: usage.input, output: usage.output }
+    : undefined
 }
 
 /**
  * Decode an untrusted WebSocket payload into a typed `AgentEvent`, or `null` if
- * it is not a well-formed agent event. Keeps the transport boundary type-safe.
+ * it is not a well-formed agent event. The wire format is the canonical backend
+ * envelope `{ type, data: { …snake_case… } }`; the event body lives under
+ * `data`. Keeps the transport boundary type-safe.
  */
 export function parseAgentEvent(raw: unknown): AgentEvent | null {
-  if (!isRecord(raw) || !hasBase(raw)) return null
+  if (!isRecord(raw) || !isRecord(raw.data)) return null
+
+  const { data } = raw
+  const base = parseBase(data)
+  if (!base) return null
 
   switch (raw.type) {
     case 'agent_message_delta':
-      return typeof raw.delta === 'string'
-        ? {
-            type: 'agent_message_delta',
-            threadId: raw.threadId,
-            messageId: raw.messageId,
-            delta: raw.delta
-          }
+      return typeof data.delta === 'string'
+        ? { type: 'agent_message_delta', ...base, delta: data.delta }
         : null
     case 'agent_tool_call':
-      return parseToolCall(raw)
+      return parseToolCall(data, base)
     case 'draft_patch':
-      return parseDraftPatch(raw)
-    case 'agent_message_done':
+      return parseDraftPatch(data, base)
+    case 'agent_message_done': {
+      const tokenUsage = parseTokenUsage(data.usage)
       return {
         type: 'agent_message_done',
-        threadId: raw.threadId,
-        messageId: raw.messageId
+        ...base,
+        ...(tokenUsage ? { tokenUsage } : {})
       }
+    }
     default:
       return null
   }

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -51,9 +51,13 @@ export function serializeAgentTurnRequest(
 ): AgentTurnRequestBody {
   return {
     content: request.content,
-    ...(request.selection ? { selection: request.selection } : {}),
-    ...(request.attachments ? { attachments: request.attachments } : {}),
-    ...(request.target ? { target: request.target } : {}),
+    ...(request.selection !== undefined
+      ? { selection: request.selection }
+      : {}),
+    ...(request.attachments !== undefined
+      ? { attachments: request.attachments }
+      : {}),
+    ...(request.target !== undefined ? { target: request.target } : {}),
     ...(request.baseVersion !== undefined
       ? { base_version: request.baseVersion }
       : {})

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -215,3 +215,29 @@ export function parseAgentEvent(raw: unknown): AgentEvent | null {
       return null
   }
 }
+
+// ---------------------------------------------------------------------------
+// Draft snapshot: GET /api/agent/draft?workflow_id=... -> { content, version }
+// ---------------------------------------------------------------------------
+
+/**
+ * The authoritative server draft for a workflow (ADR-0011). Fetched on WS
+ * (re)connect and whenever a gap is suspected, to seed/reconcile the tab's base
+ * `version` without waiting for the agent to emit a new `draft_patch`.
+ */
+export interface DraftSnapshot {
+  content: WorkflowGraph
+  version: number
+}
+
+/** Decode an untrusted `GET /api/agent/draft` body, or `null` if malformed. */
+export function parseDraftSnapshot(raw: unknown): DraftSnapshot | null {
+  if (
+    !isRecord(raw) ||
+    !isRecord(raw.content) ||
+    typeof raw.version !== 'number'
+  ) {
+    return null
+  }
+  return { content: raw.content, version: raw.version }
+}

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -108,7 +108,12 @@ export type AgentEvent =
   | AgentMessageDoneEvent
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** A finite number — rejects `NaN`/`Infinity`, which would wedge CAS version compares. */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
 }
 
 /** The base identifiers, read from the snake_case envelope body. */
@@ -156,8 +161,8 @@ function parseDraftPatch(
   if (
     typeof data.workflow_id !== 'string' ||
     !isRecord(data.content) ||
-    typeof data.version !== 'number' ||
-    typeof data.base_version !== 'number'
+    !isFiniteNumber(data.version) ||
+    !isFiniteNumber(data.base_version)
   ) {
     return null
   }
@@ -235,7 +240,7 @@ export function parseDraftSnapshot(raw: unknown): DraftSnapshot | null {
   if (
     !isRecord(raw) ||
     !isRecord(raw.content) ||
-    typeof raw.version !== 'number'
+    !isFiniteNumber(raw.version)
   ) {
     return null
   }

--- a/src/platform/agent/common/draftReconciler.test.ts
+++ b/src/platform/agent/common/draftReconciler.test.ts
@@ -40,4 +40,10 @@ describe('reconcileDraftPatch', () => {
     )
     expect(result).toEqual({ kind: 'stale' })
   })
+
+  it('reports a gap when the agent advanced past the tab (missed patches)', () => {
+    // Tab holds v5; this patch is based on v7, so v6/v7 were dropped in transit.
+    const result = reconcileDraftPatch(patch({ baseVersion: 7, version: 8 }), 5)
+    expect(result).toEqual({ kind: 'gap' })
+  })
 })

--- a/src/platform/agent/common/draftReconciler.ts
+++ b/src/platform/agent/common/draftReconciler.ts
@@ -1,10 +1,16 @@
 /**
- * Draft reconciliation (prototype — ADR-0004 / ADR-0005).
+ * Draft reconciliation (prototype — ADR-0004 / ADR-0005 / ADR-0011).
  *
  * Pure decision logic for an incoming `draft_patch`, given the version the tab
  * currently holds. This is the load-bearing correctness piece: it decides
  * whether a full-document replace applies cleanly, must surface the merge
- * dialog, or is a stale/duplicate that should be ignored.
+ * dialog, is a stale/duplicate to ignore, or reveals a gap that needs an
+ * authoritative refetch.
+ *
+ * `version` is a monotonic watermark: a patch is adopted only when it advances
+ * past what the tab already holds, so a dropped / duplicated / out-of-order
+ * Redis Pub/Sub `draft_patch` (the transport is at-most-once, BE-1886) can never
+ * regress local state.
  */
 import type { DraftPatchEvent } from './agentProtocol'
 
@@ -15,6 +21,8 @@ export type ReconcileResult =
   | { kind: 'conflict' }
   /** Patch is superseded by what the tab already has — ignore (idempotency). */
   | { kind: 'stale' }
+  /** The agent advanced past the tab — patches were missed; refetch snapshot. */
+  | { kind: 'gap' }
 
 /** User's choice in the merge dialog (ADR-0005). */
 export type ConflictResolution = 'accept-agent' | 'keep-mine' | 'new-tab'
@@ -27,5 +35,6 @@ export function reconcileDraftPatch(
   if (patch.baseVersion === currentVersion) {
     return { kind: 'apply', version: patch.version }
   }
+  if (patch.baseVersion > currentVersion) return { kind: 'gap' }
   return { kind: 'conflict' }
 }

--- a/src/platform/agent/common/useAgentDraftSync.test.ts
+++ b/src/platform/agent/common/useAgentDraftSync.test.ts
@@ -135,6 +135,33 @@ describe('useAgentDraftSync', () => {
     })
   })
 
+  describe('forgetWorkflow', () => {
+    it('clears a pending conflict targeting the closed workflow', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 7)
+      sync.setVersion('wf1', 8)
+      sync.handlePatch(patch({ baseVersion: 7, version: 9 }))
+      expect(sync.pendingConflict.value).not.toBeNull()
+
+      sync.forgetWorkflow('wf1')
+
+      expect(sync.pendingConflict.value).toBeNull()
+    })
+
+    it('leaves a pending conflict for a different workflow intact', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 7)
+      sync.setVersion('wf1', 8)
+      sync.handlePatch(patch({ baseVersion: 7, version: 9 }))
+
+      sync.forgetWorkflow('wf2')
+
+      expect(sync.pendingConflict.value).toMatchObject({ workflowId: 'wf1' })
+    })
+  })
+
   describe('wire envelope -> reconciler', () => {
     function wirePatch(version: number, baseVersion: number) {
       const event = parseAgentEvent({
@@ -240,6 +267,40 @@ describe('useAgentDraftSync', () => {
       expect(a).toBe('restored')
       expect(b).toBe('restored')
       expect(ports.fetchSnapshot).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears an open merge dialog when it restores a newer snapshot', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+      sync.setVersion('wf1', 6)
+      sync.handlePatch(patch({ baseVersion: 4, version: 7 }))
+      expect(sync.pendingConflict.value).not.toBeNull()
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('restored')
+      expect(sync.pendingConflict.value).toBeNull()
+    })
+
+    it('does not resurrect tracking for a tab closed mid-fetch', async () => {
+      const ports = makePorts()
+      let resolveFetch!: (snapshot: typeof SNAPSHOT) => void
+      vi.mocked(ports.fetchSnapshot).mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const pending = sync.resync('wf1')
+      sync.forgetWorkflow('wf1')
+      resolveFetch(SNAPSHOT)
+
+      expect(await pending).toBe('up-to-date')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.baseVersions.value.has('wf1')).toBe(false)
     })
   })
 

--- a/src/platform/agent/common/useAgentDraftSync.test.ts
+++ b/src/platform/agent/common/useAgentDraftSync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { DraftPatchEvent } from './agentProtocol'
+import { parseAgentEvent } from './agentProtocol'
 import type { AgentDraftPorts } from './useAgentDraftSync'
 import { useAgentDraftSync } from './useAgentDraftSync'
 
@@ -128,6 +129,58 @@ describe('useAgentDraftSync', () => {
       )
       expect(ports.applyToTab).not.toHaveBeenCalled()
       expect(sync.pendingConflict.value).toBeNull()
+    })
+  })
+
+  describe('wire envelope -> reconciler', () => {
+    function wirePatch(version: number, baseVersion: number) {
+      const event = parseAgentEvent({
+        type: 'draft_patch',
+        data: {
+          thread_id: 't1',
+          message_id: 'm1',
+          workflow_id: 'wf1',
+          content: { nodes: ['ksampler'] },
+          version,
+          base_version: baseVersion
+        }
+      })
+      if (event?.type !== 'draft_patch') {
+        throw new Error('expected a draft_patch event')
+      }
+      return event
+    }
+
+    it('applies when base_version matches the tab version', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 7)
+
+      const outcome = sync.handlePatch(wirePatch(8, 7))
+
+      expect(outcome).toBe('applied')
+      expect(ports.applyToTab).toHaveBeenCalledWith(
+        'wf1',
+        { nodes: ['ksampler'] },
+        8
+      )
+    })
+
+    it('conflicts when base_version differs from the tab version', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 7)
+      sync.setVersion('wf1', 8)
+
+      const outcome = sync.handlePatch(wirePatch(9, 7))
+
+      expect(outcome).toBe('conflict')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.pendingConflict.value).toMatchObject({
+        workflowId: 'wf1',
+        baseVersion: 7,
+        version: 9
+      })
     })
   })
 })

--- a/src/platform/agent/common/useAgentDraftSync.test.ts
+++ b/src/platform/agent/common/useAgentDraftSync.test.ts
@@ -5,11 +5,14 @@ import { parseAgentEvent } from './agentProtocol'
 import type { AgentDraftPorts } from './useAgentDraftSync'
 import { useAgentDraftSync } from './useAgentDraftSync'
 
+const SNAPSHOT = { content: { nodes: ['from-snapshot'] }, version: 12 }
+
 function makePorts(): AgentDraftPorts {
   return {
     applyToTab: vi.fn(),
     openInNewTab: vi.fn(),
-    discardAgentResult: vi.fn()
+    discardAgentResult: vi.fn(),
+    fetchSnapshot: vi.fn().mockResolvedValue(SNAPSHOT)
   }
 }
 
@@ -181,6 +184,130 @@ describe('useAgentDraftSync', () => {
         baseVersion: 7,
         version: 9
       })
+    })
+  })
+
+  describe('resync (reconnect / cold start)', () => {
+    it('seeds the tab from the snapshot when none is registered yet', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('restored')
+      expect(ports.fetchSnapshot).toHaveBeenCalledWith('wf1')
+      expect(ports.applyToTab).toHaveBeenCalledWith(
+        'wf1',
+        SNAPSHOT.content,
+        SNAPSHOT.version
+      )
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+    })
+
+    it('restores a newer snapshot over a stale local version', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('restored')
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+    })
+
+    it('leaves the tab untouched when the snapshot is not newer (watermark)', async () => {
+      const ports = makePorts()
+      vi.mocked(ports.fetchSnapshot).mockResolvedValue({
+        content: { nodes: ['old'] },
+        version: 8
+      })
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 8)
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('up-to-date')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.baseVersions.value.get('wf1')).toBe(8)
+    })
+
+    it('shares one in-flight request across concurrent resyncs', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+
+      const [a, b] = await Promise.all([sync.resync('wf1'), sync.resync('wf1')])
+
+      expect(a).toBe('restored')
+      expect(b).toBe('restored')
+      expect(ports.fetchSnapshot).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('gap detection', () => {
+    it('refetches the snapshot when the agent advanced past the tab', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const outcome = sync.handlePatch(patch({ baseVersion: 7, version: 8 }))
+
+      expect(outcome).toBe('gap')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      await sync.pendingResync('wf1')
+      expect(ports.fetchSnapshot).toHaveBeenCalledWith('wf1')
+      expect(ports.applyToTab).toHaveBeenCalledWith(
+        'wf1',
+        SNAPSHOT.content,
+        SNAPSHOT.version
+      )
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+      expect(sync.pendingConflict.value).toBeNull()
+    })
+  })
+
+  describe('handleVersionTip (trailing lost patch)', () => {
+    it('resyncs when the tip outruns the local watermark', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const outcome = sync.handleVersionTip('wf1', 9)
+
+      expect(outcome).toBe('resyncing')
+      await sync.pendingResync('wf1')
+      expect(ports.fetchSnapshot).toHaveBeenCalledWith('wf1')
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+    })
+
+    it('does nothing when the tip is not newer', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 9)
+
+      expect(sync.handleVersionTip('wf1', 9)).toBe('up-to-date')
+      expect(ports.fetchSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('ignores a tip for a workflow with no open tab', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+
+      expect(sync.handleVersionTip('wf-unknown', 9)).toBe('ignored')
+      expect(ports.fetchSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('preserves local state when a self-heal fetch fails', async () => {
+      const ports = makePorts()
+      const boom = new Error('network down')
+      vi.mocked(ports.fetchSnapshot).mockRejectedValue(boom)
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      expect(sync.handleVersionTip('wf1', 9)).toBe('resyncing')
+      await expect(sync.pendingResync('wf1')).rejects.toBe(boom)
+
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.baseVersions.value.get('wf1')).toBe(5)
     })
   })
 })

--- a/src/platform/agent/common/useAgentDraftSync.test.ts
+++ b/src/platform/agent/common/useAgentDraftSync.test.ts
@@ -324,6 +324,27 @@ describe('useAgentDraftSync', () => {
       expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
       expect(sync.pendingConflict.value).toBeNull()
     })
+
+    it('coalesces a gap and a concurrent version tip onto one fetch', async () => {
+      const ports = makePorts()
+      let resolveFetch!: (snapshot: typeof SNAPSHOT) => void
+      vi.mocked(ports.fetchSnapshot).mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      expect(sync.handlePatch(patch({ baseVersion: 7, version: 8 }))).toBe(
+        'gap'
+      )
+      expect(sync.handleVersionTip('wf1', 9)).toBe('resyncing')
+      resolveFetch(SNAPSHOT)
+      await sync.pendingResync('wf1')
+
+      expect(ports.fetchSnapshot).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('handleVersionTip (trailing lost patch)', () => {

--- a/src/platform/agent/common/useAgentDraftSync.test.ts
+++ b/src/platform/agent/common/useAgentDraftSync.test.ts
@@ -302,6 +302,25 @@ describe('useAgentDraftSync', () => {
       expect(ports.applyToTab).not.toHaveBeenCalled()
       expect(sync.baseVersions.value.has('wf1')).toBe(false)
     })
+
+    it('does not seed a never-registered tab closed mid-bootstrap-fetch', async () => {
+      const ports = makePorts()
+      let resolveFetch!: (snapshot: typeof SNAPSHOT) => void
+      vi.mocked(ports.fetchSnapshot).mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+      )
+      const sync = useAgentDraftSync(ports)
+
+      const pending = sync.resync('wf1')
+      sync.forgetWorkflow('wf1')
+      resolveFetch(SNAPSHOT)
+
+      expect(await pending).toBe('up-to-date')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.baseVersions.value.has('wf1')).toBe(false)
+    })
   })
 
   describe('gap detection', () => {

--- a/src/platform/agent/common/useAgentDraftSync.ts
+++ b/src/platform/agent/common/useAgentDraftSync.ts
@@ -64,6 +64,7 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
   const baseVersions = ref(new Map<WorkflowId, number>())
   const pendingConflict = ref<PendingConflict | null>(null)
   const inFlightResyncs = new Map<WorkflowId, Promise<ResyncOutcome>>()
+  const abortedResyncs = new Set<WorkflowId>()
 
   /** Call when a draft tab opens, adopting its known version. */
   function registerWorkflow(workflowId: WorkflowId, version: number): void {
@@ -79,6 +80,7 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
   function forgetWorkflow(workflowId: WorkflowId): void {
     baseVersions.value.delete(workflowId)
     clearConflictFor(workflowId)
+    if (inFlightResyncs.has(workflowId)) abortedResyncs.add(workflowId)
   }
 
   /** Call after a local autosave returns a new server version. */
@@ -120,16 +122,15 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
   }
 
   async function runResync(workflowId: WorkflowId): Promise<ResyncOutcome> {
-    const versionBeforeFetch = baseVersions.value.get(workflowId)
     const snapshot = await ports.fetchSnapshot(workflowId)
-    const current = baseVersions.value.get(workflowId)
 
     // The tab was closed mid-fetch (`forgetWorkflow`). Don't resurrect tracking
-    // or apply to a tab that no longer exists. An untracked-before-and-after
-    // resync instead seeds the tab on demand (bootstrapping a first snapshot).
-    if (versionBeforeFetch !== undefined && current === undefined) {
-      return 'up-to-date'
-    }
+    // or apply to a tab that no longer exists — this covers both a tab that was
+    // tracked and one still bootstrapping its first snapshot, since either is
+    // `undefined` after the close.
+    if (abortedResyncs.has(workflowId)) return 'up-to-date'
+
+    const current = baseVersions.value.get(workflowId)
     if (current !== undefined && snapshot.version <= current) {
       return 'up-to-date'
     }
@@ -155,6 +156,7 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
     if (existing) return existing
     const run = runResync(workflowId).finally(() => {
       inFlightResyncs.delete(workflowId)
+      abortedResyncs.delete(workflowId)
     })
     inFlightResyncs.set(workflowId, run)
     return run

--- a/src/platform/agent/common/useAgentDraftSync.ts
+++ b/src/platform/agent/common/useAgentDraftSync.ts
@@ -70,8 +70,15 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
     baseVersions.value.set(workflowId, version)
   }
 
+  function clearConflictFor(workflowId: WorkflowId): void {
+    if (pendingConflict.value?.workflowId === workflowId) {
+      pendingConflict.value = null
+    }
+  }
+
   function forgetWorkflow(workflowId: WorkflowId): void {
     baseVersions.value.delete(workflowId)
+    clearConflictFor(workflowId)
   }
 
   /** Call after a local autosave returns a new server version. */
@@ -113,13 +120,22 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
   }
 
   async function runResync(workflowId: WorkflowId): Promise<ResyncOutcome> {
+    const wasTracked = baseVersions.value.has(workflowId)
     const snapshot = await ports.fetchSnapshot(workflowId)
     const current = baseVersions.value.get(workflowId)
+
+    // The tab was closed mid-fetch (`forgetWorkflow`). Don't resurrect tracking
+    // or apply to a tab that no longer exists.
+    if (wasTracked && current === undefined) return 'up-to-date'
     if (current !== undefined && snapshot.version <= current) {
       return 'up-to-date'
     }
     ports.applyToTab(workflowId, snapshot.content, snapshot.version)
     baseVersions.value.set(workflowId, snapshot.version)
+    // The authoritative snapshot supersedes any open merge dialog for this tab;
+    // resolving it later would re-apply now-stale content and roll the version
+    // back.
+    clearConflictFor(workflowId)
     return 'restored'
   }
 

--- a/src/platform/agent/common/useAgentDraftSync.ts
+++ b/src/platform/agent/common/useAgentDraftSync.ts
@@ -120,13 +120,16 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
   }
 
   async function runResync(workflowId: WorkflowId): Promise<ResyncOutcome> {
-    const wasTracked = baseVersions.value.has(workflowId)
+    const versionBeforeFetch = baseVersions.value.get(workflowId)
     const snapshot = await ports.fetchSnapshot(workflowId)
     const current = baseVersions.value.get(workflowId)
 
     // The tab was closed mid-fetch (`forgetWorkflow`). Don't resurrect tracking
-    // or apply to a tab that no longer exists.
-    if (wasTracked && current === undefined) return 'up-to-date'
+    // or apply to a tab that no longer exists. An untracked-before-and-after
+    // resync instead seeds the tab on demand (bootstrapping a first snapshot).
+    if (versionBeforeFetch !== undefined && current === undefined) {
+      return 'up-to-date'
+    }
     if (current !== undefined && snapshot.version <= current) {
       return 'up-to-date'
     }
@@ -143,6 +146,9 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
    * Fetch the authoritative snapshot and reconcile it against the watermark.
    * Call on WS (re)connect to restore the draft without waiting for a patch.
    * Concurrent calls for the same workflow share one in-flight request.
+   * Register-on-demand: a resync for a workflow with no tracked version seeds
+   * the tab from the snapshot (bootstrapping), rather than requiring a prior
+   * `registerWorkflow`.
    */
   function resync(workflowId: WorkflowId): Promise<ResyncOutcome> {
     const existing = inFlightResyncs.get(workflowId)
@@ -154,7 +160,13 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
     return run
   }
 
-  /** In-flight resync for a workflow, if any (lets callers await self-heal). */
+  /**
+   * In-flight resync for a workflow, if any (lets callers await self-heal).
+   * @internal Test-coordination surface — the returned promise rejects if the
+   * underlying `fetchSnapshot` fails, so production call sites should not await
+   * it without a `.catch`; the self-heal itself is fire-and-forget via
+   * `scheduleResync`.
+   */
   function pendingResync(
     workflowId: WorkflowId
   ): Promise<ResyncOutcome> | undefined {

--- a/src/platform/agent/common/useAgentDraftSync.ts
+++ b/src/platform/agent/common/useAgentDraftSync.ts
@@ -3,18 +3,23 @@
  *
  * Orchestrates the frontend side of agent graph writes: tracks the base
  * `version` per open workflow (the version lifecycle), reconciles incoming
- * `draft_patch` events, and drives the three merge-dialog outcomes.
+ * `draft_patch` events, drives the three merge-dialog outcomes, and self-heals
+ * across dropped Redis Pub/Sub patches and WS reconnects by refetching the
+ * authoritative snapshot (BE-1886). The transport stays best-effort; this client
+ * provides reliability — `version` is the monotonic watermark.
  *
  * The canvas-facing effects are injected as `ports` so this is decoupled from
  * litegraph / the workflow store and is unit-testable. In the real app the
  * ports map to: `applyToTab` -> a destructive variant of `app.loadGraphData`;
  * `openInNewTab` -> the existing non-destructive load; `discardAgentResult` ->
- * a no-op (keep the user's canvas as-is).
+ * a no-op (keep the user's canvas as-is); `fetchSnapshot` -> a `GET
+ * /api/agent/draft?workflow_id=...` decoded with `parseDraftSnapshot`.
  */
 import { readonly, ref } from 'vue'
 
 import type {
   DraftPatchEvent,
+  DraftSnapshot,
   WorkflowGraph,
   WorkflowId
 } from './agentProtocol'
@@ -33,6 +38,7 @@ export interface AgentDraftPorts {
     version: number
   ): void
   discardAgentResult(workflowId: WorkflowId): void
+  fetchSnapshot(workflowId: WorkflowId): Promise<DraftSnapshot>
 }
 
 export interface PendingConflict {
@@ -42,11 +48,22 @@ export interface PendingConflict {
   baseVersion: number
 }
 
-export type PatchOutcome = 'applied' | 'conflict' | 'ignored' | 'opened-new-tab'
+export type PatchOutcome =
+  | 'applied'
+  | 'conflict'
+  | 'ignored'
+  | 'opened-new-tab'
+  | 'gap'
+
+/** `restored` = a newer snapshot replaced the tab; `up-to-date` = already current. */
+export type ResyncOutcome = 'restored' | 'up-to-date'
+
+export type VersionTipOutcome = 'resyncing' | 'up-to-date' | 'ignored'
 
 export function useAgentDraftSync(ports: AgentDraftPorts) {
   const baseVersions = ref(new Map<WorkflowId, number>())
   const pendingConflict = ref<PendingConflict | null>(null)
+  const inFlightResyncs = new Map<WorkflowId, Promise<ResyncOutcome>>()
 
   /** Call when a draft tab opens, adopting its known version. */
   function registerWorkflow(workflowId: WorkflowId, version: number): void {
@@ -87,9 +104,71 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
           baseVersion: patch.baseVersion
         }
         return 'conflict'
+      case 'gap':
+        scheduleResync(patch.workflowId)
+        return 'gap'
       case 'stale':
         return 'ignored'
     }
+  }
+
+  async function runResync(workflowId: WorkflowId): Promise<ResyncOutcome> {
+    const snapshot = await ports.fetchSnapshot(workflowId)
+    const current = baseVersions.value.get(workflowId)
+    if (current !== undefined && snapshot.version <= current) {
+      return 'up-to-date'
+    }
+    ports.applyToTab(workflowId, snapshot.content, snapshot.version)
+    baseVersions.value.set(workflowId, snapshot.version)
+    return 'restored'
+  }
+
+  /**
+   * Fetch the authoritative snapshot and reconcile it against the watermark.
+   * Call on WS (re)connect to restore the draft without waiting for a patch.
+   * Concurrent calls for the same workflow share one in-flight request.
+   */
+  function resync(workflowId: WorkflowId): Promise<ResyncOutcome> {
+    const existing = inFlightResyncs.get(workflowId)
+    if (existing) return existing
+    const run = runResync(workflowId).finally(() => {
+      inFlightResyncs.delete(workflowId)
+    })
+    inFlightResyncs.set(workflowId, run)
+    return run
+  }
+
+  /** In-flight resync for a workflow, if any (lets callers await self-heal). */
+  function pendingResync(
+    workflowId: WorkflowId
+  ): Promise<ResyncOutcome> | undefined {
+    return inFlightResyncs.get(workflowId)
+  }
+
+  /**
+   * Fire-and-forget self-heal. A failed refetch is best-effort: it leaves local
+   * state intact and is retried by the next patch / reconnect / version tip.
+   */
+  function scheduleResync(workflowId: WorkflowId): void {
+    void resync(workflowId).catch((error: unknown) => {
+      console.error('[agent] draft resync failed', workflowId, error)
+    })
+  }
+
+  /**
+   * Consume an optional `draft_version` tip (a content-less version heartbeat).
+   * Catches a trailing lost patch: if the server tip outruns our watermark for an
+   * open workflow, refetch the snapshot.
+   */
+  function handleVersionTip(
+    workflowId: WorkflowId,
+    version: number
+  ): VersionTipOutcome {
+    const current = baseVersions.value.get(workflowId)
+    if (current === undefined) return 'ignored'
+    if (version <= current) return 'up-to-date'
+    scheduleResync(workflowId)
+    return 'resyncing'
   }
 
   function resolveConflict(decision: ConflictResolution): void {
@@ -127,6 +206,9 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
     forgetWorkflow,
     setVersion,
     handlePatch,
-    resolveConflict
+    resolveConflict,
+    resync,
+    pendingResync,
+    handleVersionTip
   }
 }


### PR DESCRIPTION
## ELI-5

The in-app agent talks to the browser over a websocket. The real backend wraps
every message in an envelope `{ type, data: { …snake_case… } }`, but the
prototype decoder was reading fields off the top level in camelCase, so it would
never actually decode a real message. This teaches the decoder the real shape:
unwrap `data`, translate snake_case to the existing camelCase fields, and route
`base_version`/`workflow_id` through to the conflict/apply decision. Also adds a
serializer for the outbound request body so the browser sends what the backend
expects.

## Summary

Aligns the unwired agent protocol prototype to the canonical backend wire
contract: `parseAgentEvent` now decodes the real envelope and the conflict
reconciler receives `base_version`/`workflow_id` from the wire.

## Changes

- **What**:
  - `parseAgentEvent` reads the event body from `data` (the envelope) and maps
    snake_case → the existing camelCase interface fields for all four events:
    `thread_id→threadId`, `message_id→messageId`, `workflow_id→workflowId`,
    `base_version→baseVersion`, `tool_call_id→toolCallId`, `tool_name→toolName`,
    `duration_ms→durationMs`, `error_code→errorCode`, and `agent_message_done`
    `usage:{input,output}` → `tokenUsage`. Strict validation is preserved —
    malformed/untrusted payloads still decode to `null`.
  - Adds `serializeAgentTurnRequest` (+ `AgentTurnRequestBody`) to emit the
    inbound `/api/agent/*` body the backend expects:
    `{content, selection, attachments, target, base_version}`. `target` is the
    existing `'active' | 'new_tab'` union (unchanged).
  - `base_version` and `workflow_id` now flow from the wire through
    `useAgentDraftSync` into `reconcileDraftPatch`, which already keys the
    apply/conflict/stale decision off `tab.version === base_version`.
- **Breaking**: none (prototype with no production callers; `agentProtocol.ts`
  remains in knip's ignore list).

## Review Focus

- Snake_case → camelCase field mapping in `parseToolCall` / `parseDraftPatch` /
  `parseTokenUsage` / `parseBase`.
- `serializeAgentTurnRequest` uses `baseVersion !== undefined` (not truthiness)
  so a legitimate `base_version: 0` is not dropped.
- `draftReconciler.ts` / `draftReconciler.test.ts` are intentionally
  **unchanged**: the reconciler operates on already-parsed `DraftPatchEvent`
  (camelCase), not the raw wire, so snake_case fixtures there would be
  type-incorrect. The end-to-end envelope → reconciler flow (base_version
  matching → apply; differing → conflict) is exercised in
  `useAgentDraftSync.test.ts` via `parseAgentEvent` → `handlePatch`.
- The shared `agent_events.schema.json` is not vendored in this repo, so the
  optional schema-validation check was skipped.

## Note for reviewers

Stacked on `feat/adr-in-app-agent-graph-state` (PR #13164) — that branch is the
home of the prototype. The base will retarget to `main` automatically when the
foundation merges; review sees only the net diff.
