### PR TITLE
[candidate fix] flip dialog default renderer to Reka on cloud/1.45 (non-billing)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -5,7 +5,6 @@ import type { Preview, StoryContext, StoryFn } from '@storybook/vue3-vite'
 import { createPinia } from 'pinia'
 import 'primeicons/primeicons.css'
 import PrimeVue from 'primevue/config'
-import ConfirmationService from 'primevue/confirmationservice'
 import ToastService from 'primevue/toastservice'
 import Tooltip from 'primevue/tooltip'
 
@@ -42,7 +41,6 @@ setup((app) => {
       }
     }
   })
-  app.use(ConfirmationService)
   app.use(ToastService)
 })
 

--- a/browser_tests/fixtures/components/BaseDialog.ts
+++ b/browser_tests/fixtures/components/BaseDialog.ts
@@ -8,7 +8,7 @@ export class BaseDialog {
     public readonly page: Page,
     testId?: string
   ) {
-    this.root = testId ? page.getByTestId(testId) : page.locator('.p-dialog')
+    this.root = testId ? page.getByTestId(testId) : page.getByRole('dialog')
     this.closeButton = this.root.getByRole('button', { name: 'Close' })
   }
 

--- a/browser_tests/fixtures/helpers/BuilderSaveAsHelper.ts
+++ b/browser_tests/fixtures/helpers/BuilderSaveAsHelper.ts
@@ -36,9 +36,11 @@ export class BuilderSaveAsHelper {
     this.closeButton = this.successDialog
       .getByRole('button', { name: 'Close', exact: true })
       .filter({ hasText: 'Close' })
-    this.dismissButton = this.successDialog.locator(
-      'button.p-dialog-close-button'
-    )
+    // The icon-only X carries an aria-label, while the footer Close button
+    // is named by its text — getByLabel only matches the former.
+    this.dismissButton = this.successDialog.getByLabel('Close', {
+      exact: true
+    })
     this.exitBuilderButton = this.successDialog.getByRole('button', {
       name: 'Exit builder'
     })

--- a/browser_tests/fixtures/selectors.ts
+++ b/browser_tests/fixtures/selectors.ts
@@ -37,7 +37,6 @@ export const TestIds = {
     settings: 'settings-dialog',
     settingsContainer: 'settings-container',
     settingsTabAbout: 'settings-tab-about',
-    confirm: 'confirm-dialog',
     errorOverlay: 'error-overlay',
     errorOverlaySeeErrors: 'error-overlay-see-errors',
     errorOverlayDismiss: 'error-overlay-dismiss',

--- a/browser_tests/tests/dialogs/shareWorkflowDialog.spec.ts
+++ b/browser_tests/tests/dialogs/shareWorkflowDialog.spec.ts
@@ -99,15 +99,15 @@ async function mockShareableAssets(
 }
 
 /**
- * Dismiss stale PrimeVue dialog masks left by cloud-mode's onboarding flow
- * or auth-triggered modals by pressing Escape until they clear.
+ * Dismiss stale dialogs left by cloud-mode's onboarding flow or
+ * auth-triggered modals by pressing Escape until they clear.
  */
 async function dismissOverlays(page: Page): Promise<void> {
-  const mask = page.locator('.p-dialog-mask')
+  const dialogs = page.getByRole('dialog')
   for (let attempt = 0; attempt < 3; attempt++) {
-    if ((await mask.count()) === 0) break
+    if ((await dialogs.count()) === 0) break
     await page.keyboard.press('Escape')
-    await mask
+    await dialogs
       .first()
       .waitFor({ state: 'hidden', timeout: 2000 })
       .catch(() => {})

--- a/src/components/dialog/GlobalDialog.test.ts
+++ b/src/components/dialog/GlobalDialog.test.ts
@@ -38,14 +38,30 @@ describe('GlobalDialog renderer branching', () => {
     cleanup()
   })
 
-  it('renders the PrimeVue branch when renderer is omitted', async () => {
+  it('renders the Reka branch when renderer is omitted (default)', async () => {
     mountDialog()
     const store = useDialogStore()
 
     store.showDialog({
-      key: 'primevue-default',
-      title: 'PrimeVue dialog',
+      key: 'renderer-default',
+      title: 'Default renderer dialog',
       component: Body
+    })
+
+    const dialogs = await screen.findAllByRole('dialog')
+    expect(dialogs.length).toBeGreaterThan(0)
+    expect(dialogs.some((el) => el.classList.contains('p-dialog'))).toBe(false)
+  })
+
+  it("renders the legacy PrimeVue branch when renderer is 'primevue'", async () => {
+    mountDialog()
+    const store = useDialogStore()
+
+    store.showDialog({
+      key: 'primevue-escape-hatch',
+      title: 'PrimeVue dialog',
+      component: Body,
+      dialogComponentProps: { renderer: 'primevue' }
     })
 
     const dialogs = await screen.findAllByRole('dialog')

--- a/src/components/dialog/confirm/confirmDialog.test.ts
+++ b/src/components/dialog/confirm/confirmDialog.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Dialog migration regression net: the showConfirmDialog helper must open
+ * its dialog through the Reka renderer with zeroed section padding (the
+ * Confirm* sections carry their own). Catches accidental reverts of the
+ * Phase 6 renderer flip.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const showDialog = vi.hoisted(() => vi.fn())
+
+vi.mock('@/stores/dialogStore', () => ({
+  useDialogStore: () => ({ showDialog })
+}))
+
+import ConfirmBody from '@/components/dialog/confirm/ConfirmBody.vue'
+import ConfirmFooter from '@/components/dialog/confirm/ConfirmFooter.vue'
+import ConfirmHeader from '@/components/dialog/confirm/ConfirmHeader.vue'
+import { showConfirmDialog } from '@/components/dialog/confirm/confirmDialog'
+
+describe('showConfirmDialog Reka renderer opt-in', () => {
+  beforeEach(() => {
+    showDialog.mockReset()
+  })
+
+  it("sets renderer 'reka' with size 'md' and zeroed section padding", () => {
+    showConfirmDialog()
+
+    const [args] = showDialog.mock.calls[0]
+    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps.size).toBe('md')
+    expect(args.dialogComponentProps.headerClass).toBe('p-0')
+    expect(args.dialogComponentProps.bodyClass).toBe('p-0')
+    expect(args.dialogComponentProps.footerClass).toBe('p-0')
+    expect(args.dialogComponentProps.pt).toBeUndefined()
+  })
+
+  it('forwards the confirm section components and caller props', () => {
+    showConfirmDialog({
+      key: 'confirm-test',
+      headerProps: { title: 'Title' },
+      props: { promptText: 'Prompt' },
+      footerProps: { confirmText: 'Delete' }
+    })
+
+    const [args] = showDialog.mock.calls[0]
+    expect(args.key).toBe('confirm-test')
+    expect(args.headerComponent).toBe(ConfirmHeader)
+    expect(args.component).toBe(ConfirmBody)
+    expect(args.footerComponent).toBe(ConfirmFooter)
+    expect(args.headerProps).toEqual({ title: 'Title' })
+    expect(args.props).toEqual({ promptText: 'Prompt' })
+    expect(args.footerProps).toEqual({ confirmText: 'Delete' })
+  })
+})

--- a/src/components/dialog/confirm/confirmDialog.ts
+++ b/src/components/dialog/confirm/confirmDialog.ts
@@ -23,11 +23,13 @@ export function showConfirmDialog(options: ConfirmDialogOptions = {}) {
     props,
     footerProps,
     dialogComponentProps: {
-      pt: {
-        header: 'py-0! px-0!',
-        content: 'p-0!',
-        footer: 'p-0!'
-      }
+      renderer: 'reka',
+      size: 'md',
+      // Confirm sections carry their own padding — zero out the dialog
+      // chrome padding, like the PrimeVue `pt` overrides did.
+      headerClass: 'p-0',
+      bodyClass: 'p-0',
+      footerClass: 'p-0'
     }
   })
 }

--- a/src/components/dialog/confirm/confirmDialog.ts
+++ b/src/components/dialog/confirm/confirmDialog.ts
@@ -24,12 +24,7 @@ export function showConfirmDialog(options: ConfirmDialogOptions = {}) {
     footerProps,
     dialogComponentProps: {
       renderer: 'reka',
-      size: 'md',
-      // Confirm sections carry their own padding — zero out the dialog
-      // chrome padding, like the PrimeVue `pt` overrides did.
-      headerClass: 'p-0',
-      bodyClass: 'p-0',
-      footerClass: 'p-0'
+      size: 'md'
     }
   })
 }

--- a/src/composables/queue/useQueueClearHistoryDialog.ts
+++ b/src/composables/queue/useQueueClearHistoryDialog.ts
@@ -9,19 +9,13 @@ export const useQueueClearHistoryDialog = () => {
       key: 'queue-clear-history',
       component: QueueClearHistoryDialog,
       dialogComponentProps: {
+        renderer: 'reka',
         headless: true,
         closable: false,
         closeOnEscape: true,
         dismissableMask: true,
-        pt: {
-          root: {
-            class: 'max-w-90 w-auto bg-transparent border-none shadow-none'
-          },
-          content: {
-            class: 'bg-transparent',
-            style: 'padding: 0'
-          }
-        }
+        // The content draws its own panel — neutralize the chrome box.
+        contentClass: 'w-fit max-w-90 border-none bg-transparent shadow-none'
       }
     })
   }

--- a/src/composables/useWorkflowTemplateSelectorDialog.ts
+++ b/src/composables/useWorkflowTemplateSelectorDialog.ts
@@ -36,6 +36,15 @@ export const useWorkflowTemplateSelectorDialog = () => {
           options?.afterClose?.()
         },
         initialCategory
+      },
+      // The template browser is a wide layout. Without an explicit size the
+      // Reka DialogContent falls back to size 'md' (max-w-xl), clipping the
+      // filter bar so the Clear Filters button lands outside the viewport.
+      // Size it like the other large dialogs (Settings/Manager).
+      dialogComponentProps: {
+        size: 'full',
+        contentClass:
+          'w-[90vw] max-w-[1400px] sm:max-w-[1400px] h-[80vh] rounded-2xl overflow-hidden'
       }
     })
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { initializeApp } from 'firebase/app'
 import { createPinia } from 'pinia'
 import 'primeicons/primeicons.css'
 import PrimeVue from 'primevue/config'
+import ConfirmationService from 'primevue/confirmationservice'
 import ToastService from 'primevue/toastservice'
 import Tooltip from 'primevue/tooltip'
 import { createApp } from 'vue'
@@ -125,6 +126,7 @@ app
       }
     }
   })
+  .use(ConfirmationService)
   .use(ToastService)
   .use(pinia)
   .use(i18n)

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import { initializeApp } from 'firebase/app'
 import { createPinia } from 'pinia'
 import 'primeicons/primeicons.css'
 import PrimeVue from 'primevue/config'
-import ConfirmationService from 'primevue/confirmationservice'
 import ToastService from 'primevue/toastservice'
 import Tooltip from 'primevue/tooltip'
 import { createApp } from 'vue'
@@ -126,7 +125,6 @@ app
       }
     }
   })
-  .use(ConfirmationService)
   .use(ToastService)
   .use(pinia)
   .use(i18n)

--- a/src/platform/assets/composables/useMediaAssetActions.ts
+++ b/src/platform/assets/composables/useMediaAssetActions.ts
@@ -778,6 +778,10 @@ export function useMediaAssetActions() {
           onCancel: () => {
             resolve(false)
           }
+        },
+        dialogComponentProps: {
+          renderer: 'reka',
+          size: 'md'
         }
       })
     })

--- a/src/platform/workflow/sharing/composables/useShareDialog.ts
+++ b/src/platform/workflow/sharing/composables/useShareDialog.ts
@@ -66,11 +66,7 @@ export function useShareDialog() {
         onClose: hide
       },
       dialogComponentProps: {
-        pt: {
-          root: {
-            class: 'rounded-2xl overflow-hidden w-full sm:w-144 max-w-full'
-          }
-        }
+        contentClass: 'sm:max-w-144 rounded-2xl overflow-hidden'
       }
     })
   }

--- a/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
+++ b/src/platform/workflow/sharing/composables/useSharedWorkflowUrlLoader.ts
@@ -110,11 +110,7 @@ export function useSharedWorkflowUrlLoader() {
         },
         dialogComponentProps: {
           onClose: () => resolve({ action: 'cancel' }),
-          pt: {
-            root: {
-              class: 'rounded-2xl overflow-hidden w-full sm:w-176 max-w-full'
-            }
-          }
+          contentClass: 'sm:max-w-176 rounded-2xl overflow-hidden'
         }
       })
     })

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -79,4 +79,56 @@ describe('dialogService Reka renderer opt-in', () => {
     expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('lg')
   })
+
+  it("showTopUpCreditsDialog() sets renderer 'reka' with a transparent shrink-wrapped chrome", async () => {
+    await useDialogService().showTopUpCreditsDialog()
+    const [args] = showDialog.mock.calls[0]
+    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps.headless).toBe(true)
+    expect(args.dialogComponentProps.pt).toBeUndefined()
+    expect(args.dialogComponentProps.contentClass).toContain('w-fit')
+    expect(args.dialogComponentProps.contentClass).toContain('bg-transparent')
+  })
+
+  it("showLayoutDialog() defaults to renderer 'reka' headless without pt", () => {
+    const Component = { template: '<div />' }
+    useDialogService().showLayoutDialog({
+      key: 'layout-test',
+      component: Component,
+      props: {}
+    })
+    const [args] = showDialog.mock.calls[0]
+    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps.headless).toBe(true)
+    expect(args.dialogComponentProps.pt).toBeUndefined()
+  })
+
+  it('showLayoutDialog() lets callers override the defaults', () => {
+    const Component = { template: '<div />' }
+    useDialogService().showLayoutDialog({
+      key: 'layout-override-test',
+      component: Component,
+      props: {},
+      dialogComponentProps: { closable: false, contentClass: 'w-170' }
+    })
+    const [args] = showDialog.mock.calls[0]
+    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps.closable).toBe(false)
+    expect(args.dialogComponentProps.contentClass).toBe('w-170')
+  })
+
+  it("showSmallLayoutDialog() sets renderer 'reka' with zeroed section padding", () => {
+    const Component = { template: '<div />' }
+    useDialogService().showSmallLayoutDialog({
+      key: 'small-layout-test',
+      component: Component
+    })
+    const [args] = showDialog.mock.calls[0]
+    expect(args.dialogComponentProps.renderer).toBe('reka')
+    expect(args.dialogComponentProps.pt).toBeUndefined()
+    expect(args.dialogComponentProps.contentClass).toContain('w-fit')
+    expect(args.dialogComponentProps.headerClass).toBe('p-0')
+    expect(args.dialogComponentProps.bodyClass).toBe('p-0 overflow-y-hidden')
+    expect(args.dialogComponentProps.footerClass).toBe('p-0')
+  })
 })

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -22,10 +22,10 @@ type DialogPosition =
   | 'bottomright'
 
 /**
- * Selects the dialog renderer used by `GlobalDialog`. `'primevue'` is the
- * current default and runs the legacy PrimeVue `Dialog` path. `'reka'` opts
- * into the Reka-UI primitive set under `src/components/ui/dialog/`. Migration
- * tracked in `temp/plans/adr-0009-dialog-reka-migration-DRAFT.md`.
+ * Selects the dialog renderer used by `GlobalDialog`. `'reka'` (the default)
+ * renders the Reka-UI primitive set under `src/components/ui/dialog/`.
+ * `'primevue'` is the legacy PrimeVue `Dialog` escape hatch, kept only until
+ * the branch is deleted in the Phase 6 cleanup (FE-578).
  */
 type DialogRenderer = 'primevue' | 'reka'
 
@@ -186,6 +186,7 @@ export const useDialogStore = defineStore('dialog', () => {
         closable: true,
         closeOnEscape: true,
         dismissableMask: true,
+        renderer: 'reka' as DialogRenderer,
         ...options.dialogComponentProps,
         maximized: false,
         onMaximize: () => {


### PR DESCRIPTION
Draft candidate for the staging e2e failures. Backports #12593's default-renderer flip + e2e fixtures, **excluding** the billing dialog callers (kept cloud/1.45's divergent versions) and **keeping** ConfirmationService (SecretsPanel still uses PrimeVue useConfirm). Running CI to verify the 3 failing specs go green without billing regressions. Sibling experiment #13306 tests the default-flip alone.