### PR TITLE
fix(website): move launches nav item and add cleanplate workflow link

### DIFF
--- a/apps/website/src/data/learningTutorials.ts
+++ b/apps/website/src/data/learningTutorials.ts
@@ -38,7 +38,7 @@ export const learningTutorials: readonly LearningTutorial[] = [
         label: 'English'
       }
     ],
-    // href: '#',
+    href: 'https://comfy.org/workflows/8f2cf0df5da6-8f2cf0df5da6/',
     tags: [partnerNodesTag, imageToVideoTag]
   },
   {

--- a/apps/website/src/data/mainNavigation.ts
+++ b/apps/website/src/data/mainNavigation.ts
@@ -74,6 +74,11 @@ export function getMainNavigation(locale: Locale): NavItem[] {
             // { label: t('nav.appMode', locale), href: '#' },
             // { label: t('nav.agentSkills', locale), href: '#' },
             {
+              label: t('nav.launches', locale),
+              href: routes.launches,
+              badge: 'new'
+            },
+            {
               label: t('nav.docs', locale),
               href: externalLinks.docs,
               external: true
@@ -180,11 +185,6 @@ export function getMainNavigation(locale: Locale): NavItem[] {
             },
             // TODO: no /brand page yet
             // { label: t('nav.brand', locale), href: '#' },
-            {
-              label: t('nav.launches', locale),
-              href: routes.launches,
-              badge: 'new'
-            },
             {
               label: t('nav.blogs', locale),
               href: externalLinks.blog,


### PR DESCRIPTION
## Summary
- Move the `/launches` nav item from **Company → More** to **Products → Features** in the main navbar
- Add the workflow link to the **Cleanplate Walkthrough** learning tutorial (`https://comfy.org/workflows/8f2cf0df5da6-8f2cf0df5da6/`)

## Changes
- `apps/website/src/data/mainNavigation.ts`
- `apps/website/src/data/learningTutorials.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)