### PR TITLE
[CI experiment] flip dialog default renderer to reka on cloud/1.45

### DIFF
--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -186,6 +186,7 @@ export const useDialogStore = defineStore('dialog', () => {
         closable: true,
         closeOnEscape: true,
         dismissableMask: true,
+        renderer: 'reka' as DialogRenderer,
         ...options.dialogComponentProps,
         maximized: false,
         onMaximize: () => {


### PR DESCRIPTION
**Draft / CI-only experiment — do not merge.** Tests whether backporting #12593's one-line `createDialog` default-renderer flip (`renderer: 'reka'`) fixes the e2e mask-race failures (builderSaveFlow / memberRoleChange / keybindingPresets). cloud/1.45 still defaults dialogs to PrimeVue; main defaults to Reka.