### PR TITLE
feat: add hidden UI disable settings for commands

### DIFF
--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -692,6 +692,13 @@ export const CORE_SETTINGS: SettingParams[] = [
     versionAdded: '1.3.11'
   },
   {
+    id: 'Comfy.UI.DisabledCommands',
+    name: 'Disabled command IDs',
+    type: 'hidden',
+    defaultValue: [] as string[],
+    versionAdded: '1.47.0'
+  },
+  {
     id: 'Comfy.LinkRenderMode',
     category: ['LiteGraph', 'Graph', 'LinkRenderMode'],
     name: 'Link Render Mode',

--- a/src/platform/settings/utils/uiDisableList.test.ts
+++ b/src/platform/settings/utils/uiDisableList.test.ts
@@ -1,0 +1,47 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getDisabledCommands,
+  isCommandDisabled
+} from '@/platform/settings/utils/uiDisableList'
+
+const mockGetSetting = vi.fn()
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: mockGetSetting
+  })
+}))
+
+describe('uiDisableList', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    mockGetSetting.mockReset()
+  })
+
+  describe('getDisabledCommands', () => {
+    it('returns an empty array when the setting is unset', () => {
+      mockGetSetting.mockReturnValue(undefined)
+      expect(getDisabledCommands()).toEqual([])
+    })
+
+    it('returns the configured disabled command IDs', () => {
+      mockGetSetting.mockReturnValue(['Comfy.SaveWorkflow'])
+      expect(getDisabledCommands()).toEqual(['Comfy.SaveWorkflow'])
+    })
+  })
+
+  describe('isCommandDisabled', () => {
+    it('returns true when the command ID is disabled', () => {
+      mockGetSetting.mockReturnValue(['Comfy.SaveWorkflow'])
+      expect(isCommandDisabled('Comfy.SaveWorkflow')).toBe(true)
+    })
+
+    it('returns false when the command ID is not disabled', () => {
+      mockGetSetting.mockReturnValue(['Comfy.SaveWorkflow'])
+      expect(isCommandDisabled('Comfy.OpenWorkflow')).toBe(false)
+    })
+  })
+})

--- a/src/platform/settings/utils/uiDisableList.ts
+++ b/src/platform/settings/utils/uiDisableList.ts
@@ -1,6 +1,6 @@
 import { useSettingStore } from '@/platform/settings/settingStore'
 
-export const DISABLED_COMMANDS_SETTING_ID = 'Comfy.UI.DisabledCommands'
+const DISABLED_COMMANDS_SETTING_ID = 'Comfy.UI.DisabledCommands'
 
 export function getDisabledCommands(): string[] {
   return useSettingStore().get(DISABLED_COMMANDS_SETTING_ID) ?? []

--- a/src/platform/settings/utils/uiDisableList.ts
+++ b/src/platform/settings/utils/uiDisableList.ts
@@ -1,0 +1,11 @@
+import { useSettingStore } from '@/platform/settings/settingStore'
+
+export const DISABLED_COMMANDS_SETTING_ID = 'Comfy.UI.DisabledCommands'
+
+export function getDisabledCommands(): string[] {
+  return useSettingStore().get(DISABLED_COMMANDS_SETTING_ID) ?? []
+}
+
+export function isCommandDisabled(commandId: string): boolean {
+  return getDisabledCommands().includes(commandId)
+}

--- a/src/schemas/apiSchema.ts
+++ b/src/schemas/apiSchema.ts
@@ -394,6 +394,7 @@ const zSettings = z.object({
   'Comfy.Keybinding.NewBindings': z.array(zKeybinding),
   'Comfy.Keybinding.CurrentPreset': z.string(),
   'Comfy.Extension.Disabled': z.array(z.string()),
+  'Comfy.UI.DisabledCommands': z.array(z.string()),
   'Comfy.LinkRenderMode': z.number(),
   'Comfy.Node.AutoSnapLinkToSlot': z.boolean(),
   'Comfy.Node.SnapHighlightsNode': z.boolean(),

--- a/src/stores/commandStore.test.ts
+++ b/src/stores/commandStore.test.ts
@@ -25,9 +25,18 @@ vi.mock('@/platform/keybindings/keybindingStore', () => ({
   })
 }))
 
+const mockGetSetting = vi.fn()
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: mockGetSetting
+  })
+}))
+
 describe('commandStore', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
+    mockGetSetting.mockReturnValue([])
   })
 
   describe('registerCommand', () => {
@@ -110,6 +119,15 @@ describe('commandStore', () => {
       const handler = vi.fn()
       await store.execute('err.test', { errorHandler: handler })
       expect(handler).toHaveBeenCalledWith(error)
+    })
+
+    it('does not execute disabled commands', async () => {
+      mockGetSetting.mockReturnValue(['exec.test'])
+      const store = useCommandStore()
+      const fn = vi.fn()
+      store.registerCommand({ id: 'exec.test', function: fn })
+      await store.execute('exec.test')
+      expect(fn).not.toHaveBeenCalled()
     })
   })
 

--- a/src/stores/commandStore.ts
+++ b/src/stores/commandStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
 import { useErrorHandling } from '@/composables/useErrorHandling'
+import { isCommandDisabled } from '@/platform/settings/utils/uiDisableList'
 import type { KeybindingImpl } from '@/platform/keybindings/keybinding'
 import { useKeybindingStore } from '@/platform/keybindings/keybindingStore'
 import type { ComfyExtension } from '@/types/comfy'
@@ -100,6 +101,10 @@ export const useCommandStore = defineStore('command', () => {
       metadata?: Record<string, unknown>
     }
   ) => {
+    if (isCommandDisabled(commandId)) {
+      return
+    }
+
     const command = getCommand(commandId)
     if (command) {
       await wrapWithErrorHandlingAsync(

--- a/src/stores/menuItemStore.test.ts
+++ b/src/stores/menuItemStore.test.ts
@@ -1,0 +1,55 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMenuItemStore } from '@/stores/menuItemStore'
+
+const mockGetSetting = vi.fn()
+const mockExecute = vi.fn()
+
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({
+    get: mockGetSetting
+  })
+}))
+
+vi.mock('@/renderer/core/canvas/canvasStore', () => ({
+  useCanvasStore: () => ({
+    linearMode: false
+  })
+}))
+
+vi.mock('@/stores/commandStore', () => ({
+  useCommandStore: () => ({
+    getCommand: (id: string) => ({
+      id,
+      menubarLabel: id,
+      function: vi.fn()
+    }),
+    execute: mockExecute
+  })
+}))
+
+describe('menuItemStore', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    mockGetSetting.mockReturnValue([])
+    mockExecute.mockReset()
+  })
+
+  it('omits disabled commands from registered menu groups', () => {
+    mockGetSetting.mockReturnValue(['Comfy.SaveWorkflow'])
+    const store = useMenuItemStore()
+
+    store.registerCommands(
+      ['File'],
+      ['Comfy.SaveWorkflow', 'Comfy.OpenWorkflow']
+    )
+
+    const fileMenu = store.menuItems.find((item) => item.label === 'File')
+    const labels = fileMenu?.items?.map((item) => item.label) ?? []
+
+    expect(labels).toContain('Comfy.OpenWorkflow')
+    expect(labels).not.toContain('Comfy.SaveWorkflow')
+  })
+})

--- a/src/stores/menuItemStore.ts
+++ b/src/stores/menuItemStore.ts
@@ -4,6 +4,7 @@ import type { MenuItem } from 'primevue/menuitem'
 import { ref } from 'vue'
 
 import { CORE_MENU_COMMANDS } from '@/constants/coreMenuCommands'
+import { isCommandDisabled } from '@/platform/settings/utils/uiDisableList'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import type { ComfyExtension } from '@/types/comfy'
 
@@ -78,7 +79,12 @@ export const useMenuItemStore = defineStore('menuItem', () => {
   }
 
   const registerCommands = (path: string[], commandIds: string[]) => {
-    const items = commandIds.map((id) => commandIdToMenuItem(id, path))
+    const enabledCommandIds = commandIds.filter((id) => !isCommandDisabled(id))
+    if (!enabledCommandIds.length) {
+      return
+    }
+
+    const items = enabledCommandIds.map((id) => commandIdToMenuItem(id, path))
     registerMenuGroup(path, items)
   }
 


### PR DESCRIPTION
## What does this PR do?

Adds the initial foundation for configurable UI restrictions through hidden settings.

This PR introduces:
- `Comfy.UI.DisabledCommands` — a hidden `string[]` setting for deployment admins
- `isCommandDisabled()` utility reading that setting
- A guard in `commandStore.execute()` so disabled commands cannot run (including via keybindings)
- Menu registration filtering so disabled commands are omitted from the menubar

## Why was this PR needed?

Issue #3388 requests a way for organizations deploying ComfyUI to disable parts of the UI such as menus, commands, and sidebar tabs.

This PR implements the first phase of that architecture, focused on commands and menus.

## Related Issue

Related to #3388

## Checklist

- [x] Tests added
- [x] Tests passing
- [x] Follows project style
- [x] No breaking changes


Made with [Cursor](https://cursor.com)