### PR TITLE
test: pin unit-suite timezone to UTC for deterministic date assertions

### DIFF
--- a/src/platform/cloud/subscription/components/CreditsTile.test.ts
+++ b/src/platform/cloud/subscription/components/CreditsTile.test.ts
@@ -166,6 +166,7 @@ describe('CreditsTile', () => {
     state.isLoading = false
     state.canTopUp = true
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   it('renders the total balance (cents converted to credits) with the remaining suffix', () => {
@@ -225,6 +226,15 @@ describe('CreditsTile', () => {
     // Annual billing still grants the monthly nominal (21,100), not 12x.
     expect(container.textContent).toContain('422 left of 21,100')
     expect(container.textContent).not.toContain('253,200')
+  })
+
+  it('formats the renewal date in the local timezone, not UTC', () => {
+    activeProSubscription()
+    expect(renderTile().container.textContent).toContain('Refills Feb 20')
+
+    // The suite is pinned to TZ=UTC, so opt this render into a UTC+13 viewer.
+    vi.stubEnv('TZ', 'Pacific/Auckland')
+    expect(renderTile().container.textContent).toContain('Refills Feb 21')
   })
 
   it('falls back to a dateless refills label when renewal date is missing', () => {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -706,6 +706,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    // Pin the timezone so date-formatting assertions are deterministic
+    // regardless of the contributor's local timezone (CI runs in UTC).
+    env: { TZ: 'UTC' },
     setupFiles: ['./vitest.setup.ts'],
     retry: process.env.CI ? 2 : 0,
     include: [


### PR DESCRIPTION
## Summary

Pin the Vitest unit suite to `TZ=UTC` so date-formatting assertions are deterministic regardless of the contributor's local timezone.

## Changes

- **What**: Add `env: { TZ: 'UTC' }` to the `test` block in `vite.config.mts`.

Tests that format dates via `toLocaleDateString`/`toLocaleString` rendered in the runner's local timezone, so assertions on specific dates only passed when the runner sat in UTC (as CI does). Contributors east of UTC saw off-by-one failures. Example: `CreditsTile` formats a noon-UTC renewal date (`2026-02-20T12:00:00Z`) and asserts `"Feb 20"`; at UTC+12 that renders `"Feb 21"` and the test fails. Nine test files use locale date formatting and were all latently exposed; pinning the suite timezone fixes them uniformly and aligns local runs with CI.

## Review Focus

- Chose to pin the test timezone rather than change component formatting: rendering renewal dates in the user's local time is arguably correct UX, so this is treated as a test-determinism fix, not a component behavior change.
- Verified under a UTC+12 local timezone: previously-failing `CreditsTile` file and all other date-formatting test files now pass.
