### PR TITLE
chore(lint): warn on double assertions, fromAny, and vue-i18n mocks in unit tests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -337,6 +337,29 @@ export default defineConfig([
     }
   },
   {
+    files: ['**/*.test.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: 'TSAsExpression > TSAsExpression.expression',
+          message:
+            'Double type assertion. Use fromPartial<T>() from @total-typescript/shoehorn instead.'
+        },
+        {
+          selector: "ImportSpecifier[imported.name='fromAny']",
+          message: 'fromAny erases type checking. Use fromPartial<T>() instead.'
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='vi'][callee.property.name='mock'] > Literal[value='vue-i18n']",
+          message:
+            'Do not mock vue-i18n. Use a real createI18n instance (see src/components/searchbox/v2/__test__/testUtils.ts).'
+        }
+      ]
+    }
+  },
+  {
     files: ['scripts/**/*.js'],
     languageOptions: {
       globals: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -358,6 +358,12 @@ export default defineConfig([
             "CallExpression[callee.object.name='vi'][callee.property.name='mock'] > Literal[value='vue-i18n']",
           message:
             'Do not mock vue-i18n. Use a real createI18n instance (see src/components/searchbox/v2/__test__/testUtils.ts).'
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='vi'][callee.property.name='mock'] > ImportExpression > Literal[value='vue-i18n']",
+          message:
+            'Do not mock vue-i18n. Use a real createI18n instance (see src/components/searchbox/v2/__test__/testUtils.ts).'
         }
       ]
     }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -338,6 +338,9 @@ export default defineConfig([
   },
   {
     files: ['**/*.test.ts'],
+    // browser_tests is excluded so this warn-level entry does not override the
+    // error-level no-restricted-syntax guards defined above for those paths
+    ignores: ['browser_tests/**'],
     rules: {
       'no-restricted-syntax': [
         'warn',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -350,7 +350,8 @@ export default defineConfig([
             'Double type assertion. Use fromPartial<T>() from @total-typescript/shoehorn instead.'
         },
         {
-          selector: "ImportSpecifier[imported.name='fromAny']",
+          selector:
+            "ImportDeclaration[source.value='@total-typescript/shoehorn'] > ImportSpecifier[imported.name='fromAny']",
           message: 'fromAny erases type checking. Use fromPartial<T>() instead.'
         },
         {


### PR DESCRIPTION
## Summary

Three patterns generated ~165 review comments across recent test PRs; warn-level now so open PRs can remediate, will flip to error after.

## Changes

- **What**: Adds a new `**/*.test.ts` ESLint config block with three `no-restricted-syntax` warn-level rules:
  - Double type assertion (`x as unknown as T`) — nudges toward `fromPartial<T>()` from `@total-typescript/shoehorn`
  - `fromAny` import from `@total-typescript/shoehorn` — erases type checking, `fromPartial<T>()` preferred
  - `vi.mock('vue-i18n')` — directs to real `createI18n` instances instead

## Review Focus

- Selector correctness: `TSAsExpression > TSAsExpression.expression` catches the inner node of `x as unknown as T`; verified against `layoutStore.test.ts`
- All three rules emit warnings (exit 0) and do not affect non-test files
- No existing `no-restricted-syntax` rules for `**/*.test.ts` were touched or downgraded

## Known gap

`src/scripts/*` is in the global ESLint `ignores` (eslint.config.ts), so these rules do not fire on test files there. Remediation of the open test PRs metered those paths by grep instead. Narrowing the global ignore for `src/scripts/**/*.test.ts` would enable every rule (not just these) on legacy-adjacent tests, so it is deferred to the warn-to-error follow-up.
