### PR TITLE
[DO NOT MERGE] e2e baseline probe for cloud/1.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,3 +563,5 @@ For comprehensive troubleshooting and technical support, please refer to our off
 - **[General Troubleshooting Guide](https://docs.comfy.org/troubleshooting/overview)** - Common issues, performance optimization, and reporting bugs
 - **[Custom Node Issues](https://docs.comfy.org/troubleshooting/custom-node-issues)** - Debugging custom node problems and conflicts
 - **[Desktop Installation Guide](https://docs.comfy.org/installation/desktop/windows)** - Desktop-specific installation and troubleshooting
+
+<!-- e2e baseline probe (cloud/1.45) — do not merge -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,3 +139,5 @@ const bootstrapStore = useBootstrapStore(pinia)
 void bootstrapStore.startStoreBootstrap()
 
 app.mount('#vue-app')
+
+// e2e baseline probe — no-op (do not merge)


### PR DESCRIPTION
Throwaway. No-op README change to run e2e on pristine cloud/1.45 and capture the baseline failing-test set. Will be closed after confirmation.