### PR TITLE
fix(dialog): queue global prompts so concurrent confirm/prompt promises always settle

### DIFF
--- a/src/services/dialogService.concurrency.test.ts
+++ b/src/services/dialogService.concurrency.test.ts
@@ -1,0 +1,141 @@
+/**
+ * prompt() and confirm() share the 'global-prompt' key while
+ * dialogStore.showDialog only raises an existing dialog with the same key, so
+ * concurrent calls are serialized FIFO to guarantee every returned promise
+ * settles. These tests use the real dialogStore because the bug lives in the
+ * service/store interaction.
+ *
+ * The FIFO tail lives at module level in dialogService, so each test resets
+ * the module registry and dynamically imports the modules it needs — a
+ * mid-test failure then cannot wedge the queue for later tests.
+ */
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('@/platform/telemetry', () => ({
+  useTelemetry: () => ({ trackEvent: vi.fn() })
+}))
+
+vi.mock('@/platform/distribution/types', () => ({
+  isCloud: false
+}))
+
+vi.mock('@/composables/billing/useBillingContext', () => ({
+  useBillingContext: () => ({
+    isActiveSubscription: { value: true },
+    isFreeTier: { value: false },
+    type: { value: 'legacy' }
+  })
+}))
+
+function flushQueue() {
+  return new Promise((resolve) => setTimeout(resolve))
+}
+
+async function importDialogModules() {
+  const [{ useDialogService }, { useDialogStore }] = await Promise.all([
+    import('@/services/dialogService'),
+    import('@/stores/dialogStore')
+  ])
+  return { service: useDialogService(), dialogStore: useDialogStore() }
+}
+
+describe('dialogService global prompt FIFO queue', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    setActivePinia(createPinia())
+  })
+
+  it('settles both promises when two confirm() calls race', async () => {
+    const { service, dialogStore } = await importDialogModules()
+
+    const first = service.confirm({ title: 'First', message: 'first?' })
+    const second = service.confirm({ title: 'Second', message: 'second?' })
+
+    await flushQueue()
+
+    expect(
+      dialogStore.dialogStack.filter((d) => d.key === 'global-prompt')
+    ).toHaveLength(1)
+    expect(dialogStore.dialogStack[0].title).toBe('First')
+
+    const onConfirm = dialogStore.dialogStack[0].contentProps.onConfirm as (
+      value?: boolean
+    ) => void
+    onConfirm(true)
+    dialogStore.closeDialog()
+    await expect(first).resolves.toBe(true)
+
+    await flushQueue()
+
+    expect(dialogStore.dialogStack).toHaveLength(1)
+    expect(dialogStore.dialogStack[0].title).toBe('Second')
+    expect(dialogStore.dialogStack[0].contentProps.message).toBe('second?')
+
+    dialogStore.closeDialog()
+    await expect(second).resolves.toBeNull()
+  })
+
+  it('keeps FIFO order when prompt() is queued behind confirm()', async () => {
+    const { service, dialogStore } = await importDialogModules()
+    const { default: ConfirmationDialogContent } =
+      await import('@/components/dialog/content/ConfirmationDialogContent.vue')
+    const { default: PromptDialogContent } =
+      await import('@/components/dialog/content/PromptDialogContent.vue')
+
+    const confirmResult = service.confirm({
+      title: 'Confirm',
+      message: 'sure?'
+    })
+    const promptResult = service.prompt({
+      title: 'Prompt',
+      message: 'name?',
+      defaultValue: 'initial'
+    })
+
+    await flushQueue()
+
+    expect(dialogStore.dialogStack[0].component).toBe(ConfirmationDialogContent)
+
+    dialogStore.closeDialog()
+    await expect(confirmResult).resolves.toBeNull()
+
+    await flushQueue()
+
+    expect(dialogStore.dialogStack).toHaveLength(1)
+    const promptDialog = dialogStore.dialogStack[0]
+    expect(promptDialog.component).toBe(PromptDialogContent)
+    expect(promptDialog.title).toBe('Prompt')
+    expect(promptDialog.contentProps.defaultValue).toBe('initial')
+
+    const onConfirm = promptDialog.contentProps.onConfirm as (
+      value: string
+    ) => void
+    onConfirm('typed value')
+    dialogStore.closeDialog()
+    await expect(promptResult).resolves.toBe('typed value')
+  })
+
+  it('closeDialog without a key settles the active promise as null and releases the queue', async () => {
+    const { service, dialogStore } = await importDialogModules()
+
+    const first = service.confirm({ title: 'Escaped', message: 'close me' })
+    const second = service.confirm({ title: 'Following', message: 'next up' })
+
+    await flushQueue()
+
+    dialogStore.closeDialog()
+    await expect(first).resolves.toBeNull()
+
+    await flushQueue()
+
+    expect(dialogStore.dialogStack[0].title).toBe('Following')
+
+    dialogStore.closeDialog()
+    await expect(second).resolves.toBeNull()
+  })
+})

--- a/src/services/dialogService.concurrency.test.ts
+++ b/src/services/dialogService.concurrency.test.ts
@@ -138,4 +138,40 @@ describe('dialogService global prompt FIFO queue', () => {
     dialogStore.closeDialog()
     await expect(second).resolves.toBeNull()
   })
+
+  it('settles a cap-evicted prompt as null and releases the queue', async () => {
+    const { service, dialogStore } = await importDialogModules()
+    const filler = { render: () => null }
+
+    // 9 fillers first so the global-prompt lands at dialogStack[0] — equal
+    // priorities insert at the front, and the 10-cap evicts from index 0.
+    for (let i = 0; i < 9; i++) {
+      dialogStore.showDialog({ key: `filler-${i}`, component: filler })
+    }
+
+    const first = service.confirm({ title: 'Evicted', message: 'gone?' })
+    const second = service.confirm({ title: 'Following', message: 'next up' })
+
+    await flushQueue()
+
+    expect(dialogStore.dialogStack).toHaveLength(10)
+    expect(dialogStore.dialogStack[0].key).toBe('global-prompt')
+
+    // Overflow the cap: the prompt at index 0 is evicted without any user
+    // interaction. Its promise must settle (null) instead of hanging, and
+    // the FIFO queue must release so the second confirm can show.
+    dialogStore.showDialog({ key: 'overflow', component: filler })
+
+    await expect(first).resolves.toBeNull()
+
+    await flushQueue()
+
+    const promptDialog = dialogStore.dialogStack.find(
+      (d) => d.key === 'global-prompt'
+    )
+    expect(promptDialog?.title).toBe('Following')
+
+    dialogStore.closeDialog({ key: 'global-prompt' })
+    await expect(second).resolves.toBeNull()
+  })
 })

--- a/src/services/dialogService.concurrency.test.ts
+++ b/src/services/dialogService.concurrency.test.ts
@@ -9,7 +9,8 @@
  * the module registry and dynamically imports the modules it needs — a
  * mid-test failure then cannot wedge the queue for later tests.
  */
-import { createPinia, setActivePinia } from 'pinia'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/i18n', () => ({
@@ -32,6 +33,12 @@ vi.mock('@/composables/billing/useBillingContext', () => ({
   })
 }))
 
+/**
+ * Macrotask flush: releasing the FIFO queue takes several promise hops inside
+ * enqueueGlobalPrompt, and a macrotask runs only after all pending microtasks.
+ * `nextTick()` awaits a fixed number of hops and would couple these tests to
+ * that internal chain depth.
+ */
 function flushQueue() {
   return new Promise((resolve) => setTimeout(resolve))
 }
@@ -47,7 +54,7 @@ async function importDialogModules() {
 describe('dialogService global prompt FIFO queue', () => {
   beforeEach(() => {
     vi.resetModules()
-    setActivePinia(createPinia())
+    setActivePinia(createTestingPinia({ stubActions: false }))
   })
 
   it('settles both promises when two confirm() calls race', async () => {

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -44,7 +44,7 @@ describe('dialogService Reka renderer opt-in', () => {
     const [args] = showDialog.mock.calls[0]
     expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
-    args.dialogComponentProps.onClose()
+    args.dialogComponentProps.onRemoved()
     await expect(result).resolves.toBeNull()
   })
 
@@ -54,7 +54,7 @@ describe('dialogService Reka renderer opt-in', () => {
     const [args] = showDialog.mock.calls[0]
     expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
-    args.dialogComponentProps.onClose()
+    args.dialogComponentProps.onRemoved()
     await expect(result).resolves.toBeNull()
   })
 
@@ -71,7 +71,7 @@ describe('dialogService Reka renderer opt-in', () => {
     const result = service.confirm({ title: 'T2', message: 'M2' })
     await vi.waitFor(() => expect(showDialog).toHaveBeenCalledTimes(2))
     const [args] = showDialog.mock.calls[1]
-    args.dialogComponentProps.onClose()
+    args.dialogComponentProps.onRemoved()
     await expect(result).resolves.toBeNull()
   })
 

--- a/src/services/dialogService.renderer.test.ts
+++ b/src/services/dialogService.renderer.test.ts
@@ -38,18 +38,41 @@ describe('dialogService Reka renderer opt-in', () => {
     showDialog.mockReset()
   })
 
-  it("prompt() sets renderer 'reka' and size 'md'", () => {
-    void useDialogService().prompt({ title: 'T', message: 'M' })
+  it("prompt() sets renderer 'reka' and size 'md'", async () => {
+    const result = useDialogService().prompt({ title: 'T', message: 'M' })
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalled())
     const [args] = showDialog.mock.calls[0]
     expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
+    args.dialogComponentProps.onClose()
+    await expect(result).resolves.toBeNull()
   })
 
-  it("confirm() sets renderer 'reka' and size 'md'", () => {
-    void useDialogService().confirm({ title: 'T', message: 'M' })
+  it("confirm() sets renderer 'reka' and size 'md'", async () => {
+    const result = useDialogService().confirm({ title: 'T', message: 'M' })
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalled())
     const [args] = showDialog.mock.calls[0]
     expect(args.dialogComponentProps.renderer).toBe('reka')
     expect(args.dialogComponentProps.size).toBe('md')
+    args.dialogComponentProps.onClose()
+    await expect(result).resolves.toBeNull()
+  })
+
+  it('releases the FIFO queue when showDialog throws for the head prompt', async () => {
+    showDialog.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    const service = useDialogService()
+
+    await expect(service.prompt({ title: 'T', message: 'M' })).rejects.toThrow(
+      'boom'
+    )
+
+    const result = service.confirm({ title: 'T2', message: 'M2' })
+    await vi.waitFor(() => expect(showDialog).toHaveBeenCalledTimes(2))
+    const [args] = showDialog.mock.calls[1]
+    args.dialogComponentProps.onClose()
+    await expect(result).resolves.toBeNull()
   })
 
   it("showBillingComingSoonDialog() sets renderer 'reka', size 'sm', and 360px contentClass", () => {

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -97,8 +97,9 @@ export interface ExecutionErrorDialogInput {
 
 // prompt() and confirm() share the 'global-prompt' key, and
 // dialogStore.showDialog merely raises an existing dialog with the same key —
-// a concurrent second caller's onConfirm/onClose would never be wired and its
-// promise would never settle. Serialize them FIFO so every promise settles.
+// a concurrent second caller's onConfirm/onRemoved would never be wired and
+// its promise would never settle. Serialize them FIFO so every promise
+// settles.
 let globalPromptTail: Promise<unknown> = Promise.resolve()
 
 function enqueueGlobalPrompt<T>(
@@ -298,7 +299,9 @@ export const useDialogService = () => {
         dialogComponentProps: {
           renderer: 'reka',
           size: 'md',
-          onClose: () => {
+          // onRemoved (not onClose) so the promise also settles when the
+          // dialog is cap-evicted rather than closed by the user.
+          onRemoved: () => {
             resolve(null)
           }
         }
@@ -335,7 +338,9 @@ export const useDialogService = () => {
         dialogComponentProps: {
           renderer: 'reka',
           size: 'md',
-          onClose: () => resolve(null)
+          // onRemoved (not onClose) so the promise also settles when the
+          // dialog is cap-evicted rather than closed by the user.
+          onRemoved: () => resolve(null)
         }
       }
 

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -236,7 +236,9 @@ export const useDialogService = () => {
           renderer: 'reka',
           contentClass: HUG_CONTENT_CLASS,
           closable: false,
-          onClose: () => resolve(false)
+          // onRemoved (not onClose) so the promise also settles when the
+          // dialog is cap-evicted rather than closed by the user.
+          onRemoved: () => resolve(false)
         }
       })
     }).then((result) => {
@@ -263,7 +265,9 @@ export const useDialogService = () => {
           // 352px after the body padding; hug the intrinsic width instead.
           contentClass: HUG_CONTENT_CLASS,
           closable: true,
-          onClose: () => resolve(false)
+          // onRemoved (not onClose) so the promise also settles when the
+          // dialog is cap-evicted rather than closed by the user.
+          onRemoved: () => resolve(false)
         }
       })
     }).then((result) => {
@@ -705,7 +709,9 @@ export const useDialogService = () => {
           closable: false,
           contentClass:
             'w-170 max-w-[calc(100vw-1rem)] sm:max-w-[42.5rem] rounded-2xl overflow-hidden',
-          onClose: () => resolve()
+          // onRemoved (not onClose) so the promise also settles when the
+          // dialog is cap-evicted rather than closed by the user.
+          onRemoved: () => resolve()
         }
       })
     })

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -236,8 +236,6 @@ export const useDialogService = () => {
           renderer: 'reka',
           contentClass: HUG_CONTENT_CLASS,
           closable: false,
-          // onRemoved (not onClose) so the promise also settles when the
-          // dialog is cap-evicted rather than closed by the user.
           onRemoved: () => resolve(false)
         }
       })
@@ -265,8 +263,6 @@ export const useDialogService = () => {
           // 352px after the body padding; hug the intrinsic width instead.
           contentClass: HUG_CONTENT_CLASS,
           closable: true,
-          // onRemoved (not onClose) so the promise also settles when the
-          // dialog is cap-evicted rather than closed by the user.
           onRemoved: () => resolve(false)
         }
       })
@@ -303,8 +299,6 @@ export const useDialogService = () => {
         dialogComponentProps: {
           renderer: 'reka',
           size: 'md',
-          // onRemoved (not onClose) so the promise also settles when the
-          // dialog is cap-evicted rather than closed by the user.
           onRemoved: () => {
             resolve(null)
           }
@@ -342,8 +336,6 @@ export const useDialogService = () => {
         dialogComponentProps: {
           renderer: 'reka',
           size: 'md',
-          // onRemoved (not onClose) so the promise also settles when the
-          // dialog is cap-evicted rather than closed by the user.
           onRemoved: () => resolve(null)
         }
       }
@@ -709,8 +701,6 @@ export const useDialogService = () => {
           closable: false,
           contentClass:
             'w-170 max-w-[calc(100vw-1rem)] sm:max-w-[42.5rem] rounded-2xl overflow-hidden',
-          // onRemoved (not onClose) so the promise also settles when the
-          // dialog is cap-evicted rather than closed by the user.
           onRemoved: () => resolve()
         }
       })

--- a/src/services/dialogService.ts
+++ b/src/services/dialogService.ts
@@ -95,6 +95,23 @@ export interface ExecutionErrorDialogInput {
   traceback: string[]
 }
 
+// prompt() and confirm() share the 'global-prompt' key, and
+// dialogStore.showDialog merely raises an existing dialog with the same key —
+// a concurrent second caller's onConfirm/onClose would never be wired and its
+// promise would never settle. Serialize them FIFO so every promise settles.
+let globalPromptTail: Promise<unknown> = Promise.resolve()
+
+function enqueueGlobalPrompt<T>(
+  show: (resolve: (value: T) => void) => void
+): Promise<T> {
+  const result = globalPromptTail.then(() => new Promise<T>(show))
+  globalPromptTail = result.then(
+    () => undefined,
+    () => undefined
+  )
+  return result
+}
+
 export const useDialogService = () => {
   const dialogStore = useDialogStore()
 
@@ -265,7 +282,7 @@ export const useDialogService = () => {
     defaultValue?: string
     placeholder?: string
   }): Promise<string | null> {
-    return new Promise((resolve) => {
+    return enqueueGlobalPrompt<string | null>((resolve) => {
       dialogStore.showDialog({
         key: 'global-prompt',
         title,
@@ -302,7 +319,7 @@ export const useDialogService = () => {
     hint,
     denyLabel
   }: ConfirmOptions): Promise<boolean | null> {
-    return new Promise((resolve) => {
+    return enqueueGlobalPrompt<boolean | null>((resolve) => {
       const options: ShowDialogOptions = {
         key: 'global-prompt',
         title,

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -216,6 +216,40 @@ describe('dialogStore', () => {
       expect(store.dialogStack).toHaveLength(10)
     })
 
+    it('keeps the stack capped when evicted onClose opens another dialog', () => {
+      const store = useDialogStore()
+      const onClose = vi.fn(() => {
+        store.showDialog({
+          key: 'reentrant-dialog',
+          component: MockComponent
+        })
+      })
+
+      store.showDialog({
+        key: 'evicted-dialog',
+        component: MockComponent,
+        priority: 10,
+        dialogComponentProps: { onClose }
+      })
+
+      for (let i = 0; i < 9; i++) {
+        store.showDialog({
+          key: `filler-${i}`,
+          component: MockComponent
+        })
+      }
+
+      store.showDialog({
+        key: 'overflow-dialog',
+        component: MockComponent
+      })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(store.isDialogOpen('evicted-dialog')).toBe(false)
+      expect(store.isDialogOpen('reentrant-dialog')).toBe(true)
+      expect(store.dialogStack).toHaveLength(10)
+    })
+
     it('evicts the most recently shown dialog when priorities are equal', () => {
       const store = useDialogStore()
       const onClose = vi.fn()

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import { setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 
 import { useDialogStore } from '@/stores/dialogStore'
@@ -182,6 +182,68 @@ describe('dialogStore', () => {
       expect(store.dialogStack).toHaveLength(1)
       expect(store.dialogStack[0].key).toBe('reusable-dialog')
       expect(store.dialogStack[0].title).toBe('Original Title')
+    })
+
+    it('fires the evicted dialog onClose when the stack exceeds the cap', () => {
+      const store = useDialogStore()
+      const onClose = vi.fn()
+
+      // priority: 10 pins this dialog at dialogStack[0], the slot the cap
+      // evicts from
+      store.showDialog({
+        key: 'evicted-dialog',
+        component: MockComponent,
+        priority: 10,
+        dialogComponentProps: { onClose }
+      })
+
+      for (let i = 0; i < 9; i++) {
+        store.showDialog({
+          key: `filler-${i}`,
+          component: MockComponent
+        })
+      }
+
+      expect(store.dialogStack[0].key).toBe('evicted-dialog')
+
+      store.showDialog({
+        key: 'overflow-dialog',
+        component: MockComponent
+      })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(store.isDialogOpen('evicted-dialog')).toBe(false)
+      expect(store.dialogStack).toHaveLength(10)
+    })
+
+    it('evicts the most recently shown dialog when priorities are equal', () => {
+      const store = useDialogStore()
+      const onClose = vi.fn()
+
+      for (let i = 0; i < 9; i++) {
+        store.showDialog({
+          key: `filler-${i}`,
+          component: MockComponent
+        })
+      }
+
+      store.showDialog({
+        key: 'front-most-dialog',
+        component: MockComponent,
+        dialogComponentProps: { onClose }
+      })
+
+      expect(store.dialogStack[0].key).toBe('front-most-dialog')
+
+      store.showDialog({
+        key: 'overflow-dialog',
+        component: MockComponent
+      })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(store.isDialogOpen('front-most-dialog')).toBe(false)
+      expect(store.isDialogOpen('overflow-dialog')).toBe(true)
+      expect(store.dialogStack).toHaveLength(10)
     })
 
     it('should update existing dialog props by key', () => {

--- a/src/stores/dialogStore.test.ts
+++ b/src/stores/dialogStore.test.ts
@@ -158,6 +158,23 @@ describe('dialogStore', () => {
       expect(store.isDialogOpen('test-dialog')).toBe(false)
     })
 
+    it('fires both onClose and onRemoved when a dialog is closed', () => {
+      const store = useDialogStore()
+      const onClose = vi.fn()
+      const onRemoved = vi.fn()
+
+      store.showDialog({
+        key: 'test-dialog',
+        component: MockComponent,
+        dialogComponentProps: { onClose, onRemoved }
+      })
+
+      store.closeDialog({ key: 'test-dialog' })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(onRemoved).toHaveBeenCalledTimes(1)
+    })
+
     it('should reuse existing dialog when showing with same key', () => {
       const store = useDialogStore()
 
@@ -184,9 +201,10 @@ describe('dialogStore', () => {
       expect(store.dialogStack[0].title).toBe('Original Title')
     })
 
-    it('fires the evicted dialog onClose when the stack exceeds the cap', () => {
+    it('fires the evicted dialog onRemoved, not onClose, when the stack exceeds the cap', () => {
       const store = useDialogStore()
       const onClose = vi.fn()
+      const onRemoved = vi.fn()
 
       // priority: 10 pins this dialog at dialogStack[0], the slot the cap
       // evicts from
@@ -194,7 +212,7 @@ describe('dialogStore', () => {
         key: 'evicted-dialog',
         component: MockComponent,
         priority: 10,
-        dialogComponentProps: { onClose }
+        dialogComponentProps: { onClose, onRemoved }
       })
 
       for (let i = 0; i < 9; i++) {
@@ -211,14 +229,17 @@ describe('dialogStore', () => {
         component: MockComponent
       })
 
-      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(onRemoved).toHaveBeenCalledTimes(1)
+      // Eviction is not a user close — onClose must not fire (it carries
+      // user-intent side effects like telemetry and "don't show again").
+      expect(onClose).not.toHaveBeenCalled()
       expect(store.isDialogOpen('evicted-dialog')).toBe(false)
       expect(store.dialogStack).toHaveLength(10)
     })
 
-    it('keeps the stack capped when evicted onClose opens another dialog', () => {
+    it('keeps the stack capped when evicted onRemoved opens another dialog', () => {
       const store = useDialogStore()
-      const onClose = vi.fn(() => {
+      const onRemoved = vi.fn(() => {
         store.showDialog({
           key: 'reentrant-dialog',
           component: MockComponent
@@ -229,7 +250,7 @@ describe('dialogStore', () => {
         key: 'evicted-dialog',
         component: MockComponent,
         priority: 10,
-        dialogComponentProps: { onClose }
+        dialogComponentProps: { onRemoved }
       })
 
       for (let i = 0; i < 9; i++) {
@@ -244,7 +265,7 @@ describe('dialogStore', () => {
         component: MockComponent
       })
 
-      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(onRemoved).toHaveBeenCalledTimes(1)
       expect(store.isDialogOpen('evicted-dialog')).toBe(false)
       expect(store.isDialogOpen('reentrant-dialog')).toBe(true)
       expect(store.dialogStack).toHaveLength(10)
@@ -252,7 +273,7 @@ describe('dialogStore', () => {
 
     it('evicts the most recently shown dialog when priorities are equal', () => {
       const store = useDialogStore()
-      const onClose = vi.fn()
+      const onRemoved = vi.fn()
 
       for (let i = 0; i < 9; i++) {
         store.showDialog({
@@ -264,7 +285,7 @@ describe('dialogStore', () => {
       store.showDialog({
         key: 'front-most-dialog',
         component: MockComponent,
-        dialogComponentProps: { onClose }
+        dialogComponentProps: { onRemoved }
       })
 
       expect(store.dialogStack[0].key).toBe('front-most-dialog')
@@ -274,7 +295,7 @@ describe('dialogStore', () => {
         component: MockComponent
       })
 
-      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(onRemoved).toHaveBeenCalledTimes(1)
       expect(store.isDialogOpen('front-most-dialog')).toBe(false)
       expect(store.isDialogOpen('overflow-dialog')).toBe(true)
       expect(store.dialogStack).toHaveLength(10)

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -177,7 +177,8 @@ export const useDialogStore = defineStore('dialog', () => {
     F extends Component = Component
   >(options: ShowDialogOptions<H, B, F> & { key: string }) {
     if (dialogStack.value.length >= 10) {
-      dialogStack.value.shift()
+      const evicted = dialogStack.value.shift()
+      evicted?.dialogComponentProps?.onClose?.()
     }
 
     const dialog = {

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -32,6 +32,14 @@ interface CustomDialogComponentProps {
   maximizable?: boolean
   maximized?: boolean
   onClose?: () => void
+  /**
+   * Guaranteed cleanup: fires exactly once when the dialog leaves the stack
+   * for any reason — `closeDialog` (user or programmatic) or the
+   * 10-dialog-cap eviction in `createDialog`. Wire promise settlement here.
+   * Keep user-intent side effects (telemetry, "don't show again") in
+   * `onClose`, which never fires on eviction.
+   */
+  onRemoved?: () => void
   closable?: boolean
   modal?: boolean
   position?: DialogPosition
@@ -161,7 +169,11 @@ export const useDialogStore = defineStore('dialog', () => {
 
     targetDialog.dialogComponentProps?.onClose?.()
     const index = dialogStack.value.findIndex((d) => d.key === targetDialog.key)
-    if (index !== -1) dialogStack.value.splice(index, 1)
+    // A reentrant onClose can remove targetDialog itself (e.g. by opening a
+    // dialog that triggers the cap eviction). Whoever actually removes the
+    // dialog from the stack fires onRemoved, so it fires exactly once.
+    const removed = index !== -1
+    if (removed) dialogStack.value.splice(index, 1)
 
     activeKey.value =
       dialogStack.value.length > 0
@@ -169,6 +181,7 @@ export const useDialogStore = defineStore('dialog', () => {
         : null
 
     updateCloseOnEscapeStates()
+    if (removed) targetDialog.dialogComponentProps?.onRemoved?.()
   }
 
   function createDialog<
@@ -225,7 +238,10 @@ export const useDialogStore = defineStore('dialog', () => {
     insertDialogByPriority(dialog)
     activeKey.value = options.key
     updateCloseOnEscapeStates()
-    evicted?.dialogComponentProps?.onClose?.()
+    // Eviction is not a user close: fire only the cleanup hook, never
+    // onClose (which callers treat as user intent — telemetry, "don't show
+    // again" persistence).
+    evicted?.dialogComponentProps?.onRemoved?.()
 
     return dialog
   }

--- a/src/stores/dialogStore.ts
+++ b/src/stores/dialogStore.ts
@@ -176,10 +176,8 @@ export const useDialogStore = defineStore('dialog', () => {
     B extends Component = Component,
     F extends Component = Component
   >(options: ShowDialogOptions<H, B, F> & { key: string }) {
-    if (dialogStack.value.length >= 10) {
-      const evicted = dialogStack.value.shift()
-      evicted?.dialogComponentProps?.onClose?.()
-    }
+    const evicted =
+      dialogStack.value.length >= 10 ? dialogStack.value.shift() : undefined
 
     const dialog = {
       key: options.key,
@@ -227,6 +225,7 @@ export const useDialogStore = defineStore('dialog', () => {
     insertDialogByPriority(dialog)
     activeKey.value = options.key
     updateCloseOnEscapeStates()
+    evicted?.dialogComponentProps?.onClose?.()
 
     return dialog
   }


### PR DESCRIPTION
## What

- `dialogService.prompt()` / `confirm()` now run through a module-level FIFO queue: a call made while a `global-prompt` dialog is already open shows after the first settles, and **every** caller's promise settles.
- New `onRemoved` cleanup hook on `dialogComponentProps`: fires exactly once when a dialog leaves the stack for **any** reason — `closeDialog` (user or programmatic) or the 10-dialog-cap eviction. Whoever actually removes the dialog notifies, so a reentrant `onClose` that evicts the closing dialog cannot double-fire. `onClose` keeps its user-intent meaning and **never** fires on eviction (it carries side effects like telemetry and "don't show again" persistence — firing those on a silent eviction would misreport user action).
- Promise-settling dialogs wire their resolver to `onRemoved` instead of `onClose`: `prompt()`/`confirm()` (settles the FIFO queue on eviction too), plus `showSignInDialog`, `showApiNodesSignInDialog`, and `showCloudNotification` (whose promises were latently orphaned by eviction on main).
- New concurrency suite against the real dialog store — including a cap-eviction case asserting the evicted prompt settles `null` and releases the queue; renderer tests adapted (the dialog now opens in a microtask, imperceptible in the UI).

## Why

Both helpers hardcode the `'global-prompt'` dialog key, and `dialogStore.showDialog` raises an existing dialog with the same key without rewiring handlers — a second concurrent `confirm()`/`prompt()`'s handlers are never attached, so its promise never settles and the caller hangs forever. Concrete victims: `useAuthActions`' reauth confirm when two wrapped auth actions fail near-simultaneously, and the desktop-login approval dialog in #13418, where one orphaned confirm wedges redemption for the rest of the page load.

The eviction path needs the same guarantee (an evicted `global-prompt` must settle or the queue wedges), but `onClose` is overloaded: callers treat it as "the user closed this". Firing it on eviction would run `markConflictsAsSeen()` (permanently suppressing conflict warnings via localStorage), emit phantom `error_dialog_closed` telemetry, and phantom-decline the sign-in dialogs. Splitting settlement (`onRemoved`) from user intent (`onClose`) gives every removal path settlement without impersonating the user.

Behavior change: a true double-invocation now asks the question twice in sequence (previously the second call silently died). The raise-on-existing semantics of `dialogStore.showDialog` are untouched — extension dialogs and keyed dialogs behave exactly as before.

## Landing order

Independent. #13418 depends on it at runtime (its approval confirm can fire while another prompt is open) — merge this first.
