### PR TITLE
test: lock mixed int/string node-id tolerance in linearData; warn on uninterpretable app config

### DIFF
--- a/src/platform/workflow/validation/schemas/workflowSchema.test.ts
+++ b/src/platform/workflow/validation/schemas/workflowSchema.test.ts
@@ -119,6 +119,31 @@ describe('parseComfyWorkflow', () => {
       const result = await validateComfyWorkflow(workflow)
       expect(result).toBeNull()
     })
+
+    it('accepts mixed int/string node ids and preserves linearMode', async () => {
+      const workflow = JSON.parse(JSON.stringify(defaultGraph))
+      workflow.extra = {
+        linearMode: true,
+        linearData: {
+          inputs: [
+            [3, 'file'],
+            [5, 'upscaler_model'],
+            [5, 'upscaler_resolution'],
+            ['5', 'upscaler_creativity']
+          ],
+          outputs: [4]
+        }
+      }
+      const result = await validateComfyWorkflow(workflow)
+      expect(result).not.toBeNull()
+      expect(result!.extra!.linearMode).toBe(true)
+      expect(result!.extra!.linearData!.inputs).toEqual([
+        [3, 'file'],
+        [5, 'upscaler_model'],
+        [5, 'upscaler_resolution'],
+        ['5', 'upscaler_creativity']
+      ])
+    })
   })
 
   it('workflow.nodes.pos', async () => {

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -580,6 +580,39 @@ describe('appModeStore', () => {
       expect(warnSpy).not.toHaveBeenCalled()
       warnSpy.mockRestore()
     })
+
+    it('does not warn while a graph is still loading', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      ChangeTracker.isLoadingGraph = true
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = [nodeWithWidgets(1, ['seed'])]
+      vi.mocked(app.rootGraph).getNodeById = vi.fn(() => null)
+      mockResolveNode.mockReturnValue(undefined)
+
+      store.loadSelections({ inputs: [[99, 'gone']], outputs: [99] })
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('app config could not be interpreted'),
+        expect.anything()
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn when the graph has no nodes', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = []
+      vi.mocked(app.rootGraph).getNodeById = vi.fn(() => null)
+      mockResolveNode.mockReturnValue(undefined)
+
+      store.loadSelections({ inputs: [[99, 'gone']], outputs: [99] })
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('app config could not be interpreted'),
+        expect.anything()
+      )
+      warnSpy.mockRestore()
+    })
   })
 
   describe('pruneLinearData during graph loading', () => {

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -494,6 +494,92 @@ describe('appModeStore', () => {
         })
       }
     })
+
+    it('resolves mixed int/string node ids to the same node', () => {
+      const node3 = nodeWithWidgets(3, ['file'])
+      const node5 = nodeWithWidgets(5, [
+        'upscaler_model',
+        'upscaler_resolution',
+        'upscaler_creativity'
+      ])
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = [node3, node5]
+      vi.mocked(app.rootGraph).getNodeById = vi.fn((id) =>
+        id === toNodeId(3) ? node3 : id === toNodeId(5) ? node5 : null
+      )
+      mockResolveNode.mockImplementation((id) =>
+        id === toNodeId(5) ? node5 : undefined
+      )
+
+      const result = store.pruneLinearData({
+        inputs: [
+          [3, 'file'],
+          [5, 'upscaler_model'],
+          [5, 'upscaler_resolution'],
+          ['5', 'upscaler_creativity']
+        ],
+        outputs: [5, '5']
+      })
+
+      expect(result.inputs).toEqual([
+        [`${rootGraphId}:3:file`, 'file'],
+        [`${rootGraphId}:5:upscaler_model`, 'upscaler_model'],
+        [`${rootGraphId}:5:upscaler_resolution`, 'upscaler_resolution'],
+        [`${rootGraphId}:5:upscaler_creativity`, 'upscaler_creativity']
+      ])
+      expect(result.outputs).toEqual([toNodeId(5), toNodeId(5)])
+    })
+  })
+
+  describe('loadSelections app-config warning', () => {
+    it('warns when non-empty linearData resolves to nothing', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = [nodeWithWidgets(1, ['seed'])]
+      vi.mocked(app.rootGraph).getNodeById = vi.fn(() => null)
+      mockResolveNode.mockReturnValue(undefined)
+
+      store.loadSelections({ inputs: [[99, 'gone']], outputs: [99] })
+
+      expect(store.selectedInputs).toEqual([])
+      expect(store.selectedOutputs).toEqual([])
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('app config could not be interpreted'),
+        expect.anything()
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn when the config resolves', () => {
+      const node1 = nodeWithWidgets(1, ['seed'])
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = [node1]
+      vi.mocked(app.rootGraph).getNodeById = vi.fn((id) =>
+        id === toNodeId(1) ? node1 : null
+      )
+      mockResolveNode.mockImplementation((id) =>
+        id === toNodeId(1) ? node1 : undefined
+      )
+
+      store.loadSelections({ inputs: [[1, 'seed']], outputs: [toNodeId(1)] })
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('app config could not be interpreted'),
+        expect.anything()
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn for empty config', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(app.rootGraph).nodes = [nodeWithWidgets(1, ['seed'])]
+
+      store.loadSelections({})
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
   })
 
   describe('pruneLinearData during graph loading', () => {

--- a/src/stores/appModeStore.test.ts
+++ b/src/stores/appModeStore.test.ts
@@ -527,6 +527,8 @@ describe('appModeStore', () => {
         [`${rootGraphId}:5:upscaler_resolution`, 'upscaler_resolution'],
         [`${rootGraphId}:5:upscaler_creativity`, 'upscaler_creativity']
       ])
+      // intentional: the same node is referenced in both int and string form;
+      // duplicates are preserved and left for downstream consumers to dedupe
       expect(result.outputs).toEqual([toNodeId(5), toNodeId(5)])
     })
   })
@@ -564,6 +566,52 @@ describe('appModeStore', () => {
 
       store.loadSelections({ inputs: [[1, 'seed']], outputs: [toNodeId(1)] })
 
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('app config could not be interpreted'),
+        expect.anything()
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn when only inputs resolve (partial resolution is success)', () => {
+      const node1 = nodeWithWidgets(1, ['seed'])
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = [node1]
+      vi.mocked(app.rootGraph).getNodeById = vi.fn((id) =>
+        id === toNodeId(1) ? node1 : null
+      )
+      mockResolveNode.mockImplementation((id) =>
+        id === toNodeId(1) ? node1 : undefined
+      )
+
+      store.loadSelections({ inputs: [[1, 'seed']], outputs: [99] })
+
+      expect(store.selectedInputs.length).toBeGreaterThan(0)
+      expect(store.selectedOutputs).toEqual([])
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('app config could not be interpreted'),
+        expect.anything()
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn when only outputs resolve (partial resolution is success)', () => {
+      const node1 = nodeWithWidgets(1, ['seed'])
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.mocked(app.rootGraph).id = rootGraphId
+      vi.mocked(app.rootGraph).nodes = [node1]
+      vi.mocked(app.rootGraph).getNodeById = vi.fn((id) =>
+        id === toNodeId(1) ? node1 : null
+      )
+      mockResolveNode.mockImplementation((id) =>
+        id === toNodeId(1) ? node1 : undefined
+      )
+
+      store.loadSelections({ inputs: [[99, 'gone']], outputs: [1] })
+
+      expect(store.selectedInputs).toEqual([])
+      expect(store.selectedOutputs.length).toBeGreaterThan(0)
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('app config could not be interpreted'),
         expect.anything()

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -193,7 +193,7 @@ export const useAppModeStore = defineStore('appMode', () => {
     resolvedOutputs: NodeId[]
   ) {
     if (ChangeTracker.isLoadingGraph) return
-    if (!app.rootGraph?.nodes.length) return
+    if (!app.rootGraph?.nodes?.length) return
     const hadConfig = !!(data?.inputs?.length || data?.outputs?.length)
     if (!hadConfig || resolvedInputs.length || resolvedOutputs.length) return
     console.warn(

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -193,9 +193,12 @@ export const useAppModeStore = defineStore('appMode', () => {
     resolvedOutputs: NodeId[]
   ) {
     if (ChangeTracker.isLoadingGraph) return
+
     if (!app.rootGraph?.nodes?.length) return
+
     const hadConfig = !!(data?.inputs?.length || data?.outputs?.length)
     if (!hadConfig || resolvedInputs.length || resolvedOutputs.length) return
+
     console.warn(
       '[appModeStore] app config could not be interpreted; no inputs or outputs resolved from linearData',
       { inputs: data?.inputs, outputs: data?.outputs }

--- a/src/stores/appModeStore.ts
+++ b/src/stores/appModeStore.ts
@@ -187,10 +187,26 @@ export const useAppModeStore = defineStore('appMode', () => {
     return null
   }
 
+  function warnOnUninterpretableAppConfig(
+    data: Partial<LinearData> | undefined,
+    resolvedInputs: LinearInput[],
+    resolvedOutputs: NodeId[]
+  ) {
+    if (ChangeTracker.isLoadingGraph) return
+    if (!app.rootGraph?.nodes.length) return
+    const hadConfig = !!(data?.inputs?.length || data?.outputs?.length)
+    if (!hadConfig || resolvedInputs.length || resolvedOutputs.length) return
+    console.warn(
+      '[appModeStore] app config could not be interpreted; no inputs or outputs resolved from linearData',
+      { inputs: data?.inputs, outputs: data?.outputs }
+    )
+  }
+
   function loadSelections(data: Partial<LinearData> | undefined) {
     const { inputs, outputs } = pruneLinearData(data)
     selectedInputs.value = inputs
     selectedOutputs.value = outputs
+    warnOnUninterpretableAppConfig(data, inputs, outputs)
   }
 
   function resetSelectedToWorkflow() {


### PR DESCRIPTION
## ELI-5

Some shared workflows are "apps" (a simplified input/output UI). Whether the
editor opens an app in App Mode vs Graph Mode is decided by one authoritative
flag, `extra.linearMode`. The app's input/output config lives separately in
`extra.linearData`, whose node ids can be written as either numbers (`5`) or
strings (`"5"`) — and older app-export tooling sometimes mixed both in one file.
The worry was that this int/string mix made an app silently open as a plain
graph. This change proves the mix is already tolerated end-to-end and locks that
in with tests, and adds a diagnostic when an app's config genuinely can't be
interpreted so it no longer fails completely silently.

## Summary

Regression-proof the mixed int/string `linearData` node-id case (schema +
selection resolution) and surface a warning when an app's `linearData` resolves
to no usable inputs/outputs, without changing how app-ness is decided.

## Changes

- **What**:
  - `appModeStore`: `loadSelections` now emits a single console warning when a
    workflow supplied non-empty `linearData` but none of it resolved to a real
    input or output (guarded against the deferred-load case: skipped while the
    graph is still loading and when the root graph has no nodes yet). This
    replaces the previous fully-silent degrade path for genuinely
    uninterpretable app config.
  - Tests: schema-level test that the exact reported mixed-id payload validates
    and preserves `linearMode`; `pruneLinearData` test that a node referenced as
    both `5` and `"5"` resolves to the same node for inputs and outputs; warning
    behavior tests.
- **Breaking**: none. App-detection semantics are unchanged — `linearMode`
  stays the sole authority.

## Review Focus

- **App-detection is deliberately untouched.** Per prior maintainer guidance,
  `extra.linearMode` is the authoritative "this is an app" flag and predates
  `linearData`; a workflow may legitimately carry `linearData` without being an
  app. This PR does **not** infer App Mode from `linearData` presence.
- **The int/string mix is already tolerated on `main`** — this was verified, not
  assumed. `zNodeId` accepts either type (so the whole workflow, including
  `linearMode`, still validates), and every id consumer normalizes through
  `parseNodeId`/`String()` while `getNodeById` is JS-object-key based, so `5`
  and `"5"` collapse to the same node. The added tests lock this behavior so it
  can't regress. For a workflow already marked as an app (`linearMode: true`),
  a mixed-id `linearData` therefore opens in App Mode identically to an all-int
  version.
- **Remaining "opens as graph" cases are pre-`linearMode` exports, not the id
  mix.** A share that opens as a graph despite carrying `linearData` is one whose
  older tooling never wrote `linearMode`; re-exporting through current tooling
  (which writes the flag) is what fixes it. Making those open as apps would
  require inferring app-ness from `linearData`, which is explicitly out of scope.
  The durable fix for legacy exports belongs on the export side.
- **Warning altitude.** The "surface a warning" ask is implemented as a guarded
  `console.warn` (matching the existing per-entry warnings in this store) rather
  than a new user-facing banner — a full UI surface would need i18n + design
  review and is not warranted for this edge case. Easy to elevate later if
  desired.

## Screenshots (if applicable)

n/a
