### PR TITLE
fix(load3d): suppress node context menu after right-drag in 3D viewpor

### DIFF
--- a/src/extensions/core/load3d/ControlsManager.test.ts
+++ b/src/extensions/core/load3d/ControlsManager.test.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ControlsManager } from './ControlsManager'
 import type { EventManagerInterface } from './interfaces'
@@ -164,6 +164,126 @@ describe('ControlsManager', () => {
       manager.dispose()
 
       expect(manager.controls.dispose).toHaveBeenCalled()
+    })
+  })
+
+  describe('context menu suppression', () => {
+    function setup() {
+      const canvas = document.createElement('canvas')
+      const wrapper = document.createElement('div')
+      wrapper.appendChild(canvas)
+      const nodeRoot = document.createElement('div')
+      nodeRoot.setAttribute('data-node-id', 'node-1')
+      nodeRoot.appendChild(wrapper)
+      const releasePoint = document.createElement('div')
+      nodeRoot.appendChild(releasePoint)
+      document.body.appendChild(nodeRoot)
+      const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer
+      manager = new ControlsManager(renderer, camera, events)
+      return { canvas, nodeRoot, releasePoint }
+    }
+
+    function rightPress(target: EventTarget) {
+      target.dispatchEvent(
+        new PointerEvent('pointerdown', { button: 2, bubbles: true })
+      )
+    }
+
+    function rightRelease(target: EventTarget) {
+      target.dispatchEvent(
+        new PointerEvent('pointerup', { button: 2, bubbles: true })
+      )
+    }
+
+    function fireContextMenu(target: EventTarget): MouseEvent {
+      const event = new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true
+      })
+      target.dispatchEvent(event)
+      return event
+    }
+
+    const nextFrame = () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    afterEach(() => {
+      manager.dispose()
+      document
+        .querySelectorAll('[data-node-id]')
+        .forEach((node) => node.remove())
+    })
+
+    it('suppresses the contextmenu on the node after a right-press in the viewport', () => {
+      const { canvas, releasePoint } = setup()
+
+      rightPress(canvas)
+      const event = fireContextMenu(releasePoint)
+
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('stops the contextmenu before node-level bubble handlers', () => {
+      const { canvas, nodeRoot, releasePoint } = setup()
+      const nodeHandler = vi.fn()
+      nodeRoot.addEventListener('contextmenu', nodeHandler)
+
+      rightPress(canvas)
+      fireContextMenu(releasePoint)
+
+      expect(nodeHandler).not.toHaveBeenCalled()
+    })
+
+    it('only suppresses one contextmenu per right-press', () => {
+      const { canvas, releasePoint } = setup()
+
+      rightPress(canvas)
+      fireContextMenu(releasePoint)
+      const second = fireContextMenu(releasePoint)
+
+      expect(second.defaultPrevented).toBe(false)
+    })
+
+    it('ignores left presses', () => {
+      const { canvas, releasePoint } = setup()
+
+      canvas.dispatchEvent(
+        new PointerEvent('pointerdown', { button: 0, bubbles: true })
+      )
+      const event = fireContextMenu(releasePoint)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('disarms once the right release settles', async () => {
+      const { canvas, releasePoint } = setup()
+
+      rightPress(canvas)
+      rightRelease(canvas)
+      await nextFrame()
+      const event = fireContextMenu(releasePoint)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('does nothing without an owning node root', () => {
+      const renderer = makeRenderer({ withParent: true })
+      manager = new ControlsManager(renderer, camera, events)
+
+      rightPress(renderer.domElement)
+      const event = fireContextMenu(document.body)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('dispose removes an armed suppression', () => {
+      const { canvas, releasePoint } = setup()
+
+      rightPress(canvas)
+      manager.dispose()
+      const event = fireContextMenu(releasePoint)
+
+      expect(event.defaultPrevented).toBe(false)
     })
   })
 

--- a/src/extensions/core/load3d/ControlsManager.test.ts
+++ b/src/extensions/core/load3d/ControlsManager.test.ts
@@ -266,6 +266,19 @@ describe('ControlsManager', () => {
       expect(event.defaultPrevented).toBe(false)
     })
 
+    it('disarms after pointercancel settles', async () => {
+      const { canvas, releasePoint } = setup()
+
+      rightPress(canvas)
+      canvas.dispatchEvent(
+        new PointerEvent('pointercancel', { button: -1, bubbles: true })
+      )
+      await nextFrame()
+      const event = fireContextMenu(releasePoint)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
     it('does nothing without an owning node root', () => {
       const renderer = makeRenderer({ withParent: true })
       manager = new ControlsManager(renderer, camera, events)

--- a/src/extensions/core/load3d/ControlsManager.ts
+++ b/src/extensions/core/load3d/ControlsManager.ts
@@ -53,12 +53,12 @@ export class ControlsManager implements ControlsManagerInterface {
 
   private readonly suppressContextMenu = (event: Event): void => {
     event.preventDefault()
-    event.stopPropagation()
+    event.stopImmediatePropagation()
     this.suppressionScope = null
   }
 
   private readonly scheduleContextMenuDisarm = (event: PointerEvent): void => {
-    if (event.button !== 2) return
+    if (event.type === 'pointerup' && event.button !== 2) return
     requestAnimationFrame(() => this.disarmContextMenuSuppression())
   }
 

--- a/src/extensions/core/load3d/ControlsManager.ts
+++ b/src/extensions/core/load3d/ControlsManager.ts
@@ -10,6 +10,8 @@ export class ControlsManager implements ControlsManagerInterface {
   controls: OrbitControls
   private eventManager: EventManagerInterface
   private camera: THREE.Camera
+  private readonly interactionElement: HTMLElement
+  private suppressionScope: HTMLElement | null = null
 
   constructor(
     renderer: THREE.WebGLRenderer,
@@ -20,8 +22,53 @@ export class ControlsManager implements ControlsManagerInterface {
     this.camera = camera
 
     const container = renderer.domElement.parentElement || renderer.domElement
+    this.interactionElement = container as HTMLElement
     this.controls = new OrbitControls(camera, container)
     this.controls.enableDamping = true
+    this.interactionElement.addEventListener(
+      'pointerdown',
+      this.armContextMenuSuppression
+    )
+    this.interactionElement.addEventListener(
+      'pointerup',
+      this.scheduleContextMenuDisarm
+    )
+    this.interactionElement.addEventListener(
+      'pointercancel',
+      this.scheduleContextMenuDisarm
+    )
+  }
+
+  private readonly armContextMenuSuppression = (event: PointerEvent): void => {
+    if (event.button !== 2) return
+    this.disarmContextMenuSuppression()
+    this.suppressionScope =
+      this.interactionElement.closest<HTMLElement>('[data-node-id]')
+    this.suppressionScope?.addEventListener(
+      'contextmenu',
+      this.suppressContextMenu,
+      { capture: true, once: true }
+    )
+  }
+
+  private readonly suppressContextMenu = (event: Event): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    this.suppressionScope = null
+  }
+
+  private readonly scheduleContextMenuDisarm = (event: PointerEvent): void => {
+    if (event.button !== 2) return
+    requestAnimationFrame(() => this.disarmContextMenuSuppression())
+  }
+
+  private disarmContextMenuSuppression(): void {
+    this.suppressionScope?.removeEventListener(
+      'contextmenu',
+      this.suppressContextMenu,
+      { capture: true }
+    )
+    this.suppressionScope = null
   }
 
   init(): void {
@@ -44,6 +91,19 @@ export class ControlsManager implements ControlsManagerInterface {
   }
 
   dispose(): void {
+    this.interactionElement.removeEventListener(
+      'pointerdown',
+      this.armContextMenuSuppression
+    )
+    this.interactionElement.removeEventListener(
+      'pointerup',
+      this.scheduleContextMenuDisarm
+    )
+    this.interactionElement.removeEventListener(
+      'pointercancel',
+      this.scheduleContextMenuDisarm
+    )
+    this.disarmContextMenuSuppression()
     this.controls.dispose()
   }
 


### PR DESCRIPTION
## Summary
A right-drag that orbits or pans the scene often ends with the pointer outside the viewport, so the browser fires contextmenu on the Vue node under it and the node options menu pops up. While a right-press started in the viewport is in flight, arm a one-shot capture listener on the owning node root that swallows the contextmenu, disarmed a frame after
the release.

## Screenshots
before

https://github.com/user-attachments/assets/ca8f0b7c-1fe5-45cc-b7cc-6134a0204bf2


after

https://github.com/user-attachments/assets/1c9f8acd-5f72-4989-b60f-108ab72869b7

