### PR TITLE
feat: reconnect-and-resync agent draft from snapshot endpoint + version watermark

### DIFF
--- a/src/platform/agent/common/agentProtocol.test.ts
+++ b/src/platform/agent/common/agentProtocol.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AgentTurnRequest } from './agentProtocol'
-import { parseAgentEvent, serializeAgentTurnRequest } from './agentProtocol'
+import {
+  parseAgentEvent,
+  parseDraftSnapshot,
+  serializeAgentTurnRequest
+} from './agentProtocol'
 
 const data = { thread_id: 't1', message_id: 'm1' }
 
@@ -184,5 +188,30 @@ describe('serializeAgentTurnRequest', () => {
     expect(
       serializeAgentTurnRequest({ content: 'hi', baseVersion: 0 })
     ).toEqual({ content: 'hi', base_version: 0 })
+  })
+})
+
+describe('parseDraftSnapshot', () => {
+  it('decodes a well-formed snapshot body', () => {
+    const snapshot = parseDraftSnapshot({
+      content: { nodes: ['ksampler'] },
+      version: 12
+    })
+    expect(snapshot).toEqual({ content: { nodes: ['ksampler'] }, version: 12 })
+  })
+
+  it('accepts version 0', () => {
+    expect(parseDraftSnapshot({ content: {}, version: 0 })).toEqual({
+      content: {},
+      version: 0
+    })
+  })
+
+  it('rejects a malformed or partial body', () => {
+    expect(parseDraftSnapshot(null)).toBeNull()
+    expect(parseDraftSnapshot({ content: { nodes: [] } })).toBeNull()
+    expect(parseDraftSnapshot({ version: 3 })).toBeNull()
+    expect(parseDraftSnapshot({ content: 'nope', version: 3 })).toBeNull()
+    expect(parseDraftSnapshot({ content: {}, version: '3' })).toBeNull()
   })
 })

--- a/src/platform/agent/common/agentProtocol.ts
+++ b/src/platform/agent/common/agentProtocol.ts
@@ -215,3 +215,29 @@ export function parseAgentEvent(raw: unknown): AgentEvent | null {
       return null
   }
 }
+
+// ---------------------------------------------------------------------------
+// Draft snapshot: GET /api/agent/draft?workflow_id=... -> { content, version }
+// ---------------------------------------------------------------------------
+
+/**
+ * The authoritative server draft for a workflow (ADR-0011). Fetched on WS
+ * (re)connect and whenever a gap is suspected, to seed/reconcile the tab's base
+ * `version` without waiting for the agent to emit a new `draft_patch`.
+ */
+export interface DraftSnapshot {
+  content: WorkflowGraph
+  version: number
+}
+
+/** Decode an untrusted `GET /api/agent/draft` body, or `null` if malformed. */
+export function parseDraftSnapshot(raw: unknown): DraftSnapshot | null {
+  if (
+    !isRecord(raw) ||
+    !isRecord(raw.content) ||
+    typeof raw.version !== 'number'
+  ) {
+    return null
+  }
+  return { content: raw.content, version: raw.version }
+}

--- a/src/platform/agent/common/draftReconciler.test.ts
+++ b/src/platform/agent/common/draftReconciler.test.ts
@@ -40,4 +40,10 @@ describe('reconcileDraftPatch', () => {
     )
     expect(result).toEqual({ kind: 'stale' })
   })
+
+  it('reports a gap when the agent advanced past the tab (missed patches)', () => {
+    // Tab holds v5; this patch is based on v7, so v6/v7 were dropped in transit.
+    const result = reconcileDraftPatch(patch({ baseVersion: 7, version: 8 }), 5)
+    expect(result).toEqual({ kind: 'gap' })
+  })
 })

--- a/src/platform/agent/common/draftReconciler.ts
+++ b/src/platform/agent/common/draftReconciler.ts
@@ -1,10 +1,16 @@
 /**
- * Draft reconciliation (prototype — ADR-0004 / ADR-0005).
+ * Draft reconciliation (prototype — ADR-0004 / ADR-0005 / ADR-0011).
  *
  * Pure decision logic for an incoming `draft_patch`, given the version the tab
  * currently holds. This is the load-bearing correctness piece: it decides
  * whether a full-document replace applies cleanly, must surface the merge
- * dialog, or is a stale/duplicate that should be ignored.
+ * dialog, is a stale/duplicate to ignore, or reveals a gap that needs an
+ * authoritative refetch.
+ *
+ * `version` is a monotonic watermark: a patch is adopted only when it advances
+ * past what the tab already holds, so a dropped / duplicated / out-of-order
+ * Redis Pub/Sub `draft_patch` (the transport is at-most-once, BE-1886) can never
+ * regress local state.
  */
 import type { DraftPatchEvent } from './agentProtocol'
 
@@ -15,6 +21,8 @@ export type ReconcileResult =
   | { kind: 'conflict' }
   /** Patch is superseded by what the tab already has — ignore (idempotency). */
   | { kind: 'stale' }
+  /** The agent advanced past the tab — patches were missed; refetch snapshot. */
+  | { kind: 'gap' }
 
 /** User's choice in the merge dialog (ADR-0005). */
 export type ConflictResolution = 'accept-agent' | 'keep-mine' | 'new-tab'
@@ -27,5 +35,6 @@ export function reconcileDraftPatch(
   if (patch.baseVersion === currentVersion) {
     return { kind: 'apply', version: patch.version }
   }
+  if (patch.baseVersion > currentVersion) return { kind: 'gap' }
   return { kind: 'conflict' }
 }

--- a/src/platform/agent/common/useAgentDraftSync.test.ts
+++ b/src/platform/agent/common/useAgentDraftSync.test.ts
@@ -5,11 +5,14 @@ import { parseAgentEvent } from './agentProtocol'
 import type { AgentDraftPorts } from './useAgentDraftSync'
 import { useAgentDraftSync } from './useAgentDraftSync'
 
+const SNAPSHOT = { content: { nodes: ['from-snapshot'] }, version: 12 }
+
 function makePorts(): AgentDraftPorts {
   return {
     applyToTab: vi.fn(),
     openInNewTab: vi.fn(),
-    discardAgentResult: vi.fn()
+    discardAgentResult: vi.fn(),
+    fetchSnapshot: vi.fn().mockResolvedValue(SNAPSHOT)
   }
 }
 
@@ -181,6 +184,130 @@ describe('useAgentDraftSync', () => {
         baseVersion: 7,
         version: 9
       })
+    })
+  })
+
+  describe('resync (reconnect / cold start)', () => {
+    it('seeds the tab from the snapshot when none is registered yet', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('restored')
+      expect(ports.fetchSnapshot).toHaveBeenCalledWith('wf1')
+      expect(ports.applyToTab).toHaveBeenCalledWith(
+        'wf1',
+        SNAPSHOT.content,
+        SNAPSHOT.version
+      )
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+    })
+
+    it('restores a newer snapshot over a stale local version', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('restored')
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+    })
+
+    it('leaves the tab untouched when the snapshot is not newer (watermark)', async () => {
+      const ports = makePorts()
+      vi.mocked(ports.fetchSnapshot).mockResolvedValue({
+        content: { nodes: ['old'] },
+        version: 8
+      })
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 8)
+
+      const outcome = await sync.resync('wf1')
+
+      expect(outcome).toBe('up-to-date')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.baseVersions.value.get('wf1')).toBe(8)
+    })
+
+    it('shares one in-flight request across concurrent resyncs', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+
+      const [a, b] = await Promise.all([sync.resync('wf1'), sync.resync('wf1')])
+
+      expect(a).toBe('restored')
+      expect(b).toBe('restored')
+      expect(ports.fetchSnapshot).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('gap detection', () => {
+    it('refetches the snapshot when the agent advanced past the tab', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const outcome = sync.handlePatch(patch({ baseVersion: 7, version: 8 }))
+
+      expect(outcome).toBe('gap')
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      await sync.pendingResync('wf1')
+      expect(ports.fetchSnapshot).toHaveBeenCalledWith('wf1')
+      expect(ports.applyToTab).toHaveBeenCalledWith(
+        'wf1',
+        SNAPSHOT.content,
+        SNAPSHOT.version
+      )
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+      expect(sync.pendingConflict.value).toBeNull()
+    })
+  })
+
+  describe('handleVersionTip (trailing lost patch)', () => {
+    it('resyncs when the tip outruns the local watermark', async () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      const outcome = sync.handleVersionTip('wf1', 9)
+
+      expect(outcome).toBe('resyncing')
+      await sync.pendingResync('wf1')
+      expect(ports.fetchSnapshot).toHaveBeenCalledWith('wf1')
+      expect(sync.baseVersions.value.get('wf1')).toBe(SNAPSHOT.version)
+    })
+
+    it('does nothing when the tip is not newer', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 9)
+
+      expect(sync.handleVersionTip('wf1', 9)).toBe('up-to-date')
+      expect(ports.fetchSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('ignores a tip for a workflow with no open tab', () => {
+      const ports = makePorts()
+      const sync = useAgentDraftSync(ports)
+
+      expect(sync.handleVersionTip('wf-unknown', 9)).toBe('ignored')
+      expect(ports.fetchSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('preserves local state when a self-heal fetch fails', async () => {
+      const ports = makePorts()
+      const boom = new Error('network down')
+      vi.mocked(ports.fetchSnapshot).mockRejectedValue(boom)
+      const sync = useAgentDraftSync(ports)
+      sync.registerWorkflow('wf1', 5)
+
+      expect(sync.handleVersionTip('wf1', 9)).toBe('resyncing')
+      await expect(sync.pendingResync('wf1')).rejects.toBe(boom)
+
+      expect(ports.applyToTab).not.toHaveBeenCalled()
+      expect(sync.baseVersions.value.get('wf1')).toBe(5)
     })
   })
 })

--- a/src/platform/agent/common/useAgentDraftSync.ts
+++ b/src/platform/agent/common/useAgentDraftSync.ts
@@ -3,18 +3,23 @@
  *
  * Orchestrates the frontend side of agent graph writes: tracks the base
  * `version` per open workflow (the version lifecycle), reconciles incoming
- * `draft_patch` events, and drives the three merge-dialog outcomes.
+ * `draft_patch` events, drives the three merge-dialog outcomes, and self-heals
+ * across dropped Redis Pub/Sub patches and WS reconnects by refetching the
+ * authoritative snapshot (BE-1886). The transport stays best-effort; this client
+ * provides reliability — `version` is the monotonic watermark.
  *
  * The canvas-facing effects are injected as `ports` so this is decoupled from
  * litegraph / the workflow store and is unit-testable. In the real app the
  * ports map to: `applyToTab` -> a destructive variant of `app.loadGraphData`;
  * `openInNewTab` -> the existing non-destructive load; `discardAgentResult` ->
- * a no-op (keep the user's canvas as-is).
+ * a no-op (keep the user's canvas as-is); `fetchSnapshot` -> a `GET
+ * /api/agent/draft?workflow_id=...` decoded with `parseDraftSnapshot`.
  */
 import { readonly, ref } from 'vue'
 
 import type {
   DraftPatchEvent,
+  DraftSnapshot,
   WorkflowGraph,
   WorkflowId
 } from './agentProtocol'
@@ -33,6 +38,7 @@ export interface AgentDraftPorts {
     version: number
   ): void
   discardAgentResult(workflowId: WorkflowId): void
+  fetchSnapshot(workflowId: WorkflowId): Promise<DraftSnapshot>
 }
 
 export interface PendingConflict {
@@ -42,11 +48,22 @@ export interface PendingConflict {
   baseVersion: number
 }
 
-export type PatchOutcome = 'applied' | 'conflict' | 'ignored' | 'opened-new-tab'
+export type PatchOutcome =
+  | 'applied'
+  | 'conflict'
+  | 'ignored'
+  | 'opened-new-tab'
+  | 'gap'
+
+/** `restored` = a newer snapshot replaced the tab; `up-to-date` = already current. */
+export type ResyncOutcome = 'restored' | 'up-to-date'
+
+export type VersionTipOutcome = 'resyncing' | 'up-to-date' | 'ignored'
 
 export function useAgentDraftSync(ports: AgentDraftPorts) {
   const baseVersions = ref(new Map<WorkflowId, number>())
   const pendingConflict = ref<PendingConflict | null>(null)
+  const inFlightResyncs = new Map<WorkflowId, Promise<ResyncOutcome>>()
 
   /** Call when a draft tab opens, adopting its known version. */
   function registerWorkflow(workflowId: WorkflowId, version: number): void {
@@ -87,9 +104,71 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
           baseVersion: patch.baseVersion
         }
         return 'conflict'
+      case 'gap':
+        scheduleResync(patch.workflowId)
+        return 'gap'
       case 'stale':
         return 'ignored'
     }
+  }
+
+  async function runResync(workflowId: WorkflowId): Promise<ResyncOutcome> {
+    const snapshot = await ports.fetchSnapshot(workflowId)
+    const current = baseVersions.value.get(workflowId)
+    if (current !== undefined && snapshot.version <= current) {
+      return 'up-to-date'
+    }
+    ports.applyToTab(workflowId, snapshot.content, snapshot.version)
+    baseVersions.value.set(workflowId, snapshot.version)
+    return 'restored'
+  }
+
+  /**
+   * Fetch the authoritative snapshot and reconcile it against the watermark.
+   * Call on WS (re)connect to restore the draft without waiting for a patch.
+   * Concurrent calls for the same workflow share one in-flight request.
+   */
+  function resync(workflowId: WorkflowId): Promise<ResyncOutcome> {
+    const existing = inFlightResyncs.get(workflowId)
+    if (existing) return existing
+    const run = runResync(workflowId).finally(() => {
+      inFlightResyncs.delete(workflowId)
+    })
+    inFlightResyncs.set(workflowId, run)
+    return run
+  }
+
+  /** In-flight resync for a workflow, if any (lets callers await self-heal). */
+  function pendingResync(
+    workflowId: WorkflowId
+  ): Promise<ResyncOutcome> | undefined {
+    return inFlightResyncs.get(workflowId)
+  }
+
+  /**
+   * Fire-and-forget self-heal. A failed refetch is best-effort: it leaves local
+   * state intact and is retried by the next patch / reconnect / version tip.
+   */
+  function scheduleResync(workflowId: WorkflowId): void {
+    void resync(workflowId).catch((error: unknown) => {
+      console.error('[agent] draft resync failed', workflowId, error)
+    })
+  }
+
+  /**
+   * Consume an optional `draft_version` tip (a content-less version heartbeat).
+   * Catches a trailing lost patch: if the server tip outruns our watermark for an
+   * open workflow, refetch the snapshot.
+   */
+  function handleVersionTip(
+    workflowId: WorkflowId,
+    version: number
+  ): VersionTipOutcome {
+    const current = baseVersions.value.get(workflowId)
+    if (current === undefined) return 'ignored'
+    if (version <= current) return 'up-to-date'
+    scheduleResync(workflowId)
+    return 'resyncing'
   }
 
   function resolveConflict(decision: ConflictResolution): void {
@@ -127,6 +206,9 @@ export function useAgentDraftSync(ports: AgentDraftPorts) {
     forgetWorkflow,
     setVersion,
     handlePatch,
-    resolveConflict
+    resolveConflict,
+    resync,
+    pendingResync,
+    handleVersionTip
   }
 }


### PR DESCRIPTION
## ELI-5

When the agent edits your workflow, the server pushes the whole document over a best-effort channel (Redis Pub/Sub → WebSocket). If a push is dropped, or your tab reconnects after a hiccup, the draft on screen could get stale. This makes the in-app agent panel heal itself: on (re)connect it fetches the authoritative draft snapshot, and it treats the document `version` as a one-way ratchet so a dropped, duplicated, or out-of-order push can never roll your draft backwards.

## Summary

Make the in-app agent panel's draft state self-heal across dropped `draft_patch` messages and WS reconnects by fetching the authoritative snapshot and using `version` as a watermark. The transport stays best-effort; the client provides reliability (full-document V0 path).

## Changes

- **What**:
  - `draftReconciler`: `version` is now a monotonic watermark. A `draft_patch` is adopted only when it advances past local (`version > local`); stale/duplicate/out-of-order patches are ignored. A patch whose `base_version` is **ahead** of local means patches were missed → new `gap` result (refetch the snapshot) rather than a false merge-dialog conflict. `base_version < local` (a genuine concurrent local edit) still routes to the existing conflict dialog.
  - `useAgentDraftSync`: adds `resync(workflowId)` — fetch `GET /api/agent/draft?workflow_id=...`, watermark-guard, then restore the draft into the tab and adopt `version`. Call on WS (re)connect to restore without waiting for a patch. A suspected gap and an optional content-less `draft_version` tip (`handleVersionTip`) trigger the same refetch; concurrent resyncs share one in-flight request. Snapshot fetching is injected as a `fetchSnapshot` port, matching the existing decoupled-ports design.
  - `agentProtocol`: adds the `DraftSnapshot` type and `parseDraftSnapshot` decoder for the untrusted snapshot response.
- **Breaking**: `AgentDraftPorts` gains a required `fetchSnapshot` member (prototype is not wired into the app yet, so no runtime consumers).

## Review Focus

- **Stacked PR** — based on `matt/be-1876-agent-protocol-envelope` (canonical wire envelope), which is itself stacked on the agent graph-state prototype (`feat/adr-in-app-agent-graph-state`). Review only the net diff here; GitHub retargets to `main` as the parents merge. Reads the ratified snake_case `version`/`base_version` shape, not the drifted prototype shape.
- **Gap vs conflict split** is the load-bearing design call: `base_version > local` = transport gap (refetch); `base_version < local` = local divergence (merge dialog, unchanged). This keeps a dropped intermediate patch from surfacing a bogus merge dialog.
- **Watermark in `resync`**: a snapshot is applied only when strictly newer than local, so a reconnect that finds nothing changed (`version` equal) is a no-op and won't disrupt the canvas. The auto-triggered resyncs (gap, tip) only fire when the server is *ahead*, so they can't clobber an in-progress local-edit conflict; an explicit reconnect `resync()` treats the server as authoritative by design.
- **Error handling**: auto-triggered self-heal is fire-and-forget and best-effort — a failed `fetchSnapshot` leaves local state intact and is retried on the next patch/reconnect/tip (covered by a test). Explicit `resync()` callers receive the rejection to handle as they see fit.

### Judgment calls / notes
- **Snapshot body shape**: the endpoint is decoded as a flat `{ content, version }` per the spec, not wrapped in the WS `{ type, data }` envelope. If the backend wraps it in `data`, `parseDraftSnapshot` needs a one-line unwrap — flagged as a coordination point with the snapshot-endpoint child.
- **`draft_version` tip** is consumed via a `handleVersionTip(workflowId, version)` method rather than a new parsed wire event, since the sibling that emits it isn't landed and inventing its envelope shape would risk drift. The integration layer calls this when such a tip arrives.
- Nothing is wired into the chat UI yet (consistent with the prototype); behavior is exercised via unit tests (`draftReconciler` + `useAgentDraftSync` + `agentProtocol` suites).

Quality gates: targeted vitest (41 passing), `eslint`, `oxfmt --check`, `vue-tsc --noEmit` (0 errors), `knip` — all green.
