### PR TITLE
fix(graph): copy image works on cloud SaveImage node (FE-1011)

### DIFF
--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -117,9 +117,8 @@ export function extractFilenameFromContentDisposition(
 }
 
 /**
- * Fetch a URL and return the raw Response, throwing on non-OK status.
- * Shared by download and open-in-new-tab cloud paths that need response
- * headers (e.g. Content-Disposition).
+ * Fetch a URL and return its body as a Blob.
+ * Shared by download and open-in-new-tab cloud paths.
  */
 async function fetchAsBlob(url: string): Promise<Response> {
   const response = await fetch(url)
@@ -127,20 +126,6 @@ async function fetchAsBlob(url: string): Promise<Response> {
     throw new Error(`Failed to fetch ${url}: ${response.status}`)
   }
   return response
-}
-
-/**
- * Fetch a URL and return its body as a Blob.
- *
- * Fetching (rather than reading an already-rendered <img> via a canvas) is what
- * keeps this safe for cross-origin cloud assets (e.g. GCS): the returned blob is
- * always readable, whereas a canvas drawn from a non-CORS cross-origin image is
- * tainted and cannot be exported. Reuse this anywhere an image's bytes are
- * needed (download, open-in-tab, copy-to-clipboard).
- */
-export async function fetchUrlAsBlob(url: string): Promise<Blob> {
-  const response = await fetchAsBlob(url)
-  return response.blob()
 }
 
 async function downloadViaBlobFetch(
@@ -177,7 +162,8 @@ export async function openFileInNewTab(url: string): Promise<void> {
   const tab = window.open('', '_blank')
 
   try {
-    const blob = await fetchUrlAsBlob(url)
+    const response = await fetchAsBlob(url)
+    const blob = await response.blob()
     const blobUrl = URL.createObjectURL(blob)
 
     if (tab && !tab.closed) {

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -117,8 +117,9 @@ export function extractFilenameFromContentDisposition(
 }
 
 /**
- * Fetch a URL and return its body as a Blob.
- * Shared by download and open-in-new-tab cloud paths.
+ * Fetch a URL and return the raw Response, throwing on non-OK status.
+ * Shared by download and open-in-new-tab cloud paths that need response
+ * headers (e.g. Content-Disposition).
  */
 async function fetchAsBlob(url: string): Promise<Response> {
   const response = await fetch(url)
@@ -126,6 +127,20 @@ async function fetchAsBlob(url: string): Promise<Response> {
     throw new Error(`Failed to fetch ${url}: ${response.status}`)
   }
   return response
+}
+
+/**
+ * Fetch a URL and return its body as a Blob.
+ *
+ * Fetching (rather than reading an already-rendered <img> via a canvas) is what
+ * keeps this safe for cross-origin cloud assets (e.g. GCS): the returned blob is
+ * always readable, whereas a canvas drawn from a non-CORS cross-origin image is
+ * tainted and cannot be exported. Reuse this anywhere an image's bytes are
+ * needed (download, open-in-tab, copy-to-clipboard).
+ */
+export async function fetchUrlAsBlob(url: string): Promise<Blob> {
+  const response = await fetchAsBlob(url)
+  return response.blob()
 }
 
 async function downloadViaBlobFetch(
@@ -162,8 +177,7 @@ export async function openFileInNewTab(url: string): Promise<void> {
   const tab = window.open('', '_blank')
 
   try {
-    const response = await fetchAsBlob(url)
-    const blob = await response.blob()
+    const blob = await fetchUrlAsBlob(url)
     const blobUrl = URL.createObjectURL(blob)
 
     if (tab && !tab.closed) {

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -117,8 +117,9 @@ export function extractFilenameFromContentDisposition(
 }
 
 /**
- * Fetch a URL and return its body as a Blob.
- * Shared by download and open-in-new-tab cloud paths.
+ * Fetch a URL and return the raw Response, throwing on non-OK status.
+ * Shared by download and open-in-new-tab cloud paths that need response
+ * headers (e.g. Content-Disposition).
  */
 async function fetchAsBlob(url: string): Promise<Response> {
   const response = await fetch(url)
@@ -126,6 +127,20 @@ async function fetchAsBlob(url: string): Promise<Response> {
     throw new Error(`Failed to fetch ${url}: ${response.status}`)
   }
   return response
+}
+
+/**
+ * Fetch a URL and return its body as a Blob.
+ *
+ * Fetching (rather than reading an already-rendered <img> via a canvas) is what
+ * keeps this safe for cross-origin cloud assets (e.g. GCS): the returned blob is
+ * always readable, whereas a canvas drawn from a non-CORS cross-origin image is
+ * tainted and cannot be exported. Reuse this anywhere an image's bytes are
+ * needed (download, open-in-tab, copy-to-clipboard).
+ */
+export async function fetchUrlAsBlob(url: string): Promise<Blob> {
+  const response = await fetchAsBlob(url)
+  return response.blob()
 }
 
 async function downloadViaBlobFetch(

--- a/src/base/common/downloadUtil.ts
+++ b/src/base/common/downloadUtil.ts
@@ -117,9 +117,8 @@ export function extractFilenameFromContentDisposition(
 }
 
 /**
- * Fetch a URL and return the raw Response, throwing on non-OK status.
- * Shared by download and open-in-new-tab cloud paths that need response
- * headers (e.g. Content-Disposition).
+ * Fetch a URL and return its body as a Blob.
+ * Shared by download and open-in-new-tab cloud paths.
  */
 async function fetchAsBlob(url: string): Promise<Response> {
   const response = await fetch(url)
@@ -127,20 +126,6 @@ async function fetchAsBlob(url: string): Promise<Response> {
     throw new Error(`Failed to fetch ${url}: ${response.status}`)
   }
   return response
-}
-
-/**
- * Fetch a URL and return its body as a Blob.
- *
- * Fetching (rather than reading an already-rendered <img> via a canvas) is what
- * keeps this safe for cross-origin cloud assets (e.g. GCS): the returned blob is
- * always readable, whereas a canvas drawn from a non-CORS cross-origin image is
- * tainted and cannot be exported. Reuse this anywhere an image's bytes are
- * needed (download, open-in-tab, copy-to-clipboard).
- */
-export async function fetchUrlAsBlob(url: string): Promise<Blob> {
-  const response = await fetchAsBlob(url)
-  return response.blob()
 }
 
 async function downloadViaBlobFetch(

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -47,6 +47,7 @@ function createImageNode(
 describe('useImageMenuOptions', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   describe('getImageMenuOptions', () => {
@@ -180,6 +181,86 @@ describe('useImageMenuOptions', () => {
       await pasteOption!.action!()
 
       expect(node.pasteFiles).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('copyImage action', () => {
+    /**
+     * Capture-only ClipboardItem stub. jsdom has no ClipboardItem, and we want
+     * to resolve the PNG blob promise the composable hands it so assertions can
+     * read what would be placed on the real clipboard.
+     */
+    function stubClipboardItem() {
+      vi.stubGlobal(
+        'ClipboardItem',
+        class {
+          data: Record<string, Blob | Promise<Blob>>
+          constructor(data: Record<string, Blob | Promise<Blob>>) {
+            this.data = data
+          }
+        }
+      )
+    }
+
+    function getCopyAction(node: LGraphNode) {
+      const { getImageMenuOptions } = useImageMenuOptions()
+      return getImageMenuOptions(node).find((o) => o.label === 'Copy Image')!
+        .action!
+    }
+
+    it('fetches the image and writes a PNG blob to the clipboard', async () => {
+      const node = createImageNode()
+      const pngBlob = new Blob(['png'], { type: 'image/png' })
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(pngBlob)
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      stubClipboardItem()
+
+      const write = vi.fn().mockResolvedValue(undefined)
+      mockClipboard(fromPartial<Clipboard>({ write }))
+
+      await getCopyAction(node)()
+
+      // Fetches the source URL instead of exporting the (cloud-tainted) canvas.
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost/test.png')
+      const item = write.mock.calls[0][0][0] as {
+        data: Record<string, unknown>
+      }
+      await expect(item.data['image/png']).resolves.toBe(pngBlob)
+    })
+
+    it('strips the preview query param before fetching', async () => {
+      const img = new Image()
+      img.src = 'http://localhost/view?filename=a.png&preview=webp'
+      const node = createImageNode({ imgs: [img] })
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['png'], { type: 'image/png' }))
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      stubClipboardItem()
+      mockClipboard(
+        fromPartial<Clipboard>({ write: vi.fn().mockResolvedValue(undefined) })
+      )
+
+      await getCopyAction(node)()
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost/view?filename=a.png'
+      )
+    })
+
+    it('handles missing clipboard API gracefully', async () => {
+      const node = createImageNode()
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      mockClipboard(fromPartial<Clipboard>({ write: undefined }))
+
+      await expect(getCopyAction(node)()).resolves.toBeUndefined()
+      expect(fetchMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -19,6 +19,11 @@ vi.mock('@/stores/commandStore', () => ({
   useCommandStore: () => ({ execute: vi.fn() })
 }))
 
+const { addAlert } = vi.hoisted(() => ({ addAlert: vi.fn() }))
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert })
+}))
+
 function mockClipboard(clipboard: Partial<Clipboard> | undefined) {
   Object.defineProperty(navigator, 'clipboard', {
     value: clipboard,
@@ -48,6 +53,7 @@ describe('useImageMenuOptions', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    addAlert.mockClear()
   })
 
   describe('getImageMenuOptions', () => {
@@ -253,7 +259,45 @@ describe('useImageMenuOptions', () => {
       )
     })
 
-    it('handles missing clipboard API gracefully', async () => {
+    it('re-encodes a non-PNG source to PNG before writing', async () => {
+      const node = createImageNode()
+      const jpegBlob = new Blob(['jpeg'], { type: 'image/jpeg' })
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          blob: () => Promise.resolve(jpegBlob)
+        })
+      )
+      stubClipboardItem()
+
+      // jsdom implements neither createImageBitmap nor canvas.toBlob, so stub
+      // the decode + re-encode pipeline the non-PNG branch relies on.
+      const bitmap = { width: 2, height: 2, close: vi.fn() }
+      vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap))
+      const pngBlob = new Blob(['png'], { type: 'image/png' })
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+        fromPartial<CanvasRenderingContext2D>({ drawImage: vi.fn() }) as never
+      )
+      vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((cb) =>
+        cb(pngBlob)
+      )
+
+      const write = vi.fn().mockResolvedValue(undefined)
+      mockClipboard(fromPartial<Clipboard>({ write }))
+
+      await getCopyAction(node)()
+
+      // Await the deferred PNG promise first so the re-encode chain runs.
+      const item = write.mock.calls[0][0][0] as {
+        data: Record<string, unknown>
+      }
+      await expect(item.data['image/png']).resolves.toBe(pngBlob)
+      expect(createImageBitmap).toHaveBeenCalledWith(jpegBlob)
+      expect(bitmap.close).toHaveBeenCalled()
+    })
+
+    it('alerts the user when the clipboard API is unavailable', async () => {
       const node = createImageNode()
       const fetchMock = vi.fn()
       vi.stubGlobal('fetch', fetchMock)
@@ -261,6 +305,7 @@ describe('useImageMenuOptions', () => {
 
       await expect(getCopyAction(node)()).resolves.toBeUndefined()
       expect(fetchMock).not.toHaveBeenCalled()
+      expect(addAlert).toHaveBeenCalledWith('errorCopyImage')
     })
   })
 })

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -191,4 +191,84 @@ describe('useImageMenuOptions', () => {
       expect(node.pasteFiles).not.toHaveBeenCalled()
     })
   })
+
+  describe('copyImage action', () => {
+    /**
+     * Capture-only ClipboardItem stub. jsdom has no ClipboardItem, and we want
+     * to resolve the PNG blob promise the composable hands it so assertions can
+     * read what would be placed on the real clipboard.
+     */
+    function stubClipboardItem() {
+      vi.stubGlobal(
+        'ClipboardItem',
+        class {
+          data: Record<string, Blob | Promise<Blob>>
+          constructor(data: Record<string, Blob | Promise<Blob>>) {
+            this.data = data
+          }
+        }
+      )
+    }
+
+    function getCopyAction(node: LGraphNode) {
+      const { getImageMenuOptions } = useImageMenuOptions()
+      return getImageMenuOptions(node).find((o) => o.label === 'Copy Image')!
+        .action!
+    }
+
+    it('fetches the image and writes a PNG blob to the clipboard', async () => {
+      const node = createImageNode()
+      const pngBlob = new Blob(['png'], { type: 'image/png' })
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(pngBlob)
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      stubClipboardItem()
+
+      const write = vi.fn().mockResolvedValue(undefined)
+      mockClipboard(fromPartial<Clipboard>({ write }))
+
+      await getCopyAction(node)()
+
+      // Fetches the source URL instead of exporting the (cloud-tainted) canvas.
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost/test.png')
+      const item = write.mock.calls[0][0][0] as {
+        data: Record<string, unknown>
+      }
+      await expect(item.data['image/png']).resolves.toBe(pngBlob)
+    })
+
+    it('strips the preview query param before fetching', async () => {
+      const img = new Image()
+      img.src = 'http://localhost/view?filename=a.png&preview=webp'
+      const node = createImageNode({ imgs: [img] })
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['png'], { type: 'image/png' }))
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      stubClipboardItem()
+      mockClipboard(
+        fromPartial<Clipboard>({ write: vi.fn().mockResolvedValue(undefined) })
+      )
+
+      await getCopyAction(node)()
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost/view?filename=a.png'
+      )
+    })
+
+    it('handles missing clipboard API gracefully', async () => {
+      const node = createImageNode()
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      mockClipboard(fromPartial<Clipboard>({ write: undefined }))
+
+      await expect(getCopyAction(node)()).resolves.toBeUndefined()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/composables/graph/useImageMenuOptions.test.ts
+++ b/src/composables/graph/useImageMenuOptions.test.ts
@@ -19,6 +19,11 @@ vi.mock('@/stores/commandStore', () => ({
   useCommandStore: () => ({ execute: vi.fn() })
 }))
 
+const { addAlert } = vi.hoisted(() => ({ addAlert: vi.fn() }))
+vi.mock('@/platform/updates/common/toastStore', () => ({
+  useToastStore: () => ({ addAlert })
+}))
+
 function mockClipboard(clipboard: Partial<Clipboard> | undefined) {
   Object.defineProperty(navigator, 'clipboard', {
     value: clipboard,
@@ -261,7 +266,45 @@ describe('useImageMenuOptions', () => {
       )
     })
 
-    it('handles missing clipboard API gracefully', async () => {
+    it('re-encodes a non-PNG source to PNG before writing', async () => {
+      const node = createImageNode()
+      const jpegBlob = new Blob(['jpeg'], { type: 'image/jpeg' })
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          blob: () => Promise.resolve(jpegBlob)
+        })
+      )
+      stubClipboardItem()
+
+      // jsdom implements neither createImageBitmap nor canvas.toBlob, so stub
+      // the decode + re-encode pipeline the non-PNG branch relies on.
+      const bitmap = { width: 2, height: 2, close: vi.fn() }
+      vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap))
+      const pngBlob = new Blob(['png'], { type: 'image/png' })
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+        fromPartial<CanvasRenderingContext2D>({ drawImage: vi.fn() }) as never
+      )
+      vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((cb) =>
+        cb(pngBlob)
+      )
+
+      const write = vi.fn().mockResolvedValue(undefined)
+      mockClipboard(fromPartial<Clipboard>({ write }))
+
+      await getCopyAction(node)()
+
+      // Await the deferred PNG promise first so the re-encode chain runs.
+      const item = write.mock.calls[0][0][0] as {
+        data: Record<string, unknown>
+      }
+      await expect(item.data['image/png']).resolves.toBe(pngBlob)
+      expect(createImageBitmap).toHaveBeenCalledWith(jpegBlob)
+      expect(bitmap.close).toHaveBeenCalled()
+    })
+
+    it('alerts the user when the clipboard API is unavailable', async () => {
       const node = createImageNode()
       const fetchMock = vi.fn()
       vi.stubGlobal('fetch', fetchMock)
@@ -269,6 +312,7 @@ describe('useImageMenuOptions', () => {
 
       await expect(getCopyAction(node)()).resolves.toBeUndefined()
       expect(fetchMock).not.toHaveBeenCalled()
+      expect(addAlert).toHaveBeenCalledWith('errorCopyImage')
     })
   })
 })

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -1,10 +1,6 @@
 import { useI18n } from 'vue-i18n'
 
-import {
-  downloadFile,
-  fetchUrlAsBlob,
-  openFileInNewTab
-} from '@/base/common/downloadUtil'
+import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useCommandStore } from '@/stores/commandStore'
 
@@ -33,16 +29,22 @@ function getNodeImageUrl(node: LGraphNode): string | null {
 /**
  * Fetch an image URL and return it as a PNG blob ready for the clipboard.
  *
- * Builds on the shared cloud-aware {@link fetchUrlAsBlob}: re-fetching the URL
- * (instead of exporting the node's rendered <img> through a canvas) is what
- * avoids the tainted-canvas SecurityError for cross-origin cloud assets.
+ * Re-fetching the URL (instead of exporting the node's rendered <img> through a
+ * canvas) is what avoids the tainted-canvas SecurityError for cross-origin cloud
+ * assets: the fetched blob is always readable, whereas a canvas drawn from a
+ * non-CORS cross-origin image cannot be exported.
  *
  * The blob is re-encoded to PNG when the source is not already PNG, because the
  * async clipboard only reliably accepts `image/png`. The bitmap is decoded from
  * a same-origin blob, so this canvas is never tainted.
  */
 async function fetchImageAsPngBlob(url: string): Promise<Blob> {
-  const blob = await fetchUrlAsBlob(url)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image: ${response.status}`)
+  }
+
+  const blob = await response.blob()
   if (blob.type === 'image/png') return blob
 
   const bitmap = await createImageBitmap(blob)

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -2,6 +2,7 @@ import { useI18n } from 'vue-i18n'
 
 import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useCommandStore } from '@/stores/commandStore'
 
 import type { MenuOption } from './useMoreOptionsMenu'
@@ -112,12 +113,10 @@ export function useImageMenuOptions() {
     const url = getNodeImageUrl(node)
     if (!url) return
 
-    if (!navigator.clipboard?.write) {
-      console.warn('Clipboard API not available')
-      return
-    }
-
     try {
+      if (!navigator.clipboard?.write) {
+        throw new Error('Clipboard API not available')
+      }
       // Pass a Promise to ClipboardItem so the write is registered
       // synchronously within the click's user-gesture, keeping activation
       // alive across the fetch (required by Safari, tolerated by Chrome).
@@ -126,6 +125,11 @@ export function useImageMenuOptions() {
       ])
     } catch (error) {
       console.error('Failed to copy image to clipboard:', error)
+      useToastStore().addAlert(
+        t('toastMessages.errorCopyImage', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      )
     }
   }
 
@@ -137,6 +141,11 @@ export function useImageMenuOptions() {
       downloadFile(url)
     } catch (error) {
       console.error('Failed to save image:', error)
+      useToastStore().addAlert(
+        t('toastMessages.errorSaveImage', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      )
     }
   }
 

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -1,6 +1,10 @@
 import { useI18n } from 'vue-i18n'
 
-import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
+import {
+  downloadFile,
+  fetchUrlAsBlob,
+  openFileInNewTab
+} from '@/base/common/downloadUtil'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useCommandStore } from '@/stores/commandStore'
 
@@ -8,6 +12,56 @@ import type { MenuOption } from './useMoreOptionsMenu'
 
 function canPasteImage(node?: LGraphNode): boolean {
   return typeof node?.pasteFiles === 'function'
+}
+
+/**
+ * Resolve the full-resolution source URL of a node's currently shown image.
+ *
+ * Strips the `preview` query param so callers get the original asset rather than
+ * the downscaled canvas preview. Returns null when the node has no image.
+ * Shared by every image action (open / save / copy) so URL derivation stays in
+ * one place.
+ */
+function getNodeImageUrl(node: LGraphNode): string | null {
+  const img = node?.imgs?.[node.imageIndex ?? 0]
+  if (!img) return null
+  const url = new URL(img.src)
+  url.searchParams.delete('preview')
+  return url.toString()
+}
+
+/**
+ * Fetch an image URL and return it as a PNG blob ready for the clipboard.
+ *
+ * Builds on the shared cloud-aware {@link fetchUrlAsBlob}: re-fetching the URL
+ * (instead of exporting the node's rendered <img> through a canvas) is what
+ * avoids the tainted-canvas SecurityError for cross-origin cloud assets.
+ *
+ * The blob is re-encoded to PNG when the source is not already PNG, because the
+ * async clipboard only reliably accepts `image/png`. The bitmap is decoded from
+ * a same-origin blob, so this canvas is never tainted.
+ */
+async function fetchImageAsPngBlob(url: string): Promise<Blob> {
+  const blob = await fetchUrlAsBlob(url)
+  if (blob.type === 'image/png') return blob
+
+  const bitmap = await createImageBitmap(blob)
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Failed to get 2D canvas context')
+    ctx.drawImage(bitmap, 0, 0)
+
+    const pngBlob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/png')
+    })
+    if (!pngBlob) throw new Error('Failed to encode image as PNG')
+    return pngBlob
+  } finally {
+    bitmap.close()
+  }
 }
 
 async function pasteClipboardImageToNode(node: LGraphNode): Promise<void> {
@@ -48,45 +102,25 @@ export function useImageMenuOptions() {
   }
 
   const openImage = (node: LGraphNode) => {
-    if (!node?.imgs?.length) return
-    const img = node.imgs[node.imageIndex ?? 0]
-    if (!img) return
-    const url = new URL(img.src)
-    url.searchParams.delete('preview')
-    void openFileInNewTab(url.toString())
+    const url = getNodeImageUrl(node)
+    if (url) void openFileInNewTab(url)
   }
 
   const copyImage = async (node: LGraphNode) => {
-    if (!node?.imgs?.length) return
-    const img = node.imgs[node.imageIndex ?? 0]
-    if (!img) return
+    const url = getNodeImageUrl(node)
+    if (!url) return
 
-    const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    canvas.width = img.naturalWidth
-    canvas.height = img.naturalHeight
-    ctx.drawImage(img, 0, 0)
+    if (!navigator.clipboard?.write) {
+      console.warn('Clipboard API not available')
+      return
+    }
 
     try {
-      const blob = await new Promise<Blob | null>((resolve) => {
-        canvas.toBlob(resolve, 'image/png')
-      })
-
-      if (!blob) {
-        console.warn('Failed to create image blob')
-        return
-      }
-
-      // Check if clipboard API is available
-      if (!navigator.clipboard?.write) {
-        console.warn('Clipboard API not available')
-        return
-      }
-
+      // Pass a Promise to ClipboardItem so the write is registered
+      // synchronously within the click's user-gesture, keeping activation
+      // alive across the fetch (required by Safari, tolerated by Chrome).
       await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': blob })
+        new ClipboardItem({ 'image/png': fetchImageAsPngBlob(url) })
       ])
     } catch (error) {
       console.error('Failed to copy image to clipboard:', error)
@@ -94,14 +128,11 @@ export function useImageMenuOptions() {
   }
 
   const saveImage = (node: LGraphNode) => {
-    if (!node?.imgs?.length) return
-    const img = node.imgs[node.imageIndex ?? 0]
-    if (!img) return
+    const url = getNodeImageUrl(node)
+    if (!url) return
 
     try {
-      const url = new URL(img.src)
-      url.searchParams.delete('preview')
-      downloadFile(url.toString())
+      downloadFile(url)
     } catch (error) {
       console.error('Failed to save image:', error)
     }

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -1,6 +1,10 @@
 import { useI18n } from 'vue-i18n'
 
-import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
+import {
+  downloadFile,
+  fetchUrlAsBlob,
+  openFileInNewTab
+} from '@/base/common/downloadUtil'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useCommandStore } from '@/stores/commandStore'
 import type { CoreMediaMenuActionKind } from '@/utils/coreMediaMenuActionUtils'
@@ -16,6 +20,56 @@ const DEFAULT_IMAGE_MENU_AVAILABILITY: ImageMenuAvailability = {
 
 function canPasteImage(node?: LGraphNode): boolean {
   return typeof node?.pasteFiles === 'function'
+}
+
+/**
+ * Resolve the full-resolution source URL of a node's currently shown image.
+ *
+ * Strips the `preview` query param so callers get the original asset rather than
+ * the downscaled canvas preview. Returns null when the node has no image.
+ * Shared by every image action (open / save / copy) so URL derivation stays in
+ * one place.
+ */
+function getNodeImageUrl(node: LGraphNode): string | null {
+  const img = node?.imgs?.[node.imageIndex ?? 0]
+  if (!img) return null
+  const url = new URL(img.src)
+  url.searchParams.delete('preview')
+  return url.toString()
+}
+
+/**
+ * Fetch an image URL and return it as a PNG blob ready for the clipboard.
+ *
+ * Builds on the shared cloud-aware {@link fetchUrlAsBlob}: re-fetching the URL
+ * (instead of exporting the node's rendered <img> through a canvas) is what
+ * avoids the tainted-canvas SecurityError for cross-origin cloud assets.
+ *
+ * The blob is re-encoded to PNG when the source is not already PNG, because the
+ * async clipboard only reliably accepts `image/png`. The bitmap is decoded from
+ * a same-origin blob, so this canvas is never tainted.
+ */
+async function fetchImageAsPngBlob(url: string): Promise<Blob> {
+  const blob = await fetchUrlAsBlob(url)
+  if (blob.type === 'image/png') return blob
+
+  const bitmap = await createImageBitmap(blob)
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Failed to get 2D canvas context')
+    ctx.drawImage(bitmap, 0, 0)
+
+    const pngBlob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/png')
+    })
+    if (!pngBlob) throw new Error('Failed to encode image as PNG')
+    return pngBlob
+  } finally {
+    bitmap.close()
+  }
 }
 
 async function pasteClipboardImageToNode(node: LGraphNode): Promise<void> {
@@ -56,45 +110,25 @@ export function useImageMenuOptions() {
   }
 
   const openImage = (node: LGraphNode) => {
-    if (!node?.imgs?.length) return
-    const img = node.imgs[node.imageIndex ?? 0]
-    if (!img) return
-    const url = new URL(img.src)
-    url.searchParams.delete('preview')
-    void openFileInNewTab(url.toString())
+    const url = getNodeImageUrl(node)
+    if (url) void openFileInNewTab(url)
   }
 
   const copyImage = async (node: LGraphNode) => {
-    if (!node?.imgs?.length) return
-    const img = node.imgs[node.imageIndex ?? 0]
-    if (!img) return
+    const url = getNodeImageUrl(node)
+    if (!url) return
 
-    const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    canvas.width = img.naturalWidth
-    canvas.height = img.naturalHeight
-    ctx.drawImage(img, 0, 0)
+    if (!navigator.clipboard?.write) {
+      console.warn('Clipboard API not available')
+      return
+    }
 
     try {
-      const blob = await new Promise<Blob | null>((resolve) => {
-        canvas.toBlob(resolve, 'image/png')
-      })
-
-      if (!blob) {
-        console.warn('Failed to create image blob')
-        return
-      }
-
-      // Check if clipboard API is available
-      if (!navigator.clipboard?.write) {
-        console.warn('Clipboard API not available')
-        return
-      }
-
+      // Pass a Promise to ClipboardItem so the write is registered
+      // synchronously within the click's user-gesture, keeping activation
+      // alive across the fetch (required by Safari, tolerated by Chrome).
       await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': blob })
+        new ClipboardItem({ 'image/png': fetchImageAsPngBlob(url) })
       ])
     } catch (error) {
       console.error('Failed to copy image to clipboard:', error)
@@ -102,14 +136,11 @@ export function useImageMenuOptions() {
   }
 
   const saveImage = (node: LGraphNode) => {
-    if (!node?.imgs?.length) return
-    const img = node.imgs[node.imageIndex ?? 0]
-    if (!img) return
+    const url = getNodeImageUrl(node)
+    if (!url) return
 
     try {
-      const url = new URL(img.src)
-      url.searchParams.delete('preview')
-      downloadFile(url.toString())
+      downloadFile(url)
     } catch (error) {
       console.error('Failed to save image:', error)
     }

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -129,7 +129,7 @@ export function useImageMenuOptions() {
     if (!url) return
 
     if (!navigator.clipboard?.write) {
-      console.warn('Clipboard API not available')
+      useToastStore().addAlert(t('toastMessages.errorCopyImage'))
       return
     }
 

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -1,10 +1,6 @@
 import { useI18n } from 'vue-i18n'
 
-import {
-  downloadFile,
-  fetchUrlAsBlob,
-  openFileInNewTab
-} from '@/base/common/downloadUtil'
+import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import { useCommandStore } from '@/stores/commandStore'
 import type { CoreMediaMenuActionKind } from '@/utils/coreMediaMenuActionUtils'
@@ -41,16 +37,22 @@ function getNodeImageUrl(node: LGraphNode): string | null {
 /**
  * Fetch an image URL and return it as a PNG blob ready for the clipboard.
  *
- * Builds on the shared cloud-aware {@link fetchUrlAsBlob}: re-fetching the URL
- * (instead of exporting the node's rendered <img> through a canvas) is what
- * avoids the tainted-canvas SecurityError for cross-origin cloud assets.
+ * Re-fetching the URL (instead of exporting the node's rendered <img> through a
+ * canvas) is what avoids the tainted-canvas SecurityError for cross-origin cloud
+ * assets: the fetched blob is always readable, whereas a canvas drawn from a
+ * non-CORS cross-origin image cannot be exported.
  *
  * The blob is re-encoded to PNG when the source is not already PNG, because the
  * async clipboard only reliably accepts `image/png`. The bitmap is decoded from
  * a same-origin blob, so this canvas is never tainted.
  */
 async function fetchImageAsPngBlob(url: string): Promise<Blob> {
-  const blob = await fetchUrlAsBlob(url)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image: ${response.status}`)
+  }
+
+  const blob = await response.blob()
   if (blob.type === 'image/png') return blob
 
   const bitmap = await createImageBitmap(blob)

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -47,10 +47,11 @@ function getNodeImageUrl(node: LGraphNode): string | null {
  * async clipboard only reliably accepts `image/png`. The bitmap is decoded from
  * a same-origin blob, so this canvas is never tainted.
  */
-async function fetchImageAsPngBlob(url: string): Promise<Blob> {
+async function fetchImageAsPngBlob(url: string): Promise<Blob | null> {
   const response = await fetch(url)
   if (!response.ok) {
-    throw new Error(`Failed to fetch image: ${response.status}`)
+    console.error(`Failed to fetch image: ${response.status}`)
+    return null
   }
 
   const blob = await response.blob()
@@ -62,13 +63,19 @@ async function fetchImageAsPngBlob(url: string): Promise<Blob> {
     canvas.width = bitmap.width
     canvas.height = bitmap.height
     const ctx = canvas.getContext('2d')
-    if (!ctx) throw new Error('Failed to get 2D canvas context')
+    if (!ctx) {
+      console.error('Failed to get 2D canvas context')
+      return null
+    }
     ctx.drawImage(bitmap, 0, 0)
 
     const pngBlob = await new Promise<Blob | null>((resolve) => {
       canvas.toBlob(resolve, 'image/png')
     })
-    if (!pngBlob) throw new Error('Failed to encode image as PNG')
+    if (!pngBlob) {
+      console.error('Failed to encode image as PNG')
+      return null
+    }
     return pngBlob
   } finally {
     bitmap.close()
@@ -121,15 +128,21 @@ export function useImageMenuOptions() {
     const url = getNodeImageUrl(node)
     if (!url) return
 
+    if (!navigator.clipboard?.write) {
+      console.warn('Clipboard API not available')
+      return
+    }
+
     try {
-      if (!navigator.clipboard?.write) {
-        throw new Error('Clipboard API not available')
-      }
       // Pass a Promise to ClipboardItem so the write is registered
       // synchronously within the click's user-gesture, keeping activation
       // alive across the fetch (required by Safari, tolerated by Chrome).
+      const blobPromise = fetchImageAsPngBlob(url).then((blob): Blob => {
+        if (!blob) throw new TypeError('Failed to prepare image for clipboard')
+        return blob
+      })
       await navigator.clipboard.write([
-        new ClipboardItem({ 'image/png': fetchImageAsPngBlob(url) })
+        new ClipboardItem({ 'image/png': blobPromise })
       ])
     } catch (error) {
       console.error('Failed to copy image to clipboard:', error)

--- a/src/composables/graph/useImageMenuOptions.ts
+++ b/src/composables/graph/useImageMenuOptions.ts
@@ -2,6 +2,7 @@ import { useI18n } from 'vue-i18n'
 
 import { downloadFile, openFileInNewTab } from '@/base/common/downloadUtil'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import { useToastStore } from '@/platform/updates/common/toastStore'
 import { useCommandStore } from '@/stores/commandStore'
 import type { CoreMediaMenuActionKind } from '@/utils/coreMediaMenuActionUtils'
 
@@ -120,12 +121,10 @@ export function useImageMenuOptions() {
     const url = getNodeImageUrl(node)
     if (!url) return
 
-    if (!navigator.clipboard?.write) {
-      console.warn('Clipboard API not available')
-      return
-    }
-
     try {
+      if (!navigator.clipboard?.write) {
+        throw new Error('Clipboard API not available')
+      }
       // Pass a Promise to ClipboardItem so the write is registered
       // synchronously within the click's user-gesture, keeping activation
       // alive across the fetch (required by Safari, tolerated by Chrome).
@@ -134,6 +133,11 @@ export function useImageMenuOptions() {
       ])
     } catch (error) {
       console.error('Failed to copy image to clipboard:', error)
+      useToastStore().addAlert(
+        t('toastMessages.errorCopyImage', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      )
     }
   }
 
@@ -145,6 +149,11 @@ export function useImageMenuOptions() {
       downloadFile(url)
     } catch (error) {
       console.error('Failed to save image:', error)
+      useToastStore().addAlert(
+        t('toastMessages.errorSaveImage', {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      )
     }
   }
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2203,6 +2203,7 @@
     "errorSaveSetting": "Error saving setting {id}: {err}",
     "errorCopyImage": "Error copying image: {error}",
     "errorOpenImage": "Error opening image: {error}",
+    "errorSaveImage": "Error saving image: {error}",
     "noTemplatesToExport": "No templates to export",
     "invalidTemplateData": "Failed to load node template: invalid data",
     "failedToFetchLogs": "Failed to fetch server logs",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -2418,6 +2418,7 @@
     "errorSaveSetting": "Error saving setting {id}: {err}",
     "errorCopyImage": "Error copying image: {error}",
     "errorOpenImage": "Error opening image: {error}",
+    "errorSaveImage": "Error saving image: {error}",
     "noTemplatesToExport": "No templates to export",
     "invalidTemplateData": "Failed to load node template: invalid data",
     "failedToFetchLogs": "Failed to fetch server logs",


### PR DESCRIPTION
## Summary

Fix right-click "Copy Image" throwing a `SecurityError` on Comfy Cloud SaveImage nodes, and generalize the shared image-fetch logic that open/save/copy all rely on.

## Changes

- **What**:
  - `copyImage` no longer exports the node's rendered `<img>` through a canvas. On cloud that image is a cross-origin GCS asset loaded without CORS, so drawing it taints the canvas and `canvas.toBlob` throws `SecurityError: Tainted canvases may not be exported`. It now fetches the image URL directly (the same approach `openImage`/`saveImage` already use), yielding a clean readable blob on both cloud and local, then writes it to the clipboard.
  - The PNG blob is handed to `ClipboardItem` as a `Promise` so the clipboard write stays inside the click's user-gesture across the fetch (required by Safari, tolerated by Chrome), and is re-encoded to PNG when the source isn't already PNG.
  - Generalized the shared logic: exported `fetchUrlAsBlob` from `downloadUtil` as the cloud-aware "get image bytes" primitive (`openFileInNewTab` reuses it), and extracted `getNodeImageUrl` for the strip-`preview` URL derivation shared by open / save / copy.

## Review Focus

- Root cause is tainted-canvas from a non-CORS cross-origin (GCS) image — not a regression of FE-325; `Save Image` was always fine because it never touched a canvas.
- `copyImage` now mirrors the already-shipped cloud fix for `openImage` (#9122), so the fetch path is proven on cloud.
- Verified locally: `useImageMenuOptions` + `downloadUtil` tests pass (42), eslint and vue-tsc clean on the changed files. Live cloud behavior could not be exercised from local.

Fixes FE-1011