### PR TITLE
refactor: host-scoped promoted widget rows (no source traversal)

### DIFF
--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -143,14 +143,6 @@ const { t } = useI18n()
 
 const getNodeParentGroup = inject(GetNodeParentGroupKey, null)
 
-function isWidgetShownOnParents(widget: IBaseWidget): boolean {
-  const id = widget.widgetId
-  if (!id) return false
-  return parents.some((parent) =>
-    parent.inputs.some((input) => input.widgetId === id)
-  )
-}
-
 const isEmpty = computed(() => widgets.value.length === 0)
 
 const displayLabel = computed(
@@ -386,7 +378,6 @@ defineExpose({
             :hidden-favorite-indicator="hiddenFavoriteIndicator"
             :show-node-name="showNodeName"
             :parents="parents"
-            :is-shown-on-parents="isWidgetShownOnParents(widget)"
             @update:widget-value="handleWidgetValueUpdate(node, widget, $event)"
             @reset-to-default="handleWidgetReset(node, widget, $event)"
           />

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -12,9 +12,7 @@ import {
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import { widgetPromotedSource } from '@/core/graph/subgraph/promotedInputWidget'
 import { resolvePromotedWidgetSource } from '@/core/graph/subgraph/resolvePromotedWidgetSource'
-import { isWidgetPromotedOnSubgraphNode } from '@/core/graph/subgraph/promotionUtils'
 import type { LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { SubgraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -145,29 +143,12 @@ const { t } = useI18n()
 
 const getNodeParentGroup = inject(GetNodeParentGroupKey, null)
 
-function isWidgetShownOnParents(
-  widgetNode: LGraphNode,
-  widget: IBaseWidget
-): boolean {
-  const source = widgetPromotedSource(widgetNode, widget)
-  return parents.some((parent) => {
-    if (source) {
-      const widgetNodeId = widgetNode.id
-      const interiorNodeId =
-        String(widgetNode.id) === String(parent.id)
-          ? source.nodeId
-          : widgetNodeId
-
-      return isWidgetPromotedOnSubgraphNode(parent, {
-        sourceNodeId: interiorNodeId,
-        sourceWidgetName: source.widgetName
-      })
-    }
-    return isWidgetPromotedOnSubgraphNode(parent, {
-      sourceNodeId: widgetNode.id,
-      sourceWidgetName: widget.name
-    })
-  })
+function isWidgetShownOnParents(widget: IBaseWidget): boolean {
+  const id = widget.widgetId
+  if (!id) return false
+  return parents.some((parent) =>
+    parent.inputs.some((input) => input.widgetId === id)
+  )
 }
 
 const isEmpty = computed(() => widgets.value.length === 0)
@@ -405,7 +386,7 @@ defineExpose({
             :hidden-favorite-indicator="hiddenFavoriteIndicator"
             :show-node-name="showNodeName"
             :parents="parents"
-            :is-shown-on-parents="isWidgetShownOnParents(node, widget)"
+            :is-shown-on-parents="isWidgetShownOnParents(widget)"
             @update:widget-value="handleWidgetValueUpdate(node, widget, $event)"
             @reset-to-default="handleWidgetReset(node, widget, $event)"
           />

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -372,12 +372,12 @@ defineExpose({
           <WidgetItem
             v-for="{ widget, node } in widgets"
             :key="getStableWidgetRenderKey(widget)"
-            :widget="widget"
-            :node="node"
-            :is-draggable="isDraggable"
-            :hidden-favorite-indicator="hiddenFavoriteIndicator"
-            :show-node-name="showNodeName"
-            :host="host"
+            :widget
+            :node
+            :is-draggable
+            :hidden-favorite-indicator
+            :show-node-name
+            :host
             @update:widget-value="handleWidgetValueUpdate(node, widget, $event)"
             @reset-to-default="handleWidgetReset(node, widget, $event)"
           />

--- a/src/components/rightSidePanel/parameters/SectionWidgets.vue
+++ b/src/components/rightSidePanel/parameters/SectionWidgets.vue
@@ -43,12 +43,12 @@ const {
   isDraggable = false,
   hiddenFavoriteIndicator = false,
   showNodeName = false,
-  parents = [],
+  host,
   enableEmptyState = false,
   tooltip
 } = defineProps<{
   label?: string
-  parents?: SubgraphNode[]
+  host?: SubgraphNode
   node?: LGraphNode
   widgets: { widget: IBaseWidget; node: LGraphNode }[]
   showLocateButton?: boolean
@@ -377,7 +377,7 @@ defineExpose({
             :is-draggable="isDraggable"
             :hidden-favorite-indicator="hiddenFavoriteIndicator"
             :show-node-name="showNodeName"
-            :parents="parents"
+            :host="host"
             @update:widget-value="handleWidgetValueUpdate(node, widget, $event)"
             @reset-to-default="handleWidgetReset(node, widget, $event)"
           />

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.test.ts
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.test.ts
@@ -33,7 +33,7 @@ const captured: { rows: { node: LGraphNode; widget: IBaseWidget }[] } = {
 }
 
 const SectionWidgetsStub = {
-  props: ['widgets', 'node', 'parents'],
+  props: ['widgets', 'node', 'host'],
   setup(props: Record<string, unknown>) {
     captured.rows = props.widgets as {
       node: LGraphNode

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -5,7 +5,6 @@ import { useI18n } from 'vue-i18n'
 
 import { promotedInputWidgets } from '@/core/graph/subgraph/promotedInputWidget'
 import {
-  getWidgetName,
   isWidgetPromotedOnSubgraphNode,
   reorderSubgraphInputsByWidgetOrder
 } from '@/core/graph/subgraph/promotionUtils'
@@ -83,7 +82,7 @@ const advancedInputsWidgets = computed((): NodeWidgetsList => {
     ({ node: interiorNode, widget }) =>
       !isWidgetPromotedOnSubgraphNode(node, {
         sourceNodeId: interiorNode.id,
-        sourceWidgetName: getWidgetName(widget)
+        sourceWidgetName: widget.name
       })
   )
 })

--- a/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
+++ b/src/components/rightSidePanel/parameters/TabSubgraphInputs.vue
@@ -88,8 +88,6 @@ const advancedInputsWidgets = computed((): NodeWidgetsList => {
   )
 })
 
-const parents = computed<SubgraphNode[]>(() => [node])
-
 const searchedWidgetsList = shallowRef<NodeWidgetsList>(widgetsList.value)
 const isSearching = ref(false)
 
@@ -140,7 +138,7 @@ const label = computed(() => {
     :collapse="firstSectionCollapsed && !isSearching"
     :node
     :label
-    :parents
+    :host="node"
     :widgets="searchedWidgetsList"
     :is-draggable="!isSearching"
     :enable-empty-state="isSearching"
@@ -164,7 +162,7 @@ const label = computed(() => {
     ref="advancedInputsSectionRef"
     v-model:collapse="advancedInputsCollapsed"
     :label="t('rightSidePanel.advancedInputs')"
-    :parents="parents"
+    :host="node"
     :widgets="advancedInputsWidgets"
     show-node-name
     class="border-b border-interface-stroke"

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -17,7 +17,6 @@ const { mockGetInputSpecForWidget } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/core/graph/subgraph/promotionUtils', () => ({
-  demoteWidget: vi.fn(),
   promoteWidget: vi.fn()
 }))
 
@@ -61,7 +60,6 @@ const i18n = createI18n({
         enterNewName: 'Enter new name'
       },
       rightSidePanel: {
-        hideInput: 'Hide input',
         showInput: 'Show input',
         addFavorite: 'Favorite',
         removeFavorite: 'Unfavorite',

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -236,7 +236,10 @@ describe('WidgetActions', () => {
       type: 'TestNode',
       rootGraph: { id: 'graph-test' },
       isSubgraphNode: () => true,
-      getSlotFromWidget: () => ({ widgetId: 'graph-test:1:test_widget' })
+      getSlotFromWidget: (candidate: IBaseWidget) =>
+        candidate.name === 'test_widget'
+          ? { widgetId: 'graph-test:1:test_widget' }
+          : undefined
     })
     const host = fromAny<SubgraphNode, unknown>({ id: 2 })
 
@@ -247,11 +250,12 @@ describe('WidgetActions', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('toggles the favorite for the host node itself', async () => {
+  it("toggles the favorite for the row's node", async () => {
     const widget = createMockWidget()
     const node = createMockNode()
+    const host = fromAny<SubgraphNode, unknown>({ id: 2 })
 
-    const { user } = renderWidgetActions(widget, node)
+    const { user } = renderWidgetActions(widget, node, { host })
 
     await user.click(screen.getByRole('button', { name: /Favorite/ }))
 

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -18,8 +18,7 @@ const { mockGetInputSpecForWidget } = vi.hoisted(() => ({
 
 vi.mock('@/core/graph/subgraph/promotionUtils', () => ({
   demoteWidget: vi.fn(),
-  promoteWidget: vi.fn(),
-  isLinkedPromotion: vi.fn(() => false)
+  promoteWidget: vi.fn()
 }))
 
 vi.mock('@/stores/nodeDefStore', () => ({

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -209,19 +209,19 @@ describe('WidgetActions', () => {
     expect(onResetToDefault).toHaveBeenCalledWith('option1')
   })
 
-  it('promotes the widget when "Show input" is clicked on a node with parents', async () => {
+  it('promotes the widget into the host when "Show input" is clicked', async () => {
     const widget = createMockWidget()
     const node = createMockNode()
-    const parents = [fromAny<SubgraphNode, unknown>({ id: 2 })]
+    const host = fromAny<SubgraphNode, unknown>({ id: 2 })
 
-    const { user } = renderWidgetActions(widget, node, { parents })
+    const { user } = renderWidgetActions(widget, node, { host })
 
     await user.click(screen.getByRole('button', { name: /Show input/ }))
 
-    expect(promoteWidget).toHaveBeenCalledWith(node, widget, parents)
+    expect(promoteWidget).toHaveBeenCalledWith(node, widget, [host])
   })
 
-  it('does not offer "Show input" without parents', () => {
+  it('does not offer "Show input" without a host', () => {
     renderWidgetActions(createMockWidget(), createMockNode())
 
     expect(
@@ -238,9 +238,9 @@ describe('WidgetActions', () => {
       isSubgraphNode: () => true,
       getSlotFromWidget: () => ({ widgetId: 'graph-test:1:test_widget' })
     })
-    const parents = [fromAny<SubgraphNode, unknown>({ id: 2 })]
+    const host = fromAny<SubgraphNode, unknown>({ id: 2 })
 
-    renderWidgetActions(widget, node, { parents })
+    renderWidgetActions(widget, node, { host })
 
     expect(
       screen.queryByRole('button', { name: /Show input/ })

--- a/src/components/rightSidePanel/parameters/WidgetActions.test.ts
+++ b/src/components/rightSidePanel/parameters/WidgetActions.test.ts
@@ -8,13 +8,18 @@ import { h } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 
+import { promoteWidget } from '@/core/graph/subgraph/promotionUtils'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import WidgetActions from './WidgetActions.vue'
 
-const { mockGetInputSpecForWidget } = vi.hoisted(() => ({
-  mockGetInputSpecForWidget: vi.fn()
-}))
+const { mockGetInputSpecForWidget, mockIsFavorited, mockToggleFavorite } =
+  vi.hoisted(() => ({
+    mockGetInputSpecForWidget: vi.fn(),
+    mockIsFavorited: vi.fn(),
+    mockToggleFavorite: vi.fn()
+  }))
 
 vi.mock('@/core/graph/subgraph/promotionUtils', () => ({
   promoteWidget: vi.fn()
@@ -34,8 +39,8 @@ vi.mock('@/renderer/core/canvas/canvasStore', () => ({
 
 vi.mock('@/stores/workspace/favoritedWidgetsStore', () => ({
   useFavoritedWidgetsStore: () => ({
-    isFavorited: vi.fn().mockReturnValue(false),
-    toggleFavorite: vi.fn()
+    isFavorited: mockIsFavorited,
+    toggleFavorite: mockToggleFavorite
   })
 }))
 
@@ -73,6 +78,7 @@ describe('WidgetActions', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
     vi.resetAllMocks()
+    mockIsFavorited.mockReturnValue(false)
     mockGetInputSpecForWidget.mockReturnValue({
       type: 'INT',
       default: 42
@@ -201,5 +207,54 @@ describe('WidgetActions', () => {
     await user.click(screen.getByRole('button', { name: /Reset/ }))
 
     expect(onResetToDefault).toHaveBeenCalledWith('option1')
+  })
+
+  it('promotes the widget when "Show input" is clicked on a node with parents', async () => {
+    const widget = createMockWidget()
+    const node = createMockNode()
+    const parents = [fromAny<SubgraphNode, unknown>({ id: 2 })]
+
+    const { user } = renderWidgetActions(widget, node, { parents })
+
+    await user.click(screen.getByRole('button', { name: /Show input/ }))
+
+    expect(promoteWidget).toHaveBeenCalledWith(node, widget, parents)
+  })
+
+  it('does not offer "Show input" without parents', () => {
+    renderWidgetActions(createMockWidget(), createMockNode())
+
+    expect(
+      screen.queryByRole('button', { name: /Show input/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not offer "Show input" when the host input is already linked', () => {
+    const widget = createMockWidget()
+    const node = fromAny<LGraphNode, unknown>({
+      id: 1,
+      type: 'TestNode',
+      rootGraph: { id: 'graph-test' },
+      isSubgraphNode: () => true,
+      getSlotFromWidget: () => ({ widgetId: 'graph-test:1:test_widget' })
+    })
+    const parents = [fromAny<SubgraphNode, unknown>({ id: 2 })]
+
+    renderWidgetActions(widget, node, { parents })
+
+    expect(
+      screen.queryByRole('button', { name: /Show input/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('toggles the favorite for the host node itself', async () => {
+    const widget = createMockWidget()
+    const node = createMockNode()
+
+    const { user } = renderWidgetActions(widget, node)
+
+    await user.click(screen.getByRole('button', { name: /Favorite/ }))
+
+    expect(mockToggleFavorite).toHaveBeenCalledWith(node, 'test_widget')
   })
 })

--- a/src/components/rightSidePanel/parameters/WidgetActions.vue
+++ b/src/components/rightSidePanel/parameters/WidgetActions.vue
@@ -6,10 +6,7 @@ import { useI18n } from 'vue-i18n'
 import MoreButton from '@/components/button/MoreButton.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { inputForWidget } from '@/core/graph/subgraph/promotedInputWidget'
-import {
-  demoteWidget,
-  promoteWidget
-} from '@/core/graph/subgraph/promotionUtils'
+import { promoteWidget } from '@/core/graph/subgraph/promotionUtils'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -22,13 +19,11 @@ import type { WidgetValue } from '@/utils/widgetUtil'
 const {
   widget,
   node,
-  parents = [],
-  isShownOnParents = false
+  parents = []
 } = defineProps<{
   widget: IBaseWidget
   node: LGraphNode
   parents?: SubgraphNode[]
-  isShownOnParents?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -46,12 +41,9 @@ const isLinked = computed(() => {
   if (!node.isSubgraphNode()) return false
   return inputForWidget(node, widget)?.widgetId != null
 })
-const canToggleVisibility = computed(() => hasParents.value && !isLinked.value)
-const favoriteNode = computed(() =>
-  isShownOnParents && hasParents.value ? parents[0] : node
-)
+const canShowInput = computed(() => hasParents.value && !isLinked.value)
 const isFavorited = computed(() =>
-  favoritedWidgetsStore.isFavorited(favoriteNode.value, widget.name)
+  favoritedWidgetsStore.isFavorited(node, widget.name)
 )
 
 const inputSpec = computed(() =>
@@ -79,18 +71,13 @@ async function handleRename() {
   if (newLabel !== null) label.value = newLabel
 }
 
-function handleHideInput() {
-  if (!parents?.length) return
-  demoteWidget(node, widget, parents)
-}
-
 function handleShowInput() {
   if (!parents?.length) return
   promoteWidget(node, widget, parents)
 }
 
 function handleToggleFavorite() {
-  favoritedWidgetsStore.toggleFavorite(favoriteNode.value, widget.name)
+  favoritedWidgetsStore.toggleFavorite(node, widget.name)
 }
 
 function handleResetToDefault() {
@@ -122,26 +109,19 @@ function handleResetToDefault() {
       </Button>
 
       <Button
-        v-if="canToggleVisibility"
+        v-if="canShowInput"
         variant="textonly"
         size="unset"
         class="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-sm transition-all active:scale-95"
         @click="
           () => {
-            if (isShownOnParents) handleHideInput()
-            else handleShowInput()
+            handleShowInput()
             close()
           }
         "
       >
-        <template v-if="isShownOnParents">
-          <i class="icon-[lucide--eye-off] size-4" />
-          <span>{{ t('rightSidePanel.hideInput') }}</span>
-        </template>
-        <template v-else>
-          <i class="icon-[lucide--eye] size-4" />
-          <span>{{ t('rightSidePanel.showInput') }}</span>
-        </template>
+        <i class="icon-[lucide--eye] size-4" />
+        <span>{{ t('rightSidePanel.showInput') }}</span>
       </Button>
 
       <Button

--- a/src/components/rightSidePanel/parameters/WidgetActions.vue
+++ b/src/components/rightSidePanel/parameters/WidgetActions.vue
@@ -5,17 +5,14 @@ import { useI18n } from 'vue-i18n'
 
 import MoreButton from '@/components/button/MoreButton.vue'
 import Button from '@/components/ui/button/Button.vue'
-import { widgetPromotedSource } from '@/core/graph/subgraph/promotedInputWidget'
+import { inputForWidget } from '@/core/graph/subgraph/promotedInputWidget'
 import {
-  demotePromotedInput,
   demoteWidget,
-  isLinkedPromotion,
   promoteWidget
 } from '@/core/graph/subgraph/promotionUtils'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { useFavoritedWidgetsStore } from '@/stores/workspace/favoritedWidgetsStore'
@@ -40,7 +37,6 @@ const emit = defineEmits<{
 
 const label = defineModel<string>('label', { required: true })
 
-const canvasStore = useCanvasStore()
 const favoritedWidgetsStore = useFavoritedWidgetsStore()
 const nodeDefStore = useNodeDefStore()
 const { t } = useI18n()
@@ -48,9 +44,7 @@ const { t } = useI18n()
 const hasParents = computed(() => parents?.length > 0)
 const isLinked = computed(() => {
   if (!node.isSubgraphNode()) return false
-  const source = widgetPromotedSource(node, widget)
-  if (!source) return false
-  return isLinkedPromotion(node, source.nodeId, source.widgetName)
+  return inputForWidget(node, widget)?.widgetId != null
 })
 const canToggleVisibility = computed(() => hasParents.value && !isLinked.value)
 const favoriteNode = computed(() =>
@@ -87,22 +81,7 @@ async function handleRename() {
 
 function handleHideInput() {
   if (!parents?.length) return
-
-  const source = widgetPromotedSource(node, widget)
-  if (source) {
-    const currentNodeId = node.id
-    for (const parent of parents) {
-      const sourceNodeId =
-        String(node.id) === String(parent.id) ? source.nodeId : currentNodeId
-      demotePromotedInput(parent, {
-        sourceNodeId,
-        sourceWidgetName: source.widgetName
-      })
-    }
-    canvasStore.canvas?.setDirty(true, true)
-  } else {
-    demoteWidget(node, widget, parents)
-  }
+  demoteWidget(node, widget, parents)
 }
 
 function handleShowInput() {

--- a/src/components/rightSidePanel/parameters/WidgetActions.vue
+++ b/src/components/rightSidePanel/parameters/WidgetActions.vue
@@ -16,14 +16,10 @@ import { useFavoritedWidgetsStore } from '@/stores/workspace/favoritedWidgetsSto
 import { getWidgetDefaultValue, promptWidgetLabel } from '@/utils/widgetUtil'
 import type { WidgetValue } from '@/utils/widgetUtil'
 
-const {
-  widget,
-  node,
-  parents = []
-} = defineProps<{
+const { widget, node, host } = defineProps<{
   widget: IBaseWidget
   node: LGraphNode
-  parents?: SubgraphNode[]
+  host?: SubgraphNode
 }>()
 
 const emit = defineEmits<{
@@ -36,12 +32,11 @@ const favoritedWidgetsStore = useFavoritedWidgetsStore()
 const nodeDefStore = useNodeDefStore()
 const { t } = useI18n()
 
-const hasParents = computed(() => parents?.length > 0)
 const isLinked = computed(() => {
   if (!node.isSubgraphNode()) return false
   return inputForWidget(node, widget)?.widgetId != null
 })
-const canShowInput = computed(() => hasParents.value && !isLinked.value)
+const canShowInput = computed(() => host != null && !isLinked.value)
 const isFavorited = computed(() =>
   favoritedWidgetsStore.isFavorited(node, widget.name)
 )
@@ -72,8 +67,8 @@ async function handleRename() {
 }
 
 function handleShowInput() {
-  if (!parents?.length) return
-  promoteWidget(node, widget, parents)
+  if (!host) return
+  promoteWidget(node, widget, [host])
 }
 
 function handleToggleFavorite() {

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -40,8 +40,7 @@ const {
   hiddenFavoriteIndicator = false,
   hiddenWidgetActions = false,
   showNodeName = false,
-  parents = [],
-  isShownOnParents = false
+  parents = []
 } = defineProps<{
   widget: IBaseWidget
   node: LGraphNode
@@ -50,7 +49,6 @@ const {
   hiddenWidgetActions?: boolean
   showNodeName?: boolean
   parents?: SubgraphNode[]
-  isShownOnParents?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -116,9 +114,6 @@ const displayNodeName = computed((): string | null => {
 })
 
 const hasParents = computed(() => parents?.length > 0)
-const favoriteNode = computed(() =>
-  isShownOnParents && hasParents.value ? parents[0] : node
-)
 
 const widgetValue = computed({
   get: () => widget.value,
@@ -194,7 +189,6 @@ const displayLabel = customRef((track, trigger) => {
           :widget="widget"
           :node="node"
           :parents="parents"
-          :is-shown-on-parents="isShownOnParents"
           @reset-to-default="emit('resetToDefault', $event)"
         />
       </div>
@@ -203,7 +197,7 @@ const displayLabel = customRef((track, trigger) => {
     <div
       v-if="
         !hiddenFavoriteIndicator &&
-        favoritedWidgetsStore.isFavorited(favoriteNode, widget.name)
+        favoritedWidgetsStore.isFavorited(node, widget.name)
       "
       class="pointer-events-none relative z-2"
     >

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -166,7 +166,7 @@ const displayLabel = customRef((track, trigger) => {
       <EditableText
         v-if="widget.name"
         :model-value="displayLabel"
-        :is-editing="isEditing"
+        :is-editing
         :input-attrs="{ placeholder: widget.name }"
         class="pointer-events-auto m-0 cursor-text truncate p-0 text-sm/8"
         @edit="displayLabel = $event"
@@ -186,9 +186,9 @@ const displayLabel = customRef((track, trigger) => {
       >
         <WidgetActions
           v-model:label="displayLabel"
-          :widget="widget"
-          :node="node"
-          :host="host"
+          :widget
+          :node
+          :host
           @reset-to-default="emit('resetToDefault', $event)"
         />
       </div>

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -133,7 +133,7 @@ const displayLabel = customRef((track, trigger) => {
 
       const trimmedLabel = newValue.trim()
 
-      const success = renameWidget(widget, node, trimmedLabel, parents)
+      const success = renameWidget(widget, node, trimmedLabel)
 
       if (success) {
         canvasStore.canvas?.setDirty(true)

--- a/src/components/rightSidePanel/parameters/WidgetItem.vue
+++ b/src/components/rightSidePanel/parameters/WidgetItem.vue
@@ -40,7 +40,7 @@ const {
   hiddenFavoriteIndicator = false,
   hiddenWidgetActions = false,
   showNodeName = false,
-  parents = []
+  host
 } = defineProps<{
   widget: IBaseWidget
   node: LGraphNode
@@ -48,7 +48,7 @@ const {
   hiddenFavoriteIndicator?: boolean
   hiddenWidgetActions?: boolean
   showNodeName?: boolean
-  parents?: SubgraphNode[]
+  host?: SubgraphNode
 }>()
 
 const emit = defineEmits<{
@@ -113,7 +113,7 @@ const displayNodeName = computed((): string | null => {
   })
 })
 
-const hasParents = computed(() => parents?.length > 0)
+const hasHost = computed(() => host != null)
 
 const widgetValue = computed({
   get: () => widget.value,
@@ -175,7 +175,7 @@ const displayLabel = customRef((track, trigger) => {
       />
 
       <span
-        v-if="(showNodeName || hasParents) && displayNodeName"
+        v-if="(showNodeName || hasHost) && displayNodeName"
         class="mx-1 my-0 min-w-10 flex-1 truncate p-0 text-right text-xs text-muted-foreground"
       >
         {{ displayNodeName }}
@@ -188,7 +188,7 @@ const displayLabel = customRef((track, trigger) => {
           v-model:label="displayLabel"
           :widget="widget"
           :node="node"
-          :parents="parents"
+          :host="host"
           @reset-to-default="emit('resetToDefault', $event)"
         />
       </div>

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -7,10 +7,8 @@ import DraggableList from '@/components/common/DraggableList.vue'
 import Button from '@/components/ui/button/Button.vue'
 import { useVueFeatureFlags } from '@/composables/useVueFeatureFlags'
 import {
-  demotePromotedInput,
   demoteWidget,
   getPromotableWidgets,
-  isLinkedPromotion,
   isRecommendedWidget,
   promoteWidget,
   pruneDisconnected,
@@ -23,7 +21,10 @@ import {
 import type { PromotedSource } from '@/core/graph/subgraph/promotedInputWidget'
 import type { WidgetItem } from '@/core/graph/subgraph/promotionUtils'
 import type { PreviewExposure } from '@/core/schemas/previewExposureSchema'
-import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
+import type {
+  INodeInputSlot,
+  ISubgraphInput
+} from '@/lib/litegraph/src/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
@@ -32,7 +33,6 @@ import AsyncSearchInput from '@/components/ui/search-input/AsyncSearchInput.vue'
 import { useLitegraphService } from '@/services/litegraphService'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useRightSidePanelStore } from '@/stores/workspace/rightSidePanelStore'
-import { UNASSIGNED_NODE_ID } from '@/types/nodeId'
 import { cn } from '@comfyorg/tailwind-utils'
 
 import SubgraphNodeWidget from './SubgraphNodeWidget.vue'
@@ -40,7 +40,7 @@ import SubgraphNodeWidget from './SubgraphNodeWidget.vue'
 type PromotedRow = {
   kind: 'promoted'
   node: LGraphNode
-  input: INodeInputSlot
+  input: INodeInputSlot & Partial<ISubgraphInput>
   widget: IBaseWidget
 }
 type PreviewRow = {
@@ -248,14 +248,7 @@ function rowDisplayName(row: ActiveRow): string {
 }
 
 function isRowLinked(row: ActiveRow): boolean {
-  if (row.kind !== 'promoted') return false
-  if (row.node.id === UNASSIGNED_NODE_ID) return true
-  const source = promotedRowSource(row)
-  return (
-    !!activeNode.value &&
-    !!source &&
-    isLinkedPromotion(activeNode.value, String(row.node.id), source.widgetName)
-  )
+  return row.kind === 'promoted' && row.input.widgetId != null
 }
 
 function promotedRowKey(row: PromotedRow): string {
@@ -276,12 +269,10 @@ function demoteRow(row: ActiveRow) {
   const subgraphNode = activeNode.value
   if (!subgraphNode) return
   if (row.kind === 'promoted') {
-    const source = promotedRowSource(row)
-    if (source) {
-      demotePromotedInput(subgraphNode, {
-        sourceNodeId: source.nodeId,
-        sourceWidgetName: source.widgetName
-      })
+    const linkedInput = row.input._subgraphSlot
+    if (linkedInput) {
+      if (row.input.link != null) linkedInput.disconnect()
+      else subgraphNode.subgraph.removeInput(linkedInput)
     }
     refreshPromotedWidgetRendering()
     return

--- a/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
+++ b/src/components/rightSidePanel/subgraph/SubgraphEditor.vue
@@ -248,7 +248,7 @@ function rowDisplayName(row: ActiveRow): string {
 }
 
 function isRowLinked(row: ActiveRow): boolean {
-  return row.kind === 'promoted' && row.input.widgetId != null
+  return row.kind === 'promoted'
 }
 
 function promotedRowKey(row: PromotedRow): string {
@@ -269,10 +269,10 @@ function demoteRow(row: ActiveRow) {
   const subgraphNode = activeNode.value
   if (!subgraphNode) return
   if (row.kind === 'promoted') {
-    const linkedInput = row.input._subgraphSlot
-    if (linkedInput) {
-      if (row.input.link != null) linkedInput.disconnect()
-      else subgraphNode.subgraph.removeInput(linkedInput)
+    const subgraphSlot = row.input._subgraphSlot
+    if (subgraphSlot) {
+      if (row.input.link != null) subgraphSlot.disconnect()
+      else subgraphNode.subgraph.removeInput(subgraphSlot)
     }
     refreshPromotedWidgetRendering()
     return

--- a/src/composables/useUpstreamValue.test.ts
+++ b/src/composables/useUpstreamValue.test.ts
@@ -5,7 +5,7 @@ import type { WidgetState } from '@/types/widgetState'
 
 import { boundsExtractor, singleValueExtractor } from './useUpstreamValue'
 
-function widget(name: string, value: unknown): WidgetState {
+function widget(name: string, value: WidgetState['value']): WidgetState {
   return {
     name,
     type: 'INPUT',

--- a/src/composables/useUpstreamValue.ts
+++ b/src/composables/useUpstreamValue.ts
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { Bounds } from '@/renderer/core/layout/types'
-import type { LinkedUpstreamInfo } from '@/types/simplifiedWidget'
+import type { LinkedUpstreamInfo, WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetState } from '@/types/widgetState'
 
 type ValueExtractor<T = unknown> = (
@@ -28,7 +28,7 @@ export function useUpstreamValue<T>(
   })
 }
 
-export function singleValueExtractor<T>(
+export function singleValueExtractor<T extends WidgetValue>(
   isValid: (value: unknown) => value is T
 ): ValueExtractor<T> {
   return (widgets, outputName) => {

--- a/src/core/graph/subgraph/promotedInputWidget.ts
+++ b/src/core/graph/subgraph/promotedInputWidget.ts
@@ -1,7 +1,6 @@
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import type { NodeId } from '@/types/nodeId'
 
@@ -78,8 +77,7 @@ export function promotedInputWidget(input: INodeInputSlot): IBaseWidget | null {
       return store.getWidget(id)?.options ?? {}
     },
     get value() {
-      const value = store.getWidget(id)?.value
-      return isWidgetValue(value) ? value : undefined
+      return store.getWidget(id)?.value
     },
     set value(next) {
       store.setValue(id, next)

--- a/src/core/graph/subgraph/promotedInputWidget.ts
+++ b/src/core/graph/subgraph/promotedInputWidget.ts
@@ -39,22 +39,6 @@ export function inputForWidget(
 }
 
 /**
- * The interior source of a widget when it is a promoted subgraph input.
- * Replaces ad-hoc "is this promoted?" duck-typing: a widget is promoted iff its
- * host node is a subgraph node and its backing input slot has an interior
- * source.
- */
-export function widgetPromotedSource(
-  node: LGraphNode,
-  widget: IBaseWidget
-): PromotedSource | undefined {
-  if (!node.isSubgraphNode()) return undefined
-  const input = inputForWidget(node, widget)
-  if (!input) return undefined
-  return promotedInputSource(node, input)
-}
-
-/**
  * Projects a promoted subgraph input into an ordinary widget descriptor. The
  * descriptor is store-backed: type/value/options read live from
  * {@link useWidgetValueStore} by widgetId (mirroring BaseWidget), so the row

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -625,6 +625,38 @@ describe('reorderSubgraphInputsByName', () => {
     ])
   })
 
+  it('preserves null promoted widget values across reordering', () => {
+    const subgraph = createTestSubgraph()
+    const host = createTestSubgraphNode(subgraph)
+    const firstNode = new LGraphNode('First')
+    const secondNode = new LGraphNode('Second')
+    subgraph.add(firstNode)
+    subgraph.add(secondNode)
+
+    const firstInput = firstNode.addInput('first', 'STRING')
+    const firstWidget = firstNode.addWidget('text', 'first', '', () => {})
+    firstInput.widget = { name: firstWidget.name }
+    const secondInput = secondNode.addInput('second', 'STRING')
+    const secondWidget = secondNode.addWidget('text', 'second', '', () => {})
+    secondInput.widget = { name: secondWidget.name }
+    promoteValueWidgetViaSubgraphInput(host, firstNode, firstWidget)
+    promoteValueWidgetViaSubgraphInput(host, secondNode, secondWidget)
+    writePromotedInputValue(host, 'first', null)
+    writePromotedInputValue(host, 'second', 'second value')
+
+    reorderSubgraphInputsByName(host, ['second', 'first'])
+
+    expect(promotedInputNames(host)).toEqual(['second', 'first'])
+    const valueByName = (name: string) => {
+      const input = host.inputs.find((input) => input.name === name)
+      if (!input?.widgetId) throw new Error(`Missing promoted input ${name}`)
+      return useWidgetValueStore().getWidget(input.widgetId)?.value
+    }
+    expect(valueByName('first')).toBeNull()
+    expect(valueByName('second')).toBe('second value')
+    expect(host.serialize().widgets_values).toEqual(['second value', null])
+  })
+
   it('updates subgraph input link slot indices after reordering', () => {
     const subgraph = createTestSubgraph()
     const host = createTestSubgraphNode(subgraph)

--- a/src/core/graph/subgraph/promotionUtils.test.ts
+++ b/src/core/graph/subgraph/promotionUtils.test.ts
@@ -57,7 +57,6 @@ import {
   demoteWidget,
   getPromotableWidgets,
   hasUnpromotedWidgets,
-  isLinkedPromotion,
   isPreviewPseudoWidget,
   promoteValueWidgetViaSubgraphInput,
   promoteRecommendedWidgets,
@@ -541,53 +540,6 @@ describe('hasUnpromotedWidgets', () => {
   })
 })
 
-describe('isLinkedPromotion', () => {
-  beforeEach(() => {
-    setActivePinia(createTestingPinia({ stubActions: false }))
-  })
-
-  function promoteSource(host: SubgraphNode, widgetName: string): LGraphNode {
-    const node = new LGraphNode('Source')
-    const input = node.addInput(widgetName, 'STRING')
-    const widget = node.addWidget('text', widgetName, '', () => {})
-    input.widget = { name: widget.name }
-    host.subgraph.add(node)
-    promoteValueWidgetViaSubgraphInput(host, node, widget)
-    return node
-  }
-
-  it('returns true for a linked promotion', () => {
-    const host = createTestSubgraphNode(createTestSubgraph())
-    const node = promoteSource(host, 'text')
-
-    expect(isLinkedPromotion(host, String(node.id), 'text')).toBe(true)
-  })
-
-  it('returns false when no promotion exists', () => {
-    const host = createTestSubgraphNode(createTestSubgraph())
-
-    expect(isLinkedPromotion(host, '999', 'nonexistent')).toBe(false)
-  })
-
-  it('returns false when sourceWidgetName does not match', () => {
-    const host = createTestSubgraphNode(createTestSubgraph())
-    const node = promoteSource(host, 'text')
-
-    expect(isLinkedPromotion(host, String(node.id), 'wrong_name')).toBe(false)
-  })
-
-  it('identifies linked widgets across different inputs', () => {
-    const host = createTestSubgraphNode(createTestSubgraph())
-    const nodeA = promoteSource(host, 'string_a')
-    const nodeB = promoteSource(host, 'value')
-
-    expect(isLinkedPromotion(host, String(nodeA.id), 'string_a')).toBe(true)
-    expect(isLinkedPromotion(host, String(nodeB.id), 'value')).toBe(true)
-    expect(isLinkedPromotion(host, String(nodeA.id), 'value')).toBe(false)
-    expect(isLinkedPromotion(host, '5', 'string_a')).toBe(false)
-  })
-})
-
 describe('reorderSubgraphInputsByName', () => {
   beforeEach(() => {
     setActivePinia(createTestingPinia({ stubActions: false }))
@@ -812,9 +764,7 @@ describe('demoteWidget — axiomatic projection retraction', () => {
     expect(host.subgraph.inputs).toHaveLength(1)
     expect(host.inputs[0]?.link).toBe(9999)
     expect(host.inputs[0]?._widget).toBeUndefined()
-    expect(
-      isLinkedPromotion(host, String(interiorNode.id), interiorWidget.name)
-    ).toBe(false)
+    expect(interiorNode.inputs[0]?.link).toBeNull()
     expect(host.widgets).toHaveLength(0)
     if (!promotedInputId) throw new Error('Missing promoted input widgetId')
     expect(useWidgetValueStore().getWidget(promotedInputId)).toBeUndefined()
@@ -832,14 +782,13 @@ describe('demoteWidget — axiomatic projection retraction', () => {
   })
 
   it('demotes the second of two promoted widgets sharing a source widget name', () => {
-    const { host, nodeA, widgetA, nodeB, widgetB } =
-      buildDuplicateNamePromotion()
+    const { host, nodeA, nodeB, widgetB } = buildDuplicateNamePromotion()
 
     demoteWidget(nodeB, widgetB, [host])
 
     expect(host.subgraph.inputs.map((i) => i.name)).toEqual(['text'])
-    expect(isLinkedPromotion(host, String(nodeB.id), widgetB.name)).toBe(false)
-    expect(isLinkedPromotion(host, String(nodeA.id), widgetA.name)).toBe(true)
+    expect(nodeB.inputs[0]?.link).toBeNull()
+    expect(nodeA.inputs[0]?.link).not.toBeNull()
   })
 
   it('demotes the correct slot when widget lives on a nested SubgraphNode with same-named deep sources', () => {
@@ -866,12 +815,8 @@ describe('demoteWidget — axiomatic projection retraction', () => {
     demoteWidget(innerHost, promotedWidgetRef(innerHost, 'text_1'), [outerHost])
 
     expect(outerHost.subgraph.inputs.map((i) => i.name)).toEqual(['text'])
-    expect(isLinkedPromotion(outerHost, String(innerHost.id), 'text_1')).toBe(
-      false
-    )
-    expect(isLinkedPromotion(outerHost, String(innerHost.id), 'text')).toBe(
-      true
-    )
+    expect(innerHost.inputs.find((i) => i.name === 'text_1')?.link).toBeNull()
+    expect(innerHost.inputs.find((i) => i.name === 'text')?.link).not.toBeNull()
   })
 })
 

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -377,7 +377,7 @@ export function promoteWidget(
  * Removes the host input projecting a linked promotion identified by source.
  * Returns true when an input was found and demoted.
  */
-export function demotePromotedInput(
+function demotePromotedInput(
   subgraphNode: SubgraphNode,
   source: PromotedWidgetSource
 ): boolean {

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -8,7 +8,6 @@ import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import type { LinkId } from '@/types/linkId'
 import { reorderSubgraphInputs } from '@/lib/litegraph/src/subgraph/subgraphUtils'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
-import { isWidgetValue } from '@/lib/litegraph/src/types/widgets'
 import { nextUniqueName } from '@/lib/litegraph/src/strings'
 import { useToastStore } from '@/platform/updates/common/toastStore'
 import {
@@ -136,8 +135,7 @@ function applySubgraphInputOrder(
   const widgetValues = subgraphNode.inputs.map((input) => {
     const id = input?.widgetId
     if (!id) return undefined
-    const value = useWidgetValueStore().getWidget(id)?.value
-    return isWidgetValue(value) ? value : undefined
+    return useWidgetValueStore().getWidget(id)?.value
   })
 
   reorderSubgraphInputs(subgraphNode, orderedIndices)

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -30,10 +30,6 @@ type PartialNode = Pick<LGraphNode, 'title' | 'id' | 'type'>
 export type WidgetItem = [LGraphNode, IBaseWidget]
 export { CANVAS_IMAGE_PREVIEW_WIDGET }
 
-export function getWidgetName(w: IBaseWidget): string {
-  return w.name
-}
-
 function isLinkedPromotion(
   subgraphNode: SubgraphNode,
   sourceNodeId: SerializedNodeId,
@@ -224,7 +220,7 @@ function toPromotionSource(
 ): PromotedWidgetSource {
   return {
     sourceNodeId: node.id,
-    sourceWidgetName: getWidgetName(widget)
+    sourceWidgetName: widget.name
   }
 }
 
@@ -245,7 +241,7 @@ export function promoteValueWidgetViaSubgraphInput(
   sourceNode: LGraphNode,
   sourceWidget: IBaseWidget
 ): CanonicalPromotionResult {
-  const sourceWidgetName = getWidgetName(sourceWidget)
+  const sourceWidgetName = sourceWidget.name
   if (isLinkedPromotion(subgraphNode, sourceNode.id, sourceWidgetName)) {
     return { ok: true }
   }
@@ -595,7 +591,7 @@ export function promoteRecommendedWidgets(subgraphNode: SubgraphNode) {
       Sentry.addBreadcrumb({
         category: 'subgraph',
         level: 'warning',
-        message: `Failed to promote widget "${getWidgetName(w)}" on node ${n.id}: ${result.reason}`
+        message: `Failed to promote widget "${w.name}" on node ${n.id}: ${result.reason}`
       })
     }
   }

--- a/src/core/graph/subgraph/promotionUtils.ts
+++ b/src/core/graph/subgraph/promotionUtils.ts
@@ -34,7 +34,7 @@ export function getWidgetName(w: IBaseWidget): string {
   return w.name
 }
 
-export function isLinkedPromotion(
+function isLinkedPromotion(
   subgraphNode: SubgraphNode,
   sourceNodeId: SerializedNodeId,
   sourceWidgetName: string

--- a/src/extensions/core/load3d.ts
+++ b/src/extensions/core/load3d.ts
@@ -635,9 +635,10 @@ useExtensionService().registerExtension({
           const extrinsics = result?.[3]
           const intrinsics = result?.[4]
 
-          modelWidget.value = filePath?.replaceAll('\\', '/')
+          const modelFilePath = filePath?.replaceAll('\\', '/')
+          modelWidget.value = modelFilePath
 
-          node.properties['Last Time Model File'] = modelWidget.value
+          node.properties['Last Time Model File'] = modelFilePath
 
           const settings = {
             loadFolder: 'output',

--- a/src/extensions/core/widgetInputs.ts
+++ b/src/extensions/core/widgetInputs.ts
@@ -7,14 +7,12 @@ import type {
   LLink
 } from '@/lib/litegraph/src/litegraph'
 import { NodeSlot } from '@/lib/litegraph/src/node/NodeSlot'
-import type {
-  IBaseWidget,
-  TWidgetValue
-} from '@/lib/litegraph/src/types/widgets'
+import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { assetService } from '@/platform/assets/services/assetService'
 import { createAssetWidget } from '@/platform/assets/utils/createAssetWidget'
 import type { ComfyNodeDef, InputSpec } from '@/schemas/nodeDefSchema'
 import { app } from '@/scripts/app'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 import {
   ComfyWidgets,
   addValueControlWidgets,
@@ -29,7 +27,7 @@ import { applyFirstWidgetValueToGraph } from './widgetValuePropagation'
 
 const replacePropertyName = 'Run widget replace on values'
 export class PrimitiveNode extends LGraphNode {
-  controlValues?: TWidgetValue[]
+  controlValues?: WidgetValue[]
   lastType?: string
   static override category: string
   constructor(title: string) {

--- a/src/extensions/core/widgetValuePropagation.ts
+++ b/src/extensions/core/widgetValuePropagation.ts
@@ -2,15 +2,15 @@ import type { Point } from '@/lib/litegraph/src/interfaces'
 import type { LLink } from '@/lib/litegraph/src/litegraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
-import type { TWidgetValue } from '@/lib/litegraph/src/types/widgets'
 import { app } from '@/scripts/app'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 
 type SourceNode = Pick<LGraphNode, 'graph' | 'outputs' | 'widgets'>
 
 export function applyFirstWidgetValueToGraph(
   node: SourceNode,
   extraLinks: LLink[] = [],
-  transformValue?: (value: TWidgetValue) => TWidgetValue
+  transformValue?: (value: WidgetValue) => WidgetValue
 ) {
   const output = node.outputs[0]
   if (!output?.links?.length || !node.graph) return

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -8,6 +8,9 @@ import type {
   ISerialisedNode
 } from '@/lib/litegraph/src/litegraph'
 import type { Rect } from '@/lib/litegraph/src/interfaces'
+import type { LGraphCanvas } from '@/lib/litegraph/src/LGraphCanvas'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
+import { BaseWidget } from '@/lib/litegraph/src/widgets/BaseWidget'
 import {
   LGraphNode,
   LiteGraph,
@@ -76,12 +79,27 @@ describe('LGraphNode', () => {
     const onPropertyChanged = vi.fn(() => true)
     node.onPropertyChanged = onPropertyChanged
 
-    Reflect.apply(node.setProperty, node, ['value', null])
+    node.setProperty('value', null)
 
     expect(node.properties.value).toBeNull()
     expect(widget.value).toBeNull()
     expect(onPropertyChanged).toHaveBeenCalledWith('value', null, undefined)
     expect(node.serialize().properties?.value).toBeNull()
+  })
+
+  test('syncs null widget values to the bound property', () => {
+    const widget = node.addWidget('text', 'value', 'initial', 'value')
+    if (!(widget instanceof BaseWidget)) throw new Error('expected BaseWidget')
+    const nullableWidget: BaseWidget = widget
+    node.setProperty('value', 'initial')
+    const canvas = {
+      graph_mouse: [0, 0]
+    } as Partial<LGraphCanvas> as LGraphCanvas
+
+    nullableWidget.setValue(null, { e: {} as CanvasPointerEvent, node, canvas })
+
+    expect(node.properties.value).toBeNull()
+    expect(widget.value).toBeNull()
   })
 
   test('should serialize position/size correctly', () => {

--- a/src/lib/litegraph/src/LGraphNode.test.ts
+++ b/src/lib/litegraph/src/LGraphNode.test.ts
@@ -71,6 +71,19 @@ describe('LGraphNode', () => {
     Object.assign(LiteGraph, origLiteGraph)
   })
 
+  test('preserves null property values', () => {
+    const widget = node.addWidget('number', 'value', 1, 'value')
+    const onPropertyChanged = vi.fn(() => true)
+    node.onPropertyChanged = onPropertyChanged
+
+    Reflect.apply(node.setProperty, node, ['value', null])
+
+    expect(node.properties.value).toBeNull()
+    expect(widget.value).toBeNull()
+    expect(onPropertyChanged).toHaveBeenCalledWith('value', null, undefined)
+    expect(node.serialize().properties?.value).toBeNull()
+  })
+
   test('should serialize position/size correctly', () => {
     const node = new LGraphNode('TestNode')
     node.pos = [10, 20]

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -108,7 +108,7 @@ import type { WidgetTypeMap } from './widgets/widgetMap'
 
 // #region Types
 
-export type NodeProperty = string | number | boolean | object
+export type NodeProperty = string | number | boolean | object | null
 
 interface INodePropertyInfo {
   name?: string

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -97,6 +97,7 @@ import type {
   TWidgetType,
   TWidgetValue
 } from './types/widgets'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 import { findFreeSlotOfType } from './utils/collections'
 import { warnDeprecated } from './utils/feedback'
 import { getWidgetIds } from './utils/widget'
@@ -1079,14 +1080,17 @@ export class LGraphNode
    * @param name
    * @param value
    */
-  setProperty(name: string, value: TWidgetValue): void {
+  setProperty(name: string, value: WidgetValue): void {
     this.properties ||= {}
-    if (value === this.properties[name]) return
+    // Node properties are persisted and cannot hold null/void, so normalize
+    // before comparing and storing.
+    const nextValue = value ?? undefined
+    if (nextValue === this.properties[name]) return
 
     const prev_value = this.properties[name]
-    this.properties[name] = value
+    this.properties[name] = nextValue
     // abort change
-    if (this.onPropertyChanged?.(name, value, prev_value) === false)
+    if (this.onPropertyChanged?.(name, nextValue, prev_value) === false)
       this.properties[name] = prev_value
 
     if (this.widgets) {

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -97,7 +97,6 @@ import type {
   TWidgetType,
   TWidgetValue
 } from './types/widgets'
-import type { WidgetValue } from '@/types/simplifiedWidget'
 import { findFreeSlotOfType } from './utils/collections'
 import { warnDeprecated } from './utils/feedback'
 import { getWidgetIds } from './utils/widget'
@@ -1080,17 +1079,14 @@ export class LGraphNode
    * @param name
    * @param value
    */
-  setProperty(name: string, value: WidgetValue): void {
+  setProperty(name: string, value: TWidgetValue): void {
     this.properties ||= {}
-    // Node properties are persisted and cannot hold null/void, so normalize
-    // before comparing and storing.
-    const nextValue = value ?? undefined
-    if (nextValue === this.properties[name]) return
+    if (value === this.properties[name]) return
 
     const prev_value = this.properties[name]
-    this.properties[name] = nextValue
+    this.properties[name] = value
     // abort change
-    if (this.onPropertyChanged?.(name, nextValue, prev_value) === false)
+    if (this.onPropertyChanged?.(name, value, prev_value) === false)
       this.properties[name] = prev_value
 
     if (this.widgets) {

--- a/src/lib/litegraph/src/subgraph/SubgraphNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphNode.ts
@@ -283,8 +283,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
         return store.getWidget(id)?.options ?? {}
       },
       get value() {
-        const value = store.getWidget(id)?.value
-        return isWidgetValue(value) ? value : undefined
+        return store.getWidget(id)?.value
       },
       set value(next) {
         store.setValue(id, next)
@@ -498,9 +497,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       )
         .toReversed()
         .flatMap(({ originalEntry: [sourceNodeId, name], hostValue }) =>
-          sourceNodeId === '-1' &&
-          hostValue !== undefined &&
-          isWidgetValue(hostValue)
+          sourceNodeId === '-1' && hostValue !== undefined
             ? [[name, hostValue] as const]
             : []
         )

--- a/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphWidgetPromotion.test.ts
@@ -23,6 +23,7 @@ import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toNodeId } from '@/types/nodeId'
 import type { WidgetId } from '@/types/widgetId'
+import type { WidgetState } from '@/types/widgetState'
 import { widgetId } from '@/types/widgetId'
 import { createNodeLocatorId } from '@/types/nodeIdentification'
 import { graphToPrompt } from '@/utils/executionUtil'
@@ -112,7 +113,7 @@ function promotedWidgetStateByName(
 function writePromotedWidgetValue(
   node: { inputs: Array<{ widgetId?: WidgetId; name: string }> },
   index: number,
-  value: unknown
+  value: WidgetState['value']
 ) {
   const input = promotedInputs(node)[index]
   if (!input) throw new Error(`Missing promoted input ${index}`)

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -394,14 +394,14 @@ export interface IRangeWidget extends IBaseWidget<
  * Values not in this list will not result in litegraph errors, however they will be treated the same as "custom".
  */
 export type TWidgetType = IWidget['type']
-export type TWidgetValue = IWidget['value']
+export type TWidgetValue = WidgetValue
 
 export function isWidgetValue(value: unknown): value is TWidgetValue {
-  if (value === undefined) return true
+  if (value == null) return true
   if (typeof value === 'string') return true
   if (typeof value === 'number') return true
   if (typeof value === 'boolean') return true
-  return value !== null && typeof value === 'object'
+  return typeof value === 'object'
 }
 
 /**
@@ -484,7 +484,7 @@ export interface IBaseWidget<
 
   // TODO: Confirm this format
   callback?(
-    value: unknown,
+    value: WidgetValue,
     canvas?: LGraphCanvas,
     node?: LGraphNode,
     pos?: Point,

--- a/src/lib/litegraph/src/types/widgets.ts
+++ b/src/lib/litegraph/src/types/widgets.ts
@@ -2,6 +2,7 @@ import type { Bounds } from '@/renderer/core/layout/types'
 import type { CurveData } from '@/components/curve/types'
 import type { BoundingBox } from '@/types/boundingBoxes'
 import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetId } from '@/types/widgetId'
 
 import type {
@@ -411,7 +412,7 @@ export function isWidgetValue(value: unknown): value is TWidgetValue {
  * @see IWidget
  */
 export interface IBaseWidget<
-  TValue = boolean | number | string | object | undefined,
+  TValue = WidgetValue,
   TType extends string = string,
   TOptions extends IWidgetOptions = IWidgetOptions
 > {

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -429,7 +429,6 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this.value = v
     if (
       this.options?.property &&
-      v != null &&
       node.properties[this.options.property] !== undefined
     ) {
       node.setProperty(this.options.property, v)

--- a/src/lib/litegraph/src/widgets/BaseWidget.ts
+++ b/src/lib/litegraph/src/widgets/BaseWidget.ts
@@ -429,6 +429,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget>
     this.value = v
     if (
       this.options?.property &&
+      v != null &&
       node.properties[this.options.property] !== undefined
     ) {
       node.setProperty(this.options.property, v)

--- a/src/locales/ar/main.json
+++ b/src/locales/ar/main.json
@@ -3136,7 +3136,6 @@
     "groups": "المجموعات",
     "hideAdvancedInputsButton": "إخفاء المدخلات المتقدمة",
     "hideAdvancedShort": "إخفاء الخيارات المتقدمة",
-    "hideInput": "إخفاء المدخل",
     "info": "معلومات",
     "infoFor": "معلومات عن {item}",
     "inputs": "المدخلات",

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -3849,7 +3849,6 @@
     "settings": "Settings",
     "addFavorite": "Favorite",
     "removeFavorite": "Unfavorite",
-    "hideInput": "Hide input",
     "showInput": "Show input",
     "locateNode": "Locate node on canvas",
     "locateNodeFor": "Locate {item}",

--- a/src/locales/es/main.json
+++ b/src/locales/es/main.json
@@ -3136,7 +3136,6 @@
     "groups": "Grupos",
     "hideAdvancedInputsButton": "Ocultar entradas avanzadas",
     "hideAdvancedShort": "Ocultar avanzado",
-    "hideInput": "Ocultar entrada",
     "info": "Información",
     "infoFor": "Información para {item}",
     "inputs": "ENTRADAS",

--- a/src/locales/fa/main.json
+++ b/src/locales/fa/main.json
@@ -3136,7 +3136,6 @@
     "groups": "گروه‌ها",
     "hideAdvancedInputsButton": "مخفی کردن ورودی‌های پیشرفته",
     "hideAdvancedShort": "مخفی کردن پیشرفته",
-    "hideInput": "مخفی کردن ورودی",
     "info": "اطلاعات",
     "infoFor": "اطلاعات برای {item}",
     "inputs": "ورودی‌ها",

--- a/src/locales/fr/main.json
+++ b/src/locales/fr/main.json
@@ -3136,7 +3136,6 @@
     "groups": "Groupes",
     "hideAdvancedInputsButton": "Masquer les entrées avancées",
     "hideAdvancedShort": "Masquer les options avancées",
-    "hideInput": "Masquer l’entrée",
     "info": "Infos",
     "infoFor": "Infos pour {item}",
     "inputs": "ENTRÉES",

--- a/src/locales/he/main.json
+++ b/src/locales/he/main.json
@@ -3136,7 +3136,6 @@
     "groups": "קבוצות",
     "hideAdvancedInputsButton": "הסתרת קלטים מתקדמים",
     "hideAdvancedShort": "הסתר מתקדמים",
-    "hideInput": "הסתרת הקלט",
     "info": "מידע",
     "infoFor": "מידע עבור {item}",
     "inputs": "קלטים",

--- a/src/locales/ja/main.json
+++ b/src/locales/ja/main.json
@@ -3136,7 +3136,6 @@
     "groups": "グループ",
     "hideAdvancedInputsButton": "詳細入力を非表示",
     "hideAdvancedShort": "詳細を非表示",
-    "hideInput": "入力を非表示",
     "info": "情報",
     "infoFor": "{item} の情報",
     "inputs": "入力",

--- a/src/locales/ko/main.json
+++ b/src/locales/ko/main.json
@@ -3136,7 +3136,6 @@
     "groups": "그룹",
     "hideAdvancedInputsButton": "고급 입력 숨기기",
     "hideAdvancedShort": "고급 설정 숨기기",
-    "hideInput": "입력 숨기기",
     "info": "정보",
     "infoFor": "{item} 정보",
     "inputs": "입력",

--- a/src/locales/pt-BR/main.json
+++ b/src/locales/pt-BR/main.json
@@ -3136,7 +3136,6 @@
     "groups": "Grupos",
     "hideAdvancedInputsButton": "Ocultar entradas avançadas",
     "hideAdvancedShort": "Ocultar avançado",
-    "hideInput": "Ocultar entrada",
     "info": "Informações",
     "infoFor": "Informações para {item}",
     "inputs": "ENTRADAS",

--- a/src/locales/ru/main.json
+++ b/src/locales/ru/main.json
@@ -3136,7 +3136,6 @@
     "groups": "Группы",
     "hideAdvancedInputsButton": "Скрыть расширенные параметры",
     "hideAdvancedShort": "Скрыть расширенные",
-    "hideInput": "Скрыть вход",
     "info": "Информация",
     "infoFor": "Информация о {item}",
     "inputs": "ВХОДЫ",

--- a/src/locales/tr/main.json
+++ b/src/locales/tr/main.json
@@ -3136,7 +3136,6 @@
     "groups": "Gruplar",
     "hideAdvancedInputsButton": "Gelişmiş girişleri gizle",
     "hideAdvancedShort": "Gelişmişi gizle",
-    "hideInput": "Girdiyi gizle",
     "info": "Bilgi",
     "infoFor": "{item} için Bilgi",
     "inputs": "GİRİŞLER",

--- a/src/locales/zh-TW/main.json
+++ b/src/locales/zh-TW/main.json
@@ -3136,7 +3136,6 @@
     "groups": "群組",
     "hideAdvancedInputsButton": "隱藏進階輸入",
     "hideAdvancedShort": "隱藏進階",
-    "hideInput": "隱藏輸入",
     "info": "資訊",
     "infoFor": "{item} 的資訊",
     "inputs": "輸入",

--- a/src/locales/zh/main.json
+++ b/src/locales/zh/main.json
@@ -3136,7 +3136,6 @@
     "groups": "分组",
     "hideAdvancedInputsButton": "隐藏高级输入",
     "hideAdvancedShort": "隐藏高级选项",
-    "hideInput": "隐藏输入",
     "info": "信息",
     "infoFor": "{item} 信息",
     "inputs": "输入",

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -471,3 +471,36 @@ describe('createWidgetUpdateHandler (via computeProcessedWidgets)', () => {
     expect(afterUpdate.hasError).toBe(false)
   })
 })
+
+describe('live widget update handler', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('forwards null (not undefined) to the live widget callback', () => {
+    const callback = vi.fn()
+    const id = widgetId(GRAPH_ID, toNodeId(1), 'test_widget')
+    const liveWidget = createMockWidget({
+      widgetId: id,
+      name: 'test_widget',
+      callback
+    })
+    const { graph } = createGraphWithNode([liveWidget], toNodeId(1))
+    registerWidgetState(id, {
+      type: 'combo',
+      value: 'x',
+      options: { values: ['x'] }
+    })
+
+    const [processed] = processWidgets({
+      widgetIds: [id],
+      nodeId: toNodeId(1),
+      rootGraph: graph
+    })
+
+    processed.updateHandler(null)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback.mock.calls[0][0]).toBeNull()
+  })
+})

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -477,7 +477,7 @@ describe('live widget update handler', () => {
     setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
-  it('forwards null (not undefined) to the live widget callback', () => {
+  it('forwards null (not undefined) to both the live widget value and callback', () => {
     const callback = vi.fn()
     const id = widgetId(GRAPH_ID, toNodeId(1), 'test_widget')
     const liveWidget = createMockWidget({
@@ -500,6 +500,7 @@ describe('live widget update handler', () => {
 
     processed.updateHandler(null)
 
+    expect(liveWidget.value).toBeNull()
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback.mock.calls[0][0]).toBeNull()
   })

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.test.ts
@@ -86,7 +86,7 @@ function registerWidgetState(
   id: WidgetId,
   init: {
     type?: string
-    value?: unknown
+    value?: IBaseWidget['value']
     label?: string
     options?: IBaseWidget['options']
   } = {},

--- a/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
+++ b/src/renderer/extensions/vueNodes/composables/useProcessedWidgets.ts
@@ -241,7 +241,7 @@ function createWidgetUpdateHandler({
     widgetValueStore.setValue(id, newValue)
     if (live) {
       const normalized = normalizeWidgetValue(newValue)
-      live.widget.value = normalized ?? undefined
+      live.widget.value = normalized
       live.widget.callback?.(normalized, app.canvas, live.node)
       live.node.widgets?.forEach((w) => w.triggerDraw?.())
     }

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetButton.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetButton.test.ts
@@ -28,10 +28,10 @@ const ButtonStub = {
 
 describe('WidgetButton Interactions', () => {
   const createButtonWidget = (
-    overrides: Partial<SimplifiedWidget<void, ButtonWidgetOptions>> = {}
-  ) => createMockWidget<void>({ ...BUTTON_DEFAULTS, ...overrides })
+    overrides: Partial<SimplifiedWidget<undefined, ButtonWidgetOptions>> = {}
+  ) => createMockWidget<undefined>({ ...BUTTON_DEFAULTS, ...overrides })
 
-  const mountComponent = (widget: SimplifiedWidget<void>) => {
+  const mountComponent = (widget: SimplifiedWidget<undefined>) => {
     const user = userEvent.setup()
     const result = render(WidgetButton, {
       global: {

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetButton.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetButton.vue
@@ -26,7 +26,7 @@ import {
 
 // Button widgets don't have a v-model value, they trigger actions
 const props = defineProps<{
-  widget: SimplifiedWidget<void>
+  widget: SimplifiedWidget<undefined>
 }>()
 
 // Button specific excluded props
@@ -37,8 +37,6 @@ const filteredProps = computed(() =>
 )
 
 const handleClick = () => {
-  if (props.widget.callback) {
-    props.widget.callback()
-  }
+  props.widget.callback?.(undefined)
 }
 </script>

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.test.ts
@@ -50,7 +50,7 @@ describe('WidgetDOM', () => {
     }
     return render(WidgetDOM, {
       props: {
-        widget: createMockWidget<void>({
+        widget: createMockWidget<undefined>({
           value: undefined,
           name: 'dom',
           type: 'dom'
@@ -77,7 +77,7 @@ describe('WidgetDOM', () => {
 
     const { container } = render(WidgetDOM, {
       props: {
-        widget: createMockWidget<void>({
+        widget: createMockWidget<undefined>({
           value: undefined,
           name: 'dom',
           type: 'dom'
@@ -106,7 +106,7 @@ describe('WidgetDOM', () => {
 
     const { container } = render(WidgetDOM, {
       props: {
-        widget: createMockWidget<void>({
+        widget: createMockWidget<undefined>({
           value: undefined,
           name: 'dom',
           type: 'dom'

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetDOM.vue
@@ -11,7 +11,7 @@ import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 // Button widgets don't have a v-model value, they trigger actions
 const props = defineProps<{
-  widget: SimplifiedWidget<void>
+  widget: SimplifiedWidget<undefined>
   nodeId: NodeId
 }>()
 

--- a/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
+++ b/src/renderer/extensions/vueNodes/widgets/components/WidgetLegacy.vue
@@ -15,7 +15,7 @@ import type { NodeId } from '@/types/nodeId'
 import type { SimplifiedWidget } from '@/types/simplifiedWidget'
 
 const props = defineProps<{
-  widget: SimplifiedWidget<void>
+  widget: SimplifiedWidget<undefined>
   nodeId: NodeId
 }>()
 

--- a/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
+++ b/src/renderer/extensions/vueNodes/widgets/composables/useProgressTextWidget.ts
@@ -38,14 +38,19 @@ export function useTextPreviewWidget(
         nodeId: node.id
       },
       options: {
-        getValue: () =>
-          useWidgetValueStore().getWidget(
-            widgetId(
-              resolveNodeRootGraphId(node, app.rootGraph.id),
-              node.id,
-              inputSpec.name
-            )
-          )?.value ?? '',
+        getValue: () => {
+          const value =
+            useWidgetValueStore().getWidget(
+              widgetId(
+                resolveNodeRootGraphId(node, app.rootGraph.id),
+                node.id,
+                inputSpec.name
+              )
+            )?.value ?? ''
+          return typeof value === 'number' || typeof value === 'boolean'
+            ? String(value)
+            : value
+        },
         setValue: (value: string | object) => {
           const graphId = resolveNodeRootGraphId(node, app.rootGraph.id)
           const widgetState = useWidgetValueStore().getWidget(

--- a/src/stores/widgetValueStore.ts
+++ b/src/stores/widgetValueStore.ts
@@ -6,6 +6,7 @@ import { parseNodeId } from '@/types/nodeId'
 import type { NodeId, SerializedNodeId } from '@/types/nodeId'
 import { parseWidgetId } from '@/types/widgetId'
 import type { WidgetId } from '@/types/widgetId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 import type { WidgetState, WidgetStateInit } from '@/types/widgetState'
 
 export interface WidgetRenderState {
@@ -84,7 +85,7 @@ export const useWidgetValueStore = defineStore('widgetValue', () => {
     if (order.length === 0) graphOrders.delete(nodeId)
   }
 
-  function registerWidget<TValue = unknown>(
+  function registerWidget<TValue extends WidgetValue = WidgetValue>(
     widgetId: WidgetId,
     init: WidgetStateInit<TValue>,
     renderState: WidgetRenderState = {}

--- a/src/stores/workspace/favoritedWidgetsStore.ts
+++ b/src/stores/workspace/favoritedWidgetsStore.ts
@@ -73,6 +73,10 @@ export const useFavoritedWidgetsStore = defineStore('favoritedWidgets', () => {
   /** In-memory array of favorited widget IDs, ordered for display */
   const favoritedIds = ref<string[]>([])
 
+  // TODO(ADR0009): key favorites by the host-scoped WidgetId instead of
+  // (nodeLocatorId, widgetName). That drops the isShownOnParents/favoriteNode
+  // indirection for promoted widgets. Deferred: needs a one-time migration of
+  // the persisted workflow.extra.favoritedWidgets format.
   /**
    * Generate a unique string key for a favorited widget ID.
    */

--- a/src/types/simplifiedWidget.ts
+++ b/src/types/simplifiedWidget.ts
@@ -12,15 +12,7 @@ import type { NodeId } from '@/types/nodeId'
 import type { NodeLocatorId } from '@/types/nodeIdentification'
 
 /** Valid types for widget values */
-export type WidgetValue =
-  | string
-  | number
-  | boolean
-  | object
-  | undefined
-  | null
-  | void
-  | File[]
+export type WidgetValue = string | number | boolean | object | undefined | null
 
 export const CONTROL_OPTIONS = [
   'fixed',

--- a/src/types/widgetState.ts
+++ b/src/types/widgetState.ts
@@ -3,9 +3,10 @@ import type {
   IWidgetOptions
 } from '@/lib/litegraph/src/types/widgets'
 import type { NodeId } from '@/types/nodeId'
+import type { WidgetValue } from '@/types/simplifiedWidget'
 
 export interface WidgetState<
-  TValue = unknown,
+  TValue = WidgetValue,
   TType extends string = string,
   TOptions extends IWidgetOptions = IWidgetOptions
 > extends Pick<
@@ -22,7 +23,7 @@ export interface WidgetState<
   nodeId: NodeId
 }
 
-export type WidgetStateInit<TValue = unknown> = Omit<
+export type WidgetStateInit<TValue = WidgetValue> = Omit<
   WidgetState<TValue>,
   'nodeId' | 'name' | 'y'
 > & { y?: number }

--- a/src/utils/widgetUtil.ts
+++ b/src/utils/widgetUtil.ts
@@ -1,5 +1,4 @@
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import type { SubgraphNode } from '@/lib/litegraph/src/subgraph/SubgraphNode'
 import { NodeSlotType } from '@/lib/litegraph/src/types/globalEnums'
 import type { IBaseWidget } from '@/lib/litegraph/src/types/widgets'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
@@ -45,10 +44,8 @@ export function getWidgetDefaultValue(
 export function renameWidget(
   widget: IBaseWidget,
   node: LGraphNode,
-  newLabel: string,
-  parents?: SubgraphNode[]
+  newLabel: string
 ): boolean {
-  void parents
   const label = newLabel || undefined
   const input = widget.widgetId
     ? node.inputs?.find((inp) => inp.widgetId === widget.widgetId)
@@ -85,8 +82,7 @@ export async function promptWidgetLabel(
 export async function promptRenameWidget(
   widget: IBaseWidget,
   node: LGraphNode,
-  t: (key: string) => string,
-  parents?: SubgraphNode[]
+  t: (key: string) => string
 ): Promise<string | null> {
   const rawLabel = await promptWidgetLabel(widget, t)
   if (rawLabel === null) return null
@@ -94,7 +90,7 @@ export async function promptRenameWidget(
   const normalizedLabel = rawLabel.trim()
   if (!normalizedLabel) return null
 
-  if (!renameWidget(widget, node, normalizedLabel, parents)) return null
+  if (!renameWidget(widget, node, normalizedLabel)) return null
 
   widget.callback?.(widget.value)
   useCanvasStore().canvas?.setDirty(true)


### PR DESCRIPTION
## Summary

Make right-side-panel promoted subgraph-input widget rows host-scoped, removing runtime graph traversal, per ADR0009.

## Changes

- **What**: `SectionWidgets.vue` and `WidgetActions.vue` no longer walk live links back to the interior source to identify promoted widgets. A promoted widget is host-scoped (`widget.widgetId = graphId:hostNodeId:inputName`, also carried on the host input slot), so reuse that:
  - `isLinked` → `inputForWidget(node, widget)?.widgetId != null`
  - `isWidgetShownOnParents` → match parent inputs by `widget.widgetId`
  - `handleHideInput` → drop the unreachable source-resolution branch (with the `String(node.id)===String(parent.id)` swap), keep `demoteWidget`
  - remove the now-unused `widgetPromotedSource` export
  - favorites keep their `(nodeLocatorId, widgetName)` key; added a `TODO(ADR0009)` to move to a pure `WidgetId` key (deferred — needs a persisted-format migration)
- **Breaking**: none. `resolvePromotedWidgetSource` in `clearWidgetErrors` is left intact (ADR0009 permits source lookup for diagnostics).

## Review Focus

Behavior equivalence of the three replaced predicates. The removed `handleHideInput` branch was unreachable: reaching it requires `!isLinked`, but whenever the old source resolved, `isLinked` was already true. The only divergences are broken/unresolvable interior links, which are strictly safer under the new logic. Net -55 lines, no new APIs.

Validated: `pnpm typecheck`, `pnpm lint`, `pnpm knip` clean; 127 subgraph/parameter unit tests pass.


## Addendum: widget-value type consolidation

`f48153d` fixes null handling and starts collapsing the redundant value types. Current state and the path to one canonical type:

**The problem.** Five spellings of the same union, each able to skew independently:

| Type | Was | Now |
|---|---|---|
| `WidgetValue` (simplifiedWidget.ts) | `string\|number\|boolean\|object\|undefined\|null\|void\|File[]` | canonical: `string\|number\|boolean\|object\|undefined\|null` |
| `TWidgetValue` (litegraph widgets.ts) | `IWidget['value']` (rejected null) | `= WidgetValue` alias |
| `WidgetState['value']` (widgetState.ts) | `unknown` | defaults to `WidgetValue` |
| `NodeProperty` (LGraphNode.ts) | no null (runtime stored null anyway) | `\|null` added |
| `IBaseWidget.callback` value param | `unknown` | `WidgetValue` |

The old `unknown` in the store forced `isWidgetValue(x) ? x : undefined` laundering at 6 call sites; 4 are now deleted. The guard survives only where it does real work: untrusted workflow JSON (`proxyWidgetMigration.pickHostValue`) and the serialize path (`SubgraphNode.serialize`).

**Remaining steps (follow-up PRs):**

1. Codemod `TWidgetValue` -> `WidgetValue` (~20 imports incl. `serialisation.ts`, `litegraph-augmentation.d.ts`, panel callbacks), delete the alias. Zero behavior change.
2. `NodeProperty = Exclude<WidgetValue, undefined>` - derives the one legitimate variant (properties use `undefined` as "absent") instead of a parallel hand-written union that can drift.
3. Move `WidgetValue` to a leaf module (litegraph currently imports it from app-layer `@/types/simplifiedWidget` - inverted layering).
4. Rename the shadowing generic `migrateWidgetsValues<TWidgetValue>` in `litegraphUtil.ts` to `<T>`.
5. (Riskier, last) Narrow the bare `object` members - `IChartWidget.value: object`, `ICustomWidget.value: string\|object` - to `Record<string, unknown>`. This is the only change that makes the union meaningfully narrower than "anything non-callable"; needs an ecosystem deprecation window since `custom` is the extension escape hatch.

**Invariant to keep:** `null` and `undefined` are distinct on purpose. `undefined` = hole/absent in `widgets_values` arrays and property-presence checks; `null` = a real stored value. Regression tests in `promotionUtils.test.ts` and `LGraphNode.test.ts` pin this.
