### PR TITLE
ci: skip website report deploy for fork PRs

### DIFF
--- a/.github/workflows/ci-website-e2e.yaml
+++ b/.github/workflows/ci-website-e2e.yaml
@@ -67,7 +67,15 @@ jobs:
 
       - name: Deploy report to Cloudflare
         id: deploy
-        if: always() && !cancelled()
+        if: >-
+          ${{
+            always() &&
+            !cancelled() &&
+            (
+              github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.fork == false
+            )
+          }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Skip the website e2e report/deploy step for fork PRs, which lack the deploy secrets and otherwise fail the job.

## Changes

- **What**: Guard the report/deploy step's `if:` in `ci-website-e2e.yaml` so it runs only when the event is not a fork pull request.
- **Breaking**: none. CI-config only.

## Review Focus

CI-config only — no test or coverage change. Confirms fork PRs no longer fail on the deploy step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow condition only; no application or test logic changes.
> 
> **Overview**
> **Website E2E CI** no longer runs the **Deploy report to Cloudflare** step on pull requests from forks.
> 
> The step’s `if:` still requires `always()` and `!cancelled()`, and now also requires either a non–pull-request event or a PR whose head repo is **not** a fork. Playwright tests and artifact upload are unchanged; only the wrangler deploy (which needs `CLOUDFLARE_*` secrets) is skipped for fork PRs so those runs don’t fail when secrets aren’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a4ab076919b5267db7673ff7653c8064b19dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->