### PR TITLE
chore: add CodeRabbit path instructions for tests and Vue components

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,6 +73,10 @@ reviews:
         Use a real createI18n instance rather than vi.mock('vue-i18n').
         Flag bare expect(fn).not.toThrow() as a sole assertion, assertions that echo stub return values, and .mock.results assertions.
         Use @testing-library/vue for component tests, not @vue/test-utils.
+        For platform-owned types (Response, CustomEvent, DOM events), require real instances (new Response(), Response.json(), new CustomEvent()) instead of fromPartial or casts.
+        When a fixture cast hides a too-wide production signature, suggest narrowing the production type instead of casting the fixture.
+        Flag process-level listeners (process.on('unhandledRejection')) in tests; assert the rejected promise directly.
+        Tests should import the module under test from its public entrypoint, not deep internal paths.
     - path: 'browser_tests/**/*.spec.ts'
       instructions: |
         Every route.fulfill() body must be typed with generated types or schemas from packages/ingest-types, packages/registry-types, src/workbench/extensions/manager/types/generatedManagerTypes.ts, or src/schemas/; flag untyped inline JSON objects.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -63,3 +63,25 @@ reviews:
           Pass if none of these patterns are found in the diff.
 
           When warning, reference the specific ADR by number and link to `docs/adr/` for context. Frame findings as directional guidance since ADR 0003 and 0008 are in Proposed status.
+
+  path_instructions:
+    - path: 'src/**/*.test.ts'
+      instructions: |
+        Build partial mocks with fromPartial<T>() from @total-typescript/shoehorn; flag `as unknown as` double assertions and fromAny().
+        Reuse shared factories in src/utils/__tests__/litegraphTestUtils.ts instead of hand-rolling mock builders.
+        Mock only at seams (Pinia stores, settings, third-party libs); flag mocked type guards, litegraph classes, or sibling composables.
+        Use a real createI18n instance rather than vi.mock('vue-i18n').
+        Flag bare expect(fn).not.toThrow() as a sole assertion, assertions that echo stub return values, and .mock.results assertions.
+        Use @testing-library/vue for component tests, not @vue/test-utils.
+    - path: 'browser_tests/**/*.spec.ts'
+      instructions: |
+        Every route.fulfill() body must be typed with generated types or schemas from packages/ingest-types, packages/registry-types, src/workbench/extensions/manager/types/generatedManagerTypes.ts, or src/schemas/; flag untyped inline JSON objects.
+        Never use waitForTimeout; use Locator actions and auto-retrying assertions instead.
+        Restrict page.evaluate() to reading internal state or fixture setup; flag any page.evaluate() that drives UI actions when a Playwright action method exists.
+        New shared test helpers must be Playwright fixtures via base.extend(), not properties added to ComfyPage.
+    - path: 'src/**/*.vue'
+      instructions: |
+        Do not introduce new PrimeVue component usage; use existing design-system components or Reka UI/shadcn-vue primitives.
+        Apply Tailwind semantic tokens from the design system; flag hardcoded hex colors and the dark: variant.
+        Merge classes via cn() from @comfyorg/tailwind-utils; flag :class="[]" array bindings.
+        Avoid <style> blocks except for documented third-party :deep() exceptions.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -65,7 +65,7 @@ reviews:
           When warning, reference the specific ADR by number and link to `docs/adr/` for context. Frame findings as directional guidance since ADR 0003 and 0008 are in Proposed status.
 
   path_instructions:
-    - path: 'src/**/*.test.ts'
+    - path: '{src,packages,apps}/**/*.test.ts'
       instructions: |
         Build partial mocks with fromPartial<T>() from @total-typescript/shoehorn; flag `as unknown as` double assertions and fromAny().
         Reuse shared factories in src/utils/__tests__/litegraphTestUtils.ts instead of hand-rolling mock builders.


### PR DESCRIPTION
## Summary

Adds glob-scoped `path_instructions` to `.coderabbit.yaml` so CodeRabbit enforces project conventions that cannot be caught by lint or typecheck.

## Changes

- **What**: Three `path_instructions` entries under `reviews:` in `.coderabbit.yaml`
  - `src/**/*.test.ts` — mock hygiene (fromPartial, no double assertions, seam-only mocks, real i18n, @testing-library/vue)
  - `browser_tests/**/*.spec.ts` — typed route.fulfill() bodies, no waitForTimeout, page.evaluate() scope, fixture-based helpers
  - `src/**/*.vue` — no new PrimeVue, semantic Tailwind tokens, cn() for class merging, no \<style\> blocks

## Review Focus

- CodeRabbit schema conformance: `path_instructions` list shape under `reviews:`
- Instruction prose is concise and imperative (reviewer guidance, not policy docs)
- Complements #13408 (context delivery) and warn-level lint without duplicating what tools already catch
