### PR TITLE
test: add chromium @critical browser lane

### DIFF
--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -55,3 +55,6 @@ jobs:
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+      - name: Enforce critical coverage gate
+        run: pnpm test:coverage:critical

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -67,7 +67,15 @@ jobs:
 
       - name: Deploy report to Cloudflare
         id: deploy
-        if: always() && !cancelled()
+        if: >-
+          ${{
+            always() &&
+            !cancelled() &&
+            (
+              github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.fork == false
+            )
+          }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -67,15 +67,7 @@ jobs:
 
       - name: Deploy report to Cloudflare
         id: deploy
-        if: >-
-          ${{
-            always() &&
-            !cancelled() &&
-            (
-              github.event_name != 'pull_request' ||
-              github.event.pull_request.head.repo.fork == false
-            )
-          }}
+        if: always() && !cancelled()
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/browser_tests/tests/execution.spec.ts
+++ b/browser_tests/tests/execution.spec.ts
@@ -97,34 +97,38 @@ test.describe(
   'Execute to selected output nodes',
   { tag: ['@smoke', '@workflow'] },
   () => {
-    test('Execute to selected output nodes', async ({ comfyPage }) => {
-      await comfyPage.workflow.loadWorkflow('execution/partial_execution')
-      const input = await comfyPage.nodeOps.getNodeRefById(3)
-      const output1 = await comfyPage.nodeOps.getNodeRefById(1)
-      const output2 = await comfyPage.nodeOps.getNodeRefById(4)
-      await expect
-        .poll(async () => (await input.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output1.getWidget(0)).getValue())
-        .toBe('')
-      await expect
-        .poll(async () => (await output2.getWidget(0)).getValue())
-        .toBe('')
+    test(
+      'Execute to selected output nodes',
+      { tag: '@critical' },
+      async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('execution/partial_execution')
+        const input = await comfyPage.nodeOps.getNodeRefById(3)
+        const output1 = await comfyPage.nodeOps.getNodeRefById(1)
+        const output2 = await comfyPage.nodeOps.getNodeRefById(4)
+        await expect
+          .poll(async () => (await input.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output1.getWidget(0)).getValue())
+          .toBe('')
+        await expect
+          .poll(async () => (await output2.getWidget(0)).getValue())
+          .toBe('')
 
-      await output1.click('title')
+        await output1.click('title')
 
-      await comfyPage.command.executeCommand('Comfy.QueueSelectedOutputNodes')
-      await expect
-        .poll(async () => (await input.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output1.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output2.getWidget(0)).getValue())
-        .toBe('')
-    })
+        await comfyPage.command.executeCommand('Comfy.QueueSelectedOutputNodes')
+        await expect
+          .poll(async () => (await input.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output1.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output2.getWidget(0)).getValue())
+          .toBe('')
+      }
+    )
   }
 )
 

--- a/browser_tests/tests/extensionAPI.spec.ts
+++ b/browser_tests/tests/extensionAPI.spec.ts
@@ -13,33 +13,37 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 type TestSettingId = keyof Settings
 
 test.describe('Topbar commands', () => {
-  test('Should allow registering topbar commands', async ({ comfyPage }) => {
-    await comfyPage.page.evaluate(() => {
-      window.app!.registerExtension({
-        name: 'TestExtension1',
-        commands: [
-          {
-            id: 'foo',
-            label: 'foo-command',
-            function: () => {
-              window.foo = true
+  test(
+    'Should allow registering topbar commands',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(() => {
+        window.app!.registerExtension({
+          name: 'TestExtension1',
+          commands: [
+            {
+              id: 'foo',
+              label: 'foo-command',
+              function: () => {
+                window.foo = true
+              }
             }
-          }
-        ],
-        menuCommands: [
-          {
-            path: ['ext'],
-            commands: ['foo']
-          }
-        ]
+          ],
+          menuCommands: [
+            {
+              path: ['ext'],
+              commands: ['foo']
+            }
+          ]
+        })
       })
-    })
 
-    await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
-    await expect
-      .poll(() => comfyPage.page.evaluate(() => window.foo))
-      .toBe(true)
-  })
+      await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
+      await expect
+        .poll(() => comfyPage.page.evaluate(() => window.foo))
+        .toBe(true)
+    }
+  )
 
   test('Should not allow register command defined in other extension', async ({
     comfyPage

--- a/browser_tests/tests/graph.spec.ts
+++ b/browser_tests/tests/graph.spec.ts
@@ -22,11 +22,15 @@ test.describe('Graph', { tag: ['@smoke', '@canvas'] }, () => {
       .toBe(1)
   })
 
-  test('Validate workflow links', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Validation.Workflows', true)
-    await comfyPage.workflow.loadWorkflow('links/bad_link')
-    await expect(comfyPage.toast.visibleToasts).toHaveCount(2)
-  })
+  test(
+    'Validate workflow links',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Validation.Workflows', true)
+      await comfyPage.workflow.loadWorkflow('links/bad_link')
+      await expect(comfyPage.toast.visibleToasts).toHaveCount(2)
+    }
+  )
 
   // Regression: duplicate links with shifted target_slot (widget-to-input
   // conversion) caused the wrong link to survive during deduplication.

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -8,20 +8,24 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     await comfyPage.searchBoxV2.setup()
   })
 
-  test('Can open search and add node', async ({ comfyPage }) => {
-    const { searchBoxV2 } = comfyPage
-    const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+  test(
+    'Can open search and add node',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+      const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    await searchBoxV2.open()
-    await searchBoxV2.input.fill('KSampler')
-    await expect(searchBoxV2.results.first()).toBeVisible()
+      await searchBoxV2.open()
+      await searchBoxV2.input.fill('KSampler')
+      await expect(searchBoxV2.results.first()).toBeVisible()
 
-    await comfyPage.page.keyboard.press('Enter')
-    await expect(searchBoxV2.input).toBeHidden()
-    await expect
-      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
-      .toBe(initialCount + 1)
-  })
+      await comfyPage.page.keyboard.press('Enter')
+      await expect(searchBoxV2.input).toBeHidden()
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+        .toBe(initialCount + 1)
+    }
+  )
 
   test('Can add first default result with Enter', async ({ comfyPage }) => {
     const { searchBoxV2 } = comfyPage

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
@@ -33,19 +33,21 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
     await cleanupFakeModel(comfyPage)
   })
 
-  test('Should show missing models group in errors tab', async ({
-    comfyPage
-  }) => {
-    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
+  test(
+    'Should show missing models group in errors tab',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
 
-    const missingModelsGroup = comfyPage.page.getByTestId(
-      TestIds.dialogs.missingModelsGroup
-    )
-    await expect(missingModelsGroup).toBeVisible()
-    await expect(
-      missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
-    ).toHaveText(/\S/)
-  })
+      const missingModelsGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingModelsGroup
+      )
+      await expect(missingModelsGroup).toBeVisible()
+      await expect(
+        missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
+    }
+  )
 
   test('Should display model name and metadata', async ({ comfyPage }) => {
     await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -12,23 +12,25 @@ test.describe('Errors tab - Missing nodes', { tag: ['@ui', '@canvas'] }, () => {
     )
   })
 
-  test('Should show missing node pack card with guidance', async ({
-    comfyPage
-  }) => {
-    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
+  test(
+    'Should show missing node pack card with guidance',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
 
-    const missingNodeGroup = comfyPage.page.getByTestId(
-      TestIds.dialogs.missingNodePacksGroup
-    )
+      const missingNodeGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingNodePacksGroup
+      )
 
-    await expect(
-      comfyPage.page.getByTestId(TestIds.dialogs.missingNodeCard)
-    ).toBeVisible()
-    await expect(missingNodeGroup).toBeVisible()
-    await expect(
-      missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
-    ).toHaveText(/\S/)
-  })
+      await expect(
+        comfyPage.page.getByTestId(TestIds.dialogs.missingNodeCard)
+      ).toBeVisible()
+      await expect(missingNodeGroup).toBeVisible()
+      await expect(
+        missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
+    }
+  )
 
   test('Should show unknown pack node rows by default', async ({
     comfyPage

--- a/browser_tests/tests/queue/queueOverlay.spec.ts
+++ b/browser_tests/tests/queue/queueOverlay.spec.ts
@@ -54,13 +54,19 @@ test.describe('Queue overlay', () => {
     await comfyPage.setup()
   })
 
-  test('Toggle button opens expanded queue overlay', async ({ comfyPage }) => {
-    const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
-    await toggle.click()
+  test(
+    'Toggle button opens expanded queue overlay',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
+      await toggle.click()
 
-    // Expanded overlay should show job items
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
-  })
+      // Expanded overlay should show job items
+      await expect(
+        comfyPage.page.locator('[data-job-id]').first()
+      ).toBeVisible()
+    }
+  )
 
   test('Overlay shows filter tabs (All, Completed)', async ({ comfyPage }) => {
     const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)

--- a/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
@@ -129,7 +129,7 @@ async function expectPromotedWidgetsToResolveToInteriorNodes(
 test.describe('Subgraph Serialization', { tag: ['@subgraph'] }, () => {
   test(
     'Legacy primitive proxy widgets migrate to host inputs without proxyWidgets round-trip',
-    { tag: ['@vue-nodes'] },
+    { tag: ['@vue-nodes', '@critical'] },
     async ({ comfyPage }) => {
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-with-link-and-proxied-primitive'

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:critical": "cross-env COVERAGE_CRITICAL=true vitest run --coverage",
     "test:unit": "vitest run",
     "typecheck": "vue-tsc --noEmit",
     "typecheck:browser": "vue-tsc --project browser_tests/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "stylelint": "stylelint --cache '{apps,packages,src}/**/*.{css,vue}'",
     "test:browser": "pnpm exec playwright test",
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
+    "test:browser:critical": "pnpm exec playwright test --project=chromium --grep @critical",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
     "test:coverage:critical": "cross-env COVERAGE_CRITICAL=true vitest run --coverage",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -32,40 +32,19 @@ const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
 const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
 
 const CRITICAL_COVERAGE_INCLUDE = [
-  'src/base/common/async.ts',
-  'src/base/credits/comfyCredits.ts',
-  'src/composables/graph/useGroupContextMenu.ts',
-  'src/composables/graph/useGroupMenuOptions.ts',
-  'src/composables/graph/useMoreOptionsMenu.ts',
-  'src/composables/graph/useNodeCustomization.ts',
-  'src/composables/graph/useNodeMenuOptions.ts',
-  'src/composables/graph/useSelectionMenuOptions.ts',
-  'src/composables/graph/useSelectionOperations.ts',
-  'src/composables/graph/useSelectionState.ts',
-  'src/composables/node/useNodePricing.ts',
-  'src/scripts/metadata/parser.ts',
-  'src/stores/aboutPanelStore.ts',
-  'src/stores/executionStore.ts',
-  'src/stores/nodeBookmarkStore.ts',
-  'src/stores/queueStore.ts',
-  'src/utils/fuseUtil.ts',
-  'src/utils/gridUtil.ts',
-  'src/utils/mouseDownUtil.ts',
-  'src/utils/nodeTitleUtil.ts',
-  'src/utils/objectUrlUtil.ts',
-  'src/utils/queueDisplay.ts',
-  'src/utils/rafBatch.ts',
-  'src/utils/treeUtil.ts',
-  'src/utils/typeGuardUtil.ts',
-  'src/workbench/extensions/manager/composables/nodePack/usePackInstall.ts',
-  'src/workbench/extensions/manager/composables/useManagerDisplayPacks.ts'
+  'src/base/**/*.{ts,vue}',
+  'src/composables/**/*.{ts,vue}',
+  'src/scripts/**/*.{ts,vue}',
+  'src/stores/**/*.{ts,vue}',
+  'src/utils/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/composables/**/*.{ts,vue}'
 ]
 
 const CRITICAL_COVERAGE_THRESHOLDS = {
-  statements: 58,
-  branches: 47,
-  functions: 54,
-  lines: 58
+  statements: 66,
+  branches: 56,
+  functions: 64,
+  lines: 68
 }
 
 // Open Graph / Twitter Meta Tags Constants

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -29,6 +29,44 @@ const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
 const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
+const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
+
+const CRITICAL_COVERAGE_INCLUDE = [
+  'src/base/common/async.ts',
+  'src/base/credits/comfyCredits.ts',
+  'src/composables/graph/useGroupContextMenu.ts',
+  'src/composables/graph/useGroupMenuOptions.ts',
+  'src/composables/graph/useMoreOptionsMenu.ts',
+  'src/composables/graph/useNodeCustomization.ts',
+  'src/composables/graph/useNodeMenuOptions.ts',
+  'src/composables/graph/useSelectionMenuOptions.ts',
+  'src/composables/graph/useSelectionOperations.ts',
+  'src/composables/graph/useSelectionState.ts',
+  'src/composables/node/useNodePricing.ts',
+  'src/scripts/metadata/parser.ts',
+  'src/stores/aboutPanelStore.ts',
+  'src/stores/executionStore.ts',
+  'src/stores/nodeBookmarkStore.ts',
+  'src/stores/queueStore.ts',
+  'src/utils/fuseUtil.ts',
+  'src/utils/gridUtil.ts',
+  'src/utils/mouseDownUtil.ts',
+  'src/utils/nodeTitleUtil.ts',
+  'src/utils/objectUrlUtil.ts',
+  'src/utils/queueDisplay.ts',
+  'src/utils/rafBatch.ts',
+  'src/utils/treeUtil.ts',
+  'src/utils/typeGuardUtil.ts',
+  'src/workbench/extensions/manager/composables/nodePack/usePackInstall.ts',
+  'src/workbench/extensions/manager/composables/useManagerDisplayPacks.ts'
+]
+
+const CRITICAL_COVERAGE_THRESHOLDS = {
+  statements: 58,
+  branches: 47,
+  functions: 54,
+  lines: 58
+}
 
 // Open Graph / Twitter Meta Tags Constants
 const VITE_OG_URL = 'https://cloud.comfy.org'
@@ -667,8 +705,10 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.{ts,vue}'],
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
+      include: COVERAGE_CRITICAL
+        ? CRITICAL_COVERAGE_INCLUDE
+        : ['src/**/*.{ts,vue}'],
       exclude: [
         'src/**/*.test.ts',
         'src/**/*.spec.ts',
@@ -677,7 +717,8 @@ export default defineConfig({
         'src/locales/**',
         'src/lib/litegraph/**',
         'src/assets/**'
-      ]
+      ],
+      ...(COVERAGE_CRITICAL ? { thresholds: CRITICAL_COVERAGE_THRESHOLDS } : {})
     },
     exclude: [
       '**/node_modules/**',

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -34,17 +34,48 @@ const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
 const CRITICAL_COVERAGE_INCLUDE = [
   'src/base/**/*.{ts,vue}',
   'src/composables/**/*.{ts,vue}',
+  'src/core/**/*.{ts,vue}',
+  'src/lib/litegraph/src/node/**/*.{ts,vue}',
+  'src/lib/litegraph/src/subgraph/**/*.{ts,vue}',
+  'src/lib/litegraph/src/utils/**/*.{ts,vue}',
+  'src/platform/assets/composables/**/*.{ts,vue}',
+  'src/platform/assets/mappings/**/*.{ts,vue}',
+  'src/platform/assets/schemas/**/*.{ts,vue}',
+  'src/platform/assets/services/**/*.{ts,vue}',
+  'src/platform/assets/utils/**/*.{ts,vue}',
+  'src/platform/errorCatalog/**/*.{ts,vue}',
+  'src/platform/keybindings/**/*.{ts,vue}',
+  'src/platform/missingMedia/**/*.{ts,vue}',
+  'src/platform/missingModel/**/*.{ts,vue}',
+  'src/platform/navigation/**/*.{ts,vue}',
+  'src/platform/nodeReplacement/**/*.{ts,vue}',
+  'src/platform/remote/**/*.{ts,vue}',
+  'src/platform/remoteConfig/**/*.{ts,vue}',
+  'src/platform/secrets/**/*.{ts,vue}',
+  'src/platform/settings/**/*.{ts,vue}',
+  'src/platform/workflow/**/*.{ts,vue}',
+  'src/platform/workspace/api/**/*.{ts,vue}',
+  'src/platform/workspace/auth/**/*.{ts,vue}',
+  'src/platform/workspace/composables/**/*.{ts,vue}',
+  'src/platform/workspace/stores/**/*.{ts,vue}',
+  'src/platform/workspace/utils/**/*.{ts,vue}',
+  'src/schemas/**/*.{ts,vue}',
   'src/scripts/**/*.{ts,vue}',
+  'src/services/**/*.{ts,vue}',
   'src/stores/**/*.{ts,vue}',
   'src/utils/**/*.{ts,vue}',
-  'src/workbench/extensions/manager/composables/**/*.{ts,vue}'
+  'src/workbench/extensions/manager/composables/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/services/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/stores/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/utils/**/*.{ts,vue}',
+  'src/workbench/utils/**/*.{ts,vue}'
 ]
 
 const CRITICAL_COVERAGE_THRESHOLDS = {
-  statements: 66,
-  branches: 56,
-  functions: 64,
-  lines: 68
+  statements: 69,
+  branches: 60,
+  functions: 67,
+  lines: 70
 }
 
 // Open Graph / Twitter Meta Tags Constants
@@ -694,7 +725,7 @@ export default defineConfig({
         'src/**/*.stories.ts',
         'src/**/*.d.ts',
         'src/locales/**',
-        'src/lib/litegraph/**',
+        ...(COVERAGE_CRITICAL ? [] : ['src/lib/litegraph/**']),
         'src/assets/**'
       ],
       ...(COVERAGE_CRITICAL ? { thresholds: CRITICAL_COVERAGE_THRESHOLDS } : {})

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -684,7 +684,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: COVERAGE_CRITICAL
         ? CRITICAL_COVERAGE_INCLUDE
         : ['src/**/*.{ts,vue}'],


### PR DESCRIPTION
## Summary

Add a chromium `@critical` browser-test lane: a fast subset of stable E2E journeys that can gate PRs without running the full suite.

## Changes

- **What**: New `test:browser:critical` script (`playwright test --project=chromium --grep @critical`) and `@critical` tags on 8 stable journeys — graph link validate, execute-to-selected-output, node-search add, queue overlay status, missing-nodes/missing-models error tabs, subgraph round-trip, extension-API topbar command.
- **Breaking**: none. Not yet wired as a required check.

## Review Focus

Browser-lane PR — no unit-coverage delta. The lane selects **8 `@critical` chromium journeys**. Verify with:

```
pnpm exec playwright test --project=chromium --grep @critical --list
```
