### PR TITLE
fix(website): point launches Comfy MCP CTA to /mcp

### DIFF
--- a/apps/website/src/data/drops.ts
+++ b/apps/website/src/data/drops.ts
@@ -127,7 +127,7 @@ export const drops: readonly Drop[] = [
     },
     cta: {
       label: EXPLORE,
-      href: { en: externalLinks.docsMcp, 'zh-CN': externalLinks.docsMcp }
+      href: { en: '/mcp', 'zh-CN': '/zh-CN/mcp' }
     }
   },
   {


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Update the `EXPLORE` CTA on the Comfy MCP card on [/launches](https://comfy.org/launches) to link to [/mcp](https://comfy.org/mcp) instead of the docs (`docs.comfy.org/agent-tools/cloud`).

## Change

Single line in `apps/website/src/data/drops.ts`:

```diff
     cta: {
       label: EXPLORE,
-      href: { en: externalLinks.docsMcp, 'zh-CN': externalLinks.docsMcp }
+      href: { en: '/mcp', 'zh-CN': '/zh-CN/mcp' }
     }
```

Matches the locale-aware pattern used by sibling cards (`/download` / `/zh-CN/download`, `/api` / `/zh-CN/api`). Both `src/pages/mcp.astro` and `src/pages/zh-CN/mcp.astro` already exist, so neither link is dead. The `externalLinks.docsMcp` constant is retained because the MCP page itself still uses it.

## Verification

- `pnpm typecheck` / `pnpm typecheck:website` clean.
- `oxfmt`, `oxlint`, `eslint` clean (all ran via lint-staged on commit).
- Manually loaded `/launches` and `/zh-CN/launches` in the dev server and confirmed the Comfy MCP card now points to `/mcp` and `/zh-CN/mcp` respectively.
- Loaded `/mcp` and confirmed the destination page renders ("Comfy MCP — Drive ComfyUI from any AI agent").
- Code review by Oracle: no issues.

Screenshot shows the updated MCP card on /launches.

## Screenshots

![Comfy MCP card on /launches with EXPLORE button now linking to /mcp](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/9f315ccc2692129159ae31efab9464684ff2f6db3e144feae6dd52fd314c0b47/pr-images/1782765166237-5e83667b-8dc3-4182-9891-609385a1dae5.png)