### PR TITLE
fix: infer App Mode from linearData when linearMode flag is absent

### DIFF
--- a/browser_tests/fixtures/components/Topbar.ts
+++ b/browser_tests/fixtures/components/Topbar.ts
@@ -60,8 +60,10 @@ export class Topbar {
   }
 
   getWorkflowTab(tabName: string): Locator {
+    // App mode keeps the graph-view tab bar in the DOM (hidden) while showing
+    // the linear-view tab bar, so match only the visible label.
     return this.page
-      .locator(`.workflow-tabs .workflow-label:has-text("${tabName}")`)
+      .locator('.workflow-tabs .workflow-label:visible', { hasText: tabName })
       .locator('..')
   }
 

--- a/browser_tests/fixtures/helpers/AppModeHelper.ts
+++ b/browser_tests/fixtures/helpers/AppModeHelper.ts
@@ -202,11 +202,31 @@ export class AppModeHelper {
   }
 
   /**
+   * Ensure app mode (linear view) is active, entering it only when needed.
+   *
+   * A workflow with populated linearData resolves to app mode on load, so a
+   * blind toggle would exit it. Toggle only when the current mode is not
+   * already the linear view.
+   */
+  async enterAppMode() {
+    const { workflow } = this.comfyPage
+    await workflow.waitForActiveWorkflow()
+    const mode =
+      (await workflow.getActiveWorkflowActiveAppMode()) ??
+      (await workflow.getActiveWorkflowInitialMode()) ??
+      'graph'
+    if (mode !== 'app' && mode !== 'builder:arrange') {
+      await this.comfyPage.command.executeCommand('Comfy.ToggleLinear')
+    }
+  }
+
+  /**
    * Inject linearData into the current graph and enter app mode.
    *
    * Serializes the graph, injects linearData with the given inputs and
-   * auto-detected output node IDs, then reloads so the appModeStore
-   * picks up the data via its activeWorkflow watcher.
+   * auto-detected output node IDs, then reloads. Populated linearData now
+   * resolves to app mode on load, so this enters app mode idempotently
+   * rather than blindly toggling.
    *
    * @param inputs - Widget selections as [nodeId, widgetName] tuples
    */
@@ -233,7 +253,7 @@ export class AppModeHelper {
       )
     }, inputs)
     await this.comfyPage.nextFrame()
-    await this.toggleAppMode()
+    await this.enterAppMode()
   }
 
   /**

--- a/browser_tests/tests/appModeValidationWarning.spec.ts
+++ b/browser_tests/tests/appModeValidationWarning.spec.ts
@@ -31,7 +31,7 @@ test.describe(
     test.beforeEach(async ({ comfyPage }) => {
       await enableErrorsOverlay(comfyPage)
       await comfyPage.workflow.loadWorkflow('linear-validation-warning')
-      await comfyPage.appMode.toggleAppMode()
+      await comfyPage.appMode.enterAppMode()
       await expect(comfyPage.appMode.linearWidgets).toBeVisible()
     })
 

--- a/src/platform/workflow/core/services/workflowService.test.ts
+++ b/src/platform/workflow/core/services/workflowService.test.ts
@@ -701,6 +701,73 @@ describe('useWorkflowService', () => {
 
       expect(existingWorkflow.shareId).toBe('share-2')
     })
+
+    describe('initial app mode inference', () => {
+      async function loadFreshTemporary(
+        extra: Record<string, unknown>
+      ): Promise<LoadedComfyWorkflow> {
+        vi.mocked(workflowStore.getWorkflowByPath).mockReturnValue(null)
+        const tempWorkflow = createModeTestWorkflow({
+          path: 'workflows/shared.json'
+        })
+        vi.mocked(workflowStore.createNewTemporary).mockReturnValue(
+          tempWorkflow
+        )
+        vi.mocked(workflowStore.openWorkflow).mockResolvedValue(tempWorkflow)
+
+        await useWorkflowService().afterLoadNewGraph(
+          'shared',
+          makeWorkflowData(extra) as never
+        )
+        return tempWorkflow
+      }
+
+      it('infers app mode from linearData outputs when linearMode is absent', async () => {
+        const workflow = await loadFreshTemporary({
+          linearData: { inputs: [], outputs: [4] }
+        })
+
+        expect(workflow.initialMode).toBe('app')
+      })
+
+      it('infers app mode when linearData mixes number and string node ids', async () => {
+        const workflow = await loadFreshTemporary({
+          linearData: {
+            inputs: [
+              [3, 'file'],
+              [5, 'upscaler_model'],
+              ['5', 'upscaler_creativity']
+            ],
+            outputs: [4]
+          }
+        })
+
+        expect(workflow.initialMode).toBe('app')
+      })
+
+      it('honors an explicit linearMode:false over populated linearData', async () => {
+        const workflow = await loadFreshTemporary({
+          linearMode: false,
+          linearData: { inputs: [[1, 'prompt']], outputs: [4] }
+        })
+
+        expect(workflow.initialMode).toBe('graph')
+      })
+
+      it('leaves mode unset when there is no linearMode or linearData', async () => {
+        const workflow = await loadFreshTemporary({})
+
+        expect(workflow.initialMode).toBeNull()
+      })
+
+      it('does not infer app mode from empty linearData selections', async () => {
+        const workflow = await loadFreshTemporary({
+          linearData: { inputs: [], outputs: [] }
+        })
+
+        expect(workflow.initialMode).toBeNull()
+      })
+    })
   })
 
   describe('per-workflow mode switching', () => {

--- a/src/platform/workflow/core/services/workflowService.ts
+++ b/src/platform/workflow/core/services/workflowService.ts
@@ -43,6 +43,35 @@ function linearModeToAppMode(linearMode: unknown): AppMode | null {
   return linearMode ? 'app' : 'graph'
 }
 
+function hasAppSelections(linearData: unknown): boolean {
+  if (typeof linearData !== 'object' || linearData === null) return false
+  const { inputs, outputs } = linearData as {
+    inputs?: unknown
+    outputs?: unknown
+  }
+  return (
+    (Array.isArray(inputs) && inputs.length > 0) ||
+    (Array.isArray(outputs) && outputs.length > 0)
+  )
+}
+
+/**
+ * Resolve the initial app mode for a freshly loaded, serialized workflow.
+ *
+ * An explicit `extra.linearMode` boolean is authoritative. When it is absent,
+ * fall back to inferring App Mode from a populated `extra.linearData` so app
+ * configs written without the flag (e.g. earlier `create_app` output, whose
+ * node ids may mix number/string types) open as apps instead of silently
+ * degrading to Graph mode.
+ */
+function resolveFreshLoadMode(
+  extra: ComfyWorkflowJSON['extra']
+): AppMode | null {
+  const explicit = linearModeToAppMode(extra?.linearMode)
+  if (explicit) return explicit
+  return hasAppSelections(extra?.linearData) ? 'app' : null
+}
+
 export const useWorkflowService = () => {
   const settingStore = useSettingStore()
   const workflowStore = useWorkflowStore()
@@ -453,8 +482,8 @@ export const useWorkflowService = () => {
     const wasAppMode = isAppMode.value
 
     // Determine the initial app mode for fresh loads from serialized state.
-    // null means linearMode was never explicitly set (not builder-saved).
-    const freshLoadMode = linearModeToAppMode(workflowData.extra?.linearMode)
+    // null means neither an explicit linearMode nor an inferable app config.
+    const freshLoadMode = resolveFreshLoadMode(workflowData.extra)
     useAppModeStore().loadSelections(workflowData.extra?.linearData)
 
     function trackIfEnteringApp(workflow: ComfyWorkflow) {
@@ -495,9 +524,8 @@ export const useWorkflowService = () => {
             // Prefer the file's linearMode over the draft's since the file
             // is the authoritative saved state.
             loadedWorkflow.initialMode =
-              linearModeToAppMode(
-                loadedWorkflow.initialState?.extra?.linearMode
-              ) ?? freshLoadMode
+              resolveFreshLoadMode(loadedWorkflow.initialState?.extra) ??
+              freshLoadMode
             trackIfEnteringApp(loadedWorkflow)
           }
           if (shareId) {


### PR DESCRIPTION
## ELI-5

Some shared workflows are really "apps" (a simplified input/output UI). The app
configuration lives in `extra.linearData`, and whether the editor opens in App
Mode vs Graph Mode is decided by a separate `extra.linearMode` boolean. Older
app-builder tooling wrote the app config but not that boolean, so those
workflows quietly opened as a plain graph and their app config was ignored.
This teaches the loader: if there's no explicit flag but there *is* app config,
open it as an app.

## Summary

Infer App Mode from a populated `extra.linearData` when the explicit
`extra.linearMode` flag is absent, so app configs written without the flag stop
silently degrading to Graph Mode.

## Changes

- **What**: `afterLoadNewGraph` now resolves the initial mode via a new
  `resolveFreshLoadMode(extra)` helper. An explicit `linearMode` boolean stays
  authoritative (including `false` → Graph); when it's absent, a non-empty
  `linearData.inputs`/`outputs` infers App Mode. All three `initialMode`
  derivation paths (fresh temporary, restored-workflow file-vs-draft, and the
  `initialMode === undefined` fallback) go through the same helper.

## Review Focus

- **Why not just "normalize id types"?** The original report guessed the trigger
  was `linearData` mixing number and string node ids (e.g.
  `[[5,"model"],["5","creativity"]]`). Investigating the current code, that mix
  is already tolerated: the workflow schema's `zNodeId` accepts either type, and
  node-id consumers normalize through `parseNodeId`/`String()` with
  type-insensitive object-key lookups. The mixed ids are a *marker* of the older
  tooling, not the mechanical cause. The actual cause of the Graph-Mode fallback
  is that mode is derived solely from `extra.linearMode`, which that tooling
  omitted — so the fix targets the mode derivation. A regression test still
  covers the exact mixed-id payload from the report.
- **Regression risk on plain graphs.** Inference only runs when `linearMode` is
  absent. The current editor always writes `linearMode` on save, so any
  editor-produced file/share has an explicit flag and never hits inference;
  `linearMode: false` is honored; empty `linearData` stays Graph. So inference
  effectively only affects externally-produced app configs. Covered by tests.
- **"Surface invalid config" not implemented.** The report suggested optionally
  surfacing an "app config invalid" warning. Since mixed ids are valid and the
  workflow now opens correctly as an app, there is no invalid state to surface —
  the degradation is removed rather than annotated.

Tested via `workflowService.test.ts` (red→green verified): inference from
outputs, inference from a mixed number/string id payload, explicit
`linearMode:false` wins, and empty/absent `linearData` stays unset.
