### PR TITLE
fix(manager): drop embed=true so the Cloud survey renders its dark theme

### DIFF
--- a/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
+++ b/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.test.ts
@@ -47,7 +47,7 @@ describe('ManagerSurveyDialog', () => {
     mocks.resolvedUserInfo.value = null
   })
 
-  it('embeds the configured survey URL with embed flag and the logged-in user', () => {
+  it('embeds the configured survey URL with the logged-in user', () => {
     mocks.remoteConfig.value = { manager_survey_url: SURVEY_URL }
     mocks.resolvedUserInfo.value = { id: 'user-123' }
 
@@ -57,7 +57,7 @@ describe('ManagerSurveyDialog', () => {
       screen.getByTestId('manager-survey-iframe').getAttribute('src')!
     )
     expect(src.origin + src.pathname).toBe(SURVEY_URL)
-    expect(src.searchParams.get('embed')).toBe('true')
+    expect(src.searchParams.has('embed')).toBe(false)
     expect(src.searchParams.get('distinct_id')).toBe('user-123')
   })
 

--- a/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.vue
+++ b/src/workbench/extensions/manager/components/survey/ManagerSurveyDialog.vue
@@ -82,7 +82,6 @@ const surveyUrl = computed(() => {
   if (!base) return undefined
   try {
     const url = new URL(base)
-    url.searchParams.set('embed', 'true')
     // Link responses to the logged-in user; omit for anonymous responses.
     const distinctId = resolvedUserInfo.value?.id
     if (distinctId) url.searchParams.set('distinct_id', distinctId)


### PR DESCRIPTION
Remove `embed=true`, so PostHog applies the survey's own dark appearance and it renders correctly.

Verified live on testcloud that removing the flag fixes the styling; `distinct_id` user linkage is unaffected.