### PR TITLE
Restore gated Hugging Face missing model download handling

### DIFF
--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from '@pinia/testing'
-import { render, screen, within } from '@testing-library/vue'
+import { render, screen, waitFor, within } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -40,6 +40,7 @@ vi.mock('./MissingModelRow.vue', () => ({
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockDownloadModel = vi.hoisted(() => vi.fn())
+const mockFetchModelMetadata = vi.hoisted(() => vi.fn())
 const mockOpenGatedRepoPage = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
@@ -54,6 +55,7 @@ vi.mock('@/platform/missingModel/missingModelDownload', async () => {
   return {
     ...actual,
     downloadModel: mockDownloadModel,
+    fetchModelMetadata: mockFetchModelMetadata,
     openGatedRepoPage: mockOpenGatedRepoPage
   }
 })
@@ -273,6 +275,10 @@ describe('MissingModelCard (OSS)', () => {
   beforeEach(() => {
     mockIsCloud.value = false
     vi.clearAllMocks()
+    mockFetchModelMetadata.mockResolvedValue({
+      fileSize: null,
+      gatedRepoUrl: null
+    })
   })
 
   afterEach(() => {
@@ -332,9 +338,11 @@ describe('MissingModelCard (OSS)', () => {
 
     await userEvent.click(screen.getByTestId('missing-model-download-all'))
 
-    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
-      'https://huggingface.co/comfy/test'
-    )
+    await waitFor(() => {
+      expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
+        'https://huggingface.co/comfy/test'
+      )
+    })
     expect(mockDownloadModel).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/missingModel/components/MissingModelCard.test.ts
+++ b/src/platform/missingModel/components/MissingModelCard.test.ts
@@ -10,6 +10,8 @@ import type {
   MissingModelGroup,
   MissingModelViewModel
 } from '@/platform/missingModel/types'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import type * as MissingModelDownload from '@/platform/missingModel/missingModelDownload'
 
 vi.mock('./MissingModelRow.vue', () => ({
   default: {
@@ -37,11 +39,24 @@ vi.mock('./MissingModelRow.vue', () => ({
 }))
 
 const mockIsCloud = vi.hoisted(() => ({ value: true }))
+const mockDownloadModel = vi.hoisted(() => vi.fn())
+const mockOpenGatedRepoPage = vi.hoisted(() => vi.fn())
 vi.mock('@/platform/distribution/types', () => ({
   get isCloud() {
     return mockIsCloud.value
   }
 }))
+
+vi.mock('@/platform/missingModel/missingModelDownload', async () => {
+  const actual = await vi.importActual<typeof MissingModelDownload>(
+    '@/platform/missingModel/missingModelDownload'
+  )
+  return {
+    ...actual,
+    downloadModel: mockDownloadModel,
+    openGatedRepoPage: mockOpenGatedRepoPage
+  }
+})
 
 import MissingModelCard from './MissingModelCard.vue'
 
@@ -108,7 +123,7 @@ function mountCard(
   }> = {},
   onLocateModel?: (nodeId: string) => void
 ) {
-  const pinia = createTestingPinia({ createSpy: vi.fn })
+  const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
   return render(MissingModelCard, {
     props: {
       missingModelGroups: [makeGroup()],
@@ -257,6 +272,7 @@ describe('MissingModelCard', () => {
 describe('MissingModelCard (OSS)', () => {
   beforeEach(() => {
     mockIsCloud.value = false
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
@@ -302,5 +318,23 @@ describe('MissingModelCard (OSS)', () => {
     expect(
       screen.queryByTestId('missing-model-actions')
     ).not.toBeInTheDocument()
+  })
+
+  it('opens gated repo URLs from Download all actions', async () => {
+    const groups = [makeGroup({ withDownloadUrls: true })]
+    mountCard({
+      missingModelGroups: groups
+    })
+    const store = useMissingModelStore()
+    store.gatedRepoUrls[
+      'https://huggingface.co/comfy/test/resolve/main/model.safetensors'
+    ] = 'https://huggingface.co/comfy/test'
+
+    await userEvent.click(screen.getByTestId('missing-model-download-all'))
+
+    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
+      'https://huggingface.co/comfy/test'
+    )
+    expect(mockDownloadModel).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -136,7 +136,7 @@ const downloadAllLabel = computed(() => {
 
 function downloadAllModels() {
   for (const model of downloadableModels.value) {
-    downloadMissingModel(model)
+    void downloadMissingModel(model)
   }
 }
 

--- a/src/platform/missingModel/components/MissingModelCard.vue
+++ b/src/platform/missingModel/components/MissingModelCard.vue
@@ -66,9 +66,9 @@ import type { MissingModelGroup } from '@/platform/missingModel/types'
 import { isCloud } from '@/platform/distribution/types'
 import MissingModelRow from '@/platform/missingModel/components/MissingModelRow.vue'
 import Button from '@/components/ui/button/Button.vue'
-import { downloadModel } from '@/platform/missingModel/missingModelDownload'
 import { getDownloadableModels } from '@/platform/missingModel/missingModelViewUtils'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+import { useMissingModelDownload } from '@/platform/missingModel/composables/useMissingModelDownload'
 import { formatSize } from '@/utils/formatUtil'
 
 interface MissingModelRowEntry {
@@ -96,6 +96,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const missingModelStore = useMissingModelStore()
+const { downloadMissingModel } = useMissingModelDownload()
 
 const sortedModelRows = computed(() =>
   missingModelGroups
@@ -135,7 +136,7 @@ const downloadAllLabel = computed(() => {
 
 function downloadAllModels() {
   for (const model of downloadableModels.value) {
-    downloadModel(model, missingModelStore.folderPaths)
+    downloadMissingModel(model)
   }
 }
 

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,6 +20,8 @@ const mockIsCloud = vi.hoisted(() => ({ value: true }))
 const mockShowUploadDialog = vi.hoisted(() => vi.fn())
 const mockCopyToClipboard = vi.hoisted(() => vi.fn())
 const mockDownloadModel = vi.hoisted(() => vi.fn())
+const mockFetchModelMetadata = vi.hoisted(() => vi.fn())
+const mockOpenGatedRepoPage = vi.hoisted(() => vi.fn())
 const mockRootGraph = vi.hoisted<{
   value: Record<string, never> | null
 }>(() => ({ value: null }))
@@ -104,10 +107,8 @@ vi.mock('@/platform/missingModel/missingModelDownload', async () => {
   return {
     ...actual,
     downloadModel: mockDownloadModel,
-    fetchModelMetadata: vi.fn().mockResolvedValue({
-      fileSize: null,
-      gatedRepoUrl: null
-    })
+    fetchModelMetadata: mockFetchModelMetadata,
+    openGatedRepoPage: mockOpenGatedRepoPage
   }
 })
 
@@ -152,7 +153,7 @@ function renderRow(
   directory: string | null = 'checkpoints',
   canCloudImport = true
 ) {
-  const pinia = createPinia()
+  const pinia = createTestingPinia({ stubActions: false })
   setActivePinia(pinia)
 
   render(MissingModelRow, {
@@ -181,6 +182,10 @@ describe('MissingModelRow', () => {
     mockRootGraph.value = null
     mockApiListeners.clear()
     mockGetNodeByExecutionId.mockReset()
+    mockFetchModelMetadata.mockResolvedValue({
+      fileSize: null,
+      gatedRepoUrl: null
+    })
     mockUploadContext.resolver = undefined
     mockUploadCallbacks.onUploadSuccess = undefined
   })
@@ -401,6 +406,28 @@ describe('MissingModelRow', () => {
     )
   })
 
+  it('stores gated HuggingFace metadata for downloadable rows', async () => {
+    mockIsCloud.value = false
+    const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
+    model.representative.url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    mockFetchModelMetadata.mockResolvedValueOnce({
+      fileSize: null,
+      gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
+    })
+
+    renderRow(model, vi.fn(), false)
+    const store = useMissingModelStore()
+
+    await waitFor(() => {
+      expect(
+        store.gatedRepoUrls[
+          'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+        ]
+      ).toBe('https://huggingface.co/bfl/FLUX.1')
+    })
+  })
+
   it('shows unknown category metadata for models without a directory', () => {
     renderRow(
       makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }]),
@@ -456,5 +483,26 @@ describe('MissingModelRow', () => {
       },
       {}
     )
+    expect(mockOpenGatedRepoPage).not.toHaveBeenCalled()
+  })
+
+  it('opens gated repo URLs instead of starting the OSS download action', async () => {
+    mockIsCloud.value = false
+    const user = userEvent.setup()
+    const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
+    model.representative.url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+
+    renderRow(model, vi.fn(), false)
+    const store = useMissingModelStore()
+    store.gatedRepoUrls[model.representative.url] =
+      'https://huggingface.co/bfl/FLUX.1'
+
+    await user.click(screen.getByTestId('missing-model-download'))
+
+    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
+      'https://huggingface.co/bfl/FLUX.1'
+    )
+    expect(mockDownloadModel).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -500,9 +500,11 @@ describe('MissingModelRow', () => {
 
     await user.click(screen.getByTestId('missing-model-download'))
 
-    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
-      'https://huggingface.co/bfl/FLUX.1'
-    )
+    await waitFor(() => {
+      expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
+        'https://huggingface.co/bfl/FLUX.1'
+      )
+    })
     expect(mockDownloadModel).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/missingModel/components/MissingModelRow.test.ts
+++ b/src/platform/missingModel/components/MissingModelRow.test.ts
@@ -428,6 +428,17 @@ describe('MissingModelRow', () => {
     })
   })
 
+  it('does not prefetch metadata for non-downloadable rows', async () => {
+    mockIsCloud.value = false
+    const model = makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }])
+    model.representative.url = 'https://example.invalid/model.safetensors'
+
+    renderRow(model, vi.fn(), false)
+    await nextTick()
+
+    expect(mockFetchModelMetadata).not.toHaveBeenCalled()
+  })
+
   it('shows unknown category metadata for models without a directory', () => {
     renderRow(
       makeModel([{ nodeId: '1', widgetName: 'ckpt_name' }]),

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -358,7 +358,7 @@ onMounted(() => {
 function handleDownload() {
   const rep = model.representative
   if (rep.url && rep.directory) {
-    downloadMissingModel({
+    void downloadMissingModel({
       name: rep.name,
       url: rep.url,
       directory: rep.directory

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -202,12 +202,11 @@ import {
   getModelStateKey,
   getNodeDisplayLabel
 } from '@/platform/missingModel/composables/useMissingModelInteractions'
+import { useMissingModelDownload } from '@/platform/missingModel/composables/useMissingModelDownload'
 import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { isCloud } from '@/platform/distribution/types'
 import {
-  downloadModel,
-  fetchModelMetadata,
   isModelDownloadable,
   toBrowsableUrl
 } from '@/platform/missingModel/missingModelDownload'
@@ -231,6 +230,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { copyToClipboard } = useCopyToClipboard()
+const { prefetchModelMetadata, downloadMissingModel } =
+  useMissingModelDownload()
 
 const modelKey = computed(() =>
   getModelStateKey(model.name, directory, isAssetSupported)
@@ -349,29 +350,19 @@ onMounted(() => {
   if (isCloud) return
 
   const url = model.representative.url
-  if (url && !store.fileSizes[url]) {
-    fetchModelMetadata(url)
-      .then((metadata) => {
-        if (metadata.fileSize !== null) {
-          store.setFileSize(url, metadata.fileSize)
-        }
-      })
-      .catch((error: unknown) => {
-        console.warn(
-          `[MissingModelRow] Failed to fetch metadata for ${url}:`,
-          error
-        )
-      })
+  if (url) {
+    void prefetchModelMetadata(url)
   }
 })
 
 function handleDownload() {
   const rep = model.representative
   if (rep.url && rep.directory) {
-    downloadModel(
-      { name: rep.name, url: rep.url, directory: rep.directory },
-      store.folderPaths
-    )
+    downloadMissingModel({
+      name: rep.name,
+      url: rep.url,
+      directory: rep.directory
+    })
   } else {
     console.warn('[MissingModelRow] Cannot download: missing url or directory')
   }

--- a/src/platform/missingModel/components/MissingModelRow.vue
+++ b/src/platform/missingModel/components/MissingModelRow.vue
@@ -350,7 +350,7 @@ onMounted(() => {
   if (isCloud) return
 
   const url = model.representative.url
-  if (url) {
+  if (url && downloadable.value) {
     void prefetchModelMetadata(url)
   }
 })

--- a/src/platform/missingModel/composables/useMissingModelDownload.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.test.ts
@@ -26,12 +26,12 @@ describe('useMissingModelDownload', () => {
     })
   })
 
-  it('stores fetched file size and gated repo metadata', async () => {
+  it('stores fetched file size metadata', async () => {
     const url =
       'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
     mockFetchModelMetadata.mockResolvedValueOnce({
       fileSize: 1024,
-      gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
+      gatedRepoUrl: null
     })
 
     const { prefetchModelMetadata } = useMissingModelDownload()
@@ -39,6 +39,22 @@ describe('useMissingModelDownload', () => {
 
     const store = useMissingModelStore()
     expect(store.fileSizes[url]).toBe(1024)
+    expect(store.gatedRepoUrls[url]).toBeUndefined()
+  })
+
+  it('stores fetched gated repo metadata', async () => {
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    mockFetchModelMetadata.mockResolvedValueOnce({
+      fileSize: null,
+      gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
+    })
+
+    const { prefetchModelMetadata } = useMissingModelDownload()
+    await prefetchModelMetadata(url)
+
+    const store = useMissingModelStore()
+    expect(store.fileSizes[url]).toBeUndefined()
     expect(store.gatedRepoUrls[url]).toBe('https://huggingface.co/bfl/FLUX.1')
   })
 
@@ -77,7 +93,35 @@ describe('useMissingModelDownload', () => {
     expect(mockFetchModelMetadata).not.toHaveBeenCalled()
   })
 
-  it('passes folder paths to the platform download helper', () => {
+  it('revalidates stored gated metadata and downloads after access succeeds', async () => {
+    const store = useMissingModelStore()
+    const gatedUrl =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    const model = {
+      name: 'model.safetensors',
+      url: gatedUrl,
+      directory: 'checkpoints'
+    }
+    store.setFolderPaths({ checkpoints: ['/models/checkpoints'] })
+    store.setGatedRepoUrl(gatedUrl, 'https://huggingface.co/bfl/FLUX.1')
+    mockFetchModelMetadata.mockResolvedValueOnce({
+      fileSize: 2048,
+      gatedRepoUrl: null
+    })
+
+    const { downloadMissingModel } = useMissingModelDownload()
+    await downloadMissingModel(model)
+
+    expect(mockFetchModelMetadata).toHaveBeenCalledWith(gatedUrl)
+    expect(store.fileSizes[gatedUrl]).toBe(2048)
+    expect(store.gatedRepoUrls[gatedUrl]).toBeUndefined()
+    expect(mockDownloadModel).toHaveBeenCalledWith(model, {
+      checkpoints: ['/models/checkpoints']
+    })
+    expect(mockOpenGatedRepoPage).not.toHaveBeenCalled()
+  })
+
+  it('passes folder paths to the platform download helper', async () => {
     const store = useMissingModelStore()
     const url =
       'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
@@ -89,7 +133,7 @@ describe('useMissingModelDownload', () => {
     store.setFolderPaths({ checkpoints: ['/models/checkpoints'] })
 
     const { downloadMissingModel } = useMissingModelDownload()
-    downloadMissingModel(model)
+    await downloadMissingModel(model)
 
     expect(mockDownloadModel).toHaveBeenCalledWith(model, {
       checkpoints: ['/models/checkpoints']
@@ -97,7 +141,7 @@ describe('useMissingModelDownload', () => {
     expect(mockOpenGatedRepoPage).not.toHaveBeenCalled()
   })
 
-  it('opens stored gated repo metadata instead of downloading', () => {
+  it('opens stored gated repo metadata when revalidation does not unlock access', async () => {
     const store = useMissingModelStore()
     const url =
       'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
@@ -110,11 +154,67 @@ describe('useMissingModelDownload', () => {
     store.setGatedRepoUrl(url, 'https://huggingface.co/bfl/FLUX.1')
 
     const { downloadMissingModel } = useMissingModelDownload()
-    downloadMissingModel(model)
+    await downloadMissingModel(model)
 
+    expect(mockFetchModelMetadata).toHaveBeenCalledWith(url)
     expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
       'https://huggingface.co/bfl/FLUX.1'
     )
+    expect(mockDownloadModel).not.toHaveBeenCalled()
+  })
+
+  it('opens stored gated repo metadata when revalidation fails', async () => {
+    const store = useMissingModelStore()
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    const repoUrl = 'https://huggingface.co/bfl/FLUX.1'
+    const model = {
+      name: 'model.safetensors',
+      url,
+      directory: 'checkpoints'
+    }
+    const error = new Error('metadata failed')
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    store.setGatedRepoUrl(url, repoUrl)
+    mockFetchModelMetadata.mockRejectedValueOnce(error)
+
+    const { downloadMissingModel } = useMissingModelDownload()
+    await downloadMissingModel(model)
+
+    expect(mockFetchModelMetadata).toHaveBeenCalledWith(url)
+    expect(store.gatedRepoUrls[url]).toBe(repoUrl)
+    expect(consoleWarn).toHaveBeenCalledWith(
+      `[MissingModelDownload] Failed to revalidate gated metadata for ${url}:`,
+      error
+    )
+    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(repoUrl)
+    expect(mockDownloadModel).not.toHaveBeenCalled()
+    consoleWarn.mockRestore()
+  })
+
+  it('keeps stored gated metadata when revalidation is still gated', async () => {
+    const store = useMissingModelStore()
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    const storedRepoUrl = 'https://huggingface.co/bfl/FLUX.1'
+    const refreshedRepoUrl = 'https://huggingface.co/bfl/FLUX.1-updated'
+    const model = {
+      name: 'model.safetensors',
+      url,
+      directory: 'checkpoints'
+    }
+    store.setGatedRepoUrl(url, storedRepoUrl)
+    mockFetchModelMetadata.mockResolvedValueOnce({
+      fileSize: null,
+      gatedRepoUrl: refreshedRepoUrl
+    })
+
+    const { downloadMissingModel } = useMissingModelDownload()
+    await downloadMissingModel(model)
+
+    expect(mockFetchModelMetadata).toHaveBeenCalledWith(url)
+    expect(store.gatedRepoUrls[url]).toBe(refreshedRepoUrl)
+    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(refreshedRepoUrl)
     expect(mockDownloadModel).not.toHaveBeenCalled()
   })
 })

--- a/src/platform/missingModel/composables/useMissingModelDownload.test.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.test.ts
@@ -1,0 +1,120 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+
+const mockDownloadModel = vi.hoisted(() => vi.fn())
+const mockFetchModelMetadata = vi.hoisted(() => vi.fn())
+const mockOpenGatedRepoPage = vi.hoisted(() => vi.fn())
+
+vi.mock('@/platform/missingModel/missingModelDownload', () => ({
+  downloadModel: mockDownloadModel,
+  fetchModelMetadata: mockFetchModelMetadata,
+  openGatedRepoPage: mockOpenGatedRepoPage
+}))
+
+import { useMissingModelDownload } from './useMissingModelDownload'
+
+describe('useMissingModelDownload', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    vi.resetAllMocks()
+    mockFetchModelMetadata.mockResolvedValue({
+      fileSize: null,
+      gatedRepoUrl: null
+    })
+  })
+
+  it('stores fetched file size and gated repo metadata', async () => {
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    mockFetchModelMetadata.mockResolvedValueOnce({
+      fileSize: 1024,
+      gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
+    })
+
+    const { prefetchModelMetadata } = useMissingModelDownload()
+    await prefetchModelMetadata(url)
+
+    const store = useMissingModelStore()
+    expect(store.fileSizes[url]).toBe(1024)
+    expect(store.gatedRepoUrls[url]).toBe('https://huggingface.co/bfl/FLUX.1')
+  })
+
+  it('swallows metadata fetch failures so mounted rows do not throw', async () => {
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = new Error('metadata failed')
+    mockFetchModelMetadata.mockRejectedValueOnce(error)
+
+    const { prefetchModelMetadata } = useMissingModelDownload()
+    await expect(prefetchModelMetadata(url)).resolves.toBeUndefined()
+
+    const store = useMissingModelStore()
+    expect(store.fileSizes).toEqual({})
+    expect(store.gatedRepoUrls).toEqual({})
+    expect(consoleWarn).toHaveBeenCalledWith(
+      `[MissingModelDownload] Failed to fetch metadata for ${url}:`,
+      error
+    )
+    consoleWarn.mockRestore()
+  })
+
+  it('skips metadata fetches when metadata is already stored', async () => {
+    const store = useMissingModelStore()
+    const sizedUrl = 'https://example.com/model.safetensors'
+    const gatedUrl =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    store.setFileSize(sizedUrl, 1024)
+    store.setGatedRepoUrl(gatedUrl, 'https://huggingface.co/bfl/FLUX.1')
+
+    const { prefetchModelMetadata } = useMissingModelDownload()
+    await prefetchModelMetadata(sizedUrl)
+    await prefetchModelMetadata(gatedUrl)
+
+    expect(mockFetchModelMetadata).not.toHaveBeenCalled()
+  })
+
+  it('passes folder paths to the platform download helper', () => {
+    const store = useMissingModelStore()
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    const model = {
+      name: 'model.safetensors',
+      url,
+      directory: 'checkpoints'
+    }
+    store.setFolderPaths({ checkpoints: ['/models/checkpoints'] })
+
+    const { downloadMissingModel } = useMissingModelDownload()
+    downloadMissingModel(model)
+
+    expect(mockDownloadModel).toHaveBeenCalledWith(model, {
+      checkpoints: ['/models/checkpoints']
+    })
+    expect(mockOpenGatedRepoPage).not.toHaveBeenCalled()
+  })
+
+  it('opens stored gated repo metadata instead of downloading', () => {
+    const store = useMissingModelStore()
+    const url =
+      'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+    const model = {
+      name: 'model.safetensors',
+      url,
+      directory: 'checkpoints'
+    }
+    store.setFolderPaths({ checkpoints: ['/models/checkpoints'] })
+    store.setGatedRepoUrl(url, 'https://huggingface.co/bfl/FLUX.1')
+
+    const { downloadMissingModel } = useMissingModelDownload()
+    downloadMissingModel(model)
+
+    expect(mockOpenGatedRepoPage).toHaveBeenCalledWith(
+      'https://huggingface.co/bfl/FLUX.1'
+    )
+    expect(mockDownloadModel).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/missingModel/composables/useMissingModelDownload.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.ts
@@ -1,0 +1,45 @@
+import {
+  downloadModel,
+  fetchModelMetadata,
+  openGatedRepoPage
+} from '@/platform/missingModel/missingModelDownload'
+import type { ModelWithUrl } from '@/platform/missingModel/missingModelDownload'
+import { useMissingModelStore } from '@/platform/missingModel/missingModelStore'
+
+export function useMissingModelDownload() {
+  const store = useMissingModelStore()
+
+  async function prefetchModelMetadata(url: string): Promise<void> {
+    if (store.fileSizes[url] !== undefined || store.gatedRepoUrls[url]) return
+
+    try {
+      const metadata = await fetchModelMetadata(url)
+      if (metadata.fileSize !== null) {
+        store.setFileSize(url, metadata.fileSize)
+      }
+      if (metadata.gatedRepoUrl) {
+        store.setGatedRepoUrl(url, metadata.gatedRepoUrl)
+      }
+    } catch (error: unknown) {
+      console.warn(
+        `[MissingModelDownload] Failed to fetch metadata for ${url}:`,
+        error
+      )
+    }
+  }
+
+  function downloadMissingModel(model: ModelWithUrl): void {
+    const gatedRepoUrl = store.gatedRepoUrls[model.url]
+    if (gatedRepoUrl) {
+      openGatedRepoPage(gatedRepoUrl)
+      return
+    }
+
+    downloadModel(model, store.folderPaths)
+  }
+
+  return {
+    prefetchModelMetadata,
+    downloadMissingModel
+  }
+}

--- a/src/platform/missingModel/composables/useMissingModelDownload.ts
+++ b/src/platform/missingModel/composables/useMissingModelDownload.ts
@@ -16,8 +16,7 @@ export function useMissingModelDownload() {
       const metadata = await fetchModelMetadata(url)
       if (metadata.fileSize !== null) {
         store.setFileSize(url, metadata.fileSize)
-      }
-      if (metadata.gatedRepoUrl) {
+      } else if (metadata.gatedRepoUrl) {
         store.setGatedRepoUrl(url, metadata.gatedRepoUrl)
       }
     } catch (error: unknown) {
@@ -28,10 +27,29 @@ export function useMissingModelDownload() {
     }
   }
 
-  function downloadMissingModel(model: ModelWithUrl): void {
+  async function downloadMissingModel(model: ModelWithUrl): Promise<void> {
     const gatedRepoUrl = store.gatedRepoUrls[model.url]
     if (gatedRepoUrl) {
-      openGatedRepoPage(gatedRepoUrl)
+      let repoUrl = gatedRepoUrl
+      try {
+        const metadata = await fetchModelMetadata(model.url)
+        if (metadata.fileSize !== null) {
+          store.setFileSize(model.url, metadata.fileSize)
+          downloadModel(model, store.folderPaths)
+          return
+        }
+        if (metadata.gatedRepoUrl) {
+          store.setGatedRepoUrl(model.url, metadata.gatedRepoUrl)
+          repoUrl = metadata.gatedRepoUrl
+        }
+      } catch (error: unknown) {
+        console.warn(
+          `[MissingModelDownload] Failed to revalidate gated metadata for ${model.url}:`,
+          error
+        )
+      }
+
+      openGatedRepoPage(repoUrl)
       return
     }
 

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -100,6 +100,24 @@ describe('fetchModelMetadata', () => {
     expect(metadata.fileSize).toBeNull()
   })
 
+  it('does not cache gated HuggingFace metadata so access can be retried', async () => {
+    const url = `https://huggingface.co/bfl/FLUX.1/resolve/main/retry-gated-${testId}.safetensors`
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403 })
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'content-length': '4096' })
+    })
+
+    const first = await fetchModelMetadata(url)
+    const second = await fetchModelMetadata(url)
+
+    expect(first.gatedRepoUrl).toBe('https://huggingface.co/bfl/FLUX.1')
+    expect(first.fileSize).toBeNull()
+    expect(second.gatedRepoUrl).toBeNull()
+    expect(second.fileSize).toBe(4096)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('does not treat thrown HuggingFace HEAD requests as gated or cache them', async () => {
     const url = `https://huggingface.co/bfl/FLUX.1/resolve/main/thrown-${testId}.safetensors`
     fetchMock

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -4,6 +4,7 @@ import {
   downloadModel,
   fetchModelMetadata,
   isModelDownloadable,
+  openGatedRepoPage,
   toBrowsableUrl
 } from './missingModelDownload'
 
@@ -262,6 +263,27 @@ describe('toBrowsableUrl', () => {
     expect(toBrowsableUrl('https://civitai.red/api/v1/models/12345')).toBe(
       'https://civitai.red/models/12345'
     )
+  })
+})
+
+describe('openGatedRepoPage', () => {
+  it('opens gated HuggingFace repos without a download attribute', () => {
+    const clickedAnchors: HTMLAnchorElement[] = []
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        clickedAnchors.push(this)
+      })
+
+    openGatedRepoPage('https://huggingface.co/bfl/FLUX.1')
+
+    expect(anchorClick).toHaveBeenCalledTimes(1)
+    expect(clickedAnchors[0]?.getAttribute('href')).toBe(
+      'https://huggingface.co/bfl/FLUX.1'
+    )
+    expect(clickedAnchors[0]?.getAttribute('download')).toBeNull()
+    expect(clickedAnchors[0]?.getAttribute('target')).toBe('_blank')
+    expect(clickedAnchors[0]?.getAttribute('rel')).toBe('noopener noreferrer')
   })
 })
 

--- a/src/platform/missingModel/missingModelDownload.test.ts
+++ b/src/platform/missingModel/missingModelDownload.test.ts
@@ -99,6 +99,45 @@ describe('fetchModelMetadata', () => {
     expect(metadata.fileSize).toBeNull()
   })
 
+  it('does not treat thrown HuggingFace HEAD requests as gated or cache them', async () => {
+    const url = `https://huggingface.co/bfl/FLUX.1/resolve/main/thrown-${testId}.safetensors`
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-length': '2048' })
+      })
+
+    const first = await fetchModelMetadata(url)
+    const second = await fetchModelMetadata(url)
+
+    expect(first.gatedRepoUrl).toBeNull()
+    expect(first.fileSize).toBeNull()
+    expect(second.gatedRepoUrl).toBeNull()
+    expect(second.fileSize).toBe(2048)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not treat non-HuggingFace gated status codes as gated', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403 })
+
+    const metadata = await fetchModelMetadata(
+      `https://example.com/huggingface.co/not-gated-${testId}.safetensors`
+    )
+    expect(metadata.gatedRepoUrl).toBeNull()
+    expect(metadata.fileSize).toBeNull()
+  })
+
+  it('does not treat thrown non-HuggingFace HEAD requests as gated', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const metadata = await fetchModelMetadata(
+      `https://example.com/thrown-${testId}.safetensors`
+    )
+    expect(metadata.gatedRepoUrl).toBeNull()
+    expect(metadata.fileSize).toBeNull()
+  })
+
   it('does not treat HuggingFace 404/500 as gated', async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 404 })
 
@@ -185,6 +224,12 @@ describe('toBrowsableUrl', () => {
   it('returns non-HuggingFace URLs unchanged', () => {
     const url =
       'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth'
+    expect(toBrowsableUrl(url)).toBe(url)
+  })
+
+  it('does not treat URLs with HuggingFace in the path as HuggingFace URLs', () => {
+    const url =
+      'https://example.com/huggingface.co/org/model/resolve/main/file.safetensors'
     expect(toBrowsableUrl(url)).toBe(url)
   })
 

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -191,8 +191,8 @@ async function fetchHeadMetadata(url: string): Promise<ModelMetadata> {
   }
 }
 
-function isComplete(metadata: ModelMetadata): boolean {
-  return metadata.fileSize !== null || metadata.gatedRepoUrl !== null
+function isCacheable(metadata: ModelMetadata): boolean {
+  return metadata.fileSize !== null
 }
 
 export async function fetchModelMetadata(url: string): Promise<ModelMetadata> {
@@ -207,7 +207,7 @@ export async function fetchModelMetadata(url: string): Promise<ModelMetadata> {
       ? await fetchCivitaiMetadata(url)
       : await fetchHeadMetadata(url)
 
-    if (isComplete(metadata)) {
+    if (isCacheable(metadata)) {
       metadataCache.set(url, metadata)
     }
     return metadata

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -47,6 +47,14 @@ async function startDesktop2ModelDownload(
   }
 }
 
+function isHuggingFaceRepoUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.toLowerCase() === 'huggingface.co'
+  } catch {
+    return false
+  }
+}
+
 /**
  * Converts a model download URL to a browsable page URL.
  * - HuggingFace: `/resolve/` → `/blob/` (file page with model info)
@@ -56,7 +64,7 @@ export function toBrowsableUrl(url: string): string {
   if (isCivitaiModelUrl(url)) {
     return url.replace('/api/download/', '/').replace('/api/v1/', '/')
   }
-  if (url.includes('huggingface.co')) {
+  if (isHuggingFaceRepoUrl(url)) {
     return url.replace('/resolve/', '/blob/')
   }
   return url
@@ -156,7 +164,7 @@ async function fetchHeadMetadata(url: string): Promise<ModelMetadata> {
     const response = await fetch(url, { method: 'HEAD' })
     if (!response.ok) {
       if (
-        url.includes('huggingface.co') &&
+        isHuggingFaceRepoUrl(url) &&
         GATED_STATUS_CODES.has(response.status)
       ) {
         return { fileSize: null, gatedRepoUrl: downloadUrlToHfRepoUrl(url) }

--- a/src/platform/missingModel/missingModelDownload.ts
+++ b/src/platform/missingModel/missingModelDownload.ts
@@ -47,6 +47,14 @@ async function startDesktop2ModelDownload(
   }
 }
 
+export function openGatedRepoPage(url: string): void {
+  const link = document.createElement('a')
+  link.href = url
+  link.target = '_blank'
+  link.rel = 'noopener noreferrer'
+  link.click()
+}
+
 function isHuggingFaceRepoUrl(url: string): boolean {
   try {
     return new URL(url).hostname.toLowerCase() === 'huggingface.co'

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -31,6 +31,8 @@ const { mockHandles } = vi.hoisted(() => {
       state,
       missingModelStore: {
         missingModelCandidates: null as MissingModelCandidate[] | null,
+        fileSizes: {} as Record<string, number>,
+        gatedRepoUrls: {} as Record<string, string>,
         createVerificationAbortController: vi.fn(() => new AbortController()),
         setFolderPaths: vi.fn(),
         setFileSize: vi.fn(),
@@ -175,6 +177,8 @@ describe('missingModelPipeline', () => {
     vi.clearAllMocks()
     mockHandles.state.enrichedCandidates = []
     mockHandles.missingModelStore.missingModelCandidates = null
+    mockHandles.missingModelStore.fileSizes = {}
+    mockHandles.missingModelStore.gatedRepoUrls = {}
     mockHandles.workspaceWorkflow.activeWorkflow = null
     mockHandles.missingModelStore.createVerificationAbortController.mockImplementation(
       () => new AbortController()
@@ -494,6 +498,56 @@ describe('missingModelPipeline', () => {
       ).toHaveBeenCalledWith(
         'https://huggingface.co/bfl/FLUX.1/resolve/main/downloadable.safetensors',
         'https://huggingface.co/bfl/FLUX.1'
+      )
+    })
+
+    it('skips metadata fetches for candidates with stored download metadata', async () => {
+      const sizedCandidate = {
+        nodeType: 'CheckpointLoaderSimple',
+        widgetName: 'ckpt_name',
+        name: 'sized.safetensors',
+        url: 'https://example.com/sized.safetensors',
+        directory: 'checkpoints',
+        isMissing: true,
+        isAssetSupported: true
+      } satisfies MissingModelCandidate
+      const gatedCandidate = {
+        nodeType: 'CheckpointLoaderSimple',
+        widgetName: 'ckpt_name',
+        name: 'gated.safetensors',
+        url: 'https://huggingface.co/bfl/FLUX.1/resolve/main/gated.safetensors',
+        directory: 'checkpoints',
+        isMissing: true,
+        isAssetSupported: true
+      } satisfies MissingModelCandidate
+      const uncachedCandidate = {
+        nodeType: 'CheckpointLoaderSimple',
+        widgetName: 'ckpt_name',
+        name: 'uncached.safetensors',
+        url: 'https://example.com/uncached.safetensors',
+        directory: 'checkpoints',
+        isMissing: true,
+        isAssetSupported: true
+      } satisfies MissingModelCandidate
+      mockHandles.state.enrichedCandidates = [
+        sizedCandidate,
+        gatedCandidate,
+        uncachedCandidate
+      ]
+      mockHandles.missingModelStore.fileSizes[sizedCandidate.url] = 1024
+      mockHandles.missingModelStore.gatedRepoUrls[gatedCandidate.url] =
+        'https://huggingface.co/bfl/FLUX.1'
+
+      await runMissingModelPipeline({
+        graph: createGraph(),
+        graphData: createWorkflowGraphData(),
+        missingModelStore: mockHandles.missingModelStore
+      })
+      await vi.dynamicImportSettled()
+
+      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledOnce()
+      expect(mockHandles.fetchModelMetadata).toHaveBeenCalledWith(
+        uncachedCandidate.url
       )
     })
 

--- a/src/platform/missingModel/missingModelPipeline.test.ts
+++ b/src/platform/missingModel/missingModelPipeline.test.ts
@@ -33,7 +33,8 @@ const { mockHandles } = vi.hoisted(() => {
         missingModelCandidates: null as MissingModelCandidate[] | null,
         createVerificationAbortController: vi.fn(() => new AbortController()),
         setFolderPaths: vi.fn(),
-        setFileSize: vi.fn()
+        setFileSize: vi.fn(),
+        setGatedRepoUrl: vi.fn()
       },
       workspaceWorkflow: {
         activeWorkflow: null as {
@@ -183,7 +184,10 @@ describe('missingModelPipeline', () => {
     )
     mockHandles.scanAllModelCandidates.mockReturnValue([])
     mockHandles.api.getFolderPaths.mockResolvedValue({})
-    mockHandles.fetchModelMetadata.mockResolvedValue({ fileSize: null })
+    mockHandles.fetchModelMetadata.mockResolvedValue({
+      fileSize: null,
+      gatedRepoUrl: null
+    })
     mockHandles.isAncestorPathActive.mockReturnValue(true)
     mockHandles.isCandidateScopeActive.mockImplementation(
       (graph: LGraph, candidate: MissingModelCandidate) => {
@@ -440,7 +444,10 @@ describe('missingModelPipeline', () => {
         downloadableCandidate,
         urlOnlyCandidate
       ]
-      mockHandles.fetchModelMetadata.mockResolvedValue({ fileSize: 1024 })
+      mockHandles.fetchModelMetadata.mockResolvedValue({
+        fileSize: 1024,
+        gatedRepoUrl: null
+      })
 
       await runMissingModelPipeline({
         graph: createGraph(),
@@ -456,6 +463,37 @@ describe('missingModelPipeline', () => {
       expect(mockHandles.missingModelStore.setFileSize).toHaveBeenCalledWith(
         'https://example.com/downloadable.safetensors',
         1024
+      )
+    })
+
+    it('stores gated repo URLs for downloadable candidates', async () => {
+      const downloadableCandidate = {
+        nodeType: 'CheckpointLoaderSimple',
+        widgetName: 'ckpt_name',
+        name: 'downloadable.safetensors',
+        url: 'https://huggingface.co/bfl/FLUX.1/resolve/main/downloadable.safetensors',
+        directory: 'checkpoints',
+        isMissing: true,
+        isAssetSupported: true
+      } satisfies MissingModelCandidate
+      mockHandles.state.enrichedCandidates = [downloadableCandidate]
+      mockHandles.fetchModelMetadata.mockResolvedValue({
+        fileSize: null,
+        gatedRepoUrl: 'https://huggingface.co/bfl/FLUX.1'
+      })
+
+      await runMissingModelPipeline({
+        graph: createGraph(),
+        graphData: createWorkflowGraphData(),
+        missingModelStore: mockHandles.missingModelStore
+      })
+      await vi.dynamicImportSettled()
+
+      expect(
+        mockHandles.missingModelStore.setGatedRepoUrl
+      ).toHaveBeenCalledWith(
+        'https://huggingface.co/bfl/FLUX.1/resolve/main/downloadable.safetensors',
+        'https://huggingface.co/bfl/FLUX.1'
       )
     })
 

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -33,6 +33,7 @@ interface MissingModelPipelineStore {
   createVerificationAbortController: () => AbortController
   setFolderPaths: (paths: Record<string, string[]>) => void
   setFileSize: (url: string, size: number) => void
+  setGatedRepoUrl: (url: string, repoUrl: string) => void
 }
 
 interface RunMissingModelPipelineOptions {
@@ -211,6 +212,9 @@ export async function runMissingModelPipeline({
           const metadata = await fetchModelMetadata(c.url)
           if (!controller.signal.aborted && metadata.fileSize !== null) {
             missingModelStore.setFileSize(c.url, metadata.fileSize)
+          }
+          if (!controller.signal.aborted && metadata.gatedRepoUrl) {
+            missingModelStore.setGatedRepoUrl(c.url, metadata.gatedRepoUrl)
           }
         })
       )

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -30,6 +30,8 @@ export interface MissingModelPipelineResult {
 
 interface MissingModelPipelineStore {
   missingModelCandidates: MissingModelCandidate[] | null
+  fileSizes: Record<string, number>
+  gatedRepoUrls: Record<string, string>
   createVerificationAbortController: () => AbortController
   setFolderPaths: (paths: Record<string, string[]>) => void
   setFileSize: (url: string, size: number) => void
@@ -208,6 +210,14 @@ export async function runMissingModelPipeline({
         import('@/platform/missingModel/missingModelDownload')
       void Promise.allSettled(
         downloadableCandidates.map(async (c) => {
+          if (
+            controller.signal.aborted ||
+            missingModelStore.fileSizes[c.url] !== undefined ||
+            missingModelStore.gatedRepoUrls[c.url] !== undefined
+          ) {
+            return
+          }
+
           const { fetchModelMetadata } = await missingModelDownload
           const metadata = await fetchModelMetadata(c.url)
           if (!controller.signal.aborted && metadata.fileSize !== null) {

--- a/src/platform/missingModel/missingModelPipeline.ts
+++ b/src/platform/missingModel/missingModelPipeline.ts
@@ -212,8 +212,7 @@ export async function runMissingModelPipeline({
           const metadata = await fetchModelMetadata(c.url)
           if (!controller.signal.aborted && metadata.fileSize !== null) {
             missingModelStore.setFileSize(c.url, metadata.fileSize)
-          }
-          if (!controller.signal.aborted && metadata.gatedRepoUrl) {
+          } else if (!controller.signal.aborted && metadata.gatedRepoUrl) {
             missingModelStore.setGatedRepoUrl(c.url, metadata.gatedRepoUrl)
           }
         })

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -1,4 +1,5 @@
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeExecutionId } from '@/types/nodeIdentification'
@@ -58,7 +59,7 @@ function makeModelCandidate(
 
 describe('missingModelStore', () => {
   beforeEach(() => {
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
     vi.restoreAllMocks()
     mockNodeLocatorIdToNodeExecutionId.mockImplementation(
       (nodeLocatorId: string) => nodeLocatorId
@@ -262,6 +263,11 @@ describe('missingModelStore', () => {
       ])
       store.modelExpandState['test-key'] = true
       store.selectedLibraryModel['test-key'] = 'some-model'
+      store.setFileSize('https://example.com/model.safetensors', 1024)
+      store.setGatedRepoUrl(
+        'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors',
+        'https://huggingface.co/bfl/FLUX.1'
+      )
       expect(store.missingModelCandidates).not.toBeNull()
 
       store.clearMissingModels()
@@ -270,6 +276,8 @@ describe('missingModelStore', () => {
       expect(store.hasMissingModels).toBe(false)
       expect(store.modelExpandState).toEqual({})
       expect(store.selectedLibraryModel).toEqual({})
+      expect(store.fileSizes).toEqual({})
+      expect(store.gatedRepoUrls).toEqual({})
     })
   })
 

--- a/src/platform/missingModel/missingModelStore.test.ts
+++ b/src/platform/missingModel/missingModelStore.test.ts
@@ -281,6 +281,20 @@ describe('missingModelStore', () => {
     })
   })
 
+  describe('setFileSize', () => {
+    it('clears stale gated repo metadata for the same URL', () => {
+      const store = useMissingModelStore()
+      const url =
+        'https://huggingface.co/bfl/FLUX.1/resolve/main/model.safetensors'
+      store.setGatedRepoUrl(url, 'https://huggingface.co/bfl/FLUX.1')
+
+      store.setFileSize(url, 2048)
+
+      expect(store.fileSizes[url]).toBe(2048)
+      expect(store.gatedRepoUrls[url]).toBeUndefined()
+    })
+  })
+
   describe('isWidgetMissingModel', () => {
     it('returns true when specific widget has missing model', () => {
       const store = useMissingModelStore()

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -85,6 +85,7 @@ export const useMissingModelStore = defineStore('missingModel', () => {
   const importTaskIds = ref<Record<string, string>>({})
   const folderPaths = ref<Record<string, string[]>>({})
   const fileSizes = ref<Record<string, number>>({})
+  const gatedRepoUrls = ref<Record<string, string>>({})
 
   let _verificationAbortController: AbortController | null = null
 
@@ -245,6 +246,10 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     fileSizes.value[url] = size
   }
 
+  function setGatedRepoUrl(url: string, repoUrl: string) {
+    gatedRepoUrls.value[url] = repoUrl
+  }
+
   function clearMissingModels() {
     _verificationAbortController?.abort()
     _verificationAbortController = null
@@ -254,6 +259,7 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     importTaskIds.value = {}
     folderPaths.value = {}
     fileSizes.value = {}
+    gatedRepoUrls.value = {}
   }
 
   function isAbortError(error: unknown) {
@@ -309,8 +315,10 @@ export const useMissingModelStore = defineStore('missingModel', () => {
     importTaskIds,
     folderPaths,
     fileSizes,
+    gatedRepoUrls,
 
     setFolderPaths,
-    setFileSize
+    setFileSize,
+    setGatedRepoUrl
   }
 })

--- a/src/platform/missingModel/missingModelStore.ts
+++ b/src/platform/missingModel/missingModelStore.ts
@@ -244,6 +244,8 @@ export const useMissingModelStore = defineStore('missingModel', () => {
 
   function setFileSize(url: string, size: number) {
     fileSizes.value[url] = size
+    // A resolved file size means a previously gated URL is no longer blocked.
+    delete gatedRepoUrls.value[url]
   }
 
   function setGatedRepoUrl(url: string, repoUrl: string) {


### PR DESCRIPTION
## Summary

This restores the gated Hugging Face missing-model download behavior that was originally added in [#3004](https://github.com/Comfy-Org/ComfyUI_frontend/pull/3004) and later dropped during the changes in [#9921](https://github.com/Comfy-Org/ComfyUI_frontend/pull/9921). The goal is to bring the OSS/core behavior back while making the flow a little harder to accidentally remove again.

The previous behavior was important for gated HF models: when the metadata request tells us the model is gated, the UI should not try to download the raw file URL. Instead, it should open the Hugging Face repo page so the user can sign in, accept the model terms, or otherwise resolve access on Hugging Face.

## **Review Point: Important Browser Download Trade-Off**

**Please review this trade-off carefully before merging. In a normal browser, if the user is already signed in to Hugging Face and already has access to the gated model, the current `main` behavior can still succeed because it always hands the original download URL to a browser `<a download>` click. The browser can then use the user’s existing Hugging Face session and the file may download successfully.**

**With this PR, once a model URL is classified as gated, the download button opens the Hugging Face repo page instead of handing the original file URL to the browser. That restores the intended behavior for users who cannot download yet, because they are sent to the right Hugging Face page to sign in or accept terms. However, it can also take away one-click download from users whose browser session already has access, because the gated classification is based on metadata probing rather than a guaranteed answer about whether the current browser session can actually download the file.**

**In other words: this PR centralizes and stabilizes gated-model detection so it can be reused later, and it fixes the broken path for users who truly need to visit the gated repo page. But reviewers should consider whether the download button should always open the repo page for known gated models, or whether we should preserve the browser `<a download>` attempt and expose the gated repo page through a separate hint/action instead. That alternative would probably need a Desktop contract change too, because Desktop has a separate download path and cannot rely on the browser `<a download>` behavior in the same way.**

## What Changed

This PR preserves the gated HF repo URL instead of dropping it after metadata fetches. That gated repo URL is now stored alongside the missing-model metadata and checked before starting the normal model download path. If a missing model is known to be gated, clicking download opens the repo page instead of trying to download the model file directly.

Stored gated metadata is also revalidated on later download clicks. If a later metadata request can read the file size, the stale gated marker is cleared and the existing download path runs normally. Gated metadata itself is not cached in the shared metadata cache, so a transient gated result does not poison that cache for the rest of the session.

I also pulled the missing-model download decision into a small platform-level composable, `useMissingModelDownload()`. `MissingModelRow` and `MissingModelCard` now go through that composable instead of each wiring metadata/download behavior by hand. This keeps the row action and the bulk “Download all” action on the same path, and gives the gated behavior one place to live.

A small follow-up guard keeps metadata probing bounded: mounted rows only prefetch metadata when they are actually downloadable, and the missing-model pipeline skips URLs that already have stored file size or gated repo metadata.

The PR also adds regression coverage for the cases that matter here:

- gated HF metadata is persisted and consumed by the download action
- stored gated metadata is revalidated on click, and stale gated state is cleared once access succeeds
- row-level and bulk download actions open the gated repo page instead of starting a download
- non-HF URLs are not misclassified just because `huggingface.co` appears in the path
- thrown HEAD requests are not cached or treated as gated, so transient network/CORS/offline failures do not poison the session
- metadata prefetch and revalidation failures stay contained so mounted rows and click actions do not throw
- metadata probes are bounded to downloadable rows and skip URLs that already have stored size or gated metadata

## Commit Breakdown

1. `fix(missing-model): harden HuggingFace gated metadata detection`
   - Tightens Hugging Face URL detection to the actual `huggingface.co` host.
   - Adds regression coverage for thrown HEAD requests and non-HF URLs that should not be treated as gated.

2. `feat(missing-model): persist gated repo metadata`
   - Adds `gatedRepoUrls` to the missing-model store.
   - Stores gated repo metadata from the missing-model pipeline.
   - Clears that metadata with the rest of missing-model state.

3. `refactor(missing-model): centralize download handling`
   - Adds `useMissingModelDownload()` for metadata prefetch and download decisions.
   - Routes row and bulk download actions through the composable.
   - Opens gated repo pages before falling through to the existing download paths.

4. `fix(missing-model): revalidate stale gated metadata`
   - Keeps gated metadata out of the metadata cache so gated access can be retried.
   - Revalidates stored gated metadata when the user clicks download again.
   - Clears stale gated metadata when a later metadata request returns a file size.
   - Adds regression coverage for successful unlocks, still-gated responses, and revalidation failures.

5. `fix(missing-model): skip redundant metadata probes`
   - Limits row mount-time metadata prefetching to rows that are actually downloadable.
   - Skips pipeline metadata fetches for URLs that already have stored file size or gated repo metadata.
   - Adds regression coverage for both guard paths.

## Not In This PR

This PR intentionally keeps the scope small. It does not change the desktop download implementation, and it does not redesign `downloadModel()` into a larger action-union API. Those may be good future directions, but mixing them into this fix would make the review harder and increase the risk of changing unrelated behavior.

This PR also does not introduce a new gated-model UI flow, such as separate “open Hugging Face repo” and “try download” actions. That might be worth revisiting later, but there is related core model-download work in progress around Hugging Face authentication, so it seems better to avoid adding a parallel UI model here.

## Desktop Follow-Up

Desktop still has a separate model-download path, so this PR should be treated as the first step: restore the core/OSS behavior and centralize the FE-side decision point. It does not make the Desktop download manager gated-aware by itself.

A possible Desktop follow-up would be to extend the Desktop2 bridge payload with an optional gated/access-page hint, for example `gatedRepoUrl`, and let the Desktop download manager handle the rest of the flow. That manager could still try the real download first, then surface an auth-required state and open the Hugging Face repo page in a same-session Electron window if the download fails due to access. A retry could then reuse the same session after the user signs in or accepts the model terms.

The better long-term direction may be to hand this responsibility to the upcoming core model-download flow with Hugging Face authentication, rather than building a parallel Desktop-specific auth model here. This PR leaves that path open by keeping the gated handling centralized in the FE missing-model download layer without changing Desktop contracts yet.

## E2E Coverage

I did not add an E2E test for this flow. The key behavior depends on Hugging Face gated-model access, which requires an external authenticated session and model-specific access state. That makes a reliable E2E test hard to run in CI without either real credentials, a controlled HF fixture, or a mocked browser/network layer that would mostly duplicate the unit coverage here.

For this PR, the behavior is better covered at the unit/component level: the tests pin the metadata classification, store persistence, row action, bulk action, and click-time revalidation behavior without relying on external Hugging Face state. A future E2E would make more sense if we introduce a stable test fixture or a dedicated mocked integration harness for gated model downloads.

## Follow-Ups

A lightweight architecture guard could prevent missing-model UI components from calling low-level download helpers directly. I did not include that here because the repo’s existing restricted-import rules are mostly cross-cutting architecture rules, and a domain-specific lint rule should probably be agreed on separately.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm knip`

## Screenshot

https://github.com/user-attachments/assets/7af929c4-d89d-4910-851b-927645d28513

