### PR TITLE
fix(billing): split useWorkspacePermissions out of useWorkspaceUI to break setup-time cycle

### DIFF
--- a/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
@@ -82,24 +82,24 @@ describe('SubscribeToRun', () => {
   it('shows the subscribe label for owners who can manage the subscription', () => {
     renderButton()
 
-    expect(screen.getByTestId('subscribe-to-run-button')).toHaveTextContent(
-      'Subscribe to Run'
-    )
+    expect(
+      screen.getByRole('button', { name: /subscribe to run/i })
+    ).toBeInTheDocument()
   })
 
   it('shows a neutral run label for members who cannot subscribe', () => {
     mockCanManageSubscription.value = false
     renderButton()
 
-    const button = screen.getByTestId('subscribe-to-run-button')
-    expect(button).toHaveTextContent('Run')
+    const button = screen.getByRole('button', { name: 'Run' })
+    expect(button).toBeInTheDocument()
     expect(button).not.toHaveTextContent('Subscribe')
   })
 
   it('opens the subscription dialog for owners on click', async () => {
     const { user } = renderButton()
 
-    await user.click(screen.getByTestId('subscribe-to-run-button'))
+    await user.click(screen.getByRole('button', { name: /subscribe to run/i }))
 
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
   })
@@ -108,7 +108,7 @@ describe('SubscribeToRun', () => {
     mockCanManageSubscription.value = false
     const { user } = renderButton()
 
-    await user.click(screen.getByTestId('subscribe-to-run-button'))
+    await user.click(screen.getByRole('button', { name: 'Run' }))
 
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
   })
@@ -123,9 +123,23 @@ describe('SubscribeToRun', () => {
       const { user } = renderButton()
       expect(mockUseBillingContext).not.toHaveBeenCalled()
 
-      await user.click(screen.getByTestId('subscribe-to-run-button'))
+      await user.click(
+        screen.getByRole('button', { name: /subscribe to run/i })
+      )
 
       expect(mockUseBillingContext).toHaveBeenCalled()
+    })
+
+    it('reuses the billing context across repeated clicks', async () => {
+      const { user } = renderButton()
+      const button = screen.getByRole('button', { name: /subscribe to run/i })
+
+      await user.click(button)
+      await user.click(button)
+      await user.click(button)
+
+      expect(mockUseBillingContext).toHaveBeenCalledOnce()
+      expect(mockShowSubscriptionDialog).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.test.ts
@@ -8,17 +8,18 @@ import { createI18n } from 'vue-i18n'
 import SubscribeToRun from './SubscribeToRun.vue'
 
 const mockShowSubscriptionDialog = vi.fn()
+const mockUseBillingContext = vi.fn(() => ({
+  showSubscriptionDialog: mockShowSubscriptionDialog
+}))
 const mockCanManageSubscription = ref(true)
 const mockIsMdOrLarger = ref(true)
 
 vi.mock('@/composables/billing/useBillingContext', () => ({
-  useBillingContext: () => ({
-    showSubscriptionDialog: mockShowSubscriptionDialog
-  })
+  useBillingContext: () => mockUseBillingContext()
 }))
 
 vi.mock('@/platform/workspace/composables/useWorkspaceUI', () => ({
-  useWorkspaceUI: () => ({
+  useWorkspacePermissions: () => ({
     permissions: computed(() => ({
       canManageSubscription: mockCanManageSubscription.value
     }))
@@ -110,5 +111,21 @@ describe('SubscribeToRun', () => {
     await user.click(screen.getByTestId('subscribe-to-run-button'))
 
     expect(mockShowSubscriptionDialog).toHaveBeenCalledOnce()
+  })
+
+  describe('billing context import cycle', () => {
+    it('does not resolve useBillingContext at component setup', () => {
+      renderButton()
+      expect(mockUseBillingContext).not.toHaveBeenCalled()
+    })
+
+    it('resolves useBillingContext lazily when the button is clicked', async () => {
+      const { user } = renderButton()
+      expect(mockUseBillingContext).not.toHaveBeenCalled()
+
+      await user.click(screen.getByTestId('subscribe-to-run-button'))
+
+      expect(mockUseBillingContext).toHaveBeenCalled()
+    })
   })
 })

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -24,14 +24,13 @@ import Button from '@/components/ui/button/Button.vue'
 import { useBillingContext } from '@/composables/billing/useBillingContext'
 import { useRunButtonTelemetry } from '@/composables/useRunButtonTelemetry'
 import { isCloud } from '@/platform/distribution/types'
-import { useWorkspaceUI } from '@/platform/workspace/composables/useWorkspaceUI'
+import { useWorkspacePermissions } from '@/platform/workspace/composables/useWorkspaceUI'
 
 const { t } = useI18n()
 const breakpoints = useBreakpoints(breakpointsTailwind)
 const isMdOrLarger = breakpoints.greaterOrEqual('md')
 
-const { permissions } = useWorkspaceUI()
-const { showSubscriptionDialog } = useBillingContext()
+const { permissions } = useWorkspacePermissions()
 const { trackRunButton } = useRunButtonTelemetry()
 
 const canResubscribe = computed(() => permissions.value.canManageSubscription)
@@ -54,6 +53,6 @@ function handleSubscribeToRun() {
     trackRunButton({ subscribe_to_run: true })
   }
 
-  showSubscriptionDialog()
+  useBillingContext().showSubscriptionDialog()
 }
 </script>

--- a/src/platform/cloud/subscription/components/SubscribeToRun.vue
+++ b/src/platform/cloud/subscription/components/SubscribeToRun.vue
@@ -33,6 +33,13 @@ const isMdOrLarger = breakpoints.greaterOrEqual('md')
 const { permissions } = useWorkspacePermissions()
 const { trackRunButton } = useRunButtonTelemetry()
 
+let billingContext: ReturnType<typeof useBillingContext> | undefined
+
+function getBillingContext() {
+  billingContext ??= useBillingContext()
+  return billingContext
+}
+
 const canResubscribe = computed(() => permissions.value.canManageSubscription)
 
 const buttonLabel = computed(() => {
@@ -53,6 +60,6 @@ function handleSubscribeToRun() {
     trackRunButton({ subscribe_to_run: true })
   }
 
-  useBillingContext().showSubscriptionDialog()
+  getBillingContext().showSubscriptionDialog()
 }
 </script>

--- a/src/platform/workspace/composables/useWorkspaceUI.ts
+++ b/src/platform/workspace/composables/useWorkspaceUI.ts
@@ -156,17 +156,13 @@ function isOriginalOwnerByEmail(
   return original.email.toLowerCase() === email
 }
 
-/**
- * Internal implementation of UI configuration composable.
- */
-function useWorkspaceUIInternal() {
+// Billing-free permissions: must not read useBillingContext, directly or
+// indirectly. useWorkspaceUI sits inside the
+// useBillingContext -> useWorkspaceBilling -> useWorkspaceUI cycle, so any
+// component whose render path needs only permissions must use this composable
+// to avoid re-entering a half-built billing context at setup time.
+function useWorkspacePermissionsInternal() {
   const store = useTeamWorkspaceStore()
-  const { userEmail } = useCurrentUser()
-  const { isActiveSubscription, subscription } = useBillingContext()
-
-  const isInPersonalWorkspace = computed(() => store.isInPersonalWorkspace)
-  const isWorkspaceSubscribed = computed(() => store.isWorkspaceSubscribed)
-  const members = computed(() => store.members)
 
   const workspaceType = computed<WorkspaceType>(
     () => store.activeWorkspace?.type ?? 'personal'
@@ -201,6 +197,32 @@ function useWorkspaceUIInternal() {
   const uiConfig = computed<WorkspaceUIConfig>(() =>
     getUIConfig(workspaceType.value, workspaceRole.value)
   )
+
+  return {
+    permissions,
+    uiConfig,
+    workspaceType,
+    workspaceRole
+  }
+}
+
+export const useWorkspacePermissions = createSharedComposable(
+  useWorkspacePermissionsInternal
+)
+
+/**
+ * Internal implementation of UI configuration composable.
+ */
+function useWorkspaceUIInternal() {
+  const store = useTeamWorkspaceStore()
+  const { userEmail } = useCurrentUser()
+  const { isActiveSubscription, subscription } = useBillingContext()
+  const { permissions, uiConfig, workspaceType, workspaceRole } =
+    useWorkspacePermissions()
+
+  const isInPersonalWorkspace = computed(() => store.isInPersonalWorkspace)
+  const isWorkspaceSubscribed = computed(() => store.isWorkspaceSubscribed)
+  const members = computed(() => store.members)
 
   // Cancel / reactivate / delete are original-owner-only; personal workspaces
   // are single-member, so the user is always their own original owner.


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## What

Splits the billing-free permission/role/UI state out of `useWorkspaceUI` into a new shared composable `useWorkspacePermissions`, and points `SubscribeToRun.vue` at it. `useBillingContext()` is also moved off the component's setup path and resolved lazily inside the click handler.

## Why

`SubscribeToRun.vue` reads `useWorkspaceUI()` at component setup. `useWorkspaceUI` reads `useBillingContext()`, which sits inside the `useBillingContext -> useWorkspaceBilling -> useWorkspaceUI` cycle. If the component mounts during the boot-time window where the billing context is still being constructed (e.g. when `CloudRunButtonWrapper`'s `isActiveSubscription`-driven computed first evaluates, after `PostHogTelemetryProvider` has already kicked off a read), the cycle resolves a half-built context and the button defaults to "Subscribe to Run" for already-subscribed users — the same symptom that the user-visible bug exhibited on prod after the cloud/1.45 deploy.

`bfa534fc0` ("resolve useWorkspaceUI lazily to break subscription dialog cycle") fixed the same shape inside `useSubscriptionDialog` by deferring the `useWorkspaceUI()` read until the imperative `showPricingTable()` call. `SubscribeToRun.vue` can't use that exact pattern because it needs `permissions` at render time to pick the button label, so this PR takes the structural route: extract the billing-free parts.

The new composable has an explicit invariant comment ("must not read `useBillingContext`, directly or indirectly") to prevent the next refactor / backport conflict from collapsing them back together.

## Verification

- `pnpm typecheck` — clean
- `pnpm exec eslint` on the 3 changed files — clean
- `pnpm exec oxfmt --check` on the 3 changed files — clean
- `pnpm exec vitest run src/composables/billing src/platform/cloud/subscription src/platform/workspace` — 819/819 passed across 59 files
- `pnpm build` — clean, 11.82s
- Two new regression tests in `SubscribeToRun.test.ts` assert `useBillingContext` is not resolved at setup, only on click. Same shape as the regression test added in `bfa534fc0`'s test suite.

End-to-end browser verification of the cloud render path isn't reproducible in the local sandbox because the bug requires (a) `isCloud === true`, (b) `teamWorkspacesEnabled` flag ON, (c) an authenticated user with an inactive subscription returned from `/api/billing/status`. Manual reproduction should be done on staging once this lands.

## Reviewer note (oracle feedback)

Code review flagged that `useBillingContext()` is a `createSharedComposable`; calling it from a click handler runs it outside an effect scope, so `tryOnScopeDispose()` cleanup doesn't register. I considered this and concluded it's a non-issue here because (1) `useBillingContext` is an app-scope singleton already pinned by `PostHogTelemetryProvider`, the run-button wrapper, settings, etc. — it never gets torn down during a session, so an extra unreleased subscriber doesn't actually leak, and (2) `bfa534fc0`'s precedent uses the same lazy-call-from-handler pattern for `useWorkspaceUI()` inside `showPricingTable()`. Happy to switch to a setup-time `showSubscriptionDialog` reference paired with the new lazy permissions if you'd prefer the asymmetry to go the other direction.

## Backport note

The bug exists on `cloud/1.45` (prod) and on `main`. After merge, this needs a cherry-pick onto `cloud/1.45`. The conflict will be in `SubscribeToRun.vue`: cloud/1.45 uses `useTelemetry()?.trackRunButton(...)` while `main` uses `useRunButtonTelemetry`. Trivial resolution.

## Related

- Companion to #13288 (`bfa534fc0`)
- Follows up on the cloud/1.45 deploy regression observed on 2026-06-30, temporarily resolved by ArgoCD rollback.