### PR TITLE
chore: update platform source API types

### DIFF
--- a/packages/ingest-types/src/index.ts
+++ b/packages/ingest-types/src/index.ts
@@ -711,6 +711,7 @@ export type {
   PlanAvailability,
   PlanAvailabilityReason,
   PlanSeatSummary,
+  PlatformSource,
   PostAssetsFromWorkflowData,
   PostAssetsFromWorkflowError,
   PostAssetsFromWorkflowErrors,

--- a/packages/ingest-types/src/types.gen.ts
+++ b/packages/ingest-types/src/types.gen.ts
@@ -877,6 +877,10 @@ export type CreateTopupRequest = {
    *
    */
   idempotency_key?: string
+  /**
+   * Transaction platform/source classification for analytics attribution
+   */
+  platform_source?: PlatformSource
 }
 
 /**
@@ -1007,7 +1011,16 @@ export type SubscribeRequest = {
    *
    */
   cancel_url?: string
+  /**
+   * Transaction platform/source classification for analytics attribution
+   */
+  platform_source?: PlatformSource
 }
+
+/**
+ * Transaction platform/source classification for analytics attribution
+ */
+export type PlatformSource = 'cloud' | 'desktop_cloud' | 'desktop_local'
 
 /**
  * Plan information for preview display

--- a/packages/ingest-types/src/zod.gen.ts
+++ b/packages/ingest-types/src/zod.gen.ts
@@ -522,7 +522,10 @@ export const zCreateTopupRequest = z.object({
     .max(BigInt('9223372036854775807'), {
       message: 'Invalid value: Expected int64 to be <= 9223372036854775807'
     }),
-  idempotency_key: z.string().optional()
+  idempotency_key: z.string().optional(),
+  platform_source: z
+    .enum(['cloud', 'desktop_cloud', 'desktop_local'])
+    .optional()
 })
 
 /**
@@ -587,7 +590,10 @@ export const zSubscribeRequest = z.object({
   plan_slug: z.string(),
   idempotency_key: z.string().optional(),
   return_url: z.string().optional(),
-  cancel_url: z.string().optional()
+  cancel_url: z.string().optional(),
+  platform_source: z
+    .enum(['cloud', 'desktop_cloud', 'desktop_local'])
+    .optional()
 })
 
 /**

--- a/packages/ingest-types/tsconfig.json
+++ b/packages/ingest-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist"
   },
   "include": ["src/**/*", "*.config.ts"]

--- a/packages/registry-types/src/comfyRegistryTypes.ts
+++ b/packages/registry-types/src/comfyRegistryTypes.ts
@@ -21180,6 +21180,8 @@ export interface operations {
                     amount_micros: number;
                     /** @description the currency used in the checkout transaction */
                     currency: string;
+                    /** @description Transaction platform/source classification for analytics attribution */
+                    platform_source?: "cloud" | "desktop_cloud" | "desktop_local";
                 };
             };
         };
@@ -21319,6 +21321,8 @@ export interface operations {
                     im_ref?: string;
                     /** @description Rewardful referral UUID (window.Rewardful.referral), passed to Stripe as client_reference_id for affiliate conversion tracking */
                     rewardful_referral?: string;
+                    /** @description Transaction platform/source classification for analytics attribution */
+                    platform_source?: "cloud" | "desktop_cloud" | "desktop_local";
                 };
             };
         };
@@ -21401,6 +21405,8 @@ export interface operations {
                     im_ref?: string;
                     /** @description Rewardful referral UUID (window.Rewardful.referral), passed to Stripe as client_reference_id for affiliate conversion tracking */
                     rewardful_referral?: string;
+                    /** @description Transaction platform/source classification for analytics attribution */
+                    platform_source?: "cloud" | "desktop_cloud" | "desktop_local";
                 };
             };
         };


### PR DESCRIPTION
## Summary

Adds generated frontend API type support for the cloud `platform_source` checkout field after Comfy-Org/cloud#4685 lands.

## Changes

- **What**: Updates ingest and registry generated types/zod schemas for `platform_source` and exports the new ingest `PlatformSource` type.
- **Dependencies**: Depends on Comfy-Org/cloud#4685 being merged first so these generated snapshots match the cloud OpenAPI source.

## Review Focus

Confirm the generated type snapshots match the cloud contract for `cloud`, `desktop_cloud`, and `desktop_local`.

## Screenshots (if applicable)

N/A