### PR TITLE
fix: combo dropdowns immediately close after touch taps

### DIFF
--- a/src/lib/litegraph/src/CanvasPointer.test.ts
+++ b/src/lib/litegraph/src/CanvasPointer.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CanvasPointer } from './CanvasPointer'
+import type { CanvasPointerEvent } from './types/events'
+
+function pointerEvent(
+  type: string,
+  overrides: PointerEventInit & { timeStamp?: number } = {}
+): CanvasPointerEvent {
+  const { timeStamp, ...init } = overrides
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    buttons: type === 'pointerup' ? 0 : 1,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 1,
+    pointerType: 'mouse',
+    ...init
+  }) as CanvasPointerEvent
+
+  if (timeStamp !== undefined) {
+    Object.defineProperty(event, 'timeStamp', { value: timeStamp })
+  }
+
+  return event
+}
+
+describe('CanvasPointer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps mouse timed-drag behavior unchanged', () => {
+    const element = document.createElement('div')
+    vi.spyOn(element, 'setPointerCapture').mockImplementation(() => {})
+    vi.spyOn(element, 'hasPointerCapture').mockReturnValue(false)
+    const pointer = new CanvasPointer(element)
+    const onDragStart = vi.fn()
+
+    pointer.down(pointerEvent('pointerdown', { timeStamp: 0 }))
+    pointer.onDragStart = onDragStart
+    pointer.move(pointerEvent('pointermove', { timeStamp: 40 }))
+
+    expect(onDragStart).toHaveBeenCalledOnce()
+    expect(pointer.dragStarted).toBe(true)
+  })
+
+  it.each(['touch', 'pen'] as const)(
+    'does not turn a stationary %s pointer into a drag because of elapsed time',
+    (pointerType) => {
+      const element = document.createElement('div')
+      vi.spyOn(element, 'setPointerCapture').mockImplementation(() => {})
+      vi.spyOn(element, 'hasPointerCapture').mockReturnValue(false)
+      const pointer = new CanvasPointer(element)
+      const onClick = vi.fn()
+      const onDragStart = vi.fn()
+
+      pointer.down(pointerEvent('pointerdown', { pointerType, timeStamp: 0 }))
+      pointer.onClick = onClick
+      pointer.onDragStart = onDragStart
+      pointer.move(pointerEvent('pointermove', { pointerType, timeStamp: 80 }))
+      const isClick = pointer.up(
+        pointerEvent('pointerup', { pointerType, timeStamp: 90 })
+      )
+
+      expect(onDragStart).not.toHaveBeenCalled()
+      expect(onClick).toHaveBeenCalledOnce()
+      expect(isClick).toBe(true)
+    }
+  )
+
+  it.each(['touch', 'pen'] as const)(
+    'still starts a %s drag after moving past click drift',
+    (pointerType) => {
+      const element = document.createElement('div')
+      vi.spyOn(element, 'setPointerCapture').mockImplementation(() => {})
+      vi.spyOn(element, 'hasPointerCapture').mockReturnValue(false)
+      const pointer = new CanvasPointer(element)
+      const onDragStart = vi.fn()
+
+      pointer.down(pointerEvent('pointerdown', { pointerType, timeStamp: 0 }))
+      pointer.onDragStart = onDragStart
+      pointer.move(
+        pointerEvent('pointermove', {
+          clientX: 40,
+          pointerType,
+          timeStamp: 10
+        })
+      )
+
+      expect(onDragStart).toHaveBeenCalledOnce()
+      expect(pointer.dragStarted).toBe(true)
+    }
+  )
+})

--- a/src/lib/litegraph/src/CanvasPointer.ts
+++ b/src/lib/litegraph/src/CanvasPointer.ts
@@ -1,5 +1,6 @@
 import type { CompassCorners } from './interfaces'
 import { dist2 } from './measure'
+import { isTouchLikePointerType } from './types/events'
 import type { CanvasPointerEvent } from './types/events'
 
 /**
@@ -220,9 +221,10 @@ export class CanvasPointer {
 
     const longerThanBufferTime =
       e.timeStamp - eDown.timeStamp > CanvasPointer.bufferTime
-    if (longerThanBufferTime || !this._hasSamePosition(e, eDown)) {
-      this._setDragStarted(e)
-    }
+    const hasMoved = !this._hasSamePosition(e, eDown)
+    const shouldStartTimedDrag =
+      longerThanBufferTime && !isTouchLikePointerType(eDown.pointerType)
+    if (shouldStartTimedDrag || hasMoved) this._setDragStarted(e)
   }
 
   /**

--- a/src/lib/litegraph/src/ContextMenu.test.ts
+++ b/src/lib/litegraph/src/ContextMenu.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ContextMenu } from './ContextMenu'
+
+function pointerUpEvent(pointerType: 'touch' | 'pen') {
+  return new PointerEvent('pointerup', {
+    bubbles: true,
+    cancelable: true,
+    clientX: 20,
+    clientY: 20,
+    pointerType
+  })
+}
+
+function pointerDownEvent(pointerType: 'touch' | 'pen') {
+  return new PointerEvent('pointerdown', {
+    bubbles: true,
+    cancelable: true,
+    clientX: 20,
+    clientY: 20,
+    pointerType
+  })
+}
+
+function mouseEvent() {
+  return new MouseEvent('mouseup', {
+    bubbles: true,
+    cancelable: true,
+    clientX: 20,
+    clientY: 20
+  })
+}
+
+function getMenuItem() {
+  const item = document.querySelector<HTMLElement>('.litemenu-entry')
+  if (!item) throw new Error('Expected context menu item')
+  return item
+}
+
+describe('ContextMenu', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it.each(['touch', 'pen'] as const)(
+    'ignores the synthetic click that follows %s menu opening',
+    (pointerType) => {
+      const callback = vi.fn()
+
+      new ContextMenu(['first'], {
+        event: pointerUpEvent(pointerType),
+        callback
+      })
+
+      getMenuItem().dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+
+      expect(callback).not.toHaveBeenCalled()
+      expect(document.querySelector('.litecontextmenu')).toBeInTheDocument()
+
+      getMenuItem().dispatchEvent(pointerDownEvent(pointerType))
+      getMenuItem().dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+
+      expect(callback).toHaveBeenCalledWith(
+        'first',
+        expect.any(Object),
+        expect.any(MouseEvent),
+        expect.any(ContextMenu),
+        undefined
+      )
+      expect(document.querySelector('.litecontextmenu')).not.toBeInTheDocument()
+    }
+  )
+
+  it('allows immediate item clicks for mouse-opened menus', () => {
+    const callback = vi.fn()
+
+    new ContextMenu(['first'], {
+      event: mouseEvent(),
+      callback
+    })
+
+    getMenuItem().dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    )
+
+    expect(callback).toHaveBeenCalledWith(
+      'first',
+      expect.any(Object),
+      expect.any(MouseEvent),
+      expect.any(ContextMenu),
+      undefined
+    )
+    expect(document.querySelector('.litecontextmenu')).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/litegraph/src/ContextMenu.ts
+++ b/src/lib/litegraph/src/ContextMenu.ts
@@ -6,6 +6,7 @@ import type {
   IContextMenuValue
 } from './interfaces'
 import { LiteGraph } from './litegraph'
+import { isTouchLikePointerType } from './types/events'
 
 const ALLOWED_TAGS = ['span', 'b', 'i', 'em', 'strong']
 const ALLOWED_STYLE_PROPS = new Set([
@@ -58,6 +59,7 @@ export class ContextMenu<TValue = unknown> {
   lock?: boolean
 
   controller: AbortController = new AbortController()
+  private ignoreNextClickUntilRootPointerDown = false
 
   /**
    * @todo Interface for values requires functionality change - currently accepts
@@ -105,6 +107,10 @@ export class ContextMenu<TValue = unknown> {
       options.event = undefined
     }
 
+    this.ignoreNextClickUntilRootPointerDown = shouldIgnoreOpeningClick(
+      options.event
+    )
+
     const root: ContextMenuDivElement<TValue> = document.createElement('div')
     let classes = 'litegraph litecontextmenu litemenubar-panel'
     if (options.className) classes += ` ${options.className}`
@@ -128,6 +134,21 @@ export class ContextMenu<TValue = unknown> {
       )
     }
 
+    // Touch browsers may dispatch a synthetic click after the pointerup that
+    // opened the menu. It has no matching pointerdown inside this root, unlike
+    // a real follow-up tap, so only suppress that first unmatched click.
+    root.addEventListener(
+      'click',
+      (e) => {
+        if (!this.ignoreNextClickUntilRootPointerDown) return
+
+        this.ignoreNextClickUntilRootPointerDown = false
+        e.preventDefault()
+        e.stopImmediatePropagation()
+      },
+      eventOptions
+    )
+
     // this prevents the default context browser menu to open in case this menu was created when pressing right button
     root.addEventListener('pointerup', (e) => e.preventDefault(), eventOptions)
 
@@ -143,6 +164,8 @@ export class ContextMenu<TValue = unknown> {
     root.addEventListener(
       'pointerdown',
       (e) => {
+        this.ignoreNextClickUntilRootPointerDown = false
+
         if (e.button == 2) {
           this.close()
           e.preventDefault()
@@ -449,4 +472,14 @@ export class ContextMenu<TValue = unknown> {
     }
     return false
   }
+}
+
+function shouldIgnoreOpeningClick(event: Event | undefined): boolean {
+  return isTouchLikeEvent(event) && event.button !== 2
+}
+
+function isTouchLikeEvent(event: Event | undefined): event is PointerEvent {
+  if (!event || !('pointerType' in event)) return false
+
+  return isTouchLikePointerType((event as PointerEvent).pointerType)
 }

--- a/src/lib/litegraph/src/types/events.ts
+++ b/src/lib/litegraph/src/types/events.ts
@@ -5,6 +5,10 @@ import type { LGraphGroup } from '../LGraphGroup'
 import type { LGraphNode } from '../LGraphNode'
 import type { LinkReleaseContextExtended } from '../litegraph'
 
+export function isTouchLikePointerType(pointerType: string): boolean {
+  return pointerType === 'touch' || pointerType === 'pen'
+}
+
 /** For Canvas*Event - adds graph space co-ordinates (property names are shipped) */
 interface ICanvasPosition {
   /** X co-ordinate of the event, in graph space (NOT canvas space) */

--- a/src/locales/.source-manifest.json
+++ b/src/locales/.source-manifest.json
@@ -1,9 +1,9 @@
 {
   "files": {
     "commands.json": "6474557ea9947c6983e84c03b40b75573307717d",
-    "main.json": "b417a114d87667ee8111e6d3c575337bf7adef8f",
+    "main.json": "86ccabcd703277637eea814521ca1dd94f00b005",
     "nodeDefs.json": "93c778a69bfe43a07e3bf07d1ecfadc26bf44661",
-    "settings.json": "1028b58bfb4f3e4f5025cd8d933bd19085c291e3"
+    "settings.json": "38a9e4ebabb3783a4c1f982396aeb0a8f55a40f5"
   },
   "knownViolations": {
     "main.json": [

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -1,6 +1,7 @@
 {
   "g": {
     "shortcutSuffix": " ({shortcut})",
+    "pointerClickDriftDelayTooltip": "After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the mouse pointer is held still then released. Touch and pen taps are never time-converted to drags. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty.",
     "user": "User",
     "you": "You",
     "currentUser": "Current user",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -337,7 +337,7 @@
   },
   "Comfy_Pointer_ClickBufferTime": {
     "name": "Pointer click drift delay",
-    "tooltip": "After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the pointer is held still then released. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty."
+    "tooltip": "After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the mouse pointer is held still then released. Touch and pen taps are never time-converted to drags. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty."
   },
   "Comfy_Pointer_ClickDrift": {
     "name": "Pointer click drift (maximum distance)",

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -803,7 +803,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     category: ['LiteGraph', 'Pointer', 'ClickBufferTime'],
     name: 'Pointer click drift delay',
     tooltip:
-      'After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the pointer is held still then released. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty.',
+      'After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the mouse pointer is held still then released. Touch and pen taps are never time-converted to drags. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty.',
     experimental: true,
     type: 'slider',
     attrs: {

--- a/src/platform/settings/constants/coreSettings.ts
+++ b/src/platform/settings/constants/coreSettings.ts
@@ -1,3 +1,4 @@
+import { t } from '@/i18n'
 import { LinkMarkerShape, LiteGraph } from '@/lib/litegraph/src/litegraph'
 import {
   getDefaultLocale,
@@ -810,8 +811,7 @@ export const CORE_SETTINGS: SettingParams[] = [
     id: 'Comfy.Pointer.ClickBufferTime',
     category: ['LiteGraph', 'Pointer', 'ClickBufferTime'],
     name: 'Pointer click drift delay',
-    tooltip:
-      'After pressing a pointer button down, this is the maximum time (in milliseconds) that pointer movement can be ignored for.\n\nHelps prevent objects from being unintentionally nudged if the pointer is moved whilst clicking.\n\nThe distance threshold (Pointer click drift) already disambiguates clicks from drags; this time threshold only matters when the pointer is held still then released. A long delay here forces every pointerdown to wait before drag begins, which feels laggy when click+dragging an unselected node. ~2 frames at 60fps is plenty.',
+    tooltip: t('g.pointerClickDriftDelayTooltip'),
     experimental: true,
     type: 'slider',
     attrs: {


### PR DESCRIPTION
Touch browsers dispatch a synthetic click after pointerup. Reka handles the touch activation and then sees the follow-up click, causing combo dropdowns to toggle closed immediately after opening on tablets.

Track non-mouse trigger activation locally, toggle the combobox on pointerup, and swallow the synthetic click that follows so touch taps leave the dropdown open. Mouse click behavior is left to Reka unchanged.

Fixes Comfy-Org/ComfyUI#14584

## Summary

Making UI compatible with tablet devices again (version 0.25.0 had changes that broke drop-down menus on tablets that used to work well before).

## Changes

- **What**: better detection of touch events.

## Review Focus

Fixes Comfy-Org/ComfyUI#14584
