### PR TITLE
Gate signup submit on Turnstile being enabled, not enforced

### DIFF
--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -257,8 +257,8 @@ describe('SignUpForm', () => {
     })
   })
 
-  // Regression coverage for the BE-1345 shadow-mode race: previously submit was
-  // only gated in 'enforce' mode, so most real signups in 'shadow' mode raced
+  // Regression coverage for the shadow-mode race: previously submit was only
+  // gated in 'enforce' mode, so most real signups in 'shadow' mode raced
   // ahead of the async Cloudflare challenge and reached the backend with an
   // empty token. Gating now depends only on whether the widget is enabled
   // (shadow or enforce both render it), so both modes behave identically here.

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -7,7 +7,7 @@ import Password from 'primevue/password'
 import PrimeVue from 'primevue/config'
 import ProgressSpinner from 'primevue/progressspinner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h, nextTick, ref } from 'vue'
+import { computed, defineComponent, h, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 
 import enMessages from '@/locales/en/main.json' with { type: 'json' }
@@ -38,13 +38,28 @@ vi.mock('@/stores/authStore', () => ({
 }))
 
 const mockTurnstileEnabled = ref(false)
+const mockTurnstileToken = ref('')
+const mockTurnstileUnavailable = ref(false)
 const mockReset = vi.fn()
 let emitTurnstileToken: ((token: string) => void) | undefined
 let emitTurnstileUnavailable: ((unavailable: boolean) => void) | undefined
 
+// The reset-on-toggle behavior lives in useTurnstileGate itself (see
+// useTurnstile.test.ts); this fake just wires token/unavailable through to
+// `waiting` the same way so SignUpForm's submit gating can be exercised.
 vi.mock('@/composables/auth/useTurnstile', () => ({
   useTurnstile: () => ({
     enabled: mockTurnstileEnabled
+  }),
+  useTurnstileGate: () => ({
+    token: mockTurnstileToken,
+    unavailable: mockTurnstileUnavailable,
+    waiting: computed(
+      () =>
+        mockTurnstileEnabled.value &&
+        !mockTurnstileToken.value &&
+        !mockTurnstileUnavailable.value
+    )
   })
 }))
 
@@ -93,6 +108,8 @@ describe('SignUpForm', () => {
   beforeEach(() => {
     mockLoadingRef.value = false
     mockTurnstileEnabled.value = false
+    mockTurnstileToken.value = ''
+    mockTurnstileUnavailable.value = false
     mockReset.mockClear()
     emitTurnstileToken = undefined
     emitTurnstileUnavailable = undefined
@@ -209,51 +226,6 @@ describe('SignUpForm', () => {
       await nextTick()
 
       expect(mockReset).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('Turnstile token hygiene', () => {
-    it('clears the stale token when Turnstile becomes disabled', async () => {
-      mockTurnstileEnabled.value = true
-      const { user } = renderComponent()
-      await fillValidSignup(user)
-
-      emitTurnstileToken!('stale-token')
-      await nextTick()
-      expect(
-        screen.getByRole('button', { name: signUpButton })
-      ).not.toBeDisabled()
-
-      mockTurnstileEnabled.value = false
-      await nextTick()
-
-      // re-enable: the stale token must have been cleared so submit is blocked again
-      mockTurnstileEnabled.value = true
-      await nextTick()
-
-      expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
-    })
-
-    it('clears a stale "unavailable" fallback when Turnstile becomes disabled', async () => {
-      mockTurnstileEnabled.value = true
-      const { user } = renderComponent()
-      await fillValidSignup(user)
-
-      emitTurnstileUnavailable!(true)
-      await nextTick()
-      expect(
-        screen.getByRole('button', { name: signUpButton })
-      ).not.toBeDisabled()
-
-      mockTurnstileEnabled.value = false
-      await nextTick()
-
-      // re-enable: the stale fallback must have been cleared so submit is
-      // blocked again until the fresh widget instance proves itself
-      mockTurnstileEnabled.value = true
-      await nextTick()
-
-      expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
     })
   })
 

--- a/src/components/dialog/content/signin/SignUpForm.test.ts
+++ b/src/components/dialog/content/signin/SignUpForm.test.ts
@@ -38,29 +38,30 @@ vi.mock('@/stores/authStore', () => ({
 }))
 
 const mockTurnstileEnabled = ref(false)
-const mockTurnstileEnforced = ref(false)
 const mockReset = vi.fn()
 let emitTurnstileToken: ((token: string) => void) | undefined
+let emitTurnstileUnavailable: ((unavailable: boolean) => void) | undefined
 
 vi.mock('@/composables/auth/useTurnstile', () => ({
   useTurnstile: () => ({
-    enabled: mockTurnstileEnabled,
-    enforced: mockTurnstileEnforced
+    enabled: mockTurnstileEnabled
   })
 }))
 
 // Stub the real widget (which loads the external Turnstile script) with one that
-// exposes a spyable reset() and lets a test drive the v-model token the way a
-// solved challenge would.
+// exposes a spyable reset() and lets a test drive the v-model token/unavailable
+// the way a solved challenge (or a broken/slow widget) would.
 vi.mock('./TurnstileWidget.vue', async () => {
   const { defineComponent: defineMock } = await import('vue')
   return {
     default: defineMock({
       name: 'TurnstileWidget',
-      emits: ['update:token'],
+      emits: ['update:token', 'update:unavailable'],
       setup(_, { expose, emit }) {
         expose({ reset: mockReset })
         emitTurnstileToken = (token: string) => emit('update:token', token)
+        emitTurnstileUnavailable = (unavailable: boolean) =>
+          emit('update:unavailable', unavailable)
         return () => null
       }
     })
@@ -92,9 +93,9 @@ describe('SignUpForm', () => {
   beforeEach(() => {
     mockLoadingRef.value = false
     mockTurnstileEnabled.value = false
-    mockTurnstileEnforced.value = false
     mockReset.mockClear()
     emitTurnstileToken = undefined
+    emitTurnstileUnavailable = undefined
   })
 
   afterEach(() => {
@@ -214,7 +215,6 @@ describe('SignUpForm', () => {
   describe('Turnstile token hygiene', () => {
     it('clears the stale token when Turnstile becomes disabled', async () => {
       mockTurnstileEnabled.value = true
-      mockTurnstileEnforced.value = true
       const { user } = renderComponent()
       await fillValidSignup(user)
 
@@ -233,21 +233,46 @@ describe('SignUpForm', () => {
 
       expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
     })
+
+    it('clears a stale "unavailable" fallback when Turnstile becomes disabled', async () => {
+      mockTurnstileEnabled.value = true
+      const { user } = renderComponent()
+      await fillValidSignup(user)
+
+      emitTurnstileUnavailable!(true)
+      await nextTick()
+      expect(
+        screen.getByRole('button', { name: signUpButton })
+      ).not.toBeDisabled()
+
+      mockTurnstileEnabled.value = false
+      await nextTick()
+
+      // re-enable: the stale fallback must have been cleared so submit is
+      // blocked again until the fresh widget instance proves itself
+      mockTurnstileEnabled.value = true
+      await nextTick()
+
+      expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
+    })
   })
 
+  // Regression coverage for the BE-1345 shadow-mode race: previously submit was
+  // only gated in 'enforce' mode, so most real signups in 'shadow' mode raced
+  // ahead of the async Cloudflare challenge and reached the backend with an
+  // empty token. Gating now depends only on whether the widget is enabled
+  // (shadow or enforce both render it), so both modes behave identically here.
   describe('Turnstile submit gating', () => {
-    it('disables the submit button in enforce mode until a token is present', async () => {
+    it('disables the submit button until a token is present', async () => {
       mockTurnstileEnabled.value = true
-      mockTurnstileEnforced.value = true
       renderComponent()
       await nextTick()
 
       expect(screen.getByRole('button', { name: signUpButton })).toBeDisabled()
     })
 
-    it('does not emit submit in enforce mode while the token is empty', async () => {
+    it('does not emit submit while the token is empty', async () => {
       mockTurnstileEnabled.value = true
-      mockTurnstileEnforced.value = true
       const onSubmit = vi.fn()
       const { user } = renderComponent({ onSubmit })
       await fillValidSignup(user)
@@ -257,9 +282,8 @@ describe('SignUpForm', () => {
       expect(onSubmit).not.toHaveBeenCalled()
     })
 
-    it('emits submit with the token in enforce mode once the challenge is solved', async () => {
+    it('emits submit with the token once the challenge is solved', async () => {
       mockTurnstileEnabled.value = true
-      mockTurnstileEnforced.value = true
       const onSubmit = vi.fn()
       const { user } = renderComponent({ onSubmit })
       await fillValidSignup(user)
@@ -271,13 +295,14 @@ describe('SignUpForm', () => {
       expect(onSubmit).toHaveBeenCalledWith(expectedValues, 'token-xyz')
     })
 
-    it('emits submit without a token in shadow mode (never blocks)', async () => {
+    it('emits submit without a token once the widget reports itself unavailable (broken/slow load fallback)', async () => {
       mockTurnstileEnabled.value = true
-      mockTurnstileEnforced.value = false
       const onSubmit = vi.fn()
       const { user } = renderComponent({ onSubmit })
       await fillValidSignup(user)
 
+      emitTurnstileUnavailable!(true)
+      await nextTick()
       await user.click(screen.getByRole('button', { name: signUpButton }))
 
       expect(onSubmit).toHaveBeenCalledWith(expectedValues, undefined)

--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -37,7 +37,7 @@
     />
 
     <small
-      v-show="submitBlockedByTurnstile"
+      v-show="waitingForTurnstile"
       id="comfy-org-sign-up-turnstile-hint"
       role="status"
       aria-live="polite"
@@ -52,11 +52,9 @@
       v-else
       type="submit"
       class="mt-4 h-10 font-medium"
-      :disabled="!$form.valid || submitBlockedByTurnstile"
+      :disabled="!$form.valid || waitingForTurnstile"
       :aria-describedby="
-        submitBlockedByTurnstile
-          ? 'comfy-org-sign-up-turnstile-hint'
-          : undefined
+        waitingForTurnstile ? 'comfy-org-sign-up-turnstile-hint' : undefined
       "
     >
       {{ t('auth.signup.signUpButton') }}
@@ -71,11 +69,11 @@ import { zodResolver } from '@primevue/forms/resolvers/zod'
 import { useThrottleFn } from '@vueuse/core'
 import InputText from 'primevue/inputtext'
 import ProgressSpinner from 'primevue/progressspinner'
-import { computed, ref, useTemplateRef, watch } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Button from '@/components/ui/button/Button.vue'
-import { useTurnstile } from '@/composables/auth/useTurnstile'
+import { useTurnstile, useTurnstileGate } from '@/composables/auth/useTurnstile'
 import { signUpSchema } from '@/schemas/signInSchema'
 import type { SignUpData } from '@/schemas/signInSchema'
 import { useAuthStore } from '@/stores/authStore'
@@ -88,38 +86,20 @@ const authStore = useAuthStore()
 const loading = computed(() => authStore.loading)
 
 const { enabled: turnstileEnabled } = useTurnstile()
-const turnstileToken = ref('')
-// Set by the widget when it cannot be relied on to ever produce a token (the
-// Cloudflare script failed to load, the challenge errored out, or it just
-// hasn't resolved in time). Submission falls back to proceeding without a
-// token rather than blocking a legitimate signup forever.
-const turnstileUnavailable = ref(false)
+const {
+  token: turnstileToken,
+  unavailable: turnstileUnavailable,
+  waiting: waitingForTurnstile
+} = useTurnstileGate(turnstileEnabled)
 const turnstileWidget =
   useTemplateRef<InstanceType<typeof TurnstileWidget>>('turnstileWidget')
-// Gate submit on the widget being enabled (rendering — shadow or enforce),
-// not on it being enforced: shadow mode still needs a real token most of the
-// time to actually measure the false-positive rate, so it can't let users
-// through before the widget has had a chance to resolve.
-const submitBlockedByTurnstile = computed(
-  () =>
-    turnstileEnabled.value &&
-    !turnstileToken.value &&
-    !turnstileUnavailable.value
-)
-
-watch(turnstileEnabled, (on) => {
-  if (!on) {
-    turnstileToken.value = ''
-    turnstileUnavailable.value = false
-  }
-})
 
 const emit = defineEmits<{
   submit: [values: SignUpData, turnstileToken?: string]
 }>()
 
 const onSubmit = useThrottleFn((event: FormSubmitEvent) => {
-  if (event.valid && !submitBlockedByTurnstile.value) {
+  if (event.valid && !waitingForTurnstile.value) {
     emit(
       'submit',
       event.values as SignUpData,

--- a/src/components/dialog/content/signin/SignUpForm.vue
+++ b/src/components/dialog/content/signin/SignUpForm.vue
@@ -33,6 +33,7 @@
       v-if="turnstileEnabled"
       ref="turnstileWidget"
       v-model:token="turnstileToken"
+      v-model:unavailable="turnstileUnavailable"
     />
 
     <small
@@ -86,17 +87,31 @@ const { t } = useI18n()
 const authStore = useAuthStore()
 const loading = computed(() => authStore.loading)
 
-const { enabled: turnstileEnabled, enforced: turnstileEnforced } =
-  useTurnstile()
+const { enabled: turnstileEnabled } = useTurnstile()
 const turnstileToken = ref('')
+// Set by the widget when it cannot be relied on to ever produce a token (the
+// Cloudflare script failed to load, the challenge errored out, or it just
+// hasn't resolved in time). Submission falls back to proceeding without a
+// token rather than blocking a legitimate signup forever.
+const turnstileUnavailable = ref(false)
 const turnstileWidget =
   useTemplateRef<InstanceType<typeof TurnstileWidget>>('turnstileWidget')
+// Gate submit on the widget being enabled (rendering — shadow or enforce),
+// not on it being enforced: shadow mode still needs a real token most of the
+// time to actually measure the false-positive rate, so it can't let users
+// through before the widget has had a chance to resolve.
 const submitBlockedByTurnstile = computed(
-  () => turnstileEnforced.value && !turnstileToken.value
+  () =>
+    turnstileEnabled.value &&
+    !turnstileToken.value &&
+    !turnstileUnavailable.value
 )
 
 watch(turnstileEnabled, (on) => {
-  if (!on) turnstileToken.value = ''
+  if (!on) {
+    turnstileToken.value = ''
+    turnstileUnavailable.value = false
+  }
 })
 
 const emit = defineEmits<{

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -261,4 +261,88 @@ describe('TurnstileWidget', () => {
 
     expect(api.remove).toHaveBeenCalledWith('widget-id')
   })
+
+  // Regression coverage for BE-1345: a widget that never resolves (broken
+  // script, ad-blocker, CDN outage, or a hung challenge) must eventually tell
+  // the parent it cannot be relied on, so submission can fall back instead of
+  // blocking a legitimate signup forever.
+  describe('unavailable fallback', () => {
+    it('reports unavailable when the Turnstile script fails to load', async () => {
+      mockLoadTurnstile.mockRejectedValue(new Error('script failed'))
+
+      const { emitted } = renderWidget()
+      await flush()
+
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
+    })
+
+    it('reports unavailable on a challenge error', async () => {
+      const { api, options } = fakeTurnstile()
+      mockLoadTurnstile.mockResolvedValue(api)
+
+      const { emitted } = renderWidget()
+      await flush()
+
+      options()!['error-callback']!()
+      await flush()
+
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
+    })
+
+    it('clears the unavailable fallback once a token is solved', async () => {
+      const { api, options } = fakeTurnstile()
+      mockLoadTurnstile.mockResolvedValue(api)
+
+      const { emitted } = renderWidget()
+      await flush()
+
+      options()!['error-callback']!()
+      await flush()
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
+
+      options()!.callback!('token-abc')
+      await flush()
+
+      expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
+    })
+
+    it('falls back once the widget fails to resolve within the load timeout', async () => {
+      vi.useFakeTimers()
+      try {
+        const { api, options } = fakeTurnstile()
+        mockLoadTurnstile.mockResolvedValue(api)
+
+        const { emitted } = renderWidget()
+        // Let the onMounted hook's `await loadTurnstile()` microtask settle
+        // and render() run, without yet advancing to the timeout itself.
+        await vi.advanceTimersByTimeAsync(0)
+        expect(options()).toBeDefined()
+        expect(emitted()['update:unavailable']).toBeUndefined()
+
+        await vi.advanceTimersByTimeAsync(9_000)
+
+        expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not fall back once a token arrives before the load timeout', async () => {
+      vi.useFakeTimers()
+      try {
+        const { api, options } = fakeTurnstile()
+        mockLoadTurnstile.mockResolvedValue(api)
+
+        const { emitted } = renderWidget()
+        await vi.advanceTimersByTimeAsync(0)
+
+        options()!.callback!('token-abc')
+        await vi.advanceTimersByTimeAsync(9_000)
+
+        expect(emitted()['update:unavailable']).toBeUndefined()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
 })

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -262,10 +262,10 @@ describe('TurnstileWidget', () => {
     expect(api.remove).toHaveBeenCalledWith('widget-id')
   })
 
-  // Regression coverage for BE-1345: a widget that never resolves (broken
-  // script, ad-blocker, CDN outage, or a hung challenge) must eventually tell
-  // the parent it cannot be relied on, so submission can fall back instead of
-  // blocking a legitimate signup forever.
+  // A widget that never resolves (broken script, ad-blocker, CDN outage, or a
+  // hung challenge) must eventually tell the parent it cannot be relied on,
+  // so submission can fall back instead of blocking a legitimate signup
+  // forever.
   describe('unavailable fallback', () => {
     it('reports unavailable when the Turnstile script fails to load', async () => {
       mockLoadTurnstile.mockRejectedValue(new Error('script failed'))

--- a/src/components/dialog/content/signin/TurnstileWidget.test.ts
+++ b/src/components/dialog/content/signin/TurnstileWidget.test.ts
@@ -344,5 +344,55 @@ describe('TurnstileWidget', () => {
         vi.useRealTimers()
       }
     })
+
+    it('resets the widget to fetch a fresh challenge on token expiry', async () => {
+      const { api, options } = fakeTurnstile()
+      mockLoadTurnstile.mockResolvedValue(api)
+      window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+
+      renderWidget()
+      await flush()
+
+      options()!.callback!('token-abc')
+      options()!['expired-callback']!()
+      await flush()
+
+      expect(api.reset).toHaveBeenCalledWith('widget-id')
+    })
+
+    it('falls back if a post-solve expiry is not followed by a fresh token within the load timeout', async () => {
+      vi.useFakeTimers()
+      try {
+        const { api, options } = fakeTurnstile()
+        mockLoadTurnstile.mockResolvedValue(api)
+        window.turnstile = api as unknown as NonNullable<Window['turnstile']>
+
+        const { emitted } = renderWidget()
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Establish a solved, available widget: an initial error marks it
+        // unavailable, then solving a challenge clears that (the same
+        // transition the existing "clears the unavailable fallback" test
+        // verifies), so the expiry below is the only thing driving fallback.
+        options()!['error-callback']!()
+        options()!.callback!('token-abc')
+        expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
+
+        // The token later expires (e.g. tab backgrounded past its ~300s
+        // lifetime) without the widget itself erroring.
+        options()!['expired-callback']!()
+        await vi.advanceTimersByTimeAsync(0)
+
+        // A fresh challenge was requested, but nothing solves it before the
+        // re-armed load timeout elapses, so submission must eventually be
+        // unblocked rather than staying stuck forever.
+        expect(emitted()['update:unavailable']?.at(-1)).toEqual([false])
+        await vi.advanceTimersByTimeAsync(9_000)
+
+        expect(emitted()['update:unavailable']?.at(-1)).toEqual([true])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 })

--- a/src/components/dialog/content/signin/TurnstileWidget.vue
+++ b/src/components/dialog/content/signin/TurnstileWidget.vue
@@ -12,6 +12,7 @@
 </template>
 
 <script setup lang="ts">
+import { useTimeoutFn } from '@vueuse/core'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -38,14 +39,13 @@ let widgetId: string | undefined
 
 /** How long to wait for the widget to resolve before falling back. */
 const TURNSTILE_LOAD_TIMEOUT_MS = 9_000
-let timeoutId: ReturnType<typeof setTimeout> | undefined
-
-const armTimeout = () => {
-  clearTimeout(timeoutId)
-  timeoutId = setTimeout(() => {
+const { start: armTimeout, stop: clearLoadTimeout } = useTimeoutFn(
+  () => {
     unavailable.value = true
-  }, TURNSTILE_LOAD_TIMEOUT_MS)
-}
+  },
+  TURNSTILE_LOAD_TIMEOUT_MS,
+  { immediate: false }
+)
 
 const clearToken = () => {
   token.value = ''
@@ -89,7 +89,7 @@ onMounted(async () => {
       sitekey: getTurnstileSiteKey(),
       theme,
       callback: (newToken: string) => {
-        clearTimeout(timeoutId)
+        clearLoadTimeout()
         errorMessage.value = ''
         unavailable.value = false
         token.value = newToken
@@ -108,7 +108,7 @@ onMounted(async () => {
       },
       'error-callback': () => {
         clearToken()
-        clearTimeout(timeoutId)
+        clearLoadTimeout()
         console.warn('Turnstile challenge failed')
         errorMessage.value = t('auth.turnstile.failed')
         unavailable.value = true
@@ -116,7 +116,7 @@ onMounted(async () => {
       }
     })
   } catch (error) {
-    clearTimeout(timeoutId)
+    clearLoadTimeout()
     console.warn('Turnstile failed to load', error)
     errorMessage.value = t('auth.turnstile.failed')
     unavailable.value = true
@@ -124,7 +124,6 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
-  clearTimeout(timeoutId)
   if (widgetId && window.turnstile) {
     window.turnstile.remove(widgetId)
   }

--- a/src/components/dialog/content/signin/TurnstileWidget.vue
+++ b/src/components/dialog/content/signin/TurnstileWidget.vue
@@ -97,6 +97,14 @@ onMounted(async () => {
       'expired-callback': () => {
         clearToken()
         errorMessage.value = t('auth.turnstile.expired')
+        if (widgetId && window.turnstile) {
+          window.turnstile.reset(widgetId)
+          // A solved token can expire on its own (e.g. the tab was
+          // backgrounded past the token's ~300s lifetime) without the widget
+          // ever erroring, so proactively request a fresh challenge and
+          // re-arm the load timeout in case it doesn't resolve in time.
+          armTimeout()
+        }
       },
       'error-callback': () => {
         clearToken()

--- a/src/components/dialog/content/signin/TurnstileWidget.vue
+++ b/src/components/dialog/content/signin/TurnstileWidget.vue
@@ -20,6 +20,14 @@ import { getTurnstileSiteKey } from '@/config/turnstile'
 import { useColorPaletteStore } from '@/stores/workspace/colorPaletteStore'
 
 const token = defineModel<string>('token', { default: '' })
+/**
+ * Set true whenever the widget cannot be relied on to ever produce a token:
+ * the Cloudflare script failed to load, the rendered challenge errored out,
+ * or it simply hasn't resolved within `TURNSTILE_LOAD_TIMEOUT_MS`. The parent
+ * uses this to stop waiting on a token so a broken/slow widget (network
+ * issue, ad-blocker, CDN outage) can never permanently block signup.
+ */
+const unavailable = defineModel<boolean>('unavailable', { default: false })
 
 const { t } = useI18n()
 const colorPaletteStore = useColorPaletteStore()
@@ -27,6 +35,17 @@ const colorPaletteStore = useColorPaletteStore()
 const containerRef = ref<HTMLDivElement>()
 const errorMessage = ref('')
 let widgetId: string | undefined
+
+/** How long to wait for the widget to resolve before falling back. */
+const TURNSTILE_LOAD_TIMEOUT_MS = 9_000
+let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+const armTimeout = () => {
+  clearTimeout(timeoutId)
+  timeoutId = setTimeout(() => {
+    unavailable.value = true
+  }, TURNSTILE_LOAD_TIMEOUT_MS)
+}
 
 const clearToken = () => {
   token.value = ''
@@ -46,12 +65,18 @@ const reset = () => {
   errorMessage.value = ''
   if (widgetId && window.turnstile) {
     window.turnstile.reset(widgetId)
+    // A widget that renders can request a fresh challenge, so give it
+    // another chance before falling back again.
+    unavailable.value = false
+    armTimeout()
   }
 }
 
 defineExpose({ reset })
 
 onMounted(async () => {
+  armTimeout()
+
   try {
     const turnstile = await loadTurnstile()
     if (!containerRef.value) return
@@ -64,7 +89,9 @@ onMounted(async () => {
       sitekey: getTurnstileSiteKey(),
       theme,
       callback: (newToken: string) => {
+        clearTimeout(timeoutId)
         errorMessage.value = ''
+        unavailable.value = false
         token.value = newToken
       },
       'expired-callback': () => {
@@ -73,18 +100,23 @@ onMounted(async () => {
       },
       'error-callback': () => {
         clearToken()
+        clearTimeout(timeoutId)
         console.warn('Turnstile challenge failed')
         errorMessage.value = t('auth.turnstile.failed')
+        unavailable.value = true
         if (widgetId && window.turnstile) window.turnstile.reset(widgetId)
       }
     })
   } catch (error) {
+    clearTimeout(timeoutId)
     console.warn('Turnstile failed to load', error)
     errorMessage.value = t('auth.turnstile.failed')
+    unavailable.value = true
   }
 })
 
 onBeforeUnmount(() => {
+  clearTimeout(timeoutId)
   if (widgetId && window.turnstile) {
     window.turnstile.remove(widgetId)
   }

--- a/src/composables/auth/useTurnstile.test.ts
+++ b/src/composables/auth/useTurnstile.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 
 import {
   isTurnstileEnabled,
   normalizeTurnstileMode,
-  useTurnstile
+  useTurnstile,
+  useTurnstileGate
 } from '@/composables/auth/useTurnstile'
 import { getTurnstileSiteKey } from '@/config/turnstile'
 import { remoteConfig } from '@/platform/remoteConfig/remoteConfig'
@@ -135,5 +137,65 @@ describe('useTurnstile', () => {
       expect(enabled.value).toBe(false)
       expect(enforced.value).toBe(false)
     })
+  })
+})
+
+describe('useTurnstileGate', () => {
+  it('waits while enabled with no token yet', () => {
+    const { waiting } = useTurnstileGate(ref(true))
+    expect(waiting.value).toBe(true)
+  })
+
+  it('never waits while disabled', () => {
+    const { waiting } = useTurnstileGate(ref(false))
+    expect(waiting.value).toBe(false)
+  })
+
+  it('stops waiting once a token arrives', () => {
+    const { token, waiting } = useTurnstileGate(ref(true))
+
+    token.value = 'token-abc'
+
+    expect(waiting.value).toBe(false)
+  })
+
+  it('stops waiting once the widget reports itself unavailable', () => {
+    const { unavailable, waiting } = useTurnstileGate(ref(true))
+
+    unavailable.value = true
+
+    expect(waiting.value).toBe(false)
+  })
+
+  it('clears stale token/unavailable state when enabled turns off', async () => {
+    const enabled = ref(true)
+    const { token, unavailable } = useTurnstileGate(enabled)
+    token.value = 'stale-token'
+    unavailable.value = true
+
+    enabled.value = false
+    await nextTick()
+
+    expect(token.value).toBe('')
+    expect(unavailable.value).toBe(false)
+  })
+
+  // Regression coverage: the reset used to only run on the enabled->disabled
+  // transition, so state written while the widget was briefly disabled could
+  // survive into the next enabled widget instance.
+  it('clears stale token/unavailable state when enabled turns back on', async () => {
+    const enabled = ref(true)
+    const { token, unavailable } = useTurnstileGate(enabled)
+
+    enabled.value = false
+    await nextTick()
+    token.value = 'stale-token'
+    unavailable.value = true
+
+    enabled.value = true
+    await nextTick()
+
+    expect(token.value).toBe('')
+    expect(unavailable.value).toBe(false)
   })
 })

--- a/src/composables/auth/useTurnstile.ts
+++ b/src/composables/auth/useTurnstile.ts
@@ -1,4 +1,5 @@
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import type { Ref } from 'vue'
 
 import { getTurnstileSiteKey } from '@/config/turnstile'
 import { useFeatureFlags } from '@/composables/useFeatureFlags'
@@ -41,4 +42,32 @@ export function useTurnstile() {
   const enforced = computed(() => enabled.value && mode.value === 'enforce')
 
   return { mode, siteKey, enabled, enforced }
+}
+
+/**
+ * Submit-gating state for the signup form's Turnstile widget: a token/
+ * unavailable pair, plus `waiting`, which is true while a real token is still
+ * needed. Waits in both shadow and enforce mode (`enabled`), not just
+ * `enforced`, so shadow mode's token can't race the async Cloudflare
+ * challenge; falls back open once the widget reports `unavailable` so a
+ * broken/slow load can never permanently block signup.
+ *
+ * `token`/`unavailable` reset on every `enabled` transition, in either
+ * direction, so state from a previous widget instance can never leak into a
+ * freshly (re-)rendered one.
+ */
+export function useTurnstileGate(enabled: Ref<boolean>) {
+  const token = ref('')
+  const unavailable = ref(false)
+
+  const waiting = computed(
+    () => enabled.value && !token.value && !unavailable.value
+  )
+
+  watch(enabled, () => {
+    token.value = ''
+    unavailable.value = false
+  })
+
+  return { token, unavailable, waiting }
 }


### PR DESCRIPTION
## Summary
- Shadow-mode Turnstile never blocked the signup Submit button on the async Cloudflare challenge resolving, so most real submits raced ahead of the widget and reached the backend with an empty token. This defeated the point of shadow mode, which needs real tokens to measure the false-positive rate before flipping to enforce.
- Submit is now blocked while the widget is enabled (shadow or enforce) and has no token yet, in both modes.
- To keep a broken or slow Cloudflare load (network issue, ad-blocker, CDN outage) from permanently blocking a legitimate signup, `TurnstileWidget` now reports itself "unavailable" on a script-load failure, a challenge error, or a 9s load timeout, and the form treats that the same as shadow previously did: proceed without a token.

## Test plan
- [x] `vitest run` on `TurnstileWidget.test.ts` + `SignUpForm.test.ts` (unit tests updated/added, all passing)
- [x] `pnpm typecheck` / eslint / oxlint / stylelint / oxfmt via pre-commit hooks
- [ ] Manual click-through on staging to confirm no perceptible UX regression during normal-latency challenge solves
- [ ] Confirm the 9s fallback timeout against real p95 Turnstile challenge-solve latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)