### PR TITLE
refactor: brand link slot and reroute ids

### DIFF
--- a/src/composables/node/usePriceBadge.ts
+++ b/src/composables/node/usePriceBadge.ts
@@ -3,12 +3,13 @@ import { LGraphBadge } from '@/lib/litegraph/src/litegraph'
 
 import { useNodePricing } from '@/composables/node/useNodePricing'
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
+import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 import { adjustColor } from '@/utils/colorUtil'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 type LinkedWidgetInput = INodeInputSlot & {
-  _subgraphSlot?: { linkIds?: number[] }
+  _subgraphSlot?: SubgraphInput
 }
 
 const componentIconSvg = new Image()

--- a/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
+++ b/src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts
@@ -21,6 +21,7 @@ import {
   readHostQuarantine
 } from '@/core/graph/subgraph/migration/proxyWidgetMigration'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
+import { toLinkId } from '@/types/linkId'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 
 vi.mock('@/renderer/core/canvas/canvasStore', () => ({
@@ -369,7 +370,7 @@ describe('flushProxyWidgetMigration', () => {
       const host = buildHost()
       const { primitive } = addPrimitiveWithTargets(host, { targetCount: 1 })
 
-      const danglingLinkId = 999_999
+      const danglingLinkId = toLinkId(999_999)
       expect(host.subgraph.links.has(danglingLinkId)).toBe(false)
       primitive.outputs[0].links = [
         ...(primitive.outputs[0].links ?? []),

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -13,6 +13,7 @@ import {
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toLinkId } from '@/types/linkId'
 import type { WidgetId } from '@/types/widgetId'
 
 function promotedInputNames(host: {
@@ -800,7 +801,7 @@ describe('demoteWidget — axiomatic projection retraction', () => {
   it('drops projection but keeps slot and external link when host slot is externally connected', () => {
     const { host, interiorNode, interiorWidget } = setupPromotedWidget()
     const hostInput = host.inputs[0]
-    hostInput.link = 9999
+    hostInput.link = toLinkId(9999)
     const promotedInputId = hostInput.widgetId
 
     expect(host.subgraph.inputs).toHaveLength(1)

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -5,6 +5,7 @@ import { t } from '@/i18n'
 import type { IContextMenuValue } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
+import type { LinkId } from '@/types/linkId'
 import { reorderSubgraphInputs } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
@@ -63,7 +64,7 @@ export function findHostInputForPromotion(
 
 function resolvePromotionSource(
   subgraphNode: SubgraphNode,
-  subgraphInput: { linkIds: readonly number[] }
+  subgraphInput: { linkIds: readonly LinkId[] }
 ): PromotedWidgetSource | undefined {
   for (const linkId of subgraphInput.linkIds) {
     const link = subgraphNode.subgraph.getLink(linkId)

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -458,7 +458,7 @@ export function setWidgetConfig(slot: INodeInputSlot, config?: InputSpec) {
   if (!(slot instanceof NodeSlot)) return
   const graph = slot.node.graph
   if (!graph) return
-  const link = graph.links[slot.link ?? -1]
+  const link = graph.getLink(slot.link)
   if (!link) return
   const originNode = graph.getNodeById(link.origin_id)
   if (!originNode || !isPrimitiveNode(originNode)) return

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -17,6 +17,8 @@ import type { UUID } from '@/utils/uuid'
 import { zeroUuid } from '@/utils/uuid'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toLinkId } from '@/types/linkId'
+import { toRerouteId } from '@/types/rerouteId'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
 import { widgetId } from '@/types/widgetId'
 import {
@@ -132,7 +134,7 @@ describe('LGraph', () => {
 
     emptySubgraph.inputNode.pos = [0, 0]
     // Reroute needs offset of ~20y to align with first slot
-    const reroute = new Reroute(1, emptySubgraph, [0, 20])
+    const reroute = new Reroute(toRerouteId(1), emptySubgraph, [0, 20])
 
     node.snapToGrid(10)
     reroute.snapToGrid(10)
@@ -744,7 +746,14 @@ describe('ensureGlobalIdUniqueness', () => {
     subgraph._nodes.push(subNodeB)
     subgraph._nodes_by_id[subNodeB.id] = subNodeB
 
-    const link = new LLink(1, 'number', subNodeA.id, 0, subNodeB.id, 0)
+    const link = new LLink(
+      toLinkId(1),
+      'number',
+      subNodeA.id,
+      0,
+      subNodeB.id,
+      0
+    )
     subgraph._links.set(link.id, link)
 
     rootGraph.ensureGlobalIdUniqueness()
@@ -818,14 +827,9 @@ describe('_removeDuplicateLinks', () => {
     source: LGraphNode,
     target: LGraphNode
   ) {
-    const dup = new LLink(
-      ++graph.state.lastLinkId,
-      'number',
-      source.id,
-      0,
-      target.id,
-      0
-    )
+    const linkId = toLinkId(Number(graph.state.lastLinkId) + 1)
+    graph.state.lastLinkId = linkId
+    const dup = new LLink(linkId, 'number', source.id, 0, target.id, 0)
     graph._links.set(dup.id, dup)
     source.outputs[0].links!.push(dup.id)
     return dup
@@ -1001,8 +1005,10 @@ describe('Subgraph Unpacking', () => {
 
   function duplicateExistingLink(graph: LGraph, source: LGraphNode) {
     const existingLink = graph._links.values().next().value!
+    const linkId = toLinkId(Number(graph.state.lastLinkId) + 1)
+    graph.state.lastLinkId = linkId
     const dup = new LLink(
-      ++graph.state.lastLinkId,
+      linkId,
       existingLink.type,
       existingLink.origin_id,
       existingLink.origin_slot,

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1746,9 +1746,9 @@ export class LGraph
 
     const internalReroutes = new Map([...reroutes].map((r) => [r.id, r]))
     const externalReroutes = new Map(
-      [...this.reroutes]
-        .filter(([id]) => !internalReroutes.has(toRerouteId(id)))
-        .map(([id, reroute]) => [toRerouteId(id), reroute])
+      [...this.reroutes].filter(
+        ([id]) => !internalReroutes.has(toRerouteId(id))
+      )
     )
     const inputs = mapSubgraphInputsAndLinks(
       resolvedInputLinks,

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -240,7 +240,7 @@ export class LGraph
    * // Deprecated: const link = graph.links[linkId]
    * ```
    */
-  links: Map<LinkId, LLink> & Record<LinkId, LLink> & Record<number, LLink>
+  links: Map<LinkId, LLink> & Record<LinkId, LLink>
   list_of_graphcanvas: LGraphCanvas[] | null
   status: number = LGraph.STATUS_STOPPED
 
@@ -376,8 +376,7 @@ export class LGraph
       toLinkId(Number(value))
     )
     this.links = new Proxy(links, handler) as Map<LinkId, LLink> &
-      Record<LinkId, LLink> &
-      Record<number, LLink>
+      Record<LinkId, LLink>
 
     this.list_of_graphcanvas = null
     this.clear()

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -377,7 +377,6 @@ export class LGraph
     )
     this.links = new Proxy(links, handler) as Map<LinkId, LLink> &
       Record<LinkId, LLink> &
-      Record<number, LLink>
 
     this.list_of_graphcanvas = null
     this.clear()

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -376,7 +376,8 @@ export class LGraph
       toLinkId(Number(value))
     )
     this.links = new Proxy(links, handler) as Map<LinkId, LLink> &
-      Record<LinkId, LLink>
+      Record<LinkId, LLink> &
+      Record<number, LLink>
 
     this.list_of_graphcanvas = null
     this.clear()
@@ -1521,12 +1522,12 @@ export class LGraph
    * @param pos Position in graph space
    * @param before The existing link segment (reroute, link) that will be after this reroute,
    * going from the node output to input.
-   * @returns The newly created reroute - typically ignored.
+   * @returns The newly created reroute, or undefined when the segment cannot be resolved.
    */
-  createReroute(pos: Point, before: LinkSegment): Reroute {
+  createReroute(pos: Point, before: LinkSegment): Reroute | undefined {
     const layoutMutations = useLayoutMutations()
     if (!(before instanceof LLink) && !(before instanceof Reroute)) {
-      throw new TypeError('Cannot create reroute from unknown link segment.')
+      return
     }
     const rerouteId = toRerouteId(Number(this.state.lastRerouteId) + 1)
     this.state.lastRerouteId = rerouteId

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -228,7 +228,7 @@ export class LGraph
 
   _version: number = -1
   /** The backing store for links.  Keys are wrapped in String() */
-  _links: Map<LinkId | number, LLink> = new Map()
+  _links: Map<LinkId, LLink> = new Map()
   /**
    * Indexed property access is deprecated.
    * Backwards compatibility with a Proxy has been added, but will eventually be removed.
@@ -240,9 +240,7 @@ export class LGraph
    * // Deprecated: const link = graph.links[linkId]
    * ```
    */
-  links: Map<LinkId | number, LLink> &
-    Record<LinkId, LLink> &
-    Record<number, LLink>
+  links: Map<LinkId, LLink> & Record<LinkId, LLink> & Record<number, LLink>
   list_of_graphcanvas: LGraphCanvas[] | null
   status: number = LGraph.STATUS_STOPPED
 
@@ -312,15 +310,14 @@ export class LGraph
   /** Internal only.  Not required for serialisation; calculated on deserialise. */
   private _lastFloatingLinkId: number = 0
 
-  private readonly floatingLinksInternal: Map<LinkId | number, LLink> =
-    new Map()
-  get floatingLinks(): ReadonlyMap<LinkId | number, LLink> {
+  private readonly floatingLinksInternal: Map<LinkId, LLink> = new Map()
+  get floatingLinks(): ReadonlyMap<LinkId, LLink> {
     return this.floatingLinksInternal
   }
 
-  private readonly reroutesInternal = new Map<RerouteId | number, Reroute>()
+  private readonly reroutesInternal = new Map<RerouteId, Reroute>()
   /** All reroutes in this graph. */
-  public get reroutes(): Map<RerouteId | number, Reroute> {
+  public get reroutes(): Map<RerouteId, Reroute> {
     return this.reroutesInternal
   }
 
@@ -375,8 +372,10 @@ export class LGraph
     /** @see MapProxyHandler */
     const links = this._links
     MapProxyHandler.bindAllMethods(links)
-    const handler = new MapProxyHandler<LLink>()
-    this.links = new Proxy(links, handler) as Map<LinkId | number, LLink> &
+    const handler = new MapProxyHandler<LinkId, LLink>((value) =>
+      toLinkId(Number(value))
+    )
+    this.links = new Proxy(links, handler) as Map<LinkId, LLink> &
       Record<LinkId, LLink> &
       Record<number, LLink>
 
@@ -1473,9 +1472,9 @@ export class LGraph
    * @returns The link with the provided {@link id}, otherwise `undefined`. Always returns `undefined` if `id` is nullish.
    */
   getLink(id: null | undefined): undefined
-  getLink(id: LinkId | number | null | undefined): LLink | undefined
-  getLink(id: LinkId | number | null | undefined): LLink | undefined {
-    return id == null ? undefined : this._links.get(toLinkId(id))
+  getLink(id: LinkId | null | undefined): LLink | undefined
+  getLink(id: LinkId | null | undefined): LLink | undefined {
+    return id == null ? undefined : this._links.get(id)
   }
 
   /**
@@ -1527,12 +1526,14 @@ export class LGraph
    */
   createReroute(pos: Point, before: LinkSegment): Reroute {
     const layoutMutations = useLayoutMutations()
+    if (!(before instanceof LLink) && !(before instanceof Reroute)) {
+      throw new TypeError('Cannot create reroute from unknown link segment.')
+    }
     const rerouteId = toRerouteId(Number(this.state.lastRerouteId) + 1)
     this.state.lastRerouteId = rerouteId
-    const linkIds =
-      before instanceof Reroute ? before.linkIds : [toLinkId(before.id)]
+    const linkIds = before instanceof Reroute ? before.linkIds : [before.id]
     const floatingLinkIds =
-      before instanceof Reroute ? before.floatingLinkIds : [toLinkId(before.id)]
+      before instanceof Reroute ? before.floatingLinkIds : [before.id]
     const reroute = new Reroute(
       rerouteId,
       this,
@@ -3173,7 +3174,7 @@ export class Subgraph
 }
 
 function patchLinkNodeIds(
-  links: Map<LinkId | number, LLink>,
+  links: Map<LinkId, LLink>,
   remappedIds: Map<NodeId, NodeId>
 ): void {
   for (const link of links.values()) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -376,7 +376,7 @@ export class LGraph
       toLinkId(Number(value))
     )
     this.links = new Proxy(links, handler) as Map<LinkId, LLink> &
-      Record<LinkId, LLink> &
+      Record<LinkId, LLink>
 
     this.list_of_graphcanvas = null
     this.clear()

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1484,9 +1484,9 @@ export class LGraph
    * @returns The reroute with the provided {@link id}, otherwise `undefined`. Always returns `undefined` if `id` is nullish.
    */
   getReroute(id: null | undefined): undefined
-  getReroute(id: RerouteId | number | null | undefined): Reroute | undefined
-  getReroute(id: RerouteId | number | null | undefined): Reroute | undefined {
-    return id == null ? undefined : this.reroutes.get(toRerouteId(id))
+  getReroute(id: RerouteId | null | undefined): Reroute | undefined
+  getReroute(id: RerouteId | null | undefined): Reroute | undefined {
+    return id == null ? undefined : this.reroutes.get(id)
   }
 
   /**

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -9,6 +9,8 @@ import type { UUID } from '@/utils/uuid'
 import { createUuidv4, zeroUuid } from '@/utils/uuid'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import { toLinkId } from '@/types/linkId'
+import { toRerouteId } from '@/types/rerouteId'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { UNASSIGNED_NODE_ID, parseNodeId, toNodeId } from '@/types/nodeId'
@@ -226,7 +228,7 @@ export class LGraph
 
   _version: number = -1
   /** The backing store for links.  Keys are wrapped in String() */
-  _links: Map<LinkId, LLink> = new Map()
+  _links: Map<LinkId | number, LLink> = new Map()
   /**
    * Indexed property access is deprecated.
    * Backwards compatibility with a Proxy has been added, but will eventually be removed.
@@ -238,15 +240,17 @@ export class LGraph
    * // Deprecated: const link = graph.links[linkId]
    * ```
    */
-  links: Map<LinkId, LLink> & Record<LinkId, LLink>
+  links: Map<LinkId | number, LLink> &
+    Record<LinkId, LLink> &
+    Record<number, LLink>
   list_of_graphcanvas: LGraphCanvas[] | null
   status: number = LGraph.STATUS_STOPPED
 
   private _state: LGraphState = {
     lastGroupId: 0,
     lastNodeId: 0,
-    lastLinkId: 0,
-    lastRerouteId: 0
+    lastLinkId: toLinkId(0),
+    lastRerouteId: toRerouteId(0)
   }
 
   get state(): LGraphState {
@@ -308,14 +312,15 @@ export class LGraph
   /** Internal only.  Not required for serialisation; calculated on deserialise. */
   private _lastFloatingLinkId: number = 0
 
-  private readonly floatingLinksInternal: Map<LinkId, LLink> = new Map()
-  get floatingLinks(): ReadonlyMap<LinkId, LLink> {
+  private readonly floatingLinksInternal: Map<LinkId | number, LLink> =
+    new Map()
+  get floatingLinks(): ReadonlyMap<LinkId | number, LLink> {
     return this.floatingLinksInternal
   }
 
-  private readonly reroutesInternal = new Map<RerouteId, Reroute>()
+  private readonly reroutesInternal = new Map<RerouteId | number, Reroute>()
   /** All reroutes in this graph. */
-  public get reroutes(): Map<RerouteId, Reroute> {
+  public get reroutes(): Map<RerouteId | number, Reroute> {
     return this.reroutesInternal
   }
 
@@ -342,7 +347,7 @@ export class LGraph
   }
 
   set last_link_id(value) {
-    this.state.lastLinkId = value
+    this.state.lastLinkId = toLinkId(value)
   }
 
   onNodeAdded?(node: LGraphNode): void
@@ -371,8 +376,9 @@ export class LGraph
     const links = this._links
     MapProxyHandler.bindAllMethods(links)
     const handler = new MapProxyHandler<LLink>()
-    this.links = new Proxy(links, handler) as Map<LinkId, LLink> &
-      Record<LinkId, LLink>
+    this.links = new Proxy(links, handler) as Map<LinkId | number, LLink> &
+      Record<LinkId, LLink> &
+      Record<number, LLink>
 
     this.list_of_graphcanvas = null
     this.clear()
@@ -399,8 +405,8 @@ export class LGraph
     this.state = {
       lastGroupId: 0,
       lastNodeId: 0,
-      lastLinkId: 0,
-      lastRerouteId: 0
+      lastLinkId: toLinkId(0),
+      lastRerouteId: toRerouteId(0)
     }
 
     // used to detect changes
@@ -1415,7 +1421,7 @@ export class LGraph
 
   addFloatingLink(link: LLink): LLink {
     if (link.id === -1) {
-      link.id = ++this._lastFloatingLinkId
+      link.id = toLinkId(++this._lastFloatingLinkId)
     }
     this.floatingLinksInternal.set(link.id, link)
 
@@ -1467,9 +1473,9 @@ export class LGraph
    * @returns The link with the provided {@link id}, otherwise `undefined`. Always returns `undefined` if `id` is nullish.
    */
   getLink(id: null | undefined): undefined
-  getLink(id: LinkId | null | undefined): LLink | undefined
-  getLink(id: LinkId | null | undefined): LLink | undefined {
-    return id == null ? undefined : this._links.get(id)
+  getLink(id: LinkId | number | null | undefined): LLink | undefined
+  getLink(id: LinkId | number | null | undefined): LLink | undefined {
+    return id == null ? undefined : this._links.get(toLinkId(id))
   }
 
   /**
@@ -1478,9 +1484,9 @@ export class LGraph
    * @returns The reroute with the provided {@link id}, otherwise `undefined`. Always returns `undefined` if `id` is nullish.
    */
   getReroute(id: null | undefined): undefined
-  getReroute(id: RerouteId | null | undefined): Reroute | undefined
-  getReroute(id: RerouteId | null | undefined): Reroute | undefined {
-    return id == null ? undefined : this.reroutes.get(id)
+  getReroute(id: RerouteId | number | null | undefined): Reroute | undefined
+  getReroute(id: RerouteId | number | null | undefined): Reroute | undefined {
+    return id == null ? undefined : this.reroutes.get(toRerouteId(id))
   }
 
   /**
@@ -1495,12 +1501,20 @@ export class LGraph
     linkIds,
     floating
   }: OptionalProps<SerialisableReroute, 'id'>): Reroute {
-    id ??= ++this.state.lastRerouteId
-    if (id > this.state.lastRerouteId) this.state.lastRerouteId = id
+    const rerouteId =
+      id === undefined
+        ? toRerouteId(Number(this.state.lastRerouteId) + 1)
+        : toRerouteId(id)
+    if (rerouteId > this.state.lastRerouteId) {
+      this.state.lastRerouteId = rerouteId
+    }
 
-    const reroute = this.reroutes.get(id) ?? new Reroute(id, this)
-    reroute.update(parentId, pos, linkIds, floating)
-    this.reroutes.set(id, reroute)
+    const reroute = this.reroutes.get(rerouteId) ?? new Reroute(rerouteId, this)
+    const typedParentId =
+      parentId === undefined ? undefined : toRerouteId(parentId)
+    const typedLinkIds = linkIds?.map(toLinkId)
+    reroute.update(typedParentId, pos, typedLinkIds, floating)
+    this.reroutes.set(rerouteId, reroute)
     return reroute
   }
 
@@ -1513,10 +1527,12 @@ export class LGraph
    */
   createReroute(pos: Point, before: LinkSegment): Reroute {
     const layoutMutations = useLayoutMutations()
-    const rerouteId = ++this.state.lastRerouteId
-    const linkIds = before instanceof Reroute ? before.linkIds : [before.id]
+    const rerouteId = toRerouteId(Number(this.state.lastRerouteId) + 1)
+    this.state.lastRerouteId = rerouteId
+    const linkIds =
+      before instanceof Reroute ? before.linkIds : [toLinkId(before.id)]
     const floatingLinkIds =
-      before instanceof Reroute ? before.floatingLinkIds : [before.id]
+      before instanceof Reroute ? before.floatingLinkIds : [toLinkId(before.id)]
     const reroute = new Reroute(
       rerouteId,
       this,
@@ -1729,7 +1745,9 @@ export class LGraph
 
     const internalReroutes = new Map([...reroutes].map((r) => [r.id, r]))
     const externalReroutes = new Map(
-      [...this.reroutes].filter(([id]) => !internalReroutes.has(id))
+      [...this.reroutes]
+        .filter(([id]) => !internalReroutes.has(toRerouteId(id)))
+        .map(([id, reroute]) => [toRerouteId(id), reroute])
     )
     const inputs = mapSubgraphInputsAndLinks(
       resolvedInputLinks,
@@ -2192,7 +2210,11 @@ export class LGraph
       ) {
         console.error('Missing Parent ID')
       }
-      const migratedReroute = new Reroute(++this.state.lastRerouteId, this, [
+      const migratedRerouteId = toRerouteId(
+        Number(this.state.lastRerouteId) + 1
+      )
+      this.state.lastRerouteId = migratedRerouteId
+      const migratedReroute = new Reroute(migratedRerouteId, this, [
         reroute.pos[0] + offsetX,
         reroute.pos[1] + offsetY
       ])
@@ -2503,11 +2525,13 @@ export class LGraph
           if (lastGroupId != null)
             state.lastGroupId = Math.max(state.lastGroupId, lastGroupId)
           if (lastLinkId != null)
-            state.lastLinkId = Math.max(state.lastLinkId, lastLinkId)
+            state.lastLinkId = toLinkId(Math.max(state.lastLinkId, lastLinkId))
           if (lastNodeId != null)
             state.lastNodeId = Math.max(state.lastNodeId, lastNodeId)
           if (lastRerouteId != null)
-            state.lastRerouteId = Math.max(state.lastRerouteId, lastRerouteId)
+            state.lastRerouteId = toRerouteId(
+              Math.max(state.lastRerouteId, lastRerouteId)
+            )
         }
 
         // Links
@@ -3149,7 +3173,7 @@ export class Subgraph
 }
 
 function patchLinkNodeIds(
-  links: Map<LinkId, LLink>,
+  links: Map<LinkId | number, LLink>,
   remappedIds: Map<NodeId, NodeId>
 ): void {
   for (const link of links.values()) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1745,9 +1745,7 @@ export class LGraph
 
     const internalReroutes = new Map([...reroutes].map((r) => [r.id, r]))
     const externalReroutes = new Map(
-      [...this.reroutes].filter(
-        ([id]) => !internalReroutes.has(toRerouteId(id))
-      )
+      [...this.reroutes].filter(([id]) => !internalReroutes.has(id))
     )
     const inputs = mapSubgraphInputsAndLinks(
       resolvedInputLinks,

--- a/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts
@@ -9,6 +9,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import { LLink } from '@/lib/litegraph/src/LLink'
+import { toLinkId } from '@/types/linkId'
 import { createMockCanvas2DContext } from '@/utils/__tests__/litegraphTestUtils'
 
 vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
@@ -68,7 +69,8 @@ function createTestLink(
   targetNode: LGraphNode,
   inputSlot: number
 ): LLink {
-  const linkId = ++graph.state.lastLinkId
+  const linkId = toLinkId(Number(graph.state.lastLinkId) + 1)
+  graph.state.lastLinkId = linkId
   const link = new LLink(
     linkId,
     sourceNode.outputs[outputSlot].type,

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4294,9 +4294,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     // Remap linkIds
     for (const reroute of reroutes.values()) {
-      const ids = [...reroute.linkIds].map(
-        (x) => links.get(x)?.id ?? toLinkId(x)
-      )
+      const ids = [...reroute.linkIds].map((x) => links.get(x)?.id ?? x)
       reroute.update(reroute.parentId, undefined, ids, reroute.floating)
 
       // Remove any invalid items
@@ -4667,20 +4665,20 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       for (const input of item.inputs) {
         if (input.link == null) continue
 
-        const node = LLink.getOriginNode(graph, toLinkId(input.link))
+        const node = LLink.getOriginNode(graph, input.link)
         if (node && this.selectedItems.has(node)) continue
 
-        delete this.highlighted_links[toLinkId(input.link)]
+        delete this.highlighted_links[input.link]
       }
     }
     if (item.outputs) {
       for (const id of item.outputs.flatMap((x) => x.links)) {
         if (id == null) continue
 
-        const node = LLink.getTargetNode(graph, toLinkId(id))
+        const node = LLink.getTargetNode(graph, id)
         if (node && this.selectedItems.has(node)) continue
 
-        delete this.highlighted_links[toLinkId(id)]
+        delete this.highlighted_links[id]
       }
     }
   }

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -11,6 +11,8 @@ import { getSlotPosition } from '@/renderer/core/canvas/litegraph/slotCalculatio
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import { toLinkId } from '@/types/linkId'
+import { toRerouteId } from '@/types/rerouteId'
 import { forEachNode } from '@/utils/graphTraversalUtil'
 
 import { CanvasPointer } from './CanvasPointer'
@@ -4245,7 +4247,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
       const reroute = graph.setReroute(rerouteInfo)
       created.push(reroute)
-      reroutes.set(id, reroute)
+      reroutes.set(toRerouteId(id), reroute)
     }
 
     // Remap reroute parentIds for pasted reroutes
@@ -4262,9 +4264,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       let outNode: LGraphNode | null | undefined = nodes.get(
         serializeNodeId(info.origin_id)
       )
-      let afterRerouteId: number | undefined
+      let afterRerouteId: RerouteId | undefined
       if (info.parentId != null)
-        afterRerouteId = reroutes.get(info.parentId)?.id
+        afterRerouteId = reroutes.get(toRerouteId(info.parentId))?.id
 
       // If it wasn't copied, use the original graph value
       if (
@@ -4273,7 +4275,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       ) {
         const originNodeId = parseNodeId(info.origin_id)
         outNode ??= originNodeId ? graph.getNodeById(originNodeId) : null
-        afterRerouteId ??= info.parentId
+        if (info.parentId !== undefined) {
+          afterRerouteId ??= toRerouteId(info.parentId)
+        }
       }
 
       const inNode = nodes.get(serializeNodeId(info.target_id))
@@ -4284,13 +4288,15 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           info.target_slot,
           afterRerouteId
         )
-        if (link) links.set(info.id, link)
+        if (link) links.set(toLinkId(info.id), link)
       }
     }
 
     // Remap linkIds
     for (const reroute of reroutes.values()) {
-      const ids = [...reroute.linkIds].map((x) => links.get(x)?.id ?? x)
+      const ids = [...reroute.linkIds].map(
+        (x) => links.get(x)?.id ?? toLinkId(x)
+      )
       reroute.update(reroute.parentId, undefined, ids, reroute.floating)
 
       // Remove any invalid items
@@ -4661,20 +4667,20 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       for (const input of item.inputs) {
         if (input.link == null) continue
 
-        const node = LLink.getOriginNode(graph, input.link)
+        const node = LLink.getOriginNode(graph, toLinkId(input.link))
         if (node && this.selectedItems.has(node)) continue
 
-        delete this.highlighted_links[input.link]
+        delete this.highlighted_links[toLinkId(input.link)]
       }
     }
     if (item.outputs) {
       for (const id of item.outputs.flatMap((x) => x.links)) {
         if (id == null) continue
 
-        const node = LLink.getTargetNode(graph, id)
+        const node = LLink.getTargetNode(graph, toLinkId(id))
         if (node && this.selectedItems.has(node)) continue
 
-        delete this.highlighted_links[id]
+        delete this.highlighted_links[toLinkId(id)]
       }
     }
   }
@@ -6700,7 +6706,9 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           const linkId =
             segment instanceof Reroute
               ? segment.linkIds.values().next().value
-              : segment.id
+              : segment instanceof LLink
+                ? segment.id
+                : undefined
           if (linkId !== undefined) {
             graph.removeLink(linkId)
             // Clean up layout store

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -2591,6 +2591,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
             return
           } else if (e.altKey && !e.shiftKey) {
             const newReroute = graph.createReroute([x, y], linkSegment)
+            if (!newReroute) return
+
             pointer.onDragStart = (pointer) =>
               this._startDraggingItems(newReroute, pointer)
             pointer.onDragEnd = (e) => this._processDraggedItems(e)

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -185,7 +185,7 @@ describe('LGraphNode', () => {
       expect(disconnected).toBe(true)
       expect(node2.inputs[0].link).toBeNull()
       expect(node1.outputs[0].links?.length).toBe(0)
-      expect(graph._links.has(link?.id ?? -1)).toBe(false)
+      expect(graph._links.has(link!.id)).toBe(false)
 
       // Test disconnecting by slot name
       node1.connect(0, node2, 0)
@@ -248,8 +248,8 @@ describe('LGraphNode', () => {
       expect(disconnectedSpecific).toBe(true)
       expect(targetNode1.inputs[0].link).toBeNull()
       expect(sourceNode.outputs[0].links?.length).toBe(1)
-      expect(graph._links.has(link1?.id ?? -1)).toBe(false)
-      expect(graph._links.has(link2?.id ?? -1)).toBe(true)
+      expect(graph._links.has(link1!.id)).toBe(false)
+      expect(graph._links.has(link2!.id)).toBe(true)
 
       // Test disconnecting by slot name
       const link3 = sourceNode.connect(1, targetNode1, 0)
@@ -271,8 +271,8 @@ describe('LGraphNode', () => {
       expect(sourceNode.outputs[0].links).toBeNull()
       expect(targetNode1.inputs[0].link).toBeNull()
       expect(targetNode2.inputs[0].link).toBeNull()
-      expect(graph._links.has(link2?.id ?? -1)).toBe(false)
-      expect(graph._links.has(link4?.id ?? -1)).toBe(false)
+      expect(graph._links.has(link2!.id)).toBe(false)
+      expect(graph._links.has(link4!.id)).toBe(false)
 
       // Test disconnecting non-existent slot
       const invalidDisconnect = sourceNode.disconnectOutput(999)

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -8,6 +8,7 @@ import {
 import type { SlotPositionContext } from '@/renderer/core/canvas/litegraph/slotCalculations'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import { toLinkId } from '@/types/linkId'
 import { UNASSIGNED_NODE_ID, toNodeId, serializeNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 import { adjustColor } from '@/utils/colorUtil'
@@ -2940,8 +2941,11 @@ export class LGraphNode
     const maybeCommonType =
       input.type && output.type && commonType(input.type, output.type)
 
+    const linkId = toLinkId(Number(graph.state.lastLinkId) + 1)
+    graph.state.lastLinkId = linkId
+
     const link = new LLink(
-      ++graph.state.lastLinkId,
+      linkId,
       maybeCommonType || input.type || output.type,
       this.id,
       outputIndex,
@@ -3051,7 +3055,7 @@ export class LGraphNode
     // Adding from an output, or a floating reroute that is NOT the tip of an existing floating chain
     if (afterRerouteId == null || !fromLastFloatingReroute) {
       const link = new LLink(
-        -1,
+        toLinkId(-1),
         slot.type,
         outputIndex === -1 ? -1 : id,
         outputIndex,

--- a/src/lib/litegraph/src/LLink.test.ts
+++ b/src/lib/litegraph/src/LLink.test.ts
@@ -1,21 +1,22 @@
 import { describe, expect } from 'vitest'
 
 import { LLink } from '@/lib/litegraph/src/litegraph'
+import { toLinkId } from '@/types/linkId'
 
 import { test } from './__fixtures__/testExtensions'
 
 describe('LLink', () => {
   test('matches previous snapshot', () => {
-    const link = new LLink(1, 'float', 4, 2, 5, 3)
+    const link = new LLink(toLinkId(1), 'float', 4, 2, 5, 3)
     expect(link.serialize()).toMatchSnapshot('Basic')
   })
 
   test('serializes to the previous snapshot', () => {
-    const link = new LLink(1, 'float', 4, 2, 5, 3)
+    const link = new LLink(toLinkId(1), 'float', 4, 2, 5, 3)
     expect(link.serialize()).toMatchSnapshot('Basic')
   })
   test('matches numeric caller ids after endpoint normalization', () => {
-    const link = new LLink(1, 'float', 4, 2, 5, 3)
+    const link = new LLink(toLinkId(1), 'float', 4, 2, 5, 3)
 
     expect(link.hasOrigin(4, 2)).toBe(true)
     expect(link.hasTarget(5, 3)).toBe(true)

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -157,21 +157,21 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   }
 
   constructor(
-    id: LinkId | number,
+    id: LinkId,
     type: ISlotType,
     origin_id: SerializedNodeId,
     origin_slot: number,
     target_id: SerializedNodeId,
     target_slot: number,
-    parentId?: RerouteId | number
+    parentId?: RerouteId
   ) {
-    this.id = toLinkId(id)
+    this.id = id
     this.type = type
     this.origin_id = toNodeId(origin_id)
     this.origin_slot = origin_slot
     this.target_id = toNodeId(target_id)
     this.target_slot = target_slot
-    this.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
+    this.parentId = parentId
 
     this._data = null
     // center
@@ -180,7 +180,14 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
 
   /** @deprecated Use {@link LLink.create} */
   static createFromArray(data: SerialisedLLinkArray): LLink {
-    return new LLink(data[0], data[5], data[1], data[2], data[3], data[4])
+    return new LLink(
+      toLinkId(data[0]),
+      data[5],
+      data[1],
+      data[2],
+      data[3],
+      data[4]
+    )
   }
 
   /**
@@ -190,13 +197,13 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
    */
   static create(data: SerialisableLLink): LLink {
     return new LLink(
-      data.id,
+      toLinkId(data.id),
       data.type,
       data.origin_id,
       data.origin_slot,
       data.target_id,
       data.target_slot,
-      data.parentId
+      data.parentId === undefined ? undefined : toRerouteId(data.parentId)
     )
   }
 
@@ -277,7 +284,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
    * it is recommended to use simpler methods where appropriate.
    */
   static resolve(
-    linkId: LinkId | number | null | undefined,
+    linkId: LinkId | null | undefined,
     network: BasicReadonlyNetwork
   ): ResolvedConnection | undefined {
     return network.getLink(linkId)?.resolve(network)
@@ -292,12 +299,12 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
    * @see {@link LLink.resolve}
    */
   static resolveMany(
-    linkIds: Iterable<LinkId | number>,
+    linkIds: Iterable<LinkId>,
     network: BasicReadonlyNetwork
   ): ResolvedConnection[] {
     const resolved: ResolvedConnection[] = []
     for (const id of linkIds) {
-      const r = network.getLink(toLinkId(id))?.resolve(network)
+      const r = network.getLink(id)?.resolve(network)
       if (r) resolved.push(r)
     }
     return resolved
@@ -362,14 +369,13 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
       this.target_slot = o[4]
       this.type = o[5]
     } else {
-      this.id = toLinkId(o.id)
+      this.id = o.id
       this.type = o.type
       this.origin_id = o.origin_id
       this.origin_slot = o.origin_slot
       this.target_id = o.target_id
       this.target_slot = o.target_slot
-      this.parentId =
-        o.parentId === undefined ? undefined : toRerouteId(o.parentId)
+      this.parentId = o.parentId
     }
   }
 

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -6,11 +6,15 @@ import type { SubgraphInput } from '@/lib/litegraph/src/subgraph/SubgraphInput'
 import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput'
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { LayoutSource } from '@/renderer/core/layout/types'
+import { toLinkId } from '@/types/linkId'
 import { UNASSIGNED_NODE_ID, toNodeId, serializeNodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
 
+import type { LinkId } from '@/types/linkId'
+import type { RerouteId } from '@/types/rerouteId'
 import type { LGraphNode } from './LGraphNode'
 import type { NodeId, SerializedNodeId } from '@/types/nodeId'
-import type { Reroute, RerouteId } from './Reroute'
+import type { Reroute } from './Reroute'
 import type {
   CanvasColour,
   INodeInputSlot,
@@ -25,9 +29,9 @@ import type { Serialisable, SerialisableLLink } from './types/serialisation'
 
 const layoutMutations = useLayoutMutations()
 
-export type LinkId = number
+export type { LinkId } from '@/types/linkId'
 export type SerialisedLLinkArray = [
-  id: LinkId,
+  id: number,
   origin_id: SerializedNodeId,
   origin_slot: number,
   target_id: SerializedNodeId,
@@ -153,21 +157,21 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
   }
 
   constructor(
-    id: LinkId,
+    id: LinkId | number,
     type: ISlotType,
     origin_id: SerializedNodeId,
     origin_slot: number,
     target_id: SerializedNodeId,
     target_slot: number,
-    parentId?: RerouteId
+    parentId?: RerouteId | number
   ) {
-    this.id = id
+    this.id = toLinkId(id)
     this.type = type
     this.origin_id = toNodeId(origin_id)
     this.origin_slot = origin_slot
     this.target_id = toNodeId(target_id)
     this.target_slot = target_slot
-    this.parentId = parentId
+    this.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
 
     this._data = null
     // center
@@ -273,7 +277,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
    * it is recommended to use simpler methods where appropriate.
    */
   static resolve(
-    linkId: LinkId | null | undefined,
+    linkId: LinkId | number | null | undefined,
     network: BasicReadonlyNetwork
   ): ResolvedConnection | undefined {
     return network.getLink(linkId)?.resolve(network)
@@ -288,12 +292,12 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
    * @see {@link LLink.resolve}
    */
   static resolveMany(
-    linkIds: Iterable<LinkId>,
+    linkIds: Iterable<LinkId | number>,
     network: BasicReadonlyNetwork
   ): ResolvedConnection[] {
     const resolved: ResolvedConnection[] = []
     for (const id of linkIds) {
-      const r = network.getLink(id)?.resolve(network)
+      const r = network.getLink(toLinkId(id))?.resolve(network)
       if (r) resolved.push(r)
     }
     return resolved
@@ -351,20 +355,21 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
 
   configure(o: LLink | SerialisedLLinkArray) {
     if (Array.isArray(o)) {
-      this.id = o[0]
+      this.id = toLinkId(o[0])
       this.origin_id = toNodeId(o[1])
       this.origin_slot = o[2]
       this.target_id = toNodeId(o[3])
       this.target_slot = o[4]
       this.type = o[5]
     } else {
-      this.id = o.id
+      this.id = toLinkId(o.id)
       this.type = o.type
       this.origin_id = o.origin_id
       this.origin_slot = o.origin_slot
       this.target_id = o.target_id
       this.target_slot = o.target_slot
-      this.parentId = o.parentId
+      this.parentId =
+        o.parentId === undefined ? undefined : toRerouteId(o.parentId)
     }
   }
 
@@ -400,7 +405,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
    */
   toFloating(slotType: 'input' | 'output', parentId: RerouteId): LLink {
     const exported = this.asSerialisable()
-    exported.id = -1
+    exported.id = toLinkId(-1)
     exported.parentId = parentId
 
     if (slotType === 'input') {
@@ -434,7 +439,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
     // When floating from inputs, the final (input side) reroute may have many floating links
     if (outputFloating || (keepReroutes === 'input' && lastReroute)) {
       const newLink = LLink.create(this)
-      newLink.id = -1
+      newLink.id = toLinkId(-1)
 
       if (keepReroutes === 'input') {
         newLink.origin_id = UNASSIGNED_NODE_ID

--- a/src/lib/litegraph/src/MapProxyHandler.ts
+++ b/src/lib/litegraph/src/MapProxyHandler.ts
@@ -2,11 +2,19 @@
  * Temporary workaround until downstream consumers migrate to Map.
  * A brittle wrapper with many flaws, but should be fine for simple maps using int indexes.
  */
-export class MapProxyHandler<V> implements ProxyHandler<
-  Map<number | string, V>
-> {
+export class MapProxyHandler<
+  K extends number | string,
+  V
+> implements ProxyHandler<Map<K, V>> {
+  constructor(private readonly toKey: (value: number | string) => K) {}
+
+  private getKey(p: string): K {
+    const int = parseInt(p, 10)
+    return this.toKey(Number.isNaN(int) ? p : int)
+  }
+
   getOwnPropertyDescriptor(
-    target: Map<number | string, V>,
+    target: Map<K, V>,
     p: string | symbol
   ): PropertyDescriptor | undefined {
     const value = this.get(target, p)
@@ -19,40 +27,34 @@ export class MapProxyHandler<V> implements ProxyHandler<
     }
   }
 
-  has(target: Map<number | string, V>, p: string | symbol): boolean {
+  has(target: Map<K, V>, p: string | symbol): boolean {
     if (typeof p === 'symbol') return false
 
-    const int = parseInt(p, 10)
-    return target.has(!isNaN(int) ? int : p)
+    return target.has(this.getKey(p))
   }
 
-  ownKeys(target: Map<number | string, V>): ArrayLike<string | symbol> {
+  ownKeys(target: Map<K, V>): ArrayLike<string | symbol> {
     return [...target.keys()].map(String)
   }
 
-  get(target: Map<number | string, V>, p: string | symbol): V | undefined {
+  get(target: Map<K, V>, p: string | symbol): V | undefined {
     // Workaround does not support link IDs of "values", "entries", "constructor", etc.
     if (p in target) return Reflect.get(target, p, target)
     if (typeof p === 'symbol') return
 
-    const int = parseInt(p, 10)
-    return target.get(!isNaN(int) ? int : p)
+    return target.get(this.getKey(p))
   }
 
-  set(
-    target: Map<number | string, V>,
-    p: string | symbol,
-    newValue: V
-  ): boolean {
+  set(target: Map<K, V>, p: string | symbol, newValue: V): boolean {
     if (typeof p === 'symbol') return false
 
-    const int = parseInt(p, 10)
-    target.set(!isNaN(int) ? int : p, newValue)
+    target.set(this.getKey(p), newValue)
     return true
   }
 
-  deleteProperty(target: Map<number | string, V>, p: string | symbol): boolean {
-    return target.delete(p as number | string)
+  deleteProperty(target: Map<K, V>, p: string | symbol): boolean {
+    if (typeof p === 'symbol') return false
+    return target.delete(this.getKey(p))
   }
 
   static bindAllMethods(map: Map<unknown, unknown>): void {

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -1,6 +1,9 @@
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
+import { toLinkId } from '@/types/linkId'
 import type { NodeId } from '@/types/nodeId'
+import type { RerouteId } from '@/types/rerouteId'
 import { LayoutSource } from '@/renderer/core/layout/types'
 
 import { LGraphBadge } from './LGraphBadge'
@@ -24,7 +27,7 @@ import type { Serialisable, SerialisableReroute } from './types/serialisation'
 
 const layoutMutations = useLayoutMutations()
 
-export type RerouteId = number
+export type { RerouteId } from '@/types/rerouteId'
 
 /** The input or output slot that an incomplete reroute link is connected to. */
 export interface FloatingRerouteSlot {
@@ -52,6 +55,8 @@ export class Reroute
     const gap = Reroute.slotRadius * 0.33
     return Reroute.radius + gap + Reroute.slotRadius
   }
+
+  public readonly id: RerouteId
 
   /** The network this reroute belongs to.  Contains all valid links and reroutes. */
   private readonly network: WeakRef<LinkNetwork>
@@ -201,18 +206,19 @@ export class Reroute
    * @param linkIds Link IDs ({@link LLink.id}) of all links that use this reroute
    */
   constructor(
-    public readonly id: RerouteId,
+    id: RerouteId | number,
     network: LinkNetwork,
     pos?: Point,
-    parentId?: RerouteId,
-    linkIds?: Iterable<LinkId>,
-    floatingLinkIds?: Iterable<LinkId>
+    parentId?: RerouteId | number,
+    linkIds?: Iterable<LinkId | number>,
+    floatingLinkIds?: Iterable<LinkId | number>
   ) {
+    this.id = toRerouteId(id)
     this.network = new WeakRef(network)
-    this.parentId = parentId
+    this.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
     if (pos) this.pos = pos
-    this.linkIds = new Set(linkIds)
-    this.floatingLinkIds = new Set(floatingLinkIds)
+    this.linkIds = new Set(Array.from(linkIds ?? [], toLinkId))
+    this.floatingLinkIds = new Set(Array.from(floatingLinkIds ?? [], toLinkId))
   }
 
   /**
@@ -224,14 +230,14 @@ export class Reroute
    * @param linkIds All link IDs that pass through this reroute
    */
   update(
-    parentId: RerouteId | undefined,
+    parentId: RerouteId | number | undefined,
     pos?: Point,
-    linkIds?: Iterable<LinkId>,
+    linkIds?: Iterable<LinkId | number>,
     floating?: FloatingRerouteSlot
   ): void {
-    this.parentId = parentId
+    this.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
     if (pos) this.pos = pos
-    if (linkIds) this.linkIds = new Set(linkIds)
+    if (linkIds) this.linkIds = new Set(Array.from(linkIds, toLinkId))
     this.floating = floating
   }
 
@@ -241,8 +247,8 @@ export class Reroute
    * @returns true if any links remain after validation
    */
   validateLinks(
-    links: ReadonlyMap<LinkId, LLink>,
-    floatingLinks: ReadonlyMap<LinkId, LLink>
+    links: ReadonlyMap<LinkId | number, LLink>,
+    floatingLinks: ReadonlyMap<LinkId | number, LLink>
   ): boolean {
     const { linkIds, floatingLinkIds } = this
     for (const linkId of linkIds) {
@@ -345,7 +351,7 @@ export class Reroute
     function addAllResults(
       network: ReadonlyLinkNetwork,
       linkIds: Iterable<LinkId>,
-      links: ReadonlyMap<LinkId, LLink>
+      links: ReadonlyMap<LinkId | number, LLink>
     ) {
       for (const linkId of linkIds) {
         const link = links.get(linkId)
@@ -540,7 +546,7 @@ export class Reroute
      */
     function calculateAngles(
       linkIds: Iterable<LinkId>,
-      links: ReadonlyMap<LinkId, LLink>
+      links: ReadonlyMap<LinkId | number, LLink>
     ) {
       for (const linkId of linkIds) {
         const link = links.get(linkId)

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -1,7 +1,5 @@
 import { useLayoutMutations } from '@/renderer/core/layout/operations/layoutMutations'
 import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
-import { toRerouteId } from '@/types/rerouteId'
-import { toLinkId } from '@/types/linkId'
 import type { NodeId } from '@/types/nodeId'
 import type { RerouteId } from '@/types/rerouteId'
 import { LayoutSource } from '@/renderer/core/layout/types'
@@ -206,19 +204,19 @@ export class Reroute
    * @param linkIds Link IDs ({@link LLink.id}) of all links that use this reroute
    */
   constructor(
-    id: RerouteId | number,
+    id: RerouteId,
     network: LinkNetwork,
     pos?: Point,
-    parentId?: RerouteId | number,
-    linkIds?: Iterable<LinkId | number>,
-    floatingLinkIds?: Iterable<LinkId | number>
+    parentId?: RerouteId,
+    linkIds?: Iterable<LinkId>,
+    floatingLinkIds?: Iterable<LinkId>
   ) {
-    this.id = toRerouteId(id)
+    this.id = id
     this.network = new WeakRef(network)
-    this.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
+    this.parentId = parentId
     if (pos) this.pos = pos
-    this.linkIds = new Set(Array.from(linkIds ?? [], toLinkId))
-    this.floatingLinkIds = new Set(Array.from(floatingLinkIds ?? [], toLinkId))
+    this.linkIds = new Set(linkIds)
+    this.floatingLinkIds = new Set(floatingLinkIds)
   }
 
   /**
@@ -230,14 +228,14 @@ export class Reroute
    * @param linkIds All link IDs that pass through this reroute
    */
   update(
-    parentId: RerouteId | number | undefined,
+    parentId: RerouteId | undefined,
     pos?: Point,
-    linkIds?: Iterable<LinkId | number>,
+    linkIds?: Iterable<LinkId>,
     floating?: FloatingRerouteSlot
   ): void {
-    this.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
+    this.parentId = parentId
     if (pos) this.pos = pos
-    if (linkIds) this.linkIds = new Set(Array.from(linkIds, toLinkId))
+    if (linkIds) this.linkIds = new Set(linkIds)
     this.floating = floating
   }
 
@@ -247,8 +245,8 @@ export class Reroute
    * @returns true if any links remain after validation
    */
   validateLinks(
-    links: ReadonlyMap<LinkId | number, LLink>,
-    floatingLinks: ReadonlyMap<LinkId | number, LLink>
+    links: ReadonlyMap<LinkId, LLink>,
+    floatingLinks: ReadonlyMap<LinkId, LLink>
   ): boolean {
     const { linkIds, floatingLinkIds } = this
     for (const linkId of linkIds) {
@@ -351,7 +349,7 @@ export class Reroute
     function addAllResults(
       network: ReadonlyLinkNetwork,
       linkIds: Iterable<LinkId>,
-      links: ReadonlyMap<LinkId | number, LLink>
+      links: ReadonlyMap<LinkId, LLink>
     ) {
       for (const linkId of linkIds) {
         const link = links.get(linkId)
@@ -546,7 +544,7 @@ export class Reroute
      */
     function calculateAngles(
       linkIds: Iterable<LinkId>,
-      links: ReadonlyMap<LinkId | number, LLink>
+      links: ReadonlyMap<LinkId, LLink>
     ) {
       for (const linkId of linkIds) {
         const link = links.get(linkId)

--- a/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
@@ -17,7 +17,10 @@ import {
   LinkDirection
 } from '@/lib/litegraph/src/litegraph'
 import type { ConnectingLink } from '@/lib/litegraph/src/interfaces'
+import type { LinkId } from '@/types/linkId'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
 import {
   createMockNodeInputSlot,
   createMockNodeOutputSlot
@@ -39,11 +42,11 @@ interface TestContext {
 const test = baseTest.extend<TestContext>({
   network: async ({}, use) => {
     const graph = new LGraph()
-    const floatingLinks = new Map<number, LLink>()
-    const reroutes = new Map<number, Reroute>()
+    const floatingLinks = new Map<LinkId, LLink>()
+    const reroutes = new Map<RerouteId, Reroute>()
 
     await use({
-      links: new Map<number, LLink>(),
+      links: new Map<LinkId, LLink>(),
       reroutes,
       floatingLinks,
       getLink: graph.getLink.bind(graph),
@@ -55,7 +58,7 @@ const test = baseTest.extend<TestContext>({
       removeFloatingLink: (link: LLink) => floatingLinks.delete(link.id),
       getReroute: ((id: RerouteId | null | undefined) =>
         id == null ? undefined : reroutes.get(id)) as LinkNetwork['getReroute'],
-      removeReroute: (id: number) => reroutes.delete(id),
+      removeReroute: (id: RerouteId) => reroutes.delete(id),
       add: (node: LGraphNode) => graph.add(node)
     })
   },
@@ -88,7 +91,7 @@ const test = baseTest.extend<TestContext>({
         targetId: number,
         slotType: ISlotType = 'number'
       ): LLink => {
-        const link = new LLink(id, slotType, sourceId, 0, targetId, 0)
+        const link = new LLink(toLinkId(id), slotType, sourceId, 0, targetId, 0)
         network.links.set(link.id, link)
         return link
       }
@@ -122,7 +125,7 @@ describe('LinkConnector', () => {
       sourceNode.addOutput('out', slotType)
       targetNode.addInput('in', slotType)
 
-      const link = new LLink(1, slotType, 1, 0, 2, 0)
+      const link = new LLink(toLinkId(1), slotType, 1, 0, 2, 0)
       network.links.set(link.id, link)
       targetNode.inputs[0].link = link.id
 
@@ -141,7 +144,10 @@ describe('LinkConnector', () => {
       connector.state.connectingTo = 'input'
 
       expect(() => {
-        connector.moveInputLink(network, createMockNodeInputSlot({ link: 1 }))
+        connector.moveInputLink(
+          network,
+          createMockNodeInputSlot({ link: toLinkId(1) })
+        )
       }).toThrow('Already dragging links.')
     })
   })
@@ -159,7 +165,7 @@ describe('LinkConnector', () => {
       sourceNode.addOutput('out', slotType)
       targetNode.addInput('in', slotType)
 
-      const link = new LLink(1, slotType, 1, 0, 2, 0)
+      const link = new LLink(toLinkId(1), slotType, 1, 0, 2, 0)
       network.links.set(link.id, link)
       sourceNode.outputs[0].links = [link.id]
 
@@ -181,7 +187,7 @@ describe('LinkConnector', () => {
       expect(() => {
         connector.moveOutputLink(
           network,
-          createMockNodeOutputSlot({ links: [1] })
+          createMockNodeOutputSlot({ links: [toLinkId(1)] })
         )
       }).toThrow('Already dragging links.')
     })
@@ -235,7 +241,9 @@ describe('LinkConnector', () => {
       targetNode.addInput('in', 'number')
 
       const link = createTestLink(1, 1, 2)
-      const reroute = new Reroute(1, network, [0, 0], undefined, [link.id])
+      const reroute = new Reroute(toRerouteId(1), network, [0, 0], undefined, [
+        link.id
+      ])
       network.reroutes.set(reroute.id, reroute)
       link.parentId = reroute.id
 
@@ -262,11 +270,11 @@ describe('LinkConnector', () => {
       connector.state.multi = true
       connector.state.draggingExistingLinks = true
 
-      const link = new LLink(1, 'number', 1, 0, 2, 0)
+      const link = new LLink(toLinkId(1), 'number', 1, 0, 2, 0)
       link._dragging = true
       connector.inputLinks.push(link)
 
-      const reroute = new Reroute(1, network)
+      const reroute = new Reroute(toRerouteId(1), network)
       reroute.pos = [0, 0]
       reroute._dragging = true
       connector.hiddenReroutes.add(reroute)
@@ -303,7 +311,7 @@ describe('LinkConnector', () => {
         fromPos: [0, 0],
         fromDirection: LinkDirection.RIGHT,
         toType: 'input',
-        link: new LLink(1, 'number', 1, 0, 2, 0)
+        link: new LLink(toLinkId(1), 'number', 1, 0, 2, 0)
       } as MovingInputLink
 
       connector.events.dispatch('input-moved', mockRenderLink)
@@ -320,7 +328,7 @@ describe('LinkConnector', () => {
       connector.state.connectingTo = 'input'
       connector.state.multi = true
 
-      const link = new LLink(1, 'number', 1, 0, 2, 0)
+      const link = new LLink(toLinkId(1), 'number', 1, 0, 2, 0)
       connector.inputLinks.push(link)
 
       const exported = connector.export(network)

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -14,7 +14,7 @@ import { test as baseTest } from '../__fixtures__/testExtensions'
 import type { ConnectingLink } from '@/lib/litegraph/src/interfaces'
 import { toLinkId } from '@/types/linkId'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
-import { toRerouteId as toBrandedRerouteId } from '@/types/rerouteId'
+import { toRerouteId } from '@/types/rerouteId'
 import {
   createMockCanvasPointerEvent,
   createMockCanvasRenderingContext2D
@@ -183,7 +183,7 @@ const test = baseTest.extend<TestContext>({
   },
 
   floatingReroute: async ({ graph }, use) => {
-    const floatingReroute = graph.reroutes.get(toBrandedRerouteId(1))!
+    const floatingReroute = graph.reroutes.get(toRerouteId(1))!
     expect(floatingReroute.floating).toEqual({ slotType: 'output' })
     await use(floatingReroute)
   }
@@ -310,7 +310,7 @@ describe('LinkConnector Integration', () => {
 
       // Should have lost one reroute
       expect(graph.reroutes.size).toBe(reroutesBeforeTest.length - 1)
-      expect(graph.reroutes.get(toBrandedRerouteId(1))).toBeUndefined()
+      expect(graph.reroutes.get(toRerouteId(1))).toBeUndefined()
 
       // The two normal links should now be floating
       expect(graph.floatingLinks.size).toBe(2)
@@ -449,7 +449,7 @@ describe('LinkConnector Integration', () => {
 
       // Should have lost one reroute
       expect(graph.reroutes.size).toBe(reroutesBeforeTest.length - 1)
-      expect(graph.reroutes.get(toBrandedRerouteId(1))).toBeUndefined()
+      expect(graph.reroutes.get(toRerouteId(1))).toBeUndefined()
 
       // The two normal links should now be floating
       expect(graph.floatingLinks.size).toBe(2)
@@ -515,7 +515,7 @@ describe('LinkConnector Integration', () => {
 
       // The normal link should now be floating
       expect(graph.floatingLinks.size).toBe(2)
-      expect(graph.reroutes.get(toBrandedRerouteId(3))!.floating).toEqual({
+      expect(graph.reroutes.get(toRerouteId(3))!.floating).toEqual({
         slotType: 'output'
       })
 
@@ -524,7 +524,7 @@ describe('LinkConnector Integration', () => {
 
       // Should have lost one reroute
       expect(graph.reroutes.size).toBe(9)
-      expect(graph.reroutes.get(toBrandedRerouteId(1))).toBeUndefined()
+      expect(graph.reroutes.get(toRerouteId(1))).toBeUndefined()
 
       // Removed 4 reroutes
       expect(graph.reroutes.size).toBe(9)
@@ -577,9 +577,9 @@ describe('LinkConnector Integration', () => {
     }) => {
       const manyOutputsNode = graph.getNodeById(toNodeId(4))!
 
-      const reroute7 = graph.reroutes.get(toBrandedRerouteId(7))!
-      const reroute10 = graph.reroutes.get(toBrandedRerouteId(10))!
-      const reroute13 = graph.reroutes.get(toBrandedRerouteId(13))!
+      const reroute7 = graph.reroutes.get(toRerouteId(7))!
+      const reroute10 = graph.reroutes.get(toRerouteId(10))!
+      const reroute13 = graph.reroutes.get(toRerouteId(13))!
 
       const canvasX = reroute7.pos[0]
       const canvasY = reroute7.pos[1]
@@ -719,7 +719,7 @@ describe('LinkConnector Integration', () => {
       floatingReroute,
       validateIntegrityFloatingRemoved
     }) => {
-      const reroute8 = graph.reroutes.get(toBrandedRerouteId(8))!
+      const reroute8 = graph.reroutes.get(toRerouteId(8))!
       const canvasX = reroute8.pos[0]
       const canvasY = reroute8.pos[1]
 
@@ -765,7 +765,7 @@ describe('LinkConnector Integration', () => {
       floatingReroute,
       validateIntegrityNoChanges
     }) => {
-      const rerouteWithTwoLinks = graph.reroutes.get(toBrandedRerouteId(3))!
+      const rerouteWithTwoLinks = graph.reroutes.get(toRerouteId(3))!
       const targetNode = graph.getNodeById(toNodeId(2))!
 
       const targetDropEvent = mockedInputDropEvent(targetNode, 0)
@@ -955,13 +955,11 @@ describe('LinkConnector Integration', () => {
 
       // Parent reroutes of the target reroute
       for (const [index, parentId] of parentIds.entries()) {
-        const reroute = graph.reroutes.get(toBrandedRerouteId(parentId))!
+        const reroute = graph.reroutes.get(toRerouteId(parentId))!
         expect(reroute.linkIds.size).toBe(linksBefore[index])
       }
 
-      const targetReroute = graph.reroutes.get(
-        toBrandedRerouteId(targetRerouteId)
-      )!
+      const targetReroute = graph.reroutes.get(toRerouteId(targetRerouteId))!
       const nextLinkIds = getNextLinkIds(targetReroute.linkIds)
       const dropEvent = createMockCanvasPointerEvent(
         targetReroute.pos[0],
@@ -981,7 +979,7 @@ describe('LinkConnector Integration', () => {
 
       // Parent reroutes should have lost the links or been removed
       for (const [index, parentId] of parentIds.entries()) {
-        const reroute = graph.reroutes.get(toBrandedRerouteId(parentId))!
+        const reroute = graph.reroutes.get(toRerouteId(parentId))!
         if (linksAfter[index] === undefined) {
           expect(reroute).not.toBeUndefined()
         } else {
@@ -1001,10 +999,10 @@ describe('LinkConnector Integration', () => {
     /** Drag link from this reroute */
     fromRerouteId: number
     /** Drop link on this reroute */
-    toRerouteId: number
+    targetRerouteId: number
     /** Reroute IDs that should be removed from the resultant reroute chain */
     shouldBeRemoved: number[]
-    /** Reroutes that should have NONE of the link IDs that toReroute has */
+    /** Reroutes that should have NONE of the link IDs that targetReroute has */
     shouldHaveLinkIdsRemoved: number[]
     /** Whether to test floating inputs */
     testFloatingInputs?: true
@@ -1015,43 +1013,43 @@ describe('LinkConnector Integration', () => {
   test.for<ReconnectTestData>([
     {
       fromRerouteId: 10,
-      toRerouteId: 15,
+      targetRerouteId: 15,
       shouldBeRemoved: [14],
       shouldHaveLinkIdsRemoved: [13, 8, 6, 7]
     },
     {
       fromRerouteId: 8,
-      toRerouteId: 2,
+      targetRerouteId: 2,
       shouldBeRemoved: [4],
       shouldHaveLinkIdsRemoved: []
     },
     {
       fromRerouteId: 3,
-      toRerouteId: 12,
+      targetRerouteId: 12,
       shouldBeRemoved: [11],
       shouldHaveLinkIdsRemoved: [10, 13, 14, 15, 8, 6, 7]
     },
     {
       fromRerouteId: 15,
-      toRerouteId: 7,
+      targetRerouteId: 7,
       shouldBeRemoved: [8, 6],
       shouldHaveLinkIdsRemoved: []
     },
     {
       fromRerouteId: 1,
-      toRerouteId: 7,
+      targetRerouteId: 7,
       shouldBeRemoved: [8, 6],
       shouldHaveLinkIdsRemoved: []
     },
     {
       fromRerouteId: 1,
-      toRerouteId: 10,
+      targetRerouteId: 10,
       shouldBeRemoved: [],
       shouldHaveLinkIdsRemoved: []
     },
     {
       fromRerouteId: 4,
-      toRerouteId: 8,
+      targetRerouteId: 8,
       shouldBeRemoved: [],
       shouldHaveLinkIdsRemoved: [],
       testFloatingInputs: true,
@@ -1059,7 +1057,7 @@ describe('LinkConnector Integration', () => {
     },
     {
       fromRerouteId: 2,
-      toRerouteId: 12,
+      targetRerouteId: 12,
       shouldBeRemoved: [11],
       shouldHaveLinkIdsRemoved: [],
       testFloatingInputs: true,
@@ -1070,7 +1068,7 @@ describe('LinkConnector Integration', () => {
     (
       {
         fromRerouteId,
-        toRerouteId,
+        targetRerouteId,
         shouldBeRemoved,
         shouldHaveLinkIdsRemoved,
         testFloatingInputs,
@@ -1083,11 +1081,14 @@ describe('LinkConnector Integration', () => {
         graph.getNodeById(toNodeId(4))!.disconnectOutput(0)
       }
 
-      const fromReroute = graph.reroutes.get(toBrandedRerouteId(fromRerouteId))!
-      const toReroute = graph.reroutes.get(toBrandedRerouteId(toRerouteId))!
-      const nextLinkIds = getNextLinkIds(toReroute.linkIds, expectedExtraLinks)
+      const fromReroute = graph.reroutes.get(toRerouteId(fromRerouteId))!
+      const targetReroute = graph.reroutes.get(toRerouteId(targetRerouteId))!
+      const nextLinkIds = getNextLinkIds(
+        targetReroute.linkIds,
+        expectedExtraLinks
+      )
 
-      const originalParentChain = LLink.getReroutes(graph, toReroute)
+      const originalParentChain = LLink.getReroutes(graph, targetReroute)
 
       const sortAndJoin = (numbers: Iterable<number>) =>
         // oxlint-disable-next-line require-array-sort-compare
@@ -1098,7 +1099,7 @@ describe('LinkConnector Integration', () => {
 
       // Sanity check shouldBeRemoved
       const reroutesWithIdenticalLinkIds = originalParentChain.filter(
-        (parent) => hasIdenticalLinks(parent, toReroute)
+        (parent) => hasIdenticalLinks(parent, targetReroute)
       )
       expect(reroutesWithIdenticalLinkIds.map((reroute) => reroute.id)).toEqual(
         shouldBeRemoved
@@ -1107,13 +1108,13 @@ describe('LinkConnector Integration', () => {
       connector.dragFromReroute(graph, fromReroute)
 
       const dropEvent = createMockCanvasPointerEvent(
-        toReroute.pos[0],
-        toReroute.pos[1]
+        targetReroute.pos[0],
+        targetReroute.pos[1]
       )
       connector.dropLinks(graph, dropEvent)
       connector.reset()
 
-      const newParentChain = LLink.getReroutes(graph, toReroute)
+      const newParentChain = LLink.getReroutes(graph, targetReroute)
       for (const rerouteId of shouldBeRemoved) {
         expect(originalParentChain.map((reroute) => reroute.id)).toContain(
           rerouteId
@@ -1123,10 +1124,10 @@ describe('LinkConnector Integration', () => {
         )
       }
 
-      expect([...toReroute.linkIds.values()]).toEqual(nextLinkIds)
+      expect([...targetReroute.linkIds.values()]).toEqual(nextLinkIds)
 
       for (const rerouteId of shouldBeRemoved) {
-        const reroute = graph.reroutes.get(toBrandedRerouteId(rerouteId))!
+        const reroute = graph.reroutes.get(toRerouteId(rerouteId))!
         if (testFloatingInputs) {
           // Already-floating reroutes should be removed
           expect(reroute).toBeUndefined()
@@ -1137,8 +1138,8 @@ describe('LinkConnector Integration', () => {
       }
 
       for (const rerouteId of shouldHaveLinkIdsRemoved) {
-        const reroute = graph.reroutes.get(toBrandedRerouteId(rerouteId))!
-        for (const linkId of toReroute.linkIds) {
+        const reroute = graph.reroutes.get(toRerouteId(rerouteId))!
+        for (const linkId of targetReroute.linkIds) {
           expect(reroute.linkIds).not.toContain(linkId)
         }
       }
@@ -1176,8 +1177,8 @@ describe('LinkConnector Integration', () => {
       const listener = vi.fn()
       connector.listenUntilReset('link-created', listener)
 
-      const fromReroute = graph.reroutes.get(toBrandedRerouteId(from))!
-      const toReroute = graph.reroutes.get(toBrandedRerouteId(to))!
+      const fromReroute = graph.reroutes.get(toRerouteId(from))!
+      const toReroute = graph.reroutes.get(toRerouteId(to))!
 
       const dropEvent = createMockCanvasPointerEvent(
         toReroute.pos[0],
@@ -1194,15 +1195,15 @@ describe('LinkConnector Integration', () => {
   )
 
   const nodeReroutePairs = [
-    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(1) },
-    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(3) },
-    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(4) },
-    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(2) },
-    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(7) },
-    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(6) },
-    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(8) },
-    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(10) },
-    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(12) }
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(1) },
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(3) },
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(4) },
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(2) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(7) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(6) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(8) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(10) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(12) }
   ]
   test.for(nodeReroutePairs)(
     'Should ignore connections from input to same node via reroutes',

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -23,7 +23,7 @@ interface TestContext {
   connector: LinkConnector
   setConnectingLinks: (value: ConnectingLink[]) => void
   createTestNode: (id: number) => LGraphNode
-  reroutesBeforeTest: [rerouteId: RerouteId, reroute: Reroute][]
+  reroutesBeforeTest: [rerouteId: RerouteId | number, reroute: Reroute][]
   validateIntegrityNoChanges: () => void
   validateIntegrityFloatingRemoved: () => void
   validateLinkIntegrity: () => void

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -12,8 +12,9 @@ import { LGraphNode, LLink, LinkConnector } from '@/lib/litegraph/src/litegraph'
 
 import { test as baseTest } from '../__fixtures__/testExtensions'
 import type { ConnectingLink } from '@/lib/litegraph/src/interfaces'
+import { toLinkId } from '@/types/linkId'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
-import { toRerouteId } from '@/types/rerouteId'
+import { toRerouteId as toBrandedRerouteId } from '@/types/rerouteId'
 import {
   createMockCanvasPointerEvent,
   createMockCanvasRenderingContext2D
@@ -24,7 +25,7 @@ interface TestContext {
   connector: LinkConnector
   setConnectingLinks: (value: ConnectingLink[]) => void
   createTestNode: (id: number) => LGraphNode
-  reroutesBeforeTest: [rerouteId: RerouteId | number, reroute: Reroute][]
+  reroutesBeforeTest: [rerouteId: RerouteId, reroute: Reroute][]
   validateIntegrityNoChanges: () => void
   validateIntegrityFloatingRemoved: () => void
   validateLinkIntegrity: () => void
@@ -182,7 +183,7 @@ const test = baseTest.extend<TestContext>({
   },
 
   floatingReroute: async ({ graph }, use) => {
-    const floatingReroute = graph.reroutes.get(1)!
+    const floatingReroute = graph.reroutes.get(toBrandedRerouteId(1))!
     expect(floatingReroute.floating).toEqual({ slotType: 'output' })
     await use(floatingReroute)
   }
@@ -309,7 +310,7 @@ describe('LinkConnector Integration', () => {
 
       // Should have lost one reroute
       expect(graph.reroutes.size).toBe(reroutesBeforeTest.length - 1)
-      expect(graph.reroutes.get(1)).toBeUndefined()
+      expect(graph.reroutes.get(toBrandedRerouteId(1))).toBeUndefined()
 
       // The two normal links should now be floating
       expect(graph.floatingLinks.size).toBe(2)
@@ -448,7 +449,7 @@ describe('LinkConnector Integration', () => {
 
       // Should have lost one reroute
       expect(graph.reroutes.size).toBe(reroutesBeforeTest.length - 1)
-      expect(graph.reroutes.get(1)).toBeUndefined()
+      expect(graph.reroutes.get(toBrandedRerouteId(1))).toBeUndefined()
 
       // The two normal links should now be floating
       expect(graph.floatingLinks.size).toBe(2)
@@ -514,14 +515,16 @@ describe('LinkConnector Integration', () => {
 
       // The normal link should now be floating
       expect(graph.floatingLinks.size).toBe(2)
-      expect(graph.reroutes.get(3)!.floating).toEqual({ slotType: 'output' })
+      expect(graph.reroutes.get(toBrandedRerouteId(3))!.floating).toEqual({
+        slotType: 'output'
+      })
 
       const floatingOutNode = graph.getNodeById(toNodeId(1))!
       floatingOutNode.disconnectOutput(0)
 
       // Should have lost one reroute
       expect(graph.reroutes.size).toBe(9)
-      expect(graph.reroutes.get(1)).toBeUndefined()
+      expect(graph.reroutes.get(toBrandedRerouteId(1))).toBeUndefined()
 
       // Removed 4 reroutes
       expect(graph.reroutes.size).toBe(9)
@@ -574,9 +577,9 @@ describe('LinkConnector Integration', () => {
     }) => {
       const manyOutputsNode = graph.getNodeById(toNodeId(4))!
 
-      const reroute7 = graph.reroutes.get(7)!
-      const reroute10 = graph.reroutes.get(10)!
-      const reroute13 = graph.reroutes.get(13)!
+      const reroute7 = graph.reroutes.get(toBrandedRerouteId(7))!
+      const reroute10 = graph.reroutes.get(toBrandedRerouteId(10))!
+      const reroute13 = graph.reroutes.get(toBrandedRerouteId(13))!
 
       const canvasX = reroute7.pos[0]
       const canvasY = reroute7.pos[1]
@@ -584,7 +587,7 @@ describe('LinkConnector Integration', () => {
 
       const toSortedRerouteChain = (linkIds: number[]) =>
         linkIds
-          .map((x) => graph.links.get(x)!)
+          .map((x) => graph.links.get(toLinkId(x))!)
           .map((x) => LLink.getReroutes(graph, x))
           .sort((a, b) => a.at(-1)!.id - b.at(-1)!.id)
 
@@ -716,7 +719,7 @@ describe('LinkConnector Integration', () => {
       floatingReroute,
       validateIntegrityFloatingRemoved
     }) => {
-      const reroute8 = graph.reroutes.get(8)!
+      const reroute8 = graph.reroutes.get(toBrandedRerouteId(8))!
       const canvasX = reroute8.pos[0]
       const canvasY = reroute8.pos[1]
 
@@ -762,7 +765,7 @@ describe('LinkConnector Integration', () => {
       floatingReroute,
       validateIntegrityNoChanges
     }) => {
-      const rerouteWithTwoLinks = graph.reroutes.get(3)!
+      const rerouteWithTwoLinks = graph.reroutes.get(toBrandedRerouteId(3))!
       const targetNode = graph.getNodeById(toNodeId(2))!
 
       const targetDropEvent = mockedInputDropEvent(targetNode, 0)
@@ -952,11 +955,13 @@ describe('LinkConnector Integration', () => {
 
       // Parent reroutes of the target reroute
       for (const [index, parentId] of parentIds.entries()) {
-        const reroute = graph.reroutes.get(parentId)!
+        const reroute = graph.reroutes.get(toBrandedRerouteId(parentId))!
         expect(reroute.linkIds.size).toBe(linksBefore[index])
       }
 
-      const targetReroute = graph.reroutes.get(targetRerouteId)!
+      const targetReroute = graph.reroutes.get(
+        toBrandedRerouteId(targetRerouteId)
+      )!
       const nextLinkIds = getNextLinkIds(targetReroute.linkIds)
       const dropEvent = createMockCanvasPointerEvent(
         targetReroute.pos[0],
@@ -976,7 +981,7 @@ describe('LinkConnector Integration', () => {
 
       // Parent reroutes should have lost the links or been removed
       for (const [index, parentId] of parentIds.entries()) {
-        const reroute = graph.reroutes.get(parentId)!
+        const reroute = graph.reroutes.get(toBrandedRerouteId(parentId))!
         if (linksAfter[index] === undefined) {
           expect(reroute).not.toBeUndefined()
         } else {
@@ -1078,8 +1083,8 @@ describe('LinkConnector Integration', () => {
         graph.getNodeById(toNodeId(4))!.disconnectOutput(0)
       }
 
-      const fromReroute = graph.reroutes.get(fromRerouteId)!
-      const toReroute = graph.reroutes.get(toRerouteId)!
+      const fromReroute = graph.reroutes.get(toBrandedRerouteId(fromRerouteId))!
+      const toReroute = graph.reroutes.get(toBrandedRerouteId(toRerouteId))!
       const nextLinkIds = getNextLinkIds(toReroute.linkIds, expectedExtraLinks)
 
       const originalParentChain = LLink.getReroutes(graph, toReroute)
@@ -1121,7 +1126,7 @@ describe('LinkConnector Integration', () => {
       expect([...toReroute.linkIds.values()]).toEqual(nextLinkIds)
 
       for (const rerouteId of shouldBeRemoved) {
-        const reroute = graph.reroutes.get(rerouteId)!
+        const reroute = graph.reroutes.get(toBrandedRerouteId(rerouteId))!
         if (testFloatingInputs) {
           // Already-floating reroutes should be removed
           expect(reroute).toBeUndefined()
@@ -1132,7 +1137,7 @@ describe('LinkConnector Integration', () => {
       }
 
       for (const rerouteId of shouldHaveLinkIdsRemoved) {
-        const reroute = graph.reroutes.get(rerouteId)!
+        const reroute = graph.reroutes.get(toBrandedRerouteId(rerouteId))!
         for (const linkId of toReroute.linkIds) {
           expect(reroute.linkIds).not.toContain(linkId)
         }
@@ -1171,8 +1176,8 @@ describe('LinkConnector Integration', () => {
       const listener = vi.fn()
       connector.listenUntilReset('link-created', listener)
 
-      const fromReroute = graph.reroutes.get(from)!
-      const toReroute = graph.reroutes.get(to)!
+      const fromReroute = graph.reroutes.get(toBrandedRerouteId(from))!
+      const toReroute = graph.reroutes.get(toBrandedRerouteId(to))!
 
       const dropEvent = createMockCanvasPointerEvent(
         toReroute.pos[0],
@@ -1189,15 +1194,15 @@ describe('LinkConnector Integration', () => {
   )
 
   const nodeReroutePairs = [
-    { nodeId: toNodeId(1), rerouteId: toRerouteId(1) },
-    { nodeId: toNodeId(1), rerouteId: toRerouteId(3) },
-    { nodeId: toNodeId(1), rerouteId: toRerouteId(4) },
-    { nodeId: toNodeId(1), rerouteId: toRerouteId(2) },
-    { nodeId: toNodeId(4), rerouteId: toRerouteId(7) },
-    { nodeId: toNodeId(4), rerouteId: toRerouteId(6) },
-    { nodeId: toNodeId(4), rerouteId: toRerouteId(8) },
-    { nodeId: toNodeId(4), rerouteId: toRerouteId(10) },
-    { nodeId: toNodeId(4), rerouteId: toRerouteId(12) }
+    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(1) },
+    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(3) },
+    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(4) },
+    { nodeId: toNodeId(1), rerouteId: toBrandedRerouteId(2) },
+    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(7) },
+    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(6) },
+    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(8) },
+    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(10) },
+    { nodeId: toNodeId(4), rerouteId: toBrandedRerouteId(12) }
   ]
   test.for(nodeReroutePairs)(
     'Should ignore connections from input to same node via reroutes',

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -13,6 +13,7 @@ import { LGraphNode, LLink, LinkConnector } from '@/lib/litegraph/src/litegraph'
 import { test as baseTest } from '../__fixtures__/testExtensions'
 import type { ConnectingLink } from '@/lib/litegraph/src/interfaces'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
 import {
   createMockCanvasPointerEvent,
   createMockCanvasRenderingContext2D
@@ -1188,15 +1189,15 @@ describe('LinkConnector Integration', () => {
   )
 
   const nodeReroutePairs = [
-    { nodeId: toNodeId(1), rerouteId: 1 },
-    { nodeId: toNodeId(1), rerouteId: 3 },
-    { nodeId: toNodeId(1), rerouteId: 4 },
-    { nodeId: toNodeId(1), rerouteId: 2 },
-    { nodeId: toNodeId(4), rerouteId: 7 },
-    { nodeId: toNodeId(4), rerouteId: 6 },
-    { nodeId: toNodeId(4), rerouteId: 8 },
-    { nodeId: toNodeId(4), rerouteId: 10 },
-    { nodeId: toNodeId(4), rerouteId: 12 }
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(1) },
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(3) },
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(4) },
+    { nodeId: toNodeId(1), rerouteId: toRerouteId(2) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(7) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(6) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(8) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(10) },
+    { nodeId: toNodeId(4), rerouteId: toRerouteId(12) }
   ]
   test.for(nodeReroutePairs)(
     'Should ignore connections from input to same node via reroutes',

--- a/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts
@@ -14,6 +14,7 @@ import type {
   NodeInputSlot
 } from '@/lib/litegraph/src/litegraph'
 import { LinkDirection } from '@/lib/litegraph/src/types/globalEnums'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
 import { createTestSubgraph } from '../subgraph/__fixtures__/subgraphHelpers'
@@ -112,7 +113,14 @@ describe('LinkConnector SubgraphInput connection validation', () => {
       targetNode.addInput('number_in', 'number')
       subgraph.add(targetNode)
 
-      const link = new LLink(1, 'number', sourceNode.id, 0, targetNode.id, 0)
+      const link = new LLink(
+        toLinkId(1),
+        'number',
+        sourceNode.id,
+        0,
+        targetNode.id,
+        0
+      )
       subgraph._links.set(link.id, link)
 
       const movingLink = new MovingOutputLink(subgraph, link)
@@ -138,7 +146,7 @@ describe('LinkConnector SubgraphInput connection validation', () => {
 
       // Create valid link (number -> number)
       const validLink = new LLink(
-        1,
+        toLinkId(1),
         'number',
         sourceNode.id,
         0,
@@ -150,7 +158,7 @@ describe('LinkConnector SubgraphInput connection validation', () => {
 
       // Create invalid link (string -> number)
       const invalidLink = new LLink(
-        2,
+        toLinkId(2),
         'string',
         sourceNode.id,
         1,
@@ -182,7 +190,14 @@ describe('LinkConnector SubgraphInput connection validation', () => {
       targetNode.addInput('number_in', 'number')
       subgraph.add(targetNode)
 
-      const link = new LLink(1, 'number', sourceNode.id, 0, targetNode.id, 0)
+      const link = new LLink(
+        toLinkId(1),
+        'number',
+        sourceNode.id,
+        0,
+        targetNode.id,
+        0
+      )
       subgraph._links.set(link.id, link)
       const movingLink = new MovingOutputLink(subgraph, link)
 
@@ -225,7 +240,14 @@ describe('LinkConnector SubgraphInput connection validation', () => {
       subgraph.add(targetNode)
 
       // Create an invalid link (string output -> string input, but subgraph expects number)
-      const link = new LLink(1, 'string', sourceNode.id, 0, targetNode.id, 0)
+      const link = new LLink(
+        toLinkId(1),
+        'string',
+        sourceNode.id,
+        0,
+        targetNode.id,
+        0
+      )
       subgraph._links.set(link.id, link)
       const movingLink = new MovingOutputLink(subgraph, link)
 
@@ -277,7 +299,14 @@ describe('LinkConnector SubgraphInput connection validation', () => {
       subgraph.add(targetNode)
 
       // Create a valid link (number -> number)
-      const link = new LLink(1, 'number', sourceNode.id, 0, targetNode.id, 0)
+      const link = new LLink(
+        toLinkId(1),
+        'number',
+        sourceNode.id,
+        0,
+        targetNode.id,
+        0
+      )
       subgraph._links.set(link.id, link)
       const movingLink = new MovingOutputLink(subgraph, link)
 
@@ -324,7 +353,7 @@ describe('LinkConnector SubgraphInput connection validation', () => {
 
       // Create valid and invalid links
       const validLink = new LLink(
-        1,
+        toLinkId(1),
         'number',
         sourceNode.id,
         0,
@@ -332,7 +361,7 @@ describe('LinkConnector SubgraphInput connection validation', () => {
         0
       )
       const invalidLink = new LLink(
-        2,
+        toLinkId(2),
         'string',
         sourceNode.id,
         1,

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -3,6 +3,7 @@ import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import type { WidgetId } from '@/types/widgetId'
 import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
 import type { NodeId } from '@/types/nodeId'
+import type { SlotIndex } from '@/types/slotId'
 
 import type { ContextMenu } from './ContextMenu'
 import type { LGraphNode, NodeProperty } from './LGraphNode'
@@ -160,12 +161,12 @@ export interface IPinnable {
 }
 
 export interface ReadonlyLinkNetwork {
-  readonly links: ReadonlyMap<LinkId, LLink>
-  readonly reroutes: ReadonlyMap<RerouteId, Reroute>
-  readonly floatingLinks: ReadonlyMap<LinkId, LLink>
+  readonly links: ReadonlyMap<LinkId | number, LLink>
+  readonly reroutes: ReadonlyMap<RerouteId | number, Reroute>
+  readonly floatingLinks: ReadonlyMap<LinkId | number, LLink>
   getNodeById(id: NodeId | null | undefined): LGraphNode | null
   getLink(id: null | undefined): undefined
-  getLink(id: LinkId | null | undefined): LLink | undefined
+  getLink(id: LinkId | number | null | undefined): LLink | undefined
   getReroute(parentId: null | undefined): undefined
   getReroute(parentId: RerouteId | null | undefined): Reroute | undefined
 
@@ -177,8 +178,8 @@ export interface ReadonlyLinkNetwork {
  * Contains a list of links, reroutes, and nodes.
  */
 export interface LinkNetwork extends ReadonlyLinkNetwork {
-  readonly links: Map<LinkId, LLink>
-  readonly reroutes: Map<RerouteId, Reroute>
+  readonly links: Map<LinkId | number, LLink>
+  readonly reroutes: Map<RerouteId | number, Reroute>
   addFloatingLink(link: LLink): LLink
   removeReroute(id: RerouteId): unknown
   removeFloatingLink(link: LLink): void
@@ -237,8 +238,7 @@ export interface IFoundSlot extends IInputOrOutput {
   link_pos: Point
 }
 
-/** Index of an input or output slot on a node. */
-export type SlotIndex = number
+export type { SlotIndex } from '@/types/slotId'
 
 /** A point represented as `[x, y]` co-ordinates */
 export type Point = [x: number, y: number]
@@ -362,7 +362,7 @@ export interface IWidgetLocator {
 }
 
 export interface INodeInputSlot extends INodeSlot {
-  link: LinkId | null
+  link: LinkId | number | null
   widget?: IWidgetLocator
   widgetId?: WidgetId
   alwaysVisible?: boolean
@@ -378,7 +378,7 @@ export interface IWidgetInputSlot extends INodeInputSlot {
 }
 
 export interface INodeOutputSlot extends INodeSlot {
-  links: LinkId[] | null
+  links: Array<LinkId | number> | null
   _data?: unknown
   slot_index?: SlotIndex
 }

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -6,6 +6,7 @@ import type { NodeId } from '@/types/nodeId'
 import type { SlotIndex } from '@/types/slotId'
 
 import type { ContextMenu } from './ContextMenu'
+import type { LGraphGroup, GroupId } from './LGraphGroup'
 import type { LGraphNode, NodeProperty } from './LGraphNode'
 import type { LLink, LinkId } from './LLink'
 import type { Reroute, RerouteId } from './Reroute'
@@ -88,7 +89,7 @@ interface Parent<TChild> {
  * May contain other {@link Positionable} objects.
  */
 export interface Positionable extends Parent<Positionable>, HasBoundingRect {
-  readonly id: NodeId | RerouteId | number
+  readonly id: NodeId | RerouteId | GroupId
   /**
    * Position in graph coordinates. This may be the top-left corner,
    * the centre, or another point depending on concrete type.
@@ -161,12 +162,12 @@ export interface IPinnable {
 }
 
 export interface ReadonlyLinkNetwork {
-  readonly links: ReadonlyMap<LinkId | number, LLink>
-  readonly reroutes: ReadonlyMap<RerouteId | number, Reroute>
-  readonly floatingLinks: ReadonlyMap<LinkId | number, LLink>
+  readonly links: ReadonlyMap<LinkId, LLink>
+  readonly reroutes: ReadonlyMap<RerouteId, Reroute>
+  readonly floatingLinks: ReadonlyMap<LinkId, LLink>
   getNodeById(id: NodeId | null | undefined): LGraphNode | null
   getLink(id: null | undefined): undefined
-  getLink(id: LinkId | number | null | undefined): LLink | undefined
+  getLink(id: LinkId | null | undefined): LLink | undefined
   getReroute(parentId: null | undefined): undefined
   getReroute(parentId: RerouteId | null | undefined): Reroute | undefined
 
@@ -178,8 +179,8 @@ export interface ReadonlyLinkNetwork {
  * Contains a list of links, reroutes, and nodes.
  */
 export interface LinkNetwork extends ReadonlyLinkNetwork {
-  readonly links: Map<LinkId | number, LLink>
-  readonly reroutes: Map<RerouteId | number, Reroute>
+  readonly links: Map<LinkId, LLink>
+  readonly reroutes: Map<RerouteId, Reroute>
   addFloatingLink(link: LLink): LLink
   removeReroute(id: RerouteId): unknown
   removeFloatingLink(link: LLink): void
@@ -362,7 +363,7 @@ export interface IWidgetLocator {
 }
 
 export interface INodeInputSlot extends INodeSlot {
-  link: LinkId | number | null
+  link: LinkId | null
   widget?: IWidgetLocator
   widgetId?: WidgetId
   alwaysVisible?: boolean
@@ -378,7 +379,7 @@ export interface IWidgetInputSlot extends INodeInputSlot {
 }
 
 export interface INodeOutputSlot extends INodeSlot {
-  links: Array<LinkId | number> | null
+  links: LinkId[] | null
   _data?: unknown
   slot_index?: SlotIndex
 }

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -1,4 +1,3 @@
-import { toLinkId } from '@/types/linkId'
 import type { LGraphNode } from './LGraphNode'
 import type { SerializedNodeId } from '@/types/nodeId'
 import type { LLink, LinkId } from './LLink'
@@ -10,13 +9,13 @@ function linkTupleKey(link: LLink): string {
 
 /** Groups all link IDs by their connection tuple key. */
 export function groupLinksByTuple(
-  links: Map<LinkId | number, LLink>
+  links: Map<LinkId, LLink>
 ): Map<string, LinkId[]> {
   const groups = new Map<string, LinkId[]>()
   for (const [id, link] of links) {
     const key = linkTupleKey(link)
     if (!groups.has(key)) groups.set(key, [])
-    groups.get(key)!.push(toLinkId(id))
+    groups.get(key)!.push(id)
   }
   return groups
 }
@@ -44,7 +43,7 @@ export function selectSurvivorLink(
 export function purgeOrphanedLinks(
   ids: LinkId[],
   keepId: LinkId,
-  links: Map<LinkId | number, LLink>,
+  links: Map<LinkId, LLink>,
   getNodeById: (id: SerializedNodeId) => LGraphNode | null
 ): void {
   for (const id of ids) {
@@ -77,7 +76,7 @@ export function repairInputLinks(
 
   for (const input of node.inputs ?? []) {
     if (input?.link == null || input.link === keepId) continue
-    if (duplicateIds.has(toLinkId(input.link))) {
+    if (duplicateIds.has(input.link)) {
       input.link = keepId
     }
   }

--- a/src/lib/litegraph/src/linkDeduplication.ts
+++ b/src/lib/litegraph/src/linkDeduplication.ts
@@ -1,3 +1,4 @@
+import { toLinkId } from '@/types/linkId'
 import type { LGraphNode } from './LGraphNode'
 import type { SerializedNodeId } from '@/types/nodeId'
 import type { LLink, LinkId } from './LLink'
@@ -9,13 +10,13 @@ function linkTupleKey(link: LLink): string {
 
 /** Groups all link IDs by their connection tuple key. */
 export function groupLinksByTuple(
-  links: Map<LinkId, LLink>
+  links: Map<LinkId | number, LLink>
 ): Map<string, LinkId[]> {
   const groups = new Map<string, LinkId[]>()
   for (const [id, link] of links) {
     const key = linkTupleKey(link)
     if (!groups.has(key)) groups.set(key, [])
-    groups.get(key)!.push(id)
+    groups.get(key)!.push(toLinkId(id))
   }
   return groups
 }
@@ -43,7 +44,7 @@ export function selectSurvivorLink(
 export function purgeOrphanedLinks(
   ids: LinkId[],
   keepId: LinkId,
-  links: Map<LinkId, LLink>,
+  links: Map<LinkId | number, LLink>,
   getNodeById: (id: SerializedNodeId) => LGraphNode | null
 ): void {
   for (const id of ids) {
@@ -76,7 +77,7 @@ export function repairInputLinks(
 
   for (const input of node.inputs ?? []) {
     if (input?.link == null || input.link === keepId) continue
-    if (duplicateIds.has(input.link)) {
+    if (duplicateIds.has(toLinkId(input.link))) {
       input.link = keepId
     }
   }

--- a/src/lib/litegraph/src/node/NodeInputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.ts
@@ -16,7 +16,7 @@ import { isSubgraphInput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
-  link: LinkId | null
+  link: LinkId | number | null
   alwaysVisible?: boolean
 
   get isWidgetInputSlot(): boolean {

--- a/src/lib/litegraph/src/node/NodeInputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeInputSlot.ts
@@ -16,7 +16,7 @@ import { isSubgraphInput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 
 export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
-  link: LinkId | number | null
+  link: LinkId | null
   alwaysVisible?: boolean
 
   get isWidgetInputSlot(): boolean {

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -15,7 +15,7 @@ import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput
 import { isSubgraphOutput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
-  links: LinkId[] | null
+  links: Array<LinkId | number> | null
   _data?: unknown
   slot_index?: number
 

--- a/src/lib/litegraph/src/node/NodeOutputSlot.ts
+++ b/src/lib/litegraph/src/node/NodeOutputSlot.ts
@@ -15,7 +15,7 @@ import type { SubgraphOutput } from '@/lib/litegraph/src/subgraph/SubgraphOutput
 import { isSubgraphOutput } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {
-  links: Array<LinkId | number> | null
+  links: LinkId[] | null
   _data?: unknown
   slot_index?: number
 

--- a/src/lib/litegraph/src/node/slotUtils.test.ts
+++ b/src/lib/litegraph/src/node/slotUtils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
 import type { IWidget } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { toLinkId } from '@/types/linkId'
 
 import { outputAsSerialisable } from './slotUtils'
 
@@ -12,7 +13,7 @@ describe('outputAsSerialisable', () => {
   it('clones the links array to prevent shared reference mutation', () => {
     const node = new LGraphNode('test')
     const output = node.addOutput('out', 'number')
-    output.links = [1, 2, 3]
+    output.links = [toLinkId(1), toLinkId(2), toLinkId(3)]
 
     const serialised = outputAsSerialisable(output as OutputSlotParam)
 
@@ -20,7 +21,7 @@ describe('outputAsSerialisable', () => {
     expect(serialised.links).not.toBe(output.links)
 
     // Mutating the live array should NOT affect the serialised copy
-    output.links.push(4)
+    output.links.push(toLinkId(4))
     expect(serialised.links).toHaveLength(3)
   })
 

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts
@@ -8,6 +8,7 @@ import {
   LGraphEventMode,
   LGraphNode
 } from '@/lib/litegraph/src/litegraph'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
 import {
@@ -57,7 +58,7 @@ describe('ExecutableNodeDTO Creation', () => {
     const node = new LGraphNode('Test Node')
     node.addInput('input1', 'number')
     node.addInput('input2', 'string')
-    node.inputs[0].link = 123 // Simulate connected input
+    node.inputs[0].link = toLinkId(123) // Simulate connected input
     graph.add(node)
 
     const dto = new ExecutableNodeDTO(node, [], new Map(), undefined)
@@ -506,7 +507,7 @@ describe('ExecutableNodeDTO Properties', () => {
     const graph = new LGraph()
     const node = new LGraphNode('Test Node')
     node.addInput('testInput', 'number')
-    node.inputs[0].link = 999 // Simulate connection
+    node.inputs[0].link = toLinkId(999) // Simulate connection
     graph.add(node)
 
     const dto = new ExecutableNodeDTO(node, [], new Map(), undefined)

--- a/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/lib/litegraph/src/subgraph/ExecutableNodeDTO.ts
@@ -1,3 +1,4 @@
+import { toLinkId } from '@/types/linkId'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { SerializedNodeId } from '@/types/nodeId'
@@ -112,7 +113,7 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
     this._id = [...this.subgraphNodePath, this.node.id].join(':')
     this.graph = node.graph
     this.inputs = this.node.inputs.map((x) => ({
-      linkId: x.link,
+      linkId: x.link == null ? null : toLinkId(x.link),
       name: x.name,
       type: x.type
     }))

--- a/src/lib/litegraph/src/subgraph/SubgraphInput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInput.ts
@@ -1,5 +1,6 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
+import { toLinkId } from '@/types/linkId'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import { CustomEventTarget } from '@/lib/litegraph/src/infrastructure/CustomEventTarget'
 import type { SubgraphInputEventMap } from '@/lib/litegraph/src/infrastructure/SubgraphInputEventMap'
@@ -99,8 +100,11 @@ export class SubgraphInput extends SubgraphSlot {
       this.events.dispatch('input-connected', { input: slot })
     }
 
+    const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
+    subgraph.state.lastLinkId = linkId
+
     const link = new LLink(
-      ++subgraph.state.lastLinkId,
+      linkId,
       slot.type,
       this.parent.id,
       this.parent.slots.indexOf(this),

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -2,6 +2,7 @@ import type { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { NodeId } from '@/types/nodeId'
 import { LLink } from '@/lib/litegraph/src/LLink'
+import { toLinkId } from '@/types/linkId'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
 import { SUBGRAPH_INPUT_ID } from '@/lib/litegraph/src/constants'
@@ -107,8 +108,11 @@ export class SubgraphInputNode
     if (outputIndex === -1 || inputIndex === -1)
       throw new Error('Invalid slot indices.')
 
+    const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
+    subgraph.state.lastLinkId = linkId
+
     return new LLink(
-      ++subgraph.state.lastLinkId,
+      linkId,
       input.type || fromSlot.type,
       this.id,
       outputIndex,

--- a/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphOutput.ts
@@ -2,6 +2,7 @@ import { pull } from 'es-toolkit/compat'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { LLink } from '@/lib/litegraph/src/LLink'
+import { toLinkId } from '@/types/linkId'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type {
   INodeInputSlot,
@@ -63,8 +64,11 @@ export class SubgraphOutput extends SubgraphSlot {
       if (links) pull(links, existingLink.id)
     }
 
+    const linkId = toLinkId(Number(subgraph.state.lastLinkId) + 1)
+    subgraph.state.lastLinkId = linkId
+
     const link = new LLink(
-      ++subgraph.state.lastLinkId,
+      linkId,
       slot.type,
       node.id,
       outputIndex,

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -6,6 +6,8 @@ import { LLink } from '@/lib/litegraph/src/LLink'
 import type { ResolvedConnection } from '@/lib/litegraph/src/LLink'
 import { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
+import { toLinkId } from '@/types/linkId'
+import { toRerouteId } from '@/types/rerouteId'
 import {
   SUBGRAPH_INPUT_ID,
   SUBGRAPH_OUTPUT_ID
@@ -117,7 +119,7 @@ export function getBoundaryLinks(
 
           if (input.link == null) continue
 
-          const resolved = LLink.resolve(input.link, graph)
+          const resolved = LLink.resolve(toLinkId(input.link), graph)
           if (!resolved) {
             console.warn(`Failed to resolve link ID [${input.link}]`)
             continue
@@ -145,7 +147,7 @@ export function getBoundaryLinks(
 
           if (!output.links) continue
 
-          const many = LLink.resolveMany(output.links, graph)
+          const many = LLink.resolveMany(output.links.map(toLinkId), graph)
           for (const { link, inputNode } of many) {
             if (
               // Subgraph output node
@@ -267,12 +269,16 @@ function mapReroutes(
 ) {
   let child: SerialisableLLink | Reroute = link
   let nextReroute =
-    child.parentId === undefined ? undefined : reroutes.get(child.parentId)
+    child.parentId === undefined
+      ? undefined
+      : reroutes.get(toRerouteId(child.parentId))
 
   while (child.parentId !== undefined && nextReroute) {
     child = nextReroute
     nextReroute =
-      child.parentId === undefined ? undefined : reroutes.get(child.parentId)
+      child.parentId === undefined
+        ? undefined
+        : reroutes.get(toRerouteId(child.parentId))
   }
 
   const lastId = child.parentId
@@ -300,7 +306,8 @@ export function mapSubgraphInputsAndLinks(
       if (!input) continue
 
       const linkData = link.asSerialisable()
-      link.parentId = mapReroutes(link, reroutes)
+      const parentId = mapReroutes(link, reroutes)
+      link.parentId = parentId === undefined ? undefined : toRerouteId(parentId)
       linkData.origin_id = SUBGRAPH_INPUT_ID
       linkData.origin_slot = inputs.length
 

--- a/src/lib/litegraph/src/types/serialisation.ts
+++ b/src/lib/litegraph/src/types/serialisation.ts
@@ -1,16 +1,11 @@
 import type { UUID } from '@/utils/uuid'
 
-import type {
-  LGraphConfig,
-  LGraphExtra,
-  LGraphState,
-  SubgraphId
-} from '../LGraph'
+import type { LGraphConfig, LGraphExtra, SubgraphId } from '../LGraph'
 import type { GroupId, IGraphGroupFlags } from '../LGraphGroup'
 import type { NodeProperty } from '../LGraphNode'
 import type { SerializedNodeId } from '@/types/nodeId'
-import type { LinkId, SerialisedLLinkArray } from '../LLink'
-import type { FloatingRerouteSlot, RerouteId } from '../Reroute'
+import type { SerialisedLLinkArray } from '../LLink'
+import type { FloatingRerouteSlot } from '../Reroute'
 import type {
   Dictionary,
   INodeFlags,
@@ -52,10 +47,17 @@ interface BaseExportedGraph {
   }
 }
 
+interface SerialisableGraphState {
+  lastGroupId: GroupId
+  lastNodeId: number
+  lastLinkId: number
+  lastRerouteId: number
+}
+
 export interface SerialisableGraph extends BaseExportedGraph {
   /** Schema version.  @remarks Version bump should add to const union, which is used to narrow type during deserialise. */
   version: 0 | 1
-  state: LGraphState
+  state: SerialisableGraphState
   groups?: ISerialisedGroup[]
   nodes?: ISerialisedNode[]
   links?: SerialisableLLink[]
@@ -66,14 +68,16 @@ export interface SerialisableGraph extends BaseExportedGraph {
 
 export type ISerialisableNodeInput = Omit<
   INodeInputSlot,
-  'boundingRect' | 'widget'
+  'boundingRect' | 'widget' | 'link' | '_floatingLinks'
 > & {
+  link?: number | null
   widget?: { name: string }
 }
 export type ISerialisableNodeOutput = Omit<
   INodeOutputSlot,
-  'boundingRect' | '_data'
+  'boundingRect' | '_data' | 'links' | '_floatingLinks'
 > & {
+  links?: number[] | null
   widget?: { name: string }
 }
 
@@ -127,7 +131,7 @@ export interface ExportedSubgraphInstance extends NodeSubgraphSharedProps {
  */
 export interface ISerialisedGraph extends BaseExportedGraph {
   last_node_id: SerializedNodeId
-  last_link_id: LinkId
+  last_link_id: number
   nodes: ISerialisedNode[]
   links: SerialisedLLinkArray[]
   floatingLinks?: SerialisableLLink[]
@@ -170,7 +174,7 @@ export interface SubgraphIO extends SubgraphIOShared {
   /** The data type this slot uses. Unlike nodes, this does not support legacy numeric types. */
   type: string
   /** Links connected to this slot, or `undefined` if not connected. An output slot should only ever have one link. */
-  linkIds?: LinkId[]
+  linkIds?: number[]
 }
 
 /** A reference to a node widget shown in the parent graph */
@@ -201,16 +205,16 @@ export interface ClipboardItems {
 }
 
 export interface SerialisableReroute {
-  id: RerouteId
-  parentId?: RerouteId
+  id: number
+  parentId?: number
   pos: Point
-  linkIds: LinkId[]
+  linkIds: number[]
   floating?: FloatingRerouteSlot
 }
 
 export interface SerialisableLLink {
   /** Link ID */
-  id: LinkId
+  id: number
   /** Output node ID */
   origin_id: SerializedNodeId
   /** Output slot index */
@@ -222,7 +226,7 @@ export interface SerialisableLLink {
   /** Data type of the link */
   type: ISlotType
   /** ID of the last reroute (from input to output) that this link passes through, otherwise `undefined` */
-  parentId?: RerouteId
+  parentId?: number
 }
 
 export interface ExportedSubgraphIONode {

--- a/src/renderer/core/canvas/links/linkDropOrchestrator.test.ts
+++ b/src/renderer/core/canvas/links/linkDropOrchestrator.test.ts
@@ -1,0 +1,80 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LGraph } from '@/lib/litegraph/src/LGraph'
+import type { LinkConnectorAdapter } from '@/renderer/core/canvas/links/linkConnectorAdapter'
+import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDragUIState'
+import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import type { SlotLayout } from '@/renderer/core/layout/types'
+import { createSlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
+import { toNodeId } from '@/types/nodeId'
+import type { SlotId } from '@/types/slotId'
+
+import { resolveSlotTargetCandidate } from './linkDropOrchestrator'
+
+const NODE_ID = toNodeId('node-1')
+
+function createSlotLayout(): SlotLayout {
+  return {
+    nodeId: NODE_ID,
+    index: 1,
+    type: 'input',
+    position: { x: 10, y: 20 },
+    bounds: { x: 5, y: 15, width: 10, height: 10 }
+  }
+}
+
+function createDropTarget(slotKey: SlotId): HTMLElement {
+  const target = document.createElement('div')
+  target.className = 'lg-slot'
+
+  const slot = document.createElement('div')
+  slot.dataset.slotKey = String(slotKey)
+  target.append(slot)
+  document.body.append(target)
+
+  return target
+}
+
+function createAdapter() {
+  const isInputValidDrop = vi.fn(() => true)
+  const isOutputValidDrop = vi.fn(() => false)
+  const adapter = fromPartial<LinkConnectorAdapter>({
+    renderLinks: [{ fromSlot: { type: 'number' } }],
+    linkConnector: { state: { connectingTo: 'input' } },
+    isInputValidDrop,
+    isOutputValidDrop
+  })
+
+  return { adapter, isInputValidDrop, isOutputValidDrop }
+}
+
+describe('resolveSlotTargetCandidate', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    layoutStore.initializeFromLiteGraph([])
+    useSlotLinkDragUIState().clearCompatible()
+  })
+
+  it('resolves a DOM slot key through the layout store and caches compatibility', () => {
+    const slotKey = getSlotKey(NODE_ID, 1, true)
+    const layout = createSlotLayout()
+    layoutStore.updateSlotLayout(slotKey, layout)
+    const target = createDropTarget(slotKey)
+    const { adapter, isInputValidDrop } = createAdapter()
+    const context = {
+      adapter,
+      graph: fromPartial<LGraph>({}),
+      session: createSlotLinkDragContext()
+    }
+
+    const firstCandidate = resolveSlotTargetCandidate(target, context)
+    const secondCandidate = resolveSlotTargetCandidate(target, context)
+
+    expect(firstCandidate).toEqual({ layout, compatible: true })
+    expect(secondCandidate).toEqual({ layout, compatible: true })
+    expect(isInputValidDrop).toHaveBeenCalledTimes(1)
+    expect(isInputValidDrop).toHaveBeenCalledWith(NODE_ID, 1)
+  })
+})

--- a/src/renderer/core/canvas/links/linkDropOrchestrator.ts
+++ b/src/renderer/core/canvas/links/linkDropOrchestrator.ts
@@ -7,11 +7,19 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import type { SlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
+import type { SlotId } from '@/types/slotId'
 
 interface DropResolutionContext {
   adapter: LinkConnectorAdapter | null
   graph: LGraph | null
   session: SlotLinkDragContext
+}
+
+function findSlotId(key: string): SlotId | null {
+  return (
+    layoutStore.getAllSlotKeys().find((slotKey) => String(slotKey) === key) ??
+    null
+  )
 }
 
 export const resolveSlotTargetCandidate = (
@@ -24,7 +32,10 @@ export const resolveSlotTargetCandidate = (
   const elWithKey = target
     .closest('.lg-slot, .lg-node-widget')
     ?.querySelector<HTMLElement>('[data-slot-key]')
-  const key = elWithKey?.dataset['slotKey']
+  const rawKey = elWithKey?.dataset['slotKey']
+  if (!rawKey) return null
+
+  const key = findSlotId(rawKey)
   if (!key) return null
 
   const layout = layoutStore.getSlotLayout(key)

--- a/src/renderer/core/canvas/links/linkDropOrchestrator.ts
+++ b/src/renderer/core/canvas/links/linkDropOrchestrator.ts
@@ -4,9 +4,11 @@ import { useSlotLinkDragUIState } from '@/renderer/core/canvas/links/slotLinkDra
 import type { SlotDropCandidate } from '@/renderer/core/canvas/links/slotLinkDragUIState'
 import { getSlotKey } from '@/renderer/core/layout/slots/slotIdentifier'
 import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
+import type { SlotLayout } from '@/renderer/core/layout/types'
 import type { SlotLinkDragContext } from '@/renderer/extensions/vueNodes/composables/slotLinkDragContext'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
+import { toSlotId } from '@/types/slotId'
 import type { SlotId } from '@/types/slotId'
 
 interface DropResolutionContext {
@@ -15,11 +17,13 @@ interface DropResolutionContext {
   session: SlotLinkDragContext
 }
 
-function findSlotId(key: string): SlotId | null {
-  return (
-    layoutStore.getAllSlotKeys().find((slotKey) => String(slotKey) === key) ??
-    null
-  )
+function getCandidateSlotLayout(
+  rawKey: string
+): { key: SlotId; layout: SlotLayout } | null {
+  const key = toSlotId(rawKey)
+  const layout = layoutStore.getSlotLayout(key)
+
+  return layout ? { key, layout } : null
 }
 
 export const resolveSlotTargetCandidate = (
@@ -35,11 +39,9 @@ export const resolveSlotTargetCandidate = (
   const rawKey = elWithKey?.dataset['slotKey']
   if (!rawKey) return null
 
-  const key = findSlotId(rawKey)
-  if (!key) return null
-
-  const layout = layoutStore.getSlotLayout(key)
-  if (!layout) return null
+  const candidateLayout = getCandidateSlotLayout(rawKey)
+  if (!candidateLayout) return null
+  const { key, layout } = candidateLayout
 
   const candidate: SlotDropCandidate = { layout, compatible: false }
 

--- a/src/renderer/core/layout/operations/layoutMutations.ts
+++ b/src/renderer/core/layout/operations/layoutMutations.ts
@@ -39,7 +39,7 @@ interface LayoutMutations {
   createReroute(
     rerouteId: RerouteId,
     position: Point,
-    parentId?: LinkId,
+    parentId?: RerouteId,
     linkIds?: LinkId[]
   ): void
   deleteReroute(rerouteId: RerouteId): void
@@ -267,7 +267,7 @@ export function useLayoutMutations(): LayoutMutations {
   const createReroute = (
     rerouteId: RerouteId,
     position: Point,
-    parentId?: LinkId,
+    parentId?: RerouteId,
     linkIds: LinkId[] = []
   ): void => {
     logger.debug('Creating reroute:', {

--- a/src/renderer/core/layout/slots/slotIdentifier.ts
+++ b/src/renderer/core/layout/slots/slotIdentifier.ts
@@ -1,42 +1,32 @@
+import { slotId } from '@/types/slotId'
 import type { NodeId } from '@/types/nodeId'
-
-/**
- * Slot identifier utilities for consistent slot key generation and parsing
- *
- * Provides a centralized interface for slot identification across the layout system
- *
- * @TODO Replace this concatenated string with root cause fix
- */
+import type { SlotId, SlotIndex } from '@/types/slotId'
 
 interface SlotIdentifier {
   nodeId: NodeId
-  index: number
+  index: SlotIndex
   isInput: boolean
 }
 
-/**
- * Generate a unique key for a slot
- * Format: "{nodeId}-{in|out}-{index}"
- */
-export function getSlotKey(identifier: SlotIdentifier): string
+export function getSlotKey(identifier: SlotIdentifier): SlotId
 export function getSlotKey(
   nodeId: NodeId,
-  index: number,
+  index: SlotIndex,
   isInput: boolean
-): string
+): SlotId
 export function getSlotKey(
   nodeIdOrIdentifier: NodeId | SlotIdentifier,
-  index?: number,
+  index?: SlotIndex,
   isInput?: boolean
-): string {
+): SlotId {
   if (typeof nodeIdOrIdentifier === 'object') {
     const { nodeId, index, isInput } = nodeIdOrIdentifier
-    return `${String(nodeId)}-${isInput ? 'in' : 'out'}-${index}`
+    return slotId(nodeId, index, isInput ? 'input' : 'output')
   }
 
   if (index === undefined || isInput === undefined) {
     throw new Error('Missing required parameters for slot key generation')
   }
 
-  return `${String(nodeIdOrIdentifier)}-${isInput ? 'in' : 'out'}-${index}`
+  return slotId(nodeIdOrIdentifier, index, isInput ? 'input' : 'output')
 }

--- a/src/renderer/core/layout/slots/slotIdentifier.ts
+++ b/src/renderer/core/layout/slots/slotIdentifier.ts
@@ -21,12 +21,12 @@ export function getSlotKey(
 ): SlotId {
   if (typeof nodeIdOrIdentifier === 'object') {
     const { nodeId, index, isInput } = nodeIdOrIdentifier
-    return slotId(nodeId, index, isInput ? 'input' : 'output')
+    return slotId(nodeId, isInput ? 'input' : 'output', index)
   }
 
   if (index === undefined || isInput === undefined) {
     throw new Error('Missing required parameters for slot key generation')
   }
 
-  return slotId(nodeIdOrIdentifier, index, isInput ? 'input' : 'output')
+  return slotId(nodeIdOrIdentifier, isInput ? 'input' : 'output', index)
 }

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 import type { NodeId } from '@/types/nodeId'
 
@@ -853,7 +854,7 @@ describe('layoutStore link layout updates', () => {
 
   const stubPath = () => ({}) as unknown as Path2D
   const baseLink = (path = stubPath()) => ({
-    id: 1 as const,
+    id: toLinkId(1),
     path,
     bounds: { x: 0, y: 0, width: 50, height: 50 },
     centerPos: { x: 25, y: 25 },
@@ -893,7 +894,7 @@ describe('layoutStore link layout updates', () => {
     })
 
     expect(layoutStore.queryLinkSegmentAtPoint({ x: 1, y: 1 })).toEqual({
-      linkId: 1,
+      linkId: toLinkId(1),
       rerouteId: null
     })
 

--- a/src/renderer/core/layout/store/layoutStore.test.ts
+++ b/src/renderer/core/layout/store/layoutStore.test.ts
@@ -865,29 +865,29 @@ describe('layoutStore link layout updates', () => {
   })
 
   it('updateLinkLayout short-circuits when bounds and centerPos are unchanged', () => {
-    layoutStore.updateLinkLayout(1, baseLink())
+    layoutStore.updateLinkLayout(toLinkId(1), baseLink())
     const newPath = stubPath()
 
-    layoutStore.updateLinkLayout(1, baseLink(newPath))
+    layoutStore.updateLinkLayout(toLinkId(1), baseLink(newPath))
 
-    expect(layoutStore.getLinkLayout(1)?.path).toBe(newPath)
+    expect(layoutStore.getLinkLayout(toLinkId(1))?.path).toBe(newPath)
   })
 
   it('updateLinkLayout replaces stored layout when bounds change', () => {
-    layoutStore.updateLinkLayout(1, baseLink())
+    layoutStore.updateLinkLayout(toLinkId(1), baseLink())
     const moved = {
       ...baseLink(),
       bounds: { x: 10, y: 10, width: 50, height: 50 }
     }
 
-    layoutStore.updateLinkLayout(1, moved)
+    layoutStore.updateLinkLayout(toLinkId(1), moved)
 
-    expect(layoutStore.getLinkLayout(1)?.bounds.x).toBe(10)
+    expect(layoutStore.getLinkLayout(toLinkId(1))?.bounds.x).toBe(10)
   })
 
   it('deleteLinkLayout removes the link and its segment layouts', () => {
-    layoutStore.updateLinkLayout(1, baseLink())
-    layoutStore.updateLinkSegmentLayout(1, null, {
+    layoutStore.updateLinkLayout(toLinkId(1), baseLink())
+    layoutStore.updateLinkSegmentLayout(toLinkId(1), null, {
       path: stubPath(),
       bounds: { x: 0, y: 0, width: 5, height: 5 },
       centerPos: { x: 1, y: 1 }
@@ -898,9 +898,9 @@ describe('layoutStore link layout updates', () => {
       rerouteId: null
     })
 
-    layoutStore.deleteLinkLayout(1)
+    layoutStore.deleteLinkLayout(toLinkId(1))
 
-    expect(layoutStore.getLinkLayout(1)).toBeNull()
+    expect(layoutStore.getLinkLayout(toLinkId(1))).toBeNull()
     expect(layoutStore.queryLinkSegmentAtPoint({ x: 1, y: 1 })).toBeNull()
   })
 })

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -415,8 +415,8 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Update link layout data (for geometry/debug, no separate spatial index)
    */
-  updateLinkLayout(linkId: LinkId | number, layout: LinkLayout): void {
-    const id = toLinkId(linkId)
+  updateLinkLayout(linkId: LinkId, layout: LinkLayout): void {
+    const id = linkId
     const existing = this.linkLayouts.get(id)
 
     if (
@@ -436,8 +436,8 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Delete link layout data
    */
-  deleteLinkLayout(linkId: LinkId | number): void {
-    const id = toLinkId(linkId)
+  deleteLinkLayout(linkId: LinkId): void {
+    const id = linkId
     const deleted = this.linkLayouts.delete(id)
     if (deleted) {
       this.cleanupLinkSegments(id)
@@ -556,8 +556,8 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Get link layout data
    */
-  getLinkLayout(linkId: LinkId | number): LinkLayout | null {
-    return this.linkLayouts.get(toLinkId(linkId)) || null
+  getLinkLayout(linkId: LinkId): LinkLayout | null {
+    return this.linkLayouts.get(linkId) || null
   }
   /**
    * Get slot layout data
@@ -585,11 +585,11 @@ class LayoutStoreImpl implements LayoutStore {
    * Update link segment layout data
    */
   updateLinkSegmentLayout(
-    linkId: LinkId | number,
+    linkId: LinkId,
     rerouteId: RerouteId | null,
     layout: Omit<LinkSegmentLayout, 'linkId' | 'rerouteId'>
   ): void {
-    const id = toLinkId(linkId)
+    const id = linkId
     const key = makeLinkSegmentKey(id, rerouteId)
     const existing = this.linkSegmentLayouts.get(key)
 
@@ -631,11 +631,8 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Delete link segment layout data
    */
-  deleteLinkSegmentLayout(
-    linkId: LinkId | number,
-    rerouteId: RerouteId | null
-  ): void {
-    const id = toLinkId(linkId)
+  deleteLinkSegmentLayout(linkId: LinkId, rerouteId: RerouteId | null): void {
+    const id = linkId
     const key = makeLinkSegmentKey(id, rerouteId)
     const deleted = this.linkSegmentLayouts.delete(key)
     if (deleted) {

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -603,13 +603,13 @@ class LayoutStoreImpl implements LayoutStore {
 
     const fullLayout: LinkSegmentLayout = {
       ...layout,
-      linkId: linkId,
+      linkId,
       rerouteId
     }
 
     if (!existing) {
       logger.debug('Adding link segment:', {
-        linkId: linkId,
+        linkId,
         rerouteId,
         bounds: layout.bounds,
         hasPath: !!layout.path

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -10,7 +10,9 @@ import type { ComputedRef, Ref } from 'vue'
 import * as Y from 'yjs'
 
 import { removeNodeTitleHeight } from '@/renderer/core/layout/utils/nodeSizeUtil'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
 
 import { ACTOR_CONFIG } from '@/renderer/core/layout/constants'
 import { LayoutSource } from '@/renderer/core/layout/types'
@@ -39,6 +41,7 @@ import type {
   RerouteLayout,
   ResizeNodeOperation,
   SetNodeZIndexOperation,
+  SlotId,
   SlotLayout
 } from '@/renderer/core/layout/types'
 import {
@@ -67,11 +70,11 @@ const logger = log.getLogger('LayoutStore')
 
 // Utility functions
 function asRerouteId(id: string | number): RerouteId {
-  return Number(id)
+  return toRerouteId(Number(id))
 }
 
 function asLinkId(id: string | number): LinkId {
-  return Number(id)
+  return toLinkId(Number(id))
 }
 
 interface LinkData {
@@ -85,7 +88,7 @@ interface LinkData {
 interface RerouteData {
   id: RerouteId
   position: Point
-  parentId: LinkId
+  parentId: RerouteId
   linkIds: LinkId[]
 }
 
@@ -97,9 +100,9 @@ interface TypedYMap<T> {
 
 class LayoutStoreImpl implements LayoutStore {
   private static readonly REROUTE_DEFAULTS: RerouteData = {
-    id: 0,
+    id: toRerouteId(0),
     position: { x: 0, y: 0 },
-    parentId: 0,
+    parentId: toRerouteId(0),
     linkIds: []
   }
 
@@ -134,13 +137,13 @@ class LayoutStoreImpl implements LayoutStore {
   // New data structures for hit testing
   private linkLayouts = new Map<LinkId, LinkLayout>()
   private linkSegmentLayouts = new Map<string, LinkSegmentLayout>() // Internal string key: ${linkId}:${rerouteId ?? 'final'}
-  private slotLayouts = new Map<string, SlotLayout>()
+  private slotLayouts = new Map<SlotId, SlotLayout>()
   private rerouteLayouts = new Map<RerouteId, RerouteLayout>()
 
   // Spatial index managers
   private spatialIndex: SpatialIndexManager<NodeId> // For nodes
   private linkSegmentSpatialIndex: SpatialIndexManager<string> // For link segments (single index for all link geometry)
-  private slotSpatialIndex: SpatialIndexManager<string> // For slots
+  private slotSpatialIndex: SpatialIndexManager<SlotId> // For slots
   private rerouteSpatialIndex: SpatialIndexManager<string> // For reroutes
 
   // Vue dragging state for selection toolbox (public ref for direct mutation)
@@ -176,7 +179,7 @@ class LayoutStoreImpl implements LayoutStore {
     // Initialize spatial index managers
     this.spatialIndex = new SpatialIndexManager<NodeId>()
     this.linkSegmentSpatialIndex = new SpatialIndexManager<string>() // Single index for all link geometry
-    this.slotSpatialIndex = new SpatialIndexManager<string>()
+    this.slotSpatialIndex = new SpatialIndexManager<SlotId>()
     this.rerouteSpatialIndex = new SpatialIndexManager<string>()
 
     // Listen for Yjs changes and trigger Vue reactivity
@@ -412,39 +415,38 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Update link layout data (for geometry/debug, no separate spatial index)
    */
-  updateLinkLayout(linkId: LinkId, layout: LinkLayout): void {
-    const existing = this.linkLayouts.get(linkId)
+  updateLinkLayout(linkId: LinkId | number, layout: LinkLayout): void {
+    const id = toLinkId(linkId)
+    const existing = this.linkLayouts.get(id)
 
-    // Short-circuit if bounds and centerPos unchanged
     if (
       existing &&
       isBoundsEqual(existing.bounds, layout.bounds) &&
       isPointEqual(existing.centerPos, layout.centerPos)
     ) {
-      // Only update path if provided (for hit detection)
       if (layout.path) {
         existing.path = layout.path
       }
       return
     }
 
-    this.linkLayouts.set(linkId, layout)
+    this.linkLayouts.set(id, { ...layout, id })
   }
 
   /**
    * Delete link layout data
    */
-  deleteLinkLayout(linkId: LinkId): void {
-    const deleted = this.linkLayouts.delete(linkId)
+  deleteLinkLayout(linkId: LinkId | number): void {
+    const id = toLinkId(linkId)
+    const deleted = this.linkLayouts.delete(id)
     if (deleted) {
-      this.cleanupLinkSegments(linkId)
+      this.cleanupLinkSegments(id)
     }
   }
-
   /**
    * Update slot layout data
    */
-  updateSlotLayout(key: string, layout: SlotLayout): void {
+  updateSlotLayout(key: SlotId, layout: SlotLayout): void {
     const existing = this.slotLayouts.get(key)
 
     if (existing) {
@@ -469,7 +471,7 @@ class LayoutStoreImpl implements LayoutStore {
    * Batch update slot layouts and spatial index in one pass
    */
   batchUpdateSlotLayouts(
-    updates: Array<{ key: string; layout: SlotLayout }>
+    updates: Array<{ key: SlotId; layout: SlotLayout }>
   ): void {
     if (!updates.length) return
 
@@ -496,7 +498,7 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Delete slot layout data
    */
-  deleteSlotLayout(key: string): void {
+  deleteSlotLayout(key: SlotId): void {
     const deleted = this.slotLayouts.delete(key)
     if (deleted) {
       // Remove from spatial index
@@ -554,14 +556,13 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Get link layout data
    */
-  getLinkLayout(linkId: LinkId): LinkLayout | null {
-    return this.linkLayouts.get(linkId) || null
+  getLinkLayout(linkId: LinkId | number): LinkLayout | null {
+    return this.linkLayouts.get(toLinkId(linkId)) || null
   }
-
   /**
    * Get slot layout data
    */
-  getSlotLayout(key: string): SlotLayout | null {
+  getSlotLayout(key: SlotId): SlotLayout | null {
     return this.slotLayouts.get(key) || null
   }
 
@@ -576,7 +577,7 @@ class LayoutStoreImpl implements LayoutStore {
    * Returns all slot layout keys currently tracked by the store.
    * Useful for global passes without relying on spatial queries.
    */
-  getAllSlotKeys(): string[] {
+  getAllSlotKeys(): SlotId[] {
     return Array.from(this.slotLayouts.keys())
   }
 
@@ -584,20 +585,19 @@ class LayoutStoreImpl implements LayoutStore {
    * Update link segment layout data
    */
   updateLinkSegmentLayout(
-    linkId: LinkId,
+    linkId: LinkId | number,
     rerouteId: RerouteId | null,
     layout: Omit<LinkSegmentLayout, 'linkId' | 'rerouteId'>
   ): void {
-    const key = makeLinkSegmentKey(linkId, rerouteId)
+    const id = toLinkId(linkId)
+    const key = makeLinkSegmentKey(id, rerouteId)
     const existing = this.linkSegmentLayouts.get(key)
 
-    // Short-circuit if bounds and centerPos unchanged (prevents spatial index churn)
     if (
       existing &&
       isBoundsEqual(existing.bounds, layout.bounds) &&
       isPointEqual(existing.centerPos, layout.centerPos)
     ) {
-      // Only update path if provided (for hit detection)
       if (layout.path) {
         existing.path = layout.path
       }
@@ -606,13 +606,13 @@ class LayoutStoreImpl implements LayoutStore {
 
     const fullLayout: LinkSegmentLayout = {
       ...layout,
-      linkId,
+      linkId: id,
       rerouteId
     }
 
     if (!existing) {
       logger.debug('Adding link segment:', {
-        linkId,
+        linkId: id,
         rerouteId,
         bounds: layout.bounds,
         hasPath: !!layout.path
@@ -620,10 +620,8 @@ class LayoutStoreImpl implements LayoutStore {
     }
 
     if (existing) {
-      // Update spatial index
       this.linkSegmentSpatialIndex.update(key, layout.bounds)
     } else {
-      // Insert into spatial index
       this.linkSegmentSpatialIndex.insert(key, layout.bounds)
     }
 
@@ -633,15 +631,17 @@ class LayoutStoreImpl implements LayoutStore {
   /**
    * Delete link segment layout data
    */
-  deleteLinkSegmentLayout(linkId: LinkId, rerouteId: RerouteId | null): void {
-    const key = makeLinkSegmentKey(linkId, rerouteId)
+  deleteLinkSegmentLayout(
+    linkId: LinkId | number,
+    rerouteId: RerouteId | null
+  ): void {
+    const id = toLinkId(linkId)
+    const key = makeLinkSegmentKey(id, rerouteId)
     const deleted = this.linkSegmentLayouts.delete(key)
     if (deleted) {
-      // Remove from spatial index
       this.linkSegmentSpatialIndex.remove(key)
     }
   }
-
   /**
    * Query link segment at point (returns structured data)
    */
@@ -794,7 +794,7 @@ class LayoutStoreImpl implements LayoutStore {
   queryItemsInBounds(bounds: Bounds): {
     nodes: NodeId[]
     links: LinkId[]
-    slots: string[]
+    slots: SlotId[]
     reroutes: RerouteId[]
   } {
     // Query segments and union their linkIds

--- a/src/renderer/core/layout/store/layoutStore.ts
+++ b/src/renderer/core/layout/store/layoutStore.ts
@@ -416,8 +416,7 @@ class LayoutStoreImpl implements LayoutStore {
    * Update link layout data (for geometry/debug, no separate spatial index)
    */
   updateLinkLayout(linkId: LinkId, layout: LinkLayout): void {
-    const id = linkId
-    const existing = this.linkLayouts.get(id)
+    const existing = this.linkLayouts.get(linkId)
 
     if (
       existing &&
@@ -430,17 +429,16 @@ class LayoutStoreImpl implements LayoutStore {
       return
     }
 
-    this.linkLayouts.set(id, { ...layout, id })
+    this.linkLayouts.set(linkId, { ...layout, id: linkId })
   }
 
   /**
    * Delete link layout data
    */
   deleteLinkLayout(linkId: LinkId): void {
-    const id = linkId
-    const deleted = this.linkLayouts.delete(id)
+    const deleted = this.linkLayouts.delete(linkId)
     if (deleted) {
-      this.cleanupLinkSegments(id)
+      this.cleanupLinkSegments(linkId)
     }
   }
   /**
@@ -589,8 +587,7 @@ class LayoutStoreImpl implements LayoutStore {
     rerouteId: RerouteId | null,
     layout: Omit<LinkSegmentLayout, 'linkId' | 'rerouteId'>
   ): void {
-    const id = linkId
-    const key = makeLinkSegmentKey(id, rerouteId)
+    const key = makeLinkSegmentKey(linkId, rerouteId)
     const existing = this.linkSegmentLayouts.get(key)
 
     if (
@@ -606,13 +603,13 @@ class LayoutStoreImpl implements LayoutStore {
 
     const fullLayout: LinkSegmentLayout = {
       ...layout,
-      linkId: id,
+      linkId: linkId,
       rerouteId
     }
 
     if (!existing) {
       logger.debug('Adding link segment:', {
-        linkId: id,
+        linkId: linkId,
         rerouteId,
         bounds: layout.bounds,
         hasPath: !!layout.path
@@ -632,8 +629,7 @@ class LayoutStoreImpl implements LayoutStore {
    * Delete link segment layout data
    */
   deleteLinkSegmentLayout(linkId: LinkId, rerouteId: RerouteId | null): void {
-    const id = linkId
-    const key = makeLinkSegmentKey(id, rerouteId)
+    const key = makeLinkSegmentKey(linkId, rerouteId)
     const deleted = this.linkSegmentLayouts.delete(key)
     if (deleted) {
       this.linkSegmentSpatialIndex.remove(key)

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -295,9 +295,9 @@ export interface LayoutStore {
   }
 
   // Update methods for link, slot, and reroute layouts
-  updateLinkLayout(linkId: LinkId | number, layout: LinkLayout): void
+  updateLinkLayout(linkId: LinkId, layout: LinkLayout): void
   updateLinkSegmentLayout(
-    linkId: LinkId | number,
+    linkId: LinkId,
     rerouteId: RerouteId | null,
     layout: Omit<LinkSegmentLayout, 'linkId' | 'rerouteId'>
   ): void
@@ -305,17 +305,14 @@ export interface LayoutStore {
   updateRerouteLayout(rerouteId: RerouteId, layout: RerouteLayout): void
 
   // Delete methods for cleanup
-  deleteLinkLayout(linkId: LinkId | number): void
-  deleteLinkSegmentLayout(
-    linkId: LinkId | number,
-    rerouteId: RerouteId | null
-  ): void
+  deleteLinkLayout(linkId: LinkId): void
+  deleteLinkSegmentLayout(linkId: LinkId, rerouteId: RerouteId | null): void
   deleteSlotLayout(key: SlotId): void
   deleteRerouteLayout(rerouteId: RerouteId): void
   clearAllSlotLayouts(): void
 
   // Get layout data
-  getLinkLayout(linkId: LinkId | number): LinkLayout | null
+  getLinkLayout(linkId: LinkId): LinkLayout | null
   getSlotLayout(key: SlotId): SlotLayout | null
   getRerouteLayout(rerouteId: RerouteId): RerouteLayout | null
 

--- a/src/renderer/core/layout/types.ts
+++ b/src/renderer/core/layout/types.ts
@@ -6,7 +6,10 @@
  */
 import type { ComputedRef, Ref } from 'vue'
 
+import type { LinkId } from '@/types/linkId'
 import type { NodeId } from '@/types/nodeId'
+import type { RerouteId } from '@/types/rerouteId'
+import type { SlotDirection, SlotId, SlotIndex } from '@/types/slotId'
 
 // Enum for layout source types
 export enum LayoutSource {
@@ -39,9 +42,10 @@ export interface NodeBoundsUpdate {
   bounds: Bounds
 }
 
+export type { LinkId }
 export type { NodeId }
-export type LinkId = number
-export type RerouteId = number
+export type { RerouteId }
+export type { SlotId }
 
 // Layout data structures
 export interface NodeLayout {
@@ -56,8 +60,8 @@ export interface NodeLayout {
 
 export interface SlotLayout {
   nodeId: NodeId
-  index: number
-  type: 'input' | 'output'
+  index: SlotIndex
+  type: SlotDirection
   position: Point
   bounds: Bounds
 }
@@ -286,34 +290,37 @@ export interface LayoutStore {
   queryItemsInBounds(bounds: Bounds): {
     nodes: NodeId[]
     links: LinkId[]
-    slots: string[]
+    slots: SlotId[]
     reroutes: RerouteId[]
   }
 
   // Update methods for link, slot, and reroute layouts
-  updateLinkLayout(linkId: LinkId, layout: LinkLayout): void
+  updateLinkLayout(linkId: LinkId | number, layout: LinkLayout): void
   updateLinkSegmentLayout(
-    linkId: LinkId,
+    linkId: LinkId | number,
     rerouteId: RerouteId | null,
     layout: Omit<LinkSegmentLayout, 'linkId' | 'rerouteId'>
   ): void
-  updateSlotLayout(key: string, layout: SlotLayout): void
+  updateSlotLayout(key: SlotId, layout: SlotLayout): void
   updateRerouteLayout(rerouteId: RerouteId, layout: RerouteLayout): void
 
   // Delete methods for cleanup
-  deleteLinkLayout(linkId: LinkId): void
-  deleteLinkSegmentLayout(linkId: LinkId, rerouteId: RerouteId | null): void
-  deleteSlotLayout(key: string): void
+  deleteLinkLayout(linkId: LinkId | number): void
+  deleteLinkSegmentLayout(
+    linkId: LinkId | number,
+    rerouteId: RerouteId | null
+  ): void
+  deleteSlotLayout(key: SlotId): void
   deleteRerouteLayout(rerouteId: RerouteId): void
   clearAllSlotLayouts(): void
 
   // Get layout data
-  getLinkLayout(linkId: LinkId): LinkLayout | null
-  getSlotLayout(key: string): SlotLayout | null
+  getLinkLayout(linkId: LinkId | number): LinkLayout | null
+  getSlotLayout(key: SlotId): SlotLayout | null
   getRerouteLayout(rerouteId: RerouteId): RerouteLayout | null
 
   // Returns all slot layout keys currently tracked by the store
-  getAllSlotKeys(): string[]
+  getAllSlotKeys(): SlotId[]
 
   // Direct mutation API (CRDT-ready)
   applyOperation(operation: LayoutOperation): void
@@ -344,6 +351,6 @@ export interface LayoutStore {
   batchUpdateNodeBounds(updates: NodeBoundsUpdate[]): void
 
   batchUpdateSlotLayouts(
-    updates: Array<{ key: string; layout: SlotLayout }>
+    updates: Array<{ key: SlotId; layout: SlotLayout }>
   ): void
 }

--- a/src/renderer/core/layout/utils/layoutUtils.test.ts
+++ b/src/renderer/core/layout/utils/layoutUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { makeLinkSegmentKey } from '@/renderer/core/layout/utils/layoutUtils'
+import { toRerouteId } from '@/types/rerouteId'
 
 describe('layoutUtils', () => {
   describe('makeLinkSegmentKey', () => {
@@ -10,9 +11,9 @@ describe('layoutUtils', () => {
     })
 
     it('creates stable keys for numeric reroute ids', () => {
-      expect(makeLinkSegmentKey(10, 3)).toBe('10:3')
-      expect(makeLinkSegmentKey(42, 0)).toBe('42:0')
-      expect(makeLinkSegmentKey(42, 7)).toBe('42:7')
+      expect(makeLinkSegmentKey(10, toRerouteId(3))).toBe('10:3')
+      expect(makeLinkSegmentKey(42, toRerouteId(0))).toBe('42:0')
+      expect(makeLinkSegmentKey(42, toRerouteId(7))).toBe('42:7')
     })
   })
 })

--- a/src/renderer/core/layout/utils/layoutUtils.test.ts
+++ b/src/renderer/core/layout/utils/layoutUtils.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
 import { makeLinkSegmentKey } from '@/renderer/core/layout/utils/layoutUtils'
+import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
 
 describe('layoutUtils', () => {
   describe('makeLinkSegmentKey', () => {
     it('creates stable keys for null reroute', () => {
-      expect(makeLinkSegmentKey(10, null)).toBe('10:final')
-      expect(makeLinkSegmentKey(42, null)).toBe('42:final')
+      expect(makeLinkSegmentKey(toLinkId(10), null)).toBe('10:final')
+      expect(makeLinkSegmentKey(toLinkId(42), null)).toBe('42:final')
     })
 
     it('creates stable keys for numeric reroute ids', () => {
-      expect(makeLinkSegmentKey(10, toRerouteId(3))).toBe('10:3')
-      expect(makeLinkSegmentKey(42, toRerouteId(0))).toBe('42:0')
-      expect(makeLinkSegmentKey(42, toRerouteId(7))).toBe('42:7')
+      expect(makeLinkSegmentKey(toLinkId(10), toRerouteId(3))).toBe('10:3')
+      expect(makeLinkSegmentKey(toLinkId(42), toRerouteId(0))).toBe('42:0')
+      expect(makeLinkSegmentKey(toLinkId(42), toRerouteId(7))).toBe('42:7')
     })
   })
 })

--- a/src/renderer/core/layout/utils/layoutUtils.ts
+++ b/src/renderer/core/layout/utils/layoutUtils.ts
@@ -4,7 +4,7 @@ import type { LinkId, RerouteId } from '@/renderer/core/layout/types'
  * Creates a unique key for identifying link segments in spatial indexes
  */
 export function makeLinkSegmentKey(
-  linkId: LinkId,
+  linkId: LinkId | number,
   rerouteId: RerouteId | null
 ): string {
   return `${linkId}:${rerouteId ?? 'final'}`

--- a/src/renderer/core/layout/utils/layoutUtils.ts
+++ b/src/renderer/core/layout/utils/layoutUtils.ts
@@ -4,7 +4,7 @@ import type { LinkId, RerouteId } from '@/renderer/core/layout/types'
  * Creates a unique key for identifying link segments in spatial indexes
  */
 export function makeLinkSegmentKey(
-  linkId: LinkId | number,
+  linkId: LinkId,
   rerouteId: RerouteId | null
 ): string {
   return `${linkId}:${rerouteId ?? 'final'}`

--- a/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
+++ b/src/renderer/extensions/minimap/composables/useMinimapGraph.test.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue'
 import type { Ref } from 'vue'
 
 import type { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { toLinkId } from '@/types/linkId'
 import { useMinimapGraph } from '@/renderer/extensions/minimap/composables/useMinimapGraph'
 import { api } from '@/scripts/api'
 import {
@@ -43,7 +44,7 @@ describe('useMinimapGraph', () => {
         createMockLGraphNode({ id: '1', pos: [100, 100], size: [150, 80] }),
         createMockLGraphNode({ id: '2', pos: [300, 200], size: [120, 60] })
       ],
-      links: createMockLinks([createMockLLink({ id: 1 })]),
+      links: createMockLinks([createMockLLink({ id: toLinkId(1) })]),
       onNodeAdded: vi.fn(),
       onNodeRemoved: vi.fn(),
       onConnectionChange: vi.fn()
@@ -208,8 +209,8 @@ describe('useMinimapGraph', () => {
 
     // Change connections
     mockGraph.links = createMockLinks([
-      createMockLLink({ id: 1 }),
-      createMockLLink({ id: 2 })
+      createMockLLink({ id: toLinkId(1) }),
+      createMockLLink({ id: toLinkId(2) })
     ])
 
     const hasChanges = graphManager.checkForChanges()

--- a/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
+++ b/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
@@ -12,6 +12,7 @@ import {
   createMockLLink,
   createMockNodeOutputSlot
 } from '@/utils/__tests__/litegraphTestUtils'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
 const mockUseColorPaletteStore = vi.hoisted(() => vi.fn())
@@ -269,7 +270,7 @@ describe('minimapCanvasRenderer', () => {
 
     mockGraph.links = createMockLinks([
       createMockLLink({
-        id: 1,
+        id: toLinkId(1),
         target_id: toNodeId(2),
         origin_slot: 0,
         target_slot: 0

--- a/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
+++ b/src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts
@@ -263,7 +263,7 @@ describe('minimapCanvasRenderer', () => {
       createMockNodeOutputSlot({
         name: 'output',
         type: 'number',
-        links: [1],
+        links: [toLinkId(1)],
         boundingRect: new Float64Array([0, 0, 10, 10])
       })
     ]

--- a/src/renderer/extensions/vueNodes/composables/slotLinkDragContext.ts
+++ b/src/renderer/extensions/vueNodes/composables/slotLinkDragContext.ts
@@ -1,5 +1,6 @@
 import type { SlotLayout } from '@/renderer/core/layout/types'
 import type { NodeId } from '@/types/nodeId'
+import type { SlotId } from '@/types/slotId'
 
 /**
  * Slot link drag context
@@ -17,7 +18,7 @@ interface PendingPointerMoveData {
 export interface SlotLinkDragContext {
   preferredSlotForNode: Map<
     NodeId,
-    { index: number; key: string; layout: SlotLayout } | null
+    { index: number; key: SlotId; layout: SlotLayout } | null
   >
   lastHoverSlotKey: string | null
   lastHoverNodeId: NodeId | null

--- a/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotElementTracking.ts
@@ -16,6 +16,7 @@ import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { app } from '@/scripts/app'
 import type { SlotLayout } from '@/renderer/core/layout/types'
 import type { NodeId } from '@/types/nodeId'
+import type { SlotId } from '@/types/slotId'
 import {
   isBoundsEqual,
   isPointEqual,
@@ -160,7 +161,7 @@ export function syncNodeSlotLayoutsFromDOM(nodeId: NodeId) {
     return
   }
 
-  const batch: Array<{ key: string; layout: SlotLayout }> = []
+  const batch: Array<{ key: SlotId; layout: SlotLayout }> = []
 
   for (const [slotKey, entry] of node.slots) {
     const rect = getSlotElementRect(entry.el)
@@ -232,7 +233,7 @@ function updateNodeSlotsFromCache(nodeId: NodeId) {
   const nodeLayout = layoutStore.getNodeLayoutRef(nodeId).value
   if (!nodeLayout) return
 
-  const batch: Array<{ key: string; layout: SlotLayout }> = []
+  const batch: Array<{ key: SlotId; layout: SlotLayout }> = []
 
   for (const [slotKey, entry] of node.slots) {
     if (!entry.cachedOffset) {
@@ -318,7 +319,7 @@ export function useSlotElementTracking(options: {
           layoutStore.deleteSlotLayout(slotKey)
         }
 
-        el.dataset.slotKey = slotKey
+        el.dataset.slotKey = String(slotKey)
         node.slots.set(slotKey, { el, index, type })
 
         // Seed initial sync from DOM

--- a/src/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore.ts
+++ b/src/renderer/extensions/vueNodes/stores/nodeSlotRegistryStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 
 import type { NodeId } from '@/types/nodeId'
+import type { SlotId } from '@/types/slotId'
 
 type SlotEntry = {
   el: HTMLElement
@@ -12,7 +13,7 @@ type SlotEntry = {
 
 type NodeEntry = {
   nodeId: NodeId
-  slots: Map<string, SlotEntry>
+  slots: Map<SlotId, SlotEntry>
   stopWatch?: () => void
 }
 
@@ -28,7 +29,7 @@ export const useNodeSlotRegistryStore = defineStore('nodeSlotRegistry', () => {
     if (!node) {
       node = {
         nodeId,
-        slots: markRaw(new Map<string, SlotEntry>())
+        slots: markRaw(new Map<SlotId, SlotEntry>())
       }
       registry.set(nodeId, node)
     }

--- a/src/renderer/extensions/vueNodes/utils/__tests__/nodeDataUtils.test.ts
+++ b/src/renderer/extensions/vueNodes/utils/__tests__/nodeDataUtils.test.ts
@@ -1,4 +1,5 @@
 import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { toLinkId } from '@/types/linkId'
 import type {
   INodeInputSlot,
   IWidgetLocator
@@ -100,7 +101,7 @@ describe('nodeDataUtils', () => {
         makeFakeInputSlot('first'),
         makeFakeInputSlot('second'),
         makeFakeInputSlot('third', true),
-        makeFakeInputSlot('fourth', true, 1)
+        makeFakeInputSlot('fourth', true, toLinkId(1))
       ]
       const nodeData = makeFakeNodeData(inputs)
 
@@ -114,8 +115,8 @@ describe('nodeDataUtils', () => {
         makeFakeInputSlot('first'),
         makeFakeInputSlot('second'),
         makeFakeInputSlot('third', true),
-        makeFakeInputSlot('fourth', true, 1),
-        makeFakeInputSlot('fifth', true, 2)
+        makeFakeInputSlot('fourth', true, toLinkId(1)),
+        makeFakeInputSlot('fifth', true, toLinkId(2))
       ]
       const nodeData = makeFakeNodeData(inputs)
 

--- a/src/scripts/promotedWidgetControl.test.ts
+++ b/src/scripts/promotedWidgetControl.test.ts
@@ -10,6 +10,7 @@ import {
   createTestSubgraphNode
 } from '@/lib/litegraph/src/subgraph/__fixtures__/subgraphHelpers'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { toLinkId } from '@/types/linkId'
 
 import { IS_CONTROL_WIDGET } from './controlWidgetMarker'
 import { applyPromotedWidgetControl } from './promotedWidgetControl'
@@ -81,7 +82,7 @@ describe('applyPromotedWidgetControl', () => {
   it('does not run control on a host input fed by an external link', () => {
     const host = createPromotedSeedHost('increment')
     const seedInput = host.inputs.find((input) => input.name === 'seed')!
-    seedInput.link = 99
+    seedInput.link = toLinkId(99)
 
     applyPromotedWidgetControl(host, 'afterQueued')
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,12 @@ import type {
 
 export type { NodeId, SerializedNodeId } from './nodeId'
 export { toNodeId, parseNodeId } from './nodeId'
+export type { LinkId } from './linkId'
+export { toLinkId } from './linkId'
+export type { RerouteId } from './rerouteId'
+export { toRerouteId } from './rerouteId'
+export type { SlotDirection, SlotId, SlotIndex } from './slotId'
+export { slotId } from './slotId'
 export type { ComfyExtension } from './comfy'
 export type { ComfyDesktop2Bridge } from '@comfyorg/comfyui-desktop-bridge-types'
 export type { ComfyApi } from '@/scripts/api'

--- a/src/types/linkId.test.ts
+++ b/src/types/linkId.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { toLinkId } from '@/types/linkId'
+
+describe('toLinkId', () => {
+  it('preserves the numeric value', () => {
+    expect(toLinkId(42)).toBe(42)
+  })
+})

--- a/src/types/linkId.ts
+++ b/src/types/linkId.ts
@@ -1,0 +1,5 @@
+export type LinkId = number & { readonly __brand: 'LinkId' }
+
+export function toLinkId(value: number): LinkId {
+  return value as LinkId
+}

--- a/src/types/rerouteId.test.ts
+++ b/src/types/rerouteId.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { toRerouteId } from '@/types/rerouteId'
+
+describe('toRerouteId', () => {
+  it('preserves the numeric value', () => {
+    expect(toRerouteId(42)).toBe(42)
+  })
+})

--- a/src/types/rerouteId.ts
+++ b/src/types/rerouteId.ts
@@ -1,0 +1,5 @@
+export type RerouteId = number & { readonly __brand: 'RerouteId' }
+
+export function toRerouteId(value: number): RerouteId {
+  return value as RerouteId
+}

--- a/src/types/slotId.test.ts
+++ b/src/types/slotId.test.ts
@@ -4,23 +4,20 @@ import { toNodeId } from '@/types/nodeId'
 import { slotId } from '@/types/slotId'
 
 describe('slotId', () => {
-  it('distinguishes input and output slots', () => {
-    const nodeId = toNodeId('node-1')
-
-    expect(slotId(nodeId, 0, 'input')).not.toBe(slotId(nodeId, 0, 'output'))
+  it('uses the legacy slot key format', () => {
+    expect(slotId(toNodeId('node-1'), 'input', 0)).toBe('node-1-in-0')
+    expect(slotId(toNodeId('node-1'), 'output', 0)).toBe('node-1-out-0')
   })
 
-  it('escapes node id segments that contain separators', () => {
-    expect(slotId(toNodeId('node:input'), 0, 'input')).toBe(
-      'node%3Ainput:input:0'
-    )
+  it('preserves node id text without escaping', () => {
+    expect(slotId(toNodeId('node:input'), 'input', 0)).toBe('node:input-in-0')
   })
 
   it('sorts input slots before output slots for the same node and index', () => {
     const nodeId = toNodeId('node-1')
 
     expect(
-      [slotId(nodeId, 0, 'output'), slotId(nodeId, 0, 'input')].sort()
-    ).toEqual([slotId(nodeId, 0, 'input'), slotId(nodeId, 0, 'output')])
+      [slotId(nodeId, 'output', 0), slotId(nodeId, 'input', 0)].sort()
+    ).toEqual([slotId(nodeId, 'input', 0), slotId(nodeId, 'output', 0)])
   })
 })

--- a/src/types/slotId.test.ts
+++ b/src/types/slotId.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { toNodeId } from '@/types/nodeId'
+import { slotId } from '@/types/slotId'
+
+describe('slotId', () => {
+  it('distinguishes input and output slots', () => {
+    const nodeId = toNodeId('node-1')
+
+    expect(slotId(nodeId, 0, 'input')).not.toBe(slotId(nodeId, 0, 'output'))
+  })
+
+  it('escapes node id segments that contain separators', () => {
+    expect(slotId(toNodeId('node:input'), 0, 'input')).toBe(
+      'node%3Ainput:input:0'
+    )
+  })
+
+  it('sorts input slots before output slots for the same node and index', () => {
+    const nodeId = toNodeId('node-1')
+
+    expect(
+      [slotId(nodeId, 0, 'output'), slotId(nodeId, 0, 'input')].sort()
+    ).toEqual([slotId(nodeId, 0, 'input'), slotId(nodeId, 0, 'output')])
+  })
+})

--- a/src/types/slotId.ts
+++ b/src/types/slotId.ts
@@ -4,16 +4,11 @@ export type SlotId = string & { readonly __brand: 'SlotId' }
 export type SlotIndex = number
 export type SlotDirection = 'input' | 'output'
 
-const SEPARATOR = ':'
-
 export function slotId(
   nodeId: NodeId,
-  index: SlotIndex,
-  direction: SlotDirection
+  direction: SlotDirection,
+  index: SlotIndex
 ): SlotId {
-  return [
-    encodeURIComponent(String(nodeId)),
-    encodeURIComponent(direction),
-    encodeURIComponent(String(index))
-  ].join(SEPARATOR) as SlotId
+  const type = direction === 'input' ? 'in' : 'out'
+  return `${String(nodeId)}-${type}-${index}` as SlotId
 }

--- a/src/types/slotId.ts
+++ b/src/types/slotId.ts
@@ -1,0 +1,19 @@
+import type { NodeId } from '@/types/nodeId'
+
+export type SlotId = string & { readonly __brand: 'SlotId' }
+export type SlotIndex = number
+export type SlotDirection = 'input' | 'output'
+
+const SEPARATOR = ':'
+
+export function slotId(
+  nodeId: NodeId,
+  index: SlotIndex,
+  direction: SlotDirection
+): SlotId {
+  return [
+    encodeURIComponent(String(nodeId)),
+    encodeURIComponent(direction),
+    encodeURIComponent(String(index))
+  ].join(SEPARATOR) as SlotId
+}

--- a/src/types/slotId.ts
+++ b/src/types/slotId.ts
@@ -4,11 +4,15 @@ export type SlotId = string & { readonly __brand: 'SlotId' }
 export type SlotIndex = number
 export type SlotDirection = 'input' | 'output'
 
+export function toSlotId(value: string): SlotId {
+  return String(value) as SlotId
+}
+
 export function slotId(
   nodeId: NodeId,
   direction: SlotDirection,
   index: SlotIndex
 ): SlotId {
   const type = direction === 'input' ? 'in' : 'out'
-  return `${String(nodeId)}-${type}-${index}` as SlotId
+  return toSlotId(`${String(nodeId)}-${type}-${index}`)
 }

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -16,6 +16,7 @@ import { LGraphEventMode, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { vi } from 'vitest'
 import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
 import type { ChangeTracker } from '@/scripts/changeTracker'
+import type { LinkId } from '@/types/linkId'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
@@ -353,7 +354,7 @@ export function createMockLLink(overrides: Partial<LLink> = {}): LLink {
 }
 
 export function createMockLinks(links: LLink[]): LGraph['links'] {
-  const map = new Map<ReturnType<typeof toLinkId>, LLink>()
+  const map = new Map<LinkId, LLink>()
   const record: Record<number, LLink> = {}
   for (const link of links) {
     map.set(link.id, link)

--- a/src/utils/__tests__/litegraphTestUtils.ts
+++ b/src/utils/__tests__/litegraphTestUtils.ts
@@ -16,6 +16,7 @@ import { LGraphEventMode, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { vi } from 'vitest'
 import type { LoadedComfyWorkflow } from '@/platform/workflow/management/stores/comfyWorkflow'
 import type { ChangeTracker } from '@/scripts/changeTracker'
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
 /**
@@ -42,7 +43,7 @@ export function createMockPositionable(
   overrides: Partial<Positionable> = {}
 ): Positionable {
   const partial: Partial<Positionable> = {
-    id: 1,
+    id: toLinkId(1),
     pos: [0, 0],
     ...overrides
   }
@@ -56,7 +57,7 @@ export function createMockLGraphGroup(
   overrides: Partial<LGraphGroup> = {}
 ): LGraphGroup {
   const partial: Partial<LGraphGroup> = {
-    id: 1,
+    id: toLinkId(1),
     pos: [0, 0],
     boundingRect: new Rectangle(0, 0, 100, 100),
     ...overrides
@@ -339,7 +340,7 @@ export function createMockCanvas2DContext(
 
 export function createMockLLink(overrides: Partial<LLink> = {}): LLink {
   const partial: Partial<LLink> = {
-    id: 1,
+    id: toLinkId(1),
     type: '*',
     origin_id: toNodeId(1),
     origin_slot: 0,
@@ -352,7 +353,7 @@ export function createMockLLink(overrides: Partial<LLink> = {}): LLink {
 }
 
 export function createMockLinks(links: LLink[]): LGraph['links'] {
-  const map = new Map<number, LLink>()
+  const map = new Map<ReturnType<typeof toLinkId>, LLink>()
   const record: Record<number, LLink> = {}
   for (const link of links) {
     map.set(link.id, link)

--- a/src/utils/linkFixer.test.ts
+++ b/src/utils/linkFixer.test.ts
@@ -1,10 +1,15 @@
+import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 import { describe, expect, it, vi } from 'vitest'
 
+import type { LGraph, LGraphNode, LLink } from '@/lib/litegraph/src/litegraph'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
 import type {
   ISerialisedGraph,
   ISerialisedNode
 } from '@/lib/litegraph/src/types/serialisation'
+
+import { toLinkId } from '@/types/linkId'
+import { toNodeId } from '@/types/nodeId'
 
 import { fixBadLinks } from './linkFixer'
 
@@ -255,6 +260,40 @@ describe('fixBadLinks', () => {
       deleted: 1
     })
     expect(graph.links).toEqual([])
+  })
+
+  it('deletes stale links from live graph link maps', () => {
+    const linkId = toLinkId(1)
+    const originNode = fromAny<LGraphNode, unknown>({
+      id: toNodeId(1),
+      outputs: [{ links: [linkId] }]
+    })
+    const link = fromPartial<LLink>({
+      id: linkId,
+      origin_id: originNode.id,
+      origin_slot: 0,
+      target_id: toNodeId(2),
+      target_slot: 0,
+      type: '*'
+    })
+    const links = new Map([[linkId, link]])
+    const graph = fromAny<LGraph, unknown>({
+      links,
+      getNodeById: vi.fn((nodeId) =>
+        nodeId === originNode.id ? originNode : null
+      )
+    })
+
+    const result = fixBadLinks(graph, { fix: true, silent: true })
+
+    expect(result).toMatchObject({
+      hasBadLinks: false,
+      fixed: true,
+      patched: 1,
+      deleted: 1
+    })
+    expect(links.has(linkId)).toBe(false)
+    expect(originNode.outputs?.[0]?.links).toEqual([])
   })
 
   it('suppresses logger calls in silent mode while still applying fixes', () => {

--- a/src/utils/linkFixer.ts
+++ b/src/utils/linkFixer.ts
@@ -25,6 +25,7 @@
  * SOFTWARE.
  */
 import type { INodeOutputSlot } from '@/lib/litegraph/src/interfaces'
+import { toLinkId } from '@/types/linkId'
 import { parseNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
 import type { SerialisedLLinkArray } from '@/lib/litegraph/src/LLink'
@@ -147,7 +148,7 @@ export function fixBadLinks(
       }
       patchedNode['inputs']![slot] = linkIdToSet
       if (fix) {
-        inputSlot!.link = linkIdToSet
+        inputSlot!.link = linkIdToSet === null ? null : toLinkId(linkIdToSet)
       }
     } else {
       patchedNode['outputs'] = patchedNode['outputs'] || {}
@@ -180,7 +181,7 @@ export function fixBadLinks(
             node.outputs[slot] ||
             ({} satisfies Partial<INodeOutputSlot> as INodeOutputSlot)
           node.outputs[slot]!.links = node.outputs[slot]!.links || []
-          node.outputs[slot]!.links!.push(linkId)
+          node.outputs[slot]!.links!.push(toLinkId(linkId))
         }
       } else {
         const linkIdIndex =
@@ -226,7 +227,7 @@ export function fixBadLinks(
         has = !!nodeHasIt
       }
     } else {
-      const nodeHasIt = node.outputs?.[slot]?.links?.includes(linkId)
+      const nodeHasIt = node.outputs?.[slot]?.links?.includes(toLinkId(linkId))
       if (patchedNodeSlots[node.id]?.['outputs']?.[slot]?.['changes'][linkId]) {
         const patchedHasIt =
           patchedNodeSlots[node.id]!['outputs']![slot]?.links.includes(linkId)
@@ -282,15 +283,9 @@ export function fixBadLinks(
     return hasAny
   }
 
-  let links: Array<SerialisedLLinkArray | LLink> = []
-  if (!Array.isArray(graph.links)) {
-    links = Object.values(graph.links).reduce((acc, v) => {
-      acc[v.id] = v
-      return acc
-    }, links)
-  } else {
-    links = graph.links
-  }
+  const links: Array<SerialisedLLinkArray | LLink> = Array.isArray(graph.links)
+    ? graph.links
+    : Array.from((graph as LGraph).links.values())
 
   const linksReverse = [...links]
   linksReverse.reverse()
@@ -431,7 +426,8 @@ export function fixBadLinks(
     for (let i = data.deletedLinks.length - 1; i >= 0; i--) {
       logger.log(`Deleting link #${data.deletedLinks[i]}.`)
       if ((graph as LGraph).getNodeById) {
-        delete graph.links[data.deletedLinks[i]!]
+        const liveGraph = graph as LGraph
+        liveGraph.links.delete(toLinkId(data.deletedLinks[i]!))
       } else {
         graph = graph as ISerialisedGraph
         // Sometimes we got objects for links if passed after ComfyUI's loadGraphData modifies the


### PR DESCRIPTION
## Summary

Brand link, reroute, and slot identifiers through LiteGraph, subgraph, and layout flows so raw numeric workflow data is converted at boundaries while runtime APIs keep branded IDs.

## Changes

- **What**: Add canonical `LinkId`, `RerouteId`, and `SlotId` types plus minting helpers, then re-export litegraph/layout ID types from those modules.
- **What**: Keep `LinkId`, `RerouteId`, and `SlotId` references branded across graph links, reroutes, node slots, subgraph slots, link deduplication, link drop handling, layout storage, and tests.
- **What**: Convert raw numeric IDs only at periphery points: serialized workflow DTOs, legacy graph link proxy access, copied/pasted graph data, Yjs/string layout keys, and test fixtures.
- **What**: Move slot layout identity onto branded `SlotId` values using stable `node:direction:index` ordering, while keeping DOM dataset values stringified at the boundary.
- **What**: Avoid slot-key scans during link drops by carrying the link segment identity directly through the drop path.

## Review Focus

- Branded IDs should not be widened back to `LinkId | number` / `RerouteId | number` in runtime APIs.
- Serialized workflow shapes intentionally remain numeric for compatibility.
- `_subgraphSlot.linkIds` remains `LinkId[]`; call sites should not treat it as raw `number[]`.
- `MapProxyHandler` is the compatibility boundary for deprecated indexed `graph.links[id]` access.

## Validation

- `pnpm typecheck`
- `pnpm test:unit src/lib/litegraph/src/LLink.test.ts src/lib/litegraph/src/LGraph.test.ts src/lib/litegraph/src/LGraphNode.test.ts src/lib/litegraph/src/canvas/LinkConnector.core.test.ts src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts src/lib/litegraph/src/canvas/LinkConnectorSubgraphInputValidation.test.ts src/lib/litegraph/src/LGraphCanvas.drawConnections.test.ts src/lib/litegraph/src/node/slotUtils.test.ts src/lib/litegraph/src/subgraph/ExecutableNodeDTO.test.ts src/core/graph/subgraph/promotionUtils.test.ts src/core/graph/subgraph/migration/proxyWidgetMigration.test.ts src/renderer/core/layout/store/layoutStore.test.ts src/renderer/core/layout/utils/layoutUtils.test.ts src/renderer/extensions/minimap/minimapCanvasRenderer.test.ts src/scripts/promotedWidgetControl.test.ts`
- Commit hook: `oxfmt`, `oxlint`, `eslint`, `pnpm typecheck`
- Push hook: `knip --cache`