### PR TITLE
fix(topbar): make workflow tab close button reachable on touch devices

### DIFF
--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -27,7 +27,7 @@
             :aria-label="workflowStatusLabel"
             :class="
               cn(
-                'absolute top-1/2 left-1/2 z-10 size-4 -translate-1/2 group-hover:hidden',
+                'absolute top-1/2 left-1/2 z-10 size-4 -translate-1/2 group-hover:hidden touch:hidden',
                 workflowStatusIconClasses[workflowStatus]
               )
             "
@@ -35,7 +35,7 @@
           <span
             v-else-if="shouldShowUnsavedIndicator"
             data-testid="workflow-dirty-indicator"
-            class="absolute top-1/2 left-1/2 z-10 w-4 -translate-1/2 bg-(--comfy-menu-bg) text-2xl font-bold group-hover:hidden"
+            class="absolute top-1/2 left-1/2 z-10 w-4 -translate-1/2 bg-(--comfy-menu-bg) text-2xl font-bold group-hover:hidden touch:hidden"
             >•</span
           >
           <Button

--- a/src/components/topbar/WorkflowTab.vue
+++ b/src/components/topbar/WorkflowTab.vue
@@ -26,14 +26,14 @@
             v-if="isAgentEditing"
             role="img"
             :aria-label="t('g.agentWorking')"
-            class="absolute top-1/2 left-1/2 z-10 icon-[lucide--loader-circle] size-4 -translate-1/2 text-smoke-800 group-hover:hidden motion-safe:animate-spin"
+            class="absolute top-1/2 left-1/2 z-10 icon-[lucide--loader-circle] size-4 -translate-1/2 text-smoke-800 group-hover:hidden motion-safe:animate-spin touch:hidden"
           />
           <span
             v-else-if="showUnseenAgentDot"
             role="img"
             :aria-label="t('g.agentModified')"
             data-testid="agent-modified-indicator"
-            class="absolute top-1/2 left-1/2 z-10 size-2 -translate-1/2 rounded-full bg-primary-background group-hover:hidden"
+            class="absolute top-1/2 left-1/2 z-10 size-2 -translate-1/2 rounded-full bg-primary-background group-hover:hidden touch:hidden"
           />
           <i
             v-else-if="workflowStatus"
@@ -41,7 +41,7 @@
             :aria-label="workflowStatusLabel"
             :class="
               cn(
-                'absolute top-1/2 left-1/2 z-10 size-4 -translate-1/2 group-hover:hidden',
+                'absolute top-1/2 left-1/2 z-10 size-4 -translate-1/2 group-hover:hidden touch:hidden',
                 workflowStatusIconClasses[workflowStatus]
               )
             "
@@ -51,13 +51,13 @@
             data-testid="workflow-dirty-indicator"
             :class="
               cn(
-                'absolute top-1/2 left-1/2 z-10 size-2 -translate-1/2 rounded-full group-hover:hidden',
+                'absolute top-1/2 left-1/2 z-10 size-2 -translate-1/2 rounded-full group-hover:hidden touch:hidden',
                 isActiveTab ? 'bg-base-foreground' : 'bg-smoke-800'
               )
             "
           />
           <Button
-            class="close-button invisible size-4 rounded-none p-0 text-smoke-800 group-hover:visible"
+            class="close-button invisible size-4 rounded-none p-0 text-smoke-800 group-hover:visible touch:visible"
             variant="muted-textonly"
             size="unset"
             :aria-label="t('g.close')"

--- a/src/components/topbar/WorkflowTabs.vue
+++ b/src/components/topbar/WorkflowTabs.vue
@@ -387,6 +387,15 @@ onUpdated(() => {
   visibility: visible;
 }
 
+/* Touch devices have no hover state, so the hover-revealed close button is
+   otherwise unreachable (and the status/dirty indicator stacked over it can't
+   be dismissed). Always show the close button there. */
+@media (hover: none) {
+  :deep(.close-button) {
+    visibility: visible;
+  }
+}
+
 :deep(.p-scrollpanel-content) {
   height: 100%;
 }


### PR DESCRIPTION
## Summary

Workflow tabs cannot be closed on touch devices. The close (✕) button is `invisible` by default and revealed only via `group-hover:visible`, which never fires on a touch device. The status and dirty indicators are stacked over the button (`absolute`, `z-10`, hidden only via `group-hover:hidden`), so even on the active tab the indicator physically covers and intercepts taps on the ✕.

Net effect on mobile: tabs are unclosable, and the only practical recourse is wiping browser local storage — which deletes **all** workflows.

Fixes #13279.

## Change

One file, `src/components/topbar/WorkflowTab.vue`, using the design system's existing `touch` variant (`@custom-variant touch (@media (hover: none))`, `packages/design-system/src/css/style.css`):

- `touch:visible` on the close button, alongside the existing `group-hover:visible`.
- `touch:hidden` on each of the four overlaid `z-10` indicators — the agent loader, the unseen-agent dot, the workflow status icon, and the dirty `•` — alongside their existing `group-hover:hidden`.

This invents no new UX: on hover, the design already hides the indicators and shows the ✕; this applies that same state on devices that cannot hover. Desktop hover/active behaviour is unchanged.

The pattern matches existing usage in the codebase — `TreeExplorerTreeNode.vue` pairs `opacity-0` with `group-hover:opacity-100 touch:opacity-100` in the same class attribute.

Trade-off: on touch, the passive run-status and dirty indicators yield their slot to the close affordance, exactly as they do in the desktop hover state. Unsaved-changes safety is preserved by the existing close-confirmation dialog (`warnIfUnsaved`).

## Verification

Behaviour was verified on a live instance under Chrome DevTools mobile emulation (390×844, `matchMedia('(hover: none)').matches === true`) with 16 open workflow tabs — see the [detailed comment below](https://github.com/Comfy-Org/ComfyUI_frontend/pull/13280#issuecomment-4831834191). In short:

- Before: non-active tabs had `visibility: hidden` on `.close-button`; on the active tab, `document.elementFromPoint()` at the ✕'s centre returned the `•` indicator span, not the button.
- After: every tab's close button is visible under `(hover: none)`, `elementFromPoint()` returns the `pi-times` icon, tapping ✕ closed a tab (16 → 15), and closing a dirty tab correctly raised the unsaved-changes dialog.

That verification was performed against the original implementation, which expressed the same rule as a hand-written `@media (hover: none)` block in `WorkflowTabs.vue`. The `touch` variant compiles to that identical media query, and the indicator/close-button roles are unchanged, so the observed behaviour carries over.

Note the unit tests in `WorkflowTab.test.ts` assert nothing about these class strings, so they neither break nor validate this change — the emulation run above is the evidence.

## How to test

Open several workflows, then toggle device emulation in Chrome DevTools (or use any browser reporting `@media (hover: none)`). Before: non-active tabs have no ✕, and the indicator blocks the ✕ on the active tab. After: every tab shows a tappable ✕.

## Rebase

The original branch conflicted with `main` after the tab indicators were reworked. @DrJKL rebased it and resolved the conflict at [`rebase/pr-13280`](https://github.com/Comfy-Org/ComfyUI_frontend/tree/rebase/pr-13280), which this branch now points at. The resolution keeps main's newer agent indicators and swaps the hand-written media query for the `touch` variant, leaving `WorkflowTabs.vue` untouched.
