### PR TITLE
fix: image preview gallery keydown events leak to canvas

### DIFF
--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -384,6 +384,67 @@ describe('ImagePreview', () => {
 
       expect(screen.getByRole('img')).toHaveAttribute('src', initialSrc!)
     })
+
+    it.for(['ArrowLeft', 'ArrowRight', 'Home', 'End'])(
+      'stops propagation for %s in gallery mode',
+      async (key) => {
+        const { container } = renderImagePreview()
+        const user = userEvent.setup()
+        await switchToGallery(user)
+
+        const preview = container.querySelector('.image-preview') as HTMLElement
+        const parentListener = vi.fn()
+        preview.parentElement!.addEventListener('keydown', parentListener)
+
+        await fireEvent.keyDown(preview, { key })
+        await nextTick()
+
+        expect(parentListener).not.toHaveBeenCalled()
+      }
+    )
+
+    it('stops propagation for Escape when returning to grid', async () => {
+      const { container } = renderImagePreview()
+      const user = userEvent.setup()
+      await switchToGallery(user)
+
+      const preview = container.querySelector('.image-preview') as HTMLElement
+      const parentListener = vi.fn()
+      preview.parentElement!.addEventListener('keydown', parentListener)
+
+      await fireEvent.keyDown(preview, { key: 'Escape' })
+      await nextTick()
+
+      expect(parentListener).not.toHaveBeenCalled()
+    })
+
+    it('does not stop propagation for arrow keys in grid mode', async () => {
+      const { container } = renderImagePreview()
+
+      const preview = container.querySelector('.image-preview') as HTMLElement
+      const parentListener = vi.fn()
+      preview.parentElement!.addEventListener('keydown', parentListener)
+
+      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await nextTick()
+
+      expect(parentListener).toHaveBeenCalledOnce()
+    })
+
+    it('does not stop propagation for unhandled keys in gallery mode', async () => {
+      const { container } = renderImagePreview()
+      const user = userEvent.setup()
+      await switchToGallery(user)
+
+      const preview = container.querySelector('.image-preview') as HTMLElement
+      const parentListener = vi.fn()
+      preview.parentElement!.addEventListener('keydown', parentListener)
+
+      await fireEvent.keyDown(preview, { key: 'Delete' })
+      await nextTick()
+
+      expect(parentListener).toHaveBeenCalledOnce()
+    })
   })
 
   describe('grid view', () => {

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -84,6 +84,13 @@ describe('ImagePreview', () => {
     await nextTick()
   }
 
+  function spyOnParentPropagation(container: Element) {
+    const preview = container.querySelector('.image-preview') as HTMLElement
+    const parentListener = vi.fn()
+    preview.parentElement!.addEventListener('keydown', parentListener)
+    return { preview, parentListener }
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -391,10 +398,7 @@ describe('ImagePreview', () => {
         const { container } = renderImagePreview()
         const user = userEvent.setup()
         await switchToGallery(user)
-
-        const preview = container.querySelector('.image-preview') as HTMLElement
-        const parentListener = vi.fn()
-        preview.parentElement!.addEventListener('keydown', parentListener)
+        const { preview, parentListener } = spyOnParentPropagation(container)
 
         await fireEvent.keyDown(preview, { key })
         await nextTick()
@@ -407,10 +411,7 @@ describe('ImagePreview', () => {
       const { container } = renderImagePreview()
       const user = userEvent.setup()
       await switchToGallery(user)
-
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      const parentListener = vi.fn()
-      preview.parentElement!.addEventListener('keydown', parentListener)
+      const { preview, parentListener } = spyOnParentPropagation(container)
 
       await fireEvent.keyDown(preview, { key: 'Escape' })
       await nextTick()
@@ -420,10 +421,7 @@ describe('ImagePreview', () => {
 
     it('does not stop propagation for arrow keys in grid mode', async () => {
       const { container } = renderImagePreview()
-
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      const parentListener = vi.fn()
-      preview.parentElement!.addEventListener('keydown', parentListener)
+      const { preview, parentListener } = spyOnParentPropagation(container)
 
       await fireEvent.keyDown(preview, { key: 'ArrowRight' })
       await nextTick()
@@ -435,10 +433,7 @@ describe('ImagePreview', () => {
       const { container } = renderImagePreview()
       const user = userEvent.setup()
       await switchToGallery(user)
-
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      const parentListener = vi.fn()
-      preview.parentElement!.addEventListener('keydown', parentListener)
+      const { preview, parentListener } = spyOnParentPropagation(container)
 
       await fireEvent.keyDown(preview, { key: 'Delete' })
       await nextTick()

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -390,6 +390,67 @@ describe('ImagePreview', () => {
 
       expect(screen.getByRole('img')).toHaveAttribute('src', initialSrc!)
     })
+
+    it.for(['ArrowLeft', 'ArrowRight', 'Home', 'End'])(
+      'stops propagation for %s in gallery mode',
+      async (key) => {
+        const { container } = renderImagePreview()
+        const user = userEvent.setup()
+        await switchToGallery(user)
+
+        const preview = container.querySelector('.image-preview') as HTMLElement
+        const parentListener = vi.fn()
+        preview.parentElement!.addEventListener('keydown', parentListener)
+
+        await fireEvent.keyDown(preview, { key })
+        await nextTick()
+
+        expect(parentListener).not.toHaveBeenCalled()
+      }
+    )
+
+    it('stops propagation for Escape when returning to grid', async () => {
+      const { container } = renderImagePreview()
+      const user = userEvent.setup()
+      await switchToGallery(user)
+
+      const preview = container.querySelector('.image-preview') as HTMLElement
+      const parentListener = vi.fn()
+      preview.parentElement!.addEventListener('keydown', parentListener)
+
+      await fireEvent.keyDown(preview, { key: 'Escape' })
+      await nextTick()
+
+      expect(parentListener).not.toHaveBeenCalled()
+    })
+
+    it('does not stop propagation for arrow keys in grid mode', async () => {
+      const { container } = renderImagePreview()
+
+      const preview = container.querySelector('.image-preview') as HTMLElement
+      const parentListener = vi.fn()
+      preview.parentElement!.addEventListener('keydown', parentListener)
+
+      await fireEvent.keyDown(preview, { key: 'ArrowRight' })
+      await nextTick()
+
+      expect(parentListener).toHaveBeenCalledOnce()
+    })
+
+    it('does not stop propagation for unhandled keys in gallery mode', async () => {
+      const { container } = renderImagePreview()
+      const user = userEvent.setup()
+      await switchToGallery(user)
+
+      const preview = container.querySelector('.image-preview') as HTMLElement
+      const parentListener = vi.fn()
+      preview.parentElement!.addEventListener('keydown', parentListener)
+
+      await fireEvent.keyDown(preview, { key: 'Delete' })
+      await nextTick()
+
+      expect(parentListener).toHaveBeenCalledOnce()
+    })
   })
 
   describe('grid view', () => {

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.test.ts
@@ -91,6 +91,13 @@ describe('ImagePreview', () => {
     await nextTick()
   }
 
+  function spyOnParentPropagation(container: Element) {
+    const preview = container.querySelector('.image-preview') as HTMLElement
+    const parentListener = vi.fn()
+    preview.parentElement!.addEventListener('keydown', parentListener)
+    return { preview, parentListener }
+  }
+
   it('does not render when no imageUrls provided', () => {
     const { container } = renderImagePreview({ imageUrls: [] })
 
@@ -397,10 +404,7 @@ describe('ImagePreview', () => {
         const { container } = renderImagePreview()
         const user = userEvent.setup()
         await switchToGallery(user)
-
-        const preview = container.querySelector('.image-preview') as HTMLElement
-        const parentListener = vi.fn()
-        preview.parentElement!.addEventListener('keydown', parentListener)
+        const { preview, parentListener } = spyOnParentPropagation(container)
 
         await fireEvent.keyDown(preview, { key })
         await nextTick()
@@ -413,10 +417,7 @@ describe('ImagePreview', () => {
       const { container } = renderImagePreview()
       const user = userEvent.setup()
       await switchToGallery(user)
-
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      const parentListener = vi.fn()
-      preview.parentElement!.addEventListener('keydown', parentListener)
+      const { preview, parentListener } = spyOnParentPropagation(container)
 
       await fireEvent.keyDown(preview, { key: 'Escape' })
       await nextTick()
@@ -426,10 +427,7 @@ describe('ImagePreview', () => {
 
     it('does not stop propagation for arrow keys in grid mode', async () => {
       const { container } = renderImagePreview()
-
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      const parentListener = vi.fn()
-      preview.parentElement!.addEventListener('keydown', parentListener)
+      const { preview, parentListener } = spyOnParentPropagation(container)
 
       await fireEvent.keyDown(preview, { key: 'ArrowRight' })
       await nextTick()
@@ -441,10 +439,7 @@ describe('ImagePreview', () => {
       const { container } = renderImagePreview()
       const user = userEvent.setup()
       await switchToGallery(user)
-
-      const preview = container.querySelector('.image-preview') as HTMLElement
-      const parentListener = vi.fn()
-      preview.parentElement!.addEventListener('keydown', parentListener)
+      const { preview, parentListener } = spyOnParentPropagation(container)
 
       await fireEvent.keyDown(preview, { key: 'Delete' })
       await nextTick()

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -388,31 +388,38 @@ function handleKeyDown(event: KeyboardEvent) {
     hasMultipleImages.value
   ) {
     event.preventDefault()
+    event.stopPropagation()
     viewMode.value = 'grid'
     return
   }
 
-  if (imageUrls.length <= 1 || viewMode.value === 'grid') return
+  if (imageUrls.length <= 1 || viewMode.value === 'grid') {
+    return
+  }
 
   switch (event.key) {
     case 'ArrowLeft':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(
         currentIndex.value > 0 ? currentIndex.value - 1 : imageUrls.length - 1
       )
       break
     case 'ArrowRight':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(
         currentIndex.value < imageUrls.length - 1 ? currentIndex.value + 1 : 0
       )
       break
     case 'Home':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(0)
       break
     case 'End':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(imageUrls.length - 1)
       break
   }
@@ -426,4 +433,6 @@ function getImageFilename(url: string): string {
     return t('g.imageDoesNotExist')
   }
 }
+
+defineExpose({ handleKeyDown })
 </script>

--- a/src/renderer/extensions/vueNodes/components/ImagePreview.vue
+++ b/src/renderer/extensions/vueNodes/components/ImagePreview.vue
@@ -410,31 +410,38 @@ function handleKeyDown(event: KeyboardEvent) {
     hasMultipleImages.value
   ) {
     event.preventDefault()
+    event.stopPropagation()
     viewMode.value = 'grid'
     return
   }
 
-  if (imageUrls.length <= 1 || viewMode.value === 'grid') return
+  if (imageUrls.length <= 1 || viewMode.value === 'grid') {
+    return
+  }
 
   switch (event.key) {
     case 'ArrowLeft':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(
         currentIndex.value > 0 ? currentIndex.value - 1 : imageUrls.length - 1
       )
       break
     case 'ArrowRight':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(
         currentIndex.value < imageUrls.length - 1 ? currentIndex.value + 1 : 0
       )
       break
     case 'Home':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(0)
       break
     case 'End':
       event.preventDefault()
+      event.stopPropagation()
       setCurrentIndex(imageUrls.length - 1)
       break
   }
@@ -448,4 +455,6 @@ function getImageFilename(url: string): string {
     return t('g.imageDoesNotExist')
   }
 }
+
+defineExpose({ handleKeyDown })
 </script>

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -37,6 +37,7 @@
     @pointerdown="nodeOnPointerdown"
     @wheel="handleWheel"
     @contextmenu="handleContextMenu"
+    @keydown="nodeMediaContentRef?.handleKeyDown($event)"
     @dragover.prevent="handleDragOver"
     @dragleave="handleDragLeave"
     @drop="handleDrop"
@@ -164,6 +165,7 @@
           <div v-if="hasCustomContent" class="flex min-h-0 flex-1 flex-col">
             <NodeContent
               v-if="nodeMedia"
+              ref="nodeMediaContentRef"
               :node-data="nodeData"
               :media="nodeMedia"
             />
@@ -816,6 +818,7 @@ const nodeMedia = computed(() => {
 })
 
 const nodeContainerRef = ref<HTMLDivElement>()
+const nodeMediaContentRef = ref<InstanceType<typeof NodeContent>>()
 
 // Drag and drop support
 const isDraggingOver = ref(false)

--- a/src/renderer/extensions/vueNodes/components/LGraphNode.vue
+++ b/src/renderer/extensions/vueNodes/components/LGraphNode.vue
@@ -40,6 +40,7 @@
     @pointerdown="nodeOnPointerdown"
     @wheel="handleWheel"
     @contextmenu="handleContextMenu"
+    @keydown="nodeMediaContentRef?.handleKeyDown($event)"
     @dragover.prevent="handleDragOver"
     @dragleave="handleDragLeave"
     @drop="handleDrop"
@@ -160,7 +161,12 @@
           />
 
           <div v-if="hasCustomContent" class="flex min-h-0 flex-1 flex-col">
-            <NodeContent v-if="nodeMedia" :node-data :media="nodeMedia" />
+            <NodeContent
+              v-if="nodeMedia"
+              ref="nodeMediaContentRef"
+              :node-data
+              :media="nodeMedia"
+            />
             <NodeContent
               v-for="preview in promotedPreviews"
               :key="`${preview.sourceNodeId}-${preview.sourceWidgetName}`"
@@ -713,6 +719,8 @@ const nodeMedia = computed(() => {
 
   return { type, urls } as const
 })
+
+const nodeMediaContentRef = ref<InstanceType<typeof NodeContent>>()
 
 // Drag and drop support
 const isDraggingOver = ref(false)

--- a/src/renderer/extensions/vueNodes/components/NodeContent.vue
+++ b/src/renderer/extensions/vueNodes/components/NodeContent.vue
@@ -21,6 +21,7 @@
       />
       <ImagePreview
         v-else-if="hasMedia && media?.type === 'image'"
+        ref="imagePreviewRef"
         :image-urls="media.urls"
         :node-id="nodeId"
         class="mt-2 flex-auto"
@@ -62,5 +63,12 @@ onErrorCaptured((error) => {
   renderError.value = error.message
   toastErrorHandler(error)
   return false
+})
+
+const imagePreviewRef = ref<InstanceType<typeof ImagePreview>>()
+
+defineExpose({
+  handleKeyDown: (event: KeyboardEvent) =>
+    imagePreviewRef.value?.handleKeyDown(event)
 })
 </script>


### PR DESCRIPTION
## Summary

Preview Image gallery keydown events (Escape/ArrowLeft/ArrowRight/Home/End) leak past the node and reach the workflow canvas after being handled.

## Changes

- **What**: Adds `event.stopPropagation()` alongside the existing `event.preventDefault()` in the branches of `ImagePreview.vue`'s `handleKeyDown` that actually handle a key, so navigation keydowns stop at the widget instead of continuing to bubble. Also fixes the same leak when focus is on the node's background rather than the image widget: `ImagePreview` now exposes `handleKeyDown` via `defineExpose`, and `NodeContent`/`LGraphNode` forward node-background keydowns to it through template refs.

## Review Focus

Concrete, reproducible consequence: viewing a Preview Image node's gallery inside a subgraph and pressing Escape to return to the grid also exited the subgraph, because the leaked Escape reached the core `Comfy.Graph.ExitSubgraph` keybinding. Confirmed fixed.

Arrow/Home/End keys share the identical missing-`stopPropagation()` defect in the same function and are fixed for consistency.

The grid-mode/single-image early return is intentionally left untouched (a previous fix attempt added `stopPropagation()` there instead of in the handled branches, which had nothing to contain since arrow keys are already ignored in grid mode).