### PR TITLE
fix(dynamic-widgets): preserve saved node height when configuring graph

### DIFF
--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -1,6 +1,5 @@
 import { setActivePinia } from 'pinia'
 import { createTestingPinia } from '@pinia/testing'
-import { fromAny } from '@total-typescript/shoehorn'
 import { describe, expect, test, vi } from 'vitest'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
@@ -129,15 +128,13 @@ describe('Dynamic Combos', () => {
     const node = testNode()
     addDynamicCombo(node, [['INT'], ['INT', 'STRING']])
     node.size[1] = 800
-    fromAny<{ configuringGraphLevel: number }, unknown>(
-      app
-    ).configuringGraphLevel = 1
+    const configuringGraphSpy = vi
+      .spyOn(app, 'configuringGraph', 'get')
+      .mockReturnValue(true)
     try {
       node.widgets[0].value = '1'
     } finally {
-      fromAny<{ configuringGraphLevel: number }, unknown>(
-        app
-      ).configuringGraphLevel = 0
+      configuringGraphSpy.mockRestore()
     }
     expect(node.widgets.length).toBe(3)
     expect(node.size[1]).toBe(800)

--- a/src/core/graph/widgets/dynamicWidgets.test.ts
+++ b/src/core/graph/widgets/dynamicWidgets.test.ts
@@ -1,9 +1,11 @@
 import { setActivePinia } from 'pinia'
 import { createTestingPinia } from '@pinia/testing'
+import { fromAny } from '@total-typescript/shoehorn'
 import { describe, expect, test, vi } from 'vitest'
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { transformInputSpecV1ToV2 } from '@/schemas/nodeDef/migration'
 import type { InputSpec } from '@/schemas/nodeDefSchema'
+import { app } from '@/scripts/app'
 import { useLitegraphService } from '@/services/litegraphService'
 import type { HasInitialMinSize } from '@/services/litegraphService'
 
@@ -115,6 +117,30 @@ describe('Dynamic Combos', () => {
     expect.soft(node.widgets[1].tooltip).toBe('0')
     node.widgets[0].value = '1'
     expect.soft(node.widgets[1].tooltip).toBe('1')
+  })
+  test('Recomputes node height on selection', () => {
+    const node = testNode()
+    addDynamicCombo(node, [['INT'], ['INT', 'STRING']])
+    node.size[1] = 800
+    node.widgets[0].value = '1'
+    expect(node.size[1]).not.toBe(800)
+  })
+  test('Preserves node height while configuring graph', () => {
+    const node = testNode()
+    addDynamicCombo(node, [['INT'], ['INT', 'STRING']])
+    node.size[1] = 800
+    fromAny<{ configuringGraphLevel: number }, unknown>(
+      app
+    ).configuringGraphLevel = 1
+    try {
+      node.widgets[0].value = '1'
+    } finally {
+      fromAny<{ configuringGraphLevel: number }, unknown>(
+        app
+      ).configuringGraphLevel = 0
+    }
+    expect(node.widgets.length).toBe(3)
+    expect(node.size[1]).toBe(800)
   })
 })
 describe('Autogrow', () => {

--- a/src/core/graph/widgets/dynamicWidgets.ts
+++ b/src/core/graph/widgets/dynamicWidgets.ts
@@ -183,7 +183,10 @@ function dynamicComboWidget(
       }
     }
 
-    node.size[1] = node.computeSize([...node.size])[1]
+    // During configure the serialized size is authoritative — recomputing
+    // here would clobber the node height the user saved.
+    if (!app.configuringGraph)
+      node.size[1] = node.computeSize([...node.size])[1]
     if (!node.graph) return
     node._setConcreteSlots()
     node.arrange()


### PR DESCRIPTION
## Summary
DynamicCombo value application during graph configure rebuilt the sub-widgets and reset node height via computeSize, clobbering the size the user saved. 
Skip the recompute while app.configuringGraph, matching the existing configure guards in this module.

## Screenshots
before
https://github.com/user-attachments/assets/7fb0a643-f683-45f0-a7f9-b9b06f2d3e37

after
https://github.com/user-attachments/assets/3261a264-bb24-46da-8914-d36f30d64b18

