### PR TITLE
[backport cloud/1.45] feat: identify auth users to Syft (#13311)

### DIFF
--- a/.github/workflows/ci-dist-telemetry-scan.yaml
+++ b/.github/workflows/ci-dist-telemetry-scan.yaml
@@ -134,6 +134,27 @@ jobs:
           fi
           echo '✅ No Customer.io references found'
 
+      - name: Scan dist for Syft telemetry references
+        run: |
+          set -euo pipefail
+          echo '🔍 Scanning for Syft references...'
+          if rg --no-ignore -n \
+            -g '*.html' \
+            -g '*.js' \
+            -e '(?i)syft' \
+            -e '(?i)sy-d\.io' \
+            dist; then
+            echo '❌ ERROR: Syft references found in dist assets!'
+            echo 'Syft must be properly tree-shaken from OSS builds.'
+            echo ''
+            echo 'To fix this:'
+            echo '1. Use the TelemetryProvider pattern (see src/platform/telemetry/)'
+            echo '2. Call telemetry via useTelemetry() hook'
+            echo '3. Use conditional dynamic imports behind isCloud checks'
+            exit 1
+          fi
+          echo '✅ No Syft references found'
+
       - name: Scan dist for Cloudflare Turnstile sitekey references
         run: |
           set -euo pipefail

--- a/global.d.ts
+++ b/global.d.ts
@@ -41,6 +41,29 @@ interface GtagFunction {
   (...args: unknown[]): void
 }
 
+type SyftDataTraits = Record<string, string | number | null | undefined>
+
+interface SyftDataPendingFetch {
+  args: unknown[]
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+}
+
+interface SyftDataClient {
+  identify(email: string, traits?: SyftDataTraits): void
+  signup(email: string, traits?: SyftDataTraits): void
+  track(event: string, traits?: SyftDataTraits): void
+  page(...args: unknown[]): void
+  q?: unknown[][]
+  fi?: SyftDataPendingFetch[]
+  fetchID?: (...args: unknown[]) => Promise<unknown>
+}
+
+/** Installed by the Syft UMD instead of SyftDataClient when telemetry is opted out */
+interface SyftDisabledClient {
+  enable: () => void
+}
+
 interface Window {
   __CONFIG__: {
     gtm_container_id?: string
@@ -78,6 +101,8 @@ interface Window {
   }
   dataLayer?: Array<Record<string, unknown>>
   gtag?: GtagFunction
+  syft?: SyftDataClient | SyftDisabledClient
+  syftc?: { sourceId?: string; enabled?: boolean }
   ire_o?: string
   ire?: ImpactQueueFunction
   rewardful?: RewardfulQueueFunction

--- a/src/platform/remoteConfig/types.ts
+++ b/src/platform/remoteConfig/types.ts
@@ -82,6 +82,7 @@ export type RemoteConfig = {
   posthog_project_token?: string
   posthog_api_host?: string
   posthog_config?: Partial<PostHogConfig>
+  syftdata_source_id?: string
   customer_io?: {
     write_key?: string
     site_id?: string

--- a/src/platform/telemetry/initTelemetry.ts
+++ b/src/platform/telemetry/initTelemetry.ts
@@ -27,6 +27,7 @@ export async function initTelemetry(): Promise<void> {
       { ImpactTelemetryProvider },
       { PostHogTelemetryProvider },
       { ClickHouseTelemetryProvider },
+      { SyftTelemetryProvider },
       { CustomerIoTelemetryProvider }
     ] = await Promise.all([
       import('./TelemetryRegistry'),
@@ -35,6 +36,7 @@ export async function initTelemetry(): Promise<void> {
       import('./providers/cloud/ImpactTelemetryProvider'),
       import('./providers/cloud/PostHogTelemetryProvider'),
       import('./providers/cloud/ClickHouseTelemetryProvider'),
+      import('./providers/cloud/SyftTelemetryProvider'),
       import('./providers/cloud/CustomerIoTelemetryProvider')
     ])
 
@@ -44,6 +46,7 @@ export async function initTelemetry(): Promise<void> {
     registry.registerProvider(new ImpactTelemetryProvider())
     registry.registerProvider(new PostHogTelemetryProvider())
     registry.registerProvider(new ClickHouseTelemetryProvider())
+    registry.registerProvider(new SyftTelemetryProvider())
     registry.registerProvider(new CustomerIoTelemetryProvider())
 
     setTelemetryRegistry(registry)

--- a/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/GtmTelemetryProvider.ts
@@ -1,3 +1,5 @@
+import { normalizeEmail } from '@/platform/telemetry/utils/normalizeEmail'
+
 import type {
   AuthMetadata,
   BeginCheckoutMetadata,
@@ -139,16 +141,11 @@ export class GtmTelemetryProvider implements TelemetryProvider {
   }
 
   trackAuth(metadata: AuthMetadata): void {
+    const normalizedEmail = normalizeEmail(metadata.email)
     const payload = {
       method: metadata.method,
       ...(metadata.user_id ? { user_id: metadata.user_id } : {}),
-      ...(metadata.email
-        ? {
-            user_data: {
-              email: metadata.email.trim().toLowerCase()
-            }
-          }
-        : {})
+      ...(normalizedEmail ? { user_data: { email: normalizedEmail } } : {})
     }
 
     this.pushEvent(metadata.is_new_user ? 'sign_up' : 'login', payload)

--- a/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/ImpactTelemetryProvider.ts
@@ -1,4 +1,5 @@
 import { captureCheckoutAttributionFromSearch } from '@/platform/telemetry/utils/checkoutAttribution'
+import { normalizeEmail } from '@/platform/telemetry/utils/normalizeEmail'
 import { useApiKeyAuthStore } from '@/stores/apiKeyAuthStore'
 import { useAuthStore } from '@/stores/authStore'
 
@@ -85,7 +86,7 @@ export class ImpactTelemetryProvider implements TelemetryProvider {
     if (typeof window === 'undefined') return
 
     const { customerId, customerEmail } = this.resolveCustomerIdentity()
-    const normalizedEmail = customerEmail.trim().toLowerCase()
+    const normalizedEmail = normalizeEmail(customerEmail)
     // Impact's Identify spec requires customerEmail to be sent as a SHA1 hash.
     const hashedEmail = normalizedEmail
       ? await this.hashSha1(normalizedEmail)

--- a/src/platform/telemetry/providers/cloud/SyftTelemetryProvider.test.ts
+++ b/src/platform/telemetry/providers/cloud/SyftTelemetryProvider.test.ts
@@ -1,0 +1,384 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCurrentUser = vi.hoisted(() => ({
+  userEmail: { value: undefined as string | undefined },
+  useCurrentUser: vi.fn()
+}))
+
+const mockRemoteConfig = vi.hoisted(() => ({
+  value: {} as { syftdata_source_id?: string }
+}))
+
+vi.mock('@/composables/auth/useCurrentUser', () => ({
+  useCurrentUser: mockCurrentUser.useCurrentUser
+}))
+
+vi.mock('@/platform/remoteConfig/remoteConfig', () => ({
+  remoteConfig: mockRemoteConfig
+}))
+
+const SYFT_SRC = 'https://cdn.sy-d.io/syftnext/syft.umd.js'
+
+async function importProvider() {
+  const { SyftTelemetryProvider } =
+    await import('@/platform/telemetry/providers/cloud/SyftTelemetryProvider')
+  return SyftTelemetryProvider
+}
+
+function installSyftSpy(): SyftDataClient {
+  const syft = {
+    identify: vi.fn(),
+    signup: vi.fn(),
+    track: vi.fn(),
+    page: vi.fn()
+  } satisfies SyftDataClient
+
+  window.syft = syft
+  return syft
+}
+
+function mockScriptAppend() {
+  return vi
+    .spyOn(document.head, 'appendChild')
+    .mockImplementation(<T extends Node>(node: T) => node)
+}
+
+function syftStub(): SyftDataClient {
+  const syft = window.syft
+  if (!syft || !('identify' in syft)) {
+    throw new Error('Expected a full Syft client on window')
+  }
+  return syft
+}
+
+function failScript(
+  appendChild: ReturnType<typeof mockScriptAppend>,
+  index: number
+) {
+  const script = appendChild.mock.calls[index]?.[0]
+  if (!(script instanceof HTMLScriptElement)) {
+    throw new Error('Expected Syft script to be appended')
+  }
+  script.dispatchEvent(new Event('error'))
+}
+
+describe('SyftTelemetryProvider', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    document.head.innerHTML = ''
+    window.__CONFIG__ = {}
+    mockRemoteConfig.value = {}
+    window.syft = undefined
+    window.syftc = undefined
+    mockCurrentUser.userEmail.value = undefined
+    mockCurrentUser.useCurrentUser.mockReturnValue({
+      userEmail: mockCurrentUser.userEmail
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('loads the Syft SDK once when a source id is configured', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider()
+
+    expect(appendChild).toHaveBeenCalledTimes(1)
+    const appended = appendChild.mock.calls[0]?.[0]
+    if (!(appended instanceof HTMLScriptElement)) {
+      throw new Error('Expected Syft script to be appended')
+    }
+
+    expect(window.syftc).toEqual({ sourceId: 'src-123' })
+    expect(appended.src).toBe(SYFT_SRC)
+  })
+
+  it('clears the stub after SDK load failure so later calls can retry', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+    const provider = new SyftTelemetryProvider()
+
+    failScript(appendChild, 0)
+    await Promise.resolve()
+
+    expect(window.syft).toBeUndefined()
+
+    provider.trackAuth({
+      email: 'retry@example.com',
+      is_new_user: false,
+      method: 'email'
+    })
+
+    expect(appendChild).toHaveBeenCalledTimes(2)
+    expect(syftStub().q).toContainEqual([
+      'identify',
+      'retry@example.com',
+      { source: 'login', method: 'email' }
+    ])
+  })
+
+  it('replays a pending identify with its original traits after SDK load failure', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackAuth({
+      email: 'new@example.com',
+      is_new_user: true,
+      method: 'google'
+    })
+
+    failScript(appendChild, 0)
+    await Promise.resolve()
+
+    expect(appendChild).toHaveBeenCalledTimes(2)
+    expect(syftStub().q).toContainEqual([
+      'identify',
+      'new@example.com',
+      { source: 'signup', method: 'google' }
+    ])
+  })
+
+  it('replays at most once but still allows a later manual retry', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    mockCurrentUser.userEmail.value = 'restored@example.com'
+    const SyftTelemetryProvider = await importProvider()
+    const provider = new SyftTelemetryProvider()
+
+    provider.trackUserLoggedIn()
+
+    failScript(appendChild, 0)
+    await Promise.resolve()
+    failScript(appendChild, 1)
+    await Promise.resolve()
+
+    expect(appendChild).toHaveBeenCalledTimes(2)
+    expect(window.syft).toBeUndefined()
+
+    provider.trackUserLoggedIn()
+
+    expect(appendChild).toHaveBeenCalledTimes(3)
+    expect(syftStub().q).toContainEqual([
+      'identify',
+      'restored@example.com',
+      { source: 'login' }
+    ])
+  })
+
+  it('leaves an externally installed client untouched on script error', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackAuth({
+      email: 'new@example.com',
+      is_new_user: true,
+      method: 'google'
+    })
+
+    const syft = installSyftSpy()
+
+    failScript(appendChild, 0)
+    await Promise.resolve()
+
+    expect(window.syft).toBe(syft)
+    expect(appendChild).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects pending fetchID promises when the SDK fails to load', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider()
+    const pending = syftStub().fetchID?.('anonymousId')
+
+    failScript(appendChild, 0)
+
+    await expect(pending).rejects.toThrow('Script failed to load')
+  })
+
+  it('bootstraps on the first call after the source id arrives', async () => {
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+    const provider = new SyftTelemetryProvider()
+
+    expect(appendChild).not.toHaveBeenCalled()
+    expect(window.syftc).toBeUndefined()
+
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    provider.trackAuth({
+      email: 'late@example.com',
+      is_new_user: false,
+      method: 'email'
+    })
+
+    expect(appendChild).toHaveBeenCalledTimes(1)
+    expect(window.syftc).toEqual({ sourceId: 'src-123' })
+    expect(syftStub().q).toContainEqual([
+      'identify',
+      'late@example.com',
+      { source: 'login', method: 'email' }
+    ])
+  })
+
+  it('preserves an existing opt-out flag when writing the source id', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    window.syftc = { enabled: false }
+    mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider()
+
+    expect(window.syftc).toEqual({ enabled: false, sourceId: 'src-123' })
+  })
+
+  it('skips identify when Syft installed its disabled-mode client', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const appendChild = mockScriptAppend()
+    const disabledClient = { enable: vi.fn() }
+    window.syft = disabledClient
+    const SyftTelemetryProvider = await importProvider()
+    const provider = new SyftTelemetryProvider()
+
+    expect(() =>
+      provider.trackAuth({
+        email: 'optedout@example.com',
+        is_new_user: false,
+        method: 'email'
+      })
+    ).not.toThrow()
+    expect(window.syft).toBe(disabledClient)
+    expect(appendChild).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the current user store during construction', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider()
+
+    expect(mockCurrentUser.useCurrentUser).not.toHaveBeenCalled()
+  })
+
+  it('preserves an existing GTM-loaded Syft client and script', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    const syft = installSyftSpy()
+    const appendChild = mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider()
+
+    expect(window.syft).toBe(syft)
+    expect(appendChild).not.toHaveBeenCalled()
+  })
+
+  it('identifies new auth users with signup source and normalized email', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    mockScriptAppend()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackAuth({
+      email: ' New@Example.COM ',
+      is_new_user: true,
+      method: 'google'
+    })
+
+    expect(syftStub().q).toContainEqual([
+      'identify',
+      'new@example.com',
+      { source: 'signup', method: 'google' }
+    ])
+  })
+
+  it('identifies returning auth users with login source', async () => {
+    const syft = installSyftSpy()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackAuth({
+      email: 'back@example.com',
+      is_new_user: false,
+      method: 'github'
+    })
+
+    expect(syft.identify).toHaveBeenCalledWith('back@example.com', {
+      source: 'login',
+      method: 'github'
+    })
+    expect(syft.signup).not.toHaveBeenCalled()
+  })
+
+  it('defaults unknown auth state to login source', async () => {
+    const syft = installSyftSpy()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackAuth({
+      email: 'unknown@example.com',
+      method: 'email'
+    })
+
+    expect(syft.identify).toHaveBeenCalledWith('unknown@example.com', {
+      source: 'login',
+      method: 'email'
+    })
+  })
+
+  it('skips auth tracking when email is unavailable', async () => {
+    const syft = installSyftSpy()
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackAuth({
+      is_new_user: true,
+      method: 'email'
+    })
+
+    expect(syft.identify).not.toHaveBeenCalled()
+    expect(syft.signup).not.toHaveBeenCalled()
+  })
+
+  it('identifies restored sessions from the current user store', async () => {
+    mockRemoteConfig.value = { syftdata_source_id: 'src-123' }
+    mockScriptAppend()
+    mockCurrentUser.userEmail.value = 'Restored@Example.com'
+    const SyftTelemetryProvider = await importProvider()
+
+    new SyftTelemetryProvider().trackUserLoggedIn()
+
+    expect(mockCurrentUser.useCurrentUser).toHaveBeenCalled()
+    expect(syftStub().q).toContainEqual([
+      'identify',
+      'restored@example.com',
+      { source: 'login' }
+    ])
+  })
+
+  it('does not immediately re-identify the same email after auth tracking', async () => {
+    const syft = installSyftSpy()
+    mockCurrentUser.userEmail.value = 'new@example.com'
+    const SyftTelemetryProvider = await importProvider()
+    const provider = new SyftTelemetryProvider()
+
+    provider.trackAuth({
+      email: 'new@example.com',
+      is_new_user: true,
+      method: 'google'
+    })
+    provider.trackUserLoggedIn()
+
+    expect(syft.identify).toHaveBeenCalledTimes(1)
+    expect(syft.identify).toHaveBeenCalledWith('new@example.com', {
+      source: 'signup',
+      method: 'google'
+    })
+    expect(syft.signup).not.toHaveBeenCalled()
+  })
+})

--- a/src/platform/telemetry/providers/cloud/SyftTelemetryProvider.ts
+++ b/src/platform/telemetry/providers/cloud/SyftTelemetryProvider.ts
@@ -1,0 +1,124 @@
+import { useCurrentUser } from '@/composables/auth/useCurrentUser'
+import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
+import { normalizeEmail } from '@/platform/telemetry/utils/normalizeEmail'
+import { createScriptLoader } from '@/utils/loadExternalScript'
+
+import type { AuthMetadata, AuthMethod, TelemetryProvider } from '../../types'
+
+const SYFT_SRC = 'https://cdn.sy-d.io/syftnext/syft.umd.js'
+
+let currentStub: SyftDataClient | null = null
+let lastIdentifiedEmail: string | null = null
+let pendingIdentify: { email: string; traits: SyftDataTraits } | null = null
+let hasReplayedIdentify = false
+
+const loadSyftSdk = createScriptLoader<SyftDataClient | SyftDisabledClient>(
+  SYFT_SRC,
+  () => (window.syft && window.syft !== currentStub ? window.syft : null)
+)
+
+function createTraits(
+  source: 'signup' | 'login',
+  method?: AuthMethod
+): SyftDataTraits {
+  return method ? { source, method } : { source }
+}
+
+function createSyftStub(): SyftDataClient {
+  const q: unknown[][] = []
+  const fi: SyftDataPendingFetch[] = []
+
+  function enqueue(method: string) {
+    return (...args: unknown[]) => {
+      q.push([method, ...args])
+    }
+  }
+
+  function fetchID(...args: unknown[]): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      fi.push({ args, resolve, reject })
+    })
+  }
+
+  return {
+    q,
+    fi,
+    fetchID,
+    identify: enqueue('identify'),
+    signup: enqueue('signup'),
+    track: enqueue('track'),
+    page: enqueue('page')
+  }
+}
+
+function ensureSyftClient(): SyftDataClient | SyftDisabledClient | null {
+  const sourceId = remoteConfig.value.syftdata_source_id
+  if (!sourceId) return window.syft ?? null
+
+  window.syftc = { ...window.syftc, sourceId }
+  if (window.syft) return window.syft
+
+  const stub = createSyftStub()
+  currentStub = stub
+  window.syft = stub
+
+  loadSyftSdk().then(
+    () => {
+      pendingIdentify = null
+    },
+    (error: unknown) => {
+      const stubOwnsGlobal = window.syft === stub
+      if (stubOwnsGlobal) {
+        delete window.syft
+        lastIdentifiedEmail = null
+        stub.fi?.forEach((pending) => pending.reject(error))
+      }
+      if (currentStub === stub) {
+        currentStub = null
+      }
+      console.warn('[Syft] SDK failed to load', error)
+      if (stubOwnsGlobal) replayPendingIdentify()
+    }
+  )
+
+  return window.syft
+}
+
+function replayPendingIdentify(): void {
+  if (!pendingIdentify || hasReplayedIdentify) return
+
+  hasReplayedIdentify = true
+  identifyUser(pendingIdentify.email, pendingIdentify.traits)
+}
+
+function identifyUser(email: string, traits: SyftDataTraits): void {
+  const syft = ensureSyftClient()
+  if (!syft || !('identify' in syft)) return
+
+  syft.identify(email, traits)
+  lastIdentifiedEmail = email
+  pendingIdentify = syft === currentStub ? { email, traits } : null
+}
+
+export class SyftTelemetryProvider implements TelemetryProvider {
+  constructor() {
+    ensureSyftClient()
+  }
+
+  trackAuth({ email, is_new_user, method }: AuthMetadata): void {
+    const normalizedEmail = normalizeEmail(email)
+    if (!normalizedEmail) return
+
+    identifyUser(
+      normalizedEmail,
+      createTraits(is_new_user ? 'signup' : 'login', method)
+    )
+  }
+
+  trackUserLoggedIn(): void {
+    const normalizedEmail = normalizeEmail(useCurrentUser().userEmail.value)
+    if (!normalizedEmail || normalizedEmail === lastIdentifiedEmail) return
+
+    identifyUser(normalizedEmail, createTraits('login'))
+  }
+}

--- a/src/platform/telemetry/types.ts
+++ b/src/platform/telemetry/types.ts
@@ -17,6 +17,8 @@ import type { TierKey } from '@/platform/cloud/subscription/constants/tierPricin
 import type { BillingCycle } from '@/platform/cloud/subscription/utils/subscriptionTierRank'
 import type { AuditLog } from '@/services/customerEventsService'
 
+export type AuthMethod = 'email' | 'google' | 'github'
+
 export type PaymentIntentSource =
   | 'subscription_required'
   | 'out_of_credits'
@@ -39,7 +41,7 @@ export type SubscriptionCheckoutTier = TierKey | 'team'
  * Authentication metadata for sign-up tracking
  */
 export interface AuthMetadata {
-  method?: 'email' | 'google' | 'github'
+  method?: AuthMethod
   is_new_user?: boolean
   user_id?: string
   email?: string

--- a/src/platform/telemetry/utils/normalizeEmail.ts
+++ b/src/platform/telemetry/utils/normalizeEmail.ts
@@ -1,0 +1,5 @@
+export function normalizeEmail(
+  email: string | null | undefined
+): string | null {
+  return email?.trim().toLowerCase() || null
+}


### PR DESCRIPTION
Backport of #13311 to cloud/1.45.

Note: #13311 is still open on main; this was applied from PR head a8b60c6 via 3-way apply of the PR diff. No conflicts. Typecheck passes; the 17 new SyftTelemetryProvider tests pass. Pre-existing telemetry test failures on cloud/1.45 are unchanged (81 before and after).

Adds a cloud-only Syft telemetry provider that reads syftdata_source_id from remoteConfig, lazy-loads the Syft SDK (reusing an already-loaded GTM Syft client when present), and calls identify with source 'signup' or 'login' on auth and on session restore.