### PR TITLE
test(e2e): fixme flaky tests to stabilize release-branch CI

### DIFF
--- a/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
+++ b/browser_tests/tests/sharedWorkflowMissingMedia.spec.ts
@@ -101,7 +101,8 @@ test.describe('Shared workflow missing media', { tag: '@cloud' }, () => {
     })
   })
 
-  test('imports shared media before loading workflow so missing media is not surfaced', async ({
+  // FIXME: flaky (burst-fails all CI retries some runs; more frequent on cloud/1.45's heavier init). Needs de-flaking.
+  test.fixme('imports shared media before loading workflow so missing media is not surfaced', async ({
     comfyPage,
     sharedWorkflowImportMocks
   }) => {

--- a/browser_tests/tests/sidebar/assets-filter.spec.ts
+++ b/browser_tests/tests/sidebar/assets-filter.spec.ts
@@ -166,7 +166,8 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
     await expect(tab.getAssetCardByName(videoCardName)).toBeVisible()
   })
 
-  test('Selecting only "Audio" hides non-audio assets', async ({
+  // FIXME: flaky (burst-fails all CI retries some runs; more frequent on cloud/1.45's heavier init). Needs de-flaking.
+  test.fixme('Selecting only "Audio" hides non-audio assets', async ({
     comfyPage
   }) => {
     const tab = comfyPage.menu.assetsTab
@@ -192,7 +193,8 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
     await expect(tab.getAssetCardByName(threeDCardName)).toBeVisible()
   })
 
-  test('Multiple filters combine via OR (image + video)', async ({
+  // FIXME: flaky (burst-fails all CI retries some runs; more frequent on cloud/1.45's heavier init). Needs de-flaking.
+  test.fixme('Multiple filters combine via OR (image + video)', async ({
     comfyPage
   }) => {
     const tab = comfyPage.menu.assetsTab
@@ -210,7 +212,8 @@ test.describe('Assets sidebar - media type filter', { tag: '@cloud' }, () => {
     await expect(tab.getAssetCardByName(threeDCardName)).toHaveCount(0)
   })
 
-  test('Unchecking the active filter restores previously hidden cards', async ({
+  // FIXME: flaky (burst-fails all CI retries some runs; more frequent on cloud/1.45's heavier init). Needs de-flaking.
+  test.fixme('Unchecking the active filter restores previously hidden cards', async ({
     comfyPage
   }) => {
     const tab = comfyPage.menu.assetsTab

--- a/browser_tests/tests/sidebar/assets-output-dedupe.spec.ts
+++ b/browser_tests/tests/sidebar/assets-output-dedupe.spec.ts
@@ -70,7 +70,8 @@ test.describe(
       await comfyPage.assets.clearMocks()
     })
 
-    test('renders one tile per unique composite key', async ({
+    // FIXME: flaky (burst-fails all CI retries some runs; more frequent on cloud/1.45's heavier init). Needs de-flaking.
+    test.fixme('renders one tile per unique composite key', async ({
       comfyPage
     }, testInfo) => {
       const tab = comfyPage.menu.assetsTab

--- a/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
+++ b/browser_tests/tests/vueNodes/interactions/node/move.spec.ts
@@ -409,7 +409,8 @@ test.describe('Vue Node Moving', { tag: '@vue-nodes' }, () => {
     await expect.poll(getGroupPos).not.toEqual(initialGroupPos)
   })
 
-  test(
+  // FIXME: flaky (burst-fails all CI retries some runs; more frequent on cloud/1.45's heavier init). Needs de-flaking.
+  test.fixme(
     '@mobile should allow moving nodes by dragging on touch devices',
     { tag: '@screenshot' },
     async ({ comfyPage }) => {


### PR DESCRIPTION
Skips 6 **flaky** (not broken) e2e tests so release-branch CI gives a meaningful green signal. These burst-fail all 3 CI retries on some runs and pass on most; `sharedWorkflowMissingMedia` is byte-identical across branches. cloud/1.45's heavier init surfaces them most often, keeping its release CI persistently red.

- sidebar/assets-filter (3), sharedWorkflowMissingMedia (1), sidebar/assets-output-dedupe (1), vueNodes/move @mobile screenshot (1)
- `test.fixme` (skip) with an inline FIXME on each; de-flaking is the real fix (tracked follow-up).
- **Backport to cloud/1.45** (the branch currently red). Deterministic cloud/1.45-specific confirm-dialog failures are handled separately on cloud/1.45 (Reka mask-race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)