### PR TITLE
fix(ci): drop unsupported 'range' genhtml ignore-errors category

### DIFF
--- a/.github/workflows/ci-tests-e2e-coverage.yaml
+++ b/.github/workflows/ci-tests-e2e-coverage.yaml
@@ -121,7 +121,7 @@ jobs:
             --title "ComfyUI E2E Coverage" \
             --no-function-coverage \
             --precision 1 \
-            --ignore-errors source,unmapped,range \
+            --ignore-errors source,unmapped \
             --synthesize-missing
 
       - name: Upload HTML report artifact


### PR DESCRIPTION
## Summary
- `CI: E2E Coverage`'s `Generate HTML coverage report` step fails on every run with `genhtml: ERROR: unknown argument for --ignore-errors: 'range'`
- The runner's `apt-get install lcov` resolves to lcov 2.0-4ubuntu2 (Ubuntu 24.04/noble), but the `range` ignore-errors category was only added in lcov 2.1
- lcov 2.0 already reports the out-of-range-line condition under the `source` category, which is already in the ignore list, so `range` was both unsupported and redundant on this runner

## Test plan
- [x] Confirmed lcov 2.0-4ubuntu2 is what `apt-get install lcov` resolves to on `ubuntu-latest`
- [x] Confirmed via lcov's `lcovutil.pm` source that `range` (`$ERROR_RANGE`) is only registered as of v2.1, and in v2.0 the equivalent out-of-range case falls under `$ERROR_SOURCE`
- [ ] CI: E2E Coverage run on this branch's merge should pass the "Generate HTML coverage report" step