### PR TITLE
style: use neutral credits info button

### DIFF
--- a/src/platform/cloud/subscription/components/CreditsTile.vue
+++ b/src/platform/cloud/subscription/components/CreditsTile.vue
@@ -110,17 +110,18 @@
         >
           <span class="flex items-center gap-1 text-text-primary">
             {{ $t('subscription.additionalCredits') }}
-            <button
+            <Button
               v-tooltip="{
                 value: $t('subscription.additionalCreditsTooltip'),
                 showDelay: 300
               }"
-              type="button"
+              variant="muted-textonly"
+              size="icon-sm"
               :aria-label="$t('subscription.additionalCreditsInfo')"
-              class="flex items-center text-muted"
+              class="text-muted"
             >
               <i class="icon-[lucide--info] size-4" />
-            </button>
+            </Button>
             <span
               v-if="isSpendingAdditional"
               class="flex h-3.5 items-center rounded-full bg-base-foreground px-1 text-2xs/none font-semibold text-base-background uppercase"


### PR DESCRIPTION
## Summary

Replaces the Additional credits tooltip trigger with the shared Button component so the icon renders with the neutral muted treatment used by the rest of the UI.

## Changes

- **What**: Uses the shared Button component for the Additional credits info action while preserving the existing tooltip and aria label.
- **Dependencies**: None.

## Review Focus

Confirm this remains a visual-only change scoped to the Plan & Credits credits tile.

## Screenshots (if applicable)

Before
<img width="397" height="368" alt="스크린샷 2026-07-06 오후 11 30 38" src="https://github.com/user-attachments/assets/9cda1aee-4dc2-4ce1-b001-29d0e09fc07d" />

After
<img width="374" height="355" alt="스크린샷 2026-07-06 오후 11 31 00" src="https://github.com/user-attachments/assets/64d0b726-6031-42d4-84d7-35405150698c" />


## Testing

- `pnpm format`
- `pnpm lint`
- pre-commit hook: stylelint, oxfmt, oxlint, eslint, typecheck
- `pnpm test:unit src/platform/cloud/subscription/components/CreditsTile.test.ts`
