### PR TITLE
feat(website): add five Creative Campus customer stories

### DIFF
--- a/apps/website/e2e/customers-detail.spec.ts
+++ b/apps/website/e2e/customers-detail.spec.ts
@@ -70,4 +70,39 @@ test.describe('Customer story detail @smoke', () => {
       '/customers/series-entertainment'
     )
   })
+
+  test('renders a Creative Campus story with its education blocks', async ({
+    page
+  }) => {
+    await page.goto('/customers/xindi-zhang')
+
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: /The tool that expands my art/i
+      })
+    ).toBeVisible()
+
+    const nav = page.getByRole('navigation', { name: 'Category filter' })
+    await expect(nav.getByRole('button', { name: 'INTRO' })).toBeVisible()
+    await expect(nav.getByRole('button', { name: 'AT A GLANCE' })).toBeVisible()
+
+    // At a glance block (AtAGlance component) with its spec rows.
+    await expect(
+      page.getByRole('heading', { name: 'At a glance' })
+    ).toBeVisible()
+    await expect(page.getByText('Program', { exact: true })).toBeVisible()
+
+    // Workflow download button (Download component).
+    await expect(
+      page.getByRole('link', {
+        name: /Download Xindi's style transfer workflow/i
+      })
+    ).toBeVisible()
+
+    // Shared education call to action (EducationCta component).
+    await expect(
+      page.getByRole('link', { name: /Explore the Education Program/i })
+    ).toBeVisible()
+  })
 })

--- a/apps/website/src/components/customers/CustomerArticle.astro
+++ b/apps/website/src/components/customers/CustomerArticle.astro
@@ -4,16 +4,24 @@ import { render } from 'astro:content'
 import type { Locale } from '../../i18n/translations'
 import type { CustomerStoryEntry } from '../../utils/customers'
 import ArticleNav from './ArticleNav.vue'
+import AtAGlance from './content/AtAGlance.astro'
+import AuthorBio from './content/AuthorBio.astro'
 import BulletList from './content/BulletList.astro'
 import Contributors from './content/Contributors.astro'
+import Download from './content/Download.astro'
+import EducationCta from './content/EducationCta.astro'
+import Embed from './content/Embed.astro'
 import Figure from './content/Figure.astro'
 import Heading from './content/Heading.astro'
+import Heading4 from './content/Heading4.astro'
+import Link from './content/Link.astro'
 import ListItem from './content/ListItem.astro'
 import Paragraph from './content/Paragraph.astro'
 import Quote from './content/Quote.astro'
 import ReadMore from './content/ReadMore.vue'
 import Section from './content/Section.astro'
 import Steps from './content/Steps.astro'
+import Video from './content/Video.astro'
 
 interface Props {
   entry: CustomerStoryEntry
@@ -34,18 +42,26 @@ const categories = entry.data.sections.map((section) => ({
 // components (Section, Figure, ...) are used directly inside the MDX body.
 const contentComponents = {
   p: Paragraph,
+  a: Link,
   h3: Heading,
+  h4: Heading4,
   ul: BulletList,
   li: ListItem,
   Section,
   Figure,
   Quote,
   Contributors,
-  Steps
+  Steps,
+  AtAGlance,
+  AuthorBio,
+  Download,
+  EducationCta,
+  Embed,
+  Video
 }
 ---
 
-<section class="px-4 pt-8 pb-24 lg:px-20 lg:pt-24 lg:pb-40">
+<section class="max-w-9xl mx-auto px-4 pt-8 pb-24 lg:px-20 lg:pt-24 lg:pb-40">
   <div class="lg:flex lg:gap-16">
     <aside class="hidden scrollbar-none lg:block lg:w-48 lg:shrink-0">
       <div class="sticky top-32">

--- a/apps/website/src/components/customers/content/AtAGlance.astro
+++ b/apps/website/src/components/customers/content/AtAGlance.astro
@@ -1,0 +1,29 @@
+---
+interface Row {
+  label: string
+  value: string
+}
+
+interface Props {
+  rows: Row[]
+}
+
+const { rows } = Astro.props
+---
+
+<div
+  class="my-8 overflow-hidden rounded-2xl border border-white/10 bg-site-bg-soft"
+>
+  <dl class="divide-y divide-white/10">
+    {
+      rows.map((row) => (
+        <div class="flex flex-col gap-1 p-5 sm:flex-row sm:gap-6">
+          <dt class="text-primary-comfy-yellow shrink-0 text-xs font-bold tracking-widest uppercase sm:w-44">
+            {row.label}
+          </dt>
+          <dd class="text-sm/relaxed text-primary-comfy-canvas">{row.value}</dd>
+        </div>
+      ))
+    }
+  </dl>
+</div>

--- a/apps/website/src/components/customers/content/AuthorBio.astro
+++ b/apps/website/src/components/customers/content/AuthorBio.astro
@@ -1,0 +1,60 @@
+---
+interface Author {
+  name?: string
+  role?: string
+  photo?: string
+  bio?: string
+}
+
+interface Props {
+  label?: string
+  people: Author[]
+}
+
+const { label, people } = Astro.props
+const hasBioSlot = Astro.slots.has('default')
+---
+
+<div class="mt-12 border-t border-white/10 pt-8">
+  {
+    label && (
+      <span class="text-primary-comfy-yellow text-xs font-bold tracking-widest uppercase">
+        {label}
+      </span>
+    )
+  }
+  <div class="mt-4 space-y-8">
+    {
+      people.map((person) => (
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
+          {person.photo && (
+            <img
+              src={person.photo}
+              alt={person.name ?? ''}
+              class="size-20 shrink-0 rounded-full object-cover"
+            />
+          )}
+          <div>
+            {person.name && (
+              <p class="text-sm font-semibold text-primary-comfy-canvas">
+                {person.name}
+                {person.role && (
+                  <span class="text-primary-warm-gray"> · {person.role}</span>
+                )}
+              </p>
+            )}
+            {person.bio ? (
+              <p class="mt-2 text-sm/relaxed text-primary-comfy-canvas italic">
+                {person.bio}
+              </p>
+            ) : hasBioSlot ? (
+              <p class="mt-2 text-sm/relaxed text-primary-comfy-canvas italic">
+                <slot />
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ))
+    }
+  </div>
+</div>

--- a/apps/website/src/components/customers/content/AuthorBio.astro
+++ b/apps/website/src/components/customers/content/AuthorBio.astro
@@ -47,7 +47,7 @@ const hasBioSlot = Astro.slots.has('default')
               <p class="mt-2 text-sm/relaxed text-primary-comfy-canvas italic">
                 {person.bio}
               </p>
-            ) : hasBioSlot ? (
+            ) : hasBioSlot && people.length === 1 ? (
               <p class="mt-2 text-sm/relaxed text-primary-comfy-canvas italic">
                 <slot />
               </p>

--- a/apps/website/src/components/customers/content/Contributors.astro
+++ b/apps/website/src/components/customers/content/Contributors.astro
@@ -14,7 +14,7 @@ interface Props {
 const { label, people } = Astro.props
 ---
 
-<div class="mt-8 rounded-2xl bg-(--site-bg-soft) p-6">
+<div class="mt-8 rounded-2xl bg-site-bg-soft p-6">
   <span
     class="text-primary-comfy-yellow text-xs font-bold tracking-widest uppercase"
   >

--- a/apps/website/src/components/customers/content/Download.astro
+++ b/apps/website/src/components/customers/content/Download.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  href: string
+  label: string
+  newTab?: boolean
+}
+
+const { href, label, newTab = false } = Astro.props
+---
+
+<a
+  href={href}
+  download={newTab ? undefined : true}
+  target={newTab ? '_blank' : undefined}
+  rel={newTab ? 'noopener noreferrer' : undefined}
+  class="text-primary-comfy-yellow my-4 inline-block text-sm font-semibold underline underline-offset-2 transition-opacity hover:opacity-80"
+>
+  {label}
+</a>

--- a/apps/website/src/components/customers/content/EducationCta.astro
+++ b/apps/website/src/components/customers/content/EducationCta.astro
@@ -1,0 +1,15 @@
+---
+import Link from './Link.astro'
+---
+
+<div
+  class="border-primary-comfy-yellow mt-12 rounded-2xl border-l-4 bg-site-bg-soft p-8"
+>
+  <p class="text-base/relaxed text-primary-comfy-canvas">
+    <strong class="font-semibold">Teaching with ComfyUI?</strong> The Comfy Education
+    Program is live: educational pricing, classroom cloud accounts on one invoice,
+    <Link href="https://comfy.org/education">Explore the Education Program</Link> or
+    <Link href="https://tally.so/r/Xx97lL">apply to be a part of the Creative
+    Campus program</Link> if you're interested in exploring a deeper partnership with Comfy.
+  </p>
+</div>

--- a/apps/website/src/components/customers/content/EducationCta.astro
+++ b/apps/website/src/components/customers/content/EducationCta.astro
@@ -1,15 +1,21 @@
 ---
+import { t } from '../../../i18n/translations'
+import type { Locale } from '../../../i18n/translations'
 import Link from './Link.astro'
+
+const rawLocale = Astro.currentLocale ?? 'en'
+const locale: Locale = rawLocale === 'zh-CN' ? 'zh-CN' : 'en'
 ---
 
 <div
   class="border-primary-comfy-yellow mt-12 rounded-2xl border-l-4 bg-site-bg-soft p-8"
 >
   <p class="text-base/relaxed text-primary-comfy-canvas">
-    <strong class="font-semibold">Teaching with ComfyUI?</strong> The Comfy Education
-    Program is live: educational pricing, classroom cloud accounts on one invoice,
-    <Link href="https://comfy.org/education">Explore the Education Program</Link> or
-    <Link href="https://tally.so/r/Xx97lL">apply to be a part of the Creative
-    Campus program</Link> if you're interested in exploring a deeper partnership with Comfy.
+    <strong class="font-semibold">{t('educationCta.heading', locale)}</strong>{' '}
+    {t('educationCta.body', locale)}{' '}
+    <Link href="https://comfy.org/education">{t('educationCta.exploreLink', locale)}</Link>{' '}
+    {t('educationCta.or', locale)}{' '}
+    <Link href="https://tally.so/r/Xx97lL">{t('educationCta.applyLink', locale)}</Link>{' '}
+    {t('educationCta.tail', locale)}
   </p>
 </div>

--- a/apps/website/src/components/customers/content/Embed.astro
+++ b/apps/website/src/components/customers/content/Embed.astro
@@ -1,0 +1,22 @@
+---
+interface Props {
+  src: string
+  title: string
+}
+
+const { src, title } = Astro.props
+---
+
+<div
+  class="my-8 aspect-video overflow-hidden rounded-2xl border border-white/10 bg-black"
+>
+  <iframe
+    src={src}
+    title={title}
+    class="size-full"
+    loading="lazy"
+    allow="autoplay; fullscreen; picture-in-picture; clipboard-write"
+    referrerpolicy="strict-origin-when-cross-origin"
+    sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+  ></iframe>
+</div>

--- a/apps/website/src/components/customers/content/Figure.astro
+++ b/apps/website/src/components/customers/content/Figure.astro
@@ -6,14 +6,15 @@ interface Props {
 }
 
 const { src, alt, caption } = Astro.props
+const hasCaptionSlot = Astro.slots.has('default')
 ---
 
 <figure class="my-8">
   <img src={src} alt={alt} class="w-full rounded-2xl object-cover" />
   {
-    caption && (
+    (hasCaptionSlot || caption) && (
       <figcaption class="mt-3 text-xs text-primary-comfy-canvas">
-        {caption}
+        {hasCaptionSlot ? <slot /> : caption}
       </figcaption>
     )
   }

--- a/apps/website/src/components/customers/content/Heading4.astro
+++ b/apps/website/src/components/customers/content/Heading4.astro
@@ -1,0 +1,6 @@
+---
+---
+
+<h4 class="mt-6 mb-2 text-base font-semibold text-primary-comfy-canvas">
+  <slot />
+</h4>

--- a/apps/website/src/components/customers/content/Link.astro
+++ b/apps/website/src/components/customers/content/Link.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+  href: string
+}
+
+const { href } = Astro.props
+const isExternal = /^https?:\/\//.test(href)
+---
+
+<a
+  href={href}
+  target={isExternal ? '_blank' : undefined}
+  rel={isExternal ? 'noopener noreferrer' : undefined}
+  class="text-primary-comfy-yellow underline underline-offset-2 transition-opacity hover:opacity-80"
+><slot /></a>

--- a/apps/website/src/components/customers/content/Quote.astro
+++ b/apps/website/src/components/customers/content/Quote.astro
@@ -1,16 +1,20 @@
 ---
 interface Props {
-  name: string
+  name?: string
 }
 
 const { name } = Astro.props
 ---
 
 <blockquote
-  class="border-primary-comfy-yellow my-8 rounded-2xl border-l-4 bg-(--site-bg-soft) p-8"
+  class="border-primary-comfy-yellow my-8 rounded-2xl border-l-4 bg-site-bg-soft p-8"
 >
   <p class="text-lg/relaxed font-light text-primary-comfy-canvas italic">
     "<slot />"
   </p>
-  <p class="text-primary-comfy-yellow mt-4 text-sm font-semibold">{name}</p>
+  {
+    name && (
+      <p class="text-primary-comfy-yellow mt-4 text-sm font-semibold">{name}</p>
+    )
+  }
 </blockquote>

--- a/apps/website/src/components/customers/content/Video.astro
+++ b/apps/website/src/components/customers/content/Video.astro
@@ -1,0 +1,22 @@
+---
+import VideoPlayer from '../../common/VideoPlayer.vue'
+
+interface Props {
+  src: string
+  poster?: string
+  caption?: string
+}
+
+const { src, poster, caption } = Astro.props
+---
+
+<figure class="my-8">
+  <VideoPlayer src={src} poster={poster} client:visible />
+  {
+    caption && (
+      <figcaption class="mt-3 text-xs text-primary-comfy-canvas">
+        {caption}
+      </figcaption>
+    )
+  }
+</figure>

--- a/apps/website/src/content/customers.content.test.ts
+++ b/apps/website/src/content/customers.content.test.ts
@@ -63,8 +63,12 @@ function bodySectionIds(body: string): string[] {
 
 const stories = loadStories()
 
-it('finds all ten customer stories', () => {
-  expect(stories).toHaveLength(10)
+it('finds customer stories in every locale', () => {
+  for (const locale of locales) {
+    const prefix = `${locale}/`
+    const inLocale = stories.filter((story) => story.file.startsWith(prefix))
+    expect(inLocale.length).toBeGreaterThan(0)
+  }
 })
 
 describe.for(stories)('$file', ({ frontmatter, body }) => {

--- a/apps/website/src/content/customers/en/golan-levin.mdx
+++ b/apps/website/src/content/customers/en/golan-levin.mdx
@@ -1,0 +1,148 @@
+---
+title: "Seeing the world in new ways: how Prof. Golan Levin teaches with ComfyUI at Carnegie Mellon University"
+category: "CREATIVE CAMPUS SHOWCASE"
+description: "\"For me, ComfyUI is not just about generative AI. It's an image-processing workstation for completely new kinds of work.\""
+cover: "https://media.comfy.org/website/customers/golan-levin/cover.png"
+order: 7
+sections:
+  - id: topic-1
+    label: "INTRO"
+  - id: topic-2
+    label: "WHERE COMFYUI FITS"
+  - id: topic-3
+    label: "IMAGE SYNTHESIS"
+  - id: topic-4
+    label: "IMAGE ANALYSIS"
+  - id: topic-5
+    label: "THE CV LAB"
+  - id: topic-6
+    label: "AT A GLANCE"
+  - id: topic-7
+    label: "STUDENT WORK"
+---
+
+<Section id="topic-1">
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/augmented-hand.jpg" alt="Golan Levin, Augmented Hand Series" caption="Golan Levin, Augmented Hand Series (2014), with Chris Sugrue and Kyle McDonald. Photo: Gerlinde de Geus, courtesy Cinekid." />
+
+For many people, AI in the arts means image generation. But Levin has spent much of the past two decades teaching artists how computers can interpret, analyze, and measure the visual world. His own artworks have long explored machine perception through real-time computer vision systems, and since 2024 he has increasingly used ComfyUI to teach these principles.
+
+For Levin, ComfyUI is less an image generator than an image-processing workbench. Students use it to assemble custom workflows for segmentation, tracking, depth estimation, and other forms of computational perception. The result is an environment where artists can experiment directly with research-grade machine learning tools and combine them into systems of their own design.
+
+</Section>
+
+<Section id="topic-2">
+
+### Where does ComfyUI fit in what you're trying to do?
+
+I'm training creative technologists and technologically literate artists. The typical student in my Creative Coding class is a true hybrid: an art or design undergraduate who is also studying computer science, human-computer interaction, or information science. They have strong visual abilities, strong cultural literacy, and strong algorithmic thinking skills, but my course may be the first time they've had the opportunity to bring those together.
+
+To me, that means giving students tools they can understand, modify, and remix to make systems of their own design, rather than treating creative software as a fixed given. That's why I'm such a proponent of community-driven, open-source software development toolkits for the arts.
+
+<Quote>ComfyUI is the first AI tool I've found with both a low floor and a high ceiling. It's incredibly powerful and flexible, in terms of allowing artists to design their own AI workflows with the latest cutting-edge algorithms. But it also leapfrogs the headaches of coping with quirky GitHub repos and obsolete Colab notebooks.</Quote>
+
+### What were students stuck on before?
+
+Students often found themselves caught between two worlds. On one side were commercial AI tools that produced impressive results but offered limited opportunities for customization. On the other side were research projects published by universities and laboratories, where the software was often difficult to install, poorly documented, or already out of date.
+
+ComfyUI bridges that gap. It gives students access to state-of-the-art algorithms through an environment they can understand, modify, and extend. Instead of adapting their ideas to fit a tool's built-in workflow, they can build workflows that reflect their own interests and questions.
+
+<Quote>My students are explorers. They're artists who can write code and want to build systems that haven't existed before.</Quote>
+
+</Section>
+
+<Section id="topic-3">
+
+### The first exercise: a p5.js sketch driving image synthesis, inside ComfyUI
+
+In one of Levin's introductory exercises — students' first exposure to the ComfyUI environment — they write a simple p5.js sketch directly inside ComfyUI, then use the shapes they draw, plus a text prompt, to guide a Stable Diffusion image synthesis. They document the pairs of images it produces: their JavaScript canvas drawing on the left, and the AI synthesis on the right. Having already spent a few weeks fighting to get nuance out of p5.js, they're tickled to get these results from simple shapes, and they learn a lot about how Stable Diffusion works.
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/p5-landscape.png" alt="p5.js ellipses guiding a Stable Diffusion synthesis" caption={`Some wide ellipses drawn in p5.js (left) guiding a Stable Diffusion synthesis with the prompt "rolling hills, foggy day" (right).`} />
+
+It runs on a node-based canvas that art students pick up quickly, because it works like tools they already know.
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/p5-workflow.png" alt="Template ComfyUI workflow using the ComfyUI-p5js-node" caption="The template ComfyUI workflow students receive. It uses the custom ComfyUI-p5js-node by Ben Fox. From Levin's 60-212 course repo." />
+
+*Try it yourself: [json file](https://media.comfy.org/website/customers/golan-levin/p5-in-comfy.json) (Comfy Local only)*
+
+</Section>
+
+<Section id="topic-4">
+
+### Many artists start off by using ComfyUI for generative AI. You use it differently.
+
+Maybe so. I'm interested in AI as a framework for expanded perception, so a lot of how I've used machine learning and computer vision over the past 25 years has been for image analysis, rather than image synthesis. Essentially, I use computer vision to understand video and images, and then use the information I extract to create new kinds of interactive experiences. In the classroom, I use ComfyUI to help teach students how to "see like a machine." So I have students use ComfyUI as a framework for analyzing images, not just generating them. For example, I ask them to take an input image and then use AI to compute new ones from it, such as a semantic segmentation ("which pixels belong to the elephant?") and a monocular depth estimate ("how far away is each pixel?"). Then the students build an interactive piece that interprets the original image, but using five channels of information instead of three: the usual red, green, and blue, plus depth, plus segmentation. In my demo project, the segmentation colors the elephant pink, and the background pixels change size based on how far away the AI thinks they are.
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/depth-segmentation.png" alt="Semantic segmentation and monocular depth analysis in ComfyUI" caption={`An input image analyzed inside ComfyUI: semantic segmentation and monocular depth, feeding a five-channel "Custom Pixel" exercise. From Levin's 60-212 course repo.`} />
+
+*Try it yourself: [demo project](https://editor.p5js.org/golan/sketches/-_cFmLtoP) · [lesson plan & workflow](https://github.com/golanlevin/60-212/tree/main/lectures/comfy/image_analysis#3-segment-the-image-with-ai)*
+
+*Workflow files: download the [.json](https://media.comfy.org/website/customers/golan-levin/image-analysis-workflow.json), or the [.png with the workflow embedded in its metadata](https://media.comfy.org/website/customers/golan-levin/image-analysis-workflow.png) (drag it into ComfyUI to load the graph).*
+
+<Quote>I want students to understand that AI is not only a tool for generating images. It's also a tool for perception, measurement, and analysis.</Quote>
+
+The computer vision tools built for this are usually aimed at developers and enterprises. They assume an engineering workflow. I wanted my art students to get to segmentation, depth, and tracking inside an environment they already think in, without standing up a production pipeline first.
+
+### What changed once ComfyUI was in the workflow?
+
+Two things. First, it runs on a node-based canvas that many art students already understand from environments like TouchDesigner, Max/MSP, and Grasshopper — except it runs in a browser and it's for AI. As a result, students can focus on the ideas behind machine learning workflows instead of first learning an entirely new interaction paradigm. Second, it collapses the distance between a research lab and a classroom.
+
+<Quote>There's a fast pipeline from the lab to your classroom. It's become commonplace for enthusiasts to convert AI research code into Comfy nodes, often within days of their release.</Quote>
+
+One of the most remarkable things about the ComfyUI ecosystem is how quickly new research becomes accessible. A computer-vision paper might appear at CVPR or ICCV, and within days someone in the community has wrapped it as a reusable ComfyUI node. For educators, that dramatically shortens the distance between a research laboratory and a classroom. Instead of spending weeks reconstructing an experimental software environment, students can begin exploring the underlying ideas almost immediately.
+
+The cloud matters for accessibility and equity, too. Most of my students don't have big GPU workstations, and I don't want their access to advanced tools to depend on the caliber of their personal hardware. Cloud platforms make it possible for everyone in a class to work in the same environment, with the same models, regardless of what laptop they happen to own.
+
+</Section>
+
+<Section id="topic-5">
+
+### In your advanced Experimental Capture studio, you've turned ComfyUI into a computer-vision lab.
+
+The goal of this course is to use technologies to help us see the world in new ways: the very fast, the very slow, the very small, the very large, and in spectra beyond human perception, like IR and UV. It's about cultivating the students' curiosity. But the limitation in this studio is hardware. We have one camera that can shoot 100,000 frames per second, one high-resolution thermal camera, and access to one electron microscope — but we've got 20 students. We can't always queue them all up for one exotic camera; it's a bottleneck.
+
+<Quote>I need to give them tools they can use to see the world in new ways, that they can all run on their own hardware.</Quote>
+
+ComfyUI allows students to use their own phones to ask questions they couldn't before. So they duct-tape their phone camera to a window, record the world going by, and then track things with the LocateAnything and SAM3 ComfyUI nodes, producing data files that distill what the camera saw. ComfyUI becomes a laboratory for computational observation, allowing students to ask questions of images and videos that would otherwise be difficult to formulate.
+
+### You also wrap niche research libraries into ComfyUI nodes yourself.
+
+One of the remarkable things about the ComfyUI ecosystem is the community that forms around it. There's a hero of mine on GitHub, Kijai, who keeps taking libraries from computer vision labs and turning them into ComfyUI nodes. He's made hundreds, probably doing more than anyone to turn lab-grade models into tools anyone can use. My students and I are starting to do this too. Niche is the right word. Right now I have my eye on a zoology lab that released a good library for tracking insect legs. The people who made it probably don't even know what ComfyUI is. But I want that algorithm for my students, and there's gotta be someone else out there who would love it too.
+
+### What's the bigger pattern you see in your students?
+
+My students are explorers. They see a new tool and immediately start wondering what else it could be connected to. They explore: I should be able to combine this thing with that other thing. That's the whole reason to give them a system they can build on, instead of a tool that tells them what they're allowed to do.
+
+<Quote>We're educating students who want to invent new forms and experiences, not just reproduce existing ones.</Quote>
+
+</Section>
+
+<Section id="topic-6" title="At a glance">
+
+<AtAGlance rows={[
+  { label: "Courses", value: "Intermediate Studio: Creative Coding (60-212); Experimental Capture (co-taught with Nica Ross)" },
+  { label: "Level", value: "Undergraduate (sophomore studio + advanced studio, ~20 students)" },
+  { label: "Setup", value: "Cloud-hosted ComfyUI; runs on students' own laptops" },
+  { label: "Core techniques", value: "p5.js-driven synthesis; semantic segmentation; monocular depth; LocateAnything + SAM3 tracking" },
+  { label: "Distinctive angle", value: "ComfyUI as computer-vision lab, not just a generator" }
+]} />
+
+</Section>
+
+<Section id="topic-7" title="Student work">
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/student-tippi.png" alt="Student work by Tippi Li" caption={`"nuclear explosion" by Tippi Li`} />
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/student-xiao.png" alt="Student work by Xiao Yuan" caption={`"Chinese painting, plants, ink, transparent" by Xiao Yuan`} />
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/student-aarnav.png" alt="Student work by Aarnav Patel" caption={`"NASA space image of a new cosmos detected" by Aarnav Patel`} />
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/student-jeffrey.png" alt="Student work by Jeffrey Wang" caption={`"Dream Scene Painting" by Jeffrey Wang`} />
+
+<Figure src="https://media.comfy.org/website/customers/golan-levin/student-kai.gif" alt="Student work by Kai Okorodudu" caption={`"Electric hand" by Kai Okorodudu`} />
+
+</Section>
+
+<AuthorBio people={[{ name: "Golan Levin", photo: "https://media.comfy.org/website/customers/golan-levin/author-golan.png" }]}>Golan Levin is a Professor of Computational Art at Carnegie Mellon University and co-author, with Tega Brain, of "Code as Creative Medium." This fall he is teaching two CMU courses with ComfyUI: "Intermediate Studio: Creative Coding" (60-212), built around p5.js, and "Experimental Capture," a studio in computational and expanded photography he co-teaches with Nica Ross. Levin is also widely known for interactive art installations driven by real-time machine vision, such as his [Augmented Hand Series](https://flong.com/archive/projects/augmented-hand-series/index.html) (2014), created with Kyle McDonald and Christine Sugrue.</AuthorBio>
+
+<EducationCta />

--- a/apps/website/src/content/customers/en/ina-conradi.mdx
+++ b/apps/website/src/content/customers/en/ina-conradi.mdx
@@ -1,0 +1,149 @@
+---
+title: "From Node Graph to Building Façade: how Ina Conradi's NTU students compose architectural-scale public art with ComfyUI"
+category: "CREATIVE CAMPUS SHOWCASE"
+description: "At NTU in Singapore, Ina Conradi's students compose 90-second films for building-sized LED walls that prompt boxes cannot render but ComfyUI can, work that travels from campus to Hangzhou's West Lake Media Façade and a million viewers a day."
+cover: "https://media.comfy.org/website/customers/ina-conradi/cover.png"
+order: 6
+sections:
+  - id: topic-1
+    label: "INTRO"
+  - id: topic-2
+    label: "THE CANVAS"
+  - id: topic-3
+    label: "WHY COMFYUI"
+  - id: topic-4
+    label: "THE 2026 BRIEF"
+  - id: topic-5
+    label: "STUDENT WORK"
+  - id: topic-6
+    label: "PUBLIC SCREENS"
+  - id: topic-7
+    label: "AT A GLANCE"
+---
+
+<Section id="topic-1">
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig1-quantum-logos.jpg" alt="Quantum Logos (Vision Serpent) on the Media Art Nexus LED screen" caption="Quantum Logos (Vision Serpent), Mark Chavez and Ina Conradi. Experimental animation, Media Art Nexus LED screen (15 m × 2 m), Singapore. Photo: Quek Jia Liang." />
+
+### Building an AI art pipeline from studio to screen
+
+Ina Conradi has written and taught NTU's two AI courses since 2022: DM2012, Explorations in AI-Generated Art (undergraduate), and AP7055, Art in the Age of the Creative Machine (postgraduate). Each runs about 30 students a semester. Working alongside her on the production pipeline is Mark Chavez, an animation veteran (DreamWorks, Rhythm & Hues) and early ComfyUI adopter. Together they co-curate the platform those courses build for: a 15-metre by 2-metre LED wall installed at NTU's North Spine in 2016 as Media Art Nexus, now run by NTU Museum as NTU Index and still taking new work each semester.
+
+Work from the wall has travelled to giant public screens in Singapore (Ten Square), Hangzhou, and Chongqing, and into collaborations with Bauhaus University, the University of the Arts Berlin, and the Elbphilharmonie in Hamburg.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig2-nature-sanctuary.jpg" alt="Nature Sanctuary 3000 on the West Lake Media Façade" caption="Nature Sanctuary 3000, Sowmya Sreeshna. Experimental animation, West Lake Media Façade (170 m × 18 m), Hangzhou, China. Photo: Limpid Art." />
+
+</Section>
+
+<Section id="topic-2">
+
+### Ina, your students don't make films for laptops. Why screens the size of buildings?
+
+Because the format teaches. A 90-second film at 6K across, in an 8:1 panorama, cannot be a lucky prompt. It has to be composed. And the screens are real: the strongest student work plays on NTU Index, our 15-metre by 2-metre wall on campus, and travels to urban façades in China and Europe through the City Digital Skin Art Festival (CDSA). When a student knows a million people a day might walk past their film in Hangzhou, the conversation about craft changes.
+
+### Mark, describe the canvas.
+
+Basically, we do compositions for really large media LED screens in Singapore and China. We have a screen that's eight by one in Singapore. It's 5,888 by 768 pixels.Students create images in the class, usually about 6K resolution across, a long landscape panorama. The output is 90-second short films. Two minutes, 90 seconds. I'm not going to change. I love that format because it's manageable within the class.
+
+</Section>
+
+<Section id="topic-3">
+
+### That format breaks most AI tools. What happened?
+
+Runway is one of the tools we use, on an educational plan that has worked well for the school. The constraint we hit is format: Runway works in 16:9, and our 6K panoramas fall outside that. Last semester Midjourney gave us trouble at our resolution, and the upscale was difficult. So we're expanding the palette and bringing in ComfyUI alongside what we already run.
+
+<Quote>ComfyUI gave the cleanest results. Upscaling to 8K at a 1-by-8 panorama after composition is genuinely hard, and ComfyUI is the only pipeline that lets students compose image, motion, and upscale models together.</Quote>
+
+### What about the budget side?
+
+Budget will keep being an issue. The school supports us well, but new tools arrive every semester and students want to try them and build their own pipelines. Monthly per-seat licenses don't fit how a semester runs. Running ComfyUI locally is hard for students: most laptops don't have a GPU with enough VRAM, and getting it working takes real trial and error. Many would rather work from home, but the hardware blocks them, so they come into the lab. Others used Comfy Cloud. It charges a subscription, but it still cost significantly less than the prepaid tools, and the results were better. Either way they're chasing the same thing: a pipeline they can keep working on, wherever they are.
+
+### Ina, you insist these courses are not about tools. What are they about?
+
+My class isn’t about teaching a single tool. It is the responsive system students interact with across platforms, directing, critiquing, and shaping outputs through ongoing dialogue. ComfyUI fits this: a node graph is an argument you can read, question, and rebuild. A prompt box is not. Singaporean students become technically fluent very fast. What they need from arts education is the language to question what they're making, not just the skill to make it.
+
+</Section>
+
+<Section id="topic-4">
+
+### Ina, the 2026 brief sends students to the ocean. What's the assignment?
+
+The project is The Liquid Commons: Bringing Ocean Science into Global Media Architecture, developed in dialogue with OceanX, the organization behind the OceanXplorer research vessel, and the CDSA 2026 festival theme. The brief is strict: do not illustrate the science, translate it. The 2026 cohort is the first to build these films in ComfyUI with Topaz upscaling, working towards two real deadlines at once. Their pieces are in consideration for the OceanX Summit in Singapore this October, and jury-selected works will screen during the City Digital Skin Art Festival on Hangzhou's West Lake Media Façade: 170 metres by 18 metres, around a million viewers a day.
+
+<Quote>The delivery spec tells you why the tooling matters: final exports at 5,888 × 768 px, 8K where required. That's the brief no prompt box can fill.</Quote>
+
+</Section>
+
+<Section id="topic-5">
+
+### Mark, what does the student work look like?
+
+About eight students have built their films through Comfy so far, and they're all pretty cool. They're surprising and insightful, because they're not limited by game-engine graphics. One student was the standout: he tried every model in Comfy and pushed the furthest.
+
+Three projects from the 2026 cohort show the range.
+
+**The Tao of Water** (Wang Zilin, AP7055) reads the ocean through the Tao Te Ching, a three-part arc from water to marine plant to void and back to origin. The pipeline moves from Pinterest research boards through Midjourney into ComfyUI, where Nano Banana extends single frames into seamless panoramas and Kling 3.0 animates first-frame-to-last-frame motion at full 5,888-pixel width, before a Premiere edit.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig3-tao-of-water.jpg" alt="The Tao of Water on the NTU Index screen" caption="The Tao of Water, Wang Zilin. Experimental animation, NTU Index screen (15 m × 2 m), Singapore. Photo: Quek Jia Liang." />
+
+**microscophony** (Jiin Ko, AP7055) fuses *microscopic* and *micropolyphony*, Ligeti's term for dense webs of voices that blur into a single cloud of sound. The source is based on OceanX microscope footage of deep-sea microbes, translated into the visual logic of graphic notation (Ligeti, Xenakis, Cardew) so the panorama becomes a listening score. Images ran through Midjourney and Nano Banana, video through ComfyUI with Vidu Q2, sound design in Ableton Live, with distinct sonic textures mapped to distinct visual forms.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig4-microscophony.jpg" alt="microscophony on the NTU Index screen" caption="microscophony, Jiin Ko. Experimental animation, NTU Index screen (15 m × 2 m), Singapore. Photo: Quek Jia Liang." />
+
+**GO! PLASTIC** (Jianwei Hoe, DM2012) is an ocean-plastics piece whose production log reads like studio paperwork, not prompt history. It opens with a one-line art direction (every project states its idea in a single line, with embedded irony, before a frame is generated), then walks through model selection, a platform-versus-local cost comparison (cost per clip and per scene on an RTX 5090 against a cloud B200, render times included), and a shot-by-shot sheet pairing every source image with its full prompt and settings.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig5-go-plastic.jpg" alt="GO! PLASTIC on the NTU Index screen" caption="GO! PLASTIC, Hoe Jianwei. Experimental animation, NTU Index screen (15 m × 2 m), Singapore. Photo: Quek Jia Liang." />
+
+</Section>
+
+<Section id="topic-6">
+
+### Ina, where does the work go after the classroom?
+
+Onto public screens, and into juried international competition. The City Digital Skin Art Festival was established in 2023, initiated by the China Academy of Art's School of Sculpture and Public Art and co-curated with Public Art Lab Berlin, MEET Digital Culture Center Milan, and NTU ADM, with a network of more than 29 art academies across China and Europe.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig6-cdsa-awards.jpg" alt="CDSA Festival award winners on the West Lake Media Façade" caption="CDSA Festival award winners, curators, and organizers. West Lake Media Façade (170 m × 18 m), Hangzhou, China. Photo: Limpid Art. Asia's largest high-definition outdoor screen" />
+
+The 2024 edition ran across 11 LED screens in 9 cities in 5 countries and reached over 100 million views. The 2025–2026 edition, themed Memory Coexistence, drew over 200 international submissions, with the top 40 selected by a 16-member jury. I curate the Singapore programme across NTU Index and the Ten Square landmark façade. A student composing at 6K in our classroom is composing for that circuit.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig7-crispr.jpg" alt="Crispr on the Ten Square Landmark Façade" caption="Crispr, Lee Chaewon. Experimental animation, Ten Square Landmark Façade (21.2 m × 14.4 m), Singapore. Photo: Quek Jia Liang." />
+
+NTU ADM students have already won at this level. At CDSA 2025, the majority of the top awards went to students from these two courses: Gold (Sun Yutong, *Echoes of Her*), Silver (Tan Yu Yan Cheerie, *Eternal Flux*), Bronze (Shah Pranjal Kirti, *Mumbai Miniatures*), Business (Ong Sze Ching, *Nuwa*), and Creative (Leah Chakola, *Caravan of Memory*). The courses have also taken NTU to Ars Electronica in Linz as the only Singapore campus partner since 2023, first with *Butterfly's Dreams* (2023, "Who Owns the Truth?") and then in 2025 with *Beyond the Screen*, a joint exhibition with the China Academy of Art and Bauhaus-Universität Weimar.
+
+### Mark, you spent a decade at DreamWorks. Why does this tool fit art students?
+
+I come from visual effects. I was at DreamWorks about ten years, then Rhythm & Hues, then the game industry and big interactive installations. I'm not a programmer, so I love ComfyUI.
+
+<Quote>Everybody I know who does graphics now is using this, because it's so adaptable. Sometimes we use Comfy as just a back end. That's what everybody's doing.</Quote>
+
+We got this large 15-metre by 2-metre screen in an art installation at the university, and it let us explore media and different techniques. We found students weren't technical enough to handle TouchDesigner, so they just started making movies. Then I started playing with AI, and now everything's AI. What I'd love next is templates custom-made for these screens.
+
+Take *Echoes, Whispers and Memories*, the piece Ina and I made. We don't use Comfy to spit out finished illustrations. We build workflows that keep recomposing the image, breaking it apart and putting it back together so it evolves on screen, which is the whole point: entropy, memory, things falling apart and reforming. Then we push those outputs into real-time and projection systems for big rooms, places like Ars Electronica's Deep Space 8K and MEET in Milan.
+
+<Figure src="https://media.comfy.org/website/customers/ina-conradi/fig8-echoes.jpg" alt="Echoes, Whispers and Memories at Ars Electronica Deep Space 8K" caption="Echoes, Whispers and Memories, Mark Chavez and Ina Conradi. AI-generated immersive installation using ComfyUI, Deep Space 8K, Ars Electronica, Linz, Austria. Photo: Wolfgang Simlinger." />
+
+### The signal from the industry
+
+<Quote>I hear from my students looking for internships or jobs that the first question over there is, "Do you know Comfy?" Because they want to hire kids who know the pipeline.</Quote>
+
+</Section>
+
+<Section id="topic-7" title="At a glance">
+
+<AtAGlance rows={[
+  { label: "Institution", value: "Nanyang Technological University, School of Art, Design and Media (Singapore)" },
+  { label: "Courses", value: "DM2012: Explorations in AI-Generated Art (UG) and AP7055: Art in the Age of the Creative Machine (PG), written and taught by Ina Conradi since 2022; ~30 students/semester" },
+  { label: "The canvas", value: "6K-wide, 8:1 LED walls in Singapore and China; NTU Index wall on campus (15 m × 2 m, 5,888 × 768 px)" },
+  { label: "Core technique", value: "ComfyUI compositions with Topaz upscaling for ultra-wide panoramic output; production logs with per-clip cost and prompt sheets" },
+  { label: "Why Comfy won", value: "Hosted tools locked to 16:9; upscaling to 8K at a 1-by-8 panorama after composition needed a multi-model pipeline; per-seat monthly renewals didn't fit the semester" }
+]} />
+
+</Section>
+
+<AuthorBio label="About the authors" people={[
+  { name: "Ina Conradi", photo: "https://media.comfy.org/website/customers/ina-conradi/author-ina.jpg", bio: `Ina Conradi is an artist and curator based between Singapore and Los Angeles. She is founding faculty at NTU's School of Art, Design and Media (est. 2005), where she has written and taught the school's AI courses since 2022. Her film Moirai: Thread of Life won Best in Show at the SIGGRAPH Asia Computer Animation Festival 2023, a first for Singapore.` },
+  { name: "Mark Chavez", photo: "https://media.comfy.org/website/customers/ina-conradi/author-mark.jpg", bio: `Mark Chavez is an animator, director, and founding faculty at NTU's School of Art, Design and Media in Singapore. After a decade at DreamWorks Animation and visual effects work at the original Rhythm & Hues Studios, he established NTU's Digital Animation area (2005) and an animation research think-tank funded by Singapore's National Research Foundation and the Media Development Authority.` }
+]} />
+
+<EducationCta />

--- a/apps/website/src/content/customers/en/kathy-smith.mdx
+++ b/apps/website/src/content/customers/en/kathy-smith.mdx
@@ -1,0 +1,138 @@
+---
+title: "Built for AI: Prof. Kathy Smith on USC's Expanded Animation program and ComfyUI"
+category: "CREATIVE CAMPUS SHOWCASE"
+description: "Inside the experimental USC MFA that put AI into animation pedagogy from day one, and the student pipelines it produced."
+cover: "https://media.comfy.org/website/customers/kathy-smith/cover.png"
+order: 8
+sections:
+  - id: topic-1
+    label: "THE PROGRAM"
+  - id: topic-2
+    label: "TEACHING WITH AI"
+  - id: topic-3
+    label: "WHY COMFYUI"
+  - id: topic-4
+    label: "STUDENT WORK"
+  - id: topic-5
+    label: "AT A GLANCE"
+  - id: topic-6
+    label: "WHAT'S NEXT"
+---
+
+<Section id="topic-1">
+
+### You built the Expanded Animation program in 2022 specifically to put AI into the curriculum from day one. What did you see that other programs missed?
+
+We created Expanded Animation: Research and Practice specifically to focus on creative process and AI as part of how animators learn to make work. The thesis at the start was that AI was going to reshape animation as a medium, and the question was not whether to teach it but how to embed it in the curriculum so students learn it as part of their creative process rather than as a separate technical specialty.
+
+USC's School of Cinematic Arts already had decades of cinematic storytelling tradition. What we did with XA was put AI inside that tradition. The conceptual thinking, the storytelling, the cinematic history come first. AI is one of the many tools available to them, sitting alongside hand-drawing, paint, 3D, and live-action footage. Students do not learn AI in one course and animation in another. They learn both side by side.
+
+The students who arrive at the program are usually self-selected for it. They show up technically fluent, with their own GPU-equipped laptops. What we offer them is the storytelling, the cinematic history, and the conceptual frame. They bring the technical nimbleness.
+
+<Quote>They are way ahead of the curve. They are ahead of the faculty in the way they work, technically, but not so much artistically. That is what we are there to deliver.</Quote>
+
+<Figure src="https://media.comfy.org/website/customers/kathy-smith/usc-campus.png" alt="USC School of Cinematic Arts" caption="USC School of Cinematic Arts. Source: USC Today" />
+
+</Section>
+
+<Section id="topic-2">
+
+### How do you actually structure an AI assignment? Walk us through one.
+
+In my Animation, Dreams, and Consciousness class, I have the students document their dreams and then use the dream as the source. Some of them draw, some of them write. The dream becomes the prompt, and they generate the image and emotion of the dream. I love when you get six fingers and weird stuff happening in the algorithms. Our human perception in dreams is often doing the same thing. Therefore, AI is evolving and dreaming with us.
+
+That structure is deliberate. The students are not asking the model to produce work for them. They are using it as a layer of their process, alongside hand-drawing and painting and 3D rendering and live-action footage. The work that comes out is theirs because the creative decisions are theirs. The tool just gives them new ways to reach what they were trying to make.
+
+There is a fear factor around AI, and I understand it. There has been a lot of scraping of artists' work, and that conversation is real and is going to take time to resolve. But I have been working with AI conceptually since 1998, and the way I describe the data sets to my students is that they are a repository of all of our creation. It is like the collective unconscious of the human mind. Artists have always drawn from everything around them.
+
+<Quote>What really matters is what the artist does with it, *intentionality*.</Quote>
+
+</Section>
+
+<Section id="topic-3">
+
+### Why does ComfyUI specifically fit the way your students work?
+
+It is the node-based system. Those who have done Houdini feel very at home in Comfy. You can work with the prompts, but it is very visual. That is what they are used to. They are not asking a black box for an output. They are building a workflow.
+
+And it stays in its lane. The students are not using Comfy to make AI art. They are using Comfy as one node graph alongside Blender, hand-drawn frames, paint, and live-action footage. The reason it fits is that it does not try to be the whole pipeline. It is one stage of a creative practice that still has cinema at its core.
+
+What also matters is that Comfy is open and inspectable. The students can see what the model is doing at each step, fork a workflow, swap a sampler, drop in a custom node, and share what they built with the next cohort. That is closer to how an animation studio tradition has always behaved, with techniques passed along and improved rather than hidden behind a paywall.
+
+They also work across whatever hardware they have: Comfy Cloud at home and when they are mobile, the portable version on their personal laptops, and the research computer in my office for the high-end runs. Animation students do not sit in one cubicle for a thesis project. They work everywhere.
+
+</Section>
+
+<Section id="topic-4">
+
+### Tell us about the work coming out of the program.
+
+The pattern shows up across the cohort: the AI is in service of the cinematic story, not in place of it. Three students walked us through how Comfy actually sits inside their pipelines.
+
+#### Sijia Zheng — Ori & Kiddo
+
+<Figure src="https://media.comfy.org/website/customers/kathy-smith/ori-kiddo.png" alt="Sijia Zheng, Ori & Kiddo" />
+
+**What Comfy enabled:** an oil-paint, brush-stroke dream look that "other AI tools cannot possibly make," held consistent across shots with IP-Adapter style transfer and a custom LoRA.
+
+*Ori & Kiddo* follows two ghosts who, after the universe dies, search for old human memories, rediscover love, and reverse the universe back into being. Most of the film is hand-drawn 2D. Comfy enters in the dream sequences, where the ghost Kiddo dreams of past lives and the look had to be unlike anything else in the film. Sijia drew stylized reference images first, then used them as the style reference over video clips through an IP-Adapter workflow to produce long, oil-painted, brush-stroke sequences. The same control shows up in shots where Sijia appears on screen: real footage, masked in Comfy to change the haircut and swap the background. For a look that has to stay locked, Sijia trains a LoRA and runs it through Comfy.
+
+Sijia found Comfy in early 2025 while hunting for a style-transfer tool that Midjourney and DALL-E could not deliver, testing it on a stylized animated-film-look conversion.
+
+<Quote>It totally broke my mind. Most of the time, I think I'll just stand on other people's shoulders. The workflows are already pretty amazing, and I'll base on the workflows and add something that I want.</Quote>
+
+Since *Ori & Kiddo*, Sijia has taken the same Comfy-anchored workflow into professional commercial video work, on deadlines as tight as four days.
+
+#### Ion Yunyang Li — L1LY
+
+<Figure src="https://media.comfy.org/website/customers/kathy-smith/l1ly.gif" alt="Ion Yunyang Li, L1LY" />
+
+**What Comfy enabled:** a repeatable multi-step pipeline that drops the filmmaker into a photorealistic world, because "a sequence of a prompt is not the only thing you need."
+
+Ion taught himself ComfyUI in early 2025, from tutorials in the generative-AI community, and built his most distinctive Comfy work in a body-and-environment project: start from 3D-model stills, convert them to a pencil-sketch style so the model would not over-study the original 3D aesthetic, generate photorealistic frames from the sketches, build character T-poses, composite himself into the scene, and animate the stills with a video model.
+
+<Quote>A sequence of a prompt is not the only thing you need. You need many different settings, and it is very hard to redo those settings every time.</Quote>
+
+What he values as much as the pipeline is where it can run: the same Comfy setup moves across a workstation in his school cubicle, a remote session from his apartment laptop, and fully cloud-based instances, depending on where he is.
+
+#### Sihan Wu — Scary Coaster
+
+<Figure src="https://media.comfy.org/website/customers/kathy-smith/scary-coaster.gif" alt="Sihan Wu, Scary Coaster" />
+
+**What Comfy enabled:** roughly 100 hand-drawn keyframes carried through a single workflow so a two-to-three-minute film stays visually consistent, on his first-ever AI project.
+
+*Scary Coaster* (December 2024) was Sihan's first project ever made with AI. Coming from a digital-media and game-development undergrad, Sihan joined Professor Smith's Expanded Animation class and wanted something more controllable than the prompt-only tools on offer. The workflow he built: draw roughly 100 rough keyframes by hand, run them through Comfy to find a stylized Chinese-horror look, pick the favorite, then generate the in-betweens to produce the full sequence.
+
+<Quote>I want to have a more controllable flow. I don't want to just use prompts and generate random images. I just use one workflow to create the whole two or three minutes, and I can make everything look very consistent.</Quote>
+
+Sihan is honest that the on-ramp was steep: learning from the official ComfyUI GitHub workflows, combining them, and debugging Python environments along the way. His ask was specific: an official, beginner-to-advanced tutorial series. And his view on where AI should head next was equally specific: aim it at "the very time-consuming but not that creative process, like creating in-betweens," and leave the creative decisions to the artist.
+
+</Section>
+
+<Section id="topic-5" title="At a glance">
+
+<AtAGlance rows={[
+  { label: "Program", value: "Expanded Animation: Research + Practice (XA), USC School of Cinematic Arts" },
+  { label: "Founded", value: "2022, AI embedded in the MFA curriculum from day one" },
+  { label: "Setup", value: "Students' own GPU laptops + Comfy Cloud + lab research machine" },
+  { label: "Core techniques", value: "IP-Adapter style transfer, custom LoRAs, masked compositing, keyframe-to-in-between pipelines" },
+  { label: "Outcomes", value: "Amazing student works from Sihan, and Ion, Sijia" }
+]} />
+
+</Section>
+
+<Section id="topic-6">
+
+### What excites you about where this is going?
+
+I have a philosophy that everyone is an artist. They just forget that they are an artist. Creativity drives everything, and the tools we are getting now make it possible for more people to find that capacity in themselves. ComfyUI, because it is node-based and visual and open, gives non-programmers a way forward that is honest about how the model works. It does not pretend the AI is doing something magical. It shows the artist what is happening at each step.
+
+The two basic rights of human life are health and education. The work Comfy is doing on the education side is touching something integral. The students who came through XA are already extending the work in directions the program did not anticipate, and the next generation of educators and students will keep doing the same.
+
+<Quote>Everyone is an artist. They just forget that they are an artist.</Quote>
+
+</Section>
+
+<AuthorBio people={[{ name: "Kathy Smith", photo: "https://media.comfy.org/website/customers/kathy-smith/kathy-smith.jpg", bio: `Kathy Smith is Professor of Cinematic Arts at USC's School of Cinematic Arts and inaugural director (2022-2023) of Expanded Animation: Research + Practice (XA), the experimental MFA program she helped found in 2022 to integrate AI into animation pedagogy from the first day of the degree. To date she is the longest-serving chair of combined USC animation programs and has been exploring concepts of AI in her creative practice since 1998.` }]} />
+
+<EducationCta />

--- a/apps/website/src/content/customers/en/ual-cci.mdx
+++ b/apps/website/src/content/customers/en/ual-cci.mdx
@@ -1,0 +1,56 @@
+---
+title: "Comfy and UAL's Creative Computing Institute Announce Creative Campus Partnership"
+category: "CREATIVE CAMPUS PARTNERSHIP"
+description: "Comfy announces Creative Campus Partnership to support teaching and research across UAL CCI's masters, PhD, and industry programmes"
+cover: "https://media.comfy.org/website/customers/ual-cci/cover.png"
+order: 9
+sections:
+  - id: topic-1
+    label: "INTRO"
+  - id: topic-2
+    label: "WHAT CCI DOES"
+  - id: topic-3
+    label: "THE PARTNERSHIP"
+  - id: topic-4
+    label: "ABOUT CCI"
+---
+
+<Section id="topic-1">
+
+Comfy Org, the team behind ComfyUI, the open-source node-based interface for generative AI, and the Creative Computing Institute (CCI) at University of the Arts London today announced a Creative Campus partnership, making CCI a founding partner of the [Comfy Education Initiative](https://comfy.org/education).
+
+</Section>
+
+<Section id="topic-2">
+
+CCI already runs ComfyUI at every level of the institute. On the Applied Machine Learning for Creatives masters course, students build image, video, audio, and text workflows, train their own models, and construct interactive pipelines. PhD researchers use Comfy for fine-tuning, custom datasets, and custom node development. The institute also uses ComfyUI in industry training, where its node-based interface gives non-technical collaborators a way into generative AI that code alone does not.
+
+<Quote name="Prof Mick Grierson, Research Leader, UAL Creative Computing Institute">ComfyUI has become part of how we teach, research, and work with industry. It is one of the few generative AI environments where the workflows our students build are portable, inspectable, and forkable, and that open-source foundation is exactly what a university should be teaching on.</Quote>
+
+</Section>
+
+<Section id="topic-3">
+
+Through the partnership, CCI educators and students gain access to classroom licenses with central billing & administration, educational discounts, early access to upcoming team features, a dedicated educator community with direct support from the Comfy team, and a voice in shaping the future of the education program.
+
+Creative Campus partnerships are the deepest tier of the program: a direct, ongoing collaboration in which an institution works hand in hand with the Comfy team to roll out ComfyUI across teaching, research, and industry training.
+
+<Quote name="The Comfy Team">CCI is the model we hope every creative campus follows: ComfyUI in the masters classroom, in PhD research, and in industry collaboration, all at once. As our first Creative Campus Partner, they are helping us design an education program that works the way universities actually work.</Quote>
+
+<Figure src="https://media.comfy.org/website/customers/ual-cci/cci-camberwell.jpg" alt="Creative Computing Institute campus at UAL" caption="Creative Computing Institute Campus. Photo: Ana Escobar, courtesy UAL." />
+
+The institute is leading a major £1.5 million publicly funded research programme developing copyright-compliant audiovisual foundation models for the UK's creative industries. Bringing together expertise in sound, image, and artificial intelligence, the project is building open tools and responsible AI national infrastructure designed to support UK creative production, research, and experimentation across the sector.
+
+The outputs of the research will explore wider dissemination and adoption through open, node-based tools such as ComfyUI to support experimentation, workflows, and collaboration around emerging multimodal AI systems.
+
+UAL CCI joins a founding cohort of educators and institutions featured at the launch of the Comfy Education Initiative, alongside researchers such as CCI co-founder Dr. Phoenix Perry, whose Antigravity Machine project Comfy supports as an industry partner.
+
+</Section>
+
+<Section id="topic-4" title="About the Creative Computing Institute at UAL">
+
+The Creative Computing Institute at University of the Arts London applies computing to creativity and social impact, operating at the intersection of computational technologies and creative practice, teaching undergraduate, postgraduate, and PhD students alongside research and industry collaboration.
+
+</Section>
+
+<EducationCta />

--- a/apps/website/src/content/customers/en/xindi-zhang.mdx
+++ b/apps/website/src/content/customers/en/xindi-zhang.mdx
@@ -1,0 +1,103 @@
+---
+title: "The tool that expands my art: Xindi Zhang's Oscar-shortlisted thesis, built in ComfyUI"
+category: "CREATIVE CAMPUS SHOWCASE"
+description: "How a USC Expanded Animation thesis became a Student Academy Award winner, an Oscar shortlist entry, and helped land a job at Amazon — with the artist's own illustrations as the style guide."
+cover: "https://media.comfy.org/website/customers/xindi-zhang/cover.webp"
+order: 5
+sections:
+  - id: topic-1
+    label: "INTRO"
+  - id: topic-2
+    label: "WHY COMFYUI"
+  - id: topic-3
+    label: "THE PIPELINE"
+  - id: topic-4
+    label: "AT A GLANCE"
+  - id: topic-5
+    label: "WHAT'S NEXT"
+---
+
+<Section id="topic-1">
+
+<Embed src="https://player.vimeo.com/video/1131160045" title="The Song of Drifters by Xindi Zhang" />
+
+*From The Song of Drifters. Film images: Xindi Zhang.*
+
+### Tell us about The Song of Drifters. What is it about, and where did it start?
+
+The Song of Drifters is a documentary animation about people caught between leaving and returning, wanderers who drift through unfamiliar cities, holding onto memories of a homeland out of reach and searching for a sense of belonging. The title is a direct translation from an ancient Chinese poem about a mother's love for a child who leaves her hometown. My version takes the opposite point of view, from the child's perspective.
+
+I built the film in ComfyUI. When I started, I was not trying to show what AI could do. I was trying to prove something almost opposite.
+
+<Quote>It started as a challenge to the stereotype that AI-generated work is generic and cheap. I wanted to prove that AI could be an amplifier for personal vision, not a replacement for it.</Quote>
+
+</Section>
+
+<Section id="topic-2">
+
+### You came to this from illustration, not engineering. How did you end up in ComfyUI?
+
+I started as an illustrator. I earned my BFA in illustration at the Rhode Island School of Design, then worked as a game concept artist, where I picked up shaders, Unity, and Unreal. That technical side made me a fast learner with new tools. Later I went to USC's School of Cinematic Arts for an MFA in Expanded Animation, where I studied with Professor Kathy Smith.
+
+By my thesis year I had moved from Stable Diffusion's standard interfaces to ComfyUI, because I think in node-based structures and I wanted to control every step. Most AI tools are one click: you prompt, you click, you get a result. That is not what I wanted.
+
+<Quote>I want to control the process, and the process is even more important than the result itself. For artists like me, I don't want to automate anything. I want to participate in every single stage of designing the workflow. That's the fun part of it.</Quote>
+
+</Section>
+
+<Section id="topic-3">
+
+### Walk us through the pipeline. What were you actually feeding the model?
+
+<Figure src="https://media.comfy.org/website/customers/xindi-zhang/balloon-workflow.png" alt="Xindi's ComfyUI workflow for the balloon sequence">Xindi's ComfyUI workflow for the balloon sequence. Source: [xindizhangart.com](https://xindizhangart.com).</Figure>
+
+My core technique was style transfer in Stable Diffusion 1.5, driven by IP-Adapter and ControlNet. What mattered most was what I fed it: my own work. The base materials were live-action footage I shot on an iPhone 15 Pro and 3D animation I built in Blender. The AI restyled imagery I had already made. It did not invent it.
+
+<Figure src="https://media.comfy.org/website/customers/xindi-zhang/film-still.jpg" alt="Style-guide still from The Song of Drifters">Style-guide still from The Song of Drifters. Source: [xindizhangart.com](https://xindizhangart.com).</Figure>
+
+<Quote>Unlike most AI-generated videos, which use other artists' works from the model, I use my own illustrations as the style guide.</Quote>
+
+<Download href="https://media.comfy.org/website/customers/xindi-zhang/workflows/style-transfer-workflow.json" label="Download Xindi's style transfer workflow (json) on ComfyUI" />
+
+I also trained custom LoRAs on my own video, footage of the cities I had lived in. Capturing that footage became a vital part of the documentary process. Wandering through the streets where I once lived let me reconnect with those cities. Most of it never appears in the final cut, but it lives in the visuals as training data. The hybrid pipeline made rendering the final look more efficient and saved more time for ideation.
+
+For the dream sequences I combined animated 3D with AI morphing, moving from abstract to concrete to mimic the feeling of being half awake.
+
+<Video src="https://media.comfy.org/website/customers/xindi-zhang/bts-clip.mp4" poster="https://media.comfy.org/website/customers/xindi-zhang/bts-poster.jpg" caption="BTS clip, AI morphing. Source: Xindi Zhang." />
+
+<Download href="https://media.comfy.org/website/customers/xindi-zhang/workflows/morphing-workflow.json" label="Download Xindi's AI morphing workflow (json) on ComfyUI" />
+
+</Section>
+
+<Section id="topic-4" title="At a glance">
+
+<AtAGlance rows={[
+  { label: "Program", value: "USC School of Cinematic Arts — MFA Expanded Animation (thesis)" },
+  { label: "Base materials", value: "iPhone 15 Pro live-action; her own Blender 3D animation" },
+  { label: "Core technique", value: "Style transfer in SD 1.5 via IP-Adapter + ControlNet, in ComfyUI" },
+  { label: "Style source", value: "Her own illustrations + custom LoRAs trained on her own city footage" },
+  { label: "Finishing", value: "Depth, mask, and fade passes in After Effects; heavy compositing" },
+  { label: "Outcome", value: "Student Academy Awards Golden Award (2025); 98th Academy Awards shortlist; AI Creative role at Amazon AI Studio" }
+]} />
+
+</Section>
+
+<Section id="topic-5">
+
+### The film won gold at the Student Academy Awards and was shortlisted for the Oscars. What's next?
+
+I made the film for creative reasons, not career ones. I honestly did not expect it to connect to a job at all. Then it won the Golden Award at the 2025 Student Academy Awards and was shortlisted for the Oscars, and the calls started.
+
+<Figure src="https://media.comfy.org/website/customers/xindi-zhang/awards.png" alt="Xindi Zhang at the 2025 Student Academy Awards" caption="Xindi Zhang at the 2025 Student Academy Awards. Source: Oscars Press Office." />
+
+What people wanted was the combination: someone who understands both traditional craft and AI tools. I now work as an AI Creative at Amazon AI Studio building custom production pipelines. I see that same demand across the industry, with ComfyUI experience starting to show up as a requirement in job postings at major studios and design agencies.
+
+<Quote>It's not the tool that steals my art. It's the tool that expands my art.</Quote>
+
+My advice to other students is not really about software. AI is just another tool to convey ideas, but nothing is more important than the story itself. If you use AI, use it on purpose. The more you understand it, the more freedom you have to make work that is genuinely yours.
+
+</Section>
+
+<AuthorBio people={[{ name: "Xindi Zhang", photo: "https://media.comfy.org/website/customers/xindi-zhang/profile.jpg", bio: `Xindi Zhang is a Chinese animation director and visual artist (RISD BFA in illustration, 2020; USC MFA in Expanded Animation, 2025). The Song of Drifters won the Golden Award at the 2025 Student Academy Awards and was shortlisted for the 98th Academy Awards. She works as an AI Creative at Amazon AI Studio, has collaborated with Sony Music's immersive studio, and is now on the faculty at the University of South Florida.` }]} />
+
+<EducationCta />

--- a/apps/website/src/i18n/translations.ts
+++ b/apps/website/src/i18n/translations.ts
@@ -35,6 +35,32 @@ const translations = {
     'zh-CN': '观看演示'
   },
 
+  // Education CTA (customer story block)
+  'educationCta.heading': {
+    en: 'Teaching with ComfyUI?',
+    'zh-CN': '正在使用 ComfyUI 教学？'
+  },
+  'educationCta.body': {
+    en: 'The Comfy Education Program is live: educational pricing, classroom cloud accounts on one invoice,',
+    'zh-CN': 'Comfy 教育计划现已上线：教育定价、一张发票管理课堂云账户，'
+  },
+  'educationCta.exploreLink': {
+    en: 'Explore the Education Program',
+    'zh-CN': '了解教育计划'
+  },
+  'educationCta.or': {
+    en: 'or',
+    'zh-CN': '或'
+  },
+  'educationCta.applyLink': {
+    en: 'apply to be a part of the Creative Campus program',
+    'zh-CN': '申请加入 Creative Campus 计划'
+  },
+  'educationCta.tail': {
+    en: "if you're interested in exploring a deeper partnership with Comfy.",
+    'zh-CN': '如果你有兴趣与 Comfy 建立更深入的合作。'
+  },
+
   // HeroSection
   'hero.title': {
     en: 'Professional Control\nof Visual AI',

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -61,6 +61,11 @@
 
 @theme {
   --color-site-dropdown: #332b38;
+  --color-site-bg-soft: color-mix(
+    in srgb,
+    var(--color-primary-comfy-ink) 88%,
+    black 12%
+  );
   --color-primary-comfy-yellow: #f2ff59;
   --color-primary-comfy-orange: #fabc25;
   --color-primary-comfy-ink: #211927;
@@ -262,6 +267,6 @@ video::-webkit-media-controls-panel {
 
 :root {
   --site-bg: var(--color-primary-comfy-ink);
-  --site-bg-soft: color-mix(in srgb, var(--site-bg) 88%, black 12%);
+  --site-bg-soft: var(--color-site-bg-soft);
   --site-border-subtle: rgb(255 255 255 / 0.1);
 }


### PR DESCRIPTION
## Summary

Adds the five Creative Campus (education) customer stories into the education launch bundle (`feat/edu-page`), so pricing, the customer stories, and the education page can go live together.

These stories were originally merged to `main` in #13370, then reverted (#13407) because they went public before the education page was ready. This re-lands the exact same reviewed work on top of the bundle branch instead of `main`. Base is `feat/edu-page`, not `main`.

## Changes

- **What**: The 5 English MDX stories (Xindi Zhang, Ina Conradi, Golan Levin, Kathy Smith, UAL CCI) plus the reusable article blocks they use (`Embed`, `Video`, `Download`, `AuthorBio`, `EducationCta`, `AtAGlance`, `Link`, `Heading4`), the `CustomerArticle` element map, the `bg-site-bg-soft` theme utility, the article `max-w-9xl` cap, and the customer content/e2e tests. Identical to the reverted #13370.
- **Breaking**: none. Existing stories and pages are untouched.
- **Dependencies**: none.

## Review Focus

- This is a clean cherry-pick of the squashed #13370; it applies with zero conflicts on the current bundle.
- All prior review feedback (CodeRabbit + Michael + design) was already addressed in #13370 before it was merged and reverted, so this content is final.

## Verification

- Cherry-pick: zero conflicts. Build: 504 pages. Unit: 176/176. Typecheck: 0 errors. format:check and knip clean.
- Nav featured card and both `/customers` locales verified in-browser previously; unchanged here.

## Notes

- JSON-LD structured data for these pages will follow as a separate PR onto this same bundle (superseding the on-hold #13404).

## Screenshots

**/customers listing**

_Desktop:_

_Mobile:_

**Story detail (example: Xindi Zhang)**

_Desktop:_

_Mobile:_

Preview: https://comfy-website-preview-pr-13409.vercel.app/customers
