### PR TITLE
fix(dialog): render confirm dialogs via Reka to fix flaky e2e on cloud/1.45

### DIFF
--- a/src/components/dialog/confirm/confirmDialog.ts
+++ b/src/components/dialog/confirm/confirmDialog.ts
@@ -22,11 +22,7 @@ export function showConfirmDialog(options: ConfirmDialogOptions = {}) {
     headerProps,
     props,
     footerProps,
-    // Render confirm dialogs via Reka. The legacy PrimeVue confirm dialog has a
-    // latent-flaky enter-transition that becomes deterministic under the heavier
-    // cloud init (FE-978), hanging the e2e confirm interactions. The Reka
-    // Confirm{Header,Body,Footer} components own their padding, so the PrimeVue
-    // `pt` zeroing is no longer needed.
+    // Reka renderer — the legacy PrimeVue confirm dialog's enter-transition is flaky.
     dialogComponentProps: {
       renderer: 'reka'
     }

--- a/src/components/dialog/confirm/confirmDialog.ts
+++ b/src/components/dialog/confirm/confirmDialog.ts
@@ -22,12 +22,13 @@ export function showConfirmDialog(options: ConfirmDialogOptions = {}) {
     headerProps,
     props,
     footerProps,
+    // Render confirm dialogs via Reka. The legacy PrimeVue confirm dialog has a
+    // latent-flaky enter-transition that becomes deterministic under the heavier
+    // cloud init (FE-978), hanging the e2e confirm interactions. The Reka
+    // Confirm{Header,Body,Footer} components own their padding, so the PrimeVue
+    // `pt` zeroing is no longer needed.
     dialogComponentProps: {
-      pt: {
-        header: 'py-0! px-0!',
-        content: 'p-0!',
-        footer: 'p-0!'
-      }
+      renderer: 'reka'
     }
   })
 }


### PR DESCRIPTION
## Problem
Three confirm-interaction e2e specs hang on cloud/1.45:
- `keybindingPresets.spec.ts` (delete preset confirm)
- `builderSaveFlow.spec.ts` (save-as overwrite confirm)
- `dialogs/memberRoleChange.spec.ts` (×5 promote/demote confirm)

Root cause (per @Hunter's analysis): cloud/1.45's dialog default renderer is `primevue`, so confirm dialogs use the legacy PrimeVue `Dialog`, whose enter-transition is latent-flaky. #13209 (FE-978) added a global run-lock + extra billing/telemetry init that slows first paint enough to lose the transition race **deterministically**.

## Fix
Flip the single confirm caller (`confirmDialog.ts`) to `renderer: 'reka'`. The Reka `Confirm{Header,Body,Footer}` components already shipped to cloud/1.45 via #12041 (Phase 1) — this just routes confirm dialogs to them. The PrimeVue `pt` padding overrides are dropped (the Reka components own their padding).

## Why not the full #12593 cutover
#12593 also flips the global default + every other caller (billing/subscription/model-upload/share). On cloud/1.45 those billing dialogs have **diverged** from main (cloud-only `planMode`/`deep_link`/unified-pricing logic), and #12593's confirmDialog change relies on `headerClass/bodyClass/footerClass` props that don't exist on cloud/1.45's `DialogComponentProps`. A full backport would mean hand-merging actively-QA'd billing code (the pricing-table z-index area designers are reviewing) — out of scope for an e2e hotfix. This is the minimum @Hunter recommended ("renderer: 'reka' switch in confirmDialog.ts").

## Scope
One file. Confirm dialogs only. Billing/subscription dialogs untouched. The failing specs use role-based selectors (`getByRole('dialog')`), so no fixture changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)