### PR TITLE
refactor: simplify slot link drop finalization

### DIFF
--- a/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
+++ b/src/renderer/extensions/vueNodes/composables/useSlotLinkInteraction.ts
@@ -530,8 +530,6 @@ export function useSlotLinkInteraction({
 
     raf.flush()
 
-    raf.flush()
-
     if (!state.source) {
       cleanupInteraction()
       app.canvas?.setDirty(true, true)
@@ -579,24 +577,18 @@ export function useSlotLinkInteraction({
     const graph = app.canvas?.graph ?? null
     const context = { adapter, graph, session: dragContext }
 
-    const attemptSnapped = () => tryConnectToCandidate(snappedCandidate)
-
     const domSlotCandidate = resolveSlotTargetCandidate(target, context)
-    const attemptDomSlot = () => tryConnectToCandidate(domSlotCandidate)
-
     const nodeSurfaceSlotCandidate = resolveNodeSurfaceSlotCandidate(
       target,
       context
     )
-    const attemptNodeSurface = () =>
-      tryConnectToCandidate(nodeSurfaceSlotCandidate)
-    const attemptReroute = () => tryConnectViaRerouteAtPointer()
 
-    if (attemptSnapped()) return true
-    if (attemptDomSlot()) return true
-    if (attemptNodeSurface()) return true
-    if (attemptReroute()) return true
-    return false
+    return (
+      tryConnectToCandidate(snappedCandidate) ||
+      tryConnectToCandidate(domSlotCandidate) ||
+      tryConnectToCandidate(nodeSurfaceSlotCandidate) ||
+      tryConnectViaRerouteAtPointer()
+    )
   }
 
   const onPointerDown = (event: PointerEvent) => {


### PR DESCRIPTION
## Summary

Small cleanup in `useSlotLinkInteraction.ts`, no behavior change:

- Removed a duplicated `raf.flush()` in `finishInteraction` (it was called twice back-to-back).
- Collapsed four single-line `attempt*` alias closures in `connectByPriority` into a direct short-circuit chain, preserving the same evaluation order:

  ```ts
  return (
    tryConnectToCandidate(snappedCandidate) ||
    tryConnectToCandidate(domSlotCandidate) ||
    tryConnectToCandidate(nodeSurfaceSlotCandidate) ||
    tryConnectViaRerouteAtPointer()
  )
  ```

  The closures added no behavior beyond renaming the calls (AGENTS.md rule 26), and `||` gives the same first-truthy-wins semantics as the previous `if (attempt()) return true` ladder.

Verification not rerun after rebasing onto `Comfy-Org/main`; original branch reported `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm knip`, and the existing `useSlotLinkInteraction` unit tests passing.

Link to Devin session: https://app.devin.ai/sessions/1351ff5174494106a7a688777554f387
Requested by: @benceruleanlu
