### PR TITLE
Enable cloud PostHog pageviews

### DIFF
--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts
@@ -109,7 +109,7 @@ describe('PostHogTelemetryProvider', () => {
           api_host: 'https://t.comfy.org',
           ui_host: 'https://us.posthog.com',
           autocapture: false,
-          capture_pageview: false,
+          capture_pageview: 'history_change',
           capture_pageleave: false,
           persistence: 'localStorage+cookie'
         })
@@ -635,7 +635,7 @@ describe('PostHogTelemetryProvider', () => {
   })
 
   describe('page view', () => {
-    it('captures page view with page_name property', async () => {
+    it('captures legacy page view event with page_name property', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()
 
@@ -645,9 +645,13 @@ describe('PostHogTelemetryProvider', () => {
         TelemetryEvents.PAGE_VIEW,
         { page_name: 'workflow_editor' }
       )
+      expect(hoisted.mockCapture).not.toHaveBeenCalledWith(
+        '$pageview',
+        expect.anything()
+      )
     })
 
-    it('forwards additional metadata', async () => {
+    it('forwards additional metadata to legacy page view event', async () => {
       const provider = createProvider()
       await vi.dynamicImportSettled()
 
@@ -658,6 +662,20 @@ describe('PostHogTelemetryProvider', () => {
       expect(hoisted.mockCapture).toHaveBeenCalledWith(
         TelemetryEvents.PAGE_VIEW,
         { page_name: 'workflow_editor', path: '/workflows/123' }
+      )
+    })
+
+    it('queues legacy page view event before initialization', async () => {
+      const provider = createProvider()
+
+      provider.trackPageView('workflow_editor')
+      expect(hoisted.mockCapture).not.toHaveBeenCalled()
+
+      await vi.dynamicImportSettled()
+
+      expect(hoisted.mockCapture).toHaveBeenCalledWith(
+        TelemetryEvents.PAGE_VIEW,
+        { page_name: 'workflow_editor' }
       )
     })
   })

--- a/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.ts
@@ -126,7 +126,7 @@ export class PostHogTelemetryProvider implements TelemetryProvider {
                 window.__CONFIG__?.posthog_api_host || 'https://t.comfy.org',
               ui_host: 'https://us.posthog.com',
               autocapture: false,
-              capture_pageview: false,
+              capture_pageview: 'history_change',
               capture_pageleave: false,
               persistence: 'localStorage+cookie',
               debug: import.meta.env.VITE_POSTHOG_DEBUG === 'true',


### PR DESCRIPTION
## Summary

This PR enables native PostHog `$pageview` capture for `cloud.comfy.org` by setting cloud PostHog `capture_pageview` to `history_change`.

This keeps `autocapture` disabled, preserves the existing custom `app:page_view` event, and lets the PostHog SDK capture the initial pageview plus SPA history navigation pageviews. The goal is to make cross-domain funnel tracking cleaner between `comfy.org` and `cloud.comfy.org`, since `comfy.org` already emits native `$pageview` events.

## Why

We want to measure the visitor funnel more accurately across:

- `comfy.org` visits
- `cloud.comfy.org` visits
- signup clicks / signup opened
- signup completion
- first cloud workflow run
- first subscription
- first credit purchase

Using native `$pageview` on both website and cloud should make PostHog and downstream warehouse/Hex analysis cleaner for trackable users, while leaving custom app pageview telemetry intact for existing consumers.

## Validation

- `pnpm test:unit src/platform/telemetry/providers/cloud/PostHogTelemetryProvider.test.ts`
- `pnpm typecheck`
- `pnpm lint:unstaged`
- pre-commit hook: `oxfmt`, `oxlint`, `eslint`, `pnpm typecheck`
- pre-push hook: `knip --cache`

Note: local validation printed an engine warning because the Codex runtime has Node `v24.14.0` while this repo declares `>=25 <26`; the commands above still passed.