### PR TITLE
feat(navigation): add opt-in strip-on-capture to preserved-query tracker

### DIFF
--- a/src/platform/navigation/preservedQueryManager.test.ts
+++ b/src/platform/navigation/preservedQueryManager.test.ts
@@ -30,6 +30,27 @@ describe('preservedQueryManager', () => {
     expect(sessionStorage.getItem('Comfy.PreservedQuery.template')).toBeTruthy()
   })
 
+  it('captures the first non-empty string element of an array-valued param', () => {
+    capturePreservedQuery(NAMESPACE, { template: ['', 'flux', 'sdxl'] }, [
+      'template'
+    ])
+
+    expect(getPreservedQueryParam(NAMESPACE, 'template')).toBe('flux')
+  })
+
+  it('does not stash empty, null, or all-junk array values', () => {
+    capturePreservedQuery(
+      NAMESPACE,
+      { template: '', source: null, mode: ['', null] },
+      ['template', 'source', 'mode']
+    )
+
+    expect(getPreservedQueryParam(NAMESPACE, 'template')).toBeUndefined()
+    expect(getPreservedQueryParam(NAMESPACE, 'source')).toBeUndefined()
+    expect(getPreservedQueryParam(NAMESPACE, 'mode')).toBeUndefined()
+    expect(mergePreservedQueryIntoQuery(NAMESPACE)).toBeUndefined()
+  })
+
   it('reads a preserved query param by key', () => {
     capturePreservedQuery(NAMESPACE, { template: 'flux' }, ['template'])
 
@@ -76,6 +97,16 @@ describe('preservedQueryManager', () => {
     })
 
     expect(merged).toBeUndefined()
+  })
+
+  it('overwrites an array-valued live query key with the stashed string', () => {
+    capturePreservedQuery(NAMESPACE, { template: 'flux' }, ['template'])
+
+    const merged = mergePreservedQueryIntoQuery(NAMESPACE, {
+      template: ['existing', 'other']
+    })
+
+    expect(merged).toEqual({ template: 'flux' })
   })
 
   it('clears cached payload', () => {

--- a/src/platform/navigation/preservedQueryManager.test.ts
+++ b/src/platform/navigation/preservedQueryManager.test.ts
@@ -30,21 +30,49 @@ describe('preservedQueryManager', () => {
     expect(sessionStorage.getItem('Comfy.PreservedQuery.template')).toBeTruthy()
   })
 
-  it('merges newly captured keys into the preserved namespace payload', () => {
-    capturePreservedQuery(NAMESPACE, { template: 'flux' }, [
-      'template',
-      'source',
-      'mode'
-    ])
+  it('merges newly captured keys into the payload when merge is set', () => {
+    capturePreservedQuery(
+      NAMESPACE,
+      { template: 'flux' },
+      ['template', 'source', 'mode'],
+      { merge: true }
+    )
 
-    capturePreservedQuery(NAMESPACE, { source: 'custom' }, [
-      'template',
-      'source',
-      'mode'
-    ])
+    capturePreservedQuery(
+      NAMESPACE,
+      { source: 'custom' },
+      ['template', 'source', 'mode'],
+      { merge: true }
+    )
 
     const merged = mergePreservedQueryIntoQuery(NAMESPACE)
     expect(merged).toEqual({ template: 'flux', source: 'custom' })
+  })
+
+  it('replaces the whole payload on capture by default', () => {
+    capturePreservedQuery(NAMESPACE, { template: 'flux', source: 'custom' }, [
+      'template',
+      'source',
+      'mode'
+    ])
+
+    capturePreservedQuery(NAMESPACE, { template: 'sdxl' }, [
+      'template',
+      'source',
+      'mode'
+    ])
+
+    expect(mergePreservedQueryIntoQuery(NAMESPACE)).toEqual({
+      template: 'sdxl'
+    })
+  })
+
+  it('leaves the payload untouched when a default capture has no valid values', () => {
+    capturePreservedQuery(NAMESPACE, { template: 'flux' }, ['template'])
+
+    capturePreservedQuery(NAMESPACE, { template: '' }, ['template'])
+
+    expect(getPreservedQueryParam(NAMESPACE, 'template')).toBe('flux')
   })
 
   it('captures the first non-empty string element of an array-valued param', () => {
@@ -68,13 +96,17 @@ describe('preservedQueryManager', () => {
     expect(mergePreservedQueryIntoQuery(NAMESPACE)).toBeUndefined()
   })
 
-  it('removes a preserved key when the route supplies an empty value', () => {
-    capturePreservedQuery(NAMESPACE, { template: 'flux', source: 'custom' }, [
-      'template',
-      'source'
-    ])
+  it('removes a preserved key on empty value when merge is set', () => {
+    capturePreservedQuery(
+      NAMESPACE,
+      { template: 'flux', source: 'custom' },
+      ['template', 'source'],
+      { merge: true }
+    )
 
-    capturePreservedQuery(NAMESPACE, { template: '' }, ['template', 'source'])
+    capturePreservedQuery(NAMESPACE, { template: '' }, ['template', 'source'], {
+      merge: true
+    })
 
     expect(getPreservedQueryParam(NAMESPACE, 'template')).toBeUndefined()
     expect(mergePreservedQueryIntoQuery(NAMESPACE)).toEqual({

--- a/src/platform/navigation/preservedQueryManager.test.ts
+++ b/src/platform/navigation/preservedQueryManager.test.ts
@@ -30,6 +30,23 @@ describe('preservedQueryManager', () => {
     expect(sessionStorage.getItem('Comfy.PreservedQuery.template')).toBeTruthy()
   })
 
+  it('merges newly captured keys into the preserved namespace payload', () => {
+    capturePreservedQuery(NAMESPACE, { template: 'flux' }, [
+      'template',
+      'source',
+      'mode'
+    ])
+
+    capturePreservedQuery(NAMESPACE, { source: 'custom' }, [
+      'template',
+      'source',
+      'mode'
+    ])
+
+    const merged = mergePreservedQueryIntoQuery(NAMESPACE)
+    expect(merged).toEqual({ template: 'flux', source: 'custom' })
+  })
+
   it('captures the first non-empty string element of an array-valued param', () => {
     capturePreservedQuery(NAMESPACE, { template: ['', 'flux', 'sdxl'] }, [
       'template'
@@ -49,6 +66,20 @@ describe('preservedQueryManager', () => {
     expect(getPreservedQueryParam(NAMESPACE, 'source')).toBeUndefined()
     expect(getPreservedQueryParam(NAMESPACE, 'mode')).toBeUndefined()
     expect(mergePreservedQueryIntoQuery(NAMESPACE)).toBeUndefined()
+  })
+
+  it('removes a preserved key when the route supplies an empty value', () => {
+    capturePreservedQuery(NAMESPACE, { template: 'flux', source: 'custom' }, [
+      'template',
+      'source'
+    ])
+
+    capturePreservedQuery(NAMESPACE, { template: '' }, ['template', 'source'])
+
+    expect(getPreservedQueryParam(NAMESPACE, 'template')).toBeUndefined()
+    expect(mergePreservedQueryIntoQuery(NAMESPACE)).toEqual({
+      source: 'custom'
+    })
   })
 
   it('reads a preserved query param by key', () => {

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -12,9 +12,6 @@ const readQueryParam = (value: unknown): string | undefined => {
   )
 }
 
-const hasQueryKey = (query: LocationQuery, key: string) =>
-  Object.hasOwn(query, key)
-
 const getStorageKey = (namespace: string) => `${STORAGE_PREFIX}${namespace}`
 
 const isValidQueryRecord = (
@@ -73,11 +70,34 @@ export const hydratePreservedQuery = (namespace: string) => {
   }
 }
 
+/**
+ * By default each capture replaces the namespace stash with the values present
+ * in the given query. With `merge`, values are merged into the existing stash
+ * and a key supplied with an empty value clears its stashed entry — for
+ * namespaces where the stash, not the URL, is the surviving carrier.
+ */
 export const capturePreservedQuery = (
   namespace: string,
   query: LocationQuery,
-  keys: string[]
+  keys: string[],
+  { merge = false }: { merge?: boolean } = {}
 ) => {
+  if (!merge) {
+    const payload: Record<string, string> = {}
+    keys.forEach((key) => {
+      const value = readQueryParam(query[key])
+      if (value) {
+        payload[key] = value
+      }
+    })
+    if (Object.keys(payload).length === 0) {
+      return
+    }
+    preservedQueries.set(namespace, payload)
+    writeToStorage(namespace, payload)
+    return
+  }
+
   hydratePreservedQuery(namespace)
   const payload: Record<string, string> = {
     ...(preservedQueries.get(namespace) ?? {})
@@ -85,7 +105,7 @@ export const capturePreservedQuery = (
   let changed = false
 
   keys.forEach((key) => {
-    if (!hasQueryKey(query, key)) return
+    if (!Object.hasOwn(query, key)) return
 
     const value = readQueryParam(query[key])
     if (value) {

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -4,7 +4,12 @@ const STORAGE_PREFIX = 'Comfy.PreservedQuery.'
 const preservedQueries = new Map<string, Record<string, string>>()
 
 const readQueryParam = (value: unknown): string | undefined => {
-  return typeof value === 'string' ? value : undefined
+  if (typeof value === 'string') return value
+  if (!Array.isArray(value)) return undefined
+  return value.find(
+    (entry: unknown): entry is string =>
+      typeof entry === 'string' && entry !== ''
+  )
 }
 
 const getStorageKey = (namespace: string) => `${STORAGE_PREFIX}${namespace}`

--- a/src/platform/navigation/preservedQueryManager.ts
+++ b/src/platform/navigation/preservedQueryManager.ts
@@ -12,6 +12,9 @@ const readQueryParam = (value: unknown): string | undefined => {
   )
 }
 
+const hasQueryKey = (query: LocationQuery, key: string) =>
+  Object.hasOwn(query, key)
+
 const getStorageKey = (namespace: string) => `${STORAGE_PREFIX}${namespace}`
 
 const isValidQueryRecord = (
@@ -75,20 +78,37 @@ export const capturePreservedQuery = (
   query: LocationQuery,
   keys: string[]
 ) => {
-  const payload: Record<string, string> = {}
+  hydratePreservedQuery(namespace)
+  const payload: Record<string, string> = {
+    ...(preservedQueries.get(namespace) ?? {})
+  }
+  let changed = false
 
   keys.forEach((key) => {
+    if (!hasQueryKey(query, key)) return
+
     const value = readQueryParam(query[key])
     if (value) {
       payload[key] = value
+      changed = true
+      return
+    }
+
+    if (key in payload) {
+      delete payload[key]
+      changed = true
     }
   })
 
-  if (Object.keys(payload).length === 0) {
+  if (!changed) {
     return
   }
 
-  preservedQueries.set(namespace, payload)
+  if (Object.keys(payload).length === 0) {
+    preservedQueries.delete(namespace)
+  } else {
+    preservedQueries.set(namespace, payload)
+  }
   writeToStorage(namespace, payload)
 }
 

--- a/src/platform/navigation/preservedQueryTracker.test.ts
+++ b/src/platform/navigation/preservedQueryTracker.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Router } from 'vue-router'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+import {
+  clearPreservedQuery,
+  getPreservedQueryParam
+} from '@/platform/navigation/preservedQueryManager'
+import { installPreservedQueryTracker } from '@/platform/navigation/preservedQueryTracker'
+
+const STRIPPED_NAMESPACE = 'test_strip'
+const SECOND_STRIPPED_NAMESPACE = 'test_strip_b'
+const PLAIN_NAMESPACE = 'test_plain'
+
+const strippedDefinition = {
+  namespace: STRIPPED_NAMESPACE,
+  keys: ['one_time_code'],
+  stripAfterCapture: true
+}
+
+const plainDefinition = {
+  namespace: PLAIN_NAMESPACE,
+  keys: ['plain_code', 'plain_source']
+}
+
+function createTestRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }]
+  })
+}
+
+describe('installPreservedQueryTracker', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    clearPreservedQuery(STRIPPED_NAMESPACE)
+    clearPreservedQuery(SECOND_STRIPPED_NAMESPACE)
+    clearPreservedQuery(PLAIN_NAMESPACE)
+  })
+
+  it('strips marked keys from the URL while preserving other query and hash', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [strippedDefinition])
+
+    await router.push('/?one_time_code=otc_abc123&keep=a+b#frag')
+
+    expect(router.currentRoute.value.fullPath).toBe('/?keep=a+b#frag')
+    expect(getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')).toBe(
+      'otc_abc123'
+    )
+  })
+
+  it('keeps params of non-strip namespaces in the URL and still captures them', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [plainDefinition])
+
+    await router.push('/?plain_code=alpha&plain_source=beta')
+
+    expect(router.currentRoute.value.fullPath).toBe(
+      '/?plain_code=alpha&plain_source=beta'
+    )
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'plain_code')).toBe('alpha')
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'plain_source')).toBe('beta')
+  })
+
+  it('navigates exactly once when no strip-marked keys are present', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [strippedDefinition])
+    let completedNavigations = 0
+    router.afterEach(() => {
+      completedNavigations++
+    })
+
+    await router.push('/?keep=1')
+
+    expect(router.currentRoute.value.fullPath).toBe('/?keep=1')
+    expect(completedNavigations).toBe(1)
+  })
+
+  it('scrubs empty and null values from the URL without stashing them', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [strippedDefinition])
+
+    await router.push('/?one_time_code=')
+    expect(router.currentRoute.value.fullPath).toBe('/')
+    expect(
+      getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')
+    ).toBeUndefined()
+
+    await router.push('/?one_time_code')
+    expect(router.currentRoute.value.fullPath).toBe('/')
+    expect(
+      getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')
+    ).toBeUndefined()
+  })
+
+  it('stashes the first value of a repeated param and cleans the URL', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [strippedDefinition])
+
+    await router.push('/?one_time_code=otc_A&one_time_code=otc_B')
+
+    expect(router.currentRoute.value.fullPath).toBe('/')
+    expect(getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')).toBe(
+      'otc_A'
+    )
+  })
+
+  it('strips keys of multiple marked namespaces in a single redirect', async () => {
+    const router = createTestRouter()
+    let navigationAttempts = 0
+    router.beforeEach((_to, _from, next) => {
+      navigationAttempts++
+      next()
+    })
+    installPreservedQueryTracker(router, [
+      strippedDefinition,
+      {
+        namespace: SECOND_STRIPPED_NAMESPACE,
+        keys: ['second_code'],
+        stripAfterCapture: true
+      }
+    ])
+
+    await router.push('/?one_time_code=otc_x&second_code=sc_y&keep=1')
+
+    expect(router.currentRoute.value.fullPath).toBe('/?keep=1')
+    expect(navigationAttempts).toBe(2)
+    expect(getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')).toBe(
+      'otc_x'
+    )
+    expect(
+      getPreservedQueryParam(SECOND_STRIPPED_NAMESPACE, 'second_code')
+    ).toBe('sc_y')
+  })
+
+  it('keeps the prior history entry reachable after the strip redirect', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [strippedDefinition])
+
+    await router.push('/start')
+    await router.push('/?one_time_code=otc_abc123')
+    expect(router.currentRoute.value.fullPath).toBe('/')
+
+    router.go(-1)
+    await vi.waitFor(() =>
+      expect(router.currentRoute.value.fullPath).toBe('/start')
+    )
+  })
+})

--- a/src/platform/navigation/preservedQueryTracker.test.ts
+++ b/src/platform/navigation/preservedQueryTracker.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Router } from 'vue-router'
+import type { Router, RouterHistory } from 'vue-router'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 import {
@@ -23,9 +23,11 @@ const plainDefinition = {
   keys: ['plain_code', 'plain_source']
 }
 
-function createTestRouter(): Router {
+function createTestRouter(
+  history: RouterHistory = createMemoryHistory()
+): Router {
   return createRouter({
-    history: createMemoryHistory(),
+    history,
     routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }]
   })
 }
@@ -94,6 +96,23 @@ describe('installPreservedQueryTracker', () => {
     ).toBeUndefined()
   })
 
+  it('clears a stale stripped value when the URL supplies an empty value', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [strippedDefinition])
+
+    await router.push('/?one_time_code=otc_abc123')
+    expect(getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')).toBe(
+      'otc_abc123'
+    )
+
+    await router.push('/?one_time_code=')
+
+    expect(router.currentRoute.value.fullPath).toBe('/')
+    expect(
+      getPreservedQueryParam(STRIPPED_NAMESPACE, 'one_time_code')
+    ).toBeUndefined()
+  })
+
   it('stashes the first value of a repeated param and cleans the URL', async () => {
     const router = createTestRouter()
     installPreservedQueryTracker(router, [strippedDefinition])
@@ -146,5 +165,19 @@ describe('installPreservedQueryTracker', () => {
     await vi.waitFor(() =>
       expect(router.currentRoute.value.fullPath).toBe('/start')
     )
+  })
+
+  it('keeps replace navigation from adding a back target', async () => {
+    const history = createMemoryHistory()
+    const router = createTestRouter(history)
+    installPreservedQueryTracker(router, [strippedDefinition])
+
+    await router.push('/start')
+    await router.replace('/?one_time_code=otc_abc123')
+    expect(router.currentRoute.value.fullPath).toBe('/')
+
+    router.go(-1)
+
+    expect(history.location).toBe('/')
   })
 })

--- a/src/platform/navigation/preservedQueryTracker.test.ts
+++ b/src/platform/navigation/preservedQueryTracker.test.ts
@@ -65,6 +65,19 @@ describe('installPreservedQueryTracker', () => {
     expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'plain_source')).toBe('beta')
   })
 
+  it('replaces a non-strip namespace stash on later captures', async () => {
+    const router = createTestRouter()
+    installPreservedQueryTracker(router, [plainDefinition])
+
+    await router.push('/?plain_code=alpha&plain_source=beta')
+    await router.push('/?plain_code=gamma')
+
+    expect(getPreservedQueryParam(PLAIN_NAMESPACE, 'plain_code')).toBe('gamma')
+    expect(
+      getPreservedQueryParam(PLAIN_NAMESPACE, 'plain_source')
+    ).toBeUndefined()
+  })
+
   it('navigates exactly once when no strip-marked keys are present', async () => {
     const router = createTestRouter()
     installPreservedQueryTracker(router, [strippedDefinition])

--- a/src/platform/navigation/preservedQueryTracker.ts
+++ b/src/platform/navigation/preservedQueryTracker.ts
@@ -9,10 +9,10 @@ interface PreservedQueryDefinition {
   namespace: string
   keys: string[]
   /**
-   * When set, keys present in the query are removed from the URL before the
-   * navigation completes, so the preserved-query stash is the ONLY place the
-   * value exists afterwards. Later guards, afterEach hooks, and views must
-   * never read a strip-marked key from route.query or fullPath.
+   * When set, keys present in the query are removed from the client-side URL
+   * before navigation completes. Later guards, afterEach hooks, and views must
+   * read a strip-marked key from the preserved-query stash instead of
+   * route.query or fullPath.
    */
   stripAfterCapture?: boolean
 }

--- a/src/platform/navigation/preservedQueryTracker.ts
+++ b/src/platform/navigation/preservedQueryTracker.ts
@@ -5,25 +5,43 @@ import {
   hydratePreservedQuery
 } from '@/platform/navigation/preservedQueryManager'
 
+interface PreservedQueryDefinition {
+  namespace: string
+  keys: string[]
+  /**
+   * When set, keys present in the query are removed from the URL before the
+   * navigation completes, so the preserved-query stash is the ONLY place the
+   * value exists afterwards. Later guards, afterEach hooks, and views must
+   * never read a strip-marked key from route.query or fullPath.
+   */
+  stripAfterCapture?: boolean
+}
+
 export const installPreservedQueryTracker = (
   router: Router,
-  definitions: Array<{ namespace: string; keys: string[] }>
+  definitions: PreservedQueryDefinition[]
 ) => {
-  const trackedDefinitions = definitions.map((definition) => ({
-    ...definition
-  }))
-
   router.beforeEach((to, _from, next) => {
     const queryKeys = new Set(Object.keys(to.query))
+    const keysToStrip = new Set<string>()
 
-    trackedDefinitions.forEach(({ namespace, keys }) => {
+    definitions.forEach(({ namespace, keys, stripAfterCapture }) => {
       hydratePreservedQuery(namespace)
-      const shouldCapture = keys.some((key) => queryKeys.has(key))
-      if (shouldCapture) {
-        capturePreservedQuery(namespace, to.query, keys)
+      const presentKeys = keys.filter((key) => queryKeys.has(key))
+      if (presentKeys.length === 0) return
+      capturePreservedQuery(namespace, to.query, keys)
+      if (stripAfterCapture) {
+        presentKeys.forEach((key) => keysToStrip.add(key))
       }
     })
 
-    next()
+    if (keysToStrip.size === 0) {
+      next()
+      return
+    }
+
+    const cleanedQuery = { ...to.query }
+    keysToStrip.forEach((key) => delete cleanedQuery[key])
+    next({ path: to.path, query: cleanedQuery, hash: to.hash })
   })
 }

--- a/src/platform/navigation/preservedQueryTracker.ts
+++ b/src/platform/navigation/preservedQueryTracker.ts
@@ -12,7 +12,10 @@ interface PreservedQueryDefinition {
    * When set, keys present in the query are removed from the client-side URL
    * before navigation completes. Later guards, afterEach hooks, and views must
    * read a strip-marked key from the preserved-query stash instead of
-   * route.query or fullPath.
+   * route.query or fullPath. Because the stash is the only carrier after
+   * stripping, captures for the namespace merge into the existing stash and an
+   * explicitly empty value clears the stashed key; non-strip namespaces keep
+   * replace-on-capture semantics.
    */
   stripAfterCapture?: boolean
 }
@@ -29,7 +32,9 @@ export const installPreservedQueryTracker = (
       hydratePreservedQuery(namespace)
       const presentKeys = keys.filter((key) => queryKeys.has(key))
       if (presentKeys.length === 0) return
-      capturePreservedQuery(namespace, to.query, keys)
+      capturePreservedQuery(namespace, to.query, keys, {
+        merge: stripAfterCapture
+      })
       if (stripAfterCapture) {
         presentKeys.forEach((key) => keysToStrip.add(key))
       }


### PR DESCRIPTION
## What

- `installPreservedQueryTracker` definitions accept an opt-in `stripAfterCapture` flag: the marked keys are captured into the sessionStorage stash and removed from the URL before the navigation completes (single guard redirect at the decoded query-object level; push/replace semantics are inherited from the original navigation, and vue-router force-replaces the initial one).
- `preservedQueryManager` now captures the first non-empty string element of repeated (array-valued) params instead of silently dropping them.
- New real-router test suite for the tracker (createRouter + createMemoryHistory, no router mocks), including a history-depth test pinning the push/replace inheritance; manager tests extended for the array/junk-value cases.

## Why

One-time secrets in query params (first consumer: desktop login codes, GTM-93) must not linger in the visible URL, browser history, `previousFullPath` redirects, or telemetry. Stripping after navigation — what each loader does ad hoc today — leaves a window and forces per-feature URL scrubbing; #13418 originally needed a hand-rolled encoding-aware string parser in three places. Stripping at capture time, at the decoded query-object level, makes the stash the only carrier and lets vue-router round-trip the surviving params' encoding itself.

Capability only — no existing namespace opts in; behavior is unchanged for all current definitions. `stripAfterCapture`'s contract is documented on the option: strip-marked keys must never be read from `route.query` by later guards or views; the stash is the only post-capture source.

## Landing order

Independent of everything else; #13418 stacks on this branch.
