### PR TITLE
test: add chromium @critical browser lane

### DIFF
--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -67,7 +67,15 @@ jobs:
 
       - name: Deploy report to Cloudflare
         id: deploy
-        if: always() && !cancelled()
+        if: >-
+          ${{
+            always() &&
+            !cancelled() &&
+            (
+              github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.fork == false
+            )
+          }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/browser_tests/tests/execution.spec.ts
+++ b/browser_tests/tests/execution.spec.ts
@@ -97,34 +97,38 @@ test.describe(
   'Execute to selected output nodes',
   { tag: ['@smoke', '@workflow'] },
   () => {
-    test('Execute to selected output nodes', async ({ comfyPage }) => {
-      await comfyPage.workflow.loadWorkflow('execution/partial_execution')
-      const input = await comfyPage.nodeOps.getNodeRefById(3)
-      const output1 = await comfyPage.nodeOps.getNodeRefById(1)
-      const output2 = await comfyPage.nodeOps.getNodeRefById(4)
-      await expect
-        .poll(async () => (await input.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output1.getWidget(0)).getValue())
-        .toBe('')
-      await expect
-        .poll(async () => (await output2.getWidget(0)).getValue())
-        .toBe('')
+    test(
+      'Execute to selected output nodes',
+      { tag: '@critical' },
+      async ({ comfyPage }) => {
+        await comfyPage.workflow.loadWorkflow('execution/partial_execution')
+        const input = await comfyPage.nodeOps.getNodeRefById(3)
+        const output1 = await comfyPage.nodeOps.getNodeRefById(1)
+        const output2 = await comfyPage.nodeOps.getNodeRefById(4)
+        await expect
+          .poll(async () => (await input.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output1.getWidget(0)).getValue())
+          .toBe('')
+        await expect
+          .poll(async () => (await output2.getWidget(0)).getValue())
+          .toBe('')
 
-      await output1.click('title')
+        await output1.click('title')
 
-      await comfyPage.command.executeCommand('Comfy.QueueSelectedOutputNodes')
-      await expect
-        .poll(async () => (await input.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output1.getWidget(0)).getValue())
-        .toBe('foo')
-      await expect
-        .poll(async () => (await output2.getWidget(0)).getValue())
-        .toBe('')
-    })
+        await comfyPage.command.executeCommand('Comfy.QueueSelectedOutputNodes')
+        await expect
+          .poll(async () => (await input.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output1.getWidget(0)).getValue())
+          .toBe('foo')
+        await expect
+          .poll(async () => (await output2.getWidget(0)).getValue())
+          .toBe('')
+      }
+    )
   }
 )
 

--- a/browser_tests/tests/extensionAPI.spec.ts
+++ b/browser_tests/tests/extensionAPI.spec.ts
@@ -13,33 +13,37 @@ import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
 type TestSettingId = keyof Settings
 
 test.describe('Topbar commands', () => {
-  test('Should allow registering topbar commands', async ({ comfyPage }) => {
-    await comfyPage.page.evaluate(() => {
-      window.app!.registerExtension({
-        name: 'TestExtension1',
-        commands: [
-          {
-            id: 'foo',
-            label: 'foo-command',
-            function: () => {
-              window.foo = true
+  test(
+    'Should allow registering topbar commands',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await comfyPage.page.evaluate(() => {
+        window.app!.registerExtension({
+          name: 'TestExtension1',
+          commands: [
+            {
+              id: 'foo',
+              label: 'foo-command',
+              function: () => {
+                window.foo = true
+              }
             }
-          }
-        ],
-        menuCommands: [
-          {
-            path: ['ext'],
-            commands: ['foo']
-          }
-        ]
+          ],
+          menuCommands: [
+            {
+              path: ['ext'],
+              commands: ['foo']
+            }
+          ]
+        })
       })
-    })
 
-    await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
-    await expect
-      .poll(() => comfyPage.page.evaluate(() => window.foo))
-      .toBe(true)
-  })
+      await comfyPage.menu.topbar.triggerTopbarCommand(['ext', 'foo-command'])
+      await expect
+        .poll(() => comfyPage.page.evaluate(() => window.foo))
+        .toBe(true)
+    }
+  )
 
   test('Should not allow register command defined in other extension', async ({
     comfyPage

--- a/browser_tests/tests/graph.spec.ts
+++ b/browser_tests/tests/graph.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 
+import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
 
 import { comfyPageFixture as test } from '@e2e/fixtures/ComfyPage'
@@ -13,20 +14,27 @@ test.describe('Graph', { tag: ['@smoke', '@canvas'] }, () => {
   // Ref: https://github.com/Comfy-Org/ComfyUI_frontend/issues/3348
   test('Fix link input slots', async ({ comfyPage }) => {
     await comfyPage.workflow.loadWorkflow('inputs/input_order_swap')
+    const linkId = toLinkId(1)
+
     await expect
       .poll(() =>
-        comfyPage.page.evaluate(() => {
-          return window.app!.graph!.links.get(1)?.target_slot
-        })
+        comfyPage.page.evaluate(
+          (linkId) => window.app!.graph!.links.get(linkId)?.target_slot,
+          linkId
+        )
       )
       .toBe(1)
   })
 
-  test('Validate workflow links', async ({ comfyPage }) => {
-    await comfyPage.settings.setSetting('Comfy.Validation.Workflows', true)
-    await comfyPage.workflow.loadWorkflow('links/bad_link')
-    await expect(comfyPage.toast.visibleToasts).toHaveCount(2)
-  })
+  test(
+    'Validate workflow links',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await comfyPage.settings.setSetting('Comfy.Validation.Workflows', true)
+      await comfyPage.workflow.loadWorkflow('links/bad_link')
+      await expect(comfyPage.toast.visibleToasts).toHaveCount(2)
+    }
+  )
 
   // Regression: duplicate links with shifted target_slot (widget-to-input
   // conversion) caused the wrong link to survive during deduplication.

--- a/browser_tests/tests/nodeSearchBoxV2.spec.ts
+++ b/browser_tests/tests/nodeSearchBoxV2.spec.ts
@@ -8,20 +8,24 @@ test.describe('Node search box V2', { tag: '@node' }, () => {
     await comfyPage.searchBoxV2.setup()
   })
 
-  test('Can open search and add node', async ({ comfyPage }) => {
-    const { searchBoxV2 } = comfyPage
-    const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
+  test(
+    'Can open search and add node',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      const { searchBoxV2 } = comfyPage
+      const initialCount = await comfyPage.nodeOps.getGraphNodesCount()
 
-    await searchBoxV2.open()
-    await searchBoxV2.input.fill('KSampler')
-    await expect(searchBoxV2.results.first()).toBeVisible()
+      await searchBoxV2.open()
+      await searchBoxV2.input.fill('KSampler')
+      await expect(searchBoxV2.results.first()).toBeVisible()
 
-    await comfyPage.page.keyboard.press('Enter')
-    await expect(searchBoxV2.input).toBeHidden()
-    await expect
-      .poll(() => comfyPage.nodeOps.getGraphNodesCount())
-      .toBe(initialCount + 1)
-  })
+      await comfyPage.page.keyboard.press('Enter')
+      await expect(searchBoxV2.input).toBeHidden()
+      await expect
+        .poll(() => comfyPage.nodeOps.getGraphNodesCount())
+        .toBe(initialCount + 1)
+    }
+  )
 
   test('Can add first default result with Enter', async ({ comfyPage }) => {
     const { searchBoxV2 } = comfyPage

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingModels.spec.ts
@@ -33,19 +33,21 @@ test.describe('Errors tab - Missing models', { tag: '@ui' }, () => {
     await cleanupFakeModel(comfyPage)
   })
 
-  test('Should show missing models group in errors tab', async ({
-    comfyPage
-  }) => {
-    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
+  test(
+    'Should show missing models group in errors tab',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')
 
-    const missingModelsGroup = comfyPage.page.getByTestId(
-      TestIds.dialogs.missingModelsGroup
-    )
-    await expect(missingModelsGroup).toBeVisible()
-    await expect(
-      missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
-    ).toHaveText(/\S/)
-  })
+      const missingModelsGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingModelsGroup
+      )
+      await expect(missingModelsGroup).toBeVisible()
+      await expect(
+        missingModelsGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
+    }
+  )
 
   test('Should display model name and metadata', async ({ comfyPage }) => {
     await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_models')

--- a/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
+++ b/browser_tests/tests/propertiesPanel/errorsTabMissingNodes.spec.ts
@@ -12,23 +12,25 @@ test.describe('Errors tab - Missing nodes', { tag: ['@ui', '@canvas'] }, () => {
     )
   })
 
-  test('Should show missing node pack card with guidance', async ({
-    comfyPage
-  }) => {
-    await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
+  test(
+    'Should show missing node pack card with guidance',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      await loadWorkflowAndOpenErrorsTab(comfyPage, 'missing/missing_nodes')
 
-    const missingNodeGroup = comfyPage.page.getByTestId(
-      TestIds.dialogs.missingNodePacksGroup
-    )
+      const missingNodeGroup = comfyPage.page.getByTestId(
+        TestIds.dialogs.missingNodePacksGroup
+      )
 
-    await expect(
-      comfyPage.page.getByTestId(TestIds.dialogs.missingNodeCard)
-    ).toBeVisible()
-    await expect(missingNodeGroup).toBeVisible()
-    await expect(
-      missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
-    ).toHaveText(/\S/)
-  })
+      await expect(
+        comfyPage.page.getByTestId(TestIds.dialogs.missingNodeCard)
+      ).toBeVisible()
+      await expect(missingNodeGroup).toBeVisible()
+      await expect(
+        missingNodeGroup.getByTestId(TestIds.dialogs.errorGroupDisplayMessage)
+      ).toHaveText(/\S/)
+    }
+  )
 
   test('Should show unknown pack node rows by default', async ({
     comfyPage

--- a/browser_tests/tests/queue/queueOverlay.spec.ts
+++ b/browser_tests/tests/queue/queueOverlay.spec.ts
@@ -54,13 +54,19 @@ test.describe('Queue overlay', () => {
     await comfyPage.setup()
   })
 
-  test('Toggle button opens expanded queue overlay', async ({ comfyPage }) => {
-    const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
-    await toggle.click()
+  test(
+    'Toggle button opens expanded queue overlay',
+    { tag: '@critical' },
+    async ({ comfyPage }) => {
+      const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)
+      await toggle.click()
 
-    // Expanded overlay should show job items
-    await expect(comfyPage.page.locator('[data-job-id]').first()).toBeVisible()
-  })
+      // Expanded overlay should show job items
+      await expect(
+        comfyPage.page.locator('[data-job-id]').first()
+      ).toBeVisible()
+    }
+  )
 
   test('Overlay shows filter tabs (All, Completed)', async ({ comfyPage }) => {
     const toggle = comfyPage.page.getByTestId(TestIds.queue.overlayToggle)

--- a/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
+++ b/browser_tests/tests/subgraph/subgraphSerialization.spec.ts
@@ -129,7 +129,7 @@ async function expectPromotedWidgetsToResolveToInteriorNodes(
 test.describe('Subgraph Serialization', { tag: ['@subgraph'] }, () => {
   test(
     'Legacy primitive proxy widgets migrate to host inputs without proxyWidgets round-trip',
-    { tag: ['@vue-nodes'] },
+    { tag: ['@vue-nodes', '@critical'] },
     async ({ comfyPage }) => {
       await comfyPage.workflow.loadWorkflow(
         'subgraphs/subgraph-with-link-and-proxied-primitive'

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "stylelint": "stylelint --cache '{apps,packages,src}/**/*.{css,vue}'",
     "test:browser": "pnpm exec playwright test",
     "test:browser:coverage": "cross-env COLLECT_COVERAGE=true pnpm test:browser",
+    "test:browser:critical": "pnpm exec playwright test --project=chromium --grep @critical",
     "test:browser:local": "cross-env PLAYWRIGHT_LOCAL=1 PLAYWRIGHT_TEST_URL=http://localhost:5173 pnpm test:browser",
     "test:coverage": "vitest run --coverage",
     "test:coverage:critical": "cross-env COVERAGE_CRITICAL=true vitest run --coverage",


### PR DESCRIPTION
## Summary

Add a chromium `@critical` browser-test lane: a fast subset of stable E2E journeys that can gate PRs without running the full suite.

## Changes

- **What**: New `test:browser:critical` script (`playwright test --project=chromium --grep @critical`) and `@critical` tags on 8 stable journeys — graph link validate, execute-to-selected-output, node-search add, queue overlay status, missing-nodes/missing-models error tabs, subgraph round-trip, extension-API topbar command.
- **Breaking**: none. Not yet wired as a required check.

## Coverage

Critical branch coverage from the latest successful `CI: Tests Unit` run (`pnpm test:coverage:critical`):

| metric | before | after | delta |
|---|---:|---:|---:|
| critical branches | 60.70% | 60.77% | +0.07% |

Browser-lane PR. The unit branch ratchet is effectively unchanged; this PR adds `@critical` Chromium browser coverage.

## Review Focus

The lane selects **8 `@critical` chromium journeys**. Verify with:

```
pnpm exec playwright test --project=chromium --grep @critical --list
```
