### PR TITLE
feat: nodeBadgeStore + badge system (slice A)

### DIFF
--- a/docs/adr/0008-entity-component-system.md
+++ b/docs/adr/0008-entity-component-system.md
@@ -37,6 +37,15 @@ writes are tracked without an action chokepoint. The `layoutStore` link
 connectivity mirror and the `slot._floatingLinks` sets were deleted in
 the same work; the layout store now holds geometry only.
 
+### Amendment (2026-07-14, PR 13458)
+
+`nodeBadgeStore` joined the dedicated-store set: plain `BadgeData` rows
+keyed by `NodeId` in root-graph-scoped buckets. Unlike the
+proxy-adoption stores above, rows are written by a reactive badge
+system (`src/systems/badgeSystem.ts`) — a pure `computeBadges` inside a
+per-node effect scope — see
+[Node Badge Store](../architecture/node-badge-store.md).
+
 ## Context
 
 The litegraph layer is built on deeply coupled OOP classes (`LGraphNode`, `LLink`, `Subgraph`, `BaseWidget`, `Reroute`, `LGraphGroup`, `SlotBase`). Each entity directly references its container and children — nodes hold widget arrays, widgets back-reference their node, links reference origin/target node IDs, subgraphs extend the graph class, and so on.

--- a/docs/architecture/ecs-migration-plan.md
+++ b/docs/architecture/ecs-migration-plan.md
@@ -114,16 +114,17 @@ narrow accessor surface. There is no single container that fronts all entities.
 
 Shipped stores:
 
-| Store                      | File                                            |
-| -------------------------- | ----------------------------------------------- |
-| `widgetValueStore`         | `src/stores/widgetValueStore.ts`                |
-| `domWidgetStore`           | `src/stores/domWidgetStore.ts`                  |
-| `layoutStore`              | `src/renderer/core/layout/store/layoutStore.ts` |
-| `nodeOutputStore`          | `src/stores/nodeOutputStore.ts`                 |
-| `subgraphNavigationStore`  | `src/stores/subgraphNavigationStore.ts`         |
-| `previewExposureStore`     | `src/stores/previewExposureStore.ts`            |
-| `linkStore` ✅ PR 13436    | `src/stores/linkStore.ts`                       |
-| `rerouteStore` ✅ PR 13449 | `src/stores/rerouteStore.ts`                    |
+| Store                        | File                                            |
+| ---------------------------- | ----------------------------------------------- |
+| `widgetValueStore`           | `src/stores/widgetValueStore.ts`                |
+| `domWidgetStore`             | `src/stores/domWidgetStore.ts`                  |
+| `layoutStore`                | `src/renderer/core/layout/store/layoutStore.ts` |
+| `nodeOutputStore`            | `src/stores/nodeOutputStore.ts`                 |
+| `subgraphNavigationStore`    | `src/stores/subgraphNavigationStore.ts`         |
+| `previewExposureStore`       | `src/stores/previewExposureStore.ts`            |
+| `linkStore` ✅ PR 13436      | `src/stores/linkStore.ts`                       |
+| `rerouteStore` ✅ PR 13449   | `src/stores/rerouteStore.ts`                    |
+| `nodeBadgeStore` ✅ PR 13458 | `src/stores/nodeBadgeStore.ts`                  |
 
 `linkStore` holds `LinkTopology` records (`src/types/linkTopology.ts`) keyed by
 target input slot (`` `${targetNodeId}:${targetSlot}` ``) in root-graph-scoped
@@ -631,6 +632,7 @@ The dedicated stores use per-concern keying strategies:
 | `subgraphNavigationStore` | subgraphId or `'root'`                                                               |
 | `linkStore`               | `` `${targetNodeId}:${targetSlot}` `` (target input slot), root-graph-scoped buckets |
 | `rerouteStore`            | `RerouteId`, root-graph-scoped buckets                                               |
+| `nodeBadgeStore`          | `NodeId`, root-graph-scoped buckets                                                  |
 
 ADR 0009 refines the promoted-widget target: promoted value widgets should use
 host boundary identity (`host node locator + SubgraphInput.name`), not interior

--- a/docs/architecture/node-badge-store.md
+++ b/docs/architecture/node-badge-store.md
@@ -1,10 +1,13 @@
 # Node Badge Store
 
-Date: 2026-07-05
-Status: Draft (design interview in progress; follow-up to the
+Date: 2026-07-05 (updated 2026-07-06)
+Status: Partially implemented — decisions 1–4 shipped as
+`src/stores/nodeBadgeStore.ts` + `src/systems/badgeSystem.ts` (slice A);
+decision 5 and the open decisions below await the consumer-cutover PR
+(slice B). Follow-up to the
 [link topology store](link-topology-store.md),
 [reroute chain store](reroute-chain-store.md), and the
-[node data store draft](node-data-store.md))
+[node data store draft](node-data-store.md)
 
 Design record for extracting node badges off `LGraphNode` instances into
 a dedicated store per [ADR 0008](../adr/0008-entity-component-system.md),
@@ -98,6 +101,30 @@ mirror: no other component stores this projection.
 `LGraphBadge` draw objects keyed by row content (the `Reroute` id-badge
 pattern, memoized). `_boundingRect` hit-test state stays renderer-side.
 Frame-budget parity per ADR 0008's render mitigations applies.
+
+## Implementation notes (slice A)
+
+- Registration is bucket-key presence: the `LGraph.add`/`remove`/`clear`
+  chokepoints call the import-light store trio
+  (`registerNode`/`unregisterNode`/`clearGraph`), and the system watches
+  `registeredNodeIds` to attach/detach per-node effect scopes. Litegraph
+  never imports the system, so the pricing/nodeDef dependency graph
+  (which runtime-imports the litegraph barrel) stays acyclic; the system
+  is bootstrapped at the app layer with a `resolveNode` seam.
+- Core rows are fine-grained — one row per part in lifecycle, id, source
+  order — with one visibility rule (`badgeTextVisible`, the legacy
+  semantics: `HideBuiltIn` respected for every part). Joining,
+  bracket decoration, and truncation are renderer presentation and move
+  to the slice-B legacy draw cache. Rows store lifecycle text with the
+  `[]` brackets trimmed. Known unification effects: the Vue renderer
+  gains `HideBuiltIn` handling for id badges, and core nodes' `🦊`
+  source row becomes data the Vue partition may substitute with its
+  Comfy-logo chip.
+- A credits row is emitted only when the display price label is
+  non-empty; async pricing fills it via the per-node revision ref.
+- Subgraph credits aggregation is not yet in the system — it stays on
+  the `updateSubgraphCredits` closure path until open decision 3 below
+  is resolved.
 
 ## Open decisions (interview pending)
 

--- a/docs/architecture/node-badge-store.md
+++ b/docs/architecture/node-badge-store.md
@@ -115,6 +115,10 @@ Frame-budget parity per ADR 0008's render mitigations applies.
   closures; until then rows are written only under test. Row writes are
   refused for unregistered nodes so a late effect flush cannot
   resurrect a bucket key the chokepoints deleted.
+- Two write paths: `setBadgesOfKind` is the system's bulk
+  replace-one-kind recompute path (`@internal`); extension rows go
+  through `registerBadge`/`deleteBadge` per row, identity-checked, so
+  independent writers cannot stomp each other.
 - The shell still reads `node.constructor.nodeData` and `node.inputs`
   (untracked instance state) to map pricing input names to slot
   indices — parity with the legacy closures. Those reads become store

--- a/docs/architecture/node-badge-store.md
+++ b/docs/architecture/node-badge-store.md
@@ -109,8 +109,16 @@ Frame-budget parity per ADR 0008's render mitigations applies.
   (`registerNode`/`unregisterNode`/`clearGraph`), and the system watches
   `registeredNodeIds` to attach/detach per-node effect scopes. Litegraph
   never imports the system, so the pricing/nodeDef dependency graph
-  (which runtime-imports the litegraph barrel) stays acyclic; the system
-  is bootstrapped at the app layer with a `resolveNode` seam.
+  (which runtime-imports the litegraph barrel) stays acyclic. The system
+  takes a `resolveNode` seam and will be bootstrapped at the app layer
+  in slice B, when the `Comfy.NodeBadge` extension stops pushing
+  closures; until then rows are written only under test. Row writes are
+  refused for unregistered nodes so a late effect flush cannot
+  resurrect a bucket key the chokepoints deleted.
+- The shell still reads `node.constructor.nodeData` and `node.inputs`
+  (untracked instance state) to map pricing input names to slot
+  indices — parity with the legacy closures. Those reads become store
+  lookups when slot data is store-backed (node data store draft).
 - Core rows are fine-grained — one row per part in lifecycle, id, source
   order — with one visibility rule (`badgeTextVisible`, the legacy
   semantics: `HideBuiltIn` respected for every part). Joining,

--- a/docs/architecture/proto-ecs-stores.md
+++ b/docs/architecture/proto-ecs-stores.md
@@ -6,7 +6,7 @@ For the full problem analysis, see [Entity Problems](entity-problems.md). For th
 
 ## 1. What's Already Extracted
 
-Eight dedicated stores extract entity state out of class instances into focused,
+Nine dedicated stores extract entity state out of class instances into focused,
 queryable registries, each owning one concern. Promoted value-widget topology is
 no longer a store; ADR 0009 represents it as ordinary linked `SubgraphInput`
 state, and promoted value data lives in `WidgetValueStore` keyed by the input's
@@ -22,6 +22,7 @@ state, and promoted value data lives in `WidgetValueStore` keyed by the input's
 | PreviewExposureStore    | Subgraph host node           | host node locator | host locator + exposure name                              | Display-only preview state    |
 | LinkStore               | `LLink`                      | Root graph        | `` `${targetNodeId}:${targetSlot}` `` (target input slot) | Plain `LinkTopology` object   |
 | RerouteStore            | `Reroute`                    | Root graph        | `RerouteId`                                               | Plain `RerouteChain` object   |
+| NodeBadgeStore          | `LGraphNode.badges` closures | Root graph        | `NodeId`                                                  | Plain `BadgeData` rows        |
 
 **Update (2026-07-05):** `LinkStore` (`src/stores/linkStore.ts`, PR #13436) and
 `RerouteStore` (`src/stores/rerouteStore.ts`, PR #13449) hold plain-data records
@@ -30,6 +31,11 @@ their root's bucket). Floating links and links targeting subgraph outputs live
 in a per-graph unkeyed side set. Design records:
 [Link Topology Store](link-topology-store.md),
 [Reroute Chain Store](reroute-chain-store.md).
+
+**Update (2026-07-14):** `NodeBadgeStore` (`src/stores/nodeBadgeStore.ts`,
+PR #13458) holds plain `BadgeData` rows keyed by `NodeId` in root-graph-scoped
+buckets, written by a reactive badge system rather than adopted class state.
+Design record: [Node Badge Store](node-badge-store.md).
 
 ADR 0009 refines promoted-widget identity: promoted value widgets are keyed by
 the host boundary (`host node locator + SubgraphInput.name`), while interior

--- a/src/components/graph/widgets/domWidgetZIndex.test.ts
+++ b/src/components/graph/widgets/domWidgetZIndex.test.ts
@@ -1,8 +1,12 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { describe, expect, it } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { getDomWidgetZIndex } from './domWidgetZIndex'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('getDomWidgetZIndex', () => {
   it('follows graph node ordering when node.order is stale', () => {

--- a/src/lib/litegraph/src/LGraph.badges.test.ts
+++ b/src/lib/litegraph/src/LGraph.badges.test.ts
@@ -1,0 +1,68 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeBadgeStore } from '@/stores/nodeBadgeStore'
+
+import {
+  createTestSubgraphData,
+  createTestSubgraphNode
+} from './subgraph/__fixtures__/subgraphHelpers'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
+describe('LGraph node badge registration', () => {
+  it('registers a node in the root bucket on add, unregisters on remove', () => {
+    const graph = new LGraph()
+    const node = new LGraphNode('n')
+
+    graph.add(node)
+    expect(useNodeBadgeStore().registeredNodeIds(graph.rootGraph.id)).toEqual([
+      node.id
+    ])
+
+    graph.remove(node)
+    expect(useNodeBadgeStore().registeredNodeIds(graph.rootGraph.id)).toEqual(
+      []
+    )
+  })
+
+  it('clears the root bucket when the root graph is cleared', () => {
+    const graph = new LGraph()
+    graph.add(new LGraphNode('a'))
+    graph.add(new LGraphNode('b'))
+    const graphId = graph.rootGraph.id
+
+    graph.clear()
+
+    expect(useNodeBadgeStore().registeredNodeIds(graphId)).toEqual([])
+  })
+
+  it('registers subgraph nodes in the root bucket', () => {
+    const rootGraph = new LGraph()
+    const subgraph = rootGraph.createSubgraph(createTestSubgraphData())
+    const inner = new LGraphNode('inner')
+
+    subgraph.add(inner)
+
+    expect(
+      useNodeBadgeStore().registeredNodeIds(rootGraph.rootGraph.id)
+    ).toContainEqual(inner.id)
+  })
+
+  it('unregisters inner nodes when the subgraph definition is collected', () => {
+    const rootGraph = new LGraph()
+    const subgraph = rootGraph.createSubgraph(createTestSubgraphData())
+    const inner = new LGraphNode('inner')
+    subgraph.add(inner)
+    const subgraphNode = createTestSubgraphNode(subgraph, { pos: [100, 100] })
+    rootGraph.add(subgraphNode)
+
+    rootGraph.remove(subgraphNode)
+
+    expect(
+      useNodeBadgeStore().registeredNodeIds(rootGraph.rootGraph.id)
+    ).toEqual([])
+  })
+})

--- a/src/lib/litegraph/src/LGraph.badges.test.ts
+++ b/src/lib/litegraph/src/LGraph.badges.test.ts
@@ -51,6 +51,24 @@ describe('LGraph node badge registration', () => {
     ).toContainEqual(inner.id)
   })
 
+  it('unregisters nodes at every nesting depth when a subgraph is cleared', () => {
+    const rootGraph = new LGraph()
+    const keeper = new LGraphNode('keeper')
+    rootGraph.add(keeper)
+
+    const outer = rootGraph.createSubgraph(createTestSubgraphData())
+    outer.add(new LGraphNode('direct'))
+    const nested = rootGraph.createSubgraph(createTestSubgraphData())
+    nested.add(new LGraphNode('deep'))
+    outer.add(createTestSubgraphNode(nested, { parentGraph: outer }))
+
+    outer.clear()
+
+    expect(
+      useNodeBadgeStore().registeredNodeIds(rootGraph.rootGraph.id)
+    ).toEqual([keeper.id])
+  })
+
   it('unregisters inner nodes when the subgraph definition is collected', () => {
     const rootGraph = new LGraph()
     const subgraph = rootGraph.createSubgraph(createTestSubgraphData())

--- a/src/lib/litegraph/src/LGraph.badges.test.ts
+++ b/src/lib/litegraph/src/LGraph.badges.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { LGraph, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import { useNodeBadgeStore } from '@/stores/nodeBadgeStore'
+import { createUuidv4 } from '@/utils/uuid'
 
 import {
   createTestSubgraphData,
@@ -30,6 +31,7 @@ describe('LGraph node badge registration', () => {
 
   it('clears the root bucket when the root graph is cleared', () => {
     const graph = new LGraph()
+    graph.id = createUuidv4()
     graph.add(new LGraphNode('a'))
     graph.add(new LGraphNode('b'))
     const graphId = graph.rootGraph.id

--- a/src/lib/litegraph/src/LGraph.serialise.test.ts
+++ b/src/lib/litegraph/src/LGraph.serialise.test.ts
@@ -1,9 +1,13 @@
-import { describe } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe } from 'vitest'
 
 import { LGraph, LGraphGroup, LGraphNode } from '@/lib/litegraph/src/litegraph'
 import type { ISerialisedGraph } from '@/lib/litegraph/src/litegraph'
 
 import { test } from './__fixtures__/testExtensions'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('LGraph Serialisation', () => {
   test('can (de)serialise node / group titles', ({ expect, minimalGraph }) => {

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -15,6 +15,7 @@ import { toLinkId } from '@/types/linkId'
 import { toRerouteId } from '@/types/rerouteId'
 import { useLinkStore } from '@/stores/linkStore'
 import { useRerouteStore } from '@/stores/rerouteStore'
+import { useNodeBadgeStore } from '@/stores/nodeBadgeStore'
 import { usePreviewExposureStore } from '@/stores/previewExposureStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { UNASSIGNED_NODE_ID, parseNodeId, toNodeId } from '@/types/nodeId'
@@ -473,11 +474,15 @@ export class LGraph
       useWidgetValueStore().clearGraph(graphId)
       useLinkStore().clearGraph(graphId)
       useRerouteStore().clearGraph(graphId)
+      useNodeBadgeStore().clearGraph(graphId)
     } else {
       // Subgraphs and unconfigured (zero-uuid) graphs share their store
       // bucket with other graphs, so unregister each link individually.
       unregisterAllLinkTopologies(this)
       unregisterAllRerouteChains(this)
+      for (const node of this._nodes) {
+        useNodeBadgeStore().unregisterNode(this.rootGraph.id, node.id)
+      }
     }
 
     this.id = zeroUuid
@@ -1086,6 +1091,8 @@ export class LGraph
     node.graph = this
     this.incrementVersion()
 
+    useNodeBadgeStore().registerNode(this.rootGraph.id, node.id)
+
     // Register all widgets with the WidgetValueStore now that node has a
     // valid ID and graph reference.
     if (node.widgets) {
@@ -1201,6 +1208,9 @@ export class LGraph
 
       if (!hasRemainingReferences) {
         forEachNode(node.subgraph, fireNodeRemovalLifecycle)
+        forEachNode(node.subgraph, (innerNode) =>
+          useNodeBadgeStore().unregisterNode(this.rootGraph.id, innerNode.id)
+        )
         unregisterAllLinkTopologies(node.subgraph)
         unregisterAllRerouteChains(node.subgraph)
         this.rootGraph.subgraphs.delete(node.subgraph.id)
@@ -1229,6 +1239,7 @@ export class LGraph
     if (pos != -1) this._nodes.splice(pos, 1)
 
     delete this._nodes_by_id[node.id]
+    useNodeBadgeStore().unregisterNode(this.rootGraph.id, node.id)
 
     this.onNodeRemoved?.(node)
 

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -480,9 +480,11 @@ export class LGraph
       // bucket with other graphs, so unregister each link individually.
       unregisterAllLinkTopologies(this)
       unregisterAllRerouteChains(this)
-      for (const node of this._nodes) {
+      // ponytail: no shared-definition guard; mirror remove()'s
+      // hasRemainingReferences if cross-instance badge loss ever matters
+      forEachNode(this, (node) =>
         useNodeBadgeStore().unregisterNode(this.rootGraph.id, node.id)
-      }
+      )
     }
 
     this.id = zeroUuid

--- a/src/lib/litegraph/src/LGraph.ts
+++ b/src/lib/litegraph/src/LGraph.ts
@@ -480,8 +480,6 @@ export class LGraph
       // bucket with other graphs, so unregister each link individually.
       unregisterAllLinkTopologies(this)
       unregisterAllRerouteChains(this)
-      // ponytail: no shared-definition guard; mirror remove()'s
-      // hasRemainingReferences if cross-instance badge loss ever matters
       forEachNode(this, (node) =>
         useNodeBadgeStore().unregisterNode(this.rootGraph.id, node.id)
       )

--- a/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.clipboard.test.ts
@@ -34,6 +34,8 @@ vi.mock('@/services/litegraphService', () => ({
   useLitegraphService: () => ({ updatePreviews: () => ({}) })
 }))
 
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
+
 function createSerialisedNode(
   id: number,
   type: string,

--- a/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.cloneZIndex.test.ts
@@ -1,3 +1,5 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NodeId } from '@/types/nodeId'
@@ -12,6 +14,8 @@ import {
   LGraphNode,
   LiteGraph
 } from '@/lib/litegraph/src/litegraph'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 const TEST_NODE_TYPE = 'test/CloneZIndex' as const
 

--- a/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.ghost.test.ts
@@ -1,4 +1,6 @@
 import userEvent from '@testing-library/user-event'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LGraph, LGraphCanvas, LGraphNode } from '@/lib/litegraph/src/litegraph'
@@ -14,6 +16,8 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
     setActor: vi.fn()
   }
 }))
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function createGhostTestHarness() {
   const canvasElement = document.createElement('canvas')

--- a/src/lib/litegraph/src/LGraphCanvas.groupSelection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.groupSelection.test.ts
@@ -1,4 +1,6 @@
 import { fromAny } from '@total-typescript/shoehorn'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CanvasPointerEvent } from '@/lib/litegraph/src/types/events'
@@ -19,6 +21,8 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
     batchUpdateNodeBounds: vi.fn()
   }
 }))
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 function createCanvas(graph: LGraph): LGraphCanvas {
   const el = document.createElement('canvas')

--- a/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
+++ b/src/lib/litegraph/src/LGraphCanvas.slotHitDetection.test.ts
@@ -1,3 +1,5 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -18,6 +20,8 @@ vi.mock('@/renderer/core/layout/store/layoutStore', () => ({
     batchUpdateNodeBounds: vi.fn()
   }
 }))
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 describe('LGraphCanvas slot hit detection', () => {
   let graph: LGraph

--- a/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
+++ b/src/renderer/extensions/vueNodes/composables/usePartitionedBadges.test.ts
@@ -5,18 +5,31 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { computed, ref } from 'vue'
 
-import type { LGraph } from '@/lib/litegraph/src/litegraph'
+import type { VueNodeData } from '@/composables/graph/useGraphNodeManager'
+import { usePriceBadge } from '@/composables/node/usePriceBadge'
+import type { LGraph, LGraphBadge } from '@/lib/litegraph/src/litegraph'
 import type { INodeInputSlot } from '@/lib/litegraph/src/interfaces'
 import { useCanvasStore } from '@/renderer/core/canvas/canvasStore'
-import { trackNodePrice } from '@/renderer/extensions/vueNodes/composables/usePartitionedBadges'
+import {
+  trackNodePrice,
+  usePartitionedBadges
+} from '@/renderer/extensions/vueNodes/composables/usePartitionedBadges'
+import type { ComfyNodeDef } from '@/schemas/nodeDefSchema'
 import { useLinkStore } from '@/stores/linkStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { toLinkId } from '@/types/linkId'
 import { toNodeId } from '@/types/nodeId'
+import { NodeBadgeMode } from '@/types/nodeSource'
 
 const GRAPH_ID = 'graph-test'
 
 vi.mock('@/scripts/app', () => ({ app: {} }))
+
+const settings = vi.hoisted(() => new Map<string, unknown>())
+vi.mock('@/platform/settings/settingStore', () => ({
+  useSettingStore: () => ({ get: (key: string) => settings.get(key) })
+}))
 
 vi.mock('@/composables/node/useNodePricing', () => {
   const revision = ref(0)
@@ -110,5 +123,75 @@ describe('trackNodePrice', () => {
     connect(1, 3)
     read()
     expect(runs()).toBe(1)
+  })
+})
+
+describe('usePartitionedBadges', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+    settings.clear()
+    settings.set('Comfy.NodeBadge.NodeIdBadgeMode', NodeBadgeMode.ShowAll)
+    settings.set(
+      'Comfy.NodeBadge.NodeLifeCycleBadgeMode',
+      NodeBadgeMode.ShowAll
+    )
+    settings.set('Comfy.NodeBadge.NodeSourceBadgeMode', NodeBadgeMode.None)
+  })
+
+  function addNodeDef(name: string, python_module: string) {
+    useNodeDefStore().addNodeDef(
+      fromPartial<ComfyNodeDef>({
+        name,
+        display_name: name,
+        category: 'test',
+        python_module,
+        input: {},
+        output: []
+      })
+    )
+  }
+
+  function makeNodeData(
+    type: string,
+    badges: Partial<LGraphBadge>[]
+  ): VueNodeData {
+    return fromPartial<VueNodeData>({ id: '5', type, badges })
+  }
+
+  it('partitions badges into core, pricing, and extension rows', () => {
+    addNodeDef('CustomNode', 'custom_nodes.testpack')
+    const credits = usePriceBadge().getCreditsBadge('$0.05 x 3 Runs')
+
+    const partitioned = usePartitionedBadges(
+      makeNodeData('CustomNode', [
+        { text: 'legacy-core-slot' },
+        credits,
+        { text: 'EXT' },
+        { text: '' }
+      ])
+    )
+
+    expect(partitioned.value).toEqual({
+      hasComfyBadge: false,
+      core: [{ text: '#5' }],
+      extension: [expect.objectContaining({ text: 'EXT' })],
+      pricing: [{ required: '$0.05', rest: 'x 3 Runs' }]
+    })
+  })
+
+  it('shows the Comfy badge only for core nodes without pricing', () => {
+    settings.set('Comfy.NodeBadge.NodeSourceBadgeMode', NodeBadgeMode.ShowAll)
+    addNodeDef('CoreNode', 'nodes')
+
+    const withoutPricing = usePartitionedBadges(
+      makeNodeData('CoreNode', [{ text: 'legacy-core-slot' }])
+    )
+    expect(withoutPricing.value.hasComfyBadge).toBe(true)
+
+    const credits = usePriceBadge().getCreditsBadge('$0.10')
+    const withPricing = usePartitionedBadges(
+      makeNodeData('CoreNode', [{ text: 'legacy-core-slot' }, credits])
+    )
+    expect(withPricing.value.hasComfyBadge).toBe(false)
   })
 })

--- a/src/stores/nodeBadgeStore.test.ts
+++ b/src/stores/nodeBadgeStore.test.ts
@@ -101,14 +101,38 @@ describe('useNodeBadgeStore', () => {
     expect(texts.value).toEqual(['#1 beta'])
   })
 
-  it('clears a node without touching its neighbours', () => {
+  it('registers a node with no rows and lists it', () => {
+    const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
+
+    expect(store.registeredNodeIds(graphA)).toEqual([node1])
+    expect(store.getBadges(graphA, node1)).toEqual([])
+    expect(store.registeredNodeIds(graphB)).toEqual([])
+  })
+
+  it('tracks registration changes reactively', () => {
+    const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
+
+    const ids = computed(() => store.registeredNodeIds(graphA))
+    expect(ids.value).toEqual([node1])
+
+    store.registerNode(graphA, node2)
+    expect(ids.value).toEqual([node1, node2])
+
+    store.unregisterNode(graphA, node2)
+    expect(ids.value).toEqual([node1])
+  })
+
+  it('unregisters a node without touching its neighbours', () => {
     const store = useNodeBadgeStore()
     store.registerBadge(graphA, node1, badge('extension', 'a'))
     store.registerBadge(graphA, node2, badge('extension', 'b'))
 
-    store.clearNode(graphA, node1)
+    store.unregisterNode(graphA, node1)
 
     expect(store.getBadges(graphA, node1)).toEqual([])
+    expect(store.registeredNodeIds(graphA)).toEqual([node2])
     expect(store.getBadges(graphA, node2)).toHaveLength(1)
   })
 

--- a/src/stores/nodeBadgeStore.test.ts
+++ b/src/stores/nodeBadgeStore.test.ts
@@ -25,6 +25,7 @@ describe('useNodeBadgeStore', () => {
 
   it('registers a badge and reads it back', () => {
     const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
     store.registerBadge(graphA, node1, badge('extension', 'v2'))
 
     expect(store.getBadges(graphA, node1)).toEqual([
@@ -35,6 +36,7 @@ describe('useNodeBadgeStore', () => {
 
   it('orders rows by kind (core, credits, extension), not insertion', () => {
     const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
     store.registerBadge(graphA, node1, badge('extension', 'ext'))
     store.registerBadge(graphA, node1, badge('credits', '$0.04'))
     store.registerBadge(graphA, node1, badge('core', '#1'))
@@ -48,7 +50,8 @@ describe('useNodeBadgeStore', () => {
 
   it('returns tracked rows whose writes are observable', () => {
     const store = useNodeBadgeStore()
-    const row = store.registerBadge(graphA, node1, badge('extension', 'old'))
+    store.registerNode(graphA, node1)
+    const row = store.registerBadge(graphA, node1, badge('extension', 'old'))!
 
     const text = computed(() => store.getBadges(graphA, node1)[0]?.text)
     expect(text.value).toBe('old')
@@ -60,7 +63,8 @@ describe('useNodeBadgeStore', () => {
 
   it('deletes a row; only the registered row may vacate it', () => {
     const store = useNodeBadgeStore()
-    const row = store.registerBadge(graphA, node1, badge('extension', 'v2'))
+    store.registerNode(graphA, node1)
+    const row = store.registerBadge(graphA, node1, badge('extension', 'v2'))!
 
     expect(store.deleteBadge(graphA, node1, badge('extension', 'v2'))).toBe(
       false
@@ -74,7 +78,8 @@ describe('useNodeBadgeStore', () => {
 
   it('replaces only the written kind, preserving other kinds', () => {
     const store = useNodeBadgeStore()
-    const kept = store.registerBadge(graphA, node1, badge('extension', 'ext'))
+    store.registerNode(graphA, node1)
+    const kept = store.registerBadge(graphA, node1, badge('extension', 'ext'))!
     store.setBadgesOfKind(graphA, node1, 'credits', [badge('credits', '$0.02')])
 
     store.setBadgesOfKind(graphA, node1, 'credits', [
@@ -89,6 +94,7 @@ describe('useNodeBadgeStore', () => {
 
   it('recomputes reads when a kind is rewritten', () => {
     const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
     store.setBadgesOfKind(graphA, node1, 'core', [badge('core', '#1')])
 
     const texts = computed(() =>
@@ -126,6 +132,8 @@ describe('useNodeBadgeStore', () => {
 
   it('unregisters a node without touching its neighbours', () => {
     const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
+    store.registerNode(graphA, node2)
     store.registerBadge(graphA, node1, badge('extension', 'a'))
     store.registerBadge(graphA, node2, badge('extension', 'b'))
 
@@ -136,8 +144,33 @@ describe('useNodeBadgeStore', () => {
     expect(store.getBadges(graphA, node2)).toHaveLength(1)
   })
 
+  it('refuses row writes for unregistered nodes', () => {
+    const store = useNodeBadgeStore()
+
+    expect(store.registerBadge(graphA, node1, badge('extension', 'x'))).toBe(
+      undefined
+    )
+    store.setBadgesOfKind(graphA, node1, 'core', [badge('core', '#1')])
+
+    expect(store.registeredNodeIds(graphA)).toEqual([])
+    expect(store.getBadges(graphA, node1)).toEqual([])
+  })
+
+  it('does not resurrect a node unregistered mid-flight', () => {
+    const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
+    store.setBadgesOfKind(graphA, node1, 'core', [badge('core', '#1')])
+
+    store.unregisterNode(graphA, node1)
+    store.setBadgesOfKind(graphA, node1, 'core', [badge('core', '#1')])
+
+    expect(store.registeredNodeIds(graphA)).toEqual([])
+  })
+
   it('scopes buckets by graph', () => {
     const store = useNodeBadgeStore()
+    store.registerNode(graphA, node1)
+    store.registerNode(graphB, node1)
     store.registerBadge(graphA, node1, badge('extension', 'a'))
     store.registerBadge(graphB, node1, badge('extension', 'b'))
 

--- a/src/stores/nodeBadgeStore.test.ts
+++ b/src/stores/nodeBadgeStore.test.ts
@@ -1,0 +1,125 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { computed } from 'vue'
+
+import type { BadgeData } from '@/types/badgeData'
+import { toNodeId } from '@/types/nodeId'
+import type { UUID } from '@/utils/uuid'
+
+import { useNodeBadgeStore } from './nodeBadgeStore'
+
+const graphA: UUID = 'graph-a'
+const graphB: UUID = 'graph-b'
+const node1 = toNodeId(1)
+const node2 = toNodeId(2)
+
+function badge(kind: BadgeData['kind'], text: string): BadgeData {
+  return { kind, text }
+}
+
+describe('useNodeBadgeStore', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  it('registers a badge and reads it back', () => {
+    const store = useNodeBadgeStore()
+    store.registerBadge(graphA, node1, badge('extension', 'v2'))
+
+    expect(store.getBadges(graphA, node1)).toEqual([
+      { kind: 'extension', text: 'v2' }
+    ])
+    expect(store.getBadges(graphA, node2)).toEqual([])
+  })
+
+  it('orders rows by kind (core, credits, extension), not insertion', () => {
+    const store = useNodeBadgeStore()
+    store.registerBadge(graphA, node1, badge('extension', 'ext'))
+    store.registerBadge(graphA, node1, badge('credits', '$0.04'))
+    store.registerBadge(graphA, node1, badge('core', '#1'))
+
+    expect(store.getBadges(graphA, node1).map((b) => b.kind)).toEqual([
+      'core',
+      'credits',
+      'extension'
+    ])
+  })
+
+  it('returns tracked rows whose writes are observable', () => {
+    const store = useNodeBadgeStore()
+    const row = store.registerBadge(graphA, node1, badge('extension', 'old'))
+
+    const text = computed(() => store.getBadges(graphA, node1)[0]?.text)
+    expect(text.value).toBe('old')
+
+    row.text = 'new'
+
+    expect(text.value).toBe('new')
+  })
+
+  it('deletes a row; only the registered row may vacate it', () => {
+    const store = useNodeBadgeStore()
+    const row = store.registerBadge(graphA, node1, badge('extension', 'v2'))
+
+    expect(store.deleteBadge(graphA, node1, badge('extension', 'v2'))).toBe(
+      false
+    )
+    expect(store.getBadges(graphA, node1)).toHaveLength(1)
+
+    expect(store.deleteBadge(graphA, node1, row)).toBe(true)
+    expect(store.getBadges(graphA, node1)).toHaveLength(0)
+    expect(store.deleteBadge(graphA, node1, row)).toBe(false)
+  })
+
+  it('replaces only the written kind, preserving other kinds', () => {
+    const store = useNodeBadgeStore()
+    const kept = store.registerBadge(graphA, node1, badge('extension', 'ext'))
+    store.setBadgesOfKind(graphA, node1, 'credits', [badge('credits', '$0.02')])
+
+    store.setBadgesOfKind(graphA, node1, 'credits', [
+      badge('credits', '$0.04'),
+      badge('credits', '$0.06')
+    ])
+
+    const rows = store.getBadges(graphA, node1)
+    expect(rows.map((b) => b.text)).toEqual(['$0.04', '$0.06', 'ext'])
+    expect(store.deleteBadge(graphA, node1, kept)).toBe(true)
+  })
+
+  it('recomputes reads when a kind is rewritten', () => {
+    const store = useNodeBadgeStore()
+    store.setBadgesOfKind(graphA, node1, 'core', [badge('core', '#1')])
+
+    const texts = computed(() =>
+      store.getBadges(graphA, node1).map((b) => b.text)
+    )
+    expect(texts.value).toEqual(['#1'])
+
+    store.setBadgesOfKind(graphA, node1, 'core', [badge('core', '#1 beta')])
+
+    expect(texts.value).toEqual(['#1 beta'])
+  })
+
+  it('clears a node without touching its neighbours', () => {
+    const store = useNodeBadgeStore()
+    store.registerBadge(graphA, node1, badge('extension', 'a'))
+    store.registerBadge(graphA, node2, badge('extension', 'b'))
+
+    store.clearNode(graphA, node1)
+
+    expect(store.getBadges(graphA, node1)).toEqual([])
+    expect(store.getBadges(graphA, node2)).toHaveLength(1)
+  })
+
+  it('scopes buckets by graph', () => {
+    const store = useNodeBadgeStore()
+    store.registerBadge(graphA, node1, badge('extension', 'a'))
+    store.registerBadge(graphB, node1, badge('extension', 'b'))
+
+    store.clearGraph(graphB)
+
+    expect(store.getBadges(graphA, node1)).toHaveLength(1)
+    expect(store.getBadges(graphB, node1)).toEqual([])
+  })
+})

--- a/src/stores/nodeBadgeStore.ts
+++ b/src/stores/nodeBadgeStore.ts
@@ -75,9 +75,7 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
   /**
    * Replaces every row of one kind; the system's recompute write path.
    * Refused for unregistered nodes.
-   * @internal Not an extension API — replacing the `extension` kind
-   * wholesale stomps other writers' rows; extensions use
-   * {@link registerBadge}/{@link deleteBadge}.
+   * @internal
    */
   function setBadgesOfKind(
     graphId: UUID,

--- a/src/stores/nodeBadgeStore.ts
+++ b/src/stores/nodeBadgeStore.ts
@@ -1,0 +1,107 @@
+import { defineStore } from 'pinia'
+import { reactive, ref, toRaw } from 'vue'
+
+import { BADGE_KIND_ORDER } from '@/types/badgeData'
+import type { BadgeData, BadgeKind } from '@/types/badgeData'
+import type { NodeId } from '@/types/nodeId'
+import type { UUID } from '@/utils/uuid'
+
+const EMPTY_BADGES: readonly BadgeData[] = []
+
+function kindRank(kind: BadgeKind): number {
+  return BADGE_KIND_ORDER.indexOf(kind)
+}
+
+/**
+ * Node badge store, holding each node's badge rows in root-graph-scoped
+ * buckets keyed by `NodeId`. Rows are plain {@link BadgeData}; reads are
+ * ordered by kind (core, credits, extension), not insertion. The badge
+ * system rewrites its kinds wholesale; extension rows are appended and
+ * removed individually. See docs/architecture/node-badge-store.md.
+ */
+export const useNodeBadgeStore = defineStore('nodeBadge', () => {
+  const buckets = ref(new Map<UUID, Map<NodeId, BadgeData[]>>())
+
+  function graphBadges(graphId: UUID): Map<NodeId, BadgeData[]> {
+    const existing = buckets.value.get(graphId)
+    if (existing) return existing
+    const next = reactive(new Map<NodeId, BadgeData[]>())
+    buckets.value.set(graphId, next)
+    return next
+  }
+
+  function nodeRows(graphId: UUID, nodeId: NodeId): BadgeData[] {
+    const bucket = graphBadges(graphId)
+    const existing = bucket.get(nodeId)
+    if (existing) return existing
+    const next: BadgeData[] = reactive([])
+    bucket.set(nodeId, next)
+    return next
+  }
+
+  /**
+   * Appends a badge row.
+   * @returns The store-held reactive row — callers keep it as their live
+   * state object so later field writes are tracked and identity-checked
+   * deletes match.
+   */
+  function registerBadge(
+    graphId: UUID,
+    nodeId: NodeId,
+    badge: BadgeData
+  ): BadgeData {
+    const rows = nodeRows(graphId, nodeId)
+    rows.push(badge)
+    return rows.at(-1)!
+  }
+
+  /** Removes a badge row; only the registered row may vacate it. */
+  function deleteBadge(
+    graphId: UUID,
+    nodeId: NodeId,
+    badge: BadgeData
+  ): boolean {
+    const rows = buckets.value.get(graphId)?.get(nodeId)
+    if (!rows) return false
+    const index = rows.findIndex((row) => toRaw(row) === toRaw(badge))
+    if (index === -1) return false
+    rows.splice(index, 1)
+    return true
+  }
+
+  /** Replaces every row of one kind; the system's recompute write path. */
+  function setBadgesOfKind(
+    graphId: UUID,
+    nodeId: NodeId,
+    kind: BadgeKind,
+    badges: BadgeData[]
+  ): void {
+    const rows = nodeRows(graphId, nodeId)
+    const kept = rows.filter((row) => row.kind !== kind)
+    rows.splice(0, rows.length, ...kept, ...badges)
+  }
+
+  /** A node's rows in kind display order (core, credits, extension). */
+  function getBadges(graphId: UUID, nodeId: NodeId): readonly BadgeData[] {
+    const rows = buckets.value.get(graphId)?.get(nodeId)
+    if (!rows) return EMPTY_BADGES
+    return [...rows].sort((a, b) => kindRank(a.kind) - kindRank(b.kind))
+  }
+
+  function clearNode(graphId: UUID, nodeId: NodeId): void {
+    buckets.value.get(graphId)?.delete(nodeId)
+  }
+
+  function clearGraph(graphId: UUID): void {
+    buckets.value.delete(graphId)
+  }
+
+  return {
+    registerBadge,
+    deleteBadge,
+    setBadgesOfKind,
+    getBadges,
+    clearNode,
+    clearGraph
+  }
+})

--- a/src/stores/nodeBadgeStore.ts
+++ b/src/stores/nodeBadgeStore.ts
@@ -22,7 +22,7 @@ function kindRank(kind: BadgeKind): number {
 export const useNodeBadgeStore = defineStore('nodeBadge', () => {
   const buckets = ref(new Map<UUID, Map<NodeId, BadgeData[]>>())
 
-  function graphBadges(graphId: UUID): Map<NodeId, BadgeData[]> {
+  function graphBucket(graphId: UUID): Map<NodeId, BadgeData[]> {
     const existing = buckets.value.get(graphId)
     if (existing) return existing
     const next = reactive(new Map<NodeId, BadgeData[]>())
@@ -30,27 +30,30 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
     return next
   }
 
-  function nodeRows(graphId: UUID, nodeId: NodeId): BadgeData[] {
-    const bucket = graphBadges(graphId)
-    const existing = bucket.get(nodeId)
-    if (existing) return existing
-    const next: BadgeData[] = reactive([])
-    bucket.set(nodeId, next)
-    return next
+  /**
+   * A registered node's rows; `undefined` for unregistered nodes so row
+   * writes cannot re-create a bucket key `unregisterNode` just deleted.
+   */
+  function registeredRows(
+    graphId: UUID,
+    nodeId: NodeId
+  ): BadgeData[] | undefined {
+    return buckets.value.get(graphId)?.get(nodeId)
   }
 
   /**
-   * Appends a badge row.
+   * Appends a badge row to a registered node; refused otherwise.
    * @returns The store-held reactive row — callers keep it as their live
    * state object so later field writes are tracked and identity-checked
-   * deletes match.
+   * deletes match — or `undefined` when the node is not registered.
    */
   function registerBadge(
     graphId: UUID,
     nodeId: NodeId,
     badge: BadgeData
-  ): BadgeData {
-    const rows = nodeRows(graphId, nodeId)
+  ): BadgeData | undefined {
+    const rows = registeredRows(graphId, nodeId)
+    if (!rows) return undefined
     rows.push(badge)
     return rows.at(-1)!
   }
@@ -69,14 +72,18 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
     return true
   }
 
-  /** Replaces every row of one kind; the system's recompute write path. */
+  /**
+   * Replaces every row of one kind; the system's recompute write path.
+   * Refused for unregistered nodes.
+   */
   function setBadgesOfKind(
     graphId: UUID,
     nodeId: NodeId,
     kind: BadgeKind,
     badges: BadgeData[]
   ): void {
-    const rows = nodeRows(graphId, nodeId)
+    const rows = registeredRows(graphId, nodeId)
+    if (!rows) return
     const kept = rows.filter((row) => row.kind !== kind)
     rows.splice(0, rows.length, ...kept, ...badges)
   }
@@ -90,7 +97,8 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
 
   /** Registers a node; a registered node's rows are system-maintained. */
   function registerNode(graphId: UUID, nodeId: NodeId): void {
-    nodeRows(graphId, nodeId)
+    const bucket = graphBucket(graphId)
+    if (!bucket.has(nodeId)) bucket.set(nodeId, reactive([]))
   }
 
   function unregisterNode(graphId: UUID, nodeId: NodeId): void {

--- a/src/stores/nodeBadgeStore.ts
+++ b/src/stores/nodeBadgeStore.ts
@@ -88,8 +88,18 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
     return [...rows].sort((a, b) => kindRank(a.kind) - kindRank(b.kind))
   }
 
-  function clearNode(graphId: UUID, nodeId: NodeId): void {
+  /** Registers a node; a registered node's rows are system-maintained. */
+  function registerNode(graphId: UUID, nodeId: NodeId): void {
+    nodeRows(graphId, nodeId)
+  }
+
+  function unregisterNode(graphId: UUID, nodeId: NodeId): void {
     buckets.value.get(graphId)?.delete(nodeId)
+  }
+
+  /** The registered nodes of a graph bucket; reads are tracked. */
+  function registeredNodeIds(graphId: UUID): NodeId[] {
+    return [...(buckets.value.get(graphId)?.keys() ?? [])]
   }
 
   function clearGraph(graphId: UUID): void {
@@ -101,7 +111,9 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
     deleteBadge,
     setBadgesOfKind,
     getBadges,
-    clearNode,
+    registerNode,
+    unregisterNode,
+    registeredNodeIds,
     clearGraph
   }
 })

--- a/src/stores/nodeBadgeStore.ts
+++ b/src/stores/nodeBadgeStore.ts
@@ -64,7 +64,7 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
     nodeId: NodeId,
     badge: BadgeData
   ): boolean {
-    const rows = buckets.value.get(graphId)?.get(nodeId)
+    const rows = registeredRows(graphId, nodeId)
     if (!rows) return false
     const index = rows.findIndex((row) => toRaw(row) === toRaw(badge))
     if (index === -1) return false
@@ -75,6 +75,9 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
   /**
    * Replaces every row of one kind; the system's recompute write path.
    * Refused for unregistered nodes.
+   * @internal Not an extension API — replacing the `extension` kind
+   * wholesale stomps other writers' rows; extensions use
+   * {@link registerBadge}/{@link deleteBadge}.
    */
   function setBadgesOfKind(
     graphId: UUID,
@@ -90,7 +93,7 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
 
   /** A node's rows in kind display order (core, credits, extension). */
   function getBadges(graphId: UUID, nodeId: NodeId): readonly BadgeData[] {
-    const rows = buckets.value.get(graphId)?.get(nodeId)
+    const rows = registeredRows(graphId, nodeId)
     if (!rows) return EMPTY_BADGES
     return [...rows].sort((a, b) => kindRank(a.kind) - kindRank(b.kind))
   }

--- a/src/stores/nodeBadgeStore.ts
+++ b/src/stores/nodeBadgeStore.ts
@@ -103,7 +103,10 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
   }
 
   function unregisterNode(graphId: UUID, nodeId: NodeId): void {
-    buckets.value.get(graphId)?.delete(nodeId)
+    const bucket = buckets.value.get(graphId)
+    if (!bucket) return
+    bucket.delete(nodeId)
+    if (bucket.size === 0) buckets.value.delete(graphId)
   }
 
   /** The registered nodes of a graph bucket; reads are tracked. */
@@ -112,7 +115,9 @@ export const useNodeBadgeStore = defineStore('nodeBadge', () => {
   }
 
   function clearGraph(graphId: UUID): void {
-    buckets.value.delete(graphId)
+    for (const nodeId of registeredNodeIds(graphId)) {
+      unregisterNode(graphId, nodeId)
+    }
   }
 
   return {

--- a/src/systems/badgeSystem.test.ts
+++ b/src/systems/badgeSystem.test.ts
@@ -1,0 +1,230 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useNodeBadgeStore } from '@/stores/nodeBadgeStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { toNodeId } from '@/types/nodeId'
+import { NodeBadgeMode } from '@/types/nodeSource'
+import type { UUID } from '@/utils/uuid'
+
+import { computeBadges, startBadgeSystem } from './badgeSystem'
+import type { BadgeSources } from './badgeSystem'
+
+function sources(overrides: Partial<BadgeSources> = {}): BadgeSources {
+  return {
+    nodeId: toNodeId(5),
+    nodeDef: {
+      isCoreNode: false,
+      lifecycleText: '[BETA]',
+      sourceText: 'my-pack'
+    },
+    badgeModes: {
+      id: NodeBadgeMode.ShowAll,
+      lifecycle: NodeBadgeMode.ShowAll,
+      source: NodeBadgeMode.ShowAll
+    },
+    colors: { fgColor: '#fff', bgColor: '#0b8', creditsBgColor: '#8D6932' },
+    pricing: { isApiNode: false, showApiPricing: false, priceLabel: '' },
+    ...overrides
+  }
+}
+
+describe('computeBadges', () => {
+  it('projects lifecycle, id, and source core rows in that order', () => {
+    expect(computeBadges(sources())).toEqual([
+      { kind: 'core', text: 'BETA', fgColor: '#fff', bgColor: '#0b8' },
+      { kind: 'core', text: '#5', fgColor: '#fff', bgColor: '#0b8' },
+      { kind: 'core', text: 'my-pack', fgColor: '#fff', bgColor: '#0b8' }
+    ])
+  })
+
+  it('hides built-in nodes under HideBuiltIn, shows others', () => {
+    const hideAll = {
+      id: NodeBadgeMode.HideBuiltIn,
+      lifecycle: NodeBadgeMode.HideBuiltIn,
+      source: NodeBadgeMode.HideBuiltIn
+    }
+    const coreNode = sources({ badgeModes: hideAll })
+    coreNode.nodeDef!.isCoreNode = true
+
+    expect(computeBadges(coreNode)).toEqual([])
+    expect(computeBadges(sources({ badgeModes: hideAll }))).toHaveLength(3)
+  })
+
+  it('hides each part independently under None', () => {
+    const rows = computeBadges(
+      sources({
+        badgeModes: {
+          id: NodeBadgeMode.None,
+          lifecycle: NodeBadgeMode.ShowAll,
+          source: NodeBadgeMode.None
+        }
+      })
+    )
+
+    expect(rows.map((b) => b.text)).toEqual(['BETA'])
+  })
+
+  it('projects only the id row without a node definition', () => {
+    const rows = computeBadges(sources({ nodeDef: null }))
+
+    expect(rows.map((b) => b.text)).toEqual(['#5'])
+  })
+
+  it('drops rows whose text is empty', () => {
+    const empty = sources()
+    empty.nodeDef!.lifecycleText = ''
+    empty.nodeDef!.sourceText = ''
+
+    expect(computeBadges(empty).map((b) => b.text)).toEqual(['#5'])
+  })
+
+  it('projects a credits row for a priced api node', () => {
+    const rows = computeBadges(
+      sources({
+        pricing: { isApiNode: true, showApiPricing: true, priceLabel: '$0.04' }
+      })
+    )
+
+    expect(rows.at(-1)).toEqual({
+      kind: 'credits',
+      text: '$0.04',
+      iconKey: 'credits',
+      fgColor: '#fff',
+      bgColor: '#8D6932'
+    })
+  })
+
+  it.for([
+    {
+      name: 'not an api node',
+      pricing: { isApiNode: false, showApiPricing: true, priceLabel: '$1' }
+    },
+    {
+      name: 'pricing hidden by setting',
+      pricing: { isApiNode: true, showApiPricing: false, priceLabel: '$1' }
+    },
+    {
+      name: 'no price label yet',
+      pricing: { isApiNode: true, showApiPricing: true, priceLabel: '' }
+    }
+  ])('projects no credits row when $name', ({ pricing }) => {
+    const rows = computeBadges(sources({ pricing }))
+
+    expect(rows.filter((b) => b.kind === 'credits')).toEqual([])
+  })
+})
+
+describe('startBadgeSystem', () => {
+  const graphId: UUID = 'graph-root'
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  function makeNode(id: number): LGraphNode {
+    const node = new LGraphNode('Test')
+    node.id = toNodeId(id)
+    node.type = 'TestNode'
+    return node
+  }
+
+  function seedTestNodeDef(): void {
+    useNodeDefStore().addNodeDef({
+      name: 'TestNode',
+      display_name: 'Test Node',
+      category: 'test',
+      python_module: 'custom_nodes.my_pack',
+      description: '',
+      input: {},
+      output: [],
+      output_is_list: [],
+      output_name: [],
+      output_node: false,
+      experimental: true
+    })
+  }
+
+  it('writes rows for registered nodes and reacts to source changes', async () => {
+    const badgeStore = useNodeBadgeStore()
+    const node = makeNode(7)
+    badgeStore.registerNode(graphId, node.id)
+
+    const stop = startBadgeSystem({
+      graphId,
+      resolveNode: (id) => (id === node.id ? node : undefined)
+    })
+
+    const texts = () =>
+      badgeStore.getBadges(graphId, node.id).map((b) => b.text)
+    expect(texts()).toEqual(['#7'])
+
+    seedTestNodeDef()
+    await nextTick()
+
+    expect(texts()).toEqual(['BETA', '#7', 'my_pack'])
+
+    stop()
+  })
+
+  it('starts watching nodes registered after system start', async () => {
+    const badgeStore = useNodeBadgeStore()
+    const node = makeNode(3)
+
+    const stop = startBadgeSystem({
+      graphId,
+      resolveNode: (id) => (id === node.id ? node : undefined)
+    })
+    expect(badgeStore.getBadges(graphId, node.id)).toEqual([])
+
+    badgeStore.registerNode(graphId, node.id)
+    await nextTick()
+
+    expect(badgeStore.getBadges(graphId, node.id).map((b) => b.text)).toEqual([
+      '#3'
+    ])
+
+    stop()
+  })
+
+  it('stops maintaining rows once a node is unregistered', async () => {
+    const badgeStore = useNodeBadgeStore()
+    const node = makeNode(7)
+    badgeStore.registerNode(graphId, node.id)
+    const stop = startBadgeSystem({
+      graphId,
+      resolveNode: (id) => (id === node.id ? node : undefined)
+    })
+
+    badgeStore.unregisterNode(graphId, node.id)
+    await nextTick()
+    seedTestNodeDef()
+    await nextTick()
+
+    expect(badgeStore.registeredNodeIds(graphId)).toEqual([])
+    expect(badgeStore.getBadges(graphId, node.id)).toEqual([])
+
+    stop()
+  })
+
+  it('stops writing after the system itself is stopped', async () => {
+    const badgeStore = useNodeBadgeStore()
+    const node = makeNode(7)
+    badgeStore.registerNode(graphId, node.id)
+    const stop = startBadgeSystem({
+      graphId,
+      resolveNode: (id) => (id === node.id ? node : undefined)
+    })
+
+    stop()
+    seedTestNodeDef()
+    await nextTick()
+
+    expect(badgeStore.getBadges(graphId, node.id).map((b) => b.text)).toEqual([
+      '#7'
+    ])
+  })
+})

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -1,0 +1,230 @@
+import { trim } from 'es-toolkit'
+import { effectScope, watch, watchEffect } from 'vue'
+import type { EffectScope } from 'vue'
+
+import { useNodePricing } from '@/composables/node/useNodePricing'
+import type { LGraphNode } from '@/lib/litegraph/src/litegraph'
+import { useSettingStore } from '@/platform/settings/settingStore'
+import { useLinkStore } from '@/stores/linkStore'
+import { useNodeBadgeStore } from '@/stores/nodeBadgeStore'
+import { useNodeDefStore } from '@/stores/nodeDefStore'
+import { useWidgetValueStore } from '@/stores/widgetValueStore'
+import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+import type { BadgeData } from '@/types/badgeData'
+import type { NodeId } from '@/types/nodeId'
+import { NodeBadgeMode } from '@/types/nodeSource'
+import { widgetId } from '@/types/widgetId'
+import { adjustColor } from '@/utils/colorUtil'
+import type { UUID } from '@/utils/uuid'
+
+/** The badge-relevant projection of a node's definition. */
+export interface NodeDefBadgeSources {
+  isCoreNode: boolean
+  lifecycleText: string
+  sourceText: string
+}
+
+/**
+ * The domain state a node's system-written badges are computed from; see
+ * domain-glossary.md § Badges. Plain data so {@link computeBadges} stays
+ * pure — the watch shell gathers these from the live stores.
+ */
+export interface BadgeSources {
+  nodeId: NodeId
+  nodeDef: NodeDefBadgeSources | null
+  badgeModes: {
+    id: NodeBadgeMode
+    lifecycle: NodeBadgeMode
+    source: NodeBadgeMode
+  }
+  colors: { fgColor: string; bgColor: string; creditsBgColor: string }
+  pricing: { isApiNode: boolean; showApiPricing: boolean; priceLabel: string }
+}
+
+function badgeTextVisible(
+  nodeDef: NodeDefBadgeSources | null,
+  badgeMode: NodeBadgeMode
+): boolean {
+  return !(
+    badgeMode === NodeBadgeMode.None ||
+    (nodeDef?.isCoreNode && badgeMode === NodeBadgeMode.HideBuiltIn)
+  )
+}
+
+/** Projects a node's core and credits badge rows from their sources. */
+export function computeBadges(sources: BadgeSources): BadgeData[] {
+  const { nodeId, nodeDef, badgeModes, colors, pricing } = sources
+  const coreTexts = [
+    badgeTextVisible(nodeDef, badgeModes.lifecycle)
+      ? trim(nodeDef?.lifecycleText ?? '', ['[', ']'])
+      : '',
+    badgeTextVisible(nodeDef, badgeModes.id) ? `#${nodeId}` : '',
+    badgeTextVisible(nodeDef, badgeModes.source)
+      ? (nodeDef?.sourceText ?? '')
+      : ''
+  ]
+  const rows: BadgeData[] = coreTexts
+    .filter((text) => text.length > 0)
+    .map((text) => ({
+      kind: 'core',
+      text,
+      fgColor: colors.fgColor,
+      bgColor: colors.bgColor
+    }))
+
+  const showCredits =
+    pricing.isApiNode && pricing.showApiPricing && pricing.priceLabel.length > 0
+  if (showCredits) {
+    rows.push({
+      kind: 'credits',
+      text: pricing.priceLabel,
+      iconKey: 'credits',
+      fgColor: colors.fgColor,
+      bgColor: colors.creditsBgColor
+    })
+  }
+  return rows
+}
+
+export interface BadgeSystemOptions {
+  graphId: UUID
+  resolveNode: (nodeId: NodeId) => LGraphNode | undefined
+}
+
+const CREDITS_BASE_BG_COLOR = '#8D6932'
+
+/**
+ * Reads the pricing-relevant store state so the calling effect re-runs when
+ * a price revision, priced widget value, or priced input connection changes.
+ */
+function touchPricingSources(graphId: UUID, node: LGraphNode): void {
+  const pricing = useNodePricing()
+  const nodeId = node.id
+  void pricing.getNodeRevisionRef(nodeId).value
+
+  if (!node.type || !pricing.hasDynamicPricing(node.type)) return
+  const widgetStore = useWidgetValueStore()
+  for (const name of pricing.getRelevantWidgetNames(node.type)) {
+    void widgetStore.getWidget(widgetId(graphId, nodeId, name))?.value
+  }
+  const linkStore = useLinkStore()
+  const inputNames = pricing.getInputNames(node.type)
+  const groupPrefixes = pricing.getInputGroupPrefixes(node.type)
+  node.inputs?.forEach((input, index) => {
+    const relevant =
+      (input.name && inputNames.includes(input.name)) ||
+      groupPrefixes.some((prefix) => input.name?.startsWith(prefix + '.'))
+    if (relevant) void linkStore.isInputSlotConnected(graphId, nodeId, index)
+  })
+}
+
+function gatherSources(
+  options: BadgeSystemOptions,
+  nodeId: NodeId
+): BadgeSources {
+  const { graphId, resolveNode } = options
+  const settingStore = useSettingStore()
+  const palette = useColorPaletteStore().completedActivePalette
+  const node = resolveNode(nodeId)
+  const def = node ? useNodeDefStore().fromLGraphNode(node) : null
+  const isApiNode = !!node?.constructor?.nodeData?.api_node
+  const showApiPricing = !!settingStore.get('Comfy.NodeBadge.ShowApiPricing')
+
+  let priceLabel = ''
+  if (node && isApiNode && showApiPricing) {
+    touchPricingSources(graphId, node)
+    priceLabel = useNodePricing().getNodeDisplayPrice(node) ?? ''
+  }
+
+  return {
+    nodeId,
+    nodeDef: def
+      ? {
+          isCoreNode: def.isCoreNode,
+          lifecycleText: def.nodeLifeCycleBadgeText,
+          sourceText: def.nodeSource?.badgeText ?? ''
+        }
+      : null,
+    badgeModes: {
+      id: settingStore.get('Comfy.NodeBadge.NodeIdBadgeMode') as NodeBadgeMode,
+      lifecycle: settingStore.get(
+        'Comfy.NodeBadge.NodeLifeCycleBadgeMode'
+      ) as NodeBadgeMode,
+      source: settingStore.get(
+        'Comfy.NodeBadge.NodeSourceBadgeMode'
+      ) as NodeBadgeMode
+    },
+    colors: {
+      fgColor: palette.colors.litegraph_base.BADGE_FG_COLOR,
+      bgColor: palette.colors.litegraph_base.BADGE_BG_COLOR,
+      creditsBgColor: palette.light_theme
+        ? adjustColor(CREDITS_BASE_BG_COLOR, { lightness: 0.5 })
+        : CREDITS_BASE_BG_COLOR
+    },
+    pricing: { isApiNode, showApiPricing, priceLabel }
+  }
+}
+
+/**
+ * Starts the badge system for one root graph: every node registered in
+ * {@link useNodeBadgeStore} gets an effect scope that recomputes its core
+ * and credits rows whenever a badge source changes.
+ * @returns A disposer stopping every scope the system created.
+ */
+export function startBadgeSystem(options: BadgeSystemOptions): () => void {
+  const badgeStore = useNodeBadgeStore()
+  useSettingStore()
+  useNodeDefStore()
+  useColorPaletteStore()
+
+  const nodeScopes = new Map<NodeId, EffectScope>()
+
+  function watchNodeBadges(nodeId: NodeId): EffectScope {
+    const scope = effectScope(true)
+    scope.run(() => {
+      watchEffect(() => {
+        const rows = computeBadges(gatherSources(options, nodeId))
+        badgeStore.setBadgesOfKind(
+          options.graphId,
+          nodeId,
+          'core',
+          rows.filter((row) => row.kind === 'core')
+        )
+        badgeStore.setBadgesOfKind(
+          options.graphId,
+          nodeId,
+          'credits',
+          rows.filter((row) => row.kind === 'credits')
+        )
+      })
+    })
+    return scope
+  }
+
+  const systemScope = effectScope(true)
+  systemScope.run(() => {
+    watch(
+      () => badgeStore.registeredNodeIds(options.graphId),
+      (nodeIds) => {
+        const live = new Set(nodeIds)
+        for (const [nodeId, scope] of nodeScopes) {
+          if (live.has(nodeId)) continue
+          scope.stop()
+          nodeScopes.delete(nodeId)
+        }
+        for (const nodeId of nodeIds) {
+          if (!nodeScopes.has(nodeId)) {
+            nodeScopes.set(nodeId, watchNodeBadges(nodeId))
+          }
+        }
+      },
+      { immediate: true }
+    )
+  })
+
+  return () => {
+    systemScope.stop()
+    for (const scope of nodeScopes.values()) scope.stop()
+    nodeScopes.clear()
+  }
+}

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -18,7 +18,7 @@ import { adjustColor } from '@/utils/colorUtil'
 import type { UUID } from '@/utils/uuid'
 
 /** The badge-relevant projection of a node's definition. */
-export interface NodeDefBadgeSources {
+interface NodeDefBadgeSources {
   isCoreNode: boolean
   lifecycleText: string
   sourceText: string

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -10,6 +10,7 @@ import { useNodeBadgeStore } from '@/stores/nodeBadgeStore'
 import { useNodeDefStore } from '@/stores/nodeDefStore'
 import { useWidgetValueStore } from '@/stores/widgetValueStore'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
+import { BADGE_KIND_ORDER } from '@/types/badgeData'
 import type { BadgeData } from '@/types/badgeData'
 import type { NodeId } from '@/types/nodeId'
 import { NodeBadgeMode } from '@/types/nodeSource'
@@ -93,6 +94,10 @@ export interface BadgeSystemOptions {
 }
 
 const CREDITS_BASE_BG_COLOR = '#8D6932'
+
+const SYSTEM_BADGE_KINDS = BADGE_KIND_ORDER.filter(
+  (kind) => kind !== 'extension'
+)
 
 /**
  * Reads the pricing-relevant store state so the calling effect re-runs when
@@ -189,7 +194,7 @@ export function startBadgeSystem(options: BadgeSystemOptions): () => void {
     scope.run(() => {
       watchEffect(() => {
         const rows = computeBadges(gatherSources(options, nodeId))
-        for (const kind of ['core', 'credits'] as const) {
+        for (const kind of SYSTEM_BADGE_KINDS) {
           badgeStore.setBadgesOfKind(
             options.graphId,
             nodeId,

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -88,10 +88,7 @@ export function computeBadges(sources: BadgeSources): BadgeData[] {
 
 export interface BadgeSystemOptions {
   graphId: UUID
-  /**
-   * Registered ids include nodes nested in subgraphs, so this must search
-   * the whole hierarchy (`findNodeInHierarchy`), not `getNodeById`.
-   */
+  /** Must resolve ids anywhere in the subgraph hierarchy. */
   resolveNode: (nodeId: NodeId) => LGraphNode | undefined
 }
 
@@ -173,7 +170,7 @@ function gatherSources(
  * Starts the badge system for one root graph: every node registered in
  * {@link useNodeBadgeStore} gets an effect scope that recomputes its core
  * and credits rows whenever a badge source changes. At most one system per
- * graph — call the disposer before starting another.
+ * graph.
  * @returns A disposer stopping every scope the system created.
  */
 export function startBadgeSystem(options: BadgeSystemOptions): () => void {

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -173,6 +173,9 @@ function gatherSources(
  */
 export function startBadgeSystem(options: BadgeSystemOptions): () => void {
   const badgeStore = useNodeBadgeStore()
+  // Instantiate source stores before any effect runs: a store's first
+  // instantiation mutates pinia.state and would invalidate the effect
+  // that triggered it.
   useSettingStore()
   useNodeDefStore()
   useColorPaletteStore()
@@ -184,18 +187,14 @@ export function startBadgeSystem(options: BadgeSystemOptions): () => void {
     scope.run(() => {
       watchEffect(() => {
         const rows = computeBadges(gatherSources(options, nodeId))
-        badgeStore.setBadgesOfKind(
-          options.graphId,
-          nodeId,
-          'core',
-          rows.filter((row) => row.kind === 'core')
-        )
-        badgeStore.setBadgesOfKind(
-          options.graphId,
-          nodeId,
-          'credits',
-          rows.filter((row) => row.kind === 'credits')
-        )
+        for (const kind of ['core', 'credits'] as const) {
+          badgeStore.setBadgesOfKind(
+            options.graphId,
+            nodeId,
+            kind,
+            rows.filter((row) => row.kind === kind)
+          )
+        }
       })
     })
     return scope

--- a/src/systems/badgeSystem.ts
+++ b/src/systems/badgeSystem.ts
@@ -88,6 +88,10 @@ export function computeBadges(sources: BadgeSources): BadgeData[] {
 
 export interface BadgeSystemOptions {
   graphId: UUID
+  /**
+   * Registered ids include nodes nested in subgraphs, so this must search
+   * the whole hierarchy (`findNodeInHierarchy`), not `getNodeById`.
+   */
   resolveNode: (nodeId: NodeId) => LGraphNode | undefined
 }
 
@@ -168,7 +172,8 @@ function gatherSources(
 /**
  * Starts the badge system for one root graph: every node registered in
  * {@link useNodeBadgeStore} gets an effect scope that recomputes its core
- * and credits rows whenever a badge source changes.
+ * and credits rows whenever a badge source changes. At most one system per
+ * graph — call the disposer before starting another.
  * @returns A disposer stopping every scope the system created.
  */
 export function startBadgeSystem(options: BadgeSystemOptions): () => void {

--- a/src/types/badgeData.ts
+++ b/src/types/badgeData.ts
@@ -1,0 +1,17 @@
+/** Display order of badge kinds; see domain-glossary.md § Badges. */
+export const BADGE_KIND_ORDER = ['core', 'credits', 'extension'] as const
+
+export type BadgeKind = (typeof BADGE_KIND_ORDER)[number]
+
+/**
+ * A badge row: plain presentation data projected from its sources
+ * (settings, node definition, palette, pricing, connectivity). Icons are
+ * referenced by key, never held as live objects. Never serialized.
+ */
+export interface BadgeData {
+  kind: BadgeKind
+  text: string
+  fgColor?: string
+  bgColor?: string
+  iconKey?: string
+}

--- a/src/utils/litegraphUtil.test.ts
+++ b/src/utils/litegraphUtil.test.ts
@@ -1,3 +1,5 @@
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fromAny, fromPartial } from '@total-typescript/shoehorn'
 
@@ -9,6 +11,8 @@ import { widgetId } from '@/types/widgetId'
 import { createMockLGraphNode } from '@/utils/__tests__/litegraphTestUtils'
 
 import { createNode, getWidgetIdForNode, resolveNode } from './litegraphUtil'
+
+beforeEach(() => setActivePinia(createTestingPinia({ stubActions: false })))
 
 const mockBringNodeToFront = vi.fn()
 


### PR DESCRIPTION
## Summary

Extracts node badges into a dedicated store per ADR 0008 — slice A of `docs/architecture/node-badge-store.md`: store, plain `BadgeData` rows, reactive badge system, and LGraph chokepoint registration. Stacked on #13455.

## Changes

- **What**:
  - `src/types/badgeData.ts` — plain `BadgeData { kind, text, fgColor?, bgColor?, iconKey? }` rows (decision 1).
  - `src/stores/nodeBadgeStore.ts` — root-scoped buckets keyed by `NodeId`, kind-ordered reads, identity-checked row deletes, `registerNode`/`unregisterNode`/`clearGraph` registration trio; row writes refused for unregistered nodes (decision 2).
  - `src/systems/badgeSystem.ts` — pure `computeBadges(sources)` + effect-scope-per-node shell watching `registeredNodeIds`; writes core and credits rows from nodeDef/settings/palette/pricing/widget-value/link-connectivity sources (decisions 3–4).
  - `LGraph.add`/`remove`/`clear` + subgraph-definition GC maintain the store registration (linkStore/rerouteStore convention).
  - Design record updated with implementation notes.
- **Breaking**: none yet — `node.badges`/`useNodeBadge` closures untouched; nothing starts the system in production until slice B's consumer cutover.

## Review Focus

- Registration is bucket-key presence; the system discovers nodes by watching `registeredNodeIds`, so litegraph never imports pricing/nodeDef modules (no import cycle via the litegraph barrel).
- Core rows are fine-grained (lifecycle, id, source) under one visibility rule — unification notes in the design record (Vue gains HideBuiltIn on id badges; legacy join/truncation becomes slice-B draw-cache presentation).
- Subgraph credits aggregation, the legacy `node.badges` surface, and `badgePosition` are open decisions in the design record and deliberately not in this PR.
- Slice A+B together would exceed the ~300-line guideline, hence the split; store row APIs (`registerBadge`/`deleteBadge`) land now because the slice-B shim consumes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)