### PR TITLE
fix(billing): pricing dialog stacks above Settings + stops horizontal scroll

### DIFF
--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -46,7 +46,9 @@
               <DialogTitle v-else :id="item.key">
                 {{ item.title || ' ' }}
               </DialogTitle>
-              <DialogClose v-if="item.dialogComponentProps.closable !== false" />
+              <DialogClose
+                v-if="item.dialogComponentProps.closable !== false"
+              />
             </DialogHeader>
             <div class="flex-1 overflow-auto px-4 py-2">
               <component

--- a/src/components/dialog/GlobalDialog.vue
+++ b/src/components/dialog/GlobalDialog.vue
@@ -25,28 +25,40 @@
           "
           @mousedown="() => dialogStore.riseDialog({ key: item.key })"
         >
-          <DialogHeader v-if="!item.dialogComponentProps.headless">
-            <component
-              :is="item.headerComponent"
-              v-if="item.headerComponent"
-              v-bind="item.headerProps"
-              :id="item.key"
-            />
-            <DialogTitle v-else :id="item.key">
-              {{ item.title || ' ' }}
-            </DialogTitle>
-            <DialogClose v-if="item.dialogComponentProps.closable !== false" />
-          </DialogHeader>
-          <div class="flex-1 overflow-auto px-4 py-2">
+          <!-- Headless dialogs (e.g. the pricing table) draw their own chrome;
+               render them directly to avoid the px-4/py-2 + overflow-auto wrapper
+               that otherwise forces a horizontal scrollbar on full-width content. -->
+          <template v-if="item.dialogComponentProps.headless">
             <component
               :is="item.component"
               v-bind="item.contentProps"
               :maximized="item.dialogComponentProps.maximized"
             />
-          </div>
-          <DialogFooter v-if="item.footerComponent">
-            <component :is="item.footerComponent" v-bind="item.footerProps" />
-          </DialogFooter>
+          </template>
+          <template v-else>
+            <DialogHeader>
+              <component
+                :is="item.headerComponent"
+                v-if="item.headerComponent"
+                v-bind="item.headerProps"
+                :id="item.key"
+              />
+              <DialogTitle v-else :id="item.key">
+                {{ item.title || ' ' }}
+              </DialogTitle>
+              <DialogClose v-if="item.dialogComponentProps.closable !== false" />
+            </DialogHeader>
+            <div class="flex-1 overflow-auto px-4 py-2">
+              <component
+                :is="item.component"
+                v-bind="item.contentProps"
+                :maximized="item.dialogComponentProps.maximized"
+              />
+            </div>
+            <DialogFooter v-if="item.footerComponent">
+              <component :is="item.footerComponent" v-bind="item.footerProps" />
+            </DialogFooter>
+          </template>
         </DialogContent>
       </DialogPortal>
     </Dialog>

--- a/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
+++ b/src/platform/cloud/subscription/composables/useSubscriptionDialog.ts
@@ -41,6 +41,13 @@ export const useSubscriptionDialog = () => {
   function showPricingTable(options?: SubscriptionDialogOptions) {
     if (!isCloud) return
 
+    // Opening pricing from inside Settings (the "Subscribe" / "Upgrade to Team"
+    // CTA) would stack the Reka pricing dialog behind the PrimeVue Settings
+    // dialog (Reka z-1700 < PrimeVue modal z-1800) — and pricing is intentionally
+    // non-modal so its hosted PrimeVue popover stays clickable, so it can't just
+    // be raised above. Close Settings first so pricing opens cleanly on top.
+    dialogStore.closeDialog({ key: 'global-settings' })
+
     const { permissions } = useWorkspaceUI()
 
     // Members can't manage the workspace subscription, so a blocked run shows a


### PR DESCRIPTION
Fixes the two pricing-dialog issues flagged by design (Alex/Denys) on staging/testcloud.

## 1. Pricing renders behind Settings
cloud/1.45 is mid-Reka-migration: **Settings is still PrimeVue** (modal `z-index: 1800`) while **pricing is Reka** (overlay/content `z-1700`). So clicking Subscribe/Upgrade-to-Team inside Settings opens pricing *under* Settings. Pricing is intentionally `modal: false` (its hosted PrimeVue popover must stay clickable), so it can't just be raised above. **Fix:** close the `global-settings` dialog when opening the pricing table.

## 2. Horizontal scrollbar on the dialog
`GlobalDialog` wrapped every dialog body in `flex-1 overflow-auto px-4 py-2` — including **headless** dialogs (pricing) that draw their own chrome, forcing x-overflow on the full-width table. **Fix:** render headless dialogs directly (mirrors `main`'s GlobalDialog).

## Scope
2 files, dialog-rendering only. No billing-logic change.

## Verification
Needs a visual check on the preview/staging (z-index + overflow are visual). Please confirm: open Settings → Subscribe/Upgrade-to-Team → pricing now opens **on top**, no horizontal scrollbar, hosted popovers still clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)