### PR TITLE
chore(i18n): unify partner-node terminology to "Partner Nodes"

### DIFF
--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.test.ts
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.test.ts
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { createI18n } from 'vue-i18n'
 
+import type { SelectOption } from '@/components/ui/select/types'
 import enMain from '@/locales/en/main.json'
 import { useSettingStore } from '@/platform/settings/settingStore'
+import { RUNS_ON_PARTNER_NODES } from '@/composables/useTemplateFiltering'
 import { api } from '@/scripts/api'
 
 import WorkflowTemplateSelectorDialog from './WorkflowTemplateSelectorDialog.vue'
@@ -16,8 +18,6 @@ const SETTING_DEFAULTS: Record<string, unknown> = {
   'Comfy.Templates.SelectedRunsOn': [],
   'Comfy.Templates.SortBy': 'newest'
 }
-
-type SelectOption = { name: string; value: string }
 
 const { capturedOptionsByLabel } = vi.hoisted(() => ({
   capturedOptionsByLabel: new Map<string, SelectOption[]>()
@@ -99,5 +99,8 @@ describe('WorkflowTemplateSelectorDialog runs-on filter', () => {
 
     expect(optionNames).toContain('Partner Nodes')
     expect(optionNames).toContain('ComfyUI')
+
+    const partnerOption = runsOnOptions?.find((o) => o.name === 'Partner Nodes')
+    expect(partnerOption?.value).toBe(RUNS_ON_PARTNER_NODES)
   })
 })

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.test.ts
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.test.ts
@@ -1,0 +1,103 @@
+import { createTestingPinia } from '@pinia/testing'
+import { render } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import enMain from '@/locales/en/main.json'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { api } from '@/scripts/api'
+
+import WorkflowTemplateSelectorDialog from './WorkflowTemplateSelectorDialog.vue'
+
+const SETTING_DEFAULTS: Record<string, unknown> = {
+  'Comfy.Templates.SelectedModels': [],
+  'Comfy.Templates.SelectedUseCases': [],
+  'Comfy.Templates.SelectedRunsOn': [],
+  'Comfy.Templates.SortBy': 'newest'
+}
+
+type SelectOption = { name: string; value: string }
+
+const { capturedOptionsByLabel } = vi.hoisted(() => ({
+  capturedOptionsByLabel: new Map<string, SelectOption[]>()
+}))
+
+vi.mock(
+  '@/platform/workflow/templates/composables/useTemplateWorkflows',
+  () => ({
+    useTemplateWorkflows: () => ({
+      loadTemplates: vi.fn(),
+      loadWorkflowTemplate: vi.fn(),
+      getTemplateThumbnailUrl: () => '',
+      getTemplateTitle: () => '',
+      getTemplateDescription: () => ''
+    })
+  })
+)
+
+vi.mock('@/components/ui/multi-select/MultiSelect.vue', () => ({
+  default: defineComponent({
+    name: 'MultiSelect',
+    props: {
+      label: { type: String, default: '' },
+      options: { type: Array as () => SelectOption[], default: () => [] }
+    },
+    setup(props) {
+      return () => {
+        capturedOptionsByLabel.set(props.label, props.options)
+        return h('div')
+      }
+    }
+  })
+}))
+
+function renderDialog() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: enMain }
+  })
+
+  const pinia = createTestingPinia({ createSpy: vi.fn })
+  const settingStore = useSettingStore(pinia)
+  vi.mocked(settingStore.get).mockImplementation(
+    (key: string) => SETTING_DEFAULTS[key]
+  )
+
+  return render(WorkflowTemplateSelectorDialog, {
+    props: { onClose: vi.fn() },
+    global: {
+      plugins: [pinia, i18n],
+      stubs: {
+        SingleSelect: true,
+        BaseModalLayout: {
+          template: '<div><slot name="contentFilter" /></div>'
+        },
+        LeftSidePanel: true,
+        AsyncSearchInput: true,
+        ProgressSpinner: true
+      }
+    }
+  })
+}
+
+describe('WorkflowTemplateSelectorDialog runs-on filter', () => {
+  beforeEach(() => {
+    capturedOptionsByLabel.clear()
+    vi.spyOn(Date, 'now').mockReturnValue(0)
+    vi.spyOn(api, 'getFuseOptions').mockResolvedValue(null)
+  })
+
+  it('labels the partner-nodes runs-on option as "Partner Nodes"', () => {
+    renderDialog()
+
+    const runsOnOptions = capturedOptionsByLabel.get(
+      enMain.templateWorkflows.runsOnFilter
+    )
+    const optionNames = runsOnOptions?.map((o) => o.name)
+
+    expect(optionNames).toContain('Partner Nodes')
+    expect(optionNames).toContain('ComfyUI')
+  })
+})

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -426,7 +426,10 @@ import LeftSidePanel from '@/components/widget/panel/LeftSidePanel.vue'
 import { useIntersectionObserver } from '@/composables/useIntersectionObserver'
 import { useLazyPagination } from '@/composables/useLazyPagination'
 import { usePrimeVueOverlayChildStyle } from '@/composables/usePopoverSizing'
-import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
+import {
+  runsOnDisplayNameKey,
+  useTemplateFiltering
+} from '@/composables/useTemplateFiltering'
 import { useTelemetry } from '@/platform/telemetry'
 import { useTemplateWorkflows } from '@/platform/workflow/templates/composables/useTemplateWorkflows'
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
@@ -643,9 +646,7 @@ const selectedUseCaseObjects = computed({
 })
 
 const runsOnDisplayName = (runsOn: string) =>
-  runsOn === 'External or Remote API'
-    ? t('templateWorkflows.runsOnPartnerNodes', 'Partner Nodes')
-    : runsOn
+  t(runsOnDisplayNameKey(runsOn), runsOn)
 
 const selectedRunsOnObjects = computed({
   get() {

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -643,7 +643,9 @@ const selectedUseCaseObjects = computed({
 })
 
 const runsOnDisplayName = (runsOn: string) =>
-  runsOn === 'External or Remote API' ? 'Partner Nodes' : runsOn
+  runsOn === 'External or Remote API'
+    ? t('templateWorkflows.runsOnPartnerNodes', 'Partner Nodes')
+    : runsOn
 
 const selectedRunsOnObjects = computed({
   get() {

--- a/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
+++ b/src/components/custom/widget/WorkflowTemplateSelectorDialog.vue
@@ -642,10 +642,13 @@ const selectedUseCaseObjects = computed({
   }
 })
 
+const runsOnDisplayName = (runsOn: string) =>
+  runsOn === 'External or Remote API' ? 'Partner Nodes' : runsOn
+
 const selectedRunsOnObjects = computed({
   get() {
     return selectedRunsOn.value.map((runsOn) => ({
-      name: runsOn,
+      name: runsOnDisplayName(runsOn),
       value: runsOn
     }))
   },
@@ -684,7 +687,7 @@ const useCaseOptions = computed(() =>
 
 const runsOnOptions = computed(() =>
   availableRunsOn.value.map((runsOn) => ({
-    name: runsOn,
+    name: runsOnDisplayName(runsOn),
     value: runsOn
   }))
 )

--- a/src/composables/useTemplateFiltering.test.ts
+++ b/src/composables/useTemplateFiltering.test.ts
@@ -5,7 +5,12 @@ import type { IFuseOptions } from 'fuse.js'
 
 import type { TemplateInfo } from '@/platform/workflow/templates/types/template'
 import { TemplateIncludeOnDistributionEnum } from '@/platform/workflow/templates/types/template'
-import { useTemplateFiltering } from '@/composables/useTemplateFiltering'
+import {
+  RUNS_ON_COMFYUI,
+  RUNS_ON_PARTNER_NODES,
+  runsOnDisplayNameKey,
+  useTemplateFiltering
+} from '@/composables/useTemplateFiltering'
 
 const defaultSettingStore = {
   get: vi.fn((key: string) => {
@@ -142,7 +147,10 @@ describe('useTemplateFiltering', () => {
       'Portrait',
       'Video'
     ])
-    expect(availableRunsOn.value).toEqual(['ComfyUI', 'External or Remote API'])
+    expect(availableRunsOn.value).toEqual([
+      RUNS_ON_COMFYUI,
+      RUNS_ON_PARTNER_NODES
+    ])
 
     searchQuery.value = 'enterprise'
     await nextTick()
@@ -152,7 +160,7 @@ describe('useTemplateFiltering', () => {
       'api-template'
     ])
 
-    selectedRunsOn.value = ['External or Remote API']
+    selectedRunsOn.value = [RUNS_ON_PARTNER_NODES]
     await nextTick()
     expect(filteredTemplates.value.map((template) => template.name)).toEqual([
       'api-template'
@@ -726,7 +734,7 @@ describe('useTemplateFiltering', () => {
       const { selectedRunsOn, filteredTemplates, filteredCount } =
         useTemplateFiltering(templates)
 
-      selectedRunsOn.value = ['External or Remote API']
+      selectedRunsOn.value = [RUNS_ON_PARTNER_NODES]
 
       expect(filteredCount.value).toBe(1)
       expect(filteredTemplates.value[0].name).toBe('api-cloud')
@@ -781,5 +789,17 @@ describe('useTemplateFiltering', () => {
       expect(filteredCount.value).toBe(1)
       expect(filteredTemplates.value[0].name).toBe('mac-template')
     })
+  })
+})
+
+describe('runsOnDisplayNameKey', () => {
+  it('maps the partner-nodes value to its i18n key', () => {
+    expect(runsOnDisplayNameKey(RUNS_ON_PARTNER_NODES)).toBe(
+      'templateWorkflows.runsOnPartnerNodes'
+    )
+  })
+
+  it('passes other values through unchanged', () => {
+    expect(runsOnDisplayNameKey(RUNS_ON_COMFYUI)).toBe(RUNS_ON_COMFYUI)
   })
 })

--- a/src/composables/useTemplateFiltering.ts
+++ b/src/composables/useTemplateFiltering.ts
@@ -26,6 +26,15 @@ function isTemplateVisibleForDistributions(
   return distributions.some((d) => template.includeOnDistributions!.includes(d))
 }
 
+export const RUNS_ON_COMFYUI = 'ComfyUI'
+export const RUNS_ON_PARTNER_NODES = 'External or Remote API'
+
+export function runsOnDisplayNameKey(runsOn: string): string {
+  return runsOn === RUNS_ON_PARTNER_NODES
+    ? 'templateWorkflows.runsOnPartnerNodes'
+    : runsOn
+}
+
 // Fuse.js configuration for fuzzy search
 const defaultFuseOptions: IFuseOptions<TemplateInfo> = {
   keys: [
@@ -126,7 +135,7 @@ export function useTemplateFiltering(
   })
 
   const availableRunsOn = computed(() => {
-    return ['ComfyUI', 'External or Remote API']
+    return [RUNS_ON_COMFYUI, RUNS_ON_PARTNER_NODES]
   })
 
   // Compute which selected filters are actually applicable to the current scope
@@ -211,9 +220,9 @@ export function useTemplateFiltering(
       const isComfyUI = template.openSource !== false
 
       return selectedRunsOn.value.some((runsOn) => {
-        if (runsOn === 'External or Remote API') {
+        if (runsOn === RUNS_ON_PARTNER_NODES) {
           return isExternalAPI
-        } else if (runsOn === 'ComfyUI') {
+        } else if (runsOn === RUNS_ON_COMFYUI) {
           return isComfyUI
         }
         return false

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1546,7 +1546,7 @@
     "Light": "Light",
     "User": "User",
     "Credits": "Credits",
-    "API Nodes": "API Nodes",
+    "API Nodes": "Partner Nodes",
     "Notification Preferences": "Notification Preferences",
     "3DViewer": "3DViewer",
     "Canvas Navigation": "Canvas Navigation",
@@ -2011,11 +2011,11 @@
     "accessRestrictedMessage": "Your account is not authorized for this feature."
   },
   "apiNodesSignInDialog": {
-    "title": "Sign In Required to Use API Nodes",
-    "message": "This workflow contains API Nodes, which require you to be signed in to your account in order to run."
+    "title": "Sign In Required to Use Partner Nodes",
+    "message": "This workflow contains Partner Nodes, which require you to be signed in to your account in order to run."
   },
   "apiNodesCostBreakdown": {
-    "title": "API Node(s)",
+    "title": "Partner Nodes",
     "costPerRun": "Cost per run",
     "totalCost": "Total Cost"
   },
@@ -2289,7 +2289,7 @@
     "apiKey": {
       "title": "API Key",
       "label": "API Key",
-      "description": "Use your Comfy API key to enable API Nodes",
+      "description": "Use your Comfy API key to enable Partner Nodes",
       "placeholder": "Enter your API Key",
       "error": "Invalid API Key",
       "storageFailed": "Failed to store API Key",
@@ -2406,7 +2406,7 @@
       "cancel": "Cancel"
     },
     "loginButton": {
-      "tooltipHelp": "Login to be able to use \"API Nodes\"",
+      "tooltipHelp": "Login to be able to use \"Partner Nodes\"",
       "tooltipLearnMore": "Learn more..."
     }
   },

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1154,6 +1154,7 @@
     "useCasesSelected": "{count} Use Cases",
     "runsOnSelected": "{count} Runs On",
     "runsOnFilter": "Runs on",
+    "runsOnPartnerNodes": "Partner Nodes",
     "resultsCount": "Showing {count} of {total} templates",
     "sort": {
       "recommended": "Recommended",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -289,7 +289,7 @@
     }
   },
   "Comfy_NodeBadge_ShowApiPricing": {
-    "name": "Show API node pricing badge"
+    "name": "Show Partner node pricing badge"
   },
   "Comfy_NodeLibrary_NewDesign": {
     "name": "New Node Library Design",

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -473,7 +473,7 @@ export const CORE_SETTINGS: SettingParams[] = [
   {
     id: 'Comfy.NodeBadge.ShowApiPricing',
     category: ['Comfy', 'API Nodes'],
-    name: 'Show API node pricing badge',
+    name: 'Show Partner node pricing badge',
     type: 'boolean',
     defaultValue: true,
     versionAdded: '1.20.3'

--- a/src/services/nodeOrganizationService.test.ts
+++ b/src/services/nodeOrganizationService.test.ts
@@ -256,7 +256,7 @@ describe('nodeOrganizationService', () => {
     describe('source grouping edge cases', () => {
       const strategy = nodeOrganizationService.getGroupingStrategy('source')
 
-      it('should handle API nodes', () => {
+      it('should handle partner nodes', () => {
         const nodeDef = createMockNodeDef({
           api_node: true,
           nodeSource: {
@@ -267,7 +267,7 @@ describe('nodeOrganizationService', () => {
           }
         })
         const path = strategy?.getNodePath(nodeDef)
-        expect(path).toEqual(['API nodes', 'TestNode'])
+        expect(path).toEqual(['Partner Nodes', 'TestNode'])
       })
 
       it('should handle unknown source type', () => {

--- a/src/services/nodeOrganizationService.ts
+++ b/src/services/nodeOrganizationService.ts
@@ -78,7 +78,7 @@ class NodeOrganizationService {
       description: 'sideToolbar.nodeLibraryTab.groupStrategies.sourceDesc',
       getNodePath: (nodeDef: ComfyNodeDefImpl) => {
         if (nodeDef.api_node) {
-          return ['API nodes', nodeDef.name]
+          return ['Partner Nodes', nodeDef.name]
         } else if (nodeDef.nodeSource.type === NodeSourceType.Core) {
           return ['Core', nodeDef.name]
         } else if (nodeDef.nodeSource.type === NodeSourceType.CustomNodes) {


### PR DESCRIPTION
## Summary

The same concept was labeled three ways in the UI — "API Nodes", "API Node(s)", and "External or Remote API". Every user-facing occurrence now reads "Partner Nodes".

## Changes

**What:**
- Sign-in dialog, cost breakdown, settings category, API-key description, and login tooltip now say "Partner Nodes".
- Pricing-badge setting renamed to "Show Partner node pricing badge".
- Node Library "Source" grouping lists partner nodes under a "Partner Nodes" bucket.
- Template "Runs On" filter shows a localized "Partner Nodes" label, mapped from its stored value at display time.

**Breaking:** None. Persisted filter values, the settings category key, and the `api_node` API field are untouched — only display text changed.

## Review Focus

**Why the template filter keeps its old internal value.** The `'External or Remote API'` literal is the value persisted to `Comfy.Templates.SelectedRunsOn` and compared during filtering — not just a label. Renaming it at the root would orphan every user's saved selection and force a settings migration. So the stored value stays stable and only the display is remapped and localized. Renaming that internal token cleanly (enum + migration) is a fair follow-up, out of scope here.

Scope is English-source only; other locales regenerate from `en` via the `lobe-i18n` pipeline. i18n keys, type/component names, and comments were left alone.

## Testing

The node-library grouping asserts on the exact path label, so its test moved in lockstep. The template-filter test intentionally still asserts the stored `'External or Remote API'` value, proving the rename didn't leak into persisted state.

- `nodeOrganizationService.test.ts` — partner nodes group under the "Partner Nodes" path.
- `useTemplateFiltering.test.ts` — unchanged; confirms the display rename didn't touch stored state.

Gate: `pnpm typecheck` and `pnpm lint` clean, 4 affected unit suites pass (94 tests). Manual: verified the "Runs On" filter, settings category, and pricing-badge label all render the new copy.
