### PR TITLE
feat(website): redesign Comfy MCP setup steps and add button variant

### DIFF
--- a/apps/website/src/components/blocks/FeatureGrid01.vue
+++ b/apps/website/src/components/blocks/FeatureGrid01.vue
@@ -27,25 +27,27 @@ export interface FeatureCard {
   action?: CardAction
 }
 
+type ColumnCount = 2 | 3 | 4
+
 const {
+  cards,
+  columns = 3,
+  copiedLabel,
+  copyLabel,
   eyebrow,
   heading,
-  subtitle,
-  columns = 3,
-  cards,
-  copyLabel,
-  copiedLabel
+  subtitle
 } = defineProps<{
+  cards: readonly FeatureCard[]
+  columns?: ColumnCount
+  copiedLabel?: string
+  copyLabel?: string
   eyebrow?: string
   heading: string
   subtitle?: string
-  columns?: 2 | 3 | 4
-  cards: readonly FeatureCard[]
-  copyLabel?: string
-  copiedLabel?: string
 }>()
 
-const columnClass: Record<2 | 3 | 4, string> = {
+const columnClass: Record<ColumnCount, string> = {
   2: 'lg:grid-cols-2',
   3: 'lg:grid-cols-3',
   4: 'lg:grid-cols-4'

--- a/apps/website/src/components/blocks/FeatureGrid01.vue
+++ b/apps/website/src/components/blocks/FeatureGrid01.vue
@@ -15,6 +15,7 @@ type CardAction =
       href: string
       target?: '_blank'
       icon?: Component
+      variant?: 'default' | 'outline'
     }
   | { type: 'code'; value: string }
 
@@ -99,7 +100,7 @@ const columnClass: Record<2 | 3 | 4, string> = {
                 ? 'noopener noreferrer'
                 : undefined
             "
-            variant="outline"
+            :variant="card.action.variant ?? 'outline'"
             :append-icon="card.action.icon"
           >
             {{ card.action.label }}

--- a/apps/website/src/config/routes.ts
+++ b/apps/website/src/config/routes.ts
@@ -67,6 +67,7 @@ export const externalLinks = {
   githubInstall: 'https://github.com/Comfy-Org/ComfyUI#installing',
   instagram: 'https://www.instagram.com/comfyui/',
   mcpServer: 'https://cloud.comfy.org/mcp',
+  mcpSkills: 'https://github.com/Comfy-Org/comfy-skills',
   platform: 'https://platform.comfy.org',
   platformUsage: 'https://platform.comfy.org/profile/usage',
   reddit: 'https://www.reddit.com/r/comfyui/',

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -1895,31 +1895,31 @@ const translations = {
     'zh-CN': '三步完成 Comfy MCP 配置'
   },
   'mcp.setup.subtitle': {
-    en: 'Add Comfy Cloud as a built-in connector in Claude, and the full ComfyUI toolset is available right in your chat.',
+    en: 'Add Comfy Cloud as a custom connector in Claude, Cursor, Codex, or any MCP-compatible client. Sign in once, and the full ComfyUI toolset is available right in your chat.',
     'zh-CN':
-      '将 Comfy Cloud 添加为 Claude 的内置连接器，ComfyUI 全套工具即可直接在对话中使用。'
+      '将 Comfy Cloud 添加为 Claude、Cursor、Codex 或任意兼容 MCP 客户端的自定义连接器。登录一次，ComfyUI 全套工具即可直接在对话中使用。'
   },
   'mcp.setup.step1.label': { en: 'STEP 1', 'zh-CN': '第 1 步' },
   'mcp.setup.step1.title': {
-    en: 'Open Claude settings',
-    'zh-CN': '打开 Claude 设置'
+    en: 'Copy the MCP URL',
+    'zh-CN': '复制 MCP URL'
   },
   'mcp.setup.step1.description': {
-    en: 'Launch the app or open claude.ai and go to Settings > Connections',
-    'zh-CN': '启动应用或打开 claude.ai，前往"设置 > 连接"'
-  },
-  'mcp.setup.step1.cta': {
-    en: 'SETTINGS → CONNECTIONS',
-    'zh-CN': '设置 > 连接'
+    en: "Click the copy button below. You'll paste it into your client in the next step.",
+    'zh-CN': '点击下方的复制按钮，下一步将其粘贴到你的客户端中。'
   },
   'mcp.setup.step2.label': { en: 'STEP 2', 'zh-CN': '第 2 步' },
   'mcp.setup.step2.title': {
-    en: 'Add the Comfy Cloud custom connector',
-    'zh-CN': '添加 Comfy Cloud 自定义连接器'
+    en: 'Add the connector',
+    'zh-CN': '添加连接器'
   },
   'mcp.setup.step2.description': {
-    en: 'Name it Comfy Cloud and paste the URL',
-    'zh-CN': '将其命名为 Comfy Cloud 并粘贴 URL'
+    en: 'Name it Comfy Cloud and paste the URL. The docs below cover every client.',
+    'zh-CN': '将其命名为 Comfy Cloud 并粘贴 URL。下方文档涵盖各类客户端。'
+  },
+  'mcp.setup.step2.cta': {
+    en: 'COMFY CLOUD MCP DOCS',
+    'zh-CN': 'COMFY CLOUD MCP 文档'
   },
   'mcp.setup.step3.label': { en: 'STEP 3', 'zh-CN': '第 3 步' },
   'mcp.setup.step3.title': {
@@ -1927,9 +1927,12 @@ const translations = {
     'zh-CN': '连接并登录'
   },
   'mcp.setup.step3.description': {
-    en: "Click Add > Connect, sign in with your Comfy account. You're all set. Now just ask Claude to generate an image.",
-    'zh-CN':
-      '点击"添加 > 连接"，使用 Comfy 账户登录。配置完成。现在直接让 Claude 生成图像即可。'
+    en: 'Click Connect, sign in, and every Comfy Cloud skill is ready in your client.',
+    'zh-CN': '点击"连接"并登录，所有 Comfy Cloud 技能即可在你的客户端中使用。'
+  },
+  'mcp.setup.step3.cta': {
+    en: 'COMFY CLOUD SKILLS',
+    'zh-CN': 'COMFY CLOUD 技能'
   },
 
   // MCP – WhyBuildSection

--- a/apps/website/src/templates/mcp/SetupSection.vue
+++ b/apps/website/src/templates/mcp/SetupSection.vue
@@ -16,11 +16,8 @@ const cards: FeatureCard[] = [
     title: t('mcp.setup.step1.title', locale),
     description: t('mcp.setup.step1.description', locale),
     action: {
-      type: 'link',
-      label: t('mcp.setup.step1.cta', locale),
-      href: `${externalLinks.cloud}/settings/connections`,
-      target: '_blank',
-      icon: ArrowUpRight
+      type: 'code',
+      value: externalLinks.mcpServer
     }
   },
   {
@@ -29,15 +26,27 @@ const cards: FeatureCard[] = [
     title: t('mcp.setup.step2.title', locale),
     description: t('mcp.setup.step2.description', locale),
     action: {
-      type: 'code',
-      value: externalLinks.mcpServer
+      type: 'link',
+      label: t('mcp.setup.step2.cta', locale),
+      href: externalLinks.docsMcp,
+      target: '_blank',
+      icon: ArrowUpRight,
+      variant: 'default'
     }
   },
   {
     id: 'step3',
     label: t('mcp.setup.step3.label', locale),
     title: t('mcp.setup.step3.title', locale),
-    description: t('mcp.setup.step3.description', locale)
+    description: t('mcp.setup.step3.description', locale),
+    action: {
+      type: 'link',
+      label: t('mcp.setup.step3.cta', locale),
+      href: externalLinks.mcpSkills,
+      target: '_blank',
+      icon: ArrowUpRight,
+      variant: 'default'
+    }
   }
 ]
 </script>


### PR DESCRIPTION
## Summary

Reworks the Comfy MCP page's **"Set up Comfy MCP in three steps"** section to match the new design, and adds a per-action button `variant` option to `FeatureGrid01`.

The three steps are now:

| Step | Title | Action |
| --- | --- | --- |
| 1 | Copy the MCP URL | Copy field showing `https://cloud.comfy.org/mcp` |
| 2 | Add the connector | Filled button **"COMFY CLOUD MCP DOCS" ↗** → MCP docs |
| 3 | Connect and sign in | Filled button **"COMFY CLOUD SKILLS" ↗** → comfy-skills repo |

## Changes

- **`FeatureGrid01.vue`** — add `variant?: 'default' | 'outline'` to the link card action; button now uses `card.action.variant ?? 'outline'` instead of a hardcoded outline, so callers can opt into the filled style.
- **`config/routes.ts`** — add `mcpSkills` external link (`https://github.com/Comfy-Org/comfy-skills`).
- **`i18n/translations.ts`** — refresh the `mcp.setup.*` copy (en + zh-CN): new subtitle, reworded steps, new `step2.cta` / `step3.cta`, drop the now-unused `step1.cta`.
- **`SetupSection.vue`** — re-map cards: step 1 → copy field, steps 2 & 3 → filled link buttons.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] Pre-commit hooks (stylelint, oxfmt, oxlint, eslint, typecheck) pass
- [ ] Visual check on `/mcp` and `/zh-CN/mcp` (copy field on step 1; two filled yellow CTAs with up-right arrows on steps 2 & 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)