### PR TITLE
fix(mobile): release media decode buffers on unmount to prevent iOS Safari crash

### DIFF
--- a/src/components/sidebar/tabs/queue/ResultVideo.vue
+++ b/src/components/sidebar/tabs/queue/ResultVideo.vue
@@ -1,13 +1,14 @@
 <template>
-  <video controls class="max-h-[90vh] max-w-[90vw]">
+  <video ref="videoRef" controls class="max-h-[90vh] max-w-[90vw]">
     <source :src="url" :type="htmlVideoType" />
     {{ $t('g.videoFailedToLoad') }}
   </video>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 
+import { useReleaseMediaOnUnmount } from '@/composables/useReleaseMediaOnUnmount'
 import { useSettingStore } from '@/platform/settings/settingStore'
 import { useExtensionStore } from '@/stores/extensionStore'
 import type { ResultItemImpl } from '@/stores/queueStore'
@@ -36,4 +37,6 @@ const url = computed(() =>
 const htmlVideoType = computed(() =>
   vhsAdvancedPreviews.value ? 'video/webm' : props.result.htmlVideoType
 )
+
+useReleaseMediaOnUnmount(useTemplateRef('videoRef'))
 </script>

--- a/src/composables/useReleaseMediaOnUnmount.test.ts
+++ b/src/composables/useReleaseMediaOnUnmount.test.ts
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/vue'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import { useReleaseMediaOnUnmount } from './useReleaseMediaOnUnmount'
+
+/**
+ * Renders a component that wires the composable to a media element, so we can
+ * assert the teardown that `<video>`/`<audio>` need on iOS Safari.
+ */
+function mountWithMedia(el: HTMLMediaElement | null) {
+  const elementRef = ref(el)
+  return render(
+    defineComponent({
+      setup() {
+        useReleaseMediaOnUnmount(elementRef)
+        return () => h('div')
+      }
+    })
+  )
+}
+
+function createVideoWithSources(count: number) {
+  const video = document.createElement('video')
+  for (let i = 0; i < count; i++) {
+    video.append(document.createElement('source'))
+  }
+  return video
+}
+
+describe('useReleaseMediaOnUnmount', () => {
+  it('pauses, clears the source, and reloads the element on unmount', () => {
+    const video = createVideoWithSources(1)
+    video.setAttribute('src', 'blob:example')
+    const pause = vi.spyOn(video, 'pause')
+    const load = vi.spyOn(video, 'load')
+
+    const { unmount } = mountWithMedia(video)
+    expect(pause).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(pause).toHaveBeenCalledOnce()
+    expect(video.hasAttribute('src')).toBe(false)
+    expect(video).toBeEmptyDOMElement()
+    expect(load).toHaveBeenCalledOnce()
+  })
+
+  it('removes every nested <source> child so load() drops the buffer', () => {
+    const video = createVideoWithSources(2)
+
+    mountWithMedia(video).unmount()
+
+    expect(video).toBeEmptyDOMElement()
+  })
+
+  it('is a no-op when the element ref is empty', () => {
+    expect(() => mountWithMedia(null).unmount()).not.toThrow()
+  })
+})

--- a/src/composables/useReleaseMediaOnUnmount.ts
+++ b/src/composables/useReleaseMediaOnUnmount.ts
@@ -1,0 +1,27 @@
+import { onBeforeUnmount } from 'vue'
+import type { Ref } from 'vue'
+
+/**
+ * Force-release a media element's decode buffers before it unmounts.
+ *
+ * iOS Safari keeps a detached `<video>`/`<audio>`'s media pipeline and decoded
+ * frames alive when Vue merely removes the element from the DOM. Without an
+ * explicit pause + source clear + `load()`, repeatedly opening media previews
+ * (e.g. a long clip in the full-screen lightbox) accumulates decoded memory
+ * until WebKit kills the renderer process — the "A problem repeatedly occurred"
+ * crash. See FE-1105.
+ *
+ * Handles both the `src`-attribute and nested `<source>`-element forms.
+ */
+export function useReleaseMediaOnUnmount(
+  elementRef: Readonly<Ref<HTMLMediaElement | null>>
+) {
+  onBeforeUnmount(() => {
+    const el = elementRef.value
+    if (!el) return
+    el.pause()
+    el.removeAttribute('src')
+    while (el.firstChild) el.removeChild(el.firstChild)
+    el.load()
+  })
+}

--- a/src/renderer/extensions/linearMode/MediaOutputPreview.vue
+++ b/src/renderer/extensions/linearMode/MediaOutputPreview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, useAttrs } from 'vue'
+import { computed, defineAsyncComponent, useAttrs, useTemplateRef } from 'vue'
 
+import { useReleaseMediaOnUnmount } from '@/composables/useReleaseMediaOnUnmount'
 import ImagePreview from '@/renderer/extensions/linearMode/ImagePreview.vue'
 import VideoPreview from '@/renderer/extensions/linearMode/VideoPreview.vue'
 import { getMediaType } from '@/renderer/extensions/linearMode/mediaTypes'
@@ -23,6 +24,8 @@ const mediaType = computed(() => getMediaType(output))
 const outputLabel = computed(
   () => output.display_name?.trim() || output.filename
 )
+
+useReleaseMediaOnUnmount(useTemplateRef('audioRef'))
 </script>
 <template>
   <template v-if="mediaType === 'images' || mediaType === 'video'">
@@ -48,6 +51,7 @@ const outputLabel = computed(
   <template v-else>
     <audio
       v-if="mediaType === 'audio'"
+      ref="audioRef"
       :class="cn('m-auto w-full', attrs.class as string)"
       controls
       :src="output.url"

--- a/src/renderer/extensions/linearMode/VideoPreview.vue
+++ b/src/renderer/extensions/linearMode/VideoPreview.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, useTemplateRef } from 'vue'
 
+import { useReleaseMediaOnUnmount } from '@/composables/useReleaseMediaOnUnmount'
+
 const { src } = defineProps<{
   src: string
   label?: string
@@ -9,6 +11,8 @@ const { src } = defineProps<{
 const videoRef = useTemplateRef('videoRef')
 const width = ref('')
 const height = ref('')
+
+useReleaseMediaOnUnmount(videoRef)
 </script>
 <template>
   <video


### PR DESCRIPTION
## Problem

Cloud mobile (iPhone Safari) crashes with WebKit's "A problem repeatedly occurred" error when a user repeatedly opens a media asset preview and navigates between the full-screen preview and the workflow view.

The error is a renderer-process kill from exceeding iOS memory limits. Root cause: media elements are never torn down on unmount. When the full-screen lightbox (or the linear-mode preview) closes, Vue only detaches the `<video>`/`<audio>` from the DOM — nothing calls `pause()`, clears the source, or `load()`. On iOS Safari a detached media element keeps its media pipeline and decoded frame buffers alive, so repeatedly opening a preview (e.g. the reported 32s clip) accumulates decoded memory until the renderer is killed. "Second attempt crashes" is the classic accumulation signature.

## Fix

Add `useReleaseMediaOnUnmount` — an `onBeforeUnmount` hook that pauses, clears the source (both `src`-attribute and nested `<source>` forms), and calls `load()` to force WebKit to release the decode buffers. Wired into:

- `ResultVideo.vue` — the full-screen lightbox video (the reported crash path)
- `VideoPreview.vue` — linear-mode video preview (also covers `MediaOutputPreview`'s video)
- `MediaOutputPreview.vue` — linear-mode inline `<audio>`

Mirrors existing cleanup patterns (`LazyImage.vue`, `Media3DTop.vue`).

Scope kept minimal (the raw media elements on the crash path). Grid tiles (`MediaVideoTop.vue`), the `mediaCacheService` blob retention, and `GraphCanvas` context disposal are related amplifiers but left out to keep this focused; can follow up if the crash persists.

Note: iOS Safari memory crashes can't be reproduced deterministically in CI/local, so this eliminates a confirmed leak on the reported path rather than being a locally-verifiable fix.

- Fixes FE-1105
