### PR TITLE
feat(billing): send checkout_attempt_id to the subscription checkout API

### DIFF
--- a/src/platform/cloud/subscription/composables/useSubscription.test.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.test.ts
@@ -346,25 +346,30 @@ describe('useSubscription', () => {
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token',
             'Content-Type': 'application/json'
-          }),
-          body: JSON.stringify({
-            im_ref: 'impact-click-001',
-            utm_source: 'impact'
           })
         })
       )
+      const requestBody = JSON.parse(
+        vi.mocked(global.fetch).mock.calls[0][1]?.body as string
+      )
+      expect(requestBody).toEqual({
+        im_ref: 'impact-click-001',
+        utm_source: 'impact',
+        checkout_attempt_id: expect.any(String)
+      })
 
       expect(windowOpenSpy).toHaveBeenCalledWith(checkoutUrl, '_blank')
-      expect(
-        JSON.parse(
-          localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY) ??
-            '{}'
-        )
-      ).toMatchObject({
+      const persistedAttempt = JSON.parse(
+        localStorage.getItem(PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY) ?? '{}'
+      )
+      expect(persistedAttempt).toMatchObject({
         tier: 'standard',
         cycle: 'monthly',
         checkout_type: 'new'
       })
+      // The id sent to the backend is the persisted attempt's id — the funnel
+      // join key echoed back on the server-side billing success events.
+      expect(requestBody.checkout_attempt_id).toBe(persistedAttempt.attempt_id)
 
       windowOpenSpy.mockRestore()
     })

--- a/src/platform/cloud/subscription/composables/useSubscription.ts
+++ b/src/platform/cloud/subscription/composables/useSubscription.ts
@@ -26,8 +26,9 @@ import {
   PENDING_SUBSCRIPTION_CHECKOUT_STORAGE_KEY,
   clearPendingSubscriptionCheckoutAttempt,
   consumePendingSubscriptionCheckoutSuccess,
+  createPendingSubscriptionCheckoutAttempt,
   hasPendingSubscriptionCheckoutAttempt,
-  recordPendingSubscriptionCheckoutAttempt
+  persistPendingSubscriptionCheckoutAttempt
 } from '@/platform/cloud/subscription/utils/subscriptionCheckoutTracker'
 import { useSubscriptionCancellationWatcher } from './useSubscriptionCancellationWatcher'
 
@@ -207,7 +208,27 @@ function useSubscriptionInternal() {
   )
 
   const subscribe = wrapWithErrorHandlingAsync(async () => {
-    const response = await initiateSubscriptionCheckout()
+    // Created before the request so the attempt id rides the checkout API
+    // call into Stripe subscription metadata; the backend echoes it on the
+    // server-side billing success events. Only persisted once the checkout
+    // window actually opens, matching the previous behavior.
+    const pendingAttempt = createPendingSubscriptionCheckoutAttempt({
+      tier: 'standard',
+      cycle: 'monthly',
+      checkout_type: isSubscribedOrIsNotCloud.value ? 'change' : 'new',
+      ...(subscriptionTier.value
+        ? { previous_tier: TIER_TO_KEY[subscriptionTier.value] }
+        : {}),
+      ...(subscriptionDuration.value === 'ANNUAL'
+        ? { previous_cycle: 'yearly' as const }
+        : subscriptionDuration.value === 'MONTHLY'
+          ? { previous_cycle: 'monthly' as const }
+          : {})
+    })
+
+    const response = await initiateSubscriptionCheckout(
+      pendingAttempt.attempt_id
+    )
 
     if (!response.checkout_url) {
       throw new Error(
@@ -222,19 +243,7 @@ function useSubscriptionInternal() {
       return
     }
 
-    recordPendingSubscriptionCheckoutAttempt({
-      tier: 'standard',
-      cycle: 'monthly',
-      checkout_type: isSubscribedOrIsNotCloud.value ? 'change' : 'new',
-      ...(subscriptionTier.value
-        ? { previous_tier: TIER_TO_KEY[subscriptionTier.value] }
-        : {}),
-      ...(subscriptionDuration.value === 'ANNUAL'
-        ? { previous_cycle: 'yearly' as const }
-        : subscriptionDuration.value === 'MONTHLY'
-          ? { previous_cycle: 'monthly' as const }
-          : {})
-    })
+    persistPendingSubscriptionCheckoutAttempt(pendingAttempt)
   }, reportError)
 
   const showSubscriptionDialog = (options?: SubscriptionDialogOptions) => {
@@ -406,32 +415,36 @@ function useSubscriptionInternal() {
     { immediate: true }
   )
 
-  const initiateSubscriptionCheckout =
-    async (): Promise<CloudSubscriptionCheckoutResponse> => {
-      const headers = await buildAuthHeaders()
-      const checkoutAttribution = await getCheckoutAttributionForCloud()
+  const initiateSubscriptionCheckout = async (
+    checkoutAttemptId: string
+  ): Promise<CloudSubscriptionCheckoutResponse> => {
+    const headers = await buildAuthHeaders()
+    const checkoutAttribution = await getCheckoutAttributionForCloud()
 
-      const response = await fetchWithUnifiedRemint(
-        buildApiUrl('/customers/cloud-subscription-checkout'),
-        {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(checkoutAttribution)
-        },
-        isCloud && flags.unifiedCloudAuthEnabled
+    const response = await fetchWithUnifiedRemint(
+      buildApiUrl('/customers/cloud-subscription-checkout'),
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          ...checkoutAttribution,
+          checkout_attempt_id: checkoutAttemptId
+        })
+      },
+      isCloud && flags.unifiedCloudAuthEnabled
+    )
+
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new AuthStoreError(
+        t('toastMessages.failedToInitiateSubscription', {
+          error: errorData.message
+        })
       )
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new AuthStoreError(
-          t('toastMessages.failedToInitiateSubscription', {
-            error: errorData.message
-          })
-        )
-      }
-
-      return response.json()
     }
+
+    return response.json()
+  }
 
   return {
     // State

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.test.ts
@@ -161,21 +161,29 @@ describe('performSubscriptionCheckout', () => {
       expect.stringContaining(
         '/customers/cloud-subscription-checkout/pro-yearly'
       ),
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({
-          ga_client_id: 'ga-client-id',
-          ga_session_id: 'ga-session-id',
-          ga_session_number: 'ga-session-number',
-          im_ref: 'impact-click-123',
-          utm_source: 'impact',
-          utm_medium: 'affiliate',
-          utm_campaign: 'spring-launch',
-          gclid: 'gclid-123',
-          gbraid: 'gbraid-456',
-          wbraid: 'wbraid-789'
-        })
-      })
+      expect.objectContaining({ method: 'POST' })
+    )
+    const requestBody = JSON.parse(
+      vi.mocked(global.fetch).mock.calls[0][1]?.body as string
+    )
+    expect(requestBody).toEqual({
+      ga_client_id: 'ga-client-id',
+      ga_session_id: 'ga-session-id',
+      ga_session_number: 'ga-session-number',
+      im_ref: 'impact-click-123',
+      utm_source: 'impact',
+      utm_medium: 'affiliate',
+      utm_campaign: 'spring-launch',
+      gclid: 'gclid-123',
+      gbraid: 'gbraid-456',
+      wbraid: 'wbraid-789',
+      checkout_attempt_id: expect.any(String)
+    })
+    // The id sent to the backend must be the same one on begin_checkout and
+    // the persisted attempt — it is the funnel join key echoed back on the
+    // server-side billing success events.
+    expect(requestBody.checkout_attempt_id).toBe(
+      beginCheckoutMetadata.checkout_attempt_id
     )
     expect(openSpy).toHaveBeenCalledWith(checkoutUrl, '_blank')
   })
@@ -201,11 +209,14 @@ describe('performSubscriptionCheckout', () => {
     )
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/customers/cloud-subscription-checkout/pro'),
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({})
-      })
+      expect.objectContaining({ method: 'POST' })
     )
+    // Attribution failed, but the funnel join key is still sent.
+    expect(
+      JSON.parse(vi.mocked(global.fetch).mock.calls[0][1]?.body as string)
+    ).toEqual({
+      checkout_attempt_id: expect.any(String)
+    })
     expect(mockTelemetry.trackBeginCheckout).toHaveBeenCalledWith({
       user_id: 'user-123',
       tier: 'pro',

--- a/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
+++ b/src/platform/cloud/subscription/utils/subscriptionCheckoutUtil.ts
@@ -84,7 +84,20 @@ export async function performSubscriptionCheckout(
       error
     )
   }
-  const checkoutPayload = { ...checkoutAttribution }
+  // Created before the request so the attempt id rides the checkout API call
+  // into Stripe subscription metadata; the backend echoes it on the
+  // server-side billing success events, joining them to begin_checkout /
+  // app:monthly_subscription_succeeded (which carry the same id below).
+  const pendingAttempt = createPendingSubscriptionCheckoutAttempt({
+    tier: tierKey,
+    cycle: currentBillingCycle,
+    checkout_type: 'new',
+    payment_intent_source: paymentIntentSource
+  })
+  const checkoutPayload = {
+    ...checkoutAttribution,
+    checkout_attempt_id: pendingAttempt.attempt_id
+  }
 
   const response = await fetchWithUnifiedRemint(
     `${getComfyApiBaseUrl()}/customers/cloud-subscription-checkout/${checkoutTier}`,
@@ -122,13 +135,6 @@ export async function performSubscriptionCheckout(
   const data = await response.json()
 
   if (data.checkout_url) {
-    const pendingAttempt = createPendingSubscriptionCheckoutAttempt({
-      tier: tierKey,
-      cycle: currentBillingCycle,
-      checkout_type: 'new',
-      payment_intent_source: paymentIntentSource
-    })
-
     if (userId.value) {
       telemetry?.trackBeginCheckout(
         withPendingCheckoutAttemptId(


### PR DESCRIPTION
## Summary

Sends the existing client-generated `checkout_attempt_id` in the subscription-checkout request body so the backend can stamp it into Stripe subscription metadata and echo it on the server-authoritative billing success events — completing the checkout funnel (`begin_checkout` → `billing:subscription_succeeded`) with a deterministic join key instead of person + time-window heuristics.

## Changes

- **What**:
  - `performSubscriptionCheckout` (tier checkout): the pending checkout attempt is now created *before* the API call and its `attempt_id` is included in the request body as `checkout_attempt_id`. The same attempt object still feeds `begin_checkout` and localStorage persistence, so all three carry one id.
  - `useSubscription.subscribe` (default checkout): same change; `initiateSubscriptionCheckout` now takes the attempt id and sends it. Persistence still only happens after the checkout window actually opens (unchanged behavior).
  - Tests updated to assert the request-body id equals the `begin_checkout` id and the persisted attempt id.

## Review Focus

- The attempt is created earlier but **persisted at the same points as before** (popup-blocked flows still persist nothing) — worth double-checking no behavioral drift.
- Backend counterpart: Comfy-Org/cloud#4821 accepts the field, stores it in `SubscriptionData.Metadata`, and echoes it on `billing:subscription_created` / `billing:subscription_succeeded` (creation-gated, so renewals don't multi-match). Either PR can land first — the field is optional and ignored by older backends.

Tested: `pnpm vitest run src/platform/cloud/subscription` (22 files, 205 tests) passes; `pnpm typecheck` passes; eslint + oxfmt clean.