### PR TITLE
fix: report CLA check in merge queue

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, closed]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   actions: write
@@ -16,6 +18,10 @@ jobs:
   cla-assistant:
     runs-on: ubuntu-latest
     steps:
+      - name: CLA already verified before merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "CLA is checked on the pull request before it enters merge queue."
+
       # The CLA action normally requires every commit author in a PR to sign.
       # We only want the PR author to sign, so we allowlist all other committers
       # by computing them from the PR's commits and excluding the PR author.


### PR DESCRIPTION
Report the CLA Assistant required check for merge queue commits so queued PRs do not wait indefinitely on a check that ran on the PR head.