### PR TITLE
fix: re-export GroupNodeHandler for custom node compat

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -815,8 +815,10 @@ export class GroupNodeConfig {
  * `configure`. The load-time migration unpacks each instance via
  * {@link convertToNodes} and {@link LGraph.convertToSubgraph} repackages the
  * result as a subgraph.
+ *
+ * @knipIgnoreUnusedButUsedByCustomNodes
  */
-class GroupNodeHandler {
+export class GroupNodeHandler {
   node: LGraphNode
   groupData: GroupNodeConfig
 

--- a/src/platform/assets/composables/useMediaAssetActions.test.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.test.ts
@@ -10,6 +10,7 @@ import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { MediaAssetKey } from '@/platform/assets/schemas/mediaAssetSchema'
 import type { AssetItem } from '@/platform/assets/schemas/assetSchema'
 import type { AssetMeta } from '@/platform/assets/schemas/mediaAssetSchema'
+import { api } from '@/scripts/api'
 import type * as outputAssetUtilModule from '../utils/outputAssetUtil'
 import { useMediaAssetActions } from './useMediaAssetActions'
 
@@ -1192,6 +1193,40 @@ describe('useMediaAssetActions', () => {
         itemList: string[]
       }
       expect(dialogProps.itemList).toEqual(['fallback-image.png'])
+    })
+  })
+
+  describe('deleteAssets — temp (preview-node) outputs', () => {
+    beforeEach(() => {
+      mockIsCloud.value = false
+      mockGetAssetType.mockReturnValue('temp')
+      mockGetOutputAssetMetadata.mockReturnValue({ jobId: 'job-temp' })
+      mockShowDialog.mockImplementation(
+        (opts: { props: { onConfirm: () => Promise<void> | void } }) => {
+          void opts.props.onConfirm()
+        }
+      )
+    })
+
+    it('deletes via the history API in OSS instead of failing as an imported file', async () => {
+      const actions = useMediaAssetActions()
+      const asset = createMockAsset({
+        id: 'job-temp',
+        name: 'ComfyUI_temp_gjcnq_00002_.png',
+        tags: ['output'],
+        user_metadata: { jobId: 'job-temp' }
+      })
+
+      await actions.deleteAssets(asset)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(api.deleteItem)).toHaveBeenCalledWith(
+          'history',
+          'job-temp'
+        )
+      })
+      expect(mockDeleteAsset).not.toHaveBeenCalled()
+      expect(mockUpdateHistory).toHaveBeenCalled()
     })
   })
 

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -92,7 +92,9 @@ export function useMediaAssetActions() {
     asset: AssetItem,
     assetType: string
   ): Promise<void> => {
-    if (assetType === 'output') {
+    // Temp files (e.g. preview-node outputs) are history-backed outputs that
+    // happen to live in the temp dir, so they delete via the history API too.
+    if (assetType === 'output' || assetType === 'temp') {
       const jobId =
         getOutputAssetMetadata(asset.user_metadata)?.jobId || asset.id
       if (!jobId) {
@@ -729,9 +731,10 @@ export function useMediaAssetActions() {
               })
 
               // Update stores after deletions
-              const hasOutputAssets = assetArray.some(
-                (a) => getAssetType(a) === 'output'
-              )
+              const hasOutputAssets = assetArray.some((a) => {
+                const type = getAssetType(a)
+                return type === 'output' || type === 'temp'
+              })
               const hasInputAssets = assetArray.some(
                 (a) => getAssetType(a) === 'input'
               )

--- a/src/platform/remote/comfyui/jobs/jobTypes.ts
+++ b/src/platform/remote/comfyui/jobs/jobTypes.ts
@@ -62,6 +62,7 @@ const zRawJobListItem = z
     execution_start_time: z.number().nullable().optional(),
     execution_end_time: z.number().nullable().optional(),
     preview_output: zPreviewOutput.nullable().optional(),
+    outputs: zTaskOutput.optional(),
     outputs_count: z.number().nullable().optional(),
     execution_error: zExecutionError.nullable().optional(),
     workflow_id: z.string().nullable().optional(),
@@ -76,7 +77,6 @@ const zRawJobListItem = z
 export const zJobDetail = zRawJobListItem
   .extend({
     workflow: z.unknown().optional(),
-    outputs: zTaskOutput.optional(),
     update_time: z.number().optional(),
     execution_status: z.unknown().optional(),
     execution_meta: z.unknown().optional()

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -190,7 +190,7 @@ describe('TaskItemImpl', () => {
     })
   })
 
-  it.skip('should parse text outputs', () => {
+  it('parses a text-shaped preview_output from the jobs list payload', () => {
     const job: JobListItem = {
       ...createHistoryJob(0, 'text-job'),
       preview_output: {
@@ -203,7 +203,7 @@ describe('TaskItemImpl', () => {
     const task = new TaskItemImpl(job)
 
     expect(task.flatOutputs).toHaveLength(1)
-    expect(task.flatOutputs[0].filename).toBe('')
+    expect(task.flatOutputs[0].filename).toBe('5-text-0.txt')
     expect(task.previewableOutputs).toHaveLength(1)
     expect(task.previewOutput?.content).toBe('test')
   })

--- a/src/stores/queueStore.test.ts
+++ b/src/stores/queueStore.test.ts
@@ -208,6 +208,33 @@ describe('TaskItemImpl', () => {
     expect(task.previewOutput?.content).toBe('test')
   })
 
+  it('keeps the image as preview while exposing text in a mixed-output job', () => {
+    const job: JobListItem = {
+      ...createHistoryJob(0, 'mixed-job'),
+      outputs_count: 2,
+      preview_output: {
+        nodeId: '6',
+        mediaType: 'text',
+        content: '1048576'
+      } satisfies JobListItem['preview_output'],
+      outputs: {
+        '6': { text: ['1048576'] },
+        '7': {
+          images: [{ filename: 'result.png', subfolder: '', type: 'temp' }]
+        }
+      }
+    }
+
+    const task = new TaskItemImpl(job)
+
+    expect(task.previewableOutputs).toHaveLength(2)
+    expect(task.previewOutput?.filename).toBe('result.png')
+    expect(task.previewOutput?.isText).toBe(false)
+
+    const textOutput = task.previewableOutputs.find((output) => output.isText)
+    expect(textOutput?.content).toBe('1048576')
+  })
+
   describe('error extraction getters', () => {
     it('errorMessage returns undefined when no execution_error', () => {
       const job = createHistoryJob(0, 'job-id')

--- a/src/stores/queueStore.ts
+++ b/src/stores/queueStore.ts
@@ -257,10 +257,13 @@ export class TaskItemImpl {
     flatOutputs?: ReadonlyArray<ResultItemImpl>
   ) {
     this.job = job
-    // If no outputs provided but job has preview_output, create synthetic outputs
-    // using the real nodeId and mediaType from the backend response
+    // Prefer the full outputs map (list payload includes it for multi-output
+    // jobs); fall back to synthesizing from the single preview_output when the
+    // list omits outputs. Using only preview_output drops other outputs when
+    // the backend picks a text node as the preview.
     const effectiveOutputs =
       outputs ??
+      job.outputs ??
       (job.preview_output
         ? {
             [job.preview_output.nodeId]: {
@@ -286,11 +289,12 @@ export class TaskItemImpl {
 
   get previewOutput(): ResultItemImpl | undefined {
     const previewable = this.previewableOutputs
+    // Keep a real media file as the thumbnail; only fall back to text when the
+    // job has nothing else previewable.
+    const media = previewable.filter((output) => !output.isText)
+    const pool = media.length ? media : previewable
     // Prefer the last saved media file (most recent result) over temp previews
-    return (
-      previewable.findLast((output) => output.type === 'output') ??
-      previewable.at(-1)
-    )
+    return pool.findLast((output) => output.type === 'output') ?? pool.at(-1)
   }
 
   // Derive taskType from job status

--- a/src/stores/resultItemParsing.test.ts
+++ b/src/stores/resultItemParsing.test.ts
@@ -113,6 +113,23 @@ describe(parseNodeOutput, () => {
     expect(result[0].mediaType).toBe('images')
   })
 
+  it('parses array-shaped text outputs into text result items', () => {
+    const output = makeOutput({
+      images: [{ filename: 'img.png', subfolder: '', type: 'output' }],
+      text: ['first', 'second']
+    })
+
+    const result = parseNodeOutput('6', output)
+
+    expect(result).toHaveLength(3)
+
+    const textItems = result.filter((item) => item.isText)
+    expect(textItems).toHaveLength(2)
+    expect(textItems.map((item) => item.content)).toEqual(['first', 'second'])
+    expect(textItems[0].nodeId).toBe('6')
+    expect(textItems[0].filename).toBe('6-text-0.txt')
+  })
+
   it('excludes non-ResultItem array items', () => {
     const output = fromPartial<NodeExecutionOutput>({
       images: [{ filename: 'img.png', subfolder: '', type: 'output' }],

--- a/src/stores/resultItemParsing.test.ts
+++ b/src/stores/resultItemParsing.test.ts
@@ -130,6 +130,21 @@ describe(parseNodeOutput, () => {
     expect(textItems[0].filename).toBe('6-text-0.txt')
   })
 
+  it('parses object-shaped text entries from a synthesized preview_output', () => {
+    const output = makeOutput({
+      text: [
+        { nodeId: '6', mediaType: 'text', content: 'from preview_output' }
+      ] as unknown as NodeExecutionOutput['text']
+    })
+
+    const result = parseNodeOutput('6', output)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].isText).toBe(true)
+    expect(result[0].content).toBe('from preview_output')
+    expect(result[0].filename).toBe('6-text-0.txt')
+  })
+
   it('excludes non-ResultItem array items', () => {
     const output = fromPartial<NodeExecutionOutput>({
       images: [{ filename: 'img.png', subfolder: '', type: 'output' }],

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -28,19 +28,34 @@ function isResultItem(item: unknown): item is ResultItem {
 }
 
 /**
+ * Reads the text payload from a single `text` entry. Detail/subfeed responses
+ * deliver raw strings, while the jobs list synthesizes the array from a
+ * `preview_output` object (`{ content }`); both must resolve to a string.
+ */
+function getTextContent(item: unknown): string | undefined {
+  if (typeof item === 'string') return item
+  if (item && typeof item === 'object' && 'content' in item) {
+    const { content } = item as { content?: unknown }
+    if (typeof content === 'string') return content
+  }
+  return undefined
+}
+
+/**
  * Builds previewable text outputs from a node's `text` array.
  *
- * Text outputs arrive as raw strings with no backing file, so we synthesize a
- * `.txt` filename. This lets text ride the same filename-based machinery as
- * media outputs (media-type detection, dedupe keys, asset mapping) and render
- * via the existing text preview components.
+ * Text outputs have no backing file, so we synthesize a `.txt` filename. This
+ * lets text ride the same filename-based machinery as media outputs (media-type
+ * detection, dedupe keys, asset mapping) and render via the existing text
+ * preview components.
  */
 function parseTextOutput(
   nodeId: string | number,
   items: unknown[]
 ): ResultItemImpl[] {
   return items
-    .filter((item): item is string => typeof item === 'string')
+    .map(getTextContent)
+    .filter((content): content is string => content !== undefined)
     .map(
       (content, index) =>
         new ResultItemImpl({

--- a/src/stores/resultItemParsing.ts
+++ b/src/stores/resultItemParsing.ts
@@ -2,7 +2,7 @@ import type { NodeExecutionOutput, ResultItem } from '@/schemas/apiSchema'
 import { resultItemType } from '@/schemas/apiSchema'
 import { ResultItemImpl } from '@/stores/queueStore'
 
-const METADATA_KEYS = new Set(['animated', 'text'])
+const METADATA_KEYS = new Set(['animated'])
 
 /**
  * Validates that an unknown value is a well-formed ResultItem.
@@ -27,6 +27,31 @@ function isResultItem(item: unknown): item is ResultItem {
   return true
 }
 
+/**
+ * Builds previewable text outputs from a node's `text` array.
+ *
+ * Text outputs arrive as raw strings with no backing file, so we synthesize a
+ * `.txt` filename. This lets text ride the same filename-based machinery as
+ * media outputs (media-type detection, dedupe keys, asset mapping) and render
+ * via the existing text preview components.
+ */
+function parseTextOutput(
+  nodeId: string | number,
+  items: unknown[]
+): ResultItemImpl[] {
+  return items
+    .filter((item): item is string => typeof item === 'string')
+    .map(
+      (content, index) =>
+        new ResultItemImpl({
+          filename: `${nodeId}-text-${index}.txt`,
+          nodeId,
+          mediaType: 'text',
+          content
+        })
+    )
+}
+
 export function parseNodeOutput(
   nodeId: string | number,
   nodeOutput: NodeExecutionOutput | null | undefined
@@ -36,9 +61,11 @@ export function parseNodeOutput(
   return Object.entries(nodeOutput)
     .filter(([key, value]) => !METADATA_KEYS.has(key) && Array.isArray(value))
     .flatMap(([mediaType, items]) =>
-      (items as unknown[])
-        .filter(isResultItem)
-        .map((item) => new ResultItemImpl({ ...item, mediaType, nodeId }))
+      mediaType === 'text'
+        ? parseTextOutput(nodeId, items as unknown[])
+        : (items as unknown[])
+            .filter(isResultItem)
+            .map((item) => new ResultItemImpl({ ...item, mediaType, nodeId }))
     )
 }
 


### PR DESCRIPTION
Fixes #13175

#12931 slimmed groupNode.ts down to migration-only and dropped the export on GroupNodeHandler. 

ComfyUI-Manager still imports it (import { GroupNodeConfig, GroupNodeHandler } from "../../extensions/core/groupNode.js" in components-manager.js), so the legacy shim no longer providing that export throws "does not provide an export named 'GroupNodeHandler'" at module load. That kills the whole Manager extension before setup() runs — which is why the Manager button vanished from the toolbar since 1.47.3 (backend loads fine, frontend JS dies).

Just re-adds the export (class is still there, only the keyword was lost) plus the existing @knipIgnoreUnusedButUsedByCustomNodes tag since nothing in src imports it.

Tested by loading with ComfyUI-Manager installed: the groupNode.js import error is gone and the Manager button shows again. typecheck/knip/lint pass.