### PR TITLE
ECS: derive slot floating links; reroute cleanup follow-ups

### DIFF
--- a/docs/adr/0008-entity-component-system.md
+++ b/docs/adr/0008-entity-component-system.md
@@ -21,6 +21,22 @@ text below says "the World," read "the set of dedicated stores"; where it shows
 `world.getComponent(id, Component)`, read the matching store getter (for
 example `widgetValueStore.getWidget(widgetId)`).
 
+### Amendment (2026-07-05, PRs 13436/13449)
+
+Two stores joined the dedicated-store set: `linkStore` (link topology,
+keyed by target input slot in root-graph-scoped buckets — see
+[Link Topology Store](../architecture/link-topology-store.md)) and
+`rerouteStore` (reroute chain state with link membership derived from
+the links' `parentId` chains — see
+[Reroute Chain Store](../architecture/reroute-chain-store.md)). Both
+follow the proxy-returning registration pattern established by
+`BaseWidget`/`widgetValueStore`: the store bucket is a `reactive(Map)`,
+registration inserts the class's state object by reference and the class
+adopts the reactive proxy read back from the bucket, so class field
+writes are tracked without an action chokepoint. The `layoutStore` link
+connectivity mirror and the `slot._floatingLinks` sets were deleted in
+the same work; the layout store now holds geometry only.
+
 ## Context
 
 The litegraph layer is built on deeply coupled OOP classes (`LGraphNode`, `LLink`, `Subgraph`, `BaseWidget`, `Reroute`, `LGraphGroup`, `SlotBase`). Each entity directly references its container and children — nodes hold widget arrays, widgets back-reference their node, links reference origin/target node IDs, subgraphs extend the graph class, and so on.
@@ -115,6 +131,15 @@ Components are plain data objects — no methods, no back-references to parent e
 | `LinkVisual`    | `color`, `path`, `_pos` (center point)                         |
 | `LinkState`     | `_dragging`, `data`                                            |
 
+> **Amended (2026-07-05):** `LinkEndpoints` shipped as
+> `LinkTopology { id, originNodeId, originSlot, targetNodeId,
+targetSlot, type, parentId? }` in a dedicated `linkStore`, keyed by
+> **target input slot** (not link id) in root-graph-scoped buckets, with
+> floating and subgraph-output links in an unkeyed side set. `LLink`
+> reads through the store's reactive proxy (`_state`). See
+> [Link Topology Store](../architecture/link-topology-store.md).
+> `LinkVisual` and `LinkState` remain unextracted.
+
 #### Subgraph (Node Components)
 
 A node carrying a subgraph gains these additional components. Subgraphs are not a separate entity kind — see [Subgraph Boundaries](../architecture/subgraph-boundaries-and-promotion.md).
@@ -139,6 +164,13 @@ A node carrying a subgraph gains these additional components. Subgraphs are not 
 | `SlotIdentity`   | `name`, `type` (slot type), direction (`input` or `output`), parent node ref, index |
 | `SlotConnection` | `link` (input) or `links[]` (output), `widget` locator                              |
 | `SlotVisual`     | `pos`, `boundingRect`, `color_on`, `color_off`, `shape`                             |
+
+> **Amended (2026-07-05):** the input side of `SlotConnection` is
+> subsumed by the `linkStore` key — the input-slot→link mapping _is_ the
+> store's primary index (`isInputSlotConnected` / `getInputSlotLink`).
+> The `slot._floatingLinks` sets were deleted; floating-link attachment
+> is derived from the links' own endpoints (`slotFloatingLinks`). The
+> `input.link` / `output.links` class mirrors remain un-migrated.
 
 #### Reroute
 
@@ -278,6 +310,9 @@ Companion architecture documents that expand on the design in this ADR:
 | [ECS Migration Plan](../architecture/ecs-migration-plan.md)                                      | Phased migration roadmap with shipping milestones and go/no-go criteria                                  |
 | [ECS Lifecycle Scenarios](../architecture/ecs-lifecycle-scenarios.md)                            | Before/after walkthroughs of lifecycle operations (node removal, link creation, etc.)                    |
 | [Subgraph Boundaries and Widget Promotion](../architecture/subgraph-boundaries-and-promotion.md) | Design rationale for modeling subgraphs as node components, not separate entities                        |
+| [Link Topology Store](../architecture/link-topology-store.md)                                    | Design record for the `linkStore` — target-input-slot keying, root-scoped buckets, registration protocol |
+| [Reroute Chain Store](../architecture/reroute-chain-store.md)                                    | Design record for the `rerouteStore` — chain state, derived link membership, load-time id dedup          |
+| [Domain Glossary](../architecture/domain-glossary.md)                                            | Canonical vocabulary for links, reroutes, chains, and membership                                         |
 | [ADR 0009: Subgraph promoted widgets](0009-subgraph-promoted-widgets-use-linked-inputs.md)       | Follow-up decision for promoted widget identity and value ownership at subgraph boundaries               |
 | [Appendix: Critical Analysis](../architecture/appendix-critical-analysis.md)                     | Independent verification of the accuracy of the architecture documents                                   |
 | [Appendix: ECS Pattern Survey](../architecture/appendix-ecs-pattern-survey.md)                   | Survey of bitECS, miniplex, koota, ECSY, Thyseus, and Bevy — patterns adopted, departed, when to revisit |

--- a/docs/architecture/domain-glossary.md
+++ b/docs/architecture/domain-glossary.md
@@ -4,6 +4,11 @@ Canonical vocabulary for the graph domain. Terms are added as they are
 resolved during design work; keep entries implementation-free. Intended
 to grow into a proper reference document.
 
+Design records that rely on this vocabulary:
+[Link Topology Store](link-topology-store.md),
+[Reroute Chain Store](reroute-chain-store.md),
+[ADR 0008](../adr/0008-entity-component-system.md).
+
 ## Links & Reroutes
 
 - **Link** — a directed data connection from one node's output slot to

--- a/docs/architecture/ecs-lifecycle-scenarios.md
+++ b/docs/architecture/ecs-lifecycle-scenarios.md
@@ -96,15 +96,15 @@ sequenceDiagram
 
 ### Key Differences
 
-| Aspect              | Current                                          | ECS                                                                                                       |
-| ------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| Lines of code       | ~107 in one method                               | ~30 in system function                                                                                    |
-| Entity types known  | Graph knows about all 6+ types                   | ConnectivitySystem coordinates linkStore + layout/widget/output stores                                    |
-| Cleanup             | Manual per-slot, per-link, per-reroute           | linkStore unregistration per link (via `_removeLink`) + geometry drop per layout entry                    |
-| Canvas notification | `setDirtyCanvas()` called explicitly             | Vue reactivity: components re-render when store entries change                                            |
-| Store cleanup       | WidgetValueStore/LayoutStore NOT cleaned up      | Coordinated: `deleteWidget`, linkStore unregister + `deleteNode`, `removeNodeOutputs`, `unregisterWidget` |
-| Undo/redo           | `beforeChange()`/`afterChange()` manually placed | Layout mutations are command records, replayable and undoable                                             |
-| Testability         | Needs full LGraph + LGraphCanvas                 | Needs only the relevant stores + ConnectivitySystem                                                       |
+| Aspect              | Current                                                                       | ECS                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Lines of code       | ~107 in one method                                                            | ~30 in system function                                                                                    |
+| Entity types known  | Graph knows about all 6+ types                                                | ConnectivitySystem coordinates linkStore + layout/widget/output stores                                    |
+| Cleanup             | Manual per-slot, per-link, per-reroute                                        | linkStore unregistration per link (via `_removeLink`) + geometry drop per layout entry                    |
+| Canvas notification | `setDirtyCanvas()` called explicitly                                          | Vue reactivity: components re-render when store entries change                                            |
+| Store cleanup       | WidgetValueStore not cleaned up; link geometry still removed from LayoutStore | Coordinated: `deleteWidget`, linkStore unregister + `deleteNode`, `removeNodeOutputs`, `unregisterWidget` |
+| Undo/redo           | `beforeChange()`/`afterChange()` manually placed                              | Layout mutations are command records, replayable and undoable                                             |
+| Testability         | Needs full LGraph + LGraphCanvas                                              | Needs only the relevant stores + ConnectivitySystem                                                       |
 
 ## 2. Serialization
 

--- a/docs/architecture/ecs-lifecycle-scenarios.md
+++ b/docs/architecture/ecs-lifecycle-scenarios.md
@@ -2,7 +2,7 @@
 
 This document walks through the major entity lifecycle operations — showing the current imperative implementation and how each transforms under the ECS architecture from [ADR 0008](../adr/0008-entity-component-system.md).
 
-ECS principles are realized across a set of dedicated Pinia stores keyed by string IDs (shipped in PR 12617): `widgetValueStore` (keyed by `WidgetId` = `graphId:nodeId:name`, see `src/types/widgetId.ts`), `layoutStore` (mutated via `useLayoutMutations()`), `nodeOutputStore`, `domWidgetStore`, `subgraphNavigationStore`, and `previewExposureStore`. Components live as plain-data entries in these stores; systems read and mutate them through store getters and command-style mutations.
+ECS principles are realized across a set of dedicated Pinia stores keyed by string IDs (shipped in PR 12617): `widgetValueStore` (keyed by `WidgetId` = `graphId:nodeId:name`, see `src/types/widgetId.ts`), `layoutStore` (mutated via `useLayoutMutations()`), `nodeOutputStore`, `domWidgetStore`, `subgraphNavigationStore`, and `previewExposureStore`. Link topology and reroute chain state shipped later into `linkStore` (PR 13436, keyed by target input slot in root-graph-scoped buckets — see [link-topology-store.md](link-topology-store.md)) and `rerouteStore` (PR 13449, membership derived from the links' `parentId` chains — see [reroute-chain-store.md](reroute-chain-store.md)); `layoutStore` keeps link/reroute geometry only. Components live as plain-data entries in these stores; systems read and mutate them through store getters and command-style mutations.
 
 Each scenario follows the same structure: **Current Flow** (what happens today), **ECS Flow** (the store-backed target), and a **Key Differences** table.
 
@@ -66,6 +66,7 @@ sequenceDiagram
     participant Caller
     participant CS as ConnectivitySystem
     participant LM as useLayoutMutations()
+    participant LKS as linkStore
     participant LS as layoutStore
     participant WVS as widgetValueStore
     participant NOS as nodeOutputStore
@@ -73,12 +74,14 @@ sequenceDiagram
 
     Caller->>CS: removeNode(nodeId)
 
-    CS->>LS: read node links (incoming + outgoing)
-    LS-->>CS: linkIds
+    CS->>LKS: read node links (incoming + outgoing)
+    LKS-->>CS: link topologies
 
-    loop each linkId
-        CS->>LM: deleteLink(linkId)
-        Note over LM,LS: removes link entry +<br/>updates both slot endpoints
+    loop each link
+        CS->>LKS: unregister link topology
+        Note over CS,LKS: via the LGraph._removeLink chokepoint —<br/>map delete + store unregistration
+        CS->>LS: drop link geometry
+        Note over LKS,LS: linkStore owns topology;<br/>layoutStore only drops geometry
     end
 
     loop each widget on node
@@ -93,15 +96,15 @@ sequenceDiagram
 
 ### Key Differences
 
-| Aspect              | Current                                          | ECS                                                                                             |
-| ------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| Lines of code       | ~107 in one method                               | ~30 in system function                                                                          |
-| Entity types known  | Graph knows about all 6+ types                   | ConnectivitySystem coordinates layoutStore + widget/output stores                               |
-| Cleanup             | Manual per-slot, per-link, per-reroute           | `deleteLink()`/`deleteNode()` mutations per layout entry                                        |
-| Canvas notification | `setDirtyCanvas()` called explicitly             | Vue reactivity: components re-render when store entries change                                  |
-| Store cleanup       | WidgetValueStore/LayoutStore NOT cleaned up      | Coordinated: `deleteWidget`, `deleteLink`/`deleteNode`, `removeNodeOutputs`, `unregisterWidget` |
-| Undo/redo           | `beforeChange()`/`afterChange()` manually placed | Layout mutations are command records, replayable and undoable                                   |
-| Testability         | Needs full LGraph + LGraphCanvas                 | Needs only the relevant stores + ConnectivitySystem                                             |
+| Aspect              | Current                                          | ECS                                                                                                       |
+| ------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Lines of code       | ~107 in one method                               | ~30 in system function                                                                                    |
+| Entity types known  | Graph knows about all 6+ types                   | ConnectivitySystem coordinates linkStore + layout/widget/output stores                                    |
+| Cleanup             | Manual per-slot, per-link, per-reroute           | linkStore unregistration per link (via `_removeLink`) + geometry drop per layout entry                    |
+| Canvas notification | `setDirtyCanvas()` called explicitly             | Vue reactivity: components re-render when store entries change                                            |
+| Store cleanup       | WidgetValueStore/LayoutStore NOT cleaned up      | Coordinated: `deleteWidget`, linkStore unregister + `deleteNode`, `removeNodeOutputs`, `unregisterWidget` |
+| Undo/redo           | `beforeChange()`/`afterChange()` manually placed | Layout mutations are command records, replayable and undoable                                             |
+| Testability         | Needs full LGraph + LGraphCanvas                 | Needs only the relevant stores + ConnectivitySystem                                                       |
 
 ## 2. Serialization
 
@@ -223,7 +226,7 @@ sequenceDiagram
     end
 
     opt has subgraph definitions
-        G->>G: deduplicateSubgraphNodeIds()
+        G->>G: deduplicateSubgraphNodeIds() + deduplicateSubgraphRerouteIds()
         loop each subgraph (topological order)
             G->>G: createSubgraph(data)
         end
@@ -250,7 +253,7 @@ sequenceDiagram
     end
 
     G->>G: add floating links
-    G->>G: validate reroutes
+    G->>G: prune reroutes with derived totalLinks === 0
     G->>G: _removeDuplicateLinks()
 
     loop each serialized group
@@ -261,6 +264,8 @@ sequenceDiagram
 ```
 
 Problems: two-phase creation is necessary because nodes need to reference each other's links during configure. Widget value restoration happens deep inside `node.configure()`. Store population is a side effect of configuration. Subgraph creation requires topological sorting to handle nested subgraphs.
+
+Note on load-time id hygiene: root `configure()` deduplicates **node ids** and **reroute ids** across sibling subgraph definitions before configuring them (`deduplicateSubgraphNodeIds` / `deduplicateSubgraphRerouteIds`), because both share root-graph-scoped store buckets. Link-id dedup is deliberately absent — the linkStore key is the target input slot, not the link id, so duplicate link ids across definitions cannot collide. Orphaned reroutes are pruned by the derived `totalLinks === 0` check; the old `validateLinks` set-repair is gone (membership is derived, so there is no stored set to drift).
 
 ### ECS Flow
 
@@ -532,7 +537,7 @@ sequenceDiagram
     participant G as LGraph
     participant L as LLink
     participant R as Reroute
-    participant LS as LayoutStore
+    participant LKS as linkStore
 
     Caller->>N1: connectSlots(output, targetNode, input)
 
@@ -545,24 +550,24 @@ sequenceDiagram
     end
 
     N1->>L: new LLink(++lastLinkId, type, ...)
-    N1->>G: _links.set(link.id, link)
-    N1->>LS: layoutMutations.createLink()
+    N1->>G: graph._addLink(link)
+    G->>LKS: register topology (keyed by target input slot)
+    Note over G,LKS: chokepoint: _links.set + linkStore registration
 
     N1->>N1: output.links.push(link.id)
     N1->>N2: input.link = link.id
 
-    loop each reroute in path
-        N1->>R: reroute.linkIds.add(link.id)
-    end
+    N1->>R: anchorRerouteChain(graph, link)
+    Note over N1,R: clears floating markers on the chain —<br/>membership is derived from link.parentId,<br/>no per-reroute linkIds writes
 
-    N1->>G: _version++
+    N1->>G: incrementVersion()
     N1->>N1: onConnectionsChange?(OUTPUT, ...)
     N1->>N2: onConnectionsChange?(INPUT, ...)
     N1->>G: setDirtyCanvas()
     N1->>G: afterChange()
 ```
 
-Problems: the source node orchestrates everything — it reaches into the graph's link map, the target node's slot, the layout store, the reroute chain, and the version counter. 19 steps in one method.
+Problems: the source node orchestrates everything — it reaches into the graph's link map (via the `_addLink` chokepoint), the target node's slot, and the version counter. Reroute membership no longer needs writes (derived via rerouteStore), but the slot mirrors (`output.links`, `input.link`) are still mutated by hand.
 
 ### ECS Flow
 
@@ -570,29 +575,28 @@ Problems: the source node orchestrates everything — it reaches into the graph'
 sequenceDiagram
     participant Caller
     participant CS as ConnectivitySystem
-    participant LS as layoutStore
-    participant LM as useLayoutMutations()
+    participant LKS as linkStore
 
     Caller->>CS: connect(outputSlot, inputSlot)
 
-    CS->>LS: read input slot link
+    CS->>LKS: getInputSlotLink(graphId, targetNodeId, targetSlot)
     opt already connected
-        CS->>LM: deleteLink(existingLinkId)
+        CS->>LKS: unregister existing topology
     end
 
-    CS->>LM: createLink(linkId, {<br/>  originNodeId, originSlotIndex,<br/>  targetNodeId, targetSlotIndex, type<br/>})
-    Note over LM,LS: createLink updates both slot endpoints<br/>and emits a command record
+    CS->>LKS: register LinkTopology {<br/>  id, originNodeId, originSlot,<br/>  targetNodeId, targetSlot, type<br/>}
+    Note over CS,LKS: the target-slot key IS the input-side<br/>slot connection — no separate endpoint update.<br/>Reroute membership derives from parentId;<br/>rerouteStore needs no write
 ```
 
 ### Key Differences
 
-| Aspect           | Current                                                      | ECS                                                           |
-| ---------------- | ------------------------------------------------------------ | ------------------------------------------------------------- |
-| Orchestrator     | Source node (reaches into graph, target, reroutes)           | ConnectivitySystem (reads layoutStore)                        |
-| Side effects     | `_version++`, `setDirtyCanvas()`, `afterChange()`, callbacks | `createLink()` command — endpoints + change tracking included |
-| Reroute handling | Manual: iterate chain, add linkId to each                    | Reroute entries updated via layout mutations                  |
-| Slot mutation    | Direct: `output.links.push()`, `input.link = id`             | `createLink(linkId, ...)` updates both endpoints              |
-| Validation       | `onConnectInput`/`onConnectOutput` callbacks on nodes        | Validation system or guard function                           |
+| Aspect           | Current                                                                                                                   | ECS                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Orchestrator     | Source node (reaches into graph, target slots)                                                                            | ConnectivitySystem (reads linkStore)                                                    |
+| Side effects     | `incrementVersion()`, `setDirtyCanvas()`, `afterChange()`, callbacks                                                      | topology registration — endpoints + change tracking included                            |
+| Reroute handling | None needed — membership derived from `parentId` chains (rerouteStore); `anchorRerouteChain` only clears floating markers | Same — derived membership is already the target shape                                   |
+| Slot mutation    | Direct: `output.links.push()`, `input.link = id`                                                                          | Input side subsumed by the linkStore key; output side pending SlotConnection extraction |
+| Validation       | `onConnectInput`/`onConnectOutput` callbacks on nodes                                                                     | Validation system or guard function                                                     |
 
 ## 7. Copy / Paste
 

--- a/docs/architecture/ecs-migration-plan.md
+++ b/docs/architecture/ecs-migration-plan.md
@@ -12,7 +12,8 @@ For verified accuracy of these documents, see
 
 > **Target end-state (revised):** N dedicated Pinia stores keyed by composite
 > string IDs, one store per concern (widget values, DOM widgets, layout, node
-> outputs, subgraph navigation, preview exposure). The earlier "single unified
+> outputs, subgraph navigation, preview exposure, link topology, reroute
+> chains). The earlier "single unified
 > World with branded numeric entity IDs and `getComponent`/`setComponent`" model
 > was rejected. PR 12617 shipped the first stores against composite
 > `graphId:nodeId:name` string keys (`WidgetId`). Phases below are reframed
@@ -113,14 +114,25 @@ narrow accessor surface. There is no single container that fronts all entities.
 
 Shipped stores:
 
-| Store                     | File                                            |
-| ------------------------- | ----------------------------------------------- |
-| `widgetValueStore`        | `src/stores/widgetValueStore.ts`                |
-| `domWidgetStore`          | `src/stores/domWidgetStore.ts`                  |
-| `layoutStore`             | `src/renderer/core/layout/store/layoutStore.ts` |
-| `nodeOutputStore`         | `src/stores/nodeOutputStore.ts`                 |
-| `subgraphNavigationStore` | `src/stores/subgraphNavigationStore.ts`         |
-| `previewExposureStore`    | `src/stores/previewExposureStore.ts`            |
+| Store                      | File                                            |
+| -------------------------- | ----------------------------------------------- |
+| `widgetValueStore`         | `src/stores/widgetValueStore.ts`                |
+| `domWidgetStore`           | `src/stores/domWidgetStore.ts`                  |
+| `layoutStore`              | `src/renderer/core/layout/store/layoutStore.ts` |
+| `nodeOutputStore`          | `src/stores/nodeOutputStore.ts`                 |
+| `subgraphNavigationStore`  | `src/stores/subgraphNavigationStore.ts`         |
+| `previewExposureStore`     | `src/stores/previewExposureStore.ts`            |
+| `linkStore` ✅ PR 13436    | `src/stores/linkStore.ts`                       |
+| `rerouteStore` ✅ PR 13449 | `src/stores/rerouteStore.ts`                    |
+
+`linkStore` holds `LinkTopology` records (`src/types/linkTopology.ts`) keyed by
+target input slot (`` `${targetNodeId}:${targetSlot}` ``) in root-graph-scoped
+buckets — subgraphs share their root's bucket; floating links and links
+targeting subgraph outputs live in a per-graph unkeyed side set. `rerouteStore`
+holds `RerouteChain` records keyed by `RerouteId` in root-graph-scoped buckets;
+link membership is not stored but derived from the links' `parentId` chains.
+Design records: [Link Topology Store](link-topology-store.md),
+[Reroute Chain Store](reroute-chain-store.md).
 
 `widgetValueStore` exposes `registerWidget`, `getWidget`, `setValue`,
 `deleteWidget`, `getNodeWidgets`, and `clearGraph`, all `WidgetId`-native. There
@@ -260,6 +272,14 @@ link-endpoint records from the relevant stores:
 Does not perform mutations yet — just queries. Validates that store connectivity
 data is complete and consistent with the class-based graph.
 
+> **Status (2026-07-05):** The reroute-membership query shipped as `linkStore` +
+> `rerouteStore` (PRs 13436, 13449): "what links pass through this reroute" is
+> derived per root graph by a cached reverse index over the links' `parentId`
+> chains, and input-side connectivity is one lookup via
+> `linkStore.isInputSlotConnected()` / `getInputSlotLink()`. Remaining:
+> slot mirrors (`input.link` / `output.links`), output-side queries, and
+> execution order.
+
 **Risk:** Low. Read-only system with equivalence tests.
 
 ---
@@ -310,6 +330,12 @@ the system knowing about the callback API.
   source-then-target ordering.
 - Bridge lifecycle events remain internal. Legacy callbacks stay the public
   compatibility API during Phase 4.
+
+> **Status (2026-07-05):** Link and reroute store registration now funnels
+> through canonical `LGraph` mutation chokepoints: `_addLink`/`_removeLink` and
+> `_addReroute`/`_removeReroute` pair every map mutation with store
+> (un)registration, and `clear()` / subgraph-definition GC unregister whole
+> graphs. The callback contract above and slot-mirror extraction remain.
 
 **Risk:** High. Extensions depend on callback ordering and timing. Must be
 validated against real-world extensions.
@@ -596,13 +622,15 @@ state between these calls.
 
 The dedicated stores use per-concern keying strategies:
 
-| Store                     | Key Format                         |
-| ------------------------- | ---------------------------------- |
-| `widgetValueStore`        | `WidgetId` (`graphId:nodeId:name`) |
-| `domWidgetStore`          | Widget UUID                        |
-| `layoutStore`             | Raw nodeId/linkId/rerouteId        |
-| `nodeOutputStore`         | `"${subgraphId}:${nodeId}"`        |
-| `subgraphNavigationStore` | subgraphId or `'root'`             |
+| Store                     | Key Format                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `widgetValueStore`        | `WidgetId` (`graphId:nodeId:name`)                                                   |
+| `domWidgetStore`          | Widget UUID                                                                          |
+| `layoutStore`             | Raw nodeId/linkId/rerouteId                                                          |
+| `nodeOutputStore`         | `"${subgraphId}:${nodeId}"`                                                          |
+| `subgraphNavigationStore` | subgraphId or `'root'`                                                               |
+| `linkStore`               | `` `${targetNodeId}:${targetSlot}` `` (target input slot), root-graph-scoped buckets |
+| `rerouteStore`            | `RerouteId`, root-graph-scoped buckets                                               |
 
 ADR 0009 refines the promoted-widget target: promoted value widgets should use
 host boundary identity (`host node locator + SubgraphInput.name`), not interior
@@ -629,7 +657,8 @@ Phase 0c (doc fixes)  ─────────┤── no dependencies betwe
 
 Phase 1a (branded WidgetId)  ── ✅ shipped (PR 12617)
 Phase 1b (store state shapes) ─┐── depends on 1a
-Phase 1c (dedicated stores)  ──┘── widgetValueStore + 5 others shipped (PR 12617)
+Phase 1c (dedicated stores)  ──┘── widgetValueStore + 7 others shipped
+                                   (PR 12617; linkStore PR 13436; rerouteStore PR 13449)
 
 Phase 2a (Position via layoutStore) ─┐── depends on 1c
 Phase 2b (Widget consolidation)  ────┤── ✅ largely shipped; depends on 1a, 1c

--- a/docs/architecture/ecs-target-architecture.md
+++ b/docs/architecture/ecs-target-architecture.md
@@ -18,7 +18,12 @@ Map&lt;WidgetId, WidgetValue&gt;"]
         DomWidgetStore["domWidgetStore
 Map&lt;WidgetId, DomWidgetState&gt;"]
         LayoutStore["layoutStore (Y.js CRDT)
-nodeId / linkId / rerouteId → layout"]
+nodeId / linkId / rerouteId → geometry"]
+        LinkStore["linkStore
+rootGraphId → targetNodeId:targetSlot
+→ LinkTopology"]
+        RerouteStore["rerouteStore
+rootGraphId → RerouteId → RerouteChain"]
         NodeOutputStore["nodeOutputStore
 Map&lt;nodeLocatorId, outputs&gt;"]
         SubgraphNavStore["subgraphNavigationStore
@@ -39,7 +44,8 @@ preview exposure state"]
 
     RS -->|reads| Stores
     SS -->|reads/writes| Stores
-    CS -->|reads/writes| LayoutStore
+    CS -->|reads/writes| LinkStore
+    CS -->|reads/writes| RerouteStore
     LS -->|reads/writes| LayoutStore
     ES -->|reads| NodeOutputStore
     VS -->|reads/writes| LayoutStore
@@ -63,20 +69,31 @@ subgraphId:nodeId"]
         NID["nodeId (raw)"]
         LID["linkId (raw)"]
         RID["rerouteId (raw)"]
+        TIS["targetNodeId:targetSlot
+(root-graph-scoped bucket)"]
     end
 
     WID -->|widgetValueStore, domWidgetStore| W["keyed lookups"]
     NLID -->|nodeOutputStore| W
     NID -->|layoutStore| W
     LID -->|layoutStore| W
-    RID -->|layoutStore| W
+    RID -->|layoutStore, rerouteStore| W
+    TIS -->|linkStore| W
 ```
 
 `WidgetId = graphId:nodeId:name` is itself a branded string (see
 `src/types/widgetId.ts`). `nodeLocatorId = subgraphId:nodeId` addresses node
-outputs. `layoutStore` keys layout records by raw `nodeId` / `linkId` /
-`rerouteId`. Each store enforces its own key shape; there is no single shared
-entity-ID type across stores.
+outputs. `layoutStore` keys geometry records by raw `nodeId` / `linkId` /
+`rerouteId`. `linkStore` keys `LinkTopology` by **target input slot**
+(`targetNodeId:targetSlot`) inside root-graph-scoped buckets — the link id is
+NOT the key; at most one live link can target an input slot, so the target is
+the natural primary key (see
+[link-topology-store.md](link-topology-store.md)). Links without a unique
+target (floating links, `SUBGRAPH_OUTPUT_ID` targets) live in a per-graph
+unkeyed side set. `rerouteStore` keys `RerouteChain` by raw `rerouteId` in
+root-graph-scoped buckets (see
+[reroute-chain-store.md](reroute-chain-store.md)). Each store enforces its own
+key shape; there is no single shared entity-ID type across stores.
 
 Note: `graphId` is a scope identifier. It identifies which graph an entity
 belongs to and forms the prefix of `WidgetId`. Subgraphs are nodes with a
@@ -177,14 +194,15 @@ target_id, target_slot, type"]
         B5["resolve()"]
     end
 
-    subgraph After["linkId-keyed components (layoutStore)"]
+    subgraph After["target-slot-keyed topology (linkStore) + unextracted state"]
         direction TB
-        A1["LinkEndpoints
-{ originId, originSlot,
-targetId, targetSlot, type }"]
-        A2["LinkVisual
+        A1["LinkTopology — SHIPPED
+{ id, originNodeId, originSlot,
+targetNodeId, targetSlot, type, parentId? }
+keyed by targetNodeId:targetSlot"]
+        A2["LinkVisual — not yet extracted
 { color, path, centerPos }"]
-        A3["LinkState
+        A3["LinkState — not yet extracted
 { dragging, data }"]
     end
 
@@ -197,6 +215,26 @@ targetId, targetSlot, type }"]
     style Before fill:#4a1a1a,stroke:#6a2a2a,color:#e0e0e0
     style After fill:#1a4a1a,stroke:#2a6a2a,color:#e0e0e0
 ```
+
+`LinkTopology` has shipped in `src/stores/linkStore.ts`: `LLink._state` IS the
+store entry — the class fields are accessors over the store's reactive proxy,
+so the store and the instance cannot disagree. Registration is first-wins with
+identity-checked delete/update. See
+[link-topology-store.md](link-topology-store.md) for the full design record.
+`LinkVisual` and `LinkState` remain on the `LLink` class.
+
+### Reroute: RerouteChain (shipped)
+
+Reroutes follow the same pattern. `RerouteChain { id, parentId?, floating? }`
+lives in `src/stores/rerouteStore.ts`, keyed by `RerouteId` in
+root-graph-scoped buckets; `Reroute._chain` is the store entry. Link
+membership (`Reroute.linkIds` / `floatingLinkIds`) is **not stored** — it is
+derived per root graph by a cached computed reverse index walking the links'
+`parentId` chains, replacing ~10 hand-maintained write sites and the
+`validateLinks` set-repair. See
+[reroute-chain-store.md](reroute-chain-store.md). Reroute _position_ is not
+yet migrated: `Reroute.posInternal` remains the source of truth, with the
+layout store holding a partial `{ id, position }` mirror.
 
 ### Widget: Before vs After
 
@@ -312,9 +350,11 @@ graph LR
         Exe["Execution"]
         Props["Properties"]
         WC["WidgetContainer"]
-        LE["LinkEndpoints"]
+        LE["LinkTopology
+(linkStore — shipped)"]
         LV["LinkVisual"]
-        SC["SlotConnection"]
+        SC["SlotConnection
+(output side — future)"]
         SV["SlotVisual"]
         WVal["WidgetValue"]
         WL["WidgetLayout"]
@@ -348,6 +388,14 @@ graph LR
     VS -.->|read| Pos
     VS -.->|read| Con
 ```
+
+ConnectivitySystem's `LinkEndpoints` write target is realized as
+`LinkTopology` in `linkStore`. The input side of `SlotConnection`
+(`input.link`) is subsumed by the linkStore key itself — "which link targets
+this input slot" is the store's primary index
+(`isInputSlotConnected` / `getInputSlotLink`) — though the `input.link` slot
+mirror still exists on the class. The output side (`output.links[]`) remains
+future extraction work.
 
 ## 4. Dependency Flow
 

--- a/docs/architecture/ecs-target-architecture.md
+++ b/docs/architecture/ecs-target-architecture.md
@@ -286,8 +286,8 @@ graph TD
         direction TB
         CS["ConnectivitySystem
 Manages link/slot mutations.
-Writes: LinkEndpoints, SlotConnection,
-Connectivity"]
+Writes: LinkTopology (shipped),
+SlotConnection (future), Connectivity"]
         VS["VersionSystem
 Centralizes change tracking.
 Replaces 15+ scattered _version++.
@@ -373,7 +373,7 @@ graph LR
     LS -.->|read| WC
 
     CS -->|write| LE
-    CS -->|write| SC
+    CS -.->|future write| SC
     CS -->|write| Con
 
     ES -.->|read| Con

--- a/docs/architecture/entity-interactions.md
+++ b/docs/architecture/entity-interactions.md
@@ -66,7 +66,7 @@ graph TD
     Link -.->|"origin_id, target_id"| Node
     Link -.->|"parentId"| Reroute
     Slot -.->|"link / links[]"| Link
-    Reroute -.->|"linkIds"| Link
+    Reroute -.->|"linkIds (derived, rerouteStore)"| Link
     Reroute -.->|"parentId"| Reroute
     Group -.->|"_children Set"| Node
     Group -.->|"_children Set"| Reroute
@@ -103,9 +103,13 @@ type: ISlotType"]
     Link -.->|"parentId"| R1["Reroute A"]
     R1 -.->|"parentId"| R2["Reroute B"]
 
-    R1 -.-|"linkIds Set"| Link
-    R2 -.-|"linkIds Set"| Link
+    R1 -.-|"linkIds (derived)"| Link
+    R2 -.-|"linkIds (derived)"| Link
 ```
+
+`Reroute.linkIds` / `floatingLinkIds` are read-only accessors derived from the
+links' own `parentId` chains by `rerouteStore` — membership is never stored
+(see [reroute-chain-store.md](reroute-chain-store.md)).
 
 ### Subgraph Boundary Connections
 
@@ -142,13 +146,19 @@ graph TD
 ```mermaid
 graph LR
     Slot["Source Slot"] -->|"drag starts"| FL["Floating LLink
-origin_id=-1 or target_id=-1"]
+origin or target = UNASSIGNED_NODE_ID"]
     FL -->|"stored in"| FLMap["graph.floatingLinks Map"]
+    FL -->|"registered in"| SideSet["linkStore unkeyed side set
+(no unique target slot)"]
     FL -.->|"may pass through"| Reroute
-    Reroute -.-|"floatingLinkIds Set"| FL
+    Reroute -.-|"floatingLinkIds (derived)"| FL
     FL -->|"on drop"| Permanent["Permanent LLink
-(registered in graph._links)"]
+(graph._links + linkStore target index)"]
 ```
+
+A floating link's slot attachment is fully encoded in its own endpoints —
+slots hold no floating-link sets (`slotFloatingLinks()` in `LLink.ts` derives
+attachment by scanning `graph.floatingLinks`).
 
 ## 3. Rendering
 
@@ -254,7 +264,7 @@ stateDiagram-v2
 ```mermaid
 stateDiagram-v2
     [*] --> Created: node.connect() or connectSlots()
-    Created --> Registered: graph._links.set(id, link)
+    Created --> Registered: graph._addLink(link)
 
     state Registered {
         [*] --> Active
@@ -268,12 +278,18 @@ stateDiagram-v2
 
     note right of Created
         new LLink(id, type, origin, slot, target, slot)
+        _addLink sets graph._links entry and
+        registers topology in linkStore
+        (keyed by target input slot).
         Output slot.links[] updated.
         Input slot.link set.
     end note
 
     note right of Removed
-        Removed from graph._links.
+        Removed from graph._links and
+        unregistered from linkStore
+        (via _removeLink or link.disconnect).
+        Link geometry dropped from layoutStore.
         Orphaned reroutes cleaned up.
         graph._version incremented.
     end note
@@ -363,6 +379,10 @@ graph TD
 (Pinia)"]
         PES["PreviewExposureStore
 (Pinia)"]
+        LKS["LinkStore
+(Pinia)"]
+        RRS["RerouteStore
+(Pinia)"]
         LM["LayoutMutations
 (composable)"]
     end
@@ -383,10 +403,20 @@ lastRerouteId, lastGroupId)"]
     SGNode -->|"host-scoped preview exposures"| PES
     PES -.->|"keyed by host node locator"| SGNode
 
-    %% LayoutMutations
+    %% LinkStore
+    Graph -->|"_addLink()/_removeLink() register/unregister"| LKS
+    Link <-->|"_state IS the store entry (endpoint accessors)"| LKS
+    LKS -.->|"keyed by rootGraphId + targetNodeId:targetSlot"| Link
+
+    %% RerouteStore
+    Graph -->|"_addReroute()/_removeReroute()"| RRS
+    Reroute <-->|"_chain (parentId, floating)"| RRS
+    RRS -.->|"derived linkIds membership"| Reroute
+
+    %% LayoutMutations (geometry only)
     Node -->|"pos/size setter"| LM
     Reroute -->|"move()"| LM
-    Link -->|"connectSlots()/disconnect()"| LM
+    Link -->|"disconnect(): drop link geometry"| LM
     Graph -->|"add()/remove()"| LM
 
     %% Graph state

--- a/docs/architecture/entity-problems.md
+++ b/docs/architecture/entity-problems.md
@@ -168,11 +168,23 @@ No central mechanism exists. It's easy to forget an increment (stale render) or 
 
 Domain objects call Pinia composables at the module level or in methods, creating implicit dependencies on the Vue runtime:
 
-- `LLink.ts:24` — `const layoutMutations = useLayoutMutations()` (module scope)
-- `Reroute.ts` — same pattern at module scope
+- `Reroute.ts:31` — `const layoutMutations = useLayoutMutations()` (module scope)
+- `LLink.ts:7` — imports the `layoutStore` singleton at module scope; `useLinkStore()` is called inside methods and helpers (needs an active Pinia, but not eagerly at import time)
+- `Reroute.ts` — `useRerouteStore()` called inside methods for derived membership
 - `BaseWidget.ts` — imports `useWidgetValueStore`
 
 These make the domain objects untestable without a Vue app context.
+
+### Reroute Membership Dual-Writes (solved)
+
+`Reroute.linkIds` / `floatingLinkIds` were hand-maintained `Set`s written from
+~10 scattered call sites (connect, disconnect, paste, configure, subgraph
+pack/unpack, ...), with `Reroute.validateLinks()` repairing the inevitable
+drift on load. Membership is now derived from the links' own `parentId`
+chains via `rerouteStore` — the accessors are read-only, the write sites and
+`validateLinks` are deleted, and orphaned reroutes are pruned by the derived
+`totalLinks === 0` instead of set-repair. See
+[reroute-chain-store.md](reroute-chain-store.md) (Decision 1).
 
 ### Change Notification Sprawl
 

--- a/docs/architecture/link-topology-store.md
+++ b/docs/architecture/link-topology-store.md
@@ -1,0 +1,112 @@
+# Link Topology Store
+
+Date: 2026-07-05 (retroactive design record; implemented in PR #13436)
+Status: Accepted
+
+Design record for extracting link topology into a dedicated store per
+[ADR 0008](../adr/0008-entity-component-system.md). Amends the
+`LinkEndpoints` component described there. The
+[Reroute Chain Store](reroute-chain-store.md) builds directly on this
+store; shared vocabulary lives in the
+[Domain Glossary](domain-glossary.md).
+
+## Decision 1: One state object, class reads through it
+
+`LLink` no longer owns copies of its topology fields. A single plain
+object,
+
+```
+LinkTopology { id, originNodeId, originSlot, targetNodeId, targetSlot,
+               type, parentId? }
+```
+
+backs the link: `LLink._state` holds it, and `id`, `type`, `origin_id`,
+`origin_slot`, `target_id`, `target_slot`, and `parentId` are accessors
+over it. Registration inserts that same object into the store by
+reference and re-assigns `_state` to the reactive proxy read back from
+the bucket, so subsequent class writes are Vue-tracked (the `BaseWidget`
+pattern — see Decision 4 of the reroute chain store record). There is no
+store-side copy to drift from the class: the store entry _is_ the
+class's state.
+
+The store is runtime state only; `LLink.asSerialisable` reads the same
+fields it always did, and serialization goldens (key order plus
+byte-identical round-trips) pin the wire format.
+
+## Decision 2: Keyed by target input slot, not link id
+
+The primary index is keyed by `` `${targetNodeId}:${targetSlot}` ``.
+Two facts make this the right key:
+
+- **The domain invariant**: at most one live link targets a given input
+  slot. The key is unique by construction for live links.
+- **The dominant query**: consumers ask "is this input slot connected,
+  and by what?" (`isInputSlotConnected`, `getInputSlotLink`). The key
+  answers it in one lookup with no scan.
+
+Link _ids_ are only unique per owning graph, not per root graph, so an
+id-keyed root bucket needed a load-time link-id dedup pass and a
+first-wins registration protocol to survive collisions across sibling
+subgraph definitions. Re-keying by target slot deleted both: colliding
+link ids never touch the index, so workflows load without link-id
+rewrites.
+
+Rejected: keeping the id key plus dedup/first-wins. That machinery
+existed only to compensate for a key the queries never used.
+
+## Decision 3: Root-graph-scoped buckets, unkeyed side set
+
+Buckets are scoped by `rootGraph.id` — subgraphs share their root's
+bucket — matching `widgetValueStore` and the later `rerouteStore`.
+Re-keying entries to their owning graph was evaluated and rejected: it
+reintroduces per-graph lifecycle bookkeeping the root scope avoids, and
+no query wants owning-graph granularity that `graphTopologies` filtering
+doesn't already provide.
+
+Links without a unique live target go in a per-graph side `Set` instead
+of the primary index:
+
+- **Floating links** — exactly one assigned endpoint; the other is
+  `UNASSIGNED_NODE_ID`. A floating link attached to an input slot does
+  not answer `isInputSlotConnected`, preserving `input.link` semantics.
+- **Links targeting `SUBGRAPH_OUTPUT_ID`** — the id is a shared
+  constant, so `targetNodeId:targetSlot` is not unique across the
+  subgraphs sharing a root bucket.
+
+## Decision 4: Registration protocol
+
+- `registerLink` is **first-wins**: if a different topology already
+  holds the target key, the call returns `undefined` and the loser
+  stays detached. `link._graphId` records a won registration; it is the
+  ownership marker that lets `unregisterLink` and re-registration no-op
+  safely for losers.
+- `deleteLink` and `updateEndpoint` are **identity-checked** (`toRaw`
+  comparison): only the registered topology can vacate or re-key its
+  slot.
+- `updateEndpoint` re-keys atomically — displace, patch fields through
+  a reactive wrapper, re-place under the new key — and returns
+  `undefined` when the new target is already occupied. The `reactive()`
+  wrap stays even though registered links already hold the proxy: the
+  store is public API and may be handed a raw topology object.
+
+## Decision 5: Mutation chokepoints
+
+All `graph._links` map mutation funnels through `LGraph._addLink` /
+`_removeLink`, which pair the map write with store
+registration/unregistration (and link-layout cleanup on removal).
+`addFloatingLink` / `removeFloatingLink` do the same for the floating
+map. `LLink.disconnect` performs the equivalent effects inline because
+it only holds a `LinkNetwork`, and unregisters before reroute pruning so
+derived reroute counts exclude the dying link. `clear()` and
+subgraph-definition GC unregister whole graphs
+(`unregisterAllLinkTopologies` / `clearGraph`).
+
+## Scope
+
+This design covers link topology (endpoints, type, chain terminus).
+Link visual state (`color`, path caches) and the layout store's link
+_geometry_ records are out of scope. The `input.link` / `output.links`
+slot mirrors remain the litegraph-native representation un-migrated
+consumers read; extracting them is the `SlotConnection` component work
+in the [ECS migration plan](ecs-migration-plan.md), not part of this
+store.

--- a/docs/architecture/proto-ecs-stores.md
+++ b/docs/architecture/proto-ecs-stores.md
@@ -12,16 +12,16 @@ no longer a store; ADR 0009 represents it as ordinary linked `SubgraphInput`
 state, and promoted value data lives in `WidgetValueStore` keyed by the input's
 `WidgetId`.
 
-| Store                   | Extracts From       | Scoping           | Key Format                                                | Data Shape                    |
-| ----------------------- | ------------------- | ----------------- | --------------------------------------------------------- | ----------------------------- |
-| WidgetValueStore        | `BaseWidget`        | `graphId`         | `WidgetId` (`graphId:nodeId:name`)                        | Plain `WidgetState` object    |
-| DomWidgetStore          | `BaseDOMWidget`     | Global            | `widgetId` (UUID)                                         | Position, visibility, z-index |
-| LayoutStore             | Node, Link, Reroute | Workflow-level    | `nodeId`, `linkId`, `rerouteId`                           | Y.js CRDT maps (pos, size)    |
-| NodeOutputStore         | Execution results   | `nodeLocatorId`   | `"${subgraphId}:${nodeId}"`                               | Output data, preview URLs     |
-| SubgraphNavigationStore | Canvas viewport     | `subgraphId`      | `subgraphId` or `'root'`                                  | LRU viewport cache            |
-| PreviewExposureStore    | Subgraph host node  | host node locator | host locator + exposure name                              | Display-only preview state    |
-| LinkStore               | `LLink`             | Root graph        | `` `${targetNodeId}:${targetSlot}` `` (target input slot) | Plain `LinkTopology` object   |
-| RerouteStore            | `Reroute`           | Root graph        | `RerouteId`                                               | Plain `RerouteChain` object   |
+| Store                   | Extracts From                | Scoping           | Key Format                                                | Data Shape                    |
+| ----------------------- | ---------------------------- | ----------------- | --------------------------------------------------------- | ----------------------------- |
+| WidgetValueStore        | `BaseWidget`                 | `graphId`         | `WidgetId` (`graphId:nodeId:name`)                        | Plain `WidgetState` object    |
+| DomWidgetStore          | `BaseDOMWidget`              | Global            | `widgetId` (UUID)                                         | Position, visibility, z-index |
+| LayoutStore             | Node, Link geometry, Reroute | Workflow-level    | `nodeId`, `linkId`, `rerouteId`                           | Y.js CRDT maps (pos, size)    |
+| NodeOutputStore         | Execution results            | `nodeLocatorId`   | `"${subgraphId}:${nodeId}"`                               | Output data, preview URLs     |
+| SubgraphNavigationStore | Canvas viewport              | `subgraphId`      | `subgraphId` or `'root'`                                  | LRU viewport cache            |
+| PreviewExposureStore    | Subgraph host node           | host node locator | host locator + exposure name                              | Display-only preview state    |
+| LinkStore               | `LLink`                      | Root graph        | `` `${targetNodeId}:${targetSlot}` `` (target input slot) | Plain `LinkTopology` object   |
+| RerouteStore            | `Reroute`                    | Root graph        | `RerouteId`                                               | Plain `RerouteChain` object   |
 
 **Update (2026-07-05):** `LinkStore` (`src/stores/linkStore.ts`, PR #13436) and
 `RerouteStore` (`src/stores/rerouteStore.ts`, PR #13449) hold plain-data records

--- a/docs/architecture/proto-ecs-stores.md
+++ b/docs/architecture/proto-ecs-stores.md
@@ -6,20 +6,30 @@ For the full problem analysis, see [Entity Problems](entity-problems.md). For th
 
 ## 1. What's Already Extracted
 
-Six dedicated stores extract entity state out of class instances into focused,
+Eight dedicated stores extract entity state out of class instances into focused,
 queryable registries, each owning one concern. Promoted value-widget topology is
 no longer a store; ADR 0009 represents it as ordinary linked `SubgraphInput`
 state, and promoted value data lives in `WidgetValueStore` keyed by the input's
 `WidgetId`.
 
-| Store                   | Extracts From       | Scoping           | Key Format                         | Data Shape                    |
-| ----------------------- | ------------------- | ----------------- | ---------------------------------- | ----------------------------- |
-| WidgetValueStore        | `BaseWidget`        | `graphId`         | `WidgetId` (`graphId:nodeId:name`) | Plain `WidgetState` object    |
-| DomWidgetStore          | `BaseDOMWidget`     | Global            | `widgetId` (UUID)                  | Position, visibility, z-index |
-| LayoutStore             | Node, Link, Reroute | Workflow-level    | `nodeId`, `linkId`, `rerouteId`    | Y.js CRDT maps (pos, size)    |
-| NodeOutputStore         | Execution results   | `nodeLocatorId`   | `"${subgraphId}:${nodeId}"`        | Output data, preview URLs     |
-| SubgraphNavigationStore | Canvas viewport     | `subgraphId`      | `subgraphId` or `'root'`           | LRU viewport cache            |
-| PreviewExposureStore    | Subgraph host node  | host node locator | host locator + exposure name       | Display-only preview state    |
+| Store                   | Extracts From       | Scoping           | Key Format                                                | Data Shape                    |
+| ----------------------- | ------------------- | ----------------- | --------------------------------------------------------- | ----------------------------- |
+| WidgetValueStore        | `BaseWidget`        | `graphId`         | `WidgetId` (`graphId:nodeId:name`)                        | Plain `WidgetState` object    |
+| DomWidgetStore          | `BaseDOMWidget`     | Global            | `widgetId` (UUID)                                         | Position, visibility, z-index |
+| LayoutStore             | Node, Link, Reroute | Workflow-level    | `nodeId`, `linkId`, `rerouteId`                           | Y.js CRDT maps (pos, size)    |
+| NodeOutputStore         | Execution results   | `nodeLocatorId`   | `"${subgraphId}:${nodeId}"`                               | Output data, preview URLs     |
+| SubgraphNavigationStore | Canvas viewport     | `subgraphId`      | `subgraphId` or `'root'`                                  | LRU viewport cache            |
+| PreviewExposureStore    | Subgraph host node  | host node locator | host locator + exposure name                              | Display-only preview state    |
+| LinkStore               | `LLink`             | Root graph        | `` `${targetNodeId}:${targetSlot}` `` (target input slot) | Plain `LinkTopology` object   |
+| RerouteStore            | `Reroute`           | Root graph        | `RerouteId`                                               | Plain `RerouteChain` object   |
+
+**Update (2026-07-05):** `LinkStore` (`src/stores/linkStore.ts`, PR #13436) and
+`RerouteStore` (`src/stores/rerouteStore.ts`, PR #13449) hold plain-data records
+in reactive `Map` buckets — not Y.js — scoped by root graph (subgraphs share
+their root's bucket). Floating links and links targeting subgraph outputs live
+in a per-graph unkeyed side set. Design records:
+[Link Topology Store](link-topology-store.md),
+[Reroute Chain Store](reroute-chain-store.md).
 
 ADR 0009 refines promoted-widget identity: promoted value widgets are keyed by
 the host boundary (`host node locator + SubgraphInput.name`), while interior
@@ -149,28 +159,37 @@ The most architecturally advanced extraction — uses Y.js CRDTs for collaborati
 
 ```
 ynodes:    Y.Map<NodeLayoutMap>     // nodeId → { pos, size, zIndex, bounds }
-ylinks:    Y.Map<Y.Map<...>>       // linkId → link layout data
-yreroutes: Y.Map<Y.Map<...>>       // rerouteId → reroute layout data
+yreroutes: Y.Map<Y.Map<...>>       // rerouteId → { id, position }
 ```
+
+**Update (2026-07-05):** The link-connectivity mirror (`ylinks`, `LinkData`,
+`createLink`/`removeLink` mutations, `findLinksConnectedToNode`) was deleted
+when link topology moved to `LinkStore` (PR #13436). LayoutStore now owns only
+link/segment _geometry_ caches, and `RerouteData` carries `{ id, position }`
+only — the write-only `parentId`/`linkIds` fields were removed.
 
 ### Write API
 
 `useLayoutMutations()` (`src/renderer/core/layout/operations/layoutMutations.ts`) provides the mutation API:
 
-- `moveNode(graphId, nodeId, pos)`
-- `resizeNode(graphId, nodeId, size)`
-- `setNodeZIndex(graphId, nodeId, zIndex)`
-- `createLink(graphId, linkId, ...)`
-- `removeLink(graphId, linkId)`
-- `moveReroute(graphId, rerouteId, pos)`
+- `moveNode(nodeId, pos)` / `batchMoveNodes(...)`
+- `resizeNode(nodeId, size)`
+- `setNodeZIndex(nodeId, zIndex)` / `bringNodeToFront(nodeId)`
+- `createNode(nodeId, layout)` / `deleteNode(nodeId)`
+- `createReroute(rerouteId, pos)` / `deleteReroute(rerouteId)` /
+  `moveReroute(rerouteId, pos, prevPos)`
+
+(`createLink`/`removeLink` are gone — link topology is `LinkStore`'s concern.)
 
 ### The Scattered Access Problem
 
 This composable is called at **module scope** in domain objects:
 
-- `LLink.ts:24` — `const layoutMutations = useLayoutMutations()`
-- `Reroute.ts` — same pattern
+- `Reroute.ts:31` — `const layoutMutations = useLayoutMutations()`
 - `LGraphNode.ts` — imported and called in methods
+- `LLink.ts` no longer uses `useLayoutMutations` (its layout writes went away
+  with the `ylinks` mirror), but it still imports `layoutStore` and
+  `useLinkStore` at module scope
 
 These module-scope calls create implicit dependencies on the Vue runtime and make the domain objects untestable without a full app context.
 
@@ -234,12 +253,14 @@ graph TD
 
 Each store owns the identity scheme that fits its concern:
 
-| Store            | Key Format                         | Key Type           | Type-Safe?       |
-| ---------------- | ---------------------------------- | ------------------ | ---------------- |
-| WidgetValueStore | `WidgetId` (`graphId:nodeId:name`) | branded string     | Yes (`WidgetId`) |
-| DomWidgetStore   | Widget UUID                        | UUID (string)      | No               |
-| LayoutStore      | Raw nodeId/linkId/rerouteId        | Mixed number types | No               |
-| NodeOutputStore  | `"${subgraphId}:${nodeId}"`        | Composite string   | No               |
+| Store            | Key Format                                                  | Key Type           | Type-Safe?        |
+| ---------------- | ----------------------------------------------------------- | ------------------ | ----------------- |
+| WidgetValueStore | `WidgetId` (`graphId:nodeId:name`)                          | branded string     | Yes (`WidgetId`)  |
+| DomWidgetStore   | Widget UUID                                                 | UUID (string)      | No                |
+| LayoutStore      | Raw nodeId/linkId/rerouteId                                 | Mixed number types | No                |
+| NodeOutputStore  | `"${subgraphId}:${nodeId}"`                                 | Composite string   | No                |
+| LinkStore        | `` `${targetNodeId}:${targetSlot}` `` (root-scoped buckets) | Composite string   | No                |
+| RerouteStore     | `RerouteId` (root-scoped buckets)                           | branded number     | Yes (`RerouteId`) |
 
 `WidgetValueStore` already keys on a branded `WidgetId` string (`src/types/widgetId.ts`),
 which carries its scope and survives renames at the store layer. The remaining
@@ -286,22 +307,26 @@ graph TD
 
     subgraph Link["LLink"]
         L_ext["Extracted:
-- layout data → LayoutStore"]
+- id, endpoints, type, parentId → LinkStore
+  (LLink._state IS the store entry;
+  fields are accessors over it)
+- segment geometry → LayoutStore"]
         L_rem["Remains on class:
-- origin_id, target_id
-- origin_slot, target_slot
-- type, color, path
+- color, path, _pos, _centreAngle
 - data, _dragging
 - disconnect(), resolve()"]
     end
 
     subgraph Reroute["Reroute"]
         R_ext["Extracted:
-- pos → LayoutStore"]
+- pos → LayoutStore (partial mirror;
+  posInternal still truth)
+- parentId, floating → RerouteStore
+- linkIds, floatingLinkIds → derived
+  from links' parentId chains"]
         R_rem["Remains on class:
-- parentId, linkIds
-- floatingLinkIds
-- color, draw()
+- posInternal (position truth)
+- colour, draw()
 - findSourceOutput()"]
     end
 
@@ -346,15 +371,19 @@ graph TD
 
 What each entity needs to reach the ECS target from [ADR 0008](../adr/0008-entity-component-system.md):
 
-| Entity       | Already Extracted                                                                | Still on Class                                                                       | ECS Target Components                                                                | Gap                                                                                        |
-| ------------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| **Node**     | pos, size (LayoutStore)                                                          | type, visual, connectivity, execution, properties, widgets, rendering, serialization | Position, NodeVisual, NodeType, Connectivity, Execution, Properties, WidgetContainer | Large — 6 components unextracted, all behavior on class                                    |
-| **Link**     | layout (LayoutStore)                                                             | endpoints, visual, state, connectivity methods                                       | LinkEndpoints, LinkVisual, LinkState                                                 | Medium — 3 components unextracted                                                          |
-| **Widget**   | value, label, disabled (WidgetValueStore); DOM state (DomWidgetStore)            | node back-ref, rendering, events, layout                                             | WidgetIdentity, WidgetValue, WidgetLayout                                            | Small — value extraction done; rendering and layout remain                                 |
-| **Slot**     | (nothing)                                                                        | name, type, direction, link refs, visual, position                                   | SlotIdentity, SlotConnection, SlotVisual                                             | Full — no extraction started                                                               |
-| **Reroute**  | pos (LayoutStore)                                                                | links, visual, chain traversal                                                       | Position, RerouteLinks, RerouteVisual                                                | Medium — position done, rest unextracted                                                   |
-| **Group**    | (nothing)                                                                        | pos, size, meta, visual, children                                                    | Position, GroupMeta, GroupVisual, GroupChildren                                      | Full — no extraction started                                                               |
-| **Subgraph** | promoted value exposure (linked inputs); preview exposure (PreviewExposureStore) | structure, meta, I/O, all LGraph state                                               | SubgraphStructure, SubgraphMeta (as node components)                                 | Large — mostly unextracted; subgraph is a node with components, not a separate entity kind |
+| Entity       | Already Extracted                                                                         | Still on Class                                                                       | ECS Target Components                                                                | Gap                                                                                        |
+| ------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| **Node**     | pos, size (LayoutStore)                                                                   | type, visual, connectivity, execution, properties, widgets, rendering, serialization | Position, NodeVisual, NodeType, Connectivity, Execution, Properties, WidgetContainer | Large — 6 components unextracted, all behavior on class                                    |
+| **Link**     | endpoints, type, parentId (LinkStore, via `_state` proxy); segment geometry (LayoutStore) | visual (color, path), drag state, connectivity methods                               | LinkEndpoints ✅, LinkVisual, LinkState                                              | Small — topology shipped (PR #13436); visual state and slot mirrors remain                 |
+| **Widget**   | value, label, disabled (WidgetValueStore); DOM state (DomWidgetStore)                     | node back-ref, rendering, events, layout                                             | WidgetIdentity, WidgetValue, WidgetLayout                                            | Small — value extraction done; rendering and layout remain                                 |
+| **Slot**     | (nothing)                                                                                 | name, type, direction, link refs, visual, position                                   | SlotIdentity, SlotConnection, SlotVisual                                             | Full — no extraction started                                                               |
+| **Reroute**  | parentId, floating (RerouteStore); pos (LayoutStore, partial mirror)                      | position truth (posInternal), visual, chain traversal                                | Position, RerouteChain ✅, RerouteVisual                                             | Small — chain shipped (PR #13449); position ownership and visual remain                    |
+| **Group**    | (nothing)                                                                                 | pos, size, meta, visual, children                                                    | Position, GroupMeta, GroupVisual, GroupChildren                                      | Full — no extraction started                                                               |
+| **Subgraph** | promoted value exposure (linked inputs); preview exposure (PreviewExposureStore)          | structure, meta, I/O, all LGraph state                                               | SubgraphStructure, SubgraphMeta (as node components)                                 | Large — mostly unextracted; subgraph is a node with components, not a separate entity kind |
+
+`RerouteChain` supersedes the earlier `RerouteLinks` component (ADR 0008
+amendment, 2026-07-04): link membership is never stored — it is derived from
+the links' `parentId` chains over `LinkStore`.
 
 ### Priority Order for Extraction
 
@@ -362,8 +391,11 @@ Based on existing progress and problem severity:
 
 1. **Widget** — closest to done (value extraction complete, needs rendering/layout extraction)
 2. **Node Position** — already in LayoutStore, needs branded ID and formal component type
-3. **Link** — small component set, high coupling pain
+3. **Link** — ✅ topology shipped (LinkStore, PR #13436); slot mirrors
+   (`input.link`/`output.links`) and visual state remain
 4. **Slot** — no extraction yet, but small and self-contained
-5. **Reroute** — partially extracted, moderate complexity
+   (`SlotConnection` input side now answerable via LinkStore)
+5. **Reroute** — ✅ chain shipped (RerouteStore, PR #13449); position
+   ownership and visual remain
 6. **Group** — no extraction, but least coupled to other entities
 7. **Subgraph** — not a separate entity kind; SubgraphStructure and SubgraphMeta become node components. Depends on Node and Link extraction first. See [Subgraph Boundaries](subgraph-boundaries-and-promotion.md)

--- a/docs/architecture/reroute-chain-store.md
+++ b/docs/architecture/reroute-chain-store.md
@@ -1,8 +1,8 @@
 # Reroute Chain Store
 
 Date: 2026-07-04
-Status: Accepted (design review; follow-up to the link topology store,
-PR #13436)
+Status: Accepted (design review; follow-up to the
+[link topology store](link-topology-store.md), PR #13436)
 
 Design record for extracting reroute connectivity state into a dedicated
 store per [ADR 0008](../adr/0008-entity-component-system.md). Amends the

--- a/src/lib/litegraph/src/LGraph.test.ts
+++ b/src/lib/litegraph/src/LGraph.test.ts
@@ -22,6 +22,7 @@ import { zeroUuid } from '@/utils/uuid'
 import { useLinkStore } from '@/stores/linkStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { slotFloatingLinks } from '@/lib/litegraph/src/LLink'
 import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
 import { UNASSIGNED_NODE_ID, toNodeId } from '@/types/nodeId'
@@ -240,6 +241,25 @@ describe('Floating Links / Reroutes', () => {
     expect(graph.links.size).toBe(0)
     expect(graph.floatingLinks.size).toBe(2)
     expect(graph.reroutes.size).toBe(4)
+  })
+
+  test('slot floating links are derived from link endpoints', ({
+    expect,
+    linkedNodesGraph
+  }) => {
+    const graph = new LGraph(linkedNodesGraph)
+    graph.createReroute([0, 0], graph.links.values().next().value!)
+    const [origin, target] = graph.nodes
+
+    origin.disconnectOutput(0)
+
+    expect(slotFloatingLinks(graph, 'input', target.id, 0)).toHaveLength(1)
+    expect(slotFloatingLinks(graph, 'output', origin.id, 0)).toHaveLength(0)
+
+    const [floatingLink] = slotFloatingLinks(graph, 'input', target.id, 0)
+    graph.removeFloatingLink(floatingLink)
+
+    expect(slotFloatingLinks(graph, 'input', target.id, 0)).toHaveLength(0)
   })
 
   test('Floating reroutes should be removed when neither input nor output is connected', ({

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2223,7 +2223,8 @@ export class LGraph
 
     /**
      * A reroute chain segment, terminal-first. `complete` is false when the
-     * walk stopped at a broken reference; stitching stops there too.
+     * walk stopped at a broken reference or a cycle; stitching stops there
+     * too.
      */
     interface ChainSegment {
       segment: RerouteId[]
@@ -2236,14 +2237,17 @@ export class LGraph
       const visited = new Set<RerouteId>()
       let id = start
       while (id !== undefined) {
-        if (visited.has(id)) throw new Error('Infinite parentId loop')
+        if (visited.has(id)) {
+          console.error('Infinite parentId loop when unpacking')
+          return { segment, complete: false }
+        }
         visited.add(id)
-        segment.push(id)
         const reroute = this.reroutes.get(id)
         if (!reroute) {
           console.error('Broken Id link when unpacking')
           return { segment, complete: false }
         }
+        segment.push(id)
         id = reroute.parentId
       }
       return { segment, complete: true }
@@ -2255,7 +2259,10 @@ export class LGraph
       const visited = new Set<RerouteId>()
       let id = start
       while (id !== undefined) {
-        if (visited.has(id)) throw new Error('Infinite parentId loop')
+        if (visited.has(id)) {
+          console.error('Infinite parentId loop when unpacking')
+          return { segment, complete: false }
+        }
         visited.add(id)
         const migratedId = rerouteIdMap.get(id)
         if (migratedId === undefined) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -2206,88 +2206,89 @@ export class LGraph
       }
       newLink.id = created.id
     }
+    // Migrate the subgraph's reroutes to fresh ids at their new positions.
     const rerouteIdMap = new Map<RerouteId, RerouteId>()
-    for (const reroute of subgraphNode.subgraph.reroutes.values()) {
-      if (
-        reroute.parentId !== undefined &&
-        rerouteIdMap.get(reroute.parentId) === undefined
-      ) {
-        console.error('Missing Parent ID')
-      }
-      const migratedRerouteId = toRerouteId(
-        Number(this.state.lastRerouteId) + 1
-      )
-      this.state.lastRerouteId = migratedRerouteId
-      const migratedReroute = new Reroute(migratedRerouteId, this, [
+    const oldReroutes = subgraphNode.subgraph.reroutes
+    for (const reroute of oldReroutes.values()) {
+      const migratedId = toRerouteId(Number(this.state.lastRerouteId) + 1)
+      this.state.lastRerouteId = migratedId
+      const migratedReroute = new Reroute(migratedId, this, [
         reroute.pos[0] + offsetX,
         reroute.pos[1] + offsetY
       ])
-      rerouteIdMap.set(reroute.id, migratedReroute.id)
+      rerouteIdMap.set(reroute.id, migratedId)
       this._addReroute(migratedReroute)
       toSelect.push(migratedReroute)
     }
-    //iterate over newly created links to update reroute parentIds
+
+    /**
+     * A reroute chain segment, terminal-first. `complete` is false when the
+     * walk stopped at a broken reference; stitching stops there too.
+     */
+    interface ChainSegment {
+      segment: RerouteId[]
+      complete: boolean
+    }
+
+    /** Walks a chain of this graph's own reroutes upstream from `start`. */
+    const externalSegment = (start: RerouteId | undefined): ChainSegment => {
+      const segment: RerouteId[] = []
+      const visited = new Set<RerouteId>()
+      let id = start
+      while (id !== undefined) {
+        if (visited.has(id)) throw new Error('Infinite parentId loop')
+        visited.add(id)
+        segment.push(id)
+        const reroute = this.reroutes.get(id)
+        if (!reroute) {
+          console.error('Broken Id link when unpacking')
+          return { segment, complete: false }
+        }
+        id = reroute.parentId
+      }
+      return { segment, complete: true }
+    }
+
+    /** Walks an old subgraph chain from `start`, emitting migrated ids. */
+    const internalSegment = (start: RerouteId | undefined): ChainSegment => {
+      const segment: RerouteId[] = []
+      const visited = new Set<RerouteId>()
+      let id = start
+      while (id !== undefined) {
+        if (visited.has(id)) throw new Error('Infinite parentId loop')
+        visited.add(id)
+        const migratedId = rerouteIdMap.get(id)
+        if (migratedId === undefined) {
+          console.error('Broken Id link when unpacking')
+          return { segment, complete: false }
+        }
+        segment.push(migratedId)
+        id = oldReroutes.get(id)?.parentId
+      }
+      return { segment, complete: true }
+    }
+
+    // Stitch each link's chain from its internal (migrated) and external
+    // segments, ordered by which side was nearest the input.
     for (const newLink of dedupedNewLinks) {
       const linkInstance = this.links.get(newLink.id)
-      if (!linkInstance) {
-        continue
-      }
-      const visited = new Set<RerouteId>()
-      let instance: Reroute | LLink | undefined = linkInstance
-      let parentId: RerouteId | undefined
-      if (newLink.externalFirst) {
-        parentId = newLink.eparent
-        while (parentId) {
-          instance.parentId = parentId
-          instance = this.reroutes.get(parentId)
-          if (!instance) {
-            console.error('Broken Id link when unpacking')
-            break
-          }
-          if (visited.has(instance.id))
-            throw new Error('Infinite parentId loop')
-          visited.add(instance.id)
-          parentId = instance.parentId
-        }
-      }
-      if (!instance) continue
-      parentId = newLink.iparent
-      while (parentId) {
-        const migratedId = rerouteIdMap.get(parentId)
-        if (!migratedId) {
-          console.error('Broken Id link when unpacking')
-          break
-        }
-        instance.parentId = migratedId
-        instance = this.reroutes.get(migratedId)
-        if (!instance) {
-          console.error('Broken Id link when unpacking')
-          break
-        }
-        if (visited.has(instance.id)) throw new Error('Infinite parentId loop')
-        visited.add(instance.id)
-        const oldReroute = subgraphNode.subgraph.reroutes.get(parentId)
-        if (!oldReroute) {
-          console.error('Broken Id link when unpacking')
-          break
-        }
-        parentId = oldReroute.parentId
-      }
-      if (!instance) break
-      if (!newLink.externalFirst) {
-        parentId = newLink.eparent
-        while (parentId) {
-          instance.parentId = parentId
-          instance = this.reroutes.get(parentId)
-          if (!instance) {
-            console.error('Broken Id link when unpacking')
-            break
-          }
-          if (visited.has(instance.id))
-            throw new Error('Infinite parentId loop')
-          visited.add(instance.id)
-          parentId = instance.parentId
-        }
+      if (!linkInstance) continue
+
+      const internal = internalSegment(newLink.iparent)
+      const external = externalSegment(newLink.eparent)
+      const [first, second] = newLink.externalFirst
+        ? [external, internal]
+        : [internal, external]
+      const chain = first.complete
+        ? [...first.segment, ...second.segment]
+        : first.segment
+
+      let segmentEnd: LLink | Reroute = linkInstance
+      for (const rerouteId of chain) {
+        segmentEnd.parentId = rerouteId
+        const next = this.reroutes.get(rerouteId)
+        if (!next) break
+        segmentEnd = next
       }
     }
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -1453,34 +1453,12 @@ export class LGraph
     }
     this.floatingLinksInternal.set(link.id, link)
     registerLinkTopology(this, link)
-
-    const slot =
-      link.target_id !== UNASSIGNED_NODE_ID
-        ? this.getNodeById(link.target_id)?.inputs?.[link.target_slot]
-        : this.getNodeById(link.origin_id)?.outputs?.[link.origin_slot]
-    if (slot) {
-      slot._floatingLinks ??= new Set()
-      slot._floatingLinks.add(link)
-    } else {
-      console.warn(
-        `Adding invalid floating link: target/slot: [${link.target_id}/${link.target_slot}] origin/slot: [${link.origin_id}/${link.origin_slot}]`
-      )
-    }
-
     return link
   }
 
   removeFloatingLink(link: LLink): void {
     this.floatingLinksInternal.delete(link.id)
     unregisterLinkTopology(link)
-
-    const slot =
-      link.target_id !== UNASSIGNED_NODE_ID
-        ? this.getNodeById(link.target_id)?.inputs?.[link.target_slot]
-        : this.getNodeById(link.origin_id)?.outputs?.[link.origin_slot]
-    if (slot) {
-      slot._floatingLinks?.delete(link)
-    }
 
     const reroutes = LLink.getReroutes(this, link)
     for (const reroute of reroutes) {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -196,6 +196,55 @@ function fireNodeRemovalLifecycle(node: LGraphNode): void {
   graph?.onNodeRemoved?.(node)
 }
 
+/** A reroute chain segment, terminal-first. */
+interface ChainSegment {
+  /** Emitted reroute ids, in walk order. */
+  segment: RerouteId[]
+  /** `false` if the walk stopped at a broken reference or a cycle. */
+  complete: boolean
+}
+
+/**
+ * Resolves one hop of a reroute chain.
+ * @param id The reroute id to resolve.
+ * @returns The id to emit and the next id upstream, or `undefined` if the
+ * reference is broken.
+ */
+type ChainStep = (
+  id: RerouteId
+) => { emit: RerouteId; next: RerouteId | undefined } | undefined
+
+/**
+ * Walks a reroute chain, resolving each hop with `step`, until it runs out,
+ * hits a broken reference, or detects a cycle.
+ * @param start The reroute id to walk from, or `undefined` for an empty chain.
+ * @param step Resolves each hop of the chain.
+ * @returns The walked segment.
+ */
+function walkSegment(
+  start: RerouteId | undefined,
+  step: ChainStep
+): ChainSegment {
+  const segment: RerouteId[] = []
+  const visited = new Set<RerouteId>()
+  let id = start
+  while (id !== undefined) {
+    if (visited.has(id)) {
+      console.error('Infinite parentId loop when unpacking')
+      return { segment, complete: false }
+    }
+    visited.add(id)
+    const hop = step(id)
+    if (!hop) {
+      console.error('Broken Id link when unpacking')
+      return { segment, complete: false }
+    }
+    segment.push(hop.emit)
+    id = hop.next
+  }
+  return { segment, complete: true }
+}
+
 /**
  * LGraph is the class that contain a full graph. We instantiate one and add nodes to it, and then we can run the execution loop.
  * supported callbacks:
@@ -2221,68 +2270,24 @@ export class LGraph
       toSelect.push(migratedReroute)
     }
 
-    /**
-     * A reroute chain segment, terminal-first. `complete` is false when the
-     * walk stopped at a broken reference or a cycle; stitching stops there
-     * too.
-     */
-    interface ChainSegment {
-      segment: RerouteId[]
-      complete: boolean
-    }
-
-    /** Walks a chain of this graph's own reroutes upstream from `start`. */
-    const externalSegment = (start: RerouteId | undefined): ChainSegment => {
-      const segment: RerouteId[] = []
-      const visited = new Set<RerouteId>()
-      let id = start
-      while (id !== undefined) {
-        if (visited.has(id)) {
-          console.error('Infinite parentId loop when unpacking')
-          return { segment, complete: false }
-        }
-        visited.add(id)
-        const reroute = this.reroutes.get(id)
-        if (!reroute) {
-          console.error('Broken Id link when unpacking')
-          return { segment, complete: false }
-        }
-        segment.push(id)
-        id = reroute.parentId
-      }
-      return { segment, complete: true }
-    }
-
-    /** Walks an old subgraph chain from `start`, emitting migrated ids. */
-    const internalSegment = (start: RerouteId | undefined): ChainSegment => {
-      const segment: RerouteId[] = []
-      const visited = new Set<RerouteId>()
-      let id = start
-      while (id !== undefined) {
-        if (visited.has(id)) {
-          console.error('Infinite parentId loop when unpacking')
-          return { segment, complete: false }
-        }
-        visited.add(id)
-        const migratedId = rerouteIdMap.get(id)
-        if (migratedId === undefined) {
-          console.error('Broken Id link when unpacking')
-          return { segment, complete: false }
-        }
-        segment.push(migratedId)
-        id = oldReroutes.get(id)?.parentId
-      }
-      return { segment, complete: true }
-    }
-
     // Stitch each link's chain from its internal (migrated) and external
-    // segments, ordered by which side was nearest the input.
+    // segments, ordered by which side was nearest the input. External hops walk
+    // this graph's own reroutes; internal hops walk the old subgraph chain,
+    // emitting migrated ids.
     for (const newLink of dedupedNewLinks) {
       const linkInstance = this.links.get(newLink.id)
       if (!linkInstance) continue
 
-      const internal = internalSegment(newLink.iparent)
-      const external = externalSegment(newLink.eparent)
+      const internal = walkSegment(newLink.iparent, (id) => {
+        const emit = rerouteIdMap.get(id)
+        return emit === undefined
+          ? undefined
+          : { emit, next: oldReroutes.get(id)?.parentId }
+      })
+      const external = walkSegment(newLink.eparent, (id) => {
+        const reroute = this.reroutes.get(id)
+        return reroute && { emit: id, next: reroute.parentId }
+      })
       const [first, second] = newLink.externalFirst
         ? [external, internal]
         : [internal, external]

--- a/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
@@ -256,6 +256,31 @@ describe('_deserializeItems paste-time migration & auto-expose', () => {
     registeredTypesToCleanup.push(type)
   }
 
+  it('prunes pasted reroutes that no pasted link passes through', () => {
+    const nodeType = 'test/clipboard-reroute-prune'
+    registerClipboardNodeType(nodeType)
+
+    const rootGraph = new LGraph()
+    const canvas = createCanvas(rootGraph)
+
+    const source = LiteGraph.createNode(nodeType)!
+    rootGraph.add(source)
+    const target = LiteGraph.createNode(nodeType)!
+    rootGraph.add(target)
+    const link = source.connect(0, target, 0)!
+    rootGraph.createReroute([50, 50], link)
+
+    // Copying only the reroute leaves it with no pasted link through it
+    const result = canvas._deserializeItems(
+      canvas._serializeItems([...rootGraph.reroutes.values()]),
+      { position: [300, 300] }
+    )
+
+    expect(result?.reroutes.size).toBe(0)
+    expect(result?.created).toHaveLength(0)
+    expect(rootGraph.reroutes.size).toBe(1)
+  })
+
   it('reconnects pasted inputs when clipboard node IDs differ from link endpoint types', () => {
     const nodeType = 'test/clipboard-node-id-normalization'
     registerClipboardNodeType(nodeType)

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -4293,9 +4293,13 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
     }
 
     // Remove reroutes that no pasted link passes through
-    for (const reroute of reroutes.values()) {
+    for (const [sourceId, reroute] of reroutes) {
       if (reroute.totalLinks === 0) {
         graph.removeReroute(reroute.id)
+        reroutes.delete(sourceId)
+
+        const index = created.indexOf(reroute)
+        if (index !== -1) created.splice(index, 1)
       }
     }
 

--- a/src/lib/litegraph/src/LGraphCanvas.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ts
@@ -26,7 +26,7 @@ import { LGraphNode } from './LGraphNode'
 import type { NodeProperty } from './LGraphNode'
 import { parseNodeId, serializeNodeId } from '@/types/nodeId'
 import type { SerializedNodeId } from '@/types/nodeId'
-import { LLink } from './LLink'
+import { LLink, slotFloatingLinks } from './LLink'
 import type { LinkId } from './LLink'
 import { Reroute } from './Reroute'
 import type { RerouteId } from './Reroute'
@@ -2784,13 +2784,8 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         output: INodeOutputSlot,
         network: LinkNetwork
       ): boolean {
-        const outputLinks = [
-          ...(output.links ?? []),
-          ...[...(output._floatingLinks ?? new Set())]
-        ]
-        return outputLinks.some(
-          (linkId) =>
-            typeof linkId === 'number' && network.getLink(linkId) !== undefined
+        return (output.links ?? []).some(
+          (linkId) => network.getLink(linkId) !== undefined
         )
       }
 
@@ -2801,7 +2796,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
           if (isInRectangle(x, y, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
             // Drag multiple output links
             if (e.shiftKey && hasRelevantOutputLinks(output, graph)) {
-              linkConnector.moveOutputLink(graph, output)
+              linkConnector.moveOutputLink(graph, node, output)
               this._linkConnectorDrop()
               return
             }
@@ -2847,12 +2842,15 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
               ctrlOrMeta &&
               e.altKey &&
               !e.shiftKey
-            if (input.link !== null || input._floatingLinks?.size) {
+            if (
+              input.link !== null ||
+              slotFloatingLinks(graph, 'input', node.id, i).length > 0
+            ) {
               // Existing link
               if (shouldBreakLink || LiteGraph.click_do_break_link_to) {
                 node.disconnectInput(i, true)
               } else if (e.shiftKey || this.allow_reconnect_links) {
-                linkConnector.moveInputLink(graph, input)
+                linkConnector.moveInputLink(graph, node, input)
               }
             }
 

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -31,7 +31,7 @@ import { BadgePosition, LGraphBadge } from './LGraphBadge'
 import { LGraphButton } from './LGraphButton'
 import type { LGraphButtonOptions } from './LGraphButton'
 import { LGraphCanvas } from './LGraphCanvas'
-import { LLink } from './LLink'
+import { LLink, slotFloatingLinks } from './LLink'
 import { anchorRerouteChain } from './Reroute'
 import type { Reroute, RerouteId } from './Reroute'
 import { getNodeInputOnPos, getNodeOutputOnPos } from './canvas/measureSlots'
@@ -3093,11 +3093,14 @@ export class LGraphNode
     const output = this.outputs[slot]
     if (!output) return false
 
-    if (output._floatingLinks) {
-      for (const link of output._floatingLinks) {
-        if (link.hasOrigin(this.id, slot)) {
-          this.graph?.removeFloatingLink(link)
-        }
+    if (this.graph) {
+      for (const link of slotFloatingLinks(
+        this.graph,
+        'output',
+        this.id,
+        slot
+      )) {
+        this.graph.removeFloatingLink(link)
       }
     }
 
@@ -3257,11 +3260,9 @@ export class LGraphNode
 
     // Break floating links, except the one whose reroute chain is being
     // reconnected (its reroute would be pruned before the new link is added).
-    if (input._floatingLinks?.size) {
-      for (const link of input._floatingLinks) {
-        if (link.parentId === keepFloatingReroute) continue
-        graph.removeFloatingLink(link)
-      }
+    for (const link of slotFloatingLinks(graph, 'input', this.id, slot)) {
+      if (link.parentId === keepFloatingReroute) continue
+      graph.removeFloatingLink(link)
     }
 
     const link_id = this.inputs[slot].link

--- a/src/lib/litegraph/src/LGraphNode.ts
+++ b/src/lib/litegraph/src/LGraphNode.ts
@@ -1690,6 +1690,15 @@ export class LGraphNode
         }
       }
     }
+    if (this.graph) {
+      for (const floatingLink of this.graph.floatingLinks.values()) {
+        if (
+          floatingLink.origin_id === this.id &&
+          floatingLink.origin_slot > slot
+        )
+          floatingLink.origin_slot--
+      }
+    }
 
     this.onOutputRemoved?.(slot)
     this.setDirtyCanvas(true, true)
@@ -1742,6 +1751,15 @@ export class LGraphNode
       if (this.graph) {
         const link = this.graph._links.get(input.link)
         if (link) link.target_slot--
+      }
+    }
+    if (this.graph) {
+      for (const floatingLink of this.graph.floatingLinks.values()) {
+        if (
+          floatingLink.target_id === this.id &&
+          floatingLink.target_slot > slot
+        )
+          floatingLink.target_slot--
       }
     }
     this.onInputRemoved?.(slot, slot_info[0])

--- a/src/lib/litegraph/src/LLink.ts
+++ b/src/lib/litegraph/src/LLink.ts
@@ -578,6 +578,32 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
 }
 
 /**
+ * Finds the floating links attached to a slot. A floating link has exactly
+ * one assigned endpoint, so its attachment is fully encoded in its own
+ * origin/target fields; nothing is stored on the slot.
+ * @param network The network whose floating links to search
+ * @param side Which side of the slot's node the links attach to
+ * @param nodeId The node (or subgraph IO node id) owning the slot
+ * @param slot The slot index
+ */
+export function slotFloatingLinks(
+  network: Pick<ReadonlyLinkNetwork, 'floatingLinks'>,
+  side: 'input' | 'output',
+  nodeId: NodeId,
+  slot: number
+): LLink[] {
+  const result: LLink[] = []
+  for (const link of network.floatingLinks.values()) {
+    const attached =
+      side === 'input'
+        ? link.target_id === nodeId && link.target_slot === slot
+        : link.origin_id === nodeId && link.origin_slot === slot
+    if (attached) result.push(link)
+  }
+  return result
+}
+
+/**
  * Registers a link's topology into {@link useLinkStore} and adopts the
  * store's reactive proxy as {@link LLink._state}, so the store and the link
  * always agree and field writes are tracked.  Call this at every site that

--- a/src/lib/litegraph/src/Reroute.store.test.ts
+++ b/src/lib/litegraph/src/Reroute.store.test.ts
@@ -5,6 +5,7 @@ import { computed } from 'vue'
 
 import { LGraph, LGraphNode, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import type { SerialisableGraph } from '@/lib/litegraph/src/types/serialisation'
+import { layoutStore } from '@/renderer/core/layout/store/layoutStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
 import { toRerouteId } from '@/types/rerouteId'
 
@@ -190,6 +191,18 @@ describe('Reroute ↔ rerouteStore integration', () => {
 
     expect(a.parentId).toBeUndefined()
     expect(c.getReroutes()).not.toBeNull()
+  })
+
+  it('snapToGrid mirrors the snapped position into the layout store', () => {
+    const { graph, link } = connectedGraph()
+    const reroute = graph.createReroute([12, 17], link)!
+
+    reroute.snapToGrid(10)
+
+    expect(layoutStore.getRerouteLayout(reroute.id)?.position).toEqual({
+      x: reroute.pos[0],
+      y: reroute.pos[1]
+    })
   })
 
   it('floating marker survives through the store state', () => {

--- a/src/lib/litegraph/src/Reroute.store.test.ts
+++ b/src/lib/litegraph/src/Reroute.store.test.ts
@@ -205,6 +205,22 @@ describe('Reroute ↔ rerouteStore integration', () => {
     })
   })
 
+  it('refuses parentId writes that would create a cycle, allows repair', () => {
+    const { graph, link } = connectedGraph()
+    const first = graph.createReroute([10, 10], link)!
+    const second = graph.createReroute([20, 20], first)!
+    expect(first.parentId).toBe(second.id)
+
+    second.parentId = first.id
+
+    expect(second.parentId).toBeUndefined()
+
+    second._chain.parentId = first.id
+    second.parentId = undefined
+
+    expect(second.parentId).toBeUndefined()
+  })
+
   it('floating marker survives through the store state', () => {
     const { graph, a, link } = connectedGraph()
     const store = useRerouteStore()

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -384,31 +384,14 @@ export class Reroute
   /**
    * Changes the origin node/output of all floating links that pass through this reroute.
    * @param node The new origin node
-   * @param output The new origin output slot
-   * @param index The slot index of {@link output}
+   * @param index The slot index of the new origin output
    */
-  setFloatingLinkOrigin(
-    node: LGraphNode,
-    output: INodeOutputSlot,
-    index: number
-  ) {
-    const network = this.network.deref()
+  setFloatingLinkOrigin(node: LGraphNode, index: number) {
     const floatingOutLinks = this.getFloatingLinks('output')
     if (!floatingOutLinks)
       throw new Error('[setFloatingLinkOrigin]: Invalid network.')
-    if (!floatingOutLinks.length) return
-
-    output._floatingLinks ??= new Set()
 
     for (const link of floatingOutLinks) {
-      // Update cached floating links
-      output._floatingLinks.add(link)
-
-      network
-        ?.getNodeById(link.origin_id)
-        ?.outputs[link.origin_slot]?._floatingLinks?.delete(link)
-
-      // Update the floating link
       link.origin_id = node.id
       link.origin_slot = index
     }

--- a/src/lib/litegraph/src/Reroute.ts
+++ b/src/lib/litegraph/src/Reroute.ts
@@ -418,8 +418,12 @@ export class Reroute
 
     const offsetY = LiteGraph.NODE_SLOT_HEIGHT * 0.7
     const { pos } = this
+    const previousPos = { x: pos[0], y: pos[1] }
     pos[0] = snapTo * Math.round(pos[0] / snapTo)
     pos[1] = snapTo * Math.round((pos[1] - offsetY) / snapTo) + offsetY
+
+    layoutMutations.setSource(LayoutSource.Canvas)
+    layoutMutations.moveReroute(this.id, { x: pos[0], y: pos[1] }, previousPos)
     return true
   }
 

--- a/src/lib/litegraph/src/canvas/FloatingRenderLink.test.ts
+++ b/src/lib/litegraph/src/canvas/FloatingRenderLink.test.ts
@@ -1,0 +1,93 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { SUBGRAPH_OUTPUT_ID } from '@/lib/litegraph/src/constants'
+import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
+import { LGraph, LGraphNode, Reroute } from '@/lib/litegraph/src/litegraph'
+import { toLinkId } from '@/types/linkId'
+import { toNodeId, UNASSIGNED_NODE_ID } from '@/types/nodeId'
+import { toRerouteId } from '@/types/rerouteId'
+
+import { createTestSubgraph } from '../subgraph/__fixtures__/subgraphHelpers'
+import { FloatingRenderLink } from './FloatingRenderLink'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
+function inputFloatingLink(targetId: number, targetSlot: number): LLink {
+  return new LLink(
+    toLinkId(-1),
+    'INT',
+    UNASSIGNED_NODE_ID,
+    -1,
+    toNodeId(targetId),
+    targetSlot
+  )
+}
+
+describe('FloatingRenderLink', () => {
+  it('connectToSubgraphOutput re-targets the floating link to the output slot', () => {
+    const subgraph = createTestSubgraph({
+      nodeCount: 1,
+      outputs: [{ name: 'result', type: 'INT' }]
+    })
+    const [node] = subgraph.nodes
+    const floatingLink = inputFloatingLink(Number(node.id), 0)
+    floatingLink.parentId = toRerouteId(1)
+    const reroute = new Reroute(toRerouteId(1), subgraph, [0, 0])
+    subgraph._addReroute(reroute)
+    subgraph.addFloatingLink(floatingLink)
+
+    const renderLink = new FloatingRenderLink(
+      subgraph,
+      floatingLink,
+      'input',
+      reroute
+    )
+    renderLink.connectToSubgraphOutput(subgraph.outputs[0])
+
+    expect(floatingLink.target_id).toBe(SUBGRAPH_OUTPUT_ID)
+    expect(floatingLink.target_slot).toBe(0)
+    expect(floatingLink.origin_id).toBe(UNASSIGNED_NODE_ID)
+    expect(slotFloatingLinks(subgraph, 'input', node.id, 0)).toHaveLength(0)
+  })
+})
+
+describe('slot removal renumbers floating link attachments', () => {
+  it('removeInput shifts floating links on later inputs', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('N')
+    node.addInput('a', 'INT')
+    node.addInput('b', 'INT')
+    graph.add(node)
+    const floatingLink = inputFloatingLink(Number(node.id), 1)
+    graph.addFloatingLink(floatingLink)
+
+    node.removeInput(0)
+
+    expect(slotFloatingLinks(graph, 'input', node.id, 0)).toHaveLength(1)
+    expect(floatingLink.target_slot).toBe(0)
+  })
+
+  it('removeOutput shifts floating links on later outputs', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('N')
+    node.addOutput('a', 'INT')
+    node.addOutput('b', 'INT')
+    graph.add(node)
+    const floatingLink = new LLink(
+      toLinkId(-1),
+      'INT',
+      node.id,
+      1,
+      UNASSIGNED_NODE_ID,
+      -1
+    )
+    graph.addFloatingLink(floatingLink)
+
+    node.removeOutput(0)
+
+    expect(slotFloatingLinks(graph, 'output', node.id, 0)).toHaveLength(1)
+    expect(floatingLink.origin_slot).toBe(0)
+  })
+})

--- a/src/lib/litegraph/src/canvas/FloatingRenderLink.ts
+++ b/src/lib/litegraph/src/canvas/FloatingRenderLink.ts
@@ -147,15 +147,13 @@ export class FloatingRenderLink implements RenderLink {
     input: INodeInputSlot,
     _events?: CustomEventTarget<LinkConnectorEventMap>
   ): void {
+    // Disconnect before re-targeting, or the floating link would be
+    // caught (and removed) by the target slot's floating-link cleanup.
+    node.disconnectInput(node.inputs.indexOf(input))
+
     const floatingLink = this.link
     floatingLink.target_id = node.id
     floatingLink.target_slot = node.inputs.indexOf(input)
-
-    node.disconnectInput(node.inputs.indexOf(input))
-
-    this.fromSlot._floatingLinks?.delete(floatingLink)
-    input._floatingLinks ??= new Set()
-    input._floatingLinks.add(floatingLink)
   }
 
   connectToOutput(
@@ -166,10 +164,6 @@ export class FloatingRenderLink implements RenderLink {
     const floatingLink = this.link
     floatingLink.origin_id = node.id
     floatingLink.origin_slot = node.outputs.indexOf(output)
-
-    this.fromSlot._floatingLinks?.delete(floatingLink)
-    output._floatingLinks ??= new Set()
-    output._floatingLinks.add(floatingLink)
   }
 
   connectToSubgraphInput(
@@ -179,10 +173,6 @@ export class FloatingRenderLink implements RenderLink {
     const floatingLink = this.link
     floatingLink.origin_id = SUBGRAPH_INPUT_ID
     floatingLink.origin_slot = input.parent.slots.indexOf(input)
-
-    this.fromSlot._floatingLinks?.delete(floatingLink)
-    input._floatingLinks ??= new Set()
-    input._floatingLinks.add(floatingLink)
   }
 
   connectToSubgraphOutput(
@@ -192,10 +182,6 @@ export class FloatingRenderLink implements RenderLink {
     const floatingLink = this.link
     floatingLink.origin_id = SUBGRAPH_OUTPUT_ID
     floatingLink.origin_slot = output.parent.slots.indexOf(output)
-
-    this.fromSlot._floatingLinks?.delete(floatingLink)
-    output._floatingLinks ??= new Set()
-    output._floatingLinks.add(floatingLink)
   }
 
   connectToRerouteInput(
@@ -207,10 +193,6 @@ export class FloatingRenderLink implements RenderLink {
     const floatingLink = this.link
     floatingLink.target_id = inputNode.id
     floatingLink.target_slot = inputNode.inputs.indexOf(input)
-
-    this.fromSlot._floatingLinks?.delete(floatingLink)
-    input._floatingLinks ??= new Set()
-    input._floatingLinks.add(floatingLink)
 
     events.dispatch('input-moved', this)
   }
@@ -225,10 +207,6 @@ export class FloatingRenderLink implements RenderLink {
     const floatingLink = this.link
     floatingLink.origin_id = outputNode.id
     floatingLink.origin_slot = outputNode.outputs.indexOf(output)
-
-    this.fromSlot._floatingLinks?.delete(floatingLink)
-    output._floatingLinks ??= new Set()
-    output._floatingLinks.add(floatingLink)
 
     events.dispatch('output-moved', this)
   }

--- a/src/lib/litegraph/src/canvas/FloatingRenderLink.ts
+++ b/src/lib/litegraph/src/canvas/FloatingRenderLink.ts
@@ -180,8 +180,8 @@ export class FloatingRenderLink implements RenderLink {
     _events?: CustomEventTarget<LinkConnectorEventMap>
   ): void {
     const floatingLink = this.link
-    floatingLink.origin_id = SUBGRAPH_OUTPUT_ID
-    floatingLink.origin_slot = output.parent.slots.indexOf(output)
+    floatingLink.target_id = SUBGRAPH_OUTPUT_ID
+    floatingLink.target_slot = output.parent.slots.indexOf(output)
   }
 
   connectToRerouteInput(

--- a/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.core.test.ts
@@ -138,7 +138,7 @@ describe('LinkConnector', () => {
       network.links.set(link.id, link)
       targetNode.inputs[0].link = link.id
 
-      connector.moveInputLink(network, targetNode.inputs[0])
+      connector.moveInputLink(network, targetNode, targetNode.inputs[0])
 
       expect(connector.state.connectingTo).toBe('input')
       expect(connector.state.draggingExistingLinks).toBe(true)
@@ -155,6 +155,7 @@ describe('LinkConnector', () => {
       expect(() => {
         connector.moveInputLink(
           network,
+          new LGraphNode('mock'),
           createMockNodeInputSlot({ link: toLinkId(1) })
         )
       }).toThrow('Already dragging links.')
@@ -178,7 +179,7 @@ describe('LinkConnector', () => {
       network.links.set(link.id, link)
       sourceNode.outputs[0].links = [link.id]
 
-      connector.moveOutputLink(network, sourceNode.outputs[0])
+      connector.moveOutputLink(network, sourceNode, sourceNode.outputs[0])
 
       expect(connector.state.connectingTo).toBe('output')
       expect(connector.state.draggingExistingLinks).toBe(true)
@@ -196,6 +197,7 @@ describe('LinkConnector', () => {
       expect(() => {
         connector.moveOutputLink(
           network,
+          new LGraphNode('mock'),
           createMockNodeOutputSlot({ links: [toLinkId(1)] })
         )
       }).toThrow('Already dragging links.')

--- a/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.integration.test.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/lib/litegraph/src/litegraph'
 import { LGraphNode, LLink, LinkConnector } from '@/lib/litegraph/src/litegraph'
 
+import { slotFloatingLinks } from '../LLink'
 import { test as baseTest } from '../__fixtures__/testExtensions'
 import type { ConnectingLink } from '@/lib/litegraph/src/interfaces'
 import { toLinkId } from '@/types/linkId'
@@ -168,18 +169,23 @@ const test = baseTest.extend<TestContext>({
           expect(link.origin_id).not.toBe(UNASSIGNED_NODE_ID)
           expect(link.origin_slot).not.toBe(-1)
           expect(link.target_slot).toBe(-1)
-          const outputFloatingLinks = graph.getNodeById(link.origin_id)
-            ?.outputs[link.origin_slot]._floatingLinks
-          expect(outputFloatingLinks).toBeDefined()
+          const outputFloatingLinks = slotFloatingLinks(
+            graph,
+            'output',
+            link.origin_id,
+            link.origin_slot
+          )
           expect(outputFloatingLinks).toContain(link)
         } else {
           expect(link.origin_id).toBe(UNASSIGNED_NODE_ID)
           expect(link.origin_slot).toBe(-1)
           expect(link.target_slot).not.toBe(-1)
-          const inputFloatingLinks = graph.getNodeById(link.target_id)?.inputs[
+          const inputFloatingLinks = slotFloatingLinks(
+            graph,
+            'input',
+            link.target_id,
             link.target_slot
-          ]._floatingLinks
-          expect(inputFloatingLinks).toBeDefined()
+          )
           expect(inputFloatingLinks).toContain(link)
         }
       }
@@ -240,7 +246,7 @@ describe('LinkConnector Integration', () => {
         graph.links.get(hasInputNode.inputs[0].link!)!
       )
 
-      connector.moveInputLink(graph, hasInputNode.inputs[0])
+      connector.moveInputLink(graph, hasInputNode, hasInputNode.inputs[0])
       expect(connector.state.connectingTo).toBe('input')
       expect(connector.state.draggingExistingLinks).toBe(true)
       expect(connector.renderLinks.length).toBe(1)
@@ -346,9 +352,13 @@ describe('LinkConnector Integration', () => {
 
         expect([0, undefined]).toContain(output.links?.length)
 
-        expect([0, undefined]).toContain(input._floatingLinks?.size)
+        expect(
+          slotFloatingLinks(graph, 'input', toNodeId(nodeId), 0)
+        ).toHaveLength(0)
 
-        expect([0, undefined]).toContain(output._floatingLinks?.size)
+        expect(
+          slotFloatingLinks(graph, 'output', toNodeId(nodeId), 0)
+        ).toHaveLength(0)
       }
     })
 
@@ -367,7 +377,7 @@ describe('LinkConnector Integration', () => {
 
       const atOutputNodeEvent = mockedNodeTitleDropEvent(hasOutputNode)
 
-      connector.moveInputLink(graph, hasInputNode.inputs[0])
+      connector.moveInputLink(graph, hasInputNode, hasInputNode.inputs[0])
       connector.dropLinks(graph, atOutputNodeEvent)
       connector.reset()
 
@@ -396,7 +406,7 @@ describe('LinkConnector Integration', () => {
 
       const atHasOutputNode = mockedInputDropEvent(hasOutputNode, 0)
 
-      connector.moveInputLink(graph, hasInputNode.inputs[0])
+      connector.moveInputLink(graph, hasInputNode, hasInputNode.inputs[0])
       connector.dropLinks(graph, atHasOutputNode)
       connector.reset()
 
@@ -422,7 +432,7 @@ describe('LinkConnector Integration', () => {
         ?.map((linkId) => graph.links.get(linkId)!)
         .map((link) => LLink.getReroutes(graph, link))
 
-      connector.moveOutputLink(graph, hasOutputNode.outputs[0])
+      connector.moveOutputLink(graph, hasOutputNode, hasOutputNode.outputs[0])
       expect(connector.state.connectingTo).toBe('output')
       expect(connector.state.draggingExistingLinks).toBe(true)
       expect(connector.renderLinks.length).toBe(3)
@@ -551,9 +561,13 @@ describe('LinkConnector Integration', () => {
 
         expect([0, undefined]).toContain(output.links?.length)
 
-        expect([0, undefined]).toContain(input._floatingLinks?.size)
+        expect(
+          slotFloatingLinks(graph, 'input', toNodeId(nodeId), 0)
+        ).toHaveLength(0)
 
-        expect([0, undefined]).toContain(output._floatingLinks?.size)
+        expect(
+          slotFloatingLinks(graph, 'output', toNodeId(nodeId), 0)
+        ).toHaveLength(0)
       }
     })
 
@@ -571,7 +585,11 @@ describe('LinkConnector Integration', () => {
         canvasY
       )
 
-      connector.moveOutputLink(graph, manyOutputsNode.outputs[0])
+      connector.moveOutputLink(
+        graph,
+        manyOutputsNode,
+        manyOutputsNode.outputs[0]
+      )
       connector.dropLinks(graph, floatingRerouteEvent)
       connector.reset()
 
@@ -606,7 +624,11 @@ describe('LinkConnector Integration', () => {
         manyOutputsNode.outputs[0].links!
       )
 
-      connector.moveOutputLink(graph, manyOutputsNode.outputs[0])
+      connector.moveOutputLink(
+        graph,
+        manyOutputsNode,
+        manyOutputsNode.outputs[0]
+      )
       expect(connector.isRerouteValidDrop(reroute7)).toBe(false)
       expect(connector.isRerouteValidDrop(reroute10)).toBe(false)
       expect(connector.isRerouteValidDrop(reroute13)).toBe(false)
@@ -643,7 +665,7 @@ describe('LinkConnector Integration', () => {
 
       const atInputNodeEvent = mockedNodeTitleDropEvent(hasInputNode)
 
-      connector.moveOutputLink(graph, hasOutputNode.outputs[0])
+      connector.moveOutputLink(graph, hasOutputNode, hasOutputNode.outputs[0])
       connector.dropLinks(graph, atInputNodeEvent)
       connector.reset()
 
@@ -681,7 +703,7 @@ describe('LinkConnector Integration', () => {
 
       const atInputNodeOutSlot = mockedOutputDropEvent(hasInputNode, 0)
 
-      connector.moveOutputLink(graph, hasOutputNode.outputs[0])
+      connector.moveOutputLink(graph, hasOutputNode, hasOutputNode.outputs[0])
       connector.dropLinks(graph, atInputNodeOutSlot)
       connector.reset()
 
@@ -758,16 +780,20 @@ describe('LinkConnector Integration', () => {
       const hasInputNode = graph.getNodeById(toNodeId(2))!
       const toInput = hasInputNode.inputs[0]
 
-      connector.moveInputLink(graph, fromFloatingInput)
+      connector.moveInputLink(graph, floatingInputNode, fromFloatingInput)
       const dropEvent = mockedInputDropEvent(hasInputNode, 0)
       connector.dropLinks(graph, dropEvent)
       connector.reset()
 
       expect(fromFloatingInput.link).toBeNull()
-      expect(fromFloatingInput._floatingLinks?.size).toBe(0)
+      expect(
+        slotFloatingLinks(graph, 'input', floatingInputNode.id, 0)
+      ).toHaveLength(0)
 
       expect(toInput.link).toBeNull()
-      expect(toInput._floatingLinks?.size).toBe(1)
+      expect(
+        slotFloatingLinks(graph, 'input', hasInputNode.id, 0)
+      ).toHaveLength(1)
     })
 
     test('Allow reroutes to be used as manual switches', ({
@@ -817,7 +843,7 @@ describe('LinkConnector Integration', () => {
     validateIntegrityNoChanges
   }) => {
     const floatingOutNode = graph.getNodeById(toNodeId(1))!
-    connector.moveOutputLink(graph, floatingOutNode.outputs[0])
+    connector.moveOutputLink(graph, floatingOutNode, floatingOutNode.outputs[0])
 
     const manyOutputsNode = graph.getNodeById(toNodeId(4))!
     const dropEvent = createMockCanvasPointerEvent(
@@ -829,12 +855,14 @@ describe('LinkConnector Integration', () => {
 
     const output = manyOutputsNode.outputs[0]
     expect(output.links!.length).toBe(6)
-    expect(output._floatingLinks!.size).toBe(1)
+    expect(
+      slotFloatingLinks(graph, 'output', manyOutputsNode.id, 0)
+    ).toHaveLength(1)
 
     validateIntegrityNoChanges()
 
     // Move again
-    connector.moveOutputLink(graph, manyOutputsNode.outputs[0])
+    connector.moveOutputLink(graph, manyOutputsNode, manyOutputsNode.outputs[0])
 
     const disconnectedNode = graph.getNodeById(toNodeId(9))!
     const dropEvent2 = createMockCanvasPointerEvent(
@@ -846,13 +874,17 @@ describe('LinkConnector Integration', () => {
 
     const newOutput = disconnectedNode.outputs[0]
     expect(newOutput.links!.length).toBe(6)
-    expect(newOutput._floatingLinks!.size).toBe(1)
+    expect(
+      slotFloatingLinks(graph, 'output', disconnectedNode.id, 0)
+    ).toHaveLength(1)
 
     validateIntegrityNoChanges()
 
     disconnectedNode.disconnectOutput(0)
 
-    expect(newOutput._floatingLinks!.size).toBe(0)
+    expect(
+      slotFloatingLinks(graph, 'output', disconnectedNode.id, 0)
+    ).toHaveLength(0)
     expect(graph.floatingLinks.size).toBe(6)
 
     // The final reroutes should all be floating
@@ -878,9 +910,13 @@ describe('LinkConnector Integration', () => {
 
       expect([0, undefined]).toContain(output.links?.length)
 
-      expect([0, undefined]).toContain(input._floatingLinks?.size)
+      expect(
+        slotFloatingLinks(graph, 'input', toNodeId(nodeId), 0)
+      ).toHaveLength(0)
 
-      expect([0, undefined]).toContain(output._floatingLinks?.size)
+      expect(
+        slotFloatingLinks(graph, 'output', toNodeId(nodeId), 0)
+      ).toHaveLength(0)
     }
   })
 

--- a/src/lib/litegraph/src/canvas/LinkConnector.test.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.test.ts
@@ -1,6 +1,9 @@
+import { fromPartial } from '@total-typescript/shoehorn'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { LinkConnector } from '@/lib/litegraph/src/litegraph'
+import type { Reroute } from '@/lib/litegraph/src/litegraph'
+import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
 import {
   createMockLGraphNode,
   createMockLinkNetwork,
@@ -13,8 +16,19 @@ const mockSetConnectingLinks = vi.fn()
 
 type RenderLinkItem = LinkConnector['renderLinks'][number]
 
+interface MockRenderLinkOptions {
+  canConnectToOutput?: boolean
+  canConnectToReroute?: boolean
+}
+
 // Mock a structure that has the needed method
-function mockRenderLinkImpl(canConnect: boolean): RenderLinkItem {
+function mockRenderLinkImpl(
+  canConnect: boolean,
+  {
+    canConnectToOutput = false,
+    canConnectToReroute = false
+  }: MockRenderLinkOptions = {}
+): RenderLinkItem {
   const partial: Partial<RenderLinkItem> = {
     toType: 'output',
     fromPos: [0, 0],
@@ -25,8 +39,8 @@ function mockRenderLinkImpl(canConnect: boolean): RenderLinkItem {
     fromSlot: createMockNodeOutputSlot(),
     dragDirection: 0,
     canConnectToInput: vi.fn().mockReturnValue(canConnect),
-    canConnectToOutput: vi.fn().mockReturnValue(false),
-    canConnectToReroute: vi.fn().mockReturnValue(false),
+    canConnectToOutput: vi.fn().mockReturnValue(canConnectToOutput),
+    canConnectToReroute: vi.fn().mockReturnValue(canConnectToReroute),
     connectToInput: vi.fn(),
     connectToOutput: vi.fn(),
     connectToSubgraphInput: vi.fn(),
@@ -71,6 +85,35 @@ describe('LinkConnector', () => {
       expect(connector.isInputValidDrop(mockNode, mockInput)).toBe(false)
       expect(link1.canConnectToInput).toHaveBeenCalledWith(mockNode, mockInput)
       expect(link2.canConnectToInput).toHaveBeenCalledWith(mockNode, mockInput)
+    })
+  })
+
+  describe('dropOnReroute', () => {
+    test('skips render links that cannot connect to the reroute', () => {
+      const valid = mockRenderLinkImpl(false, {
+        canConnectToOutput: true,
+        canConnectToReroute: true
+      })
+      const invalid = mockRenderLinkImpl(false, {
+        canConnectToOutput: true,
+        canConnectToReroute: false
+      })
+      connector.renderLinks.push(valid, invalid)
+      connector.state.connectingTo = 'output'
+      const output = createMockNodeOutputSlot()
+      const reroute = fromPartial<Reroute>({
+        findSourceOutput: () => ({ node: mockNode, output })
+      })
+
+      connector.dropOnReroute(reroute, fromPartial<CanvasPointerEvent>({}))
+
+      expect(valid.connectToRerouteOutput).toHaveBeenCalledWith(
+        reroute,
+        mockNode,
+        output,
+        connector.events
+      )
+      expect(invalid.connectToRerouteOutput).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/lib/litegraph/src/canvas/LinkConnector.ts
+++ b/src/lib/litegraph/src/canvas/LinkConnector.ts
@@ -1,7 +1,7 @@
 import { remove } from 'es-toolkit'
 
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LLink } from '@/lib/litegraph/src/LLink'
+import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import {
   SUBGRAPH_INPUT_ID,
@@ -135,6 +135,7 @@ export class LinkConnector {
   /** Drag an existing link to a different input. */
   moveInputLink(
     network: LinkNetwork,
+    node: LGraphNode,
     input: INodeInputSlot,
     opts?: { startPoint?: Point }
   ): void {
@@ -145,7 +146,12 @@ export class LinkConnector {
     const linkId = input.link
     if (linkId == null) {
       // No link connected, check for a floating link
-      const floatingLink = input._floatingLinks?.values().next().value
+      const [floatingLink] = slotFloatingLinks(
+        network,
+        'input',
+        node.id,
+        node.inputs.indexOf(input)
+      )
       if (floatingLink?.parentId == null) return
 
       try {
@@ -270,42 +276,49 @@ export class LinkConnector {
   }
 
   /** Drag all links from an output to a new output. */
-  moveOutputLink(network: LinkNetwork, output: INodeOutputSlot): void {
+  moveOutputLink(
+    network: LinkNetwork,
+    node: LGraphNode,
+    output: INodeOutputSlot
+  ): void {
     if (this.isConnecting) throw new Error('Already dragging links.')
 
     const { state, renderLinks } = this
 
     // Floating links
-    if (output._floatingLinks?.size) {
-      for (const floatingLink of output._floatingLinks.values()) {
-        try {
-          const reroute = LLink.getFirstReroute(network, floatingLink)
-          if (!reroute)
-            throw new Error(
-              `Invalid reroute id: [${floatingLink.parentId}] for floating link id: [${floatingLink.id}].`
-            )
+    for (const floatingLink of slotFloatingLinks(
+      network,
+      'output',
+      node.id,
+      node.outputs.indexOf(output)
+    )) {
+      try {
+        const reroute = LLink.getFirstReroute(network, floatingLink)
+        if (!reroute)
+          throw new Error(
+            `Invalid reroute id: [${floatingLink.parentId}] for floating link id: [${floatingLink.id}].`
+          )
 
-          const renderLink = new FloatingRenderLink(
-            network,
-            floatingLink,
-            'output',
-            reroute
-          )
-          const mayContinue = this.events.dispatch(
-            'before-move-output',
-            renderLink
-          )
-          if (mayContinue === false) continue
+        const renderLink = new FloatingRenderLink(
+          network,
+          floatingLink,
+          'output',
+          reroute
+        )
+        const mayContinue = this.events.dispatch(
+          'before-move-output',
+          renderLink
+        )
+        if (mayContinue === false) continue
 
-          renderLinks.push(renderLink)
-          this.floatingLinks.push(floatingLink)
-        } catch (error) {
-          console.warn(
-            `Could not create render link for link id: [${floatingLink.id}].`,
-            floatingLink,
-            error
-          )
-        }
+        renderLinks.push(renderLink)
+        this.floatingLinks.push(floatingLink)
+      } catch (error) {
+        console.warn(
+          `Could not create render link for link id: [${floatingLink.id}].`,
+          floatingLink,
+          error
+        )
       }
     }
 
@@ -843,9 +856,9 @@ export class LinkConnector {
 
     // From reroute to reroute
     if (renderLink instanceof ToInputRenderLink) {
-      const { node, fromSlot, fromSlotIndex } = renderLink
+      const { node, fromSlotIndex } = renderLink
 
-      reroute.setFloatingLinkOrigin(node, fromSlot, fromSlotIndex)
+      reroute.setFloatingLinkOrigin(node, fromSlotIndex)
     }
 
     // Filter before any connections are re-created

--- a/src/lib/litegraph/src/interfaces.ts
+++ b/src/lib/litegraph/src/interfaces.ts
@@ -332,11 +332,6 @@ export interface INodeSlot extends HasBoundingRect {
   /** @remarks Automatically calculated; not included in serialisation. */
   boundingRect: ReadOnlyRect
   /**
-   * A list of floating link IDs that are connected to this slot.
-   * This is calculated at runtime; it is **not** serialized.
-   */
-  _floatingLinks?: Set<LLink>
-  /**
    * Whether the slot has errors. It is **not** serialized.
    */
   hasErrors?: boolean

--- a/src/lib/litegraph/src/node/SlotBase.ts
+++ b/src/lib/litegraph/src/node/SlotBase.ts
@@ -1,4 +1,3 @@
-import type { LLink } from '@/lib/litegraph/src/LLink'
 import { Rectangle } from '@/lib/litegraph/src/infrastructure/Rectangle'
 import type {
   CanvasColour,
@@ -28,7 +27,6 @@ export abstract class SlotBase implements INodeSlot {
   locked?: boolean
   nameLocked?: boolean
   widget?: IWidgetLocator
-  _floatingLinks?: Set<LLink>
   hasErrors?: boolean
 
   /** The centre point of the slot. */

--- a/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphConversion.test.ts
@@ -8,6 +8,7 @@ import {
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
 import type { LGraph, ISlotType } from '@/lib/litegraph/src/litegraph'
+import { toRerouteId } from '@/types/rerouteId'
 
 import {
   createTestSubgraph,
@@ -202,6 +203,65 @@ describe('SubgraphConversion', () => {
         linkRefCount += reroute.linkIds.size
       }
       expect(linkRefCount).toBe(4)
+    })
+    it('Should truncate cyclic reroute chains instead of aborting unpack', () => {
+      const subgraph = createTestSubgraph({
+        outputs: [{ name: 'value', type: 'number' }]
+      })
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph!
+      graph.add(subgraphNode)
+
+      const inner = createNode(subgraph, [], ['number'])
+      const innerLink = subgraph.outputNode.slots[0].connect(
+        inner.outputs[0],
+        inner
+      )
+      assert(innerLink)
+      const outer = createNode(graph, ['number'])
+      const outerLink = subgraphNode.connect(0, outer, 0)
+      assert(outerLink)
+
+      const first = subgraph.createReroute([10, 10], innerLink)!
+      const second = subgraph.createReroute([20, 20], first)!
+      // Simulate corrupt data: first → second → first
+      second._chain.parentId = first.id
+
+      expect(() => graph.unpackSubgraph(subgraphNode)).not.toThrow()
+
+      expect(graph.nodes.length).toBe(2)
+      expect(graph.links.size).toBe(1)
+      expect(graph.reroutes.size).toBe(2)
+      const [link] = [...graph.links.values()]
+      assert(link.parentId !== undefined)
+      expect(graph.reroutes.get(link.parentId)).toBeDefined()
+    })
+    it('Should not stitch broken external parentId references onto merged links', () => {
+      const subgraph = createTestSubgraph({
+        outputs: [{ name: 'value', type: 'number' }]
+      })
+      const subgraphNode = createTestSubgraphNode(subgraph)
+      const graph = subgraphNode.graph!
+      graph.add(subgraphNode)
+
+      const inner = createNode(subgraph, [], ['number'])
+      const innerLink = subgraph.outputNode.slots[0].connect(
+        inner.outputs[0],
+        inner
+      )
+      assert(innerLink)
+      const outer = createNode(graph, ['number'])
+      const outerLink = subgraphNode.connect(0, outer, 0)
+      assert(outerLink)
+
+      // Simulate corrupt data: the external chain names a missing reroute
+      outerLink.parentId = toRerouteId(999)
+
+      graph.unpackSubgraph(subgraphNode)
+
+      expect(graph.links.size).toBe(1)
+      const [link] = [...graph.links.values()]
+      expect(link.parentId).toBeUndefined()
     })
   })
 })

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -1,7 +1,7 @@
 import type { CanvasPointer } from '@/lib/litegraph/src/CanvasPointer'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
 import type { NodeId } from '@/types/nodeId'
-import { LLink } from '@/lib/litegraph/src/LLink'
+import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
 import { toLinkId } from '@/types/linkId'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
 import type { LinkConnector } from '@/lib/litegraph/src/canvas/LinkConnector'
@@ -179,10 +179,14 @@ export class SubgraphInputNode
     const { subgraph } = this
 
     // Break floating links
-    if (input._floatingLinks?.size) {
-      for (const link of input._floatingLinks) {
-        subgraph.removeFloatingLink(link)
-      }
+    const inputIndex = node.inputs.indexOf(input)
+    for (const link of slotFloatingLinks(
+      subgraph,
+      'input',
+      node.id,
+      inputIndex
+    )) {
+      subgraph.removeFloatingLink(link)
     }
 
     input.link = null

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -180,13 +180,13 @@ export class SubgraphInputNode
 
     // Break floating links
     const inputIndex = node.inputs.indexOf(input)
-    for (const link of slotFloatingLinks(
+    for (const floatingLink of slotFloatingLinks(
       subgraph,
       'input',
       node.id,
       inputIndex
     )) {
-      subgraph.removeFloatingLink(link)
+      subgraph.removeFloatingLink(floatingLink)
     }
 
     input.link = null

--- a/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphInputNode.ts
@@ -226,11 +226,10 @@ export class SubgraphInputNode
       input: subgraphInput
     })
 
-    const slotIndex = node.inputs.findIndex((inp) => inp === input)
-    if (slotIndex !== -1) {
+    if (inputIndex !== -1) {
       node.onConnectionsChange?.(
         NodeSlotType.INPUT,
-        slotIndex,
+        inputIndex,
         false,
         link,
         subgraphInput
@@ -238,7 +237,7 @@ export class SubgraphInputNode
       subgraph.trigger('node:slot-links:changed', {
         nodeId: node.id,
         slotType: NodeSlotType.INPUT,
-        slotIndex: slotIndex,
+        slotIndex: inputIndex,
         connected: false,
         linkId: link.id
       })

--- a/src/lib/litegraph/src/subgraph/SubgraphSlotConnections.test.ts
+++ b/src/lib/litegraph/src/subgraph/SubgraphSlotConnections.test.ts
@@ -154,7 +154,11 @@ describe('Subgraph slot connections', () => {
       const connector = new LinkConnector(setConnectingLinks)
 
       // Now try to drag from the input slot
-      connector.moveInputLink(subgraph as LinkNetwork, internalNode.inputs[0])
+      connector.moveInputLink(
+        subgraph as LinkNetwork,
+        internalNode,
+        internalNode.inputs[0]
+      )
 
       // Verify that we're dragging the existing link
       expect(connector.isConnecting).toBe(true)

--- a/src/lib/litegraph/src/subgraph/subgraphUtils.ts
+++ b/src/lib/litegraph/src/subgraph/subgraphUtils.ts
@@ -2,7 +2,7 @@ import { isEqual } from 'es-toolkit'
 import type { LGraph, SubgraphId } from '@/lib/litegraph/src/LGraph'
 import { LGraphGroup } from '@/lib/litegraph/src/LGraphGroup'
 import { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LLink } from '@/lib/litegraph/src/LLink'
+import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
 import type { ResolvedConnection } from '@/lib/litegraph/src/LLink'
 import { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { RerouteId } from '@/lib/litegraph/src/Reroute'
@@ -114,8 +114,10 @@ export function getBoundaryLinks(
 
       // Inputs
       if (node.inputs) {
-        for (const input of node.inputs) {
-          addFloatingLinks(input._floatingLinks)
+        for (const [inputIndex, input] of node.inputs.entries()) {
+          addFloatingLinks(
+            slotFloatingLinks(graph, 'input', node.id, inputIndex)
+          )
 
           if (input.link == null) continue
 
@@ -142,8 +144,10 @@ export function getBoundaryLinks(
 
       // Outputs
       if (node.outputs) {
-        for (const output of node.outputs) {
-          addFloatingLinks(output._floatingLinks)
+        for (const [outputIndex, output] of node.outputs.entries()) {
+          addFloatingLinks(
+            slotFloatingLinks(graph, 'output', node.id, outputIndex)
+          )
 
           if (!output.links) continue
 
@@ -204,9 +208,7 @@ export function getBoundaryLinks(
    * Adds any floating links that cross the boundary.
    * @param floatingLinks The floating links to check
    */
-  function addFloatingLinks(floatingLinks: Set<LLink> | undefined): void {
-    if (!floatingLinks) return
-
+  function addFloatingLinks(floatingLinks: LLink[]): void {
     for (const link of floatingLinks) {
       const crossesBoundary = LLink.getReroutes(graph, link).some(
         (reroute) => !items.has(reroute)

--- a/src/lib/litegraph/src/types/serialisation.ts
+++ b/src/lib/litegraph/src/types/serialisation.ts
@@ -68,14 +68,14 @@ export interface SerialisableGraph extends BaseExportedGraph {
 
 export type ISerialisableNodeInput = Omit<
   INodeInputSlot,
-  'boundingRect' | 'widget' | 'link' | '_floatingLinks'
+  'boundingRect' | 'widget' | 'link'
 > & {
   link?: number | null
   widget?: { name: string }
 }
 export type ISerialisableNodeOutput = Omit<
   INodeOutputSlot,
-  'boundingRect' | '_data' | 'links' | '_floatingLinks'
+  'boundingRect' | '_data' | 'links'
 > & {
   links?: number[] | null
   widget?: { name: string }
@@ -164,7 +164,7 @@ export interface ExportedSubgraph extends SerialisableGraph {
 /** Properties shared by subgraph and node I/O slots. */
 type SubgraphIOShared = Omit<
   INodeSlot,
-  'boundingRect' | 'nameLocked' | 'locked' | 'removable' | '_floatingLinks'
+  'boundingRect' | 'nameLocked' | 'locked' | 'removable'
 >
 
 /** Subgraph I/O slots */

--- a/src/renderer/core/canvas/links/linkConnectorAdapter.ts
+++ b/src/renderer/core/canvas/links/linkConnectorAdapter.ts
@@ -54,7 +54,7 @@ export class LinkConnectorAdapter {
     const fromReroute = this.network.getReroute(opts?.fromRerouteId)
 
     if (opts?.moveExisting) {
-      this.linkConnector.moveOutputLink(this.network, output)
+      this.linkConnector.moveOutputLink(this.network, node, output)
     } else {
       this.linkConnector.dragNewFromOutput(
         this.network,
@@ -90,7 +90,9 @@ export class LinkConnectorAdapter {
       const startPoint: Point | undefined = opts.layout
         ? [opts.layout.position.x, opts.layout.position.y]
         : undefined
-      this.linkConnector.moveInputLink(this.network, input, { startPoint })
+      this.linkConnector.moveInputLink(this.network, node, input, {
+        startPoint
+      })
     } else {
       this.linkConnector.dragNewFromInput(
         this.network,

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.autoPan.test.ts
@@ -62,7 +62,7 @@ vi.mock('@/scripts/app', () => ({
         getNodeById: (id: string) => ({
           id,
           inputs: [],
-          outputs: [{ name: 'out', type: '*', links: [], _floatingLinks: null }]
+          outputs: [{ name: 'out', type: '*', links: [] }]
         }),
         getLink: () => null,
         getReroute: () => null
@@ -186,7 +186,8 @@ vi.mock('@vueuse/core', () => ({
 }))
 
 vi.mock('@/lib/litegraph/src/LLink', () => ({
-  LLink: { getReroutes: () => [] }
+  LLink: { getReroutes: () => [] },
+  slotFloatingLinks: () => []
 }))
 
 vi.mock('@/lib/litegraph/src/types/globalEnums', () => ({

--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -5,7 +5,7 @@ import { useSharedCanvasPositionConversion } from '@/composables/element/useCanv
 import { AutoPanController } from '@/renderer/core/canvas/useAutoPan'
 import type { LGraph } from '@/lib/litegraph/src/LGraph'
 import type { LGraphNode } from '@/lib/litegraph/src/LGraphNode'
-import { LLink } from '@/lib/litegraph/src/LLink'
+import { LLink, slotFloatingLinks } from '@/lib/litegraph/src/LLink'
 import type { Reroute } from '@/lib/litegraph/src/Reroute'
 import type { RenderLink } from '@/lib/litegraph/src/canvas/RenderLink'
 import type {
@@ -230,6 +230,8 @@ export function useSlotLinkInteraction({
 
   const resolveExistingInputLinkAnchor = (
     graph: LGraph,
+    nodeId: NodeId,
+    slotIndex: number,
     inputSlot: INodeInputSlot | undefined
   ): { position: Point; direction: LinkDirection } | null => {
     if (!inputSlot) return null
@@ -260,10 +262,7 @@ export function useSlotLinkInteraction({
       if (directAnchor) return directAnchor
     }
 
-    const floatingLinkIterator = inputSlot._floatingLinks?.values()
-    const floatingLink = floatingLinkIterator
-      ? floatingLinkIterator.next().value
-      : undefined
+    const [floatingLink] = slotFloatingLinks(graph, 'input', nodeId, slotIndex)
     if (!floatingLink) return null
 
     if (floatingLink.parentId != null) {
@@ -631,11 +630,15 @@ export function useSlotLinkInteraction({
     const ctrlOrMeta = event.ctrlKey || event.metaKey
 
     const inputLinkId = inputSlot?.link ?? null
-    const inputFloatingCount = inputSlot?._floatingLinks?.size ?? 0
+    const inputFloatingCount = isInputSlot
+      ? slotFloatingLinks(graph, 'input', localNodeId, index).length
+      : 0
     const hasExistingInputLink = inputLinkId != null || inputFloatingCount > 0
 
     const outputLinkCount = outputSlot?.links?.length ?? 0
-    const outputFloatingCount = outputSlot?._floatingLinks?.size ?? 0
+    const outputFloatingCount = isOutputSlot
+      ? slotFloatingLinks(graph, 'output', localNodeId, index).length
+      : 0
     const hasExistingOutputLink = outputLinkCount > 0 || outputFloatingCount > 0
 
     const shouldBreakExistingInputLink =
@@ -675,7 +678,7 @@ export function useSlotLinkInteraction({
 
     const existingAnchor =
       isInputSlot && !shouldBreakExistingInputLink
-        ? resolveExistingInputLinkAnchor(graph, inputSlot)
+        ? resolveExistingInputLinkAnchor(graph, localNodeId, index, inputSlot)
         : null
 
     const shouldMoveExistingOutput =


### PR DESCRIPTION
## Summary

Follow-up cleanups from the reroute chain store work (#13449): deletes the `slot._floatingLinks` mirror in favor of endpoint derivation, fixes two position/endpoint integrity gaps the mirror had masked, and restructures the subgraph-unpack chain stitching.

Stacked on #13449.

## Changes

- **What**:
  - `slot._floatingLinks` Sets deleted — a floating link's attachment is fully encoded in its own endpoints, so `slotFloatingLinks(network, side, nodeId, slot)` derives it; ~25 write sites across `addFloatingLink`/`removeFloatingLink`, `setFloatingLinkOrigin`, and every `FloatingRenderLink` connect method are gone
  - `moveInputLink`/`moveOutputLink` gain the `node` param their `dragNewFrom*` siblings already take
  - `FloatingRenderLink.connectToSubgraphOutput` now writes the link's **target** end (it wrote `origin_id = SUBGRAPH_OUTPUT_ID`, clobbering/skewing endpoints — masked by the mirror)
  - `removeInput`/`removeOutput` renumber floating-link slot indices alongside real links (stale indices previously persisted into serialized floating links)
  - `Reroute.snapToGrid` mirrors into the layout store like `move()` does (Vue hit-testing read a stale spatial index after snapped drags)
  - Subgraph-unpack reroute chain stitching rewritten as collect-then-stitch (two segment walks + one generic pointer pass, replacing three interleaved walk-and-write loops)

## Review Focus

- Scoped out with written assessments: `input.link`/`output.links` mirror removal (roadmap-scale `SlotConnection` extraction, ~530 accesses) and reroute position ownership inversion (layout store only seeds the active graph, no writeback)
- Corrupt-data error paths in unpack stitching are normalized to per-link skip (the old code broke the whole loop on some internal-segment failures)
