### PR TITLE
[DO NOT MERGE] core/1.46 e2e diagnostic probe

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -149,3 +149,5 @@ const bootstrapStore = useBootstrapStore(pinia)
 void bootstrapStore.startStoreBootstrap()
 
 app.mount('#vue-app')
+
+// e2e diagnostic probe (core/1.46) — do not merge


### PR DESCRIPTION
Throwaway — runs e2e on core/1.46 to capture the current failing set (playwright-tests cloud job). Will close after.