### PR TITLE
fix: re-export GroupNodeHandler for custom node compat

### DIFF
--- a/src/extensions/core/groupNode.ts
+++ b/src/extensions/core/groupNode.ts
@@ -815,8 +815,10 @@ export class GroupNodeConfig {
  * `configure`. The load-time migration unpacks each instance via
  * {@link convertToNodes} and {@link LGraph.convertToSubgraph} repackages the
  * result as a subgraph.
+ *
+ * @knipIgnoreUnusedButUsedByCustomNodes
  */
-class GroupNodeHandler {
+export class GroupNodeHandler {
   node: LGraphNode
   groupData: GroupNodeConfig
 


### PR DESCRIPTION
Fixes #13175

#12931 slimmed groupNode.ts down to migration-only and dropped the export on GroupNodeHandler. 

ComfyUI-Manager still imports it (import { GroupNodeConfig, GroupNodeHandler } from "../../extensions/core/groupNode.js" in components-manager.js), so the legacy shim no longer providing that export throws "does not provide an export named 'GroupNodeHandler'" at module load. That kills the whole Manager extension before setup() runs — which is why the Manager button vanished from the toolbar since 1.47.3 (backend loads fine, frontend JS dies).

Just re-adds the export (class is still there, only the keyword was lost) plus the existing @knipIgnoreUnusedButUsedByCustomNodes tag since nothing in src imports it.

Tested by loading with ComfyUI-Manager installed: the groupNode.js import error is gone and the Manager button shows again. typecheck/knip/lint pass.