### PR TITLE
fix: restore preview text after workflow tab switch

### DIFF
--- a/browser_tests/tests/previewAsText.spec.ts
+++ b/browser_tests/tests/previewAsText.spec.ts
@@ -3,7 +3,7 @@ import {
   comfyExpect as expect
 } from '@e2e/fixtures/ComfyPage'
 
-test.describe('Preview as Text node', () => {
+test.describe('Preview as Text node', { tag: ['@node', '@widget'] }, () => {
   test('does not include preview widget values in the API prompt', async ({
     comfyPage
   }) => {
@@ -38,5 +38,42 @@ test.describe('Preview as Text node', () => {
     expect(previewEntry!.inputs).not.toHaveProperty('preview_markdown')
     expect(previewEntry!.inputs).not.toHaveProperty('preview_text')
     expect(previewEntry!.inputs).not.toHaveProperty('previewMode')
+  })
+
+  test('restores displayed text after switching workflow tabs', async ({
+    comfyPage
+  }) => {
+    await comfyPage.page.evaluate(() => {
+      const node = window.LiteGraph!.createNode('PreviewAny')!
+      node.pos = [500, 200]
+      window.app!.graph.add(node)
+    })
+
+    await comfyPage.menu.topbar.saveWorkflow('preview-as-text-restore')
+
+    const previewText = 'rendered preview content from previous execution'
+    await comfyPage.page.evaluate((text) => {
+      const node = window.app!.graph.nodes.find((n) => n.type === 'PreviewAny')!
+      window.app!.nodeOutputs = {
+        [String(node.id)]: { text }
+      }
+    }, previewText)
+
+    const previewTextWidgetValue = () =>
+      comfyPage.page.evaluate(() => {
+        const node = window.app!.graph.nodes.find(
+          (n) => n.type === 'PreviewAny'
+        )
+        return node?.widgets?.find((w) => w.name === 'preview_text')?.value
+      })
+
+    await expect.poll(previewTextWidgetValue).toBe(previewText)
+
+    await comfyPage.command.executeCommand('Comfy.NewBlankWorkflow')
+    await comfyPage.workflow.waitForWorkflowIdle()
+
+    await comfyPage.workflow.switchToTab('preview-as-text-restore')
+
+    await expect.poll(previewTextWidgetValue).toBe(previewText)
   })
 })

--- a/docs/extensions/core.md
+++ b/docs/extensions/core.md
@@ -54,6 +54,13 @@ The following table lists ALL core extensions in the system as of 2025-01-30:
 | webcamCapture.ts        | Provides webcam capture capabilities                         | Media     |
 | widgetInputs.ts         | Implements various widget input types                        | Widgets   |
 
+### PreviewAny Compatibility
+
+`Comfy.PreviewAny` reapplies restored runtime outputs to its own
+`preview_markdown` and `preview_text` widgets when `onNodeOutputsUpdated` fires,
+matching the values set after execution. This is limited to nodes whose
+`comfyClass` is `PreviewAny`.
+
 ### Conditional Lines Subdirectory
 
 Located in `extensions/core/load3d/conditional-lines/`:

--- a/src/extensions/core/previewAny.test.ts
+++ b/src/extensions/core/previewAny.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { NodeExecutionOutput } from '@/schemas/apiSchema'
 import type { ComfyExtension } from '@/types/comfy'
+import { toNodeId } from '@/types/nodeId'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { createNodeLocatorId } from '@/types/nodeIdentification'
 
 const { getNodeByLocatorIdMock } = vi.hoisted(() => ({
   getNodeByLocatorIdMock: vi.fn()
@@ -40,7 +44,7 @@ interface MockNode {
 
 type PreviewAnyExtension = ComfyExtension & {
   onNodeOutputsUpdated: (
-    nodeOutputs: Record<string, { text?: string | string[] }>
+    nodeOutputs: Record<NodeLocatorId, NodeExecutionOutput>
   ) => void
 }
 
@@ -131,9 +135,10 @@ describe('PreviewAny extension', () => {
   it('restores preview widgets from node output updates', async () => {
     const { ext, node } = await setupNode()
     getNodeByLocatorIdMock.mockReturnValue(node)
+    const locatorId = createNodeLocatorId(null, toNodeId(1))
 
     ext.onNodeOutputsUpdated({
-      '1': { text: 'restored preview text' }
+      [locatorId]: { text: 'restored preview text' }
     })
 
     expect(

--- a/src/extensions/core/previewAny.test.ts
+++ b/src/extensions/core/previewAny.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComfyExtension } from '@/types/comfy'
 
+const { getNodeByLocatorIdMock } = vi.hoisted(() => ({
+  getNodeByLocatorIdMock: vi.fn()
+}))
+
 const capturedExtensions: ComfyExtension[] = []
 
 vi.mock('@/services/extensionService', () => ({
@@ -12,7 +16,11 @@ vi.mock('@/services/extensionService', () => ({
   })
 }))
 
-vi.mock('@/scripts/app', () => ({ app: {} }))
+vi.mock('@/scripts/app', () => ({ app: { rootGraph: {} } }))
+
+vi.mock('@/utils/graphTraversalUtil', () => ({
+  getNodeByLocatorId: getNodeByLocatorIdMock
+}))
 
 interface MockWidget {
   name: string
@@ -25,17 +33,23 @@ interface MockWidget {
   serialize?: boolean
 }
 
+interface MockNode {
+  widgets?: MockWidget[]
+  comfyClass?: string
+}
+
+type PreviewAnyExtension = ComfyExtension & {
+  onNodeOutputsUpdated: (
+    nodeOutputs: Record<string, { text?: string | string[] }>
+  ) => void
+}
+
 const createdWidgets: MockWidget[] = []
 
 vi.mock('@/scripts/widgets', () => {
   const create =
     (kind: string) =>
-    (
-      node: { widgets?: MockWidget[] },
-      name: string,
-      _info: unknown,
-      _app: unknown
-    ) => {
+    (node: MockNode, name: string, _info: unknown, _app: unknown) => {
       const widget: MockWidget = {
         name,
         options: {},
@@ -62,6 +76,7 @@ describe('PreviewAny extension', () => {
   beforeEach(async () => {
     capturedExtensions.length = 0
     createdWidgets.length = 0
+    getNodeByLocatorIdMock.mockReset()
     vi.resetModules()
     await import('./previewAny')
   })
@@ -83,10 +98,10 @@ describe('PreviewAny extension', () => {
       {} as Parameters<NonNullable<ComfyExtension['beforeRegisterNodeDef']>>[2]
     )
 
-    const node: { widgets?: MockWidget[] } = {}
+    const node: MockNode = { comfyClass: 'PreviewAny' }
     const proto = nodeType.prototype as { onNodeCreated?: () => void }
     proto.onNodeCreated!.call(node)
-    return node
+    return { ext: ext! as PreviewAnyExtension, node }
   }
 
   it('excludes preview widgets from the API prompt to prevent re-execution', async () => {
@@ -102,6 +117,7 @@ describe('PreviewAny extension', () => {
     expect(previewText).toBeDefined()
     expect(previewMode).toBeDefined()
 
+    expect(previewMode!.label).toBe('Preview Mode')
     // widget.options.serialize === false is what executionUtil.graphToPrompt
     // checks to exclude a widget from the API prompt sent to the backend.
     // Without this, post-execution widget value updates (the rendered preview
@@ -110,5 +126,21 @@ describe('PreviewAny extension', () => {
     expect(previewMarkdown!.options.serialize).toBe(false)
     expect(previewText!.options.serialize).toBe(false)
     expect(previewMode!.options.serialize).toBe(false)
+  })
+
+  it('restores preview widgets from node output updates', async () => {
+    const { ext, node } = await setupNode()
+    getNodeByLocatorIdMock.mockReturnValue(node)
+
+    ext.onNodeOutputsUpdated({
+      '1': { text: 'restored preview text' }
+    })
+
+    expect(
+      createdWidgets.find((w) => w.name === 'preview_markdown')?.value
+    ).toBe('restored preview text')
+    expect(createdWidgets.find((w) => w.name === 'preview_text')?.value).toBe(
+      'restored preview text'
+    )
   })
 })

--- a/src/extensions/core/previewAny.ts
+++ b/src/extensions/core/previewAny.ts
@@ -4,14 +4,35 @@ https://github.com/rgthree/rgthree-comfy/blob/main/py/display_any.py
 upstream requested in https://github.com/Kosinkadink/rfcs/blob/main/rfcs/0000-corenodes.md#preview-nodes
  */
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
+import type { NodeExecutionOutput } from '@/schemas/apiSchema'
 import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
 import { type DOMWidget } from '@/scripts/domWidget'
 import { ComfyWidgets } from '@/scripts/widgets'
 import { useExtensionService } from '@/services/extensionService'
+import type { NodeLocatorId } from '@/types/nodeIdentification'
+import { getNodeByLocatorId } from '@/utils/graphTraversalUtil'
+
+function updatePreviewWidgets(node: LGraphNode, output: NodeExecutionOutput) {
+  const widgets =
+    node.widgets?.filter((w) => w.name.startsWith('preview_')) ?? []
+
+  for (const widget of widgets) {
+    widget.value = Array.isArray(output.text)
+      ? output.text.join('\n\n')
+      : (output.text ?? '')
+  }
+}
 
 useExtensionService().registerExtension({
   name: 'Comfy.PreviewAny',
+  onNodeOutputsUpdated(outputs: Record<NodeLocatorId, NodeExecutionOutput>) {
+    for (const [locatorId, output] of Object.entries(outputs)) {
+      const node = getNodeByLocatorId(app.rootGraph, locatorId)
+      if (node?.comfyClass !== 'PreviewAny') continue
+      updatePreviewWidgets(node, output)
+    }
+  },
   async beforeRegisterNodeDef(
     nodeType: typeof LGraphNode,
     nodeData: ComfyNodeDef
@@ -69,6 +90,7 @@ useExtensionService().registerExtension({
         showValueWidgetPlain.element.readOnly = true
         showValueWidgetPlain.serialize = false
 
+        showAsPlaintextWidget.widget.label = 'Preview Mode'
         // The previewMode toggle is a frontend-only display preference and
         // is not declared in the backend INPUT_TYPES, so it must not be
         // serialized into the API prompt (would alter the cache signature).
@@ -82,15 +104,7 @@ useExtensionService().registerExtension({
           ? void 0
           : onExecuted.apply(this, [message])
 
-        const previewWidgets =
-          this.widgets?.filter((w) => w.name.startsWith('preview_')) ?? []
-
-        for (const previewWidget of previewWidgets) {
-          const text = message.text ?? ''
-          previewWidget.value = Array.isArray(text)
-            ? (text?.join('\n\n') ?? '')
-            : text
-        }
+        updatePreviewWidgets(this, message)
       }
     }
   }


### PR DESCRIPTION
## Summary

Restores `PreviewAny` preview text after workflow tab switches by replaying runtime node outputs into preview widgets, and relabels the `previewMode` toggle as "Preview Mode".

## Changes

- **What**: Added `onNodeOutputsUpdated` to `PreviewAny` to replay restored `nodeOutputStore` outputs into the preview widgets on tab restore. Set the `previewMode` toggle's display `label` to "Preview Mode" (internal name kept for API/serialization compat). Added unit tests and a Playwright regression.

## Review Focus

- Restore uses the existing `nodeOutputStore` snapshot/restore path instead of persisting generated text into workflow JSON, to keep saved workflows clean.
- `previewMode` widget name is unchanged; only the displayed label changes.

Fixes #12815

## Screenshots (if applicable)


https://github.com/user-attachments/assets/beb00ba2-de0d-4e9d-ae65-ab803ceab775
