### PR TITLE
test: add critical unit coverage gate

### DIFF
--- a/.github/workflows/ci-tests-unit.yaml
+++ b/.github/workflows/ci-tests-unit.yaml
@@ -55,3 +55,6 @@ jobs:
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+      - name: Enforce critical coverage gate
+        run: pnpm test:coverage:critical

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -67,7 +67,15 @@ jobs:
 
       - name: Deploy report to Cloudflare
         id: deploy
-        if: always() && !cancelled()
+        if: >-
+          ${{
+            always() &&
+            !cancelled() &&
+            (
+              github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.fork == false
+            )
+          }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -67,15 +67,7 @@ jobs:
 
       - name: Deploy report to Cloudflare
         id: deploy
-        if: >-
-          ${{
-            always() &&
-            !cancelled() &&
-            (
-              github.event_name != 'pull_request' ||
-              github.event.pull_request.head.repo.fork == false
-            )
-          }}
+        if: always() && !cancelled()
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:critical": "cross-env COVERAGE_CRITICAL=true vitest run --coverage",
     "test:unit": "vitest run",
     "typecheck": "vue-tsc --noEmit",
     "typecheck:browser": "vue-tsc --project browser_tests/tsconfig.json",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -32,40 +32,19 @@ const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
 const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
 
 const CRITICAL_COVERAGE_INCLUDE = [
-  'src/base/common/async.ts',
-  'src/base/credits/comfyCredits.ts',
-  'src/composables/graph/useGroupContextMenu.ts',
-  'src/composables/graph/useGroupMenuOptions.ts',
-  'src/composables/graph/useMoreOptionsMenu.ts',
-  'src/composables/graph/useNodeCustomization.ts',
-  'src/composables/graph/useNodeMenuOptions.ts',
-  'src/composables/graph/useSelectionMenuOptions.ts',
-  'src/composables/graph/useSelectionOperations.ts',
-  'src/composables/graph/useSelectionState.ts',
-  'src/composables/node/useNodePricing.ts',
-  'src/scripts/metadata/parser.ts',
-  'src/stores/aboutPanelStore.ts',
-  'src/stores/executionStore.ts',
-  'src/stores/nodeBookmarkStore.ts',
-  'src/stores/queueStore.ts',
-  'src/utils/fuseUtil.ts',
-  'src/utils/gridUtil.ts',
-  'src/utils/mouseDownUtil.ts',
-  'src/utils/nodeTitleUtil.ts',
-  'src/utils/objectUrlUtil.ts',
-  'src/utils/queueDisplay.ts',
-  'src/utils/rafBatch.ts',
-  'src/utils/treeUtil.ts',
-  'src/utils/typeGuardUtil.ts',
-  'src/workbench/extensions/manager/composables/nodePack/usePackInstall.ts',
-  'src/workbench/extensions/manager/composables/useManagerDisplayPacks.ts'
+  'src/base/**/*.{ts,vue}',
+  'src/composables/**/*.{ts,vue}',
+  'src/scripts/**/*.{ts,vue}',
+  'src/stores/**/*.{ts,vue}',
+  'src/utils/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/composables/**/*.{ts,vue}'
 ]
 
 const CRITICAL_COVERAGE_THRESHOLDS = {
-  statements: 58,
-  branches: 47,
-  functions: 54,
-  lines: 58
+  statements: 66,
+  branches: 56,
+  functions: 64,
+  lines: 68
 }
 
 // Open Graph / Twitter Meta Tags Constants

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -29,6 +29,44 @@ const VITE_REMOTE_DEV = process.env.VITE_REMOTE_DEV === 'true'
 const DISABLE_TEMPLATES_PROXY = process.env.DISABLE_TEMPLATES_PROXY === 'true'
 const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP !== 'false'
 const IS_STORYBOOK = process.env.npm_lifecycle_event === 'storybook'
+const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
+
+const CRITICAL_COVERAGE_INCLUDE = [
+  'src/base/common/async.ts',
+  'src/base/credits/comfyCredits.ts',
+  'src/composables/graph/useGroupContextMenu.ts',
+  'src/composables/graph/useGroupMenuOptions.ts',
+  'src/composables/graph/useMoreOptionsMenu.ts',
+  'src/composables/graph/useNodeCustomization.ts',
+  'src/composables/graph/useNodeMenuOptions.ts',
+  'src/composables/graph/useSelectionMenuOptions.ts',
+  'src/composables/graph/useSelectionOperations.ts',
+  'src/composables/graph/useSelectionState.ts',
+  'src/composables/node/useNodePricing.ts',
+  'src/scripts/metadata/parser.ts',
+  'src/stores/aboutPanelStore.ts',
+  'src/stores/executionStore.ts',
+  'src/stores/nodeBookmarkStore.ts',
+  'src/stores/queueStore.ts',
+  'src/utils/fuseUtil.ts',
+  'src/utils/gridUtil.ts',
+  'src/utils/mouseDownUtil.ts',
+  'src/utils/nodeTitleUtil.ts',
+  'src/utils/objectUrlUtil.ts',
+  'src/utils/queueDisplay.ts',
+  'src/utils/rafBatch.ts',
+  'src/utils/treeUtil.ts',
+  'src/utils/typeGuardUtil.ts',
+  'src/workbench/extensions/manager/composables/nodePack/usePackInstall.ts',
+  'src/workbench/extensions/manager/composables/useManagerDisplayPacks.ts'
+]
+
+const CRITICAL_COVERAGE_THRESHOLDS = {
+  statements: 58,
+  branches: 47,
+  functions: 54,
+  lines: 58
+}
 
 // Open Graph / Twitter Meta Tags Constants
 const VITE_OG_URL = 'https://cloud.comfy.org'
@@ -667,8 +705,10 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.{ts,vue}'],
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
+      include: COVERAGE_CRITICAL
+        ? CRITICAL_COVERAGE_INCLUDE
+        : ['src/**/*.{ts,vue}'],
       exclude: [
         'src/**/*.test.ts',
         'src/**/*.spec.ts',
@@ -677,7 +717,8 @@ export default defineConfig({
         'src/locales/**',
         'src/lib/litegraph/**',
         'src/assets/**'
-      ]
+      ],
+      ...(COVERAGE_CRITICAL ? { thresholds: CRITICAL_COVERAGE_THRESHOLDS } : {})
     },
     exclude: [
       '**/node_modules/**',

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -34,17 +34,48 @@ const COVERAGE_CRITICAL = process.env.COVERAGE_CRITICAL === 'true'
 const CRITICAL_COVERAGE_INCLUDE = [
   'src/base/**/*.{ts,vue}',
   'src/composables/**/*.{ts,vue}',
+  'src/core/**/*.{ts,vue}',
+  'src/lib/litegraph/src/node/**/*.{ts,vue}',
+  'src/lib/litegraph/src/subgraph/**/*.{ts,vue}',
+  'src/lib/litegraph/src/utils/**/*.{ts,vue}',
+  'src/platform/assets/composables/**/*.{ts,vue}',
+  'src/platform/assets/mappings/**/*.{ts,vue}',
+  'src/platform/assets/schemas/**/*.{ts,vue}',
+  'src/platform/assets/services/**/*.{ts,vue}',
+  'src/platform/assets/utils/**/*.{ts,vue}',
+  'src/platform/errorCatalog/**/*.{ts,vue}',
+  'src/platform/keybindings/**/*.{ts,vue}',
+  'src/platform/missingMedia/**/*.{ts,vue}',
+  'src/platform/missingModel/**/*.{ts,vue}',
+  'src/platform/navigation/**/*.{ts,vue}',
+  'src/platform/nodeReplacement/**/*.{ts,vue}',
+  'src/platform/remote/**/*.{ts,vue}',
+  'src/platform/remoteConfig/**/*.{ts,vue}',
+  'src/platform/secrets/**/*.{ts,vue}',
+  'src/platform/settings/**/*.{ts,vue}',
+  'src/platform/workflow/**/*.{ts,vue}',
+  'src/platform/workspace/api/**/*.{ts,vue}',
+  'src/platform/workspace/auth/**/*.{ts,vue}',
+  'src/platform/workspace/composables/**/*.{ts,vue}',
+  'src/platform/workspace/stores/**/*.{ts,vue}',
+  'src/platform/workspace/utils/**/*.{ts,vue}',
+  'src/schemas/**/*.{ts,vue}',
   'src/scripts/**/*.{ts,vue}',
+  'src/services/**/*.{ts,vue}',
   'src/stores/**/*.{ts,vue}',
   'src/utils/**/*.{ts,vue}',
-  'src/workbench/extensions/manager/composables/**/*.{ts,vue}'
+  'src/workbench/extensions/manager/composables/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/services/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/stores/**/*.{ts,vue}',
+  'src/workbench/extensions/manager/utils/**/*.{ts,vue}',
+  'src/workbench/utils/**/*.{ts,vue}'
 ]
 
 const CRITICAL_COVERAGE_THRESHOLDS = {
-  statements: 66,
-  branches: 56,
-  functions: 64,
-  lines: 68
+  statements: 69,
+  branches: 60,
+  functions: 67,
+  lines: 70
 }
 
 // Open Graph / Twitter Meta Tags Constants
@@ -694,7 +725,7 @@ export default defineConfig({
         'src/**/*.stories.ts',
         'src/**/*.d.ts',
         'src/locales/**',
-        'src/lib/litegraph/**',
+        ...(COVERAGE_CRITICAL ? [] : ['src/lib/litegraph/**']),
         'src/assets/**'
       ],
       ...(COVERAGE_CRITICAL ? { thresholds: CRITICAL_COVERAGE_THRESHOLDS } : {})

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -684,7 +684,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       include: COVERAGE_CRITICAL
         ? CRITICAL_COVERAGE_INCLUDE
         : ['src/**/*.{ts,vue}'],


### PR DESCRIPTION
## Summary

Add a `COVERAGE_CRITICAL` unit-coverage gate over folder-based critical runtime areas and wire it into the unit CI job. First PR of a stacked series that ratchets the gate upward as tests land.

## Changes

- **What**: `vite.config.mts` gains `CRITICAL_COVERAGE_INCLUDE` folder globs for core runtime areas: `src/base`, `src/composables`, `src/core`, `src/schemas`, `src/scripts`, `src/services`, `src/stores`, `src/utils`, selected `src/platform` logic slices, selected `src/lib/litegraph/src/{node,subgraph,utils}` primitives, and selected `src/workbench` manager logic; `package.json` gains `test:coverage:critical` (`COVERAGE_CRITICAL=true vitest run --coverage`); `ci-tests-unit.yaml` runs the gate. The thresholds are env-gated, so the normal `test:coverage` run is unaffected.
- **Breaking**: none.

## Review Focus

Establishes the measurement substrate, no tests added yet. Thresholds are locked to the current baseline over the folder-based critical scope so CI is green:

| metric | baseline | threshold |
|---|---|---|
| statements | 69.53% (24287/34930) | 69 |
| branches | 60.7% (11497/18940) | 60 |
| functions | 67.34% (4980/7395) | 67 |
| lines | 70.83% (22619/31930) | 70 |

The scope is intentionally not whole `src/platform`, `src/lib`, or `src/workbench`: UI-heavy and specialized lanes like platform components, telemetry/surveys, litegraph canvas/widgets/infrastructure/types, and manager components/types stay outside this gate for now.

Subsequent stacked PRs add tests and bump these thresholds; a later refactor series ratchets branches to 90.

Created by Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test/coverage configuration and CI; no application runtime behavior is modified.
> 
> **Overview**
> Introduces a **critical-path unit coverage gate** that only runs when `COVERAGE_CRITICAL=true`, leaving the existing `pnpm test:coverage` behavior unchanged.
> 
> **Vitest** (`vite.config.mts`): when the flag is set, coverage is limited to folder globs for core runtime areas (base, composables, core, services, stores, utils, selected platform/workspace/auth slices, litegraph node/subgraph/utils, workbench manager logic, etc.) and **Vitest thresholds** are enforced (statements 69%, branches 60%, functions 67%, lines 70%). In that mode, litegraph is no longer blanket-excluded from coverage the way the full `src` run still excludes `src/lib/litegraph/**`.
> 
> **Tooling & CI**: adds `test:coverage:critical` in `package.json` and a new unit CI step after Codecov upload that runs the gate so regressions in those areas fail the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e73f38449ec9eab0f352a15ce6c2cbffb0cace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->