### PR TITLE
refactor(website): tidy customer story review nits

### DIFF
--- a/apps/website/src/components/customers/ArticleNav.vue
+++ b/apps/website/src/components/customers/ArticleNav.vue
@@ -15,7 +15,7 @@ const { categories } = defineProps<{
 
 const activeSection = ref(categories[0]?.value ?? '')
 
-const HEADER_OFFSET = -144
+const HEADER_OFFSET_PX = -144
 const BOTTOM_THRESHOLD_PX = 4
 const SCROLL_SAFETY_MS = 1500
 
@@ -52,7 +52,7 @@ function scrollToSection(id: string) {
   const el = document.getElementById(id)
   if (el) {
     scrollTo(el, {
-      offset: HEADER_OFFSET,
+      offset: HEADER_OFFSET_PX,
       duration: 0.8,
       immediate: prefersReducedMotion(),
       onComplete: clearScrollLock

--- a/apps/website/src/components/customers/content/ListItem.astro
+++ b/apps/website/src/components/customers/content/ListItem.astro
@@ -1,5 +1,5 @@
 <li
-  class="flex items-start gap-2 text-primary-comfy-canvas before:mt-1.5 before:size-1.5 before:shrink-0 before:rounded-full before:bg-primary-comfy-yellow before:content-['']"
+  class="flex items-start gap-2 text-primary-comfy-canvas before:mt-1.5 before:size-1.5 before:shrink-0 before:rounded-full before:bg-primary-comfy-yellow"
 >
   <slot />
 </li>


### PR DESCRIPTION
## Summary

Small follow-up to #13289 applying two non-blocking review nits from Alex's review.

## Changes

- **What**: drop the redundant `before:content-['']` on the customer-story list bullet (Tailwind emits the empty `content` automatically once another `before:` utility is present), and rename `HEADER_OFFSET` to `HEADER_OFFSET_PX` in `ArticleNav` so the scroll constants use consistent unit suffixes.

## Review Focus

Both changes are cosmetic with no behavior change. Confirmed in the browser that the list bullet still renders identically (6px yellow dot) without the explicit `content` utility.

## Notes from the #13289 review (left as-is here, open to discussion)

Three other comments from the review are intentionally not changed in this PR; reasoning below so the decisions are on record:

- **`Category` type in `ArticleNav`**: kept the `ComponentProps<typeof CategoryNav>` derivation. AGENTS.md says to derive component types via `vue-component-type-helpers` rather than redefining them, so the current form follows the styleguide. Happy to switch to a plain named type if preferred.
- **Section ids in frontmatter vs the body `<Section>`**: kept the `customers.content.test.ts` parity test. The short TOC labels live only in frontmatter and Astro can't introspect the rendered MDX body to build the nav, so the frontmatter `sections` list and the body anchor ids can't be trivially deduplicated. A real fix would need a remark plugin (larger, separate change). The test guards against silent drift in the meantime.
- **`nextStory` throw**: left as a fail-loud, build-time invariant. The slug always comes from the same `getStaticPaths` collection, so the throw is effectively unreachable; it surfaces a future-refactor bug loudly instead of linking to the wrong story.
